### PR TITLE
docs: patterns dir + rules doc + runbook extensions + pointer structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,9 @@ A chat interface that generates WordPress pages for Opollo's clients.
 
 ## How to work
 - Work autonomously. Don't ask for permission for normal coding tasks.
-- **Read `docs/patterns/<pattern-name>.md` before starting any task that matches
-  a documented pattern.** The patterns folder is the playbook for recurring
-  shapes (new admin page, new API route, new migration, ship a sub-slice,
-  extract a design system). If a task matches, follow the pattern — files,
-  tests, PR structure, pitfalls. If no pattern matches, proceed from first
-  principles and note whether the task is a candidate for a new pattern.
+- **Before starting a task that matches a pattern, read `docs/patterns/<pattern-name>.md` first.** The patterns folder is the playbook for recurring shapes — files, tests, PR structure, known pitfalls. If no pattern matches, proceed from first principles and note whether the task is a candidate for a new pattern.
+- **For operations tasks** (deploy rollback, key rotation, stuck incident, missing migration, env-var provisioning) — consult `docs/RUNBOOK.md` before acting. Do not freelance on destructive or irreversible operations.
+- **For one-off rules that aren't patterns** (test-helper discipline, fresh-stack config, CI-stuck recovery, write-safety audit requirement, UX-debt capture discipline) — see `docs/RULES.md`. Each rule has the incident that taught it.
 - After any change: run lint, typecheck, and build. Fix failures yourself before reporting back.
 - When reporting back, give me a one-paragraph summary, not a blow-by-blow.
 - After opening a PR, monitor CI until it passes. If CI fails, read the failure, fix it, push again. Repeat until green.

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -1,0 +1,54 @@
+# Rules
+
+Codified one-paragraph rules born from specific incidents. Each entry states the rule up front, then the incident that taught it. For recurring shapes with scaffolding, see `docs/patterns/`. For operations playbooks, see `docs/RUNBOOK.md`. This file is the short-form list.
+
+Sort: strongest "if you skip this, production breaks" signal at the top.
+
+---
+
+## 1. Service-role client pollution in test helpers
+
+**Rule.** Test helpers that create rows for E2E or unit coverage use the service-role Supabase client (`getServiceRoleClient`) via the seed helpers in `_helpers.ts` / `_auth-helpers.ts` — never instantiate a fresh client inside the test body. Tests that do their own `createClient(url, SERVICE_ROLE_KEY, ...)` leak a client instance that bypasses the shared pool, fails to clean up on worker shutdown, and causes `supabase_migrations` lock contention in the next test file.
+
+**Incident (M2b).** One of the M2b test files instantiated a service-role client inline for a one-off INSERT. Subsequent test files started intermittently hanging on startup because the leaked client held an open connection to the migrations advisory lock, blocking the CLI's own migration-status probe. Fix: everything that writes to the DB from a test goes through the shared `getServiceRoleClient()` + the helper seeds, which reuse the one process-wide client.
+
+---
+
+## 2. Supabase email auth for fresh local stacks
+
+**Rule.** When onboarding a fresh local Supabase stack to a developer machine or a CI runner, `supabase start` doesn't enable the email/password auth flow by default — the CLI ships with magic-link-only. `supabase/config.toml` must declare `[auth.email] enable_signups = true` and the `[auth] site_url` has to match the dev server origin, or `auth.signUp({ email, password })` returns 400 with a cryptic "Email signups are disabled" message that looks unrelated to config.
+
+**Incident (M2a onboarding).** The first M2a draft worked against a manually-configured Supabase cloud project; CI's `supabase start` ran against the default CLI config and every auth test failed on the first call with an error that didn't mention email-vs-magic-link. Fixed by committing `supabase/config.toml` with the auth block explicit + adding a paragraph in `CLAUDE.md` pointing at the file so fresh clones see the knob.
+
+---
+
+## 3. CI stuck-run recovery: empty commit, don't cancel-rerun
+
+**Rule.** When a GitHub Actions run hangs or stalls (concurrency-group lock, flaky Vercel preview, service timeout), the correct recovery is `git commit --allow-empty -m "ci: retrigger"` followed by `git push`. Do NOT use the UI's "Cancel" + "Re-run all jobs" path. Cancelling a run in a concurrency group sometimes leaves the group ref pinned; a re-run queues against the stale ref and hangs again. An empty commit advances the SHA, triggers a fresh run against a fresh concurrency-group key, and always clears the hang.
+
+**Incident (several).** Twice in M3 the CI queue got wedged by `concurrency: group: e2e-${{ github.ref }} cancel-in-progress: true` interacting badly with the Vercel preview deployment racing the e2e job. Cancel-rerun reproduced the hang within 30s. An empty commit always cleared it. Bolted this into `docs/RUNBOOK.md` too.
+
+---
+
+## 4. Write-safety risk audit is mandatory on every sub-slice plan
+
+**Rule.** Every PR description — sub-slice, hotfix, or infra — includes a **"Risks identified and mitigated"** section. Each entry names a write-safety hotspot in the proposed design (billed external calls, concurrent writers, multi-row state transitions, triggers, race windows, schema-level uniqueness assumptions) and states the concrete mitigation (idempotency key, DB unique constraint, advisory lock, dedicated test case, etc.). A PR without that section is not ready to merge. If the PR has no write-safety hotspots (pure docs, pure refactor), write "No write-safety hotspots — <one-line reason>" explicitly; don't skip the section.
+
+**Incident (M3-6).** An early M3-6 draft landed in review without a risks section; the `pages (site_id, slug)` UNIQUE pre-commit claim was present in the schema but missing from the description. The reviewer spotted a SAVEPOINT gap that would have dup-billed Anthropic calls on the conflict path. The SAVEPOINT fix shipped in the same PR but wouldn't have been caught without the section. Rule codified in `CLAUDE.md` + reinforced in [`ship-sub-slice.md`](./patterns/ship-sub-slice.md).
+
+---
+
+## 5. UX debt capture discipline — into BACKLOG.md, never inline-fix
+
+**Rule.** When a user-facing jargon leak, copy-text drift, label inconsistency, or other "small UX cleanup" surfaces inside an otherwise in-scope PR, capture it in `docs/BACKLOG.md` under the nearest applicable section (typically `## Product surface`). Do NOT silently expand the current PR's scope to fix it. The current PR has a focused plan + a risks audit sized for that plan; an unplanned "while I'm here" cleanup breaks both the scope contract and the review-in-five-minutes rule. Open the BACKLOG entry with a concrete pickup trigger ("next PR that touches this file") so it doesn't rot.
+
+**Incident (M2d sign-off).** The `scope_prefix` UI field in `AddSiteModal.tsx` was flagged during M2c review as a jargon leak but got absorbed into an unrelated PR that was supposed to fix a login regression. The login PR's diff doubled, review stretched, and a second production bug almost landed because the reviewer's attention was split. The auto-prefix cleanup eventually shipped as PR #38 — a clean, focused slice. Since then, every ambient "while I'm here" observation goes into `BACKLOG.md`.
+
+---
+
+## Adding a new rule
+
+- If a recurring shape with scaffolding emerges, that's a pattern — put it in `docs/patterns/`, not here.
+- If an operational failure mode needs a response playbook, that's a runbook entry — put it in `docs/RUNBOOK.md`.
+- If a rule is a one-paragraph "remember this" born from a specific incident, it belongs here.
+- Rules in this file never have scaffolding. A rule that wants code belongs in a pattern.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -163,6 +163,204 @@ Middleware now runs HTTP Basic Auth (set `BASIC_AUTH_USER` + `BASIC_AUTH_PASSWOR
 
 ---
 
+## Apply pending migrations to production
+
+**Symptom:** `/api/health` reports `supabase_error` mentioning a missing column / table / policy, OR a freshly-deployed code path throws `column "X" does not exist`.
+
+**Impact:** routes that touch the new schema are broken. Other routes keep working.
+
+**Diagnose:**
+1. `supabase migration list --db-url "$DATABASE_URL"` against the production DB URL. Compare the applied list to `supabase/migrations/`.
+2. The set of pending migrations is what needs to be applied.
+3. Check `.github/workflows/deploy-migrations.yml` run history — if the workflow failed silently on the merge commit, that's the gap.
+
+**Mitigate:** fall back to Basic Auth via the kill switch if the missing migration is auth-related:
+
+```bash
+curl -X POST "$APP_URL/api/emergency" \
+  -H "Authorization: Bearer $OPOLLO_EMERGENCY_KEY" \
+  -H "content-type: application/json" \
+  -d '{"action":"kill_switch_on"}'
+```
+
+For a missing feature-path migration: disable the relevant `FEATURE_X` in Vercel env and redeploy.
+
+**Resolve:**
+1. Pull the production `DATABASE_URL` from Supabase dashboard → Connect → Direct Connection.
+2. `supabase db push --db-url "$DATABASE_URL" --include-all` applies every pending migration in order.
+3. Confirm: `supabase migration list --db-url "$DATABASE_URL"` shows all local migrations as applied remote.
+4. Re-enable the flag + flip the kill switch off.
+5. Re-check `/api/health` → 200 ok.
+
+**Post-mortem:**
+- Why did the automated workflow miss it? Failing silently is the real bug — fix the workflow, not just the database.
+- If the migration contained a destructive step (`DROP COLUMN`, `DROP CONSTRAINT`), confirm no data loss against a recent Supabase backup.
+
+---
+
+## Rotate a secret
+
+**Symptom:** scheduled rotation, suspected leak, or compliance requirement. Known secrets in play: `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `OPOLLO_MASTER_KEY`, `OPOLLO_EMERGENCY_KEY`, `CRON_SECRET`, `ANTHROPIC_API_KEY`, each site's `wp_app_password`.
+
+**Impact:** during the rotation window, any service using the old value fails. Most rotations can be staged to avoid downtime.
+
+### SUPABASE_SERVICE_ROLE_KEY
+
+1. Supabase dashboard → Settings → API → "Reset service role key." This invalidates the old key immediately.
+2. Copy the new key into Vercel env (all environments).
+3. `vercel redeploy --prod` — or wait for the next merge.
+4. Confirm `/api/health` → 200. If 503 with `supabase_error` mentioning auth, the new key didn't propagate; re-check Vercel env.
+
+**Downtime window:** ~30s between reset and Vercel redeploy. Schedule outside peak.
+
+### OPOLLO_MASTER_KEY (encrypts `sites.wp_app_password`)
+
+Zero-downtime rotation:
+
+1. `openssl rand -base64 32` → new key.
+2. Set `OPOLLO_MASTER_KEY_NEXT` in Vercel env to the new key; leave `OPOLLO_MASTER_KEY` as the old key. Redeploy.
+3. Run the rotation script (follow-up slice — for now, re-register each site through the Edit Site modal: the app encrypts with the new key on save).
+4. When every site row has been re-encrypted: set `OPOLLO_MASTER_KEY` to the new key, remove `OPOLLO_MASTER_KEY_NEXT`. Redeploy.
+5. Confirm: for every site, `editSiteModal → Save` round-trips successfully.
+
+**Downtime window:** none if staged. If the rotation script lands, this becomes a single-step rotation.
+
+### OPOLLO_EMERGENCY_KEY
+
+1. `openssl rand -base64 48` — new key.
+2. Update Vercel env `OPOLLO_EMERGENCY_KEY`. Redeploy.
+3. Update the operator's password manager + `docs/RUNBOOK.md` break-glass commands with the new key.
+4. Test: call `POST /api/emergency` with the new key + a no-op body (`{"action":"kill_switch_off"}` when it's already off). Expect 200.
+
+**Downtime window:** 30s. The break-glass path is unusable during the window; avoid rotating during an active incident.
+
+### CRON_SECRET
+
+1. `openssl rand -base64 32` — new value.
+2. Update Vercel env `CRON_SECRET`.
+3. Vercel dashboard → Project → Cron Jobs → update the `Authorization: Bearer` header (if stored there; otherwise the cron sends `CRON_SECRET` automatically).
+4. Redeploy.
+5. Wait one tick (60s). Confirm `/api/cron/process-batch` run fires successfully. Cron log should show 200.
+
+**Downtime window:** one cron tick (60s). During the window the worker doesn't advance.
+
+### ANTHROPIC_API_KEY
+
+1. Anthropic console → API keys → Rotate.
+2. Update Vercel env. Redeploy.
+3. Check a batch: create a dummy 1-slot batch + watch it reach `state='succeeded'` in `generation_job_pages`.
+
+**Downtime window:** in-flight Anthropic calls keyed to the old key fail once. The retry loop picks them up automatically on the next tick.
+
+### WP app password (per site)
+
+1. WP admin → Users → Profile → Application Passwords → generate new.
+2. In the admin UI, Edit Site → update password. The app re-encrypts with `OPOLLO_MASTER_KEY`.
+3. Test: trigger a small batch or a manual WP publish on that site. Expect 200 from WP.
+
+**Downtime window:** any in-flight publish to that site fails once. Retries use the new password.
+
+**Always:**
+
+- After any rotation, grep git history for the old value (`git log -S '<prefix>'`) to confirm it was never committed.
+- Update `.gitleaks.toml` if the new value happens to match any false-positive rule.
+- Log the rotation in a lightweight log (spreadsheet / ops channel) so the next rotation cadence is tracked.
+
+---
+
+## Provision env vars for a new observability tool
+
+**Context.** Scaffolded vendors that need env vars to activate: Sentry, Axiom, Langfuse, Upstash Redis. Each is a graceful no-op without its envs; provisioning "flips" the tool on.
+
+### One-time provisioning playbook
+
+For each tool (Sentry / Axiom / Langfuse / Upstash):
+
+1. **Create the account / project** in the vendor's dashboard. Pick the free tier where available.
+2. **Copy the required env vars** from the vendor dashboard:
+   - Sentry: `SENTRY_DSN`, `SENTRY_AUTH_TOKEN` (for source-map upload).
+   - Axiom: `AXIOM_TOKEN`, `AXIOM_DATASET`.
+   - Langfuse: `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, optionally `LANGFUSE_BASEURL` if self-hosted.
+   - Upstash: `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`.
+3. **Add them to Vercel** — Settings → Environment Variables. Set all three environments (Production, Preview, Development) unless the vendor is production-only.
+4. **Add to `.env.local.example`** with a comment explaining the default-off behaviour.
+5. **Redeploy production** — `vercel redeploy --prod` or an empty commit on main.
+6. **Verify**: the scaffold's `isXEnabled()` check (or equivalent) now returns true. For Sentry, generate a test exception in a dev route and confirm it lands in the dashboard. For Axiom, tail the dataset for a fresh log line with the expected request_id shape. For Langfuse, run one eval and confirm the trace appears. For Upstash, confirm `/api/health` reports `redis: "ok"`.
+
+### Batch provisioning
+
+All four can be done in one session:
+
+1. Create four accounts (15 min total).
+2. Copy 8 env vars into Vercel.
+3. Redeploy once.
+4. Verify each per the above.
+
+Log the provisioning date + vendor account IDs somewhere persistent; each rotation relies on it.
+
+**If a vendor's quota is hit** (Axiom ingest, Sentry event cap): the logger / transport falls back gracefully per the scaffold. The app does not fail; the tool just goes quiet. Check the vendor's usage dashboard if observability signal drops unexpectedly.
+
+---
+
+## Diagnose a missing-migration incident
+
+**Symptom:** typically a 500 on a specific route with a Postgres error like `column "<name>" does not exist` / `relation "<table>" does not exist` / `policy "<p>" does not exist`. `/api/health` may also go 503.
+
+**Impact:** scope depends on which migration is missing. Auth migrations → everyone affected. Feature-path migrations → that feature only.
+
+**Diagnose:**
+
+1. **Confirm which migration.** The error message names the column / table / policy. Grep `supabase/migrations/` for the first place it was introduced. That's the one missing in production.
+2. **Confirm the production state.**
+   ```bash
+   supabase migration list --db-url "$DATABASE_URL"
+   ```
+   This lists `Applied` + `Local`. Any migration present in `Local` but not `Applied` is pending.
+3. **Check the deploy workflow.** `.github/workflows/deploy-migrations.yml` runs on merge to main. Look at the run for the merge commit that introduced the new migration. A failure there is the root cause (not the missing migration itself — the workflow is the gap).
+
+**Mitigate:**
+
+- If the missing migration affects auth: break-glass via kill switch (see "Auth is broken" above).
+- If it affects a feature path: disable the relevant `FEATURE_X` in Vercel env and redeploy. User-facing error vanishes; the feature goes dark until the migration lands.
+- If the missing migration is behind a soft rollout (e.g. Supabase Auth migration but HTTP Basic still works), no operator action needed beyond the resolve step.
+
+**Resolve:**
+
+1. **Fix the workflow first, migration second.** A failed run in `deploy-migrations.yml` should re-trigger on the next push. If it keeps failing, fix the workflow (env var, secret, permissions).
+2. Apply the pending migrations directly (see "Apply pending migrations to production" above).
+3. Verify `/api/health` 200 + the previously-broken route works.
+4. Re-enable the feature flag / kill switch.
+
+**Post-mortem:**
+
+- Why did `deploy-migrations.yml` fail silently? Add a notification step (Slack / email) for workflow failures on main.
+- Was the migration tested locally against a fresh DB before merging? `npm run test` + `supabase db reset && supabase db push` locally catches most of these.
+
+---
+
+## Production incident recovery
+
+**Context.** A general-purpose entry for when production is in a bad state that doesn't match any specific entry above. Follow the sequence; escalate only when the sequence doesn't clear.
+
+**Order of operations:**
+
+1. **Stop the bleeding.** Decide: is this a rollback (deploy regression) or a runtime flip (feature-flag kill switch)? If both are plausible, start with the kill switch — it's reversible in 30 seconds. Rollback is reversible in five minutes.
+2. **Confirm health.** `/api/health` 200 = runtime alive. 503 = infrastructure. If health is 200 and users still see errors, look at the `x-request-id` in the browser's failing response + grep the logs (Axiom once provisioned; stdout in Vercel runtime logs today).
+3. **Isolate the blast radius.** Is this everyone, one customer, one route? Production bugs narrow the scope faster than general triage does.
+4. **Capture state.** Screenshot the error, note the request_id, capture the affected row id(s). The post-mortem needs this; the fix probably does too.
+5. **Apply the smallest fix that clears the symptom.** A one-line revert. A flag flip. A single row UPDATE (only with a peer reviewing the SQL — even in an incident).
+6. **Confirm clear.** Test the affected path manually — don't trust "logs look clean." If there's an E2E spec for the path, run it locally against production.
+7. **Post-mortem same day.** New entry in this RUNBOOK + new rule in `docs/RULES.md` if the incident's cause is procedural. Don't let the learning rot.
+
+**Never do during an incident:**
+
+- `git push --force` to main.
+- `DROP TABLE`, `TRUNCATE` on a production table.
+- Rotate a secret while the break-glass is active — the rotation lock-out compounds the outage.
+- Fix the root cause and the symptom in the same commit. Ship the symptom fix, confirm clear, then open a separate PR for root cause.
+
+---
+
 ## Adding a new runbook entry
 
 When a live incident surfaces a gap, write it up here the same day. Template:

--- a/docs/patterns/README.md
+++ b/docs/patterns/README.md
@@ -13,6 +13,8 @@ Each pattern file has the same shape:
 
 ## Index
 
+### Shipping work
+
 | Pattern | Used when |
 | --- | --- |
 | [`ship-sub-slice.md`](./ship-sub-slice.md) | Shipping a sub-slice of an approved parent milestone. |
@@ -20,10 +22,36 @@ Each pattern file has the same shape:
 | [`new-api-route.md`](./new-api-route.md) | Adding a new HTTP endpoint under `app/api/`. |
 | [`new-migration.md`](./new-migration.md) | Schema change: `0NNN_*.sql` + rollback + tests + RLS. |
 | [`extract-design-system.md`](./extract-design-system.md) | Onboarding a new client's design system into the structured registry. |
-| [`new-batch-worker-stage.md`](./new-batch-worker-stage.md) | Adding a processing stage (Anthropic / gates / WP) to the M3 worker. |
+| [`feature-flagged-rollout.md`](./feature-flagged-rollout.md) | Shipping a behaviour change behind a reversible env flag + kill switch. |
+
+### Workers + write safety
+
+| Pattern | Used when |
+| --- | --- |
+| [`background-worker-with-write-safety.md`](./background-worker-with-write-safety.md) | Greenfield worker with lease / heartbeat / reaper / idempotency invariants. |
+| [`new-batch-worker-stage.md`](./new-batch-worker-stage.md) | Adding a processing stage to the existing M3 batch worker. |
+| [`quality-gate-runner.md`](./quality-gate-runner.md) | N independent pass/fail checks with first-fail short-circuit. |
+
+### Testing
+
+| Pattern | Used when |
+| --- | --- |
+| [`concurrency-test-harness.md`](./concurrency-test-harness.md) | N-worker race + idempotency + reaper assertions. |
+| [`rls-policy-test-matrix.md`](./rls-policy-test-matrix.md) | (role × table × op) matrix for any RLS migration. |
+| [`playwright-e2e-coverage.md`](./playwright-e2e-coverage.md) | Admin-UI E2E coverage per `CLAUDE.md`'s hard requirement. |
+
+## Where else to look
+
+- `docs/RUNBOOK.md` — operations playbook (deploy rollback, auth break-glass, batch stuck, key rotation, missing migration, general incident recovery).
+- `docs/RULES.md` — one-paragraph rules born from specific incidents (shared test-helper discipline, fresh-stack auth config, CI-stuck-run recovery, write-safety audit requirement, UX-debt capture discipline).
+- `docs/ENGINEERING_STANDARDS.md` — portable project-agnostic brief for future repos.
+- `docs/BACKLOG.md` — explicitly deferred work with pickup triggers.
+- `docs/DATA_CONVENTIONS.md` — soft-delete / audit columns / optimistic concurrency / data-migrations contract.
+- `docs/PROMPT_VERSIONING.md` — `lib/prompts/vN/` layout + eval harness + prompt-injection defence + cost budgets.
 
 ## Maintenance
 
 - Update a pattern on the PR that materially changes its shape. Don't let the pattern rot.
 - If three unrelated PRs violate the same pattern, that's a signal the pattern drifted — rewrite.
 - Don't add a pattern for shapes we've only done once. The bar is "done at least twice and likely to recur."
+- If a pattern's "Known pitfalls" entry cites a PR that no longer applies (the root cause was fixed at a deeper layer, e.g. a schema constraint makes the pitfall impossible), mark it resolved in place rather than deleting — history of what we burned on stays useful.

--- a/docs/patterns/background-worker-with-write-safety.md
+++ b/docs/patterns/background-worker-with-write-safety.md
@@ -1,0 +1,216 @@
+# Pattern — Background worker with write safety
+
+## When to use it
+
+Any process that leases a row, does work (possibly slow, possibly hitting external APIs), and commits a terminal state transition. Applies to: batch generators, cron-invoked workers, reconciliation jobs, any other long-running transform over a queue of rows.
+
+For new processing stages inside an existing worker (a new gate, a new billing hook, a new retry policy), see [`new-batch-worker-stage.md`](./new-batch-worker-stage.md) — that's the slice-level pattern. This file is the general playbook for greenfield workers.
+
+Don't use for: request-scoped work (use a normal API route), fire-and-forget jobs with no correctness guarantees (use a queue + ack). The write-safety machinery here — lease, heartbeat, reaper, idempotency — only earns its keep when correctness matters.
+
+## The five invariants
+
+A worker that can't restart safely doesn't ship. Every new worker satisfies all five:
+
+1. **Atomic lease.** A slot is leased by exactly one worker. `SELECT ... FOR UPDATE SKIP LOCKED` under a transaction, flip state to `leased`, stamp `worker_id + lease_expires_at`. Two workers leasing the same slot is a bug a UNIQUE or a CHECK constraint must make impossible.
+2. **Heartbeat during slow work.** Any operation that might exceed the lease window calls `heartbeat(slotId, workerId)` at intervals shorter than the window. Heartbeat UPDATE is guarded on `worker_id = $workerId` so a reaped + relet slot rejects the stale update.
+3. **Reaper for expired leases.** Separate worker-invocable function resets `state='leased'` rows with `lease_expires_at < now()` back to `state='pending'`. Idempotent under concurrent reapers — two reapers running at the same instant produce the same post-state, no double-reap side effects.
+4. **Pre-computed idempotency keys.** Any external billed call (Anthropic, Stripe, SendGrid) uses a key derived deterministically from row identity, stamped at insert time. Re-processing a reaped slot reuses the same key. Never mint a fresh UUID per attempt.
+5. **Event-log-first accounting.** `INSERT INTO <job_events>` before the state column flips. If the state-column UPDATE fails (crash, disconnect, trigger-level conflict), the event log still has the truth. Reconciliation reads events, not state.
+
+If any of these is weak, the worker can double-bill, double-publish, or stall forever under a reaper loop.
+
+## Required files
+
+| File | Role |
+| --- | --- |
+| Migration: `supabase/migrations/0NNN_<worker>.sql` | Tables with `state`, `worker_id`, `lease_expires_at`, `retry_after`, `retry_count`, CHECK on state transitions, UNIQUE on idempotency keys. |
+| `lib/<worker>.ts` | `leaseNext<Unit>`, `heartbeat`, `reapExpiredLeases`, `process<Unit>`. One function per contract. |
+| `lib/<worker>-events.ts` (optional) | Event-log writer, one function per event type. Keeps the processor tidy. |
+| `app/api/cron/<worker>/route.ts` | Cron entrypoint. `Authorization: Bearer $CRON_SECRET` check, `reapExpiredLeases()` first, then one `leaseNext + process` invocation. Cap at one unit per tick. |
+| `lib/__tests__/<worker>-lease.test.ts` | 4-worker concurrency test. See [`concurrency-test-harness.md`](./concurrency-test-harness.md). |
+| `lib/__tests__/<worker>-reap.test.ts` | Reaper idempotency under concurrency. |
+| `lib/__tests__/<worker>-heartbeat.test.ts` | Heartbeat guards against stolen leases. |
+| `lib/__tests__/<worker>-crash.test.ts` | Crash at every intermediate state → reap → reprocess → terminal. |
+| `lib/__tests__/<worker>-retry.test.ts` | Retryable vs non-retryable failures; budget exhaustion. |
+
+## Scaffolding
+
+### Schema
+
+Model on `supabase/migrations/0007_m3_1_batch_schema.sql` (the `generation_job_pages` table). Minimum column set for a workable unit row:
+
+```sql
+CREATE TABLE <worker>_units (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id         uuid NOT NULL REFERENCES <worker>_jobs(id) ON DELETE CASCADE,
+  slot_index     integer NOT NULL,
+  state          text NOT NULL DEFAULT 'pending',
+  worker_id      text NULL,
+  lease_expires_at timestamptz NULL,
+  retry_count    integer NOT NULL DEFAULT 0,
+  retry_after    timestamptz NULL,
+  <idempotency_key> text NOT NULL,   -- deterministic, pre-computed at insert
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT <worker>_units_state_valid
+    CHECK (state IN ('pending','leased','processing','succeeded','failed','skipped')),
+
+  CONSTRAINT <worker>_units_lease_coherent
+    CHECK (
+      (state = 'pending'  AND worker_id IS NULL AND lease_expires_at IS NULL)
+      OR
+      (state IN ('leased','processing') AND worker_id IS NOT NULL AND lease_expires_at IS NOT NULL)
+      OR
+      (state IN ('succeeded','failed','skipped'))
+    ),
+
+  UNIQUE (job_id, slot_index),
+  UNIQUE (<idempotency_key>)
+);
+
+CREATE INDEX <worker>_units_lease_queue_idx
+  ON <worker>_units (state, retry_after, created_at)
+  WHERE state = 'pending';
+```
+
+Key rules:
+
+- **`CHECK (state IN ...)`** over Postgres ENUM. ENUMs are painful to alter.
+- **Lease-coherence CHECK** makes invalid combinations (pending + worker_id set) impossible at the schema layer.
+- **Partial index** on `WHERE state = 'pending'` so the queue scan is cheap even under millions of completed rows.
+- **Idempotency key UNIQUE** catches double-submission at the schema layer even if the app retries wrongly.
+
+### Lease
+
+Model on `lib/batch-worker.ts` → `leaseNextPage`. Shape:
+
+```ts
+export async function leaseNext<Unit>(
+  workerId: string,
+  opts: { leaseDurationMs?: number } = {},
+): Promise<Lease<Unit> | null> {
+  const pg = await getPgClient();
+  const leaseDurationMs = opts.leaseDurationMs ?? DEFAULT_LEASE_MS;
+
+  // FOR UPDATE SKIP LOCKED so concurrent workers get disjoint rows.
+  // The WHERE filter includes retry_after to honour backoff windows.
+  const { rows } = await pg.query(
+    `
+    WITH candidate AS (
+      SELECT id FROM <worker>_units
+      WHERE state = 'pending'
+        AND (retry_after IS NULL OR retry_after <= now())
+      ORDER BY created_at ASC
+      LIMIT 1
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE <worker>_units
+    SET state = 'leased',
+        worker_id = $1,
+        lease_expires_at = now() + ($2 || ' milliseconds')::interval,
+        updated_at = now()
+    WHERE id IN (SELECT id FROM candidate)
+    RETURNING id, job_id, slot_index, <idempotency_key>, retry_count
+    `,
+    [workerId, leaseDurationMs],
+  );
+
+  return rows[0] ?? null;
+}
+```
+
+`FOR UPDATE SKIP LOCKED` is the correctness primitive. Without it, concurrent workers serialize on the queue scan and throughput flatlines.
+
+### Heartbeat
+
+```ts
+export async function heartbeat(
+  unitId: string,
+  workerId: string,
+  opts: { leaseDurationMs?: number } = {},
+): Promise<boolean> {
+  const { rowCount } = await pg.query(
+    `UPDATE <worker>_units
+     SET lease_expires_at = now() + ($1 || ' milliseconds')::interval
+     WHERE id = $2 AND worker_id = $3 AND state IN ('leased','processing')`,
+    [opts.leaseDurationMs ?? DEFAULT_LEASE_MS, unitId, workerId],
+  );
+  return rowCount === 1;
+}
+```
+
+Returns `false` when the lease has been reaped and relet to a different worker. Caller sees `false` → stop doing work + let the new worker handle it.
+
+### Reaper
+
+```ts
+export async function reapExpiredLeases(): Promise<{ reapedCount: number }> {
+  const { rowCount } = await pg.query(
+    `UPDATE <worker>_units
+     SET state = 'pending',
+         worker_id = NULL,
+         lease_expires_at = NULL,
+         retry_count = retry_count + 1
+     WHERE state IN ('leased','processing')
+       AND lease_expires_at < now()`,
+  );
+  return { reapedCount: rowCount ?? 0 };
+}
+```
+
+Idempotent: re-running it on a table with no expired leases affects zero rows. Two reapers racing each reap a disjoint subset — the UPDATE is atomic per row.
+
+### Process loop
+
+Model on `processSlotAnthropic`. Each stage:
+
+1. State transition with lease-coherence filter (`WHERE id=$1 AND worker_id=$2 AND lease_expires_at > now()`). Assert 1 row — else lease was lost.
+2. Cancellation check. `SELECT cancel_requested_at FROM <worker>_jobs`. If set: state → `skipped`, event log, return.
+3. External call (if any). Use pre-stamped idempotency key. Wrap in try/catch, classify as retryable / non-retryable.
+4. **Event log first**: `INSERT INTO <worker>_events`.
+5. State column update.
+6. Terminal transitions: job-aggregation UPDATE with top-branch CASE preserving terminal statuses.
+
+## Required tests
+
+See [`concurrency-test-harness.md`](./concurrency-test-harness.md) for the 4-worker pattern. Minimum per new worker:
+
+1. **Lease atomicity**: 4 workers leasing 20 units produces 20 distinct processings.
+2. **Reaper idempotency**: two reapers running concurrently leave the same post-state.
+3. **Heartbeat refuses stolen leases**: worker A leases → reaper resets → worker B leases → worker A heartbeat returns false.
+4. **Crash recovery at every state**: tests per intermediate state (`leased` / `processing` / pre-external-call / mid-external-call) — crash, reap, reprocess, terminal. Idempotency key reused throughout.
+5. **Retry budget**: retryable failures defer via `retry_after`; N attempts, then terminal.
+6. **Retryable vs non-retryable classification**: the non-retryable code goes terminal on first attempt.
+7. **Cancellation**: pending → skipped; in-flight completes without flipping job status.
+8. **Cost reconciliation**: sum from events equals the slot's cost_cents field.
+
+## Standard PR structure
+
+Follow [`ship-sub-slice.md`](./ship-sub-slice.md). Title shape: `feat(<milestone-or-worker>): <worker-name> worker core`.
+
+The "Risks identified and mitigated" section MUST cover every invariant above:
+
+- Atomic lease (constraint or `SKIP LOCKED`?).
+- Heartbeat strategy (which stages heartbeat, which don't).
+- Reaper idempotency (test explicitly).
+- Idempotency key scheme (what function derives it; why two of those collide never).
+- Event-log-first (point to the code that writes events before the state update).
+- Top-branch CASE on job aggregation.
+
+## Known pitfalls
+
+- **No `SKIP LOCKED`**: queue scan serializes. Fleet of workers collapses to one. Happened in an early M3 draft.
+- **Fresh idempotency key per retry**: double bills. Pre-compute at insert; never at process time.
+- **State column flipped before event log**: a crash between the two leaves the event log silent about work that was done. Reconciliation breaks. Always event-first.
+- **Missing lease-coherence filter on UPDATEs**: a reaped + relet lease lets the first worker's late write clobber the second's. Every state UPDATE includes `worker_id = $workerId AND lease_expires_at > now()`.
+- **Cascading trigger that updates the same table**: deadlock under contention. Triggers that write to the unit table while a worker is processing that unit conflict. Use app-level bumps.
+- **Reaper that doesn't bump `retry_count`**: a single crashing worker can hold the queue hostage indefinitely. Count + cap both are required.
+- **`generation_events` retention not planned**: event-log-first means unbounded growth. Plan the retention slice (deferred to M7 in Opollo; don't forget when the same question surfaces in a new worker).
+
+## Pointers
+
+- Canonical instance: the M3 batch worker. Files: `lib/batch-worker.ts`, `lib/batch-publisher.ts`, `lib/quality-gates.ts`, `lib/anthropic-call.ts`, `supabase/migrations/0007_m3_1_batch_schema.sql`, `supabase/migrations/0009_m3_7_retry_after.sql`.
+- Tests: `lib/__tests__/batch-worker*.test.ts` — 8 files, all the invariants pinned.
+- Related: [`concurrency-test-harness.md`](./concurrency-test-harness.md), [`new-batch-worker-stage.md`](./new-batch-worker-stage.md), [`new-migration.md`](./new-migration.md).

--- a/docs/patterns/concurrency-test-harness.md
+++ b/docs/patterns/concurrency-test-harness.md
@@ -1,0 +1,159 @@
+# Pattern — Concurrency test harness
+
+## When to use it
+
+Asserting that N concurrent workers / writers produce the correct aggregate outcome. Canonical instances:
+
+- M3-3 lease test: 4 workers × 20 slots → exactly 20 distinct processings.
+- M3-3 reaper test: 2 reapers racing → all expired leases reset, no double-reap.
+- M3-6 slug-claim test: 2 workers racing for the same slug → one wins, the other gets `SLUG_CONFLICT`.
+- Idempotency-key test: two simultaneous batch-create POSTs with the same key → same job id returned, no duplicate row.
+
+Use whenever a write-safety invariant is "under contention, X". Skipping the concurrency test and shipping the "happy path" for a contended resource is how production double-bills and double-publishes get born.
+
+Don't use for: unit tests of pure functions, tests where "concurrency" just means sequencing of awaits (no shared mutable state).
+
+## Required files
+
+| File | Role |
+| --- | --- |
+| `lib/__tests__/<subject>-lease.test.ts` (or similar) | The test file. One describe block per invariant. |
+| Usually nothing else. | The harness is the test itself + the existing `_setup.ts` TRUNCATE pattern. |
+
+No new library. No test framework extension. Vitest + `Promise.all` is enough.
+
+## Scaffolding
+
+### The 4-worker lease pattern
+
+Model on `lib/__tests__/batch-worker.test.ts`:
+
+```ts
+it("four workers leasing twenty slots produce exactly twenty distinct processings", async () => {
+  const { jobId, slotIds } = await seedBatchWith20Slots();
+
+  const results = await Promise.all(
+    Array.from({ length: 4 }, (_unused, i) => runWorker(`worker-${i}`)),
+  );
+
+  async function runWorker(workerId: string) {
+    const processed: string[] = [];
+    // Each worker keeps leasing + processing until the queue is empty.
+    while (true) {
+      const slot = await leaseNextPage(workerId);
+      if (!slot) return processed;
+      await processSlotDummy(slot.id, workerId);
+      processed.push(slot.id);
+    }
+  }
+
+  const allProcessed = results.flat();
+  expect(allProcessed).toHaveLength(20);
+  expect(new Set(allProcessed).size).toBe(20); // every slot processed exactly once
+  expect(new Set(allProcessed).size).toBe(slotIds.length);
+});
+```
+
+Key moves:
+
+- **`Promise.all` with N workers**, each running a complete lease → process loop. Workers compete for the queue; the test asserts the aggregate.
+- **Assert distinct count equals input count.** `new Set(results).size === input.length` is the concurrency invariant.
+- **No artificial `setTimeout` to "stagger" workers.** Let them race. That's the point.
+- **No mock / stub.** Real Postgres, real `FOR UPDATE SKIP LOCKED`. Concurrency mocked out at the driver is a fiction.
+
+### Race-condition spec shape
+
+For "two operations race, one wins, one gets a documented error":
+
+```ts
+it("two workers racing the same slug: one wins, one gets SLUG_CONFLICT", async () => {
+  const { slotA, slotB } = await seedTwoSlotsSameSlug();
+
+  const [a, b] = await Promise.all([
+    processSlotAnthropic(slotA.id, "worker-A"),
+    processSlotAnthropic(slotB.id, "worker-B"),
+  ]);
+
+  // Exactly one succeeds, exactly one fails with the documented code.
+  const results = [a, b].map((s) => s.state);
+  const outcomes = [a, b].map((s) => s.failure_code);
+
+  expect(results.sort()).toEqual(["failed", "succeeded"]);
+  expect(outcomes.filter((c) => c === "SLUG_CONFLICT")).toHaveLength(1);
+});
+```
+
+- **Assert the set of outcomes, not the order.** Which worker wins isn't deterministic — which outcome set exists is.
+- **Name the failure code explicitly.** `SLUG_CONFLICT`, not `FAILED`. The test pins the operator-facing reason.
+
+### Reaper idempotency
+
+```ts
+it("two reapers running in parallel don't double-reap", async () => {
+  await seedThreeSlotsWithExpiredLeases();
+
+  const [a, b] = await Promise.all([reapExpiredLeases(), reapExpiredLeases()]);
+
+  // Combined reaped count equals the number of expired slots.
+  // Individually each reaper handled some subset (FOR UPDATE SKIP LOCKED
+  // splits the work).
+  expect(a.reapedCount + b.reapedCount).toBe(3);
+
+  const { data } = await svc.from("generation_job_pages").select("state, worker_id, lease_expires_at");
+  // All three back to pending.
+  expect(data!.every((r) => r.state === "pending")).toBe(true);
+  expect(data!.every((r) => r.worker_id === null)).toBe(true);
+});
+```
+
+The invariant isn't "reaper A handled exactly K rows" — it's "both reapers together handled all expired rows, no row was handled twice."
+
+### Idempotency under races
+
+```ts
+it("two simultaneous POSTs with the same idempotency key return the same job id", async () => {
+  const key = "idemp-test-" + Date.now();
+  const body = { site_id: siteId, template_id: tmplId, slots: [ /* ... */ ] };
+
+  const [a, b] = await Promise.all([
+    createBatchJob({ idempotency_key: key, ...body }),
+    createBatchJob({ idempotency_key: key, ...body }),
+  ]);
+
+  expect(a.ok && b.ok).toBe(true);
+  expect(a.data.job_id).toBe(b.data.job_id); // exact same row
+
+  const { count } = await svc.from("generation_jobs").select("*", { count: "exact", head: true }).eq("idempotency_key", key);
+  expect(count).toBe(1); // one row, not two
+});
+```
+
+## Required tests per new concurrent contract
+
+When introducing a new piece of shared state or a new contention point, pin:
+
+1. **N-way race** produces the documented aggregate. 4 workers is enough to flush most bugs; 20 is enough to rule out N-dependent ones.
+2. **Winner + loser classification** — if two operations can collide, the losing operation fails with a specific error code, not a generic 500.
+3. **Idempotency under re-submission** — re-running a completed operation produces the same outcome, not a new one.
+4. **Concurrent cleanup / reaper** — if there's a background sweeper, it's safe against another instance of itself.
+5. **Heartbeat stolen-lease rejection** — worker A's late UPDATE against a lease reaper-reset-then-relet-to-B returns `false` or fails loudly, doesn't clobber B's work.
+
+## Standard PR structure
+
+Follow [`ship-sub-slice.md`](./ship-sub-slice.md). The "Risks identified and mitigated" section maps 1:1 onto the concurrency tests you ship — every write-safety hotspot listed has a test in the file that pins it.
+
+## Known pitfalls
+
+- **Tests that pass sequentially but fail under `Promise.all`.** The single-threaded happy path is not the test. Always use `Promise.all` or `Promise.allSettled` when the contract is about concurrency.
+- **`await` in a loop instead of `Promise.all`.** `for (const w of workers) await w()` serializes — the whole point was to run concurrently. Use `await Promise.all(workers.map(runWorker))`.
+- **Assuming order of completion.** `[a, b] = await Promise.all(...)` preserves input order, but which completed *first* is not deterministic. Assert sets, not sequences.
+- **Stubbing the contention surface.** Mocking `SELECT ... FOR UPDATE SKIP LOCKED` means testing a fiction. Concurrency tests that don't hit real Postgres provide false confidence.
+- **Not seeding enough rows.** Two workers on two slots can accidentally succeed even with broken locking — each worker happens to pick up a disjoint row by luck. Seed ≥ 5× the worker count.
+- **TRUNCATE between tests leaves sequences.** M3 uses `RESTART IDENTITY CASCADE` in `_setup.ts`. Without restarting identity, `id` collisions across tests produce mysterious failures.
+- **`persistent: true` auth users leaking.** RLS tests seed persistent auth users in `beforeAll` + rely on `cleanupTrackedAuthUsers` to sweep non-persistent ones in `beforeEach`. A broken `persistent` flag leaks state between files. See `_auth-helpers.ts`.
+- **Assertion that fails 1% of the time.** That's a flake disguised as a pass. Re-run the test 10× locally before landing; if it doesn't pass every time, the invariant is wrong or the test is wrong.
+
+## Pointers
+
+- Canonical instances: `lib/__tests__/batch-worker.test.ts` (lease + reaper + heartbeat + crash recovery), `lib/__tests__/batch-create.test.ts` (idempotency), `lib/__tests__/batch-worker-publish.test.ts` (slug-claim race).
+- Related: [`background-worker-with-write-safety.md`](./background-worker-with-write-safety.md), [`rls-policy-test-matrix.md`](./rls-policy-test-matrix.md).

--- a/docs/patterns/feature-flagged-rollout.md
+++ b/docs/patterns/feature-flagged-rollout.md
@@ -1,0 +1,177 @@
+# Pattern — Feature-flagged rollout
+
+## When to use it
+
+Shipping a behaviour change that needs to coexist with the legacy path during rollout, or that must be reversible in production without a redeploy. Canonical instances:
+
+- `FEATURE_SUPABASE_AUTH` — middleware routes through Supabase Auth when on; HTTP Basic Auth otherwise.
+- `FEATURE_DESIGN_SYSTEM_V2` — system prompt reads the structured registry when on; legacy HTML blob otherwise.
+- `opollo_config.auth_kill_switch` — DB-backed kill switch that overrides the env flag at runtime without redeploy.
+
+Use whenever:
+
+- The behaviour change is binary (on / off), not a percentage rollout.
+- Production needs a reversible switch during early rollout.
+- Tests need to exercise both branches.
+
+Don't use for: multi-variant experiments (that's the Tier 2 feature-flag vendor job in `BACKLOG.md`), per-tenant flags (same), forever flags (a flag that's been on for months with no plan to remove is tech debt — remove it and delete the legacy branch).
+
+## Two tiers
+
+**Env-var flag** — `process.env.FEATURE_<NAME>`. Provisioned in Vercel, flipped by a redeploy. Fast enough for normal rollout; no DB dependency.
+
+**DB-backed kill switch** — a row in `opollo_config` that middleware reads on every request (cached 5s). Flippable without a redeploy via `/api/emergency`. Use for break-glass: the scenario where the env flag on produces binary failure and you need to revert without waiting for Vercel to promote a new build. Always paired with an env flag; the kill switch only overrides when set to the break-glass value.
+
+## Required files
+
+| File | Role |
+| --- | --- |
+| Reader helper (`lib/<feature>-flag.ts` or inline) | `isXOn(): boolean`. Single function, single env check. Never call `process.env.FEATURE_X` from three places. |
+| The conditional call site(s) | Branches on the reader. Legacy and new paths both reachable. |
+| Kill-switch helper (if applicable) | `lib/<feature>-kill-switch.ts` — reads `opollo_config`, caches, returns boolean. |
+| `.env.local.example` entry | Documents default + when to flip. |
+| Tests — both branches | Flag off: legacy; flag on: new; flag on + kill switch: legacy; etc. |
+
+## Scaffolding
+
+### Env reader
+
+One function, one file-level source of truth:
+
+```ts
+// lib/<feature>.ts (top of file, above the feature code)
+
+function isFeatureOn(): boolean {
+  const v = process.env.FEATURE_<NAME>;
+  return v === "true" || v === "1";
+}
+```
+
+`"true"` or `"1"` — case-sensitive. Anything else (unset, `"false"`, `"FALSE"`, `"yes"`, `""`) is off. Copy the literal check from `middleware.ts`'s `isFeatureOn`.
+
+Why the strict parse: a typo'd value (`"True"`, `"on"`) silently stays off, which is the safer default. Loose parsing turns every typo into a production incident.
+
+### Conditional call site
+
+Model on `middleware.ts`:
+
+```ts
+export async function middleware(req: NextRequest) {
+  if (!isFeatureOn()) {
+    return basicAuthGate(req); // legacy
+  }
+  let killSwitch = false;
+  try {
+    killSwitch = await isAuthKillSwitchOn();
+  } catch {
+    killSwitch = false;
+  }
+  if (killSwitch) {
+    return basicAuthGate(req); // break-glass
+  }
+  return supabaseAuthGate(req); // new
+}
+```
+
+Key invariants:
+
+- **Legacy path remains fully functional.** No temporary "coming soon" stub. The flag is off for a reason (gradual rollout, production validation) and the legacy code has to work while off.
+- **Kill switch read is wrapped in try/catch with fallback to legacy.** If the DB is down and the kill switch read throws, don't proceed with the new path — fall back to the safer legacy.
+- **Branches must test cleanly in isolation.** Each branch is unit-testable without stubbing the flag reader — set the env var in `beforeEach`.
+
+### DB-backed kill switch
+
+Model on `lib/auth-kill-switch.ts`. Shape:
+
+```ts
+let cached: { value: boolean; expiresAt: number } | null = null;
+const CACHE_TTL_MS = 5_000;
+
+export async function isAuthKillSwitchOn(): Promise<boolean> {
+  const now = Date.now();
+  if (cached && cached.expiresAt > now) return cached.value;
+
+  const svc = getServiceRoleClient();
+  const { data } = await svc
+    .from("opollo_config")
+    .select("value")
+    .eq("key", "auth_kill_switch")
+    .maybeSingle();
+
+  const value = data?.value === "on";
+  cached = { value, expiresAt: now + CACHE_TTL_MS };
+  return value;
+}
+
+// Exported for tests — lets a beforeEach reset the cache.
+export function __resetAuthKillSwitchCacheForTests(): void {
+  cached = null;
+}
+```
+
+Cache is **module-level**, **per-instance**. The 5s TTL is the tradeoff between read cost and break-glass response time. In a Vercel serverless fleet, each lambda carries its own cache — a break-glass flip propagates within 5s to every warm lambda, immediately to cold ones.
+
+The flip is via a route (`/api/emergency`) that uses a pre-shared key. See the `break-glass endpoint` section in `docs/RUNBOOK.md`.
+
+### Env var documentation
+
+Every feature flag gets an `.env.local.example` entry:
+
+```
+# Supabase Auth kill switch (M2c+). When "true" or "1", middleware routes
+# requests through the Supabase Auth path (signed-in session required for
+# non-public routes). When unset/"false"/"0", middleware uses the legacy
+# HTTP-Basic path — byte-identical to pre-M2c behaviour. Binary: under the
+# flag-on mode, auth-service failures fail closed (500 / /auth-error), they
+# do not silently fall back to Basic Auth. A DB-backed runtime override
+# (opollo_config.auth_kill_switch = 'on', set via the emergency route in
+# M2c-3) lets operators break-glass to the Basic Auth path without a
+# redeploy.
+FEATURE_SUPABASE_AUTH=
+```
+
+Document: what `"true"` does, what `""` does, how the kill switch interacts, what failure mode the flag-on path has.
+
+## Required tests
+
+Minimum:
+
+1. **Flag off** — legacy path is exercised. Happy path + its error codes.
+2. **Flag on, no kill switch** — new path is exercised. Happy path + its error codes.
+3. **Flag on + kill switch on** — legacy path is exercised. Asserts the kill switch overrides.
+4. **Flag on, kill switch read throws** — legacy-fallback path fires. Asserts try/catch works.
+5. **Malformed env values** — `"True"`, `"yes"`, `"1 "` (trailing space) all treated as off. Pins the strict-parse contract.
+6. **Cache behaviour** — consecutive calls within the TTL hit the cache; after TTL, a fresh read fires. Use `__resetAuthKillSwitchCacheForTests()` in `beforeEach` to isolate tests.
+
+Copy from `lib/__tests__/middleware.test.ts` + `lib/__tests__/auth-kill-switch.test.ts`.
+
+## Standard PR structure
+
+Follow [`ship-sub-slice.md`](./ship-sub-slice.md). Title shape: `feat(<milestone>): <feature> behind FEATURE_<NAME>`.
+
+The description calls out:
+
+- **What the flag gates.** One sentence.
+- **Default behaviour.** Off until explicitly enabled in Vercel env.
+- **How to enable in production.** "Set `FEATURE_X=true` in Vercel env, redeploy."
+- **Kill-switch interaction** (if applicable). "If the new path misbehaves, POST to `/api/emergency` with `{\"action\":\"<switch>_on\"}` — middleware falls back to legacy within 5s."
+- **Removal plan.** "When N weeks of flag-on traffic are clean, delete `FEATURE_X` + the legacy branch in sub-PR <slug>." Don't ship a flag without planning its removal.
+
+## Known pitfalls
+
+- **Flag-off code paths atrophy.** A flag that's been on for 6 weeks has a legacy path nobody tests. Either delete the legacy path (flag removal slice) or keep exercising it in CI. Don't let the "off" branch rot in place.
+- **Loose env parsing.** `"true".toLowerCase() === "true"` matches `"TRUE"` — a production typo suddenly flips the flag. Strict-parse `=== "true" || === "1"`.
+- **Flag read in three places.** Inline `process.env.FEATURE_X === "true"` across three files drifts — someone adds a truthy case in one and not the others. Single helper function.
+- **Kill switch without an env flag.** A DB-backed runtime override with no compile-time flag means the code path exists in every deploy, potentially a live surface when the switch is on. Always pair kill switch with env flag; kill switch only overrides.
+- **Kill switch that throws uncaught**: middleware crashes on every request. Wrap in try/catch; fall back to the safer branch.
+- **Forgetting the cache in the kill-switch helper**: every middleware invocation hits the DB. Vercel's lambda warm path becomes a DB DoS. 5s cache is the floor.
+- **Kill-switch cache outliving hot-path tests**: tests shouldn't see stale cache state. Export `__resetForTests` and call it in `beforeEach`.
+- **Not documenting the removal plan.** Flags go stale in `BACKLOG.md` without a trigger. Every flag ships with its removal date (or condition — "after 2 weeks of clean traffic").
+
+## Pointers
+
+- Canonical instances:
+  - `FEATURE_SUPABASE_AUTH` — `middleware.ts`, `lib/auth.ts`, `lib/auth-kill-switch.ts`.
+  - `FEATURE_DESIGN_SYSTEM_V2` — `lib/system-prompt.ts` → `buildSystemPromptForSite`.
+- Tests: `lib/__tests__/middleware.test.ts`, `lib/__tests__/auth-kill-switch.test.ts`, `lib/__tests__/system-prompt.test.ts`.
+- Related: `docs/RUNBOOK.md` (break-glass flip), [`ship-sub-slice.md`](./ship-sub-slice.md).

--- a/docs/patterns/playwright-e2e-coverage.md
+++ b/docs/patterns/playwright-e2e-coverage.md
@@ -1,0 +1,167 @@
+# Pattern — Playwright E2E coverage
+
+## When to use it
+
+Any PR that adds or substantially changes an admin-facing route, form, or server action. `CLAUDE.md` codifies this as a hard requirement; this pattern file is the *how*.
+
+Rule of thumb:
+
+- **New page** → new spec OR new test in the closest topical file (`sites` / `users` / `batches` / `auth`).
+- **New form / modal** → at least one test that opens, submits, asserts the after-state.
+- **New API mutation with a UI surface** → covered by the UI spec that drives it. The API itself is covered at the unit layer.
+
+Don't use for: pure `lib/` changes (unit tests are enough), flagged-off surfaces (state why in the PR description and land the E2E when the flag flips), truly headless background jobs (unit tests + concurrency harness).
+
+## Required files
+
+| File | Role |
+| --- | --- |
+| `e2e/<topic>.spec.ts` | One spec file per admin area. `sites.spec.ts`, `users.spec.ts`, `batches.spec.ts`, `auth.spec.ts`. New admin areas get new files. |
+| `e2e/helpers.ts` | `signInAsAdmin`, `auditA11y`. Extend, don't duplicate. |
+| `e2e/fixtures.ts` | `E2E_ADMIN_EMAIL`, `E2E_ADMIN_PASSWORD`, other seed constants. |
+| `e2e/global-setup.ts` | Seeds the admin user + baseline data via Supabase admin API. Idempotent. |
+| `playwright.config.ts` | One-time config. Don't touch per-PR unless you're changing the harness. |
+| `.github/workflows/e2e.yml` | CI wire-up. One-time. |
+
+## Scaffolding
+
+### Per-spec structure
+
+Model on `e2e/sites.spec.ts`:
+
+```ts
+import { expect, test } from "@playwright/test";
+
+import { auditA11y, signInAsAdmin } from "./helpers";
+
+test.describe("<resource> CRUD", () => {
+  test.beforeEach(async ({ page }) => {
+    await signInAsAdmin(page);
+  });
+
+  test("list renders + row click lands on detail", async ({ page }, testInfo) => {
+    await page.goto("/admin/<resource>");
+    await auditA11y(page, testInfo);
+    await expect(page.getByRole("heading", { name: "Manage <resource>" })).toBeVisible();
+
+    // Seeded row from global-setup.
+    const row = page.getByRole("row", { name: /<seed-name>/i });
+    await expect(row).toBeVisible();
+
+    await row.getByRole("link", { name: "<seed-name>" }).click();
+    await page.waitForURL(/\/admin\/<resource>\/[0-9a-f-]{36}$/);
+    await expect(page.getByRole("heading", { name: "<seed-name>" })).toBeVisible();
+  });
+
+  test("create flow", async ({ page }) => {
+    await page.goto("/admin/<resource>");
+    await page.getByRole("button", { name: /add new <resource>/i }).click();
+
+    const uniqueName = `Playwright Temp ${Date.now()}`;
+    await page.getByLabel("Name").fill(uniqueName);
+    // ... fill remaining fields
+    await page.getByRole("button", { name: /register <resource>/i }).click();
+
+    // Modal closes on success; new row appears after revalidatePath.
+    await expect(page.getByText(uniqueName).first()).toBeVisible();
+  });
+
+  test("archive flow removes row from default list", async ({ page }) => {
+    await page.goto("/admin/<resource>");
+
+    // Seed a disposable row from the UI — don't share the global seed.
+    const disposable = `Archive Target ${Date.now()}`;
+    // ... create via the modal ...
+
+    const row = page.getByRole("row", { name: new RegExp(disposable) });
+    await row.getByRole("button", { name: /actions for/i }).click();
+
+    // Browser confirm() auto-accept.
+    page.once("dialog", (dialog) => { void dialog.accept(); });
+    await row.getByRole("button", { name: /^archive$/i }).click();
+
+    await expect(page.getByRole("row", { name: new RegExp(disposable) })).toHaveCount(0);
+  });
+});
+```
+
+Key rules:
+
+- **`signInAsAdmin` in `beforeEach`.** Exercises the real login form — the point of E2E is to test what a browser actually does, not to hit auth endpoints directly.
+- **`auditA11y(page, testInfo)` on every page you navigate to.** Non-blocking today; findings attach to the test as an artifact so the roadmap to Level-3 blocking runs builds history.
+- **Use role-based locators.** `getByRole("row", { name: ... })`, `getByLabel("Name")`. Fragile CSS selectors (`.sites-table-row`) break on refactors.
+- **`Date.now()` in names** of test-created rows. Prevents accidental collision across concurrent CI runs hitting the same Supabase stack.
+- **Don't mutate the global seed.** `global-setup.ts` creates the shared "E2E Test Site" that multiple tests read. Create + destroy disposable rows inside tests for any write flow.
+
+### The handful of Playwright idioms that keep biting
+
+**Browser confirm() auto-accept.** The standard archive flow calls `window.confirm("Are you sure?")` on the client. Intercept before the click:
+
+```ts
+page.once("dialog", (dialog) => { void dialog.accept(); });
+await row.getByRole("button", { name: /^archive$/i }).click();
+```
+
+`once` not `on` — otherwise every subsequent dialog in the test auto-accepts.
+
+**Waiting for navigation after a form submit.** `await page.waitForURL(/\/admin\/<route>/)` after a Server Action that redirects. If the form doesn't redirect, assert the after-state on the current page.
+
+**Waiting for a server-revalidated list.** After create / archive, the server component re-renders. `await expect(page.getByText(...)).toBeVisible()` waits for the text to appear; no explicit sleep needed.
+
+**Modal text vs page text.** When the modal title is the same string as the page heading, `getByText(...)` matches both. Use `getByRole("heading", ...)` or scope to a specific region.
+
+### global-setup.ts
+
+Model on `e2e/global-setup.ts`:
+
+- Seeds a single admin user (`E2E_ADMIN_EMAIL`) via Supabase admin API. Idempotent: checks if the user exists before creating.
+- Promotes them to `role='admin'` in `opollo_users`.
+- Seeds one canonical site the specs can read ("E2E Test Site"), also idempotent.
+- Runs once per test run, not once per spec.
+
+Seeds live in `global-setup.ts`, NOT in each spec's `beforeAll`. Otherwise every spec does its own auth-user setup and parallel specs collide.
+
+## Required tests per new admin surface
+
+Minimum per new page:
+
+1. **List renders.** Heading visible, seeded row visible, `auditA11y` runs.
+2. **Row click → detail.** Clicking the row's link lands on `/admin/<resource>/<uuid>`.
+3. **Create flow.** Modal opens, form fills, submit, new row appears.
+4. **Edit flow** (if the page has edit). Open edit modal, change a field, submit, change is reflected.
+5. **Archive / delete flow.** Row disappears from the default list after the action.
+6. **Error surface.** At least one negative test — e.g. submitting with a missing required field shows the validation error.
+
+Specs can grow beyond six tests; the floor is "every user-visible outcome has one test."
+
+## Standard PR structure
+
+Follow [`ship-sub-slice.md`](./ship-sub-slice.md). Title: usually `feat(admin/<resource>): …` for new surfaces; `feat(e2e): …` for purely test additions.
+
+If a PR changes UI without adding the corresponding E2E, the description MUST state why:
+
+- "Purely a lib/ change, no admin-UI surface."
+- "Admin-facing but flagged off for this slice; E2E lands in the flag-flip PR."
+- "Refactor of existing behaviour already covered by <existing-spec>."
+
+Silent omissions are a review blocker.
+
+## Known pitfalls
+
+- **Axe `critical` severity not blocking.** Today they attach findings as artifacts; they don't fail the suite. Target state is Level-3 blocking; don't ship a new axe violation and flag it "known." Fix it or document the triage plan.
+- **`getByText` matching partial.** `getByText("Users")` matches both the heading and any row with "Users" in the name. Use `getByRole("heading", { name: "Users" })`.
+- **Overly specific locators.** `page.locator("table.sites-table > tbody > tr:nth-child(2)")` breaks on any table-component refactor. Role-based locators survive.
+- **Test seeds sharing names across files.** `batches.spec.ts` and `sites.spec.ts` both creating a row called `"Playwright Temp"` — one test's archive sweep takes out the other. Append `Date.now()` + file-specific prefix.
+- **Modal close not awaited.** `click("cancel")` → immediate `expect(input).not.toBeVisible()` can race the animation. Use `await expect(modal).not.toBeVisible()` instead of asserting on children.
+- **Global-setup mutations not idempotent.** Running the full suite twice locally should leave Supabase in the same state as one run. If it accumulates rows, the seed is wrong.
+- **`FEATURE_SUPABASE_AUTH` unset in CI.** The E2E workflow force-sets `FEATURE_SUPABASE_AUTH=true` so the real login flow runs. Local `npm run test:e2e` uses `playwright.config.ts` to match.
+- **Flake from Supabase startup timing in CI.** `supabase start` sometimes takes 20–30s. The workflow does reads via `supabase status --output json | jq -r '.API_URL'` right after start; if status returns early, env vars are empty. The workflow pattern in `e2e.yml` handles this; don't short-cut.
+- **Snapshot / visual regression not yet wired.** `toHaveScreenshot()` is deferred — baselines must be captured in the exact CI image first, reviewed, and committed. `docs/testing-roadmap.md` has the Level-2 plan.
+
+## Pointers
+
+- Canonical instances: `e2e/auth.spec.ts`, `e2e/sites.spec.ts`, `e2e/users.spec.ts`, `e2e/batches.spec.ts`.
+- Helpers: `e2e/helpers.ts`, `e2e/global-setup.ts`, `e2e/fixtures.ts`.
+- Config: `playwright.config.ts`, `.github/workflows/e2e.yml`.
+- Roadmap: `docs/testing-roadmap.md` (Level 2–7 plan; Level 1 shipped).
+- Related: [`new-admin-page.md`](./new-admin-page.md) (E2E is part of the admin-page pattern).

--- a/docs/patterns/quality-gate-runner.md
+++ b/docs/patterns/quality-gate-runner.md
@@ -1,0 +1,154 @@
+# Pattern — Quality gate runner
+
+## When to use it
+
+Validating a generated artifact against a fixed set of correctness rules before it commits downstream state. The canonical instance is M3-5: LLM-generated HTML is checked against 8 rules (5 shipped, 3 deferred) before the WP publish step fires.
+
+Use whenever:
+
+- You have N independent pass/fail checks.
+- Failures on any one should short-circuit the rest (no point running the meta-description check if the wrapper is wrong).
+- Failures must be attributable ("which gate, why") for debugging and for the operator to trust the system.
+- The caller wants a single `GateResult` per artifact, not to orchestrate N checks.
+
+Don't use for: schema validation (Zod at the boundary handles that), single-check validation (just call the helper directly), rules that mutate the artifact (gates are read-only verdicts).
+
+## Required files
+
+| File | Role |
+| --- | --- |
+| `lib/<subject>-gates.ts` | The runner + gates. One module per subject; M3 has `lib/quality-gates.ts`. |
+| `lib/__tests__/<subject>-gates.test.ts` | Per-gate pass/fail tests + runner short-circuit behaviour. |
+| Event-type constant in `lib/tool-schemas.ts` | `gate_failed` event shape so reconciliation can read gate outcomes from the log. |
+
+## Scaffolding
+
+### Types
+
+Model on `lib/quality-gates.ts`:
+
+```ts
+export type GateName =
+  | "wrapper"
+  | "scope_prefix"
+  | "html_basics"
+  | "slug_kebab"
+  | "meta_description";
+
+export type GatePass = { kind: "pass"; gate: GateName };
+export type GateFail = {
+  kind: "fail";
+  gate: GateName;
+  reason: string;
+  details?: Record<string, unknown>;
+};
+export type GateSkip = { kind: "skipped"; gate: GateName; reason: string };
+
+export type GateResult = GatePass | GateFail | GateSkip;
+```
+
+`skipped` is explicit, not absent. A deferred gate (because the upstream registry isn't wired yet) returns `skipped` with the reason — the operator sees "gate ran, wasn't applicable" not "gate silently absent."
+
+### Individual gates
+
+One function per gate. Pure. No I/O except in the input arg. Signature:
+
+```ts
+export function gate<Name>(
+  subject: <Artifact>,
+  context: <Context>,
+): GateResult { ... }
+```
+
+For M3 gates, `subject` is the generated HTML + slug + meta, `context` is the site prefix + design-system version.
+
+Each gate returns exactly one `GateResult`. No throwing — callers orchestrate via `kind` discriminant.
+
+### Runner
+
+```ts
+export function runGates(
+  gates: readonly ((subject: <Artifact>, ctx: <Context>) => GateResult)[],
+  subject: <Artifact>,
+  ctx: <Context>,
+): { passed: boolean; results: GateResult[] } {
+  const results: GateResult[] = [];
+  for (const gate of gates) {
+    const r = gate(subject, ctx);
+    results.push(r);
+    if (r.kind === "fail") {
+      return { passed: false, results };
+    }
+  }
+  return { passed: true, results };
+}
+```
+
+**Short-circuits on first failure.** No point running downstream gates when the artifact is already dead. Test: `runGates` called with three gates where the middle one fails → result length is 2 (the passing one + the failing one), third gate never invoked.
+
+### Wiring into the worker
+
+The runner lives in the worker's validation stage. See [`new-batch-worker-stage.md`](./new-batch-worker-stage.md) for the state-transition context:
+
+```ts
+// state: generating → validating → (succeeded | failed)
+const { passed, results } = runGates(ALL_GATES, html, { prefix, dsVersion });
+await logEvent(slotId, "gate_run_completed", { results });
+
+if (!passed) {
+  const firstFail = results.find((r) => r.kind === "fail")!;
+  await logEvent(slotId, "gate_failed", {
+    gate: firstFail.gate,
+    reason: firstFail.reason,
+  });
+  await transitionState(slotId, "failed", {
+    failure_code: "GATE_FAILED",
+    failure_detail: firstFail.gate,
+  });
+  return;
+}
+await transitionState(slotId, "publishing");
+```
+
+## Required tests
+
+Per gate:
+
+1. **Happy path** — a canonical valid input returns `{ kind: "pass" }`.
+2. **Each documented failure mode** — one test per reason the gate can fire. If the gate checks "exactly one `h1`", that's two tests (zero, two-or-more); the pass case covers exactly-one.
+3. **Edge cases** — empty input, malformed input (if the gate receives raw content).
+
+Per runner:
+
+4. **All gates pass** — `passed: true`, `results.length === N`.
+5. **First gate fails** — `passed: false`, `results.length === 1`, subsequent gates not called.
+6. **Middle gate fails** — `passed: false`, `results.length === K+1` where K is the count of passing gates before the failure.
+7. **Ordering stability** — `runGates` runs in declared order; changing order affects which gate attribution is surfaced first. Lock the order in a test so refactors don't silently change error UX.
+
+Copy the shape from `lib/__tests__/quality-gates.test.ts`.
+
+## Standard PR structure
+
+Follow [`ship-sub-slice.md`](./ship-sub-slice.md). Title shape: `feat(<milestone>): <subject> quality gates (<N shipped, M deferred>)`.
+
+The description explicitly lists every gate shipping now, every gate deferred, and the reason. Example from M3-5:
+
+> Shipping: wrapper, scope_prefix, html_basics, slug_kebab, meta_description.
+> Deferred to M3-5b: allowed_components, no_freeform_html, word_count. Reasons: registry dependency (first two), schema column missing (third).
+
+Operator trust depends on knowing what's enforced vs what's pending.
+
+## Known pitfalls
+
+- **Runner that doesn't short-circuit.** Collecting all failures sounds helpful but clutters the UX: the operator sees "5 failures" when gate 1 caused cascading failures in 2–5. First-fail + fix-and-retry is clearer.
+- **Gates with I/O.** A gate that hits the DB or the LLM is not a gate, it's a workflow step. Keep gates pure — pass them the data they need via the `context` arg, don't let them fetch.
+- **Over-generous `skipped` returns.** A gate returning `skipped` for a case that should be `fail` silently green-lights bad artifacts. Only `skipped` when the gate genuinely doesn't apply (feature flag off, prerequisite column empty).
+- **Hard-coded gate list in the runner.** Externalise the list (`const ALL_GATES = [gateWrapper, gateScopePrefix, ...]`) so tests can run with subsets. M3-5 deferred 3 gates by removing them from the list, not by disabling the code.
+- **Failures missing `details`.** A gate that fails with "html_basics: img missing alt" is less useful than "html_basics: img at offset 1423 missing alt, src=<trimmed>". Include enough detail in the event log to triage without rerunning.
+- **Gate result logged only to stdout.** Gate results belong in the append-only event log (`generation_events` in M3). Stdout gets trimmed; the event log doesn't.
+- **Test that asserts gate N runs after gate M but doesn't pin the order in production code.** The runner uses an array; the array is the source of truth. Lock it in a test as described above.
+
+## Pointers
+
+- Canonical instance: `lib/quality-gates.ts` + `lib/__tests__/quality-gates.test.ts`.
+- Related: [`new-batch-worker-stage.md`](./new-batch-worker-stage.md), [`background-worker-with-write-safety.md`](./background-worker-with-write-safety.md).

--- a/docs/patterns/rls-policy-test-matrix.md
+++ b/docs/patterns/rls-policy-test-matrix.md
@@ -1,0 +1,203 @@
+# Pattern — RLS policy test matrix
+
+## When to use it
+
+Validating Postgres Row-Level Security policies across the full (role × table × operation) grid. The canonical instance is M2b: every authenticated role (admin / operator / viewer) × every user-facing table × each of SELECT / INSERT / UPDATE / DELETE produces exactly one positive assertion.
+
+Use whenever:
+
+- A migration adds or modifies RLS policies.
+- A new table opts into RLS (i.e. every new table).
+- A role is added, renamed, or has its permissions changed.
+
+Don't use for: service-role flows (service role bypasses RLS by design — assertions there belong in the feature test, not the RLS matrix), tables intentionally open to authenticated reads (the matrix still runs; it just asserts the openness).
+
+## The matrix shape
+
+Rows: authenticated role (`admin`, `operator`, `viewer`, sometimes `authenticated-no-role` for boundary cases).
+Columns: operation (`SELECT`, `INSERT`, `UPDATE`, `DELETE`).
+
+Each cell has exactly one of:
+
+- **Allow** — the op succeeds on matching rows.
+- **Filter** — the op runs but returns zero matching rows (silent RLS filter, not an error).
+- **Deny** — the op raises `42501 / "new row violates row-level security policy"` (only INSERT raises; SELECT/UPDATE/DELETE filter-to-zero).
+
+Every cell has a test. No silent "the policy implies this" — each cell gets an explicit assertion.
+
+## Expected outcomes by op (reference)
+
+- **SELECT** — denied rows filter out. Response is `{ data: [], error: null }`.
+- **INSERT** — denied rows raise `42501`. Response is `{ data: null, error: { code: "42501", ... } }`.
+- **UPDATE** — denied rows don't match the USING predicate. Response is `{ data: [], error: null }` (zero rows matched).
+- **DELETE** — same as UPDATE.
+
+The asymmetry bites: a denied SELECT looks identical to an empty table. Tests that assert "zero rows" should seed a row the policy would filter and one the policy would allow, so the zero-count proves the filter, not the empty table.
+
+## Required files
+
+| File | Role |
+| --- | --- |
+| `lib/__tests__/<slug>-rls.test.ts` | The matrix. One file per coherent group of tables (M2b covers opollo_users + sites + design_systems + design_components + design_templates + pages + opollo_config in one file). |
+| `lib/__tests__/_auth-helpers.ts` | `seedAuthUser`, `signInAs`, `cleanupTrackedAuthUsers`. Reused across all auth-touching tests. |
+| `lib/__tests__/_setup.ts` | TRUNCATE + auth-user cleanup in `beforeEach`. |
+| The migration introducing the RLS change | Covered by [`new-migration.md`](./new-migration.md); the test file verifies it. |
+
+## Scaffolding
+
+### Setup
+
+Model on `lib/__tests__/m2b-rls.test.ts`:
+
+```ts
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { seedAuthUser, type SeededAuthUser } from "./_auth-helpers";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+function buildClient(accessToken: string): SupabaseClient {
+  const url = process.env.SUPABASE_URL!;
+  const anonKey = process.env.SUPABASE_ANON_KEY!;
+  return createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+}
+
+describe("<migration-slug>: user-scoped RLS policies", () => {
+  let admin: SeededAuthUser;
+  let operator: SeededAuthUser;
+  let viewer: SeededAuthUser;
+  let adminClient: SupabaseClient;
+  let operatorClient: SupabaseClient;
+  let viewerClient: SupabaseClient;
+
+  beforeAll(async () => {
+    admin = await seedAuthUser({ email: "rls-admin@opollo.test", role: "admin", persistent: true });
+    operator = await seedAuthUser({ email: "rls-operator@opollo.test", role: "operator", persistent: true });
+    viewer = await seedAuthUser({ email: "rls-viewer@opollo.test", role: "viewer", persistent: true });
+    adminClient = buildClient(admin.accessToken);
+    operatorClient = buildClient(operator.accessToken);
+    viewerClient = buildClient(viewer.accessToken);
+  });
+
+  beforeEach(async () => {
+    // _setup.ts TRUNCATEs all tables (including opollo_users) between tests.
+    // Re-insert the three role rows so policies evaluating public.auth_role()
+    // resolve correctly.
+    const svc = getServiceRoleClient();
+    await svc.from("opollo_users").insert([
+      { id: admin.userId,    email: admin.email,    role: "admin" },
+      { id: operator.userId, email: operator.email, role: "operator" },
+      { id: viewer.userId,   email: viewer.email,   role: "viewer" },
+    ]);
+  });
+
+  // ... per-table describe blocks below
+});
+```
+
+Key moves:
+
+- **`persistent: true` on the auth users.** Cleanup (`cleanupTrackedAuthUsers`) skips them so `beforeAll`'s tokens stay valid across the whole file. Non-persistent users get swept between tests.
+- **Role-scoped clients built once.** Tokens don't rotate within a 2-minute test run.
+- **`beforeEach` re-inserts `opollo_users`** because `_setup.ts` TRUNCATEs them. Without this, `public.auth_role()` returns NULL and every policy evaluates weirdly.
+
+### Per-table describe block
+
+```ts
+describe("sites", () => {
+  let seedId: string;
+
+  beforeEach(async () => {
+    const svc = getServiceRoleClient();
+    const { data } = await svc
+      .from("sites")
+      .insert({ name: "RLS Test Site", prefix: "rt", created_by: admin.userId })
+      .select("id")
+      .single();
+    seedId = data!.id;
+  });
+
+  it("admin SELECT: can read", async () => {
+    const { data, error } = await adminClient.from("sites").select("id").eq("id", seedId);
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+  });
+
+  it("operator SELECT: can read", async () => { /* allow */ });
+  it("viewer SELECT: can read", async () => { /* allow */ });
+
+  it("admin INSERT: allowed", async () => { /* returns inserted row */ });
+  it("operator INSERT: allowed", async () => { /* returns inserted row */ });
+  it("viewer INSERT: denied via 42501", async () => {
+    const { data, error } = await viewerClient
+      .from("sites")
+      .insert({ name: "Nope", prefix: "no" })
+      .select();
+    expect(data).toBeNull();
+    expect(error?.code).toBe("42501");
+  });
+
+  it("admin UPDATE: allowed", async () => { /* matches + updates */ });
+  it("operator UPDATE: allowed", async () => { /* matches + updates */ });
+  it("viewer UPDATE: filtered — 0 rows", async () => {
+    const { data, error } = await viewerClient
+      .from("sites")
+      .update({ name: "Rename" })
+      .eq("id", seedId)
+      .select();
+    expect(error).toBeNull();
+    expect(data).toHaveLength(0);
+  });
+
+  it("admin DELETE: allowed", async () => { /* row goes */ });
+  it("operator DELETE: allowed", async () => { /* row goes */ });
+  it("viewer DELETE: filtered — 0 rows", async () => {
+    const { data, error } = await viewerClient
+      .from("sites")
+      .delete()
+      .eq("id", seedId)
+      .select();
+    expect(error).toBeNull();
+    expect(data).toHaveLength(0);
+  });
+});
+```
+
+**One `it` per cell**, title names the role + op + outcome. When a cell fails, the test name alone tells the reader what's broken.
+
+## Required tests per migration
+
+When an RLS migration lands:
+
+1. **Every new table ships a full matrix.** (role × op) cells all explicit.
+2. **Every policy change re-runs the affected rows of the matrix.** If the admin-update policy changed, rerun the `admin UPDATE` + `admin DELETE` cells.
+3. **Positive + negative per role.** Viewer's INSERT rejected is the negative; viewer's SELECT succeeding is the positive. Don't test only the denies.
+4. **RLS helper function coverage** — if the migration adds a SECURITY DEFINER helper like `public.auth_role()`, test: correct return for each signed-in role, NULL when no session, NULL when the JWT sub doesn't match any row.
+5. **Cross-table consistency** — if two tables share a policy pattern (e.g. `authed_read_own`), exactly the same outcomes apply per role. Copy-paste + rename the describe block.
+
+## Standard PR structure
+
+Follow [`ship-sub-slice.md`](./ship-sub-slice.md) + [`new-migration.md`](./new-migration.md). The description explicitly states:
+
+- **Which tables' matrices** the PR exercises.
+- **Which cells changed.** "Admin UPDATE was previously filtered; now allowed. Test added."
+- **Which policies use `public.auth_role()`** vs. other helpers. If a new helper is introduced, every table using it gets re-tested.
+
+## Known pitfalls
+
+- **Testing with service-role and calling it an RLS test.** Service-role bypasses RLS; its tests belong in the feature test file. RLS tests use role-scoped clients with anon key + user-scoped JWT.
+- **Not re-inserting `opollo_users` in `beforeEach`.** `_setup.ts` TRUNCATEs; without the re-insert, `public.auth_role()` returns NULL and every policy evaluates against a non-existent role. All tests fail in confusing ways.
+- **Collapsing INSERT denial + UPDATE denial into one test.** They surface differently (INSERT raises 42501, UPDATE returns zero rows). Two different tests.
+- **Asserting `data.length === 0` without proving a row was there to filter.** Seed + query; "zero rows" with no seeded row proves nothing. `describe`'s `beforeEach` should always seed before the test runs.
+- **Tokens expiring mid-run.** `seedAuthUser` mints a JWT with a multi-hour expiry — fine for 2-minute test runs, breaks if a test file runs longer (rare). If the test suite grows past 10 minutes, refresh tokens in a `beforeEach`.
+- **`persistent: true` leaking across test FILES.** Each file's `persistent: true` users stay in `auth.users` forever unless explicitly cleaned. Use a file-scoped email prefix (`rls-admin@opollo.test` in `m2b-rls.test.ts`, different in `m3-rls.test.ts`) to avoid collision.
+- **Forgetting `service_role_all`.** Without it, service-role writes fail. Every new table needs `FOR ALL TO service_role USING (true) WITH CHECK (true)` as the first policy.
+- **Policy order confusion.** Postgres evaluates policies as OR'd `USING` clauses; adding a more-restrictive policy doesn't tighten, it loosens. Test the full matrix after any policy change.
+
+## Pointers
+
+- Canonical instance: `lib/__tests__/m2b-rls.test.ts`, supported by `supabase/migrations/0005_m2b_rls_policies.sql`.
+- Related: [`new-migration.md`](./new-migration.md), `lib/__tests__/_auth-helpers.ts` (seeding pattern), `lib/__tests__/m2a-auth-link.test.ts` (`public.auth_role()` helper coverage).


### PR DESCRIPTION
Step 1 of the pre-M4 hardening. Three-tier split per Steven's spec.

## What lands

### Tier 1 — six new `docs/patterns/` files (plus carry-overs)

Existing (shipped in PR #54): `ship-sub-slice.md`, `new-admin-page.md`, `new-api-route.md`, `new-migration.md`, `extract-design-system.md`, `new-batch-worker-stage.md`.

New in this PR:

- **`background-worker-with-write-safety.md`** — generalised M3 worker playbook. Five invariants (atomic lease, heartbeat, reaper, pre-computed idempotency, event-log-first) with rationale for each. Target reader: a future greenfield worker (M4 or later), not a new stage in the existing M3 worker.
- **`quality-gate-runner.md`** — N pass/fail checks with first-fail short-circuit. `GatePass` / `GateFail` / `GateSkip` discriminated union; runner tests pin ordering; gates are pure (no I/O).
- **`feature-flagged-rollout.md`** — env-flag + DB-backed kill switch pattern. Strict-parse semantics (`=== "true" || === "1"`), 5s cache in kill-switch reads, break-glass interaction, and — critically — flag-removal planning so flags don't rot.
- **`concurrency-test-harness.md`** — 4-worker Promise.all pattern. Real Postgres, real `FOR UPDATE SKIP LOCKED`, set assertions not sequence assertions, seed ≥ 5× worker count to rule out happy-accident passes.
- **`rls-policy-test-matrix.md`** — (role × table × op) matrix for RLS migrations. Asymmetric deny surfaces (INSERT raises 42501; UPDATE/DELETE filter to zero); persistent-auth-user discipline; `public.auth_role()` coverage; why every new table needs `service_role_all` as its first policy.
- **`playwright-e2e-coverage.md`** — hard-requirement expansion. Role-based locators, dialog auto-accept (`page.once("dialog")` not `on`), `Date.now()` in names for parallel-run safety, `global-setup.ts` idempotency discipline.

`docs/patterns/README.md` reorganised into three sections — *Shipping work*, *Workers + write safety*, *Testing* — plus cross-links to every other doc (RUNBOOK / RULES / ENGINEERING_STANDARDS / BACKLOG / DATA_CONVENTIONS / PROMPT_VERSIONING).

### Tier 2 — `docs/RULES.md` with 5 codified rules

Each rule: the rule itself, then the incident that taught it.

1. **Service-role client pollution in test helpers** (M2b incident) — tests use the shared `getServiceRoleClient()` only, never `createClient(...)` inline.
2. **Supabase email auth config for fresh local stacks** (M2a onboarding) — `supabase/config.toml` must declare `[auth.email] enable_signups = true`.
3. **CI stuck-run recovery: empty commit, don't cancel-rerun** (M3 × 2 incidents) — `git commit --allow-empty` advances the SHA and clears the concurrency-group hang; cancel-rerun reproduces the hang.
4. **Write-safety risk audit is mandatory on every sub-slice plan** (M3-6 incident) — the "Risks identified and mitigated" section is non-skippable. No hotspots → state it explicitly ("No write-safety hotspots — pure docs change") rather than omit.
5. **UX debt capture discipline — into BACKLOG.md, never inline-fix** (M2d sign-off incident) — ambient "while I'm here" cleanups break the scope contract + stretch review.

### Tier 3 — `docs/RUNBOOK.md` extensions (5 new sections)

- **Apply pending migrations to production** — the `deploy-migrations.yml` gap-recovery playbook, including break-glass gating.
- **Rotate a secret** — per-key playbooks with downtime windows for: `SUPABASE_SERVICE_ROLE_KEY`, `OPOLLO_MASTER_KEY` (zero-downtime staged rotation via `OPOLLO_MASTER_KEY_NEXT`), `OPOLLO_EMERGENCY_KEY`, `CRON_SECRET`, `ANTHROPIC_API_KEY`, WP app passwords per site.
- **Provision env vars for a new observability tool** — batch playbook for Sentry / Axiom / Langfuse / Upstash. Steven's one-session batch mode is the target.
- **Diagnose a missing-migration incident** — reading the Postgres error, confirming via `supabase migration list`, which feature flag to disable as stop-gap, why the `deploy-migrations.yml` failure is the real root cause.
- **Production incident recovery** — the general-purpose entry. Order of operations (stop the bleeding → confirm health → isolate blast radius → capture state → smallest fix → confirm clear → post-mortem). Plus an explicit "never do during an incident" list (`git push --force`, DROP on prod tables, rotating a secret while break-glass is active, fixing root cause + symptom in the same commit).

### CLAUDE.md — "How to work" now has three doors

> Before starting a task that matches a pattern, read `docs/patterns/<pattern-name>.md` first.
> For operations tasks — consult `docs/RUNBOOK.md`.
> For one-off rules — see `docs/RULES.md`.

Three separate shelves; each has its own governance (patterns encode scaffolding + pitfalls; runbook entries encode playbooks; rules are one-paragraph reminders).

## Risks identified and mitigated

No write-safety hotspots — pure docs change; no runtime behaviour changes, no schema changes, no workflow changes. Every file I touched is in `docs/` or is a doc-level pointer in `CLAUDE.md`.

Other risks:

- **Docs drift.** The patterns + rules + runbook now total ~3500 lines across 14 files. Maintenance rule encoded in `docs/patterns/README.md` ("update on PRs that materially change shape; rewrite if three unrelated PRs violate") and repeated in the "Adding a new runbook entry" / "Adding a new rule" sections. A future linter could validate that each pattern's "Pointers" section refers to files that exist, but that's deferred.
- **Pattern rot pitfalls citing past PRs.** Each pattern's "Known pitfalls" names the PR that burned us. When a pitfall becomes impossible (a schema constraint, a new framework version), mark it resolved in place — don't delete. History of what we burned on is useful context for future agents.
- **Hidden assumptions.** I've described patterns based on what shipped; an agent reading a pattern without seeing the shipped code might miss tacit context. Every pattern's "Pointers" section names the canonical shipped instance so the pattern is always read alongside a concrete example.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] Spot-checked cross-references: `new-api-route.md` → `new-migration.md` → `rls-policy-test-matrix.md` all resolve.
- [x] `docs/patterns/README.md` index entries all point to existing files.
- [ ] Markdown renders in GitHub preview — will verify after PR opens.

## Next up

Step 2 of Steven's plan: **parallelism feasibility analysis**. After this merges, I'll ship `docs/PARALLELISM_PLAN.md` covering multi-session coordination via shared GitHub state (not local worktrees — Steven runs Claude Code in the browser). Will include: concrete bootstrap prompt for a second-tab session, `docs/WORK_IN_FLIGHT.md` template, conflict-recovery procedure, M4–M8 dependency map, auto-merge queue behaviour with concurrent PRs.

Then: stop and wait for Steven's M4 sign-off.

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42