### PR TITLE
ci: add build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,25 @@ jobs:
       - run: npm run lint
       - run: npm run lint:css
 
+  build:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: actions/cache@v4
+        id: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+      - run: npm run build
+
   test:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a fourth CI job, `build`, that runs `npm run build` on Node 20 with the same node_modules caching pattern as the other jobs.
- Uses the same fork-PR gate as the existing typecheck/lint/test jobs so forks can't trigger builds.

## Test plan
- [ ] CI `build` job runs on this PR and passes
- [ ] Existing `typecheck`, `lint`, and `test` jobs continue to pass