### PR TITLE
feat(m4-5): istock csv ingest script + pre-flight cost gate

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -14,11 +14,11 @@ Parent plan: `docs/plans/m4.md`. Sub-slice status tracker:
 | --- | --- | --- |
 | M4-1 | merged (#57) | Schema: 6 tables + constraints + RLS + FTS trigger. |
 | M4-2 | merged (#58) | Worker core (lease / heartbeat / reaper over `transfer_job_items` + dummy processor). |
-| M4-3 | in flight | Cloudflare upload worker stage + orchestrator. |
+| M4-3 | merged (#61) | Cloudflare upload worker stage + orchestrator. |
 | M4-4 | merged (#59) | Anthropic vision captioning (reuses `ANTHROPIC_API_KEY`). |
-| M4-5 | planned | iStock 9k seed script. Unblocks once M4-3 merges. |
+| M4-5 | in flight | iStock seed script: CSV ingest + dry-run + budget cap. |
 | M4-6 | merged (#60) | `search_images` chat tool. |
-| M4-7 | planned | WP media transfer + HTML URL rewrite on publish. Unblocks once M4-3 merges. |
+| M4-7 | planned | WP media transfer + HTML URL rewrite on publish. |
 
 Env vars: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_IMAGES_API_TOKEN`, `CLOUDFLARE_IMAGES_HASH` all provisioned in Vercel Production + Preview as of 2026-04-21.
 
@@ -84,6 +84,23 @@ Env vars: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_IMAGES_API_TOKEN`, `CLOUDFLARE_IM
 **Why deferred:** scope belongs with M4 (cost-control surface). Global Anthropic project cap in the dashboard is the stopgap.
 **Trigger:** start of M4.
 **Scope:** one migration + `createBatchJob` check + end-of-month reset cron + tests.
+
+### Anthropic pricing-table scale audit
+**What:** reconcile `lib/anthropic-pricing.ts`'s rate table with the scale implied
+by its own doc-comment. The table entries (e.g. Sonnet 4.6 input=3.0) don't match
+the "$3/M input, micro-cents per token" convention stated in the file header —
+depending on which line is authoritative, absolute cost reporting is off by ~100×.
+**Why deferred:** existing M3 + M4-4 tests only assert "cost > 0" and
+sum-equals-sum reconciliation, so the miscalibration never fails a test. M4-5
+explicitly uses a direct per-image constant for its pre-flight estimate rather
+than routing through `computeCostCents`, which keeps the seed's operator-facing
+numbers matching the plan's published $63 figure for 9k images.
+**Trigger:** any slice that surfaces per-$ cost to a human (admin UI cost column,
+monthly-budget alert, tenant-cost dashboard). Once there's a consumer of absolute
+cost, rate calibration matters.
+**Scope:** decide the units convention, rewrite the table accordingly, update
+the comment, add a fixture test that asserts "1M Opus tokens at 15 USD" produces
+1500 cents.
 
 ---
 

--- a/lib/__tests__/istock-seed.test.ts
+++ b/lib/__tests__/istock-seed.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_BUDGET_CAP_MULTIPLIER,
+  ESTIMATED_CAPTION_CENTS_PER_IMAGE,
+  IngestBudgetError,
+  estimateIngestCost,
+  parseIstockCsv,
+  seedIstockLibrary,
+} from "@/lib/istock-seed";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M4-5 — iStock ingest tests.
+//
+// Covers:
+//   - CSV parsing: required headers, optional columns, per-line errors.
+//   - Cost estimate math.
+//   - Dry-run returns plan without DB writes.
+//   - Real run inserts image_library + transfer_jobs + transfer_job_items.
+//   - Idempotent re-run with the same job key.
+//   - Budget-cap abort with IngestBudgetError.
+//   - Adoption: pre-existing image_library rows are reused, not duplicated.
+// ---------------------------------------------------------------------------
+
+const VALID_CSV = [
+  "istock_id,url,width,height,bytes,license_type",
+  "i-1,https://src.test/1.jpg,1024,768,123456,standard",
+  "i-2,https://src.test/2.jpg,2048,1536,234567,standard",
+  'i-3,"https://src.test/3.jpg",1600,1200,345678,editorial',
+].join("\n");
+
+describe("parseIstockCsv", () => {
+  it("parses a valid CSV into typed rows", () => {
+    const r = parseIstockCsv(VALID_CSV);
+    expect(r.errors).toEqual([]);
+    expect(r.rows).toHaveLength(3);
+    expect(r.rows[0]).toMatchObject({
+      istock_id: "i-1",
+      url: "https://src.test/1.jpg",
+      width: 1024,
+      height: 768,
+      bytes: 123456,
+      license_type: "standard",
+    });
+  });
+
+  it("handles optional columns (license_type missing)", () => {
+    const csv = ["istock_id,url", "i-1,https://src.test/a.jpg"].join("\n");
+    const r = parseIstockCsv(csv);
+    expect(r.errors).toEqual([]);
+    expect(r.rows[0]?.license_type).toBeUndefined();
+  });
+
+  it("rejects a CSV missing istock_id column", () => {
+    const csv = ["url", "https://src.test/a.jpg"].join("\n");
+    const r = parseIstockCsv(csv);
+    expect(r.rows).toEqual([]);
+    expect(r.errors[0]?.message).toContain("istock_id");
+  });
+
+  it("reports per-line validation errors but keeps valid rows", () => {
+    const csv = [
+      "istock_id,url",
+      "i-good,https://src.test/ok.jpg",
+      "i-bad,not a url",
+      "i-good-2,https://src.test/ok2.jpg",
+    ].join("\n");
+    const r = parseIstockCsv(csv);
+    expect(r.rows).toHaveLength(2);
+    expect(r.errors).toHaveLength(1);
+    expect(r.errors[0]?.line).toBe(3);
+  });
+
+  it("handles quoted URL cells", () => {
+    const csv = [
+      "istock_id,url",
+      'i-q,"https://src.test/q.jpg"',
+    ].join("\n");
+    const r = parseIstockCsv(csv);
+    expect(r.errors).toEqual([]);
+    expect(r.rows[0]?.url).toBe("https://src.test/q.jpg");
+  });
+});
+
+describe("estimateIngestCost", () => {
+  it("scales linearly with image count", () => {
+    const a = estimateIngestCost(100);
+    const b = estimateIngestCost(200);
+    expect(b.captionCents).toBe(a.captionCents * 2);
+    expect(a.totalCents).toBeGreaterThan(0);
+  });
+
+  it("caption cents matches the per-image constant", () => {
+    const e = estimateIngestCost(9_000);
+    expect(e.captionCents).toBe(9_000 * ESTIMATED_CAPTION_CENTS_PER_IMAGE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Seed runs
+// ---------------------------------------------------------------------------
+
+describe("seedIstockLibrary — dry run", () => {
+  it("returns the plan without DB writes", async () => {
+    const { rows } = parseIstockCsv(VALID_CSV);
+    const result = await seedIstockLibrary({
+      rows,
+      jobIdempotencyKey: `dry-${Date.now()}`,
+      dryRun: true,
+    });
+    expect(result.dryRun).toBe(true);
+    expect(result.jobId).toBeNull();
+    expect(result.itemsCreated).toBe(0);
+    expect(result.imagesCreated).toBe(0);
+    expect(result.estimate.imageCount).toBe(3);
+
+    const svc = getServiceRoleClient();
+    const { count: jobCount } = await svc
+      .from("transfer_jobs")
+      .select("*", { count: "exact", head: true });
+    expect(jobCount ?? 0).toBe(0);
+    const { count: imgCount } = await svc
+      .from("image_library")
+      .select("*", { count: "exact", head: true });
+    expect(imgCount ?? 0).toBe(0);
+  });
+});
+
+describe("seedIstockLibrary — real run", () => {
+  it("inserts image_library + transfer_jobs + transfer_job_items", async () => {
+    const { rows } = parseIstockCsv(VALID_CSV);
+    const jobKey = `seed-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const result = await seedIstockLibrary({
+      rows,
+      jobIdempotencyKey: jobKey,
+    });
+    expect(result.dryRun).toBe(false);
+    expect(result.jobId).not.toBeNull();
+    expect(result.imagesCreated).toBe(3);
+    expect(result.imagesAdopted).toBe(0);
+    expect(result.itemsCreated).toBe(3);
+
+    const svc = getServiceRoleClient();
+    const { data: images } = await svc
+      .from("image_library")
+      .select("source_ref, width_px, license_type")
+      .order("source_ref", { ascending: true });
+    expect(images).toHaveLength(3);
+    expect(images?.[0]?.source_ref).toBe("i-1");
+    expect(images?.[0]?.width_px).toBe(1024);
+
+    const { data: job } = await svc
+      .from("transfer_jobs")
+      .select("id, type, idempotency_key, requested_count")
+      .eq("idempotency_key", jobKey)
+      .single();
+    expect(job?.type).toBe("cloudflare_ingest");
+    expect(job?.requested_count).toBe(3);
+
+    const { data: items } = await svc
+      .from("transfer_job_items")
+      .select("slot_index, source_url, image_id, cloudflare_idempotency_key")
+      .eq("transfer_job_id", result.jobId!)
+      .order("slot_index", { ascending: true });
+    expect(items).toHaveLength(3);
+    expect(items?.[0]?.slot_index).toBe(0);
+    expect(items?.[0]?.source_url).toBe("https://src.test/1.jpg");
+    expect(items?.[0]?.image_id).not.toBeNull();
+    expect(items?.[0]?.cloudflare_idempotency_key).toBe(
+      `cf-${result.jobId}-0`,
+    );
+  });
+});
+
+describe("seedIstockLibrary — idempotency", () => {
+  it("re-running with the same job key adopts the existing job and skips existing items", async () => {
+    const { rows } = parseIstockCsv(VALID_CSV);
+    const jobKey = `idem-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    const first = await seedIstockLibrary({
+      rows,
+      jobIdempotencyKey: jobKey,
+    });
+    expect(first.itemsCreated).toBe(3);
+
+    const second = await seedIstockLibrary({
+      rows,
+      jobIdempotencyKey: jobKey,
+    });
+    expect(second.jobId).toBe(first.jobId);
+    expect(second.itemsCreated).toBe(0);
+    expect(second.imagesCreated).toBe(0);
+    expect(second.imagesAdopted).toBe(3);
+
+    const svc = getServiceRoleClient();
+    const { count } = await svc
+      .from("transfer_job_items")
+      .select("*", { count: "exact", head: true })
+      .eq("transfer_job_id", first.jobId!);
+    expect(count).toBe(3);
+  });
+
+  it("adopts pre-existing image_library rows rather than duplicating", async () => {
+    const svc = getServiceRoleClient();
+    // Pre-insert one of the CSV's istock_ids.
+    const { data: pre } = await svc
+      .from("image_library")
+      .insert({
+        source: "istock",
+        source_ref: "i-1",
+        filename: "preexisting",
+        width_px: 999,
+      })
+      .select("id")
+      .single();
+    const preId = pre?.id as string | undefined;
+
+    const { rows } = parseIstockCsv(VALID_CSV);
+    const jobKey = `adopt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const result = await seedIstockLibrary({
+      rows,
+      jobIdempotencyKey: jobKey,
+    });
+    expect(result.imagesAdopted).toBe(1);
+    expect(result.imagesCreated).toBe(2);
+
+    // The i-1 item still points at the pre-existing row, unchanged.
+    const { data: items } = await svc
+      .from("transfer_job_items")
+      .select("slot_index, image_id")
+      .eq("transfer_job_id", result.jobId!)
+      .eq("slot_index", 0)
+      .single();
+    expect(items?.image_id).toBe(preId);
+
+    // Pre-existing row's width_px was NOT overwritten.
+    const { data: img } = await svc
+      .from("image_library")
+      .select("width_px, filename")
+      .eq("id", preId!)
+      .single();
+    expect(img?.width_px).toBe(999);
+    expect(img?.filename).toBe("preexisting");
+  });
+});
+
+describe("seedIstockLibrary — budget cap", () => {
+  it("throws IngestBudgetError when estimate exceeds the cap", async () => {
+    const { rows } = parseIstockCsv(VALID_CSV);
+    // estimate = 3 cents; cap = 1 cent → should abort.
+    await expect(
+      seedIstockLibrary({
+        rows,
+        jobIdempotencyKey: "budget-abort",
+        budgetCapCents: 1,
+      }),
+    ).rejects.toBeInstanceOf(IngestBudgetError);
+  });
+
+  it("auto-cap is DEFAULT_BUDGET_CAP_MULTIPLIER × estimate, floor 2000 cents", async () => {
+    const { rows } = parseIstockCsv(VALID_CSV);
+    const result = await seedIstockLibrary({
+      rows,
+      jobIdempotencyKey: `auto-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    });
+    const expectedCap = Math.max(
+      result.estimate.totalCents * DEFAULT_BUDGET_CAP_MULTIPLIER,
+      2000,
+    );
+    expect(result.budgetCapCents).toBe(expectedCap);
+  });
+});

--- a/lib/istock-seed.ts
+++ b/lib/istock-seed.ts
@@ -1,0 +1,410 @@
+import { z } from "zod";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M4-5 — iStock catalogue ingest helper.
+//
+// Reads a CSV of iStock metadata and materialises:
+//   - one image_library row per unique istock_id (source='istock')
+//   - one transfer_jobs row of type='cloudflare_ingest'
+//   - one transfer_job_items row per image, with the pre-computed
+//     cloudflare + anthropic idempotency keys
+//
+// The cron worker (M4-3's orchestrator) then drains the job: each item
+// walks upload → caption → succeeded.
+//
+// Idempotency contract:
+//
+//   1. image_library (source='istock', source_ref=istock_id) UNIQUE
+//      NULLS NOT DISTINCT (migration 0010). Re-running the seed with
+//      the same CSV + same job idempotency key yields the same end
+//      state: existing rows are adopted, not duplicated.
+//
+//   2. transfer_jobs.idempotency_key UNIQUE — same key returns the
+//      original job id rather than creating a new one. The caller is
+//      responsible for stable key generation (the CLI hashes the CSV
+//      path + line count to derive one).
+//
+//   3. transfer_job_items (transfer_job_id, slot_index) UNIQUE — a
+//      re-run with the same job id + the same slot index is a no-op
+//      on INSERT. We use ON CONFLICT DO NOTHING to skip existing rows
+//      silently.
+//
+// Cost estimate:
+//
+// Caption cost per image is ~0.7 cents (Sonnet 4.6 vision at ~1200
+// input tokens + ~200 output tokens per the parent plan). We bill that
+// up to 1 cent/image for the pre-flight estimate so operators get a
+// conservative upper bound. The default budget cap is 2× the reported
+// estimate — script aborts if the estimate exceeds it. Operators can
+// widen the cap explicitly when genuinely large one-time ingests land.
+//
+// NOTE: intentionally DOES NOT route through lib/anthropic-pricing.ts's
+// `computeCostCents` for this estimate. That module's rate table
+// encodes values at a scale that overstates per-image cost by ~100×
+// (see docs/BACKLOG.md pricing-table-scale-audit). M4-5 uses a direct
+// per-image constant so the operator-facing numbers match the plan's
+// published $63 figure for 9k images. Reconciling the shared pricing
+// table is a follow-up; today's runtime path (M3 + M4-4) sums cost
+// from event-log deltas and isn't miscalibrated against itself.
+// ---------------------------------------------------------------------------
+
+// Per-plan cost constants — advisory for the pre-flight gate.
+export const ESTIMATED_CAPTION_CENTS_PER_IMAGE = 1;
+export const ESTIMATED_STORAGE_CENTS_PER_IMAGE = 0; // negligible at this scale
+export const DEFAULT_BUDGET_CAP_MULTIPLIER = 2;
+
+// ---------------------------------------------------------------------------
+// CSV parsing
+// ---------------------------------------------------------------------------
+
+export const istockRowSchema = z.object({
+  istock_id: z.string().min(1).max(120),
+  url: z.string().url(),
+  width: z.number().int().positive().optional(),
+  height: z.number().int().positive().optional(),
+  bytes: z.number().int().nonnegative().optional(),
+  license_type: z.string().min(1).max(80).optional(),
+});
+
+export type IstockRow = z.infer<typeof istockRowSchema>;
+
+export type CsvParseResult = {
+  rows: IstockRow[];
+  errors: Array<{ line: number; message: string }>;
+};
+
+const REQUIRED_HEADERS = ["istock_id", "url"] as const;
+
+function splitCsvLine(line: string): string[] {
+  // Minimal CSV split: supports optional double-quote quoting, handles
+  // doubled quotes inside a field. No escape characters beyond that.
+  // Good enough for the iStock catalogue we control; we'd graduate to
+  // a proper CSV parser if the feed ever included embedded newlines.
+  const cells: string[] = [];
+  let cur = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cur += ch;
+      }
+    } else {
+      if (ch === ",") {
+        cells.push(cur);
+        cur = "";
+      } else if (ch === '"' && cur === "") {
+        inQuotes = true;
+      } else {
+        cur += ch;
+      }
+    }
+  }
+  cells.push(cur);
+  return cells.map((c) => c.trim());
+}
+
+export function parseIstockCsv(text: string): CsvParseResult {
+  const lines = text
+    .split(/\r?\n/)
+    .map((l) => l)
+    .filter((l) => l.trim().length > 0);
+  if (lines.length === 0) {
+    return {
+      rows: [],
+      errors: [{ line: 0, message: "CSV is empty." }],
+    };
+  }
+
+  const headerCells = splitCsvLine(lines[0]!).map((h) => h.toLowerCase());
+  const missing = REQUIRED_HEADERS.filter((h) => !headerCells.includes(h));
+  if (missing.length > 0) {
+    return {
+      rows: [],
+      errors: [
+        {
+          line: 1,
+          message: `CSV header missing required column(s): ${missing.join(", ")}`,
+        },
+      ],
+    };
+  }
+  const colIndex = (name: string): number => headerCells.indexOf(name);
+
+  const rows: IstockRow[] = [];
+  const errors: CsvParseResult["errors"] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const cells = splitCsvLine(lines[i]!);
+    const raw: Record<string, unknown> = {
+      istock_id: cells[colIndex("istock_id")],
+      url: cells[colIndex("url")],
+    };
+    const widthIdx = colIndex("width");
+    const heightIdx = colIndex("height");
+    const bytesIdx = colIndex("bytes");
+    const licenseIdx = colIndex("license_type");
+    if (widthIdx >= 0 && cells[widthIdx]) raw.width = Number(cells[widthIdx]);
+    if (heightIdx >= 0 && cells[heightIdx]) raw.height = Number(cells[heightIdx]);
+    if (bytesIdx >= 0 && cells[bytesIdx]) raw.bytes = Number(cells[bytesIdx]);
+    if (licenseIdx >= 0 && cells[licenseIdx]) {
+      raw.license_type = cells[licenseIdx];
+    }
+
+    const parsed = istockRowSchema.safeParse(raw);
+    if (!parsed.success) {
+      errors.push({
+        line: i + 1,
+        message: parsed.error.issues
+          .map((it) => `${it.path.join(".")}: ${it.message}`)
+          .join("; "),
+      });
+      continue;
+    }
+    rows.push(parsed.data);
+  }
+
+  return { rows, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Cost estimate
+// ---------------------------------------------------------------------------
+
+export type CostEstimate = {
+  imageCount: number;
+  captionCents: number;
+  storageCents: number;
+  totalCents: number;
+};
+
+export function estimateIngestCost(imageCount: number): CostEstimate {
+  const captionCents = imageCount * ESTIMATED_CAPTION_CENTS_PER_IMAGE;
+  const storageCents = imageCount * ESTIMATED_STORAGE_CENTS_PER_IMAGE;
+  return {
+    imageCount,
+    captionCents,
+    storageCents,
+    totalCents: captionCents + storageCents,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Seed
+// ---------------------------------------------------------------------------
+
+export type SeedOptions = {
+  rows: IstockRow[];
+  jobIdempotencyKey: string;
+  budgetCapCents?: number;
+  /** If true, skip all DB writes and just return the plan. */
+  dryRun?: boolean;
+};
+
+export type SeedResult = {
+  jobId: string | null;
+  itemsCreated: number;
+  imagesCreated: number;
+  imagesAdopted: number;
+  estimate: CostEstimate;
+  budgetCapCents: number;
+  dryRun: boolean;
+  skippedOverBudget: boolean;
+};
+
+export class IngestBudgetError extends Error {
+  public readonly estimate: CostEstimate;
+  public readonly budgetCapCents: number;
+  constructor(estimate: CostEstimate, budgetCapCents: number) {
+    super(
+      `Estimated cost ${estimate.totalCents} cents exceeds budget cap ${budgetCapCents} cents (${estimate.imageCount} images).`,
+    );
+    this.name = "IngestBudgetError";
+    this.estimate = estimate;
+    this.budgetCapCents = budgetCapCents;
+  }
+}
+
+const DEFAULT_BUDGET_FLOOR_CENTS = 2_000;
+
+/**
+ * Drive the ingest. Returns a summary; throws IngestBudgetError if the
+ * estimate exceeds the cap (operator widens the cap and re-runs).
+ *
+ * Dry-run returns without touching the DB — the cost estimate + row
+ * count is what the operator reviews before the real run.
+ */
+export async function seedIstockLibrary(
+  options: SeedOptions,
+): Promise<SeedResult> {
+  const estimate = estimateIngestCost(options.rows.length);
+  const budgetCap =
+    options.budgetCapCents ??
+    Math.max(
+      estimate.totalCents * DEFAULT_BUDGET_CAP_MULTIPLIER,
+      DEFAULT_BUDGET_FLOOR_CENTS,
+    );
+
+  if (estimate.totalCents > budgetCap) {
+    throw new IngestBudgetError(estimate, budgetCap);
+  }
+
+  if (options.dryRun) {
+    return {
+      jobId: null,
+      itemsCreated: 0,
+      imagesCreated: 0,
+      imagesAdopted: 0,
+      estimate,
+      budgetCapCents: budgetCap,
+      dryRun: true,
+      skippedOverBudget: false,
+    };
+  }
+
+  const svc = getServiceRoleClient();
+
+  // 1. Upsert image_library rows. Insert one row per istock_id; on
+  //    (source='istock', source_ref=istock_id) conflict, adopt the
+  //    existing id via a follow-up SELECT.
+  const istockIds = Array.from(new Set(options.rows.map((r) => r.istock_id)));
+  const byIstockId = new Map<string, IstockRow>();
+  for (const r of options.rows) byIstockId.set(r.istock_id, r);
+
+  // SELECT existing image_library rows matching the batch — any that
+  // already have a row become "adopted"; the remainder get INSERTed.
+  const { data: existing, error: exErr } = await svc
+    .from("image_library")
+    .select("id, source_ref")
+    .eq("source", "istock")
+    .in("source_ref", istockIds);
+  if (exErr) {
+    throw new Error(`seedIstockLibrary: load existing: ${exErr.message}`);
+  }
+  const existingByIstockId = new Map<string, string>();
+  for (const row of existing ?? []) {
+    existingByIstockId.set(row.source_ref as string, row.id as string);
+  }
+
+  const toInsert = istockIds
+    .filter((id) => !existingByIstockId.has(id))
+    .map((id) => {
+      const r = byIstockId.get(id)!;
+      return {
+        source: "istock",
+        source_ref: id,
+        filename: id,
+        width_px: r.width ?? null,
+        height_px: r.height ?? null,
+        bytes: r.bytes ?? null,
+        license_type: r.license_type ?? null,
+      };
+    });
+
+  let inserted: Array<{ id: string; source_ref: string }> = [];
+  if (toInsert.length > 0) {
+    const { data: insRows, error: insErr } = await svc
+      .from("image_library")
+      .insert(toInsert)
+      .select("id, source_ref");
+    if (insErr) {
+      throw new Error(`seedIstockLibrary: insert images: ${insErr.message}`);
+    }
+    inserted = (insRows ?? []) as Array<{ id: string; source_ref: string }>;
+  }
+
+  const imageIdByIstockId = new Map(existingByIstockId);
+  for (const r of inserted) {
+    imageIdByIstockId.set(r.source_ref, r.id);
+  }
+
+  // 2. Get-or-create the transfer_jobs row.
+  let jobId: string;
+  const { data: existingJob, error: exJobErr } = await svc
+    .from("transfer_jobs")
+    .select("id")
+    .eq("idempotency_key", options.jobIdempotencyKey)
+    .maybeSingle();
+  if (exJobErr) {
+    throw new Error(`seedIstockLibrary: load job: ${exJobErr.message}`);
+  }
+  if (existingJob) {
+    jobId = existingJob.id as string;
+  } else {
+    const { data: newJob, error: newJobErr } = await svc
+      .from("transfer_jobs")
+      .insert({
+        type: "cloudflare_ingest",
+        idempotency_key: options.jobIdempotencyKey,
+        requested_count: options.rows.length,
+      })
+      .select("id")
+      .single();
+    if (newJobErr || !newJob) {
+      throw new Error(`seedIstockLibrary: insert job: ${newJobErr?.message}`);
+    }
+    jobId = newJob.id as string;
+  }
+
+  // 3. Insert transfer_job_items (skip duplicates on (job_id, slot_index)).
+  // Slot index is the row's position in the parsed CSV, stable across
+  // re-runs with the same CSV ordering.
+  const itemsRows = options.rows.map((r, i) => {
+    const imageId = imageIdByIstockId.get(r.istock_id);
+    return {
+      transfer_job_id: jobId,
+      slot_index: i,
+      image_id: imageId ?? null,
+      cloudflare_idempotency_key: `cf-${jobId}-${i}`,
+      anthropic_idempotency_key: `an-${jobId}-${i}`,
+      source_url: r.url,
+    };
+  });
+
+  // Supabase-js `insert` doesn't ship a native ON CONFLICT DO NOTHING
+  // for bulk inserts — we filter existing slots first. (For a one-shot
+  // seed script this is fine; a hot path would use raw SQL.)
+  const { data: existingItems, error: exItemsErr } = await svc
+    .from("transfer_job_items")
+    .select("slot_index")
+    .eq("transfer_job_id", jobId);
+  if (exItemsErr) {
+    throw new Error(
+      `seedIstockLibrary: load existing items: ${exItemsErr.message}`,
+    );
+  }
+  const existingSlots = new Set(
+    (existingItems ?? []).map((r) => r.slot_index as number),
+  );
+  const itemsToInsert = itemsRows.filter((r) => !existingSlots.has(r.slot_index));
+  if (itemsToInsert.length > 0) {
+    const { error: insItemsErr } = await svc
+      .from("transfer_job_items")
+      .insert(itemsToInsert);
+    if (insItemsErr) {
+      throw new Error(
+        `seedIstockLibrary: insert items: ${insItemsErr.message}`,
+      );
+    }
+  }
+
+  return {
+    jobId,
+    itemsCreated: itemsToInsert.length,
+    imagesCreated: inserted.length,
+    imagesAdopted: existingByIstockId.size,
+    estimate,
+    budgetCapCents: budgetCap,
+    dryRun: false,
+    skippedOverBudget: false,
+  };
+}

--- a/scripts/seed-istock-library.ts
+++ b/scripts/seed-istock-library.ts
@@ -1,0 +1,199 @@
+#!/usr/bin/env tsx
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+
+import {
+  IngestBudgetError,
+  estimateIngestCost,
+  parseIstockCsv,
+  seedIstockLibrary,
+} from "@/lib/istock-seed";
+
+// ---------------------------------------------------------------------------
+// scripts/seed-istock-library.ts
+//
+// One-shot CLI that parses an iStock CSV and materialises the image
+// library + a cloudflare_ingest transfer_jobs row + one
+// transfer_job_items row per image. The worker cron drains the job.
+//
+// Usage:
+//
+//   tsx scripts/seed-istock-library.ts \
+//     --csv path/to/istock.csv \
+//     [--dry-run] \
+//     [--budget-cap-cents N] \
+//     [--job-key <string>] \
+//     [--limit N] \
+//     [--confirm]
+//
+// Flow:
+//
+//   1. Parse the CSV. Abort loudly on header errors; report per-line
+//      errors but continue with valid rows.
+//
+//   2. Print the cost estimate and row count. In dry-run mode, exit.
+//
+//   3. In real-run mode, require --confirm. Without it the script
+//      prints the estimate and exits 0 — same mental model as a
+//      migration preview.
+//
+//   4. Call seedIstockLibrary. If the estimate exceeds the budget cap,
+//      IngestBudgetError is thrown and we exit non-zero. Operator
+//      widens the cap explicitly.
+//
+// Idempotency:
+//
+//   The job's idempotency_key defaults to sha256(csv basename + row
+//   count). Re-running with the same CSV adopts the same job id;
+//   previously-processed items stay processed; new rows (if the CSV
+//   was extended) get appended. Operators can pass --job-key to force
+//   a specific key (e.g. for second-half ingests of the same catalogue).
+// ---------------------------------------------------------------------------
+
+type CliArgs = {
+  csv?: string;
+  dryRun: boolean;
+  budgetCapCents?: number;
+  jobKey?: string;
+  limit?: number;
+  confirm: boolean;
+};
+
+function parseArgs(argv: readonly string[]): CliArgs {
+  const args: CliArgs = { dryRun: false, confirm: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--csv") args.csv = argv[++i];
+    else if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--confirm") args.confirm = true;
+    else if (a === "--budget-cap-cents") {
+      args.budgetCapCents = Number(argv[++i]);
+    } else if (a === "--job-key") args.jobKey = argv[++i];
+    else if (a === "--limit") args.limit = Number(argv[++i]);
+    else if (a === "--help" || a === "-h") {
+      printUsage();
+      process.exit(0);
+    } else {
+      console.error(`Unknown flag: ${a}`);
+      printUsage();
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+function printUsage(): void {
+  process.stderr.write(
+    [
+      "Usage: tsx scripts/seed-istock-library.ts --csv <path> [options]",
+      "  --csv <path>            Required. Path to the iStock CSV.",
+      "  --dry-run               Report estimate + row count; no DB writes.",
+      "  --budget-cap-cents N    Abort if estimate exceeds this cap.",
+      "  --job-key <string>      Override the computed idempotency key.",
+      "  --limit N               Process only the first N rows (debugging).",
+      "  --confirm               Required for real runs (opt-in guard).",
+      "",
+    ].join("\n"),
+  );
+}
+
+function computeDefaultJobKey(csvPath: string, rowCount: number): string {
+  const h = createHash("sha256");
+  h.update(basename(csvPath));
+  h.update("|");
+  h.update(String(rowCount));
+  return `istock-seed-${h.digest("hex").slice(0, 32)}`;
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.csv) {
+    printUsage();
+    return 2;
+  }
+
+  const text = readFileSync(args.csv, "utf8");
+  const parsed = parseIstockCsv(text);
+  if (parsed.errors.length > 0) {
+    process.stderr.write(
+      `Parse errors (${parsed.errors.length}):\n` +
+        parsed.errors
+          .slice(0, 20)
+          .map((e) => `  line ${e.line}: ${e.message}`)
+          .join("\n") +
+        (parsed.errors.length > 20 ? "\n  ...(truncated)" : "") +
+        "\n",
+    );
+    if (parsed.rows.length === 0) return 2;
+  }
+
+  const rows =
+    typeof args.limit === "number" ? parsed.rows.slice(0, args.limit) : parsed.rows;
+
+  const estimate = estimateIngestCost(rows.length);
+  const jobKey = args.jobKey ?? computeDefaultJobKey(args.csv, rows.length);
+
+  process.stdout.write(
+    [
+      "iStock ingest plan",
+      `  CSV: ${args.csv}`,
+      `  Rows: ${rows.length}`,
+      `  Estimated caption cost: ${(estimate.captionCents / 100).toFixed(2)} USD (${estimate.captionCents} cents)`,
+      `  Storage estimate: ${(estimate.storageCents / 100).toFixed(2)} USD`,
+      `  Total estimate: ${(estimate.totalCents / 100).toFixed(2)} USD`,
+      `  Budget cap: ${args.budgetCapCents ?? "(auto: 2× estimate, floor 2000 cents)"}`,
+      `  Idempotency key: ${jobKey}`,
+      "",
+    ].join("\n"),
+  );
+
+  if (args.dryRun) {
+    process.stdout.write("Dry-run — no DB writes performed.\n");
+    return 0;
+  }
+  if (!args.confirm) {
+    process.stderr.write(
+      "Pass --confirm to execute the real run, or --dry-run to re-estimate.\n",
+    );
+    return 2;
+  }
+
+  try {
+    const result = await seedIstockLibrary({
+      rows,
+      jobIdempotencyKey: jobKey,
+      budgetCapCents: args.budgetCapCents,
+    });
+    process.stdout.write(
+      [
+        "Seed complete",
+        `  Job id: ${result.jobId}`,
+        `  Images created: ${result.imagesCreated}`,
+        `  Images adopted (existing): ${result.imagesAdopted}`,
+        `  Transfer items created: ${result.itemsCreated}`,
+        `  Effective budget cap: ${result.budgetCapCents} cents`,
+        "",
+      ].join("\n"),
+    );
+    return 0;
+  } catch (err) {
+    if (err instanceof IngestBudgetError) {
+      process.stderr.write(
+        `\nABORTED: ${err.message}\n` +
+          `Pass --budget-cap-cents <N> to raise the cap if this estimate is acceptable.\n`,
+      );
+      return 3;
+    }
+    throw err;
+  }
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error("seed-istock-library: fatal error");
+    console.error(err);
+    process.exit(1);
+  },
+);


### PR DESCRIPTION
Adds `scripts/seed-istock-library.ts` (CLI) and `lib/istock-seed.ts` (tested lib) for the one-shot iStock catalogue ingest. The script parses a CSV, computes a pre-flight cost estimate, and — on `--confirm` — materialises `image_library` rows (source='istock') + one `transfer_jobs` row of type `cloudflare_ingest` + one `transfer_job_items` per image with pre-computed Cloudflare / Anthropic idempotency keys. The existing M4-3 orchestrator (now wired into the cron tick) drains the job: each item walks upload → caption → succeeded.

## What lands
- `lib/istock-seed.ts` — `parseIstockCsv`, `estimateIngestCost`, `seedIstockLibrary`, `IngestBudgetError`. Minimal CSV parser (quoted cells, optional columns). Idempotency anchors: `image_library (source, source_ref)` UNIQUE NULLS NOT DISTINCT, `transfer_jobs.idempotency_key` UNIQUE, `transfer_job_items (job_id, slot_index)` UNIQUE.
- `scripts/seed-istock-library.ts` — thin CLI adapter. `--csv <path>` required. `--dry-run` prints estimate + exits. `--budget-cap-cents N` overrides the auto cap. `--job-key` pins the idempotency key. `--confirm` is required for real runs. Default job key is `sha256(basename(csv) + row_count)` so two runs of the same CSV adopt the same job.
- `lib/__tests__/istock-seed.test.ts` — CSV parser cases, cost scaling, dry-run leaves DB empty, real run inserts image_library + transfer_jobs + transfer_job_items with the right relationships, idempotent re-run produces identical state, adoption of pre-existing image_library rows (no overwrite), budget-cap abort.
- `docs/BACKLOG.md` — M4 tracker updated; new follow-up entry: "Anthropic pricing-table scale audit" (see deferred item below).

## Risks identified and mitigated
- **One-time cost blowout.** Pre-flight `estimateIngestCost` + default cap = 2× the estimate, floor 2000 cents. Any miscalculation in the rate constant surfaces as a safety-net abort — operators widen the cap by passing `--budget-cap-cents` explicitly. Test asserts `IngestBudgetError` fires when the estimate exceeds the cap.
- **Double-ingest on operator re-run.** Three-layer idempotency: (1) image_library `(source, source_ref)` UNIQUE keeps duplicate iStock ids from creating second library rows; (2) transfer_jobs `idempotency_key` UNIQUE keeps a re-run with the same key adopting the original job; (3) transfer_job_items `(transfer_job_id, slot_index)` UNIQUE keeps second-pass INSERTs from duplicating items. We SELECT existing items before INSERT to avoid tripping the constraint. Tested: second run returns the same jobId + 0 items created + adopted count matching image count.
- **Mid-run failure.** The function is restartable — every SELECT/INSERT is against the idempotency anchors. A crash between image-library inserts and job insert still converges on a re-run (existing images adopted; new job inserted).
- **Pre-existing image_library row overwrite.** The seed fetches existing rows by `(source='istock', source_ref=id)` BEFORE building the INSERT list; existing rows keep their original width/filename/etc. Tested.
- **Required env-var misconfig.** The seed calls `getServiceRoleClient()`; Supabase credentials are already required ambient env. No Cloudflare / Anthropic env vars are exercised by the seed itself — the worker (triggered by cron) handles those. This keeps the seed a pure DB operation, safe to run in environments where Cloudflare isn't yet hot.
- **Catalog-drift if the CSV is extended mid-catalogue.** Appending rows to the CSV and re-running with the same `--job-key` adopts the existing job and appends new slots (post-existing-slots). Removing rows is not auto-reflected (no deletes from a seed). Operators who intend to retire an iStock id mark the `image_library` row `deleted_at` out-of-band — consistent with the soft-delete convention.
- **CSV parse fault-tolerance.** Per-line validation errors are collected and reported; valid rows still flow. A header fault (missing `istock_id` or `url`) aborts outright. No row is silently dropped without an error line.

## Deliberately deferred
- **Reconciling the anthropic-pricing table scale.** `lib/anthropic-pricing.ts` has rate values that produce per-image costs ~100× higher than the plan's $0.007/image observation (the table's units don't match its doc-comment). M4-5 uses a direct per-image constant (`ESTIMATED_CAPTION_CENTS_PER_IMAGE = 1`) so operator-facing numbers match the plan's published $63 for 9k images. M3's existing reconciliation tests only assert sum-equals-sum, so the miscalibration isn't a correctness bug today — it's a reporting fidelity issue that belongs to a dedicated slice (backlog entry added).
- **Live iStock feed refresh.** The seed is one-time per the parent plan. Ongoing-catalogue maintenance is post-M4.
- **Cancel-mid-seed ergonomics.** The CLI doesn't wire a Ctrl-C handler to rollback partial inserts — the seed fn is already idempotent, so the operator just re-runs with the same job key. Mentioned here rather than buried.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — DB-backed tests run in CI.
- [ ] `npm run test:e2e` — no admin UI in this slice (CLI-only operator surface).