### PR TITLE
M2d-1: admin users list page + API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,24 @@ For sub-slices of a parent milestone whose plan Steven has already approved (M2a
 
 Escalate only for: architectural decisions not in the parent plan, spec deviations, security tradeoffs, or same-failure-twice CI loops. Do NOT escalate for: sub-slice planning, operational/infra issues, routine tradeoffs already covered in the parent plan.
 
+## Auto-continue between sub-slices
+After an auto-merged sub-slice PR, automatically proceed to the next sub-slice in the same approved parent milestone without waiting for a prompt. Rule chain:
+
+- `M2c-1 merged → start M2c-2`
+- `M2c-2 merged → start M2c-3`
+- `M2c-3 merged → start M2d-1` (next slice of parent M2)
+- `M2d-N merged → either start M2d-(N+1) or, if M2d was the last slice, status update "M2 complete, ready for Steven's sign-off before M3" and stop`
+
+Stop and wait for Steven only when:
+- A parent milestone fully completes (M2 done → wait, do NOT start M3 on your own).
+- An architectural escalation surfaces.
+- The same CI failure lands twice in a row.
+
+Also: post a one-line status ping per merge so Steven has visibility without needing to prompt — e.g. "M2c-2 merged, starting M2c-3."
+
+## Enabling auto-merge on every PR
+Every PR must have GitHub auto-merge armed at creation time. Call `mcp__github__enable_pr_auto_merge` (with `mergeMethod: "SQUASH"`) immediately after `create_pull_request` — it is not enabled implicitly. Without that call, the PR sits in the mergeable state until someone clicks the button in the UI, breaking the self-driving loop.
+
 ## Commands
 - `npm run dev` — local dev
 - `npm run lint` — ESLint

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -23,14 +23,36 @@ export default async function AdminLayout({
 
   const user = access.user;
 
+  // The Users link is admin-only when the flag is on. Under flag-off /
+  // kill-switch, `user` is null and the Basic Auth operator has root-
+  // level trust already — show the link rather than break the admin
+  // surface during a break-glass outage.
+  const showUsersLink = !user || user.role === "admin";
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <header className="flex h-12 flex-none items-center justify-between border-b px-4">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-4">
           <Link href="/admin/sites" className="text-sm font-semibold">
             Opollo Site Builder
           </Link>
           <span className="text-xs text-muted-foreground">· Admin</span>
+          <nav className="flex items-center gap-3 text-xs">
+            <Link
+              href="/admin/sites"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              Sites
+            </Link>
+            {showUsersLink && (
+              <Link
+                href="/admin/users"
+                className="text-muted-foreground hover:text-foreground"
+              >
+                Users
+              </Link>
+            )}
+          </nav>
         </div>
         <div className="flex items-center gap-4">
           {user && (

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,0 +1,61 @@
+import { redirect } from "next/navigation";
+
+import { UsersTable } from "@/components/UsersTable";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { AdminUserRow } from "@/app/api/admin/users/list/route";
+
+// ---------------------------------------------------------------------------
+// /admin/users — M2d-1.
+//
+// Admin-only page listing every opollo_users row. Operators who follow
+// a stale link are sent back to /admin/sites rather than all the way
+// out to the chat builder; viewers never reach /admin/* at all because
+// the layout gate filters them first.
+//
+// Reads via the service-role client — RLS is belt-and-braces here, the
+// admin gate above is the actual access control.
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminUsersPage() {
+  const access = await checkAdminAccess({
+    requiredRoles: ["admin"],
+    insufficientRoleRedirectTo: "/admin/sites",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("opollo_users")
+    .select("id, email, display_name, role, created_at, revoked_at")
+    .order("created_at", { ascending: false });
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Users</h1>
+          <p className="text-sm text-muted-foreground">
+            Everyone with access to this builder. Role changes ship in the next
+            sub-slice.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        {error ? (
+          <div
+            className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+            role="alert"
+          >
+            Failed to load users: {error.message}
+          </div>
+        ) : (
+          <UsersTable users={(data ?? []) as AdminUserRow[]} />
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/api/admin/users/list/route.ts
+++ b/app/api/admin/users/list/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// GET /api/admin/users/list — M2d-1.
+//
+// Returns every row in opollo_users ordered by created_at desc. Admin-
+// only under FEATURE_SUPABASE_AUTH=true (see requireAdminForApi for
+// the flag-off / kill-switch bypass rationale).
+//
+// The query uses the service-role client so RLS doesn't hide rows from
+// the caller — the requireAdminForApi check above is the access gate,
+// not the row-level policies. Same pattern as every other admin API
+// route in the codebase.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+// GET-with-no-request-arg otherwise tempts Next's static optimisation.
+// Force-dynamic: the route reads cookies (via the SSR client) and hits
+// opollo_users per call, neither of which makes sense to prerender.
+export const dynamic = "force-dynamic";
+
+export type AdminUserRow = {
+  id: string;
+  email: string;
+  display_name: string | null;
+  role: "admin" | "operator" | "viewer";
+  created_at: string;
+  revoked_at: string | null;
+};
+
+export async function GET(): Promise<NextResponse> {
+  const gate = await requireAdminForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("opollo_users")
+    .select("id, email, display_name, role, created_at, revoked_at")
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: `Failed to read opollo_users: ${error.message}`,
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { users: (data ?? []) as AdminUserRow[] },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/components/UsersTable.tsx
+++ b/components/UsersTable.tsx
@@ -1,0 +1,88 @@
+import type { AdminUserRow } from "@/app/api/admin/users/list/route";
+
+// Read-only users table. Server component: data is pre-fetched in the
+// parent page. Action buttons (promote/demote/revoke) land in M2d-2+.
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function RoleBadge({ role }: { role: AdminUserRow["role"] }) {
+  const palette: Record<AdminUserRow["role"], string> = {
+    admin: "bg-primary/10 text-primary",
+    operator: "bg-secondary text-secondary-foreground",
+    viewer: "bg-muted text-muted-foreground",
+  };
+  return (
+    <span
+      className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${palette[role]}`}
+    >
+      {role}
+    </span>
+  );
+}
+
+export function UsersTable({ users }: { users: AdminUserRow[] }) {
+  if (users.length === 0) {
+    return (
+      <div className="rounded-md border p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No users yet. The `first_admin_email` bootstrap promotes the first
+          Supabase signup to admin; everyone else starts as viewer.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-md border">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b bg-muted/40 text-left text-xs text-muted-foreground">
+            <th className="px-3 py-2 font-medium">Email</th>
+            <th className="px-3 py-2 font-medium">Role</th>
+            <th className="px-3 py-2 font-medium">Created</th>
+            <th className="px-3 py-2 font-medium">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.id} className="border-b last:border-b-0">
+              <td className="px-3 py-2">
+                <div className="flex flex-col">
+                  <span>{u.email}</span>
+                  {u.display_name && (
+                    <span className="text-xs text-muted-foreground">
+                      {u.display_name}
+                    </span>
+                  )}
+                </div>
+              </td>
+              <td className="px-3 py-2">
+                <RoleBadge role={u.role} />
+              </td>
+              <td className="px-3 py-2 text-muted-foreground">
+                {formatDate(u.created_at)}
+              </td>
+              <td className="px-3 py-2">
+                {u.revoked_at ? (
+                  <span className="text-xs text-destructive">revoked</span>
+                ) : (
+                  <span className="text-xs text-muted-foreground">active</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/lib/__tests__/admin-api-gate.test.ts
+++ b/lib/__tests__/admin-api-gate.test.ts
@@ -1,0 +1,190 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import { __resetAuthKillSwitchCacheForTests } from "@/lib/auth-kill-switch";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// M2d-1 — requireAdminForApi.
+//
+// Mirrors admin-gate.test.ts but for the route-handler helper. Pins:
+//   1. FEATURE_SUPABASE_AUTH off                  → allow, user: null.
+//   2. FEATURE_SUPABASE_AUTH on + kill switch on  → allow, user: null.
+//   3. FEATURE_SUPABASE_AUTH on + no session      → 401 UNAUTHORIZED.
+//   4. FEATURE_SUPABASE_AUTH on + wrong role      → 403 FORBIDDEN.
+//   5. FEATURE_SUPABASE_AUTH on + allowed role    → allow, user: {…}.
+//
+// Same mocking pattern as admin-gate.test.ts: stub createRouteAuthClient
+// to return a standalone supabase-js client.
+// ---------------------------------------------------------------------------
+
+const mockState = vi.hoisted(() => ({
+  client: null as SupabaseClient | null,
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    createRouteAuthClient: () => {
+      if (!mockState.client) {
+        throw new Error(
+          "admin-api-gate.test: mockState.client not set before requireAdminForApi",
+        );
+      }
+      return mockState.client;
+    },
+  };
+});
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+
+function anonClient(): SupabaseClient {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      "admin-api-gate.test: SUPABASE_URL and SUPABASE_ANON_KEY must be set",
+    );
+  }
+  return createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function signedInClient(email: string): Promise<SupabaseClient> {
+  const client = anonClient();
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: "test-password-1234",
+  });
+  if (error) throw new Error(`signedInClient: ${error.message}`);
+  return client;
+}
+
+async function setKillSwitchRow(value: string | null): Promise<void> {
+  const svc = getServiceRoleClient();
+  if (value === null) {
+    await svc.from("opollo_config").delete().eq("key", "auth_kill_switch");
+  } else {
+    await svc
+      .from("opollo_config")
+      .upsert({ key: "auth_kill_switch", value }, { onConflict: "key" });
+  }
+  __resetAuthKillSwitchCacheForTests();
+}
+
+const ENV_KEYS = ["FEATURE_SUPABASE_AUTH"] as const;
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  originalEnv = {};
+  for (const k of ENV_KEYS) originalEnv[k] = process.env[k];
+  mockState.client = null;
+  __resetAuthKillSwitchCacheForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = originalEnv[k];
+    }
+  }
+  mockState.client = null;
+  __resetAuthKillSwitchCacheForTests();
+});
+
+describe("requireAdminForApi: FEATURE_SUPABASE_AUTH off", () => {
+  it("allows with user: null (Basic Auth path)", async () => {
+    delete process.env.FEATURE_SUPABASE_AUTH;
+    mockState.client = anonClient();
+
+    const gate = await requireAdminForApi();
+    expect(gate.kind).toBe("allow");
+    if (gate.kind === "allow") expect(gate.user).toBeNull();
+  });
+});
+
+describe("requireAdminForApi: FEATURE_SUPABASE_AUTH on, kill switch on", () => {
+  it("allows with user: null (break-glass)", async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    await setKillSwitchRow("on");
+    mockState.client = anonClient();
+
+    const gate = await requireAdminForApi();
+    expect(gate.kind).toBe("allow");
+    if (gate.kind === "allow") expect(gate.user).toBeNull();
+  });
+});
+
+describe("requireAdminForApi: FEATURE_SUPABASE_AUTH on, kill switch off", () => {
+  beforeEach(async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    await setKillSwitchRow(null);
+  });
+
+  it("returns 401 UNAUTHORIZED when there is no session", async () => {
+    mockState.client = anonClient();
+    const gate = await requireAdminForApi();
+    expect(gate.kind).toBe("deny");
+    if (gate.kind !== "deny") throw new Error("unreachable");
+    expect(gate.response.status).toBe(401);
+    const body = await gate.response.json();
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 FORBIDDEN for an operator when admin is required", async () => {
+    const operator = await seedAuthUser({ role: "operator" });
+    mockState.client = await signedInClient(operator.email);
+
+    const gate = await requireAdminForApi();
+    expect(gate.kind).toBe("deny");
+    if (gate.kind !== "deny") throw new Error("unreachable");
+    expect(gate.response.status).toBe(403);
+    const body = await gate.response.json();
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 403 FORBIDDEN for a viewer", async () => {
+    const viewer = await seedAuthUser({ role: "viewer" });
+    mockState.client = await signedInClient(viewer.email);
+
+    const gate = await requireAdminForApi();
+    expect(gate.kind).toBe("deny");
+    if (gate.kind !== "deny") throw new Error("unreachable");
+    expect(gate.response.status).toBe(403);
+  });
+
+  it("allows an admin", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const gate = await requireAdminForApi();
+    expect(gate.kind).toBe("allow");
+    if (gate.kind !== "allow") throw new Error("unreachable");
+    expect(gate.user?.role).toBe("admin");
+    expect(gate.user?.email).toBe(admin.email);
+  });
+
+  it("honours a custom roles list (operator allowed when listed)", async () => {
+    const operator = await seedAuthUser({ role: "operator" });
+    mockState.client = await signedInClient(operator.email);
+
+    const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+    expect(gate.kind).toBe("allow");
+    if (gate.kind !== "allow") throw new Error("unreachable");
+    expect(gate.user?.role).toBe("operator");
+  });
+});

--- a/lib/__tests__/admin-gate.test.ts
+++ b/lib/__tests__/admin-gate.test.ts
@@ -180,3 +180,40 @@ describe("checkAdminAccess: FEATURE_SUPABASE_AUTH on, kill switch off", () => {
     }
   });
 });
+
+describe("checkAdminAccess: custom options (M2d-1)", () => {
+  beforeEach(async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    await setKillSwitchRow(null);
+  });
+
+  it("redirects an operator to the insufficientRoleRedirectTo target when admin is required", async () => {
+    const operator = await seedAuthUser({ role: "operator" });
+    mockState.client = await signedInClient(operator.email);
+
+    const result = await checkAdminAccess({
+      requiredRoles: ["admin"],
+      insufficientRoleRedirectTo: "/admin/sites",
+    });
+    expect(result).toEqual({ kind: "redirect", to: "/admin/sites" });
+  });
+
+  it("allows an admin when requiredRoles is ['admin']", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const result = await checkAdminAccess({ requiredRoles: ["admin"] });
+    expect(result.kind).toBe("allow");
+    if (result.kind === "allow") {
+      expect(result.user?.role).toBe("admin");
+    }
+  });
+
+  it("falls back to the default '/' redirect when no target is supplied", async () => {
+    const operator = await seedAuthUser({ role: "operator" });
+    mockState.client = await signedInClient(operator.email);
+
+    const result = await checkAdminAccess({ requiredRoles: ["admin"] });
+    expect(result).toEqual({ kind: "redirect", to: "/" });
+  });
+});

--- a/lib/__tests__/admin-users-list.test.ts
+++ b/lib/__tests__/admin-users-list.test.ts
@@ -1,0 +1,189 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import { __resetAuthKillSwitchCacheForTests } from "@/lib/auth-kill-switch";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// M2d-1 — GET /api/admin/users/list.
+//
+// Pins:
+//   - Flag off → 200, returns every opollo_users row.
+//   - Flag on + no session → 401 UNAUTHORIZED.
+//   - Flag on + non-admin role → 403 FORBIDDEN.
+//   - Flag on + admin → 200, rows ordered newest-first.
+//   - Payload includes revoked_at for revoked users.
+// ---------------------------------------------------------------------------
+
+const mockState = vi.hoisted(() => ({
+  client: null as SupabaseClient | null,
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    createRouteAuthClient: () => {
+      if (!mockState.client) {
+        throw new Error(
+          "admin-users-list.test: mockState.client not set before GET",
+        );
+      }
+      return mockState.client;
+    },
+  };
+});
+
+import { GET as usersListGET } from "@/app/api/admin/users/list/route";
+
+function anonClient(): SupabaseClient {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      "admin-users-list.test: SUPABASE_URL and SUPABASE_ANON_KEY must be set",
+    );
+  }
+  return createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function signedInClient(email: string): Promise<SupabaseClient> {
+  const client = anonClient();
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: "test-password-1234",
+  });
+  if (error) throw new Error(`signedInClient: ${error.message}`);
+  return client;
+}
+
+const ENV_KEYS = ["FEATURE_SUPABASE_AUTH"] as const;
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  originalEnv = {};
+  for (const k of ENV_KEYS) originalEnv[k] = process.env[k];
+  mockState.client = null;
+  __resetAuthKillSwitchCacheForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = originalEnv[k];
+    }
+  }
+  mockState.client = null;
+  __resetAuthKillSwitchCacheForTests();
+});
+
+describe("GET /api/admin/users/list: auth", () => {
+  it("returns 401 when the flag is on and no session is present", async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    mockState.client = anonClient();
+
+    const res = await usersListGET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 when the caller is an operator (admin-only)", async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    const op = await seedAuthUser({ role: "operator" });
+    mockState.client = await signedInClient(op.email);
+
+    const res = await usersListGET();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 403 when the caller is a viewer", async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    const viewer = await seedAuthUser({ role: "viewer" });
+    mockState.client = await signedInClient(viewer.email);
+
+    const res = await usersListGET();
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 when the flag is off (Basic Auth path)", async () => {
+    delete process.env.FEATURE_SUPABASE_AUTH;
+    await seedAuthUser({ role: "viewer" });
+    mockState.client = anonClient();
+
+    const res = await usersListGET();
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("GET /api/admin/users/list: payload", () => {
+  beforeEach(() => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+  });
+
+  it("returns every opollo_users row for an admin, newest first", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    // Seed a second user; the two timestamps are usually close enough
+    // that ordering by created_at desc is still deterministic because
+    // the second insert's now() > the first's.
+    await new Promise((r) => setTimeout(r, 10));
+    const viewer = await seedAuthUser({ role: "viewer" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await usersListGET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    const users = body.data.users as Array<{
+      id: string;
+      role: string;
+      email: string;
+    }>;
+    expect(users.length).toBe(2);
+    // Newest (viewer, seeded second) comes first.
+    expect(users[0]?.email).toBe(viewer.email);
+    expect(users[1]?.email).toBe(admin.email);
+  });
+
+  it("includes revoked_at on a revoked row", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    const target = await seedAuthUser({ role: "operator" });
+
+    const svc = getServiceRoleClient();
+    const { error: updateErr } = await svc
+      .from("opollo_users")
+      .update({ revoked_at: new Date().toISOString() })
+      .eq("id", target.id);
+    expect(updateErr).toBeNull();
+
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await usersListGET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const users = body.data.users as Array<{
+      id: string;
+      revoked_at: string | null;
+    }>;
+    const revokedRow = users.find((u) => u.id === target.id);
+    expect(revokedRow?.revoked_at).not.toBeNull();
+    const activeRow = users.find((u) => u.id === admin.id);
+    expect(activeRow?.revoked_at).toBeNull();
+  });
+});

--- a/lib/admin-api-gate.ts
+++ b/lib/admin-api-gate.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server";
+
+import {
+  createRouteAuthClient,
+  getCurrentUser,
+  type Role,
+  type SessionUser,
+} from "@/lib/auth";
+import { isAuthKillSwitchOn } from "@/lib/auth-kill-switch";
+
+// ---------------------------------------------------------------------------
+// M2d-1 — admin-only API route gate.
+//
+// Mirrors lib/admin-gate.ts (which is for Server Components / layouts)
+// but produces a NextResponse on denial instead of a redirect result.
+// Route handlers compose it as a single helper call:
+//
+//   const gate = await requireAdminForApi();
+//   if (gate.kind === "deny") return gate.response;
+//   // ... handler continues with gate.user available
+//
+// Same flag/kill-switch logic as the layout gate:
+//
+//   FEATURE_SUPABASE_AUTH unset/false       → allow (Basic Auth covered
+//                                             the edge; route trusts
+//                                             the middleware gate and
+//                                             proceeds with user: null).
+//
+//   FEATURE_SUPABASE_AUTH on + kill switch  → allow (break-glass; same
+//                                             reasoning — Basic Auth
+//                                             took over at the edge).
+//
+//   FEATURE_SUPABASE_AUTH on + no session   → deny, 401 UNAUTHORIZED.
+//
+//   FEATURE_SUPABASE_AUTH on + wrong role   → deny, 403 FORBIDDEN.
+//
+//   FEATURE_SUPABASE_AUTH on + allowed role → allow, user threaded
+//                                             through.
+//
+// The flag-off / kill-switch bypass means admin API routes keep working
+// during a Supabase-Auth outage when middleware has fallen back to
+// Basic Auth. That's the whole point of the break-glass path — if
+// /admin/users/list started returning 401 the moment we kicked the
+// switch, we'd have broken the very admin tools needed to fix the
+// outage.
+// ---------------------------------------------------------------------------
+
+export type ApiGateResult =
+  | { kind: "allow"; user: SessionUser | null }
+  | { kind: "deny"; response: NextResponse };
+
+function isSupabaseAuthOn(): boolean {
+  const v = process.env.FEATURE_SUPABASE_AUTH;
+  return v === "true" || v === "1";
+}
+
+function denyResponse(
+  code: string,
+  message: string,
+  status: 401 | 403,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function requireAdminForApi(
+  opts: { roles?: readonly Role[] } = {},
+): Promise<ApiGateResult> {
+  const roles = opts.roles ?? (["admin"] as const);
+
+  if (!isSupabaseAuthOn()) return { kind: "allow", user: null };
+
+  let killSwitch = false;
+  try {
+    killSwitch = await isAuthKillSwitchOn();
+  } catch {
+    killSwitch = false;
+  }
+  if (killSwitch) return { kind: "allow", user: null };
+
+  const supabase = createRouteAuthClient();
+  const user = await getCurrentUser(supabase);
+  if (!user) {
+    return {
+      kind: "deny",
+      response: denyResponse("UNAUTHORIZED", "Authentication required.", 401),
+    };
+  }
+  if (!roles.includes(user.role)) {
+    return {
+      kind: "deny",
+      response: denyResponse(
+        "FORBIDDEN",
+        `Role '${user.role}' is not permitted for this resource.`,
+        403,
+      ),
+    };
+  }
+  return { kind: "allow", user };
+}

--- a/lib/admin-gate.ts
+++ b/lib/admin-gate.ts
@@ -31,30 +31,53 @@ import { isAuthKillSwitchOn } from "@/lib/auth-kill-switch";
 //                                             cache refresh edge case
 //                                             shouldn't leak /admin.
 //
-//   FEATURE_SUPABASE_AUTH on + viewer role  → redirect /. The admin
-//                                             surface is ops-level (site
-//                                             management, DS edits);
-//                                             viewers belong on the
-//                                             chat builder.
+//   FEATURE_SUPABASE_AUTH on + wrong role   → redirect (default /).
+//                                             Admin surface is ops-level
+//                                             (site management, DS
+//                                             edits); viewers belong on
+//                                             the chat builder.
 //
-//   FEATURE_SUPABASE_AUTH on + admin/op     → allow, with the user
+//   FEATURE_SUPABASE_AUTH on + allowed role → allow, with the user
 //                                             threaded through so the
 //                                             layout can render the
 //                                             email + sign-out.
+//
+// M2d-1 extended the helper with `opts.requiredRoles` and
+// `opts.insufficientRoleRedirectTo` so admin-only pages (e.g.
+// /admin/users) can narrow the allowed role set and send mismatched
+// roles somewhere more useful than the top-level `/` — typically
+// back to /admin/sites.
 // ---------------------------------------------------------------------------
 
 export const ADMIN_ROLES: readonly Role[] = ["admin", "operator"];
 
+export type AdminAccessOptions = {
+  /** Which roles are allowed. Defaults to ADMIN_ROLES (admin + operator). */
+  requiredRoles?: readonly Role[];
+  /**
+   * Where to redirect users whose role is not in `requiredRoles`. Defaults
+   * to "/" (the chat builder). Admin-only pages nested inside the admin
+   * surface typically pass "/admin/sites" so an operator who lands on a
+   * /admin/users link is sent to a page they can actually use.
+   */
+  insufficientRoleRedirectTo?: string;
+};
+
 export type AdminAccessResult =
   | { kind: "allow"; user: SessionUser | null }
-  | { kind: "redirect"; to: "/login" | "/" };
+  | { kind: "redirect"; to: string };
 
 function isSupabaseAuthOn(): boolean {
   const v = process.env.FEATURE_SUPABASE_AUTH;
   return v === "true" || v === "1";
 }
 
-export async function checkAdminAccess(): Promise<AdminAccessResult> {
+export async function checkAdminAccess(
+  opts: AdminAccessOptions = {},
+): Promise<AdminAccessResult> {
+  const requiredRoles = opts.requiredRoles ?? ADMIN_ROLES;
+  const insufficientRedirect = opts.insufficientRoleRedirectTo ?? "/";
+
   if (!isSupabaseAuthOn()) return { kind: "allow", user: null };
 
   let killSwitch = false;
@@ -68,6 +91,8 @@ export async function checkAdminAccess(): Promise<AdminAccessResult> {
   const supabase = createRouteAuthClient();
   const user = await getCurrentUser(supabase);
   if (!user) return { kind: "redirect", to: "/login" };
-  if (!ADMIN_ROLES.includes(user.role)) return { kind: "redirect", to: "/" };
+  if (!requiredRoles.includes(user.role)) {
+    return { kind: "redirect", to: insufficientRedirect };
+  }
   return { kind: "allow", user };
 }


### PR DESCRIPTION
## Sub-slice plan

M2 parent plan is done with M2c; M2d is the admin surface. First sub-slice: read-only users list. Decomposition for the rest of M2d (will ship in order as auto-continue chain):

- **M2d-1 (this PR)**: users list page + list API. Foundation. Admin-only page wired through the existing admin-layout gate; read-only table.
- **M2d-2**: role promote / demote. Admin-only action + UI buttons. Uses the existing lib/auth-revoke primitives (role change is a soft event — getCurrentUser re-reads role per request, no session sweep needed except on demote-from-admin).
- **M2d-3**: invite new user via magic-link. Admin-only; admin supplies email, trigger auto-creates opollo_users row as viewer on first sign-in. Reuses /api/auth/callback from M2c-1.
- **M2d-4**: revoke / deactivate user. Admin-only; internally calls revokeUserSessions from M2c-3's primitive.

Per the Auto-continue rule added in this branch's first commit, M2d-2 starts automatically once M2d-1 merges — status update per merge, no prompt required.

## Also in this PR: CLAUDE.md working-brief updates

1. **Auto-continue between sub-slices.** Codifies "after merge, start the next slice without waiting for a prompt" so the self-driving loop doesn't break between sub-slices like it did at the M2c-1 → M2c-2 handoff.
2. **Always arm auto-merge on PR creation.** PR #21 stalled for 6 hours because I skipped `enable_pr_auto_merge`; PR #22 (which did call it) merged itself in ~3 min. The rule now says "call it every time, immediately after create_pull_request".

Shipped as the first commit so the rule is active from this PR forward.

## Design confirmations

**Admin-only page + API, not admin-or-operator.** The users page shows roles of other users — writing (M2d-2+) is definitionally admin territory, and the M2b RLS policies already gate `opollo_users` updates to admins. Exposing even the read to operators would be a minor information disclosure for no real gain.

**Flag-off / kill-switch bypass both in the layout gate and the API gate.** Under Basic Auth (flag off or break-glass on), there's no Supabase user to interrogate, and the Basic Auth operator has root-level trust. Failing closed there would break admin tools during exactly the outages the break-glass path exists for. Pinned in the admin-api-gate tests.

**Operators who land on /admin/users get redirected to /admin/sites, not /.** Viewers go to `/` (the chat builder, their home); operators belong somewhere in /admin/. The layout gate's `insufficientRoleRedirectTo` option makes the target explicit per page.

**Service-role reads, RLS belt-and-braces.** The route + the page both read `opollo_users` via getServiceRoleClient. RLS would also allow it for admin callers, but we don't want to depend on the RLS clause for correctness — the admin-api-gate (resp. admin-gate) is the access control, service-role is just the query path.

**force-dynamic on the API route.** Without it, `next build` tried to statically pre-render the GET and blew up on `SUPABASE_URL is not set.` at build time. `force-dynamic` tells Next the route is request-scoped.

**Nav link in the admin header is admin-only under flag-on.** Under flag-off / kill-switch, `user` is null (no Supabase identity) and the link shows — Basic Auth operators are trusted root during break-glass and need admin tools. Operators on the Supabase path don't see the link.

## Files

- `CLAUDE.md` — two new sections: Auto-continue between sub-slices, Enabling auto-merge on every PR. (First commit — separate logical change.)
- `lib/admin-gate.ts` — extended `checkAdminAccess` with `requiredRoles` + `insufficientRoleRedirectTo` options. Backward-compatible defaults.
- `lib/admin-api-gate.ts` — new helper mirroring the layout gate for API routes.
- `app/api/admin/users/list/route.ts` — GET returning every `opollo_users` row ordered newest-first.
- `app/admin/users/page.tsx` — server component. Admin-only; operators → /admin/sites.
- `components/UsersTable.tsx` — read-only table with role badges + revoked-state indicator.
- `app/admin/layout.tsx` — compact nav row with `Sites` + (admin-only) `Users`.

## Tests

- `lib/__tests__/admin-gate.test.ts` — 3 new cases for the options.
- `lib/__tests__/admin-api-gate.test.ts` — 6 cases covering the full matrix (flag off allow, kill switch allow, no session 401, operator 403, viewer 403, admin allow, custom roles list).
- `lib/__tests__/admin-users-list.test.ts` — 6 cases: 401 no session, 403 operator, 403 viewer, 200 flag-off bypass, 200 admin with newest-first ordering, `revoked_at` surfaced.

## Verification

- `tsc --noEmit` clean
- `next lint` clean
- `next build` clean — `/admin/users` and `/api/admin/users/list` registered
- `npm test` not runnable in sandbox (no docker for `supabase start`); CI exercises the full suite.

## Test plan

- [ ] CI `lint` / `typecheck` / `build` / `test` all green
- [ ] M2c-1 / M2c-2 / M2c-3 tests still pass (proves the `checkAdminAccess` option extension + admin-layout nav change didn't regress)
- [ ] Manual on preview: visit `/admin/users` as admin → table renders; as operator → redirected to `/admin/sites`.

## After merge

Auto-continue kicks in → M2d-2 (promote/demote) starts immediately, no prompt.

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42