### PR TITLE
M1d: structured design-system registry in system prompt

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -17,3 +17,11 @@ SUPABASE_SERVICE_ROLE_KEY=
 # Master encryption key for site credentials (Week 2+).
 # Must decode to exactly 32 bytes. Generate with: openssl rand -base64 32
 OPOLLO_MASTER_KEY=
+
+# Design system v2 (M1+). When "true" or "1", buildSystemPromptForSite() reads
+# the structured component/template registry from the design_systems tables.
+# Any other value (unset, "false", "0") keeps the legacy HTML-blob path.
+# Flip on per-site by activating a design_systems row first; if this flag is
+# on but no active DS exists for the target site, the code logs an error and
+# falls back to the legacy path so chat stays functional.
+FEATURE_DESIGN_SYSTEM_V2=

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -58,11 +58,21 @@ const MODEL = "claude-opus-4-7";
 const MAX_TOKENS = 4096;
 const MAX_ITERATIONS = 5;
 
-const LEADSOURCE_FALLBACK_PROMPT = buildSystemPromptForSite({
-  site_name: "LeadSource",
-  prefix: "ls",
-  design_system_version: "1.0.0",
-});
+// The memoised prompt captures DS state at first-request time within each
+// Vercel function instance. Activations propagate lazily as instances recycle.
+// This is intentional for M1d; explicit invalidation comes in a later milestone
+// alongside per-page iteration (M6 in the roadmap).
+let leadsourceFallbackPromptPromise: Promise<string> | null = null;
+function getLeadsourceFallbackPrompt(): Promise<string> {
+  if (leadsourceFallbackPromptPromise === null) {
+    leadsourceFallbackPromptPromise = buildSystemPromptForSite({
+      site_name: "LeadSource",
+      prefix: "ls",
+      design_system_version: "1.0.0",
+    });
+  }
+  return leadsourceFallbackPromptPromise;
+}
 
 function cachedSystemBlocks(prompt: string): Anthropic.TextBlockParam[] {
   return [{ type: "text", text: prompt, cache_control: EPHEMERAL }];
@@ -147,7 +157,8 @@ export async function POST(req: Request) {
       wp_user: credentials.wp_user,
       wp_app_password: credentials.wp_app_password,
     };
-    systemPrompt = buildSystemPromptForSite({
+    systemPrompt = await buildSystemPromptForSite({
+      id: site.id,
       site_name: site.name,
       prefix: site.prefix,
       design_system_version: site.design_system_version,
@@ -155,7 +166,7 @@ export async function POST(req: Request) {
     siteLogId = site.id;
     siteLogName = site.name;
   } else {
-    systemPrompt = LEADSOURCE_FALLBACK_PROMPT;
+    systemPrompt = await getLeadsourceFallbackPrompt();
     wpCreds = undefined;
   }
 

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -1,0 +1,384 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  renderComponentSummary,
+  renderRegistryBlock,
+  renderTemplateSummary,
+} from "@/lib/design-system-prompt";
+import {
+  buildSystemPromptForSite,
+  isDesignSystemV2Enabled,
+  loadActiveRegistry,
+} from "@/lib/system-prompt";
+import {
+  createDesignSystem,
+  activateDesignSystem,
+  type DesignSystem,
+} from "@/lib/design-systems";
+import { createComponent, type DesignComponent } from "@/lib/components";
+import { createTemplate, type DesignTemplate } from "@/lib/templates";
+import { minimalComponentContentSchema, minimalComposition, seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// Pure render tests — no DB, synthetic input.
+// ---------------------------------------------------------------------------
+
+function fakeComponent(overrides: Partial<DesignComponent> = {}): DesignComponent {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    design_system_id: "00000000-0000-0000-0000-000000000002",
+    name: "hero-centered",
+    variant: "default",
+    category: "hero",
+    html_template: "<section>...</section>",
+    css: ".ls-hero { padding: 2rem; }",
+    content_schema: {
+      type: "object",
+      required: ["headline", "sub"],
+      properties: {
+        headline: { type: "string" },
+        sub: { type: "string" },
+      },
+    },
+    image_slots: null,
+    usage_notes: "Default hero.\nSecond line should be dropped.",
+    preview_html: null,
+    version_lock: 1,
+    created_at: "2026-04-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function fakeTemplate(overrides: Partial<DesignTemplate> = {}): DesignTemplate {
+  return {
+    id: "00000000-0000-0000-0000-000000000010",
+    design_system_id: "00000000-0000-0000-0000-000000000002",
+    page_type: "homepage",
+    name: "homepage-default",
+    composition: [
+      { component: "nav-default", content_source: "site_context.nav" },
+      { component: "hero-centered", content_source: "brief.hero" },
+      { component: "footer-default", content_source: "site_context.footer" },
+    ],
+    required_fields: { hero: ["headline"] },
+    seo_defaults: null,
+    is_default: true,
+    version_lock: 1,
+    created_at: "2026-04-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function fakeDesignSystem(overrides: Partial<DesignSystem> = {}): DesignSystem {
+  return {
+    id: "00000000-0000-0000-0000-000000000002",
+    site_id: "00000000-0000-0000-0000-000000000003",
+    version: 1,
+    status: "active",
+    tokens_css: ".ls-scope {\n  --ls-blue: #185FA5;\n}",
+    base_styles: ".ls-container { max-width: 1160px; }",
+    notes: null,
+    created_by: null,
+    created_at: "2026-04-01T00:00:00Z",
+    activated_at: "2026-04-02T00:00:00Z",
+    archived_at: null,
+    version_lock: 1,
+    ...overrides,
+  };
+}
+
+describe("renderComponentSummary", () => {
+  it("renders name, category/variant, purpose, and required fields", () => {
+    const out = renderComponentSummary(fakeComponent());
+    expect(out).toContain("hero-centered [hero/default]");
+    expect(out).toContain("Default hero.");
+    expect(out).toContain("Required fields: headline, sub");
+  });
+
+  it("drops the variant when null", () => {
+    const out = renderComponentSummary(fakeComponent({ variant: null }));
+    expect(out).toContain("hero-centered [hero]");
+    expect(out).not.toContain("[hero/");
+  });
+
+  it("uses only the first line of usage_notes", () => {
+    const out = renderComponentSummary(fakeComponent());
+    expect(out).not.toContain("Second line should be dropped.");
+  });
+
+  it("omits the purpose segment entirely when usage_notes is empty", () => {
+    const out = renderComponentSummary(fakeComponent({ usage_notes: null }));
+    expect(out.startsWith("- hero-centered")).toBe(true);
+    expect(out).not.toContain(" — ");
+  });
+
+  it("omits the fields line when content_schema.required is missing or invalid", () => {
+    const out = renderComponentSummary(
+      fakeComponent({ content_schema: { type: "object" } }),
+    );
+    expect(out).not.toContain("Required fields:");
+  });
+});
+
+describe("renderTemplateSummary", () => {
+  it("renders name, page type, default flag, and composition", () => {
+    const out = renderTemplateSummary(fakeTemplate());
+    expect(out).toContain("homepage-default [homepage] (default)");
+    expect(out).toContain(
+      "Composition: nav-default → hero-centered → footer-default",
+    );
+  });
+
+  it("drops the default tag when is_default is false", () => {
+    const out = renderTemplateSummary(fakeTemplate({ is_default: false }));
+    expect(out).not.toContain("(default)");
+  });
+
+  it("handles empty composition gracefully", () => {
+    const out = renderTemplateSummary(fakeTemplate({ composition: [] }));
+    expect(out).toContain("homepage-default [homepage]");
+    expect(out).not.toContain("Composition:");
+  });
+});
+
+describe("renderRegistryBlock", () => {
+  it("puts components in category-then-name order and templates in page_type-then-name order", () => {
+    const block = renderRegistryBlock({
+      site_name: "LeadSource",
+      prefix: "ls",
+      ds: fakeDesignSystem(),
+      components: [
+        fakeComponent({ name: "footer-default", category: "footer", variant: null }),
+        fakeComponent({ name: "hero-centered", category: "hero", variant: "default" }),
+        fakeComponent({ name: "nav-default", category: "nav", variant: "default" }),
+      ],
+      templates: [
+        fakeTemplate({ name: "integration-gravity", page_type: "integration" }),
+        fakeTemplate({ name: "homepage-default", page_type: "homepage" }),
+      ],
+    });
+
+    expect(block).toContain("# Site: LeadSource");
+    expect(block).toContain("# Design system version: 1");
+    expect(block).toContain("# Scope prefix: ls-");
+    expect(block).toContain("## Available components (3 total)");
+    expect(block).toContain("## Page templates (2 total)");
+    expect(block).toContain("--ls-blue: #185FA5");
+    expect(block).toContain(`<div class="ls-scope">`);
+
+    // Category ordering: footer → hero → nav
+    const footerIdx = block.indexOf("footer-default");
+    const heroIdx = block.indexOf("hero-centered");
+    const navIdx = block.indexOf("nav-default");
+    expect(footerIdx).toBeLessThan(heroIdx);
+    expect(heroIdx).toBeLessThan(navIdx);
+
+    // Template ordering: homepage → integration
+    const homeTmpl = block.indexOf("homepage-default [homepage]");
+    const intTmpl = block.indexOf("integration-gravity [integration]");
+    expect(homeTmpl).toBeLessThan(intTmpl);
+  });
+
+  it("renders empty sections without crashing", () => {
+    const block = renderRegistryBlock({
+      site_name: "Empty",
+      prefix: "em",
+      ds: fakeDesignSystem(),
+      components: [],
+      templates: [],
+    });
+    expect(block).toContain("## Available components (0 total)");
+    expect(block).toContain("## Page templates (0 total)");
+    expect(block).toContain("(none registered)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feature flag
+// ---------------------------------------------------------------------------
+
+describe("isDesignSystemV2Enabled", () => {
+  const original = process.env.FEATURE_DESIGN_SYSTEM_V2;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.FEATURE_DESIGN_SYSTEM_V2;
+    else process.env.FEATURE_DESIGN_SYSTEM_V2 = original;
+  });
+
+  it("treats 'true' and '1' as enabled", () => {
+    process.env.FEATURE_DESIGN_SYSTEM_V2 = "true";
+    expect(isDesignSystemV2Enabled()).toBe(true);
+    process.env.FEATURE_DESIGN_SYSTEM_V2 = "1";
+    expect(isDesignSystemV2Enabled()).toBe(true);
+  });
+
+  it("treats anything else as disabled", () => {
+    process.env.FEATURE_DESIGN_SYSTEM_V2 = "false";
+    expect(isDesignSystemV2Enabled()).toBe(false);
+    process.env.FEATURE_DESIGN_SYSTEM_V2 = "0";
+    expect(isDesignSystemV2Enabled()).toBe(false);
+    process.env.FEATURE_DESIGN_SYSTEM_V2 = "";
+    expect(isDesignSystemV2Enabled()).toBe(false);
+    delete process.env.FEATURE_DESIGN_SYSTEM_V2;
+    expect(isDesignSystemV2Enabled()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: loadActiveRegistry + buildSystemPromptForSite against real DB.
+// ---------------------------------------------------------------------------
+
+async function seedActiveDesignSystem(siteId: string): Promise<{
+  ds: DesignSystem;
+  componentName: string;
+  templateName: string;
+}> {
+  const dsRes = await createDesignSystem({
+    site_id: siteId,
+    version: 1,
+    tokens_css: ".ls-scope { --ls-blue: #185FA5; }",
+    base_styles: ".ls-container { max-width: 1160px; }",
+  });
+  if (!dsRes.ok) throw new Error(`createDesignSystem: ${dsRes.error.message}`);
+
+  const compRes = await createComponent({
+    design_system_id: dsRes.data.id,
+    name: "hero-centered",
+    variant: "default",
+    category: "hero",
+    html_template: "<section>{{headline}}</section>",
+    css: ".ls-hero {}",
+    content_schema: minimalComponentContentSchema(),
+    usage_notes: "Homepage hero.",
+  });
+  if (!compRes.ok) throw new Error(`createComponent: ${compRes.error.message}`);
+
+  const tmplRes = await createTemplate({
+    design_system_id: dsRes.data.id,
+    page_type: "homepage",
+    name: "homepage-default",
+    composition: minimalComposition(),
+    required_fields: { hero: ["headline"] },
+    is_default: true,
+  });
+  if (!tmplRes.ok) throw new Error(`createTemplate: ${tmplRes.error.message}`);
+
+  const activated = await activateDesignSystem(
+    dsRes.data.id,
+    dsRes.data.version_lock,
+  );
+  if (!activated.ok) {
+    throw new Error(`activateDesignSystem: ${activated.error.message}`);
+  }
+
+  return {
+    ds: activated.data,
+    componentName: compRes.data.name,
+    templateName: tmplRes.data.name,
+  };
+}
+
+describe("loadActiveRegistry", () => {
+  it("returns null when the site has no active design system", async () => {
+    const site = await seedSite();
+    const result = await loadActiveRegistry(site.id);
+    expect(result).toBeNull();
+  });
+
+  it("returns ds + components + templates when an active DS exists", async () => {
+    const site = await seedSite();
+    const seeded = await seedActiveDesignSystem(site.id);
+    const result = await loadActiveRegistry(site.id);
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(result.ds.id).toBe(seeded.ds.id);
+    expect(result.components.map((c) => c.name)).toContain(seeded.componentName);
+    expect(result.templates.map((t) => t.name)).toContain(seeded.templateName);
+  });
+});
+
+describe("buildSystemPromptForSite", () => {
+  const originalFlag = process.env.FEATURE_DESIGN_SYSTEM_V2;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalFlag === undefined) delete process.env.FEATURE_DESIGN_SYSTEM_V2;
+    else process.env.FEATURE_DESIGN_SYSTEM_V2 = originalFlag;
+    errorSpy.mockRestore();
+  });
+
+  it("uses legacy path when flag is off, even with active DS", async () => {
+    delete process.env.FEATURE_DESIGN_SYSTEM_V2;
+    const site = await seedSite();
+    await seedActiveDesignSystem(site.id);
+
+    const prompt = await buildSystemPromptForSite({
+      id: site.id,
+      site_name: "Test",
+      prefix: site.prefix,
+      design_system_version: "1.0.0",
+    });
+
+    // Legacy path fills {{design_system_html_full_file}} with empty string,
+    // so the heading markers from the registry block are absent.
+    expect(prompt).not.toContain("## Available components");
+    expect(prompt).not.toContain("## Page templates");
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses legacy path when id is missing, regardless of flag", async () => {
+    process.env.FEATURE_DESIGN_SYSTEM_V2 = "true";
+    const prompt = await buildSystemPromptForSite({
+      site_name: "Fallback",
+      prefix: "fb",
+      design_system_version: "1.0.0",
+    });
+    expect(prompt).not.toContain("## Available components");
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses new path when flag is on and active DS exists", async () => {
+    process.env.FEATURE_DESIGN_SYSTEM_V2 = "true";
+    const site = await seedSite();
+    await seedActiveDesignSystem(site.id);
+
+    const prompt = await buildSystemPromptForSite({
+      id: site.id,
+      site_name: "Test",
+      prefix: site.prefix,
+      design_system_version: "1.0.0",
+    });
+
+    expect(prompt).toContain("## Available components (1 total)");
+    expect(prompt).toContain("## Page templates (1 total)");
+    expect(prompt).toContain("hero-centered [hero/default]");
+    expect(prompt).toContain("homepage-default [homepage] (default)");
+    expect(prompt).toContain("--ls-blue: #185FA5");
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to legacy and logs structured error when flag is on but no active DS", async () => {
+    process.env.FEATURE_DESIGN_SYSTEM_V2 = "true";
+    const site = await seedSite();
+
+    const prompt = await buildSystemPromptForSite({
+      id: site.id,
+      site_name: "Test",
+      prefix: site.prefix,
+      design_system_version: "1.0.0",
+    });
+
+    expect(prompt).not.toContain("## Available components");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[system-prompt] FEATURE_DESIGN_SYSTEM_V2=on but no active design_system for site",
+      expect.objectContaining({
+        site_id: site.id,
+        site_name: "Test",
+        fallback: "legacy_html_blob",
+      }),
+    );
+  });
+});

--- a/lib/design-system-prompt.ts
+++ b/lib/design-system-prompt.ts
@@ -1,0 +1,101 @@
+import type { DesignSystem } from "@/lib/design-systems";
+import type { DesignComponent } from "@/lib/components";
+import type { DesignTemplate } from "@/lib/templates";
+
+// ---------------------------------------------------------------------------
+// Pure render helpers for the design-system section of the system prompt.
+//
+// No database access — callers pass in already-fetched rows. This keeps the
+// render layer testable without Supabase and lets loadActiveRegistry() in
+// lib/system-prompt.ts do all the I/O in one place.
+//
+// Output is compact Markdown. The brief (§3.7) is explicit that component
+// HTML templates are NOT inlined here — they'd blow the context window at
+// 40-page batch scale. The generator (M3) fetches component HTML on demand
+// via getComponent(id).
+// ---------------------------------------------------------------------------
+
+export function renderComponentSummary(c: DesignComponent): string {
+  const head = c.variant
+    ? `- ${c.name} [${c.category}/${c.variant}]`
+    : `- ${c.name} [${c.category}]`;
+
+  const purpose = (c.usage_notes ?? "").trim().split("\n")[0] ?? "";
+  const purposeLine = purpose.length > 0 ? ` — ${purpose}` : "";
+
+  const required = extractRequiredFields(c.content_schema);
+  const fieldsLine =
+    required.length > 0 ? `\n  Required fields: ${required.join(", ")}` : "";
+
+  return `${head}${purposeLine}${fieldsLine}`;
+}
+
+export function renderTemplateSummary(t: DesignTemplate): string {
+  const components = Array.isArray(t.composition)
+    ? t.composition.map((entry) => String(entry.component ?? "?"))
+    : [];
+  const defaultTag = t.is_default ? " (default)" : "";
+  const compositionLine =
+    components.length > 0
+      ? `\n  Composition: ${components.join(" → ")}`
+      : "";
+  return `- ${t.name} [${t.page_type}]${defaultTag}${compositionLine}`;
+}
+
+export function renderRegistryBlock(args: {
+  site_name: string;
+  prefix: string;
+  ds: DesignSystem;
+  components: DesignComponent[];
+  templates: DesignTemplate[];
+}): string {
+  const { site_name, prefix, ds, components, templates } = args;
+  const sortedComponents = [...components].sort((a, b) => {
+    const cat = a.category.localeCompare(b.category);
+    return cat !== 0 ? cat : a.name.localeCompare(b.name);
+  });
+  const sortedTemplates = [...templates].sort((a, b) => {
+    const pt = a.page_type.localeCompare(b.page_type);
+    return pt !== 0 ? pt : a.name.localeCompare(b.name);
+  });
+
+  const componentsSection = sortedComponents.length === 0
+    ? "(none registered)"
+    : sortedComponents.map(renderComponentSummary).join("\n");
+
+  const templatesSection = sortedTemplates.length === 0
+    ? "(none registered)"
+    : sortedTemplates.map(renderTemplateSummary).join("\n");
+
+  return [
+    `# Site: ${site_name}`,
+    `# Design system version: ${ds.version}`,
+    `# Scope prefix: ${prefix}-`,
+    ``,
+    `## Available components (${sortedComponents.length} total)`,
+    componentsSection,
+    ``,
+    `## Page templates (${sortedTemplates.length} total)`,
+    templatesSection,
+    ``,
+    `## Design tokens`,
+    ds.tokens_css.trim(),
+    ``,
+    `## Hard constraints`,
+    `- Use only components listed above. Never invent class names outside the registry.`,
+    `- Wrap every generated page in <div class="${prefix}-scope">...</div>.`,
+    `- When you need a component's HTML template, request it by name — don't guess the markup.`,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Private: extract the top-level `required` array from a JSON Schema. Tolerant
+// of schemas that omit `required` or embed it under nested `properties`.
+// ---------------------------------------------------------------------------
+
+function extractRequiredFields(schema: unknown): string[] {
+  if (!schema || typeof schema !== "object") return [];
+  const required = (schema as { required?: unknown }).required;
+  if (!Array.isArray(required)) return [];
+  return required.filter((f): f is string => typeof f === "string");
+}

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -1,5 +1,12 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  getActiveDesignSystem,
+  type DesignSystem,
+} from "@/lib/design-systems";
+import { listComponents, type DesignComponent } from "@/lib/components";
+import { listTemplates, type DesignTemplate } from "@/lib/templates";
+import { renderRegistryBlock } from "@/lib/design-system-prompt";
 
 export type SystemPromptContext = {
   site_name: string;
@@ -70,19 +77,112 @@ Power phrases to use: "Stop guessing. Start knowing.", "We tell you exactly.", "
 
 Never say: "Every form", "100% accurate", "Leverage/Utilise/Seamlessly", "Powerful/Robust/Comprehensive", passive voice like "data is captured"`;
 
+/**
+ * Identity fields needed to build a system prompt for a site.
+ *
+ * `id` is optional for backwards compatibility with hard-coded fallback
+ * callers (e.g. the module-init LeadSource prompt in app/api/chat/route.ts).
+ *
+ * When `id` is present AND FEATURE_DESIGN_SYSTEM_V2 is enabled AND the site
+ * has an active design_systems row, `buildSystemPromptForSite` takes the
+ * new registry path: queries the M1 data layer and injects a structured
+ * component/template/tokens summary into the prompt.
+ *
+ * Otherwise — no id, flag off, or no active DS — it takes the legacy path,
+ * which produces the same output as before M1d: empty design_system_html
+ * blob plus the baked-in defaults.
+ */
 export type SiteIdentity = {
   site_name: string;
   prefix: string;
   design_system_version: string;
+  id?: string;
 };
 
-export function buildSystemPromptForSite(site: SiteIdentity): string {
+// ---------------------------------------------------------------------------
+// Feature flag — single source of truth. Treats "true" and "1" as on.
+// Everything else (unset, "false", "0", other strings) is off.
+// ---------------------------------------------------------------------------
+
+export function isDesignSystemV2Enabled(): boolean {
+  const raw = process.env.FEATURE_DESIGN_SYSTEM_V2;
+  return raw === "true" || raw === "1";
+}
+
+// ---------------------------------------------------------------------------
+// Registry loader — the one place in M1d that hits Supabase.
+//
+// Returns null if the site has no active design system, so callers can fall
+// back to the legacy path without caring why. Throws ONLY for genuinely
+// unexpected errors — the underlying lib returns ApiResponse envelopes for
+// the known failure modes and we translate those to null + log.
+// ---------------------------------------------------------------------------
+
+// TODO(M3): consider site-keyed LRU with 5-min TTL around loadActiveRegistry().
+// Expected to matter when batch generator makes ~40 consecutive reads per site.
+export async function loadActiveRegistry(
+  site_id: string,
+): Promise<{
+  ds: DesignSystem;
+  components: DesignComponent[];
+  templates: DesignTemplate[];
+} | null> {
+  const dsRes = await getActiveDesignSystem(site_id);
+  if (!dsRes.ok) {
+    console.error("[system-prompt] getActiveDesignSystem failed", {
+      site_id,
+      error: dsRes.error,
+    });
+    return null;
+  }
+  if (dsRes.data === null) return null;
+
+  const ds = dsRes.data;
+  const [compRes, tmplRes] = await Promise.all([
+    listComponents(ds.id),
+    listTemplates(ds.id),
+  ]);
+
+  if (!compRes.ok) {
+    console.error("[system-prompt] listComponents failed", {
+      site_id,
+      ds_id: ds.id,
+      error: compRes.error,
+    });
+    return null;
+  }
+  if (!tmplRes.ok) {
+    console.error("[system-prompt] listTemplates failed", {
+      site_id,
+      ds_id: ds.id,
+      error: tmplRes.error,
+    });
+    return null;
+  }
+
+  return { ds, components: compRes.data, templates: tmplRes.data };
+}
+
+// ---------------------------------------------------------------------------
+// Main builder. Async as of M1d — see SiteIdentity JSDoc for the path
+// selection logic.
+// ---------------------------------------------------------------------------
+
+export async function buildSystemPromptForSite(
+  site: SiteIdentity,
+): Promise<string> {
+  const {
+    design_system_html_full_file,
+    design_system_version,
+    design_system_updated,
+  } = await resolveDesignSystemSlot(site);
+
   return buildSystemPrompt({
     site_name: site.site_name,
     prefix: site.prefix,
-    design_system_version: site.design_system_version,
-    design_system_updated: "n/a (Week 2)",
-    design_system_html_full_file: "",
+    design_system_version,
+    design_system_updated,
+    design_system_html_full_file,
     brand_voice_content: LEADSOURCE_BRAND_VOICE_DEFAULT,
     site_pages_tree: "[]",
     site_menus_current: "{}",
@@ -90,4 +190,54 @@ export function buildSystemPromptForSite(site: SiteIdentity): string {
     templates_list: "[]",
     session_recent_pages: "[]",
   });
+}
+
+// Picks which content fills {{design_system_html_full_file}} and how the
+// version / updated fields are labelled. Kept private — the path-selection
+// logic is an implementation detail of buildSystemPromptForSite.
+async function resolveDesignSystemSlot(site: SiteIdentity): Promise<{
+  design_system_html_full_file: string;
+  design_system_version: string;
+  design_system_updated: string;
+}> {
+  const legacy = {
+    design_system_html_full_file: "",
+    design_system_version: site.design_system_version,
+    design_system_updated: "n/a (Week 2)",
+  };
+
+  if (!isDesignSystemV2Enabled() || !site.id) {
+    return legacy;
+  }
+
+  const registry = await loadActiveRegistry(site.id);
+  if (!registry) {
+    // Flag is on but we have no active DS (or a transient read failure). The
+    // log is deliberately console.error + structured so operators see it
+    // clearly in production — an active-DS miss usually means someone forgot
+    // to activate a seeded design system.
+    console.error(
+      "[system-prompt] FEATURE_DESIGN_SYSTEM_V2=on but no active design_system for site",
+      {
+        site_id: site.id,
+        site_name: site.site_name,
+        fallback: "legacy_html_blob",
+      },
+    );
+    return legacy;
+  }
+
+  const block = renderRegistryBlock({
+    site_name: site.site_name,
+    prefix: site.prefix,
+    ds: registry.ds,
+    components: registry.components,
+    templates: registry.templates,
+  });
+
+  return {
+    design_system_html_full_file: block,
+    design_system_version: String(registry.ds.version),
+    design_system_updated: registry.ds.activated_at ?? registry.ds.created_at,
+  };
 }


### PR DESCRIPTION
## Summary

Rewrites `buildSystemPromptForSite()` to inject a structured component + template + tokens registry instead of the legacy `design_system_html` blob, gated behind `FEATURE_DESIGN_SYSTEM_V2`. Per the brief §3.7 and the seven plan answers in thread.

## New path (flag on, site has active DS)

- `loadActiveRegistry(site_id)` — single DB-touching helper. Runs `getActiveDesignSystem` then `listComponents` + `listTemplates` in parallel. Returns `null` on no-active-DS or any read failure (logged + swallowed).
- `renderRegistryBlock()` — pure render, compact Markdown:
  - site / version / scope prefix headers
  - components sorted by category then name; required-fields extracted from `content_schema.required`
  - templates sorted by page_type then name; composition rendered as arrow chain
  - full `tokens.css` embedded
  - hard-constraints section (use only listed components, wrap in `<div class="{prefix}-scope">`, never invent classes)
- Component HTML templates are **deliberately not inlined** — context-budget constraint. M3 fetches on demand via `getComponent(id)`.

## Fallback behaviour

| Condition | Path |
|-----------|------|
| Flag off | Legacy empty-blob path, bit-for-bit unchanged |
| Flag on + no `id` on `SiteIdentity` | Legacy (for hard-coded fallbacks) |
| Flag on + no active DS or read failure | Legacy + **structured `console.error`** so operators notice forgotten activations in production |
| Flag on + active DS | New registry block |

The `console.error` on the no-active-DS branch matches the exact shape we agreed in Q5:
```ts
console.error(
  "[system-prompt] FEATURE_DESIGN_SYSTEM_V2=on but no active design_system for site",
  { site_id: site.id, site_name: site.site_name, fallback: "legacy_html_blob" },
);
```

## Signature changes

- `buildSystemPromptForSite()` is now **async**. Both call sites in `app/api/chat/route.ts` updated.
- Module-level `LEADSOURCE_FALLBACK_PROMPT` → `getLeadsourceFallbackPrompt()` async memoised getter. Per-Vercel-instance memoisation is intentional — see lifecycle comment in the file. Explicit invalidation lands with M6.
- `SiteIdentity` gains optional `id` with JSDoc explaining the path selection logic.

## Deliberate deferrals (flagged in code, per Q4 + Q2)

- **No caching around `loadActiveRegistry`.** `TODO(M3)` comment in `lib/system-prompt.ts` records the proposed site-keyed LRU with 5-min TTL so the batch generator picks it up without re-reasoning.
- **`sites.design_system_version` (text) stays as-is.** Per Q2 it becomes dead data after this rolls out; flagged for deprecation cleanup in a later milestone.

## Tests

`lib/__tests__/system-prompt.test.ts`:

- **Pure** (no DB): `renderComponentSummary` (variant handling, first-line-of-usage_notes, optional fields), `renderTemplateSummary` (default flag, empty composition), `renderRegistryBlock` (sort order, empty case), `isDesignSystemV2Enabled` (flag parsing).
- **Integration**: `loadActiveRegistry` null + populated; `buildSystemPromptForSite` across flag-off / no-id / flag-on-with-DS / flag-on-without-DS paths, asserting both prompt content and the `console.error` contract.

## Files changed

```
.env.local.example                   # +FEATURE_DESIGN_SYSTEM_V2 with doc comment
app/api/chat/route.ts                # two call sites awaited; memoised async getter
lib/system-prompt.ts                 # async, flag branch, loadActiveRegistry
lib/design-system-prompt.ts          # new — pure render helpers
lib/__tests__/system-prompt.test.ts  # new — unit + integration
```

No changes to `docs/SYSTEM_PROMPT_v1.md` — the existing `{{design_system_html_full_file}}` placeholder is what the new registry block substitutes into (Q3).

## Verification performed

- `tsc --noEmit` clean.
- `grep -rn "buildSystemPromptForSite("` — no stale sync callers.
- Vitest suite **not** run here — sandbox lacks a Docker daemon (see README note from M1b). Run `supabase start && npm test` locally before rollout.

## Rollout sketch

1. Merge this PR. `FEATURE_DESIGN_SYSTEM_V2` unset → legacy path for everyone; zero behavioural change.
2. Run `npx tsx scripts/seed-leadsource.ts --site-id <leadsource_uuid>` from the M1c Phase 2 seed.
3. `SELECT activate_design_system('<ds_id>'::uuid, 1);` to flip the draft to active.
4. Set `FEATURE_DESIGN_SYSTEM_V2=true` in the LeadSource Vercel env.
5. First chat request after redeploy uses the new path. Monitor for the `[system-prompt] FEATURE_DESIGN_SYSTEM_V2=on but no active design_system for site` error log — it should not appear.

## Test plan

- [ ] Run `npm test` locally — all four integration cases pass
- [ ] Smoke-check a chat request with the flag off → prompt identical to pre-M1d output
- [ ] Seed + activate the LeadSource DS locally, flip the flag → prompt contains all 12 component summaries and the tokens block
- [ ] Spot-check a chat without an `activeSiteId` → fallback prompt loads once per instance (no crash, no flag-on warning since fallback has no `id`)

Do not merge until local verification is green.

https://claude.ai/code/session_01PTCJrskyCmW3t9NvLXM7rT