### PR TITLE
chore: UX-debt backlog — scope_prefix + admin form audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,3 +91,55 @@ A plan without a populated "Risks identified and mitigated" section is not ready
 - Don't loop me in on routine errors — fix and retry
 - Do loop me in on design decisions or scope questions
 - Keep PRs small enough to review in 5 minutes
+
+## Backlog — UX debt
+
+Operator-facing jargon that leaks DB column names or internal implementation
+detail. Pick up on a cleanup slice that naturally lives in M6 (Per-Page
+Iteration UI, where admin UX polish fits), or earlier if a sibling slice
+happens to be in the same file.
+
+### High — remove scope_prefix from the Add Site form
+**Surface:** `components/AddSiteModal.tsx` line ~211 "Scope prefix" field.
+**Problem:** A solo-dev operator adding a client site shouldn't have to
+understand CSS-scoping strategy. The field leaks `sites.prefix` into the UX.
+**Fix:** auto-generate server-side at site creation. Algorithm:
+1. Lower-case, ASCII-slugify the site name; keep only `[a-z0-9]`.
+2. Take the first 2–4 characters.
+3. If that prefix already exists in `sites.prefix`, append a single digit
+   (2, 3, …) until unique, capped at length 4.
+4. If still colliding past `<prefix>9`, fall back to `<prefix>` + base-36
+   counter.
+
+Hide the field from the form entirely. `lib/sites.createSite` accepts
+`prefix` today; flip it to optional + server-compute when absent.
+
+### Medium — jargon in design-system authoring forms
+Audited 2026-04; current offenders:
+
+- `components/TemplateFormModal.tsx`:
+  - "Composition (JSON array)" → "Template composition"
+  - "required_fields (JSON)" → "Required fields per component"
+  - "seo_defaults JSON (optional)" → "SEO defaults (optional)"
+- `components/ComponentFormModal.tsx`:
+  - "content_schema (JSON)" → "Content shape (JSON Schema)"
+  - "image_slots JSON (optional)" → "Image slots (optional)"
+- `components/CreateDesignSystemModal.tsx`:
+  - "tokens.css" / "base-styles.css" — keep the filenames (designers write
+    CSS; the names are accurate), but add a one-line sub-label explaining
+    what each section controls.
+
+Design-system authoring is a developer surface, so full de-jargoning isn't
+the goal — just hide the raw column names. JSON editing UX itself
+(`<Textarea>` with JSON.parse in onBlur) can survive.
+
+### Low — admin-surface labels that expose IDs
+Scan done 2026-04, none found on the primary surfaces:
+
+- `app/admin/batches` / `[id]` — shows "WP id" as a column, which is
+  operator-meaningful (they can click through to WP admin); keep.
+- `/admin/users` — email + role + status, clean.
+- `/admin/sites` — name + URL + status, clean.
+
+No `design_system_id`, `version_lock`, `wp_page_id`, `created_by_uuid`
+leaked into labels. Revisit if future surfaces add them.


### PR DESCRIPTION
## Summary

Captures two UX-debt items Steven flagged during M3 sign-off testing. No code change — CLAUDE.md's new `Backlog — UX debt` section is the single source of truth for this debt until a cleanup slice lands.

- **High:** auto-generate `sites.prefix` server-side at site creation, hide the field from `AddSiteModal`. Full algorithm in the backlog note.
- **Medium:** re-label design-system authoring forms to hide DB column names. Specific labels listed.
- **Low:** audit of remaining admin surfaces for leaked IDs — clean as of today.

Targeted at M6 (Per-Page Iteration UI) or an earlier cleanup slice if one lands nearby.

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42