### PR TITLE
M1e-1: API routes + shared admin layout + scope-prefix validator

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+// Shared shell for every page under /admin.
+//
+// Matches the h-12 border-b header + max-w-5xl p-6 container pattern that
+// /admin/sites/page.tsx pioneered. Introduced as part of M1e-1 because the
+// admin surface area is about to quadruple (design-system versions,
+// components, templates, preview) and duplicating the header in every page
+// was headed toward drift.
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="flex h-12 flex-none items-center justify-between border-b px-4">
+        <div className="flex items-center gap-3">
+          <Link href="/admin/sites" className="text-sm font-semibold">
+            Opollo Site Builder
+          </Link>
+          <span className="text-xs text-muted-foreground">· Admin</span>
+        </div>
+        <Link
+          href="/"
+          className="text-xs text-muted-foreground hover:text-foreground"
+        >
+          ← Back to builder
+        </Link>
+      </header>
+      <main className="mx-auto max-w-5xl p-6">{children}</main>
+    </div>
+  );
+}

--- a/app/admin/sites/page.tsx
+++ b/app/admin/sites/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 
 import { AddSiteModal } from "@/components/AddSiteModal";
@@ -48,53 +47,38 @@ export default function ManageSitesPage() {
   }, [load]);
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <header className="flex h-12 flex-none items-center justify-between border-b px-4">
-        <div className="flex items-center gap-3">
-          <span className="text-sm font-semibold">Opollo Site Builder</span>
-          <span className="text-xs text-muted-foreground">· Admin</span>
+    <>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Manage sites</h1>
+          <p className="text-sm text-muted-foreground">
+            WordPress sites connected to this builder.
+          </p>
         </div>
-        <Link
-          href="/"
-          className="text-xs text-muted-foreground hover:text-foreground"
-        >
-          ← Back to builder
-        </Link>
-      </header>
+        <Button onClick={() => setModalOpen(true)}>Add new site</Button>
+      </div>
 
-      <main className="mx-auto max-w-5xl p-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-xl font-semibold">Manage sites</h1>
-            <p className="text-sm text-muted-foreground">
-              WordPress sites connected to this builder.
-            </p>
+      <div className="mt-6">
+        {state.status === "loading" && (
+          <div className="rounded-md border p-8 text-center">
+            <p className="text-sm text-muted-foreground">Loading sites…</p>
           </div>
-          <Button onClick={() => setModalOpen(true)}>Add new site</Button>
-        </div>
+        )}
 
-        <div className="mt-6">
-          {state.status === "loading" && (
-            <div className="rounded-md border p-8 text-center">
-              <p className="text-sm text-muted-foreground">Loading sites…</p>
-            </div>
-          )}
+        {state.status === "error" && (
+          <div
+            className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+            role="alert"
+          >
+            <span>{state.message}</span>
+            <Button variant="outline" size="sm" onClick={() => void load()}>
+              Retry
+            </Button>
+          </div>
+        )}
 
-          {state.status === "error" && (
-            <div
-              className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-              role="alert"
-            >
-              <span>{state.message}</span>
-              <Button variant="outline" size="sm" onClick={() => void load()}>
-                Retry
-              </Button>
-            </div>
-          )}
-
-          {state.status === "ready" && <SitesTable sites={state.sites} />}
-        </div>
-      </main>
+        {state.status === "ready" && <SitesTable sites={state.sites} />}
+      </div>
 
       <AddSiteModal
         open={modalOpen}
@@ -103,6 +87,6 @@ export default function ManageSitesPage() {
           void load();
         }}
       />
-    </div>
+    </>
   );
 }

--- a/app/api/design-systems/[id]/activate/route.ts
+++ b/app/api/design-systems/[id]/activate/route.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { activateDesignSystem } from "@/lib/design-systems";
+import {
+  parseBodyWith,
+  readJsonBody,
+  respond,
+  validateUuidParam,
+} from "@/lib/http";
+
+export const runtime = "nodejs";
+
+const BodySchema = z.object({
+  expected_version_lock: z.number().int().positive(),
+});
+
+// POST /api/design-systems/[id]/activate — promotes the target DS and
+// archives any currently-active DS for the same site, atomically, via the
+// activate_design_system RPC from 0003_m1b_rpcs.sql.
+export async function POST(req: Request, ctx: { params: { id: string } }) {
+  const param = validateUuidParam(ctx.params.id, "id");
+  if (!param.ok) return param.response;
+
+  const body = parseBodyWith(BodySchema, await readJsonBody(req));
+  if (!body.ok) return body.response;
+
+  return respond(
+    await activateDesignSystem(param.value, body.data.expected_version_lock),
+  );
+}

--- a/app/api/design-systems/[id]/archive/route.ts
+++ b/app/api/design-systems/[id]/archive/route.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { archiveDesignSystem } from "@/lib/design-systems";
+import {
+  parseBodyWith,
+  readJsonBody,
+  respond,
+  validateUuidParam,
+} from "@/lib/http";
+
+export const runtime = "nodejs";
+
+const BodySchema = z.object({
+  expected_version_lock: z.number().int().positive(),
+});
+
+// POST /api/design-systems/[id]/archive — soft-archive the design system.
+// When the target was the site's active DS, the success payload contains
+// warnings[] noting the site now has no active design system (per §M1b Q6).
+export async function POST(req: Request, ctx: { params: { id: string } }) {
+  const param = validateUuidParam(ctx.params.id, "id");
+  if (!param.ok) return param.response;
+
+  const body = parseBodyWith(BodySchema, await readJsonBody(req));
+  if (!body.ok) return body.response;
+
+  return respond(
+    await archiveDesignSystem(param.value, body.data.expected_version_lock),
+  );
+}

--- a/app/api/design-systems/[id]/components/[cid]/route.ts
+++ b/app/api/design-systems/[id]/components/[cid]/route.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import {
+  UpdateDesignComponentSchema,
+  deleteComponent,
+  updateComponent,
+} from "@/lib/components";
+import { getDesignSystemSitePrefix } from "@/lib/design-systems";
+import {
+  parseBodyWith,
+  readJsonBody,
+  respond,
+  validationError,
+  validateUuidParam,
+} from "@/lib/http";
+import { validateScopedCss } from "@/lib/scope-prefix";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: { id: string; cid: string } };
+
+// PATCH /api/design-systems/[id]/components/[cid]
+//
+// The body merges the updatable fields from UpdateDesignComponentSchema with
+// the optimistic-lock token. If the patch touches CSS, we revalidate the
+// scope prefix against the parent design system's site.
+const PatchBodySchema = UpdateDesignComponentSchema.and(
+  z.object({
+    expected_version_lock: z.number().int().positive(),
+  }),
+);
+
+export async function PATCH(req: Request, ctx: RouteContext) {
+  const dsParam = validateUuidParam(ctx.params.id, "id");
+  if (!dsParam.ok) return dsParam.response;
+  const cidParam = validateUuidParam(ctx.params.cid, "cid");
+  if (!cidParam.ok) return cidParam.response;
+
+  const parsed = parseBodyWith(PatchBodySchema, await readJsonBody(req));
+  if (!parsed.ok) return parsed.response;
+
+  const { expected_version_lock, ...patch } = parsed.data;
+
+  if (patch.css !== undefined) {
+    const prefixRes = await getDesignSystemSitePrefix(dsParam.value);
+    if (!prefixRes.ok) return respond(prefixRes);
+    const check = validateScopedCss(patch.css, prefixRes.data);
+    if (!check.valid) {
+      return validationError(
+        `CSS contains class selector(s) not prefixed with "${prefixRes.data}-".`,
+        { prefix: prefixRes.data, violations: check.violations },
+      );
+    }
+  }
+
+  return respond(
+    await updateComponent(cidParam.value, patch, expected_version_lock),
+  );
+}
+
+// DELETE /api/design-systems/[id]/components/[cid]?expected_version_lock=N
+//
+// expected_version_lock rides as a query param per the M1e plan (DELETE
+// with a body is unreliable across proxies).
+export async function DELETE(req: Request, ctx: RouteContext) {
+  const dsParam = validateUuidParam(ctx.params.id, "id");
+  if (!dsParam.ok) return dsParam.response;
+  const cidParam = validateUuidParam(ctx.params.cid, "cid");
+  if (!cidParam.ok) return cidParam.response;
+
+  const url = new URL(req.url);
+  const raw = url.searchParams.get("expected_version_lock");
+  const parsed = z.coerce.number().int().positive().safeParse(raw);
+  if (!parsed.success) {
+    return validationError(
+      `Query param "expected_version_lock" must be a positive integer.`,
+      { received: raw },
+    );
+  }
+
+  return respond(await deleteComponent(cidParam.value, parsed.data));
+}

--- a/app/api/design-systems/[id]/components/route.ts
+++ b/app/api/design-systems/[id]/components/route.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import {
+  CreateDesignComponentSchema,
+  createComponent,
+  listComponents,
+} from "@/lib/components";
+import { getDesignSystemSitePrefix } from "@/lib/design-systems";
+import {
+  parseBodyWith,
+  readJsonBody,
+  respond,
+  validationError,
+  validateUuidParam,
+} from "@/lib/http";
+import { validateScopedCss } from "@/lib/scope-prefix";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: { id: string } };
+
+// GET /api/design-systems/[id]/components — list components for a design system.
+export async function GET(_req: Request, ctx: RouteContext) {
+  const param = validateUuidParam(ctx.params.id, "id");
+  if (!param.ok) return param.response;
+  return respond(await listComponents(param.value));
+}
+
+// POST /api/design-systems/[id]/components — add a component.
+//
+// The body omits design_system_id (taken from the path) and may force the
+// parent DS from the caller's input. Layer-2 CSS validation runs before the
+// lib-level Zod pass, so prefix violations surface as a VALIDATION_FAILED
+// envelope with the offending selectors listed.
+const CreateBodySchema = CreateDesignComponentSchema.omit({
+  design_system_id: true,
+});
+
+export async function POST(req: Request, ctx: RouteContext) {
+  const param = validateUuidParam(ctx.params.id, "id");
+  if (!param.ok) return param.response;
+
+  const parsed = parseBodyWith(CreateBodySchema, await readJsonBody(req));
+  if (!parsed.ok) return parsed.response;
+
+  const prefixRes = await getDesignSystemSitePrefix(param.value);
+  if (!prefixRes.ok) return respond(prefixRes);
+
+  const cssCheck = validateScopedCss(parsed.data.css, prefixRes.data);
+  if (!cssCheck.valid) {
+    return validationError(
+      `CSS contains class selector(s) not prefixed with "${prefixRes.data}-".`,
+      { prefix: prefixRes.data, violations: cssCheck.violations },
+    );
+  }
+
+  return respond(
+    await createComponent({
+      design_system_id: param.value,
+      ...parsed.data,
+    }),
+  );
+}

--- a/app/api/design-systems/[id]/preview/route.ts
+++ b/app/api/design-systems/[id]/preview/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { getDesignSystem } from "@/lib/design-systems";
+import { listComponents } from "@/lib/components";
+import { listTemplates } from "@/lib/templates";
+import { respond, validateUuidParam } from "@/lib/http";
+
+export const runtime = "nodejs";
+
+// GET /api/design-systems/[id]/preview
+//
+// Bundles everything the preview gallery UI (M1e-4) needs in one round-trip:
+// the DS row itself plus all components and templates. Any design system —
+// draft, active, or archived — is previewable.
+export async function GET(_req: Request, ctx: { params: { id: string } }) {
+  const param = validateUuidParam(ctx.params.id, "id");
+  if (!param.ok) return param.response;
+
+  const dsRes = await getDesignSystem(param.value);
+  if (!dsRes.ok) return respond(dsRes);
+
+  const [compRes, tmplRes] = await Promise.all([
+    listComponents(param.value),
+    listTemplates(param.value),
+  ]);
+
+  if (!compRes.ok) return respond(compRes);
+  if (!tmplRes.ok) return respond(tmplRes);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        design_system: dsRes.data,
+        components: compRes.data,
+        templates: tmplRes.data,
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/design-systems/[id]/templates/[tid]/route.ts
+++ b/app/api/design-systems/[id]/templates/[tid]/route.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import {
+  UpdateDesignTemplateSchema,
+  deleteTemplate,
+  updateTemplate,
+} from "@/lib/templates";
+import {
+  parseBodyWith,
+  readJsonBody,
+  respond,
+  validationError,
+  validateUuidParam,
+} from "@/lib/http";
+import { validateCompositionRefs } from "../_helpers";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: { id: string; tid: string } };
+
+const PatchBodySchema = UpdateDesignTemplateSchema.and(
+  z.object({
+    expected_version_lock: z.number().int().positive(),
+  }),
+);
+
+// PATCH /api/design-systems/[id]/templates/[tid]
+//
+// If the patch rewrites composition, we re-run the reference check against
+// the current set of components in the parent DS. Renaming a component
+// elsewhere after a template already referenced it could otherwise leave a
+// dangling ref; this route refuses such writes at the admin layer.
+export async function PATCH(req: Request, ctx: RouteContext) {
+  const dsParam = validateUuidParam(ctx.params.id, "id");
+  if (!dsParam.ok) return dsParam.response;
+  const tidParam = validateUuidParam(ctx.params.tid, "tid");
+  if (!tidParam.ok) return tidParam.response;
+
+  const parsed = parseBodyWith(PatchBodySchema, await readJsonBody(req));
+  if (!parsed.ok) return parsed.response;
+
+  const { expected_version_lock, ...patch } = parsed.data;
+
+  if (patch.composition !== undefined) {
+    const refCheck = await validateCompositionRefs(
+      dsParam.value,
+      patch.composition.map((c) => c.component),
+    );
+    if (refCheck !== null) return refCheck;
+  }
+
+  return respond(
+    await updateTemplate(tidParam.value, patch, expected_version_lock),
+  );
+}
+
+// DELETE /api/design-systems/[id]/templates/[tid]?expected_version_lock=N
+export async function DELETE(req: Request, ctx: RouteContext) {
+  const dsParam = validateUuidParam(ctx.params.id, "id");
+  if (!dsParam.ok) return dsParam.response;
+  const tidParam = validateUuidParam(ctx.params.tid, "tid");
+  if (!tidParam.ok) return tidParam.response;
+
+  const url = new URL(req.url);
+  const raw = url.searchParams.get("expected_version_lock");
+  const parsed = z.coerce.number().int().positive().safeParse(raw);
+  if (!parsed.success) {
+    return validationError(
+      `Query param "expected_version_lock" must be a positive integer.`,
+      { received: raw },
+    );
+  }
+
+  return respond(await deleteTemplate(tidParam.value, parsed.data));
+}

--- a/app/api/design-systems/[id]/templates/_helpers.ts
+++ b/app/api/design-systems/[id]/templates/_helpers.ts
@@ -1,0 +1,27 @@
+import type { NextResponse } from "next/server";
+import { listComponents } from "@/lib/components";
+import { respond, validationError } from "@/lib/http";
+
+// Shared pre-flight check for the POST + PATCH template routes. Mirrors the
+// validation the seed script runs (scripts/seed-leadsource.ts): every
+// composition[].component must exist in the parent design system's
+// components, or we refuse the write.
+export async function validateCompositionRefs(
+  ds_id: string,
+  refs: string[],
+): Promise<NextResponse | null> {
+  const componentsRes = await listComponents(ds_id);
+  if (!componentsRes.ok) return respond(componentsRes);
+  const existing = new Set(componentsRes.data.map((c) => c.name));
+  const unknown = refs.filter((r) => !existing.has(r));
+  if (unknown.length > 0) {
+    return validationError(
+      `Template composition references component(s) that do not exist in this design system.`,
+      {
+        design_system_id: ds_id,
+        unknown_components: unknown,
+      },
+    );
+  }
+  return null;
+}

--- a/app/api/design-systems/[id]/templates/route.ts
+++ b/app/api/design-systems/[id]/templates/route.ts
@@ -1,0 +1,54 @@
+import {
+  CreateDesignTemplateSchema,
+  createTemplate,
+  listTemplates,
+} from "@/lib/templates";
+import {
+  parseBodyWith,
+  readJsonBody,
+  respond,
+  validateUuidParam,
+} from "@/lib/http";
+import { validateCompositionRefs } from "./_helpers";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: { id: string } };
+
+// GET /api/design-systems/[id]/templates
+export async function GET(_req: Request, ctx: RouteContext) {
+  const param = validateUuidParam(ctx.params.id, "id");
+  if (!param.ok) return param.response;
+  return respond(await listTemplates(param.value));
+}
+
+// POST /api/design-systems/[id]/templates — create a template.
+//
+// Composition-reference pre-flight: every composition[].component must
+// exist in the parent design system's components. Same invariant the seed
+// script enforces (scripts/seed-leadsource.ts), re-checked here because the
+// admin UI is the other way new templates can be introduced.
+const CreateBodySchema = CreateDesignTemplateSchema.omit({
+  design_system_id: true,
+});
+
+export async function POST(req: Request, ctx: RouteContext) {
+  const param = validateUuidParam(ctx.params.id, "id");
+  if (!param.ok) return param.response;
+
+  const parsed = parseBodyWith(CreateBodySchema, await readJsonBody(req));
+  if (!parsed.ok) return parsed.response;
+
+  const refCheck = await validateCompositionRefs(
+    param.value,
+    parsed.data.composition.map((c) => c.component),
+  );
+  if (refCheck !== null) return refCheck;
+
+  return respond(
+    await createTemplate({
+      design_system_id: param.value,
+      ...parsed.data,
+    }),
+  );
+}

--- a/app/api/sites/[id]/design-systems/route.ts
+++ b/app/api/sites/[id]/design-systems/route.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import {
+  createDesignSystem,
+  listDesignSystems,
+} from "@/lib/design-systems";
+import {
+  parseBodyWith,
+  readJsonBody,
+  respond,
+  validateUuidParam,
+} from "@/lib/http";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: { id: string } };
+
+// GET /api/sites/[id]/design-systems — list versions for a site.
+export async function GET(_req: Request, ctx: RouteContext) {
+  const param = validateUuidParam(ctx.params.id, "id");
+  if (!param.ok) return param.response;
+  return respond(await listDesignSystems(param.value));
+}
+
+// POST /api/sites/[id]/design-systems — create a new DRAFT.
+//
+// `version` is optional in the body. When omitted, the route picks the
+// next integer above the current max version for this site. Operators can
+// override if they need a specific version number.
+const CreateBodySchema = z.object({
+  tokens_css: z.string(),
+  base_styles: z.string(),
+  notes: z.string().nullable().optional(),
+  created_by: z.string().uuid().nullable().optional(),
+  version: z.number().int().positive().optional(),
+});
+
+export async function POST(req: Request, ctx: RouteContext) {
+  const param = validateUuidParam(ctx.params.id, "id");
+  if (!param.ok) return param.response;
+
+  const parsed = parseBodyWith(CreateBodySchema, await readJsonBody(req));
+  if (!parsed.ok) return parsed.response;
+
+  let version = parsed.data.version;
+  if (version === undefined) {
+    const listRes = await listDesignSystems(param.value);
+    if (!listRes.ok) return respond(listRes);
+    const max = listRes.data.reduce((m, d) => Math.max(m, d.version), 0);
+    version = max + 1;
+  }
+
+  const result = await createDesignSystem({
+    site_id: param.value,
+    version,
+    tokens_css: parsed.data.tokens_css,
+    base_styles: parsed.data.base_styles,
+    notes: parsed.data.notes ?? null,
+    created_by: parsed.data.created_by ?? null,
+  });
+  return respond(result);
+}

--- a/lib/__tests__/api-components.test.ts
+++ b/lib/__tests__/api-components.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from "vitest";
+import {
+  GET as listComponentsRoute,
+  POST as createComponentRoute,
+} from "@/app/api/design-systems/[id]/components/route";
+import {
+  DELETE as deleteComponentRoute,
+  PATCH as patchComponentRoute,
+} from "@/app/api/design-systems/[id]/components/[cid]/route";
+import { createDesignSystem } from "@/lib/design-systems";
+import { createComponent } from "@/lib/components";
+import { minimalComponentContentSchema, seedSite } from "./_helpers";
+
+async function seedSiteWithDS() {
+  const site = await seedSite();
+  const ds = await createDesignSystem({
+    site_id: site.id,
+    version: 1,
+    tokens_css: "",
+    base_styles: "",
+  });
+  if (!ds.ok) throw new Error("seed failed");
+  return { site, ds: ds.data };
+}
+
+function jsonReq(url: string, body?: unknown, method = "POST"): Request {
+  return new Request(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe("GET /api/design-systems/[id]/components", () => {
+  it("lists components for the DS", async () => {
+    const { ds } = await seedSiteWithDS();
+    await createComponent({
+      design_system_id: ds.id,
+      name: "hero-centered",
+      variant: null,
+      category: "hero",
+      html_template: "<section>{{headline}}</section>",
+      css: ".ls-hero {}",
+      content_schema: minimalComponentContentSchema(),
+    });
+
+    const res = await listComponentsRoute(
+      new Request(`http://t/api/design-systems/${ds.id}/components`),
+      { params: { id: ds.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].name).toBe("hero-centered");
+  });
+
+  it("400s on a non-UUID DS id", async () => {
+    const res = await listComponentsRoute(
+      new Request(`http://t/api/design-systems/nope/components`),
+      { params: { id: "nope" } },
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/design-systems/[id]/components", () => {
+  it("creates a component and passes the scope-prefix check", async () => {
+    const { ds } = await seedSiteWithDS();
+    const res = await createComponentRoute(
+      jsonReq(`http://t/api/design-systems/${ds.id}/components`, {
+        name: "hero-centered",
+        variant: "default",
+        category: "hero",
+        html_template: "<section>{{headline}}</section>",
+        css: ".ls-hero { padding: 2rem; }",
+        content_schema: minimalComponentContentSchema(),
+      }),
+      { params: { id: ds.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.name).toBe("hero-centered");
+  });
+
+  it("400s when CSS contains an unprefixed class selector", async () => {
+    const { ds } = await seedSiteWithDS();
+    const res = await createComponentRoute(
+      jsonReq(`http://t/api/design-systems/${ds.id}/components`, {
+        name: "hero-centered",
+        variant: null,
+        category: "hero",
+        html_template: "<section>{{headline}}</section>",
+        css: ".hero { padding: 2rem; }",
+        content_schema: minimalComponentContentSchema(),
+      }),
+      { params: { id: ds.id } },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+    expect(body.error.details.prefix).toMatch(/^[a-z0-9]{2,4}$/);
+    expect(body.error.details.violations[0].selector).toBe(".hero");
+  });
+});
+
+describe("PATCH /api/design-systems/[id]/components/[cid]", () => {
+  it("updates a component and bumps version_lock", async () => {
+    const { ds } = await seedSiteWithDS();
+    const created = await createComponent({
+      design_system_id: ds.id,
+      name: "hero-centered",
+      variant: null,
+      category: "hero",
+      html_template: "<section>{{headline}}</section>",
+      css: ".ls-hero {}",
+      content_schema: minimalComponentContentSchema(),
+    });
+    if (!created.ok) throw new Error("seed failed");
+
+    const res = await patchComponentRoute(
+      jsonReq(
+        `http://t/api/design-systems/${ds.id}/components/${created.data.id}`,
+        {
+          usage_notes: "Updated.",
+          expected_version_lock: created.data.version_lock,
+        },
+        "PATCH",
+      ),
+      { params: { id: ds.id, cid: created.data.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.usage_notes).toBe("Updated.");
+    expect(body.data.version_lock).toBe(created.data.version_lock + 1);
+  });
+
+  it("409s on stale expected_version_lock", async () => {
+    const { ds } = await seedSiteWithDS();
+    const created = await createComponent({
+      design_system_id: ds.id,
+      name: "hero-centered",
+      variant: null,
+      category: "hero",
+      html_template: "<section>{{headline}}</section>",
+      css: ".ls-hero {}",
+      content_schema: minimalComponentContentSchema(),
+    });
+    if (!created.ok) throw new Error("seed failed");
+
+    const res = await patchComponentRoute(
+      jsonReq(
+        `http://t/api/design-systems/${ds.id}/components/${created.data.id}`,
+        { usage_notes: "Stale.", expected_version_lock: 999 },
+        "PATCH",
+      ),
+      { params: { id: ds.id, cid: created.data.id } },
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe("VERSION_CONFLICT");
+  });
+});
+
+describe("DELETE /api/design-systems/[id]/components/[cid]", () => {
+  it("deletes when the query-param expected_version_lock matches", async () => {
+    const { ds } = await seedSiteWithDS();
+    const created = await createComponent({
+      design_system_id: ds.id,
+      name: "hero-centered",
+      variant: null,
+      category: "hero",
+      html_template: "<section>{{headline}}</section>",
+      css: ".ls-hero {}",
+      content_schema: minimalComponentContentSchema(),
+    });
+    if (!created.ok) throw new Error("seed failed");
+
+    const res = await deleteComponentRoute(
+      new Request(
+        `http://t/api/design-systems/${ds.id}/components/${created.data.id}?expected_version_lock=${created.data.version_lock}`,
+        { method: "DELETE" },
+      ),
+      { params: { id: ds.id, cid: created.data.id } },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("400s when expected_version_lock query param is missing", async () => {
+    const { ds } = await seedSiteWithDS();
+    const cid = "00000000-0000-0000-0000-000000000001";
+    const res = await deleteComponentRoute(
+      new Request(
+        `http://t/api/design-systems/${ds.id}/components/${cid}`,
+        { method: "DELETE" },
+      ),
+      { params: { id: ds.id, cid } },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+});

--- a/lib/__tests__/api-design-systems.test.ts
+++ b/lib/__tests__/api-design-systems.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import {
+  GET as listDS,
+  POST as createDS,
+} from "@/app/api/sites/[id]/design-systems/route";
+import { POST as activate } from "@/app/api/design-systems/[id]/activate/route";
+import { POST as archive } from "@/app/api/design-systems/[id]/archive/route";
+import { GET as preview } from "@/app/api/design-systems/[id]/preview/route";
+import { createDesignSystem } from "@/lib/design-systems";
+import { createComponent } from "@/lib/components";
+import { createTemplate } from "@/lib/templates";
+import { minimalComponentContentSchema, minimalComposition, seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// Smoke tests for the design-system-scoped routes. Per the M1e plan these
+// are thin wrappers around the lib layer, so we only verify:
+//   - happy path renders the expected envelope at HTTP 200
+//   - one representative error path surfaces the right code at the right
+//     status
+// Deep lib coverage already lives in design-systems.test.ts / components.test.ts.
+// ---------------------------------------------------------------------------
+
+type RouteBody = Record<string, unknown> | undefined;
+
+function jsonReq(url: string, body?: RouteBody, method = "POST"): Request {
+  return new Request(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe("GET /api/sites/[id]/design-systems", () => {
+  it("lists empty when the site has no DS", async () => {
+    const site = await seedSite();
+    const res = await listDS(
+      new Request(`http://t/api/sites/${site.id}/design-systems`),
+      { params: { id: site.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toEqual([]);
+  });
+
+  it("400s on a non-UUID site id", async () => {
+    const res = await listDS(
+      new Request(`http://t/api/sites/nope/design-systems`),
+      { params: { id: "nope" } },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+});
+
+describe("POST /api/sites/[id]/design-systems", () => {
+  it("creates a draft with auto-incremented version", async () => {
+    const site = await seedSite();
+    await createDesignSystem({
+      site_id: site.id,
+      version: 1,
+      tokens_css: "",
+      base_styles: "",
+    });
+
+    const res = await createDS(
+      jsonReq(`http://t/api/sites/${site.id}/design-systems`, {
+        tokens_css: ".ls-scope { --ls-blue: #185FA5; }",
+        base_styles: "",
+      }),
+      { params: { id: site.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.version).toBe(2);
+    expect(body.data.status).toBe("draft");
+  });
+
+  it("400s on malformed body", async () => {
+    const site = await seedSite();
+    const res = await createDS(
+      jsonReq(`http://t/api/sites/${site.id}/design-systems`, {
+        tokens_css: 123,
+      } as unknown as RouteBody),
+      { params: { id: site.id } },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+});
+
+describe("POST /api/design-systems/[id]/activate", () => {
+  it("activates a draft", async () => {
+    const site = await seedSite();
+    const ds = await createDesignSystem({
+      site_id: site.id,
+      version: 1,
+      tokens_css: "",
+      base_styles: "",
+    });
+    if (!ds.ok) throw new Error("seed failed");
+
+    const res = await activate(
+      jsonReq(`http://t/api/design-systems/${ds.data.id}/activate`, {
+        expected_version_lock: ds.data.version_lock,
+      }),
+      { params: { id: ds.data.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.status).toBe("active");
+  });
+
+  it("409s on stale expected_version_lock", async () => {
+    const site = await seedSite();
+    const ds = await createDesignSystem({
+      site_id: site.id,
+      version: 1,
+      tokens_css: "",
+      base_styles: "",
+    });
+    if (!ds.ok) throw new Error("seed failed");
+
+    const res = await activate(
+      jsonReq(`http://t/api/design-systems/${ds.data.id}/activate`, {
+        expected_version_lock: 999,
+      }),
+      { params: { id: ds.data.id } },
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe("VERSION_CONFLICT");
+  });
+});
+
+describe("POST /api/design-systems/[id]/archive", () => {
+  it("archives a draft with no warnings", async () => {
+    const site = await seedSite();
+    const ds = await createDesignSystem({
+      site_id: site.id,
+      version: 1,
+      tokens_css: "",
+      base_styles: "",
+    });
+    if (!ds.ok) throw new Error("seed failed");
+
+    const res = await archive(
+      jsonReq(`http://t/api/design-systems/${ds.data.id}/archive`, {
+        expected_version_lock: ds.data.version_lock,
+      }),
+      { params: { id: ds.data.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.design_system.status).toBe("archived");
+    expect(body.data.warnings).toEqual([]);
+  });
+
+  it("404s on unknown id", async () => {
+    const missing = "00000000-0000-0000-0000-000000000000";
+    const res = await archive(
+      jsonReq(`http://t/api/design-systems/${missing}/archive`, {
+        expected_version_lock: 1,
+      }),
+      { params: { id: missing } },
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("GET /api/design-systems/[id]/preview", () => {
+  it("bundles ds + components + templates", async () => {
+    const site = await seedSite();
+    const ds = await createDesignSystem({
+      site_id: site.id,
+      version: 1,
+      tokens_css: "",
+      base_styles: "",
+    });
+    if (!ds.ok) throw new Error("seed failed");
+    await createComponent({
+      design_system_id: ds.data.id,
+      name: "hero-centered",
+      variant: "default",
+      category: "hero",
+      html_template: "<section>{{headline}}</section>",
+      css: ".ls-hero {}",
+      content_schema: minimalComponentContentSchema(),
+    });
+    await createTemplate({
+      design_system_id: ds.data.id,
+      page_type: "homepage",
+      name: "homepage-default",
+      composition: minimalComposition(),
+      required_fields: { hero: ["headline"] },
+      is_default: true,
+    });
+
+    const res = await preview(
+      new Request(`http://t/api/design-systems/${ds.data.id}/preview`),
+      { params: { id: ds.data.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.design_system.id).toBe(ds.data.id);
+    expect(body.data.components).toHaveLength(1);
+    expect(body.data.templates).toHaveLength(1);
+  });
+
+  it("404s on unknown DS", async () => {
+    const missing = "00000000-0000-0000-0000-000000000000";
+    const res = await preview(
+      new Request(`http://t/api/design-systems/${missing}/preview`),
+      { params: { id: missing } },
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/lib/__tests__/api-templates.test.ts
+++ b/lib/__tests__/api-templates.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import {
+  GET as listTemplatesRoute,
+  POST as createTemplateRoute,
+} from "@/app/api/design-systems/[id]/templates/route";
+import {
+  DELETE as deleteTemplateRoute,
+  PATCH as patchTemplateRoute,
+} from "@/app/api/design-systems/[id]/templates/[tid]/route";
+import { createDesignSystem } from "@/lib/design-systems";
+import { createComponent } from "@/lib/components";
+import { createTemplate } from "@/lib/templates";
+import {
+  minimalComponentContentSchema,
+  minimalComposition,
+  seedSite,
+} from "./_helpers";
+
+async function seedSiteWithDSAndComponents() {
+  const site = await seedSite();
+  const ds = await createDesignSystem({
+    site_id: site.id,
+    version: 1,
+    tokens_css: "",
+    base_styles: "",
+  });
+  if (!ds.ok) throw new Error("seed DS failed");
+
+  for (const name of ["hero-centered", "footer-default"]) {
+    const r = await createComponent({
+      design_system_id: ds.data.id,
+      name,
+      variant: null,
+      category: name.split("-")[0],
+      html_template: `<section>${name}</section>`,
+      css: ".ls-x {}",
+      content_schema: minimalComponentContentSchema(),
+    });
+    if (!r.ok) throw new Error(`seed component ${name} failed`);
+  }
+
+  return { site, ds: ds.data };
+}
+
+function jsonReq(url: string, body?: unknown, method = "POST"): Request {
+  return new Request(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe("GET /api/design-systems/[id]/templates", () => {
+  it("lists templates", async () => {
+    const { ds } = await seedSiteWithDSAndComponents();
+    await createTemplate({
+      design_system_id: ds.id,
+      page_type: "homepage",
+      name: "homepage-default",
+      composition: minimalComposition(),
+      required_fields: { hero: ["headline"] },
+      is_default: true,
+    });
+
+    const res = await listTemplatesRoute(
+      new Request(`http://t/api/design-systems/${ds.id}/templates`),
+      { params: { id: ds.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].name).toBe("homepage-default");
+  });
+
+  it("400s on a non-UUID DS id", async () => {
+    const res = await listTemplatesRoute(
+      new Request(`http://t/api/design-systems/nope/templates`),
+      { params: { id: "nope" } },
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/design-systems/[id]/templates", () => {
+  it("creates a template when composition references exist", async () => {
+    const { ds } = await seedSiteWithDSAndComponents();
+    const res = await createTemplateRoute(
+      jsonReq(`http://t/api/design-systems/${ds.id}/templates`, {
+        page_type: "homepage",
+        name: "homepage-default",
+        composition: [
+          { component: "hero-centered", content_source: "brief.hero" },
+          { component: "footer-default", content_source: "site_context.footer" },
+        ],
+        required_fields: { hero: ["headline"] },
+        is_default: true,
+      }),
+      { params: { id: ds.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.name).toBe("homepage-default");
+  });
+
+  it("400s when composition references an unknown component", async () => {
+    const { ds } = await seedSiteWithDSAndComponents();
+    const res = await createTemplateRoute(
+      jsonReq(`http://t/api/design-systems/${ds.id}/templates`, {
+        page_type: "homepage",
+        name: "homepage-default",
+        composition: [
+          { component: "hero-centered", content_source: "brief.hero" },
+          { component: "ghost-component", content_source: "brief.ghost" },
+        ],
+        required_fields: {},
+        is_default: false,
+      }),
+      { params: { id: ds.id } },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+    expect(body.error.details.unknown_components).toEqual(["ghost-component"]);
+  });
+});
+
+describe("PATCH /api/design-systems/[id]/templates/[tid]", () => {
+  it("updates and bumps version_lock", async () => {
+    const { ds } = await seedSiteWithDSAndComponents();
+    const created = await createTemplate({
+      design_system_id: ds.id,
+      page_type: "homepage",
+      name: "homepage-default",
+      composition: minimalComposition(),
+      required_fields: { hero: ["headline"] },
+    });
+    if (!created.ok) throw new Error("seed failed");
+
+    const res = await patchTemplateRoute(
+      jsonReq(
+        `http://t/api/design-systems/${ds.id}/templates/${created.data.id}`,
+        {
+          name: "homepage-renamed",
+          expected_version_lock: created.data.version_lock,
+        },
+        "PATCH",
+      ),
+      { params: { id: ds.id, tid: created.data.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.name).toBe("homepage-renamed");
+    expect(body.data.version_lock).toBe(created.data.version_lock + 1);
+  });
+
+  it("409s on stale expected_version_lock", async () => {
+    const { ds } = await seedSiteWithDSAndComponents();
+    const created = await createTemplate({
+      design_system_id: ds.id,
+      page_type: "homepage",
+      name: "homepage-default",
+      composition: minimalComposition(),
+      required_fields: {},
+    });
+    if (!created.ok) throw new Error("seed failed");
+
+    const res = await patchTemplateRoute(
+      jsonReq(
+        `http://t/api/design-systems/${ds.id}/templates/${created.data.id}`,
+        { name: "stale", expected_version_lock: 999 },
+        "PATCH",
+      ),
+      { params: { id: ds.id, tid: created.data.id } },
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe("VERSION_CONFLICT");
+  });
+});
+
+describe("DELETE /api/design-systems/[id]/templates/[tid]", () => {
+  it("deletes when the query-param expected_version_lock matches", async () => {
+    const { ds } = await seedSiteWithDSAndComponents();
+    const created = await createTemplate({
+      design_system_id: ds.id,
+      page_type: "homepage",
+      name: "homepage-default",
+      composition: minimalComposition(),
+      required_fields: {},
+    });
+    if (!created.ok) throw new Error("seed failed");
+
+    const res = await deleteTemplateRoute(
+      new Request(
+        `http://t/api/design-systems/${ds.id}/templates/${created.data.id}?expected_version_lock=${created.data.version_lock}`,
+        { method: "DELETE" },
+      ),
+      { params: { id: ds.id, tid: created.data.id } },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("400s when expected_version_lock query param is missing", async () => {
+    const { ds } = await seedSiteWithDSAndComponents();
+    const tid = "00000000-0000-0000-0000-000000000002";
+    const res = await deleteTemplateRoute(
+      new Request(`http://t/api/design-systems/${ds.id}/templates/${tid}`, {
+        method: "DELETE",
+      }),
+      { params: { id: ds.id, tid } },
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/lib/__tests__/scope-prefix.test.ts
+++ b/lib/__tests__/scope-prefix.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { validateScopedCss } from "@/lib/scope-prefix";
+
+describe("validateScopedCss", () => {
+  it("passes a single prefixed selector", () => {
+    const r = validateScopedCss(".ls-hero { padding: 2rem; }", "ls");
+    expect(r.valid).toBe(true);
+  });
+
+  it("passes nested prefixed selectors", () => {
+    const css = `
+      .ls-hero .ls-btn { font-weight: 500; }
+      .ls-hero__eyebrow::before { content: ''; }
+    `;
+    expect(validateScopedCss(css, "ls").valid).toBe(true);
+  });
+
+  it("passes element selectors without classes", () => {
+    const css = `
+      .ls-scope h1 { font-size: 88px; }
+      .ls-scope a { color: var(--ls-blue); }
+    `;
+    expect(validateScopedCss(css, "ls").valid).toBe(true);
+  });
+
+  it("rejects an unprefixed class selector", () => {
+    const r = validateScopedCss(".hero { padding: 2rem; }", "ls");
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.violations).toEqual([{ selector: ".hero", line: 1 }]);
+  });
+
+  it("rejects a foreign-prefixed class selector", () => {
+    const r = validateScopedCss(".p6-hero { padding: 2rem; }", "ls");
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.violations[0].selector).toBe(".p6-hero");
+  });
+
+  it("reports line numbers correctly with multiple violations", () => {
+    const css =
+      "\n" +
+      ".ls-hero { padding: 2rem; }\n" +
+      ".nope { color: red; }\n" +
+      "\n" +
+      ".another-nope { color: blue; }\n";
+    const r = validateScopedCss(css, "ls");
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.violations).toEqual([
+      { selector: ".nope", line: 3 },
+      { selector: ".another-nope", line: 5 },
+    ]);
+  });
+
+  it("ignores class-looking fragments inside block comments", () => {
+    const css = `
+      /* .hero-old-name was the legacy class */
+      .ls-hero { padding: 2rem; }
+    `;
+    expect(validateScopedCss(css, "ls").valid).toBe(true);
+  });
+
+  it("ignores class-looking fragments inside url(...) values", () => {
+    const css = `
+      .ls-check::before {
+        background-image: url("data:image/svg+xml,%3Csvg.path/class%3E");
+      }
+    `;
+    expect(validateScopedCss(css, "ls").valid).toBe(true);
+  });
+
+  it("does not treat decimal numbers like 1.4em as class selectors", () => {
+    const css = `.ls-box { line-height: 1.4; padding: 1.4em; }`;
+    expect(validateScopedCss(css, "ls").valid).toBe(true);
+  });
+
+  it("handles multiple selectors on one line with mixed validity", () => {
+    const r = validateScopedCss(".ls-a, .ls-b, .bad { color: red; }", "ls");
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.violations.map((v) => v.selector)).toEqual([".bad"]);
+  });
+
+  it("throws if called with an empty prefix", () => {
+    expect(() => validateScopedCss(".ls-hero {}", "")).toThrow();
+  });
+
+  it("validates the real LeadSource base-styles.css as clean", async () => {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const css = fs.readFileSync(
+      path.join(process.cwd(), "seed/leadsource/base-styles.css"),
+      "utf-8",
+    );
+    const r = validateScopedCss(css, "ls");
+    expect(r.valid).toBe(true);
+  });
+});

--- a/lib/design-systems.ts
+++ b/lib/design-systems.ts
@@ -126,6 +126,40 @@ export async function getActiveDesignSystem(
   });
 }
 
+// Convenience: resolve a design-system id to its site's scope prefix.
+// Needed by the component POST/PATCH routes for Layer-2 CSS validation.
+// Two sequential reads — acceptable at admin-UI write frequency.
+export async function getDesignSystemSitePrefix(
+  ds_id: string,
+): Promise<ApiResponse<string>> {
+  return guardImpl(RESOURCE, async () => {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("design_systems")
+      .select("site_id")
+      .eq("id", ds_id)
+      .maybeSingle();
+
+    if (error) return mapPgError(RESOURCE, error);
+    if (!data) return notFound(RESOURCE, ds_id);
+
+    const siteRes = await supabase
+      .from("sites")
+      .select("prefix")
+      .eq("id", data.site_id)
+      .maybeSingle();
+
+    if (siteRes.error) return mapPgError(RESOURCE, siteRes.error);
+    if (!siteRes.data) return notFound("site", data.site_id as string);
+
+    return {
+      ok: true,
+      data: siteRes.data.prefix as string,
+      timestamp: now(),
+    };
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Writes
 // ---------------------------------------------------------------------------

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from "next/server";
+import type { ZodError, ZodType } from "zod";
+import {
+  errorCodeToStatus,
+  type ApiResponse,
+  type ToolError,
+} from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// Shared HTTP helpers for M1e API routes. Every route is a thin wrapper:
+// parse params + body, call the lib layer, return the ApiResponse at the
+// matching HTTP status. These helpers keep the boilerplate identical across
+// routes so a reader can skim 13 handlers and see the shape immediately.
+// ---------------------------------------------------------------------------
+
+// Known Next.js App Router UUID param shape. Matches validateUuidParam.
+const UUID_RE =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+// Render an ApiResponse as an HTTP response at the conventional status.
+export function respond<T>(result: ApiResponse<T>): NextResponse {
+  const status = result.ok ? 200 : errorCodeToStatus(result.error.code);
+  return NextResponse.json(result, { status });
+}
+
+// Render a standalone validation failure (Zod or hand-authored).
+export function validationError(
+  message: string,
+  details?: Record<string, unknown>,
+): NextResponse {
+  const body: ToolError = {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      details,
+      retryable: false,
+      suggested_action: "Correct the listed fields and retry.",
+    },
+    timestamp: now(),
+  };
+  return NextResponse.json(body, { status: 400 });
+}
+
+// Pull a UUID out of the route params or return a 400. Used by every
+// [id]-style dynamic route.
+export function validateUuidParam(
+  raw: unknown,
+  name: string,
+):
+  | { ok: true; value: string }
+  | { ok: false; response: NextResponse } {
+  if (typeof raw !== "string" || !UUID_RE.test(raw)) {
+    return {
+      ok: false,
+      response: validationError(
+        `Param "${name}" must be a UUID.`,
+        { param: name, received: String(raw) },
+      ),
+    };
+  }
+  return { ok: true, value: raw };
+}
+
+// Safely read the request body as JSON; treat empty bodies as {} so simple
+// POST/DELETE signatures don't have to hand-roll their own try/catch.
+export async function readJsonBody(req: Request): Promise<unknown> {
+  const text = await req.text();
+  if (text.length === 0) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+// Parse + validate with a Zod schema. Returns either the parsed data or a
+// NextResponse with the standard VALIDATION_FAILED envelope.
+export function parseBodyWith<T>(
+  schema: ZodType<T>,
+  body: unknown,
+): { ok: true; data: T } | { ok: false; response: NextResponse } {
+  if (body === undefined) {
+    return {
+      ok: false,
+      response: validationError("Request body must be valid JSON."),
+    };
+  }
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      response: validationError(
+        "Request body failed validation.",
+        { issues: formatZodIssues(parsed.error) },
+      ),
+    };
+  }
+  return { ok: true, data: parsed.data };
+}
+
+function formatZodIssues(err: ZodError): Array<{
+  path: string;
+  code: string;
+  message: string;
+}> {
+  return err.issues.map((i) => ({
+    path: i.path.join("."),
+    code: i.code,
+    message: i.message,
+  }));
+}

--- a/lib/scope-prefix.ts
+++ b/lib/scope-prefix.ts
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------------
+// Layer 2 scope-prefix validator (§3.6 of the M1 brief).
+//
+// Every component's CSS must use class selectors prefixed with the client's
+// scope — e.g. `ls-` for LeadSource. This validator runs at admin-UI input
+// time (component POST/PATCH routes) and rejects inserts that contain any
+// unprefixed class selector, listing the offending selectors with line
+// numbers so operators can fix them.
+//
+// Layer 1 (stylelint build-time) and Layer 3 (generator-runtime class
+// registry check) are M1f. This file is intentionally small and
+// dependency-free — a targeted regex pass is good enough for the M1e-1
+// validator role.
+// ---------------------------------------------------------------------------
+
+export type ScopePrefixViolation = {
+  selector: string;
+  line: number;
+};
+
+export type ScopePrefixValidation =
+  | { valid: true }
+  | { valid: false; violations: ScopePrefixViolation[] };
+
+// A class selector is a literal `.` followed by an identifier:
+//   first char: letter or underscore (we don't support CSS escapes here)
+//   rest:       letters, digits, underscore, hyphen
+const CLASS_SELECTOR_RE = /\.([a-zA-Z_][a-zA-Z0-9_-]*)/g;
+
+// CSS block comments /* ... */ and url(...) values can contain the literal
+// `.classname` shape inside them (e.g. inside data: URLs). Stripping both
+// before regex-matching avoids false positives without needing a real CSS
+// parser.
+const BLOCK_COMMENT_RE = /\/\*[\s\S]*?\*\//g;
+const URL_VALUE_RE = /url\([^)]*\)/g;
+
+/**
+ * Checks that every class selector in `css` starts with `${prefix}-`.
+ *
+ * The check is literal and regex-based — it will not catch advanced CSS
+ * like `@supports` blocks with nested selectors, escape sequences in class
+ * names, or class-like fragments inside non-URL strings. Those aren't in the
+ * M1 usage scope; if they show up, tighten the validator then.
+ *
+ * Prefix must match the sites.prefix CHECK constraint: 2–4 lowercase
+ * alphanumerics. That's enforced at the sites layer; this function accepts
+ * any non-empty prefix and trusts the caller.
+ */
+export function validateScopedCss(
+  css: string,
+  prefix: string,
+): ScopePrefixValidation {
+  if (!prefix) {
+    throw new Error("validateScopedCss: prefix is required.");
+  }
+
+  const required = `${prefix}-`;
+  const stripped = stripIgnorable(css);
+  const violations: ScopePrefixViolation[] = [];
+
+  const lines = stripped.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    CLASS_SELECTOR_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = CLASS_SELECTOR_RE.exec(line)) !== null) {
+      const className = match[1];
+      if (!className.startsWith(required)) {
+        violations.push({ selector: `.${className}`, line: i + 1 });
+      }
+    }
+  }
+
+  return violations.length === 0
+    ? { valid: true }
+    : { valid: false, violations };
+}
+
+// Replaces block comments and url(...) values with equal-length blank runs
+// so line numbers stay accurate for the violation reporter.
+function stripIgnorable(css: string): string {
+  const blanked = css.replace(BLOCK_COMMENT_RE, (m) =>
+    m.replace(/[^\n]/g, " "),
+  );
+  return blanked.replace(URL_VALUE_RE, (m) => m.replace(/[^\n]/g, " "));
+}


### PR DESCRIPTION
## Summary

First of four M1e slices. Lays down the HTTP surface that M1e-2/3/4's admin pages will consume: 13 route handlers across 8 route files, plus the shared admin layout and the Layer-2 scope-prefix CSS validator.

## What's in

### Shared infrastructure
- **`lib/scope-prefix.ts`** — Layer-2 CSS validator (§3.6). Regex pass that rejects class selectors not prefixed with the site's scope. Strips block comments and `url(...)` values before matching so data-URL innards (like the SVG check icons in the seed) don't false-positive. Reports violations with line numbers.
- **`lib/http.ts`** — `respond()` / `validationError()` / `parseBodyWith()` / `readJsonBody()` / `validateUuidParam()`. Every route file is sub-100 lines and identical in shape.
- **`lib/design-systems.ts`** — `+getDesignSystemSitePrefix(ds_id)` helper for components routes that need the prefix to run Layer-2 CSS validation.

### API routes (13 handlers, 8 files)
| Method | Path | Purpose |
|--------|------|---------|
| `GET` | `/api/sites/[id]/design-systems` | list versions |
| `POST` | `/api/sites/[id]/design-systems` | create draft (auto-increments version if body omits it) |
| `POST` | `/api/design-systems/[id]/activate` | via `activate_design_system` RPC |
| `POST` | `/api/design-systems/[id]/archive` | soft-archive, warns on active |
| `GET` | `/api/design-systems/[id]/components` | list |
| `POST` | `/api/design-systems/[id]/components` | create + **Layer-2 CSS check** |
| `PATCH` | `/api/design-systems/[id]/components/[cid]` | update + **Layer-2 CSS check when css in patch** |
| `DELETE` | `/api/design-systems/[id]/components/[cid]?expected_version_lock=N` | delete |
| `GET` | `/api/design-systems/[id]/templates` | list |
| `POST` | `/api/design-systems/[id]/templates` | create + **composition-reference check** |
| `PATCH` | `/api/design-systems/[id]/templates/[tid]` | update + composition check when composition in patch |
| `DELETE` | `/api/design-systems/[id]/templates/[tid]?expected_version_lock=N` | delete |
| `GET` | `/api/design-systems/[id]/preview` | bundled ds + components + templates |

- `expected_version_lock` on DELETE is a **query param**, not a body — bodies on DELETE are unreliable across proxies.
- Composition-reference pre-flight runs on template POST + PATCH (when `composition` is in the patch), matching the seed-script invariant. Unknown refs fail before any DB write.
- All Zod validation reuses the schemas exported from `lib/design-systems.ts` / `lib/components.ts` / `lib/templates.ts` — no hand-rolled duplicates.

### Admin shell
- **`app/admin/layout.tsx`** — shared header (h-12 border-b, `max-w-5xl p-6`) per Q2. Header link now routes to `/admin/sites`.
- **`app/admin/sites/page.tsx`** refactored to drop its inline header and emit fragment children. Visual output unchanged.

## Tests (smoke-level per Q8)

- `lib/__tests__/scope-prefix.test.ts` — 12 unit cases: prefixed/unprefixed/nested/foreign-prefix/block-comment/url-value/decimal-number edge cases + acceptance against the real `seed/leadsource/base-styles.css`.
- `lib/__tests__/api-{design-systems,components,templates}.test.ts` — 26 route cases, one happy + one error path per route. Handlers imported and called directly (no HTTP server).

## Verification

- `tsc --noEmit` clean.
- `next build` passes; routes registered:
  ```
  ƒ /api/design-systems/[id]/activate
  ƒ /api/design-systems/[id]/archive
  ƒ /api/design-systems/[id]/components
  ƒ /api/design-systems/[id]/components/[cid]
  ƒ /api/design-systems/[id]/preview
  ƒ /api/design-systems/[id]/templates
  ƒ /api/design-systems/[id]/templates/[tid]
  ƒ /api/sites/[id]/design-systems
  ```
- Vitest suite **not** run — sandbox lacks a Docker daemon (see README flag from M1b).

## Test plan

- [ ] `supabase start && npm test` locally — all scope-prefix and api-*.test.ts files green
- [ ] Hit each route with a small curl/Postman script against a real stack to eyeball the envelope shapes
- [ ] `/admin/sites` still renders and functions identically after the layout refactor
- [ ] `next build` passes in your environment

Do not merge until local verification is green.

https://claude.ai/code/session_01PTCJrskyCmW3t9NvLXM7rT