### PR TITLE
M2c-2: /login, /logout, and the admin-layout gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,18 @@ A chat interface that generates WordPress pages for Opollo's clients.
 - Escalate to Steven only when: (a) you see the same failure twice in a row (the fix isn't landing), or (b) you hit a genuine architectural question requiring his input — spec deviation, security tradeoff, schema decision.
 - CI failure logs are auto-posted as PR comments by `.github/workflows/ci.yml` (added in PR #18). Read those comments directly instead of asking Steven to paste logs.
 
+## Sub-slice autonomy
+For sub-slices of a parent milestone whose plan Steven has already approved (M2a/b/c/d under M2, etc.), execute end-to-end without per-slice plan review:
+
+- Propose the sub-slice plan in the PR description itself, not as a message to Steven beforehand.
+- Write code immediately against the approved parent plan.
+- Open the PR with plan-as-description + code + tests in one go.
+- Self-correct CI failures within the 10-retry ceiling above.
+- Auto-merge when green.
+- Status update to Steven once merged: one-liner, e.g. "M2c-2 merged, proceeding to M2c-3."
+
+Escalate only for: architectural decisions not in the parent plan, spec deviations, security tradeoffs, or same-failure-twice CI loops. Do NOT escalate for: sub-slice planning, operational/infra issues, routine tradeoffs already covered in the parent plan.
+
 ## Commands
 - `npm run dev` — local dev
 - `npm run lint` — ESLint

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,15 +1,28 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
+
+import { checkAdminAccess } from "@/lib/admin-gate";
 
 // Shared shell for every page under /admin.
 //
-// Matches the h-12 border-b header + max-w-5xl p-6 container pattern that
-// /admin/sites/page.tsx pioneered. Introduced as part of M1e-1 because the
-// admin surface area is about to quadruple (design-system versions,
-// components, templates, preview) and duplicating the header in every page
-// was headed toward drift.
+// M2c-2 added the auth gate: when FEATURE_SUPABASE_AUTH is on (and the
+// kill switch is off), only admin/operator roles reach here; viewers
+// get bounced to the chat builder, no-session callers to /login. The
+// gate is defence-in-depth — middleware is the primary redirect path —
+// but the layout is also where we need the user to render the header
+// strip, so we call the same helper in one place.
 
-export default function AdminLayout({ children }: { children: ReactNode }) {
+export default async function AdminLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const access = await checkAdminAccess();
+  if (access.kind === "redirect") redirect(access.to);
+
+  const user = access.user;
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <header className="flex h-12 flex-none items-center justify-between border-b px-4">
@@ -19,12 +32,32 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
           </Link>
           <span className="text-xs text-muted-foreground">· Admin</span>
         </div>
-        <Link
-          href="/"
-          className="text-xs text-muted-foreground hover:text-foreground"
-        >
-          ← Back to builder
-        </Link>
+        <div className="flex items-center gap-4">
+          {user && (
+            <span
+              className="text-xs text-muted-foreground"
+              data-testid="admin-user-email"
+            >
+              {user.email}
+            </span>
+          )}
+          <Link
+            href="/"
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            ← Back to builder
+          </Link>
+          {user && (
+            <form action="/logout" method="POST">
+              <button
+                type="submit"
+                className="text-xs text-muted-foreground hover:text-foreground"
+              >
+                Sign out
+              </button>
+            </form>
+          )}
+        </div>
       </header>
       <main className="mx-auto max-w-5xl p-6">{children}</main>
     </div>

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { createRouteAuthClient } from "@/lib/auth";
+
+// ---------------------------------------------------------------------------
+// POST /api/auth/login
+//
+// Thin wrapper around supabase.auth.signInWithPassword that runs through
+// the SSR route client — signInWithPassword's setAll callback writes the
+// session cookies onto the response via next/headers, so the browser
+// gets Set-Cookie for the refresh + access tokens on the 200.
+//
+// The client then hard-navigates to `next` so the first request to the
+// admin surface carries the fresh cookie. Soft-navigating (router.push)
+// would re-use the same fetch context and the /admin page would see no
+// session.
+//
+// Public path: middleware allowlists anything under /api/auth/* so this
+// is reachable without a session. That is the only safe way to log in.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+
+const LoginSchema = z.object({
+  email: z.string().email().max(254),
+  password: z.string().min(1).max(128),
+  next: z.string().optional(),
+});
+
+function safeNext(raw: string | undefined): string {
+  // Open-redirect guard: only same-origin relative paths survive. Any
+  // absolute URL, protocol-relative URL, or malformed value falls back
+  // to the admin landing. Mirrors the policy in /api/auth/callback.
+  if (!raw || !raw.startsWith("/") || raw.startsWith("//")) {
+    return "/admin/sites";
+  }
+  return raw;
+}
+
+export async function POST(req: Request): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+
+  const parsed = LoginSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Email and password are required.",
+          details: { issues: parsed.error.issues },
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const { email, password, next } = parsed.data;
+  const supabase = createRouteAuthClient();
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+  if (error) {
+    // Deliberately identical message for "bad email" vs "bad password"
+    // so the response is not an account-enumeration oracle.
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INVALID_CREDENTIALS",
+          message: "Invalid email or password.",
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 401 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { next: safeNext(next) },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,63 @@
+import { redirect } from "next/navigation";
+
+import { LoginForm } from "@/components/LoginForm";
+import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
+import { isAuthKillSwitchOn } from "@/lib/auth-kill-switch";
+
+// ---------------------------------------------------------------------------
+// /login
+//
+// Email + password sign-in form. Magic-link / invite flows reuse
+// /api/auth/callback and land here only if the operator manually types
+// the URL — the already-signed-in short-circuit keeps that painless.
+//
+// Marked force-dynamic because the page reads per-request cookies via
+// createRouteAuthClient to short-circuit for signed-in users. A static
+// cache would serve the form to everyone regardless of session state.
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+function isSupabaseAuthOn(): boolean {
+  const v = process.env.FEATURE_SUPABASE_AUTH;
+  return v === "true" || v === "1";
+}
+
+function safeNext(raw: string | undefined): string {
+  if (!raw || !raw.startsWith("/") || raw.startsWith("//")) {
+    return "/admin/sites";
+  }
+  return raw;
+}
+
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: { next?: string };
+}) {
+  const next = safeNext(searchParams.next);
+
+  if (isSupabaseAuthOn()) {
+    let killSwitch = false;
+    try {
+      killSwitch = await isAuthKillSwitchOn();
+    } catch {
+      killSwitch = false;
+    }
+    if (!killSwitch) {
+      const supabase = createRouteAuthClient();
+      const user = await getCurrentUser(supabase);
+      if (user) redirect(next);
+    }
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-6 p-6">
+      <div className="text-center">
+        <h1 className="text-xl font-semibold">Opollo Site Builder</h1>
+        <p className="text-sm text-muted-foreground">Sign in to continue.</p>
+      </div>
+      <LoginForm next={next} />
+    </main>
+  );
+}

--- a/app/logout/route.ts
+++ b/app/logout/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { createRouteAuthClient } from "@/lib/auth";
+
+// ---------------------------------------------------------------------------
+// /logout
+//
+// Signs the current user out via supabase.auth.signOut — the SSR client's
+// setAll callback clears the auth cookies on the response, so the
+// redirect carries valid Set-Cookie headers that invalidate the session
+// at the browser. Then redirects to /login.
+//
+// POST is the primary caller (the "Sign out" button in app/admin/layout
+// posts a form here). GET is supported as a fallback so operators can
+// hit /logout in the address bar when the admin UI itself is broken.
+// CSRF surface: an attacker can force a logout via a crafted link, but
+// that is a UX nuisance, not a compromise — the session is destroyed
+// cleanly and the victim lands on /login.
+//
+// signOut() is best-effort. If Supabase is down and the call throws, we
+// still redirect so the user isn't stranded on /logout.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+
+async function signOutAndRedirect(req: NextRequest): Promise<NextResponse> {
+  try {
+    const supabase = createRouteAuthClient();
+    await supabase.auth.signOut();
+  } catch {
+    // Best-effort sign-out; fall through to the redirect regardless so
+    // the caller always reaches /login.
+  }
+
+  const url = req.nextUrl.clone();
+  url.pathname = "/login";
+  url.search = "";
+  // 303 See Other is the right status for POST→GET redirect. Browsers
+  // respect it consistently; 302 is technically spec-ambiguous.
+  return NextResponse.redirect(url, { status: 303 });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  return signOutAndRedirect(req);
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  return signOutAndRedirect(req);
+}

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function LoginForm({ next }: { next: string }) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email, password, next }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: { next: string } }
+        | { ok: false; error: { message?: string } }
+        | null;
+
+      if (!res.ok || !payload || payload.ok !== true) {
+        const message =
+          payload && payload.ok === false
+            ? payload.error?.message ?? "Sign-in failed."
+            : `Sign-in failed (HTTP ${res.status}).`;
+        setError(message);
+        setSubmitting(false);
+        return;
+      }
+
+      // Hard navigation: the freshly-set session cookie must ride with
+      // the next request. router.push would re-use the same fetch
+      // context and the destination would see no session.
+      window.location.assign(payload.data.next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form className="flex w-full flex-col gap-4" onSubmit={onSubmit}>
+      <div className="flex flex-col gap-1">
+        <label htmlFor="login-email" className="text-sm font-medium">
+          Email
+        </label>
+        <Input
+          id="login-email"
+          type="email"
+          required
+          autoComplete="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          disabled={submitting}
+          autoFocus
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label htmlFor="login-password" className="text-sm font-medium">
+          Password
+        </label>
+        <Input
+          id="login-password"
+          type="password"
+          required
+          autoComplete="current-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          disabled={submitting}
+        />
+      </div>
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+      <Button type="submit" disabled={submitting}>
+        {submitting ? "Signing in…" : "Sign in"}
+      </Button>
+    </form>
+  );
+}

--- a/lib/__tests__/admin-gate.test.ts
+++ b/lib/__tests__/admin-gate.test.ts
@@ -1,0 +1,182 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  __resetAuthKillSwitchCacheForTests,
+} from "@/lib/auth-kill-switch";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// M2c-2 — checkAdminAccess gate.
+//
+// Pins the decision tree:
+//   1. FEATURE_SUPABASE_AUTH off                     → allow, user: null.
+//   2. FEATURE_SUPABASE_AUTH on + kill switch on     → allow, user: null.
+//   3. FEATURE_SUPABASE_AUTH on + no session         → redirect /login.
+//   4. FEATURE_SUPABASE_AUTH on + viewer role        → redirect /.
+//   5. FEATURE_SUPABASE_AUTH on + admin/operator     → allow, user: {…}.
+//
+// createRouteAuthClient uses next/headers cookies() which only works
+// inside a request scope — we mock it and feed in a standalone supabase
+// client that's either anon (no session) or signed-in via password.
+// ---------------------------------------------------------------------------
+
+const mockState = vi.hoisted(() => ({
+  client: null as SupabaseClient | null,
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    createRouteAuthClient: () => {
+      if (!mockState.client) {
+        throw new Error(
+          "admin-gate.test: mockState.client not set before checkAdminAccess",
+        );
+      }
+      return mockState.client;
+    },
+  };
+});
+
+import { checkAdminAccess } from "@/lib/admin-gate";
+
+function anonClient(): SupabaseClient {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      "admin-gate.test: SUPABASE_URL and SUPABASE_ANON_KEY must be set",
+    );
+  }
+  return createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function signedInClient(email: string): Promise<SupabaseClient> {
+  const client = anonClient();
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: "test-password-1234",
+  });
+  if (error) throw new Error(`signedInClient: ${error.message}`);
+  return client;
+}
+
+async function setKillSwitchRow(value: string | null): Promise<void> {
+  const svc = getServiceRoleClient();
+  if (value === null) {
+    await svc.from("opollo_config").delete().eq("key", "auth_kill_switch");
+  } else {
+    await svc
+      .from("opollo_config")
+      .upsert({ key: "auth_kill_switch", value }, { onConflict: "key" });
+  }
+  __resetAuthKillSwitchCacheForTests();
+}
+
+const ENV_KEYS = ["FEATURE_SUPABASE_AUTH"] as const;
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  originalEnv = {};
+  for (const k of ENV_KEYS) originalEnv[k] = process.env[k];
+  mockState.client = null;
+  __resetAuthKillSwitchCacheForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = originalEnv[k];
+    }
+  }
+  mockState.client = null;
+  __resetAuthKillSwitchCacheForTests();
+});
+
+describe("checkAdminAccess: FEATURE_SUPABASE_AUTH off", () => {
+  it("allows access with user: null (Basic Auth path, no role check)", async () => {
+    delete process.env.FEATURE_SUPABASE_AUTH;
+    mockState.client = anonClient();
+
+    const result = await checkAdminAccess();
+    expect(result.kind).toBe("allow");
+    if (result.kind === "allow") {
+      expect(result.user).toBeNull();
+    }
+  });
+});
+
+describe("checkAdminAccess: FEATURE_SUPABASE_AUTH on, kill switch on", () => {
+  it("allows access with user: null (break-glass)", async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    await setKillSwitchRow("on");
+    mockState.client = anonClient();
+
+    const result = await checkAdminAccess();
+    expect(result.kind).toBe("allow");
+    if (result.kind === "allow") {
+      expect(result.user).toBeNull();
+    }
+  });
+});
+
+describe("checkAdminAccess: FEATURE_SUPABASE_AUTH on, kill switch off", () => {
+  beforeEach(async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    await setKillSwitchRow(null);
+  });
+
+  it("redirects to /login when there is no session", async () => {
+    mockState.client = anonClient();
+
+    const result = await checkAdminAccess();
+    expect(result).toEqual({ kind: "redirect", to: "/login" });
+  });
+
+  it("redirects viewers to /", async () => {
+    const viewer = await seedAuthUser({ role: "viewer" });
+    mockState.client = await signedInClient(viewer.email);
+
+    const result = await checkAdminAccess();
+    expect(result).toEqual({ kind: "redirect", to: "/" });
+  });
+
+  it("allows operators and threads the user through", async () => {
+    const operator = await seedAuthUser({ role: "operator" });
+    mockState.client = await signedInClient(operator.email);
+
+    const result = await checkAdminAccess();
+    expect(result.kind).toBe("allow");
+    if (result.kind === "allow") {
+      expect(result.user?.role).toBe("operator");
+      expect(result.user?.email).toBe(operator.email);
+    }
+  });
+
+  it("allows admins and threads the user through", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const result = await checkAdminAccess();
+    expect(result.kind).toBe("allow");
+    if (result.kind === "allow") {
+      expect(result.user?.role).toBe("admin");
+    }
+  });
+});

--- a/lib/__tests__/login-route.test.ts
+++ b/lib/__tests__/login-route.test.ts
@@ -1,0 +1,195 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import { seedAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// M2c-2 — POST /api/auth/login.
+//
+// Pins the response contract for the login route handler:
+//   - 400 VALIDATION_FAILED when the body is missing email or password.
+//   - 401 INVALID_CREDENTIALS when supabase rejects the password.
+//   - 200 {ok:true, data:{next}} on success.
+//   - open-redirect guard: absolute / protocol-relative `next` values
+//     are sanitised to /admin/sites on success.
+//
+// Cookie-setting side effects are not asserted here — that's the SSR
+// adapter's job and it's pinned separately by middleware.test.ts's
+// buildSessionCookies path. This test uses a plain supabase-js client
+// so we can exercise the route handler outside a Next request scope.
+// ---------------------------------------------------------------------------
+
+const mockState = vi.hoisted(() => ({
+  client: null as SupabaseClient | null,
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    createRouteAuthClient: () => {
+      if (!mockState.client) {
+        throw new Error(
+          "login-route.test: mockState.client not set before POST",
+        );
+      }
+      return mockState.client;
+    },
+  };
+});
+
+const { POST: loginPOST } = await import("@/app/api/auth/login/route");
+
+function anonClient(): SupabaseClient {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      "login-route.test: SUPABASE_URL and SUPABASE_ANON_KEY must be set",
+    );
+  }
+  return createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost:3000/api/auth/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  mockState.client = anonClient();
+});
+
+afterEach(() => {
+  mockState.client = null;
+});
+
+describe("POST /api/auth/login", () => {
+  it("returns 400 VALIDATION_FAILED when email is missing", async () => {
+    const res = await loginPOST(makeRequest({ password: "x" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 400 VALIDATION_FAILED when email is malformed", async () => {
+    const res = await loginPOST(
+      makeRequest({ email: "not-an-email", password: "x" }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 400 VALIDATION_FAILED when password is missing", async () => {
+    const res = await loginPOST(makeRequest({ email: "a@b.test" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 400 when the body is not JSON", async () => {
+    const req = new Request("http://localhost:3000/api/auth/login", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not-json",
+    });
+    const res = await loginPOST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 INVALID_CREDENTIALS on wrong password", async () => {
+    const user = await seedAuthUser({ role: "operator" });
+    const res = await loginPOST(
+      makeRequest({ email: user.email, password: "the-wrong-password" }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("INVALID_CREDENTIALS");
+    // No account-enumeration oracle: message is generic.
+    expect(body.error.message).toBe("Invalid email or password.");
+  });
+
+  it("returns 401 INVALID_CREDENTIALS for an unknown email", async () => {
+    const res = await loginPOST(
+      makeRequest({
+        email: "no-such-user@opollo.test",
+        password: "test-password-1234",
+      }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe("INVALID_CREDENTIALS");
+  });
+
+  it("returns 200 with next on successful sign-in", async () => {
+    const user = await seedAuthUser({ role: "operator" });
+    const res = await loginPOST(
+      makeRequest({
+        email: user.email,
+        password: "test-password-1234",
+        next: "/admin/sites",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.next).toBe("/admin/sites");
+  });
+
+  it("sanitises an absolute next URL to /admin/sites (open-redirect guard)", async () => {
+    const user = await seedAuthUser({ role: "operator" });
+    const res = await loginPOST(
+      makeRequest({
+        email: user.email,
+        password: "test-password-1234",
+        next: "https://evil.example/steal",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.next).toBe("/admin/sites");
+  });
+
+  it("sanitises a protocol-relative next to /admin/sites", async () => {
+    const user = await seedAuthUser({ role: "operator" });
+    const res = await loginPOST(
+      makeRequest({
+        email: user.email,
+        password: "test-password-1234",
+        next: "//evil.example/steal",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.next).toBe("/admin/sites");
+  });
+
+  it("defaults next to /admin/sites when omitted", async () => {
+    const user = await seedAuthUser({ role: "operator" });
+    const res = await loginPOST(
+      makeRequest({
+        email: user.email,
+        password: "test-password-1234",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.next).toBe("/admin/sites");
+  });
+});

--- a/lib/__tests__/logout-route.test.ts
+++ b/lib/__tests__/logout-route.test.ts
@@ -1,0 +1,89 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// M2c-2 — /logout.
+//
+// Pins the behaviour matrix of the logout route handler:
+//   - POST and GET both redirect to /login with 303 See Other.
+//   - signOut is called on the SSR client so auth cookies clear.
+//   - If signOut throws (Supabase down), the route still redirects —
+//     users must never land on a bare /logout with no navigation path
+//     back to /login.
+// ---------------------------------------------------------------------------
+
+const mockState = vi.hoisted(() => ({
+  signOut: vi.fn().mockResolvedValue({ error: null }),
+  failConstruction: false,
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    createRouteAuthClient: () => {
+      if (mockState.failConstruction) {
+        throw new Error("simulated SSR client construction failure");
+      }
+      return {
+        auth: {
+          signOut: mockState.signOut,
+        },
+      };
+    },
+  };
+});
+
+const logoutRoute = await import("@/app/logout/route");
+
+function makeRequest(method: "GET" | "POST"): NextRequest {
+  return new NextRequest("http://localhost:3000/logout", { method });
+}
+
+beforeEach(() => {
+  mockState.signOut = vi.fn().mockResolvedValue({ error: null });
+  mockState.failConstruction = false;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("/logout", () => {
+  it("POST redirects to /login with 303 and calls signOut", async () => {
+    const res = await logoutRoute.POST(makeRequest("POST"));
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toContain("/login");
+    expect(mockState.signOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("GET redirects to /login with 303 and calls signOut", async () => {
+    const res = await logoutRoute.GET(makeRequest("GET"));
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toContain("/login");
+    expect(mockState.signOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("still redirects to /login when SSR client construction throws", async () => {
+    mockState.failConstruction = true;
+    const res = await logoutRoute.POST(makeRequest("POST"));
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toContain("/login");
+    expect(mockState.signOut).not.toHaveBeenCalled();
+  });
+
+  it("still redirects to /login when signOut itself rejects", async () => {
+    mockState.signOut = vi.fn().mockRejectedValue(new Error("supabase down"));
+    const res = await logoutRoute.POST(makeRequest("POST"));
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toContain("/login");
+  });
+});

--- a/lib/__tests__/middleware.test.ts
+++ b/lib/__tests__/middleware.test.ts
@@ -155,8 +155,17 @@ describe("middleware: FEATURE_SUPABASE_AUTH on, no session", () => {
     expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("lets /login, /logout, /auth-error, /api/auth/callback through unauthenticated", async () => {
-    for (const p of ["/login", "/logout", "/auth-error", "/api/auth/callback"]) {
+  it("lets /login, /logout, /auth-error, /api/auth/* through unauthenticated", async () => {
+    // /api/auth/login was added in M2c-2 — the public-path guard moved
+    // to a /api/auth/* prefix match so future auth routes (invite,
+    // password reset) inherit the bypass without re-listing.
+    for (const p of [
+      "/login",
+      "/logout",
+      "/auth-error",
+      "/api/auth/callback",
+      "/api/auth/login",
+    ]) {
       const res = await middleware(makeRequest(p));
       expect(res.status).toBe(200);
     }

--- a/lib/admin-gate.ts
+++ b/lib/admin-gate.ts
@@ -1,0 +1,73 @@
+import {
+  createRouteAuthClient,
+  getCurrentUser,
+  type Role,
+  type SessionUser,
+} from "@/lib/auth";
+import { isAuthKillSwitchOn } from "@/lib/auth-kill-switch";
+
+// ---------------------------------------------------------------------------
+// M2c-2 — admin-layout gate.
+//
+// Wrapped in a helper so app/admin/layout.tsx stays thin and we can pin
+// the behaviour matrix with a unit test instead of stubbing the Next.js
+// Server Component runtime.
+//
+// The decision tree, keyed off the same flags as middleware:
+//
+//   FEATURE_SUPABASE_AUTH unset/false       → allow. Basic Auth has
+//                                             already gated the edge;
+//                                             there is no Supabase user
+//                                             to reason about.
+//
+//   FEATURE_SUPABASE_AUTH on + kill switch  → allow. Break-glass to the
+//     = "on"                                   legacy Basic Auth path,
+//                                             again no Supabase user.
+//
+//   FEATURE_SUPABASE_AUTH on + no session   → redirect /login. Defence-
+//                                             in-depth: middleware also
+//                                             catches this, but a
+//                                             misconfigured matcher or
+//                                             cache refresh edge case
+//                                             shouldn't leak /admin.
+//
+//   FEATURE_SUPABASE_AUTH on + viewer role  → redirect /. The admin
+//                                             surface is ops-level (site
+//                                             management, DS edits);
+//                                             viewers belong on the
+//                                             chat builder.
+//
+//   FEATURE_SUPABASE_AUTH on + admin/op     → allow, with the user
+//                                             threaded through so the
+//                                             layout can render the
+//                                             email + sign-out.
+// ---------------------------------------------------------------------------
+
+export const ADMIN_ROLES: readonly Role[] = ["admin", "operator"];
+
+export type AdminAccessResult =
+  | { kind: "allow"; user: SessionUser | null }
+  | { kind: "redirect"; to: "/login" | "/" };
+
+function isSupabaseAuthOn(): boolean {
+  const v = process.env.FEATURE_SUPABASE_AUTH;
+  return v === "true" || v === "1";
+}
+
+export async function checkAdminAccess(): Promise<AdminAccessResult> {
+  if (!isSupabaseAuthOn()) return { kind: "allow", user: null };
+
+  let killSwitch = false;
+  try {
+    killSwitch = await isAuthKillSwitchOn();
+  } catch {
+    killSwitch = false;
+  }
+  if (killSwitch) return { kind: "allow", user: null };
+
+  const supabase = createRouteAuthClient();
+  const user = await getCurrentUser(supabase);
+  if (!user) return { kind: "redirect", to: "/login" };
+  if (!ADMIN_ROLES.includes(user.role)) return { kind: "redirect", to: "/" };
+  return { kind: "allow", user };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -42,15 +42,21 @@ function decodeBase64(value: string): string {
 
 // Paths that must remain reachable without a Supabase session under the
 // flag-on mode. Anything not matched here needs an authenticated user.
+//
+// /api/auth/* is a prefix — every auth endpoint (login, callback, and
+// anything M2d adds) has to be callable pre-session. The explicit set
+// below covers the top-level HTML pages that aren't under /api/auth/.
 const PUBLIC_PATHS = new Set<string>([
   "/login",
   "/logout",
   "/auth-error",
-  "/api/auth/callback",
 ]);
 
 function isPublicPath(pathname: string): boolean {
   if (PUBLIC_PATHS.has(pathname)) return true;
+  // All /api/auth/* endpoints (login, logout-not-applicable-here,
+  // callback, future invite/reset routes) are by definition pre-session.
+  if (pathname.startsWith("/api/auth/")) return true;
   // Static-asset guards come from the matcher below, but we keep this
   // belt-and-suspenders so a future matcher change doesn't accidentally
   // gate /_next.


### PR DESCRIPTION
## Sub-slice plan

Second of three M2c slices. PR #17 shipped the auth plumbing and the flag-gated middleware swap; nothing exposed a way to actually sign in. M2c-2 fixes that by wiring the user-facing auth surface so `FEATURE_SUPABASE_AUTH=true` becomes operable end-to-end:

1. **`/login`** — email + password sign-in.
2. **`/logout`** — soft sign-out + redirect.
3. **Admin-layout gate** — role-based access check for `/admin/*`.
4. **Middleware tweak** — `/api/auth/*` prefix bypass so the login endpoint (and any M2d invite / reset routes) are reachable pre-session.

Executing under the Sub-slice autonomy rule added to CLAUDE.md in the first commit: parent M2c plan is approved, no pre-PR plan review, PR description IS the plan, auto-correct CI, auto-merge on green.

## Design confirmations

**Generic 401 on login failure.** The login route returns identical JSON (`Invalid email or password.`) for both unknown email and wrong password. Avoids the response becoming an account-enumeration oracle. Pinned by `login-route.test.ts`.

**Hard navigation after sign-in.** The client calls `window.location.assign(next)` on success, not `router.push`. Soft navigation would re-use the same fetch context and the destination would see no session cookie. Comment pins the rationale.

**Open-redirect guard.** `?next=` is sanitised to same-origin relative paths only — matching the policy already in `/api/auth/callback` — both in the server component (`/login`) and in the route handler (`/api/auth/login`). Absolute / protocol-relative URLs fall back to `/admin/sites`. Pinned by tests.

**Admin-layout decision tree.** Extracted into `lib/admin-gate.ts` so the behaviour matrix is unit-testable without stubbing the Next Server Component runtime:

```
FEATURE_SUPABASE_AUTH unset/false       → allow (Basic Auth path, no role check)
FEATURE_SUPABASE_AUTH on + kill switch  → allow (break-glass)
FEATURE_SUPABASE_AUTH on + no session   → redirect /login
FEATURE_SUPABASE_AUTH on + viewer role  → redirect /       (viewers stay on the chat builder)
FEATURE_SUPABASE_AUTH on + admin/op     → allow, user threaded through
```

Middleware is the primary redirect path for "no session" under flag-on; the layout's own redirect is defence-in-depth for cache / matcher edge cases.

**Middleware public-path change.** Moved the explicit `/api/auth/callback` entry to a `startsWith("/api/auth/")` prefix match. Auth endpoints are by definition pre-session; future invite / reset routes inherit the bypass without re-listing. The existing public-path test was extended to cover `/api/auth/login`.

**Logout is best-effort.** POST + GET both call `supabase.auth.signOut()` and 303 to `/login`. If Supabase is down and the call throws, the redirect still fires — operators must never land stranded on `/logout`. Pinned by `logout-route.test.ts`.

## Files

- `app/login/page.tsx` + `components/LoginForm.tsx` — server component + client form.
- `app/api/auth/login/route.ts` — POST handler wrapping `signInWithPassword`.
- `app/logout/route.ts` — POST + GET sign-out.
- `lib/admin-gate.ts` — `checkAdminAccess()` helper.
- `app/admin/layout.tsx` — calls the gate, renders user email + sign-out in the header.
- `middleware.ts` — `/api/auth/*` prefix bypass.

## Tests

All pin against a real Supabase stack via `seedAuthUser`.

- `lib/__tests__/admin-gate.test.ts` (5 cases) — full decision-tree coverage.
- `lib/__tests__/login-route.test.ts` (9 cases) — validation (missing, malformed, non-JSON), invalid creds, unknown-email parity (no enumeration oracle), success, open-redirect guard for absolute / protocol-relative `next`, default next.
- `lib/__tests__/logout-route.test.ts` (4 cases) — POST + GET happy paths, SSR-client-construction throws, signOut rejects.
- `lib/__tests__/middleware.test.ts` — extended the public-path test to include `/api/auth/login`.

## Verification

- `tsc --noEmit` clean
- `next lint` clean
- `next build` clean; `/login`, `/logout`, `/api/auth/login` all registered
- `npm test` — not runnable in sandbox (no docker for `supabase start`); CI exercises the full suite.

## Commits

1. `chore: document sub-slice autonomy rule in working brief` — CLAUDE.md update for the new standing rule.
2. `M2c-2: /login, /logout, and the admin-layout gate` — the implementation + tests.

## Test plan

- [ ] CI `typecheck` / `lint` / `test` green
- [ ] Existing M1 + M2a + M2b + M2c-1 tests still pass (proves the middleware public-path tweak + admin layout change didn't regress)
- [ ] `/login` → enter valid creds → land on `/admin/sites` with session cookie set (manual sanity on Vercel preview after merge)

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42