### PR TITLE
feat(e2e): Playwright Level 1 + axe-core a11y audit

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,102 @@
+name: E2E
+
+# Level-1 (happy-path) + axe-core a11y audit, running against a
+# built Next.js server backed by ephemeral local Supabase. Visual
+# regression is a follow-up — baselines need to be captured in
+# this exact CI image first, reviewed, and committed.
+#
+# Runs on every PR + push to main. Separate workflow from ci.yml
+# so vitest + E2E run in parallel and each is independently
+# reportable.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      # Force the admin gate ON so E2E exercises the real Supabase
+      # Auth flow (matches the webServer config in playwright.config).
+      FEATURE_SUPABASE_AUTH: "true"
+      # Deterministic key — matches what lib/__tests__/_setup.ts seeds
+      # for the vitest suite. Never used for production-grade
+      # encryption; this stack is ephemeral.
+      OPOLLO_MASTER_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - uses: actions/cache@v4
+        id: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase local stack
+        run: supabase start
+
+      - name: Read Supabase credentials into env
+        id: supa
+        run: |
+          URL=$(supabase status --output json | jq -r '.API_URL')
+          SVC=$(supabase status --output json | jq -r '.SERVICE_ROLE_KEY')
+          ANON=$(supabase status --output json | jq -r '.ANON_KEY')
+          DB=$(supabase status --output json | jq -r '.DB_URL')
+          echo "SUPABASE_URL=$URL" >> "$GITHUB_ENV"
+          echo "SUPABASE_SERVICE_ROLE_KEY=$SVC" >> "$GITHUB_ENV"
+          echo "SUPABASE_ANON_KEY=$ANON" >> "$GITHUB_ENV"
+          echo "SUPABASE_DB_URL=$DB" >> "$GITHUB_ENV"
+
+      - name: Run Playwright suite
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7
+
+      - name: Upload test artifacts (traces + axe findings)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results
+          retention-days: 7
+
+      - name: Stop Supabase
+        if: always()
+        run: supabase stop --no-backup || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,16 @@ A plan without a populated "Risks identified and mitigated" section is not ready
 - Do loop me in on design decisions or scope questions
 - Keep PRs small enough to review in 5 minutes
 
+## E2E coverage is a hard requirement for admin UI changes
+Every PR that adds or substantially changes an admin-facing route, form, or action MUST include a Playwright spec for its happy path. Specs live in `e2e/*.spec.ts`; run locally with `npm run test:e2e` (requires `supabase start`).
+
+- A new page → a new spec OR a new test in the closest topical file (sites / users / batches / auth).
+- A new form or modal → at least one test that opens it, submits it, and verifies the after-state.
+- A new API mutation that has a UI surface → covered by the UI spec that drives it (the API itself is covered at the unit layer).
+- Every spec navigates to every page it touches and runs `auditA11y(page, testInfo)` — axe findings are non-blocking today but the history is building for the Level-3 upgrade.
+
+If a change is tested only at the unit layer and not in E2E, state why in the PR description ("purely a lib/ change", "admin-facing but flagged off for this slice", etc.). Silent omissions are a review-blocker.
+
 ## Backlog — UX debt
 
 Operator-facing jargon that leaks DB column names or internal implementation

--- a/docs/testing-roadmap.md
+++ b/docs/testing-roadmap.md
@@ -1,0 +1,33 @@
+# Testing roadmap
+
+Captures where we are on the testing ladder and what's deliberately
+deferred. Update this as levels ship.
+
+## Where we are today
+
+| Level | Name                                   | Status                                                              |
+| ----- | -------------------------------------- | ------------------------------------------------------------------- |
+| 1     | Playwright happy-path E2E              | **Shipped.** See `e2e/*.spec.ts`, CI `.github/workflows/e2e.yml`. |
+| 2     | Visual regression (`toHaveScreenshot`) | **Deferred.** Needs first-run baselines captured in CI + reviewed + committed. Follow-up slice. |
+| 3     | Accessibility + keyboard testing       | **Partial.** axe-core audits run on every page (report-only via `auditA11y` helper). Keyboard-only nav tests not yet written. Flip axe from report-only → blocking once the initial backlog is triaged. |
+| 4     | Property-based / fuzz testing          | **Deferred.** No user-facing benefit until the API surface is stable and we have paying customers. Natural fit: `fast-check` around `computeBodyHash`, slug generation, and the auto-prefix algorithm. |
+| 5     | Load + concurrency (production-like)   | **Deferred.** M3's unit-level 4-worker × 20-slot test pins the concurrency contract. A 20-browser session load test against a real preview deploy is the next rung — needs a staging Supabase project first. |
+| 6     | Chaos / failure injection              | **Deferred indefinitely.** Netflix-scale infra territory. M3 already has crash-recovery tests at the unit layer. |
+| 7     | Synthetic production monitoring        | **Deferred until public launch.** ~$50–100/mo for Checkly / Datadog Synthetics / Playwright Cloud running every 5 min against prod. Worth it once we have paying customers. |
+
+## Why Playwright runs against localhost, not Vercel preview
+
+The user's original spec said "running against Vercel preview deploys." We ship against localhost in CI instead because:
+
+1. Vercel preview deploys use the **production** Supabase project (no staging env exists). Running E2E against prod would pollute real customer data.
+2. Setting up a staging Supabase project is its own slice — provisioning, preview-branch wiring, seeded data policy.
+3. Running in CI against a fresh `supabase start` per run is deterministic, fast, and safe.
+
+When staging Supabase lands, flip `PLAYWRIGHT_BASE_URL` to the preview URL + point `SUPABASE_*` env vars at the staging project. No Playwright code changes needed.
+
+## Upcoming follow-up slices
+
+- **Visual regression (Level 2 remaining).** Add `toHaveScreenshot` to login, sites list, site detail, users list, batches list. First CI run captures baselines as an artifact; developer downloads + commits them; subsequent runs gate on diff.
+- **Keyboard-only nav tests.** Tab-order assertions on each form. Part of the Level-3 upgrade.
+- **Axe blocking.** After the initial a11y backlog is cleared, flip `auditA11y`'s default `blocking` to `true`.
+- **Staging Supabase + preview-deploy E2E.** Level-5 prep; until it lands, localhost remains the target.

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+import { E2E_ADMIN_EMAIL, E2E_ADMIN_PASSWORD } from "./fixtures";
+import { auditA11y, signInAsAdmin } from "./helpers";
+
+test.describe("auth happy path", () => {
+  test("unauthenticated visit to /admin/sites redirects to /login", async ({
+    page,
+  }) => {
+    await page.goto("/admin/sites");
+    await page.waitForURL(/\/login/);
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("sign in → admin landing → sign out", async ({ page }, testInfo) => {
+    await page.goto("/login");
+    await auditA11y(page, testInfo);
+
+    await page.getByLabel("Email").fill(E2E_ADMIN_EMAIL);
+    await page.getByLabel("Password").fill(E2E_ADMIN_PASSWORD);
+    await page.getByRole("button", { name: /sign in/i }).click();
+
+    await page.waitForURL(/\/admin\/sites/);
+    await expect(page.getByRole("heading", { name: "Manage sites" })).toBeVisible();
+
+    // Header shows the email + sign-out control.
+    await expect(page.getByText(E2E_ADMIN_EMAIL)).toBeVisible();
+
+    await page.getByRole("button", { name: /sign out/i }).click();
+    await page.waitForURL(/\/login/);
+  });
+
+  test("wrong password shows the generic invalid message", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByLabel("Email").fill(E2E_ADMIN_EMAIL);
+    await page.getByLabel("Password").fill("definitely-wrong-password");
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(
+      page.getByText(/invalid email or password/i),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("signed-in admin reaches /admin/users", async ({ page }, testInfo) => {
+    await signInAsAdmin(page);
+    await page.goto("/admin/users");
+    await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
+    await auditA11y(page, testInfo);
+  });
+});

--- a/e2e/batches.spec.ts
+++ b/e2e/batches.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+
+import { auditA11y, signInAsAdmin } from "./helpers";
+
+test.describe("batches admin surface", () => {
+  test.beforeEach(async ({ page }) => {
+    await signInAsAdmin(page);
+  });
+
+  test("/admin/batches renders empty-or-populated list without erroring", async ({
+    page,
+  }, testInfo) => {
+    await page.goto("/admin/batches");
+    await expect(
+      page.getByRole("heading", { name: "Batches" }),
+    ).toBeVisible();
+    await auditA11y(page, testInfo);
+
+    // Either shows the "No batches yet" empty state or a table.
+    // Both paths are valid — the test pins only that the page
+    // renders without an error banner.
+    await expect(
+      page.getByRole("alert").filter({ hasText: /failed to load/i }),
+    ).toHaveCount(0);
+  });
+
+  test("?site_id=<uuid> filters + primes the New batch button", async ({
+    page,
+  }) => {
+    // Navigate via the site detail → "View all" link for a real flow.
+    await page.goto("/admin/sites");
+    await page
+      .getByRole("link", { name: "E2E Test Site" })
+      .first()
+      .click();
+    await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}$/);
+
+    // On the site detail page the "Run batch" button is present but
+    // may be disabled if the site has no active DS / templates. The
+    // button itself should be rendered.
+    await expect(
+      page.getByRole("button", { name: /run batch/i }),
+    ).toBeVisible();
+
+    // View-all link navigates to the filtered batches list.
+    await page.getByRole("link", { name: /view all/i }).click();
+    await page.waitForURL(/\/admin\/batches\?site_id=/);
+    await expect(
+      page.getByRole("heading", { name: "Batches" }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,12 @@
+// Shared fixtures for the Playwright suite.
+//
+// Credentials are deterministic — the global-setup script seeds them,
+// every spec signs in as this user. A production Supabase must NEVER
+// have this account; the Playwright CI runs against a local
+// `supabase start` stack.
+
+export const E2E_ADMIN_EMAIL = "playwright-admin@opollo.test";
+export const E2E_ADMIN_PASSWORD = "playwright-password-1234";
+
+// Pre-seeded test site (global-setup inserts if missing).
+export const E2E_TEST_SITE_PREFIX = "e2e";

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,113 @@
+import { createClient } from "@supabase/supabase-js";
+
+// ---------------------------------------------------------------------------
+// Global setup — runs once before the E2E suite.
+//
+// Responsibilities:
+//   1. Reach a local Supabase (tests assume `supabase start` has already
+//      run; the e2e CI workflow handles this explicitly).
+//   2. Seed a predictable admin user the suite can sign in as. Email +
+//      password live in e2e/fixtures.ts so every spec shares them.
+//   3. Seed a single active site + design system + template so the
+//      batches spec has something to create against. Unit-test seeding
+//      helpers can't be reused here — they live behind vitest's module
+//      graph — so we re-implement the minimal path via the service
+//      role REST client.
+//
+// This runs OUTSIDE the Next.js process, so no @/ imports. Direct
+// supabase-js only.
+// ---------------------------------------------------------------------------
+
+import {
+  E2E_ADMIN_EMAIL,
+  E2E_ADMIN_PASSWORD,
+  E2E_TEST_SITE_PREFIX,
+} from "./fixtures";
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    throw new Error(
+      `E2E globalSetup: ${name} is not set. Run \`supabase start\` and re-export the CLI output before running Playwright.`,
+    );
+  }
+  return v;
+}
+
+async function ensureAdminUser(): Promise<void> {
+  const supabase = createClient(
+    requireEnv("SUPABASE_URL"),
+    requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+
+  // Look up existing user via listUsers; createUser is idempotent-ish
+  // but errors loudly on duplicate email.
+  const { data: list, error: listErr } = await supabase.auth.admin.listUsers();
+  if (listErr) {
+    throw new Error(`listUsers failed: ${listErr.message}`);
+  }
+  const existing = list.users.find(
+    (u) => u.email?.toLowerCase() === E2E_ADMIN_EMAIL.toLowerCase(),
+  );
+
+  let userId: string;
+  if (existing) {
+    userId = existing.id;
+  } else {
+    const { data: created, error: createErr } =
+      await supabase.auth.admin.createUser({
+        email: E2E_ADMIN_EMAIL,
+        password: E2E_ADMIN_PASSWORD,
+        email_confirm: true,
+      });
+    if (createErr || !created.user) {
+      throw new Error(
+        `createUser failed: ${createErr?.message ?? "no user"}`,
+      );
+    }
+    userId = created.user.id;
+  }
+
+  // Trigger in migration 0004 auto-inserts opollo_users on new
+  // auth.users row with role='viewer'. Promote to admin.
+  const { error: roleErr } = await supabase
+    .from("opollo_users")
+    .update({ role: "admin" })
+    .eq("id", userId);
+  if (roleErr) {
+    throw new Error(`opollo_users promote failed: ${roleErr.message}`);
+  }
+}
+
+async function ensureTestSite(): Promise<void> {
+  const supabase = createClient(
+    requireEnv("SUPABASE_URL"),
+    requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+
+  // Existing site with the E2E prefix? Use it.
+  const { data: existing } = await supabase
+    .from("sites")
+    .select("id")
+    .eq("prefix", E2E_TEST_SITE_PREFIX)
+    .neq("status", "removed")
+    .maybeSingle();
+  if (existing) return;
+
+  const { error } = await supabase.from("sites").insert({
+    name: "E2E Test Site",
+    wp_url: "https://e2e.test",
+    prefix: E2E_TEST_SITE_PREFIX,
+    status: "active",
+  });
+  if (error) {
+    throw new Error(`seed test site failed: ${error.message}`);
+  }
+}
+
+export default async function globalSetup(): Promise<void> {
+  await ensureAdminUser();
+  await ensureTestSite();
+}

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,8 @@
+// No-op teardown for now. The CI workflow tears down the Supabase
+// stack itself; local developers keep state between runs intentionally
+// so iteration is fast. If E2E pollution becomes a problem we'll
+// swap this for a TRUNCATE of test-owned rows.
+
+export default async function globalTeardown(): Promise<void> {
+  // Intentionally empty.
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,72 @@
+import AxeBuilder from "@axe-core/playwright";
+import type { Page, TestInfo } from "@playwright/test";
+
+import {
+  E2E_ADMIN_EMAIL,
+  E2E_ADMIN_PASSWORD,
+} from "./fixtures";
+
+// Shared helpers for the Playwright suite.
+
+/**
+ * Sign in as the seeded admin via the real /login form flow. Returns
+ * after landing on the admin surface so callers can immediately
+ * navigate further. Deliberately uses the HTML form (Server Action)
+ * rather than hitting the Supabase Auth endpoint directly — the
+ * point of E2E is to exercise what a real user's browser does.
+ */
+export async function signInAsAdmin(page: Page): Promise<void> {
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(E2E_ADMIN_EMAIL);
+  await page.getByLabel("Password").fill(E2E_ADMIN_PASSWORD);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  // Default post-login redirect is /admin/sites.
+  await page.waitForURL(/\/admin\/sites/);
+}
+
+/**
+ * Run axe-core against the current page and attach findings to the
+ * test result. Non-blocking by default — the Level 3 roadmap calls
+ * for surfacing findings in CI without failing the build so we can
+ * triage them incrementally. Flip `blocking` to true on a per-test
+ * basis when fixing a specific rule, or raise the whole suite's
+ * severity ceiling once initial findings are cleared.
+ */
+export async function auditA11y(
+  page: Page,
+  testInfo: TestInfo,
+  opts: { blocking?: boolean } = {},
+): Promise<void> {
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa"])
+    .analyze();
+
+  if (results.violations.length === 0) return;
+
+  const summary = results.violations
+    .map(
+      (v) =>
+        `- ${v.id} (${v.impact ?? "unknown"}): ${v.help}\n  ${v.helpUrl}`,
+    )
+    .join("\n");
+  await testInfo.attach("axe-violations", {
+    body: `Page: ${page.url()}\n\n${summary}\n\nFull report:\n${JSON.stringify(
+      results.violations,
+      null,
+      2,
+    )}`,
+    contentType: "text/plain",
+  });
+
+  if (opts.blocking) {
+    throw new Error(
+      `axe-core found ${results.violations.length} violation(s) on ${page.url()}. See the attached report.`,
+    );
+  }
+  // Non-blocking: log to stderr so CI's test-summary step surfaces
+  // the count without failing the suite.
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[a11y] ${results.violations.length} axe violation(s) on ${page.url()}`,
+  );
+}

--- a/e2e/sites.spec.ts
+++ b/e2e/sites.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test";
+
+import { auditA11y, signInAsAdmin } from "./helpers";
+
+test.describe("sites CRUD", () => {
+  test.beforeEach(async ({ page }) => {
+    await signInAsAdmin(page);
+  });
+
+  test("sites list renders + row click lands on detail", async ({
+    page,
+  }, testInfo) => {
+    await page.goto("/admin/sites");
+    await auditA11y(page, testInfo);
+    await expect(
+      page.getByRole("heading", { name: "Manage sites" }),
+    ).toBeVisible();
+
+    // Seeded test site should appear (global-setup guarantees it).
+    const siteRow = page.getByRole("row", { name: /E2E Test Site/i });
+    await expect(siteRow).toBeVisible();
+
+    // Clicking the site name link navigates to the detail page.
+    await siteRow.getByRole("link", { name: "E2E Test Site" }).click();
+    await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}$/);
+    await expect(
+      page.getByRole("heading", { name: "E2E Test Site" }),
+    ).toBeVisible();
+  });
+
+  test("add new site — flows end-to-end without the prefix field", async ({
+    page,
+  }) => {
+    await page.goto("/admin/sites");
+    await page.getByRole("button", { name: /add new site/i }).click();
+
+    const uniqueName = `Playwright Temp ${Date.now()}`;
+    await page.getByLabel("Name").fill(uniqueName);
+    await page.getByLabel("WordPress URL").fill("https://temp.test");
+    await page.getByLabel("WordPress user").fill("wp-user");
+    await page.getByLabel("WordPress app password").fill("password-1234");
+
+    // Scope prefix field MUST NOT be present — M2d UX cleanup removed
+    // it entirely in favour of server-side auto-generation.
+    await expect(page.getByLabel(/scope prefix/i)).toHaveCount(0);
+
+    await page.getByRole("button", { name: /register site/i }).click();
+
+    // Modal closes on success and the new row appears after
+    // revalidatePath('/admin/sites').
+    await expect(page.getByText(uniqueName).first()).toBeVisible();
+  });
+
+  test("archive flow removes the site from the default list", async ({
+    page,
+  }) => {
+    await page.goto("/admin/sites");
+
+    // Create a throwaway site for this test so we don't archive the
+    // shared e2e seed.
+    const disposableName = `Archive Target ${Date.now()}`;
+    await page.getByRole("button", { name: /add new site/i }).click();
+    await page.getByLabel("Name").fill(disposableName);
+    await page.getByLabel("WordPress URL").fill("https://archive-me.test");
+    await page.getByLabel("WordPress user").fill("wp");
+    await page.getByLabel("WordPress app password").fill("password-1234");
+    await page.getByRole("button", { name: /register site/i }).click();
+
+    await expect(page.getByText(disposableName).first()).toBeVisible();
+
+    // Open the actions menu on the new row and archive.
+    const row = page.getByRole("row", { name: new RegExp(disposableName) });
+    await row.getByRole("button", { name: /actions for/i }).click();
+
+    // Browser confirm() auto-accept.
+    page.once("dialog", (dialog) => {
+      void dialog.accept();
+    });
+    await row.getByRole("button", { name: /^archive$/i }).click();
+
+    // After router.refresh the row should be gone.
+    await expect(
+      page.getByRole("row", { name: new RegExp(disposableName) }),
+    ).toHaveCount(0);
+  });
+});

--- a/e2e/users.spec.ts
+++ b/e2e/users.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+
+import { E2E_ADMIN_EMAIL } from "./fixtures";
+import { auditA11y, signInAsAdmin } from "./helpers";
+
+test.describe("users admin surface", () => {
+  test.beforeEach(async ({ page }) => {
+    await signInAsAdmin(page);
+  });
+
+  test("/admin/users shows the seeded admin + invite modal opens", async ({
+    page,
+  }, testInfo) => {
+    await page.goto("/admin/users");
+    await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
+    await auditA11y(page, testInfo);
+
+    // The seeded admin row is present.
+    await expect(page.getByText(E2E_ADMIN_EMAIL)).toBeVisible();
+
+    // Invite button opens the modal (M2d-3 shipped the backend + UI).
+    await page.getByRole("button", { name: /invite user/i }).click();
+    await expect(
+      page.getByRole("heading", { name: /invite user/i }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: /cancel/i }).click();
+  });
+
+  test("role dropdown is disabled for self (CANNOT_MODIFY_SELF guard)", async ({
+    page,
+  }) => {
+    await page.goto("/admin/users");
+    const selfRow = page.getByRole("row", {
+      name: new RegExp(E2E_ADMIN_EMAIL),
+    });
+    const select = selfRow.getByRole("combobox");
+    // The self row's <select> should be disabled per M2d-2's
+    // UserRoleActionCell guard.
+    await expect(select).toBeDisabled();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "zod": "^4.0.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
+        "@playwright/test": "^1.59.1",
         "@supabase/ssr": "^0.10.2",
         "@types/node": "^20.16.11",
         "@types/pg": "^8.20.0",
@@ -70,6 +72,19 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1192,6 +1207,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -6924,6 +6955,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint:css": "stylelint 'seed/**/*.css'",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:update-snapshots": "playwright test --update-snapshots"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
@@ -27,6 +29,8 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
+    "@playwright/test": "^1.59.1",
     "@supabase/ssr": "^0.10.2",
     "@types/node": "^20.16.11",
     "@types/pg": "^8.20.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,78 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Playwright configuration — Level 1 + 2 E2E suite.
+//
+// Design choices:
+//
+// - **Target: localhost in CI**, not Vercel preview. Preview deploys use
+//   the production Supabase URL; running E2E against prod would pollute
+//   real data. A dedicated staging Supabase project is future work. For
+//   now the webServer block builds Next.js once and starts it on 3000,
+//   and a per-run local Supabase (from `supabase start`) backs it with
+//   fresh data. Same stack the unit suite uses.
+//
+// - **Single Chromium project.** Multi-browser (Firefox, WebKit) is
+//   overkill for a single-operator admin surface today; every extra
+//   project multiplies runtime and flakiness surface.
+//
+// - **snapshotPathTemplate pins Linux baselines** so CI-generated
+//   screenshots don't thrash against developer-local ones. Local dev
+//   should run `npm run test:e2e -- --update-snapshots` on Linux (or
+//   skip visual regression specs locally). Visual regression specs
+//   themselves arrive in a follow-up PR — first-run baselines need to
+//   be captured in CI and committed before the gate turns on.
+//
+// - **Strict + trace on retry**: fail fast on test file issues, capture
+//   traces only when a retry happens so CI artifacts stay small.
+// ---------------------------------------------------------------------------
+
+const PORT = Number(process.env.PORT ?? 3000);
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "playwright-report", open: "never" }],
+  ],
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    video: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  snapshotPathTemplate:
+    "{testDir}/__screenshots__/{testFilePath}/{arg}-linux{ext}",
+  // Start Next.js in production mode + use a seeded test user in
+  // local Supabase (see e2e/global-setup.ts). The server is reused if
+  // something is already listening — developers iterating locally
+  // skip the boot delay between runs.
+  webServer: {
+    command: process.env.CI
+      ? "npm run build && npm run start"
+      : "npm run dev",
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      // Opt-in: Playwright runs with FEATURE_SUPABASE_AUTH=true so the
+      // admin-layout gate is on and the sign-in flow is exercised.
+      FEATURE_SUPABASE_AUTH: "true",
+    },
+  },
+  globalSetup: "./e2e/global-setup.ts",
+  globalTeardown: "./e2e/global-teardown.ts",
+});


### PR DESCRIPTION
## Summary

Ships the functional half of the testing-ladder roadmap: **Level 1 (Playwright happy-path E2E)** + **Level 3 starter (axe-core a11y audit, report-only)**. M2d UX cleanup already landed in #40 — per your "split into 2 if too large" permission, this is PR B.

**Up-front tradeoff I'm flagging:** ran Playwright against **localhost in CI** rather than Vercel preview deploys. Preview deploys hit the **production** Supabase (no staging project exists), so running E2E there would pollute real customer data. Staging-Supabase + preview-target is a follow-up slice — documented in `docs/testing-roadmap.md`.

## What lands

**Playwright suite** (`e2e/`)
- `global-setup.ts` — seeds a deterministic admin `playwright-admin@opollo.test` via the Supabase service-role admin API and promotes to `role='admin'`; seeds a fixed test site (`prefix=e2e`). Idempotent.
- `fixtures.ts` + `helpers.ts` — shared credentials, `signInAsAdmin()` that runs the real form flow, `auditA11y()` helper that runs `@axe-core/playwright` on every test page and attaches findings as a test artifact.
- `auth.spec.ts` — unauthenticated redirect to `/login`; sign-in + logout round-trip; wrong-password generic message; signed-in admin reaches `/admin/users`.
- `sites.spec.ts` — list + row-link to `/admin/sites/[id]`; Add new site flow **without** the prefix field (pins M2d UX cleanup's auto-prefix); archive via three-dot menu.
- `users.spec.ts` — list renders; invite modal opens; self-row role dropdown is disabled (`CANNOT_MODIFY_SELF` UI guard).
- `batches.spec.ts` — list renders without error; site-detail → View all lands on `/admin/batches?site_id=<uuid>`.

**CI** (`.github/workflows/e2e.yml`)
Separate workflow from `ci.yml` so unit + E2E run in parallel on their own runners. Installs Chromium (cached), boots local Supabase, runs the suite, uploads the HTML report + test-results on every run.

**Config**
- `playwright.config.ts` — Chromium-only, single worker, webServer boots Next.js with `FEATURE_SUPABASE_AUTH=true` so the admin gate is exercised. `snapshotPathTemplate` scopes baselines to Linux (pre-staged for the visual-regression follow-up).
- `package.json` — `test:e2e` + `test:e2e:update-snapshots` scripts.

**Docs / standing rules**
- `docs/testing-roadmap.md` — where we are on the 7-level ladder; what's deferred and why.
- `CLAUDE.md` — new section: "E2E coverage is a hard requirement for admin UI changes." Every admin PR adds a Playwright happy path; silent omissions are a review-blocker.

## Risks identified and mitigated

| # | Hotspot | Mitigation |
| --- | --- | --- |
| 1 | Test user leaks into prod Supabase. | Workflow runs `supabase start` and reads URLs from its JSON output; never touches prod creds. |
| 2 | Snapshot thrashing between Linux CI and dev macOS/Windows. | `snapshotPathTemplate` scopes to Linux; visual regression tests not included in this PR — devs running `--update-snapshots` locally won't accidentally commit platform-specific baselines. |
| 3 | Axe-core rejects every page on day one, breaking the build. | `auditA11y` defaults to non-blocking; findings land in Playwright's test-attachment stream for incremental triage. Flip to blocking per-test as issues are fixed. |
| 4 | Supabase port conflict between `ci.yml` and `e2e.yml`. | Separate runners + separate concurrency groups. No conflict. |
| 5 | Playwright install slows cold-start CI. | `~/.cache/ms-playwright` cached against `package-lock.json`. |
| 6 | E2E spec assumes pages from M2d that weren't yet in main when the branch was created. | Merged `main` into this branch after #40 landed — site-detail, archive menu, auto-prefix, new-batch-button all covered against their real surfaces. |

## Deliberately deferred

- **Level 2 (visual regression).** Needs a CI-captured baseline pass that someone reviews + commits. Shipping as a separate follow-up slice once this PR's CI is proven working. The config already has `snapshotPathTemplate` set up — just drop in `toHaveScreenshot()` calls.
- **Keyboard-only navigation tests.** Part of the Level-3 upgrade; today's axe audit is the starting point.
- **Vercel-preview target + staging Supabase.** Needs its own slice (staging project provisioning, preview env var wiring, seeded-data policy).
- **Levels 4–7** (property-based, load, chaos, synthetic monitoring). Deferred per your ladder analysis until post-MVP / paying customers.

## How to run locally

```bash
supabase start            # sets up local stack
npm install
npx playwright install chromium
npm run test:e2e          # runs against npm run dev
```

## Verification

- `tsc --noEmit` clean
- `next lint` clean
- `next build` clean
- `npm run test:e2e` NOT run in sandbox (no docker for `supabase start`); first CI run is the real signal. Expect some iteration via the same-failure-twice ceiling.

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42