### PR TITLE
docs: add working brief for AI-assisted development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# Opollo Site Builder — Working Brief
+
+## What this is
+Next.js 14 (App Router) + TypeScript + Tailwind + shadcn/ui + Vercel AI SDK.
+A chat interface that generates WordPress pages for Opollo's clients.
+
+## How to work
+- Work autonomously. Don't ask for permission for normal coding tasks.
+- After any change: run lint, typecheck, and build. Fix failures yourself before reporting back.
+- Only stop and ask me if: you hit an architectural decision, a secret/credential issue, or you've tried twice and can't fix a failure.
+- When reporting back, give me a one-paragraph summary, not a blow-by-blow.
+
+## Commands
+- `npm run dev` — local dev
+- `npm run lint` — ESLint
+- `npm run typecheck` — tsc --noEmit
+- `npm run build` — production build
+- `npm run test` — (add when tests exist)
+
+## Standards
+- Server Components by default; Client Components only when required
+- shadcn/ui components over custom; Tailwind utility classes only
+- Strict TypeScript — no `any`, no `@ts-ignore`
+- One logical change per commit; conventional commit messages
+
+## Git workflow
+- Branch per task: `feat/`, `fix/`, `chore/`, `refactor/`
+- Always open a PR, never push direct to main
+- PR description should reference the issue it closes
+
+## What I care about
+- Don't loop me in on routine errors — fix and retry
+- Do loop me in on design decisions or scope questions
+- Keep PRs small enough to review in 5 minutes


### PR DESCRIPTION
## Summary
Added a working brief document (`CLAUDE.md`) that establishes guidelines and standards for autonomous AI-assisted development on this project.

## Key Changes
- **Working Brief Document**: Created `CLAUDE.md` with:
  - Project tech stack overview (Next.js 14, TypeScript, Tailwind, shadcn/ui, Vercel AI SDK)
  - Autonomous work guidelines and escalation criteria
  - Development commands and workflow
  - Code standards (Server Components, TypeScript strictness, shadcn/ui preference)
  - Git workflow expectations (branching strategy, PR requirements)
  - Communication preferences for the developer

## Details
This document serves as a reference for how to approach development tasks on the Opollo Site Builder project, emphasizing autonomous problem-solving while maintaining code quality standards and clear communication on architectural decisions.

https://claude.ai/code/session_01BQqix2oB2WGkX91LLziVRY