### PR TITLE
M1e-3+4: component + template editor + preview gallery

### DIFF
--- a/app/admin/sites/[id]/design-system/components/page.tsx
+++ b/app/admin/sites/[id]/design-system/components/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { ComponentFormModal, type ComponentFormMode } from "@/components/ComponentFormModal";
+import { ComponentsGrid } from "@/components/ComponentsGrid";
+import { ConfirmActionModal } from "@/components/ConfirmActionModal";
+import {
+  resolveSelectedDesignSystem,
+  useDesignSystemLayout,
+} from "@/components/design-system-context";
+import type { DesignComponent } from "@/lib/components";
+import type { DesignTemplate } from "@/lib/templates";
+
+type LoadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | {
+      status: "ready";
+      components: DesignComponent[];
+      templates: DesignTemplate[];
+    }
+  | { status: "error"; message: string };
+
+export default function DesignSystemComponentsPage() {
+  const { versions, refetch: refetchLayout } = useDesignSystemLayout();
+  const search = useSearchParams();
+  const dsParam = search.get("ds");
+  const selectedDs = useMemo(
+    () => resolveSelectedDesignSystem(versions, dsParam),
+    [versions, dsParam],
+  );
+
+  const [state, setState] = useState<LoadState>({ status: "idle" });
+  const [formMode, setFormMode] = useState<ComponentFormMode | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<DesignComponent | null>(null);
+
+  const load = useCallback(async () => {
+    if (!selectedDs) {
+      setState({ status: "idle" });
+      return;
+    }
+    setState({ status: "loading" });
+    try {
+      const res = await fetch(
+        `/api/design-systems/${selectedDs.id}/preview`,
+        { cache: "no-store" },
+      );
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        setState({
+          status: "error",
+          message:
+            payload?.error?.message ??
+            `Failed to load components (HTTP ${res.status}).`,
+        });
+        return;
+      }
+      setState({
+        status: "ready",
+        components: (payload.data?.components ?? []) as DesignComponent[],
+        templates: (payload.data?.templates ?? []) as DesignTemplate[],
+      });
+    } catch (err) {
+      setState({
+        status: "error",
+        message: `Network error: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      });
+    }
+  }, [selectedDs]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Before deleting a component, find any templates that reference it by
+  // name so the confirm modal can list them for the operator.
+  const orphanTemplates = useMemo<DesignTemplate[]>(() => {
+    if (!deleteTarget || state.status !== "ready") return [];
+    return state.templates.filter((t) =>
+      Array.isArray(t.composition)
+        ? t.composition.some(
+            (entry) =>
+              typeof entry === "object" &&
+              entry !== null &&
+              (entry as { component?: string }).component ===
+                deleteTarget.name,
+          )
+        : false,
+    );
+  }, [deleteTarget, state]);
+
+  if (!selectedDs) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No design system selected for this site. Create a draft from the
+          Versions tab first.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Components</h1>
+          <p className="text-sm text-muted-foreground">
+            Components registered on design system v{selectedDs.version} (
+            {selectedDs.status}).
+          </p>
+        </div>
+        <Button
+          onClick={() => setFormMode({ kind: "create" })}
+          disabled={state.status !== "ready" && state.status !== "error"}
+        >
+          New component
+        </Button>
+      </div>
+
+      <div className="mt-6">
+        {state.status === "loading" && (
+          <div className="rounded-md border p-8 text-center">
+            <p className="text-sm text-muted-foreground">Loading components…</p>
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <div
+            className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+            role="alert"
+          >
+            <span>{state.message}</span>
+            <Button variant="outline" size="sm" onClick={() => void load()}>
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {state.status === "ready" && (
+          <ComponentsGrid
+            components={state.components}
+            onEdit={(c) => setFormMode({ kind: "edit", component: c })}
+            onDelete={(c) => setDeleteTarget(c)}
+          />
+        )}
+      </div>
+
+      {formMode && (
+        <ComponentFormModal
+          open
+          mode={formMode}
+          designSystemId={selectedDs.id}
+          onClose={() => setFormMode(null)}
+          onSuccess={() => {
+            void load();
+            refetchLayout();
+          }}
+        />
+      )}
+
+      {deleteTarget && (
+        <ConfirmActionModal
+          open
+          title={`Delete "${deleteTarget.name}"?`}
+          description={
+            "This removes the component from the design system. Page templates that reference it by name will be left with unresolvable composition entries."
+          }
+          confirmLabel="Delete component"
+          confirmVariant="destructive"
+          endpoint={`/api/design-systems/${selectedDs.id}/components/${deleteTarget.id}`}
+          request={{
+            method: "DELETE",
+            searchParams: {
+              expected_version_lock: deleteTarget.version_lock,
+            },
+          }}
+          extraContent={
+            orphanTemplates.length > 0 ? (
+              <div
+                className="rounded-md border border-yellow-500/40 bg-yellow-500/10 p-3 text-sm text-yellow-900 dark:text-yellow-200"
+                role="status"
+              >
+                <p className="font-medium">
+                  This component is referenced by {orphanTemplates.length}{" "}
+                  template{orphanTemplates.length === 1 ? "" : "s"}:
+                </p>
+                <ul className="mt-2 list-disc space-y-1 pl-5">
+                  {orphanTemplates.map((t) => (
+                    <li key={t.id}>
+                      {t.page_type}/{t.name}
+                    </li>
+                  ))}
+                </ul>
+                <p className="mt-2">
+                  Delete anyway, or cancel and rewire the templates first.
+                </p>
+              </div>
+            ) : null
+          }
+          onClose={() => setDeleteTarget(null)}
+          onSuccess={() => {
+            setDeleteTarget(null);
+            void load();
+            refetchLayout();
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/app/admin/sites/[id]/design-system/layout.tsx
+++ b/app/admin/sites/[id]/design-system/layout.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import Link from "next/link";
+import {
+  useParams,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DesignSystemLayoutContext,
+  resolveSelectedDesignSystem,
+  type DesignSystemSiteSummary,
+} from "@/components/design-system-context";
+import { cn } from "@/lib/utils";
+import type { DesignSystem } from "@/lib/design-systems";
+
+// Shared shell for every page under /admin/sites/[id]/design-system.
+//
+// Responsibilities:
+//   - load the site summary (for breadcrumb) and the full list of DS
+//     versions (for the version selector + child pages via context)
+//   - render the version selector dropdown, updating ?ds=<uuid> in the URL
+//     on change
+//   - render the tab nav for Versions / Components / Templates / Preview,
+//     preserving the current ?ds across tabs
+//   - provide { site, versions, refetch } via DesignSystemLayoutContext
+//
+// Children (each page) are responsible for reading ?ds themselves and
+// handling the "no active DS" case — a single layout cannot represent
+// every page's empty state cleanly.
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "ready"; site: DesignSystemSiteSummary; versions: DesignSystem[] }
+  | { status: "error"; message: string };
+
+const TABS = [
+  { key: "versions", label: "Versions", subpath: "" },
+  { key: "components", label: "Components", subpath: "/components" },
+  { key: "templates", label: "Templates", subpath: "/templates" },
+  { key: "preview", label: "Preview", subpath: "/preview" },
+] as const;
+
+type TabKey = (typeof TABS)[number]["key"];
+
+function currentTab(pathname: string, siteId: string): TabKey {
+  const base = `/admin/sites/${siteId}/design-system`;
+  const tail = pathname.startsWith(base) ? pathname.slice(base.length) : "";
+  if (tail.startsWith("/components")) return "components";
+  if (tail.startsWith("/templates")) return "templates";
+  if (tail.startsWith("/preview")) return "preview";
+  return "versions";
+}
+
+export default function DesignSystemLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const params = useParams<{ id: string }>();
+  const siteId = params.id;
+  const search = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+
+  const load = useCallback(async () => {
+    setState({ status: "loading" });
+    try {
+      const [siteRes, dsRes] = await Promise.all([
+        fetch(`/api/sites/${siteId}`, { cache: "no-store" }),
+        fetch(`/api/sites/${siteId}/design-systems`, { cache: "no-store" }),
+      ]);
+      const [sitePayload, dsPayload] = await Promise.all([
+        siteRes.json().catch(() => null),
+        dsRes.json().catch(() => null),
+      ]);
+
+      if (!siteRes.ok || !sitePayload?.ok) {
+        setState({
+          status: "error",
+          message:
+            sitePayload?.error?.message ??
+            `Failed to load site (HTTP ${siteRes.status}).`,
+        });
+        return;
+      }
+      if (!dsRes.ok || !dsPayload?.ok) {
+        setState({
+          status: "error",
+          message:
+            dsPayload?.error?.message ??
+            `Failed to load design systems (HTTP ${dsRes.status}).`,
+        });
+        return;
+      }
+
+      const site = sitePayload.data?.site as DesignSystemSiteSummary | undefined;
+      if (!site) {
+        setState({ status: "error", message: "Site payload missing." });
+        return;
+      }
+
+      setState({
+        status: "ready",
+        site: { id: site.id, name: site.name, prefix: site.prefix },
+        versions: (dsPayload.data ?? []) as DesignSystem[],
+      });
+    } catch (err) {
+      setState({
+        status: "error",
+        message: `Network error: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      });
+    }
+  }, [siteId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const dsParam = search.get("ds");
+  const selectedDs = useMemo(
+    () =>
+      state.status === "ready"
+        ? resolveSelectedDesignSystem(state.versions, dsParam)
+        : null,
+    [state, dsParam],
+  );
+  const tab = currentTab(pathname, siteId);
+
+  function navigateToDs(newDsId: string) {
+    const newParams = new URLSearchParams(search.toString());
+    newParams.set("ds", newDsId);
+    router.push(`${pathname}?${newParams.toString()}`);
+  }
+
+  function tabHref(subpath: string): string {
+    const base = `/admin/sites/${siteId}/design-system${subpath}`;
+    if (!selectedDs) return base;
+    return `${base}?ds=${selectedDs.id}`;
+  }
+
+  const siteName = state.status === "ready" ? state.site.name : null;
+
+  return (
+    <>
+      <div className="flex flex-col gap-2 border-b pb-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="text-xs text-muted-foreground">
+            <Link href="/admin/sites" className="hover:underline">
+              Sites
+            </Link>
+            <span className="mx-1">/</span>
+            <span>{siteName ?? "…"}</span>
+            <span className="mx-1">/</span>
+            <span>Design system</span>
+          </div>
+          {state.status === "ready" && state.versions.length > 0 && (
+            <label className="flex items-center gap-2 text-xs text-muted-foreground">
+              Version
+              <select
+                value={selectedDs?.id ?? ""}
+                onChange={(e) => navigateToDs(e.target.value)}
+                className="rounded-md border bg-background px-2 py-1 text-xs"
+              >
+                {state.versions
+                  .slice()
+                  .sort((a, b) => b.version - a.version)
+                  .map((v) => (
+                    <option key={v.id} value={v.id}>
+                      v{v.version} · {v.status}
+                    </option>
+                  ))}
+              </select>
+            </label>
+          )}
+        </div>
+
+        <nav className="flex gap-1 text-sm">
+          {TABS.map((t) => (
+            <Link
+              key={t.key}
+              href={tabHref(t.subpath)}
+              className={cn(
+                "rounded-md px-3 py-1.5",
+                tab === t.key
+                  ? "bg-muted font-medium text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {t.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+
+      <div className="mt-6">
+        {state.status === "loading" && (
+          <div className="rounded-md border p-8 text-center">
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <div
+            className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+            role="alert"
+          >
+            <span>{state.message}</span>
+            <Button variant="outline" size="sm" onClick={() => void load()}>
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {state.status === "ready" && (
+          <DesignSystemLayoutContext.Provider
+            value={{
+              site: state.site,
+              versions: state.versions,
+              refetch: () => void load(),
+            }}
+          >
+            {children}
+          </DesignSystemLayoutContext.Provider>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/admin/sites/[id]/design-system/page.tsx
+++ b/app/admin/sites/[id]/design-system/page.tsx
@@ -1,164 +1,55 @@
 "use client";
 
-import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
 import { CreateDesignSystemModal } from "@/components/CreateDesignSystemModal";
 import { DesignSystemsTable } from "@/components/DesignSystemsTable";
+import { useDesignSystemLayout } from "@/components/design-system-context";
 import type { DesignSystem } from "@/lib/design-systems";
-
-// Site-summary shape used for the breadcrumb + header. Narrower than
-// SiteRecord — we only need what the UI displays.
-type SiteSummary = {
-  id: string;
-  name: string;
-  prefix: string;
-};
-
-type LoadState =
-  | { status: "loading" }
-  | { status: "ready"; site: SiteSummary; designSystems: DesignSystem[] }
-  | { status: "error"; message: string };
 
 type ActionTarget =
   | { kind: "activate"; ds: DesignSystem }
   | { kind: "archive"; ds: DesignSystem }
   | null;
 
-export default function DesignSystemVersionsPage({
-  params,
-}: {
-  params: { id: string };
-}) {
-  const siteId = params.id;
-  const [state, setState] = useState<LoadState>({ status: "loading" });
+export default function DesignSystemVersionsPage() {
+  const { site, versions, refetch } = useDesignSystemLayout();
   const [createOpen, setCreateOpen] = useState(false);
   const [action, setAction] = useState<ActionTarget>(null);
-
-  const load = useCallback(async () => {
-    setState({ status: "loading" });
-    try {
-      const [siteRes, dsRes] = await Promise.all([
-        fetch(`/api/sites/${siteId}`, { cache: "no-store" }),
-        fetch(`/api/sites/${siteId}/design-systems`, { cache: "no-store" }),
-      ]);
-      const [sitePayload, dsPayload] = await Promise.all([
-        siteRes.json().catch(() => null),
-        dsRes.json().catch(() => null),
-      ]);
-
-      if (!siteRes.ok || !sitePayload?.ok) {
-        setState({
-          status: "error",
-          message:
-            sitePayload?.error?.message ??
-            `Failed to load site (HTTP ${siteRes.status}).`,
-        });
-        return;
-      }
-      if (!dsRes.ok || !dsPayload?.ok) {
-        setState({
-          status: "error",
-          message:
-            dsPayload?.error?.message ??
-            `Failed to load design systems (HTTP ${dsRes.status}).`,
-        });
-        return;
-      }
-
-      const site = sitePayload.data?.site as SiteSummary | undefined;
-      if (!site) {
-        setState({ status: "error", message: "Site payload missing." });
-        return;
-      }
-
-      setState({
-        status: "ready",
-        site: { id: site.id, name: site.name, prefix: site.prefix },
-        designSystems: (dsPayload.data ?? []) as DesignSystem[],
-      });
-    } catch (err) {
-      setState({
-        status: "error",
-        message: `Network error: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      });
-    }
-  }, [siteId]);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
-
-  const siteName = state.status === "ready" ? state.site.name : null;
 
   return (
     <>
       <div className="flex items-center justify-between">
         <div>
-          <div className="text-xs text-muted-foreground">
-            <Link href="/admin/sites" className="hover:underline">
-              Sites
-            </Link>
-            <span className="mx-1">/</span>
-            <span>{siteName ?? "…"}</span>
-          </div>
-          <h1 className="mt-1 text-xl font-semibold">Design system</h1>
+          <h1 className="text-xl font-semibold">Versions</h1>
           <p className="text-sm text-muted-foreground">
-            Versions attached to this site. Exactly one can be active at a time.
+            One version is active at a time. Edit draft versions before
+            activating — activation is atomic and archives the previous active
+            version.
           </p>
         </div>
-        <Button
-          onClick={() => setCreateOpen(true)}
-          disabled={state.status !== "ready"}
-        >
-          New draft
-        </Button>
+        <Button onClick={() => setCreateOpen(true)}>New draft</Button>
       </div>
 
       <div className="mt-6">
-        {state.status === "loading" && (
-          <div className="rounded-md border p-8 text-center">
-            <p className="text-sm text-muted-foreground">
-              Loading design systems…
-            </p>
-          </div>
-        )}
-
-        {state.status === "error" && (
-          <div
-            className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-            role="alert"
-          >
-            <span>{state.message}</span>
-            <Button variant="outline" size="sm" onClick={() => void load()}>
-              Retry
-            </Button>
-          </div>
-        )}
-
-        {state.status === "ready" && (
-          <DesignSystemsTable
-            designSystems={state.designSystems}
-            onActivate={(ds) => setAction({ kind: "activate", ds })}
-            onArchive={(ds) => setAction({ kind: "archive", ds })}
-          />
-        )}
+        <DesignSystemsTable
+          designSystems={versions}
+          siteId={site.id}
+          onActivate={(ds) => setAction({ kind: "activate", ds })}
+          onArchive={(ds) => setAction({ kind: "archive", ds })}
+        />
       </div>
 
-      {state.status === "ready" && (
-        <CreateDesignSystemModal
-          open={createOpen}
-          siteId={state.site.id}
-          onClose={() => setCreateOpen(false)}
-          onSuccess={() => {
-            void load();
-          }}
-        />
-      )}
+      <CreateDesignSystemModal
+        open={createOpen}
+        siteId={site.id}
+        onClose={() => setCreateOpen(false)}
+        onSuccess={() => {
+          refetch();
+        }}
+      />
 
       {action?.kind === "activate" && (
         <ConfirmActionModal
@@ -171,11 +62,14 @@ export default function DesignSystemVersionsPage({
           }
           confirmLabel="Activate"
           endpoint={`/api/design-systems/${action.ds.id}/activate`}
-          body={{ expected_version_lock: action.ds.version_lock }}
+          request={{
+            method: "POST",
+            body: { expected_version_lock: action.ds.version_lock },
+          }}
           onClose={() => setAction(null)}
           onSuccess={() => {
             setAction(null);
-            void load();
+            refetch();
           }}
         />
       )}
@@ -192,7 +86,10 @@ export default function DesignSystemVersionsPage({
           confirmLabel="Archive"
           confirmVariant="destructive"
           endpoint={`/api/design-systems/${action.ds.id}/archive`}
-          body={{ expected_version_lock: action.ds.version_lock }}
+          request={{
+            method: "POST",
+            body: { expected_version_lock: action.ds.version_lock },
+          }}
           warningsAccessor={(data) => {
             if (
               data &&
@@ -206,10 +103,7 @@ export default function DesignSystemVersionsPage({
           }}
           onClose={() => setAction(null)}
           onSuccess={() => {
-            void load();
-            // Don't clear action state here — if warnings were returned, the
-            // modal stays open to show them, and the operator closes it
-            // themselves via its Close button.
+            refetch();
           }}
         />
       )}

--- a/app/admin/sites/[id]/design-system/preview/page.tsx
+++ b/app/admin/sites/[id]/design-system/preview/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { PreviewGallery } from "@/components/PreviewGallery";
+import {
+  resolveSelectedDesignSystem,
+  useDesignSystemLayout,
+} from "@/components/design-system-context";
+import type { DesignComponent } from "@/lib/components";
+import type { DesignTemplate } from "@/lib/templates";
+
+type LoadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | {
+      status: "ready";
+      components: DesignComponent[];
+      templates: DesignTemplate[];
+    }
+  | { status: "error"; message: string };
+
+export default function DesignSystemPreviewPage() {
+  const { versions } = useDesignSystemLayout();
+  const search = useSearchParams();
+  const dsParam = search.get("ds");
+  const selectedDs = useMemo(
+    () => resolveSelectedDesignSystem(versions, dsParam),
+    [versions, dsParam],
+  );
+
+  const [state, setState] = useState<LoadState>({ status: "idle" });
+
+  const load = useCallback(async () => {
+    if (!selectedDs) {
+      setState({ status: "idle" });
+      return;
+    }
+    setState({ status: "loading" });
+    try {
+      const res = await fetch(
+        `/api/design-systems/${selectedDs.id}/preview`,
+        { cache: "no-store" },
+      );
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        setState({
+          status: "error",
+          message:
+            payload?.error?.message ??
+            `Failed to load preview (HTTP ${res.status}).`,
+        });
+        return;
+      }
+      setState({
+        status: "ready",
+        components: (payload.data?.components ?? []) as DesignComponent[],
+        templates: (payload.data?.templates ?? []) as DesignTemplate[],
+      });
+    } catch (err) {
+      setState({
+        status: "error",
+        message: `Network error: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      });
+    }
+  }, [selectedDs]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (!selectedDs) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No design system selected. Create a draft from the Versions tab first.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div>
+        <h1 className="text-xl font-semibold">Preview</h1>
+        <p className="text-sm text-muted-foreground">
+          Read-only metadata view of design system v{selectedDs.version} (
+          {selectedDs.status}). Live component rendering lands with M3 — this
+          page shows raw templates + CSS + field schemas + composition chains.
+        </p>
+      </div>
+
+      <div className="mt-6">
+        {state.status === "loading" && (
+          <div className="rounded-md border p-8 text-center">
+            <p className="text-sm text-muted-foreground">Loading preview…</p>
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <div
+            className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+            role="alert"
+          >
+            <span>{state.message}</span>
+            <Button variant="outline" size="sm" onClick={() => void load()}>
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {state.status === "ready" && (
+          <PreviewGallery
+            components={state.components}
+            templates={state.templates}
+          />
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/admin/sites/[id]/design-system/templates/page.tsx
+++ b/app/admin/sites/[id]/design-system/templates/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { ConfirmActionModal } from "@/components/ConfirmActionModal";
+import { TemplateFormModal, type TemplateFormMode } from "@/components/TemplateFormModal";
+import { TemplatesTable } from "@/components/TemplatesTable";
+import {
+  resolveSelectedDesignSystem,
+  useDesignSystemLayout,
+} from "@/components/design-system-context";
+import type { DesignComponent } from "@/lib/components";
+import type { DesignTemplate } from "@/lib/templates";
+
+type LoadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | {
+      status: "ready";
+      components: DesignComponent[];
+      templates: DesignTemplate[];
+    }
+  | { status: "error"; message: string };
+
+export default function DesignSystemTemplatesPage() {
+  const { versions, refetch: refetchLayout } = useDesignSystemLayout();
+  const search = useSearchParams();
+  const dsParam = search.get("ds");
+  const selectedDs = useMemo(
+    () => resolveSelectedDesignSystem(versions, dsParam),
+    [versions, dsParam],
+  );
+
+  const [state, setState] = useState<LoadState>({ status: "idle" });
+  const [formMode, setFormMode] = useState<TemplateFormMode | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<DesignTemplate | null>(null);
+
+  const load = useCallback(async () => {
+    if (!selectedDs) {
+      setState({ status: "idle" });
+      return;
+    }
+    setState({ status: "loading" });
+    try {
+      const res = await fetch(
+        `/api/design-systems/${selectedDs.id}/preview`,
+        { cache: "no-store" },
+      );
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        setState({
+          status: "error",
+          message:
+            payload?.error?.message ??
+            `Failed to load templates (HTTP ${res.status}).`,
+        });
+        return;
+      }
+      setState({
+        status: "ready",
+        components: (payload.data?.components ?? []) as DesignComponent[],
+        templates: (payload.data?.templates ?? []) as DesignTemplate[],
+      });
+    } catch (err) {
+      setState({
+        status: "error",
+        message: `Network error: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      });
+    }
+  }, [selectedDs]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const availableComponentNames =
+    state.status === "ready" ? state.components.map((c) => c.name) : [];
+
+  if (!selectedDs) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No design system selected. Create a draft from the Versions tab
+          first.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Templates</h1>
+          <p className="text-sm text-muted-foreground">
+            Page-type templates on design system v{selectedDs.version} (
+            {selectedDs.status}).
+          </p>
+        </div>
+        <Button
+          onClick={() => setFormMode({ kind: "create" })}
+          disabled={state.status !== "ready" && state.status !== "error"}
+        >
+          New template
+        </Button>
+      </div>
+
+      <div className="mt-6">
+        {state.status === "loading" && (
+          <div className="rounded-md border p-8 text-center">
+            <p className="text-sm text-muted-foreground">Loading templates…</p>
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <div
+            className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+            role="alert"
+          >
+            <span>{state.message}</span>
+            <Button variant="outline" size="sm" onClick={() => void load()}>
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {state.status === "ready" && (
+          <TemplatesTable
+            templates={state.templates}
+            onEdit={(t) => setFormMode({ kind: "edit", template: t })}
+            onDelete={(t) => setDeleteTarget(t)}
+          />
+        )}
+      </div>
+
+      {formMode && (
+        <TemplateFormModal
+          open
+          mode={formMode}
+          designSystemId={selectedDs.id}
+          availableComponentNames={availableComponentNames}
+          onClose={() => setFormMode(null)}
+          onSuccess={() => {
+            void load();
+            refetchLayout();
+          }}
+        />
+      )}
+
+      {deleteTarget && (
+        <ConfirmActionModal
+          open
+          title={`Delete template "${deleteTarget.page_type}/${deleteTarget.name}"?`}
+          description={
+            "This removes the template. Pages that reference it by template_id will keep working — templates are a snapshot at page-generation time."
+          }
+          confirmLabel="Delete template"
+          confirmVariant="destructive"
+          endpoint={`/api/design-systems/${selectedDs.id}/templates/${deleteTarget.id}`}
+          request={{
+            method: "DELETE",
+            searchParams: {
+              expected_version_lock: deleteTarget.version_lock,
+            },
+          }}
+          onClose={() => setDeleteTarget(null)}
+          onSuccess={() => {
+            setDeleteTarget(null);
+            void load();
+            refetchLayout();
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/components/ComponentFormModal.tsx
+++ b/components/ComponentFormModal.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { DesignComponent } from "@/lib/components";
+
+// Single modal for both creating and editing components. The mode prop
+// determines which API endpoint and HTTP verb to use, and whether the name
+// field is editable (not after create — name is part of a uniqueness key).
+
+type FormState = {
+  name: string;
+  variant: string;
+  category: string;
+  html_template: string;
+  css: string;
+  content_schema: string; // JSON text
+  image_slots: string; // JSON text (optional)
+  usage_notes: string;
+};
+
+const INITIAL: FormState = {
+  name: "",
+  variant: "",
+  category: "",
+  html_template: "",
+  css: "",
+  content_schema:
+    '{\n  "type": "object",\n  "required": [],\n  "properties": {}\n}',
+  image_slots: "",
+  usage_notes: "",
+};
+
+function Label({
+  htmlFor,
+  children,
+}: {
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label htmlFor={htmlFor} className="block text-sm font-medium">
+      {children}
+    </label>
+  );
+}
+
+function FieldError({ message }: { message?: string | null }) {
+  if (!message) return null;
+  return <p className="mt-1 text-xs text-destructive">{message}</p>;
+}
+
+function initialFromComponent(c: DesignComponent): FormState {
+  return {
+    name: c.name,
+    variant: c.variant ?? "",
+    category: c.category,
+    html_template: c.html_template,
+    css: c.css,
+    content_schema: JSON.stringify(c.content_schema ?? {}, null, 2),
+    image_slots: c.image_slots ? JSON.stringify(c.image_slots, null, 2) : "",
+    usage_notes: c.usage_notes ?? "",
+  };
+}
+
+export type ComponentFormMode =
+  | { kind: "create" }
+  | { kind: "edit"; component: DesignComponent };
+
+export function ComponentFormModal({
+  open,
+  mode,
+  designSystemId,
+  onClose,
+  onSuccess,
+}: {
+  open: boolean;
+  mode: ComponentFormMode;
+  designSystemId: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const initial = useMemo<FormState>(
+    () => (mode.kind === "edit" ? initialFromComponent(mode.component) : INITIAL),
+    [mode],
+  );
+  const [form, setForm] = useState<FormState>(initial);
+  const [fieldErrors, setFieldErrors] = useState<
+    Partial<Record<keyof FormState, string>>
+  >({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setForm(initial);
+      setFieldErrors({});
+      setFormError(null);
+    }
+  }, [open, initial]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !submitting) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, submitting, onClose]);
+
+  if (!open) return null;
+
+  function setField<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    if (fieldErrors[key]) {
+      setFieldErrors((prev) => ({ ...prev, [key]: undefined }));
+    }
+  }
+
+  function validateClient(): {
+    ok: boolean;
+    parsedSchema?: unknown;
+    parsedImageSlots?: unknown;
+  } {
+    const errs: Partial<Record<keyof FormState, string>> = {};
+
+    if (mode.kind === "create") {
+      if (!/^[a-z0-9-]+$/.test(form.name)) {
+        errs.name = "Must be lowercase kebab-case (letters, digits, hyphens).";
+      }
+    }
+    if (form.category.trim().length === 0) {
+      errs.category = "Required.";
+    }
+    if (form.html_template.trim().length === 0) {
+      errs.html_template = "Required.";
+    }
+
+    let parsedSchema: unknown = {};
+    try {
+      parsedSchema = JSON.parse(form.content_schema);
+      if (typeof parsedSchema !== "object" || parsedSchema === null) {
+        errs.content_schema = "Must be a JSON object.";
+      }
+    } catch (e) {
+      errs.content_schema = `Invalid JSON: ${
+        e instanceof Error ? e.message : String(e)
+      }`;
+    }
+
+    let parsedImageSlots: unknown = null;
+    if (form.image_slots.trim().length > 0) {
+      try {
+        parsedImageSlots = JSON.parse(form.image_slots);
+        if (typeof parsedImageSlots !== "object" || parsedImageSlots === null) {
+          errs.image_slots = "Must be a JSON object (or leave blank).";
+        }
+      } catch (e) {
+        errs.image_slots = `Invalid JSON: ${
+          e instanceof Error ? e.message : String(e)
+        }`;
+      }
+    }
+
+    setFieldErrors(errs);
+    if (Object.keys(errs).length > 0) return { ok: false };
+    return { ok: true, parsedSchema, parsedImageSlots };
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+
+    const check = validateClient();
+    if (!check.ok) return;
+
+    setSubmitting(true);
+    try {
+      const common = {
+        variant: form.variant.trim().length > 0 ? form.variant : null,
+        category: form.category,
+        html_template: form.html_template,
+        css: form.css,
+        content_schema: check.parsedSchema,
+        image_slots:
+          form.image_slots.trim().length > 0 ? check.parsedImageSlots : null,
+        usage_notes:
+          form.usage_notes.trim().length > 0 ? form.usage_notes : null,
+      };
+
+      let res: Response;
+      if (mode.kind === "create") {
+        res = await fetch(
+          `/api/design-systems/${designSystemId}/components`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ name: form.name, ...common }),
+          },
+        );
+      } else {
+        res = await fetch(
+          `/api/design-systems/${designSystemId}/components/${mode.component.id}`,
+          {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              ...common,
+              expected_version_lock: mode.component.version_lock,
+            }),
+          },
+        );
+      }
+
+      const payload = await res.json().catch(() => null);
+      if (res.ok && payload?.ok) {
+        onSuccess();
+        onClose();
+        return;
+      }
+
+      // Field-mapping for Zod-issue payloads
+      const code = payload?.error?.code;
+      if (code === "VALIDATION_FAILED" && payload?.error?.details) {
+        const details = payload.error.details as {
+          issues?: Array<{ path?: string; message?: string }>;
+          violations?: Array<{ selector?: string; line?: number }>;
+          prefix?: string;
+        };
+        if (Array.isArray(details.violations) && details.violations.length > 0) {
+          const pretty = details.violations
+            .map((v) => `${v.selector ?? "?"} (line ${v.line ?? "?"})`)
+            .join(", ");
+          setFieldErrors({
+            css: `Selectors not prefixed with ${details.prefix ?? "site prefix"}-: ${pretty}`,
+          });
+          setSubmitting(false);
+          return;
+        }
+        if (Array.isArray(details.issues)) {
+          const newErrs: Partial<Record<keyof FormState, string>> = {};
+          for (const issue of details.issues) {
+            const root = issue.path?.split(".")?.[0] as
+              | keyof FormState
+              | undefined;
+            if (root && root in INITIAL) {
+              newErrs[root] = issue.message ?? "Invalid.";
+            }
+          }
+          if (Object.keys(newErrs).length > 0) {
+            setFieldErrors(newErrs);
+            setSubmitting(false);
+            return;
+          }
+        }
+      }
+
+      setFormError(
+        payload?.error?.message ??
+          `Request failed (HTTP ${res.status}). Please try again.`,
+      );
+    } catch (err) {
+      setFormError(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const title =
+    mode.kind === "create"
+      ? "New component"
+      : `Edit component · ${mode.component.name}`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="component-form-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !submitting) onClose();
+      }}
+    >
+      <div className="max-h-[90vh] w-full max-w-3xl overflow-auto rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="component-form-title" className="text-lg font-semibold">
+          {title}
+        </h2>
+
+        <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="cf-name">Name</Label>
+              <Input
+                id="cf-name"
+                value={form.name}
+                onChange={(e) => setField("name", e.target.value)}
+                readOnly={mode.kind === "edit"}
+                className={
+                  mode.kind === "edit" ? "cursor-not-allowed opacity-60" : ""
+                }
+                placeholder="hero-with-showcase"
+                disabled={submitting}
+              />
+              <FieldError message={fieldErrors.name} />
+              {mode.kind === "edit" && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Name is immutable after create — it&apos;s part of the uniqueness
+                  key with variant.
+                </p>
+              )}
+            </div>
+            <div>
+              <Label htmlFor="cf-variant">Variant (optional)</Label>
+              <Input
+                id="cf-variant"
+                value={form.variant}
+                onChange={(e) => setField("variant", e.target.value)}
+                placeholder="default"
+                disabled={submitting}
+              />
+              <FieldError message={fieldErrors.variant} />
+            </div>
+          </div>
+
+          <div>
+            <Label htmlFor="cf-category">Category</Label>
+            <Input
+              id="cf-category"
+              value={form.category}
+              onChange={(e) => setField("category", e.target.value)}
+              placeholder="hero"
+              disabled={submitting}
+            />
+            <FieldError message={fieldErrors.category} />
+          </div>
+
+          <div>
+            <Label htmlFor="cf-html">HTML template</Label>
+            <textarea
+              id="cf-html"
+              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              value={form.html_template}
+              onChange={(e) => setField("html_template", e.target.value)}
+              spellCheck={false}
+              disabled={submitting}
+            />
+            <FieldError message={fieldErrors.html_template} />
+          </div>
+
+          <div>
+            <Label htmlFor="cf-css">CSS</Label>
+            <textarea
+              id="cf-css"
+              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              value={form.css}
+              onChange={(e) => setField("css", e.target.value)}
+              spellCheck={false}
+              disabled={submitting}
+            />
+            <FieldError message={fieldErrors.css} />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Every class selector must use the site&apos;s scope prefix (e.g.
+              .ls-*). The server rejects unscoped CSS at submit time.
+            </p>
+          </div>
+
+          <div>
+            <Label htmlFor="cf-schema">content_schema (JSON)</Label>
+            <textarea
+              id="cf-schema"
+              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              value={form.content_schema}
+              onChange={(e) => setField("content_schema", e.target.value)}
+              spellCheck={false}
+              disabled={submitting}
+            />
+            <FieldError message={fieldErrors.content_schema} />
+          </div>
+
+          <div>
+            <Label htmlFor="cf-image-slots">image_slots JSON (optional)</Label>
+            <textarea
+              id="cf-image-slots"
+              className="mt-1 h-20 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              value={form.image_slots}
+              onChange={(e) => setField("image_slots", e.target.value)}
+              spellCheck={false}
+              disabled={submitting}
+            />
+            <FieldError message={fieldErrors.image_slots} />
+          </div>
+
+          <div>
+            <Label htmlFor="cf-notes">Usage notes (optional)</Label>
+            <textarea
+              id="cf-notes"
+              className="mt-1 h-20 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              value={form.usage_notes}
+              onChange={(e) => setField("usage_notes", e.target.value)}
+              disabled={submitting}
+            />
+            <FieldError message={fieldErrors.usage_notes} />
+          </div>
+
+          {formError && (
+            <div
+              className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+              role="alert"
+            >
+              {formError}
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting
+                ? "Saving…"
+                : mode.kind === "create"
+                  ? "Create component"
+                  : "Save changes"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/ComponentsGrid.tsx
+++ b/components/ComponentsGrid.tsx
@@ -1,0 +1,98 @@
+import { Button } from "@/components/ui/button";
+import type { DesignComponent } from "@/lib/components";
+
+function countRequiredFields(schema: unknown): number {
+  if (!schema || typeof schema !== "object") return 0;
+  const required = (schema as { required?: unknown }).required;
+  if (!Array.isArray(required)) return 0;
+  return required.filter((s) => typeof s === "string").length;
+}
+
+function variantLabel(c: DesignComponent): string {
+  return c.variant ? `${c.category} · ${c.variant}` : c.category;
+}
+
+export function ComponentsGrid({
+  components,
+  onEdit,
+  onDelete,
+}: {
+  components: DesignComponent[];
+  onEdit: (c: DesignComponent) => void;
+  onDelete: (c: DesignComponent) => void;
+}) {
+  if (components.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No components in this design system yet. Click &ldquo;New component&rdquo; to add
+          one.
+        </p>
+      </div>
+    );
+  }
+
+  const grouped = components.reduce<Record<string, DesignComponent[]>>(
+    (acc, c) => {
+      (acc[c.category] ??= []).push(c);
+      return acc;
+    },
+    {},
+  );
+  const categories = Object.keys(grouped).sort();
+
+  return (
+    <div className="space-y-8">
+      {categories.map((cat) => (
+        <section key={cat}>
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {cat}
+          </h2>
+          <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {grouped[cat]
+              .slice()
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((c) => (
+                <li
+                  key={c.id}
+                  className="flex flex-col gap-2 rounded-md border p-4"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <div className="text-sm font-medium">{c.name}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {variantLabel(c)}
+                      </div>
+                    </div>
+                    <div className="shrink-0 text-xs text-muted-foreground">
+                      v<span className="font-mono">{c.version_lock}</span>
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {countRequiredFields(c.content_schema)} required field
+                    {countRequiredFields(c.content_schema) === 1 ? "" : "s"}
+                  </p>
+                  <div className="mt-auto flex items-center justify-end gap-2 pt-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onDelete(c)}
+                    >
+                      Delete
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onEdit(c)}
+                    >
+                      Edit
+                    </Button>
+                  </div>
+                </li>
+              ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/components/ConfirmActionModal.tsx
+++ b/components/ConfirmActionModal.tsx
@@ -4,19 +4,22 @@ import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
-// Generic confirmation modal for mutating actions that need a
-// server round-trip. Used by the version manager for activate and
-// archive — both are structurally identical (POST a body, refetch on
-// success, surface envelope errors inline, show warnings[] if present).
+// Generic confirmation modal for mutating actions that need a server
+// round-trip. Used by the version manager (POST activate / POST archive)
+// and the components/templates editors (DELETE with a query param).
 //
-// Design note: intentionally untied from any specific API shape. The caller
-// supplies the URL + body + success/error messages; this component only
-// orchestrates open state, submission state, and error display.
+// Two request shapes via a discriminated union so DELETE endpoints can
+// pass expected_version_lock as ?query param rather than a body — DELETE
+// bodies are unreliable across proxies and we took that choice at M1e-1.
 
 export type ConfirmActionSuccess = {
   ok: true;
   data: unknown;
 };
+
+export type ConfirmActionRequest =
+  | { method: "POST"; body: Record<string, unknown> }
+  | { method: "DELETE"; searchParams: Record<string, string | number> };
 
 export type ConfirmActionModalProps = {
   open: boolean;
@@ -25,13 +28,28 @@ export type ConfirmActionModalProps = {
   confirmLabel: string;
   confirmVariant?: "default" | "destructive";
   endpoint: string;
-  body: Record<string, unknown>;
-  // When the API envelope's data.warnings is a string[], surface them here.
-  // (Used by archive when the site had the target as its active DS.)
+  request: ConfirmActionRequest;
+  // When the API envelope's data contains a warnings[] string array, surface
+  // them here so operators notice (archive returns warnings when the site
+  // would end up with no active DS; delete-component warns about orphaned
+  // template refs).
   warningsAccessor?: (data: unknown) => string[] | undefined;
+  // Optional block of additional content rendered inside the modal body —
+  // used for pre-confirm orphan warnings, sample previews, etc.
+  extraContent?: React.ReactNode;
   onClose: () => void;
   onSuccess: (payload: ConfirmActionSuccess) => void;
 };
+
+function buildUrl(
+  endpoint: string,
+  searchParams: Record<string, string | number>,
+): string {
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(searchParams)) qs.set(k, String(v));
+  const sep = endpoint.includes("?") ? "&" : "?";
+  return qs.toString().length === 0 ? endpoint : `${endpoint}${sep}${qs}`;
+}
 
 export function ConfirmActionModal({
   open,
@@ -40,8 +58,9 @@ export function ConfirmActionModal({
   confirmLabel,
   confirmVariant = "default",
   endpoint,
-  body,
+  request,
   warningsAccessor,
+  extraContent,
   onClose,
   onSuccess,
 }: ConfirmActionModalProps) {
@@ -73,11 +92,19 @@ export function ConfirmActionModal({
     setFormError(null);
     setWarnings(null);
     try {
-      const res = await fetch(endpoint, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(body),
-      });
+      let res: Response;
+      if (request.method === "POST") {
+        res = await fetch(endpoint, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(request.body),
+        });
+      } else {
+        res = await fetch(buildUrl(endpoint, request.searchParams), {
+          method: "DELETE",
+        });
+      }
+
       let payload: any = null;
       try {
         payload = await res.json();
@@ -88,9 +115,6 @@ export function ConfirmActionModal({
       if (res.ok && payload?.ok) {
         const derived = warningsAccessor?.(payload.data) ?? null;
         if (derived && derived.length > 0) {
-          // Surface warnings in-modal, give operator a chance to read them
-          // before the modal closes. Still call onSuccess so the parent
-          // refetches.
           setWarnings(derived);
           onSuccess({ ok: true, data: payload.data });
           return;
@@ -128,6 +152,8 @@ export function ConfirmActionModal({
           {title}
         </h2>
         <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+
+        {extraContent && <div className="mt-4">{extraContent}</div>}
 
         {warnings && warnings.length > 0 && (
           <div

--- a/components/DesignSystemsTable.tsx
+++ b/components/DesignSystemsTable.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { DesignSystem } from "@/lib/design-systems";
 import { Button } from "@/components/ui/button";
 import { cn, formatRelativeTime } from "@/lib/utils";
@@ -32,10 +33,12 @@ function StatusCell({ status }: { status: DesignSystem["status"] }) {
 
 export function DesignSystemsTable({
   designSystems,
+  siteId,
   onActivate,
   onArchive,
 }: {
   designSystems: DesignSystem[];
+  siteId: string;
   onActivate: (ds: DesignSystem) => void;
   onArchive: (ds: DesignSystem) => void;
 }) {
@@ -83,7 +86,25 @@ export function DesignSystemsTable({
                 {ds.created_by ? ds.created_by : "—"}
               </td>
               <td className="px-4 py-3">
-                <div className="flex justify-end gap-2">
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  <Link
+                    href={`/admin/sites/${siteId}/design-system/components?ds=${ds.id}`}
+                    className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+                  >
+                    Components →
+                  </Link>
+                  <Link
+                    href={`/admin/sites/${siteId}/design-system/templates?ds=${ds.id}`}
+                    className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+                  >
+                    Templates →
+                  </Link>
+                  <Link
+                    href={`/admin/sites/${siteId}/design-system/preview?ds=${ds.id}`}
+                    className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+                  >
+                    Preview →
+                  </Link>
                   {ds.status === "draft" && (
                     <Button
                       size="sm"

--- a/components/PreviewGallery.tsx
+++ b/components/PreviewGallery.tsx
@@ -1,0 +1,218 @@
+import type { DesignComponent } from "@/lib/components";
+import type { DesignTemplate } from "@/lib/templates";
+
+// Read-only preview. Renders each component's raw HTML template + CSS in
+// <pre> blocks along with its content_schema fields; each template gets a
+// composition chain arrow-diagram. No live rendering of the component
+// output — that waits for M3's Handlebars-compatible renderer.
+
+function fieldsList(schema: unknown): Array<{
+  name: string;
+  type: string;
+  required: boolean;
+  constraint?: string;
+}> {
+  if (!schema || typeof schema !== "object") return [];
+  const s = schema as {
+    properties?: Record<string, unknown>;
+    required?: unknown;
+  };
+  const required = Array.isArray(s.required)
+    ? s.required.filter((x): x is string => typeof x === "string")
+    : [];
+  const props = s.properties ?? {};
+  return Object.entries(props).map(([name, def]) => {
+    const d = (def ?? {}) as {
+      type?: unknown;
+      maxLength?: unknown;
+      enum?: unknown;
+      format?: unknown;
+    };
+    const constraints: string[] = [];
+    if (typeof d.maxLength === "number") constraints.push(`max ${d.maxLength}`);
+    if (Array.isArray(d.enum)) constraints.push(`enum ${d.enum.length}`);
+    if (typeof d.format === "string") constraints.push(`format ${d.format}`);
+    return {
+      name,
+      type: typeof d.type === "string" ? d.type : "any",
+      required: required.includes(name),
+      constraint: constraints.length > 0 ? constraints.join(", ") : undefined,
+    };
+  });
+}
+
+function compositionChain(t: DesignTemplate): string[] {
+  if (!Array.isArray(t.composition)) return [];
+  return t.composition.map((c) =>
+    typeof c === "object" && c !== null
+      ? String((c as { component?: string }).component ?? "?")
+      : "?",
+  );
+}
+
+function Block({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1">{children}</div>
+    </div>
+  );
+}
+
+function CodeBlock({ text }: { text: string }) {
+  return (
+    <pre className="max-h-80 overflow-auto rounded-md border bg-muted/40 p-3 font-mono text-xs leading-relaxed">
+      {text.length > 0 ? text : <em className="text-muted-foreground">(empty)</em>}
+    </pre>
+  );
+}
+
+export function PreviewGallery({
+  components,
+  templates,
+}: {
+  components: DesignComponent[];
+  templates: DesignTemplate[];
+}) {
+  const sortedComponents = [...components].sort((a, b) => {
+    const cat = a.category.localeCompare(b.category);
+    return cat !== 0 ? cat : a.name.localeCompare(b.name);
+  });
+  const sortedTemplates = [...templates].sort((a, b) => {
+    const pt = a.page_type.localeCompare(b.page_type);
+    return pt !== 0 ? pt : a.name.localeCompare(b.name);
+  });
+
+  return (
+    <div className="space-y-10">
+      <section>
+        <h2 className="mb-4 text-sm font-medium">
+          Components ({sortedComponents.length})
+        </h2>
+        {sortedComponents.length === 0 ? (
+          <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+            No components in this design system yet.
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {sortedComponents.map((c) => {
+              const fields = fieldsList(c.content_schema);
+              return (
+                <article key={c.id} className="rounded-md border p-4">
+                  <header className="flex items-center justify-between border-b pb-3">
+                    <div>
+                      <div className="text-sm font-medium">{c.name}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {c.variant ? `${c.category} · ${c.variant}` : c.category}
+                      </div>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      v<span className="font-mono">{c.version_lock}</span>
+                    </div>
+                  </header>
+
+                  <div className="grid gap-4 pt-4 lg:grid-cols-2">
+                    <Block label="HTML template">
+                      <CodeBlock text={c.html_template} />
+                    </Block>
+                    <Block label="CSS">
+                      <CodeBlock text={c.css} />
+                    </Block>
+                  </div>
+
+                  <div className="mt-4">
+                    <Block label={`Fields (${fields.length})`}>
+                      {fields.length === 0 ? (
+                        <p className="text-xs text-muted-foreground">
+                          content_schema has no properties.
+                        </p>
+                      ) : (
+                        <ul className="mt-1 divide-y rounded-md border text-sm">
+                          {fields.map((f) => (
+                            <li
+                              key={f.name}
+                              className="flex items-center justify-between px-3 py-2"
+                            >
+                              <span className="font-mono text-xs">
+                                {f.name}
+                                {f.required && (
+                                  <span className="ml-1 text-destructive">*</span>
+                                )}
+                              </span>
+                              <span className="text-xs text-muted-foreground">
+                                {f.type}
+                                {f.constraint ? ` · ${f.constraint}` : ""}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </Block>
+                  </div>
+
+                  {c.usage_notes && (
+                    <div className="mt-4">
+                      <Block label="Usage notes">
+                        <p className="text-sm text-muted-foreground">
+                          {c.usage_notes}
+                        </p>
+                      </Block>
+                    </div>
+                  )}
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h2 className="mb-4 text-sm font-medium">
+          Templates ({sortedTemplates.length})
+        </h2>
+        {sortedTemplates.length === 0 ? (
+          <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+            No templates in this design system yet.
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {sortedTemplates.map((t) => {
+              const chain = compositionChain(t);
+              return (
+                <article key={t.id} className="rounded-md border p-4">
+                  <header className="flex items-center justify-between border-b pb-3">
+                    <div>
+                      <div className="text-sm font-medium">{t.name}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {t.page_type}
+                        {t.is_default ? " · default" : ""}
+                      </div>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      v<span className="font-mono">{t.version_lock}</span>
+                    </div>
+                  </header>
+                  <div className="pt-3">
+                    <Block label={`Composition (${chain.length})`}>
+                      {chain.length === 0 ? (
+                        <p className="text-xs text-muted-foreground">
+                          (empty composition)
+                        </p>
+                      ) : (
+                        <p className="text-xs text-muted-foreground">
+                          <span className="font-mono">{chain.join(" → ")}</span>
+                        </p>
+                      )}
+                    </Block>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/components/TemplateFormModal.tsx
+++ b/components/TemplateFormModal.tsx
@@ -1,0 +1,469 @@
+"use client";
+
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { DesignTemplate } from "@/lib/templates";
+
+type FormState = {
+  page_type: string;
+  name: string;
+  is_default: boolean;
+  composition: string; // JSON text
+  required_fields: string; // JSON text
+  seo_defaults: string; // JSON text (optional)
+};
+
+const INITIAL: FormState = {
+  page_type: "",
+  name: "",
+  is_default: false,
+  composition:
+    '[\n  { "component": "nav-default", "content_source": "site_context.nav" }\n]',
+  required_fields: "{}",
+  seo_defaults: "",
+};
+
+function Label({
+  htmlFor,
+  children,
+}: {
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label htmlFor={htmlFor} className="block text-sm font-medium">
+      {children}
+    </label>
+  );
+}
+
+function FieldError({ message }: { message?: string | null }) {
+  if (!message) return null;
+  return <p className="mt-1 text-xs text-destructive">{message}</p>;
+}
+
+function FieldWarning({ message }: { message?: string | null }) {
+  if (!message) return null;
+  return <p className="mt-1 text-xs text-yellow-700 dark:text-yellow-400">{message}</p>;
+}
+
+function initialFromTemplate(t: DesignTemplate): FormState {
+  return {
+    page_type: t.page_type,
+    name: t.name,
+    is_default: t.is_default,
+    composition: JSON.stringify(t.composition ?? [], null, 2),
+    required_fields: JSON.stringify(t.required_fields ?? {}, null, 2),
+    seo_defaults: t.seo_defaults
+      ? JSON.stringify(t.seo_defaults, null, 2)
+      : "",
+  };
+}
+
+export type TemplateFormMode =
+  | { kind: "create" }
+  | { kind: "edit"; template: DesignTemplate };
+
+export function TemplateFormModal({
+  open,
+  mode,
+  designSystemId,
+  availableComponentNames,
+  onClose,
+  onSuccess,
+}: {
+  open: boolean;
+  mode: TemplateFormMode;
+  designSystemId: string;
+  // Component names that currently exist in the DS. Used for the non-blocking
+  // composition-reference warning in the JSON textarea.
+  availableComponentNames: string[];
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const initial = useMemo<FormState>(
+    () => (mode.kind === "edit" ? initialFromTemplate(mode.template) : INITIAL),
+    [mode],
+  );
+  const [form, setForm] = useState<FormState>(initial);
+  const [fieldErrors, setFieldErrors] = useState<
+    Partial<Record<keyof FormState, string>>
+  >({});
+  const [fieldWarnings, setFieldWarnings] = useState<
+    Partial<Record<keyof FormState, string>>
+  >({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setForm(initial);
+      setFieldErrors({});
+      setFieldWarnings({});
+      setFormError(null);
+    }
+  }, [open, initial]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !submitting) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, submitting, onClose]);
+
+  // Non-blocking reference check on composition. Fires whenever composition
+  // text changes — operators who plan to create a component next get a
+  // warning, not a hard error.
+  useEffect(() => {
+    if (form.composition.trim().length === 0) {
+      setFieldWarnings((prev) => ({ ...prev, composition: undefined }));
+      return;
+    }
+    try {
+      const parsed = JSON.parse(form.composition);
+      if (!Array.isArray(parsed)) return;
+      const refs = parsed
+        .filter(
+          (x): x is { component: string } =>
+            x !== null &&
+            typeof x === "object" &&
+            typeof (x as { component?: unknown }).component === "string",
+        )
+        .map((x) => x.component);
+      const missing = refs.filter((r) => !availableComponentNames.includes(r));
+      if (missing.length > 0) {
+        setFieldWarnings((prev) => ({
+          ...prev,
+          composition: `References to components not in this design system yet: ${missing.join(", ")}. Not blocking — create them before activating the template.`,
+        }));
+      } else {
+        setFieldWarnings((prev) => ({ ...prev, composition: undefined }));
+      }
+    } catch {
+      // Parse errors surface on submit via fieldErrors — don't pile on.
+    }
+  }, [form.composition, availableComponentNames]);
+
+  if (!open) return null;
+
+  function setField<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    if (fieldErrors[key]) {
+      setFieldErrors((prev) => ({ ...prev, [key]: undefined }));
+    }
+  }
+
+  function validateClient(): {
+    ok: boolean;
+    parsedComposition?: unknown;
+    parsedRequired?: unknown;
+    parsedSeo?: unknown;
+  } {
+    const errs: Partial<Record<keyof FormState, string>> = {};
+
+    if (mode.kind === "create") {
+      if (form.page_type.trim().length === 0) {
+        errs.page_type = "Required.";
+      }
+    }
+    if (form.name.trim().length === 0) {
+      errs.name = "Required.";
+    }
+
+    let parsedComposition: unknown = [];
+    try {
+      parsedComposition = JSON.parse(form.composition);
+      if (!Array.isArray(parsedComposition) || parsedComposition.length === 0) {
+        errs.composition = "Must be a non-empty JSON array.";
+      }
+    } catch (e) {
+      errs.composition = `Invalid JSON: ${
+        e instanceof Error ? e.message : String(e)
+      }`;
+    }
+
+    let parsedRequired: unknown = {};
+    try {
+      parsedRequired = JSON.parse(form.required_fields);
+      if (typeof parsedRequired !== "object" || parsedRequired === null) {
+        errs.required_fields = "Must be a JSON object.";
+      }
+    } catch (e) {
+      errs.required_fields = `Invalid JSON: ${
+        e instanceof Error ? e.message : String(e)
+      }`;
+    }
+
+    let parsedSeo: unknown = null;
+    if (form.seo_defaults.trim().length > 0) {
+      try {
+        parsedSeo = JSON.parse(form.seo_defaults);
+        if (typeof parsedSeo !== "object" || parsedSeo === null) {
+          errs.seo_defaults = "Must be a JSON object (or leave blank).";
+        }
+      } catch (e) {
+        errs.seo_defaults = `Invalid JSON: ${
+          e instanceof Error ? e.message : String(e)
+        }`;
+      }
+    }
+
+    setFieldErrors(errs);
+    if (Object.keys(errs).length > 0) return { ok: false };
+    return {
+      ok: true,
+      parsedComposition,
+      parsedRequired,
+      parsedSeo,
+    };
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+
+    const check = validateClient();
+    if (!check.ok) return;
+
+    setSubmitting(true);
+    try {
+      let res: Response;
+      if (mode.kind === "create") {
+        res = await fetch(
+          `/api/design-systems/${designSystemId}/templates`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              page_type: form.page_type,
+              name: form.name,
+              is_default: form.is_default,
+              composition: check.parsedComposition,
+              required_fields: check.parsedRequired,
+              seo_defaults:
+                form.seo_defaults.trim().length > 0 ? check.parsedSeo : null,
+            }),
+          },
+        );
+      } else {
+        const patch: Record<string, unknown> = {
+          name: form.name,
+          is_default: form.is_default,
+          composition: check.parsedComposition,
+          required_fields: check.parsedRequired,
+          seo_defaults:
+            form.seo_defaults.trim().length > 0 ? check.parsedSeo : null,
+          expected_version_lock: mode.template.version_lock,
+        };
+        res = await fetch(
+          `/api/design-systems/${designSystemId}/templates/${mode.template.id}`,
+          {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(patch),
+          },
+        );
+      }
+
+      const payload = await res.json().catch(() => null);
+      if (res.ok && payload?.ok) {
+        onSuccess();
+        onClose();
+        return;
+      }
+
+      const code = payload?.error?.code;
+      if (code === "VALIDATION_FAILED" && payload?.error?.details) {
+        const details = payload.error.details as {
+          issues?: Array<{ path?: string; message?: string }>;
+          unknown_components?: string[];
+        };
+        if (
+          Array.isArray(details.unknown_components) &&
+          details.unknown_components.length > 0
+        ) {
+          setFieldErrors({
+            composition: `Server rejected composition — references missing components: ${details.unknown_components.join(", ")}.`,
+          });
+          setSubmitting(false);
+          return;
+        }
+        if (Array.isArray(details.issues)) {
+          const newErrs: Partial<Record<keyof FormState, string>> = {};
+          for (const issue of details.issues) {
+            const root = issue.path?.split(".")?.[0] as
+              | keyof FormState
+              | undefined;
+            if (root && root in INITIAL) {
+              newErrs[root] = issue.message ?? "Invalid.";
+            }
+          }
+          if (Object.keys(newErrs).length > 0) {
+            setFieldErrors(newErrs);
+            setSubmitting(false);
+            return;
+          }
+        }
+      }
+
+      setFormError(
+        payload?.error?.message ??
+          `Request failed (HTTP ${res.status}). Please try again.`,
+      );
+    } catch (err) {
+      setFormError(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const title =
+    mode.kind === "create"
+      ? "New template"
+      : `Edit template · ${mode.template.page_type}/${mode.template.name}`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="template-form-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !submitting) onClose();
+      }}
+    >
+      <div className="max-h-[90vh] w-full max-w-3xl overflow-auto rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="template-form-title" className="text-lg font-semibold">
+          {title}
+        </h2>
+
+        <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="tf-page-type">Page type</Label>
+              <Input
+                id="tf-page-type"
+                value={form.page_type}
+                onChange={(e) => setField("page_type", e.target.value)}
+                placeholder="homepage"
+                readOnly={mode.kind === "edit"}
+                className={
+                  mode.kind === "edit" ? "cursor-not-allowed opacity-60" : ""
+                }
+                disabled={submitting}
+              />
+              <FieldError message={fieldErrors.page_type} />
+              {mode.kind === "edit" && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Page type is immutable after create.
+                </p>
+              )}
+            </div>
+            <div>
+              <Label htmlFor="tf-name">Name</Label>
+              <Input
+                id="tf-name"
+                value={form.name}
+                onChange={(e) => setField("name", e.target.value)}
+                placeholder="homepage-default"
+                disabled={submitting}
+              />
+              <FieldError message={fieldErrors.name} />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              id="tf-is-default"
+              type="checkbox"
+              checked={form.is_default}
+              onChange={(e) => setField("is_default", e.target.checked)}
+              disabled={submitting}
+            />
+            <label htmlFor="tf-is-default" className="text-sm">
+              Default for this page type (only one per DS × page_type)
+            </label>
+          </div>
+
+          <div>
+            <Label htmlFor="tf-composition">Composition (JSON array)</Label>
+            <textarea
+              id="tf-composition"
+              className="mt-1 h-48 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              value={form.composition}
+              onChange={(e) => setField("composition", e.target.value)}
+              spellCheck={false}
+              disabled={submitting}
+            />
+            <FieldError message={fieldErrors.composition} />
+            <FieldWarning message={fieldWarnings.composition} />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Ordered array of {"{"} component, content_source {"}"} entries.
+              Every <code>component</code> must resolve to a component in this
+              design system — a warning shows above if one doesn&apos;t.
+            </p>
+          </div>
+
+          <div>
+            <Label htmlFor="tf-required">required_fields (JSON)</Label>
+            <textarea
+              id="tf-required"
+              className="mt-1 h-24 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              value={form.required_fields}
+              onChange={(e) => setField("required_fields", e.target.value)}
+              spellCheck={false}
+              disabled={submitting}
+            />
+            <FieldError message={fieldErrors.required_fields} />
+          </div>
+
+          <div>
+            <Label htmlFor="tf-seo">seo_defaults JSON (optional)</Label>
+            <textarea
+              id="tf-seo"
+              className="mt-1 h-20 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              value={form.seo_defaults}
+              onChange={(e) => setField("seo_defaults", e.target.value)}
+              spellCheck={false}
+              disabled={submitting}
+            />
+            <FieldError message={fieldErrors.seo_defaults} />
+          </div>
+
+          {formError && (
+            <div
+              className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+              role="alert"
+            >
+              {formError}
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting
+                ? "Saving…"
+                : mode.kind === "create"
+                  ? "Create template"
+                  : "Save changes"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/TemplatesTable.tsx
+++ b/components/TemplatesTable.tsx
@@ -1,0 +1,88 @@
+import { Button } from "@/components/ui/button";
+import type { DesignTemplate } from "@/lib/templates";
+
+function compositionPreview(t: DesignTemplate): string {
+  if (!Array.isArray(t.composition)) return "—";
+  const names = t.composition.map((c) =>
+    typeof c === "object" && c !== null
+      ? String((c as { component?: string }).component ?? "?")
+      : "?",
+  );
+  if (names.length === 0) return "(empty)";
+  if (names.length <= 3) return names.join(" → ");
+  return `${names.slice(0, 3).join(" → ")} → +${names.length - 3} more`;
+}
+
+export function TemplatesTable({
+  templates,
+  onEdit,
+  onDelete,
+}: {
+  templates: DesignTemplate[];
+  onEdit: (t: DesignTemplate) => void;
+  onDelete: (t: DesignTemplate) => void;
+}) {
+  if (templates.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No templates in this design system yet. Click &ldquo;New template&rdquo; to add
+          one.
+        </p>
+      </div>
+    );
+  }
+
+  const sorted = [...templates].sort((a, b) => {
+    const pt = a.page_type.localeCompare(b.page_type);
+    return pt !== 0 ? pt : a.name.localeCompare(b.name);
+  });
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <table className="w-full text-sm">
+        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+          <tr>
+            <th className="px-4 py-2 font-medium">Page type</th>
+            <th className="px-4 py-2 font-medium">Name</th>
+            <th className="px-4 py-2 font-medium">Composition</th>
+            <th className="px-4 py-2 font-medium">Default</th>
+            <th className="px-4 py-2 font-medium text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((t) => (
+            <tr key={t.id} className="border-b last:border-b-0">
+              <td className="px-4 py-3 font-mono text-xs">{t.page_type}</td>
+              <td className="px-4 py-3 font-medium">{t.name}</td>
+              <td className="px-4 py-3 text-xs text-muted-foreground">
+                {compositionPreview(t)}
+              </td>
+              <td className="px-4 py-3 text-xs text-muted-foreground">
+                {t.is_default ? "Yes" : "—"}
+              </td>
+              <td className="px-4 py-3">
+                <div className="flex justify-end gap-2">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => onDelete(t)}
+                  >
+                    Delete
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => onEdit(t)}
+                  >
+                    Edit
+                  </Button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/design-system-context.tsx
+++ b/components/design-system-context.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { DesignSystem } from "@/lib/design-systems";
+
+// Context provided by app/admin/sites/[id]/design-system/layout.tsx.
+//
+// Children pages (Versions / Components / Templates / Preview) pull the
+// site + all versions from here so each page doesn't re-fetch the same data.
+// Selection of the "currently viewed" DS is a per-page concern, not a
+// context concern — pages read the `?ds=<uuid>` query param themselves and
+// look up from `versions`.
+
+export type DesignSystemSiteSummary = {
+  id: string;
+  name: string;
+  prefix: string;
+};
+
+export type DesignSystemLayoutContextValue = {
+  site: DesignSystemSiteSummary;
+  versions: DesignSystem[];
+  refetch: () => void;
+};
+
+export const DesignSystemLayoutContext =
+  createContext<DesignSystemLayoutContextValue | null>(null);
+
+export function useDesignSystemLayout(): DesignSystemLayoutContextValue {
+  const ctx = useContext(DesignSystemLayoutContext);
+  if (ctx === null) {
+    throw new Error(
+      "useDesignSystemLayout must be used within DesignSystemLayoutContext.Provider — " +
+        "make sure the component is rendered under app/admin/sites/[id]/design-system/layout.tsx.",
+    );
+  }
+  return ctx;
+}
+
+// Helper: resolve the DS a page is "viewing" from the URL's ?ds param +
+// the versions list. Priority:
+//   1. ?ds=<uuid> if valid (exists in versions)
+//   2. the active version for the site
+//   3. the newest version (highest version number)
+//   4. null when the site has no versions at all
+export function resolveSelectedDesignSystem(
+  versions: DesignSystem[],
+  dsParam: string | null,
+): DesignSystem | null {
+  if (dsParam) {
+    const match = versions.find((v) => v.id === dsParam);
+    if (match) return match;
+  }
+  const active = versions.find((v) => v.status === "active");
+  if (active) return active;
+  if (versions.length === 0) return null;
+  return [...versions].sort((a, b) => b.version - a.version)[0];
+}


### PR DESCRIPTION
## Summary

Combined final slice of M1e. Lands the three sub-pages under `/admin/sites/[id]/design-system` that edit components, edit templates, and preview the full design system — plus the shared sub-layout that ties all four design-system pages together.

## What's in

### Shared infrastructure
- **`components/design-system-context.tsx`** — React context wrapping `site` + `versions` + `refetch()`. `resolveSelectedDesignSystem(versions, dsParam)` helper picks DS by `?ds=<uuid>`, then active, then newest.
- **`app/admin/sites/[id]/design-system/layout.tsx`** — loads site + versions, renders breadcrumb + version selector dropdown + tab nav (Versions / Components / Templates / Preview). Provides the context.
- **`components/ConfirmActionModal.tsx`** — extended with a discriminated-union `Request` type (`POST` with body OR `DELETE` with `searchParams`). Existing activate/archive callers migrated.

### Version manager refactor
- **`app/admin/sites/[id]/design-system/page.tsx`** — dropped its own site fetch + header (now in layout), consumes context.
- **`components/DesignSystemsTable.tsx`** — per-row deep-link pills (Components / Templates / Preview) carrying `?ds=<uuid>`.

### Components editor (`/components`)
- **`components/ComponentsGrid.tsx`** — card grid grouped by category. Name + variant + version_lock + required-field count + Edit / Delete buttons.
- **`components/ComponentFormModal.tsx`** — combined Create + Edit modal (`mode` prop). Name immutable in edit. Fields for html_template, css, content_schema (JSON), image_slots (JSON optional), usage_notes. Layer-2 CSS violations surface with line numbers.
- **Page** — fetches the preview bundle (DS + components + templates). Delete scans templates for orphan references and surfaces affected templates in the confirm modal's `extraContent` slot — non-blocking per Q8.

### Templates editor (`/templates`)
- **`components/TemplatesTable.tsx`** — rows grouped by page_type, composition preview shortened, default flag.
- **`components/TemplateFormModal.tsx`** — combined Create + Edit modal. `page_type` immutable in edit. Composition JSON textarea with **live non-blocking warning** when a referenced component name isn't in the current DS (operator might create it next — Additional requirement from the approved plan).

### Preview gallery (`/preview`)
- **`components/PreviewGallery.tsx`** — per-component card (raw HTML + CSS in `<pre>` blocks, content_schema fields listed with required marker + type + constraints, usage_notes). Per-template card with composition chain. No live rendering (M3).

## Conventions followed
- `"use client"` + `LoadState` discriminated union + refetch on success.
- Plain `fetch()` with `cache: "no-store"`, custom modal divs, inline red destructive alerts.
- shadcn primitives reused from `components/ui/`.
- Plain textareas, no code-editor library, no drag-and-drop — per Q3/Q4.
- No UI unit tests — consistent with the existing codebase; the HTTP contract is covered by M1e-1's route smoke tests.

## Verification

- `tsc --noEmit` clean.
- `next build` passes; all four admin routes registered:
  ```
  /admin/sites/[id]/design-system             4.73 kB
  /admin/sites/[id]/design-system/components  6.11 kB
  /admin/sites/[id]/design-system/templates   6.03 kB
  /admin/sites/[id]/design-system/preview     3.27 kB
  ```
- Browser click-through **not** verified — sandbox has no dev server or Supabase stack.

## Test plan

- [ ] `supabase start && npm run dev`
- [ ] Visit `/admin/sites/[id]/design-system` — tabs render, version selector lists all versions
- [ ] Version manager: create draft → appears → activate → prior active archived → warnings on archiving active
- [ ] Components: create a valid component; create one with unscoped CSS → see line-numbered error; edit changes pushes new version_lock; delete component referenced by a template → orphan warning before confirm
- [ ] Templates: create valid; create with unknown component → warning (not blocking); submit → server rejects with listed unknown_components → error updates with server's list
- [ ] Preview: verify each component card shows HTML/CSS `<pre>` blocks + field list
- [ ] Deep-link from version manager row → lands on components page with correct `?ds=<uuid>`
- [ ] `?ds=` query param preserved across tab switches
- [ ] All empty/loading/error states render cleanly

Do not merge until local browser verification is green.

https://claude.ai/code/session_01PTCJrskyCmW3t9NvLXM7rT