### PR TITLE
M2d-3: invite user via magic-link

### DIFF
--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 
+import { InviteUserButton } from "@/components/InviteUserButton";
 import { UsersTable } from "@/components/UsersTable";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -48,6 +49,7 @@ export default async function AdminUsersPage() {
             server blocks self-modification and last-admin demotions.
           </p>
         </div>
+        <InviteUserButton />
       </div>
 
       <div className="mt-6">

--- a/app/api/admin/users/invite/route.ts
+++ b/app/api/admin/users/invite/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/users/invite — M2d-3.
+//
+// Admin-only. Creates an invite for `email` via Supabase Auth's admin
+// generateLink (type: 'invite') and returns the action URL. Using
+// generateLink rather than inviteUserByEmail means:
+//
+//   - The call is deterministic in tests — no SMTP configuration
+//     required for the request to succeed.
+//   - Prod ops can copy-paste the action_link to the invitee if email
+//     delivery is broken or the invite expires.
+//   - When SMTP is configured on the Supabase project, the same link
+//     is also delivered by email (generateLink triggers the standard
+//     invite template when `options.redirectTo` is passed and the
+//     project has mail enabled).
+//
+// Side effects: the call creates an auth.users row (email_confirmed_at
+// still null). The handle_new_auth_user trigger from migration 0004
+// fires immediately and inserts the matching opollo_users row with
+// role='viewer', so the invitee shows up in /admin/users as pending
+// before they click the link. After acceptance, the callback exchanges
+// the code for a session and lands them on `next` (default `/`).
+//
+// Errors:
+//   400 VALIDATION_FAILED   — bad email / missing body.
+//   401 UNAUTHORIZED        — flag on + no session.
+//   403 FORBIDDEN           — non-admin caller.
+//   409 ALREADY_EXISTS      — the email already maps to an auth user.
+//                             Demote/revoke / reinvite separately;
+//                             magic-link re-send is a separate route.
+//   500 INTERNAL_ERROR      — everything else (Supabase admin API
+//                             failure, DB failure).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const InviteSchema = z.object({
+  email: z.string().email().max(254),
+  next: z.string().optional(),
+});
+
+function safeNext(raw: string | undefined): string {
+  if (!raw || !raw.startsWith("/") || raw.startsWith("//")) return "/";
+  return raw;
+}
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+  extra?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false, ...(extra ?? {}) },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const gate = await requireAdminForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = InviteSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body must be { email: string; next?: string }.",
+          details: { issues: parsed.error.issues },
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const email = parsed.data.email.trim().toLowerCase();
+  const next = safeNext(parsed.data.next);
+
+  // Build the redirect target from the current request origin so
+  // invite links work across dev / preview / prod without wiring a
+  // separate SITE_URL env var. Supabase's magic-link flow tacks
+  // `?code=<uuid>` onto redirect_to when the invitee clicks it; our
+  // /api/auth/callback handler does the PKCE exchange.
+  const origin = req.nextUrl.origin;
+  const redirectTo = `${origin}/api/auth/callback?next=${encodeURIComponent(next)}`;
+
+  const svc = getServiceRoleClient();
+
+  const { data, error } = await svc.auth.admin.generateLink({
+    type: "invite",
+    email,
+    options: { redirectTo },
+  });
+
+  if (error) {
+    // Supabase returns 422 for "User already registered" (email
+    // collision). Translate that to a dedicated 409 so the UI can
+    // distinguish a duplicate invite from any other failure.
+    const status = (error as { status?: number }).status;
+    if (
+      status === 422 ||
+      /already (registered|exists)/i.test(error.message)
+    ) {
+      return errorJson(
+        "ALREADY_EXISTS",
+        "A user with that email already exists. Promote or revoke them from the users list instead.",
+        409,
+      );
+    }
+    return errorJson(
+      "INTERNAL_ERROR",
+      `Failed to generate invite: ${error.message}`,
+      500,
+    );
+  }
+
+  const actionLink = data?.properties?.action_link ?? null;
+  const userId = data?.user?.id ?? null;
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        email,
+        user_id: userId,
+        action_link: actionLink,
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/components/InviteUserButton.tsx
+++ b/components/InviteUserButton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { InviteUserModal } from "@/components/InviteUserModal";
+
+// Lightweight client wrapper so the server-rendered /admin/users page
+// stays mostly server — only the button + modal need client state.
+
+export function InviteUserButton() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Invite user</Button>
+      <InviteUserModal open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+}

--- a/components/InviteUserModal.tsx
+++ b/components/InviteUserModal.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | {
+      kind: "success";
+      email: string;
+      actionLink: string | null;
+    }
+  | { kind: "error"; message: string };
+
+export function InviteUserModal({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  useEffect(() => {
+    if (open) {
+      setEmail("");
+      setStatus({ kind: "idle" });
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && status.kind !== "submitting") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, status, onClose]);
+
+  if (!open) return null;
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setStatus({ kind: "submitting" });
+
+    try {
+      const res = await fetch("/api/admin/users/invite", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | {
+            ok: true;
+            data: { email: string; action_link: string | null };
+          }
+        | { ok: false; error: { message?: string } }
+        | null;
+
+      if (!res.ok || !payload || payload.ok !== true) {
+        const message =
+          payload && payload.ok === false
+            ? payload.error?.message ?? "Invite failed."
+            : `Invite failed (HTTP ${res.status}).`;
+        setStatus({ kind: "error", message });
+        return;
+      }
+
+      setStatus({
+        kind: "success",
+        email: payload.data.email,
+        actionLink: payload.data.action_link,
+      });
+      // Refresh the users table so the new pending user row appears.
+      router.refresh();
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const submitting = status.kind === "submitting";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="invite-user-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !submitting) onClose();
+      }}
+    >
+      <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="invite-user-title" className="text-lg font-semibold">
+          Invite user
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          New users start as <code>viewer</code>. Promote from the users list
+          after they accept.
+        </p>
+
+        {status.kind === "success" ? (
+          <div className="mt-4 space-y-3">
+            <div
+              className="rounded-md border border-primary/40 bg-primary/10 px-3 py-2 text-sm"
+              role="status"
+            >
+              Invite generated for{" "}
+              <span className="font-medium">{status.email}</span>.
+            </div>
+            {status.actionLink && (
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="invite-action-link"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Invite URL (copy + share if email delivery is disabled)
+                </label>
+                <Input
+                  id="invite-action-link"
+                  readOnly
+                  value={status.actionLink}
+                  onFocus={(e) => e.currentTarget.select()}
+                  className="font-mono text-xs"
+                />
+              </div>
+            )}
+            <div className="flex justify-end">
+              <Button onClick={onClose}>Done</Button>
+            </div>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+            <div>
+              <label
+                htmlFor="invite-email"
+                className="block text-sm font-medium"
+              >
+                Email
+              </label>
+              <Input
+                id="invite-email"
+                type="email"
+                required
+                autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={submitting}
+                autoFocus
+              />
+            </div>
+            {status.kind === "error" && (
+              <div
+                className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                role="alert"
+              >
+                {status.message}
+              </div>
+            )}
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onClose}
+                disabled={submitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={submitting}>
+                {submitting ? "Inviting…" : "Send invite"}
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/__tests__/admin-users-invite.test.ts
+++ b/lib/__tests__/admin-users-invite.test.ts
@@ -1,0 +1,261 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { NextRequest } from "next/server";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import { __resetAuthKillSwitchCacheForTests } from "@/lib/auth-kill-switch";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// M2d-3 — POST /api/admin/users/invite.
+//
+// Pins:
+//   - 401 when flag on + no session.
+//   - 403 when caller is non-admin.
+//   - 400 when email is missing / malformed.
+//   - 409 ALREADY_EXISTS when the email is already in auth.users.
+//   - 200 returns { email, user_id, action_link } on success AND
+//         creates an opollo_users row via the handle_new_auth_user
+//         trigger (role='viewer').
+// ---------------------------------------------------------------------------
+
+const mockState = vi.hoisted(() => ({
+  client: null as SupabaseClient | null,
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    createRouteAuthClient: () => {
+      if (!mockState.client) {
+        throw new Error(
+          "admin-users-invite.test: mockState.client not set before POST",
+        );
+      }
+      return mockState.client;
+    },
+  };
+});
+
+import { POST as invitePOST } from "@/app/api/admin/users/invite/route";
+
+function anonClient(): SupabaseClient {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      "admin-users-invite.test: SUPABASE_URL and SUPABASE_ANON_KEY must be set",
+    );
+  }
+  return createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function signedInClient(email: string): Promise<SupabaseClient> {
+  const client = anonClient();
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: "test-password-1234",
+  });
+  if (error) throw new Error(`signedInClient: ${error.message}`);
+  return client;
+}
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/admin/users/invite", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+async function readOpolloUserByEmail(
+  email: string,
+): Promise<{ id: string; role: string } | null> {
+  const svc = getServiceRoleClient();
+  const { data } = await svc
+    .from("opollo_users")
+    .select("id, role")
+    .eq("email", email.toLowerCase())
+    .maybeSingle();
+  if (!data) return null;
+  return { id: data.id as string, role: data.role as string };
+}
+
+async function deleteAuthUserByEmail(email: string): Promise<void> {
+  const svc = getServiceRoleClient();
+  // Look up the auth user via the admin API (listUsers is paginated;
+  // for test cleanup we just filter client-side).
+  const { data } = await svc.auth.admin.listUsers();
+  const match = data.users.find(
+    (u) => u.email?.toLowerCase() === email.toLowerCase(),
+  );
+  if (match) await svc.auth.admin.deleteUser(match.id);
+}
+
+const ENV_KEYS = ["FEATURE_SUPABASE_AUTH"] as const;
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  originalEnv = {};
+  for (const k of ENV_KEYS) originalEnv[k] = process.env[k];
+  mockState.client = null;
+  __resetAuthKillSwitchCacheForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = originalEnv[k];
+    }
+  }
+  mockState.client = null;
+  __resetAuthKillSwitchCacheForTests();
+});
+
+// ---------------------------------------------------------------------------
+// Auth canaries
+// ---------------------------------------------------------------------------
+
+describe("POST /api/admin/users/invite: auth", () => {
+  it("returns 401 when flag on and no session", async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    mockState.client = anonClient();
+
+    const res = await invitePOST(
+      makeRequest({ email: "new-person@opollo.test" }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller is operator", async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    const op = await seedAuthUser({ role: "operator" });
+    mockState.client = await signedInClient(op.email);
+
+    const res = await invitePOST(
+      makeRequest({ email: "new-person@opollo.test" }),
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe("POST /api/admin/users/invite: validation", () => {
+  beforeEach(() => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await invitePOST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 400 when email is malformed", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await invitePOST(
+      makeRequest({ email: "not-an-email" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is not JSON", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await invitePOST(makeRequest("not-json"));
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success + duplicate
+// ---------------------------------------------------------------------------
+
+describe("POST /api/admin/users/invite: outcomes", () => {
+  beforeEach(() => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+  });
+
+  it("creates an invite + opollo_users row with role='viewer'", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const inviteEmail = `invitee-${Date.now()}@opollo.test`;
+    try {
+      const res = await invitePOST(
+        makeRequest({ email: inviteEmail }),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.data.email).toBe(inviteEmail.toLowerCase());
+      expect(typeof body.data.action_link).toBe("string");
+      expect(body.data.action_link).toContain("http");
+      expect(typeof body.data.user_id).toBe("string");
+
+      // Trigger fired → opollo_users row exists with role='viewer'.
+      const row = await readOpolloUserByEmail(inviteEmail);
+      expect(row).not.toBeNull();
+      expect(row?.role).toBe("viewer");
+    } finally {
+      await deleteAuthUserByEmail(inviteEmail);
+    }
+  });
+
+  it("returns 409 ALREADY_EXISTS for a duplicate email", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    // Seed a second user — that email is now registered in auth.users
+    // via the admin API, matching what inviteUserByEmail would collide
+    // against.
+    const existing = await seedAuthUser({ role: "viewer" });
+    mockState.client = await signedInClient(admin.email);
+
+    const res = await invitePOST(
+      makeRequest({ email: existing.email }),
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe("ALREADY_EXISTS");
+  });
+
+  it("normalises the returned email to lowercase", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const inviteEmail = `CaseTest-${Date.now()}@Opollo.Test`;
+    try {
+      const res = await invitePOST(
+        makeRequest({ email: inviteEmail }),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.email).toBe(inviteEmail.toLowerCase());
+    } finally {
+      await deleteAuthUserByEmail(inviteEmail);
+    }
+  });
+});


### PR DESCRIPTION
## Sub-slice plan

Third of four M2d sub-slices. M2d-1 shipped the list, M2d-2 the role editor, M2d-3 adds invites. M2d-4 (revoke / deactivate) follows in the auto-continue chain.

## Design confirmations

**`generateLink` instead of `inviteUserByEmail`.** Both paths create the `auth.users` row and fire the `handle_new_auth_user` trigger that provisions `opollo_users` as `viewer`. The difference is that `inviteUserByEmail` also tries to send an SMTP email and fails loudly when no SMTP is configured; `generateLink` just returns the action URL. In local dev (`inbucket = false`) the request needs to succeed; in CI we need it deterministic; in prod an operator wants a URL to copy when email delivery is broken. Using `generateLink` covers all three.

**`redirectTo` is derived from the request origin.** No separate `SITE_URL` env var. The invite URL is built as `${req.nextUrl.origin}/api/auth/callback?next=${next}` so the same route works across dev / preview / prod without wiring per-environment config. Supabase's magic-link handler appends `?code=<uuid>` to `redirectTo` on click; our existing `/api/auth/callback` from M2c-1 does the PKCE exchange.

**Email normalised to lowercase.** Supabase's email comparison is case-insensitive but stores what you passed. Lowercasing on our side keeps the row stable and guarantees `ALREADY_EXISTS` collisions are caught regardless of casing.

**422 → 409 `ALREADY_EXISTS`.** Supabase returns 422 for duplicate-email invites (alongside other validation errors). The route filters on status + message so the UI gets a dedicated error code distinct from generic validation.

**Invite shows the pending user in the list immediately.** Because `generateLink` inserts the auth.users row synchronously, the trigger creates the `opollo_users` row before the response returns. `router.refresh()` on the client picks it up. No two-step polling or eventually-consistent UI.

**Invite URL surfaced in the success view.** When SMTP isn't wired (dev, some self-hosted prod deployments), the operator needs a way to get the link to the invitee. The success modal shows the URL in a readonly copyable `<input>` so a click-to-select + copy is one gesture.

## Files

- `app/api/admin/users/invite/route.ts` — POST handler.
- `components/InviteUserModal.tsx` — client component: email form, success state with copyable action link.
- `components/InviteUserButton.tsx` — lightweight client wrapper that owns the modal open-state so the page stays server-rendered.
- `app/admin/users/page.tsx` — renders the Invite button in the header.

## Tests

`lib/__tests__/admin-users-invite.test.ts` — 8 cases against real Supabase:

- **Auth (2):** 401 no session, 403 operator.
- **Validation (3):** missing email, malformed email, non-JSON body.
- **Outcomes (3):** 200 creates invite + `opollo_users` viewer row + returns `action_link`; 409 `ALREADY_EXISTS` for duplicate; 200 normalises email casing.

Test cleanup deletes any auth user it created so repeated runs stay green.

## Verification

- `tsc --noEmit` clean
- `next lint` clean
- `next build` clean; `/api/admin/users/invite` registered
- `npm test` not runnable in sandbox; CI exercises the full suite.

## Test plan

- [ ] CI all green
- [ ] M2d-1 + M2d-2 + M2c tests still pass
- [ ] Manual on preview: as admin, click "Invite user" → submit an unused email → success modal shows the URL; the users table shows the pending viewer row. Re-invite same email → 409 ALREADY_EXISTS.

## After merge

Auto-continue → M2d-4 (revoke / deactivate user). After M2d-4 merges, M2d is complete and the whole M2 milestone is done — that's the natural stop point per the auto-continue rule.

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42