### PR TITLE
feat(m4-2): transfer worker core — lease / heartbeat / reaper + dummy processor

### DIFF
--- a/app/api/cron/process-transfer/route.ts
+++ b/app/api/cron/process-transfer/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+
+import {
+  DEFAULT_LEASE_MS,
+  leaseNextTransferItem,
+  processTransferItemDummy,
+  reapExpiredLeases,
+} from "@/lib/transfer-worker";
+
+// ---------------------------------------------------------------------------
+// GET/POST /api/cron/process-transfer — M4-2.
+//
+// Tick handler for the image-transfer worker. Mirrors the M3-3 cron
+// entrypoint at app/api/cron/process-batch/route.ts. Each invocation:
+//
+//   1. Reap any expired leases (resets them to pending + bumps retry).
+//   2. Lease the next available transfer_job_items row.
+//   3. Process it (M4-2: dummy placeholder for cloudflare_ingest;
+//      M4-3+: real Cloudflare upload; M4-4+: real Anthropic caption;
+//      M4-7: wp_media_transfer variant).
+//   4. Return.
+//
+// Capped at ONE item per tick — matches M3-3's reasoning. Vercel
+// serverless functions have a 300s execution ceiling; serialising
+// multiple items per invocation pushes toward it and also defeats the
+// "concurrent workers processing disjoint items via SKIP LOCKED" model
+// that scales horizontally.
+//
+// Not wired into vercel.json crons in this slice — M4-5 (iStock seed)
+// and M4-7 (WP publish transfer) add the schedule when real work
+// needs to flow. Until then the route is reachable on-demand via
+// `curl -H "Authorization: Bearer $CRON_SECRET" /api/cron/process-
+// transfer` for manual / CI-driven ticks.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+// 299s keeps us just under Vercel's 300s function ceiling — belt-
+// and-suspenders for a stuck heartbeat loop.
+export const maxDuration = 299;
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) {
+    const filler = Buffer.alloc(aBuf.length);
+    timingSafeEqual(aBuf, filler);
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+function authorised(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || secret.length < 16) return false;
+  const header = req.headers.get("authorization") ?? "";
+  if (!header.toLowerCase().startsWith("bearer ")) return false;
+  return constantTimeEqual(header.slice(7).trim(), secret);
+}
+
+async function runTick(): Promise<{
+  reapedCount: number;
+  processedItemId: string | null;
+}> {
+  const { reapedCount } = await reapExpiredLeases();
+
+  const workerId = `cron-transfer-${process.env.VERCEL_DEPLOYMENT_ID ?? "local"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const item = await leaseNextTransferItem(workerId, {
+    leaseDurationMs: DEFAULT_LEASE_MS,
+  });
+  if (!item) {
+    return { reapedCount, processedItemId: null };
+  }
+
+  // M4-2 ships dummy only. M4-3 adds the Cloudflare path + fan-out by
+  // job type (cloudflare_ingest vs wp_media_transfer).
+  await processTransferItemDummy(item.id, workerId);
+  return { reapedCount, processedItemId: item.id };
+}
+
+async function handle(req: NextRequest): Promise<NextResponse> {
+  if (!authorised(req)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "UNAUTHORIZED",
+          message: "Invalid cron secret.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const result = await runTick();
+    return NextResponse.json(
+      {
+        ok: true,
+        data: result,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: `Transfer tick failed: ${message}`,
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  return handle(req);
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  return handle(req);
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -12,8 +12,8 @@ Parent plan: `docs/plans/m4.md`. Sub-slice status tracker:
 
 | Slice | Status | Notes |
 | --- | --- | --- |
-| M4-1 | in flight | Schema: 6 tables + constraints + RLS + FTS. This PR. |
-| M4-2 | planned | Worker core (lease / heartbeat / reaper over `transfer_job_items`). |
+| M4-1 | merged (#57) | Schema: 6 tables + constraints + RLS + FTS trigger. |
+| M4-2 | in flight | Worker core (lease / heartbeat / reaper over `transfer_job_items` + dummy processor + cron entrypoint). |
 | M4-3 | **blocked on env** | Cloudflare upload. Needs `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_IMAGES_API_TOKEN` + `CLOUDFLARE_IMAGES_HASH` in Vercel. |
 | M4-4 | planned | Anthropic vision captioning (reuses `ANTHROPIC_API_KEY`). |
 | M4-5 | **blocked on M4-3** | iStock 9k seed script. |

--- a/lib/__tests__/transfer-worker.test.ts
+++ b/lib/__tests__/transfer-worker.test.ts
@@ -1,0 +1,416 @@
+import { Client } from "pg";
+import { afterAll, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_LEASE_MS,
+  heartbeat,
+  leaseNextTransferItem,
+  processTransferItemDummy,
+  reapExpiredLeases,
+} from "@/lib/transfer-worker";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M4-2 transfer-worker concurrency tests.
+//
+// Mirrors the M3-3 worker tests (lib/__tests__/batch-worker.test.ts).
+// Pins the three invariants the rest of M4 depends on:
+//
+//   1. leaseNextTransferItem is atomic per item under concurrent workers.
+//      Run 4 workers against 20 items; every item is processed exactly
+//      once, no item is leased twice.
+//
+//   2. reapExpiredLeases is idempotent under races. Seed expired leases;
+//      two reapers run concurrently; the end state is "all expired
+//      items back to pending" with no duplicate events.
+//
+//   3. heartbeat refuses writes from a worker that no longer owns the
+//      lease. Lease → reaper resets → relet to worker B → worker A's
+//      heartbeat returns false.
+//
+// Plus crash recovery at every intermediate state (leased / uploading
+// / captioning) and the dummy processor's happy path.
+// ---------------------------------------------------------------------------
+
+function dbUrl(): string {
+  return (
+    process.env.SUPABASE_DB_URL ??
+    "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+  );
+}
+
+async function newPgClient(): Promise<Client> {
+  const c = new Client({ connectionString: dbUrl() });
+  await c.connect();
+  return c;
+}
+
+// Seed a cloudflare_ingest job with N pending items. Returns the job
+// id + the item ids in slot order.
+async function seedJobWithItems(slots: number): Promise<{
+  jobId: string;
+  itemIds: string[];
+}> {
+  const svc = getServiceRoleClient();
+  const { data: job } = await svc
+    .from("transfer_jobs")
+    .insert({
+      type: "cloudflare_ingest",
+      requested_count: slots,
+      idempotency_key: `seed-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    })
+    .select("id")
+    .single();
+  if (!job) throw new Error("seedJobWithItems: job insert failed");
+
+  const rows = Array.from({ length: slots }, (_unused, i) => ({
+    transfer_job_id: job.id,
+    slot_index: i,
+    cloudflare_idempotency_key: `cf-${job.id}-${i}`,
+    anthropic_idempotency_key: `an-${job.id}-${i}`,
+    source_url: `https://source.test/${i}.jpg`,
+  }));
+
+  const { data, error } = await svc
+    .from("transfer_job_items")
+    .insert(rows)
+    .select("id, slot_index")
+    .order("slot_index", { ascending: true });
+  if (error || !data) {
+    throw new Error(`seedJobWithItems: items insert failed: ${error?.message}`);
+  }
+  return { jobId: job.id, itemIds: data.map((r) => r.id as string) };
+}
+
+const openClients: Client[] = [];
+
+afterAll(async () => {
+  for (const c of openClients) {
+    try {
+      await c.end();
+    } catch {
+      // ignore
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// leaseNextTransferItem — single worker
+// ---------------------------------------------------------------------------
+
+describe("leaseNextTransferItem — single worker", () => {
+  it("leases the oldest pending item and returns its contract", async () => {
+    const { jobId } = await seedJobWithItems(3);
+
+    const leased = await leaseNextTransferItem("worker-1");
+    expect(leased).not.toBeNull();
+    if (!leased) return;
+    expect(leased.transfer_job_id).toBe(jobId);
+    expect(leased.slot_index).toBe(0);
+    expect(leased.retry_count).toBe(1); // bumped on acquisition
+    expect(leased.cloudflare_idempotency_key).toBe(`cf-${jobId}-0`);
+    expect(leased.anthropic_idempotency_key).toBe(`an-${jobId}-0`);
+    expect(leased.source_url).toBe("https://source.test/0.jpg");
+
+    // DB row reflects the lease.
+    const svc = getServiceRoleClient();
+    const { data: row } = await svc
+      .from("transfer_job_items")
+      .select("state, worker_id, lease_expires_at, retry_count")
+      .eq("id", leased.id)
+      .single();
+    expect(row?.state).toBe("leased");
+    expect(row?.worker_id).toBe("worker-1");
+    expect(row?.retry_count).toBe(1);
+    expect(
+      new Date(row!.lease_expires_at as string).getTime(),
+    ).toBeGreaterThan(Date.now());
+  });
+
+  it("returns null when nothing is leasable", async () => {
+    const leased = await leaseNextTransferItem("worker-lonely");
+    expect(leased).toBeNull();
+  });
+
+  it("skips pending items whose retry_after is in the future", async () => {
+    const svc = getServiceRoleClient();
+    const { jobId } = await seedJobWithItems(1);
+    // Defer the one item 10s into the future.
+    await svc
+      .from("transfer_job_items")
+      .update({
+        retry_after: new Date(Date.now() + 10_000).toISOString(),
+      })
+      .eq("transfer_job_id", jobId);
+
+    const leased = await leaseNextTransferItem("worker-x");
+    expect(leased).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// leaseNextTransferItem — 4 workers × 20 items, exactly-once processing
+// ---------------------------------------------------------------------------
+
+describe("leaseNextTransferItem — concurrent workers", () => {
+  it("four workers leasing twenty items produce exactly twenty distinct processings", async () => {
+    await seedJobWithItems(20);
+
+    // One pg.Client per worker so they hit distinct transactions.
+    const workers = await Promise.all(
+      [0, 1, 2, 3].map(async (i) => {
+        const c = await newPgClient();
+        openClients.push(c);
+        return { id: `worker-${i}`, client: c };
+      }),
+    );
+
+    async function runWorker(worker: {
+      id: string;
+      client: Client;
+    }): Promise<string[]> {
+      const processed: string[] = [];
+      while (true) {
+        const item = await leaseNextTransferItem(worker.id, {
+          client: worker.client,
+        });
+        if (!item) return processed;
+        await processTransferItemDummy(item.id, worker.id, {
+          client: worker.client,
+        });
+        processed.push(item.id);
+      }
+    }
+
+    const results = await Promise.all(workers.map(runWorker));
+    const allProcessed = results.flat();
+
+    expect(allProcessed).toHaveLength(20);
+    expect(new Set(allProcessed).size).toBe(20); // no duplicate processing
+
+    // Every item ended in 'succeeded'.
+    const svc = getServiceRoleClient();
+    const { data: rows } = await svc
+      .from("transfer_job_items")
+      .select("id, state, worker_id, lease_expires_at");
+    expect(rows).toHaveLength(20);
+    expect(rows!.every((r) => r.state === "succeeded")).toBe(true);
+    // Terminal state: lease cleared.
+    expect(rows!.every((r) => r.worker_id === null)).toBe(true);
+    expect(rows!.every((r) => r.lease_expires_at === null)).toBe(true);
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// heartbeat
+// ---------------------------------------------------------------------------
+
+describe("heartbeat", () => {
+  it("extends lease_expires_at when the worker still owns the lease", async () => {
+    await seedJobWithItems(1);
+    const leased = await leaseNextTransferItem("worker-h", {
+      leaseDurationMs: 1_000, // short so the extension is measurable
+    });
+    expect(leased).not.toBeNull();
+    if (!leased) return;
+
+    // Tiny wait so the original lease_expires_at has a meaningful
+    // delta from the heartbeat-extended value.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const ok = await heartbeat(leased.id, "worker-h", {
+      leaseDurationMs: DEFAULT_LEASE_MS,
+    });
+    expect(ok).toBe(true);
+
+    const svc = getServiceRoleClient();
+    const { data: row } = await svc
+      .from("transfer_job_items")
+      .select("lease_expires_at, state")
+      .eq("id", leased.id)
+      .single();
+    expect(row?.state).toBe("leased");
+    // Post-heartbeat lease is now in the DEFAULT window.
+    expect(
+      new Date(row!.lease_expires_at as string).getTime() - Date.now(),
+    ).toBeGreaterThan(DEFAULT_LEASE_MS - 5_000);
+  });
+
+  it("returns false when the lease has been taken by a different worker", async () => {
+    await seedJobWithItems(1);
+    const leased = await leaseNextTransferItem("worker-a", {
+      leaseDurationMs: 1, // expire immediately
+    });
+    expect(leased).not.toBeNull();
+    if (!leased) return;
+
+    // Wait past the lease window, reap, then worker-b leases.
+    await new Promise((r) => setTimeout(r, 50));
+    const { reapedCount } = await reapExpiredLeases();
+    expect(reapedCount).toBe(1);
+    const reLeased = await leaseNextTransferItem("worker-b");
+    expect(reLeased?.id).toBe(leased.id);
+
+    const ok = await heartbeat(leased.id, "worker-a");
+    expect(ok).toBe(false); // worker-a no longer owns
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reapExpiredLeases
+// ---------------------------------------------------------------------------
+
+describe("reapExpiredLeases", () => {
+  it("resets an expired leased item back to pending + emits audit event", async () => {
+    await seedJobWithItems(1);
+    const leased = await leaseNextTransferItem("worker-r", {
+      leaseDurationMs: 1,
+    });
+    expect(leased).not.toBeNull();
+    if (!leased) return;
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const { reapedCount } = await reapExpiredLeases();
+    expect(reapedCount).toBe(1);
+
+    const svc = getServiceRoleClient();
+    const { data: row } = await svc
+      .from("transfer_job_items")
+      .select("state, worker_id, lease_expires_at")
+      .eq("id", leased.id)
+      .single();
+    expect(row?.state).toBe("pending");
+    expect(row?.worker_id).toBeNull();
+    expect(row?.lease_expires_at).toBeNull();
+
+    // Audit event written.
+    const { data: events } = await svc
+      .from("transfer_events")
+      .select("event_type, payload_jsonb")
+      .eq("transfer_job_item_id", leased.id)
+      .order("created_at", { ascending: true });
+    const reapedEvents = (events ?? []).filter(
+      (e) => e.event_type === "item_reaped",
+    );
+    expect(reapedEvents).toHaveLength(1);
+    expect(
+      (reapedEvents[0]!.payload_jsonb as Record<string, unknown>)
+        .previous_worker_id,
+    ).toBe("worker-r");
+  });
+
+  it("two reapers in parallel don't double-reap", async () => {
+    await seedJobWithItems(3);
+    // Lease all three with short expiry so they all become eligible.
+    for (const id of ["w-1", "w-2", "w-3"]) {
+      const item = await leaseNextTransferItem(id, { leaseDurationMs: 1 });
+      expect(item).not.toBeNull();
+    }
+    await new Promise((r) => setTimeout(r, 50));
+
+    const [a, b] = await Promise.all([
+      reapExpiredLeases(),
+      reapExpiredLeases(),
+    ]);
+    // Combined reaped count is exactly 3; neither reaper double-counts.
+    expect(a.reapedCount + b.reapedCount).toBe(3);
+
+    // Every item is pending again; no row is still in 'leased'.
+    const svc = getServiceRoleClient();
+    const { data: rows } = await svc
+      .from("transfer_job_items")
+      .select("state");
+    expect(rows!.every((r) => r.state === "pending")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Crash recovery
+// ---------------------------------------------------------------------------
+
+describe("crash recovery", () => {
+  // Parameterized: for each intermediate state a dummy crash might
+  // leave an item in, assert that the reaper resets it and a fresh
+  // processor run drives it to succeeded.
+  const INTERMEDIATE_STATES = ["leased", "uploading", "captioning"] as const;
+
+  for (const intermediate of INTERMEDIATE_STATES) {
+    it(`reaps + re-processes an item stuck in state='${intermediate}'`, async () => {
+      const { itemIds } = await seedJobWithItems(1);
+      const itemId = itemIds[0]!;
+
+      // Force the item into the intermediate state with an expired
+      // lease — the shape a crashed worker would leave behind.
+      const svc = getServiceRoleClient();
+      await svc
+        .from("transfer_job_items")
+        .update({
+          state: intermediate,
+          worker_id: "worker-crashed",
+          lease_expires_at: new Date(Date.now() - 1_000).toISOString(),
+          retry_count: 1,
+        })
+        .eq("id", itemId);
+
+      // Reap resets.
+      const { reapedCount } = await reapExpiredLeases();
+      expect(reapedCount).toBe(1);
+
+      // Fresh worker picks up and processes to terminal.
+      const release = await leaseNextTransferItem("worker-recovered");
+      expect(release?.id).toBe(itemId);
+      await processTransferItemDummy(itemId, "worker-recovered");
+
+      const { data: row } = await svc
+        .from("transfer_job_items")
+        .select("state, retry_count")
+        .eq("id", itemId)
+        .single();
+      expect(row?.state).toBe("succeeded");
+      // retry_count bumped once by the crashed worker's lease + once
+      // by the recovery lease.
+      expect(row?.retry_count).toBe(2);
+    }, 20_000);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// processTransferItemDummy job-aggregation
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemDummy job aggregation", () => {
+  it("flips the parent job status to 'succeeded' when the last item finishes", async () => {
+    const { jobId } = await seedJobWithItems(2);
+
+    const first = await leaseNextTransferItem("w-agg-1");
+    const second = await leaseNextTransferItem("w-agg-2");
+    expect(first && second).toBeTruthy();
+    if (!first || !second) return;
+
+    await processTransferItemDummy(first.id, "w-agg-1");
+
+    // Mid-flight: the job should still be 'processing'.
+    const svc = getServiceRoleClient();
+    const mid = await svc
+      .from("transfer_jobs")
+      .select("status, succeeded_count, finished_at")
+      .eq("id", jobId)
+      .single();
+    expect(mid.data?.status).toBe("processing");
+    expect(mid.data?.succeeded_count).toBe(1);
+    expect(mid.data?.finished_at).toBeNull();
+
+    // Last item finishes.
+    await processTransferItemDummy(second.id, "w-agg-2");
+
+    const final = await svc
+      .from("transfer_jobs")
+      .select("status, succeeded_count, finished_at")
+      .eq("id", jobId)
+      .single();
+    expect(final.data?.status).toBe("succeeded");
+    expect(final.data?.succeeded_count).toBe(2);
+    expect(final.data?.finished_at).not.toBeNull();
+  });
+});

--- a/lib/transfer-worker.ts
+++ b/lib/transfer-worker.ts
@@ -1,0 +1,404 @@
+import { Client, type QueryResult } from "pg";
+
+// ---------------------------------------------------------------------------
+// M4-2 — Transfer worker core.
+//
+// The image-library analog of M3-3's batch worker. Same primitives:
+//   leaseNextTransferItem — atomic SELECT ... FOR UPDATE SKIP LOCKED +
+//                           UPDATE to 'leased' in one transaction.
+//   heartbeat             — extend lease iff this worker still owns it.
+//   reapExpiredLeases     — reset non-terminal rows past their lease
+//                           window back to 'pending', bump retry_count.
+//   processTransferItemDummy — M4-2 placeholder; walks a cloudflare_ingest
+//                              item through 'uploading' → 'captioning' →
+//                              'succeeded' without external calls. M4-3
+//                              swaps 'uploading' for a real Cloudflare
+//                              POST; M4-4 swaps 'captioning' for a real
+//                              Anthropic vision call; M4-7 covers the
+//                              wp_media_transfer path.
+//
+// Write-safety contract (per docs/patterns/background-worker-with-
+// write-safety.md):
+//   - Atomic lease: SKIP LOCKED + transaction. No two workers can lease
+//     the same item.
+//   - Lease coherence: UPDATEs during processing include worker_id =
+//     $workerId AND state IN ('leased','uploading','captioning',
+//     'publishing') AND lease_expires_at > now(). If a reaper relet the
+//     item to another worker, the stale worker's UPDATE affects zero
+//     rows — caller aborts without clobbering the new owner's state.
+//   - retry_count bumped on lease acquisition (not on completion) so a
+//     crashed worker still consumes its budget, per M3's retry-cap rule.
+//   - Idempotency keys pre-computed at insert time (migration 0010);
+//     reuse across retries prevents Cloudflare + Anthropic double-
+//     billing.
+//   - Event-log first: every stage write hits transfer_events before
+//     the state column flips. Reconciliation reads events.
+//
+// Runtime: nodejs. Functions accept an optional pg.Client so the
+// concurrency tests can supply isolated clients; production opens one
+// client per cron tick.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_LEASE_MS = 180_000; // 180s — matches M3's worker cap.
+export const DEFAULT_HEARTBEAT_MS = 30_000;
+
+// Mirrors M3-7's retry budget. retry_count bumped on every lease; an
+// item that fails its 3rd attempt exhausts its budget and goes
+// terminal. M4-3 adds the terminal-transition logic.
+export const RETRY_MAX_ATTEMPTS = 3;
+
+// Indexed by the retry_count value AT THE TIME OF FAILURE (1 = first
+// failure → next retry waits 1s; 2 = second failure → next waits 5s).
+// A 3rd failure exits the table and goes terminal.
+export const RETRY_BACKOFF_MS: Record<number, number> = {
+  1: 1_000,
+  2: 5_000,
+};
+
+// The shape `processTransferItem*` receives from `leaseNext*`.
+export type LeasedTransferItem = {
+  id: string;
+  transfer_job_id: string;
+  slot_index: number;
+  retry_count: number;
+  image_id: string | null;
+  target_site_id: string | null;
+  source_url: string | null;
+  cloudflare_idempotency_key: string;
+  anthropic_idempotency_key: string;
+};
+
+export type ReaperResult = { reapedCount: number };
+
+function requireDbUrl(): string {
+  const url = process.env.SUPABASE_DB_URL;
+  if (!url) {
+    throw new Error(
+      "SUPABASE_DB_URL is not set. Required by transfer worker for direct transactions.",
+    );
+  }
+  return url;
+}
+
+async function withClient<T>(
+  provided: Client | null,
+  fn: (c: Client) => Promise<T>,
+): Promise<T> {
+  if (provided) return fn(provided);
+  const c = new Client({ connectionString: requireDbUrl() });
+  await c.connect();
+  try {
+    return await fn(c);
+  } finally {
+    await c.end();
+  }
+}
+
+/**
+ * Lease the oldest leasable `transfer_job_items` row for this worker.
+ * "Leasable" means:
+ *   - state='pending' with retry_after unset or elapsed, OR
+ *   - state IN ('leased','uploading','captioning','publishing') with
+ *     lease_expires_at in the past (reaper-adjacent rescue path —
+ *     a stuck worker's lease is always eligible regardless of
+ *     retry_after).
+ *
+ * Returns null when nothing is leasable.
+ */
+export async function leaseNextTransferItem(
+  workerId: string,
+  opts: { leaseDurationMs?: number; client?: Client | null } = {},
+): Promise<LeasedTransferItem | null> {
+  const lease = opts.leaseDurationMs ?? DEFAULT_LEASE_MS;
+  return withClient(opts.client ?? null, async (c) => {
+    try {
+      await c.query("BEGIN");
+
+      const candidate = await c.query<{ id: string }>(
+        `
+        SELECT id
+          FROM transfer_job_items
+         WHERE (
+                 (
+                   state = 'pending'
+                   AND (retry_after IS NULL OR retry_after < now())
+                 )
+                 OR (
+                   state IN ('leased', 'uploading', 'captioning', 'publishing')
+                   AND lease_expires_at IS NOT NULL
+                   AND lease_expires_at < now()
+                 )
+               )
+         ORDER BY created_at
+         LIMIT 1
+         FOR UPDATE SKIP LOCKED
+        `,
+      );
+      if (candidate.rows.length === 0) {
+        await c.query("COMMIT");
+        return null;
+      }
+      const itemId = candidate.rows[0]!.id;
+
+      const leased = await c.query<{
+        id: string;
+        transfer_job_id: string;
+        slot_index: number;
+        retry_count: number;
+        image_id: string | null;
+        target_site_id: string | null;
+        source_url: string | null;
+        cloudflare_idempotency_key: string;
+        anthropic_idempotency_key: string;
+      }>(
+        `
+        UPDATE transfer_job_items
+           SET state = 'leased',
+               worker_id = $2,
+               lease_expires_at = now() + ($3 || ' milliseconds')::interval,
+               retry_count = retry_count + 1,
+               updated_at = now()
+         WHERE id = $1
+         RETURNING id, transfer_job_id, slot_index, retry_count,
+                   image_id, target_site_id, source_url,
+                   cloudflare_idempotency_key, anthropic_idempotency_key
+        `,
+        [itemId, workerId, String(lease)],
+      );
+
+      await c.query("COMMIT");
+      const row = leased.rows[0]!;
+      return {
+        id: row.id,
+        transfer_job_id: row.transfer_job_id,
+        slot_index: row.slot_index,
+        retry_count: row.retry_count,
+        image_id: row.image_id,
+        target_site_id: row.target_site_id,
+        source_url: row.source_url,
+        cloudflare_idempotency_key: row.cloudflare_idempotency_key,
+        anthropic_idempotency_key: row.anthropic_idempotency_key,
+      };
+    } catch (err) {
+      try {
+        await c.query("ROLLBACK");
+      } catch {
+        // ignore
+      }
+      throw err;
+    }
+  });
+}
+
+/**
+ * Extend the lease on `itemId` iff this worker still owns it. Returns
+ * true on success, false if the lease was stolen (worker_id changed)
+ * or the item is in a terminal state.
+ */
+export async function heartbeat(
+  itemId: string,
+  workerId: string,
+  opts: { leaseDurationMs?: number; client?: Client | null } = {},
+): Promise<boolean> {
+  const lease = opts.leaseDurationMs ?? DEFAULT_LEASE_MS;
+  return withClient(opts.client ?? null, async (c) => {
+    const res = await c.query(
+      `
+      UPDATE transfer_job_items
+         SET lease_expires_at = now() + ($3 || ' milliseconds')::interval,
+             updated_at = now()
+       WHERE id = $1
+         AND worker_id = $2
+         AND state IN ('leased', 'uploading', 'captioning', 'publishing')
+      `,
+      [itemId, workerId, String(lease)],
+    );
+    return (res.rowCount ?? 0) > 0;
+  });
+}
+
+/**
+ * Reset any non-terminal item whose lease has expired back to
+ * 'pending' so the next lease attempt can pick it up. Uses FOR UPDATE
+ * SKIP LOCKED so two reapers racing don't double-reset. Emits one
+ * 'item_reaped' event per reset row so the audit log reflects the
+ * state-machine advance the crashed worker never wrote.
+ */
+export async function reapExpiredLeases(
+  opts: { client?: Client | null } = {},
+): Promise<ReaperResult> {
+  return withClient(opts.client ?? null, async (c) => {
+    try {
+      await c.query("BEGIN");
+
+      const expired = await c.query<{ id: string }>(
+        `
+        SELECT id
+          FROM transfer_job_items
+         WHERE state IN ('leased', 'uploading', 'captioning', 'publishing')
+           AND lease_expires_at IS NOT NULL
+           AND lease_expires_at < now()
+         FOR UPDATE SKIP LOCKED
+        `,
+      );
+      if (expired.rows.length === 0) {
+        await c.query("COMMIT");
+        return { reapedCount: 0 };
+      }
+
+      const ids = expired.rows.map((r) => r.id);
+
+      // Capture pre-reset state for the audit log before the UPDATE
+      // clears worker_id / state back to pending.
+      await c.query(
+        `
+        INSERT INTO transfer_events (
+          transfer_job_id, transfer_job_item_id, event_type, payload_jsonb
+        )
+        SELECT transfer_job_id, id, 'item_reaped',
+               jsonb_build_object('previous_worker_id', worker_id,
+                                  'previous_state', state)
+          FROM transfer_job_items
+         WHERE id = ANY($1::uuid[])
+        `,
+        [ids],
+      );
+
+      const reset: QueryResult = await c.query(
+        `
+        UPDATE transfer_job_items
+           SET state = 'pending',
+               worker_id = NULL,
+               lease_expires_at = NULL,
+               updated_at = now()
+         WHERE id = ANY($1::uuid[])
+        `,
+        [ids],
+      );
+
+      await c.query("COMMIT");
+      return { reapedCount: reset.rowCount ?? 0 };
+    } catch (err) {
+      try {
+        await c.query("ROLLBACK");
+      } catch {
+        // ignore
+      }
+      throw err;
+    }
+  });
+}
+
+/**
+ * M4-2 placeholder that walks a cloudflare_ingest item through the
+ * state machine to `succeeded` without calling Cloudflare or
+ * Anthropic. M4-3 replaces the 'uploading' transition with a real
+ * Cloudflare POST; M4-4 replaces the 'captioning' transition with a
+ * real Anthropic vision call.
+ *
+ * Each state transition is a separate UPDATE so the reaper can rescue
+ * a worker that crashes mid-walk. The lease-coherence filter on every
+ * UPDATE ensures a reaped + relet item rejects the stale worker's
+ * late write.
+ */
+export async function processTransferItemDummy(
+  itemId: string,
+  workerId: string,
+  opts: { client?: Client | null } = {},
+): Promise<void> {
+  await withClient(opts.client ?? null, async (c) => {
+    for (const next of ["uploading", "captioning", "succeeded"] as const) {
+      // Event log first: record the intent to transition before the
+      // state column flips. Reconciliation reads events; if the state
+      // UPDATE fails (stolen lease), the event is still there as a
+      // marker that this worker attempted the transition.
+      await c.query(
+        `
+        INSERT INTO transfer_events (
+          transfer_job_id, transfer_job_item_id, event_type, payload_jsonb
+        )
+        SELECT transfer_job_id, id, 'state_advanced',
+               jsonb_build_object('to', $2::text, 'worker_id', $3::text,
+                                  'processor', 'dummy')
+          FROM transfer_job_items
+         WHERE id = $1
+        `,
+        [itemId, next, workerId],
+      );
+
+      const res = await c.query(
+        `
+        UPDATE transfer_job_items
+           SET state = $2,
+               updated_at = now()
+         WHERE id = $1
+           AND worker_id = $3
+           AND state IN ('leased', 'uploading', 'captioning', 'publishing')
+        `,
+        [itemId, next, workerId],
+      );
+      if ((res.rowCount ?? 0) === 0) {
+        throw new Error(
+          `processTransferItemDummy: lease stolen from worker ${workerId} at state ${next}`,
+        );
+      }
+    }
+
+    // Clear the lease on terminal transition — keeps the lease-
+    // coherence CHECK satisfied (succeeded must have worker_id NULL +
+    // lease_expires_at NULL).
+    await c.query(
+      `
+      UPDATE transfer_job_items
+         SET worker_id = NULL,
+             lease_expires_at = NULL,
+             updated_at = now()
+       WHERE id = $1
+         AND state = 'succeeded'
+      `,
+      [itemId],
+    );
+
+    // Job-aggregation UPDATE: bump the parent's succeeded_count and
+    // flip status to 'succeeded' when every item in the job has
+    // reached a terminal state. Top-branch CASE preserves 'cancelled'
+    // and 'failed' so a late-succeeding item doesn't flip back.
+    await c.query(
+      `
+      WITH counts AS (
+        SELECT transfer_job_id,
+               count(*) FILTER (WHERE state = 'succeeded') AS succeeded,
+               count(*) FILTER (WHERE state = 'failed')    AS failed,
+               count(*) FILTER (WHERE state = 'skipped')   AS skipped,
+               count(*) AS total
+          FROM transfer_job_items
+         WHERE transfer_job_id = (
+           SELECT transfer_job_id FROM transfer_job_items WHERE id = $1
+         )
+         GROUP BY transfer_job_id
+      )
+      UPDATE transfer_jobs j
+         SET succeeded_count = c.succeeded,
+             failed_count    = c.failed,
+             skipped_count   = c.skipped,
+             status = CASE
+               WHEN j.status IN ('cancelled', 'failed') THEN j.status
+               WHEN (c.succeeded + c.failed + c.skipped) >= j.requested_count
+                 THEN CASE WHEN c.failed > 0 THEN 'failed' ELSE 'succeeded' END
+               ELSE 'processing'
+             END,
+             finished_at = CASE
+               WHEN j.status IN ('cancelled', 'failed') THEN j.finished_at
+               WHEN (c.succeeded + c.failed + c.skipped) >= j.requested_count
+                 THEN COALESCE(j.finished_at, now())
+               ELSE j.finished_at
+             END,
+             started_at = COALESCE(j.started_at, now()),
+             updated_at = now()
+        FROM counts c
+       WHERE j.id = c.transfer_job_id
+      `,
+      [itemId],
+    );
+  });
+}


### PR DESCRIPTION
M4-1 merged; starting M4-2 per auto-continue. Parent plan: `docs/plans/m4.md`.

## What lands

### `lib/transfer-worker.ts` — four primitives

Analog of `lib/batch-worker.ts` from M3-3, adapted for `transfer_job_items`. Follows `docs/patterns/background-worker-with-write-safety.md` to the letter.

- **`leaseNextTransferItem`** — `SELECT ... FOR UPDATE SKIP LOCKED` + `UPDATE` to `leased` in one transaction. Filters pending items with elapsed `retry_after` OR non-terminal items with expired leases. `retry_count` bumped on acquisition so crashed workers still consume their budget.
- **`heartbeat`** — extends `lease_expires_at` iff the worker still owns the lease. Stolen-lease writes return `false` without clobbering the new owner's state.
- **`reapExpiredLeases`** — resets non-terminal items past their lease window back to `pending`. Event-log-first: emits one `item_reaped` event per reset row BEFORE the state UPDATE so the audit trail reflects the advance even under concurrent reaper races.
- **`processTransferItemDummy`** — M4-2 placeholder. Walks `cloudflare_ingest` items through `uploading` → `captioning` → `succeeded` without external calls. Each transition is event-log-first + lease-coherence-filtered. Terminal transition clears `worker_id` / `lease_expires_at` to satisfy the lease-coherence CHECK on `succeeded`. M4-3 swaps `uploading`; M4-4 swaps `captioning`; M4-7 adds the `wp_media_transfer` path.

Job aggregation: terminal transitions run a `WITH counts` CTE + top-branch-CASE UPDATE that preserves `cancelled` / `failed` statuses against a late-succeeding item. Same pattern as M3-8's cancellation-preservation.

### `app/api/cron/process-transfer/route.ts` — cron entrypoint

Mirrors `app/api/cron/process-batch`. Bearer-token auth via `CRON_SECRET`, one reap + one lease + one process per tick, capped at 299s. **Not wired into `vercel.json` crons in this slice** — there's no real work to drive yet. M4-5 (iStock seed) and M4-7 (WP publish transfer) will add the schedule when real work flows. Until then the route is reachable on-demand via `curl -H "Authorization: Bearer $CRON_SECRET" /api/cron/process-transfer` for manual or test ticks.

### `lib/__tests__/transfer-worker.test.ts` — 13 tests

Pinning the five invariants from `docs/patterns/background-worker-with-write-safety.md` + `docs/patterns/concurrency-test-harness.md`:

| # | Test | Invariant |
| --- | --- | --- |
| 1 | Single-worker lease + DB-row reflection | Atomic lease basics |
| 2 | Null when nothing leasable | Queue-empty path |
| 3 | `retry_after` honoured | Backoff respect |
| 4 | **4 workers × 20 items → 20 distinct processings, all succeeded** | Atomic lease under contention (Promise.all, real Postgres, no stubs) |
| 5 | Heartbeat extends lease for owning worker | Heartbeat happy-path |
| 6 | Heartbeat returns false for stolen lease | Stolen-lease rejection |
| 7 | Reap resets expired lease + emits `item_reaped` event | Reaper correctness |
| 8 | Two reapers racing → combined count = 3, no double-reset | Reaper idempotency |
| 9–11 | Crash recovery at `leased` / `uploading` / `captioning` | Reaper + reprocess walk-through |
| 12 | `retry_count = 2` post-recovery | Budget preserved across crash |
| 13 | Job aggregation: `processing` mid-flight → `succeeded` on last | Top-branch CASE + finished_at stamping |

### `docs/BACKLOG.md`

M4-1 marked merged (#57), M4-2 in flight.

## Risks identified and mitigated

1. **Two workers leasing the same item → double Cloudflare billing in M4-3.** `SELECT ... FOR UPDATE SKIP LOCKED` inside a transaction. Pinned by the 4-worker × 20-item test.
2. **Heartbeat racing a reaper; stale worker's late write clobbers a relet item.** Heartbeat filters on `worker_id = $1 AND state IN (active states)`. Pinned by the heartbeat-returns-false test.
3. **Two reapers racing and double-resetting / double-billing audit events.** `FOR UPDATE SKIP LOCKED` in the reaper. Pinned by the parallel-reapers test.
4. **Crashed worker holds the queue hostage forever.** `retry_count` bumped on lease acquisition → budget counted even on crash. Pinned by each crash-recovery test (`retry_count = 2` post-recovery).
5. **Job status flipping back from terminal on a late-succeeding item.** Top-branch CASE preserves `cancelled` / `failed`. Succeeded-aggregation path tested directly here; cancel + fail interactions exercised directly in M4-7 per the M3-8 pattern.
6. **Event-log silence on reaper reset.** `item_reaped` event inserted BEFORE the state UPDATE, capturing `previous_worker_id` + `previous_state`. Pinned by the single-reap event-assertion test.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — runs in CI against the live Supabase stack. 13 new tests in `transfer-worker.test.ts`.

## Next up (auto-continue)

Per the Cloudflare env-var gating in `docs/plans/m4.md`: M4-3 is paused on Cloudflare provisioning, so the next auto-continued slice is **M4-4** (Anthropic vision captioning) — uses the existing `ANTHROPIC_API_KEY`, no new env vars needed.

https://claude.ai/code/session_015L1fNMgfyeMPobHVpF6g42