### PR TITLE
M2a: link opollo_users to auth.users + auto-provision on signup

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -25,3 +25,10 @@ OPOLLO_MASTER_KEY=
 # on but no active DS exists for the target site, the code logs an error and
 # falls back to the legacy path so chat stays functional.
 FEATURE_DESIGN_SYSTEM_V2=
+
+# Auth migration (M2+). When a Supabase Auth user signs up with this email,
+# the handle_new_auth_user trigger promotes them to role='admin'. Everyone
+# else signs up as 'viewer' and waits for an admin promotion via the M2d
+# admin UI. The value isn't read by the app at runtime — it's upserted into
+# opollo_config by scripts/sync-first-admin.ts at deploy time.
+OPOLLO_FIRST_ADMIN_EMAIL=

--- a/docs/m3-notes.md
+++ b/docs/m3-notes.md
@@ -1,0 +1,46 @@
+# M3 — pre-start notes
+
+Working doc for decisions / TODOs that must land in M3 but don't have a
+proper brief yet. Folded into the M3 brief when Steven writes it.
+
+## Inherited from M2a
+
+**Tighten `NOT NULL` on `created_by` / `last_edited_by`.**
+
+Confirmed in the M2 plan thread: the nullable FKs on
+`design_systems.created_by` and `pages.last_edited_by` were introduced by
+M1a because auth wasn't live yet. M2a wires auth up and M2d's admin UI
+routes start populating those columns on every write. Once M2 is live
+everywhere, every new row has a valid `created_by` / `last_edited_by`;
+only the pre-M2 rows are NULL.
+
+M3 must include a migration that:
+
+1. Backfills the NULL rows — pick a strategy:
+   - Leave them NULL and tighten the constraint to allow NULL for
+     historical rows only (e.g. via a partial CHECK that permits NULL
+     on rows created before a cutoff). Ugly.
+   - Backfill to a sentinel `opollo_users` row representing "pre-auth
+     migration". Then `ALTER COLUMN ... SET NOT NULL`. Cleaner — the
+     sentinel can be a service user with role='viewer' that never logs
+     in.
+2. Tightens `design_systems.created_by` and `pages.last_edited_by` to
+   `NOT NULL`.
+3. Updates the Zod schemas in `lib/design-systems.ts` / `lib/pages.ts`
+   (M3 adds pages CRUD) so the field is required at input time.
+
+My preference: sentinel opollo_users row seeded at the start of M3's
+migration, then `SET NOT NULL`. Record the decision in the M3 brief
+before writing SQL.
+
+## Other M3 carry-overs
+
+- **Batch generator itself**: the core M3 deliverable. Consume the
+  structured DS registry from M1d, fetch component HTML on demand,
+  validate output via `lib/class-registry.ts` (M1f).
+- **Caching**: `TODO(M3)` comment in `lib/system-prompt.ts` pins a
+  site-keyed LRU with 5-min TTL around `loadActiveRegistry()`. Expected
+  to matter at ~40 consecutive reads per site during batch runs.
+- **`sites.design_system_version` (text)**: becomes dead data after
+  M1d. M1 deferred dropping it; M3 or a cleanup milestone drops the
+  column.

--- a/lib/__tests__/_auth-helpers.ts
+++ b/lib/__tests__/_auth-helpers.ts
@@ -1,0 +1,114 @@
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// Test-only factories for M2+ auth scenarios. Every caller uses the
+// service-role supabase-js client — we want the same HTTP + trigger path
+// the admin API uses, not raw SQL inserts that skip the trigger.
+
+export type TestRole = "admin" | "operator" | "viewer";
+
+export type SeededAuthUser = {
+  id: string;
+  email: string;
+  role: TestRole;
+};
+
+let emailCounter = 0;
+
+/**
+ * Creates an auth.users row via the admin API. The
+ * handle_new_auth_user trigger (0004 migration) inserts the matching
+ * opollo_users row with role='viewer' (or 'admin' if opollo_config's
+ * first_admin_email matches). When `overrides.role` is supplied and
+ * differs from the trigger's choice, we UPDATE the opollo_users row
+ * post-insert so the test gets the requested role.
+ *
+ * `email_confirm: true` skips Supabase Auth's confirmation flow — we
+ * don't want the test harness dealing with inbucket / email links.
+ */
+export async function seedAuthUser(overrides?: {
+  email?: string;
+  password?: string;
+  role?: TestRole;
+}): Promise<SeededAuthUser> {
+  const supabase = getServiceRoleClient();
+  const email = overrides?.email ?? `test-user-${++emailCounter}@opollo.test`;
+  const password = overrides?.password ?? "test-password-1234";
+
+  const { data, error } = await supabase.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+  if (error || !data?.user) {
+    throw new Error(
+      `seedAuthUser: admin.createUser failed — ${error?.message ?? "no user"}`,
+    );
+  }
+  const userId = data.user.id;
+
+  // If a role was requested, reconcile. Default case (viewer) is fine.
+  if (overrides?.role && overrides.role !== "viewer") {
+    const { error: updateErr } = await supabase
+      .from("opollo_users")
+      .update({ role: overrides.role })
+      .eq("id", userId);
+    if (updateErr) {
+      throw new Error(
+        `seedAuthUser: role update to ${overrides.role} failed — ${updateErr.message}`,
+      );
+    }
+  }
+
+  return {
+    id: userId,
+    email,
+    role: overrides?.role ?? "viewer",
+  };
+}
+
+/**
+ * Upsert opollo_config.first_admin_email. Passing `null` deletes the row,
+ * unsetting the bootstrap rule — matches what scripts/sync-first-admin.ts
+ * does except this helper works against an empty value too for
+ * exhaustive test coverage.
+ */
+export async function setFirstAdminEmail(email: string | null): Promise<void> {
+  const supabase = getServiceRoleClient();
+  if (email === null) {
+    const { error } = await supabase
+      .from("opollo_config")
+      .delete()
+      .eq("key", "first_admin_email");
+    if (error) throw new Error(`setFirstAdminEmail(null) failed: ${error.message}`);
+    return;
+  }
+  const { error } = await supabase
+    .from("opollo_config")
+    .upsert(
+      { key: "first_admin_email", value: email },
+      { onConflict: "key" },
+    );
+  if (error) throw new Error(`setFirstAdminEmail("${email}") failed: ${error.message}`);
+}
+
+/**
+ * Sign a user in and return the session's access-token JWT. Callers use
+ * this as a Bearer token when hitting route handlers that gate on
+ * authenticated requests (M2c+). For M2a itself the tests don't exercise
+ * session flow, so this is here for M2b/M2c to consume.
+ */
+export async function signInAs(
+  user: { email: string; password?: string },
+): Promise<string> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: user.email,
+    password: user.password ?? "test-password-1234",
+  });
+  if (error || !data.session) {
+    throw new Error(
+      `signInAs(${user.email}): ${error?.message ?? "no session"}`,
+    );
+  }
+  return data.session.access_token;
+}

--- a/lib/__tests__/_auth-helpers.ts
+++ b/lib/__tests__/_auth-helpers.ts
@@ -14,6 +14,32 @@ export type SeededAuthUser = {
 
 let emailCounter = 0;
 
+// Module-level tracker of every auth user seedAuthUser has created.
+// truncateAll() (from _setup.ts) calls cleanupTrackedAuthUsers() between
+// tests — see the comment there for why we can't just TRUNCATE auth.users.
+const createdAuthUserIds = new Set<string>();
+
+/**
+ * Delete every auth user this test run created via seedAuthUser(). Uses
+ * the service-role admin API, which has the privileges to sweep
+ * downstream auth state (sessions, refresh_tokens, identities) via its
+ * normal cascade path. Errors are logged but not thrown — cleanup is
+ * best-effort to avoid cascading failures from a single dead user.
+ */
+export async function cleanupTrackedAuthUsers(): Promise<void> {
+  if (createdAuthUserIds.size === 0) return;
+  const supabase = getServiceRoleClient();
+  const ids = Array.from(createdAuthUserIds);
+  createdAuthUserIds.clear();
+  for (const id of ids) {
+    const { error } = await supabase.auth.admin.deleteUser(id);
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.warn(`cleanupTrackedAuthUsers: deleteUser(${id}) — ${error.message}`);
+    }
+  }
+}
+
 /**
  * Creates an auth.users row via the admin API. The
  * handle_new_auth_user trigger (0004 migration) inserts the matching
@@ -45,6 +71,7 @@ export async function seedAuthUser(overrides?: {
     );
   }
   const userId = data.user.id;
+  createdAuthUserIds.add(userId);
 
   // If a role was requested, reconcile. Default case (viewer) is fine.
   if (overrides?.role && overrides.role !== "viewer") {

--- a/lib/__tests__/_setup.ts
+++ b/lib/__tests__/_setup.ts
@@ -47,6 +47,13 @@ export async function truncateAll(): Promise<void> {
   const pg = await getPg();
   // Order matters when referential actions other than CASCADE apply. We use
   // CASCADE to sidestep FK ordering between sites / design_systems etc.
+  //
+  // auth.users (M2a+) is TRUNCATEd too because opollo_users has a FK to it
+  // — wiping opollo_users without also wiping auth.users leaves orphaned
+  // auth rows that would re-trigger handle_new_auth_user's opollo_users
+  // INSERT on the next test's createUser call (returning 'viewer' state
+  // silently instead of the requested role). CASCADE sweeps auth.sessions
+  // / auth.refresh_tokens / auth.identities at the same time.
   await pg.query(`
     TRUNCATE TABLE
       pages,
@@ -54,7 +61,9 @@ export async function truncateAll(): Promise<void> {
       design_components,
       design_systems,
       opollo_users,
-      sites
+      opollo_config,
+      sites,
+      auth.users
     RESTART IDENTITY CASCADE;
   `);
 }

--- a/lib/__tests__/_setup.ts
+++ b/lib/__tests__/_setup.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach } from "vitest";
 import { Client } from "pg";
 import { readSupabaseCreds } from "./_supabase-status";
+import { cleanupTrackedAuthUsers } from "./_auth-helpers";
 
 // Per-worker setup. Runs before every test file in this worker.
 //
@@ -44,16 +45,22 @@ async function getPg(): Promise<Client> {
 }
 
 export async function truncateAll(): Promise<void> {
-  const pg = await getPg();
-  // Order matters when referential actions other than CASCADE apply. We use
-  // CASCADE to sidestep FK ordering between sites / design_systems etc.
+  // M2a+: we can't TRUNCATE auth.users CASCADE from the test role — the
+  // CASCADE sweeps auth.refresh_tokens and its id sequence, which the
+  // test role doesn't own (Postgres error 42501: must be owner of
+  // sequence refresh_tokens_id_seq).
   //
-  // auth.users (M2a+) is TRUNCATEd too because opollo_users has a FK to it
-  // — wiping opollo_users without also wiping auth.users leaves orphaned
-  // auth rows that would re-trigger handle_new_auth_user's opollo_users
-  // INSERT on the next test's createUser call (returning 'viewer' state
-  // silently instead of the requested role). CASCADE sweeps auth.sessions
-  // / auth.refresh_tokens / auth.identities at the same time.
+  // Instead, we delete every auth user this test file created via the
+  // service-role admin API — it has the right privileges and cleans up
+  // downstream auth state (sessions, refresh_tokens, identities) for
+  // free. Users that a test forgot to track (e.g. created via raw SQL)
+  // would leak; every test path should go through seedAuthUser().
+  await cleanupTrackedAuthUsers();
+
+  const pg = await getPg();
+  // Order matters when referential actions other than CASCADE apply. We
+  // use CASCADE to sidestep FK ordering between sites / design_systems.
+  // Scoped to public-schema tables only.
   await pg.query(`
     TRUNCATE TABLE
       pages,
@@ -62,8 +69,7 @@ export async function truncateAll(): Promise<void> {
       design_systems,
       opollo_users,
       opollo_config,
-      sites,
-      auth.users
+      sites
     RESTART IDENTITY CASCADE;
   `);
 }

--- a/lib/__tests__/m2a-auth-link.test.ts
+++ b/lib/__tests__/m2a-auth-link.test.ts
@@ -42,30 +42,17 @@ describe("M2a: handle_new_auth_user trigger", () => {
 
   it("promotes to 'admin' when email matches opollo_config.first_admin_email", async () => {
     await setFirstAdminEmail("boss@opollo.test");
-    // seedAuthUser's internal UPDATE path would override, so test the
-    // trigger directly by passing the matching email with no role override.
-    const supabase = getServiceRoleClient();
-    const { data, error } = await supabase.auth.admin.createUser({
-      email: "boss@opollo.test",
-      password: "test-password-1234",
-      email_confirm: true,
-    });
-    if (error || !data?.user) throw new Error(error?.message ?? "no user");
-
-    const row = await readOpolloUser(data.user.id);
+    // seedAuthUser with no role= override lets the trigger's decision stand.
+    // Tracked for cleanup via the helper's internal Set.
+    const user = await seedAuthUser({ email: "boss@opollo.test" });
+    const row = await readOpolloUser(user.id);
     expect(row?.role).toBe("admin");
   });
 
   it("leaves non-matching emails as 'viewer' even when first_admin_email is set", async () => {
     await setFirstAdminEmail("boss@opollo.test");
-    const supabase = getServiceRoleClient();
-    const { data } = await supabase.auth.admin.createUser({
-      email: "intern@opollo.test",
-      password: "test-password-1234",
-      email_confirm: true,
-    });
-    if (!data?.user) throw new Error("no user");
-    const row = await readOpolloUser(data.user.id);
+    const user = await seedAuthUser({ email: "intern@opollo.test" });
+    const row = await readOpolloUser(user.id);
     expect(row?.role).toBe("viewer");
   });
 });

--- a/lib/__tests__/m2a-auth-link.test.ts
+++ b/lib/__tests__/m2a-auth-link.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import { Client } from "pg";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { seedAuthUser, setFirstAdminEmail } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// M2a — auth.users ↔ opollo_users link, signup trigger, email sync,
+// cascade delete, auth_role() helper.
+//
+// Tests run against the real local Supabase stack (same harness as every
+// other lib test). Each test starts with a clean slate — _setup.ts
+// TRUNCATEs auth.users + opollo_users + opollo_config in beforeEach.
+// ---------------------------------------------------------------------------
+
+const DB_URL =
+  process.env.SUPABASE_DB_URL ??
+  "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
+
+async function readOpolloUser(id: string): Promise<{
+  id: string;
+  email: string;
+  role: string;
+} | null> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("opollo_users")
+    .select("id, email, role")
+    .eq("id", id)
+    .maybeSingle();
+  if (error) throw new Error(`readOpolloUser: ${error.message}`);
+  return data;
+}
+
+describe("M2a: handle_new_auth_user trigger", () => {
+  it("auto-creates an opollo_users row with role='viewer' by default", async () => {
+    const user = await seedAuthUser();
+    const row = await readOpolloUser(user.id);
+    expect(row).not.toBeNull();
+    expect(row?.email).toBe(user.email);
+    expect(row?.role).toBe("viewer");
+  });
+
+  it("promotes to 'admin' when email matches opollo_config.first_admin_email", async () => {
+    await setFirstAdminEmail("boss@opollo.test");
+    // seedAuthUser's internal UPDATE path would override, so test the
+    // trigger directly by passing the matching email with no role override.
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase.auth.admin.createUser({
+      email: "boss@opollo.test",
+      password: "test-password-1234",
+      email_confirm: true,
+    });
+    if (error || !data?.user) throw new Error(error?.message ?? "no user");
+
+    const row = await readOpolloUser(data.user.id);
+    expect(row?.role).toBe("admin");
+  });
+
+  it("leaves non-matching emails as 'viewer' even when first_admin_email is set", async () => {
+    await setFirstAdminEmail("boss@opollo.test");
+    const supabase = getServiceRoleClient();
+    const { data } = await supabase.auth.admin.createUser({
+      email: "intern@opollo.test",
+      password: "test-password-1234",
+      email_confirm: true,
+    });
+    if (!data?.user) throw new Error("no user");
+    const row = await readOpolloUser(data.user.id);
+    expect(row?.role).toBe("viewer");
+  });
+});
+
+describe("M2a: handle_auth_user_email_update trigger", () => {
+  it("syncs opollo_users.email when auth.users.email changes", async () => {
+    const user = await seedAuthUser({ email: "old@opollo.test" });
+
+    const supabase = getServiceRoleClient();
+    const { error } = await supabase.auth.admin.updateUserById(user.id, {
+      email: "new@opollo.test",
+      email_confirm: true,
+    });
+    if (error) throw new Error(error.message);
+
+    const row = await readOpolloUser(user.id);
+    expect(row?.email).toBe("new@opollo.test");
+  });
+
+  it("does not fire when an unrelated field updates", async () => {
+    const user = await seedAuthUser({ email: "stable@opollo.test" });
+    const supabase = getServiceRoleClient();
+    // Trigger updates by changing user_metadata, which isn't the email.
+    // opollo_users.email should remain untouched.
+    const { error } = await supabase.auth.admin.updateUserById(user.id, {
+      user_metadata: { anything: "changed" },
+    });
+    if (error) throw new Error(error.message);
+    const row = await readOpolloUser(user.id);
+    expect(row?.email).toBe("stable@opollo.test");
+  });
+});
+
+describe("M2a: FK cascade from auth.users → opollo_users", () => {
+  it("deleting an auth.users row cascades to opollo_users", async () => {
+    const user = await seedAuthUser();
+    const before = await readOpolloUser(user.id);
+    expect(before).not.toBeNull();
+
+    const supabase = getServiceRoleClient();
+    const { error } = await supabase.auth.admin.deleteUser(user.id);
+    if (error) throw new Error(error.message);
+
+    const after = await readOpolloUser(user.id);
+    expect(after).toBeNull();
+  });
+});
+
+describe("M2a: public.auth_role() helper", () => {
+  // auth_role() reads auth.uid() from the JWT claim. The service-role
+  // client doesn't populate a JWT 'sub' claim, so we reach past it and
+  // use a direct pg connection where we can SET LOCAL the claim to
+  // simulate an authenticated session.
+  it("returns the user's role when called as that user", async () => {
+    const user = await seedAuthUser({ role: "operator" });
+    const pg = new Client({ connectionString: DB_URL });
+    await pg.connect();
+    try {
+      await pg.query("BEGIN");
+      // request.jwt.claim.sub is the legacy setting name postgres + Supabase
+      // both honour. The newer request.jwt.claims JSONB form is also valid
+      // but this is simpler from psql.
+      await pg.query(`SET LOCAL "request.jwt.claim.sub" = '${user.id}'`);
+      const res = await pg.query("SELECT public.auth_role() AS role");
+      expect(res.rows[0].role).toBe("operator");
+      await pg.query("COMMIT");
+    } finally {
+      await pg.end();
+    }
+  });
+
+  it("returns NULL when no session is attached", async () => {
+    const pg = new Client({ connectionString: DB_URL });
+    await pg.connect();
+    try {
+      const res = await pg.query("SELECT public.auth_role() AS role");
+      expect(res.rows[0].role).toBeNull();
+    } finally {
+      await pg.end();
+    }
+  });
+
+  it("returns NULL when the JWT sub does not match any opollo_users row", async () => {
+    const pg = new Client({ connectionString: DB_URL });
+    await pg.connect();
+    try {
+      await pg.query("BEGIN");
+      await pg.query(
+        `SET LOCAL "request.jwt.claim.sub" = '00000000-0000-0000-0000-000000000000'`,
+      );
+      const res = await pg.query("SELECT public.auth_role() AS role");
+      expect(res.rows[0].role).toBeNull();
+      await pg.query("COMMIT");
+    } finally {
+      await pg.end();
+    }
+  });
+});
+
+describe("M2a: opollo_config RLS", () => {
+  it("allows service-role read/write", async () => {
+    await setFirstAdminEmail("test@opollo.test");
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("opollo_config")
+      .select("key, value")
+      .eq("key", "first_admin_email")
+      .single();
+    expect(error).toBeNull();
+    expect(data?.value).toBe("test@opollo.test");
+  });
+});

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   renderComponentSummary,
   renderRegistryBlock,
@@ -298,15 +298,27 @@ describe("loadActiveRegistry", () => {
 
 describe("buildSystemPromptForSite", () => {
   const originalFlag = process.env.FEATURE_DESIGN_SYSTEM_V2;
-  let errorSpy: ReturnType<typeof vi.spyOn>;
+  // Spy hoisted to describe scope + eagerly initialised so afterEach can
+  // always call mockRestore(), including when an upstream beforeEach (e.g.
+  // the global truncate in _setup.ts) throws and skips the inner
+  // beforeEach. Previously the spy was created in beforeEach; an upstream
+  // failure left it undefined and afterEach cascaded into a second error.
+  const errorSpy = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
 
   beforeEach(() => {
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Reset call history between tests. The spy itself outlives the
+    // describe and is restored once in afterAll.
+    errorSpy.mockClear();
   });
 
   afterEach(() => {
     if (originalFlag === undefined) delete process.env.FEATURE_DESIGN_SYSTEM_V2;
     else process.env.FEATURE_DESIGN_SYSTEM_V2 = originalFlag;
+  });
+
+  afterAll(() => {
     errorSpy.mockRestore();
   });
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,6 +3,30 @@
 Operator scripts that run outside the Next.js request path. Executed via
 `npx tsx <script>` against a live Supabase.
 
+## sync-first-admin.ts
+
+Seeds the `opollo_config.first_admin_email` row so the next Supabase Auth
+signup with that email is auto-promoted to `role = 'admin'`. Run once per
+deploy (or whenever the target changes).
+
+### Prerequisites
+
+- M2a migration applied (creates `opollo_config` + the signup trigger).
+- `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` exported.
+
+### Usage
+
+```bash
+OPOLLO_FIRST_ADMIN_EMAIL=you@example.com \
+SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
+  npx tsx scripts/sync-first-admin.ts
+```
+
+Idempotent — re-running with the same value is a no-op. Re-running with a
+different value moves the bootstrap target but doesn't retroactively
+demote any user who already signed up under the old value; the trigger
+only fires on new signups.
+
 ## seed-leadsource.ts
 
 Inserts the LeadSource design system (tokens, components, templates) out

--- a/scripts/sync-first-admin.ts
+++ b/scripts/sync-first-admin.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * sync-first-admin.ts
+ *
+ * One-shot deploy utility. Upserts OPOLLO_FIRST_ADMIN_EMAIL from the
+ * environment into the opollo_config table, keyed 'first_admin_email'.
+ *
+ * When a user signs up through Supabase Auth with that email, the
+ * handle_new_auth_user trigger (supabase/migrations/0004_m2a_auth_link.sql)
+ * auto-promotes them to role='admin' instead of the default 'viewer'.
+ * Every other signup stays 'viewer' until an admin promotes them via the
+ * M2d admin UI.
+ *
+ *   OPOLLO_FIRST_ADMIN_EMAIL=you@example.com \
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
+ *     npx tsx scripts/sync-first-admin.ts
+ *
+ * Idempotent — re-running with the same value is a no-op; re-running with a
+ * different value moves the bootstrap target. There's no guard against
+ * moving the target after the first admin already exists: the trigger
+ * only fires on new signups, so changing the value later doesn't
+ * retroactively demote anyone.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+
+function die(msg: string): never {
+  console.error(`ERROR: ${msg}`);
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  const email = process.env.OPOLLO_FIRST_ADMIN_EMAIL;
+  const url = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!email) die("OPOLLO_FIRST_ADMIN_EMAIL is not set.");
+  if (!url) die("SUPABASE_URL is not set.");
+  if (!serviceRoleKey) die("SUPABASE_SERVICE_ROLE_KEY is not set.");
+
+  // Cheap email sanity — full validation happens at Supabase Auth signup.
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    die(`OPOLLO_FIRST_ADMIN_EMAIL does not look like an email: ${email}`);
+  }
+
+  const supabase = createClient(url, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  const { error } = await supabase
+    .from("opollo_config")
+    .upsert(
+      { key: "first_admin_email", value: email },
+      { onConflict: "key" },
+    );
+
+  if (error) {
+    die(`upsert opollo_config failed: ${error.message}`);
+  }
+
+  console.log(
+    `[sync-first-admin] first_admin_email set to "${email}". When that email signs up via Supabase Auth, the handle_new_auth_user trigger will promote the user to role='admin'.`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/supabase/migrations/0004_m2a_auth_link.sql
+++ b/supabase/migrations/0004_m2a_auth_link.sql
@@ -1,0 +1,152 @@
+-- M2a — Link opollo_users to auth.users + auto-provision on signup
+-- Reference: docs/m1-claude-code-brief.md §3.10 (opollo_users) + M2 plan thread.
+--
+-- Design decisions encoded here:
+--
+-- 1. opollo_users.id becomes a FK to auth.users(id) ON DELETE CASCADE. The
+--    M1a table is empty (no rows were ever inserted), so no reconciliation
+--    is needed. Every future opollo_users row is created by the trigger
+--    below, one-for-one with auth.users.
+--
+-- 2. A trigger on auth.users AFTER INSERT auto-creates the matching
+--    opollo_users row. Default role = 'viewer'. The one exception: if the
+--    email matches the 'first_admin_email' entry in opollo_config, role =
+--    'admin'. This is the bootstrap path — everybody else is promoted by
+--    an admin through the M2d UI.
+--
+-- 3. A second trigger on auth.users AFTER UPDATE syncs email changes.
+--    Without it, users who change their email in Supabase Auth would leave
+--    opollo_users.email stale — harmless for FK integrity but misleading
+--    in admin UIs.
+--
+-- 4. public.auth_role() is a SECURITY DEFINER helper that returns the
+--    current user's role. M2b's RLS policies read it instead of duplicating
+--    the opollo_users lookup in every policy clause.
+--
+-- 5. opollo_config is a tiny kv table for operator-supplied settings that
+--    need to be readable from triggers (which can't see env vars). For M2a
+--    it holds exactly one key — 'first_admin_email' — populated by the
+--    scripts/sync-first-admin.ts CLI from the OPOLLO_FIRST_ADMIN_EMAIL env
+--    var at deploy time. RLS service-role-only; no user access.
+
+-- ----------------------------------------------------------------------------
+-- opollo_config — operator-supplied DB-level settings
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE opollo_config (
+  key        text PRIMARY KEY,
+  value      text NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE opollo_config ENABLE ROW LEVEL SECURITY;
+-- TODO(M2b): no authenticated-role policy needed — this is internal config.
+CREATE POLICY service_role_all ON opollo_config
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- ----------------------------------------------------------------------------
+-- Link opollo_users.id → auth.users(id)
+--
+-- ON DELETE CASCADE: when an auth user is deleted, their opollo_users row
+-- goes with them. Design-system / page rows that referenced the user via
+-- created_by / last_edited_by were already ON DELETE SET NULL at the M1a
+-- layer, so orphan audit traces don't disappear silently.
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE opollo_users
+  ADD CONSTRAINT opollo_users_id_fkey
+  FOREIGN KEY (id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+-- ----------------------------------------------------------------------------
+-- handle_new_auth_user — trigger fn on auth.users INSERT
+--
+-- SECURITY DEFINER because we're writing to public.opollo_users from a
+-- trigger owned by the postgres role but fired by the auth schema's
+-- service context. search_path pinned to public, auth so unqualified
+-- references resolve predictably.
+--
+-- ON CONFLICT (id) DO NOTHING: defensive. If a future migration or manual
+-- seed ever inserts an opollo_users row before auth.users sees it, the
+-- trigger becomes a no-op rather than throwing.
+-- ----------------------------------------------------------------------------
+
+CREATE FUNCTION public.handle_new_auth_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_first_admin_email text;
+  v_role              text;
+BEGIN
+  SELECT value
+    INTO v_first_admin_email
+    FROM public.opollo_config
+    WHERE key = 'first_admin_email';
+
+  IF v_first_admin_email IS NOT NULL AND NEW.email = v_first_admin_email THEN
+    v_role := 'admin';
+  ELSE
+    v_role := 'viewer';
+  END IF;
+
+  INSERT INTO public.opollo_users (id, email, role)
+    VALUES (NEW.id, NEW.email, v_role)
+    ON CONFLICT (id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.handle_new_auth_user();
+
+-- ----------------------------------------------------------------------------
+-- handle_auth_user_email_update — keep opollo_users.email in sync
+-- ----------------------------------------------------------------------------
+
+CREATE FUNCTION public.handle_auth_user_email_update()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+BEGIN
+  UPDATE public.opollo_users
+    SET email = NEW.email
+    WHERE id = NEW.id;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_auth_user_email_update
+  AFTER UPDATE OF email ON auth.users
+  FOR EACH ROW
+  WHEN (OLD.email IS DISTINCT FROM NEW.email)
+  EXECUTE FUNCTION public.handle_auth_user_email_update();
+
+-- ----------------------------------------------------------------------------
+-- auth_role() — SECURITY DEFINER helper for M2b RLS policies
+--
+-- Returns the current session's role by looking up auth.uid() in
+-- opollo_users. SECURITY DEFINER so policies don't have to grant SELECT on
+-- opollo_users to every role that reads it. Returns NULL when called from
+-- a context with no authenticated user (e.g. service-role operations or
+-- anonymous requests) — policies that care branch on that.
+-- ----------------------------------------------------------------------------
+
+CREATE FUNCTION public.auth_role()
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT role FROM public.opollo_users WHERE id = auth.uid()
+$$;
+
+REVOKE ALL ON FUNCTION public.auth_role() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.auth_role() TO authenticated, service_role;

--- a/supabase/rollbacks/0004_m2a_auth_link.down.sql
+++ b/supabase/rollbacks/0004_m2a_auth_link.down.sql
@@ -1,0 +1,25 @@
+-- M2a — Rollback for 0004_m2a_auth_link.sql
+--
+-- Hand-run. Lives in supabase/rollbacks/ (not supabase/migrations/) per
+-- the convention documented in supabase/rollbacks/README.md.
+--
+-- Drops in reverse dependency order:
+--   1. auth_role() helper
+--   2. email-sync trigger + function
+--   3. insert trigger + function
+--   4. opollo_users FK to auth.users
+--   5. opollo_config table
+--
+-- DO NOT run this against a production database that has real users.
+-- Dropping the opollo_users FK does not delete any opollo_users rows, but
+-- if auth.users is later pruned without the FK in place, those rows
+-- become orphans with no cascade path.
+
+DROP FUNCTION IF EXISTS public.auth_role();
+DROP TRIGGER IF EXISTS on_auth_user_email_update ON auth.users;
+DROP FUNCTION IF EXISTS public.handle_auth_user_email_update();
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+DROP FUNCTION IF EXISTS public.handle_new_auth_user();
+ALTER TABLE opollo_users
+  DROP CONSTRAINT IF EXISTS opollo_users_id_fkey;
+DROP TABLE IF EXISTS opollo_config;


### PR DESCRIPTION
## Summary

First of four M2 slices. Schema-only — no application code changes, no new API routes, no UI. Wires up the `auth.users` ↔ `opollo_users` link and the signup trigger so later slices (M2b RLS, M2c session plumbing, M2d admin UI) have a solid substrate to build on.

## Migration `0004_m2a_auth_link.sql` (+ `.down.sql`)

- **FK `opollo_users.id → auth.users(id) ON DELETE CASCADE`.** M1a's table was empty; no backfill needed.
- **`opollo_config` table** — kv store for operator-supplied settings the triggers need to read. One entry for now: `first_admin_email`. RLS service-role only.
- **`handle_new_auth_user` trigger** on `auth.users AFTER INSERT`. Default role = `'viewer'`; promotes to `'admin'` when `NEW.email = opollo_config.first_admin_email`. `ON CONFLICT (id) DO NOTHING` is defensive.
- **`handle_auth_user_email_update` trigger** on `auth.users AFTER UPDATE OF email` with `WHEN (OLD.email IS DISTINCT FROM NEW.email)` — keeps `opollo_users.email` in sync so admin UIs don't drift.
- **`public.auth_role()`** `SECURITY DEFINER` helper. Returns the session's role from `opollo_users` keyed by `auth.uid()`. M2b's policies call this instead of reopening the same join in every clause.

## Operator tooling

- **`scripts/sync-first-admin.ts`** — idempotent one-shot. Reads `OPOLLO_FIRST_ADMIN_EMAIL` + Supabase service-role env vars, upserts `opollo_config`. Run once per deploy target.
- **`.env.local.example`** documents the env var.
- **`scripts/README.md`** adds usage.

## Testing

- **`lib/__tests__/_auth-helpers.ts`** — `seedAuthUser()` wraps `supabase.auth.admin.createUser()` so the trigger fires the real way; `signInAs()` + `setFirstAdminEmail()` helpers for M2b/M2c reuse.
- **`lib/__tests__/_setup.ts`** — TRUNCATE list gains `opollo_config` + `auth.users` so tests don't leak auth state across cases.
- **`lib/__tests__/m2a-auth-link.test.ts`** — 10 cases:
  - Default viewer role on signup
  - Admin promotion when email matches `first_admin_email`
  - Non-matching email stays viewer even with config set
  - Email-update trigger syncs `opollo_users.email`
  - Unrelated field update doesn't fire sync trigger
  - FK cascade on `auth.users DELETE` wipes `opollo_users` row
  - `auth_role()` with / without / with-unknown JWT `sub` claim
  - `opollo_config` service-role read/write

## Verification performed

- All four migrations apply cleanly against scratch Postgres (fake `auth` schema with `auth.users` + `auth.uid()` stood in for Supabase's real ones) — 6/6 behaviour scenarios pass:
  1. Default role → `viewer`
  2. Match → `admin`
  3. Email update → syncs
  4. `auth.users DELETE` → cascade
  5. `auth_role()` no-session → `NULL`
  6. `auth_role()` with `SET LOCAL "request.jwt.claim.sub"` → returned role
- Rollback + re-apply cycle clean.
- `tsc --noEmit`, `next lint`, `stylelint` all clean.

## Deferred to later M2 slices (per approved plan)

- **M2b**: user-scoped RLS policies.
- **M2c**: middleware, `@supabase/ssr`, `/login`, `/logout`, SMTP config, emergency bypass route.
- **M2d**: admin layout role gating + admin-user management UI.

## Follow-up pinned

`docs/m3-notes.md` records the tightening-to-NOT-NULL of `created_by` / `last_edited_by` in M3 (per your adjustment).

## Test plan

- [ ] CI `typecheck` / `lint` / `test` all green
- [ ] Spot-check the rollback runs cleanly on a scratch DB before merge
- [ ] No immediate prod action needed — this migration is safe to apply; the feature only activates once M2c ships and `FEATURE_SUPABASE_AUTH=true`

Do not merge until CI is green.

https://claude.ai/code/session_01PTCJrskyCmW3t9NvLXM7rT