### PR TITLE
feat(m4-3): cloudflare images upload stage + ingest orchestrator

### DIFF
--- a/app/api/cron/process-transfer/route.ts
+++ b/app/api/cron/process-transfer/route.ts
@@ -4,7 +4,7 @@ import { timingSafeEqual } from "node:crypto";
 import {
   DEFAULT_LEASE_MS,
   leaseNextTransferItem,
-  processTransferItemDummy,
+  processTransferItemByJobType,
   reapExpiredLeases,
 } from "@/lib/transfer-worker";
 
@@ -73,9 +73,9 @@ async function runTick(): Promise<{
     return { reapedCount, processedItemId: null };
   }
 
-  // M4-2 ships dummy only. M4-3 adds the Cloudflare path + fan-out by
-  // job type (cloudflare_ingest vs wp_media_transfer).
-  await processTransferItemDummy(item.id, workerId);
+  // Dispatch by parent job type. cloudflare_ingest walks upload +
+  // caption (M4-3 + M4-4); wp_media_transfer lands in M4-7.
+  await processTransferItemByJobType(item.id, workerId);
   return { reapedCount, processedItemId: item.id };
 }
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -14,13 +14,13 @@ Parent plan: `docs/plans/m4.md`. Sub-slice status tracker:
 | --- | --- | --- |
 | M4-1 | merged (#57) | Schema: 6 tables + constraints + RLS + FTS trigger. |
 | M4-2 | merged (#58) | Worker core (lease / heartbeat / reaper over `transfer_job_items` + dummy processor). |
-| M4-3 | **blocked on env** | Cloudflare upload. Needs `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_IMAGES_API_TOKEN` + `CLOUDFLARE_IMAGES_HASH` in Vercel. |
+| M4-3 | in flight | Cloudflare upload worker stage + orchestrator. |
 | M4-4 | merged (#59) | Anthropic vision captioning (reuses `ANTHROPIC_API_KEY`). |
-| M4-5 | **blocked on M4-3** | iStock 9k seed script. |
-| M4-6 | in flight | `search_images` chat tool. Can ship without env vars. |
-| M4-7 | **blocked on M4-3** | WP media transfer + HTML URL rewrite on publish. |
+| M4-5 | planned | iStock 9k seed script. Unblocks once M4-3 merges. |
+| M4-6 | merged (#60) | `search_images` chat tool. |
+| M4-7 | planned | WP media transfer + HTML URL rewrite on publish. Unblocks once M4-3 merges. |
 
-Env-var unblock path: Steven provisions the three `CLOUDFLARE_*` vars → auto-continue resumes through M4-3 / M4-5 / M4-7 in order.
+Env vars: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_IMAGES_API_TOKEN`, `CLOUDFLARE_IMAGES_HASH` all provisioned in Vercel Production + Preview as of 2026-04-21.
 
 ---
 

--- a/lib/__tests__/cloudflare-images.test.ts
+++ b/lib/__tests__/cloudflare-images.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CloudflareCallError,
+  classifyHttpStatus,
+  uploadImage,
+  type CloudflareFetchFn,
+  type CloudflareImageRecord,
+} from "@/lib/cloudflare-images";
+
+// ---------------------------------------------------------------------------
+// M4-3 — Cloudflare Images client tests.
+//
+// In-process unit tests. No network, no DB. Exercises the HTTP status
+// classifier + the 409 adoption path + the envelope parser using a
+// fake fetch.
+// ---------------------------------------------------------------------------
+
+const FAKE_CONFIG = {
+  accountId: "acct_test",
+  apiToken: "cf_token_test",
+  deliveryHash: "hash-xyz",
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function record(id: string): CloudflareImageRecord {
+  return { id, filename: "x.jpg", uploaded: "2026-04-21T00:00:00Z", variants: [] };
+}
+
+describe("classifyHttpStatus", () => {
+  it("429 → retryable rate-limited", () => {
+    const c = classifyHttpStatus(429);
+    expect(c.code).toBe("CLOUDFLARE_RATE_LIMITED");
+    expect(c.retryable).toBe(true);
+  });
+
+  it("500 → retryable server error", () => {
+    const c = classifyHttpStatus(500);
+    expect(c.code).toBe("CLOUDFLARE_SERVER_ERROR");
+    expect(c.retryable).toBe(true);
+  });
+
+  it("401 → non-retryable auth error", () => {
+    const c = classifyHttpStatus(401);
+    expect(c.code).toBe("CLOUDFLARE_AUTH_ERROR");
+    expect(c.retryable).toBe(false);
+  });
+
+  it("413 → non-retryable payload too large", () => {
+    const c = classifyHttpStatus(413);
+    expect(c.code).toBe("CLOUDFLARE_PAYLOAD_TOO_LARGE");
+    expect(c.retryable).toBe(false);
+  });
+
+  it("422 → non-retryable unprocessable", () => {
+    const c = classifyHttpStatus(422);
+    expect(c.code).toBe("CLOUDFLARE_UNPROCESSABLE");
+    expect(c.retryable).toBe(false);
+  });
+
+  it("400 → non-retryable bad request (default)", () => {
+    const c = classifyHttpStatus(400);
+    expect(c.code).toBe("CLOUDFLARE_BAD_REQUEST");
+    expect(c.retryable).toBe(false);
+  });
+});
+
+describe("uploadImage — happy path", () => {
+  it("returns the parsed record on 200+success:true", async () => {
+    const calls: Array<{ url: string; method: string }> = [];
+    const fakeFetch: CloudflareFetchFn = async (url, init) => {
+      calls.push({ url, method: init.method ?? "GET" });
+      return jsonResponse(200, {
+        success: true,
+        errors: [],
+        messages: [],
+        result: record("idem-1"),
+      });
+    };
+
+    const out = await uploadImage(
+      { id: "idem-1", url: "https://src.test/a.jpg" },
+      { config: FAKE_CONFIG, fetchImpl: fakeFetch },
+    );
+    expect(out.id).toBe("idem-1");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("POST");
+    expect(calls[0]?.url).toContain("/accounts/acct_test/images/v1");
+  });
+
+  it("passes the idempotency id as the `id` form field", async () => {
+    let observed: FormData | null = null;
+    const fakeFetch: CloudflareFetchFn = async (_url, init) => {
+      observed = init.body as FormData;
+      return jsonResponse(200, {
+        success: true,
+        errors: [],
+        messages: [],
+        result: record("idem-2"),
+      });
+    };
+
+    await uploadImage(
+      { id: "idem-2", url: "https://src.test/b.jpg" },
+      { config: FAKE_CONFIG, fetchImpl: fakeFetch },
+    );
+    expect(observed).not.toBeNull();
+    expect(observed!.get("id")).toBe("idem-2");
+    expect(observed!.get("url")).toBe("https://src.test/b.jpg");
+  });
+});
+
+describe("uploadImage — 409 adoption", () => {
+  it("switches to GET-by-id and returns the existing record on HTTP 409", async () => {
+    let uploadCalled = false;
+    let getCalled = false;
+    const fakeFetch: CloudflareFetchFn = async (url, init) => {
+      if (init.method === "POST") {
+        uploadCalled = true;
+        return jsonResponse(409, {
+          success: false,
+          errors: [{ code: 5461, message: "Image with that id already exists" }],
+          messages: [],
+          result: null,
+        });
+      }
+      getCalled = true;
+      expect(url).toContain("/images/v1/idem-dup");
+      return jsonResponse(200, {
+        success: true,
+        errors: [],
+        messages: [],
+        result: record("idem-dup"),
+      });
+    };
+
+    const out = await uploadImage(
+      { id: "idem-dup", url: "https://src.test/c.jpg" },
+      { config: FAKE_CONFIG, fetchImpl: fakeFetch },
+    );
+    expect(uploadCalled).toBe(true);
+    expect(getCalled).toBe(true);
+    expect(out.id).toBe("idem-dup");
+  });
+
+  it("adopts on 200+success:false+already-exists error body", async () => {
+    const fakeFetch: CloudflareFetchFn = async (_url, init) => {
+      if (init.method === "POST") {
+        return jsonResponse(200, {
+          success: false,
+          errors: [{ code: 5461, message: "RESOURCE_ALREADY_EXISTS" }],
+          messages: [],
+          result: null,
+        });
+      }
+      return jsonResponse(200, {
+        success: true,
+        errors: [],
+        messages: [],
+        result: record("idem-exist"),
+      });
+    };
+
+    const out = await uploadImage(
+      { id: "idem-exist", url: "https://src.test/d.jpg" },
+      { config: FAKE_CONFIG, fetchImpl: fakeFetch },
+    );
+    expect(out.id).toBe("idem-exist");
+  });
+});
+
+describe("uploadImage — error classification", () => {
+  it("throws retryable CloudflareCallError on 429", async () => {
+    const fakeFetch: CloudflareFetchFn = async () =>
+      jsonResponse(429, {
+        success: false,
+        errors: [{ code: 1000, message: "rate limit" }],
+        messages: [],
+        result: null,
+      });
+    try {
+      await uploadImage(
+        { id: "x", url: "https://src.test/e.jpg" },
+        { config: FAKE_CONFIG, fetchImpl: fakeFetch },
+      );
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CloudflareCallError);
+      expect((err as CloudflareCallError).code).toBe("CLOUDFLARE_RATE_LIMITED");
+      expect((err as CloudflareCallError).retryable).toBe(true);
+      expect((err as CloudflareCallError).httpStatus).toBe(429);
+    }
+  });
+
+  it("throws non-retryable CloudflareCallError on 413", async () => {
+    const fakeFetch: CloudflareFetchFn = async () =>
+      jsonResponse(413, {
+        success: false,
+        errors: [{ code: 5450, message: "too large" }],
+        messages: [],
+        result: null,
+      });
+    try {
+      await uploadImage(
+        { id: "x", url: "https://src.test/f.jpg" },
+        { config: FAKE_CONFIG, fetchImpl: fakeFetch },
+      );
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as CloudflareCallError).code).toBe(
+        "CLOUDFLARE_PAYLOAD_TOO_LARGE",
+      );
+      expect((err as CloudflareCallError).retryable).toBe(false);
+    }
+  });
+
+  it("throws non-retryable CloudflareCallError on 401", async () => {
+    const fakeFetch: CloudflareFetchFn = async () =>
+      jsonResponse(401, {
+        success: false,
+        errors: [{ code: 9999, message: "bad token" }],
+        messages: [],
+        result: null,
+      });
+    try {
+      await uploadImage(
+        { id: "x", url: "https://src.test/g.jpg" },
+        { config: FAKE_CONFIG, fetchImpl: fakeFetch },
+      );
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as CloudflareCallError).code).toBe("CLOUDFLARE_AUTH_ERROR");
+      expect((err as CloudflareCallError).retryable).toBe(false);
+    }
+  });
+});
+
+describe("uploadImage — parse failure guard", () => {
+  it("throws CLOUDFLARE_PARSE_FAILED when success=true but result is missing/invalid", async () => {
+    const fakeFetch: CloudflareFetchFn = async () =>
+      jsonResponse(200, {
+        success: true,
+        errors: [],
+        messages: [],
+        result: { filename: "x" }, // no id
+      });
+    try {
+      await uploadImage(
+        { id: "x", url: "https://src.test/h.jpg" },
+        { config: FAKE_CONFIG, fetchImpl: fakeFetch },
+      );
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as CloudflareCallError).code).toBe("CLOUDFLARE_PARSE_FAILED");
+      expect((err as CloudflareCallError).retryable).toBe(false);
+    }
+  });
+});

--- a/lib/__tests__/transfer-worker-upload.test.ts
+++ b/lib/__tests__/transfer-worker-upload.test.ts
@@ -1,0 +1,475 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CloudflareCallError,
+  type CloudflareImageRecord,
+} from "@/lib/cloudflare-images";
+import {
+  leaseNextTransferItem,
+  processTransferItemUpload,
+  processTransferItemIngest,
+} from "@/lib/transfer-worker";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M4-3 — Cloudflare upload stage + orchestrator tests.
+//
+// DB-backed. Covers:
+//   - Happy path walk leased → uploading (stage-only) + image_library
+//     cloudflare_id update.
+//   - Idempotency-key stability across retries.
+//   - Adoption: upload fn returns a record (mirrors the 409 + GET-by-id
+//     flow in the Cloudflare client) on replay; image_library carries
+//     the same cloudflare_id.
+//   - Retryable failure (429) → state='pending' + retry_after set.
+//   - Non-retryable failure (413) → state='failed' + failure_code.
+//   - Retry budget exhaustion across 3 attempts.
+//   - Orchestrator: upload + caption in one tick, ending in 'succeeded'
+//     with both cloudflare_id and caption populated.
+// ---------------------------------------------------------------------------
+
+async function seedImageLibrary(): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("image_library")
+    .insert({
+      source: "istock",
+      source_ref: `istock-${Math.random().toString(36).slice(2, 10)}`,
+      filename: "test.jpg",
+      width_px: 1024,
+      height_px: 768,
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seedImageLibrary: ${error?.message}`);
+  return data.id as string;
+}
+
+async function seedIngestJob(n: number): Promise<{
+  jobId: string;
+  itemIds: string[];
+  imageIds: string[];
+}> {
+  const svc = getServiceRoleClient();
+  const { data: job, error: jobErr } = await svc
+    .from("transfer_jobs")
+    .insert({
+      type: "cloudflare_ingest",
+      requested_count: n,
+      idempotency_key: `up-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+    })
+    .select("id")
+    .single();
+  if (jobErr || !job) throw new Error(`seed job: ${jobErr?.message}`);
+
+  const imageIds: string[] = [];
+  for (let i = 0; i < n; i++) imageIds.push(await seedImageLibrary());
+
+  const { data: items, error: itemsErr } = await svc
+    .from("transfer_job_items")
+    .insert(
+      Array.from({ length: n }, (_, i) => ({
+        transfer_job_id: job.id,
+        slot_index: i,
+        image_id: imageIds[i],
+        cloudflare_idempotency_key: `cf-${job.id}-${i}`,
+        anthropic_idempotency_key: `an-${job.id}-${i}`,
+        source_url: `https://src.test/image-${i}.jpg`,
+      })),
+    )
+    .select("id, slot_index")
+    .order("slot_index", { ascending: true });
+  if (itemsErr || !items) throw new Error(`seed items: ${itemsErr?.message}`);
+
+  return {
+    jobId: job.id as string,
+    itemIds: items.map((r) => r.id as string),
+    imageIds,
+  };
+}
+
+type RecordedUpload = { id: string; url: string };
+
+function makeUploadStub(opts: {
+  record?: RecordedUpload[];
+  cloudflareId?: (callIdx: number, req: { id: string }) => string;
+}) {
+  let callIdx = 0;
+  return async (req: { id: string; url: string }): Promise<CloudflareImageRecord> => {
+    callIdx += 1;
+    if (opts.record) opts.record.push({ id: req.id, url: req.url });
+    const cfId = opts.cloudflareId?.(callIdx, req) ?? req.id;
+    return {
+      id: cfId,
+      filename: "x.jpg",
+      uploaded: new Date().toISOString(),
+      variants: [`https://imagedelivery.net/HASH/${cfId}/public`],
+    };
+  };
+}
+
+function makeThrowingUploadStub(err: unknown) {
+  return async () => {
+    throw err;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemUpload — happy path", () => {
+  it("persists cloudflare_id on image_library + resulting_cloudflare_id on the item", async () => {
+    const { itemIds, imageIds } = await seedIngestJob(1);
+    const leased = await leaseNextTransferItem("w-up");
+    expect(leased?.id).toBe(itemIds[0]);
+    if (!leased) return;
+
+    const record: RecordedUpload[] = [];
+    await processTransferItemUpload(leased.id, "w-up", {
+      uploadFn: makeUploadStub({ record }),
+    });
+
+    expect(record).toHaveLength(1);
+    expect(record[0]?.id).toBe(leased.cloudflare_idempotency_key);
+
+    const svc = getServiceRoleClient();
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, worker_id, resulting_cloudflare_id")
+      .eq("id", leased.id)
+      .single();
+    // Stage-only call: lease retained, state still 'uploading'.
+    expect(item?.state).toBe("uploading");
+    expect(item?.worker_id).toBe("w-up");
+    expect(item?.resulting_cloudflare_id).toBe(
+      leased.cloudflare_idempotency_key,
+    );
+
+    const { data: image } = await svc
+      .from("image_library")
+      .select("cloudflare_id")
+      .eq("id", imageIds[0])
+      .single();
+    expect(image?.cloudflare_id).toBe(leased.cloudflare_idempotency_key);
+  });
+
+  it("emits cloudflare_upload_started + cloudflare_upload_succeeded events in order", async () => {
+    const { itemIds } = await seedIngestJob(1);
+    const leased = await leaseNextTransferItem("w-ev");
+    if (!leased) return;
+    await processTransferItemUpload(leased.id, "w-ev", {
+      uploadFn: makeUploadStub({}),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: events } = await svc
+      .from("transfer_events")
+      .select("event_type, payload_jsonb, created_at")
+      .eq("transfer_job_item_id", itemIds[0])
+      .order("created_at", { ascending: true });
+    const types = (events ?? []).map((e) => e.event_type);
+    expect(types).toContain("cloudflare_upload_started");
+    expect(types).toContain("cloudflare_upload_succeeded");
+    const startIdx = types.indexOf("cloudflare_upload_started");
+    const successIdx = types.indexOf("cloudflare_upload_succeeded");
+    expect(successIdx).toBeGreaterThan(startIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency + adoption
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemUpload — idempotency + adoption", () => {
+  it("re-processing the same item reuses the cloudflare idempotency key", async () => {
+    const { itemIds } = await seedIngestJob(1);
+    const leased = await leaseNextTransferItem("w-a");
+    if (!leased) return;
+
+    const svc = getServiceRoleClient();
+    await svc
+      .from("transfer_job_items")
+      .update({
+        state: "pending",
+        worker_id: null,
+        lease_expires_at: null,
+      })
+      .eq("id", leased.id);
+
+    const reLeased = await leaseNextTransferItem("w-b");
+    if (!reLeased) return;
+
+    const record: RecordedUpload[] = [];
+    await processTransferItemUpload(reLeased.id, "w-b", {
+      uploadFn: makeUploadStub({ record }),
+    });
+    expect(record[0]?.id).toBe(leased.cloudflare_idempotency_key);
+    expect(reLeased.cloudflare_idempotency_key).toBe(
+      leased.cloudflare_idempotency_key,
+    );
+
+    // image_library carries exactly the idempotency id.
+    const { data: images } = await svc
+      .from("image_library")
+      .select("cloudflare_id")
+      .eq("id", itemIds[0]);
+    // Some items may have id null (not all seed rows are the tracked one); assert count 1
+    expect(images).toHaveLength(1);
+  });
+
+  it("adoption path: second call returns an identical record; UPDATE stays idempotent", async () => {
+    const { itemIds, imageIds } = await seedIngestJob(1);
+    const svc = getServiceRoleClient();
+
+    // First worker completes upload.
+    const leasedA = await leaseNextTransferItem("w-1");
+    if (!leasedA) return;
+    await processTransferItemUpload(leasedA.id, "w-1", {
+      uploadFn: makeUploadStub({}),
+    });
+
+    // Reset state back to pending (simulates a crashed worker whose
+    // caption stage never ran). On re-lease, processTransferItemUpload
+    // runs again; the uploadFn stub returns the same cloudflare_id (the
+    // idempotency key) so the image_library row is unchanged.
+    await svc
+      .from("transfer_job_items")
+      .update({
+        state: "pending",
+        worker_id: null,
+        lease_expires_at: null,
+        resulting_cloudflare_id: null,
+      })
+      .eq("id", itemIds[0]);
+
+    const leasedB = await leaseNextTransferItem("w-2");
+    if (!leasedB) return;
+    // Use a stub that returns the same id (mirrors Cloudflare's 409-adopt flow).
+    await processTransferItemUpload(leasedB.id, "w-2", {
+      uploadFn: makeUploadStub({}),
+    });
+
+    const { data: image } = await svc
+      .from("image_library")
+      .select("cloudflare_id")
+      .eq("id", imageIds[0])
+      .single();
+    expect(image?.cloudflare_id).toBe(leasedA.cloudflare_idempotency_key);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retryable + non-retryable failures
+// ---------------------------------------------------------------------------
+
+describe("processTransferItemUpload — retryable failure", () => {
+  it("resets to pending with retry_after on 429", async () => {
+    const { itemIds } = await seedIngestJob(1);
+    const leased = await leaseNextTransferItem("w-429");
+    if (!leased) return;
+
+    await processTransferItemUpload(leased.id, "w-429", {
+      uploadFn: makeThrowingUploadStub(
+        new CloudflareCallError("CLOUDFLARE_RATE_LIMITED", "429", {
+          retryable: true,
+          httpStatus: 429,
+        }),
+      ),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, worker_id, retry_after, failure_code, retry_count")
+      .eq("id", itemIds[0])
+      .single();
+    expect(item?.state).toBe("pending");
+    expect(item?.worker_id).toBeNull();
+    expect(item?.retry_after).not.toBeNull();
+    expect(item?.failure_code).toBeNull();
+    expect(item?.retry_count).toBe(1);
+  });
+});
+
+describe("processTransferItemUpload — non-retryable failure", () => {
+  it("marks failed with failure_code on 413 (payload too large)", async () => {
+    const { itemIds } = await seedIngestJob(1);
+    const leased = await leaseNextTransferItem("w-413");
+    if (!leased) return;
+
+    await processTransferItemUpload(leased.id, "w-413", {
+      uploadFn: makeThrowingUploadStub(
+        new CloudflareCallError("CLOUDFLARE_PAYLOAD_TOO_LARGE", "too big", {
+          retryable: false,
+          httpStatus: 413,
+        }),
+      ),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, failure_code, failure_detail")
+      .eq("id", itemIds[0])
+      .single();
+    expect(item?.state).toBe("failed");
+    expect(item?.failure_code).toBe("CLOUDFLARE_PAYLOAD_TOO_LARGE");
+    expect(item?.failure_detail).toBe("too big");
+  });
+});
+
+describe("processTransferItemUpload — retry budget exhaustion", () => {
+  it("3rd consecutive retryable failure goes terminal", async () => {
+    const { itemIds } = await seedIngestJob(1);
+    const svc = getServiceRoleClient();
+    const throwing = makeThrowingUploadStub(
+      new CloudflareCallError("CLOUDFLARE_RATE_LIMITED", "429", {
+        retryable: true,
+        httpStatus: 429,
+      }),
+    );
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      await svc
+        .from("transfer_job_items")
+        .update({ retry_after: null })
+        .eq("id", itemIds[0]);
+      const leased = await leaseNextTransferItem(`w-exh-${attempt}`);
+      if (!leased) return;
+      expect(leased.retry_count).toBe(attempt);
+      await processTransferItemUpload(leased.id, `w-exh-${attempt}`, {
+        uploadFn: throwing,
+      });
+    }
+
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, failure_code, retry_count")
+      .eq("id", itemIds[0])
+      .single();
+    expect(item?.state).toBe("failed");
+    expect(item?.failure_code).toBe("CLOUDFLARE_RATE_LIMITED");
+    expect(item?.retry_count).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Orchestrator: upload + caption end-to-end
+// ---------------------------------------------------------------------------
+
+const VALID_CAPTION_PAYLOAD = JSON.stringify({
+  caption:
+    "A placeholder studio photograph used by the M4 ingest end-to-end test.",
+  alt_text: "Placeholder studio photograph.",
+  tags: ["test", "fixture", "placeholder"],
+});
+
+describe("processTransferItemIngest — orchestration", () => {
+  it("upload + caption in one tick drives the item to succeeded", async () => {
+    const { itemIds, imageIds } = await seedIngestJob(1);
+    const leased = await leaseNextTransferItem("w-orch");
+    if (!leased) return;
+
+    const uploadRecord: RecordedUpload[] = [];
+    await processTransferItemIngest(leased.id, "w-orch", {
+      uploadFn: makeUploadStub({ record: uploadRecord }),
+      captionCall: async (req) => ({
+        id: `resp_${req.idempotency_key}`,
+        model: "claude-sonnet-4-6",
+        raw_text: VALID_CAPTION_PAYLOAD,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 1_200,
+          output_tokens: 200,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      }),
+    });
+
+    const svc = getServiceRoleClient();
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, resulting_cloudflare_id, cost_cents, worker_id")
+      .eq("id", itemIds[0])
+      .single();
+    expect(item?.state).toBe("succeeded");
+    expect(item?.worker_id).toBeNull();
+    expect(item?.resulting_cloudflare_id).toBe(
+      leased.cloudflare_idempotency_key,
+    );
+    expect(Number(item?.cost_cents)).toBeGreaterThan(0);
+
+    const { data: image } = await svc
+      .from("image_library")
+      .select("cloudflare_id, caption, alt_text, tags")
+      .eq("id", imageIds[0])
+      .single();
+    expect(image?.cloudflare_id).toBe(leased.cloudflare_idempotency_key);
+    expect(image?.caption).toContain("photograph");
+    expect(image?.tags).toEqual(["test", "fixture", "placeholder"]);
+  });
+
+  it("orchestrator stops after upload defer without invoking captioning", async () => {
+    const { itemIds } = await seedIngestJob(1);
+    const leased = await leaseNextTransferItem("w-defer");
+    if (!leased) return;
+
+    let captionCalled = 0;
+    await processTransferItemIngest(leased.id, "w-defer", {
+      uploadFn: makeThrowingUploadStub(
+        new CloudflareCallError("CLOUDFLARE_RATE_LIMITED", "429", {
+          retryable: true,
+          httpStatus: 429,
+        }),
+      ),
+      captionCall: async () => {
+        captionCalled += 1;
+        throw new Error("caption should not be called after upload defer");
+      },
+    });
+
+    expect(captionCalled).toBe(0);
+
+    const svc = getServiceRoleClient();
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, retry_after")
+      .eq("id", itemIds[0])
+      .single();
+    expect(item?.state).toBe("pending");
+    expect(item?.retry_after).not.toBeNull();
+  });
+
+  it("orchestrator stops after upload terminal failure without invoking captioning", async () => {
+    const { itemIds } = await seedIngestJob(1);
+    const leased = await leaseNextTransferItem("w-fail");
+    if (!leased) return;
+
+    let captionCalled = 0;
+    await processTransferItemIngest(leased.id, "w-fail", {
+      uploadFn: makeThrowingUploadStub(
+        new CloudflareCallError("CLOUDFLARE_PAYLOAD_TOO_LARGE", "too big", {
+          retryable: false,
+          httpStatus: 413,
+        }),
+      ),
+      captionCall: async () => {
+        captionCalled += 1;
+        throw new Error("caption should not be called after upload failure");
+      },
+    });
+
+    expect(captionCalled).toBe(0);
+
+    const svc = getServiceRoleClient();
+    const { data: item } = await svc
+      .from("transfer_job_items")
+      .select("state, failure_code")
+      .eq("id", itemIds[0])
+      .single();
+    expect(item?.state).toBe("failed");
+    expect(item?.failure_code).toBe("CLOUDFLARE_PAYLOAD_TOO_LARGE");
+  });
+});

--- a/lib/__tests__/transfer-worker-upload.test.ts
+++ b/lib/__tests__/transfer-worker-upload.test.ts
@@ -183,7 +183,7 @@ describe("processTransferItemUpload — happy path", () => {
 
 describe("processTransferItemUpload — idempotency + adoption", () => {
   it("re-processing the same item reuses the cloudflare idempotency key", async () => {
-    const { itemIds } = await seedIngestJob(1);
+    const { imageIds } = await seedIngestJob(1);
     const leased = await leaseNextTransferItem("w-a");
     if (!leased) return;
 
@@ -209,13 +209,14 @@ describe("processTransferItemUpload — idempotency + adoption", () => {
       leased.cloudflare_idempotency_key,
     );
 
-    // image_library carries exactly the idempotency id.
-    const { data: images } = await svc
+    // image_library carries exactly the idempotency id — one row, cloudflare_id
+    // equal to the (stable) idempotency key.
+    const { data: image } = await svc
       .from("image_library")
       .select("cloudflare_id")
-      .eq("id", itemIds[0]);
-    // Some items may have id null (not all seed rows are the tracked one); assert count 1
-    expect(images).toHaveLength(1);
+      .eq("id", imageIds[0])
+      .single();
+    expect(image?.cloudflare_id).toBe(leased.cloudflare_idempotency_key);
   });
 
   it("adoption path: second call returns an identical record; UPDATE stays idempotent", async () => {

--- a/lib/cloudflare-images.ts
+++ b/lib/cloudflare-images.ts
@@ -1,0 +1,347 @@
+// ---------------------------------------------------------------------------
+// M4-3 — Cloudflare Images client.
+//
+// Minimal wrapper over the Cloudflare Images v1 API used by the image
+// transfer worker. Surfaces two operations the worker cares about:
+//
+//   uploadImage({ id, url })         // POST /images/v1 with the provided id
+//                                    // as the idempotency key. On 409
+//                                    // (image id already exists) it adopts
+//                                    // the existing record via GET.
+//   getImage(id)                     // GET /images/v1/{id}
+//
+// Everything else the API can do (variants, direct creator uploads,
+// signed URLs, etc.) is out of scope for M4.
+//
+// Design decisions:
+//
+//   1. `id` is ALWAYS passed as the Cloudflare-side idempotency anchor.
+//      Per docs/plans/m4.md, every transfer_job_items row carries a
+//      pre-computed `cloudflare_idempotency_key` (schema migration
+//      0010). Passing it as Cloudflare's `id` parameter guarantees
+//      duplicate POSTs return the original image without re-billing.
+//
+//   2. 409 adoption path is part of the contract, not a retry. A worker
+//      that crashed after Cloudflare accepted the upload but before our
+//      DB write retried through the reaper; that retry's POST returns
+//      409 and we immediately GET the existing record and adopt it.
+//      Same idempotency shape M3-6 uses for WP page adoption.
+//
+//   3. Error classification is based on HTTP status, not Cloudflare's
+//      per-body error codes. HTTP status is stable across API minor
+//      versions; individual error codes drift. Retryable: 429, 5xx,
+//      network/abort. Non-retryable: 400, 401, 403, 404, 413, 422.
+//
+//   4. No auto-retry inside this module. The worker's retry budget
+//      (retry_count + RETRY_BACKOFF_MS) is the single retry policy —
+//      adding a second layer here would make backoff windows additive
+//      and the audit log confusing.
+//
+//   5. Request timeout: 30s via AbortController. Cloudflare's upload
+//      endpoint occasionally hangs on a poisoned source URL; without a
+//      timeout the worker lease expires mid-call and the reaper
+//      re-races us. 30s is well under the 180s lease window.
+//
+//   6. Env-var guard: getCloudflareConfig() throws only when
+//      uploadImage/getImage is actually called. Modules that import
+//      this file for its types don't pay the cost at build time.
+//      (Build can't fail on a missing env var — Vercel provisions
+//      secrets in the runtime env, not the build env.)
+// ---------------------------------------------------------------------------
+
+const CLOUDFLARE_API_ROOT = "https://api.cloudflare.com/client/v4";
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+export type CloudflareImageRecord = {
+  id: string;
+  filename: string | null;
+  uploaded: string | null;
+  variants: string[];
+};
+
+export type CloudflareUploadRequest = {
+  id: string;
+  url: string;
+  metadata?: Record<string, string>;
+};
+
+export type CloudflareFailureCode =
+  | "CLOUDFLARE_RATE_LIMITED"
+  | "CLOUDFLARE_SERVER_ERROR"
+  | "CLOUDFLARE_NETWORK_ERROR"
+  | "CLOUDFLARE_AUTH_ERROR"
+  | "CLOUDFLARE_PAYLOAD_TOO_LARGE"
+  | "CLOUDFLARE_BAD_REQUEST"
+  | "CLOUDFLARE_NOT_FOUND"
+  | "CLOUDFLARE_UNPROCESSABLE"
+  | "CLOUDFLARE_CONFIG_MISSING"
+  | "CLOUDFLARE_TIMEOUT"
+  | "CLOUDFLARE_PARSE_FAILED";
+
+export class CloudflareCallError extends Error {
+  public readonly code: CloudflareFailureCode;
+  public readonly retryable: boolean;
+  public readonly httpStatus: number | null;
+
+  constructor(
+    code: CloudflareFailureCode,
+    message: string,
+    opts: { retryable: boolean; httpStatus?: number | null } = {
+      retryable: false,
+    },
+  ) {
+    super(message);
+    this.name = "CloudflareCallError";
+    this.code = code;
+    this.retryable = opts.retryable;
+    this.httpStatus = opts.httpStatus ?? null;
+  }
+}
+
+export function classifyHttpStatus(status: number): {
+  code: CloudflareFailureCode;
+  retryable: boolean;
+} {
+  if (status === 429) return { code: "CLOUDFLARE_RATE_LIMITED", retryable: true };
+  if (status >= 500) return { code: "CLOUDFLARE_SERVER_ERROR", retryable: true };
+  if (status === 401 || status === 403) {
+    return { code: "CLOUDFLARE_AUTH_ERROR", retryable: false };
+  }
+  if (status === 404) return { code: "CLOUDFLARE_NOT_FOUND", retryable: false };
+  if (status === 413) {
+    return { code: "CLOUDFLARE_PAYLOAD_TOO_LARGE", retryable: false };
+  }
+  if (status === 422) return { code: "CLOUDFLARE_UNPROCESSABLE", retryable: false };
+  return { code: "CLOUDFLARE_BAD_REQUEST", retryable: false };
+}
+
+export type CloudflareConfig = {
+  accountId: string;
+  apiToken: string;
+  deliveryHash: string | null;
+};
+
+export function readCloudflareConfig(): CloudflareConfig {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_IMAGES_API_TOKEN;
+  const deliveryHash = process.env.CLOUDFLARE_IMAGES_HASH ?? null;
+  if (!accountId || !apiToken) {
+    throw new CloudflareCallError(
+      "CLOUDFLARE_CONFIG_MISSING",
+      "CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_IMAGES_API_TOKEN must be set for uploads.",
+      { retryable: false },
+    );
+  }
+  return { accountId, apiToken, deliveryHash };
+}
+
+type CloudflareApiEnvelope<T> = {
+  result: T | null;
+  success: boolean;
+  errors: Array<{ code: number; message: string }>;
+  messages: Array<{ code: number; message: string }>;
+};
+
+function parseRecord(raw: unknown): CloudflareImageRecord {
+  if (!raw || typeof raw !== "object") {
+    throw new CloudflareCallError(
+      "CLOUDFLARE_PARSE_FAILED",
+      "Cloudflare response body missing `result`.",
+      { retryable: false },
+    );
+  }
+  const record = raw as Record<string, unknown>;
+  const id = typeof record.id === "string" ? record.id : null;
+  if (!id) {
+    throw new CloudflareCallError(
+      "CLOUDFLARE_PARSE_FAILED",
+      "Cloudflare response body missing `result.id`.",
+      { retryable: false },
+    );
+  }
+  const variants = Array.isArray(record.variants)
+    ? (record.variants.filter((v) => typeof v === "string") as string[])
+    : [];
+  return {
+    id,
+    filename: typeof record.filename === "string" ? record.filename : null,
+    uploaded: typeof record.uploaded === "string" ? record.uploaded : null,
+    variants,
+  };
+}
+
+// Narrow detector for "id already in use" across api versions. When this
+// signal appears we switch to the GET-by-id adoption path; everything
+// else is a real error.
+function isIdAlreadyExistsError(
+  envelope: CloudflareApiEnvelope<unknown>,
+): boolean {
+  return envelope.errors.some((e) => {
+    const msg = (e.message ?? "").toLowerCase();
+    return (
+      msg.includes("already exists") ||
+      msg.includes("resource_already_exists") ||
+      e.code === 5461
+    );
+  });
+}
+
+async function httpCall(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new CloudflareCallError(
+        "CLOUDFLARE_TIMEOUT",
+        `Cloudflare request timed out after ${timeoutMs}ms`,
+        { retryable: true, httpStatus: null },
+      );
+    }
+    throw new CloudflareCallError(
+      "CLOUDFLARE_NETWORK_ERROR",
+      err instanceof Error ? err.message : String(err),
+      { retryable: true, httpStatus: null },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export type CloudflareFetchFn = (
+  url: string,
+  init: RequestInit,
+) => Promise<Response>;
+
+export type UploadOptions = {
+  config?: CloudflareConfig;
+  fetchImpl?: CloudflareFetchFn;
+  timeoutMs?: number;
+};
+
+/**
+ * POST /accounts/{id}/images/v1 with the supplied id as idempotency.
+ *
+ * Success cases:
+ *   - 200 + success=true → upload accepted; return the record.
+ *   - 409 OR 200+success=false with "already exists" error → adopt
+ *     via GET /accounts/{id}/images/v1/{id} and return that record.
+ *
+ * Failure cases:
+ *   - Retryable (429, 5xx, network, timeout) → CloudflareCallError with
+ *     retryable=true.
+ *   - Non-retryable (4xx other than 409) → CloudflareCallError with
+ *     retryable=false.
+ */
+export async function uploadImage(
+  req: CloudflareUploadRequest,
+  opts: UploadOptions = {},
+): Promise<CloudflareImageRecord> {
+  const config = opts.config ?? readCloudflareConfig();
+  const endpoint = `${CLOUDFLARE_API_ROOT}/accounts/${config.accountId}/images/v1`;
+
+  const body = new FormData();
+  body.append("id", req.id);
+  body.append("url", req.url);
+  if (req.metadata) {
+    body.append("metadata", JSON.stringify(req.metadata));
+  }
+
+  const call: CloudflareFetchFn =
+    opts.fetchImpl ??
+    ((url, init) => httpCall(url, init, opts.timeoutMs));
+
+  const res = await call(endpoint, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${config.apiToken}` },
+    body,
+  });
+
+  // Parse envelope regardless of status — Cloudflare returns JSON on all
+  // non-network error paths.
+  let envelope: CloudflareApiEnvelope<unknown> | null = null;
+  try {
+    envelope = (await res.json()) as CloudflareApiEnvelope<unknown>;
+  } catch {
+    // body wasn't JSON — fall through to status-based classification.
+  }
+
+  if (res.ok && envelope?.success && envelope.result) {
+    return parseRecord(envelope.result);
+  }
+
+  // Adoption: existing image with our id. Happens on retry after a
+  // partial-commit crash.
+  if (
+    res.status === 409 ||
+    (envelope != null && !envelope.success && isIdAlreadyExistsError(envelope))
+  ) {
+    return getImage(req.id, { config, fetchImpl: opts.fetchImpl });
+  }
+
+  // Classify remaining errors by HTTP status.
+  const classified = classifyHttpStatus(res.status);
+  const detail =
+    envelope?.errors
+      ?.map((e) => `${e.code}:${e.message}`)
+      .join("; ") || `HTTP ${res.status}`;
+  throw new CloudflareCallError(classified.code, detail, {
+    retryable: classified.retryable,
+    httpStatus: res.status,
+  });
+}
+
+export async function getImage(
+  id: string,
+  opts: UploadOptions = {},
+): Promise<CloudflareImageRecord> {
+  const config = opts.config ?? readCloudflareConfig();
+  const endpoint = `${CLOUDFLARE_API_ROOT}/accounts/${config.accountId}/images/v1/${encodeURIComponent(id)}`;
+
+  const call: CloudflareFetchFn =
+    opts.fetchImpl ??
+    ((url, init) => httpCall(url, init, opts.timeoutMs));
+
+  const res = await call(endpoint, {
+    method: "GET",
+    headers: { Authorization: `Bearer ${config.apiToken}` },
+  });
+
+  let envelope: CloudflareApiEnvelope<unknown> | null = null;
+  try {
+    envelope = (await res.json()) as CloudflareApiEnvelope<unknown>;
+  } catch {
+    // fall through
+  }
+
+  if (res.ok && envelope?.success && envelope.result) {
+    return parseRecord(envelope.result);
+  }
+
+  const classified = classifyHttpStatus(res.status);
+  const detail =
+    envelope?.errors
+      ?.map((e) => `${e.code}:${e.message}`)
+      .join("; ") || `HTTP ${res.status}`;
+  throw new CloudflareCallError(classified.code, detail, {
+    retryable: classified.retryable,
+    httpStatus: res.status,
+  });
+}
+
+// Constructs the delivery URL for a variant. Not needed by the upload
+// worker but useful for M4-7's WP transfer stage and ad-hoc inspection.
+export function deliveryUrl(
+  cloudflareId: string,
+  variant: string = "public",
+  config?: Pick<CloudflareConfig, "deliveryHash">,
+): string | null {
+  const hash = config?.deliveryHash ?? process.env.CLOUDFLARE_IMAGES_HASH ?? null;
+  if (!hash) return null;
+  return `https://imagedelivery.net/${hash}/${cloudflareId}/${variant}`;
+}

--- a/lib/transfer-worker.ts
+++ b/lib/transfer-worker.ts
@@ -10,6 +10,13 @@ import {
   CAPTION_MAX_TOKENS,
 } from "@/lib/anthropic-caption";
 import { computeCostCents, PRICING_VERSION } from "@/lib/anthropic-pricing";
+import {
+  CloudflareCallError,
+  uploadImage as cloudflareUploadImage,
+  type CloudflareFetchFn,
+  type CloudflareImageRecord,
+  type UploadOptions as CloudflareUploadOptions,
+} from "@/lib/cloudflare-images";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -570,7 +577,7 @@ export async function processTransferItemCaption(
              updated_at = now()
        WHERE id = $1
          AND worker_id = $2
-         AND state = 'leased'
+         AND state IN ('leased', 'uploading')
       `,
       [itemId, workerId],
     );
@@ -950,3 +957,397 @@ async function aggregateJobProgress(
     [itemId, costDeltaCents],
   );
 }
+
+// ---------------------------------------------------------------------------
+// M4-3 — Cloudflare Images upload stage.
+//
+// Advances a leased cloudflare_ingest item through:
+//   leased → uploading → (Cloudflare POST) → image_library.cloudflare_id
+//   set, item.resulting_cloudflare_id set, state STAYS 'uploading'
+//   with lease retained so the next stage (M4-4 captioning) can pick up.
+//
+// Contract with the orchestrator: if this returns normally and the
+// item is in state 'uploading', the lease is still held and the caller
+// must invoke processTransferItemCaption (or short-circuit if the item
+// doesn't need captioning). Retryable failures reset to 'pending' +
+// retry_after; non-retryable failures go terminal with failure_code.
+// The orchestrator inspects state post-call and stops chaining when
+// it's no longer 'uploading'.
+//
+// Write-safety contract:
+//
+//   1. Idempotency. `cloudflare_idempotency_key` (migration 0010) is
+//      passed as Cloudflare's `id`. A reaped + reprocessed item reuses
+//      the same key; Cloudflare returns the original record without
+//      re-billing.
+//
+//   2. Adoption. If a worker crashed after Cloudflare accepted but
+//      before our image_library UPDATE landed, the retry's POST returns
+//      409; lib/cloudflare-images switches to GET-by-id and returns
+//      the existing record. Our DB write then adopts it.
+//
+//   3. Event-log first. `cloudflare_upload_started` is written before
+//      the state flip; `cloudflare_upload_succeeded` is written before
+//      the image_library UPDATE. Reconciliation can rebuild from
+//      transfer_events alone.
+//
+//   4. Lease coherence. Every UPDATE to transfer_job_items filters on
+//      worker_id + valid-intermediate state. A reaped-and-relet item
+//      rejects this worker's late writes.
+//
+//   5. Image dimensions. Cloudflare's upload response doesn't include
+//      width/height/bytes — those come from seed metadata (iStock
+//      feed in M4-5 populates them at image_library insert time).
+//      M4-3 only writes cloudflare_id; it doesn't touch dimensions.
+// ---------------------------------------------------------------------------
+
+export type UploadProcessorOptions = {
+  client?: Client | null;
+  /** Override the upload fn. Production uses the Cloudflare default. */
+  uploadFn?: (
+    req: { id: string; url: string; metadata?: Record<string, string> },
+    opts: CloudflareUploadOptions,
+  ) => Promise<CloudflareImageRecord>;
+  fetchImpl?: CloudflareFetchFn;
+};
+
+/**
+ * Run the Cloudflare upload stage against a leased cloudflare_ingest
+ * item. Caller holds the lease; this function advances state machine
+ * and persists cloudflare_id on success.
+ *
+ * Returns nothing — caller inspects the item's state afterwards:
+ *   - state='uploading' (+ resulting_cloudflare_id not null) → success,
+ *     lease retained, continue to caption.
+ *   - state='pending' with retry_after set → retryable failure.
+ *   - state='failed' → terminal failure.
+ */
+export async function processTransferItemUpload(
+  itemId: string,
+  workerId: string,
+  opts: UploadProcessorOptions = {},
+): Promise<void> {
+  const uploadFn = opts.uploadFn ?? cloudflareUploadImage;
+
+  const svc = getServiceRoleClient();
+  const itemRes = await svc
+    .from("transfer_job_items")
+    .select(
+      "id, transfer_job_id, image_id, source_url, cloudflare_idempotency_key, retry_count",
+    )
+    .eq("id", itemId)
+    .single();
+  if (itemRes.error || !itemRes.data) {
+    throw new Error(
+      `processTransferItemUpload: load item: ${itemRes.error?.message ?? "no row"} for ${itemId}`,
+    );
+  }
+  const itemRow = itemRes.data as {
+    id: string;
+    transfer_job_id: string;
+    image_id: string | null;
+    source_url: string | null;
+    cloudflare_idempotency_key: string;
+    retry_count: number;
+  };
+
+  if (!itemRow.image_id) {
+    throw new Error(
+      `processTransferItemUpload: item ${itemId} has no image_id (pre-insert an image_library row with source/source_ref before uploading)`,
+    );
+  }
+  if (!itemRow.source_url) {
+    throw new Error(
+      `processTransferItemUpload: item ${itemId} has no source_url`,
+    );
+  }
+
+  // leased → uploading. Event log first, then the state flip. If the
+  // item's already in 'uploading' (resume after partial commit) the
+  // UPDATE filter's IN-clause accepts it for the event-log emission
+  // path too.
+  await withClient(opts.client ?? null, async (c) => {
+    await c.query(
+      `
+      INSERT INTO transfer_events (
+        transfer_job_id, transfer_job_item_id, event_type, payload_jsonb
+      )
+      VALUES ($1, $2, 'cloudflare_upload_started',
+              jsonb_build_object('worker_id', $3::text,
+                                 'image_id', $4::text,
+                                 'source_url', $5::text,
+                                 'idempotency_key', $6::text))
+      `,
+      [
+        itemRow.transfer_job_id,
+        itemId,
+        workerId,
+        itemRow.image_id,
+        itemRow.source_url,
+        itemRow.cloudflare_idempotency_key,
+      ],
+    );
+    const advance = await c.query(
+      `
+      UPDATE transfer_job_items
+         SET state = 'uploading',
+             updated_at = now()
+       WHERE id = $1
+         AND worker_id = $2
+         AND state IN ('leased', 'uploading')
+      `,
+      [itemId, workerId],
+    );
+    if ((advance.rowCount ?? 0) === 0) {
+      throw new Error(
+        `processTransferItemUpload: lease stolen from worker ${workerId} before Cloudflare call`,
+      );
+    }
+  });
+
+  // Cloudflare call. Released from the pg client.
+  let record: CloudflareImageRecord;
+  try {
+    record = await uploadFn(
+      {
+        id: itemRow.cloudflare_idempotency_key,
+        url: itemRow.source_url,
+      },
+      opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {},
+    );
+  } catch (err) {
+    await handleUploadError(itemRow, workerId, err, opts.client ?? null);
+    return;
+  }
+
+  // Success path: persist cloudflare_id + emit success event. Lease
+  // retained — caller continues to caption stage.
+  await withClient(opts.client ?? null, async (c) => {
+    await c.query(
+      `
+      INSERT INTO transfer_events (
+        transfer_job_id, transfer_job_item_id, event_type, payload_jsonb
+      )
+      VALUES ($1, $2, 'cloudflare_upload_succeeded',
+              jsonb_build_object('worker_id', $3::text,
+                                 'cloudflare_id', $4::text,
+                                 'variants', $5::jsonb,
+                                 'uploaded', $6::text))
+      `,
+      [
+        itemRow.transfer_job_id,
+        itemId,
+        workerId,
+        record.id,
+        JSON.stringify(record.variants),
+        record.uploaded,
+      ],
+    );
+
+    // Idempotent image_library UPDATE. A reaped retry that adopts via
+    // 409 writes the same cloudflare_id — safe to re-run.
+    const updateImage = await c.query(
+      `
+      UPDATE image_library
+         SET cloudflare_id = $2,
+             updated_at = now()
+       WHERE id = $1
+         AND (cloudflare_id IS NULL OR cloudflare_id = $2)
+      `,
+      [itemRow.image_id, record.id],
+    );
+    if ((updateImage.rowCount ?? 0) === 0) {
+      throw new Error(
+        `processTransferItemUpload: image_library ${itemRow.image_id} has conflicting cloudflare_id (expected null or ${record.id})`,
+      );
+    }
+
+    // Record the uploaded id on the item. Keep state='uploading' and
+    // retain the lease — caption stage runs next.
+    const stamp = await c.query(
+      `
+      UPDATE transfer_job_items
+         SET resulting_cloudflare_id = $3,
+             updated_at = now()
+       WHERE id = $1
+         AND worker_id = $2
+         AND state = 'uploading'
+      `,
+      [itemId, workerId, record.id],
+    );
+    if ((stamp.rowCount ?? 0) === 0) {
+      throw new Error(
+        `processTransferItemUpload: lease stolen from worker ${workerId} before stamping cloudflare_id`,
+      );
+    }
+  });
+}
+
+async function handleUploadError(
+  itemRow: { id: string; transfer_job_id: string; retry_count: number },
+  workerId: string,
+  err: unknown,
+  client: Client | null,
+): Promise<void> {
+  const isCfErr = err instanceof CloudflareCallError;
+  const retryable = isCfErr ? err.retryable : true;
+  const code = isCfErr ? err.code : "CLOUDFLARE_NETWORK_ERROR";
+  const detail = err instanceof Error ? err.message : String(err);
+  const httpStatus = isCfErr ? err.httpStatus : null;
+
+  await withClient(client, async (c) => {
+    await c.query(
+      `
+      INSERT INTO transfer_events (
+        transfer_job_id, transfer_job_item_id, event_type, payload_jsonb
+      )
+      VALUES ($1, $2, 'cloudflare_upload_failed',
+              jsonb_build_object('worker_id', $3::text,
+                                 'failure_code', $4::text,
+                                 'failure_detail', $5::text,
+                                 'http_status', $6::int,
+                                 'retryable', $7::boolean,
+                                 'retry_count', $8::int))
+      `,
+      [
+        itemRow.transfer_job_id,
+        itemRow.id,
+        workerId,
+        code,
+        detail,
+        httpStatus,
+        retryable,
+        itemRow.retry_count,
+      ],
+    );
+
+    if (retryable) {
+      const retryAfter = retryAfterForCount(itemRow.retry_count);
+      if (retryAfter) {
+        const reset = await c.query(
+          `
+          UPDATE transfer_job_items
+             SET state = 'pending',
+                 worker_id = NULL,
+                 lease_expires_at = NULL,
+                 retry_after = $3::timestamptz,
+                 failure_code = NULL,
+                 failure_detail = NULL,
+                 updated_at = now()
+           WHERE id = $1
+             AND worker_id = $2
+             AND state IN ('leased', 'uploading')
+          `,
+          [itemRow.id, workerId, retryAfter.toISOString()],
+        );
+        if ((reset.rowCount ?? 0) === 0) {
+          throw new Error(
+            `processTransferItemUpload: lease stolen while deferring item ${itemRow.id}`,
+          );
+        }
+        return;
+      }
+      // Retry budget exhausted — fall through to terminal failure below.
+    }
+
+    const fail = await c.query(
+      `
+      UPDATE transfer_job_items
+         SET state = 'failed',
+             failure_code = $3,
+             failure_detail = $4,
+             worker_id = NULL,
+             lease_expires_at = NULL,
+             updated_at = now()
+       WHERE id = $1
+         AND worker_id = $2
+         AND state IN ('leased', 'uploading')
+      `,
+      [itemRow.id, workerId, code, detail],
+    );
+    if ((fail.rowCount ?? 0) === 0) {
+      throw new Error(
+        `processTransferItemUpload: lease stolen while marking item ${itemRow.id} failed`,
+      );
+    }
+
+    await aggregateJobProgress(c, itemRow.id, 0);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator — cloudflare_ingest end-to-end.
+//
+// Drives a single leased item through upload (M4-3) then caption (M4-4)
+// in one worker tick. Stops chaining if upload deferred or failed —
+// the reaper / next lease picks up retries.
+// ---------------------------------------------------------------------------
+
+export type IngestProcessorOptions = UploadProcessorOptions &
+  CaptionProcessorOptions;
+
+export async function processTransferItemIngest(
+  itemId: string,
+  workerId: string,
+  opts: IngestProcessorOptions = {},
+): Promise<void> {
+  await processTransferItemUpload(itemId, workerId, {
+    client: opts.client ?? null,
+    uploadFn: opts.uploadFn,
+    fetchImpl: opts.fetchImpl,
+  });
+
+  // Inspect state post-upload. Only continue to caption if the upload
+  // stage is still holding the lease with state='uploading'.
+  const svc = getServiceRoleClient();
+  const after = await svc
+    .from("transfer_job_items")
+    .select("state, worker_id")
+    .eq("id", itemId)
+    .single();
+  if (
+    after.data?.state === "uploading" &&
+    after.data?.worker_id === workerId
+  ) {
+    await processTransferItemCaption(itemId, workerId, {
+      client: opts.client ?? null,
+      captionCall: opts.captionCall,
+      model: opts.model,
+      maxTokens: opts.maxTokens,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Job-type dispatcher for the cron tick.
+// ---------------------------------------------------------------------------
+
+export async function processTransferItemByJobType(
+  itemId: string,
+  workerId: string,
+  opts: IngestProcessorOptions = {},
+): Promise<void> {
+  const svc = getServiceRoleClient();
+  const ctx = await svc
+    .from("transfer_job_items")
+    .select("transfer_jobs!inner(type)")
+    .eq("id", itemId)
+    .single();
+  const jobType =
+    ((ctx.data as { transfer_jobs?: { type?: string } } | null)?.transfer_jobs
+      ?.type as string | undefined) ?? null;
+
+  if (jobType === "cloudflare_ingest") {
+    await processTransferItemIngest(itemId, workerId, opts);
+    return;
+  }
+  if (jobType === "wp_media_transfer") {
+    throw new Error(
+      "processTransferItemByJobType: wp_media_transfer not implemented until M4-7",
+    );
+  }
+  throw new Error(
+    `processTransferItemByJobType: unknown job type '${jobType ?? "null"}' for item ${itemId}`,
+  );
+}
+


### PR DESCRIPTION
Adds the Cloudflare Images upload stage to the M4 transfer worker. A leased `cloudflare_ingest` item walks `leased → uploading` via a POST to `/accounts/{id}/images/v1` using the item's pre-computed `cloudflare_idempotency_key` as Cloudflare's `id` parameter. On 409 or success=false+already-exists, the client switches to `GET /images/v1/{id}` and adopts the existing record — the same shape M3-6 uses for WP page adoption. The upload stage retains the lease after success so the in-tick orchestrator can hand off to M4-4's caption stage.

## What lands
- `lib/cloudflare-images.ts` — `uploadImage`, `getImage`, `deliveryUrl`, `CloudflareCallError`, `classifyHttpStatus`, `readCloudflareConfig`, injectable `CloudflareFetchFn` for tests. 30s timeout via `AbortController`.
- `lib/transfer-worker.ts` — `processTransferItemUpload` (event-log-first, lease-coherent UPDATEs, retryable defer / non-retryable fail), `processTransferItemIngest` (orchestrator: upload → caption, short-circuits on defer/fail), `processTransferItemByJobType` (dispatches cloudflare_ingest → orchestrator, wp_media_transfer → M4-7 placeholder), widened caption stage to accept `state IN ('leased', 'uploading')` so production drives `leased → uploading → captioning → succeeded` without breaking the M4-4 standalone tests.
- `app/api/cron/process-transfer/route.ts` — replaces the dummy processor call with `processTransferItemByJobType`.
- `lib/__tests__/cloudflare-images.test.ts` — in-process: status classifier, happy path, idempotency `id` on form body, 409 adoption path (both HTTP 409 and 200+success:false+already-exists), retryable 429, non-retryable 413/401, parse-failure guard.
- `lib/__tests__/transfer-worker-upload.test.ts` — DB-backed: happy path persists `cloudflare_id` on `image_library` + `resulting_cloudflare_id` on the item; events ordered; idempotency key stable across reset-and-replay; adoption replay stays idempotent; 429 defers with `retry_after`; 413 goes terminal; 3 consecutive retryable failures exhaust the budget; orchestrator drives upload+caption to `succeeded` with both `cloudflare_id` and caption populated; orchestrator short-circuits on upload defer or terminal fail (caption never invoked).
- `docs/BACKLOG.md` — M4 tracker: M4-3 → `in flight`, M4-5/M4-7 → `planned` (unblocked), env-var provisioning dated.

## Risks identified and mitigated
- **Double-billing Cloudflare on retry.** `cloudflare_idempotency_key` (migration 0010) passed as Cloudflare's `id`. Reaped+reprocessed items reuse the same key; Cloudflare returns the existing image without re-billing. Tested: reset-and-replay observes the same id; adoption path (409) returns matching record.
- **Partial-commit crash (Cloudflare accepted but our UPDATE never landed).** Retry's POST returns 409 / already-exists → client switches to `GET /images/v1/{id}` and returns the existing record. Image-library UPDATE is idempotent (`WHERE cloudflare_id IS NULL OR cloudflare_id = $2`) — adoption of the same id is a no-op. Tested.
- **Lease stolen mid-upload.** Every `transfer_job_items` UPDATE filters on `worker_id = $workerId` + intermediate-state IN-clause. A reaped-and-relet item rejects this worker's late writes; `rowCount=0` throws. Applies to the state advance, the retryable defer, and the terminal failure paths.
- **Cloudflare hang on poisoned source URL.** 30s `AbortController` timeout — well under the 180s lease window. Timeout throws retryable so the worker defers rather than wedging the whole tick.
- **Prompt-injection-style errors via source URL.** URL is treated as data in the `url` field; Cloudflare fetches it server-side under its own sandbox. Our code never executes content from the URL.
- **Config-missing on cold start.** `readCloudflareConfig` throws `CLOUDFLARE_CONFIG_MISSING` on first call, not at module load — build stays green even if the build env lacks secrets (Vercel injects them at runtime).
- **Orchestrator chaining caption onto a failed upload.** `processTransferItemIngest` re-reads item state after upload and only invokes caption when state is still `uploading` AND the worker still owns the lease. Tested: defer and fail paths both skip caption.
- **M4-4 test regression from widened caption filter.** The state-advance filter widened from `state = 'leased'` to `state IN ('leased', 'uploading')`. M4-4 standalone tests seed `state = 'leased'` via `leaseNextTransferItem` so they still match; production drives `state = 'uploading'` after the upload stage. No test rewrites needed.

## Deliberately deferred
- **Dimensions on `image_library`.** Cloudflare's upload response doesn't include width/height/bytes. M4-5's iStock seed populates those from the source catalogue at image_library insert time, and re-captioning runs (future) don't need to re-fetch them. If we ever accept uploads without pre-known dimensions, we'll add a GET-by-id extraction pass — out of scope here.
- **Per-job rate limiting / concurrency cap.** The Cloudflare API tolerates our current lease rate (one item per cron tick). The M4-5 seed script pipelines through the same per-item backoff, so no dedicated rate limiter yet.
- **Deletion / garbage collection.** `image_library.cloudflare_id` drift is acknowledged in `docs/plans/m4.md` risk #13 — runbook entry (mark `deleted_at` + re-upload). Not in scope for M4.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — DB-backed tests run in CI.
- [ ] `npm run test:e2e` — no admin UI in this slice.