### PR TITLE
docs: allow Claude Code to auto-merge its own PRs when CI is green

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,18 @@ A chat interface that generates WordPress pages for Opollo's clients.
 - After any change: run lint, typecheck, and build. Fix failures yourself before reporting back.
 - When reporting back, give me a one-paragraph summary, not a blow-by-blow.
 - After opening a PR, monitor CI until it passes. If CI fails, read the failure, fix it, push again. Repeat until green.
-- "Done" means: PR open, CI green, summary posted. Not: PR open, CI running, waiting for input.
+- "Done" means: PR merged (or handed to Steven for merge, where required) and summary posted. Not: PR open, CI running, waiting for input.
+
+## Merging
+- Auto-merge your own PRs when ALL of these are true:
+  - CI is fully green (all required checks pass)
+  - No review requested and no pending review comments
+  - The PR was opened by Claude Code (not by Steven)
+  - The PR is not write-safety-critical (see below)
+- Human merge still required for:
+  - Any PR Claude Code escalates to Steven for a decision
+  - M3, M4, M7 milestone PRs (concurrency / transactional / circuit breaker code)
+  - Any PR Steven explicitly flags for review
 
 ## Self-test loop
 - Retry ceiling is 10 attempts per PR, not 3. Retry count alone is no longer the escalation trigger — "not converging" is.


### PR DESCRIPTION
## Summary
Replaces the implicit "human merges after CI green" workflow with an explicit auto-merge policy for Claude Code's own PRs.

Claude Code auto-merges its own PR when ALL of these are true:
- CI is fully green (all required checks pass)
- No review requested and no pending review comments
- The PR was opened by Claude Code (not by Steven)
- The PR is not write-safety-critical (M3, M4, M7 milestones)

Human merge still required for:
- Any PR Claude Code escalates to Steven for a decision
- M3, M4, M7 milestone PRs (concurrency / transactional / circuit breaker code)
- Any PR Steven explicitly flags for review

## Test plan
- [ ] CI green on this PR
- [ ] After merge, apply the new policy retroactively by merging PR #17 when its CI goes green