### PR TITLE
M3-7: retry loop with exponential backoff + budget cap

### DIFF
--- a/lib/__tests__/batch-worker-publish.test.ts
+++ b/lib/__tests__/batch-worker-publish.test.ts
@@ -478,13 +478,18 @@ describe("WP failure path", () => {
     if (!leased) throw new Error("lease failed");
 
     const counters = { getBySlug: 0, create: 0, update: 0 };
+    // retryable=false so the M3-7 retry loop short-circuits to
+    // terminal-fail immediately. The retry-enabled behaviour is
+    // pinned by batch-worker-retry.test.ts; this test stays focused
+    // on the M3-6 cost-preservation + publish_failed-event
+    // invariant.
     const wp = makeWp({
       counters,
       createReturns: {
         ok: false,
-        code: "WP_API_ERROR",
-        message: "500 Server Error",
-        retryable: true,
+        code: "WP_API_NON_RETRYABLE",
+        message: "400 Bad Request",
+        retryable: false,
       },
     });
 
@@ -500,8 +505,8 @@ describe("WP failure path", () => {
       .eq("id", leased.id)
       .single();
     expect(slot?.state).toBe("failed");
-    expect(slot?.last_error_code).toBe("WP_API_ERROR");
-    expect(slot?.last_error_message).toContain("500");
+    expect(slot?.last_error_code).toBe("WP_API_NON_RETRYABLE");
+    expect(slot?.last_error_message).toContain("400");
     expect(Number(slot?.cost_usd_cents)).toBeGreaterThan(0);
 
     const { data: events } = await svc

--- a/lib/__tests__/batch-worker-retry.test.ts
+++ b/lib/__tests__/batch-worker-retry.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it } from "vitest";
+
+import { createBatchJob } from "@/lib/batch-jobs";
+import {
+  leaseNextPage,
+  processSlotAnthropic,
+  RETRY_BACKOFF_MS,
+  RETRY_MAX_ATTEMPTS,
+} from "@/lib/batch-worker";
+import { createComponent } from "@/lib/components";
+import {
+  activateDesignSystem,
+  createDesignSystem,
+} from "@/lib/design-systems";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { createTemplate } from "@/lib/templates";
+import type { AnthropicCallFn } from "@/lib/anthropic-call";
+import type { WpCallBundle } from "@/lib/batch-publisher";
+
+import {
+  minimalComponentContentSchema,
+  minimalComposition,
+  seedSite,
+} from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M3-7 — Retry loop with budget cap.
+//
+// Pins:
+//   1. Retryable publish failure under budget → slot 'pending',
+//      retry_after set to now()+backoff, attempts carried over.
+//   2. retry_after in the future → leaseNextPage skips the slot.
+//   3. retry_after in the past → slot is leasable again.
+//   4. After RETRY_MAX_ATTEMPTS (3) failures, slot → terminal 'failed'
+//      + job.failed_count++, regardless of retryable flag.
+//   5. Non-retryable error → terminal 'failed' immediately (no
+//      deferral) even if budget remains.
+//   6. Retry budget is exhausted only on failures that got to the
+//      publish step; successful retries zero out the path.
+// ---------------------------------------------------------------------------
+
+async function seedActiveTemplateForSite(siteId: string): Promise<string> {
+  const ds = await createDesignSystem({
+    site_id: siteId,
+    version: 1,
+    tokens_css: "",
+    base_styles: "",
+  });
+  if (!ds.ok) throw new Error(ds.error.message);
+  for (const name of ["hero-centered", "footer-default"]) {
+    const c = await createComponent({
+      design_system_id: ds.data.id,
+      name,
+      variant: null,
+      category: name.split("-")[0] ?? "misc",
+      html_template: `<section>${name}</section>`,
+      css: ".ls-x {}",
+      content_schema: minimalComponentContentSchema(),
+    });
+    if (!c.ok) throw new Error(c.error.message);
+  }
+  const t = await createTemplate({
+    design_system_id: ds.data.id,
+    page_type: "homepage",
+    name: "homepage-default",
+    composition: minimalComposition(),
+    required_fields: { hero: ["headline"] },
+    is_default: true,
+  });
+  if (!t.ok) throw new Error(t.error.message);
+  const activated = await activateDesignSystem(ds.data.id, 1);
+  if (!activated.ok) throw new Error(activated.error.message);
+  return t.data.id;
+}
+
+async function seedSingleSlotBatch(): Promise<{
+  jobId: string;
+  slotId: string;
+}> {
+  const site = await seedSite({ prefix: "ls" });
+  const templateId = await seedActiveTemplateForSite(site.id);
+  const res = await createBatchJob({
+    site_id: site.id,
+    template_id: templateId,
+    slots: [{ inputs: { slug: "retry-target", title: "Retry" } }],
+    idempotency_key: `retry-${Date.now()}-${Math.random()}`,
+    created_by: null,
+  });
+  if (!res.ok) throw new Error(res.error.message);
+  const svc = getServiceRoleClient();
+  const { data: slots } = await svc
+    .from("generation_job_pages")
+    .select("id")
+    .eq("job_id", res.data.job_id)
+    .limit(1);
+  return { jobId: res.data.job_id, slotId: slots![0]!.id as string };
+}
+
+const DESCRIPTIVE_META =
+  "A descriptive meta summary of the page that is comfortably between fifty and one hundred sixty characters.";
+
+const GATE_PASSING_HTML = [
+  '<section class="ls-hero" data-ds-version="1">',
+  '  <h1 class="ls-hero-title">Hello</h1>',
+  '  <p class="ls-hero-body"><a href="/x">x</a></p>',
+  '  <img src="/a.png" alt="d" class="ls-hero-image"/>',
+  `  <meta name="description" content="${DESCRIPTIVE_META}"/>`,
+  "</section>",
+].join("\n");
+
+function stubAnthropic(): AnthropicCallFn {
+  return async (req) => ({
+    id: `resp_${req.idempotency_key}`,
+    model: req.model,
+    content: [{ type: "text", text: GATE_PASSING_HTML }],
+    stop_reason: "end_turn",
+    usage: { input_tokens: 100, output_tokens: 50 },
+  });
+}
+
+function stubWpFailing(opts: {
+  code: string;
+  retryable: boolean;
+}): WpCallBundle {
+  return {
+    getBySlug: async () => ({ ok: true, found: null }),
+    create: async () => ({
+      ok: false,
+      code: opts.code,
+      message: `stubbed ${opts.code}`,
+      retryable: opts.retryable,
+    }),
+    update: async () => ({ ok: true, wp_page_id: 0 }),
+  };
+}
+
+function stubWpSucceeding(): WpCallBundle {
+  return {
+    getBySlug: async () => ({ ok: true, found: null }),
+    create: async ({ slug }) => ({ ok: true, wp_page_id: 1234, slug }),
+    update: async ({ wp_page_id }) => ({ ok: true, wp_page_id }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Retryable failure under budget → defer with retry_after
+// ---------------------------------------------------------------------------
+
+describe("retry: retryable failure with budget", () => {
+  it("sets state=pending and retry_after to now()+backoff", async () => {
+    const { slotId } = await seedSingleSlotBatch();
+    const leased = await leaseNextPage("retry-worker");
+    if (!leased) throw new Error("lease failed");
+    expect(leased.attempts).toBe(1);
+
+    const before = Date.now();
+    await processSlotAnthropic(leased.id, "retry-worker", {
+      anthropicCall: stubAnthropic(),
+      wp: stubWpFailing({ code: "WP_API_ERROR", retryable: true }),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: slot } = await svc
+      .from("generation_job_pages")
+      .select(
+        "state, worker_id, lease_expires_at, retry_after, attempts, last_error_code",
+      )
+      .eq("id", slotId)
+      .single();
+    expect(slot?.state).toBe("pending");
+    expect(slot?.worker_id).toBeNull();
+    expect(slot?.lease_expires_at).toBeNull();
+    expect(slot?.attempts).toBe(1);
+    expect(slot?.last_error_code).toBe("WP_API_ERROR");
+
+    const retryAt = new Date(slot!.retry_after as string).getTime();
+    // Backoff for attempts=1 is 1s. Allow a ~500ms window for test lag.
+    expect(retryAt).toBeGreaterThanOrEqual(before + RETRY_BACKOFF_MS[1]! - 500);
+    expect(retryAt).toBeLessThan(before + RETRY_BACKOFF_MS[1]! + 2_000);
+
+    // retry_scheduled event logged.
+    const { data: events } = await svc
+      .from("generation_events")
+      .select("event, details")
+      .eq("page_slot_id", slotId)
+      .eq("event", "retry_scheduled");
+    expect(events?.length).toBe(1);
+    expect((events![0]!.details as { backoff_ms: number }).backoff_ms).toBe(
+      RETRY_BACKOFF_MS[1],
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// leaseNextPage respects retry_after
+// ---------------------------------------------------------------------------
+
+describe("leaseNextPage retry_after honoured", () => {
+  it("skips a pending slot whose retry_after is in the future", async () => {
+    const { slotId } = await seedSingleSlotBatch();
+    const svc = getServiceRoleClient();
+    await svc
+      .from("generation_job_pages")
+      .update({ retry_after: new Date(Date.now() + 60_000).toISOString() })
+      .eq("id", slotId);
+
+    const leased = await leaseNextPage("future-worker");
+    expect(leased).toBeNull();
+  });
+
+  it("picks up a pending slot whose retry_after has passed", async () => {
+    const { slotId } = await seedSingleSlotBatch();
+    const svc = getServiceRoleClient();
+    await svc
+      .from("generation_job_pages")
+      .update({ retry_after: new Date(Date.now() - 5_000).toISOString() })
+      .eq("id", slotId);
+
+    const leased = await leaseNextPage("past-worker");
+    expect(leased).not.toBeNull();
+    expect(leased?.id).toBe(slotId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exhausting the retry budget → terminal
+// ---------------------------------------------------------------------------
+
+describe("retry: budget exhaustion", () => {
+  it("marks the slot 'failed' on the Nth consecutive retryable failure", async () => {
+    const { jobId, slotId } = await seedSingleSlotBatch();
+    const svc = getServiceRoleClient();
+
+    for (let attempt = 1; attempt <= RETRY_MAX_ATTEMPTS; attempt++) {
+      // Clear retry_after from prior iteration so the test doesn't
+      // have to wait out the real backoff.
+      await svc
+        .from("generation_job_pages")
+        .update({ retry_after: null })
+        .eq("id", slotId);
+
+      const leased = await leaseNextPage(`ex-worker-${attempt}`);
+      expect(leased?.id).toBe(slotId);
+      expect(leased?.attempts).toBe(attempt);
+
+      await processSlotAnthropic(leased!.id, `ex-worker-${attempt}`, {
+        anthropicCall: stubAnthropic(),
+        wp: stubWpFailing({ code: "WP_API_ERROR", retryable: true }),
+      });
+
+      const { data: slot } = await svc
+        .from("generation_job_pages")
+        .select("state, attempts")
+        .eq("id", slotId)
+        .single();
+
+      if (attempt < RETRY_MAX_ATTEMPTS) {
+        expect(slot?.state).toBe("pending");
+      } else {
+        expect(slot?.state).toBe("failed");
+      }
+      expect(slot?.attempts).toBe(attempt);
+    }
+
+    const { data: job } = await svc
+      .from("generation_jobs")
+      .select("status, failed_count")
+      .eq("id", jobId)
+      .single();
+    expect(job?.failed_count).toBe(1);
+    expect(job?.status).toBe("failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-retryable → terminal immediately
+// ---------------------------------------------------------------------------
+
+describe("retry: non-retryable is terminal immediately", () => {
+  it("marks the slot 'failed' on first failure when code is non-retryable", async () => {
+    const { jobId, slotId } = await seedSingleSlotBatch();
+
+    const leased = await leaseNextPage("nonret-worker");
+    if (!leased) throw new Error("lease failed");
+    expect(leased.attempts).toBe(1);
+
+    await processSlotAnthropic(leased.id, "nonret-worker", {
+      anthropicCall: stubAnthropic(),
+      // SLUG_CONFLICT is flagged non-retryable in publishSlot.
+      wp: stubWpFailing({ code: "SLUG_CONFLICT", retryable: false }),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: slot } = await svc
+      .from("generation_job_pages")
+      .select("state, attempts, retry_after")
+      .eq("id", slotId)
+      .single();
+    expect(slot?.state).toBe("failed");
+    expect(slot?.attempts).toBe(1);
+    expect(slot?.retry_after).toBeNull();
+
+    const { data: job } = await svc
+      .from("generation_jobs")
+      .select("status, failed_count")
+      .eq("id", jobId)
+      .single();
+    expect(job?.failed_count).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retry eventually succeeds → zero failed_count, job status 'succeeded'
+// ---------------------------------------------------------------------------
+
+describe("retry: eventual success", () => {
+  it("first attempt fails retryably, second attempt succeeds → job 'succeeded'", async () => {
+    const { jobId, slotId } = await seedSingleSlotBatch();
+    const svc = getServiceRoleClient();
+
+    // Attempt 1: retryable failure.
+    const first = await leaseNextPage("eventual-1");
+    if (!first) throw new Error("lease failed");
+    await processSlotAnthropic(first.id, "eventual-1", {
+      anthropicCall: stubAnthropic(),
+      wp: stubWpFailing({ code: "WP_API_ERROR", retryable: true }),
+    });
+
+    // Fast-forward past retry_after so the next lease picks it up.
+    await svc
+      .from("generation_job_pages")
+      .update({ retry_after: null })
+      .eq("id", slotId);
+
+    // Attempt 2: succeeds.
+    const second = await leaseNextPage("eventual-2");
+    if (!second) throw new Error("re-lease failed");
+    expect(second.id).toBe(slotId);
+    expect(second.attempts).toBe(2);
+    await processSlotAnthropic(second.id, "eventual-2", {
+      anthropicCall: stubAnthropic(),
+      wp: stubWpSucceeding(),
+    });
+
+    const { data: slot } = await svc
+      .from("generation_job_pages")
+      .select("state, attempts, wp_page_id")
+      .eq("id", slotId)
+      .single();
+    expect(slot?.state).toBe("succeeded");
+    expect(slot?.attempts).toBe(2);
+    expect(Number(slot?.wp_page_id)).toBe(1234);
+
+    const { data: job } = await svc
+      .from("generation_jobs")
+      .select("status, succeeded_count, failed_count")
+      .eq("id", jobId)
+      .single();
+    expect(job?.status).toBe("succeeded");
+    expect(job?.succeeded_count).toBe(1);
+    expect(job?.failed_count).toBe(0);
+  });
+});

--- a/lib/batch-worker.ts
+++ b/lib/batch-worker.ts
@@ -66,6 +66,19 @@ import { getServiceRoleClient } from "@/lib/supabase";
 export const DEFAULT_LEASE_MS = 180_000; // 180s per M3 plan §2.
 export const DEFAULT_HEARTBEAT_MS = 30_000;
 
+// M3-7 retry budget. attempts is bumped on every lease; a slot that
+// fails on its 3rd attempt has no remaining budget and goes terminal.
+export const RETRY_MAX_ATTEMPTS = 3;
+
+// Indexed by the `attempts` value AT THE TIME OF FAILURE (i.e. 1 = first
+// attempt just failed, next retry waits 1s; 2 = second attempt just
+// failed, next retry waits 5s). A 3rd failure exits the table and goes
+// terminal per the cap above.
+export const RETRY_BACKOFF_MS: Record<number, number> = {
+  1: 1_000,
+  2: 5_000,
+};
+
 export type LeasedSlot = {
   id: string;
   job_id: string;
@@ -117,12 +130,20 @@ export async function leaseNextPage(
     try {
       await c.query("BEGIN");
 
+      // M3-7: pending slots with a retry_after in the future are
+      // deferred (waiting out their exponential-backoff window) and
+      // must be excluded. Expired leases on any non-terminal state
+      // are always eligible — the reaper path handles stuck workers
+      // regardless of retry_after.
       const candidate = await c.query<{ id: string }>(
         `
         SELECT id
           FROM generation_job_pages
          WHERE (
-                 state = 'pending'
+                 (
+                   state = 'pending'
+                   AND (retry_after IS NULL OR retry_after < now())
+                 )
                  OR (
                    state IN ('leased', 'generating', 'validating', 'publishing')
                    AND lease_expires_at IS NOT NULL
@@ -884,9 +905,9 @@ export async function processSlotAnthropic(
     );
 
     if (!result.ok) {
-      // Record the publish failure: slot → 'failed', parent job
-      // failed_count++. Cost was already accumulated above, so the
-      // billing side of the audit stays intact.
+      // M3-7: decide retry-defer vs. terminal-fail. Retry-defer when
+      // the error is retryable AND we still have budget
+      // (attempts < RETRY_MAX_ATTEMPTS). Anything else is terminal.
       await withClient(opts.client ?? null, async (c) => {
         await c.query(
           `
@@ -906,6 +927,67 @@ export async function processSlotAnthropic(
             workerId,
           ],
         );
+
+        // Fetch current attempts to decide. We bumped it on lease so
+        // this value is "attempts made including the one we just
+        // completed (failed)".
+        const attemptRow = await c.query<{ attempts: number }>(
+          `SELECT attempts FROM generation_job_pages WHERE id = $1`,
+          [slotId],
+        );
+        const attempts = attemptRow.rows[0]?.attempts ?? RETRY_MAX_ATTEMPTS;
+        const shouldRetry =
+          result.retryable && attempts < RETRY_MAX_ATTEMPTS;
+
+        if (shouldRetry) {
+          // Defer: slot → 'pending' with retry_after set to the
+          // backoff for this attempt count. The lease-candidate query
+          // excludes pending rows whose retry_after is in the future,
+          // so the reaper and other workers skip this slot until its
+          // backoff expires.
+          const backoffMs = RETRY_BACKOFF_MS[attempts] ?? 30_000;
+
+          const deferred = await c.query(
+            `
+            UPDATE generation_job_pages
+               SET state = 'pending',
+                   worker_id = NULL,
+                   lease_expires_at = NULL,
+                   retry_after = now() + ($3 || ' milliseconds')::interval,
+                   last_error_code = $4,
+                   last_error_message = $5,
+                   updated_at = now()
+             WHERE id = $1 AND worker_id = $2 AND state = 'publishing'
+            `,
+            [slotId, workerId, String(backoffMs), result.code, result.message],
+          );
+          if ((deferred.rowCount ?? 0) === 0) {
+            throw new Error(
+              `processSlotAnthropic: lease stolen while deferring slot ${slotId}`,
+            );
+          }
+          await c.query(
+            `
+            INSERT INTO generation_events (job_id, page_slot_id, event, details)
+            VALUES ($1, $2, 'retry_scheduled',
+                    jsonb_build_object('attempts', $3::int,
+                                       'backoff_ms', $4::int,
+                                       'code', $5::text,
+                                       'worker_id', $6::text))
+            `,
+            [
+              ctx.job_id,
+              slotId,
+              attempts,
+              backoffMs,
+              result.code,
+              workerId,
+            ],
+          );
+          return;
+        }
+
+        // Terminal failure path: cap reached OR non-retryable.
         const markFailed = await c.query(
           `
           UPDATE generation_job_pages
@@ -955,9 +1037,11 @@ export async function processSlotAnthropic(
           INSERT INTO generation_events (job_id, page_slot_id, event, details)
           VALUES ($1, $2, 'state_advanced',
                   jsonb_build_object('to', 'failed', 'worker_id', $3::text,
-                                     'reason', 'publish_failed'))
+                                     'reason', 'publish_failed',
+                                     'attempts', $4::int,
+                                     'retryable', $5::boolean))
           `,
-          [ctx.job_id, slotId, workerId],
+          [ctx.job_id, slotId, workerId, attempts, result.retryable],
         );
       });
     }

--- a/supabase/migrations/0009_m3_7_retry_after.sql
+++ b/supabase/migrations/0009_m3_7_retry_after.sql
@@ -1,0 +1,24 @@
+-- M3-7 — Retry backoff column
+--
+-- retry_after stamps the earliest clock time at which the lease-next
+-- query can pick up a slot that was deferred after a retryable
+-- failure. Only consulted when state = 'pending'; other states have
+-- their own lifecycle timer (lease_expires_at). NULL means "eligible
+-- now" (first attempt, or no retry deferral was set).
+--
+-- The retry loop in lib/batch-worker.ts (processSlotAnthropic
+-- publish-fail branch) sets retry_after on a retryable failure with
+-- remaining budget; the leaseNextPage SQL in the same file filters it
+-- out when retry_after is in the future.
+--
+-- Retries are capped at 3 attempts per slot, the attempts column
+-- already in place carries the counter. A terminal failure at the
+-- cap OR on a non-retryable code bypasses retry_after entirely.
+
+ALTER TABLE generation_job_pages
+  ADD COLUMN retry_after timestamptz;
+
+COMMENT ON COLUMN generation_job_pages.retry_after IS
+  'Earliest wall-clock time the lease-next query may pick this slot up. '
+  'Set by the retry loop on a retryable failure with remaining budget. '
+  'NULL means eligible immediately.';


### PR DESCRIPTION
## Sub-slice plan (M3-7)

Seventh M3 slice. Retry semantics the plan §3.3 specified: up to 3 attempts per slot, exponential backoff 1s / 5s, retry only on retryable errors. Past the cap OR on a non-retryable code, the slot goes terminal `failed`.

## Design confirmations

**Retry path reuses existing state machine.** A retryable failure with remaining budget drops the slot back to `pending` with a `retry_after` timestamp; the normal `leaseNextPage` then picks it up once the window expires. No new "retry queue" abstraction, no separate worker. The existing lease / attempts / reaper machinery from M3-3 is already the retry engine; M3-7 just teaches it to wait.

**`retry_after` column, not overloading `lease_expires_at`.** `lease_expires_at` is NULL on pending slots (enforced by the lease-coherence CHECK). Overloading it to also mean "retry deferral" would tangle two lifecycle timers. New column keeps the semantics distinct.

**Backoff indexed by the failing attempt's count.** After attempt 1 fails → wait 1s; after attempt 2 fails → wait 5s. After attempt 3 fails → terminal. The `attempts` counter is already bumped on lease (M3-3), so the value at failure time is exactly what we key the backoff table off.

**Gate failures are NOT retried.** Regenerating with the same `anthropic_idempotency_key` returns the same HTML, which would fail the same gate. Operator must fix the prompt / brief and create a fresh batch. Slot stays terminal-`failed` with `QUALITY_GATE_FAILED`.

**Anthropic-call exceptions fall back to the reaper path.** If `processSlotAnthropic` throws before the publish branch runs, the slot sits in `generating` with an expired lease; the reaper resets it to `pending`; the next lease bumps attempts. That implicit retry path existed since M3-3. Noted in the risk audit that the cap isn't enforced there — acceptable for v1 given rarity; M3-7b if empirical data argues otherwise.

## Risks identified and mitigated (M3-7 scope)

| # | Hotspot | Mitigation |
| --- | --- | --- |
| 1 | Infinite retry loop (retryable error on every attempt) burns budget forever. | `RETRY_MAX_ATTEMPTS = 3` cap. Past cap → terminal regardless of retryable flag. Budget-exhaustion test pins this. |
| 2 | Backoff window violated by a concurrent worker picking up the slot early. | `retry_after` is a timestamp column; `leaseNextPage` excludes pending slots whose value is still in the future. Reaper's expired-lease path touches `state` and `lease_expires_at` only — `retry_after` is preserved across reaper runs. "lease skips future retry_after" test pins this. |
| 3 | Anthropic double-billed on retry. | Deterministic `anthropic_idempotency_key` from M3-2 is unchanged across attempts; Anthropic returns cached response. M3-4 token-reconciliation test still holds. |
| 4 | attempts counter inflation from reaper. | attempts is bumped in the lease SQL (M3-3), not in the retry path. Reaper only resets state → pending; next lease's bump is the same increment path as a first attempt. Cap enforcement is consistent across both retry origins. |
| 5 | Cost double-counted on retry. | Cost fields (slot + job) write once per Anthropic response; cached response on retry has the same usage numbers. |
| 6 | Non-retryable error mis-classified as retryable → loops instead of failing fast. | `retryable: false` is set explicitly by publishSlot on SLUG_CONFLICT and by WP error mappers on 4xx client errors. 5xx + network errors stay retryable. Test pins the SLUG_CONFLICT non-retryable path. |
| 7 | Retrying a successful slot. | `shouldRetry` branch only fires on `publishSlot` returning `!result.ok`. Success path proceeds to state=succeeded as before. |
| 8 | Cap-reached terminal failure missing audit info. | `state_advanced` event on terminal carries `attempts` and `retryable` flags so operator can see whether the cap was the reason or a non-retryable code. |

**Deliberately deferred:**
- **Retry for gate failures.** Intentionally not retried (see design confirmation).
- **Retry for thrown exceptions in `processSlotAnthropic`.** Reaper handles recovery; cap enforcement on that path is an M3-7b cleanup.
- **Jitter on backoff windows.** Not needed yet — a single operator running a single batch has no thundering-herd concern.

## Files

- `supabase/migrations/0009_m3_7_retry_after.sql` *(new)* — `ADD COLUMN retry_after timestamptz`.
- `lib/batch-worker.ts` — `RETRY_MAX_ATTEMPTS` + `RETRY_BACKOFF_MS` exports; `leaseNextPage` filter update; `processSlotAnthropic` publish-fail branch with retry-vs-terminal decision.

## Tests

`lib/__tests__/batch-worker-retry.test.ts` — 6 cases:

- **Retryable + budget (1):** slot → pending, `retry_after` ≈ `now()+1s`, attempts=1, `retry_scheduled` event with backoff_ms=1000.
- **Lease respects retry_after (2):** future value → lease returns null; past value → lease picks up.
- **Budget exhaustion (1):** 3 consecutive retryable failures → slot terminal `failed`, attempts=3, job.failed_count=1, status=`failed`.
- **Non-retryable terminal (1):** SLUG_CONFLICT on first attempt → `failed` immediately, no `retry_after` set.
- **Eventual success (1):** retryable fail then WP success → slot `succeeded` at attempts=2, job status `succeeded`, failed_count=0.

## Verification

- `tsc --noEmit` clean
- `next lint` clean
- `next build` clean
- `npm test` not runnable in sandbox; CI exercises the suite.

## Next

After merge, auto-continue to **M3-8** (progress UI + cancel button — final M3 slice).

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42