### PR TITLE
M2d-2: promote / demote role action

### DIFF
--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -26,6 +26,12 @@ export default async function AdminUsersPage() {
   });
   if (access.kind === "redirect") redirect(access.to);
 
+  // Under flag-off / kill-switch, `access.user` is null — the role
+  // action cell treats null as "no self to compare against" and
+  // enables every row. The server route still enforces the
+  // last-admin guard.
+  const currentUserId = access.user?.id ?? null;
+
   const svc = getServiceRoleClient();
   const { data, error } = await svc
     .from("opollo_users")
@@ -38,8 +44,8 @@ export default async function AdminUsersPage() {
         <div>
           <h1 className="text-xl font-semibold">Users</h1>
           <p className="text-sm text-muted-foreground">
-            Everyone with access to this builder. Role changes ship in the next
-            sub-slice.
+            Everyone with access to this builder. Change a role inline; the
+            server blocks self-modification and last-admin demotions.
           </p>
         </div>
       </div>
@@ -53,7 +59,10 @@ export default async function AdminUsersPage() {
             Failed to load users: {error.message}
           </div>
         ) : (
-          <UsersTable users={(data ?? []) as AdminUserRow[]} />
+          <UsersTable
+            users={(data ?? []) as AdminUserRow[]}
+            currentUserId={currentUserId}
+          />
         )}
       </div>
     </>

--- a/app/api/admin/users/[id]/role/route.ts
+++ b/app/api/admin/users/[id]/role/route.ts
@@ -1,0 +1,186 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// PATCH /api/admin/users/[id]/role — M2d-2.
+//
+// Admin-only. Promotes or demotes a user to one of the three roles.
+// Role changes are "soft" events in this codebase: lib/auth.ts
+// getCurrentUser re-reads opollo_users.role on every request, so the
+// demoted caller sees the new role on their very next page load with
+// no session sweep needed. See the comment in auth.ts and the
+// regression test "reflects a server-side role demotion on the next
+// getCurrentUser call" for the primary pin.
+//
+// Guardrails:
+//
+//   CANNOT_MODIFY_SELF (409)
+//     An admin cannot change their own role. Prevents an admin from
+//     accidentally demoting themselves out of the admin surface and
+//     then needing the emergency route to recover. Applies only when
+//     the caller identity is known (flag-on path); under flag-off /
+//     kill-switch we don't know who is calling.
+//
+//   LAST_ADMIN (409)
+//     We will not demote the last remaining admin. Without this, a
+//     single mis-click from the only admin's colleague would lock the
+//     org out of /admin/users entirely and force an emergency-key
+//     recovery. The emergency route (M2c-3) is a valid recovery path
+//     if this check ever blocks something the operator really wants.
+//
+// Same role → no-op, 200 with { changed: false }. Keeps the UI cell
+// idempotent when a dropdown triggers onChange for the already-set
+// value.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const RoleSchema = z.object({
+  role: z.enum(["admin", "operator", "viewer"]),
+});
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+  extra?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false, ...(extra ?? {}) },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  const userId = params.id;
+  if (!UUID_RE.test(userId)) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "User id must be a UUID.",
+      400,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = RoleSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body must be { role: 'admin' | 'operator' | 'viewer' }.",
+          details: { issues: parsed.error.issues },
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+  const targetRole = parsed.data.role;
+
+  // Self-modification guard — only enforceable when we know the caller.
+  if (gate.user && gate.user.id === userId) {
+    return errorJson(
+      "CANNOT_MODIFY_SELF",
+      "You cannot change your own role. Ask another admin.",
+      409,
+    );
+  }
+
+  const svc = getServiceRoleClient();
+
+  const { data: target, error: fetchErr } = await svc
+    .from("opollo_users")
+    .select("id, role")
+    .eq("id", userId)
+    .maybeSingle();
+  if (fetchErr) {
+    return errorJson(
+      "INTERNAL_ERROR",
+      `Failed to read target user: ${fetchErr.message}`,
+      500,
+    );
+  }
+  if (!target) {
+    return errorJson("NOT_FOUND", "No user with that id.", 404);
+  }
+
+  const currentRole = target.role as "admin" | "operator" | "viewer";
+  if (currentRole === targetRole) {
+    return NextResponse.json(
+      {
+        ok: true,
+        data: { id: userId, role: targetRole, changed: false },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }
+
+  // Last-admin guard — only matters when demoting away from 'admin'.
+  if (currentRole === "admin" && targetRole !== "admin") {
+    const { count, error: countErr } = await svc
+      .from("opollo_users")
+      .select("id", { count: "exact", head: true })
+      .eq("role", "admin");
+    if (countErr) {
+      return errorJson(
+        "INTERNAL_ERROR",
+        `Failed to count admins: ${countErr.message}`,
+        500,
+      );
+    }
+    if ((count ?? 0) <= 1) {
+      return errorJson(
+        "LAST_ADMIN",
+        "Refusing to demote the last remaining admin. Promote another admin first, or use the emergency route.",
+        409,
+      );
+    }
+  }
+
+  const { error: updateErr } = await svc
+    .from("opollo_users")
+    .update({ role: targetRole })
+    .eq("id", userId);
+  if (updateErr) {
+    return errorJson(
+      "INTERNAL_ERROR",
+      `Failed to update role: ${updateErr.message}`,
+      500,
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { id: userId, role: targetRole, changed: true },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/components/UserRoleActionCell.tsx
+++ b/components/UserRoleActionCell.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type ChangeEvent } from "react";
+
+type Role = "admin" | "operator" | "viewer";
+
+export function UserRoleActionCell({
+  userId,
+  currentRole,
+  selfUserId,
+}: {
+  userId: string;
+  currentRole: Role;
+  selfUserId: string | null;
+}) {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isSelf = selfUserId !== null && selfUserId === userId;
+
+  async function handleChange(e: ChangeEvent<HTMLSelectElement>) {
+    const newRole = e.target.value as Role;
+    if (newRole === currentRole) return;
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/admin/users/${encodeURIComponent(userId)}/role`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ role: newRole }),
+        },
+      );
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        setError(
+          payload?.error?.message ??
+            `Role change failed (HTTP ${res.status}).`,
+        );
+        // Revert the visual state — router.refresh would re-render
+        // with the stale role, but we want the select to snap back
+        // immediately so the operator doesn't think the change
+        // landed.
+        router.refresh();
+        setSubmitting(false);
+        return;
+      }
+      // Server-rendered page; refresh re-fetches the list with the
+      // new role.
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      router.refresh();
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <select
+        value={currentRole}
+        onChange={handleChange}
+        disabled={isSelf || submitting}
+        aria-label={`Change role for user ${userId}`}
+        title={isSelf ? "You cannot change your own role." : undefined}
+        className="rounded border bg-background px-2 py-1 text-xs disabled:opacity-60"
+      >
+        <option value="admin">admin</option>
+        <option value="operator">operator</option>
+        <option value="viewer">viewer</option>
+      </select>
+      {error && (
+        <p role="alert" className="text-xs text-destructive">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/UsersTable.tsx
+++ b/components/UsersTable.tsx
@@ -1,7 +1,9 @@
 import type { AdminUserRow } from "@/app/api/admin/users/list/route";
+import { UserRoleActionCell } from "@/components/UserRoleActionCell";
 
-// Read-only users table. Server component: data is pre-fetched in the
-// parent page. Action buttons (promote/demote/revoke) land in M2d-2+.
+// Users table for /admin/users. Server component for the shell + static
+// cells; the role <select> is a client island so the action stays
+// interactive without forcing the whole table client-side.
 
 function formatDate(iso: string): string {
   try {
@@ -15,22 +17,19 @@ function formatDate(iso: string): string {
   }
 }
 
-function RoleBadge({ role }: { role: AdminUserRow["role"] }) {
-  const palette: Record<AdminUserRow["role"], string> = {
-    admin: "bg-primary/10 text-primary",
-    operator: "bg-secondary text-secondary-foreground",
-    viewer: "bg-muted text-muted-foreground",
-  };
-  return (
-    <span
-      className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${palette[role]}`}
-    >
-      {role}
-    </span>
-  );
-}
-
-export function UsersTable({ users }: { users: AdminUserRow[] }) {
+export function UsersTable({
+  users,
+  currentUserId,
+}: {
+  users: AdminUserRow[];
+  /**
+   * ID of the currently-signed-in admin, when known. Used by the role
+   * action cell to disable self-modification. `null` under flag-off /
+   * kill-switch (no Supabase identity); the server-side guard still
+   * enforces the rest.
+   */
+  currentUserId: string | null;
+}) {
   if (users.length === 0) {
     return (
       <div className="rounded-md border p-8 text-center">
@@ -55,7 +54,7 @@ export function UsersTable({ users }: { users: AdminUserRow[] }) {
         </thead>
         <tbody>
           {users.map((u) => (
-            <tr key={u.id} className="border-b last:border-b-0">
+            <tr key={u.id} className="border-b last:border-b-0 align-top">
               <td className="px-3 py-2">
                 <div className="flex flex-col">
                   <span>{u.email}</span>
@@ -67,7 +66,11 @@ export function UsersTable({ users }: { users: AdminUserRow[] }) {
                 </div>
               </td>
               <td className="px-3 py-2">
-                <RoleBadge role={u.role} />
+                <UserRoleActionCell
+                  userId={u.id}
+                  currentRole={u.role}
+                  selfUserId={currentUserId}
+                />
               </td>
               <td className="px-3 py-2 text-muted-foreground">
                 {formatDate(u.created_at)}

--- a/lib/__tests__/admin-users-role.test.ts
+++ b/lib/__tests__/admin-users-role.test.ts
@@ -1,0 +1,369 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import { __resetAuthKillSwitchCacheForTests } from "@/lib/auth-kill-switch";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// M2d-2 — PATCH /api/admin/users/[id]/role.
+//
+// Pins the promote/demote guardrails:
+//   - 400 VALIDATION_FAILED — non-UUID id, bad body, wrong role string.
+//   - 401 UNAUTHORIZED — flag on + no session.
+//   - 403 FORBIDDEN — non-admin caller.
+//   - 404 NOT_FOUND — id valid but no such user.
+//   - 409 CANNOT_MODIFY_SELF — admin demoting themself.
+//   - 409 LAST_ADMIN — demoting the only admin.
+//   - 200 same role → { changed: false }.
+//   - 200 promote viewer → admin → opollo_users.role updated.
+//   - 200 demote admin → operator (when multiple admins).
+// ---------------------------------------------------------------------------
+
+const mockState = vi.hoisted(() => ({
+  client: null as SupabaseClient | null,
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    createRouteAuthClient: () => {
+      if (!mockState.client) {
+        throw new Error(
+          "admin-users-role.test: mockState.client not set before PATCH",
+        );
+      }
+      return mockState.client;
+    },
+  };
+});
+
+import { PATCH as roleRoutePATCH } from "@/app/api/admin/users/[id]/role/route";
+
+function anonClient(): SupabaseClient {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      "admin-users-role.test: SUPABASE_URL and SUPABASE_ANON_KEY must be set",
+    );
+  }
+  return createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function signedInClient(email: string): Promise<SupabaseClient> {
+  const client = anonClient();
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: "test-password-1234",
+  });
+  if (error) throw new Error(`signedInClient: ${error.message}`);
+  return client;
+}
+
+function makeRequest(id: string, body: unknown): Request {
+  return new Request(
+    `http://localhost:3000/api/admin/users/${id}/role`,
+    {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    },
+  );
+}
+
+async function readRole(userId: string): Promise<string | null> {
+  const svc = getServiceRoleClient();
+  const { data } = await svc
+    .from("opollo_users")
+    .select("role")
+    .eq("id", userId)
+    .maybeSingle();
+  return (data?.role as string | undefined) ?? null;
+}
+
+const ENV_KEYS = ["FEATURE_SUPABASE_AUTH"] as const;
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  originalEnv = {};
+  for (const k of ENV_KEYS) originalEnv[k] = process.env[k];
+  mockState.client = null;
+  __resetAuthKillSwitchCacheForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = originalEnv[k];
+    }
+  }
+  mockState.client = null;
+  __resetAuthKillSwitchCacheForTests();
+});
+
+// ---------------------------------------------------------------------------
+// Auth — delegate to admin-api-gate; one canary case each for completeness.
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/admin/users/[id]/role: auth", () => {
+  it("returns 401 when flag on and no session", async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    mockState.client = anonClient();
+
+    const user = await seedAuthUser({ role: "viewer" });
+    const res = await roleRoutePATCH(
+      makeRequest(user.id, { role: "admin" }),
+      { params: { id: user.id } },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller is operator", async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    const op = await seedAuthUser({ role: "operator" });
+    const target = await seedAuthUser({ role: "viewer" });
+    mockState.client = await signedInClient(op.email);
+
+    const res = await roleRoutePATCH(
+      makeRequest(target.id, { role: "admin" }),
+      { params: { id: target.id } },
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/admin/users/[id]/role: validation", () => {
+  beforeEach(async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+  });
+
+  it("returns 400 when id is not a UUID", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await roleRoutePATCH(
+      makeRequest("not-a-uuid", { role: "viewer" }),
+      { params: { id: "not-a-uuid" } },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 400 when role is missing", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    const target = await seedAuthUser({ role: "viewer" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await roleRoutePATCH(
+      makeRequest(target.id, {}),
+      { params: { id: target.id } },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when role is an unknown string", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    const target = await seedAuthUser({ role: "viewer" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await roleRoutePATCH(
+      makeRequest(target.id, { role: "godmode" }),
+      { params: { id: target.id } },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is not JSON", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    const target = await seedAuthUser({ role: "viewer" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await roleRoutePATCH(
+      makeRequest(target.id, "not-json"),
+      { params: { id: target.id } },
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guardrails
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/admin/users/[id]/role: guardrails", () => {
+  beforeEach(() => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+  });
+
+  it("returns 404 when the target user does not exist", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await roleRoutePATCH(
+      makeRequest("00000000-0000-0000-0000-000000000000", { role: "admin" }),
+      { params: { id: "00000000-0000-0000-0000-000000000000" } },
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 409 CANNOT_MODIFY_SELF when admin targets themselves", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await roleRoutePATCH(
+      makeRequest(admin.id, { role: "viewer" }),
+      { params: { id: admin.id } },
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe("CANNOT_MODIFY_SELF");
+  });
+
+  it("returns 409 LAST_ADMIN when demoting the only admin", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    // A separate admin is the caller so CANNOT_MODIFY_SELF doesn't
+    // short-circuit the guard we want to exercise. Since only the
+    // first admin is the "last admin" candidate, we need to make
+    // another admin first, then promote them away, then try to
+    // demote the original. Easier path: seed a second admin, demote
+    // that one to operator first (leaving only one admin left), then
+    // try to demote the remaining admin via *this* second (now
+    // operator → can't be caller). Use service role to wire up the
+    // initial state instead.
+    const secondAdmin = await seedAuthUser({ role: "admin" });
+
+    // Demote the second admin first — this succeeds because there are
+    // still two admins at the moment of the check.
+    mockState.client = await signedInClient(admin.email);
+    const demote = await roleRoutePATCH(
+      makeRequest(secondAdmin.id, { role: "operator" }),
+      { params: { id: secondAdmin.id } },
+    );
+    expect(demote.status).toBe(200);
+
+    // Now `admin` is the last admin. Sign in as that operator to act
+    // as the caller, and have them attempt to demote `admin`. The
+    // operator caller will be 403'd by the gate, not the last-admin
+    // check, so we bypass the gate by staying signed in as `admin`
+    // but targeting `admin` — that triggers CANNOT_MODIFY_SELF first.
+    //
+    // To exercise LAST_ADMIN cleanly we need a third admin to be the
+    // caller. Promote the demoted operator back to admin, then have
+    // them attempt to demote `admin` again — but then there are two
+    // admins and the check passes. Net: LAST_ADMIN is only
+    // reachable via a service-role seeded state plus a *second*
+    // admin attempting the demotion.
+    //
+    // Set it up: make a fresh admin caller, revoke their admin-ness
+    // directly in the DB is one option — cleaner is to seed a third
+    // admin then directly DELETE the second admin row via
+    // service-role, leaving two admins total (third + original).
+    // Then third admin demotes original → LAST_ADMIN should NOT fire
+    // (count=2). We want count=1 at the moment of the check, so:
+    // seed third admin as caller, DELETE second admin + keep a lone
+    // *non-caller* target admin to demote. The caller must be an
+    // admin for the gate; the caller must not be the target; the
+    // target must currently be the only admin → impossible without
+    // the caller also being admin, bumping the count to 2.
+    //
+    // Correct interpretation: LAST_ADMIN triggers when
+    // count(admin) <= 1 AT THE MOMENT OF THE CHECK, which counts the
+    // caller too. So we need exactly one admin in the DB = the
+    // target = demoting them to non-admin. The caller is admin → the
+    // caller IS the target → CANNOT_MODIFY_SELF fires first.
+    //
+    // LAST_ADMIN is therefore only reachable when the caller has
+    // super-powers without being in opollo_users (flag-off path).
+    // That's the test we write below — flag-off, sole admin in DB,
+    // demote them.
+    delete process.env.FEATURE_SUPABASE_AUTH;
+    mockState.client = anonClient();
+
+    // State: `admin` is admin; `secondAdmin` is operator. `admin` is
+    // the only admin row. Try to demote.
+    const res = await roleRoutePATCH(
+      makeRequest(admin.id, { role: "operator" }),
+      { params: { id: admin.id } },
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe("LAST_ADMIN");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success cases
+// ---------------------------------------------------------------------------
+
+describe("PATCH /api/admin/users/[id]/role: success", () => {
+  beforeEach(() => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+  });
+
+  it("200 with changed:false on a no-op role assignment", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    const target = await seedAuthUser({ role: "viewer" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await roleRoutePATCH(
+      makeRequest(target.id, { role: "viewer" }),
+      { params: { id: target.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.changed).toBe(false);
+    expect(body.data.role).toBe("viewer");
+    expect(await readRole(target.id)).toBe("viewer");
+  });
+
+  it("promotes viewer → admin", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    const target = await seedAuthUser({ role: "viewer" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await roleRoutePATCH(
+      makeRequest(target.id, { role: "admin" }),
+      { params: { id: target.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.changed).toBe(true);
+    expect(await readRole(target.id)).toBe("admin");
+  });
+
+  it("demotes admin → operator when another admin exists", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    const target = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await roleRoutePATCH(
+      makeRequest(target.id, { role: "operator" }),
+      { params: { id: target.id } },
+    );
+    expect(res.status).toBe(200);
+    expect(await readRole(target.id)).toBe("operator");
+  });
+});


### PR DESCRIPTION
## Sub-slice plan

Second of four M2d sub-slices. M2d-1 shipped the read-only users list; M2d-2 adds the promote/demote action. M2d-3 (invite) and M2d-4 (revoke) follow in the auto-continue chain.

**Core decision** — role changes are soft events, no session sweep. `lib/auth.ts getCurrentUser` re-reads `opollo_users.role` on every request, so a demoted admin sees the new role on their very next page load with no refresh-token fiddling. The regression test "reflects a server-side role demotion on the next getCurrentUser call" (landed in M2c-1) is the primary pin for this contract, so M2d-2 does NOT call `revokeUserSessions` — role changes and hard revocations are separate concerns.

## Design confirmations

**Three-role dropdown vs. two buttons.** A `<select>` with admin/operator/viewer is the most honest representation of the state: one value at a time, obvious semantics, same widget for promote and demote. Separate "Promote" / "Demote" buttons get awkward once there are three roles (promote-from-viewer-to-admin requires a double-click through operator?).

**`CANNOT_MODIFY_SELF` 409.** An admin cannot change their own role — prevents the "I demoted myself and now I can't get back in" foot-gun. Only enforceable when the caller identity is known (flag-on). Under flag-off / kill-switch the server can't tell who the Basic-Auth caller is; the last-admin guard below still catches the worst outcome.

**`LAST_ADMIN` 409.** Refuses to demote the sole remaining admin. Without this a single mis-click locks the org out of `/admin/users` entirely and forces an emergency-key recovery. The M2c-3 emergency route remains the recovery hatch if this guard ever gets in the way for legitimate reasons.

**Same-role assignments short-circuit to `200 { changed: false }`.** The dropdown's `onChange` fires with the already-selected value in some browser/edge cases; a round-trip that writes nothing is cheaper than teaching the client to filter those.

**UUID check before DB lookup.** Params that come out of the URL are strings — a non-UUID id would cause the service-role query to 400 downstream with a noisy message. Explicit validation keeps the error shape predictable.

**`router.refresh()` on success AND failure.** On success we need the new role to appear; on failure we need the `<select>` to snap back to the server's current value rather than showing the optimistic (and now wrong) visual state. Comment in the component pins this.

## Files

- `app/api/admin/users/[id]/role/route.ts` — PATCH handler.
- `components/UserRoleActionCell.tsx` — client `<select>` island, one per row.
- `components/UsersTable.tsx` — new Role column now renders the action cell; accepts `currentUserId` so the cell knows which row is "self".
- `app/admin/users/page.tsx` — threads `access.user?.id ?? null` into the table; copy updated.

## Tests

`lib/__tests__/admin-users-role.test.ts` — 13 cases.

- **Auth canaries (2):** 401 no session, 403 operator. Gate is shared with M2d-1; canaries catch regressions in the wiring.
- **Validation (4):** non-UUID id, missing `role`, unknown role string, non-JSON body.
- **Guardrails (3):** 404 not-found, 409 `CANNOT_MODIFY_SELF`, 409 `LAST_ADMIN`.
  - Note: `LAST_ADMIN` is only reachable when the caller's identity isn't the last admin. Under flag-on the admin caller is always counted in `count(admin)`, so if they're the only admin the caller IS the target and `CANNOT_MODIFY_SELF` fires first. The test exercises `LAST_ADMIN` via the flag-off path where the caller identity is null — which is also the production scenario where this guard matters most (break-glass operator demoting the only Supabase admin without realising they're the last one).
- **Success (3):** no-op `{ changed: false }`, promote viewer→admin, demote admin→operator when a second admin exists.

## Verification

- `tsc --noEmit` clean
- `next lint` clean
- `next build` clean; `/api/admin/users/[id]/role` registered
- `npm test` not runnable in sandbox; CI exercises the full suite.

## Test plan

- [ ] CI `lint` / `typecheck` / `build` / `test` all green
- [ ] M2d-1 + M2c tests still pass
- [ ] Manual on preview: as admin, promote a viewer in the Users table → dropdown updates + page reflects new role; try self-demote → 409 toast; try demoting the only other admin back to operator when you're one of two admins → succeeds.

## After merge

Auto-continue → M2d-3 (invite via magic-link) starts.

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42