### PR TITLE
M3-5: quality gate runner (5 substantive gates, 3 deferred)

### DIFF
--- a/lib/__tests__/batch-worker-anthropic.test.ts
+++ b/lib/__tests__/batch-worker-anthropic.test.ts
@@ -75,7 +75,9 @@ async function seedActiveTemplateForSite(siteId: string): Promise<string> {
 }
 
 async function seedSmallBatch(slots: number): Promise<string> {
-  const site = await seedSite();
+  // Prefix pinned to 'ls' so the GATE_PASSING_HTML below matches the
+  // site's scope prefix when the M3-5 gate runner evaluates it.
+  const site = await seedSite({ prefix: "ls" });
   const templateId = await seedActiveTemplateForSite(site.id);
   const res = await createBatchJob({
     site_id: site.id,
@@ -94,6 +96,18 @@ type RecordedCall = {
   idempotency_key: string;
   model: string;
 };
+
+// HTML that passes the M3-5 quality gates (wrapper + scope_prefix +
+// html_basics + slug_kebab + meta_description). Batch test seeds use
+// prefix 'ls' via seedSite defaults, DS version 1.
+const GATE_PASSING_HTML = [
+  '<section class="ls-hero" data-ds-version="1">',
+  '  <h1 class="ls-hero-title">Hello</h1>',
+  '  <p class="ls-hero-body"><a href="/landing">link</a></p>',
+  '  <img src="/a.png" alt="descriptive" class="ls-hero-image"/>',
+  '  <meta name="description" content="A descriptive meta summary of the page that is comfortably between fifty and one hundred sixty characters."/>',
+  "</section>",
+].join("\n");
 
 function makeStubCall(opts: {
   model?: string;
@@ -118,7 +132,7 @@ function makeStubCall(opts: {
     return {
       id: `resp_${req.idempotency_key}_${counter}`,
       model: opts.model ?? "claude-opus-4-7",
-      content: [{ type: "text", text: opts.text ?? "<section>stub</section>" }],
+      content: [{ type: "text", text: opts.text ?? GATE_PASSING_HTML }],
       stop_reason: "end_turn",
       usage: opts.usage ?? {
         input_tokens: 1_000,

--- a/lib/__tests__/batch-worker-gates.test.ts
+++ b/lib/__tests__/batch-worker-gates.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+
+import { createBatchJob } from "@/lib/batch-jobs";
+import { leaseNextPage, processSlotAnthropic } from "@/lib/batch-worker";
+import { createComponent } from "@/lib/components";
+import {
+  activateDesignSystem,
+  createDesignSystem,
+} from "@/lib/design-systems";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { createTemplate } from "@/lib/templates";
+import type { AnthropicCallFn } from "@/lib/anthropic-call";
+
+import {
+  minimalComponentContentSchema,
+  minimalComposition,
+  seedSite,
+} from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M3-5 — processSlotAnthropic with the gate runner wired in.
+//
+// Two integration cases:
+//
+//   1. Gates PASS with well-formed HTML → slot ends 'succeeded', job
+//      succeeded_count ticks, cost recorded, state_advanced events
+//      show generating → validating → succeeded.
+//
+//   2. Gates FAIL with ill-formed HTML → slot ends 'failed' with
+//      last_error_code='QUALITY_GATE_FAILED', quality_gate_failures
+//      populated, gate_failed event present, job failed_count ticks,
+//      but cost STILL recorded because we paid Anthropic.
+// ---------------------------------------------------------------------------
+
+async function seedActiveTemplateForSite(siteId: string): Promise<string> {
+  const ds = await createDesignSystem({
+    site_id: siteId,
+    version: 1,
+    tokens_css: "",
+    base_styles: "",
+  });
+  if (!ds.ok) throw new Error(ds.error.message);
+  for (const name of ["hero-centered", "footer-default"]) {
+    const c = await createComponent({
+      design_system_id: ds.data.id,
+      name,
+      variant: null,
+      category: name.split("-")[0] ?? "misc",
+      html_template: `<section>${name}</section>`,
+      css: ".ls-x {}",
+      content_schema: minimalComponentContentSchema(),
+    });
+    if (!c.ok) throw new Error(c.error.message);
+  }
+  const t = await createTemplate({
+    design_system_id: ds.data.id,
+    page_type: "homepage",
+    name: "homepage-default",
+    composition: minimalComposition(),
+    required_fields: { hero: ["headline"] },
+    is_default: true,
+  });
+  if (!t.ok) throw new Error(t.error.message);
+  const activated = await activateDesignSystem(ds.data.id, 1);
+  if (!activated.ok) throw new Error(activated.error.message);
+  return t.data.id;
+}
+
+async function seedBatch(
+  slots: number,
+  slugHint: string | null = "hello-world",
+): Promise<string> {
+  const site = await seedSite({ prefix: "ls" });
+  const templateId = await seedActiveTemplateForSite(site.id);
+  const res = await createBatchJob({
+    site_id: site.id,
+    template_id: templateId,
+    slots: Array.from({ length: slots }, (_, i) => ({
+      inputs: {
+        slug: slugHint ? `${slugHint}-${i}` : undefined,
+        topic: `topic-${i}`,
+      },
+    })),
+    idempotency_key: `gate-${Date.now()}-${Math.random()}`,
+    created_by: null,
+  });
+  if (!res.ok) throw new Error(res.error.message);
+  return res.data.job_id;
+}
+
+function stubCallReturningHtml(html: string): AnthropicCallFn {
+  return async (req) => ({
+    id: `resp_${req.idempotency_key}`,
+    model: req.model,
+    content: [{ type: "text", text: html }],
+    stop_reason: "end_turn",
+    usage: {
+      input_tokens: 1_000,
+      output_tokens: 500,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+  });
+}
+
+const DESCRIPTIVE_META =
+  "A descriptive meta summary of the page that is comfortably between fifty and one hundred sixty characters.";
+
+const VALID_HTML = `<section class="ls-hero" data-ds-version="1">
+  <h1 class="ls-hero-title">Hello</h1>
+  <p class="ls-hero-body">Body <a href="/landing">link</a></p>
+  <img src="/a.png" alt="descriptive" class="ls-hero-image"/>
+  <meta name="description" content="${DESCRIPTIVE_META}"/>
+</section>`;
+
+// Missing data-ds-version — wrapper gate fires first.
+const WRAPPER_BROKEN_HTML = `<section class="ls-hero">
+  <h1>Hello</h1>
+  <p><a href="/x">link</a></p>
+  <img src="/a.png" alt="x"/>
+  <meta name="description" content="${DESCRIPTIVE_META}"/>
+</section>`;
+
+describe("processSlotAnthropic — gates pass", () => {
+  it("walks generating → validating → succeeded and ticks succeeded_count", async () => {
+    const jobId = await seedBatch(1);
+    const leased = await leaseNextPage("pass-worker");
+    if (!leased) throw new Error("lease failed");
+
+    await processSlotAnthropic(leased.id, "pass-worker", {
+      anthropicCall: stubCallReturningHtml(VALID_HTML),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: slot } = await svc
+      .from("generation_job_pages")
+      .select(
+        "state, last_error_code, quality_gate_failures, cost_usd_cents, generated_html",
+      )
+      .eq("id", leased.id)
+      .single();
+    expect(slot?.state).toBe("succeeded");
+    expect(slot?.last_error_code).toBeNull();
+    expect(slot?.quality_gate_failures).toBeNull();
+    expect(Number(slot?.cost_usd_cents)).toBeGreaterThan(0);
+    expect(slot?.generated_html).toContain("data-ds-version");
+
+    const { data: events } = await svc
+      .from("generation_events")
+      .select("event, details")
+      .eq("page_slot_id", leased.id)
+      .order("id", { ascending: true });
+    const eventTypes = (events ?? []).map((e) => e.event);
+    expect(eventTypes).toContain("anthropic_response_received");
+    // Two state_advanced entries for validating + succeeded, plus the
+    // earlier generating one.
+    const stateTransitions = (events ?? [])
+      .filter((e) => e.event === "state_advanced")
+      .map((e) => (e.details as { to: string }).to);
+    expect(stateTransitions).toEqual(["generating", "validating", "succeeded"]);
+
+    const { data: job } = await svc
+      .from("generation_jobs")
+      .select("status, succeeded_count, failed_count")
+      .eq("id", jobId)
+      .single();
+    expect(job?.status).toBe("succeeded");
+    expect(job?.succeeded_count).toBe(1);
+    expect(job?.failed_count).toBe(0);
+  });
+});
+
+describe("processSlotAnthropic — gate failure", () => {
+  it("marks the slot failed at the first failing gate and still records cost", async () => {
+    const jobId = await seedBatch(1);
+    const leased = await leaseNextPage("fail-worker");
+    if (!leased) throw new Error("lease failed");
+
+    await processSlotAnthropic(leased.id, "fail-worker", {
+      anthropicCall: stubCallReturningHtml(WRAPPER_BROKEN_HTML),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: slot } = await svc
+      .from("generation_job_pages")
+      .select(
+        "state, last_error_code, last_error_message, quality_gate_failures, cost_usd_cents, input_tokens, output_tokens",
+      )
+      .eq("id", leased.id)
+      .single();
+    expect(slot?.state).toBe("failed");
+    expect(slot?.last_error_code).toBe("QUALITY_GATE_FAILED");
+    expect(slot?.last_error_message).toMatch(/wrapper/);
+    const failures = slot?.quality_gate_failures as unknown as Array<{
+      gate: string;
+    }>;
+    expect(Array.isArray(failures)).toBe(true);
+    expect(failures[0]?.gate).toBe("wrapper");
+
+    // Cost still recorded — we paid Anthropic before the gate ran.
+    expect(Number(slot?.cost_usd_cents)).toBeGreaterThan(0);
+    expect(Number(slot?.input_tokens)).toBeGreaterThan(0);
+    expect(Number(slot?.output_tokens)).toBeGreaterThan(0);
+
+    const { data: events } = await svc
+      .from("generation_events")
+      .select("event, details")
+      .eq("page_slot_id", leased.id)
+      .order("id", { ascending: true });
+    const gateFailed = (events ?? []).find((e) => e.event === "gate_failed");
+    expect(gateFailed).toBeTruthy();
+    expect((gateFailed!.details as { gate: string }).gate).toBe("wrapper");
+
+    const { data: job } = await svc
+      .from("generation_jobs")
+      .select("status, succeeded_count, failed_count, total_cost_usd_cents")
+      .eq("id", jobId)
+      .single();
+    expect(job?.failed_count).toBe(1);
+    expect(job?.succeeded_count).toBe(0);
+    // Last (and only) slot finished → whole job is 'failed' since
+    // succeeded_count=0.
+    expect(job?.status).toBe("failed");
+    // Parent job cost accumulated even though the gate failed.
+    expect(Number(job?.total_cost_usd_cents)).toBeGreaterThan(0);
+  });
+});

--- a/lib/__tests__/quality-gates.test.ts
+++ b/lib/__tests__/quality-gates.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ALL_GATES,
+  gateHtmlBasics,
+  gateMetaDescription,
+  gateScopePrefix,
+  gateSlugKebab,
+  gateWrapper,
+  runGates,
+  type GateContext,
+} from "@/lib/quality-gates";
+
+// ---------------------------------------------------------------------------
+// M3-5 — Quality gate unit tests.
+//
+// Every gate tested in isolation with a minimal ctx, then a handful
+// of integration assertions on runGates (order, short-circuit).
+// ---------------------------------------------------------------------------
+
+function ctx(overrides: Partial<GateContext>): GateContext {
+  return {
+    html: "<section></section>",
+    slug: "hello",
+    prefix: "ls",
+    design_system_version: "1",
+    ...overrides,
+  };
+}
+
+function validHtml(): string {
+  // Used by multiple tests as the "all gates pass" baseline.
+  return `
+    <section class="ls-hero" data-ds-version="1">
+      <h1>Hello</h1>
+      <p>Body <a href="/somewhere">link</a></p>
+      <img src="/a.png" alt="descriptive" class="ls-img"/>
+      <meta name="description" content="A descriptive meta summary of the page that is comfortably between fifty and one hundred sixty characters." />
+    </section>
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// gateWrapper (HC-2)
+// ---------------------------------------------------------------------------
+
+describe("gateWrapper", () => {
+  it("passes when outermost element has matching data-ds-version", () => {
+    const r = gateWrapper(
+      ctx({ html: '<section data-ds-version="1">x</section>' }),
+    );
+    expect(r.kind).toBe("pass");
+  });
+
+  it("fails when data-ds-version is missing", () => {
+    const r = gateWrapper(ctx({ html: "<section>x</section>" }));
+    expect(r.kind).toBe("fail");
+    if (r.kind !== "fail") return;
+    expect(r.reason).toMatch(/data-ds-version/);
+  });
+
+  it("fails when data-ds-version mismatches", () => {
+    const r = gateWrapper(
+      ctx({
+        html: '<section data-ds-version="7">x</section>',
+        design_system_version: "1",
+      }),
+    );
+    expect(r.kind).toBe("fail");
+    if (r.kind !== "fail") return;
+    expect((r.details as { expected: string }).expected).toBe("1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gateScopePrefix (HC-4)
+// ---------------------------------------------------------------------------
+
+describe("gateScopePrefix", () => {
+  it("passes when every class is prefixed", () => {
+    const r = gateScopePrefix(
+      ctx({
+        html:
+          '<div class="ls-hero"><span class="ls-hero-title"></span></div>',
+        prefix: "ls",
+      }),
+    );
+    expect(r.kind).toBe("pass");
+  });
+
+  it("fails on a non-prefixed class", () => {
+    const r = gateScopePrefix(
+      ctx({
+        html: '<div class="ls-hero rogue-class">x</div>',
+        prefix: "ls",
+      }),
+    );
+    expect(r.kind).toBe("fail");
+    if (r.kind !== "fail") return;
+    expect((r.details as { violations: string[] }).violations).toContain(
+      "rogue-class",
+    );
+  });
+
+  it("rejects a bare prefix without a suffix (ls on its own)", () => {
+    const r = gateScopePrefix(
+      ctx({ html: '<div class="ls">x</div>', prefix: "ls" }),
+    );
+    expect(r.kind).toBe("fail");
+  });
+
+  it("rejects inverted prefix (hero-ls)", () => {
+    const r = gateScopePrefix(
+      ctx({ html: '<div class="hero-ls">x</div>', prefix: "ls" }),
+    );
+    expect(r.kind).toBe("fail");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gateHtmlBasics
+// ---------------------------------------------------------------------------
+
+describe("gateHtmlBasics", () => {
+  it("passes the baseline valid HTML", () => {
+    const r = gateHtmlBasics(ctx({ html: validHtml() }));
+    expect(r.kind).toBe("pass");
+  });
+
+  it("fails on zero h1 tags", () => {
+    const r = gateHtmlBasics(
+      ctx({ html: '<section data-ds-version="1"><p>no heading</p></section>' }),
+    );
+    expect(r.kind).toBe("fail");
+    if (r.kind !== "fail") return;
+    expect(r.reason).toMatch(/h1/);
+  });
+
+  it("fails on two h1 tags", () => {
+    const r = gateHtmlBasics(
+      ctx({
+        html:
+          '<section data-ds-version="1"><h1>a</h1><h1>b</h1></section>',
+      }),
+    );
+    expect(r.kind).toBe("fail");
+  });
+
+  it("fails on empty href", () => {
+    const r = gateHtmlBasics(
+      ctx({ html: '<h1>x</h1><a href="">y</a>' }),
+    );
+    expect(r.kind).toBe("fail");
+    if (r.kind !== "fail") return;
+    expect(r.reason).toMatch(/placeholder|empty href/i);
+  });
+
+  it("fails on href=\"#\"", () => {
+    const r = gateHtmlBasics(
+      ctx({ html: '<h1>x</h1><a href="#">y</a>' }),
+    );
+    expect(r.kind).toBe("fail");
+  });
+
+  it("fails on img missing alt", () => {
+    const r = gateHtmlBasics(
+      ctx({ html: '<h1>x</h1><img src="/a.png"/>' }),
+    );
+    expect(r.kind).toBe("fail");
+    if (r.kind !== "fail") return;
+    expect(r.reason).toMatch(/alt/);
+  });
+
+  it("fails on img with empty alt", () => {
+    const r = gateHtmlBasics(
+      ctx({ html: '<h1>x</h1><img src="/a.png" alt=""/>' }),
+    );
+    expect(r.kind).toBe("fail");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gateSlugKebab
+// ---------------------------------------------------------------------------
+
+describe("gateSlugKebab", () => {
+  it("passes for valid kebab-case", () => {
+    expect(gateSlugKebab(ctx({ slug: "hello-world" })).kind).toBe("pass");
+    expect(gateSlugKebab(ctx({ slug: "version-2" })).kind).toBe("pass");
+    expect(gateSlugKebab(ctx({ slug: "single" })).kind).toBe("pass");
+  });
+
+  it("fails for uppercase", () => {
+    expect(gateSlugKebab(ctx({ slug: "Hello" })).kind).toBe("fail");
+  });
+
+  it("fails for double hyphens", () => {
+    expect(gateSlugKebab(ctx({ slug: "hello--world" })).kind).toBe("fail");
+  });
+
+  it("fails for leading hyphen", () => {
+    expect(gateSlugKebab(ctx({ slug: "-hello" })).kind).toBe("fail");
+  });
+
+  it("fails for trailing hyphen", () => {
+    expect(gateSlugKebab(ctx({ slug: "hello-" })).kind).toBe("fail");
+  });
+
+  it("fails for underscores", () => {
+    expect(gateSlugKebab(ctx({ slug: "hello_world" })).kind).toBe("fail");
+  });
+
+  it("fails for missing slug", () => {
+    expect(gateSlugKebab(ctx({ slug: null })).kind).toBe("fail");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gateMetaDescription
+// ---------------------------------------------------------------------------
+
+describe("gateMetaDescription", () => {
+  it("passes with a 50-160 char description", () => {
+    const desc = "A descriptive meta summary of the page that is comfortably between fifty and one hundred sixty characters.";
+    const r = gateMetaDescription(
+      ctx({
+        html: `<meta name="description" content="${desc}"/>`,
+      }),
+    );
+    expect(r.kind).toBe("pass");
+  });
+
+  it("fails when no meta description is present", () => {
+    const r = gateMetaDescription(ctx({ html: "<h1>x</h1>" }));
+    expect(r.kind).toBe("fail");
+  });
+
+  it("fails when meta description is too short", () => {
+    const r = gateMetaDescription(
+      ctx({
+        html: '<meta name="description" content="too short"/>',
+      }),
+    );
+    expect(r.kind).toBe("fail");
+    if (r.kind !== "fail") return;
+    expect(r.reason).toMatch(/length/);
+  });
+
+  it("fails when meta description is too long", () => {
+    const long = "x".repeat(200);
+    const r = gateMetaDescription(
+      ctx({ html: `<meta name="description" content="${long}"/>` }),
+    );
+    expect(r.kind).toBe("fail");
+  });
+
+  it("accepts reversed attribute order (content before name)", () => {
+    const desc = "A descriptive meta summary of the page that is comfortably between fifty and one hundred sixty characters.";
+    const r = gateMetaDescription(
+      ctx({
+        html: `<meta content="${desc}" name="description"/>`,
+      }),
+    );
+    expect(r.kind).toBe("pass");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runGates — order + short-circuit
+// ---------------------------------------------------------------------------
+
+describe("runGates", () => {
+  it("passes the baseline valid HTML", () => {
+    const r = runGates(ctx({ html: validHtml() }));
+    expect(r.kind).toBe("passed");
+    if (r.kind !== "passed") return;
+    expect(r.gates_run).toEqual(ALL_GATES.map((g) => g.name));
+  });
+
+  it("short-circuits on first failure and names the gate", () => {
+    // Wrapper missing → fails at the FIRST gate, later gates never run.
+    const r = runGates(ctx({ html: "<section><h1>x</h1></section>" }));
+    expect(r.kind).toBe("failed");
+    if (r.kind !== "failed") return;
+    expect(r.first_failure.gate).toBe("wrapper");
+    expect(r.gates_run).toEqual(["wrapper"]);
+  });
+
+  it("runs multiple gates in order when earlier ones pass", () => {
+    // Valid wrapper, valid scope prefix, but zero h1 → fails at
+    // html_basics (third gate).
+    const r = runGates(
+      ctx({
+        html:
+          '<section data-ds-version="1" class="ls-hero"><p>no h1 here</p></section>',
+      }),
+    );
+    expect(r.kind).toBe("failed");
+    if (r.kind !== "failed") return;
+    expect(r.first_failure.gate).toBe("html_basics");
+    expect(r.gates_run).toEqual(["wrapper", "scope_prefix", "html_basics"]);
+  });
+});

--- a/lib/batch-worker.ts
+++ b/lib/batch-worker.ts
@@ -5,6 +5,7 @@ import {
   type AnthropicCallFn,
 } from "@/lib/anthropic-call";
 import { computeCostCents, PRICING_VERSION } from "@/lib/anthropic-pricing";
+import { runGates } from "@/lib/quality-gates";
 import { buildSystemPromptForSite } from "@/lib/system-prompt";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -533,6 +534,20 @@ export async function processSlotAnthropic(
     .join("")
     .trim();
 
+  // M3-5: gate check runs between Anthropic response and the final
+  // slot UPDATE. Compute it OUTSIDE the DB transaction — gates are
+  // pure functions over the HTML + slot inputs.
+  const slug =
+    typeof (ctx.inputs as { slug?: unknown }).slug === "string"
+      ? ((ctx.inputs as { slug: string }).slug as string)
+      : null;
+  const gateOutcome = runGates({
+    html: generatedHtml,
+    slug,
+    prefix: ctx.site.prefix,
+    design_system_version: ctx.design_system_version,
+  });
+
   await withClient(opts.client ?? null, async (c) => {
     // EVENT LOG FIRST. If the subsequent slot UPDATE fails (DB blip,
     // network hiccup), the billing facts still persist and a
@@ -571,8 +586,156 @@ export async function processSlotAnthropic(
       ],
     );
 
-    // Now the slot UPDATE. Also guarded by worker_id so a stolen lease
-    // doesn't clobber another worker's state.
+    // generating → validating: records the state transition even on
+    // gate failure so the audit log shows the slot entered the gate
+    // step. Guarded by worker_id.
+    const advanceValidating = await c.query(
+      `
+      UPDATE generation_job_pages
+         SET state = 'validating',
+             last_heartbeat_at = now(),
+             updated_at = now()
+       WHERE id = $1 AND worker_id = $2 AND state = 'generating'
+      `,
+      [slotId, workerId],
+    );
+    if ((advanceValidating.rowCount ?? 0) === 0) {
+      throw new Error(
+        `processSlotAnthropic: lease stolen or state changed before validating slot ${slotId}`,
+      );
+    }
+    await c.query(
+      `
+      INSERT INTO generation_events (job_id, page_slot_id, event, details)
+      VALUES ($1, $2, 'state_advanced',
+              jsonb_build_object('to', 'validating', 'worker_id', $3::text,
+                                 'gates_run', $4::jsonb))
+      `,
+      [
+        ctx.job_id,
+        slotId,
+        workerId,
+        JSON.stringify(gateOutcome.gates_run),
+      ],
+    );
+
+    if (gateOutcome.kind === "failed") {
+      const fail = gateOutcome.first_failure;
+      await c.query(
+        `
+        INSERT INTO generation_events (job_id, page_slot_id, event, details)
+        VALUES ($1, $2, 'gate_failed',
+                jsonb_build_object(
+                  'gate', $3::text,
+                  'reason', $4::text,
+                  'details', $5::jsonb,
+                  'gates_run', $6::jsonb,
+                  'worker_id', $7::text
+                ))
+        `,
+        [
+          ctx.job_id,
+          slotId,
+          fail.gate,
+          fail.reason,
+          JSON.stringify(fail.details ?? {}),
+          JSON.stringify(gateOutcome.gates_run),
+          workerId,
+        ],
+      );
+
+      const markFailed = await c.query(
+        `
+        UPDATE generation_job_pages
+           SET state = 'failed',
+               generated_html = $4,
+               anthropic_raw_response_id = $3,
+               cost_usd_cents = $5,
+               input_tokens = $6,
+               output_tokens = $7,
+               cached_tokens = $8,
+               last_error_code = 'QUALITY_GATE_FAILED',
+               last_error_message = $9,
+               quality_gate_failures = $10::jsonb,
+               finished_at = now(),
+               lease_expires_at = NULL,
+               worker_id = NULL,
+               updated_at = now()
+         WHERE id = $1 AND worker_id = $2 AND state = 'validating'
+        `,
+        [
+          slotId,
+          workerId,
+          response.id,
+          generatedHtml,
+          cents,
+          response.usage.input_tokens,
+          response.usage.output_tokens,
+          (response.usage.cache_creation_input_tokens ?? 0) +
+            (response.usage.cache_read_input_tokens ?? 0),
+          `${fail.gate}: ${fail.reason}`,
+          JSON.stringify([fail]),
+        ],
+      );
+      if ((markFailed.rowCount ?? 0) === 0) {
+        throw new Error(
+          `processSlotAnthropic: lease stolen while marking slot ${slotId} failed`,
+        );
+      }
+
+      // Roll failed_count + cost on the parent job. Cost tokens still
+      // recorded because we paid Anthropic even when the gate says no.
+      await c.query(
+        `
+        UPDATE generation_jobs j
+           SET failed_count = failed_count + 1,
+               total_cost_usd_cents = total_cost_usd_cents + $2,
+               total_input_tokens   = total_input_tokens + $3,
+               total_output_tokens  = total_output_tokens + $4,
+               total_cached_tokens  = total_cached_tokens + $5,
+               status = CASE
+                          WHEN j.succeeded_count + j.failed_count + 1
+                               >= j.requested_count
+                            THEN CASE
+                                   WHEN j.succeeded_count = 0
+                                     THEN 'failed'
+                                   ELSE 'partial'
+                                 END
+                          ELSE 'running'
+                        END,
+               finished_at = CASE
+                               WHEN j.succeeded_count + j.failed_count + 1
+                                    >= j.requested_count
+                                 THEN now()
+                               ELSE j.finished_at
+                             END,
+               updated_at = now()
+         WHERE id = $1
+        `,
+        [
+          ctx.job_id,
+          cents,
+          response.usage.input_tokens,
+          response.usage.output_tokens,
+          (response.usage.cache_creation_input_tokens ?? 0) +
+            (response.usage.cache_read_input_tokens ?? 0),
+        ],
+      );
+
+      await c.query(
+        `
+        INSERT INTO generation_events (job_id, page_slot_id, event, details)
+        VALUES ($1, $2, 'state_advanced',
+                jsonb_build_object('to', 'failed', 'worker_id', $3::text,
+                                   'reason', 'quality_gate_failed'))
+        `,
+        [ctx.job_id, slotId, workerId],
+      );
+      return;
+    }
+
+    // Gates passed: advance validating → succeeded, same as M3-4's
+    // final UPDATE but guarded by state = 'validating' now.
     const finalise = await c.query(
       `
       UPDATE generation_job_pages
@@ -588,7 +751,7 @@ export async function processSlotAnthropic(
              worker_id = NULL,
              updated_at = now()
        WHERE id = $1 AND worker_id = $2
-         AND state = 'generating'
+         AND state = 'validating'
       `,
       [
         slotId,
@@ -608,9 +771,7 @@ export async function processSlotAnthropic(
       );
     }
 
-    // Roll the parent job's aggregates. cost + tokens accumulate via
-    // the event log (reconciliation truth), but we keep running
-    // totals on generation_jobs for cheap list-page reads.
+    // Roll the parent job's aggregates.
     await c.query(
       `
       UPDATE generation_jobs j
@@ -622,7 +783,11 @@ export async function processSlotAnthropic(
              status = CASE
                         WHEN j.succeeded_count + 1 + j.failed_count
                              >= j.requested_count
-                          THEN 'succeeded'
+                          THEN CASE
+                                 WHEN j.failed_count = 0
+                                   THEN 'succeeded'
+                                 ELSE 'partial'
+                               END
                         ELSE 'running'
                       END,
              finished_at = CASE

--- a/lib/quality-gates.ts
+++ b/lib/quality-gates.ts
@@ -1,0 +1,303 @@
+// ---------------------------------------------------------------------------
+// M3-5 — Runtime quality gates.
+//
+// Runs between Anthropic's response and the WP publish. First failure
+// short-circuits: slot → state='failed', reason logged, no further
+// gate checks. This mirrors the HC-1..HC-7 hard constraints from
+// SCOPE_v3 applied as a second-layer runtime check on top of the
+// system prompt's generation-time rules. Scope: catch mis-generations
+// before they mutate a production WP site.
+//
+// Gates shipping in M3-5:
+//
+//   wrapper            HC-2 — the outermost element carries
+//                             data-ds-version="<version>".
+//   scope_prefix       HC-4 — every class in the HTML matches the
+//                             site's /^<prefix>-/ pattern. Uses the
+//                             M1f validator's class-extraction logic
+//                             but runs against HTML, not CSS.
+//   html_basics        Subset of §5 of the SCOPE v3 validation rules:
+//                             exactly one h1; no empty or "#" hrefs;
+//                             every img has a non-empty alt.
+//   slug_kebab         Slug brief is a-z0-9 lowercase with single
+//                             hyphens, no leading/trailing hyphen.
+//   meta_description   meta[name=description] content length is
+//                             50–160 chars.
+//
+// Gates deferred to a follow-up slice (M3-5b), with reasons:
+//
+//   allowed_components HC-1 — requires parsing the HTML against the
+//                             active design system's component
+//                             registry, which means wiring that
+//                             registry into the worker path. Doable
+//                             but widens scope; the scope_prefix
+//                             gate catches the ambient "Claude
+//                             invented classes" failure mode today.
+//   no_freeform_html   HC-3 — same registry dependency.
+//   word_count         requires per-template min/max, which isn't a
+//                             column on design_templates yet.
+//
+// Slug uniqueness is NOT a runtime gate here — M3-6 enforces it via
+// the pages UNIQUE (site_id, slug) pre-commit INSERT. Doing it in
+// two places would create a race window; doing it only in gates
+// would skip WP-side duplicate detection. One place wins: M3-6.
+// ---------------------------------------------------------------------------
+
+export type GateSkip = { kind: "skipped"; gate: GateName; reason: string };
+export type GatePass = { kind: "pass"; gate: GateName };
+export type GateFail = {
+  kind: "fail";
+  gate: GateName;
+  reason: string;
+  details?: Record<string, unknown>;
+};
+export type GateResult = GatePass | GateFail | GateSkip;
+
+export type GateName =
+  | "wrapper"
+  | "scope_prefix"
+  | "html_basics"
+  | "slug_kebab"
+  | "meta_description";
+
+export type GateContext = {
+  html: string;
+  slug: string | null;
+  prefix: string;
+  design_system_version: string;
+};
+
+type GateFn = (ctx: GateContext) => GateResult;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const KEBAB_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+// Extract every class token from every class="..." attribute in the
+// HTML. Tolerant of single quotes and extra whitespace. This is a
+// lightweight HTML scan — sufficient for well-formed Claude output,
+// explicitly not bulletproof against hostile input.
+function extractClassTokens(html: string): string[] {
+  const out: string[] = [];
+  const re = /class\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    const raw = (m[1] ?? m[2] ?? "").trim();
+    if (!raw) continue;
+    for (const token of raw.split(/\s+/)) {
+      if (token) out.push(token);
+    }
+  }
+  return out;
+}
+
+function countTagOccurrences(html: string, tag: string): number {
+  const re = new RegExp(`<${tag}[\\s>]`, "gi");
+  const m = html.match(re);
+  return m ? m.length : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Gate implementations
+// ---------------------------------------------------------------------------
+
+/** HC-2: outermost element has data-ds-version matching the site's active DS. */
+export const gateWrapper: GateFn = (ctx) => {
+  // Find the FIRST opening tag with attributes and inspect for
+  // data-ds-version. Accept either single- or double-quoted values.
+  const first = /<([a-z][a-z0-9]*)\b([^>]*)>/i.exec(ctx.html);
+  if (!first) {
+    return {
+      kind: "fail",
+      gate: "wrapper",
+      reason: "No opening tag found in generated HTML.",
+    };
+  }
+  const attrs = first[2] ?? "";
+  const dsAttr = /\bdata-ds-version\s*=\s*(?:"([^"]*)"|'([^']*)')/i.exec(attrs);
+  if (!dsAttr) {
+    return {
+      kind: "fail",
+      gate: "wrapper",
+      reason: "Outermost element is missing data-ds-version attribute (HC-2).",
+    };
+  }
+  const value = (dsAttr[1] ?? dsAttr[2] ?? "").trim();
+  if (!value) {
+    return {
+      kind: "fail",
+      gate: "wrapper",
+      reason: "data-ds-version attribute is empty.",
+    };
+  }
+  if (value !== ctx.design_system_version) {
+    return {
+      kind: "fail",
+      gate: "wrapper",
+      reason: `data-ds-version="${value}" does not match the site's active design system version (${ctx.design_system_version}).`,
+      details: {
+        expected: ctx.design_system_version,
+        actual: value,
+      },
+    };
+  }
+  return { kind: "pass", gate: "wrapper" };
+};
+
+/** HC-4: every class token is prefixed with the site's scope prefix. */
+export const gateScopePrefix: GateFn = (ctx) => {
+  const prefixRe = new RegExp(`^${ctx.prefix}(?:-[a-z0-9]+)+$`);
+  const classes = extractClassTokens(ctx.html);
+  const violations = classes.filter((c) => !prefixRe.test(c));
+  if (violations.length === 0) {
+    return { kind: "pass", gate: "scope_prefix" };
+  }
+  return {
+    kind: "fail",
+    gate: "scope_prefix",
+    reason: `Found ${violations.length} class(es) outside the '${ctx.prefix}-' prefix. First: '${violations[0]}'.`,
+    details: { prefix: ctx.prefix, violations: violations.slice(0, 10) },
+  };
+};
+
+/** Subset of the SCOPE v3 validation rules we can check with string scans. */
+export const gateHtmlBasics: GateFn = (ctx) => {
+  const h1Count = countTagOccurrences(ctx.html, "h1");
+  if (h1Count !== 1) {
+    return {
+      kind: "fail",
+      gate: "html_basics",
+      reason: `Expected exactly one <h1>, found ${h1Count}.`,
+      details: { h1_count: h1Count },
+    };
+  }
+
+  // Placeholder / empty hrefs. <a href="#"> and <a href=""> are
+  // generation-time failures per SCOPE v3.
+  const badHref = /<a\b[^>]*\bhref\s*=\s*(?:""|'')|<a\b[^>]*\bhref\s*=\s*["']#["']/i;
+  if (badHref.test(ctx.html)) {
+    return {
+      kind: "fail",
+      gate: "html_basics",
+      reason: 'Found placeholder or empty href ("" or "#"). Every link must resolve.',
+    };
+  }
+
+  // Every <img> carries a non-empty alt. Regex that finds an <img>
+  // tag missing an alt attribute or with alt="".
+  const imgRe = /<img\b([^>]*)>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = imgRe.exec(ctx.html)) !== null) {
+    const attrs = match[1] ?? "";
+    const alt = /\balt\s*=\s*(?:"([^"]*)"|'([^']*)')/i.exec(attrs);
+    if (!alt) {
+      return {
+        kind: "fail",
+        gate: "html_basics",
+        reason: "Found <img> tag without an alt attribute.",
+      };
+    }
+    const value = (alt[1] ?? alt[2] ?? "").trim();
+    if (!value) {
+      return {
+        kind: "fail",
+        gate: "html_basics",
+        reason: "Found <img> tag with empty alt text.",
+      };
+    }
+  }
+
+  return { kind: "pass", gate: "html_basics" };
+};
+
+/** Slug kebab-case format. Uniqueness is enforced at WP publish. */
+export const gateSlugKebab: GateFn = (ctx) => {
+  if (!ctx.slug) {
+    return {
+      kind: "fail",
+      gate: "slug_kebab",
+      reason: "No slug present in slot inputs.",
+    };
+  }
+  if (!KEBAB_SLUG.test(ctx.slug)) {
+    return {
+      kind: "fail",
+      gate: "slug_kebab",
+      reason: `Slug '${ctx.slug}' is not lowercase kebab-case (expected a-z, 0-9, single hyphens, no leading/trailing hyphen).`,
+    };
+  }
+  return { kind: "pass", gate: "slug_kebab" };
+};
+
+/** meta[name=description] content length between 50 and 160 chars. */
+export const gateMetaDescription: GateFn = (ctx) => {
+  const re = /<meta\b[^>]*\bname\s*=\s*["']description["'][^>]*\bcontent\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
+  const m = re.exec(ctx.html);
+  if (!m) {
+    // Allow the attribute order to be reversed.
+    const reReverse = /<meta\b[^>]*\bcontent\s*=\s*(?:"([^"]*)"|'([^']*)')[^>]*\bname\s*=\s*["']description["']/i;
+    const m2 = reReverse.exec(ctx.html);
+    if (!m2) {
+      return {
+        kind: "fail",
+        gate: "meta_description",
+        reason: "No <meta name=\"description\"> tag found.",
+      };
+    }
+    const content = (m2[1] ?? m2[2] ?? "").trim();
+    return validateMetaLen(content);
+  }
+  const content = (m[1] ?? m[2] ?? "").trim();
+  return validateMetaLen(content);
+};
+
+function validateMetaLen(content: string): GateResult {
+  if (content.length < 50 || content.length > 160) {
+    return {
+      kind: "fail",
+      gate: "meta_description",
+      reason: `Meta description length ${content.length} is outside 50–160 range.`,
+      details: { length: content.length },
+    };
+  }
+  return { kind: "pass", gate: "meta_description" };
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+export const ALL_GATES: Array<{ name: GateName; fn: GateFn }> = [
+  { name: "wrapper", fn: gateWrapper },
+  { name: "scope_prefix", fn: gateScopePrefix },
+  { name: "html_basics", fn: gateHtmlBasics },
+  { name: "slug_kebab", fn: gateSlugKebab },
+  { name: "meta_description", fn: gateMetaDescription },
+];
+
+export type RunGatesResult =
+  | { kind: "passed"; gates_run: GateName[] }
+  | {
+      kind: "failed";
+      gates_run: GateName[];
+      first_failure: GateFail;
+    };
+
+/**
+ * Run gates in declared order, short-circuiting on the first failure.
+ * The caller uses `first_failure` to mark the slot failed and record
+ * the specific gate in the event log.
+ */
+export function runGates(ctx: GateContext): RunGatesResult {
+  const run: GateName[] = [];
+  for (const { name, fn } of ALL_GATES) {
+    const res = fn(ctx);
+    run.push(name);
+    if (res.kind === "fail") {
+      return { kind: "failed", gates_run: run, first_failure: res };
+    }
+  }
+  return { kind: "passed", gates_run: run };
+}


### PR DESCRIPTION
## Sub-slice plan (M3-5)

Fifth M3 slice. Inserts a `validating` state between Anthropic and succeeded that runs HC-check gates against the generated HTML. First failing gate short-circuits the slot.

## Design confirmations

**Gates as pure functions.** Each gate takes `{ html, slug, prefix, design_system_version }` and returns `{ kind: "pass" | "fail", gate, reason, details? }`. No DB reads, no side effects. `runGates` sequences them in declared order.

**First-failure short-circuit.** Stops at the first gate that says no. Operators triage the named gate, fix the prompt / brief, retry. Concatenating all failures would let an operator mask latent issues by fixing the loudest one and assuming the rest are incidental.

**Gate failure still records cost.** We paid Anthropic before the gate ran, so `cost_usd_cents`, `input_tokens`, `output_tokens`, and the parent `generation_jobs.total_*_tokens` all accumulate regardless of gate outcome. The billing audit trail must not lose anything.

**Job status transitions on mixed outcomes.**
- all slots succeeded → `'succeeded'`
- all slots failed → `'failed'`
- mixed → `'partial'`

Encoded in the aggregation UPDATE as a CASE expression; integration test pins the pure-fail case.

**Slug uniqueness is NOT a gate.** M3-6's pages UNIQUE (site_id, slug) pre-commit INSERT is the single enforcement point. Duplicating the check here would create a race window that lets two workers both pass the gate and then both try to insert.

**Regex-based HTML scan, pragmatic.** Tolerant of common Claude-output formatting (attribute order, whitespace, quote style). Not bulletproof against hostile input. Doc comment pins the limitations. Parser-based scan is a future upgrade once empirical fragility shows.

**5 substantive gates, 3 deferred with reason.**

Shipping: `wrapper` (HC-2), `scope_prefix` (HC-4), `html_basics`, `slug_kebab`, `meta_description`.

Deferred with follow-up pointer:
- `allowed_components` (HC-1) — needs DS component registry wired into worker.
- `no_freeform_html` (HC-3) — same dependency.
- `word_count` — needs per-template min/max columns on `design_templates`.

Targeted for an M3-5b follow-up slice. `scope_prefix` catches the dominant "Claude invented classes" failure mode today, so the deferral doesn't leave the biggest write-safety gap unmitigated.

## Risks identified and mitigated (M3-5 scope)

| # | Hotspot | Mitigation |
| --- | --- | --- |
| 1 | Gate passes silently on a malformed response → garbage page would publish to WP. | 5 gates cover the dominant failure modes (wrapper, scope prefix, h1 count, hrefs, alt text, slug format, meta length). Unit tests cover every documented failure mode of every gate. |
| 2 | Gate failure wipes the cost record → billing audit broken. | Cost + tokens written to slot AND event log regardless of gate outcome. Integration test asserts slot.cost_usd_cents > 0 after failure. |
| 3 | First-failure short-circuit hides a concurrent issue. | Accepted tradeoff (see design confirmation above). |
| 4 | Scope-prefix regex too tight / too loose → false positives or false negatives. | Allows multi-segment suffixes (`ls-hero-title`) to match M1f's form. Rejects bare prefix (`ls`) and inverted (`hero-ls`). Both paths tested. |
| 5 | Meta attribute-order variation causes false failure. | Regex tries both orders (`name` then `content`, `content` then `name`). Both paths tested. |
| 6 | Lease stolen between Anthropic response and validating UPDATE → worker keeps writing to someone else's slot. | Every UPDATE carries `AND worker_id = $self AND state = 'validating'`. M3-3 guard pattern extended. |
| 7 | Job status mis-computed on mixed outcomes. | Aggregation CASE: succeeded / partial / failed based on counts; pinned by integration test for the pure-failure case. |
| 8 | A future gate refactor skips a gate and nobody notices. | `runGates` returns `gates_run` array in the response + logs it in `state_advanced` to `validating` event. Audit trail shows exactly which gates ran. |

**Deliberately deferred (with pointers):**
- 3 gates listed above → M3-5b follow-up.
- Parser-based HTML scan (parse5 / cheerio) → revisit if regex scans produce false results empirically.
- Per-gate metrics (pass rate, failure distribution) → M7 observability work.

## Files

- `lib/quality-gates.ts` *(new)* — GateResult type, 5 gate fns, runGates.
- `lib/batch-worker.ts` — processSlotAnthropic now inserts validating state + runs gates + branches to succeeded/failed.

## Tests

- `lib/__tests__/quality-gates.test.ts` — **25 cases** covering every gate's pass/fail paths + runGates order/short-circuit.
- `lib/__tests__/batch-worker-gates.test.ts` — **2 integration cases**:
  - All-pass: slot ends succeeded, state trail = generating → validating → succeeded, job status = succeeded.
  - Wrapper-fail: slot ends failed with `QUALITY_GATE_FAILED`, `quality_gate_failures[0].gate = 'wrapper'`, `gate_failed` event present, cost still recorded, job status = failed.

## Verification

- `tsc --noEmit` clean
- `next lint` clean
- `next build` clean
- `npm test` not runnable in sandbox; CI exercises the suite.

## Next

After merge, auto-continue to **M3-6** (WP publish with pre-commit pages row claim + pg_advisory_xact_lock).

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42