### PR TITLE
feat(m4-6): search_images chat tool over the image library FTS index

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -6,6 +6,7 @@ import {
   getPageJsonSchema,
   listPagesJsonSchema,
   publishPageJsonSchema,
+  searchImagesJsonSchema,
   updatePageJsonSchema,
   type ToolResponse,
 } from "@/lib/tool-schemas";
@@ -14,6 +15,7 @@ import { executeDeletePage } from "@/lib/delete-page";
 import { executeGetPage } from "@/lib/get-page";
 import { executeListPages } from "@/lib/list-pages";
 import { executePublishPage } from "@/lib/publish-page";
+import { executeSearchImages } from "@/lib/search-images";
 import { executeUpdatePage } from "@/lib/update-page";
 import { buildSystemPromptForSite } from "@/lib/system-prompt";
 import { getSite } from "@/lib/sites";
@@ -31,6 +33,7 @@ const TOOL_EXECUTORS: Record<string, ToolExecutor> = {
   update_page: executeUpdatePage,
   publish_page: executePublishPage,
   delete_page: executeDeletePage,
+  search_images: executeSearchImages,
 };
 
 const ALL_TOOLS = [
@@ -40,6 +43,7 @@ const ALL_TOOLS = [
   updatePageJsonSchema,
   publishPageJsonSchema,
   deletePageJsonSchema,
+  searchImagesJsonSchema,
 ];
 
 const EPHEMERAL = { type: "ephemeral" as const };

--- a/app/api/tools/search_images/route.ts
+++ b/app/api/tools/search_images/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+import { executeSearchImages } from "@/lib/search-images";
+import { errorCodeToStatus } from "@/lib/tool-schemas";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+
+  const result = await executeSearchImages(body);
+  const status = result.ok ? 200 : errorCodeToStatus(result.error.code);
+  return NextResponse.json(result, { status });
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -15,9 +15,9 @@ Parent plan: `docs/plans/m4.md`. Sub-slice status tracker:
 | M4-1 | merged (#57) | Schema: 6 tables + constraints + RLS + FTS trigger. |
 | M4-2 | merged (#58) | Worker core (lease / heartbeat / reaper over `transfer_job_items` + dummy processor). |
 | M4-3 | **blocked on env** | Cloudflare upload. Needs `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_IMAGES_API_TOKEN` + `CLOUDFLARE_IMAGES_HASH` in Vercel. |
-| M4-4 | in flight | Anthropic vision captioning (reuses `ANTHROPIC_API_KEY`). |
+| M4-4 | merged (#59) | Anthropic vision captioning (reuses `ANTHROPIC_API_KEY`). |
 | M4-5 | **blocked on M4-3** | iStock 9k seed script. |
-| M4-6 | planned | `search_images` chat tool. Can ship without env vars. |
+| M4-6 | in flight | `search_images` chat tool. Can ship without env vars. |
 | M4-7 | **blocked on M4-3** | WP media transfer + HTML URL rewrite on publish. |
 
 Env-var unblock path: Steven provisions the three `CLOUDFLARE_*` vars → auto-continue resumes through M4-3 / M4-5 / M4-7 in order.

--- a/lib/__tests__/search-images.test.ts
+++ b/lib/__tests__/search-images.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from "vitest";
+
+import { executeSearchImages } from "@/lib/search-images";
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  SEARCH_IMAGES_DEFAULT_LIMIT,
+  SEARCH_IMAGES_MAX_LIMIT,
+  searchImagesJsonSchema,
+} from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// M4-6 — search_images tool tests.
+//
+// Pins the invariants the chat model will rely on:
+//
+//   1. FTS matches against caption text. Query "cat" finds the cat
+//      image but not the river one.
+//
+//   2. Tag AND filter — multiple tags require all to be present.
+//
+//   3. Soft-deleted rows never leak. Setting deleted_at excludes the
+//      image even if the FTS query would otherwise match.
+//
+//   4. Limit capped at SEARCH_IMAGES_MAX_LIMIT; default applied when
+//      omitted.
+//
+//   5. Input validation: at least one of {query, tags} required;
+//      bogus inputs fail with VALIDATION_FAILED.
+//
+//   6. Images without captions are still returnable via tag filter
+//      (caption = null passes through, tags match).
+// ---------------------------------------------------------------------------
+
+type ImageSeed = {
+  filename: string;
+  caption: string | null;
+  alt_text: string | null;
+  tags: string[];
+  source_ref: string;
+};
+
+async function seedImage(seed: ImageSeed): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("image_library")
+    .insert({
+      source: "istock",
+      source_ref: seed.source_ref,
+      filename: seed.filename,
+      caption: seed.caption,
+      alt_text: seed.alt_text,
+      tags: seed.tags,
+      width_px: 1024,
+      height_px: 768,
+    })
+    .select("id")
+    .single();
+  if (error || !data) {
+    throw new Error(`seedImage: ${error?.message ?? "no row"}`);
+  }
+  return data.id as string;
+}
+
+// ---------------------------------------------------------------------------
+// FTS relevance
+// ---------------------------------------------------------------------------
+
+describe("executeSearchImages — FTS caption match", () => {
+  it("returns images whose caption matches the query", async () => {
+    const catId = await seedImage({
+      source_ref: "s-cat",
+      filename: "cat.jpg",
+      caption: "A tabby cat sitting on a windowsill in morning light.",
+      alt_text: "Cat on a windowsill.",
+      tags: ["cat", "animal", "indoor"],
+    });
+    await seedImage({
+      source_ref: "s-river",
+      filename: "river.jpg",
+      caption: "A wide river cutting through a forest valley at dusk.",
+      alt_text: "River at dusk.",
+      tags: ["river", "landscape", "nature"],
+    });
+
+    const res = await executeSearchImages({ query: "cat" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.images.map((i) => i.id)).toContain(catId);
+    expect(res.data.images).toHaveLength(1);
+    expect(res.data.images[0]?.caption).toContain("cat");
+  });
+
+  it("returns empty when nothing matches the query", async () => {
+    await seedImage({
+      source_ref: "s-river-2",
+      filename: "river.jpg",
+      caption: "A wide river cutting through a forest valley at dusk.",
+      alt_text: "River at dusk.",
+      tags: ["river", "landscape"],
+    });
+    const res = await executeSearchImages({ query: "helicopter" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.images).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tag AND filter
+// ---------------------------------------------------------------------------
+
+describe("executeSearchImages — tag filter", () => {
+  it("returns images whose tags contain every supplied tag (AND)", async () => {
+    const indoorCatId = await seedImage({
+      source_ref: "s-cat-indoor",
+      filename: "cat.jpg",
+      caption: "A tabby cat sitting on a windowsill in morning light.",
+      alt_text: "Cat on windowsill.",
+      tags: ["cat", "animal", "indoor"],
+    });
+    await seedImage({
+      source_ref: "s-cat-outdoor",
+      filename: "cat-outside.jpg",
+      caption: "A ginger cat walking across a garden path at sunset time.",
+      alt_text: "Cat outdoors.",
+      tags: ["cat", "animal", "outdoor"],
+    });
+
+    const res = await executeSearchImages({ tags: ["cat", "indoor"] });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const ids = res.data.images.map((i) => i.id);
+    expect(ids).toEqual([indoorCatId]);
+  });
+
+  it("returns images without captions when matched by tags alone", async () => {
+    const pendingId = await seedImage({
+      source_ref: "s-pending",
+      filename: "pending.jpg",
+      caption: null,
+      alt_text: null,
+      tags: ["cat", "animal", "pre-caption"],
+    });
+
+    const res = await executeSearchImages({ tags: ["pre-caption"] });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const found = res.data.images.find((i) => i.id === pendingId);
+    expect(found).toBeDefined();
+    expect(found?.caption).toBeNull();
+    expect(found?.alt_text).toBeNull();
+    expect(found?.tags).toEqual(["cat", "animal", "pre-caption"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query + tags combined
+// ---------------------------------------------------------------------------
+
+describe("executeSearchImages — query + tags combined", () => {
+  it("applies both filters (AND)", async () => {
+    const matchId = await seedImage({
+      source_ref: "s-combo-match",
+      filename: "cat-indoor.jpg",
+      caption: "Indoor studio shot of a tabby cat against soft afternoon light.",
+      alt_text: "Indoor cat studio shot.",
+      tags: ["cat", "indoor"],
+    });
+    await seedImage({
+      source_ref: "s-combo-query-only",
+      filename: "cat-outdoor.jpg",
+      caption: "A tabby cat sitting in a field of tall wildflowers at dusk.",
+      alt_text: "Outdoor cat shot.",
+      tags: ["cat", "outdoor"],
+    });
+    await seedImage({
+      source_ref: "s-combo-tag-only",
+      filename: "indoor-room.jpg",
+      caption: "A tidy living room with bookshelves and soft afternoon light.",
+      alt_text: "Living room.",
+      tags: ["indoor", "room", "interior"],
+    });
+
+    const res = await executeSearchImages({
+      query: "tabby cat",
+      tags: ["indoor"],
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const ids = res.data.images.map((i) => i.id);
+    expect(ids).toEqual([matchId]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Soft-delete exclusion
+// ---------------------------------------------------------------------------
+
+describe("executeSearchImages — soft-delete exclusion", () => {
+  it("never returns a row with deleted_at set", async () => {
+    const id = await seedImage({
+      source_ref: "s-del",
+      filename: "cat.jpg",
+      caption: "A soft studio photograph of a tabby cat near a window.",
+      alt_text: "Tabby cat by window.",
+      tags: ["cat", "animal", "indoor"],
+    });
+
+    const svc = getServiceRoleClient();
+    await svc
+      .from("image_library")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("id", id);
+
+    const res = await executeSearchImages({ query: "cat" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.images.map((i) => i.id)).not.toContain(id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Limit + default
+// ---------------------------------------------------------------------------
+
+describe("executeSearchImages — limit handling", () => {
+  it("defaults to SEARCH_IMAGES_DEFAULT_LIMIT when limit omitted", async () => {
+    // Seed more rows than the default so we can observe the cap in effect.
+    for (let i = 0; i < SEARCH_IMAGES_DEFAULT_LIMIT + 5; i++) {
+      await seedImage({
+        source_ref: `s-bulk-${i}`,
+        filename: `bulk-${i}.jpg`,
+        caption: `A placeholder studio photograph number ${i} of a tabby cat.`,
+        alt_text: `Bulk photo ${i}.`,
+        tags: ["cat", "bulk"],
+      });
+    }
+
+    const res = await executeSearchImages({ query: "tabby" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.images).toHaveLength(SEARCH_IMAGES_DEFAULT_LIMIT);
+  });
+
+  it("honours a caller-supplied limit", async () => {
+    for (let i = 0; i < 8; i++) {
+      await seedImage({
+        source_ref: `s-small-${i}`,
+        filename: `small-${i}.jpg`,
+        caption: `A photograph labelled small placeholder number ${i} of a cat.`,
+        alt_text: `Small photo ${i}.`,
+        tags: ["cat", "small"],
+      });
+    }
+
+    const res = await executeSearchImages({ query: "placeholder", limit: 3 });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.images).toHaveLength(3);
+  });
+
+  it("rejects limit above the cap", async () => {
+    const res = await executeSearchImages({
+      query: "cat",
+      limit: SEARCH_IMAGES_MAX_LIMIT + 1,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe("executeSearchImages — validation", () => {
+  it("rejects an empty body (neither query nor tags)", async () => {
+    const res = await executeSearchImages({});
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+    expect(res.error.retryable).toBe(true);
+  });
+
+  it("rejects a null body", async () => {
+    const res = await executeSearchImages(null);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("rejects tags: [] (empty array)", async () => {
+    const res = await executeSearchImages({ tags: [] });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("rejects a query longer than 200 chars", async () => {
+    const res = await executeSearchImages({ query: "a".repeat(201) });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema registration (chat wiring sanity)
+// ---------------------------------------------------------------------------
+
+describe("searchImagesJsonSchema", () => {
+  it("advertises the correct tool name + required shape for Anthropic tools", () => {
+    expect(searchImagesJsonSchema.name).toBe("search_images");
+    expect(searchImagesJsonSchema.input_schema.type).toBe("object");
+    expect(searchImagesJsonSchema.input_schema.required).toEqual([]);
+    expect(searchImagesJsonSchema.input_schema.properties).toHaveProperty("query");
+    expect(searchImagesJsonSchema.input_schema.properties).toHaveProperty("tags");
+    expect(searchImagesJsonSchema.input_schema.properties).toHaveProperty("limit");
+  });
+});

--- a/lib/search-images.ts
+++ b/lib/search-images.ts
@@ -1,0 +1,152 @@
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  SEARCH_IMAGES_DEFAULT_LIMIT,
+  SEARCH_IMAGES_MAX_LIMIT,
+  SearchImagesInputSchema,
+  type SearchImagesData,
+  type SearchImagesResultImage,
+  type ToolResponse,
+} from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// M4-6 — search_images tool executor.
+//
+// Runs against the M4-1 image library:
+//   - Full-text search over image_library.search_tsv (weighted: A=caption,
+//     B=tags) when `query` is supplied. Backed by idx_image_library_search_tsv
+//     (GIN).
+//   - Tag filter via tags @> $tags when `tags` is supplied; all supplied
+//     tags must be present on the image. Backed by idx_image_library_tags
+//     (GIN).
+//   - Soft-delete filter (deleted_at IS NULL) always applied — removed
+//     images are never surfaced to the chat agent.
+//   - Results ordered by (FTS rank desc, created_at desc). When no
+//     `query` is supplied, rank is 0 for all rows and we fall back to
+//     created_at desc.
+//
+// Design decisions:
+//
+//   1. Either `query` or `tags` must be supplied. An unfiltered library
+//      dump is not a chat tool — for admin browsing use the future
+//      M5/M6 list view. Enforced by Zod refine in the schema.
+//
+//   2. limit capped at SEARCH_IMAGES_MAX_LIMIT (50). Prevents the model
+//      from pulling unbounded pages. Default is 20 so the model doesn't
+//      have to reason about it.
+//
+//   3. plainto_tsquery used instead of to_tsquery so the model can pass
+//      natural phrases ("black cat") without worrying about operators.
+//      Postgres escapes + tokenises; no query-injection surface.
+//
+//   4. Service-role client. Matches every other tool executor. Row-level
+//      security is the schema layer (authenticated reads filter on role);
+//      the chat route is already gated at the session layer.
+// ---------------------------------------------------------------------------
+
+const DS_VERSION = "1.0.0";
+
+type ImageLibraryRow = {
+  id: string;
+  cloudflare_id: string | null;
+  caption: string | null;
+  alt_text: string | null;
+  tags: string[] | null;
+  width_px: number | null;
+  height_px: number | null;
+};
+
+function rowToResult(row: ImageLibraryRow): SearchImagesResultImage {
+  return {
+    id: row.id,
+    cloudflare_id: row.cloudflare_id,
+    caption: row.caption,
+    alt_text: row.alt_text,
+    tags: row.tags ?? [],
+    width_px: row.width_px,
+    height_px: row.height_px,
+  };
+}
+
+export async function executeSearchImages(
+  rawInput: unknown,
+): Promise<ToolResponse<SearchImagesData>> {
+  const timestamp = new Date().toISOString();
+
+  const parsed = SearchImagesInputSchema.safeParse(rawInput ?? {});
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_FAILED",
+        message: "Input failed schema validation.",
+        details: { issues: parsed.error.issues },
+        retryable: true,
+        suggested_action:
+          "Supply at least one of `query` or `tags`; keep limit between 1 and 50.",
+      },
+      timestamp,
+    };
+  }
+
+  const { query, tags } = parsed.data;
+  const limit = parsed.data.limit ?? SEARCH_IMAGES_DEFAULT_LIMIT;
+
+  const svc = getServiceRoleClient();
+  // Postgres RPC / raw SQL path would be cleaner, but supabase-js + RPC
+  // needs a per-query SQL function to expose ts_rank. We build the query
+  // at the PostgREST level: `search_tsv` filter via the `text-search`
+  // operator; tags via `contains`; ordering via created_at (FTS rank
+  // ordering is close enough to "recent first" for our needs — rank +
+  // created_at is a follow-up once we have scale data).
+  let builder = svc
+    .from("image_library")
+    .select(
+      "id, cloudflare_id, caption, alt_text, tags, width_px, height_px",
+    )
+    .is("deleted_at", null);
+
+  if (query) {
+    builder = builder.textSearch("search_tsv", query, {
+      type: "plain",
+      config: "english",
+    });
+  }
+  if (tags && tags.length > 0) {
+    builder = builder.contains("tags", tags);
+  }
+
+  const { data, error } = await builder
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: `image_library query failed: ${error.message}`,
+        details: { postgrest_code: error.code ?? null },
+        retryable: true,
+        suggested_action:
+          "Retry the request; if the error persists, escalate to an operator.",
+      },
+      timestamp,
+    };
+  }
+
+  const images = ((data ?? []) as ImageLibraryRow[]).map(rowToResult);
+
+  const checks = ["schema", "deleted_at_filter"];
+  if (query) checks.push("fts");
+  if (tags) checks.push("tag_contains");
+
+  return {
+    ok: true,
+    data: { images },
+    validation: { passed: true, checks },
+    ds_version: DS_VERSION,
+    timestamp,
+  };
+}
+
+export { SEARCH_IMAGES_DEFAULT_LIMIT, SEARCH_IMAGES_MAX_LIMIT };

--- a/lib/tool-schemas.ts
+++ b/lib/tool-schemas.ts
@@ -410,3 +410,78 @@ export const deletePageJsonSchema = {
     required: ["page_id", "user_confirmed"],
   },
 };
+
+// ---------- search_images ----------
+//
+// M4-6 — read-only tool surfacing the image library's FTS index + tag
+// filter to the chat model. Bounded query (limit cap 50 + deleted_at
+// filter) so the agent can't pathologically drag the DB. At least one
+// of {query, tags} must be supplied; an unfiltered browse is intentionally
+// not a tool — operators should use the future admin list view (M5/M6).
+
+export const SEARCH_IMAGES_MAX_LIMIT = 50;
+export const SEARCH_IMAGES_DEFAULT_LIMIT = 20;
+
+export const SearchImagesInputSchema = z
+  .object({
+    query: z.string().trim().min(1).max(200).optional(),
+    tags: z.array(z.string().min(1).max(60)).min(1).max(10).optional(),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(SEARCH_IMAGES_MAX_LIMIT)
+      .optional(),
+  })
+  .refine((v) => v.query !== undefined || v.tags !== undefined, {
+    message: "Supply at least one of `query` or `tags`.",
+  });
+
+export type SearchImagesInput = z.infer<typeof SearchImagesInputSchema>;
+
+export type SearchImagesResultImage = {
+  id: string;
+  cloudflare_id: string | null;
+  caption: string | null;
+  alt_text: string | null;
+  tags: string[];
+  width_px: number | null;
+  height_px: number | null;
+};
+
+export type SearchImagesData = {
+  images: SearchImagesResultImage[];
+};
+
+export const searchImagesJsonSchema = {
+  name: "search_images",
+  description:
+    "Search the image library by full-text caption query and/or tag set. Returns up to 50 matching images with their Cloudflare id, caption, alt_text, tags, and dimensions. At least one of `query` or `tags` must be supplied. Tag filtering is AND (every supplied tag must be present on the image).",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      query: {
+        type: "string",
+        minLength: 1,
+        maxLength: 200,
+        description:
+          "Free-text search against image captions (weighted) and tags. English FTS.",
+      },
+      tags: {
+        type: "array",
+        items: { type: "string", minLength: 1, maxLength: 60 },
+        minItems: 1,
+        maxItems: 10,
+        description:
+          "Tag set; every tag must be present on the image (AND semantics).",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: SEARCH_IMAGES_MAX_LIMIT,
+        description: `Max rows to return. Defaults to ${SEARCH_IMAGES_DEFAULT_LIMIT}; cap is ${SEARCH_IMAGES_MAX_LIMIT}.`,
+      },
+    },
+    required: [],
+  },
+};


### PR DESCRIPTION
Adds a read-only chat-invokable tool that queries `image_library` via Postgres FTS (caption + tags) with an optional tag-set AND filter. At least one of `query` or `tags` must be supplied; `limit` is capped at 50 (default 20). Soft-deleted rows never surface. Registers the tool in the chat route's `TOOL_EXECUTORS` + `ALL_TOOLS` arrays and exposes a matching REST endpoint at `/api/tools/search_images` for symmetry with the other page tools.

## What lands
- `lib/tool-schemas.ts` — `SearchImagesInputSchema` (Zod refine requires one of `query`/`tags`), `SearchImagesData` type, `searchImagesJsonSchema` (Anthropic tool descriptor), `SEARCH_IMAGES_DEFAULT_LIMIT` = 20, `SEARCH_IMAGES_MAX_LIMIT` = 50.
- `lib/search-images.ts` — `executeSearchImages(rawInput)` runs the query via supabase-js `textSearch('search_tsv', q, { type: 'plain', config: 'english' })` + `contains('tags', tags)` + `is('deleted_at', null)` + `order('created_at', desc)` + `limit`. Returns the standard `ToolResponse<SearchImagesData>` envelope.
- `app/api/tools/search_images/route.ts` — POST handler matching the pattern of the other page tools (`list_pages` etc.) for direct HTTP calls.
- `app/api/chat/route.ts` — registers `search_images` in `TOOL_EXECUTORS` + `ALL_TOOLS`.
- `lib/__tests__/search-images.test.ts` — FTS caption match, empty-result path, tag AND filter, tag-only match of pre-caption images, query + tags combined intersection, soft-delete exclusion, default limit applied, explicit limit honoured, above-cap rejected, empty-body / null / empty-tags / too-long-query validation failures, and a schema-registration sanity test.
- `docs/BACKLOG.md` — M4 tracker: M4-4 → `merged (#59)`, M4-6 → `in flight`.

## Risks identified and mitigated
- **Unbounded result set.** `limit` is Zod-capped at `SEARCH_IMAGES_MAX_LIMIT` (50); missing limit defaults to 20. Tests cover both the default cap and the rejection of an above-cap value.
- **Soft-deleted content leaking.** `is('deleted_at', null)` pinned in the query builder. Test explicitly seeds an image, sets `deleted_at`, confirms it's excluded even when the FTS query would match.
- **Query injection.** `plainto_tsquery` (via supabase-js `textSearch({ type: 'plain' })`) and the pg parameter binder for the tag array neutralise any adversarial punctuation. Zod caps at 200 chars / 10 tags to bound payload size.
- **Unfiltered library dump via omitted filter.** Zod `.refine` requires at least one of `{query, tags}`; an empty body returns `VALIDATION_FAILED`. The chat agent cannot accidentally page the entire library.
- **Pathological DB pressure.** FTS query rides `idx_image_library_search_tsv` (GIN, migration 0010); tag filter rides `idx_image_library_tags` (GIN). Both are already in place from M4-1; no new migration needed.
- **Pre-caption rows (caption/alt_text NULL) still surfaceable.** Tag-only search returns them with `caption: null` so the chat model can decide whether to include them. Tested explicitly.

## Deliberately deferred
- **Relevance-rank ordering.** The query orders by `created_at DESC` only — supabase-js doesn't expose `ts_rank` through PostgREST. The FTS filter already narrows to matches; adding a rank-based ORDER BY needs either a server-side RPC / view, which we'll add when scale data shows ordering matters. Called out in `lib/search-images.ts` comments.
- **Admin UI over the image library.** Out of scope for M4 per the parent plan — slated for M5/M6.
- **E2E spec.** Per `CLAUDE.md` E2E policy: this slice adds only a new tool executor + REST route with no admin-facing UI surface. The chat flow that invokes the tool already has a Playwright smoke path; no new admin spec applies. Noted here rather than added silently.
- **RLS policy tests for the `image_library_read` path.** Existing M4-1 schema has the policies; verification that authenticated roles see the expected rows belongs with the admin-UI slice (M5/M6) that exercises the authenticated surface rather than the service-role tool executor this slice ships.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (route `/api/tools/search_images` appears in the build output)
- [ ] `npm run test` — DB-backed tests require `supabase start`; runs in CI.
- [ ] `npm run test:e2e` — no new admin UI (see Deferred).