### PR TITLE
M1b: data layer for design systems, components, templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+## Running tests locally
+
+The test suite is integration-level: tests exercise the real data layer
+against a running Supabase stack. Mocks are deliberately avoided — every
+SQLSTATE behaviour (unique-violation, FK-violation, optimistic-lock
+mismatch via PostgREST) is what we actually care about catching.
+
+### Prerequisites
+
+- **Docker** — required by the Supabase CLI to boot the local stack
+  (Postgres, PostgREST, GoTrue, Studio, etc.)
+- **Supabase CLI** — install via [the official instructions](https://supabase.com/docs/guides/local-development/cli/getting-started)
+  or, on macOS, `brew install supabase/tap/supabase`
+- **Node + npm** — the versions pinned in `.nvmrc` / `package.json`
+
+### First-time setup
+
+```bash
+npm install
+supabase start   # ~15–30s on first boot; applies all migrations automatically
+```
+
+`supabase start` reads `supabase/migrations/*.sql` and applies every file in
+order against the local Postgres. When you add a new migration, run
+`supabase db reset` to replay all migrations from scratch — the tests do not
+reset migrations themselves.
+
+### Running tests
+
+```bash
+npm test            # run once
+npm run test:watch  # watch mode
+```
+
+Vitest's `globalSetup` calls `supabase status --output json` to find the
+local API URL and service-role key. If the stack isn't running, it'll run
+`supabase start` for you. Between tests, a `TRUNCATE ... CASCADE` clears
+every M1 table via a direct Postgres connection on port 54322.
+
+### Stopping the stack
+
+```bash
+supabase stop
+```
+
+Leaving it running between test runs is fine and recommended — `supabase
+start` is slow, `supabase status` is instant.
+
+### CI considerations (future)
+
+GitHub Actions and similar runners need either Docker-in-Docker or the
+Supabase CLI action (`supabase/setup-cli@v1` + `supabase start`). When we
+wire up CI, the matrix job running `npm test` will:
+
+1. Install Node + Supabase CLI
+2. `supabase start`
+3. `npm test`
+
+This is not yet set up — track it under the M1 acceptance criteria for a
+later slice. For now, tests are run locally by the operator.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,17 @@ cp .env.local.example .env.local
 npm install
 npm run dev
 ```
+
+## Tests
+
+See `CONTRIBUTING.md` for the full setup. TL;DR: `supabase start && npm test`,
+which requires Docker and the Supabase CLI installed locally.
+
+> **Status (as of M1b):** the Vitest suite for the M1 data layer has been
+> written and type-checked, and the `0003_m1b_rpcs.sql` RPC has been
+> verified against scratch Postgres via psql. The full `npm test` run has
+> NOT yet been executed end-to-end against `supabase start` because M1
+> development happened in a sandbox without a Docker daemon. Run it
+> locally before M3 (batch generator) starts — that's where data-layer
+> regressions actually bite.
+

--- a/lib/__tests__/_globalSetup.ts
+++ b/lib/__tests__/_globalSetup.ts
@@ -1,0 +1,74 @@
+import { execSync } from "node:child_process";
+
+// Vitest globalSetup. Runs once per test invocation, before workers fork.
+//
+// Responsibilities:
+//   1. Ensure a local Supabase stack is running. If `supabase status` succeeds
+//      we assume it's already up (common dev loop). Otherwise `supabase start`
+//      boots it (CI cold start).
+//   2. Emit the API URL + service-role key into process.env so the lib code's
+//      getServiceRoleClient() finds them at first-call time in workers.
+//
+// Between-test TRUNCATEs are handled per-worker in _setup.ts — they don't
+// need the Supabase CLI, only a direct Postgres connection on port 54322
+// (default for `supabase start`).
+//
+// Prerequisites (see CONTRIBUTING.md):
+//   - Docker daemon running
+//   - Supabase CLI installed (`brew install supabase/tap/supabase` or equivalent)
+
+type SupabaseStatus = {
+  API_URL?: string;
+  DB_URL?: string;
+  SERVICE_ROLE_KEY?: string;
+  ANON_KEY?: string;
+};
+
+function runCmd(cmd: string, opts?: { allowFailure?: boolean }): string {
+  try {
+    return execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (err) {
+    if (opts?.allowFailure) return "";
+    throw err;
+  }
+}
+
+function parseStatus(): SupabaseStatus | null {
+  const raw = runCmd("supabase status --output json", { allowFailure: true });
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as SupabaseStatus;
+  } catch {
+    return null;
+  }
+}
+
+export async function setup() {
+  let status = parseStatus();
+
+  if (!status || !status.API_URL || !status.SERVICE_ROLE_KEY) {
+    // eslint-disable-next-line no-console
+    console.log(
+      "[vitest] Supabase stack not running — calling `supabase start` (may take 15–30s)...",
+    );
+    runCmd("supabase start");
+    status = parseStatus();
+  }
+
+  if (!status || !status.API_URL || !status.SERVICE_ROLE_KEY) {
+    throw new Error(
+      "Unable to fetch Supabase stack credentials after `supabase start`. " +
+        "Check `supabase status` manually and ensure Docker is running.",
+    );
+  }
+
+  process.env.SUPABASE_URL = status.API_URL;
+  process.env.SUPABASE_SERVICE_ROLE_KEY = status.SERVICE_ROLE_KEY;
+  if (status.ANON_KEY) process.env.SUPABASE_ANON_KEY = status.ANON_KEY;
+  if (status.DB_URL) process.env.SUPABASE_DB_URL = status.DB_URL;
+}
+
+export async function teardown() {
+  // Leave the stack running — dev loop keeps it warm between invocations.
+  // CI runners are short-lived, so nothing to clean up there either.
+}

--- a/lib/__tests__/_helpers.ts
+++ b/lib/__tests__/_helpers.ts
@@ -1,0 +1,53 @@
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// Test-only factories. Inserts happen via service-role supabase-js so they go
+// through the exact PostgREST code path the lib code uses.
+
+export async function seedSite(overrides?: {
+  name?: string;
+  wp_url?: string;
+  prefix?: string;
+}): Promise<{ id: string; prefix: string }> {
+  const supabase = getServiceRoleClient();
+  const prefix = overrides?.prefix ?? randomPrefix();
+  const { data, error } = await supabase
+    .from("sites")
+    .insert({
+      name: overrides?.name ?? `Test Site ${prefix}`,
+      wp_url: overrides?.wp_url ?? `https://${prefix}.test`,
+      prefix,
+      status: "active",
+    })
+    .select("id,prefix")
+    .single();
+  if (error || !data) {
+    throw new Error(`seedSite failed: ${error?.message ?? "no data"}`);
+  }
+  return { id: data.id as string, prefix: data.prefix as string };
+}
+
+export function randomPrefix(): string {
+  // 2–4 lowercase alphanumerics — matches the CHECK constraint on sites.prefix.
+  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+  let out = "";
+  for (let i = 0; i < 4; i++) out += chars[Math.floor(Math.random() * chars.length)];
+  return out;
+}
+
+export function minimalComponentContentSchema() {
+  return {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "object",
+    required: ["headline"],
+    properties: {
+      headline: { type: "string", maxLength: 120 },
+    },
+  };
+}
+
+export function minimalComposition() {
+  return [
+    { component: "hero-centered", content_source: "brief.hero" },
+    { component: "footer-default", content_source: "site_context.footer" },
+  ];
+}

--- a/lib/__tests__/_setup.ts
+++ b/lib/__tests__/_setup.ts
@@ -1,0 +1,83 @@
+import { execSync } from "node:child_process";
+import { afterAll, beforeEach } from "vitest";
+import { Client } from "pg";
+
+// Per-worker setup. Runs before every test file in this worker.
+//
+// Responsibilities:
+//   1. Ensure process.env is populated (globalSetup already did this for the
+//      main process, but some CI configurations fork fresh env — re-read if
+//      missing).
+//   2. Open a direct Postgres connection for TRUNCATE between tests.
+//
+// beforeEach truncates every M1 table plus `sites` (tests create their own
+// sites to have something to point FKs at). RESTART IDENTITY is a no-op here
+// since every PK is uuid-generated, but it's harmless.
+
+type SupabaseStatus = {
+  API_URL?: string;
+  DB_URL?: string;
+  SERVICE_ROLE_KEY?: string;
+  ANON_KEY?: string;
+};
+
+function readStatusIfNeeded() {
+  if (process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) return;
+  try {
+    const raw = execSync("supabase status --output json", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const s = JSON.parse(raw) as SupabaseStatus;
+    if (s.API_URL) process.env.SUPABASE_URL = s.API_URL;
+    if (s.SERVICE_ROLE_KEY) process.env.SUPABASE_SERVICE_ROLE_KEY = s.SERVICE_ROLE_KEY;
+    if (s.ANON_KEY) process.env.SUPABASE_ANON_KEY = s.ANON_KEY;
+    if (s.DB_URL) process.env.SUPABASE_DB_URL = s.DB_URL;
+  } catch (err) {
+    throw new Error(
+      `Cannot reach Supabase CLI in worker. Run \`supabase start\` before \`npm test\`. (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+}
+
+readStatusIfNeeded();
+
+const DB_URL =
+  process.env.SUPABASE_DB_URL ??
+  "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
+
+let pgClient: Client | null = null;
+
+async function getPg(): Promise<Client> {
+  if (pgClient) return pgClient;
+  pgClient = new Client({ connectionString: DB_URL });
+  await pgClient.connect();
+  return pgClient;
+}
+
+export async function truncateAll(): Promise<void> {
+  const pg = await getPg();
+  // Order matters when referential actions other than CASCADE apply. We use
+  // CASCADE to sidestep FK ordering between sites / design_systems etc.
+  await pg.query(`
+    TRUNCATE TABLE
+      pages,
+      design_templates,
+      design_components,
+      design_systems,
+      opollo_users,
+      sites
+    RESTART IDENTITY CASCADE;
+  `);
+}
+
+beforeEach(async () => {
+  await truncateAll();
+});
+
+afterAll(async () => {
+  if (pgClient) {
+    await pgClient.end();
+    pgClient = null;
+  }
+});

--- a/lib/__tests__/components.test.ts
+++ b/lib/__tests__/components.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import {
+  createComponent,
+  deleteComponent,
+  getComponent,
+  listComponents,
+  updateComponent,
+} from "@/lib/components";
+import { createDesignSystem } from "@/lib/design-systems";
+import { minimalComponentContentSchema, seedSite } from "./_helpers";
+
+async function seedDS() {
+  const site = await seedSite();
+  const ds = await createDesignSystem({
+    site_id: site.id,
+    version: 1,
+    tokens_css: "",
+    base_styles: "",
+  });
+  if (!ds.ok) throw new Error("seedDS failed");
+  return { site, ds: ds.data };
+}
+
+function validComponent(design_system_id: string, overrides?: Partial<{ name: string; variant: string | null; category: string }>) {
+  return {
+    design_system_id,
+    name: overrides?.name ?? "hero-centered",
+    variant: overrides?.variant === undefined ? "default" : overrides.variant,
+    category: overrides?.category ?? "hero",
+    html_template: "<section class=\"ls-hero\">{{headline}}</section>",
+    css: ".ls-hero { padding: 2rem; }",
+    content_schema: minimalComponentContentSchema(),
+  };
+}
+
+describe("components: create", () => {
+  it("creates a component and returns it", async () => {
+    const { ds } = await seedDS();
+    const res = await createComponent(validComponent(ds.id));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.name).toBe("hero-centered");
+    expect(res.data.variant).toBe("default");
+    expect(res.data.version_lock).toBe(1);
+  });
+
+  it("rejects bad component name with VALIDATION_FAILED", async () => {
+    const { ds } = await seedDS();
+    const res = await createComponent({
+      ...validComponent(ds.id),
+      name: "Hero_Centered",  // uppercase + underscore fails the regex
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns FK_VIOLATION when design_system_id does not exist", async () => {
+    const res = await createComponent(
+      validComponent("00000000-0000-0000-0000-000000000000"),
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("FK_VIOLATION");
+  });
+
+  it("returns UNIQUE_VIOLATION on duplicate (ds, name, variant)", async () => {
+    const { ds } = await seedDS();
+    await createComponent(validComponent(ds.id));
+    const res = await createComponent(validComponent(ds.id));
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("UNIQUE_VIOLATION");
+  });
+
+  it("allows same name with different variant", async () => {
+    const { ds } = await seedDS();
+    const a = await createComponent(validComponent(ds.id, { variant: "default" }));
+    const b = await createComponent(validComponent(ds.id, { variant: "dark" }));
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+  });
+});
+
+describe("components: read", () => {
+  it("lists components ordered by category then name", async () => {
+    const { ds } = await seedDS();
+    await createComponent(validComponent(ds.id, { name: "footer-default", category: "footer" }));
+    await createComponent(validComponent(ds.id, { name: "hero-centered", category: "hero" }));
+    await createComponent(validComponent(ds.id, { name: "cta-dark", category: "cta" }));
+
+    const res = await listComponents(ds.id);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.map((c) => c.category)).toEqual(["cta", "footer", "hero"]);
+  });
+
+  it("getComponent returns NOT_FOUND for unknown id", async () => {
+    const res = await getComponent("00000000-0000-0000-0000-000000000000");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("components: update", () => {
+  it("updates and bumps version_lock", async () => {
+    const { ds } = await seedDS();
+    const created = await createComponent(validComponent(ds.id));
+    if (!created.ok) throw new Error("setup failed");
+
+    const res = await updateComponent(
+      created.data.id,
+      { usage_notes: "Use sparingly." },
+      created.data.version_lock,
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.usage_notes).toBe("Use sparingly.");
+    expect(res.data.version_lock).toBe(created.data.version_lock + 1);
+  });
+
+  it("rejects empty patch", async () => {
+    const { ds } = await seedDS();
+    const created = await createComponent(validComponent(ds.id));
+    if (!created.ok) throw new Error("setup failed");
+
+    const res = await updateComponent(created.data.id, {}, created.data.version_lock);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns VERSION_CONFLICT on stale lock", async () => {
+    const { ds } = await seedDS();
+    const created = await createComponent(validComponent(ds.id));
+    if (!created.ok) throw new Error("setup failed");
+
+    await updateComponent(created.data.id, { css: ".a{}" }, 1);
+    const res = await updateComponent(created.data.id, { css: ".b{}" }, 1);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VERSION_CONFLICT");
+  });
+
+  it("returns NOT_FOUND for unknown id", async () => {
+    const res = await updateComponent(
+      "00000000-0000-0000-0000-000000000000",
+      { css: ".x{}" },
+      1,
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("components: delete", () => {
+  it("deletes when version_lock matches", async () => {
+    const { ds } = await seedDS();
+    const created = await createComponent(validComponent(ds.id));
+    if (!created.ok) throw new Error("setup failed");
+
+    const res = await deleteComponent(created.data.id, created.data.version_lock);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.id).toBe(created.data.id);
+
+    const after = await getComponent(created.data.id);
+    expect(after.ok).toBe(false);
+    if (after.ok) return;
+    expect(after.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns VERSION_CONFLICT on stale lock", async () => {
+    const { ds } = await seedDS();
+    const created = await createComponent(validComponent(ds.id));
+    if (!created.ok) throw new Error("setup failed");
+
+    await updateComponent(created.data.id, { css: ".a{}" }, 1);
+    const res = await deleteComponent(created.data.id, 1);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VERSION_CONFLICT");
+  });
+
+  it("returns NOT_FOUND for unknown id", async () => {
+    const res = await deleteComponent(
+      "00000000-0000-0000-0000-000000000000",
+      1,
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/lib/__tests__/design-systems.test.ts
+++ b/lib/__tests__/design-systems.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from "vitest";
+import {
+  activateDesignSystem,
+  archiveDesignSystem,
+  createDesignSystem,
+  getActiveDesignSystem,
+  getDesignSystem,
+  listDesignSystems,
+  updateDesignSystem,
+} from "@/lib/design-systems";
+import { seedSite } from "./_helpers";
+
+function validCreateInput(site_id: string, version = 1) {
+  return {
+    site_id,
+    version,
+    tokens_css: ":root { --x: 1; }",
+    base_styles: "body { margin: 0; }",
+    notes: "v1 baseline",
+  };
+}
+
+describe("design-systems: create", () => {
+  it("creates a draft and returns it", async () => {
+    const site = await seedSite();
+    const res = await createDesignSystem(validCreateInput(site.id));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.site_id).toBe(site.id);
+    expect(res.data.status).toBe("draft");
+    expect(res.data.version).toBe(1);
+    expect(res.data.version_lock).toBe(1);
+  });
+
+  it("rejects malformed input with VALIDATION_FAILED", async () => {
+    const res = await createDesignSystem({
+      site_id: "not-a-uuid",
+      version: -1,
+      tokens_css: 123,
+      base_styles: null,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+    expect(Array.isArray((res.error.details as { issues?: unknown[] })?.issues))
+      .toBe(true);
+  });
+
+  it("returns FK_VIOLATION when site_id does not exist", async () => {
+    const res = await createDesignSystem(
+      validCreateInput("00000000-0000-0000-0000-000000000000"),
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("FK_VIOLATION");
+  });
+
+  it("returns UNIQUE_VIOLATION on duplicate (site_id, version)", async () => {
+    const site = await seedSite();
+    await createDesignSystem(validCreateInput(site.id, 1));
+    const res = await createDesignSystem(validCreateInput(site.id, 1));
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("UNIQUE_VIOLATION");
+  });
+});
+
+describe("design-systems: read", () => {
+  it("lists all versions for a site in version-desc order", async () => {
+    const site = await seedSite();
+    await createDesignSystem(validCreateInput(site.id, 1));
+    await createDesignSystem(validCreateInput(site.id, 2));
+    await createDesignSystem(validCreateInput(site.id, 3));
+
+    const res = await listDesignSystems(site.id);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.map((ds) => ds.version)).toEqual([3, 2, 1]);
+  });
+
+  it("getDesignSystem returns NOT_FOUND for unknown id", async () => {
+    const res = await getDesignSystem("00000000-0000-0000-0000-000000000000");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+
+  it("getActiveDesignSystem returns null when none active", async () => {
+    const site = await seedSite();
+    await createDesignSystem(validCreateInput(site.id, 1));
+    const res = await getActiveDesignSystem(site.id);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data).toBeNull();
+  });
+
+  it("getActiveDesignSystem returns the active row when one exists", async () => {
+    const site = await seedSite();
+    const created = await createDesignSystem(validCreateInput(site.id, 1));
+    if (!created.ok) throw new Error("setup failed");
+    const activated = await activateDesignSystem(created.data.id, created.data.version_lock);
+    if (!activated.ok) throw new Error("activate failed");
+
+    const res = await getActiveDesignSystem(site.id);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data?.id).toBe(activated.data.id);
+    expect(res.data?.status).toBe("active");
+  });
+});
+
+describe("design-systems: update", () => {
+  it("updates metadata and bumps version_lock", async () => {
+    const site = await seedSite();
+    const created = await createDesignSystem(validCreateInput(site.id, 1));
+    if (!created.ok) throw new Error("setup failed");
+
+    const res = await updateDesignSystem(
+      created.data.id,
+      { notes: "updated" },
+      created.data.version_lock,
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.notes).toBe("updated");
+    expect(res.data.version_lock).toBe(created.data.version_lock + 1);
+  });
+
+  it("rejects empty patch with VALIDATION_FAILED", async () => {
+    const site = await seedSite();
+    const created = await createDesignSystem(validCreateInput(site.id, 1));
+    if (!created.ok) throw new Error("setup failed");
+
+    const res = await updateDesignSystem(
+      created.data.id,
+      {},
+      created.data.version_lock,
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns VERSION_CONFLICT on stale version_lock", async () => {
+    const site = await seedSite();
+    const created = await createDesignSystem(validCreateInput(site.id, 1));
+    if (!created.ok) throw new Error("setup failed");
+    // First update succeeds and bumps the lock.
+    await updateDesignSystem(created.data.id, { notes: "first" }, 1);
+    // Second update with the stale lock must fail.
+    const res = await updateDesignSystem(created.data.id, { notes: "second" }, 1);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VERSION_CONFLICT");
+    expect((res.error.details as { expected_version_lock?: number })?.expected_version_lock).toBe(1);
+  });
+
+  it("returns NOT_FOUND for unknown id", async () => {
+    const res = await updateDesignSystem(
+      "00000000-0000-0000-0000-000000000000",
+      { notes: "x" },
+      1,
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("design-systems: activate", () => {
+  it("promotes a draft and archives the previous active atomically", async () => {
+    const site = await seedSite();
+    const v1 = await createDesignSystem(validCreateInput(site.id, 1));
+    const v2 = await createDesignSystem(validCreateInput(site.id, 2));
+    if (!v1.ok || !v2.ok) throw new Error("setup failed");
+
+    const act1 = await activateDesignSystem(v1.data.id, v1.data.version_lock);
+    expect(act1.ok).toBe(true);
+    if (!act1.ok) return;
+    expect(act1.data.status).toBe("active");
+
+    const act2 = await activateDesignSystem(v2.data.id, v2.data.version_lock);
+    expect(act2.ok).toBe(true);
+    if (!act2.ok) return;
+    expect(act2.data.status).toBe("active");
+
+    // v1 should now be archived.
+    const v1After = await getDesignSystem(v1.data.id);
+    expect(v1After.ok).toBe(true);
+    if (!v1After.ok) return;
+    expect(v1After.data.status).toBe("archived");
+    expect(v1After.data.version_lock).toBeGreaterThan(v1.data.version_lock);
+  });
+
+  it("returns VERSION_CONFLICT on stale version_lock", async () => {
+    const site = await seedSite();
+    const ds = await createDesignSystem(validCreateInput(site.id, 1));
+    if (!ds.ok) throw new Error("setup failed");
+
+    await updateDesignSystem(ds.data.id, { notes: "bump" }, ds.data.version_lock);
+    const res = await activateDesignSystem(ds.data.id, ds.data.version_lock);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VERSION_CONFLICT");
+  });
+
+  it("returns NOT_FOUND for unknown id", async () => {
+    const res = await activateDesignSystem(
+      "00000000-0000-0000-0000-000000000000",
+      1,
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("design-systems: archive", () => {
+  it("archives a draft without warnings", async () => {
+    const site = await seedSite();
+    const ds = await createDesignSystem(validCreateInput(site.id, 1));
+    if (!ds.ok) throw new Error("setup failed");
+
+    const res = await archiveDesignSystem(ds.data.id, ds.data.version_lock);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.design_system.status).toBe("archived");
+    expect(res.data.warnings).toEqual([]);
+  });
+
+  it("archiving the active DS returns a soft warning", async () => {
+    const site = await seedSite();
+    const ds = await createDesignSystem(validCreateInput(site.id, 1));
+    if (!ds.ok) throw new Error("setup failed");
+
+    const act = await activateDesignSystem(ds.data.id, ds.data.version_lock);
+    if (!act.ok) throw new Error("activate failed");
+
+    const res = await archiveDesignSystem(act.data.id, act.data.version_lock);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.design_system.status).toBe("archived");
+    expect(res.data.warnings.length).toBeGreaterThan(0);
+    expect(res.data.warnings[0]).toMatch(/no active design system/i);
+  });
+
+  it("returns VERSION_CONFLICT on stale version_lock", async () => {
+    const site = await seedSite();
+    const ds = await createDesignSystem(validCreateInput(site.id, 1));
+    if (!ds.ok) throw new Error("setup failed");
+
+    await updateDesignSystem(ds.data.id, { notes: "bump" }, ds.data.version_lock);
+    const res = await archiveDesignSystem(ds.data.id, ds.data.version_lock);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VERSION_CONFLICT");
+  });
+
+  it("returns NOT_FOUND for unknown id", async () => {
+    const res = await archiveDesignSystem(
+      "00000000-0000-0000-0000-000000000000",
+      1,
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/lib/__tests__/templates.test.ts
+++ b/lib/__tests__/templates.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import {
+  createTemplate,
+  deleteTemplate,
+  getDefaultTemplate,
+  getTemplate,
+  listTemplates,
+  updateTemplate,
+} from "@/lib/templates";
+import { createDesignSystem } from "@/lib/design-systems";
+import { minimalComposition, seedSite } from "./_helpers";
+
+async function seedDS() {
+  const site = await seedSite();
+  const ds = await createDesignSystem({
+    site_id: site.id,
+    version: 1,
+    tokens_css: "",
+    base_styles: "",
+  });
+  if (!ds.ok) throw new Error("seedDS failed");
+  return { site, ds: ds.data };
+}
+
+function validTemplate(
+  design_system_id: string,
+  overrides?: Partial<{ name: string; page_type: string; is_default: boolean }>,
+) {
+  return {
+    design_system_id,
+    page_type: overrides?.page_type ?? "homepage",
+    name: overrides?.name ?? "homepage-default",
+    composition: minimalComposition(),
+    required_fields: { hero: ["headline"] },
+    seo_defaults: { title_suffix: " — Test" },
+    is_default: overrides?.is_default ?? false,
+  };
+}
+
+describe("templates: create", () => {
+  it("creates a template", async () => {
+    const { ds } = await seedDS();
+    const res = await createTemplate(validTemplate(ds.id));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.page_type).toBe("homepage");
+    expect(res.data.is_default).toBe(false);
+    expect(res.data.version_lock).toBe(1);
+  });
+
+  it("rejects empty composition with VALIDATION_FAILED", async () => {
+    const { ds } = await seedDS();
+    const res = await createTemplate({
+      ...validTemplate(ds.id),
+      composition: [],
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns FK_VIOLATION when design_system_id does not exist", async () => {
+    const res = await createTemplate(
+      validTemplate("00000000-0000-0000-0000-000000000000"),
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("FK_VIOLATION");
+  });
+
+  it("returns UNIQUE_VIOLATION on second default for the same (ds, page_type)", async () => {
+    const { ds } = await seedDS();
+    await createTemplate(validTemplate(ds.id, { name: "a", is_default: true }));
+    const res = await createTemplate(
+      validTemplate(ds.id, { name: "b", is_default: true }),
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("UNIQUE_VIOLATION");
+  });
+
+  it("allows multiple non-default templates per (ds, page_type)", async () => {
+    const { ds } = await seedDS();
+    const a = await createTemplate(validTemplate(ds.id, { name: "a" }));
+    const b = await createTemplate(validTemplate(ds.id, { name: "b" }));
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+  });
+});
+
+describe("templates: read", () => {
+  it("lists templates ordered by page_type then name", async () => {
+    const { ds } = await seedDS();
+    await createTemplate(validTemplate(ds.id, { page_type: "integration", name: "b" }));
+    await createTemplate(validTemplate(ds.id, { page_type: "homepage", name: "a" }));
+    await createTemplate(validTemplate(ds.id, { page_type: "homepage", name: "z" }));
+
+    const res = await listTemplates(ds.id);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.map((t) => [t.page_type, t.name])).toEqual([
+      ["homepage", "a"],
+      ["homepage", "z"],
+      ["integration", "b"],
+    ]);
+  });
+
+  it("getTemplate returns NOT_FOUND for unknown id", async () => {
+    const res = await getTemplate("00000000-0000-0000-0000-000000000000");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+
+  it("getDefaultTemplate returns the default when present", async () => {
+    const { ds } = await seedDS();
+    await createTemplate(validTemplate(ds.id, { name: "a", is_default: false }));
+    const def = await createTemplate(
+      validTemplate(ds.id, { name: "b", is_default: true }),
+    );
+    if (!def.ok) throw new Error("setup failed");
+
+    const res = await getDefaultTemplate(ds.id, "homepage");
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data?.id).toBe(def.data.id);
+  });
+
+  it("getDefaultTemplate returns null when no default", async () => {
+    const { ds } = await seedDS();
+    await createTemplate(validTemplate(ds.id, { is_default: false }));
+    const res = await getDefaultTemplate(ds.id, "homepage");
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data).toBeNull();
+  });
+});
+
+describe("templates: update", () => {
+  it("updates and bumps version_lock", async () => {
+    const { ds } = await seedDS();
+    const created = await createTemplate(validTemplate(ds.id));
+    if (!created.ok) throw new Error("setup failed");
+
+    const res = await updateTemplate(
+      created.data.id,
+      { name: "renamed" },
+      created.data.version_lock,
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.name).toBe("renamed");
+    expect(res.data.version_lock).toBe(created.data.version_lock + 1);
+  });
+
+  it("returns VERSION_CONFLICT on stale lock", async () => {
+    const { ds } = await seedDS();
+    const created = await createTemplate(validTemplate(ds.id));
+    if (!created.ok) throw new Error("setup failed");
+
+    await updateTemplate(created.data.id, { name: "first" }, 1);
+    const res = await updateTemplate(created.data.id, { name: "second" }, 1);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VERSION_CONFLICT");
+  });
+
+  it("rejects empty patch", async () => {
+    const { ds } = await seedDS();
+    const created = await createTemplate(validTemplate(ds.id));
+    if (!created.ok) throw new Error("setup failed");
+
+    const res = await updateTemplate(created.data.id, {}, created.data.version_lock);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("promoting to default clashes with existing default (UNIQUE_VIOLATION)", async () => {
+    const { ds } = await seedDS();
+    await createTemplate(validTemplate(ds.id, { name: "a", is_default: true }));
+    const b = await createTemplate(validTemplate(ds.id, { name: "b", is_default: false }));
+    if (!b.ok) throw new Error("setup failed");
+
+    const res = await updateTemplate(
+      b.data.id,
+      { is_default: true },
+      b.data.version_lock,
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("UNIQUE_VIOLATION");
+  });
+});
+
+describe("templates: delete", () => {
+  it("deletes when version_lock matches", async () => {
+    const { ds } = await seedDS();
+    const created = await createTemplate(validTemplate(ds.id));
+    if (!created.ok) throw new Error("setup failed");
+
+    const res = await deleteTemplate(created.data.id, created.data.version_lock);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.id).toBe(created.data.id);
+
+    const after = await getTemplate(created.data.id);
+    expect(after.ok).toBe(false);
+    if (after.ok) return;
+    expect(after.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns VERSION_CONFLICT on stale lock", async () => {
+    const { ds } = await seedDS();
+    const created = await createTemplate(validTemplate(ds.id));
+    if (!created.ok) throw new Error("setup failed");
+
+    await updateTemplate(created.data.id, { name: "renamed" }, 1);
+    const res = await deleteTemplate(created.data.id, 1);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VERSION_CONFLICT");
+  });
+
+  it("returns NOT_FOUND for unknown id", async () => {
+    const res = await deleteTemplate(
+      "00000000-0000-0000-0000-000000000000",
+      1,
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/lib/components.ts
+++ b/lib/components.ts
@@ -1,0 +1,248 @@
+import { z } from "zod";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ApiResponse } from "@/lib/tool-schemas";
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  guardImpl,
+  internalError,
+  mapPgError,
+  notFound,
+  validationFailed,
+  versionConflict,
+} from "@/lib/design-system-errors";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DesignComponent = {
+  id: string;
+  design_system_id: string;
+  name: string;
+  variant: string | null;
+  category: string;
+  html_template: string;
+  css: string;
+  content_schema: Record<string, unknown>;
+  image_slots: Record<string, unknown> | null;
+  usage_notes: string | null;
+  preview_html: string | null;
+  version_lock: number;
+  created_at: string;
+};
+
+const SELECT_ALL = "*";
+const RESOURCE = "design_component";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Zod schemas
+// ---------------------------------------------------------------------------
+
+// content_schema is user-supplied JSON Schema (see brief §3.5). We don't
+// attempt to validate the JSON Schema itself here — that's Layer 3 enforcement
+// at generation time (M3). At this layer we only require a JSON object.
+const JsonObjectSchema = z.record(z.string(), z.unknown());
+
+export const CreateDesignComponentSchema = z.object({
+  design_system_id: z.string().uuid(),
+  name: z
+    .string()
+    .min(1)
+    .max(120)
+    .regex(/^[a-z0-9-]+$/, {
+      message: "Component name must be lowercase kebab-case.",
+    }),
+  variant: z.string().min(1).max(60).nullable().optional(),
+  category: z.string().min(1).max(60),
+  html_template: z.string().min(1),
+  css: z.string(),
+  content_schema: JsonObjectSchema,
+  image_slots: JsonObjectSchema.nullable().optional(),
+  usage_notes: z.string().nullable().optional(),
+  preview_html: z.string().nullable().optional(),
+});
+export type CreateDesignComponentInput = z.infer<
+  typeof CreateDesignComponentSchema
+>;
+
+export const UpdateDesignComponentSchema = z
+  .object({
+    category: z.string().min(1).max(60).optional(),
+    html_template: z.string().min(1).optional(),
+    css: z.string().optional(),
+    content_schema: JsonObjectSchema.optional(),
+    image_slots: JsonObjectSchema.nullable().optional(),
+    usage_notes: z.string().nullable().optional(),
+    preview_html: z.string().nullable().optional(),
+  })
+  .refine((patch) => Object.keys(patch).length > 0, {
+    message: "At least one updatable field must be provided.",
+  });
+export type UpdateDesignComponentInput = z.infer<
+  typeof UpdateDesignComponentSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+export async function listComponents(
+  design_system_id: string,
+): Promise<ApiResponse<DesignComponent[]>> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_components")
+      .select(SELECT_ALL)
+      .eq("design_system_id", design_system_id)
+      .order("category", { ascending: true })
+      .order("name", { ascending: true });
+
+    if (error) return mapPgError(RESOURCE, error);
+    return {
+      ok: true,
+      data: (data ?? []) as DesignComponent[],
+      timestamp: now(),
+    };
+  });
+}
+
+export async function getComponent(
+  id: string,
+): Promise<ApiResponse<DesignComponent>> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_components")
+      .select(SELECT_ALL)
+      .eq("id", id)
+      .maybeSingle();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (!data) return notFound(RESOURCE, id);
+    return { ok: true, data: data as DesignComponent, timestamp: now() };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+export async function createComponent(
+  input: unknown,
+): Promise<ApiResponse<DesignComponent>> {
+  const parsed = CreateDesignComponentSchema.safeParse(input);
+  if (!parsed.success) return validationFailed(RESOURCE, parsed.error);
+
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_components")
+      .insert({
+        design_system_id: parsed.data.design_system_id,
+        name: parsed.data.name,
+        variant: parsed.data.variant ?? null,
+        category: parsed.data.category,
+        html_template: parsed.data.html_template,
+        css: parsed.data.css,
+        content_schema: parsed.data.content_schema,
+        image_slots: parsed.data.image_slots ?? null,
+        usage_notes: parsed.data.usage_notes ?? null,
+        preview_html: parsed.data.preview_html ?? null,
+      })
+      .select(SELECT_ALL)
+      .single();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (!data) return internalError("INSERT returned no row.");
+    return { ok: true, data: data as DesignComponent, timestamp: now() };
+  });
+}
+
+export async function updateComponent(
+  id: string,
+  patch: unknown,
+  expected_version_lock: number,
+): Promise<ApiResponse<DesignComponent>> {
+  const parsed = UpdateDesignComponentSchema.safeParse(patch);
+  if (!parsed.success) return validationFailed(RESOURCE, parsed.error);
+
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_components")
+      .update({
+        ...parsed.data,
+        version_lock: expected_version_lock + 1,
+      })
+      .eq("id", id)
+      .eq("version_lock", expected_version_lock)
+      .select(SELECT_ALL)
+      .maybeSingle();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (data) {
+      return { ok: true, data: data as DesignComponent, timestamp: now() };
+    }
+    return disambiguateMissingUpdate(supabase, id, expected_version_lock);
+  });
+}
+
+// Hard delete. Requires expected_version_lock to prevent deleting a component
+// another operator just edited (Q5). Zero rows affected → NOT_FOUND vs
+// VERSION_CONFLICT disambiguated by follow-up SELECT.
+export async function deleteComponent(
+  id: string,
+  expected_version_lock: number,
+): Promise<ApiResponse<{ id: string }>> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_components")
+      .delete()
+      .eq("id", id)
+      .eq("version_lock", expected_version_lock)
+      .select("id")
+      .maybeSingle();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (data) {
+      return { ok: true, data: { id: data.id as string }, timestamp: now() };
+    }
+
+    // Zero rows deleted. Disambiguate.
+    const follow = await supabase
+      .from("design_components")
+      .select("id,version_lock")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (follow.error) return mapPgError(RESOURCE, follow.error);
+    if (!follow.data) return notFound(RESOURCE, id);
+    return versionConflict(RESOURCE, id, expected_version_lock);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function disambiguateMissingUpdate(
+  supabase: SupabaseClient,
+  id: string,
+  expected_version_lock: number,
+): Promise<ApiResponse<DesignComponent>> {
+  const { data, error } = await supabase
+    .from("design_components")
+    .select("id,version_lock")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) return mapPgError(RESOURCE, error);
+  if (!data) return notFound(RESOURCE, id);
+  return versionConflict(RESOURCE, id, expected_version_lock);
+}

--- a/lib/design-system-errors.ts
+++ b/lib/design-system-errors.ts
@@ -1,0 +1,238 @@
+import type { ZodError } from "zod";
+import type { ApiResponse, ToolError } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// SQLSTATE → ApiResponse mapping for the design-system data layer.
+//
+// Supabase/PostgREST surface Postgres errors via `.error.code`, which is the
+// five-char SQLSTATE. We care about a narrow set:
+//   23505 — unique_violation        → UNIQUE_VIOLATION
+//   23503 — foreign_key_violation   → FK_VIOLATION
+//   23514 — check_violation         → VALIDATION_FAILED (DB-level check)
+//   40001 — serialization_failure   → VERSION_CONFLICT (used by our RPC to
+//                                     signal optimistic-lock mismatch)
+//   P0002 — no_data_found           → NOT_FOUND (RPC raised)
+//
+// Anything outside this set is treated as INTERNAL_ERROR — genuinely
+// unexpected. We log, return 500-ish, and do not retry.
+// ---------------------------------------------------------------------------
+
+type SupabaseLikeError = {
+  code?: string | null;
+  message?: string | null;
+  details?: string | null;
+  hint?: string | null;
+};
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function toDetails(err: SupabaseLikeError): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (err.code) out.sqlstate = err.code;
+  if (err.message) out.pg_message = err.message;
+  if (err.details) out.pg_details = err.details;
+  if (err.hint) out.pg_hint = err.hint;
+  return out;
+}
+
+export function notFound(
+  resource: string,
+  id: string,
+): ApiResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message: `${resource} ${id} not found.`,
+      details: { resource, id },
+      retryable: false,
+      suggested_action: "Verify the id. It may have been deleted or never existed.",
+    },
+    timestamp: now(),
+  };
+}
+
+export function versionConflict(
+  resource: string,
+  id: string,
+  expected: number,
+): ApiResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "VERSION_CONFLICT",
+      message: `${resource} ${id} was modified by another operator. Expected version_lock ${expected} no longer matches.`,
+      details: { resource, id, expected_version_lock: expected },
+      retryable: false,
+      suggested_action:
+        "Reload the resource to see the current state, then reapply your change against the new version_lock.",
+    },
+    timestamp: now(),
+  };
+}
+
+export function uniqueViolation(
+  resource: string,
+  pgError: SupabaseLikeError,
+): ApiResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "UNIQUE_VIOLATION",
+      message: `${resource} violates a uniqueness constraint.`,
+      details: { resource, ...toDetails(pgError) },
+      retryable: false,
+      suggested_action:
+        "A row with these identifying fields already exists. Adjust the input or update the existing row.",
+    },
+    timestamp: now(),
+  };
+}
+
+export function fkViolation(
+  resource: string,
+  pgError: SupabaseLikeError,
+): ApiResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "FK_VIOLATION",
+      message: `${resource} references a row that does not exist.`,
+      details: { resource, ...toDetails(pgError) },
+      retryable: false,
+      suggested_action:
+        "Check that every referenced id (site_id, design_system_id, template_id, etc.) points to a live row.",
+    },
+    timestamp: now(),
+  };
+}
+
+export function checkViolation(
+  resource: string,
+  pgError: SupabaseLikeError,
+): ApiResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message: `${resource} failed a database-level check constraint.`,
+      details: { resource, ...toDetails(pgError) },
+      retryable: false,
+      suggested_action:
+        "Review the input — a field value violates a domain constraint enforced at the DB level.",
+    },
+    timestamp: now(),
+  };
+}
+
+export function internalError(
+  message: string,
+  details?: Record<string, unknown>,
+): ApiResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      details,
+      retryable: false,
+      suggested_action:
+        "Unexpected database error. Check server logs and Supabase connectivity.",
+    },
+    timestamp: now(),
+  };
+}
+
+// Map a supabase-js error object to the appropriate ApiResponse. `resource`
+// is the logical name for the call site (e.g. "design_system", "component").
+export function mapPgError(
+  resource: string,
+  err: SupabaseLikeError,
+): ApiResponse<never> {
+  switch (err.code) {
+    case "23505":
+      return uniqueViolation(resource, err);
+    case "23503":
+      return fkViolation(resource, err);
+    case "23514":
+      return checkViolation(resource, err);
+    case "40001":
+      // RPC's version_lock mismatch. The RPC doesn't know the expected
+      // value, so we can't surface it here — callers should use
+      // versionConflict() directly when they hold that context.
+      return {
+        ok: false,
+        error: {
+          code: "VERSION_CONFLICT",
+          message: `${resource} optimistic lock mismatch.`,
+          details: { resource, ...toDetails(err) },
+          retryable: false,
+          suggested_action:
+            "Reload the resource to see the current state, then reapply your change against the new version_lock.",
+        },
+        timestamp: now(),
+      };
+    case "P0002":
+      return {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: `${resource} not found.`,
+          details: { resource, ...toDetails(err) },
+          retryable: false,
+          suggested_action:
+            "Verify the id. It may have been deleted or never existed.",
+        },
+        timestamp: now(),
+      };
+    default:
+      return internalError(
+        `Unexpected database error on ${resource}: ${err.message ?? "unknown"}`,
+        toDetails(err),
+      );
+  }
+}
+
+// Standardised Zod-failure response. Used at the top of every CRUD function
+// before we touch the database.
+export function validationFailed(
+  resource: string,
+  zodErr: ZodError,
+): ApiResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message: `Input for ${resource} failed validation.`,
+      details: {
+        resource,
+        issues: zodErr.issues.map((i) => ({
+          path: i.path.join("."),
+          code: i.code,
+          message: i.message,
+        })),
+      },
+      retryable: false,
+      suggested_action:
+        "Correct the listed fields and retry. See `details.issues` for the specific failures.",
+    },
+    timestamp: now(),
+  };
+}
+
+// Wrap unexpected throws from an impl function in a uniform INTERNAL_ERROR
+// envelope. Mirrors the pattern in lib/sites.ts.
+export async function guardImpl<T>(
+  resource: string,
+  impl: () => Promise<ApiResponse<T>>,
+): Promise<ApiResponse<T>> {
+  try {
+    return await impl();
+  } catch (err) {
+    return internalError(
+      `Unhandled error in ${resource}: ${err instanceof Error ? err.message : String(err)}`,
+    ) as ToolError;
+  }
+}

--- a/lib/design-systems.ts
+++ b/lib/design-systems.ts
@@ -1,0 +1,304 @@
+import { z } from "zod";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ApiResponse } from "@/lib/tool-schemas";
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  guardImpl,
+  internalError,
+  mapPgError,
+  notFound,
+  validationFailed,
+  versionConflict,
+} from "@/lib/design-system-errors";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export const DESIGN_SYSTEM_STATUSES = ["draft", "active", "archived"] as const;
+export type DesignSystemStatus = (typeof DESIGN_SYSTEM_STATUSES)[number];
+
+export type DesignSystem = {
+  id: string;
+  site_id: string;
+  version: number;
+  status: DesignSystemStatus;
+  tokens_css: string;
+  base_styles: string;
+  notes: string | null;
+  created_by: string | null;
+  created_at: string;
+  activated_at: string | null;
+  archived_at: string | null;
+  version_lock: number;
+};
+
+const SELECT_ALL = "*";
+const RESOURCE = "design_system";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Zod schemas
+// ---------------------------------------------------------------------------
+
+export const CreateDesignSystemSchema = z.object({
+  site_id: z.string().uuid(),
+  version: z.number().int().positive(),
+  tokens_css: z.string(),
+  base_styles: z.string(),
+  notes: z.string().nullable().optional(),
+  created_by: z.string().uuid().nullable().optional(),
+});
+export type CreateDesignSystemInput = z.infer<typeof CreateDesignSystemSchema>;
+
+export const UpdateDesignSystemSchema = z
+  .object({
+    tokens_css: z.string().optional(),
+    base_styles: z.string().optional(),
+    notes: z.string().nullable().optional(),
+  })
+  .refine((patch) => Object.keys(patch).length > 0, {
+    message: "At least one updatable field must be provided.",
+  });
+export type UpdateDesignSystemInput = z.infer<typeof UpdateDesignSystemSchema>;
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+export async function listDesignSystems(
+  site_id: string,
+): Promise<ApiResponse<DesignSystem[]>> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_systems")
+      .select(SELECT_ALL)
+      .eq("site_id", site_id)
+      .order("version", { ascending: false });
+
+    if (error) return mapPgError(RESOURCE, error);
+    return { ok: true, data: (data ?? []) as DesignSystem[], timestamp: now() };
+  });
+}
+
+export async function getDesignSystem(
+  id: string,
+): Promise<ApiResponse<DesignSystem>> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_systems")
+      .select(SELECT_ALL)
+      .eq("id", id)
+      .maybeSingle();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (!data) return notFound(RESOURCE, id);
+    return { ok: true, data: data as DesignSystem, timestamp: now() };
+  });
+}
+
+// Returns null-data on found-but-no-active, rather than NOT_FOUND, because
+// "no active version yet" is an expected state for a newly-created site.
+// Callers that treat this as an error should check `data === null`.
+export async function getActiveDesignSystem(
+  site_id: string,
+): Promise<ApiResponse<DesignSystem | null>> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_systems")
+      .select(SELECT_ALL)
+      .eq("site_id", site_id)
+      .eq("status", "active")
+      .maybeSingle();
+
+    if (error) return mapPgError(RESOURCE, error);
+    return {
+      ok: true,
+      data: (data ?? null) as DesignSystem | null,
+      timestamp: now(),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+export async function createDesignSystem(
+  input: unknown,
+): Promise<ApiResponse<DesignSystem>> {
+  const parsed = CreateDesignSystemSchema.safeParse(input);
+  if (!parsed.success) return validationFailed(RESOURCE, parsed.error);
+
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_systems")
+      .insert({
+        site_id: parsed.data.site_id,
+        version: parsed.data.version,
+        tokens_css: parsed.data.tokens_css,
+        base_styles: parsed.data.base_styles,
+        notes: parsed.data.notes ?? null,
+        created_by: parsed.data.created_by ?? null,
+        status: "draft",
+      })
+      .select(SELECT_ALL)
+      .single();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (!data) return internalError("INSERT returned no row.");
+    return { ok: true, data: data as DesignSystem, timestamp: now() };
+  });
+}
+
+// Optimistic lock: UPDATE with WHERE id=$id AND version_lock=$expected. If
+// zero rows affected, follow-up SELECT disambiguates NOT_FOUND vs
+// VERSION_CONFLICT. Does not touch status — use activate/archive for that.
+export async function updateDesignSystem(
+  id: string,
+  patch: unknown,
+  expected_version_lock: number,
+): Promise<ApiResponse<DesignSystem>> {
+  const parsed = UpdateDesignSystemSchema.safeParse(patch);
+  if (!parsed.success) return validationFailed(RESOURCE, parsed.error);
+
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_systems")
+      .update({
+        ...parsed.data,
+        version_lock: expected_version_lock + 1,
+      })
+      .eq("id", id)
+      .eq("version_lock", expected_version_lock)
+      .select(SELECT_ALL)
+      .maybeSingle();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (data) return { ok: true, data: data as DesignSystem, timestamp: now() };
+
+    return disambiguateMissingUpdate(supabase, id, expected_version_lock);
+  });
+}
+
+// Atomic. Delegates to the activate_design_system RPC (0003 migration) which
+// archives the current active DS and promotes the target in a single SQL
+// body. Version-lock mismatch surfaces as SQLSTATE 40001 → VERSION_CONFLICT.
+export async function activateDesignSystem(
+  id: string,
+  expected_version_lock: number,
+): Promise<ApiResponse<DesignSystem>> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .rpc("activate_design_system", {
+        p_ds_id: id,
+        p_expected_version_lock: expected_version_lock,
+      })
+      .single();
+
+    if (error) {
+      // 40001 from the RPC means optimistic-lock mismatch; we know the
+      // expected value, so surface it in the response.
+      if (error.code === "40001") {
+        return versionConflict(RESOURCE, id, expected_version_lock);
+      }
+      return mapPgError(RESOURCE, error);
+    }
+    if (!data) return internalError("RPC returned no row.");
+    return { ok: true, data: data as DesignSystem, timestamp: now() };
+  });
+}
+
+// Archive is allowed on any status. Archiving the active DS leaves the site
+// with no active design system — we surface that as a soft warning on the
+// payload rather than an error (per Q6). Archiving an already-archived row
+// is a no-op success that still bumps version_lock.
+export async function archiveDesignSystem(
+  id: string,
+  expected_version_lock: number,
+): Promise<
+  ApiResponse<{ design_system: DesignSystem; warnings: string[] }>
+> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_systems")
+      .update({
+        status: "archived",
+        archived_at: now(),
+        version_lock: expected_version_lock + 1,
+      })
+      .eq("id", id)
+      .eq("version_lock", expected_version_lock)
+      .select(SELECT_ALL)
+      .maybeSingle();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (!data) {
+      const follow = await disambiguateMissingUpdate(
+        supabase,
+        id,
+        expected_version_lock,
+      );
+      return follow as ApiResponse<{
+        design_system: DesignSystem;
+        warnings: string[];
+      }>;
+    }
+
+    const ds = data as DesignSystem;
+    const warnings: string[] = [];
+
+    // If the archived row was the previously-active one, check whether the
+    // site now has any active design system. Read-after-write is safe here:
+    // RLS service-role bypass + partial unique index guarantee at most one.
+    const { data: stillActive, error: checkErr } = await supabase
+      .from("design_systems")
+      .select("id")
+      .eq("site_id", ds.site_id)
+      .eq("status", "active")
+      .maybeSingle();
+
+    if (checkErr) return mapPgError(RESOURCE, checkErr);
+    if (!stillActive) {
+      warnings.push(
+        `Site ${ds.site_id} has no active design system after this archive. Activate another version before generating new pages.`,
+      );
+    }
+
+    return {
+      ok: true,
+      data: { design_system: ds, warnings },
+      timestamp: now(),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function disambiguateMissingUpdate(
+  supabase: SupabaseClient,
+  id: string,
+  expected_version_lock: number,
+): Promise<ApiResponse<DesignSystem>> {
+  const { data, error } = await supabase
+    .from("design_systems")
+    .select("id,version_lock")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) return mapPgError(RESOURCE, error);
+  if (!data) return notFound(RESOURCE, id);
+  return versionConflict(RESOURCE, id, expected_version_lock);
+}

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -1,0 +1,256 @@
+import { z } from "zod";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ApiResponse } from "@/lib/tool-schemas";
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  guardImpl,
+  internalError,
+  mapPgError,
+  notFound,
+  validationFailed,
+  versionConflict,
+} from "@/lib/design-system-errors";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DesignTemplate = {
+  id: string;
+  design_system_id: string;
+  page_type: string;
+  name: string;
+  composition: Array<Record<string, unknown>>;
+  required_fields: Record<string, unknown>;
+  seo_defaults: Record<string, unknown> | null;
+  is_default: boolean;
+  version_lock: number;
+  created_at: string;
+};
+
+const SELECT_ALL = "*";
+const RESOURCE = "design_template";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Zod schemas
+// ---------------------------------------------------------------------------
+
+const JsonObjectSchema = z.record(z.string(), z.unknown());
+
+// Composition is an ordered array of component references (see brief §3.4).
+// Each entry has at minimum { component, content_source }. We don't enforce
+// tighter structure here — that's verified at generation time against the
+// component registry.
+const CompositionEntrySchema = z.object({
+  component: z.string().min(1),
+  content_source: z.string().min(1),
+}).and(z.record(z.string(), z.unknown()));
+
+export const CreateDesignTemplateSchema = z.object({
+  design_system_id: z.string().uuid(),
+  page_type: z.string().min(1).max(60),
+  name: z.string().min(1).max(120),
+  composition: z.array(CompositionEntrySchema).min(1),
+  required_fields: JsonObjectSchema,
+  seo_defaults: JsonObjectSchema.nullable().optional(),
+  is_default: z.boolean().optional(),
+});
+export type CreateDesignTemplateInput = z.infer<
+  typeof CreateDesignTemplateSchema
+>;
+
+export const UpdateDesignTemplateSchema = z
+  .object({
+    name: z.string().min(1).max(120).optional(),
+    composition: z.array(CompositionEntrySchema).min(1).optional(),
+    required_fields: JsonObjectSchema.optional(),
+    seo_defaults: JsonObjectSchema.nullable().optional(),
+    is_default: z.boolean().optional(),
+  })
+  .refine((patch) => Object.keys(patch).length > 0, {
+    message: "At least one updatable field must be provided.",
+  });
+export type UpdateDesignTemplateInput = z.infer<
+  typeof UpdateDesignTemplateSchema
+>;
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+export async function listTemplates(
+  design_system_id: string,
+): Promise<ApiResponse<DesignTemplate[]>> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_templates")
+      .select(SELECT_ALL)
+      .eq("design_system_id", design_system_id)
+      .order("page_type", { ascending: true })
+      .order("name", { ascending: true });
+
+    if (error) return mapPgError(RESOURCE, error);
+    return {
+      ok: true,
+      data: (data ?? []) as DesignTemplate[],
+      timestamp: now(),
+    };
+  });
+}
+
+export async function getTemplate(
+  id: string,
+): Promise<ApiResponse<DesignTemplate>> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_templates")
+      .select(SELECT_ALL)
+      .eq("id", id)
+      .maybeSingle();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (!data) return notFound(RESOURCE, id);
+    return { ok: true, data: data as DesignTemplate, timestamp: now() };
+  });
+}
+
+export async function getDefaultTemplate(
+  design_system_id: string,
+  page_type: string,
+): Promise<ApiResponse<DesignTemplate | null>> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_templates")
+      .select(SELECT_ALL)
+      .eq("design_system_id", design_system_id)
+      .eq("page_type", page_type)
+      .eq("is_default", true)
+      .maybeSingle();
+
+    if (error) return mapPgError(RESOURCE, error);
+    return {
+      ok: true,
+      data: (data ?? null) as DesignTemplate | null,
+      timestamp: now(),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+export async function createTemplate(
+  input: unknown,
+): Promise<ApiResponse<DesignTemplate>> {
+  const parsed = CreateDesignTemplateSchema.safeParse(input);
+  if (!parsed.success) return validationFailed(RESOURCE, parsed.error);
+
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_templates")
+      .insert({
+        design_system_id: parsed.data.design_system_id,
+        page_type: parsed.data.page_type,
+        name: parsed.data.name,
+        composition: parsed.data.composition,
+        required_fields: parsed.data.required_fields,
+        seo_defaults: parsed.data.seo_defaults ?? null,
+        is_default: parsed.data.is_default ?? false,
+      })
+      .select(SELECT_ALL)
+      .single();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (!data) return internalError("INSERT returned no row.");
+    return { ok: true, data: data as DesignTemplate, timestamp: now() };
+  });
+}
+
+export async function updateTemplate(
+  id: string,
+  patch: unknown,
+  expected_version_lock: number,
+): Promise<ApiResponse<DesignTemplate>> {
+  const parsed = UpdateDesignTemplateSchema.safeParse(patch);
+  if (!parsed.success) return validationFailed(RESOURCE, parsed.error);
+
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_templates")
+      .update({
+        ...parsed.data,
+        version_lock: expected_version_lock + 1,
+      })
+      .eq("id", id)
+      .eq("version_lock", expected_version_lock)
+      .select(SELECT_ALL)
+      .maybeSingle();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (data) {
+      return { ok: true, data: data as DesignTemplate, timestamp: now() };
+    }
+    return disambiguateMissingUpdate(supabase, id, expected_version_lock);
+  });
+}
+
+export async function deleteTemplate(
+  id: string,
+  expected_version_lock: number,
+): Promise<ApiResponse<{ id: string }>> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_templates")
+      .delete()
+      .eq("id", id)
+      .eq("version_lock", expected_version_lock)
+      .select("id")
+      .maybeSingle();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (data) {
+      return { ok: true, data: { id: data.id as string }, timestamp: now() };
+    }
+
+    const follow = await supabase
+      .from("design_templates")
+      .select("id,version_lock")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (follow.error) return mapPgError(RESOURCE, follow.error);
+    if (!follow.data) return notFound(RESOURCE, id);
+    return versionConflict(RESOURCE, id, expected_version_lock);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function disambiguateMissingUpdate(
+  supabase: SupabaseClient,
+  id: string,
+  expected_version_lock: number,
+): Promise<ApiResponse<DesignTemplate>> {
+  const { data, error } = await supabase
+    .from("design_templates")
+    .select("id,version_lock")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) return mapPgError(RESOURCE, error);
+  if (!data) return notFound(RESOURCE, id);
+  return versionConflict(RESOURCE, id, expected_version_lock);
+}

--- a/lib/tool-schemas.ts
+++ b/lib/tool-schemas.ts
@@ -28,6 +28,9 @@ export const ERROR_CODES = [
   "INTERNAL_ERROR",
   "NOT_FOUND",
   "PREFIX_TAKEN",
+  "VERSION_CONFLICT",
+  "UNIQUE_VIOLATION",
+  "FK_VIOLATION",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];
@@ -67,6 +70,7 @@ export type ApiResponse<T> = ApiSuccess<T> | ToolError;
 export function errorCodeToStatus(code: ErrorCode): number {
   switch (code) {
     case "VALIDATION_FAILED":
+    case "FK_VIOLATION":
       return 400;
     case "AUTH_FAILED":
       return 401;
@@ -75,6 +79,8 @@ export function errorCodeToStatus(code: ErrorCode): number {
     case "NOT_FOUND":
       return 404;
     case "PREFIX_TAKEN":
+    case "VERSION_CONFLICT":
+    case "UNIQUE_VIOLATION":
       return 409;
     case "RATE_LIMIT":
       return 429;

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,12 +23,16 @@
       },
       "devDependencies": {
         "@types/node": "^20.16.11",
+        "@types/pg": "^8.20.0",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
+        "@vitest/ui": "^4.1.4",
         "autoprefixer": "^10.4.20",
+        "pg": "^8.20.0",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.13",
-        "typescript": "^5.6.2"
+        "typescript": "^5.6.2",
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -72,6 +76,40 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -105,6 +143,25 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@next/env": {
@@ -291,6 +348,23 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -493,6 +567,277 @@
         }
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.103.3",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.3.tgz",
@@ -595,6 +940,42 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -602,6 +983,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -641,6 +1034,141 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.4.tgz",
+      "integrity": "sha512-EgFR7nlj5iTDYZYCvavjFokNYwr3c3ry0sFiCg+N7B233Nwp+NNx7eoF/XvMWDCKY71xXAG3kFkt97ZHBJVL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "fflate": "^0.8.2",
+        "flatted": "^3.4.2",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.4"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -665,6 +1193,16 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
@@ -814,6 +1352,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -886,6 +1434,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -904,6 +1459,16 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -933,6 +1498,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -941,6 +1513,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-glob": {
@@ -980,6 +1572,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -991,6 +1590,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",
@@ -1153,6 +1759,267 @@
         "node": ">=16"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -1183,6 +2050,16 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1203,6 +2080,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mz": {
@@ -1346,11 +2233,126 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1544,6 +2546,49 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1641,6 +2686,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -1673,6 +2752,28 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1681,6 +2782,30 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -1824,6 +2949,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -1869,6 +3011,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1879,6 +3031,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ts-algebra": {
@@ -1956,6 +3118,217 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -1975,6 +3348,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
@@ -25,11 +27,15 @@
   },
   "devDependencies": {
     "@types/node": "^20.16.11",
+    "@types/pg": "^8.20.0",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
+    "@vitest/ui": "^4.1.4",
     "autoprefixer": "^10.4.20",
+    "pg": "^8.20.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.2",
+    "vitest": "^4.1.4"
   }
 }

--- a/supabase/migrations/0003_m1b_rpcs.down.sql
+++ b/supabase/migrations/0003_m1b_rpcs.down.sql
@@ -1,0 +1,17 @@
+-- M1b — Rollback for 0003_m1b_rpcs.sql
+--
+-- Drops activate_design_system. Run before 0002's rollback if tearing down
+-- the M1 schema completely. Safe to run on its own — does not affect tables
+-- or data.
+--
+-- Verification steps:
+--   1. With the forward migration applied, confirm the function exists:
+--        SELECT proname FROM pg_proc WHERE proname = 'activate_design_system';
+--      Expected: 1 row.
+--   2. Run this file.
+--   3. Confirm it is gone:
+--        SELECT proname FROM pg_proc WHERE proname = 'activate_design_system';
+--      Expected: 0 rows.
+--   4. Re-apply 0003 — should succeed with no residue.
+
+DROP FUNCTION IF EXISTS activate_design_system(uuid, integer);

--- a/supabase/migrations/0003_m1b_rpcs.sql
+++ b/supabase/migrations/0003_m1b_rpcs.sql
@@ -1,0 +1,84 @@
+-- M1b — RPCs for multi-step operations on the design system schema
+-- Reference: docs/m1-claude-code-brief.md §3.3; M1b plan thread.
+--
+-- Purpose:
+--   activate_design_system(ds_id, expected_version_lock) atomically:
+--     1. Archives any currently-active design system for the same site.
+--     2. Sets the target design system to 'active' and bumps its version_lock.
+--   Both updates run inside a single SQL statement body, so either both apply
+--   or neither does — the partial unique index one_active_design_system can
+--   never observe two active rows for the same site.
+--
+-- Error semantics (surfaced to callers via RAISE):
+--   - P0002 (no_data_found) if the target DS does not exist.
+--   - VERSION_CONFLICT (SQLSTATE '40001') if expected_version_lock mismatch,
+--     so the data layer can map it to the same ApiResponse as a row-level
+--     optimistic-lock miss on a plain UPDATE.
+--
+-- Why SECURITY DEFINER:
+--   RLS is service-role-only today (§M1a), so DEFINER is redundant with the
+--   current policy set. It is set explicitly so M2's authenticated-role
+--   policies don't accidentally break activation — the function runs with
+--   the owner's privileges regardless of who calls it.
+
+CREATE OR REPLACE FUNCTION activate_design_system(
+  p_ds_id                 uuid,
+  p_expected_version_lock integer
+)
+RETURNS design_systems
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_site_id        uuid;
+  v_current_lock   integer;
+  v_result         design_systems;
+BEGIN
+  -- Resolve the target row and lock it for the duration of the transaction.
+  SELECT site_id, version_lock
+    INTO v_site_id, v_current_lock
+    FROM design_systems
+    WHERE id = p_ds_id
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'design_system % not found', p_ds_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_current_lock <> p_expected_version_lock THEN
+    RAISE EXCEPTION
+      'version_lock mismatch for design_system %: expected %, actual %',
+      p_ds_id, p_expected_version_lock, v_current_lock
+      USING ERRCODE = '40001';
+  END IF;
+
+  -- Archive any currently-active DS for this site (may be zero rows — the
+  -- target itself might already be active and have no peer to archive).
+  UPDATE design_systems
+    SET status       = 'archived',
+        archived_at  = now(),
+        version_lock = version_lock + 1
+    WHERE site_id = v_site_id
+      AND status = 'active'
+      AND id <> p_ds_id;
+
+  -- Promote the target row.
+  UPDATE design_systems
+    SET status       = 'active',
+        activated_at = coalesce(activated_at, now()),
+        archived_at  = NULL,
+        version_lock = version_lock + 1
+    WHERE id = p_ds_id
+    RETURNING * INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+
+-- Lock the function down — only roles that have rights on design_systems
+-- should be able to invoke the activation RPC. service_role is the only
+-- caller in M1.
+REVOKE ALL ON FUNCTION activate_design_system(uuid, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION activate_design_system(uuid, integer) TO service_role;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+  test: {
+    globalSetup: ["./lib/__tests__/_globalSetup.ts"],
+    setupFiles: ["./lib/__tests__/_setup.ts"],
+    include: ["lib/__tests__/**/*.test.ts"],
+    testTimeout: 15_000,
+    hookTimeout: 60_000,
+    // Tests share one Supabase stack. fileParallelism: false forces files to
+    // run serially, which avoids cross-test TRUNCATE races when multiple
+    // files hit the same database.
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## Summary

The pure data-access slice of M1, implementing the M1b plan approved in the handoff thread. No API routes, no UI, no `buildSystemPromptForSite()` changes — those are M1d / M1e per `docs/m1-claude-code-brief.md` §5.

### What's in

- **Migration `0003_m1b_rpcs.sql`** (+ `.down.sql`) — `activate_design_system(ds_id, expected_version_lock)` RPC. `SECURITY DEFINER`, parameterised, atomic. Archives the previously-active DS and promotes the target in a single SQL body. Raises SQLSTATE `40001` on `version_lock` mismatch and `P0002` on unknown id.
- **`lib/tool-schemas.ts`** — additive only: three new `ERROR_CODES` (`VERSION_CONFLICT`, `UNIQUE_VIOLATION`, `FK_VIOLATION`) and matching `errorCodeToStatus` entries.
- **`lib/design-system-errors.ts`** — shared SQLSTATE → `ApiResponse` mapper, reused by all three modules. Maps `23505` → `UNIQUE_VIOLATION`, `23503` → `FK_VIOLATION`, `23514` → `VALIDATION_FAILED`, `40001` → `VERSION_CONFLICT`, `P0002` → `NOT_FOUND`; everything else becomes `INTERNAL_ERROR`. Plus small helpers (`notFound`, `versionConflict`, `validationFailed`, `guardImpl`) that other modules compose.
- **`lib/design-systems.ts`** — list / get / getActive / create / update / activate / archive. Archive of the currently-active DS returns a soft warning on the payload rather than an error (per Q6).
- **`lib/components.ts`** — list / get / create / update / delete. Name validated as lowercase kebab-case.
- **`lib/templates.ts`** — list / get / getDefault / create / update / delete. Composition validated as a non-empty array of `{ component, content_source, ... }` entries.
- **Every update and delete takes `expected_version_lock`** and returns 409-equivalent `VERSION_CONFLICT` on mismatch. Zero-row updates do a follow-up SELECT to disambiguate `NOT_FOUND` vs `VERSION_CONFLICT`.
- **Every input is Zod-validated** at the top of each write function, ahead of any DB call.

### Tests

Integration-level against a running Supabase local stack, per the agreed-on "real PostgREST code path" plan.

- **Vitest 4** (`vitest`, `@vitest/ui`), plus `pg` for direct TRUNCATE between tests.
- `lib/__tests__/_globalSetup.ts` — checks `supabase status`, runs `supabase start` if needed, seeds `process.env` with API URL + service-role key.
- `lib/__tests__/_setup.ts` — per-worker; opens a `pg` connection to `localhost:54322` and TRUNCATEs every M1 table in a `beforeEach`.
- Coverage per module: happy path, Zod rejection, version conflict, not-found, FK violation, unique violation. Plus activate/archive specifics (atomic promotion, soft-warning on active archive, same-name-different-variant, default-template uniqueness, promote-to-default collides).
- **`CONTRIBUTING.md`** documents the Docker + Supabase CLI prerequisites and the `supabase start && npm test` workflow.

### Verification performed in this sandbox

- `tsc --noEmit`: clean.
- RPC semantics verified against scratch Postgres (psql):
  - Activate draft → promotes to active, bumps lock, sets `activated_at`.
  - Activate v2 while v1 is active → v1 archived + locked, v2 active + locked, all in one transaction.
  - Stale `version_lock` → SQLSTATE `40001` raised with the helpful message.
  - Unknown id → SQLSTATE `P0002`.
  - Re-activating the already-active row → success, lock bumped, `activated_at` preserved.
  - Partial unique index `one_active_design_system` still rejects manual `INSERT … status='active'` while another active row exists.
- 0003 rollback + re-apply cycle runs clean.

### Verification NOT performed

- **Full Vitest suite did not run in this sandbox.** The environment has `docker` installed but the daemon can't start (no iptables/nftables), so `supabase start` has no runtime. Test files parse, imports resolve, config loads — Vitest fails only at the `supabase start` step in `globalSetup`. This is what you flagged as an expected CI-local concern.

Please run `supabase start && npm test` on your machine before merging, and let me know if anything doesn't pass — I'll adjust in a follow-up commit on this branch.

## Test plan

- [ ] `supabase start` (first run downloads images, ~15–30s thereafter)
- [ ] `npm test` passes all three test files
- [ ] `tsc --noEmit` clean (verified here)
- [ ] `0003_m1b_rpcs.down.sql` tears down cleanly (verified here against scratch Postgres)
- [ ] Spot-check behaviour of activate on a site with 2+ design systems

Do not merge until the test suite is green in your environment.

https://claude.ai/code/session_01PTCJrskyCmW3t9NvLXM7rT