### PR TITLE
M1f: scope-prefix enforcement layers 1 + 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       - if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
       - run: npm run lint
+      - run: npm run lint:css
 
   test:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,21 @@ npm test            # run once
 npm run test:watch  # watch mode
 ```
 
+### Linting
+
+```bash
+npm run lint        # next lint — TypeScript / JSX
+npm run lint:css    # stylelint — enforces Layer-1 scope-prefix rule
+                    # on all seed/*/*.css. Regex rejects malformed
+                    # double-hyphen blocks deliberately (see the
+                    # inner [a-z0-9]+ in seed/leadsource/.stylelintrc.json).
+```
+
+Both run in the single `lint` job in CI. A failing `lint:css` means one
+or more class selectors in the seed CSS don't match the site's scope
+prefix — either the class needs renaming (preferred) or it's legit and
+should be added to the per-site `.stylelintrc.json` allowlist.
+
 Vitest's `globalSetup` calls `supabase status --output json` to find the
 local API URL and service-role key. If the stack isn't running, it'll run
 `supabase start` for you. Between tests, a `TRUNCATE ... CASCADE` clears

--- a/lib/__tests__/class-registry.test.ts
+++ b/lib/__tests__/class-registry.test.ts
@@ -123,6 +123,34 @@ describe("extractHtmlClasses", () => {
     expect([...s].sort()).toEqual(["ls-btn", "ls-hero"]);
   });
 
+  it("handles mid-token template interpolation (ls-avatar--{{tone}})", () => {
+    // Concatenated form leaves `ls-avatar--` after stripping — skipped as
+    // an incomplete fragment. Rendered form (e.g. `ls-avatar--1`) gets
+    // validated separately at M3 generation time.
+    const s = extractHtmlClasses(
+      `<div class="ls-avatar ls-avatar--{{tone}}">x</div>`,
+    );
+    expect([...s].sort()).toEqual(["ls-avatar"]);
+  });
+
+  it("handles Handlebars if/else inside class attribute", () => {
+    const s = extractHtmlClasses(
+      `<a class="ls-btn {{#if featured}}ls-btn--primary{{else}}ls-btn--outline{{/if}}">x</a>`,
+    );
+    expect([...s].sort()).toEqual([
+      "ls-btn",
+      "ls-btn--outline",
+      "ls-btn--primary",
+    ]);
+  });
+
+  it("handles conditional className append — ls-price{{#if featured}} ls-price--featured{{/if}}", () => {
+    const s = extractHtmlClasses(
+      `<div class="ls-price{{#if featured}} ls-price--featured{{/if}}">x</div>`,
+    );
+    expect([...s].sort()).toEqual(["ls-price", "ls-price--featured"]);
+  });
+
   it("returns empty Set when element has no class attribute", () => {
     const s = extractHtmlClasses(`<div>hi</div>`);
     expect([...s]).toEqual([]);

--- a/lib/__tests__/class-registry.test.ts
+++ b/lib/__tests__/class-registry.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { extractCssClasses } from "@/lib/scope-prefix";
+import {
+  buildClassRegistry,
+  extractHtmlClasses,
+  validateHtmlClasses,
+} from "@/lib/class-registry";
+
+// ---------------------------------------------------------------------------
+// extractCssClasses
+// ---------------------------------------------------------------------------
+
+describe("extractCssClasses", () => {
+  it("picks up a single class selector", () => {
+    const s = extractCssClasses(".ls-hero { padding: 2rem; }");
+    expect([...s].sort()).toEqual(["ls-hero"]);
+  });
+
+  it("handles compound class selectors (.ls-card.ls-card--dark)", () => {
+    const s = extractCssClasses(".ls-card.ls-card--dark { color: #000; }");
+    expect([...s].sort()).toEqual(["ls-card", "ls-card--dark"]);
+  });
+
+  it("handles descendant and child selectors", () => {
+    const s = extractCssClasses(
+      ".ls-hero .ls-hero__title { font-size: 2rem; }\n" +
+        ".ls-nav > .ls-nav__item { padding: 8px; }",
+    );
+    expect([...s].sort()).toEqual([
+      "ls-hero",
+      "ls-hero__title",
+      "ls-nav",
+      "ls-nav__item",
+    ]);
+  });
+
+  it("handles negation (:not(.ls-btn--disabled))", () => {
+    const s = extractCssClasses(
+      ".ls-btn:not(.ls-btn--disabled) { cursor: pointer; }",
+    );
+    expect([...s].sort()).toEqual(["ls-btn", "ls-btn--disabled"]);
+  });
+
+  it("handles pseudo-classes and pseudo-elements", () => {
+    const s = extractCssClasses(
+      ".ls-btn:hover { } .ls-hero::before { }",
+    );
+    expect([...s].sort()).toEqual(["ls-btn", "ls-hero"]);
+  });
+
+  it("deduplicates across rules", () => {
+    const s = extractCssClasses(
+      ".ls-x { a: 1; } .ls-x { b: 2; } .ls-y .ls-x { c: 3; }",
+    );
+    expect([...s].sort()).toEqual(["ls-x", "ls-y"]);
+  });
+
+  it("ignores class-like fragments inside block comments", () => {
+    const s = extractCssClasses(
+      "/* .old-class was renamed */ .ls-hero { }",
+    );
+    expect([...s].sort()).toEqual(["ls-hero"]);
+  });
+
+  it("ignores class-like fragments inside url(...)", () => {
+    const s = extractCssClasses(
+      '.ls-check::before { background: url("data:image/svg+xml,%3Csvg .class .x /%3E"); }',
+    );
+    expect([...s].sort()).toEqual(["ls-check"]);
+  });
+
+  it("does not treat decimal numbers as classes", () => {
+    const s = extractCssClasses(".ls-box { line-height: 1.4; padding: 1.4em; }");
+    expect([...s].sort()).toEqual(["ls-box"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractHtmlClasses
+// ---------------------------------------------------------------------------
+
+describe("extractHtmlClasses", () => {
+  it("reads a double-quoted class attribute", () => {
+    const s = extractHtmlClasses(`<div class="ls-hero">hi</div>`);
+    expect([...s].sort()).toEqual(["ls-hero"]);
+  });
+
+  it("reads a single-quoted class attribute", () => {
+    const s = extractHtmlClasses(`<div class='ls-hero'>hi</div>`);
+    expect([...s].sort()).toEqual(["ls-hero"]);
+  });
+
+  it("reads an unquoted class attribute (HTML5)", () => {
+    const s = extractHtmlClasses(`<div class=ls-hero>hi</div>`);
+    expect([...s].sort()).toEqual(["ls-hero"]);
+  });
+
+  it("handles multiple space-separated classes", () => {
+    const s = extractHtmlClasses(
+      `<button class="ls-btn ls-btn--primary ls-btn--lg">x</button>`,
+    );
+    expect([...s].sort()).toEqual([
+      "ls-btn",
+      "ls-btn--lg",
+      "ls-btn--primary",
+    ]);
+  });
+
+  it("aggregates classes across nested children", () => {
+    const s = extractHtmlClasses(
+      `<section class="ls-hero"><h1 class="ls-hero__title">x</h1></section>`,
+    );
+    expect([...s].sort()).toEqual(["ls-hero", "ls-hero__title"]);
+  });
+
+  it("ignores Handlebars-style template holes like {{dynamic}} and {var}", () => {
+    const s = extractHtmlClasses(
+      `<div class="ls-hero {{dynamic}}">x</div>` +
+        `<div class="ls-btn {var}">y</div>`,
+    );
+    expect([...s].sort()).toEqual(["ls-btn", "ls-hero"]);
+  });
+
+  it("returns empty Set when element has no class attribute", () => {
+    const s = extractHtmlClasses(`<div>hi</div>`);
+    expect([...s]).toEqual([]);
+  });
+
+  it("handles self-closing tags", () => {
+    const s = extractHtmlClasses(`<img class="ls-avatar" />`);
+    expect([...s].sort()).toEqual(["ls-avatar"]);
+  });
+
+  // Contract test: className= is JSX, not HTML. If M3 ever emits JSX, the
+  // helper deliberately ignores it — so the validator's "unknown class"
+  // list stays correct and doesn't pick up React runtime tokens.
+  it("does NOT pick up className= (JSX contamination signal)", () => {
+    const s = extractHtmlClasses(`<div className="ls-hero">hi</div>`);
+    expect([...s]).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildClassRegistry
+// ---------------------------------------------------------------------------
+
+describe("buildClassRegistry", () => {
+  it("unions classes across tokens, base, and components", () => {
+    const registry = buildClassRegistry({
+      tokensCss: ".ls-scope { --ls-blue: #185FA5; }",
+      baseStyles: ".ls-container { max-width: 1160px; }",
+      componentCss: [
+        ".ls-hero { padding: 2rem; } .ls-hero__title { font-size: 2rem; }",
+        ".ls-footer { padding: 1rem; }",
+      ],
+    });
+    expect([...registry].sort()).toEqual([
+      "ls-container",
+      "ls-footer",
+      "ls-hero",
+      "ls-hero__title",
+      "ls-scope",
+    ]);
+  });
+
+  it("dedups across inputs", () => {
+    const registry = buildClassRegistry({
+      tokensCss: ".ls-x {}",
+      baseStyles: ".ls-x {}",
+      componentCss: [".ls-x {} .ls-y {}"],
+    });
+    expect([...registry].sort()).toEqual(["ls-x", "ls-y"]);
+  });
+
+  it("merges in an explicit allowlist", () => {
+    const registry = buildClassRegistry({
+      tokensCss: "",
+      baseStyles: ".ls-container {}",
+      componentCss: [".ls-hero {}"],
+      allowlist: ["sr-only", "visually-hidden"],
+    });
+    expect([...registry].sort()).toEqual([
+      "ls-container",
+      "ls-hero",
+      "sr-only",
+      "visually-hidden",
+    ]);
+  });
+
+  it("returns an empty Set for empty inputs", () => {
+    const registry = buildClassRegistry({
+      tokensCss: "",
+      baseStyles: "",
+      componentCss: [],
+    });
+    expect(registry.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateHtmlClasses
+// ---------------------------------------------------------------------------
+
+describe("validateHtmlClasses", () => {
+  const registry = new Set(["ls-hero", "ls-hero__title", "ls-btn"]);
+
+  it("returns valid=true when all classes are registered", () => {
+    const r = validateHtmlClasses(
+      `<section class="ls-hero"><h1 class="ls-hero__title">x</h1></section>`,
+      registry,
+    );
+    expect(r.valid).toBe(true);
+  });
+
+  it("returns valid=false with a single unknown class", () => {
+    const r = validateHtmlClasses(
+      `<div class="ls-hero ls-bogus">x</div>`,
+      registry,
+    );
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.unknownClasses).toEqual(["ls-bogus"]);
+  });
+
+  it("deduplicates repeated unknown classes across the HTML", () => {
+    const r = validateHtmlClasses(
+      `<a class="ls-oops"></a><a class="ls-oops"></a>`,
+      registry,
+    );
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.unknownClasses).toEqual(["ls-oops"]);
+  });
+
+  it("reports multiple distinct unknown classes", () => {
+    const r = validateHtmlClasses(
+      `<div class="ls-a ls-b ls-hero">x</div>`,
+      registry,
+    );
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.unknownClasses.sort()).toEqual(["ls-a", "ls-b"]);
+  });
+
+  it("returns valid=true on HTML with no class attributes", () => {
+    const r = validateHtmlClasses(`<div>x</div>`, registry);
+    expect(r.valid).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance: the real LeadSource seed
+//
+// Load every committed CSS file from seed/leadsource/, build the registry,
+// and validate the 12 committed component HTML templates against it.
+// Every ls-prefixed class reference has to resolve. This is the regression
+// net that catches future extractions whose CSS and HTML drift apart.
+//
+// Template placeholders ({{field}}, {var}, Handlebars blocks) are skipped
+// by extractHtmlClasses so the raw templates — not rendered output — can
+// be validated directly.
+// ---------------------------------------------------------------------------
+
+function readSeed(relPath: string): string {
+  return fs.readFileSync(
+    path.join(process.cwd(), "seed/leadsource", relPath),
+    "utf8",
+  );
+}
+
+function listComponentNames(): string[] {
+  const dir = path.join(process.cwd(), "seed/leadsource/components");
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".html"))
+    .map((f) => f.slice(0, -".html".length))
+    .sort();
+}
+
+describe("class-registry: real LeadSource seed acceptance", () => {
+  const componentNames = listComponentNames();
+  const tokensCss = readSeed("tokens.css");
+  const baseStyles = readSeed("base-styles.css");
+  const componentCss = componentNames.map((n) =>
+    readSeed(`components/${n}.css`),
+  );
+  const registry = buildClassRegistry({ tokensCss, baseStyles, componentCss });
+
+  it("collects the expected breadth of registered classes", () => {
+    // Sanity floor — number moves with seed changes; keep lax.
+    expect(registry.size).toBeGreaterThanOrEqual(120);
+    // Spot-check a handful of known classes.
+    for (const cls of [
+      "ls-hero",
+      "ls-btn--primary",
+      "ls-footer__grid",
+      "ls-pricing",
+      "ls-arc",
+    ]) {
+      expect(registry.has(cls)).toBe(true);
+    }
+  });
+
+  it.each(componentNames)("component %s validates against the registry", (name) => {
+    const html = readSeed(`components/${name}.html`);
+    const result = validateHtmlClasses(html, registry);
+    if (!result.valid) {
+      // Make the failure message useful — which component, which classes.
+      throw new Error(
+        `Component "${name}" references unregistered classes: ${result.unknownClasses.join(", ")}`,
+      );
+    }
+  });
+});

--- a/lib/class-registry.ts
+++ b/lib/class-registry.ts
@@ -36,14 +36,27 @@ export function extractHtmlClasses(html: string): Set<string> {
   let match: RegExpExecArray | null;
   while ((match = HTML_CLASS_ATTR_RE.exec(html)) !== null) {
     const raw = match[1] ?? match[2] ?? match[3] ?? "";
-    for (const token of raw.split(/\s+/)) {
+    // Strip Handlebars-style template holes inside the class-attribute value
+    // before tokenising. `{{x}}`-style and `{var}`-style both go. This lets
+    // us validate raw templates directly — any class literals sandwiching
+    // the holes are kept; fragments that were composed with the hole
+    // (e.g. `ls-avatar--{{tone}}` → `ls-avatar--`) are filtered out below
+    // because a valid class never ends with `-`. The M3 renderer calls
+    // this helper with fully-substituted HTML and never sees these cases
+    // in practice.
+    const stripped = raw
+      .replace(/\{\{[\s\S]*?\}\}/g, " ")
+      .replace(/\{[^{}]*\}/g, " ");
+    for (const token of stripped.split(/\s+/)) {
       const trimmed = token.trim();
       if (trimmed.length === 0) continue;
-      // Skip Handlebars-style template holes — {{x}} / {dynamic}. The M3
-      // generator swaps them with real values before validation runs, but
-      // a defensive skip here makes the helper safe to call during
-      // preview-time too.
-      if (/^[{}]/.test(trimmed)) continue;
+      // Any brace left behind is a malformed fragment.
+      if (/[{}]/.test(trimmed)) continue;
+      // Trailing hyphen(s) = incomplete class left over from a stripped
+      // template interpolation. `ls-avatar--{{tone}}` would leave
+      // `ls-avatar--` after stripping — skip it; the rendered form gets
+      // validated at M3 generation time.
+      if (/-$/.test(trimmed)) continue;
       out.add(trimmed);
     }
   }

--- a/lib/class-registry.ts
+++ b/lib/class-registry.ts
@@ -1,0 +1,93 @@
+import { extractCssClasses } from "./scope-prefix";
+
+// ---------------------------------------------------------------------------
+// Layer-3 scope-prefix enforcement (§3.6 of the M1 brief).
+//
+// Runtime check for the M3 batch generator. Every class referenced in a
+// page's HTML must exist in the design system's registered classes (union
+// of classes defined across tokens.css + base-styles.css + every
+// component's CSS). Classes that don't appear in the registry are almost
+// certainly hallucinated by the LLM; the generator calls
+// validateHtmlClasses() and refuses to commit pages that come back with
+// unknownClasses.
+//
+// Everything in this file is pure — no I/O, no DB. The caller (M3) loads
+// CSS strings from the design_systems / design_components rows, builds the
+// registry once per batch, and validates each generated page's HTML
+// against it.
+// ---------------------------------------------------------------------------
+
+// HTML class attribute extractor.
+//
+// Matches:
+//   class="foo bar"   (double-quoted)
+//   class='foo bar'   (single-quoted)
+//   class=foo         (unquoted — HTML5 allows for single tokens)
+//
+// Does NOT match className= — that's JSX, not HTML. If the M3 generator
+// ever emits JSX-looking content, there's a bug upstream and Layer 3
+// should fail loud; we rely on the unit test to assert that contract.
+const HTML_CLASS_ATTR_RE =
+  /\bclass\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'<>=`]+))/gi;
+
+export function extractHtmlClasses(html: string): Set<string> {
+  const out = new Set<string>();
+  HTML_CLASS_ATTR_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HTML_CLASS_ATTR_RE.exec(html)) !== null) {
+    const raw = match[1] ?? match[2] ?? match[3] ?? "";
+    for (const token of raw.split(/\s+/)) {
+      const trimmed = token.trim();
+      if (trimmed.length === 0) continue;
+      // Skip Handlebars-style template holes — {{x}} / {dynamic}. The M3
+      // generator swaps them with real values before validation runs, but
+      // a defensive skip here makes the helper safe to call during
+      // preview-time too.
+      if (/^[{}]/.test(trimmed)) continue;
+      out.add(trimmed);
+    }
+  }
+  return out;
+}
+
+export function buildClassRegistry(args: {
+  tokensCss: string;
+  baseStyles: string;
+  componentCss: string[];
+  allowlist?: ReadonlyArray<string>;
+}): Set<string> {
+  const registry = new Set<string>();
+  for (const cls of extractCssClasses(args.tokensCss)) registry.add(cls);
+  for (const cls of extractCssClasses(args.baseStyles)) registry.add(cls);
+  for (const css of args.componentCss) {
+    for (const cls of extractCssClasses(css)) registry.add(cls);
+  }
+  if (args.allowlist) {
+    for (const cls of args.allowlist) registry.add(cls);
+  }
+  return registry;
+}
+
+// Stable, minimal return shape. M3 is the consumer — formatting of retry
+// prompts, diff rendering, etc. all live there; this layer just reports
+// facts.
+export type ClassRegistryValidation =
+  | { valid: true }
+  | { valid: false; unknownClasses: string[] };
+
+export function validateHtmlClasses(
+  html: string,
+  registry: Set<string>,
+): ClassRegistryValidation {
+  const htmlClasses = extractHtmlClasses(html);
+  const unknown: string[] = [];
+  const seen = new Set<string>();
+  for (const cls of htmlClasses) {
+    if (registry.has(cls)) continue;
+    if (seen.has(cls)) continue;
+    seen.add(cls);
+    unknown.push(cls);
+  }
+  if (unknown.length === 0) return { valid: true };
+  return { valid: false, unknownClasses: unknown };
+}

--- a/lib/scope-prefix.ts
+++ b/lib/scope-prefix.ts
@@ -84,3 +84,31 @@ function stripIgnorable(css: string): string {
   );
   return blanked.replace(URL_VALUE_RE, (m) => m.replace(/[^\n]/g, " "));
 }
+
+// ---------------------------------------------------------------------------
+// extractCssClasses — Layer-3 helper (M1f).
+//
+// Returns the full set of class names DEFINED by the CSS, regardless of
+// prefix. Used by lib/class-registry.ts to build the registry against which
+// generated HTML is validated at page-render time. Compound selectors
+// (`.a.b`), descendant chains (`.a > .b`), and negations (`:not(.x)`) all
+// contribute every class they mention.
+//
+// The parsing strategy is intentionally regex-based to stay dep-free: same
+// strip-ignorable pass as validateScopedCss() runs, then CLASS_SELECTOR_RE
+// picks up every `.ident` occurrence in selector context. This will false-
+// positive only if operator CSS embeds a `.classlike` token inside an
+// attribute selector's string literal (e.g. `[data-x=".foo"]`), which the
+// current seed doesn't do and the M3 generator won't emit.
+// ---------------------------------------------------------------------------
+
+export function extractCssClasses(css: string): Set<string> {
+  const out = new Set<string>();
+  const stripped = stripIgnorable(css);
+  CLASS_SELECTOR_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = CLASS_SELECTOR_RE.exec(stripped)) !== null) {
+    out.add(match[1]);
+  }
+  return out;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint-config-next": "^14.2.35",
         "pg": "^8.20.0",
         "postcss": "^8.4.47",
+        "stylelint": "^17.8.0",
         "tailwindcss": "^3.4.13",
         "tsx": "^4.21.0",
         "typescript": "^5.6.2",
@@ -70,6 +71,31 @@
         }
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -77,6 +103,183 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+      "integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.4.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+      "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -737,6 +940,13 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -1468,6 +1678,19 @@
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2670,6 +2893,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2851,6 +3084,30 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz",
+      "integrity": "sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.9.0"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/call-bind": {
@@ -3052,6 +3309,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -3075,6 +3339,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3088,6 +3379,30 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/cssesc": {
@@ -3301,6 +3616,26 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -4097,6 +4432,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -4295,6 +4657,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4427,6 +4802,47 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/globals": {
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -4459,6 +4875,57 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/globby": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/globby/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -4567,6 +5034,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -4577,6 +5057,26 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-tags": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
+      "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/iceberg-js": {
@@ -4615,6 +5115,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -4641,6 +5152,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
     },
@@ -4676,6 +5194,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -4944,6 +5469,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5175,6 +5710,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
@@ -5239,6 +5781,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -5577,6 +6129,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5614,6 +6173,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mathml-tag-names": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
+      "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/meow": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -6096,6 +6686,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6436,6 +7045,33 @@
         "postcss": "^8.2.14"
       }
     },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
@@ -6529,6 +7165,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qified": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.9.1.tgz",
+      "integrity": "sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.1.1.tgz",
+      "integrity": "sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6645,6 +7301,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -7054,6 +7720,37 @@
         "node": ">=18"
       }
     },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7372,6 +8069,205 @@
         }
       }
     },
+    "node_modules/stylelint": {
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.8.0.tgz",
+      "integrity": "sha512-oHkld9T60LDSaUQ4CSVc+tlt9eUoDlxhaGWShsUCKyIL14boZfmK5bSphZqx64aiC5tCqX+BsQMTMoSz8D1zIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.2",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/media-query-list-parser": "^5.0.0",
+        "@csstools/selector-resolve-nested": "^4.0.0",
+        "@csstools/selector-specificity": "^6.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.1",
+        "css-functions-list": "^3.3.3",
+        "css-tree": "^3.2.1",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^11.1.2",
+        "global-modules": "^2.0.0",
+        "globby": "^16.2.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^5.1.0",
+        "ignore": "^7.0.5",
+        "import-meta-resolve": "^4.2.0",
+        "is-plain-object": "^5.0.0",
+        "mathml-tag-names": "^4.0.0",
+        "meow": "^14.1.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.9",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.1",
+        "postcss-value-parser": "^4.2.0",
+        "string-width": "^8.2.0",
+        "supports-hyperlinks": "^4.4.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^7.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/@csstools/selector-resolve-nested": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.0.tgz",
+      "integrity": "sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/stylelint/node_modules/@csstools/selector-specificity": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+      "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/stylelint/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/stylelint/node_modules/file-entry-cache": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+      "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.20"
+      }
+    },
+    "node_modules/stylelint/node_modules/flat-cache": {
+      "version": "6.1.22",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
+      "integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.3.4",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/stylelint/node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/stylelint/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylelint/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -7407,6 +8303,49 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-hyperlinks": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
+      "integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -7417,6 +8356,75 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tailwind-merge": {
@@ -7803,6 +8811,19 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
@@ -8319,6 +9340,19 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/ws": {
       "version": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "lint:css": "stylelint 'seed/**/*.css'",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
@@ -36,6 +37,7 @@
     "eslint-config-next": "^14.2.35",
     "pg": "^8.20.0",
     "postcss": "^8.4.47",
+    "stylelint": "^17.8.0",
     "tailwindcss": "^3.4.13",
     "tsx": "^4.21.0",
     "typescript": "^5.6.2",

--- a/seed/leadsource/.stylelintrc.json
+++ b/seed/leadsource/.stylelintrc.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/stylelintrc",
+  "rules": {
+    "selector-class-pattern": [
+      "^ls(-[a-z0-9]+)+(__[a-z0-9-]+)?(--[a-z0-9-]+)?$",
+      {
+        "message": "Class selectors must start with 'ls-' (LeadSource scope prefix). See §3.6 of docs/m1-claude-code-brief.md.",
+        "severity": "error"
+      }
+    ]
+  }
+}

--- a/seed/leadsource/components/before-after-compare.css
+++ b/seed/leadsource/components/before-after-compare.css
@@ -123,7 +123,7 @@
   font-size: 11px;
   font-weight: 500;
 }
-.ls-ls-mockup__val .pill {
+.ls-ls-mockup__val .ls-pill {
   display: inline-block;
   background: rgba(133, 183, 235, 0.2);
   color: #B5D4F4;

--- a/seed/leadsource/components/before-after-compare.html
+++ b/seed/leadsource/components/before-after-compare.html
@@ -27,7 +27,7 @@
           {{#each after.mockup_rows}}
           <div class="ls-ls-mockup__row">
             <span class="ls-ls-mockup__key">{{key}}</span>
-            <span class="ls-ls-mockup__val">{{#if (eq value_style "pill")}}<span class="pill">{{value}}</span>{{else}}{{value}}{{/if}}</span>
+            <span class="ls-ls-mockup__val">{{#if (eq value_style "pill")}}<span class="ls-pill">{{value}}</span>{{else}}{{value}}{{/if}}</span>
           </div>
           {{/each}}
         </div>

--- a/seed/leadsource/components/final-cta-dark.css
+++ b/seed/leadsource/components/final-cta-dark.css
@@ -33,7 +33,7 @@
   color: var(--ls-white);
   font-weight: 500;
 }
-.ls-final h2 .arc {
+.ls-final h2 .ls-arc {
   background: var(--ls-arc);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;

--- a/seed/leadsource/components/final-cta-dark.html
+++ b/seed/leadsource/components/final-cta-dark.html
@@ -1,6 +1,6 @@
 <section class="ls-final">
   <div class="ls-final__inner">
-    <h2>{{headline_line1}}<br><span class="arc">{{headline_line2_accent}}</span></h2>
+    <h2>{{headline_line1}}<br><span class="ls-arc">{{headline_line2_accent}}</span></h2>
     <p>{{sub}}</p>
     <a href="{{primary_cta.href}}" class="ls-btn ls-btn--primary ls-btn--lg">{{primary_cta.label}}</a>
     <div class="ls-final__friction">{{friction_text}}</div>

--- a/seed/leadsource/components/honest-line-contrast.css
+++ b/seed/leadsource/components/honest-line-contrast.css
@@ -33,7 +33,7 @@
   margin-bottom: 56px;
   color: var(--ls-ink);
 }
-.ls-honest__quote .arc {
+.ls-honest__quote .ls-arc {
   background: var(--ls-arc);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;

--- a/seed/leadsource/components/honest-line-contrast.html
+++ b/seed/leadsource/components/honest-line-contrast.html
@@ -2,7 +2,7 @@
   <div class="ls-container ls-honest__inner">
     <div class="ls-eyebrow">{{eyebrow}}</div>
     <div class="ls-honest__quote">
-      {{quote_prefix}} <span class="arc">{{quote_accent}}</span>{{quote_suffix}}
+      {{quote_prefix}} <span class="ls-arc">{{quote_accent}}</span>{{quote_suffix}}
     </div>
     <div class="ls-honest__contrast">
       <div class="ls-honest-card">

--- a/seed/leadsource/components/how-it-works-3-steps.css
+++ b/seed/leadsource/components/how-it-works-3-steps.css
@@ -17,9 +17,9 @@
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.08), 0 0 0 1px var(--ls-border-strong);
   overflow-x: auto;
 }
-.ls-code .tag { color: #F4C0D1; }
-.ls-code .attr { color: #85B7EB; }
-.ls-code .str { color: #9FE1CB; }
+.ls-code .ls-syntax-tag { color: #F4C0D1; }
+.ls-code .ls-syntax-attr { color: #85B7EB; }
+.ls-code .ls-syntax-str { color: #9FE1CB; }
 .ls-code__copy {
   position: absolute;
   top: 10px;

--- a/seed/leadsource/components/how-it-works-3-steps.html
+++ b/seed/leadsource/components/how-it-works-3-steps.html
@@ -10,7 +10,7 @@
     <div class="ls-howitworks__code-wrap">
       <div class="ls-code">
         <button class="ls-code__copy">{{code_snippet.copy_label}}</button>
-        {{#each code_snippet.tokens}}{{#if (eq kind "tag")}}<span class="tag">{{text}}</span>{{/if}}{{#if (eq kind "attr")}}<span class="attr">{{text}}</span>{{/if}}{{#if (eq kind "str")}}<span class="str">{{text}}</span>{{/if}}{{#if (eq kind "plain")}}{{text}}{{/if}}{{/each}}
+        {{#each code_snippet.tokens}}{{#if (eq kind "tag")}}<span class="ls-syntax-tag">{{text}}</span>{{/if}}{{#if (eq kind "attr")}}<span class="ls-syntax-attr">{{text}}</span>{{/if}}{{#if (eq kind "str")}}<span class="ls-syntax-str">{{text}}</span>{{/if}}{{#if (eq kind "plain")}}{{text}}{{/if}}{{/each}}
       </div>
     </div>
     <div class="ls-steps">

--- a/seed/leadsource/components/wordpress-install-block.css
+++ b/seed/leadsource/components/wordpress-install-block.css
@@ -56,11 +56,11 @@
   color: var(--ls-white);
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.08);
 }
-.ls-wp__code .comment { color: var(--ls-dim); }
-.ls-wp__code .tag { color: #F4C0D1; }
-.ls-wp__code .attr { color: #85B7EB; }
-.ls-wp__code .str { color: #9FE1CB; }
-.ls-wp__code .highlight {
+.ls-wp__code .ls-syntax-comment { color: var(--ls-dim); }
+.ls-wp__code .ls-syntax-tag { color: #F4C0D1; }
+.ls-wp__code .ls-syntax-attr { color: #85B7EB; }
+.ls-wp__code .ls-syntax-str { color: #9FE1CB; }
+.ls-wp__code .ls-syntax-highlight {
   background: rgba(133, 183, 235, 0.15);
   border-left: 2px solid #85B7EB;
   padding: 2px 4px;

--- a/seed/leadsource/components/wordpress-install-block.html
+++ b/seed/leadsource/components/wordpress-install-block.html
@@ -7,7 +7,7 @@
       <a href="{{link.href}}" class="ls-wp__link">{{link.label}} →</a>
     </div>
     <div class="ls-wp__code">
-      {{#each code_snippet.tokens}}{{#if (eq kind "comment")}}<span class="comment">{{text}}</span>{{/if}}{{#if (eq kind "tag")}}<span class="tag">{{text}}</span>{{/if}}{{#if (eq kind "attr")}}<span class="attr">{{text}}</span>{{/if}}{{#if (eq kind "str")}}<span class="str">{{text}}</span>{{/if}}{{#if (eq kind "plain")}}{{text}}{{/if}}{{#if (eq kind "break")}}<br>{{/if}}{{#if (eq kind "highlight_open")}}<span class="highlight">{{/if}}{{#if (eq kind "highlight_close")}}</span>{{/if}}{{/each}}
+      {{#each code_snippet.tokens}}{{#if (eq kind "comment")}}<span class="ls-syntax-comment">{{text}}</span>{{/if}}{{#if (eq kind "tag")}}<span class="ls-syntax-tag">{{text}}</span>{{/if}}{{#if (eq kind "attr")}}<span class="ls-syntax-attr">{{text}}</span>{{/if}}{{#if (eq kind "str")}}<span class="ls-syntax-str">{{text}}</span>{{/if}}{{#if (eq kind "plain")}}{{text}}{{/if}}{{#if (eq kind "break")}}<br>{{/if}}{{#if (eq kind "highlight_open")}}<span class="ls-syntax-highlight">{{/if}}{{#if (eq kind "highlight_close")}}</span>{{/if}}{{/each}}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

Final slice of M1. Layer 2 was already live in M1e-1 (route-time validator); this adds the build-time linter (Layer 1) and the runtime class-registry validator (Layer 3) that the M3 batch generator will call.

## Layer 1 — stylelint build-time

- **`seed/leadsource/.stylelintrc.json`** — `selector-class-pattern` with LeadSource's prefix. Per-directory config; each future client gets its own.
- **Regex** `^ls(-[a-z0-9]+)+(__[a-z0-9-]+)?(--[a-z0-9-]+)?$`. Inner block segments use `[a-z0-9]+` joined by literal hyphens — tighter than the BEM suffix groups, **deliberately**. Rejects `ls--foo` (block=empty, modifier=foo — malformed) while accepting `ls-crm-mockup` and the whole BEM shape. Validated against all 142 real classes in the current seed; every one matches.
- **Solo rule.** No `stylelint-config-standard` — don't want 30 rules re-litigating seed CSS style.
- Wired into the existing `lint` CI job as a second step (`npm run lint:css`). PR-check count stays at three.

### Seed cleanup forced by Layer 1

Layer 1 flagged 7 real scope-prefix violations in the M1c extraction — exactly the bleed bugs §3.6 is designed to catch:

| Old bare class | New prefixed name | Components |
|---|---|---|
| `.arc` | `.ls-arc` | `final-cta-dark`, `honest-line-contrast` |
| `.tag` | `.ls-syntax-tag` | `how-it-works-3-steps`, `wordpress-install-block` |
| `.attr` | `.ls-syntax-attr` | same two |
| `.str` | `.ls-syntax-str` | same two |
| `.comment` | `.ls-syntax-comment` | `wordpress-install-block` |
| `.highlight` | `.ls-syntax-highlight` | `wordpress-install-block` |
| `.pill` | `.ls-pill` | `before-after-compare` |

All renames applied consistently to CSS + HTML templates.

## Layer 3 — runtime class-registry validator

Pure functions, no I/O, no DB. M3 composes them.

- **`lib/scope-prefix.ts`** — `+extractCssClasses(css): Set<string>`. Reuses the existing `stripIgnorable` + regex pipeline.
- **`lib/class-registry.ts`** (new) exports:
  - `extractHtmlClasses(html)` — quoted/single/unquoted class attrs, skips `{{template}}` / `{dynamic}` holes so raw templates validate cleanly. **Does NOT pick up `className=`** — contract test pins that so JSX contamination from future M3 bugs fails loud.
  - `buildClassRegistry({ tokensCss, baseStyles, componentCss, allowlist? })` — union of CSS sources plus an explicit `allowlist` parameter for legit unscoped classes (`sr-only` etc.). No silent pass-through.
  - `validateHtmlClasses(html, registry)` — returns `{ valid: true }` or `{ valid: false; unknownClasses: string[] }`. Stable, minimal; M3 formats the retry prompts.

## Tests — `lib/__tests__/class-registry.test.ts`

- `extractCssClasses`: compound `.a.b`, descendant `.a .b`, child `.a > .b`, negation `:not(.x)`, pseudo-class/element, dedup, comment / `url(...)` / decimal-number exclusions.
- `extractHtmlClasses`: double/single/unquoted, multi-token, nested, self-closing, no-class-attr, Handlebars-hole skipping, `className=` contract test.
- `buildClassRegistry`: union + dedup + allowlist + empty inputs.
- `validateHtmlClasses`: happy, single unknown, multiple distinct unknowns, duplicate-dedup, no-class-attr.
- **Acceptance**: loads every committed LeadSource CSS file, builds the registry, validates each of the 12 component HTML templates via `it.each` so failures name the offending component. Catches future extraction drift.

## Wiring

- `package.json` — `stylelint@^17` devDep, `lint:css` script.
- `.github/workflows/ci.yml` — `lint` job runs `npm run lint:css` after `npm run lint`.
- `CONTRIBUTING.md` — linting section explains `lint` vs `lint:css`.

## Verification

- `tsc --noEmit` clean
- `npm run lint` clean
- `npm run lint:css` clean (after the 7 seed renames)
- `next build` clean
- CI will run the full Vitest suite against live Supabase as always

Do not merge until CI is green and you've eyeballed the 7 class renames.

https://claude.ai/code/session_01PTCJrskyCmW3t9NvLXM7rT