### PR TITLE
M1e-2: design system version manager page

### DIFF
--- a/app/admin/sites/[id]/design-system/page.tsx
+++ b/app/admin/sites/[id]/design-system/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { ConfirmActionModal } from "@/components/ConfirmActionModal";
+import { CreateDesignSystemModal } from "@/components/CreateDesignSystemModal";
+import { DesignSystemsTable } from "@/components/DesignSystemsTable";
+import type { DesignSystem } from "@/lib/design-systems";
+
+// Site-summary shape used for the breadcrumb + header. Narrower than
+// SiteRecord — we only need what the UI displays.
+type SiteSummary = {
+  id: string;
+  name: string;
+  prefix: string;
+};
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "ready"; site: SiteSummary; designSystems: DesignSystem[] }
+  | { status: "error"; message: string };
+
+type ActionTarget =
+  | { kind: "activate"; ds: DesignSystem }
+  | { kind: "archive"; ds: DesignSystem }
+  | null;
+
+export default function DesignSystemVersionsPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const siteId = params.id;
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  const [createOpen, setCreateOpen] = useState(false);
+  const [action, setAction] = useState<ActionTarget>(null);
+
+  const load = useCallback(async () => {
+    setState({ status: "loading" });
+    try {
+      const [siteRes, dsRes] = await Promise.all([
+        fetch(`/api/sites/${siteId}`, { cache: "no-store" }),
+        fetch(`/api/sites/${siteId}/design-systems`, { cache: "no-store" }),
+      ]);
+      const [sitePayload, dsPayload] = await Promise.all([
+        siteRes.json().catch(() => null),
+        dsRes.json().catch(() => null),
+      ]);
+
+      if (!siteRes.ok || !sitePayload?.ok) {
+        setState({
+          status: "error",
+          message:
+            sitePayload?.error?.message ??
+            `Failed to load site (HTTP ${siteRes.status}).`,
+        });
+        return;
+      }
+      if (!dsRes.ok || !dsPayload?.ok) {
+        setState({
+          status: "error",
+          message:
+            dsPayload?.error?.message ??
+            `Failed to load design systems (HTTP ${dsRes.status}).`,
+        });
+        return;
+      }
+
+      const site = sitePayload.data?.site as SiteSummary | undefined;
+      if (!site) {
+        setState({ status: "error", message: "Site payload missing." });
+        return;
+      }
+
+      setState({
+        status: "ready",
+        site: { id: site.id, name: site.name, prefix: site.prefix },
+        designSystems: (dsPayload.data ?? []) as DesignSystem[],
+      });
+    } catch (err) {
+      setState({
+        status: "error",
+        message: `Network error: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      });
+    }
+  }, [siteId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const siteName = state.status === "ready" ? state.site.name : null;
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-xs text-muted-foreground">
+            <Link href="/admin/sites" className="hover:underline">
+              Sites
+            </Link>
+            <span className="mx-1">/</span>
+            <span>{siteName ?? "…"}</span>
+          </div>
+          <h1 className="mt-1 text-xl font-semibold">Design system</h1>
+          <p className="text-sm text-muted-foreground">
+            Versions attached to this site. Exactly one can be active at a time.
+          </p>
+        </div>
+        <Button
+          onClick={() => setCreateOpen(true)}
+          disabled={state.status !== "ready"}
+        >
+          New draft
+        </Button>
+      </div>
+
+      <div className="mt-6">
+        {state.status === "loading" && (
+          <div className="rounded-md border p-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              Loading design systems…
+            </p>
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <div
+            className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+            role="alert"
+          >
+            <span>{state.message}</span>
+            <Button variant="outline" size="sm" onClick={() => void load()}>
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {state.status === "ready" && (
+          <DesignSystemsTable
+            designSystems={state.designSystems}
+            onActivate={(ds) => setAction({ kind: "activate", ds })}
+            onArchive={(ds) => setAction({ kind: "archive", ds })}
+          />
+        )}
+      </div>
+
+      {state.status === "ready" && (
+        <CreateDesignSystemModal
+          open={createOpen}
+          siteId={state.site.id}
+          onClose={() => setCreateOpen(false)}
+          onSuccess={() => {
+            void load();
+          }}
+        />
+      )}
+
+      {action?.kind === "activate" && (
+        <ConfirmActionModal
+          open
+          title={`Activate v${action.ds.version}?`}
+          description={
+            "This will archive the currently-active version for this site and promote v" +
+            action.ds.version +
+            " to active."
+          }
+          confirmLabel="Activate"
+          endpoint={`/api/design-systems/${action.ds.id}/activate`}
+          body={{ expected_version_lock: action.ds.version_lock }}
+          onClose={() => setAction(null)}
+          onSuccess={() => {
+            setAction(null);
+            void load();
+          }}
+        />
+      )}
+
+      {action?.kind === "archive" && (
+        <ConfirmActionModal
+          open
+          title={`Archive v${action.ds.version}?`}
+          description={
+            action.ds.status === "active"
+              ? `This will archive the currently-active version. The site will have no active design system until another version is activated.`
+              : `Archive this draft. It won't be available to activate afterwards.`
+          }
+          confirmLabel="Archive"
+          confirmVariant="destructive"
+          endpoint={`/api/design-systems/${action.ds.id}/archive`}
+          body={{ expected_version_lock: action.ds.version_lock }}
+          warningsAccessor={(data) => {
+            if (
+              data &&
+              typeof data === "object" &&
+              "warnings" in data &&
+              Array.isArray((data as { warnings: unknown }).warnings)
+            ) {
+              return (data as { warnings: string[] }).warnings;
+            }
+            return undefined;
+          }}
+          onClose={() => setAction(null)}
+          onSuccess={() => {
+            void load();
+            // Don't clear action state here — if warnings were returned, the
+            // modal stays open to show them, and the operator closes it
+            // themselves via its Close button.
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/components/ConfirmActionModal.tsx
+++ b/components/ConfirmActionModal.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+// Generic confirmation modal for mutating actions that need a
+// server round-trip. Used by the version manager for activate and
+// archive — both are structurally identical (POST a body, refetch on
+// success, surface envelope errors inline, show warnings[] if present).
+//
+// Design note: intentionally untied from any specific API shape. The caller
+// supplies the URL + body + success/error messages; this component only
+// orchestrates open state, submission state, and error display.
+
+export type ConfirmActionSuccess = {
+  ok: true;
+  data: unknown;
+};
+
+export type ConfirmActionModalProps = {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  confirmVariant?: "default" | "destructive";
+  endpoint: string;
+  body: Record<string, unknown>;
+  // When the API envelope's data.warnings is a string[], surface them here.
+  // (Used by archive when the site had the target as its active DS.)
+  warningsAccessor?: (data: unknown) => string[] | undefined;
+  onClose: () => void;
+  onSuccess: (payload: ConfirmActionSuccess) => void;
+};
+
+export function ConfirmActionModal({
+  open,
+  title,
+  description,
+  confirmLabel,
+  confirmVariant = "default",
+  endpoint,
+  body,
+  warningsAccessor,
+  onClose,
+  onSuccess,
+}: ConfirmActionModalProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [warnings, setWarnings] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setSubmitting(false);
+      setFormError(null);
+      setWarnings(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !submitting) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, submitting, onClose]);
+
+  if (!open) return null;
+
+  async function handleConfirm() {
+    setSubmitting(true);
+    setFormError(null);
+    setWarnings(null);
+    try {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      let payload: any = null;
+      try {
+        payload = await res.json();
+      } catch {
+        /* ignore */
+      }
+
+      if (res.ok && payload?.ok) {
+        const derived = warningsAccessor?.(payload.data) ?? null;
+        if (derived && derived.length > 0) {
+          // Surface warnings in-modal, give operator a chance to read them
+          // before the modal closes. Still call onSuccess so the parent
+          // refetches.
+          setWarnings(derived);
+          onSuccess({ ok: true, data: payload.data });
+          return;
+        }
+        onSuccess({ ok: true, data: payload.data });
+        onClose();
+        return;
+      }
+
+      setFormError(
+        payload?.error?.message ??
+          `Request failed (HTTP ${res.status}). Please try again.`,
+      );
+    } catch (err) {
+      setFormError(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !submitting) onClose();
+      }}
+    >
+      <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="confirm-title" className="text-lg font-semibold">
+          {title}
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+
+        {warnings && warnings.length > 0 && (
+          <div
+            className="mt-4 rounded-md border border-yellow-500/40 bg-yellow-500/10 p-3 text-sm text-yellow-900 dark:text-yellow-200"
+            role="status"
+          >
+            <p className="font-medium">Completed with warnings:</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              {warnings.map((w, i) => (
+                <li key={i}>{w}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {formError && (
+          <div
+            className="mt-4 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+            role="alert"
+          >
+            {formError}
+          </div>
+        )}
+
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            {warnings ? "Close" : "Cancel"}
+          </Button>
+          {!warnings && (
+            <Button
+              type="button"
+              variant={confirmVariant === "destructive" ? "destructive" : "default"}
+              onClick={handleConfirm}
+              disabled={submitting}
+            >
+              {submitting ? "Working…" : confirmLabel}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/CreateDesignSystemModal.tsx
+++ b/components/CreateDesignSystemModal.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+
+type FormState = {
+  tokens_css: string;
+  base_styles: string;
+  notes: string;
+};
+
+const INITIAL_STATE: FormState = {
+  tokens_css: "",
+  base_styles: "",
+  notes: "",
+};
+
+function Label({
+  htmlFor,
+  children,
+}: {
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label htmlFor={htmlFor} className="block text-sm font-medium">
+      {children}
+    </label>
+  );
+}
+
+function FieldError({ message }: { message?: string | null }) {
+  if (!message) return null;
+  return <p className="mt-1 text-xs text-destructive">{message}</p>;
+}
+
+export function CreateDesignSystemModal({
+  open,
+  siteId,
+  onClose,
+  onSuccess,
+}: {
+  open: boolean;
+  siteId: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const [form, setForm] = useState<FormState>(INITIAL_STATE);
+  const [fieldErrors, setFieldErrors] = useState<
+    Partial<Record<keyof FormState, string>>
+  >({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setForm(INITIAL_STATE);
+      setFieldErrors({});
+      setFormError(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !submitting) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, submitting, onClose]);
+
+  if (!open) return null;
+
+  function setField<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    if (fieldErrors[key]) {
+      setFieldErrors((prev) => ({ ...prev, [key]: undefined }));
+    }
+  }
+
+  function validateClient(): boolean {
+    const errs: Partial<Record<keyof FormState, string>> = {};
+    // tokens_css and base_styles are string-required at the DB — the M1b
+    // Zod schema accepts empty strings, so we don't enforce non-empty here.
+    // Operators who want a blank draft and intend to paste later are fine.
+    setFieldErrors(errs);
+    return Object.keys(errs).length === 0;
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+    if (!validateClient()) return;
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/sites/${siteId}/design-systems`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          tokens_css: form.tokens_css,
+          base_styles: form.base_styles,
+          notes: form.notes.trim().length > 0 ? form.notes : null,
+        }),
+      });
+      let payload: any = null;
+      try {
+        payload = await res.json();
+      } catch {
+        /* ignore */
+      }
+
+      if (res.ok && payload?.ok) {
+        onSuccess();
+        onClose();
+        return;
+      }
+
+      const code = payload?.error?.code;
+      if (code === "VALIDATION_FAILED" && payload?.error?.details?.issues) {
+        const errs: Partial<Record<keyof FormState, string>> = {};
+        for (const issue of payload.error.details.issues) {
+          const key = issue.path?.split(".")?.[0] as
+            | keyof FormState
+            | undefined;
+          if (key && key in INITIAL_STATE) errs[key] = issue.message;
+        }
+        setFieldErrors(errs);
+        if (Object.keys(errs).length === 0) {
+          setFormError(payload.error.message ?? "Validation failed.");
+        }
+      } else {
+        setFormError(
+          payload?.error?.message ??
+            `Request failed (HTTP ${res.status}). Please try again.`,
+        );
+      }
+    } catch (err) {
+      setFormError(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="new-ds-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !submitting) onClose();
+      }}
+    >
+      <div className="w-full max-w-2xl rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="new-ds-title" className="text-lg font-semibold">
+          New design system draft
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Version number is auto-assigned to the next integer. The draft is
+          not activated — you can edit components and templates, then activate
+          from the list when ready.
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+          <div>
+            <Label htmlFor="ds-tokens">tokens.css</Label>
+            <textarea
+              id="ds-tokens"
+              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              value={form.tokens_css}
+              onChange={(e) => setField("tokens_css", e.target.value)}
+              placeholder=".ls-scope {\n  --ls-blue: #185FA5;\n  /* ... */\n}"
+              spellCheck={false}
+              disabled={submitting}
+              autoFocus
+            />
+            <FieldError message={fieldErrors.tokens_css} />
+          </div>
+
+          <div>
+            <Label htmlFor="ds-base-styles">base-styles.css</Label>
+            <textarea
+              id="ds-base-styles"
+              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              value={form.base_styles}
+              onChange={(e) => setField("base_styles", e.target.value)}
+              placeholder=".ls-container { max-width: 1160px; }"
+              spellCheck={false}
+              disabled={submitting}
+            />
+            <FieldError message={fieldErrors.base_styles} />
+          </div>
+
+          <div>
+            <Label htmlFor="ds-notes">Notes (optional)</Label>
+            <textarea
+              id="ds-notes"
+              className="mt-1 h-20 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              value={form.notes}
+              onChange={(e) => setField("notes", e.target.value)}
+              placeholder="What changed in this version?"
+              disabled={submitting}
+            />
+            <FieldError message={fieldErrors.notes} />
+          </div>
+
+          {formError && (
+            <div
+              className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+              role="alert"
+            >
+              {formError}
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Creating…" : "Create draft"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/DesignSystemsTable.tsx
+++ b/components/DesignSystemsTable.tsx
@@ -1,0 +1,113 @@
+import type { DesignSystem } from "@/lib/design-systems";
+import { Button } from "@/components/ui/button";
+import { cn, formatRelativeTime } from "@/lib/utils";
+
+function statusDotClass(status: DesignSystem["status"]): string {
+  switch (status) {
+    case "active":
+      return "bg-green-500";
+    case "draft":
+      return "bg-slate-400";
+    case "archived":
+      return "bg-slate-300";
+    default:
+      return "bg-red-500";
+  }
+}
+
+function StatusCell({ status }: { status: DesignSystem["status"] }) {
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span
+        aria-hidden="true"
+        className={cn(
+          "inline-block h-2 w-2 rounded-full",
+          statusDotClass(status),
+        )}
+      />
+      <span className="text-sm capitalize">{status}</span>
+    </span>
+  );
+}
+
+export function DesignSystemsTable({
+  designSystems,
+  onActivate,
+  onArchive,
+}: {
+  designSystems: DesignSystem[];
+  onActivate: (ds: DesignSystem) => void;
+  onArchive: (ds: DesignSystem) => void;
+}) {
+  if (designSystems.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No design system versions yet. Click "New draft" to create the first
+          one.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <table className="w-full text-sm">
+        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+          <tr>
+            <th className="px-4 py-2 font-medium">Version</th>
+            <th className="px-4 py-2 font-medium">Status</th>
+            <th className="px-4 py-2 font-medium">Created</th>
+            <th className="px-4 py-2 font-medium">Activated</th>
+            <th className="px-4 py-2 font-medium">Created by</th>
+            <th className="px-4 py-2 font-medium text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {designSystems.map((ds) => (
+            <tr key={ds.id} className="border-b last:border-b-0">
+              <td className="px-4 py-3 font-mono text-sm font-medium">
+                v{ds.version}
+              </td>
+              <td className="px-4 py-3">
+                <StatusCell status={ds.status} />
+              </td>
+              <td className="px-4 py-3 text-muted-foreground">
+                {formatRelativeTime(ds.created_at)}
+              </td>
+              <td className="px-4 py-3 text-muted-foreground">
+                {ds.activated_at ? formatRelativeTime(ds.activated_at) : "—"}
+              </td>
+              <td className="px-4 py-3 text-muted-foreground">
+                {/* created_by is NULL until M2 auth backfill */}
+                {ds.created_by ? ds.created_by : "—"}
+              </td>
+              <td className="px-4 py-3">
+                <div className="flex justify-end gap-2">
+                  {ds.status === "draft" && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => onActivate(ds)}
+                    >
+                      Activate
+                    </Button>
+                  )}
+                  {ds.status !== "archived" && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => onArchive(ds)}
+                    >
+                      Archive
+                    </Button>
+                  )}
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Second of four M1e slices. Adds `/admin/sites/[id]/design-system` — the first admin page that consumes M1e-1's HTTP surface. Operators can list every version for a site, create a new draft, activate a draft, and archive any non-archived version.

## What's in

### Page
- **`app/admin/sites/[id]/design-system/page.tsx`** — `"use client"` page using the `LoadState` discriminated union + refetch pattern pioneered by `app/admin/sites/page.tsx`. Loads `/api/sites/[id]` (for breadcrumb site name) and `/api/sites/[id]/design-systems` (for the list) in parallel on mount.

### Components
- **`components/DesignSystemsTable.tsx`** — pure presentation, status dots (green active / slate draft / muted archived), per-row **Activate** (draft only) and **Archive** (draft or active) buttons. `created_by` renders as `—` since it's NULL until M2 auth backfill (per Q7 of the plan).
- **`components/CreateDesignSystemModal.tsx`** — three textareas (`tokens_css`, `base_styles`, `notes`). POSTs to `/api/sites/[id]/design-systems` with the body omitting `version` so the route auto-picks the next integer (M1e-1 behaviour). Parses `VALIDATION_FAILED` issues into field-level errors.
- **`components/ConfirmActionModal.tsx`** — generic confirm dialog used for both activate and archive. Surfaces `warnings[]` from the archive envelope inline — when archiving the currently-active DS, the modal stays open to show "no active design system" warning until the operator reads it.

## What it doesn't do (deferred per Q3 / Q4 / Q5)

- No live component preview — waits for M3.
- No code-editor dependency — plain textareas with mono font, `spellCheck={false}`.
- No drag-and-drop — not applicable to this page anyway.
- No UI unit tests — existing codebase has none for `SitesTable` / `AddSiteModal`. Adding RTL + jsdom is a separate dep decision; API routes have smoke tests from M1e-1, and the version manager is thin presentation over that API.

## Verification

- `tsc --noEmit` clean.
- `next build` passes; `/admin/sites/[id]/design-system` registered at 4.69 kB.
- Browser click-through **not** verified — sandbox has no dev server or Supabase stack.

## Test plan

- [ ] `supabase start && npm run dev`
- [ ] Navigate to `/admin/sites/[id]/design-system` for a seeded site
- [ ] Create a new draft — appears in the list with next-integer version
- [ ] Activate a draft — active DS switches; previous active becomes archived
- [ ] Archive the currently-active DS — warning surfaces in modal ("site has no active design system")
- [ ] Archive a draft — no warning
- [ ] Try activating a version with a stale client (two tabs) — second one gets a 409 error
- [ ] All empty/loading/error states render cleanly
- [ ] Layout matches existing `/admin/sites` page visual style

Do not merge until local browser verification is green.

https://claude.ai/code/session_01PTCJrskyCmW3t9NvLXM7rT