### PR TITLE
fix(admin/sites): server-render the list + revalidatePath on create

### DIFF
--- a/app/admin/sites/page.tsx
+++ b/app/admin/sites/page.tsx
@@ -1,92 +1,30 @@
-"use client";
-
-import { useCallback, useEffect, useState } from "react";
-
-import { AddSiteModal } from "@/components/AddSiteModal";
-import { SitesTable } from "@/components/SitesTable";
-import { Button } from "@/components/ui/button";
+import { SitesListClient } from "@/components/SitesListClient";
+import { listSites } from "@/lib/sites";
 import type { SiteListItem } from "@/lib/tool-schemas";
 
-type LoadState =
-  | { status: "loading" }
-  | { status: "ready"; sites: SiteListItem[] }
-  | { status: "error"; message: string };
+// Server component. Reads the site list at request time via
+// lib/sites.listSites (service-role; bypasses RLS) and passes it into
+// the client shell that owns modal state + create button. The
+// previous implementation was a client component that fetched
+// /api/sites/list on mount — under Next's default caching for static
+// page shells, stale responses could persist even across full
+// reloads. Reading on the server eliminates every layer between
+// Supabase and the DOM where a stale list could survive.
 
-export default function ManageSitesPage() {
-  const [state, setState] = useState<LoadState>({ status: "loading" });
-  const [modalOpen, setModalOpen] = useState(false);
+export const dynamic = "force-dynamic";
 
-  const load = useCallback(async () => {
-    setState({ status: "loading" });
-    try {
-      const res = await fetch("/api/sites/list", { cache: "no-store" });
-      const payload = await res.json().catch(() => null);
-      if (!res.ok || !payload?.ok) {
-        setState({
-          status: "error",
-          message:
-            payload?.error?.message ??
-            `Failed to load sites (HTTP ${res.status}).`,
-        });
-        return;
-      }
-      setState({
-        status: "ready",
-        sites: (payload.data?.sites ?? []) as SiteListItem[],
-      });
-    } catch (err) {
-      setState({
-        status: "error",
-        message: `Network error: ${err instanceof Error ? err.message : String(err)}`,
-      });
-    }
-  }, []);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
-
-  return (
-    <>
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-semibold">Manage sites</h1>
-          <p className="text-sm text-muted-foreground">
-            WordPress sites connected to this builder.
-          </p>
-        </div>
-        <Button onClick={() => setModalOpen(true)}>Add new site</Button>
+export default async function ManageSitesPage() {
+  const result = await listSites();
+  if (!result.ok) {
+    return (
+      <div
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        role="alert"
+      >
+        Failed to load sites: {result.error.message}
       </div>
-
-      <div className="mt-6">
-        {state.status === "loading" && (
-          <div className="rounded-md border p-8 text-center">
-            <p className="text-sm text-muted-foreground">Loading sites…</p>
-          </div>
-        )}
-
-        {state.status === "error" && (
-          <div
-            className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-            role="alert"
-          >
-            <span>{state.message}</span>
-            <Button variant="outline" size="sm" onClick={() => void load()}>
-              Retry
-            </Button>
-          </div>
-        )}
-
-        {state.status === "ready" && <SitesTable sites={state.sites} />}
-      </div>
-
-      <AddSiteModal
-        open={modalOpen}
-        onClose={() => setModalOpen(false)}
-        onSuccess={() => {
-          void load();
-        }}
-      />
-    </>
-  );
+    );
+  }
+  const sites: SiteListItem[] = result.data.sites;
+  return <SitesListClient sites={sites} />;
 }

--- a/app/api/sites/register/route.ts
+++ b/app/api/sites/register/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 
 import { createSite } from "@/lib/sites";
 import {
@@ -36,6 +37,12 @@ export async function POST(req: Request) {
   }
 
   const result = await createSite(parsed.data);
+  if (result.ok) {
+    // Bust the cached server-component render of /admin/sites so the
+    // list reflects the new row on the next navigation — without this
+    // the client had to full-reload (reported during M3 sign-off).
+    revalidatePath("/admin/sites");
+  }
   const status = result.ok ? 200 : errorCodeToStatus(result.error.code);
   return NextResponse.json(result, { status });
 }

--- a/components/SitesListClient.tsx
+++ b/components/SitesListClient.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { AddSiteModal } from "@/components/AddSiteModal";
+import { SitesTable } from "@/components/SitesTable";
+import { Button } from "@/components/ui/button";
+import type { SiteListItem } from "@/lib/tool-schemas";
+
+// Client island for /admin/sites. The server component renders the
+// initial list; this shell owns the "Add new site" button + modal
+// state and refreshes the route on successful create via
+// router.refresh(). Paired with the revalidatePath call inside
+// /api/sites/register, the modal's success path is guaranteed to
+// present the new row without a full-page reload.
+
+export function SitesListClient({ sites }: { sites: SiteListItem[] }) {
+  const router = useRouter();
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Manage sites</h1>
+          <p className="text-sm text-muted-foreground">
+            WordPress sites connected to this builder.
+          </p>
+        </div>
+        <Button onClick={() => setModalOpen(true)}>Add new site</Button>
+      </div>
+
+      <div className="mt-6">
+        <SitesTable sites={sites} />
+      </div>
+
+      <AddSiteModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSuccess={() => {
+          // revalidatePath in /api/sites/register already busted the
+          // page's cache; router.refresh() re-fetches the server
+          // component tree so the new row appears immediately.
+          router.refresh();
+        }}
+      />
+    </>
+  );
+}

--- a/lib/__tests__/sites-list.test.ts
+++ b/lib/__tests__/sites-list.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { listSites } from "@/lib/sites";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// Regression pin for the M3 sign-off bug where /admin/sites showed only
+// LeadSource even though four other active sites existed in the DB.
+// listSites must return every non-removed row — no silent filter,
+// no hidden limit, no default pagination that would miss rows.
+// ---------------------------------------------------------------------------
+
+describe("listSites", () => {
+  it("returns every non-removed site regardless of created_at / prefix shape", async () => {
+    // Seed five sites with distinct prefixes mimicking Steven's report
+    // (digit-leading + letter-only). All default to status='active'
+    // inside seedSite.
+    const a = await seedSite({ name: "Alpha", prefix: "ls" });
+    const b = await seedSite({ name: "Opollo testme", prefix: "lst" });
+    const c = await seedSite({ name: "Testme", prefix: "1st" });
+    const d = await seedSite({ name: "testme", prefix: "1st1" });
+    const e = await seedSite({ name: "testme", prefix: "1234" });
+
+    const res = await listSites();
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const ids = new Set(res.data.sites.map((s) => s.id));
+    expect(ids.has(a.id)).toBe(true);
+    expect(ids.has(b.id)).toBe(true);
+    expect(ids.has(c.id)).toBe(true);
+    expect(ids.has(d.id)).toBe(true);
+    expect(ids.has(e.id)).toBe(true);
+    expect(res.data.sites.length).toBe(5);
+  });
+
+  it("excludes removed sites", async () => {
+    const alive = await seedSite({ name: "Alive", prefix: "al" });
+    const dead = await seedSite({ name: "Dead", prefix: "de" });
+
+    // Manually flip one to 'removed'; listSites must filter it out.
+    const svc = getServiceRoleClient();
+    const { error } = await svc
+      .from("sites")
+      .update({ status: "removed" })
+      .eq("id", dead.id);
+    expect(error).toBeNull();
+
+    const res = await listSites();
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const ids = new Set(res.data.sites.map((s) => s.id));
+    expect(ids.has(alive.id)).toBe(true);
+    expect(ids.has(dead.id)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Two bugs Steven caught during M3 sign-off:

1. `/admin/sites` showed only LeadSource despite four other active sites in the DB.
2. After a successful create, the page didn't update without a full reload.

Same root cause at different layers: the page was a client component fetching `/api/sites/list` in `useEffect`, the page shell was statically pre-rendered (no `force-dynamic`), and there was no `revalidatePath` on the create path. Stale RSC / CDN / data-cache responses could survive both full reloads and the modal's refetch.

## Fix

- **`app/admin/sites/page.tsx`** — rewritten as a server component with `force-dynamic`. Reads `listSites()` directly at request time. No `/api/sites/list` fetch, no intermediate layers.
- **`components/SitesListClient.tsx`** *(new)* — the old client body, minus the fetch/loading logic. Owns modal state + Add button + `AddSiteModal`. `onSuccess` calls `router.refresh()` so the server component re-executes and the new row appears immediately.
- **`app/api/sites/register/route.ts`** — calls `revalidatePath('/admin/sites')` on successful create. Defence in depth: even if `router.refresh()` didn't fire for any reason, the next navigation rebuilds from scratch.

## Tests

`lib/__tests__/sites-list.test.ts` — 2 cases:

- Five active sites (varying prefixes — mirrors Steven's repro: `ls`, `lst`, `1st`, `1st1`, `1234`) all appear in `listSites`. Pins that no silent filter, limit, or pagination masks rows.
- A `removed`-status site is filtered out; alive sites remain.

## Verification

- `tsc --noEmit` clean
- `next lint` clean
- `next build` clean; `/admin/sites` flipped from `○` (static) to `ƒ` (dynamic) — expected.
- `npm test` not runnable in sandbox; CI exercises the suite.

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42