### PR TITLE
M2c-3: emergency break-glass route

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -43,3 +43,13 @@ OPOLLO_FIRST_ADMIN_EMAIL=
 # M2c-3) lets operators break-glass to the Basic Auth path without a
 # redeploy.
 FEATURE_SUPABASE_AUTH=
+
+# Emergency break-glass key (M2c-3). Static pre-shared key that
+# authenticates POST /api/emergency. That route is the only way to flip
+# opollo_config.auth_kill_switch without a redeploy AND to revoke a
+# user's sessions when Supabase Auth is misbehaving. Must be at least 32
+# characters; generate with `openssl rand -base64 48` (then strip the
+# trailing =). Leave unset in non-production environments — the route
+# returns 503 EMERGENCY_NOT_CONFIGURED when the variable is absent or
+# too short.
+OPOLLO_EMERGENCY_KEY=

--- a/app/api/emergency/route.ts
+++ b/app/api/emergency/route.ts
@@ -1,0 +1,247 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { timingSafeEqual } from "node:crypto";
+
+import { revokeUserSessions } from "@/lib/auth-revoke";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/emergency — M2c-3 break-glass operator surface.
+//
+// Purpose: recover the app when Supabase Auth (GoTrue) is down or mis-
+// configured. This is the ONLY route that is reachable without a
+// Supabase session AND can mutate opollo_config.auth_kill_switch —
+// which in turn tells middleware to fall back to Basic Auth.
+//
+// Authentication: static pre-shared key via OPOLLO_EMERGENCY_KEY env
+// var. Header format (either accepted):
+//
+//   X-Opollo-Emergency-Key: <key>
+//   Authorization: Bearer <key>
+//
+// Why pre-shared key and not Supabase: the whole reason this route
+// exists is that Supabase Auth might be broken. Anything that depends
+// on it for access control can't be the emergency hatch.
+//
+// Why 503 when unset: "key not configured" is a deployment state, not
+// a credential problem. A 401 here would be misleading — it would say
+// "your creds are wrong" when the reality is the server refuses to
+// accept ANY key.
+//
+// Actions:
+//
+//   kill_switch_on
+//     Upserts opollo_config.auth_kill_switch = 'on'. Middleware then
+//     routes every request through basicAuthGate. Propagation up to 5s
+//     per serverless instance (see lib/auth-kill-switch.ts cache).
+//
+//   kill_switch_off
+//     Deletes the opollo_config row. Middleware resumes the Supabase
+//     Auth path on the next cache refresh.
+//
+//   revoke_user { user_id }
+//     Hard revocation — opollo_users.revoked_at = now() and session +
+//     refresh tokens swept. See lib/auth-revoke.ts revokeUserSessions.
+//     Immediate effect on the next getCurrentUser call.
+//
+// Logging: structured console output. A dedicated opollo_audit_events
+// table is future work (M7 fleet infra) — for v1 the Vercel log
+// viewer is the audit trail, plus anyone with the emergency key is
+// already trusted root-level.
+//
+// Runtime: nodejs. revokeUserSessions imports pg (Node-only) and
+// middleware bypasses /api/emergency anyway, so no Edge concerns.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+
+const ActionSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("kill_switch_on") }),
+  z.object({ action: z.literal("kill_switch_off") }),
+  z.object({
+    action: z.literal("revoke_user"),
+    user_id: z.string().uuid(),
+  }),
+]);
+
+// Minimum length for the emergency key. Short keys are brute-force
+// targets and the route is reachable without Supabase — any
+// misconfiguration that sets e.g. "changeme" would be catastrophic.
+const MIN_KEY_LENGTH = 32;
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) {
+    // timingSafeEqual throws on length mismatch; compare equal-length
+    // dummies so the length-mismatch path takes roughly the same time
+    // as a content mismatch.
+    const filler = Buffer.alloc(aBuf.length);
+    timingSafeEqual(aBuf, filler);
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+function extractKey(req: Request): string | null {
+  const custom = req.headers.get("x-opollo-emergency-key");
+  if (custom) return custom.trim();
+  const bearer = req.headers.get("authorization");
+  if (bearer && bearer.toLowerCase().startsWith("bearer ")) {
+    return bearer.slice(7).trim();
+  }
+  return null;
+}
+
+type EmergencyLog = {
+  ok: boolean;
+  action?: string;
+  user_id?: string;
+  reason?: string;
+  error?: string;
+};
+
+function logEmergencyEvent(event: EmergencyLog): void {
+  // eslint-disable-next-line no-console
+  console.error(
+    "[emergency]",
+    JSON.stringify({ ts: new Date().toISOString(), ...event }),
+  );
+}
+
+function jsonError(
+  code: string,
+  message: string,
+  status: number,
+  retryable = false,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(req: Request): Promise<NextResponse> {
+  const expected = process.env.OPOLLO_EMERGENCY_KEY;
+  if (!expected || expected.length < MIN_KEY_LENGTH) {
+    logEmergencyEvent({ ok: false, reason: "not_configured" });
+    return jsonError(
+      "EMERGENCY_NOT_CONFIGURED",
+      "Emergency access is not configured on this deployment.",
+      503,
+    );
+  }
+
+  const provided = extractKey(req);
+  if (!provided || !constantTimeEqual(provided, expected)) {
+    logEmergencyEvent({ ok: false, reason: "auth_failed" });
+    return jsonError(
+      "UNAUTHORIZED",
+      "Invalid emergency key.",
+      401,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = ActionSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Invalid emergency action payload.",
+          details: { issues: parsed.error.issues },
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const svc = getServiceRoleClient();
+  const action = parsed.data.action;
+
+  try {
+    if (action === "kill_switch_on") {
+      const { error } = await svc
+        .from("opollo_config")
+        .upsert(
+          { key: "auth_kill_switch", value: "on" },
+          { onConflict: "key" },
+        );
+      if (error) throw new Error(error.message);
+      logEmergencyEvent({ ok: true, action });
+      return NextResponse.json(
+        {
+          ok: true,
+          data: {
+            action,
+            note: "Middleware will fall back to Basic Auth. Propagation up to 5s per serverless instance.",
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 200 },
+      );
+    }
+
+    if (action === "kill_switch_off") {
+      const { error } = await svc
+        .from("opollo_config")
+        .delete()
+        .eq("key", "auth_kill_switch");
+      if (error) throw new Error(error.message);
+      logEmergencyEvent({ ok: true, action });
+      return NextResponse.json(
+        {
+          ok: true,
+          data: {
+            action,
+            note: "Middleware will resume the Supabase Auth path. Propagation up to 5s per serverless instance.",
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 200 },
+      );
+    }
+
+    // action === "revoke_user"
+    await revokeUserSessions(parsed.data.user_id);
+    logEmergencyEvent({
+      ok: true,
+      action,
+      user_id: parsed.data.user_id,
+    });
+    return NextResponse.json(
+      {
+        ok: true,
+        data: {
+          action,
+          user_id: parsed.data.user_id,
+          note: "revoked_at stamped and sessions swept. The next getCurrentUser call rejects the user's prior JWT.",
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logEmergencyEvent({ ok: false, action, error: message });
+    return jsonError(
+      "INTERNAL_ERROR",
+      "Emergency action failed. See server logs.",
+      500,
+      true,
+    );
+  }
+}

--- a/lib/__tests__/emergency-route.test.ts
+++ b/lib/__tests__/emergency-route.test.ts
@@ -1,0 +1,342 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { Client } from "pg";
+
+import { __resetAuthKillSwitchCacheForTests } from "@/lib/auth-kill-switch";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { POST as emergencyPOST } from "@/app/api/emergency/route";
+import { seedAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// M2c-3 — POST /api/emergency.
+//
+// Pins the behaviour matrix:
+//   1. OPOLLO_EMERGENCY_KEY unset / <32 chars → 503 EMERGENCY_NOT_CONFIGURED.
+//   2. Wrong key → 401 UNAUTHORIZED (constant-time comparison).
+//   3. Bad body → 400 VALIDATION_FAILED.
+//   4. kill_switch_on → opollo_config row present with value='on'.
+//   5. kill_switch_off → opollo_config row absent.
+//   6. revoke_user → opollo_users.revoked_at stamped + refresh tokens gone.
+// ---------------------------------------------------------------------------
+
+const KEY_32 =
+  "0123456789abcdef0123456789abcdef"; // exactly 32 chars
+const WRONG_KEY_32 =
+  "ffffffffffffffffffffffffffffffff";
+
+const ENV_KEYS = ["OPOLLO_EMERGENCY_KEY"] as const;
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  originalEnv = {};
+  for (const k of ENV_KEYS) originalEnv[k] = process.env[k];
+  __resetAuthKillSwitchCacheForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = originalEnv[k];
+    }
+  }
+  vi.restoreAllMocks();
+});
+
+function makeRequest(
+  body: unknown,
+  init?: { key?: string; auth?: "custom" | "bearer" },
+): Request {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (init?.key) {
+    if (init.auth === "bearer") {
+      headers["authorization"] = `Bearer ${init.key}`;
+    } else {
+      headers["x-opollo-emergency-key"] = init.key;
+    }
+  }
+  return new Request("http://localhost:3000/api/emergency", {
+    method: "POST",
+    headers,
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+async function readKillSwitchRow(): Promise<string | null> {
+  const svc = getServiceRoleClient();
+  const { data } = await svc
+    .from("opollo_config")
+    .select("value")
+    .eq("key", "auth_kill_switch")
+    .maybeSingle();
+  return (data?.value as string | undefined) ?? null;
+}
+
+async function countRefreshTokens(userId: string): Promise<number> {
+  const client = new Client({
+    connectionString:
+      process.env.SUPABASE_DB_URL ??
+      "postgresql://postgres:postgres@127.0.0.1:54322/postgres",
+  });
+  await client.connect();
+  try {
+    const res = await client.query<{ n: string }>(
+      "SELECT count(*)::text AS n FROM auth.refresh_tokens WHERE user_id = $1",
+      [userId],
+    );
+    return parseInt(res.rows[0]?.n ?? "0", 10);
+  } finally {
+    await client.end();
+  }
+}
+
+async function signedInClient(email: string): Promise<SupabaseClient> {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      "emergency-route.test: SUPABASE_URL and SUPABASE_ANON_KEY must be set",
+    );
+  }
+  const client = createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: "test-password-1234",
+  });
+  if (error) throw new Error(`signedInClient: ${error.message}`);
+  return client;
+}
+
+// ---------------------------------------------------------------------------
+// Auth surface
+// ---------------------------------------------------------------------------
+
+describe("POST /api/emergency: authentication", () => {
+  it("returns 503 when OPOLLO_EMERGENCY_KEY is unset", async () => {
+    delete process.env.OPOLLO_EMERGENCY_KEY;
+    const res = await emergencyPOST(
+      makeRequest({ action: "kill_switch_on" }, { key: KEY_32 }),
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error.code).toBe("EMERGENCY_NOT_CONFIGURED");
+  });
+
+  it("returns 503 when OPOLLO_EMERGENCY_KEY is shorter than 32 chars", async () => {
+    process.env.OPOLLO_EMERGENCY_KEY = "too-short";
+    const res = await emergencyPOST(
+      makeRequest({ action: "kill_switch_on" }, { key: "too-short" }),
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error.code).toBe("EMERGENCY_NOT_CONFIGURED");
+  });
+
+  it("returns 401 when no key header is present", async () => {
+    process.env.OPOLLO_EMERGENCY_KEY = KEY_32;
+    const res = await emergencyPOST(
+      makeRequest({ action: "kill_switch_on" }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the key is wrong (same length)", async () => {
+    process.env.OPOLLO_EMERGENCY_KEY = KEY_32;
+    const res = await emergencyPOST(
+      makeRequest({ action: "kill_switch_on" }, { key: WRONG_KEY_32 }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the key is wrong (different length)", async () => {
+    process.env.OPOLLO_EMERGENCY_KEY = KEY_32;
+    const res = await emergencyPOST(
+      makeRequest(
+        { action: "kill_switch_on" },
+        { key: `${KEY_32}-extra` },
+      ),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("accepts the key via Authorization: Bearer", async () => {
+    process.env.OPOLLO_EMERGENCY_KEY = KEY_32;
+    const res = await emergencyPOST(
+      makeRequest(
+        { action: "kill_switch_on" },
+        { key: KEY_32, auth: "bearer" },
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe("POST /api/emergency: validation", () => {
+  beforeEach(() => {
+    process.env.OPOLLO_EMERGENCY_KEY = KEY_32;
+  });
+
+  it("returns 400 when body has no action", async () => {
+    const res = await emergencyPOST(makeRequest({}, { key: KEY_32 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 400 when action is unknown", async () => {
+    const res = await emergencyPOST(
+      makeRequest({ action: "eject" }, { key: KEY_32 }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 400 for revoke_user without user_id", async () => {
+    const res = await emergencyPOST(
+      makeRequest({ action: "revoke_user" }, { key: KEY_32 }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for revoke_user with a non-UUID user_id", async () => {
+    const res = await emergencyPOST(
+      makeRequest(
+        { action: "revoke_user", user_id: "not-a-uuid" },
+        { key: KEY_32 },
+      ),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is not JSON", async () => {
+    const req = new Request("http://localhost:3000/api/emergency", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-opollo-emergency-key": KEY_32,
+      },
+      body: "not-json",
+    });
+    const res = await emergencyPOST(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+describe("POST /api/emergency: kill_switch_on / kill_switch_off", () => {
+  beforeEach(() => {
+    process.env.OPOLLO_EMERGENCY_KEY = KEY_32;
+  });
+
+  it("kill_switch_on upserts opollo_config.auth_kill_switch = 'on'", async () => {
+    expect(await readKillSwitchRow()).toBeNull();
+
+    const res = await emergencyPOST(
+      makeRequest({ action: "kill_switch_on" }, { key: KEY_32 }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.action).toBe("kill_switch_on");
+
+    expect(await readKillSwitchRow()).toBe("on");
+  });
+
+  it("kill_switch_on is idempotent", async () => {
+    await emergencyPOST(
+      makeRequest({ action: "kill_switch_on" }, { key: KEY_32 }),
+    );
+    const res = await emergencyPOST(
+      makeRequest({ action: "kill_switch_on" }, { key: KEY_32 }),
+    );
+    expect(res.status).toBe(200);
+    expect(await readKillSwitchRow()).toBe("on");
+  });
+
+  it("kill_switch_off removes the opollo_config row", async () => {
+    await emergencyPOST(
+      makeRequest({ action: "kill_switch_on" }, { key: KEY_32 }),
+    );
+    expect(await readKillSwitchRow()).toBe("on");
+
+    const res = await emergencyPOST(
+      makeRequest({ action: "kill_switch_off" }, { key: KEY_32 }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.action).toBe("kill_switch_off");
+
+    expect(await readKillSwitchRow()).toBeNull();
+  });
+
+  it("kill_switch_off is idempotent when no row exists", async () => {
+    expect(await readKillSwitchRow()).toBeNull();
+    const res = await emergencyPOST(
+      makeRequest({ action: "kill_switch_off" }, { key: KEY_32 }),
+    );
+    expect(res.status).toBe(200);
+    expect(await readKillSwitchRow()).toBeNull();
+  });
+});
+
+describe("POST /api/emergency: revoke_user", () => {
+  beforeEach(() => {
+    process.env.OPOLLO_EMERGENCY_KEY = KEY_32;
+  });
+
+  it("stamps opollo_users.revoked_at and sweeps refresh tokens", async () => {
+    const user = await seedAuthUser({ role: "operator" });
+    await signedInClient(user.email);
+
+    // Sanity: refresh token exists before revoke.
+    expect(await countRefreshTokens(user.id)).toBeGreaterThan(0);
+
+    const res = await emergencyPOST(
+      makeRequest(
+        { action: "revoke_user", user_id: user.id },
+        { key: KEY_32 },
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.user_id).toBe(user.id);
+
+    expect(await countRefreshTokens(user.id)).toBe(0);
+
+    const svc = getServiceRoleClient();
+    const { data } = await svc
+      .from("opollo_users")
+      .select("revoked_at")
+      .eq("id", user.id)
+      .maybeSingle();
+    expect(data?.revoked_at).not.toBeNull();
+  });
+});

--- a/lib/__tests__/middleware.test.ts
+++ b/lib/__tests__/middleware.test.ts
@@ -155,16 +155,20 @@ describe("middleware: FEATURE_SUPABASE_AUTH on, no session", () => {
     expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("lets /login, /logout, /auth-error, /api/auth/* through unauthenticated", async () => {
+  it("lets /login, /logout, /auth-error, /api/auth/*, /api/emergency through unauthenticated", async () => {
     // /api/auth/login was added in M2c-2 — the public-path guard moved
     // to a /api/auth/* prefix match so future auth routes (invite,
-    // password reset) inherit the bypass without re-listing.
+    // password reset) inherit the bypass without re-listing. M2c-3
+    // added /api/emergency: it must be reachable without a Supabase
+    // session because its purpose is to recover when Supabase Auth is
+    // down (its own OPOLLO_EMERGENCY_KEY check is the authentication).
     for (const p of [
       "/login",
       "/logout",
       "/auth-error",
       "/api/auth/callback",
       "/api/auth/login",
+      "/api/emergency",
     ]) {
       const res = await middleware(makeRequest(p));
       expect(res.status).toBe(200);

--- a/middleware.ts
+++ b/middleware.ts
@@ -46,10 +46,16 @@ function decodeBase64(value: string): string {
 // /api/auth/* is a prefix — every auth endpoint (login, callback, and
 // anything M2d adds) has to be callable pre-session. The explicit set
 // below covers the top-level HTML pages that aren't under /api/auth/.
+//
+// /api/emergency bypasses the gate entirely: it's the break-glass hatch
+// for when Supabase Auth itself is down, and its own OPOLLO_EMERGENCY_KEY
+// check is the authentication for that route. See
+// app/api/emergency/route.ts for the rationale.
 const PUBLIC_PATHS = new Set<string>([
   "/login",
   "/logout",
   "/auth-error",
+  "/api/emergency",
 ]);
 
 function isPublicPath(pathname: string): boolean {


### PR DESCRIPTION
## Sub-slice plan

Third and final slice of M2c. M2c-1 shipped auth plumbing + the flag-gated middleware swap; M2c-2 added `/login`, `/logout`, and the admin-layout gate. Both paths depend on Supabase Auth being up. M2c-3 closes that dependency with the break-glass hatch.

**POST /api/emergency** — a pre-shared-key-authenticated route that:

1. Flips `opollo_config.auth_kill_switch` on / off so middleware can fall back to Basic Auth without a redeploy (the runtime override the M2c-1 kill-switch module was designed for).
2. Revokes a specific user's sessions via `revokeUserSessions` from `lib/auth-revoke.ts` (stamps `revoked_at`, sweeps sessions + refresh tokens) — for compromised credentials or departing-employee scenarios.

Executed under the Sub-slice autonomy rule (CLAUDE.md): no pre-PR plan, PR description is the plan, auto-correct CI, auto-merge on green.

## Design confirmations

**Pre-shared key, not Supabase.** The reason this route exists is that Supabase Auth might be broken — anything that depends on it for access control can't be the emergency hatch. `OPOLLO_EMERGENCY_KEY` env var, compared with `node:crypto.timingSafeEqual` so the check isn't a timing oracle. Length-mismatch path still runs a constant-time compare on a filler buffer to blunt length probing.

**503 vs 401.** If `OPOLLO_EMERGENCY_KEY` is unset or shorter than 32 chars, the route returns 503 `EMERGENCY_NOT_CONFIGURED` — "this deployment refuses this feature" — rather than 401 "your creds are wrong". A 401 there would mislead operators into thinking they had the wrong key when the server just has no key configured.

**Minimum key length 32.** `OPOLLO_EMERGENCY_KEY` is service-wide root access. Short values like `"changeme"` would be catastrophic on a misconfigured deploy — short keys fall into the "not configured" path, not the auth path.

**Two header shapes accepted.** `X-Opollo-Emergency-Key: <key>` OR `Authorization: Bearer <key>`. Operators reach this route from tools of varying flavours (curl, ops dashboards); insisting on one shape adds friction for no gain.

**Three actions via zod discriminated union.**

```
kill_switch_on                         → opollo_config.auth_kill_switch = 'on'
kill_switch_off                        → row deleted
revoke_user { user_id: uuid }          → revokeUserSessions(user_id)
```

`kill_switch_on` / `off` are idempotent — tests pin this.

**Propagation note in the response.** `lib/auth-kill-switch.ts` caches `isAuthKillSwitchOn` for 5 s per serverless instance. Flipping the switch therefore has up to 5 s + warm-pool-turnover propagation delay. The 200 response says this explicitly so operators know what to expect.

**Middleware bypass.** `/api/emergency` joins the explicit `PUBLIC_PATHS` set. Its own key check is the authentication; if it were behind Supabase Auth, the recovery path would require the broken thing to work.

**Audit logging v1 = structured console.error.** Enough for Vercel's log viewer to be the audit trail. A dedicated `opollo_audit_events` table is future work (M7 fleet infra).

**Runtime: nodejs.** `revokeUserSessions` imports `pg` (Node-only) and middleware bypasses this route anyway — no Edge concerns.

## Files

- `app/api/emergency/route.ts` — the route handler.
- `middleware.ts` — `/api/emergency` added to `PUBLIC_PATHS`.
- `.env.local.example` — `OPOLLO_EMERGENCY_KEY` documented (generation recipe, minimum length, non-prod guidance).

## Tests

`lib/__tests__/emergency-route.test.ts` — 16 cases against real Supabase via `seedAuthUser`:

- **Auth surface (6)**: 503 when key unset; 503 when <32 chars; 401 missing header; 401 wrong key (same length); 401 wrong key (different length); 200 via `Authorization: Bearer`.
- **Validation (5)**: missing action; unknown action; `revoke_user` missing `user_id`; `revoke_user` non-UUID `user_id`; non-JSON body.
- **Kill switch (4)**: `on` upserts row to `'on'`; `on` idempotent; `off` deletes row; `off` idempotent when no row.
- **Revoke user (1)**: stamps `opollo_users.revoked_at` + sweeps `auth.refresh_tokens`.

`lib/__tests__/middleware.test.ts` — extended the existing public-path test to cover `/api/emergency`.

## Verification

- `tsc --noEmit` clean
- `next lint` clean
- `next build` clean; `/api/emergency` registered
- `npm test` — not runnable in sandbox (no docker for `supabase start`); CI exercises the full suite.

## Test plan

- [ ] CI `lint` / `typecheck` / `build` / `test` green
- [ ] Existing M1 + M2a + M2b + M2c-1 + M2c-2 tests still pass (proves the middleware `PUBLIC_PATHS` tweak didn't regress)
- [ ] Manual: `OPOLLO_EMERGENCY_KEY=$(openssl rand -base64 48)` set on preview → `curl -sS -H "X-Opollo-Emergency-Key: $KEY" -X POST https://.../api/emergency -d '{"action":"kill_switch_on"}'` → subsequent page loads fall back to Basic Auth within 5 s.

## After merge

Closes the M2c milestone. Next: M2d admin surface (invite / promote / demote).

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42