### PR TITLE
Week 2 Stage 1b-3: site dropdown and dynamic site context in chat

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -15,10 +15,12 @@ import { executeGetPage } from "@/lib/get-page";
 import { executeListPages } from "@/lib/list-pages";
 import { executePublishPage } from "@/lib/publish-page";
 import { executeUpdatePage } from "@/lib/update-page";
+import { buildSystemPromptForSite } from "@/lib/system-prompt";
+import { getSite } from "@/lib/sites";
 import {
-  buildSystemPrompt,
-  type SystemPromptContext,
-} from "@/lib/system-prompt";
+  runWithWpCredentials,
+  type WpCredentialsOverride,
+} from "@/lib/wordpress";
 
 type ToolExecutor = (input: unknown) => Promise<ToolResponse<any>>;
 
@@ -56,45 +58,15 @@ const MODEL = "claude-opus-4-7";
 const MAX_TOKENS = 4096;
 const MAX_ITERATIONS = 5;
 
-const LEADSOURCE_BRAND_VOICE = `Outcome-led. Bold statements. No hedging. Lead with what the product does, not what's broken in the world. Say the thing everyone's thinking but nobody writes on their website. Keep it short. Make it sound like a real person said it. If it sounds like an AI or a committee wrote it, rewrite it.
-
-Six voice rules:
-1. Outcomes first — lead with the result, not the problem
-2. Bold statements — "We tell you exactly." Full stop.
-3. Short sentences
-4. Say the real thing — if everyone's thinking it, say it
-5. Honest about limits — "Works with most forms" not "every form"
-6. Never salesy — no exclamation marks, no "Amazing!", no pressure
-
-Power phrases to use: "Stop guessing. Start knowing.", "We tell you exactly.", "Where your best clients are coming from.", "Add the code. We do the rest.", "No BS."
-
-Never say: "Every form", "100% accurate", "Leverage/Utilise/Seamlessly", "Powerful/Robust/Comprehensive", passive voice like "data is captured"`;
-
-const LEADSOURCE_CONTEXT: SystemPromptContext = {
+const LEADSOURCE_FALLBACK_PROMPT = buildSystemPromptForSite({
   site_name: "LeadSource",
   prefix: "ls",
   design_system_version: "1.0.0",
-  design_system_updated: "n/a (Week 2)",
-  design_system_html_full_file: "",
-  brand_voice_content: LEADSOURCE_BRAND_VOICE,
-  site_pages_tree: "[]",
-  site_menus_current: "{}",
-  homepage_id: "null",
-  templates_list: "[]",
-  session_recent_pages: "[]",
-};
+});
 
-const SYSTEM_PROMPT = buildSystemPrompt(LEADSOURCE_CONTEXT);
-
-// System prompt as a cached text block. cache_control on the last system block
-// marks the entire system prompt as a cacheable prefix.
-const CACHED_SYSTEM: Anthropic.TextBlockParam[] = [
-  {
-    type: "text",
-    text: SYSTEM_PROMPT,
-    cache_control: EPHEMERAL,
-  },
-];
+function cachedSystemBlocks(prompt: string): Anthropic.TextBlockParam[] {
+  return [{ type: "text", text: prompt, cache_control: EPHEMERAL }];
+}
 
 function sseEvent(event: string, data: unknown): string {
   return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
@@ -111,7 +83,9 @@ function errorResponse(code: string, message: string, status: number) {
         suggested_action:
           code === "VALIDATION_FAILED"
             ? "Send a JSON body with { messages: [...] }."
-            : "Check server configuration.",
+            : code === "NOT_FOUND"
+              ? "Pick a site that still exists from /api/sites/list."
+              : "Check server configuration.",
       },
       timestamp: new Date().toISOString(),
     }),
@@ -136,6 +110,55 @@ export async function POST(req: Request) {
     );
   }
 
+  const activeSiteIdRaw = body?.activeSiteId;
+  const hasActiveSiteId =
+    typeof activeSiteIdRaw === "string" && activeSiteIdRaw.trim().length > 0;
+
+  // Resolve per-site context: explicit activeSiteId wins. A non-existent or
+  // credential-less site returns a 4xx — we do not fall back silently, so the
+  // caller sees exactly which site failed.
+  let systemPrompt: string;
+  let wpCreds: WpCredentialsOverride | undefined;
+  let siteLogId: string | null = null;
+  let siteLogName: string | null = null;
+
+  if (hasActiveSiteId) {
+    const siteId = activeSiteIdRaw.trim();
+    const siteResult = await getSite(siteId, { includeCredentials: true });
+    if (!siteResult.ok) {
+      const code = siteResult.error.code;
+      const status =
+        code === "NOT_FOUND" ? 404 : code === "INTERNAL_ERROR" ? 500 : 400;
+      return new Response(JSON.stringify(siteResult), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    const { site, credentials } = siteResult.data;
+    if (!credentials) {
+      return errorResponse(
+        "INTERNAL_ERROR",
+        `Site ${site.id} has no credentials — re-register or restore the credentials row.`,
+        500,
+      );
+    }
+    wpCreds = {
+      wp_url: site.wp_url,
+      wp_user: credentials.wp_user,
+      wp_app_password: credentials.wp_app_password,
+    };
+    systemPrompt = buildSystemPromptForSite({
+      site_name: site.name,
+      prefix: site.prefix,
+      design_system_version: site.design_system_version,
+    });
+    siteLogId = site.id;
+    siteLogName = site.name;
+  } else {
+    systemPrompt = LEADSOURCE_FALLBACK_PROMPT;
+    wpCreds = undefined;
+  }
+
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     return errorResponse(
@@ -147,6 +170,7 @@ export async function POST(req: Request) {
 
   const client = new Anthropic({ apiKey });
   const encoder = new TextEncoder();
+  const cachedSystem = cachedSystemBlocks(systemPrompt);
 
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -165,14 +189,17 @@ export async function POST(req: Request) {
         console.log("[api/chat] starting stream", {
           model: MODEL,
           msg_count: convo.length,
-          system_prompt_chars: SYSTEM_PROMPT.length,
+          system_prompt_chars: systemPrompt.length,
+          site_id: siteLogId,
+          site_name: siteLogName,
+          using_env_fallback: !hasActiveSiteId,
         });
 
         for (let iter = 0; iter < MAX_ITERATIONS; iter++) {
           const streamed = client.messages.stream({
             model: MODEL,
             max_tokens: MAX_TOKENS,
-            system: CACHED_SYSTEM,
+            system: cachedSystem,
             tools: CACHED_TOOLS,
             messages: convo,
           });
@@ -198,6 +225,7 @@ export async function POST(req: Request) {
               finalMsg.usage.cache_creation_input_tokens ?? 0,
             cache_read_input_tokens:
               finalMsg.usage.cache_read_input_tokens ?? 0,
+            site_id: siteLogId,
           });
 
           const toolUseBlocks = finalMsg.content.filter(
@@ -216,7 +244,9 @@ export async function POST(req: Request) {
             let isError = false;
             const executor = TOOL_EXECUTORS[tu.name];
             if (executor) {
-              const r = await executor(tu.input);
+              const r = await runWithWpCredentials(wpCreds, () =>
+                executor(tu.input),
+              );
               result = r;
               if (!r.ok) isError = true;
             } else {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import Link from "next/link";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { PreviewPane } from "@/components/PreviewPane";
+import {
+  ACTIVE_SITE_EVENT,
+  SiteSwitcher,
+  readStoredActiveSiteId,
+  type ActiveSiteEventDetail,
+} from "@/components/SiteSwitcher";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
@@ -31,8 +36,19 @@ export default function HomePage() {
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
   const [previewPageId, setPreviewPageId] = useState<number | null>(null);
+  const [activeSiteId, setActiveSiteId] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const toolUseNamesRef = useRef<Record<string, string>>({});
+
+  useEffect(() => {
+    setActiveSiteId(readStoredActiveSiteId());
+    const onChange = (e: Event) => {
+      const detail = (e as CustomEvent<ActiveSiteEventDetail>).detail;
+      setActiveSiteId(detail?.activeSiteId ?? null);
+    };
+    window.addEventListener(ACTIVE_SITE_EVENT, onChange);
+    return () => window.removeEventListener(ACTIVE_SITE_EVENT, onChange);
+  }, []);
 
   const appendDeltaToLastAssistant = useCallback((delta: string) => {
     setMessages((prev) => {
@@ -47,6 +63,7 @@ export default function HomePage() {
   const handleSend = useCallback(async () => {
     const trimmed = input.trim();
     if (!trimmed || streaming) return;
+    if (!activeSiteId) return;
 
     const userMsg: ChatMessage = { role: "user", text: trimmed };
     const apiMessages: ApiMessage[] = [...messages, userMsg].map((m) => ({
@@ -69,7 +86,7 @@ export default function HomePage() {
       const res = await fetch("/api/chat", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ messages: apiMessages }),
+        body: JSON.stringify({ messages: apiMessages, activeSiteId }),
         signal: ctrl.signal,
       });
 
@@ -145,23 +162,25 @@ export default function HomePage() {
       setStreaming(false);
       abortRef.current = null;
     }
-  }, [appendDeltaToLastAssistant, input, messages, streaming]);
+  }, [
+    activeSiteId,
+    appendDeltaToLastAssistant,
+    input,
+    messages,
+    streaming,
+  ]);
+
+  const sendDisabled = streaming || !input.trim() || !activeSiteId;
 
   return (
     <div className="flex h-screen flex-col bg-background text-foreground">
       <header className="flex h-12 flex-none items-center justify-between border-b px-4">
         <div className="flex items-center gap-3">
-          <span className="text-sm font-semibold">LeadSource</span>
+          <SiteSwitcher />
           <span className="text-xs text-muted-foreground">
             Opollo Site Builder
           </span>
         </div>
-        <Link
-          href="/admin/sites"
-          className="text-xs text-muted-foreground hover:text-foreground"
-        >
-          Manage sites →
-        </Link>
       </header>
       <div className="flex flex-1 overflow-hidden">
         <section className="flex w-2/5 flex-col border-r">
@@ -169,7 +188,9 @@ export default function HomePage() {
             <div className="space-y-3 p-4">
               {messages.length === 0 && (
                 <p className="text-sm text-muted-foreground">
-                  Describe the page you want to create.
+                  {activeSiteId
+                    ? "Describe the page you want to create."
+                    : "Select a site from the dropdown above to start."}
                 </p>
               )}
               {messages.map((m, i) => (
@@ -204,8 +225,12 @@ export default function HomePage() {
             <Textarea
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              placeholder="Describe the page you want…"
-              disabled={streaming}
+              placeholder={
+                activeSiteId
+                  ? "Describe the page you want…"
+                  : "Select a site first…"
+              }
+              disabled={streaming || !activeSiteId}
               className="min-h-[60px] flex-1 resize-none"
               onKeyDown={(e) => {
                 if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
@@ -216,7 +241,7 @@ export default function HomePage() {
             />
             <Button
               type="submit"
-              disabled={streaming || !input.trim()}
+              disabled={sendDisabled}
               className="self-end"
             >
               {streaming ? "…" : "Send"}

--- a/components/SiteSwitcher.tsx
+++ b/components/SiteSwitcher.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import type { SiteListItem } from "@/lib/tool-schemas";
+
+export const ACTIVE_SITE_STORAGE_KEY = "opollo.activeSiteId";
+export const ACTIVE_SITE_EVENT = "opollo:active-site-changed";
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "ready"; sites: SiteListItem[] }
+  | { status: "error"; message: string };
+
+export type ActiveSiteEventDetail = {
+  activeSiteId: string | null;
+  site: SiteListItem | null;
+};
+
+function statusDotClass(status: string): string {
+  switch (status) {
+    case "active":
+      return "bg-green-500";
+    case "pending_pairing":
+      return "bg-slate-400";
+    case "paused":
+      return "bg-yellow-500";
+    case "removed":
+      return "bg-slate-300";
+    default:
+      return "bg-red-500";
+  }
+}
+
+export function readStoredActiveSiteId(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(ACTIVE_SITE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredActiveSiteId(id: string | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (id === null) window.localStorage.removeItem(ACTIVE_SITE_STORAGE_KEY);
+    else window.localStorage.setItem(ACTIVE_SITE_STORAGE_KEY, id);
+  } catch {
+    /* ignore quota/denied */
+  }
+}
+
+function dispatchChange(detail: ActiveSiteEventDetail): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<ActiveSiteEventDetail>(ACTIVE_SITE_EVENT, { detail }),
+  );
+}
+
+export function SiteSwitcher() {
+  const [loadState, setLoadState] = useState<LoadState>({ status: "loading" });
+  const [activeSiteId, setActiveSiteId] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const loadSites = useCallback(async () => {
+    setLoadState({ status: "loading" });
+    try {
+      const res = await fetch("/api/sites/list", { cache: "no-store" });
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        setLoadState({
+          status: "error",
+          message:
+            payload?.error?.message ??
+            `Failed to load sites (HTTP ${res.status}).`,
+        });
+        return;
+      }
+      const sites = (payload.data?.sites ?? []) as SiteListItem[];
+      setLoadState({ status: "ready", sites });
+
+      const stored = readStoredActiveSiteId();
+      const storedExists =
+        stored !== null && sites.some((s) => s.id === stored);
+      const chosen = storedExists ? stored : sites[0]?.id ?? null;
+
+      if (chosen !== stored) writeStoredActiveSiteId(chosen);
+      setActiveSiteId(chosen);
+      const site = chosen ? sites.find((s) => s.id === chosen) ?? null : null;
+      dispatchChange({ activeSiteId: chosen, site });
+    } catch (err) {
+      setLoadState({
+        status: "error",
+        message: `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSites();
+  }, [loadSites]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClickAway = (e: MouseEvent) => {
+      if (!rootRef.current) return;
+      if (!rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onClickAway);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClickAway);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const sites = loadState.status === "ready" ? loadState.sites : [];
+  const activeSite = activeSiteId
+    ? sites.find((s) => s.id === activeSiteId) ?? null
+    : null;
+
+  const selectSite = (id: string) => {
+    if (id === activeSiteId) {
+      setOpen(false);
+      return;
+    }
+    setActiveSiteId(id);
+    writeStoredActiveSiteId(id);
+    const site = sites.find((s) => s.id === id) ?? null;
+    dispatchChange({ activeSiteId: id, site });
+    setOpen(false);
+  };
+
+  let triggerLabel: React.ReactNode;
+  let triggerDotClass = "bg-slate-300";
+  if (loadState.status === "loading") {
+    triggerLabel = (
+      <span className="text-sm text-muted-foreground">Loading sites…</span>
+    );
+  } else if (loadState.status === "error") {
+    triggerLabel = (
+      <span className="text-sm text-destructive">Failed to load sites</span>
+    );
+  } else if (activeSite) {
+    triggerLabel = (
+      <span className="text-sm font-semibold">{activeSite.name}</span>
+    );
+    triggerDotClass = statusDotClass(activeSite.status);
+  } else if (sites.length === 0) {
+    triggerLabel = (
+      <span className="text-sm text-muted-foreground">
+        No site selected — click Manage sites to add one
+      </span>
+    );
+  } else {
+    triggerLabel = (
+      <span className="text-sm text-muted-foreground">Select a site</span>
+    );
+  }
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={cn(
+          "flex items-center gap-2 rounded-md px-2 py-1 text-left hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring",
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className={cn("inline-block h-2 w-2 rounded-full", triggerDotClass)}
+        />
+        {triggerLabel}
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="h-3 w-3 text-muted-foreground"
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 111.08 1.04l-4.24 4.38a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          className="absolute left-0 top-full z-50 mt-1 w-72 rounded-md border bg-popover p-1 shadow-md"
+        >
+          {loadState.status === "loading" && (
+            <div className="px-3 py-2 text-sm text-muted-foreground">
+              Loading…
+            </div>
+          )}
+          {loadState.status === "error" && (
+            <div className="px-3 py-2 text-sm text-destructive">
+              {loadState.message}
+            </div>
+          )}
+          {loadState.status === "ready" && sites.length === 0 && (
+            <div className="px-3 py-2 text-sm text-muted-foreground">
+              No sites registered yet.
+            </div>
+          )}
+          {loadState.status === "ready" &&
+            sites.map((s) => {
+              const selected = s.id === activeSiteId;
+              return (
+                <button
+                  key={s.id}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  onClick={() => selectSite(s.id)}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-muted",
+                    selected && "bg-muted",
+                  )}
+                >
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      "inline-block h-2 w-2 rounded-full",
+                      statusDotClass(s.status),
+                    )}
+                  />
+                  <span className="flex-1 truncate">{s.name}</span>
+                  {selected && (
+                    <span className="text-xs text-muted-foreground">✓</span>
+                  )}
+                </button>
+              );
+            })}
+          <div className="my-1 border-t" />
+          <Link
+            href="/admin/sites"
+            className="block rounded-sm px-2 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+            onClick={() => setOpen(false)}
+          >
+            + Manage sites
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -50,3 +50,44 @@ export function buildSystemPrompt(ctx: SystemPromptContext): string {
     .replaceAll("{{templates_list}}", ctx.templates_list)
     .replaceAll("{{session_recent_pages}}", ctx.session_recent_pages);
 }
+
+// Week 2 interim: site_context table stays empty, so brand voice, pages
+// tree, menus, etc. reuse the LeadSource defaults for every site. Only the
+// identity fields (name, prefix, DS version) come from the site record.
+// When Stage 2 lands, the defaults will be overridable per-site via a
+// site_context row.
+export const LEADSOURCE_BRAND_VOICE_DEFAULT = `Outcome-led. Bold statements. No hedging. Lead with what the product does, not what's broken in the world. Say the thing everyone's thinking but nobody writes on their website. Keep it short. Make it sound like a real person said it. If it sounds like an AI or a committee wrote it, rewrite it.
+
+Six voice rules:
+1. Outcomes first — lead with the result, not the problem
+2. Bold statements — "We tell you exactly." Full stop.
+3. Short sentences
+4. Say the real thing — if everyone's thinking it, say it
+5. Honest about limits — "Works with most forms" not "every form"
+6. Never salesy — no exclamation marks, no "Amazing!", no pressure
+
+Power phrases to use: "Stop guessing. Start knowing.", "We tell you exactly.", "Where your best clients are coming from.", "Add the code. We do the rest.", "No BS."
+
+Never say: "Every form", "100% accurate", "Leverage/Utilise/Seamlessly", "Powerful/Robust/Comprehensive", passive voice like "data is captured"`;
+
+export type SiteIdentity = {
+  site_name: string;
+  prefix: string;
+  design_system_version: string;
+};
+
+export function buildSystemPromptForSite(site: SiteIdentity): string {
+  return buildSystemPrompt({
+    site_name: site.site_name,
+    prefix: site.prefix,
+    design_system_version: site.design_system_version,
+    design_system_updated: "n/a (Week 2)",
+    design_system_html_full_file: "",
+    brand_voice_content: LEADSOURCE_BRAND_VOICE_DEFAULT,
+    site_pages_tree: "[]",
+    site_menus_current: "{}",
+    homepage_id: "null",
+    templates_list: "[]",
+    session_recent_pages: "[]",
+  });
+}

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import type {
   CreatePageData,
   CreatePageInput,
@@ -15,11 +17,44 @@ export type WpConfig = {
   appPassword: string;
 };
 
+export type WpCredentialsOverride = {
+  wp_url: string;
+  wp_user: string;
+  wp_app_password: string;
+};
+
 export type WpConfigResult =
   | { ok: true; value: WpConfig }
   | { ok: false; missing: string[] };
 
+// Per-invocation credentials override. The chat route wraps each tool call
+// in runWithWpCredentials(creds, …) so readWpConfig(), which still lives in
+// the existing tool executors, picks the site's credentials up without any
+// signature change. When no override is set, readWpConfig() falls back to
+// the LEADSOURCE_* env vars (backward compatibility during Week 2).
+const credentialsContext = new AsyncLocalStorage<WpCredentialsOverride>();
+
+export function runWithWpCredentials<T>(
+  creds: WpCredentialsOverride | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!creds) return fn();
+  return credentialsContext.run(creds, fn);
+}
+
 export function readWpConfig(): WpConfigResult {
+  const override = credentialsContext.getStore();
+  if (override) {
+    return {
+      ok: true,
+      value: {
+        baseUrl: override.wp_url,
+        user: override.wp_user,
+        appPassword: override.wp_app_password,
+      },
+    };
+  }
+
   const baseUrl = process.env.LEADSOURCE_WP_URL;
   const user = process.env.LEADSOURCE_WP_USER;
   const appPassword = process.env.LEADSOURCE_WP_APP_PASSWORD;
@@ -148,7 +183,7 @@ async function mapHttpErrorToWpError(res: Response): Promise<WpError | null> {
       details: { status: res.status, wp_response: wpBody },
       retryable: false,
       suggested_action:
-        "Verify LEADSOURCE_WP_USER and LEADSOURCE_WP_APP_PASSWORD, and that Application Passwords are enabled.",
+        "Verify the site's WordPress user and application password, and that Application Passwords are enabled on the host.",
     };
   }
 


### PR DESCRIPTION
- Add SiteSwitcher component in /app/page.tsx header: lists sites from /api/sites/list with status dots, persists activeSiteId in localStorage, dispatches a custom event so the chat surface can react. Includes a "+ Manage sites" link to /admin/sites.
- /app/page.tsx now tracks activeSiteId, disables the composer when no site is selected, and sends activeSiteId in each chat request.
- /app/api/chat/route.ts: accepts activeSiteId in the body. When provided, loads the site via getSite(id, {includeCredentials: true}), decrypts the app password, and builds the system prompt from the site's identity (name, prefix, DS version) so prompt cache keys differ per site. A missing site returns 404; a credential-less site returns 500 — neither falls back silently. Missing activeSiteId still falls back to the LEADSOURCE_* env vars for the transition.
- /lib/wordpress.ts: adds runWithWpCredentials() backed by AsyncLocalStorage so readWpConfig() transparently returns the active site's credentials inside a request scope, with env vars as the outer fallback. The 6 tool executors keep their signatures unchanged.
- /lib/system-prompt.ts: factors out buildSystemPromptForSite() so the chat route only has to supply the site identity — brand voice, pages tree, and other placeholders stay on LeadSource defaults until Stage 2 per-site site_context lands.