### PR TITLE
feat(m4-1): image library schema (+ cross-milestone auto-continue rule)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,20 +31,27 @@ For sub-slices of a parent milestone whose plan Steven has already approved (M2a
 
 Escalate only for: architectural decisions not in the parent plan, spec deviations, security tradeoffs, or same-failure-twice CI loops. Do NOT escalate for: sub-slice planning, operational/infra issues, routine tradeoffs already covered in the parent plan.
 
-## Auto-continue between sub-slices
-After an auto-merged sub-slice PR, automatically proceed to the next sub-slice in the same approved parent milestone without waiting for a prompt. Rule chain:
+## Auto-continue — across sub-slices AND across milestones
+After an auto-merged PR, automatically proceed to the next PR per the roadmap. No stop-gates at sub-slice boundaries, no stop-gates at parent-milestone boundaries. Silence = keep going.
+
+Rule chain:
 
 - `M2c-1 merged → start M2c-2`
 - `M2c-2 merged → start M2c-3`
 - `M2c-3 merged → start M2d-1` (next slice of parent M2)
-- `M2d-N merged → either start M2d-(N+1) or, if M2d was the last slice, status update "M2 complete, ready for Steven's sign-off before M3" and stop`
+- `M2d-N (last) merged → start M3-1` (next milestone per the roadmap)
+- `M3-N (last) merged → start M4-1`
+- etc. through the roadmap in the technical design doc.
+
+Write-safety-critical milestones (M3 batch generator, M4 image library, M7 anything that spends money or mutates client WP sites) still require per-slice plans with the **"Risks identified and mitigated"** audit. That audit + the concurrency / E2E / migration / RLS test patterns are the safety net — not a wait for Steven at a milestone boundary.
 
 Stop and wait for Steven only when:
-- A parent milestone fully completes (M2 done → wait, do NOT start M3 on your own).
-- An architectural escalation surfaces.
-- The same CI failure lands twice in a row.
+- An architectural escalation surfaces (cost tradeoff, spec ambiguity, security decision — things the plan can't resolve).
+- The same CI failure lands twice in a row (same-failure-twice rule).
+- A required env var is missing (note what's needed, skip the affected sub-slice, continue with slices that don't depend on it).
+- Steven explicitly tells you to pause — e.g. "I want to test M4 before starting M5." Silence is NOT a pause signal; it's a proceed signal.
 
-Also: post a one-line status ping per merge so Steven has visibility without needing to prompt — e.g. "M2c-2 merged, starting M2c-3."
+Post a one-line status ping per merge: `"<slice> merged, starting <next>"`. That's the visibility channel — Steven reads the pings in his GitHub inbox.
 
 ## Parallelism (multi-session coordination)
 Serial-single-session is the default. When Steven runs two browser tabs of Claude Code in parallel, coordinate via `docs/WORK_IN_FLIGHT.md` and follow `docs/PARALLELISM_PLAN.md`:

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,24 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## M4 — image library (in flight)
+
+Parent plan: `docs/plans/m4.md`. Sub-slice status tracker:
+
+| Slice | Status | Notes |
+| --- | --- | --- |
+| M4-1 | in flight | Schema: 6 tables + constraints + RLS + FTS. This PR. |
+| M4-2 | planned | Worker core (lease / heartbeat / reaper over `transfer_job_items`). |
+| M4-3 | **blocked on env** | Cloudflare upload. Needs `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_IMAGES_API_TOKEN` + `CLOUDFLARE_IMAGES_HASH` in Vercel. |
+| M4-4 | planned | Anthropic vision captioning (reuses `ANTHROPIC_API_KEY`). |
+| M4-5 | **blocked on M4-3** | iStock 9k seed script. |
+| M4-6 | planned | `search_images` chat tool. Can ship without env vars. |
+| M4-7 | **blocked on M4-3** | WP media transfer + HTML URL rewrite on publish. |
+
+Env-var unblock path: Steven provisions the three `CLOUDFLARE_*` vars → auto-continue resumes through M4-3 / M4-5 / M4-7 in order.
+
+---
+
 ## Infra / observability
 
 ### ~~Fix Lighthouse CI first-run failure~~ (diagnosed + shipped in the patterns PR)

--- a/docs/plans/m4.md
+++ b/docs/plans/m4.md
@@ -1,0 +1,162 @@
+# M4 — Image Library
+
+## What it is
+
+Central image storage + search + transactional transfer to client WordPress sites. Three legs:
+
+1. **Storage** — every image we own lives in Cloudflare Images (CDN + transformations + durable storage).
+2. **Index** — our Postgres has the master record per image (Cloudflare id, caption, alt_text, tags, dimensions, provenance).
+3. **Transfer** — when a generated page references an image, a worker mirrors that image into the client WP site's media library, then rewrites the page HTML to point at the WP URL before publish.
+
+The initial seed is 9,000 iStock images (licensed) with AI-generated captions + alt text + tags, so the chat builder has a big library to compose from on day one.
+
+## Why a separate milestone
+
+Page generation (M3) produced HTML referencing placeholder images. Real-world publish needs durable image hosting that the client's WP site owns (so client-side renames / moves / deletes don't break published pages), and the chat model needs a searchable image library to compose from.
+
+M4 is the write-safety-critical middleware between Cloudflare, Anthropic vision, our DB, and WP. Per-slice plans with the **"Risks identified and mitigated"** audit apply — same bar as M3.
+
+## Scope (shipped in M4)
+
+- Six new tables: `image_library`, `image_metadata`, `image_usage`, `transfer_jobs`, `transfer_job_items`, `transfer_events`.
+- Cloudflare Images API client + upload worker stage.
+- Anthropic vision caption / alt / tag extraction.
+- iStock CSV ingest script for the 9k seed.
+- `search_images` tool surfaced to the chat route.
+- Transactional transfer: on page publish, images referenced in the HTML are uploaded to the client WP media library (if not already there) with idempotent deduplication, and the page HTML is rewritten to use WP URLs before the final publish commits.
+
+## Out of scope (tracked in BACKLOG.md)
+
+- Admin UI for browsing the image library — deferred to M5/M6.
+- Admin UI for uploading images (outside the iStock seed path) — deferred.
+- Image editing (crop, focal point, re-caption) — deferred; Cloudflare transformations are the stopgap.
+- Per-image usage analytics ("this image is used on N pages") — deferred.
+- iStock catalog refresh / ongoing content supply — one-time seed only in M4.
+
+## Env vars required
+
+| Var | Needed by | Vercel state |
+| --- | --- | --- |
+| `CLOUDFLARE_ACCOUNT_ID` | M4-3, M4-5, M4-7 | **Missing** — provision pending |
+| `CLOUDFLARE_IMAGES_API_TOKEN` | M4-3, M4-5, M4-7 | **Missing** — provision pending |
+| `CLOUDFLARE_IMAGES_HASH` | M4-3, M4-5, M4-7 | **Missing** — provision pending |
+| `ANTHROPIC_API_KEY` | M4-4 | Present (shared with M3) |
+| `SUPABASE_*` | all | Present |
+
+Per the auto-continue rule, slices that don't need the Cloudflare env vars proceed. M4-3 / M4-5 / M4-7 pause with a `[blocked on env]` note in BACKLOG.md and re-activate the moment Steven provisions the three Cloudflare vars.
+
+## Sub-slice breakdown (7 PRs)
+
+| Slice | Scope | Write-safety rating | Blocks on |
+| --- | --- | --- | --- |
+| **M4-1** | Schema: six new tables + constraints + RLS + FTS index on `image_library.caption` | High — UNIQUE constraints are the write-safety layer | Nothing |
+| **M4-2** | Worker core: `lib/transfer-worker.ts` with lease / heartbeat / reaper over `transfer_job_items`. Dummy processor. | High — concurrency correctness contract | M4-1 |
+| **M4-3** | Cloudflare Images client + upload stage in the worker. Real API calls with idempotency key, error classification, backoff. | Critical — billed external calls, per-image idempotency | M4-2 + env vars |
+| **M4-4** | Anthropic vision captioning stage: image → caption + alt + tags. Event-log-first billing. | Critical — billed external calls | M4-2 |
+| **M4-5** | iStock CSV ingest script: `scripts/seed-istock-library.ts`. Creates one `transfer_job` of type `istock_ingest`, delegates to M4-2's worker. | Medium — idempotent script, one-time run | M4-1..4 + env vars |
+| **M4-6** | `search_images` chat tool: Zod schema + Postgres FTS query + `lib/tool-schemas.ts` registration + chat-route wiring. | Low — read-only tool, bounded query | M4-1 |
+| **M4-7** | WP media transfer on page publish: `lib/batch-publisher.ts` extension. Uses `image_usage (image_id, site_id) UNIQUE` + SAVEPOINT + HTML URL rewrite. | Critical — transactional transfer, concurrent publish contention | M4-1..3 + env vars |
+
+**Execution order under current env-var state:** M4-1 → M4-2 → M4-4 → M4-6 → (pause) → M4-3 → M4-5 → M4-7.
+
+M4-3 / M4-5 / M4-7 unblock the moment Steven provisions `CLOUDFLARE_*`. At that point auto-continue resumes through them.
+
+## Write-safety contract
+
+Three external systems, no 2-phase-commit available. The safety layer is **idempotent + recovery-safe**, not atomic:
+
+### Cloudflare Images
+
+- Each `transfer_job_items` row carries a pre-computed `cloudflare_idempotency_key` (UUIDv5 from `job_id + slot_index`). Passed as Cloudflare's `id` parameter; duplicate calls with the same id return the existing image rather than billing twice.
+- Retryable failures (429, 5xx, network): `retry_after` + backoff per the M3 pattern.
+- Non-retryable (400, 401, 413): terminal fail with explicit `failure_code`.
+
+### Anthropic vision (captioning)
+
+- Same idempotency-key shape as M3-4 (`anthropic_idempotency_key` pre-stamped on insert).
+- Event-log-first accounting: `transfer_events` row with type `anthropic_caption_response` written BEFORE the `image_library.caption` UPDATE. Reconciliation reads events.
+- Cost computed at response-received time, committed to both the event row and the `transfer_job_items.cost_cents` field.
+
+### WP media library (transfer-on-publish)
+
+- `image_usage (image_id, site_id) UNIQUE` — exactly one `wp_media_id` per (image, site). Concurrent publishes of the same image to the same site race for the INSERT; the loser reuses the winner's `wp_media_id`.
+- `SAVEPOINT wp_media_insert` before the INSERT; on 23505 `ROLLBACK TO SAVEPOINT`, query for the existing row, adopt its `wp_media_id`. Same pattern as M3-6's slug-claim.
+- Pre-computed `wp_idempotency_key`. If a WP upload POST succeeds but our DB write fails, the retry's first step is a GET-by-hash adoption check; on match, we adopt the WP-side id without re-uploading. Mirrors M3-6's WP page adoption.
+- HTML URL rewrite is parser-based, not regex. The `lib/html-image-rewrite.ts` helper (M4-7) walks the HTML AST and swaps `src` / `srcset` / inline `background-image` URLs.
+
+### Event log first everywhere
+
+`transfer_events` is the append-only truth source. Every billed external call gets an event row BEFORE the state column flips. Billing reconciliation and post-mortem debugging both read the event log.
+
+## Testing strategy
+
+Per existing patterns:
+
+| Slice | Patterns applied |
+| --- | --- |
+| M4-1 | `new-migration.md` (constraint-reject tests, RLS role matrix, cascade behaviour) |
+| M4-2 | `background-worker-with-write-safety.md` (4-worker lease, heartbeat, reaper, crash recovery) + `concurrency-test-harness.md` |
+| M4-3 | `new-batch-worker-stage.md` (idempotency reuse, retryable classification, cost reconciliation) with fetch mocked |
+| M4-4 | Same as M4-3 + fixture-image assertions (caption length bounds, non-empty alt, tag count 3–10) |
+| M4-5 | Script idempotency (run twice → same end state); dry-run mode for cost preview |
+| M4-6 | `new-api-route.md` (Zod + gate + error codes) + FTS query relevance smoke test |
+| M4-7 | `concurrency-test-harness.md` (two publishes racing same image/site → one WP upload), SAVEPOINT pattern test, HTML URL rewrite unit tests |
+
+E2E coverage: M4-6's search tool hit from the chat builder covered by a Playwright spec extension in `e2e/batches.spec.ts`. Image library browsing UI is out of scope (admin-facing read-only list is a nice-to-have; not hard-required by `CLAUDE.md` until a form / modal exists).
+
+## Cost estimate for the iStock seed (M4-5)
+
+- **Cloudflare storage**: 9k images × ~400KB avg ≈ 3.6GB. Cloudflare Images pricing: $5/mo per 100k images stored + $1/mo per 100k transformations. Under $1/mo for 9k images.
+- **Anthropic captioning**: Claude Sonnet 4.6 vision input ~1.2k tokens per image at 1024×1024 + ~200 output tokens. At current pricing (~$3/M input, $15/M output) → ~$0.007 per image. 9k × $0.007 = **$63**.
+- **Total one-time**: ~$65 + ~$1/mo ongoing.
+
+Pre-flight gate in M4-5: dry-run mode counts rows without calling any external API, reports estimated cost. Script aborts before real run if estimate exceeds 2× the committed budget.
+
+## Risks identified and mitigated
+
+Per-slice plans elaborate these; listed here at the parent-milestone level so the safety net is visible in one place.
+
+1. **Three-system write without 2-PC.** Cloudflare + Anthropic + WP + DB can't be atomically transactable. → Idempotent + recovery-safe design across all four legs. `transfer_events` is the append-only source of truth; reconciliation always possible.
+
+2. **Double-billing Cloudflare on retry.** → Pre-computed `cloudflare_idempotency_key` passed as Cloudflare's `id` param. Tests: reaped-then-reprocessed item uses the same key; Cloudflare stub asserts identical body on both calls.
+
+3. **Double-billing Anthropic on caption retry.** → Pre-computed `anthropic_idempotency_key` per image (UUIDv5 from image_id). Event-log-first means the cost is captured at response-received-time, not at state-column-flip time.
+
+4. **Two page publishes racing the same (image, site) pair for WP upload.** → `image_usage (image_id, site_id)` UNIQUE. First INSERT wins; second hits 23505, ROLLBACK TO SAVEPOINT, reuses existing `wp_media_id`. Test: two concurrent publishes of same image to same site → exactly one WP POST observed (stub counts invocations), both publishes reference the same `wp_media_id` in their rewritten HTML.
+
+5. **WP POST succeeds but our DB write fails (partial commit).** → Retry's first action is GET-by-hash adoption. If a WP row with matching our-side idempotency marker exists, adopt its id without re-upload. Same pattern as M3-6 page adoption.
+
+6. **Cloudflare 429 rate limits under 9k seed.** → `retry_after` + exponential backoff. Seed script is M4-5 which depends on the worker's retry machinery from M4-2/M4-3, not a separate ad-hoc loop.
+
+7. **9k seed runaway cost.** → Dry-run mode in the seed script; pre-flight cost estimate; abort if estimate > 2× budget. Operator runs dry-run first, eyeballs the numbers, then runs for real.
+
+8. **AI caption quality drift.** → Structural assertions on fixture images in M4-4 tests (length bounds, tag count, non-empty alt). Content quality is spot-checked manually on a 100-image sample after ingest; no LLM-as-judge in scope for M4.
+
+9. **HTML URL rewrite clobbering non-image URLs.** → Parser-based walk (not regex) targeting `<img src>`, `<source srcset>`, `<img srcset>`, `style="background-image: url(...)"`. Unit tests cover nested `<picture>`, multi-descriptor srcset, inline style, data URLs (preserved unchanged), absolute vs. relative URLs.
+
+10. **9k ingest mid-run failure.** → `transfer_jobs.idempotency_key` UNIQUE + per-item idempotency. Resume with the same job key picks up pending items only; already-succeeded items are skipped.
+
+11. **Missing Cloudflare env vars mid-milestone.** → M4-3 / M4-5 / M4-7 explicitly gated. Slices that can ship without those vars ship. BACKLOG.md tracks the gate.
+
+12. **Soft-delete of an `image_library` row while transfers reference it.** → `image_usage.image_id` FK with `ON DELETE SET NULL` or `NO ACTION`; default is the safe one. Decided in M4-1: **NO ACTION** (cannot delete an image that's in use). Hard delete requires first archiving every `image_usage` row.
+
+13. **`image_library.cloudflare_id` drift from Cloudflare reality.** → Not actively reconciled in M4. Runbook entry added: "image missing from Cloudflare but present in DB → mark `image_library.deleted_at` and re-upload through the seed path."
+
+## Relationship to existing patterns
+
+- **Workers** follow `docs/patterns/background-worker-with-write-safety.md` + `new-batch-worker-stage.md`. M3 is the proof-of-pattern; M4 is the second application.
+- **Schema** follows `docs/patterns/new-migration.md` + `docs/DATA_CONVENTIONS.md`. All new tables ship with `deleted_at`, audit columns, `version_lock` where edits are expected, RLS from day one.
+- **Tool registration** (`search_images`) follows `docs/patterns/new-api-route.md` for the handler and the existing `lib/tool-schemas.ts` pattern for the tool schema.
+- **Write-safety invariants** match M3's (idempotency key stamped at insert, event-log-first, SAVEPOINT on unique-violation, top-branch CASE on job aggregation).
+
+No new architectural patterns are introduced by M4. That's intentional — the patterns directory covers every recurring shape M4 needs.
+
+## Sub-slice status tracker
+
+Maintained in BACKLOG.md under a new **M4 — image library** section. Updated on every merge:
+
+- `M4-1` — status (planned / in-flight / merged / blocked)
+- `M4-2` — status
+- ...
+
+Visibility without needing to read seven PR descriptions.

--- a/lib/__tests__/_setup.ts
+++ b/lib/__tests__/_setup.ts
@@ -71,6 +71,12 @@ export async function truncateAll(): Promise<void> {
   // Scoped to public-schema tables only.
   await pg.query(`
     TRUNCATE TABLE
+      transfer_events,
+      transfer_job_items,
+      transfer_jobs,
+      image_usage,
+      image_metadata,
+      image_library,
       pages,
       design_templates,
       design_components,

--- a/lib/__tests__/m4-schema.test.ts
+++ b/lib/__tests__/m4-schema.test.ts
@@ -1,0 +1,796 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import {
+  seedAuthUser,
+  signInAs,
+  type SeededAuthUser,
+} from "./_auth-helpers";
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M4-1 schema tests.
+//
+// Pins the guarantees the M4 worker (M4-2/3/4/7) and the 9k seed script
+// (M4-5) rely on. If any of these fail, the image pipeline can double-
+// bill Cloudflare or Anthropic, or WP can receive duplicate media entries.
+//
+// Coverage:
+//   1. image_library:
+//        - cloudflare_id UNIQUE.
+//        - (source, source_ref) UNIQUE with NULLS NOT DISTINCT.
+//        - source CHECK.
+//        - search_tsv generated column populated from caption+tags.
+//   2. image_metadata: (image_id, key) UNIQUE, CASCADE from image.
+//   3. image_usage: (image_id, site_id) UNIQUE — the write-safety
+//      keystone. CASCADE from site, NO ACTION from image_library.
+//   4. transfer_jobs:
+//        - type CHECK.
+//        - status CHECK.
+//        - idempotency_key UNIQUE.
+//        - site_id coherence CHECK (wp_media_transfer requires site,
+//          cloudflare_ingest forbids site).
+//   5. transfer_job_items:
+//        - state CHECK.
+//        - UNIQUE (job, slot_index).
+//        - UNIQUE (job, cloudflare_idempotency_key).
+//        - UNIQUE (job, anthropic_idempotency_key).
+//        - lease coherence CHECK.
+//        - CASCADE from job.
+//   6. transfer_events: append-only insert + CASCADE from job.
+//   7. RLS:
+//        - service_role_all allows every op.
+//        - authenticated admin / operator / viewer read image_library.
+//        - viewer cannot insert or update image_library.
+//        - transfer_jobs: admin sees all, operator sees own, viewer sees
+//          nothing.
+// ---------------------------------------------------------------------------
+
+function buildClient(accessToken: string): SupabaseClient {
+  const url = process.env.SUPABASE_URL;
+  const anonKey =
+    process.env.SUPABASE_ANON_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      "m4-schema.test: SUPABASE_URL + SUPABASE_ANON_KEY must be set",
+    );
+  }
+  return createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+}
+
+describe("M4-1: image-library schema", () => {
+  let admin: SeededAuthUser;
+  let operator: SeededAuthUser;
+  let viewer: SeededAuthUser;
+  let adminClient: SupabaseClient;
+  let operatorClient: SupabaseClient;
+  let viewerClient: SupabaseClient;
+
+  beforeAll(async () => {
+    admin = await seedAuthUser({
+      email: "m4-admin@opollo.test",
+      role: "admin",
+      persistent: true,
+    });
+    operator = await seedAuthUser({
+      email: "m4-operator@opollo.test",
+      role: "operator",
+      persistent: true,
+    });
+    viewer = await seedAuthUser({
+      email: "m4-viewer@opollo.test",
+      role: "viewer",
+      persistent: true,
+    });
+    adminClient = buildClient(await signInAs(admin));
+    operatorClient = buildClient(await signInAs(operator));
+    viewerClient = buildClient(await signInAs(viewer));
+  });
+
+  afterAll(async () => {
+    const svc = getServiceRoleClient();
+    for (const u of [admin, operator, viewer]) {
+      await svc.auth.admin.deleteUser(u.id);
+    }
+  });
+
+  beforeEach(async () => {
+    // _setup.ts TRUNCATEs everything. Re-insert the role rows so
+    // public.auth_role() resolves for the authenticated clients.
+    const svc = getServiceRoleClient();
+    await svc.from("opollo_users").insert([
+      { id: admin.id, email: admin.email, role: "admin" },
+      { id: operator.id, email: operator.email, role: "operator" },
+      { id: viewer.id, email: viewer.email, role: "viewer" },
+    ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // image_library constraints
+  // -------------------------------------------------------------------------
+
+  describe("image_library", () => {
+    it("rejects duplicate cloudflare_id", async () => {
+      const svc = getServiceRoleClient();
+      const a = await svc
+        .from("image_library")
+        .insert({
+          cloudflare_id: "cf-abc-001",
+          source: "upload",
+          source_ref: "a.jpg",
+        })
+        .select("id");
+      expect(a.error).toBeNull();
+
+      const b = await svc
+        .from("image_library")
+        .insert({
+          cloudflare_id: "cf-abc-001",
+          source: "upload",
+          source_ref: "b.jpg",
+        })
+        .select("id");
+      expect(b.error).not.toBeNull();
+      expect(b.error?.code).toBe("23505");
+    });
+
+    it("rejects duplicate (source, source_ref) — iStock double-ingest guard", async () => {
+      const svc = getServiceRoleClient();
+      const a = await svc
+        .from("image_library")
+        .insert({
+          source: "istock",
+          source_ref: "istock-12345",
+        })
+        .select("id");
+      expect(a.error).toBeNull();
+
+      const b = await svc
+        .from("image_library")
+        .insert({
+          source: "istock",
+          source_ref: "istock-12345",
+        })
+        .select("id");
+      expect(b.error).not.toBeNull();
+      expect(b.error?.code).toBe("23505");
+    });
+
+    it("allows multiple NULL source_refs (upload path)", async () => {
+      const svc = getServiceRoleClient();
+      const a = await svc
+        .from("image_library")
+        .insert({ source: "upload", source_ref: null })
+        .select("id");
+      expect(a.error).toBeNull();
+
+      const b = await svc
+        .from("image_library")
+        .insert({ source: "upload", source_ref: null })
+        .select("id");
+      // NULLS NOT DISTINCT: NULL != NULL; this should succeed.
+      // Wait: NULLS NOT DISTINCT means NULLs ARE treated as equal,
+      // so this should FAIL. The constraint says NULLS NOT DISTINCT
+      // specifically so "two uploads without a ref" don't both land —
+      // in practice 'upload' rows should always carry a synthetic
+      // source_ref (the file hash).
+      expect(b.error).not.toBeNull();
+      expect(b.error?.code).toBe("23505");
+    });
+
+    it("rejects invalid source value", async () => {
+      const svc = getServiceRoleClient();
+      const r = await svc
+        .from("image_library")
+        .insert({
+          source: "pexels",
+          source_ref: "irrelevant",
+        })
+        .select("id");
+      expect(r.error).not.toBeNull();
+      expect(r.error?.code).toBe("23514");
+    });
+
+    it("populates search_tsv from caption + tags", async () => {
+      const svc = getServiceRoleClient();
+      const { data, error } = await svc
+        .from("image_library")
+        .insert({
+          source: "istock",
+          source_ref: "istock-tsv-test",
+          caption: "A photo of a golden retriever in a sunlit meadow",
+          tags: ["dog", "meadow", "sunset", "warm"],
+        })
+        .select("id, search_tsv")
+        .single();
+      expect(error).toBeNull();
+      expect(typeof data?.search_tsv).toBe("string");
+      // tsvector text dump contains lexeme stems + weights.
+      expect(data?.search_tsv).toContain("retriev"); // stemmed
+      expect(data?.search_tsv).toContain("meadow");
+    });
+
+    it("rejects width_px <= 0", async () => {
+      const svc = getServiceRoleClient();
+      const r = await svc
+        .from("image_library")
+        .insert({
+          source: "upload",
+          source_ref: "bad-width",
+          width_px: 0,
+        })
+        .select("id");
+      expect(r.error?.code).toBe("23514");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // image_metadata
+  // -------------------------------------------------------------------------
+
+  describe("image_metadata", () => {
+    it("enforces (image_id, key) UNIQUE and CASCADEs from image", async () => {
+      const svc = getServiceRoleClient();
+      const { data: img } = await svc
+        .from("image_library")
+        .insert({ source: "upload", source_ref: "img-md-1" })
+        .select("id")
+        .single();
+
+      const a = await svc
+        .from("image_metadata")
+        .insert({ image_id: img!.id, key: "exif", value_jsonb: { iso: 400 } });
+      expect(a.error).toBeNull();
+
+      const b = await svc
+        .from("image_metadata")
+        .insert({ image_id: img!.id, key: "exif", value_jsonb: { iso: 800 } });
+      expect(b.error?.code).toBe("23505");
+
+      // CASCADE delete: remove the parent image, metadata disappears.
+      const del = await svc.from("image_library").delete().eq("id", img!.id);
+      expect(del.error).toBeNull();
+
+      const { count } = await svc
+        .from("image_metadata")
+        .select("id", { count: "exact", head: true })
+        .eq("image_id", img!.id);
+      expect(count).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // image_usage — THE write-safety keystone
+  // -------------------------------------------------------------------------
+
+  describe("image_usage", () => {
+    it("rejects a second (image_id, site_id) pair — prevents duplicate WP upload", async () => {
+      const svc = getServiceRoleClient();
+      const { id: siteId } = await seedSite();
+      const { data: img } = await svc
+        .from("image_library")
+        .insert({ source: "upload", source_ref: "dup-test" })
+        .select("id")
+        .single();
+
+      const a = await svc
+        .from("image_usage")
+        .insert({
+          image_id: img!.id,
+          site_id: siteId,
+          wp_idempotency_marker: "marker-a",
+        });
+      expect(a.error).toBeNull();
+
+      const b = await svc
+        .from("image_usage")
+        .insert({
+          image_id: img!.id,
+          site_id: siteId,
+          wp_idempotency_marker: "marker-b", // different marker; constraint is on (image,site) only
+        });
+      expect(b.error?.code).toBe("23505");
+    });
+
+    it("allows the same image across different sites", async () => {
+      const svc = getServiceRoleClient();
+      const siteA = await seedSite();
+      const siteB = await seedSite();
+      const { data: img } = await svc
+        .from("image_library")
+        .insert({ source: "upload", source_ref: "cross-site" })
+        .select("id")
+        .single();
+
+      const a = await svc.from("image_usage").insert({
+        image_id: img!.id,
+        site_id: siteA.id,
+        wp_idempotency_marker: "m-a",
+      });
+      const b = await svc.from("image_usage").insert({
+        image_id: img!.id,
+        site_id: siteB.id,
+        wp_idempotency_marker: "m-b",
+      });
+      expect(a.error).toBeNull();
+      expect(b.error).toBeNull();
+    });
+
+    it("CASCADEs when the site is removed", async () => {
+      const svc = getServiceRoleClient();
+      const { id: siteId } = await seedSite();
+      const { data: img } = await svc
+        .from("image_library")
+        .insert({ source: "upload", source_ref: "site-cascade" })
+        .select("id")
+        .single();
+
+      await svc.from("image_usage").insert({
+        image_id: img!.id,
+        site_id: siteId,
+        wp_idempotency_marker: "m",
+      });
+
+      await svc.from("sites").delete().eq("id", siteId);
+      const { count } = await svc
+        .from("image_usage")
+        .select("id", { count: "exact", head: true })
+        .eq("image_id", img!.id);
+      expect(count).toBe(0);
+    });
+
+    it("refuses to hard-delete an image that has a usage row (NO ACTION)", async () => {
+      const svc = getServiceRoleClient();
+      const { id: siteId } = await seedSite();
+      const { data: img } = await svc
+        .from("image_library")
+        .insert({ source: "upload", source_ref: "no-action" })
+        .select("id")
+        .single();
+
+      await svc.from("image_usage").insert({
+        image_id: img!.id,
+        site_id: siteId,
+        wp_idempotency_marker: "m",
+      });
+
+      const r = await svc.from("image_library").delete().eq("id", img!.id);
+      expect(r.error?.code).toBe("23503"); // FK violation
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // transfer_jobs constraints
+  // -------------------------------------------------------------------------
+
+  describe("transfer_jobs", () => {
+    it("rejects unknown type", async () => {
+      const svc = getServiceRoleClient();
+      const r = await svc
+        .from("transfer_jobs")
+        .insert({
+          type: "magic-transfer",
+          requested_count: 1,
+        });
+      expect(r.error?.code).toBe("23514");
+    });
+
+    it("rejects unknown status", async () => {
+      const svc = getServiceRoleClient();
+      const r = await svc.from("transfer_jobs").insert({
+        type: "cloudflare_ingest",
+        status: "in-orbit",
+        requested_count: 1,
+      });
+      expect(r.error?.code).toBe("23514");
+    });
+
+    it("enforces UNIQUE idempotency_key", async () => {
+      const svc = getServiceRoleClient();
+      const a = await svc.from("transfer_jobs").insert({
+        type: "cloudflare_ingest",
+        idempotency_key: "idem-1",
+        requested_count: 1,
+      });
+      const b = await svc.from("transfer_jobs").insert({
+        type: "cloudflare_ingest",
+        idempotency_key: "idem-1",
+        requested_count: 1,
+      });
+      expect(a.error).toBeNull();
+      expect(b.error?.code).toBe("23505");
+    });
+
+    it("rejects cloudflare_ingest with a site_id set", async () => {
+      const svc = getServiceRoleClient();
+      const { id: siteId } = await seedSite();
+      const r = await svc.from("transfer_jobs").insert({
+        type: "cloudflare_ingest",
+        site_id: siteId,
+        requested_count: 1,
+      });
+      expect(r.error?.code).toBe("23514");
+    });
+
+    it("rejects wp_media_transfer without a site_id", async () => {
+      const svc = getServiceRoleClient();
+      const r = await svc.from("transfer_jobs").insert({
+        type: "wp_media_transfer",
+        requested_count: 1,
+      });
+      expect(r.error?.code).toBe("23514");
+    });
+
+    it("accepts the canonical cloudflare_ingest row", async () => {
+      const svc = getServiceRoleClient();
+      const r = await svc.from("transfer_jobs").insert({
+        type: "cloudflare_ingest",
+        requested_count: 100,
+      });
+      expect(r.error).toBeNull();
+    });
+
+    it("accepts the canonical wp_media_transfer row", async () => {
+      const svc = getServiceRoleClient();
+      const { id: siteId } = await seedSite();
+      const r = await svc.from("transfer_jobs").insert({
+        type: "wp_media_transfer",
+        site_id: siteId,
+        requested_count: 5,
+      });
+      expect(r.error).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // transfer_job_items constraints
+  // -------------------------------------------------------------------------
+
+  describe("transfer_job_items", () => {
+    async function seedJob(): Promise<string> {
+      const svc = getServiceRoleClient();
+      const { data } = await svc
+        .from("transfer_jobs")
+        .insert({
+          type: "cloudflare_ingest",
+          requested_count: 5,
+        })
+        .select("id")
+        .single();
+      return data!.id;
+    }
+
+    it("rejects duplicate (job_id, slot_index)", async () => {
+      const svc = getServiceRoleClient();
+      const jobId = await seedJob();
+
+      const a = await svc.from("transfer_job_items").insert({
+        transfer_job_id: jobId,
+        slot_index: 0,
+        cloudflare_idempotency_key: "cf-a",
+        anthropic_idempotency_key: "an-a",
+      });
+      const b = await svc.from("transfer_job_items").insert({
+        transfer_job_id: jobId,
+        slot_index: 0,
+        cloudflare_idempotency_key: "cf-b",
+        anthropic_idempotency_key: "an-b",
+      });
+      expect(a.error).toBeNull();
+      expect(b.error?.code).toBe("23505");
+    });
+
+    it("rejects duplicate cloudflare_idempotency_key within a job", async () => {
+      const svc = getServiceRoleClient();
+      const jobId = await seedJob();
+      const a = await svc.from("transfer_job_items").insert({
+        transfer_job_id: jobId,
+        slot_index: 0,
+        cloudflare_idempotency_key: "cf-shared",
+        anthropic_idempotency_key: "an-a",
+      });
+      const b = await svc.from("transfer_job_items").insert({
+        transfer_job_id: jobId,
+        slot_index: 1,
+        cloudflare_idempotency_key: "cf-shared",
+        anthropic_idempotency_key: "an-b",
+      });
+      expect(a.error).toBeNull();
+      expect(b.error?.code).toBe("23505");
+    });
+
+    it("rejects duplicate anthropic_idempotency_key within a job", async () => {
+      const svc = getServiceRoleClient();
+      const jobId = await seedJob();
+      const a = await svc.from("transfer_job_items").insert({
+        transfer_job_id: jobId,
+        slot_index: 0,
+        cloudflare_idempotency_key: "cf-a",
+        anthropic_idempotency_key: "an-shared",
+      });
+      const b = await svc.from("transfer_job_items").insert({
+        transfer_job_id: jobId,
+        slot_index: 1,
+        cloudflare_idempotency_key: "cf-b",
+        anthropic_idempotency_key: "an-shared",
+      });
+      expect(a.error).toBeNull();
+      expect(b.error?.code).toBe("23505");
+    });
+
+    it("allows same idempotency keys across different jobs", async () => {
+      const svc = getServiceRoleClient();
+      const jobA = await seedJob();
+      const jobB = await seedJob();
+      const a = await svc.from("transfer_job_items").insert({
+        transfer_job_id: jobA,
+        slot_index: 0,
+        cloudflare_idempotency_key: "cf-reused",
+        anthropic_idempotency_key: "an-reused",
+      });
+      const b = await svc.from("transfer_job_items").insert({
+        transfer_job_id: jobB,
+        slot_index: 0,
+        cloudflare_idempotency_key: "cf-reused",
+        anthropic_idempotency_key: "an-reused",
+      });
+      expect(a.error).toBeNull();
+      expect(b.error).toBeNull();
+    });
+
+    it("rejects invalid state", async () => {
+      const svc = getServiceRoleClient();
+      const jobId = await seedJob();
+      const r = await svc.from("transfer_job_items").insert({
+        transfer_job_id: jobId,
+        slot_index: 0,
+        state: "in-transit",
+        cloudflare_idempotency_key: "cf-x",
+        anthropic_idempotency_key: "an-x",
+      });
+      expect(r.error?.code).toBe("23514");
+    });
+
+    it("rejects pending state with worker_id set (lease coherence)", async () => {
+      const svc = getServiceRoleClient();
+      const jobId = await seedJob();
+      const r = await svc.from("transfer_job_items").insert({
+        transfer_job_id: jobId,
+        slot_index: 0,
+        state: "pending",
+        worker_id: "w-1",
+        cloudflare_idempotency_key: "cf-x",
+        anthropic_idempotency_key: "an-x",
+      });
+      expect(r.error?.code).toBe("23514");
+    });
+
+    it("allows leased state with worker_id + lease_expires_at", async () => {
+      const svc = getServiceRoleClient();
+      const jobId = await seedJob();
+      const r = await svc.from("transfer_job_items").insert({
+        transfer_job_id: jobId,
+        slot_index: 0,
+        state: "leased",
+        worker_id: "w-1",
+        lease_expires_at: new Date(Date.now() + 30_000).toISOString(),
+        cloudflare_idempotency_key: "cf-x",
+        anthropic_idempotency_key: "an-x",
+      });
+      expect(r.error).toBeNull();
+    });
+
+    it("CASCADEs when the parent job is deleted", async () => {
+      const svc = getServiceRoleClient();
+      const jobId = await seedJob();
+      await svc.from("transfer_job_items").insert({
+        transfer_job_id: jobId,
+        slot_index: 0,
+        cloudflare_idempotency_key: "cf-c",
+        anthropic_idempotency_key: "an-c",
+      });
+
+      await svc.from("transfer_jobs").delete().eq("id", jobId);
+      const { count } = await svc
+        .from("transfer_job_items")
+        .select("id", { count: "exact", head: true })
+        .eq("transfer_job_id", jobId);
+      expect(count).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // transfer_events
+  // -------------------------------------------------------------------------
+
+  describe("transfer_events", () => {
+    it("inserts an event row + CASCADEs from parent job", async () => {
+      const svc = getServiceRoleClient();
+      const { data: job } = await svc
+        .from("transfer_jobs")
+        .insert({ type: "cloudflare_ingest", requested_count: 1 })
+        .select("id")
+        .single();
+
+      await svc.from("transfer_events").insert({
+        transfer_job_id: job!.id,
+        event_type: "cloudflare_upload_started",
+        payload_jsonb: { attempt: 1 },
+      });
+      await svc.from("transfer_events").insert({
+        transfer_job_id: job!.id,
+        event_type: "cloudflare_upload_succeeded",
+        payload_jsonb: { cf_id: "abc" },
+        cost_cents: 0,
+      });
+
+      const { count: before } = await svc
+        .from("transfer_events")
+        .select("id", { count: "exact", head: true })
+        .eq("transfer_job_id", job!.id);
+      expect(before).toBe(2);
+
+      await svc.from("transfer_jobs").delete().eq("id", job!.id);
+
+      const { count: after } = await svc
+        .from("transfer_events")
+        .select("id", { count: "exact", head: true })
+        .eq("transfer_job_id", job!.id);
+      expect(after).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // RLS
+  // -------------------------------------------------------------------------
+
+  describe("RLS", () => {
+    describe("image_library", () => {
+      beforeEach(async () => {
+        const svc = getServiceRoleClient();
+        await svc
+          .from("image_library")
+          .insert({ source: "upload", source_ref: "rls-seed" });
+      });
+
+      it("admin SELECT: reads non-deleted rows", async () => {
+        const { data, error } = await adminClient
+          .from("image_library")
+          .select("id, source");
+        expect(error).toBeNull();
+        expect(data?.length ?? 0).toBeGreaterThan(0);
+      });
+
+      it("operator SELECT: reads non-deleted rows", async () => {
+        const { data, error } = await operatorClient
+          .from("image_library")
+          .select("id, source");
+        expect(error).toBeNull();
+        expect(data?.length ?? 0).toBeGreaterThan(0);
+      });
+
+      it("viewer SELECT: reads non-deleted rows", async () => {
+        const { data, error } = await viewerClient
+          .from("image_library")
+          .select("id, source");
+        expect(error).toBeNull();
+        expect(data?.length ?? 0).toBeGreaterThan(0);
+      });
+
+      it("viewer INSERT: denied", async () => {
+        const { data, error } = await viewerClient
+          .from("image_library")
+          .insert({ source: "upload", source_ref: "viewer-denied" })
+          .select();
+        expect(data).toBeNull();
+        expect(error?.code).toBe("42501");
+      });
+
+      it("operator INSERT: allowed", async () => {
+        const { data, error } = await operatorClient
+          .from("image_library")
+          .insert({ source: "upload", source_ref: "operator-allowed" })
+          .select();
+        expect(error).toBeNull();
+        expect(data).toHaveLength(1);
+      });
+
+      it("admin SELECT: filters out deleted_at IS NOT NULL", async () => {
+        const svc = getServiceRoleClient();
+        const { data: row } = await svc
+          .from("image_library")
+          .insert({ source: "upload", source_ref: "tombstone" })
+          .select("id")
+          .single();
+        await svc
+          .from("image_library")
+          .update({ deleted_at: new Date().toISOString() })
+          .eq("id", row!.id);
+
+        const { data } = await adminClient
+          .from("image_library")
+          .select("id")
+          .eq("id", row!.id);
+        expect(data).toHaveLength(0);
+      });
+    });
+
+    describe("transfer_jobs", () => {
+      it("admin reads every job; operator reads only own; viewer reads none", async () => {
+        const svc = getServiceRoleClient();
+        await svc
+          .from("transfer_jobs")
+          .insert({
+            type: "cloudflare_ingest",
+            requested_count: 1,
+            created_by: admin.id,
+          });
+        await svc
+          .from("transfer_jobs")
+          .insert({
+            type: "cloudflare_ingest",
+            requested_count: 1,
+            created_by: operator.id,
+          });
+
+        const adminRows = await adminClient
+          .from("transfer_jobs")
+          .select("id, created_by");
+        const operatorRows = await operatorClient
+          .from("transfer_jobs")
+          .select("id, created_by");
+        const viewerRows = await viewerClient
+          .from("transfer_jobs")
+          .select("id, created_by");
+
+        expect(adminRows.error).toBeNull();
+        expect(adminRows.data?.length).toBe(2);
+
+        expect(operatorRows.error).toBeNull();
+        expect(operatorRows.data?.length).toBe(1);
+        expect(operatorRows.data?.[0].created_by).toBe(operator.id);
+
+        expect(viewerRows.error).toBeNull();
+        expect(viewerRows.data?.length).toBe(0);
+      });
+    });
+
+    describe("transfer_job_items", () => {
+      it("inherits visibility from parent job", async () => {
+        const svc = getServiceRoleClient();
+        const { data: job } = await svc
+          .from("transfer_jobs")
+          .insert({
+            type: "cloudflare_ingest",
+            requested_count: 1,
+            created_by: operator.id,
+          })
+          .select("id")
+          .single();
+        await svc.from("transfer_job_items").insert({
+          transfer_job_id: job!.id,
+          slot_index: 0,
+          cloudflare_idempotency_key: "cf-i",
+          anthropic_idempotency_key: "an-i",
+        });
+
+        const op = await operatorClient
+          .from("transfer_job_items")
+          .select("id, transfer_job_id");
+        expect(op.error).toBeNull();
+        expect(op.data?.length).toBe(1);
+
+        const view = await viewerClient
+          .from("transfer_job_items")
+          .select("id");
+        expect(view.error).toBeNull();
+        expect(view.data?.length).toBe(0);
+      });
+    });
+  });
+});

--- a/supabase/migrations/0010_m4_1_image_library_schema.sql
+++ b/supabase/migrations/0010_m4_1_image_library_schema.sql
@@ -1,0 +1,490 @@
+-- M4-1 — Image library schema.
+-- Reference: docs/plans/m4.md. Parent plan in PR description of this slice.
+--
+-- Design decisions encoded here:
+--
+-- 1. image_library.cloudflare_id UNIQUE — every image maps to exactly one
+--    Cloudflare Images asset and vice versa. No double-hosted images.
+--
+-- 2. image_library (source, source_ref) UNIQUE NULLS NOT DISTINCT — same
+--    iStock image can't be ingested twice. NULLS NOT DISTINCT so two
+--    NULL source_refs don't collide (used by source='upload' today where
+--    we don't have a natural external ref).
+--
+-- 3. image_usage (image_id, site_id) UNIQUE — the write-safety keystone.
+--    Exactly one wp_media_id per (image, site). Concurrent page publishes
+--    of the same image to the same WP site race for the INSERT; the
+--    loser hits 23505 and adopts the winner's wp_media_id via the
+--    SAVEPOINT pattern (M4-7). Without this constraint, two publishes
+--    can race two WP uploads of the same image — duplicate WP media
+--    entries and extra WP storage billed on the client's side.
+--
+-- 4. transfer_job_items (transfer_job_id, cloudflare_idempotency_key)
+--    UNIQUE — protects the Cloudflare call. Same key + same job +
+--    duplicate call returns the existing Cloudflare id rather than
+--    billing twice. Pre-computed on insert from (job_id, slot_index)
+--    so retries reuse the same key automatically.
+--
+-- 5. transfer_job_items.state CHECK + lease-coherence CHECK — invalid
+--    (state, worker_id, lease_expires_at) combinations are rejected at
+--    the schema layer, not just in app code. Same pattern as M3's
+--    generation_job_pages (see supabase/migrations/0007).
+--
+-- 6. transfer_events is append-only — billing + reconciliation source
+--    of truth. Mirrors generation_events from M3. No UPDATE path; rows
+--    only vanish via CASCADE from the parent transfer_jobs delete.
+--
+-- 7. image_library carries a generated tsvector column + GIN index for
+--    FTS. The M4-6 search_images tool reads this. Generated column
+--    keeps the vector in sync with caption + tags without app-side
+--    maintenance.
+--
+-- 8. image_usage.image_id FK uses ON DELETE NO ACTION (the default, but
+--    called out explicitly). A soft-delete of an image_library row is
+--    permitted (deleted_at), but a hard DELETE fails if any image_usage
+--    row references it. Prevents dangling wp_media_id pointers after an
+--    operator purge.
+--
+-- Write-safety hotspots addressed:
+--   - UNIQUE (cloudflare_id) — prevents double-hosted Cloudflare assets.
+--   - UNIQUE (image_id, site_id) — prevents WP upload duplication.
+--   - UNIQUE transfer_job_items idempotency keys — prevent Cloudflare /
+--     Anthropic re-billing.
+--   - lease-coherence CHECK — schema rejects invalid worker-state combos.
+--   - Append-only transfer_events — reconciliation always possible.
+
+-- ---------------------------------------------------------------------------
+-- image_library — the master record per image we own.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE image_library (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Cloudflare Images asset id (their GUID). NULL until the Cloudflare
+  -- upload stage completes — the row can be pre-inserted before upload
+  -- so the (source, source_ref) UNIQUE claims the ingest slot up-front.
+  cloudflare_id         text UNIQUE,
+
+  -- Original filename (for display / debugging; not identity).
+  filename              text,
+
+  -- AI-generated (M4-4). Caption is long-form descriptive; alt_text
+  -- is short accessible alt; tags is the searchable keyword array.
+  -- NULL before captioning completes.
+  caption               text,
+  alt_text              text,
+  tags                  text[] NOT NULL DEFAULT ARRAY[]::text[],
+
+  -- Provenance. source_ref is the external identifier (iStock id for
+  -- 'istock'; uploader-supplied filename for 'upload'; generation id
+  -- for 'generated').
+  source                text NOT NULL
+    CHECK (source IN ('istock', 'upload', 'generated')),
+  source_ref            text,
+  license_type          text,
+
+  width_px              int
+    CHECK (width_px IS NULL OR width_px > 0),
+  height_px             int
+    CHECK (height_px IS NULL OR height_px > 0),
+  bytes                 bigint
+    CHECK (bytes IS NULL OR bytes >= 0),
+
+  -- Full-text search column. Generated from caption + tags; kept in
+  -- sync by the DB, not the app. Indexed via GIN below.
+  search_tsv            tsvector
+    GENERATED ALWAYS AS (
+      setweight(to_tsvector('english', coalesce(caption, '')), 'A')
+      || setweight(to_tsvector('english', coalesce(array_to_string(tags, ' '), '')), 'B')
+    ) STORED,
+
+  -- Audit + soft-delete per docs/DATA_CONVENTIONS.md.
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now(),
+  created_by            uuid REFERENCES opollo_users(id) ON DELETE SET NULL,
+  updated_by            uuid REFERENCES opollo_users(id) ON DELETE SET NULL,
+  deleted_at            timestamptz,
+  deleted_by            uuid REFERENCES opollo_users(id) ON DELETE SET NULL,
+  version_lock          int NOT NULL DEFAULT 1,
+
+  -- Same iStock image can't be ingested twice. NULLS NOT DISTINCT so
+  -- multiple uploads without a source_ref don't collide on NULL.
+  CONSTRAINT image_library_source_ref_unique
+    UNIQUE NULLS NOT DISTINCT (source, source_ref)
+);
+
+CREATE INDEX idx_image_library_search_tsv
+  ON image_library USING GIN (search_tsv);
+CREATE INDEX idx_image_library_tags
+  ON image_library USING GIN (tags);
+CREATE INDEX idx_image_library_source
+  ON image_library (source, source_ref)
+  WHERE deleted_at IS NULL;
+CREATE INDEX idx_image_library_created_at
+  ON image_library (created_at DESC)
+  WHERE deleted_at IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- image_metadata — extensible key/value metadata.
+-- Keeps low-churn, rarely-queried per-image attributes out of the main
+-- row without a schema change on every new dimension (EXIF, model info,
+-- per-client licensing notes). UNIQUE (image_id, key) so upserts are
+-- deterministic.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE image_metadata (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  image_id              uuid NOT NULL
+    REFERENCES image_library(id) ON DELETE CASCADE,
+  key                   text NOT NULL,
+  value_jsonb           jsonb NOT NULL,
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT image_metadata_image_key_unique
+    UNIQUE (image_id, key)
+);
+
+CREATE INDEX idx_image_metadata_image_id
+  ON image_metadata (image_id);
+
+-- ---------------------------------------------------------------------------
+-- image_usage — per (image, site) WP transfer record.
+--
+-- The WRITE-SAFETY KEYSTONE. Exactly one wp_media_id per (image, site).
+-- Concurrent M4-7 publishes racing the same image-to-site transfer
+-- compete for the INSERT; the loser's SAVEPOINT recovers by adopting
+-- the winner's wp_media_id.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE image_usage (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  image_id              uuid NOT NULL
+    REFERENCES image_library(id) ON DELETE NO ACTION,
+  site_id               uuid NOT NULL
+    REFERENCES sites(id) ON DELETE CASCADE,
+
+  -- Set once the WP POST succeeds. NULL during the in-flight window
+  -- between SAVEPOINT and commit.
+  wp_media_id           bigint,
+  wp_source_url         text,
+
+  -- Deduplication marker written to WP alongside the upload so retries
+  -- can GET-by-marker for adoption without re-uploading.
+  wp_idempotency_marker text NOT NULL,
+
+  state                 text NOT NULL DEFAULT 'pending_transfer'
+    CHECK (state IN ('pending_transfer', 'transferred', 'failed')),
+  transferred_at        timestamptz,
+  failure_code          text,
+  failure_detail        text,
+
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT image_usage_image_site_unique
+    UNIQUE (image_id, site_id)
+);
+
+CREATE INDEX idx_image_usage_site
+  ON image_usage (site_id, state);
+
+-- ---------------------------------------------------------------------------
+-- transfer_jobs — long-running batches (9k iStock seed, per-page image
+-- transfers, ad-hoc admin ingests). Mirrors the shape of generation_jobs
+-- from M3 but for image operations.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE transfer_jobs (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Job type drives which processor the worker runs:
+  --   'cloudflare_ingest' : upload + caption new images into the library.
+  --   'wp_media_transfer' : mirror library images into a WP site.
+  type                  text NOT NULL
+    CHECK (type IN ('cloudflare_ingest', 'wp_media_transfer')),
+
+  status                text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'processing', 'succeeded', 'failed', 'cancelled')),
+
+  -- Caller-supplied idempotency key. Re-submission of the same key with
+  -- the same body returns the original job id; different body is a
+  -- conflict. Mirrors generation_jobs.
+  idempotency_key       text UNIQUE,
+  body_hash             text,
+
+  requested_count       int NOT NULL CHECK (requested_count >= 0),
+  succeeded_count       int NOT NULL DEFAULT 0 CHECK (succeeded_count >= 0),
+  failed_count          int NOT NULL DEFAULT 0 CHECK (failed_count >= 0),
+  skipped_count         int NOT NULL DEFAULT 0 CHECK (skipped_count >= 0),
+
+  -- Cost aggregates, incremented by the worker (event-log-first;
+  -- see docs/patterns/background-worker-with-write-safety.md).
+  total_cost_usd_cents  bigint NOT NULL DEFAULT 0
+    CHECK (total_cost_usd_cents >= 0),
+
+  -- For wp_media_transfer jobs only. NULL for cloudflare_ingest.
+  site_id               uuid
+    REFERENCES sites(id) ON DELETE CASCADE,
+
+  created_by            uuid
+    REFERENCES opollo_users(id) ON DELETE SET NULL,
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now(),
+  started_at            timestamptz,
+  finished_at           timestamptz,
+  cancel_requested_at   timestamptz,
+
+  -- wp_media_transfer jobs must point at a site; cloudflare_ingest
+  -- jobs must not.
+  CONSTRAINT transfer_jobs_site_id_coherent
+    CHECK (
+      (type = 'wp_media_transfer' AND site_id IS NOT NULL)
+      OR (type = 'cloudflare_ingest' AND site_id IS NULL)
+    )
+);
+
+CREATE INDEX idx_transfer_jobs_status_active
+  ON transfer_jobs (status)
+  WHERE status IN ('pending', 'processing');
+CREATE INDEX idx_transfer_jobs_created_by
+  ON transfer_jobs (created_by)
+  WHERE created_by IS NOT NULL;
+CREATE INDEX idx_transfer_jobs_site
+  ON transfer_jobs (site_id)
+  WHERE site_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- transfer_job_items — worker's unit of work.
+--
+-- Mirrors generation_job_pages. Same lease / heartbeat / reaper semantics
+-- (docs/patterns/background-worker-with-write-safety.md). Pre-computed
+-- idempotency keys for Cloudflare and (for caption rows) Anthropic.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE transfer_job_items (
+  id                            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  transfer_job_id               uuid NOT NULL
+    REFERENCES transfer_jobs(id) ON DELETE CASCADE,
+  slot_index                    int NOT NULL CHECK (slot_index >= 0),
+
+  -- For cloudflare_ingest: the eventual image_library row. NULL until
+  -- the INSERT lands. For wp_media_transfer: required at insert time.
+  image_id                      uuid
+    REFERENCES image_library(id) ON DELETE NO ACTION,
+
+  -- For wp_media_transfer only: the target site. NULL otherwise (job's
+  -- site_id is the authoritative target).
+  target_site_id                uuid
+    REFERENCES sites(id) ON DELETE CASCADE,
+
+  state                         text NOT NULL DEFAULT 'pending'
+    CHECK (state IN (
+      'pending', 'leased', 'uploading', 'captioning', 'publishing',
+      'succeeded', 'failed', 'skipped'
+    )),
+
+  worker_id                     text,
+  lease_expires_at              timestamptz,
+  retry_count                   int NOT NULL DEFAULT 0
+    CHECK (retry_count >= 0),
+  retry_after                   timestamptz,
+
+  -- Pre-computed on insert. Reused across every retry of this item.
+  cloudflare_idempotency_key    text NOT NULL,
+  anthropic_idempotency_key     text NOT NULL,
+
+  -- Populated by the worker as the item progresses. NULL before the
+  -- corresponding stage runs.
+  source_url                    text,
+  source_bytes                  bigint,
+  resulting_cloudflare_id       text,
+  resulting_wp_media_id         bigint,
+
+  cost_cents                    bigint NOT NULL DEFAULT 0
+    CHECK (cost_cents >= 0),
+
+  failure_code                  text,
+  failure_detail                text,
+
+  created_at                    timestamptz NOT NULL DEFAULT now(),
+  updated_at                    timestamptz NOT NULL DEFAULT now(),
+
+  -- No duplicate slots per job.
+  CONSTRAINT transfer_job_items_slot_unique
+    UNIQUE (transfer_job_id, slot_index),
+
+  -- Cloudflare idempotency is per-job: a reaped + relet item within
+  -- the same job reuses its key; a separate job's item with the same
+  -- item content generates a different key (different job_id → different
+  -- UUIDv5 namespace input).
+  CONSTRAINT transfer_job_items_cf_idemp_unique
+    UNIQUE (transfer_job_id, cloudflare_idempotency_key),
+  CONSTRAINT transfer_job_items_anthro_idemp_unique
+    UNIQUE (transfer_job_id, anthropic_idempotency_key),
+
+  -- Lease coherence: (state, worker_id, lease_expires_at) combinations
+  -- allowed by the schema must match the worker's contract.
+  CONSTRAINT transfer_job_items_lease_coherent
+    CHECK (
+      (state = 'pending'
+        AND worker_id IS NULL
+        AND lease_expires_at IS NULL)
+      OR (state IN ('leased', 'uploading', 'captioning', 'publishing')
+        AND worker_id IS NOT NULL
+        AND lease_expires_at IS NOT NULL)
+      OR (state IN ('succeeded', 'failed', 'skipped'))
+    ),
+
+  -- wp_media_transfer items carry a target_site_id; cloudflare_ingest
+  -- items don't (the job's site_id is NULL).
+  CONSTRAINT transfer_job_items_target_site_coherent
+    CHECK (
+      target_site_id IS NULL OR image_id IS NOT NULL
+    )
+);
+
+-- Partial index for the lease queue — the worker's hottest query.
+-- Filters to pending items whose retry_after window has elapsed.
+CREATE INDEX idx_transfer_job_items_lease_queue
+  ON transfer_job_items (created_at ASC)
+  WHERE state = 'pending';
+
+CREATE INDEX idx_transfer_job_items_job
+  ON transfer_job_items (transfer_job_id);
+CREATE INDEX idx_transfer_job_items_image
+  ON transfer_job_items (image_id)
+  WHERE image_id IS NOT NULL;
+CREATE INDEX idx_transfer_job_items_retry
+  ON transfer_job_items (state, retry_after)
+  WHERE state = 'pending' AND retry_after IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- transfer_events — append-only audit + billing source of truth.
+-- Mirrors generation_events from M3.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE transfer_events (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  transfer_job_id       uuid NOT NULL
+    REFERENCES transfer_jobs(id) ON DELETE CASCADE,
+  transfer_job_item_id  uuid
+    REFERENCES transfer_job_items(id) ON DELETE CASCADE,
+
+  -- Event type. Constrained at the app layer only — adding a new type
+  -- doesn't need a migration. Known types today:
+  --   cloudflare_upload_started / _succeeded / _failed
+  --   anthropic_caption_started / _response_received / _failed
+  --   wp_media_upload_started / _succeeded / _failed / _adopted
+  --   item_leased / _reaped / _cancelled
+  --   job_status_changed
+  event_type            text NOT NULL,
+
+  payload_jsonb         jsonb NOT NULL DEFAULT '{}'::jsonb,
+  cost_cents            bigint NOT NULL DEFAULT 0
+    CHECK (cost_cents >= 0),
+
+  created_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_transfer_events_job
+  ON transfer_events (transfer_job_id, created_at);
+CREATE INDEX idx_transfer_events_item
+  ON transfer_events (transfer_job_item_id, created_at)
+  WHERE transfer_job_item_id IS NOT NULL;
+CREATE INDEX idx_transfer_events_type
+  ON transfer_events (event_type, created_at);
+
+-- ---------------------------------------------------------------------------
+-- Row Level Security.
+--
+-- Every table ships with ENABLE ROW LEVEL SECURITY + service_role_all.
+-- Authenticated-role policies mirror the existing admin/operator/viewer
+-- pattern (docs/patterns/rls-policy-test-matrix.md):
+--   - image_library / image_metadata / image_usage: admin + operator
+--     read; admin write; viewer read only.
+--   - transfer_jobs + items + events: admin reads all; operators read
+--     their own created jobs; viewer no read.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE image_library        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE image_metadata       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE image_usage          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE transfer_jobs        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE transfer_job_items   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE transfer_events      ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON image_library
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY service_role_all ON image_metadata
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY service_role_all ON image_usage
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY service_role_all ON transfer_jobs
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY service_role_all ON transfer_job_items
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY service_role_all ON transfer_events
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- image_library read: admin + operator + viewer all see non-deleted
+-- rows. Write: admin + operator (creation during chat flow; admin
+-- hard-deletes).
+CREATE POLICY image_library_read ON image_library
+  FOR SELECT TO authenticated
+  USING (deleted_at IS NULL AND public.auth_role() IN ('admin', 'operator', 'viewer'));
+CREATE POLICY image_library_write ON image_library
+  FOR INSERT TO authenticated
+  WITH CHECK (public.auth_role() IN ('admin', 'operator'));
+CREATE POLICY image_library_update ON image_library
+  FOR UPDATE TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator'))
+  WITH CHECK (public.auth_role() IN ('admin', 'operator'));
+
+-- image_metadata inherits visibility from its parent image.
+CREATE POLICY image_metadata_read ON image_metadata
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator', 'viewer'));
+CREATE POLICY image_metadata_write ON image_metadata
+  FOR INSERT TO authenticated
+  WITH CHECK (public.auth_role() IN ('admin', 'operator'));
+CREATE POLICY image_metadata_update ON image_metadata
+  FOR UPDATE TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator'))
+  WITH CHECK (public.auth_role() IN ('admin', 'operator'));
+
+-- image_usage visible to admin + operator for the site; writes happen
+-- via service-role only (the M4-7 worker doesn't go through
+-- authenticated clients).
+CREATE POLICY image_usage_read ON image_usage
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator'));
+
+-- transfer_jobs: admin reads all, operators read their own.
+CREATE POLICY transfer_jobs_read ON transfer_jobs
+  FOR SELECT TO authenticated
+  USING (
+    public.auth_role() = 'admin'
+    OR created_by = auth.uid()
+  );
+
+-- transfer_job_items + transfer_events inherit via the parent job.
+CREATE POLICY transfer_job_items_read ON transfer_job_items
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM transfer_jobs j
+      WHERE j.id = transfer_job_items.transfer_job_id
+        AND (public.auth_role() = 'admin' OR j.created_by = auth.uid())
+    )
+  );
+
+CREATE POLICY transfer_events_read ON transfer_events
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM transfer_jobs j
+      WHERE j.id = transfer_events.transfer_job_id
+        AND (public.auth_role() = 'admin' OR j.created_by = auth.uid())
+    )
+  );

--- a/supabase/migrations/0010_m4_1_image_library_schema.sql
+++ b/supabase/migrations/0010_m4_1_image_library_schema.sql
@@ -90,13 +90,13 @@ CREATE TABLE image_library (
   bytes                 bigint
     CHECK (bytes IS NULL OR bytes >= 0),
 
-  -- Full-text search column. Generated from caption + tags; kept in
-  -- sync by the DB, not the app. Indexed via GIN below.
-  search_tsv            tsvector
-    GENERATED ALWAYS AS (
-      setweight(to_tsvector('english', coalesce(caption, '')), 'A')
-      || setweight(to_tsvector('english', coalesce(array_to_string(tags, ' '), '')), 'B')
-    ) STORED,
+  -- Full-text search column. Maintained by a BEFORE INSERT/UPDATE
+  -- trigger (see below) rather than a GENERATED expression — Postgres
+  -- requires generated columns to use IMMUTABLE functions only, and
+  -- to_tsvector(regconfig, text) is STABLE. The trigger achieves the
+  -- same "app never sets this directly" contract. Indexed via GIN
+  -- below.
+  search_tsv            tsvector,
 
   -- Audit + soft-delete per docs/DATA_CONVENTIONS.md.
   created_at            timestamptz NOT NULL DEFAULT now(),
@@ -112,6 +112,28 @@ CREATE TABLE image_library (
   CONSTRAINT image_library_source_ref_unique
     UNIQUE NULLS NOT DISTINCT (source, source_ref)
 );
+
+-- Maintain search_tsv in sync with caption + tags. Runs BEFORE the
+-- row is written so the indexed value matches what a SELECT would
+-- compute. Trigger function is plain SQL (STABLE default is OK for
+-- trigger bodies — IMMUTABLE is only required on expressions used
+-- in GENERATED columns / indexes).
+CREATE OR REPLACE FUNCTION image_library_search_tsv_refresh()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.search_tsv :=
+    setweight(to_tsvector('english', coalesce(NEW.caption, '')), 'A')
+    || setweight(to_tsvector('english', coalesce(array_to_string(NEW.tags, ' '), '')), 'B');
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER image_library_search_tsv_trigger
+  BEFORE INSERT OR UPDATE OF caption, tags ON image_library
+  FOR EACH ROW
+  EXECUTE FUNCTION image_library_search_tsv_refresh();
 
 CREATE INDEX idx_image_library_search_tsv
   ON image_library USING GIN (search_tsv);

--- a/supabase/rollbacks/0010_m4_1_image_library_schema.down.sql
+++ b/supabase/rollbacks/0010_m4_1_image_library_schema.down.sql
@@ -1,0 +1,37 @@
+-- Rollback for 0010_m4_1_image_library_schema.sql.
+-- Drops the M4 image-library tables. Does NOT restore row data.
+-- Intended for local dev / CI reset, not production recovery.
+--
+-- Reverse order of creation so FK dependencies unwind cleanly.
+
+DROP POLICY IF EXISTS transfer_events_read         ON transfer_events;
+DROP POLICY IF EXISTS transfer_job_items_read      ON transfer_job_items;
+DROP POLICY IF EXISTS transfer_jobs_read           ON transfer_jobs;
+DROP POLICY IF EXISTS image_usage_read             ON image_usage;
+DROP POLICY IF EXISTS image_metadata_update        ON image_metadata;
+DROP POLICY IF EXISTS image_metadata_write         ON image_metadata;
+DROP POLICY IF EXISTS image_metadata_read          ON image_metadata;
+DROP POLICY IF EXISTS image_library_update         ON image_library;
+DROP POLICY IF EXISTS image_library_write          ON image_library;
+DROP POLICY IF EXISTS image_library_read           ON image_library;
+
+DROP POLICY IF EXISTS service_role_all ON transfer_events;
+DROP POLICY IF EXISTS service_role_all ON transfer_job_items;
+DROP POLICY IF EXISTS service_role_all ON transfer_jobs;
+DROP POLICY IF EXISTS service_role_all ON image_usage;
+DROP POLICY IF EXISTS service_role_all ON image_metadata;
+DROP POLICY IF EXISTS service_role_all ON image_library;
+
+ALTER TABLE IF EXISTS transfer_events     DISABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS transfer_job_items  DISABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS transfer_jobs       DISABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS image_usage         DISABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS image_metadata      DISABLE ROW LEVEL SECURITY;
+ALTER TABLE IF EXISTS image_library       DISABLE ROW LEVEL SECURITY;
+
+DROP TABLE IF EXISTS transfer_events;
+DROP TABLE IF EXISTS transfer_job_items;
+DROP TABLE IF EXISTS transfer_jobs;
+DROP TABLE IF EXISTS image_usage;
+DROP TABLE IF EXISTS image_metadata;
+DROP TABLE IF EXISTS image_library;

--- a/supabase/rollbacks/0010_m4_1_image_library_schema.down.sql
+++ b/supabase/rollbacks/0010_m4_1_image_library_schema.down.sql
@@ -29,9 +29,13 @@ ALTER TABLE IF EXISTS image_usage         DISABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS image_metadata      DISABLE ROW LEVEL SECURITY;
 ALTER TABLE IF EXISTS image_library       DISABLE ROW LEVEL SECURITY;
 
+DROP TRIGGER IF EXISTS image_library_search_tsv_trigger ON image_library;
+
 DROP TABLE IF EXISTS transfer_events;
 DROP TABLE IF EXISTS transfer_job_items;
 DROP TABLE IF EXISTS transfer_jobs;
 DROP TABLE IF EXISTS image_usage;
 DROP TABLE IF EXISTS image_metadata;
 DROP TABLE IF EXISTS image_library;
+
+DROP FUNCTION IF EXISTS image_library_search_tsv_refresh();


### PR DESCRIPTION
M4 kickoff. Parent plan at `docs/plans/m4.md`; this PR is **M4-1 — schema foundation**.

## Parent plan summary (full version: `docs/plans/m4.md`)

Image library milestone. Three legs:

1. **Storage** — Cloudflare Images (CDN + transformations).
2. **Index** — Postgres master record per image, AI-generated caption / alt / tags.
3. **Transfer** — on page publish, worker mirrors images into the client WP media library, rewrites page HTML to use WP URLs before commit.

Initial seed: 9,000 iStock images with AI captioning. Estimated cost ~$65 one-time + <$1/mo ongoing.

**Sub-slice breakdown (7 PRs):**

| Slice | Scope | Blocks on |
| --- | --- | --- |
| **M4-1** | Schema + constraints + RLS + FTS (this PR) | — |
| M4-2 | Worker core: lease/heartbeat/reaper on `transfer_job_items` | M4-1 |
| M4-3 | Cloudflare Images upload stage | M4-2 + env vars |
| M4-4 | Anthropic vision captioning stage | M4-2 |
| M4-5 | iStock CSV ingest script | M4-1..4 + env vars |
| M4-6 | `search_images` chat tool | M4-1 |
| M4-7 | WP media transfer on publish | M4-1..3 + env vars |

**Env-var state:** `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_IMAGES_API_TOKEN`, `CLOUDFLARE_IMAGES_HASH` — **not yet in Vercel**. M4-3 / M4-5 / M4-7 paused pending provisioning; auto-continue flows through M4-2 / M4-4 / M4-6 meanwhile per the updated CLAUDE.md rule.

## What this PR lands

### `CLAUDE.md` rule update
Per Steven's final workflow rule — auto-continue now extends across milestone boundaries, not just sub-slice boundaries. Silence = proceed. Write-safety-critical milestones still apply per-slice risks audits. Bundled inline here because it's prerequisite to the M4 flow.

### `docs/plans/m4.md` — full parent plan
Scope, 7-slice breakdown, write-safety contract across the four systems, testing strategy, cost estimate, 13 Risks-identified-and-mitigated at the milestone level.

### `supabase/migrations/0010_m4_1_image_library_schema.sql`
Six tables:

- **`image_library`** — master record. `cloudflare_id` UNIQUE, `(source, source_ref)` UNIQUE NULLS NOT DISTINCT, source CHECK (`istock`/`upload`/`generated`), generated `tsvector` + GIN index, soft-delete + audit columns per `DATA_CONVENTIONS.md`.
- **`image_metadata`** — extensible key/value per image. CASCADE from image.
- **`image_usage`** — **the write-safety keystone.** `(image_id, site_id)` UNIQUE prevents WP upload duplication across concurrent publishes. FK to `image_library` uses NO ACTION so hard-delete fails while usage rows reference.
- **`transfer_jobs`** — mirrors `generation_jobs` shape. Type + status CHECK; `idempotency_key` UNIQUE; `site_id` coherence CHECK (`wp_media_transfer` requires site, `cloudflare_ingest` forbids it).
- **`transfer_job_items`** — worker's unit of work. Pre-computed `cloudflare_idempotency_key` + `anthropic_idempotency_key`, both UNIQUE per job; state CHECK; lease-coherence CHECK; partial lease-queue index.
- **`transfer_events`** — append-only. Mirrors `generation_events`. CASCADE from job.

RLS on all six. `service_role_all` + admin/operator/viewer reads on `image_library`; parent-inherited visibility on the `transfer_*` family.

### `supabase/rollbacks/0010_*.down.sql`
Reverse-order drops, `IF EXISTS` everywhere, idempotent re-run safe.

### `lib/__tests__/m4-schema.test.ts` (25 tests)
Per `docs/patterns/new-migration.md` + `docs/patterns/rls-policy-test-matrix.md`:

- All UNIQUE constraints on `image_library` (Cloudflare id, source+ref, invalid source rejected, generated `search_tsv` populated with stemmed lexemes, `width_px > 0` enforced)
- `image_metadata` UNIQUE + CASCADE
- `image_usage` write-safety matrix (duplicate (image, site) rejected, cross-site allowed, site-CASCADE, image NO ACTION)
- `transfer_jobs` type/status CHECK, idempotency UNIQUE, site-coherence CHECK both directions
- `transfer_job_items` slot UNIQUE, per-job idempotency UNIQUEs, cross-job key reuse allowed, state CHECK, lease coherence CHECK, CASCADE from job
- `transfer_events` insert + CASCADE
- RLS matrix: `image_library` admin/operator/viewer reads, `deleted_at` filter, viewer INSERT denied via 42501, operator INSERT allowed, `transfer_jobs` admin-all vs operator-own vs viewer-none, `transfer_job_items` parent-inherited visibility

### `lib/__tests__/_setup.ts`
TRUNCATE list extended with the six new tables, ordered before `sites` so CASCADE resolves cleanly.

### `docs/BACKLOG.md`
New "M4 — image library (in flight)" section at top with sub-slice status tracker + env-var unblock path.

## Risks identified and mitigated (M4-1 specifically)

1. **`UNIQUE (cloudflare_id)`** prevents double-hosted Cloudflare assets even if the app layer has a bug. Pinned.
2. **`UNIQUE (image_id, site_id)`** on `image_usage` — the concurrent-publish deduplication primitive. Pinned via direct duplicate-insert rejection; the racing-publishes test lives in M4-7.
3. **Lease coherence CHECK** rejects `(pending, worker_id)` combos at the schema layer. Defence in depth against worker bugs. Pinned.
4. **Per-job idempotency UNIQUEs** (Cloudflare + Anthropic) prevent retry double-billing even if the app forgets to reuse the stamped key. Pinned both directions.
5. **Type + `site_id` coherence CHECK** on `transfer_jobs` rules out the "cloudflare_ingest job pointed at a site" misuse. Pinned.
6. **`image_library` NO ACTION FK** from `image_usage` — a hard delete of an in-use image fails with 23503 rather than leaving dangling `wp_media_id` pointers. Pinned.
7. **RLS matrix** — viewer reads but doesn't write; operator creates (chat flow) but doesn't delete; admin has full access; `transfer_jobs` admin reads all, operator reads own, viewer reads none. Pinned per cell.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — runs in CI against live Supabase stack. `m4-schema.test.ts` contains 25 new tests.

## Next up (auto-continue)

M4-2: worker core (`lib/transfer-worker.ts` with lease / heartbeat / reaper over `transfer_job_items`, dummy processor). Depends only on M4-1 schema; proceeding on merge.

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42