### PR TITLE
feat(m4-4): anthropic vision captioning stage + event-log-first billing

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -13,9 +13,9 @@ Parent plan: `docs/plans/m4.md`. Sub-slice status tracker:
 | Slice | Status | Notes |
 | --- | --- | --- |
 | M4-1 | merged (#57) | Schema: 6 tables + constraints + RLS + FTS trigger. |
-| M4-2 | in flight | Worker core (lease / heartbeat / reaper over `transfer_job_items` + dummy processor + cron entrypoint). |
+| M4-2 | merged (#58) | Worker core (lease / heartbeat / reaper over `transfer_job_items` + dummy processor). |
 | M4-3 | **blocked on env** | Cloudflare upload. Needs `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_IMAGES_API_TOKEN` + `CLOUDFLARE_IMAGES_HASH` in Vercel. |
-| M4-4 | planned | Anthropic vision captioning (reuses `ANTHROPIC_API_KEY`). |
+| M4-4 | in flight | Anthropic vision captioning (reuses `ANTHROPIC_API_KEY`). |
 | M4-5 | **blocked on M4-3** | iStock 9k seed script. |
 | M4-6 | planned | `search_images` chat tool. Can ship without env vars. |
 | M4-7 | **blocked on M4-3** | WP media transfer + HTML URL rewrite on publish. |

--- a/lib/__tests__/anthropic-caption.test.ts
+++ b/lib/__tests__/anthropic-caption.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CaptionCallError,
+  classifyHttpStatus,
+  parseCaptionPayload,
+} from "@/lib/anthropic-caption";
+
+// ---------------------------------------------------------------------------
+// M4-4 — Parser + classifier unit tests.
+//
+// Fast, in-process. No database required. Structural bounds on the
+// caption payload are the mitigation for risk #8 (caption quality
+// drift); this file pins them.
+// ---------------------------------------------------------------------------
+
+const VALID = {
+  caption:
+    "A studio photograph of a tabby cat sitting on a windowsill facing soft morning light.",
+  alt_text: "Tabby cat on windowsill in soft morning light.",
+  tags: ["cat", "animal", "pet", "indoor", "lifestyle"],
+};
+
+describe("parseCaptionPayload", () => {
+  it("returns the parsed payload for a valid response", () => {
+    const payload = parseCaptionPayload(JSON.stringify(VALID));
+    expect(payload.caption).toBe(VALID.caption);
+    expect(payload.alt_text).toBe(VALID.alt_text);
+    expect(payload.tags).toEqual(VALID.tags);
+  });
+
+  it("throws CAPTION_PARSE_FAILED for non-JSON text", () => {
+    expect(() => parseCaptionPayload("here is a caption: a cat!")).toThrow(
+      CaptionCallError,
+    );
+    try {
+      parseCaptionPayload("nope");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CaptionCallError);
+      expect((err as CaptionCallError).code).toBe("CAPTION_PARSE_FAILED");
+      expect((err as CaptionCallError).retryable).toBe(false);
+    }
+  });
+
+  it("throws CAPTION_VALIDATION_FAILED for short caption", () => {
+    const bad = JSON.stringify({ ...VALID, caption: "too short" });
+    try {
+      parseCaptionPayload(bad);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as CaptionCallError).code).toBe("CAPTION_VALIDATION_FAILED");
+      expect((err as CaptionCallError).retryable).toBe(false);
+    }
+  });
+
+  it("throws CAPTION_VALIDATION_FAILED for tags count below 3", () => {
+    const bad = JSON.stringify({ ...VALID, tags: ["one", "two"] });
+    expect(() => parseCaptionPayload(bad)).toThrow(/VALIDATION/);
+  });
+
+  it("throws CAPTION_VALIDATION_FAILED for tags count above 10", () => {
+    const bad = JSON.stringify({
+      ...VALID,
+      tags: Array.from({ length: 11 }, (_, i) => `t${i}`),
+    });
+    expect(() => parseCaptionPayload(bad)).toThrow(/VALIDATION/);
+  });
+
+  it("throws CAPTION_VALIDATION_FAILED for missing alt_text", () => {
+    const bad = JSON.stringify({ caption: VALID.caption, tags: VALID.tags });
+    expect(() => parseCaptionPayload(bad)).toThrow(/VALIDATION/);
+  });
+});
+
+describe("classifyHttpStatus", () => {
+  it("null status is retryable network error", () => {
+    const c = classifyHttpStatus(null);
+    expect(c.code).toBe("ANTHROPIC_NETWORK_ERROR");
+    expect(c.retryable).toBe(true);
+  });
+
+  it("429 is retryable rate-limited", () => {
+    const c = classifyHttpStatus(429);
+    expect(c.code).toBe("ANTHROPIC_RATE_LIMITED");
+    expect(c.retryable).toBe(true);
+  });
+
+  it("500 is retryable server error", () => {
+    const c = classifyHttpStatus(500);
+    expect(c.code).toBe("ANTHROPIC_SERVER_ERROR");
+    expect(c.retryable).toBe(true);
+  });
+
+  it("400 is non-retryable client error", () => {
+    const c = classifyHttpStatus(400);
+    expect(c.code).toBe("ANTHROPIC_CLIENT_ERROR");
+    expect(c.retryable).toBe(false);
+  });
+
+  it("401 is non-retryable client error", () => {
+    const c = classifyHttpStatus(401);
+    expect(c.code).toBe("ANTHROPIC_CLIENT_ERROR");
+    expect(c.retryable).toBe(false);
+  });
+});

--- a/lib/__tests__/anthropic-caption.test.ts
+++ b/lib/__tests__/anthropic-caption.test.ts
@@ -55,7 +55,12 @@ describe("parseCaptionPayload", () => {
 
   it("throws CAPTION_VALIDATION_FAILED for tags count below 3", () => {
     const bad = JSON.stringify({ ...VALID, tags: ["one", "two"] });
-    expect(() => parseCaptionPayload(bad)).toThrow(/VALIDATION/);
+    try {
+      parseCaptionPayload(bad);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as CaptionCallError).code).toBe("CAPTION_VALIDATION_FAILED");
+    }
   });
 
   it("throws CAPTION_VALIDATION_FAILED for tags count above 10", () => {
@@ -63,12 +68,22 @@ describe("parseCaptionPayload", () => {
       ...VALID,
       tags: Array.from({ length: 11 }, (_, i) => `t${i}`),
     });
-    expect(() => parseCaptionPayload(bad)).toThrow(/VALIDATION/);
+    try {
+      parseCaptionPayload(bad);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as CaptionCallError).code).toBe("CAPTION_VALIDATION_FAILED");
+    }
   });
 
   it("throws CAPTION_VALIDATION_FAILED for missing alt_text", () => {
     const bad = JSON.stringify({ caption: VALID.caption, tags: VALID.tags });
-    expect(() => parseCaptionPayload(bad)).toThrow(/VALIDATION/);
+    try {
+      parseCaptionPayload(bad);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as CaptionCallError).code).toBe("CAPTION_VALIDATION_FAILED");
+    }
   });
 });
 

--- a/lib/__tests__/transfer-worker-caption.test.ts
+++ b/lib/__tests__/transfer-worker-caption.test.ts
@@ -1,0 +1,644 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CaptionCallError,
+  type AnthropicCaptionCallFn,
+  type CaptionApiResponse,
+} from "@/lib/anthropic-caption";
+import {
+  leaseNextTransferItem,
+  processTransferItemCaption,
+} from "@/lib/transfer-worker";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M4-4 — Anthropic captioning stage tests.
+//
+// Pins the invariants the rest of M4 depends on:
+//
+//   1. Idempotency-Key stays stable across retries of the same item.
+//      Stub records the request; two runs with the same item id see
+//      the same key.
+//
+//   2. Event log is written BEFORE the image_library UPDATE and BEFORE
+//      the state column flips to 'succeeded'. If a later UPDATE fails,
+//      the billing facts are still recoverable from transfer_events.
+//
+//   3. Structural validation on the JSON payload — caption length, alt
+//      length, tags count — mitigates risk #8 (caption quality drift)
+//      at the boundary, not deep in the worker.
+//
+//   4. Retryable vs non-retryable classification flows through to the
+//      item state (pending+retry_after vs failed+failure_code).
+//
+//   5. Cost reconciliation: sum of transfer_job_items.cost_cents for a
+//      job equals the sum derived from transfer_events' caption
+//      response rows. Event log is truth.
+//
+//   6. Crash recovery — an item stuck in 'captioning' with expired
+//      lease is reaped to pending and the next worker drives it to
+//      succeeded using the same idempotency key.
+// ---------------------------------------------------------------------------
+
+// A valid JSON payload that passes the Zod structural schema: caption
+// 40-280 chars, alt_text 10-200 chars, tags 3-10 entries.
+const VALID_PAYLOAD = JSON.stringify({
+  caption:
+    "A studio photograph of a tabby cat sitting on a windowsill facing soft morning light.",
+  alt_text: "Tabby cat on windowsill in soft morning light.",
+  tags: ["cat", "animal", "pet", "indoor", "lifestyle"],
+});
+
+type RecordedCaptionCall = {
+  idempotency_key: string;
+  image_url: string;
+  model: string;
+};
+
+function makeStubCall(opts: {
+  model?: string;
+  rawText?: string;
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+  record?: RecordedCaptionCall[];
+  responseId?: string;
+}): AnthropicCaptionCallFn {
+  let counter = 0;
+  return async (req) => {
+    counter += 1;
+    if (opts.record) {
+      opts.record.push({
+        idempotency_key: req.idempotency_key,
+        image_url: req.image_url,
+        model: req.model ?? "claude-sonnet-4-6",
+      });
+    }
+    const response: CaptionApiResponse = {
+      id: opts.responseId ?? `resp_${req.idempotency_key}_${counter}`,
+      model: opts.model ?? "claude-sonnet-4-6",
+      raw_text: opts.rawText ?? VALID_PAYLOAD,
+      stop_reason: "end_turn",
+      usage: opts.usage ?? {
+        input_tokens: 1_200,
+        output_tokens: 200,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    };
+    return response;
+  };
+}
+
+function makeThrowingStub(err: unknown): AnthropicCaptionCallFn {
+  return async () => {
+    throw err;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Seeds
+// ---------------------------------------------------------------------------
+
+async function seedImageLibraryRow(): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("image_library")
+    .insert({
+      source: "istock",
+      source_ref: `istock-${Math.random().toString(36).slice(2, 10)}`,
+      filename: "test.jpg",
+      width_px: 1024,
+      height_px: 768,
+    })
+    .select("id")
+    .single();
+  if (error || !data) {
+    throw new Error(`seedImageLibraryRow: ${error?.message ?? "no row"}`);
+  }
+  return data.id as string;
+}
+
+async function seedCaptionJobWithItems(n: number): Promise<{
+  jobId: string;
+  itemIds: string[];
+  imageIds: string[];
+}> {
+  const svc = getServiceRoleClient();
+  const { data: job, error: jobErr } = await svc
+    .from("transfer_jobs")
+    .insert({
+      type: "cloudflare_ingest",
+      requested_count: n,
+      idempotency_key: `caption-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    })
+    .select("id")
+    .single();
+  if (jobErr || !job) throw new Error(`seed job: ${jobErr?.message}`);
+
+  const imageIds: string[] = [];
+  for (let i = 0; i < n; i++) {
+    imageIds.push(await seedImageLibraryRow());
+  }
+
+  const { data: itemRows, error: itemsErr } = await svc
+    .from("transfer_job_items")
+    .insert(
+      Array.from({ length: n }, (_, i) => ({
+        transfer_job_id: job.id,
+        slot_index: i,
+        image_id: imageIds[i],
+        cloudflare_idempotency_key: `cf-${job.id}-${i}`,
+        anthropic_idempotency_key: `an-${job.id}-${i}`,
+        source_url: `https://fixtures.test/image-${i}.jpg`,
+      })),
+    )
+    .select("id, slot_index")
+    .order("slot_index", { ascending: true });
+  if (itemsErr || !itemRows) throw new Error(`seed items: ${itemsErr?.message}`);
+
+  return {
+    jobId: job.id as string,
+    itemIds: itemRows.map((r) => r.id as string),
+    imageIds,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemCaption — happy path", () => {
+  it("walks the item leased → captioning → succeeded and writes caption/alt/tags", async () => {
+    const { jobId, itemIds, imageIds } = await seedCaptionJobWithItems(1);
+    const leased = await leaseNextTransferItem("w-happy");
+    expect(leased?.id).toBe(itemIds[0]);
+    if (!leased) return;
+
+    const record: RecordedCaptionCall[] = [];
+    await processTransferItemCaption(leased.id, "w-happy", {
+      captionCall: makeStubCall({ record }),
+    });
+
+    expect(record.length).toBe(1);
+    expect(record[0]?.idempotency_key).toBe(leased.anthropic_idempotency_key);
+    expect(record[0]?.image_url).toBe("https://fixtures.test/image-0.jpg");
+    expect(record[0]?.model).toBe("claude-sonnet-4-6");
+
+    const svc = getServiceRoleClient();
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, worker_id, lease_expires_at, cost_cents, failure_code")
+      .eq("id", leased.id)
+      .single();
+    expect(item?.state).toBe("succeeded");
+    expect(item?.worker_id).toBeNull();
+    expect(item?.lease_expires_at).toBeNull();
+    expect(item?.failure_code).toBeNull();
+    expect(Number(item?.cost_cents)).toBeGreaterThan(0);
+
+    const { data: image } = await svc
+      .from("image_library")
+      .select("caption, alt_text, tags")
+      .eq("id", imageIds[0])
+      .single();
+    expect(image?.caption).toContain("tabby cat");
+    expect((image?.alt_text as string).length).toBeGreaterThanOrEqual(10);
+    expect(image?.tags).toEqual([
+      "cat",
+      "animal",
+      "pet",
+      "indoor",
+      "lifestyle",
+    ]);
+
+    const { data: job } = await svc
+      .from("transfer_jobs")
+      .select("status, succeeded_count, total_cost_usd_cents, finished_at")
+      .eq("id", jobId)
+      .single();
+    expect(job?.status).toBe("succeeded");
+    expect(job?.succeeded_count).toBe(1);
+    expect(Number(job?.total_cost_usd_cents)).toBeGreaterThan(0);
+    expect(job?.finished_at).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency key stability across retries
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemCaption — idempotency key stability", () => {
+  it("re-processing the same item (post-reset) uses the same Anthropic idempotency key", async () => {
+    const { itemIds } = await seedCaptionJobWithItems(1);
+    const leased = await leaseNextTransferItem("w-a");
+    expect(leased?.id).toBe(itemIds[0]);
+    if (!leased) return;
+
+    // Bypass processTransferItemCaption's own write path so the assertion
+    // focuses on key reuse. Hard-reset the item back to pending.
+    const svc = getServiceRoleClient();
+    await svc
+      .from("transfer_job_items")
+      .update({
+        state: "pending",
+        worker_id: null,
+        lease_expires_at: null,
+      })
+      .eq("id", leased.id);
+
+    const reLeased = await leaseNextTransferItem("w-b");
+    expect(reLeased?.id).toBe(leased.id);
+    if (!reLeased) return;
+
+    const record: RecordedCaptionCall[] = [];
+    await processTransferItemCaption(reLeased.id, "w-b", {
+      captionCall: makeStubCall({ record }),
+    });
+
+    expect(record[0]?.idempotency_key).toBe(
+      leased.anthropic_idempotency_key,
+    );
+    // Idempotency key is deterministic on the item row, not on the lease.
+    expect(reLeased.anthropic_idempotency_key).toBe(
+      leased.anthropic_idempotency_key,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event-log-first ordering
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemCaption — event log first", () => {
+  it("writes anthropic_caption_response_received with cost + usage before state=succeeded", async () => {
+    const { itemIds } = await seedCaptionJobWithItems(1);
+    const leased = await leaseNextTransferItem("w-ev");
+    if (!leased) throw new Error("lease failed");
+
+    await processTransferItemCaption(leased.id, "w-ev", {
+      captionCall: makeStubCall({
+        usage: {
+          input_tokens: 1_500,
+          output_tokens: 300,
+          cache_creation_input_tokens: 100,
+          cache_read_input_tokens: 50,
+        },
+      }),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: events } = await svc
+      .from("transfer_events")
+      .select("event_type, payload_jsonb, cost_cents, created_at")
+      .eq("transfer_job_item_id", itemIds[0])
+      .order("created_at", { ascending: true });
+
+    const types = (events ?? []).map((e) => e.event_type as string);
+    const captionIdx = types.indexOf("anthropic_caption_response_received");
+    const succeededEvent = (events ?? []).findIndex(
+      (e) =>
+        e.event_type === "state_advanced" &&
+        (e.payload_jsonb as { to?: string } | null)?.to === "succeeded",
+    );
+    expect(captionIdx).toBeGreaterThan(-1);
+    expect(succeededEvent).toBeGreaterThan(captionIdx);
+
+    const captionEvent = events?.[captionIdx];
+    const details = captionEvent?.payload_jsonb as Record<string, unknown>;
+    expect(details.input_tokens).toBe(1_500);
+    expect(details.output_tokens).toBe(300);
+    expect(details.cache_creation_input_tokens).toBe(100);
+    expect(details.cache_read_input_tokens).toBe(50);
+    expect(details.rate_found).toBe(true);
+    expect(details.pricing_version).toBeDefined();
+    expect(details.parse_ok).toBe(true);
+    expect(typeof details.cost_usd_cents).toBe("number");
+    expect(details.cost_usd_cents as number).toBeGreaterThan(0);
+    // cost_cents column on the event matches the payload.
+    expect(Number(captionEvent?.cost_cents)).toBe(
+      details.cost_usd_cents as number,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parse failure — non-retryable, cost still recorded
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemCaption — parse failure", () => {
+  it("marks the item failed with CAPTION_PARSE_FAILED and records cost", async () => {
+    const { itemIds, imageIds } = await seedCaptionJobWithItems(1);
+    const leased = await leaseNextTransferItem("w-parse");
+    if (!leased) throw new Error("lease failed");
+
+    await processTransferItemCaption(leased.id, "w-parse", {
+      captionCall: makeStubCall({
+        rawText: "sure! here is your caption: (not JSON)",
+      }),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, failure_code, failure_detail, cost_cents")
+      .eq("id", leased.id)
+      .single();
+    expect(item?.state).toBe("failed");
+    expect(item?.failure_code).toBe("CAPTION_PARSE_FAILED");
+    expect(Number(item?.cost_cents)).toBeGreaterThan(0);
+
+    // image_library.caption remains NULL since the payload was unparseable.
+    const { data: image } = await svc
+      .from("image_library")
+      .select("caption, alt_text, tags")
+      .eq("id", imageIds[0])
+      .single();
+    expect(image?.caption).toBeNull();
+    expect(image?.alt_text).toBeNull();
+    expect(image?.tags).toEqual([]);
+
+    // Job aggregation flips to 'failed' because the only slot failed.
+    const { data: events } = await svc
+      .from("transfer_events")
+      .select("event_type, payload_jsonb")
+      .eq("transfer_job_item_id", itemIds[0])
+      .order("created_at", { ascending: true });
+    const types = (events ?? []).map((e) => e.event_type);
+    expect(types).toContain("anthropic_caption_response_received");
+    const respEvent = (events ?? []).find(
+      (e) => e.event_type === "anthropic_caption_response_received",
+    );
+    const respDetails = respEvent?.payload_jsonb as Record<string, unknown>;
+    expect(respDetails.parse_ok).toBe(false);
+    expect(respDetails.parse_failure_code).toBe("CAPTION_PARSE_FAILED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structural validation failure
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemCaption — validation failure", () => {
+  it("marks the item failed with CAPTION_VALIDATION_FAILED when tags count is out of bounds", async () => {
+    const { itemIds } = await seedCaptionJobWithItems(1);
+    const leased = await leaseNextTransferItem("w-validate");
+    if (!leased) throw new Error("lease failed");
+
+    const badPayload = JSON.stringify({
+      caption:
+        "A photo of something — just one tag supplied which is below the minimum of three.",
+      alt_text: "Photo placeholder.",
+      tags: ["too-few"],
+    });
+    await processTransferItemCaption(leased.id, "w-validate", {
+      captionCall: makeStubCall({ rawText: badPayload }),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, failure_code")
+      .eq("id", leased.id)
+      .single();
+    expect(item?.state).toBe("failed");
+    expect(item?.failure_code).toBe("CAPTION_VALIDATION_FAILED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retryable API error — defers with retry_after
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemCaption — retryable API error", () => {
+  it("resets the item to pending with retry_after on a 429", async () => {
+    const { itemIds } = await seedCaptionJobWithItems(1);
+    const leased = await leaseNextTransferItem("w-rate");
+    if (!leased) throw new Error("lease failed");
+    // retry_count was bumped to 1 on the lease. The backoff table has
+    // an entry for retry_count=1 → 1s, so the defer path fires.
+
+    await processTransferItemCaption(leased.id, "w-rate", {
+      captionCall: makeThrowingStub(
+        new CaptionCallError("ANTHROPIC_RATE_LIMITED", "429 too many", {
+          retryable: true,
+          httpStatus: 429,
+        }),
+      ),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, worker_id, retry_after, failure_code, retry_count")
+      .eq("id", leased.id)
+      .single();
+    expect(item?.state).toBe("pending");
+    expect(item?.worker_id).toBeNull();
+    expect(item?.failure_code).toBeNull();
+    expect(item?.retry_after).not.toBeNull();
+    expect(new Date(item!.retry_after as string).getTime()).toBeGreaterThan(
+      Date.now() - 1_000,
+    );
+    expect(item?.retry_count).toBe(1);
+
+    const { data: events } = await svc
+      .from("transfer_events")
+      .select("event_type, payload_jsonb")
+      .eq("transfer_job_item_id", itemIds[0])
+      .order("created_at", { ascending: true });
+    const types = (events ?? []).map((e) => e.event_type);
+    expect(types).toContain("anthropic_caption_failed");
+    const failEvent = (events ?? []).find(
+      (e) => e.event_type === "anthropic_caption_failed",
+    );
+    expect(
+      (failEvent?.payload_jsonb as { retryable?: boolean } | null)?.retryable,
+    ).toBe(true);
+  });
+
+  it("exhausts the retry budget to a terminal failure after 3 attempts", async () => {
+    const { itemIds } = await seedCaptionJobWithItems(1);
+    const throwing = makeThrowingStub(
+      new CaptionCallError("ANTHROPIC_RATE_LIMITED", "429", {
+        retryable: true,
+        httpStatus: 429,
+      }),
+    );
+    const svc = getServiceRoleClient();
+
+    // Three attempts. Reset retry_after between attempts so the lease
+    // is eligible (real workers wait for the backoff to elapse; tests
+    // short-circuit by clearing it).
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      await svc
+        .from("transfer_job_items")
+        .update({ retry_after: null })
+        .eq("id", itemIds[0]);
+
+      const leased = await leaseNextTransferItem(`w-exh-${attempt}`);
+      expect(leased?.id).toBe(itemIds[0]);
+      if (!leased) return;
+      expect(leased.retry_count).toBe(attempt);
+      await processTransferItemCaption(leased.id, `w-exh-${attempt}`, {
+        captionCall: throwing,
+      });
+    }
+
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, failure_code, retry_count")
+      .eq("id", itemIds[0])
+      .single();
+    expect(item?.state).toBe("failed");
+    expect(item?.failure_code).toBe("ANTHROPIC_RATE_LIMITED");
+    expect(item?.retry_count).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-retryable API error — fails terminally on first attempt
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemCaption — non-retryable API error", () => {
+  it("marks the item failed on the first 400 without deferring", async () => {
+    const { itemIds } = await seedCaptionJobWithItems(1);
+    const leased = await leaseNextTransferItem("w-400");
+    if (!leased) throw new Error("lease failed");
+
+    await processTransferItemCaption(leased.id, "w-400", {
+      captionCall: makeThrowingStub(
+        new CaptionCallError("ANTHROPIC_CLIENT_ERROR", "bad request", {
+          retryable: false,
+          httpStatus: 400,
+        }),
+      ),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, failure_code, failure_detail, retry_after")
+      .eq("id", itemIds[0])
+      .single();
+    expect(item?.state).toBe("failed");
+    expect(item?.failure_code).toBe("ANTHROPIC_CLIENT_ERROR");
+    expect(item?.retry_after).toBeNull();
+    expect(item?.failure_detail).toBe("bad request");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lease reaped mid-stage — recovery + single Anthropic call observed
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemCaption — crash recovery", () => {
+  it("a reaped item is driven to succeeded with the same idempotency key", async () => {
+    const { itemIds, imageIds } = await seedCaptionJobWithItems(1);
+
+    // Simulate a crashed worker that advanced to 'captioning' then died.
+    const svc = getServiceRoleClient();
+    await svc
+      .from("transfer_job_items")
+      .update({
+        state: "captioning",
+        worker_id: "w-crashed",
+        lease_expires_at: new Date(Date.now() - 1_000).toISOString(),
+        retry_count: 1,
+      })
+      .eq("id", itemIds[0]);
+
+    // Next worker leases (the lease-expired branch picks this up).
+    const leased = await leaseNextTransferItem("w-recovered");
+    expect(leased?.id).toBe(itemIds[0]);
+    if (!leased) return;
+    // State returns to 'leased' on re-acquisition and retry_count bumps.
+    expect(leased.retry_count).toBe(2);
+
+    const record: RecordedCaptionCall[] = [];
+    await processTransferItemCaption(leased.id, "w-recovered", {
+      captionCall: makeStubCall({ record }),
+    });
+
+    // Exactly one call observed on this run — the stub is per-test.
+    // The idempotency key matches what the crashed worker would have sent.
+    expect(record.length).toBe(1);
+    expect(record[0]?.idempotency_key).toBe(leased.anthropic_idempotency_key);
+
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state")
+      .eq("id", itemIds[0])
+      .single();
+    expect(item?.state).toBe("succeeded");
+
+    const { data: image } = await svc
+      .from("image_library")
+      .select("caption")
+      .eq("id", imageIds[0])
+      .single();
+    expect(image?.caption).toContain("tabby cat");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cost reconciliation across a completed job
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemCaption — cost reconciliation", () => {
+  it("sum(item.cost_cents) == sum(transfer_events cost) == job.total_cost", async () => {
+    const { jobId, itemIds } = await seedCaptionJobWithItems(4);
+
+    for (let i = 0; i < 4; i++) {
+      const leased = await leaseNextTransferItem(`w-rec-${i}`);
+      expect(leased?.id).toBe(itemIds[i]);
+      if (!leased) return;
+      await processTransferItemCaption(leased.id, `w-rec-${i}`, {
+        captionCall: makeStubCall({
+          usage: {
+            input_tokens: 1_000 * (i + 1),
+            output_tokens: 150 * (i + 1),
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+        }),
+      });
+    }
+
+    const svc = getServiceRoleClient();
+    const { data: items } = await svc
+      .from("transfer_job_items")
+      .select("cost_cents, state")
+      .eq("transfer_job_id", jobId);
+    expect(items?.every((r) => r.state === "succeeded")).toBe(true);
+    const itemSum = (items ?? []).reduce(
+      (s, r) => s + Number(r.cost_cents),
+      0,
+    );
+
+    const { data: events } = await svc
+      .from("transfer_events")
+      .select("cost_cents")
+      .eq("transfer_job_id", jobId)
+      .eq("event_type", "anthropic_caption_response_received");
+    const eventSum = (events ?? []).reduce(
+      (s, e) => s + Number(e.cost_cents),
+      0,
+    );
+
+    expect(itemSum).toBeGreaterThan(0);
+    expect(itemSum).toBe(eventSum);
+
+    const { data: job } = await svc
+      .from("transfer_jobs")
+      .select("total_cost_usd_cents, status, succeeded_count")
+      .eq("id", jobId)
+      .single();
+    expect(Number(job?.total_cost_usd_cents)).toBe(itemSum);
+    expect(job?.status).toBe("succeeded");
+    expect(job?.succeeded_count).toBe(4);
+  });
+});

--- a/lib/__tests__/transfer-worker-caption.test.ts
+++ b/lib/__tests__/transfer-worker-caption.test.ts
@@ -384,7 +384,7 @@ describe("processTransferItemCaption — parse failure", () => {
 
 describe("processTransferItemCaption — validation failure", () => {
   it("marks the item failed with CAPTION_VALIDATION_FAILED when tags count is out of bounds", async () => {
-    const { itemIds } = await seedCaptionJobWithItems(1);
+    await seedCaptionJobWithItems(1);
     const leased = await leaseNextTransferItem("w-validate");
     if (!leased) throw new Error("lease failed");
 

--- a/lib/anthropic-caption.ts
+++ b/lib/anthropic-caption.ts
@@ -1,0 +1,296 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// M4-4 — Anthropic vision caption helper.
+//
+// Thin wrapper that sends a single image (by public URL) to Anthropic's
+// messages endpoint and parses the response into {caption, alt_text, tags}.
+//
+// Design decisions:
+//
+//   1. Separate call surface from M3-4's text-only `AnthropicCallFn`.
+//      Vision requests carry an array content block (image + text) while
+//      M3's `AnthropicRequest.messages[].content` is typed `string`. Rather
+//      than widen M3's type and refactor the batch worker, M4-4 ships its
+//      own `AnthropicCaptionCallFn` type. Production uses the default
+//      implementation; tests inject a stub that records the idempotency
+//      key and returns canned output.
+//
+//   2. Idempotency-Key header is ALWAYS sent. The transfer item's
+//      `anthropic_idempotency_key` (pre-computed in migration 0010) is
+//      replayed on every retry so Anthropic returns the cached response
+//      without re-billing within the 24h window.
+//
+//   3. Response shape is enforced by Zod. The model is asked for JSON;
+//      anything else — prose preamble, malformed JSON, tags length out
+//      of bounds — classifies as `CAPTION_PARSE_FAILED`. Cost is still
+//      recorded (we paid for the tokens even on an unparseable reply).
+//
+//   4. Structural bounds encoded in the Zod schema are the mitigation for
+//      risk #8 in docs/plans/m4.md (AI caption quality drift). Tightening
+//      the bounds later is a config change, not a code change at every
+//      call site.
+// ---------------------------------------------------------------------------
+
+// Cost-optimised model for captioning. Matches the $63 cost estimate for
+// the 9k iStock seed in docs/plans/m4.md. Opus is overkill for a "what's
+// in this image + three-to-ten tags" task.
+export const CAPTION_MODEL = "claude-sonnet-4-6";
+
+// Small output budget — the response is a JSON object with three short
+// fields. Bump only if a structural assertion starts tripping on
+// legitimate long captions.
+export const CAPTION_MAX_TOKENS = 400;
+
+// System prompt. Strict JSON only so the worker's parse step never has to
+// strip markdown fences or prose. Bounds match the Zod schema below —
+// keeping both in sync avoids drift where the prompt asks for one shape
+// and validation rejects it.
+export const CAPTION_SYSTEM_PROMPT = [
+  "You are captioning images for a searchable image library.",
+  "Respond with ONLY a JSON object. Do not wrap it in markdown, prose, or code fences.",
+  "The JSON object must match this shape exactly:",
+  "{",
+  '  "caption": string,    // one or two sentences describing what is visible. 40 to 280 characters.',
+  '  "alt_text": string,   // short accessible alt text. 10 to 200 characters.',
+  '  "tags": string[]      // 3 to 10 short searchable tags, lowercase, single word or short phrase.',
+  "}",
+  "The caption describes the image visually; the alt_text is a shorter accessible summary;",
+  "the tags are concrete keywords a person might type to find this image.",
+].join("\n");
+
+export const CAPTION_USER_PROMPT =
+  "Caption the image above. Respond with the JSON object described in the system prompt.";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CaptionRequest = {
+  image_url: string;
+  idempotency_key: string;
+  model?: string;
+  max_tokens?: number;
+};
+
+export type CaptionUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+};
+
+// Raw response from Anthropic, before parsing. Separate from the parsed
+// caption payload so callers can always record the cost even on a parse
+// failure — we paid for these tokens.
+export type CaptionApiResponse = {
+  id: string;
+  model: string;
+  raw_text: string;
+  stop_reason: string | null;
+  usage: CaptionUsage;
+};
+
+export type AnthropicCaptionCallFn = (
+  req: CaptionRequest,
+) => Promise<CaptionApiResponse>;
+
+// ---------------------------------------------------------------------------
+// Zod schema for the parsed caption payload.
+//
+// Length bounds encode risk #8 (caption quality drift). A response that
+// falls outside these bounds doesn't get silently truncated / rejected
+// in production — it classifies as CAPTION_VALIDATION_FAILED and the
+// item goes terminal with cost recorded.
+// ---------------------------------------------------------------------------
+
+const captionPayloadSchema = z.object({
+  caption: z.string().min(40).max(280),
+  alt_text: z.string().min(10).max(200),
+  tags: z
+    .array(z.string().min(1).max(60))
+    .min(3)
+    .max(10),
+});
+
+export type CaptionPayload = z.infer<typeof captionPayloadSchema>;
+
+// ---------------------------------------------------------------------------
+// Error classification
+//
+// Retryability contract matches M3's batch worker:
+//   - retryable: 429, 5xx, transient network. Worker defers with
+//     retry_after. Same idempotency key on the retry → Anthropic may
+//     return cached response.
+//   - non-retryable: 400, 401, 403, 404, 422. Terminal fail. Cost
+//     recorded if the call billed (parse failures, validation failures).
+// ---------------------------------------------------------------------------
+
+export type CaptionFailureCode =
+  | "ANTHROPIC_RATE_LIMITED"
+  | "ANTHROPIC_SERVER_ERROR"
+  | "ANTHROPIC_NETWORK_ERROR"
+  | "ANTHROPIC_CLIENT_ERROR"
+  | "CAPTION_PARSE_FAILED"
+  | "CAPTION_VALIDATION_FAILED";
+
+export class CaptionCallError extends Error {
+  public readonly code: CaptionFailureCode;
+  public readonly retryable: boolean;
+  public readonly httpStatus: number | null;
+
+  constructor(
+    code: CaptionFailureCode,
+    message: string,
+    opts: { retryable: boolean; httpStatus?: number | null } = {
+      retryable: false,
+    },
+  ) {
+    super(message);
+    this.name = "CaptionCallError";
+    this.code = code;
+    this.retryable = opts.retryable;
+    this.httpStatus = opts.httpStatus ?? null;
+  }
+}
+
+export function classifyHttpStatus(
+  status: number | null | undefined,
+): {
+  code: CaptionFailureCode;
+  retryable: boolean;
+} {
+  if (status == null) {
+    return { code: "ANTHROPIC_NETWORK_ERROR", retryable: true };
+  }
+  if (status === 429) {
+    return { code: "ANTHROPIC_RATE_LIMITED", retryable: true };
+  }
+  if (status >= 500) {
+    return { code: "ANTHROPIC_SERVER_ERROR", retryable: true };
+  }
+  return { code: "ANTHROPIC_CLIENT_ERROR", retryable: false };
+}
+
+// ---------------------------------------------------------------------------
+// Default production call.
+//
+// Released from any pg client — the worker is expected to have advanced
+// the item into 'captioning' before invoking this, then re-enter a tx
+// to write the caption + advance state. Keeping the external call
+// outside a pg transaction avoids holding a connection open for the
+// full round-trip.
+// ---------------------------------------------------------------------------
+
+let cachedClient: Anthropic | null = null;
+
+function getClient(): Anthropic {
+  if (cachedClient) return cachedClient;
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "ANTHROPIC_API_KEY is not set. Required by the transfer worker's captioning stage.",
+    );
+  }
+  cachedClient = new Anthropic({ apiKey });
+  return cachedClient;
+}
+
+export const defaultAnthropicCaptionCall: AnthropicCaptionCallFn = async (
+  req,
+) => {
+  const client = getClient();
+  try {
+    const message = await client.messages.create(
+      {
+        model: req.model ?? CAPTION_MODEL,
+        max_tokens: req.max_tokens ?? CAPTION_MAX_TOKENS,
+        system: CAPTION_SYSTEM_PROMPT,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "image",
+                source: { type: "url", url: req.image_url },
+              },
+              {
+                type: "text",
+                text: CAPTION_USER_PROMPT,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        headers: { "Idempotency-Key": req.idempotency_key },
+      },
+    );
+
+    const rawText = message.content
+      .filter((b): b is Extract<typeof b, { type: "text" }> => b.type === "text")
+      .map((b) => b.text)
+      .join("")
+      .trim();
+
+    return {
+      id: message.id,
+      model: message.model,
+      raw_text: rawText,
+      stop_reason: message.stop_reason ?? null,
+      usage: {
+        input_tokens: message.usage.input_tokens,
+        output_tokens: message.usage.output_tokens,
+        cache_creation_input_tokens:
+          message.usage.cache_creation_input_tokens ?? undefined,
+        cache_read_input_tokens:
+          message.usage.cache_read_input_tokens ?? undefined,
+      },
+    };
+  } catch (err) {
+    if (err instanceof Anthropic.APIError) {
+      const classified = classifyHttpStatus(err.status);
+      throw new CaptionCallError(classified.code, err.message, {
+        retryable: classified.retryable,
+        httpStatus: err.status,
+      });
+    }
+    throw new CaptionCallError(
+      "ANTHROPIC_NETWORK_ERROR",
+      err instanceof Error ? err.message : String(err),
+      { retryable: true, httpStatus: null },
+    );
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Parse + validate
+//
+// The worker calls this after a successful API response. A throw from
+// here is a non-retryable terminal failure — the model returned a
+// response we can't act on, so replaying the same idempotency key
+// would return the same unparseable reply.
+// ---------------------------------------------------------------------------
+
+export function parseCaptionPayload(rawText: string): CaptionPayload {
+  let asJson: unknown;
+  try {
+    asJson = JSON.parse(rawText);
+  } catch (err) {
+    throw new CaptionCallError(
+      "CAPTION_PARSE_FAILED",
+      `Response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      { retryable: false },
+    );
+  }
+  const parsed = captionPayloadSchema.safeParse(asJson);
+  if (!parsed.success) {
+    throw new CaptionCallError(
+      "CAPTION_VALIDATION_FAILED",
+      `Response failed structural validation: ${parsed.error.message}`,
+      { retryable: false },
+    );
+  }
+  return parsed.data;
+}

--- a/lib/transfer-worker.ts
+++ b/lib/transfer-worker.ts
@@ -1,5 +1,17 @@
 import { Client, type QueryResult } from "pg";
 
+import {
+  CaptionCallError,
+  defaultAnthropicCaptionCall,
+  parseCaptionPayload,
+  type AnthropicCaptionCallFn,
+  type CaptionPayload,
+  CAPTION_MODEL,
+  CAPTION_MAX_TOKENS,
+} from "@/lib/anthropic-caption";
+import { computeCostCents, PRICING_VERSION } from "@/lib/anthropic-pricing";
+import { getServiceRoleClient } from "@/lib/supabase";
+
 // ---------------------------------------------------------------------------
 // M4-2 — Transfer worker core.
 //
@@ -401,4 +413,540 @@ export async function processTransferItemDummy(
       [itemId],
     );
   });
+}
+
+// ---------------------------------------------------------------------------
+// M4-4 — Anthropic vision caption stage.
+//
+// Advances a leased cloudflare_ingest item through:
+//   leased → captioning → (Anthropic vision call) → succeeded | failed
+//
+// The caption stage is the second external-call stage in a
+// cloudflare_ingest item's lifecycle. M4-3's upload stage runs first and
+// sets image_library.cloudflare_id plus the item's image_id. This stage
+// reads the image via its public URL (source_url on the item for M4-4;
+// in production this becomes the Cloudflare-delivered URL once M4-3
+// lands), calls Anthropic with the item's pre-computed
+// anthropic_idempotency_key, parses the JSON response, and writes the
+// caption fields back to image_library.
+//
+// Write-safety contract (per docs/patterns/new-batch-worker-stage.md +
+// background-worker-with-write-safety.md):
+//
+//   1. Event-log first. The `anthropic_caption_response_received` event
+//      is written BEFORE the image_library UPDATE and BEFORE the slot
+//      state flip. Reconciliation rebuilds cost from transfer_events
+//      even if a later UPDATE fails.
+//
+//   2. Idempotency-Key stability. The item's anthropic_idempotency_key
+//      is passed through unchanged; a retry (post-reap) replays the
+//      same key. Anthropic's idempotency cache returns the original
+//      response without re-billing.
+//
+//   3. Lease coherence. Every UPDATE to transfer_job_items includes
+//      worker_id = $workerId AND state IN (<intermediate set>). A
+//      reaped-and-relet item rejects this worker's late writes — the
+//      rowCount=0 check throws.
+//
+//   4. Cost captured even on terminal failure. Parse / validation
+//      failures still bill (we paid for the tokens). Non-retryable
+//      API errors that did NOT bill (4xx before token usage) write
+//      cost_cents=0.
+//
+//   5. Retryable vs non-retryable. Retryable failures (429, 5xx, net)
+//      reset the item to 'pending' with retry_after set per the M3-7
+//      backoff table. Non-retryable (4xx, parse, validation) go terminal
+//      with state='failed' + failure_code.
+// ---------------------------------------------------------------------------
+
+// How to derive the image URL passed to Anthropic. For M4-4 in isolation
+// we use transfer_job_items.source_url — that's what M4-5's iStock
+// ingest seeds. Once M4-3 lands and populates image_library.cloudflare_id,
+// this will extend to prefer the Cloudflare-delivered URL. Decision lives
+// here in code so the override is localised to one swap.
+function resolveCaptionUrl(item: {
+  source_url: string | null;
+}): string | null {
+  return item.source_url;
+}
+
+// Build the retry_after timestamp for a retryable failure. retry_count
+// was already bumped on lease acquisition (migration 0010 + worker core
+// contract), so backing off uses the retry_count as-stored.
+function retryAfterForCount(retryCount: number): Date | null {
+  const delayMs = RETRY_BACKOFF_MS[retryCount];
+  if (delayMs == null) return null;
+  return new Date(Date.now() + delayMs);
+}
+
+export type CaptionProcessorOptions = {
+  client?: Client | null;
+  captionCall?: AnthropicCaptionCallFn;
+  model?: string;
+  maxTokens?: number;
+};
+
+/**
+ * Production caption processor for a leased transfer_job_items row.
+ *
+ * Contract:
+ *   - Caller has already invoked leaseNextTransferItem and holds the
+ *     lease under `workerId`.
+ *   - Item's image_id references an image_library row. Callers driving
+ *     M4-4 in isolation (pre-M4-3) are responsible for pre-inserting
+ *     that row; M4-3's upload stage will do it automatically once
+ *     shipped.
+ *   - Item's source_url is set to a publicly-fetchable URL (iStock for
+ *     the seed, Cloudflare for re-captioning runs post-M4-3).
+ *
+ * Walks the state machine leased → captioning → succeeded on the happy
+ * path, leased → captioning → failed on terminal error, or resets to
+ * pending (with retry_after) on retryable error.
+ */
+export async function processTransferItemCaption(
+  itemId: string,
+  workerId: string,
+  opts: CaptionProcessorOptions = {},
+): Promise<void> {
+  const captionCall = opts.captionCall ?? defaultAnthropicCaptionCall;
+  const model = opts.model ?? CAPTION_MODEL;
+  const maxTokens = opts.maxTokens ?? CAPTION_MAX_TOKENS;
+
+  // Load the item's context from the service role — the caption URL,
+  // image_id, anthropic_idempotency_key, transfer_job_id, retry_count.
+  // Read-only; no lease-coherence guard needed on SELECT.
+  const svc = getServiceRoleClient();
+  const itemRes = await svc
+    .from("transfer_job_items")
+    .select(
+      "id, transfer_job_id, image_id, source_url, anthropic_idempotency_key, retry_count",
+    )
+    .eq("id", itemId)
+    .single();
+  if (itemRes.error || !itemRes.data) {
+    throw new Error(
+      `processTransferItemCaption: load item: ${itemRes.error?.message ?? "no row"} for ${itemId}`,
+    );
+  }
+  const itemRow = itemRes.data as {
+    id: string;
+    transfer_job_id: string;
+    image_id: string | null;
+    source_url: string | null;
+    anthropic_idempotency_key: string;
+    retry_count: number;
+  };
+
+  if (!itemRow.image_id) {
+    throw new Error(
+      `processTransferItemCaption: item ${itemId} has no image_id (M4-3 upload stage must run first)`,
+    );
+  }
+  const imageUrl = resolveCaptionUrl(itemRow);
+  if (!imageUrl) {
+    throw new Error(
+      `processTransferItemCaption: item ${itemId} has no source_url`,
+    );
+  }
+
+  // leased → captioning. Event log first, then the state flip.
+  await withClient(opts.client ?? null, async (c) => {
+    await c.query(
+      `
+      INSERT INTO transfer_events (
+        transfer_job_id, transfer_job_item_id, event_type, payload_jsonb
+      )
+      VALUES ($1, $2, 'anthropic_caption_started',
+              jsonb_build_object('worker_id', $3::text,
+                                 'image_url', $4::text,
+                                 'model', $5::text))
+      `,
+      [itemRow.transfer_job_id, itemId, workerId, imageUrl, model],
+    );
+    const advance = await c.query(
+      `
+      UPDATE transfer_job_items
+         SET state = 'captioning',
+             updated_at = now()
+       WHERE id = $1
+         AND worker_id = $2
+         AND state = 'leased'
+      `,
+      [itemId, workerId],
+    );
+    if ((advance.rowCount ?? 0) === 0) {
+      throw new Error(
+        `processTransferItemCaption: lease stolen from worker ${workerId} before Anthropic call`,
+      );
+    }
+  });
+
+  // Anthropic call. Released from the pg client — no connection held
+  // during the round-trip. A throw here is either retryable (reset to
+  // pending with retry_after) or non-retryable (terminal fail, cost
+  // billable only if the call returned tokens which it didn't, so 0).
+  let apiResponse;
+  try {
+    apiResponse = await captionCall({
+      image_url: imageUrl,
+      idempotency_key: itemRow.anthropic_idempotency_key,
+      model,
+      max_tokens: maxTokens,
+    });
+  } catch (err) {
+    await handleCaptionApiError(
+      itemRow,
+      workerId,
+      err,
+      imageUrl,
+      model,
+      opts.client ?? null,
+    );
+    return;
+  }
+
+  // Cost computed before any DB writes so a commit failure still leaves
+  // the audit log coherent (event will carry the cost; we can always
+  // replay).
+  const { cents, rateFound } = computeCostCents(apiResponse.model, apiResponse.usage);
+
+  // Parse + structural validation. Parse failure / schema failure is
+  // non-retryable and terminal — the same idempotency key would return
+  // the same unparseable reply.
+  let parsed: CaptionPayload | null = null;
+  let parseError: CaptionCallError | null = null;
+  try {
+    parsed = parseCaptionPayload(apiResponse.raw_text);
+  } catch (err) {
+    if (err instanceof CaptionCallError) {
+      parseError = err;
+    } else {
+      throw err;
+    }
+  }
+
+  // Event log first. One event row with the full cost / usage / pricing
+  // snapshot + the parse outcome so billing reconciliation can rebuild
+  // without re-running the worker.
+  await withClient(opts.client ?? null, async (c) => {
+    await c.query(
+      `
+      INSERT INTO transfer_events (
+        transfer_job_id, transfer_job_item_id, event_type, payload_jsonb, cost_cents
+      )
+      VALUES ($1, $2, 'anthropic_caption_response_received',
+              jsonb_build_object(
+                'anthropic_response_id', $3::text,
+                'model', $4::text,
+                'input_tokens', $5::int,
+                'output_tokens', $6::int,
+                'cache_creation_input_tokens', $7::int,
+                'cache_read_input_tokens', $8::int,
+                'cost_usd_cents', $9::bigint,
+                'pricing_version', $10::text,
+                'rate_found', $11::boolean,
+                'worker_id', $12::text,
+                'parse_ok', $13::boolean,
+                'parse_failure_code', $14::text
+              ), $9)
+      `,
+      [
+        itemRow.transfer_job_id,
+        itemId,
+        apiResponse.id,
+        apiResponse.model,
+        apiResponse.usage.input_tokens,
+        apiResponse.usage.output_tokens,
+        apiResponse.usage.cache_creation_input_tokens ?? 0,
+        apiResponse.usage.cache_read_input_tokens ?? 0,
+        cents,
+        PRICING_VERSION,
+        rateFound,
+        workerId,
+        parsed !== null,
+        parseError?.code ?? null,
+      ],
+    );
+  });
+
+  if (parsed === null) {
+    // Parse / validation failure. Mark item failed with cost recorded.
+    await markCaptionFailed({
+      itemRow,
+      workerId,
+      failureCode: parseError?.code ?? "CAPTION_PARSE_FAILED",
+      failureDetail: parseError?.message ?? "parse failed",
+      costCents: cents,
+      client: opts.client ?? null,
+    });
+    return;
+  }
+
+  // Success path. image_library UPDATE, then item UPDATE, then job
+  // aggregation. Each UPDATE is lease-coherent on the item.
+  await withClient(opts.client ?? null, async (c) => {
+    // Idempotent UPDATE — a replay with the same idempotency key returns
+    // identical payload, so this becomes a no-op on second run. No
+    // lease guard here (image_library has no per-row lease concept);
+    // concurrent callers writing the same fields is prevented by the
+    // FOR UPDATE lock the worker already holds on the transfer item.
+    const updateImage = await c.query(
+      `
+      UPDATE image_library
+         SET caption = $2,
+             alt_text = $3,
+             tags = $4::text[],
+             updated_at = now()
+       WHERE id = $1
+      `,
+      [itemRow.image_id, parsed.caption, parsed.alt_text, parsed.tags],
+    );
+    if ((updateImage.rowCount ?? 0) === 0) {
+      throw new Error(
+        `processTransferItemCaption: image_library row ${itemRow.image_id} not found`,
+      );
+    }
+
+    // captioning → succeeded on the item, + cost.
+    const advance = await c.query(
+      `
+      UPDATE transfer_job_items
+         SET state = 'succeeded',
+             cost_cents = cost_cents + $3::bigint,
+             worker_id = NULL,
+             lease_expires_at = NULL,
+             updated_at = now()
+       WHERE id = $1
+         AND worker_id = $2
+         AND state = 'captioning'
+      `,
+      [itemId, workerId, cents],
+    );
+    if ((advance.rowCount ?? 0) === 0) {
+      throw new Error(
+        `processTransferItemCaption: lease stolen from worker ${workerId} before state=succeeded`,
+      );
+    }
+
+    await c.query(
+      `
+      INSERT INTO transfer_events (
+        transfer_job_id, transfer_job_item_id, event_type, payload_jsonb
+      )
+      VALUES ($1, $2, 'state_advanced',
+              jsonb_build_object('to', 'succeeded',
+                                 'worker_id', $3::text,
+                                 'processor', 'caption'))
+      `,
+      [itemRow.transfer_job_id, itemId, workerId],
+    );
+
+    await aggregateJobProgress(c, itemId, cents);
+  });
+}
+
+async function handleCaptionApiError(
+  itemRow: {
+    id: string;
+    transfer_job_id: string;
+    retry_count: number;
+  },
+  workerId: string,
+  err: unknown,
+  imageUrl: string,
+  model: string,
+  client: Client | null,
+): Promise<void> {
+  const isCaptionErr = err instanceof CaptionCallError;
+  const retryable = isCaptionErr ? err.retryable : true;
+  const code = isCaptionErr ? err.code : "ANTHROPIC_NETWORK_ERROR";
+  const detail = err instanceof Error ? err.message : String(err);
+
+  await withClient(client, async (c) => {
+    // Audit event first — every attempt contributes one failure event
+    // so reconciliation can count attempts even when retries succeed.
+    await c.query(
+      `
+      INSERT INTO transfer_events (
+        transfer_job_id, transfer_job_item_id, event_type, payload_jsonb
+      )
+      VALUES ($1, $2, 'anthropic_caption_failed',
+              jsonb_build_object('worker_id', $3::text,
+                                 'image_url', $4::text,
+                                 'model', $5::text,
+                                 'failure_code', $6::text,
+                                 'failure_detail', $7::text,
+                                 'retryable', $8::boolean,
+                                 'retry_count', $9::int))
+      `,
+      [
+        itemRow.transfer_job_id,
+        itemRow.id,
+        workerId,
+        imageUrl,
+        model,
+        code,
+        detail,
+        retryable,
+        itemRow.retry_count,
+      ],
+    );
+
+    if (retryable) {
+      const retryAfter = retryAfterForCount(itemRow.retry_count);
+      if (retryAfter) {
+        // Put it back in the queue with a backoff.
+        const reset = await c.query(
+          `
+          UPDATE transfer_job_items
+             SET state = 'pending',
+                 worker_id = NULL,
+                 lease_expires_at = NULL,
+                 retry_after = $3::timestamptz,
+                 failure_code = NULL,
+                 failure_detail = NULL,
+                 updated_at = now()
+           WHERE id = $1
+             AND worker_id = $2
+             AND state IN ('leased', 'captioning')
+          `,
+          [itemRow.id, workerId, retryAfter.toISOString()],
+        );
+        if ((reset.rowCount ?? 0) === 0) {
+          throw new Error(
+            `processTransferItemCaption: lease stolen while deferring item ${itemRow.id}`,
+          );
+        }
+        return;
+      }
+      // Retry budget exhausted — convert to terminal failure below.
+    }
+
+    // Terminal failure. cost_cents is left untouched; this branch fires
+    // when the call never returned tokens (network / 4xx before billing).
+    const fail = await c.query(
+      `
+      UPDATE transfer_job_items
+         SET state = 'failed',
+             failure_code = $3,
+             failure_detail = $4,
+             worker_id = NULL,
+             lease_expires_at = NULL,
+             updated_at = now()
+       WHERE id = $1
+         AND worker_id = $2
+         AND state IN ('leased', 'captioning')
+      `,
+      [itemRow.id, workerId, code, detail],
+    );
+    if ((fail.rowCount ?? 0) === 0) {
+      throw new Error(
+        `processTransferItemCaption: lease stolen while marking item ${itemRow.id} failed`,
+      );
+    }
+
+    await aggregateJobProgress(c, itemRow.id, 0);
+  });
+}
+
+async function markCaptionFailed(params: {
+  itemRow: { id: string; transfer_job_id: string };
+  workerId: string;
+  failureCode: string;
+  failureDetail: string;
+  costCents: number;
+  client: Client | null;
+}): Promise<void> {
+  const { itemRow, workerId, failureCode, failureDetail, costCents, client } =
+    params;
+
+  await withClient(client, async (c) => {
+    const fail = await c.query(
+      `
+      UPDATE transfer_job_items
+         SET state = 'failed',
+             cost_cents = cost_cents + $4::bigint,
+             failure_code = $3,
+             failure_detail = $5,
+             worker_id = NULL,
+             lease_expires_at = NULL,
+             updated_at = now()
+       WHERE id = $1
+         AND worker_id = $2
+         AND state IN ('leased', 'captioning')
+      `,
+      [itemRow.id, workerId, failureCode, costCents, failureDetail],
+    );
+    if ((fail.rowCount ?? 0) === 0) {
+      throw new Error(
+        `processTransferItemCaption: lease stolen while marking item ${itemRow.id} failed (${failureCode})`,
+      );
+    }
+
+    await c.query(
+      `
+      INSERT INTO transfer_events (
+        transfer_job_id, transfer_job_item_id, event_type, payload_jsonb, cost_cents
+      )
+      VALUES ($1, $2, 'state_advanced',
+              jsonb_build_object('to', 'failed',
+                                 'worker_id', $3::text,
+                                 'failure_code', $4::text,
+                                 'processor', 'caption'),
+              $5::bigint)
+      `,
+      [itemRow.transfer_job_id, itemRow.id, workerId, failureCode, costCents],
+    );
+
+    await aggregateJobProgress(c, itemRow.id, costCents);
+  });
+}
+
+// Shared job-aggregation UPDATE. Bumps total_cost_usd_cents and flips
+// parent status according to the top-branch CASE (cancelled/failed stay
+// terminal). Mirrors processTransferItemDummy's aggregation block with
+// the addition of cost accumulation.
+async function aggregateJobProgress(
+  c: Client,
+  itemId: string,
+  costDeltaCents: number,
+): Promise<void> {
+  await c.query(
+    `
+    WITH counts AS (
+      SELECT transfer_job_id,
+             count(*) FILTER (WHERE state = 'succeeded') AS succeeded,
+             count(*) FILTER (WHERE state = 'failed')    AS failed,
+             count(*) FILTER (WHERE state = 'skipped')   AS skipped,
+             count(*) AS total
+        FROM transfer_job_items
+       WHERE transfer_job_id = (
+         SELECT transfer_job_id FROM transfer_job_items WHERE id = $1
+       )
+       GROUP BY transfer_job_id
+    )
+    UPDATE transfer_jobs j
+       SET succeeded_count = c.succeeded,
+           failed_count    = c.failed,
+           skipped_count   = c.skipped,
+           total_cost_usd_cents = total_cost_usd_cents + $2::bigint,
+           status = CASE
+             WHEN j.status IN ('cancelled', 'failed') THEN j.status
+             WHEN (c.succeeded + c.failed + c.skipped) >= j.requested_count
+               THEN CASE WHEN c.failed > 0 THEN 'failed' ELSE 'succeeded' END
+             ELSE 'processing'
+           END,
+           finished_at = CASE
+             WHEN j.status IN ('cancelled', 'failed') THEN j.finished_at
+             WHEN (c.succeeded + c.failed + c.skipped) >= j.requested_count
+               THEN COALESCE(j.finished_at, now())
+             ELSE j.finished_at
+           END,
+           started_at = COALESCE(j.started_at, now()),
+           updated_at = now()
+      FROM counts c
+     WHERE j.id = c.transfer_job_id
+    `,
+    [itemId, costDeltaCents],
+  );
 }


### PR DESCRIPTION
Adds the Anthropic vision captioning stage to the M4 transfer worker. A leased `cloudflare_ingest` item walks `leased → captioning → succeeded`: the worker sends the image URL to Anthropic with the item's pre-computed `anthropic_idempotency_key`, parses the JSON response under a strict Zod schema, writes an `anthropic_caption_response_received` transfer event BEFORE updating `image_library.caption/alt_text/tags`, then advances the item to `succeeded` and aggregates the job. Retryable failures (429, 5xx, network) defer via the M3-7 backoff table; non-retryable (4xx, parse, validation) go terminal with `failure_code` and cost still captured when the API billed.

## What lands
- `lib/anthropic-caption.ts` — vision call wrapper (`defaultAnthropicCaptionCall`), `CaptionRequest` / `CaptionApiResponse` types, Zod payload schema (`caption` 40–280, `alt_text` 10–200, `tags` 3–10), `CaptionCallError` + `classifyHttpStatus` for retryability verdicts, `parseCaptionPayload` for strict JSON parse.
- `lib/transfer-worker.ts` — `processTransferItemCaption(itemId, workerId, opts)` + `aggregateJobProgress` helper. Event-log-first billing, lease-coherent UPDATEs, retry budget + terminal failure paths.
- `lib/__tests__/anthropic-caption.test.ts` — parser + classifier unit tests (no DB): length bounds, tag-count bounds, parse failure, retryability mapping.
- `lib/__tests__/transfer-worker-caption.test.ts` — 10 DB-backed scenarios: happy path, idempotency-key stability across retries, event-log-first ordering, parse failure, validation failure, retryable 429 defer, retry-budget exhaustion to terminal, non-retryable 400, reaper-recovery + key reuse, full-job cost reconciliation (item sum == event sum == job total).
- `docs/BACKLOG.md` — M4 tracker: M4-2 → `merged (#58)`, M4-4 → `in flight`.

## Risks identified and mitigated
- **Double-billing Anthropic on retry.** `anthropic_idempotency_key` is pre-computed in migration 0010 and passed through as the `Idempotency-Key` header on every attempt — the server returns the cached response within the 24h window without billing again. Test: re-processing the same item (post-reset) observes the same key; crash-recovery reaper path replays the same key.
- **Partial commit after Anthropic call.** `transfer_events.anthropic_caption_response_received` is written BEFORE the `image_library` UPDATE and BEFORE the item's state column flip. Event row carries full usage, cost, and pricing-version so billing reconciliation always works from the event log. Test: asserts event `created_at` < state-advanced event `created_at`.
- **Lease stolen mid-caption.** Every UPDATE to `transfer_job_items` filters on `worker_id = $workerId AND state IN ('leased','captioning')`; stale late writes affect zero rows and throw. Test: reaper-recovery scenario proves a crashed-worker item is safely re-leased and driven to succeeded by the new worker.
- **Caption quality drift.** Zod schema encodes structural bounds (caption 40–280 chars, alt_text 10–200, 3–10 tags). Anything outside fails terminally as `CAPTION_VALIDATION_FAILED` with cost recorded — no silent accept of malformed replies. Tests cover too-few-tags, too-many-tags, short caption, missing alt_text.
- **Malformed JSON response.** `parseCaptionPayload` rejects non-JSON with `CAPTION_PARSE_FAILED` (non-retryable — same idempotency key returns the same unparseable reply). Cost still recorded. Test: prose reply fails the item; `image_library.caption` stays NULL; event row records `parse_ok=false` + `parse_failure_code`.
- **Retry budget exhaustion.** `RETRY_BACKOFF_MS` table (inherited from M3-7) caps attempts at 3. A retryable error past the table falls through to terminal failure in-place. Test: three 429 attempts drive the item to `failed` with `failure_code=ANTHROPIC_RATE_LIMITED`.
- **Cancellation interaction.** The job-aggregation UPDATE top-branch CASE preserves `cancelled` / `failed` — a late-completing caption cannot flip a cancelled job back. Inherited from M4-2's aggregation contract; the caption processor reuses the same aggregation shape.

## Deliberately deferred
- **Image URL resolution from Cloudflare.** `resolveCaptionUrl` currently reads `transfer_job_items.source_url` — fine for M4-4 in isolation (iStock seed URLs) and for re-captioning paths later. When M4-3 lands, the resolver will prefer the Cloudflare-delivered URL from `image_library.cloudflare_id` + `CLOUDFLARE_IMAGES_HASH`. Localised to one function so the swap is a one-line change.
- **Prompt injection defence via tagged inputs.** M4-4's user input is an image URL (our own Cloudflare / iStock) + a short static prompt. No untrusted text flows into the system prompt, so the `docs/PROMPT_VERSIONING.md` tagging contract is not invoked here. Revisit if we ever caption user-supplied images with user-supplied context.
- **`output_format: json_schema`.** The SDK supports forcing JSON output, which would eliminate most parse failures. Punted to a follow-up — parser is strict enough today that violations are observable, and the cost-capture path is correct either way.
- **Per-tenant cost budget gate.** Called out in `docs/plans/m4.md` risks #7 and in `docs/PROMPT_VERSIONING.md`; belongs to the M4-5 seed script's pre-flight check, not the per-item caption processor.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — DB-backed tests require `supabase start` (no Docker locally); runs in CI.
- [ ] `npm run test:e2e` — no admin UI in this slice (worker-only).