### PR TITLE
feat(m4-7): wp media transfer + html url rewrite on publish

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -16,9 +16,9 @@ Parent plan: `docs/plans/m4.md`. Sub-slice status tracker:
 | M4-2 | merged (#58) | Worker core (lease / heartbeat / reaper over `transfer_job_items` + dummy processor). |
 | M4-3 | merged (#61) | Cloudflare upload worker stage + orchestrator. |
 | M4-4 | merged (#59) | Anthropic vision captioning (reuses `ANTHROPIC_API_KEY`). |
-| M4-5 | in flight | iStock seed script: CSV ingest + dry-run + budget cap. |
+| M4-5 | merged (#62) | iStock seed script: CSV ingest + dry-run + budget cap. |
 | M4-6 | merged (#60) | `search_images` chat tool. |
-| M4-7 | planned | WP media transfer + HTML URL rewrite on publish. |
+| M4-7 | in flight | WP media transfer + HTML URL rewrite on publish. |
 
 Env vars: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_IMAGES_API_TOKEN`, `CLOUDFLARE_IMAGES_HASH` all provisioned in Vercel Production + Preview as of 2026-04-21.
 

--- a/lib/__tests__/html-image-rewrite.test.ts
+++ b/lib/__tests__/html-image-rewrite.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractCloudflareIds,
+  rewriteImageUrls,
+} from "@/lib/html-image-rewrite";
+
+// ---------------------------------------------------------------------------
+// M4-7 — HTML image URL rewriter tests.
+//
+// Pure string-in / string-out; no DB. Covers the matrix the parent
+// plan calls out: src, srcset (multi-descriptor), style="background:
+// url(...)", nested <picture>, data: URLs preserved, external URLs
+// preserved, relative URLs preserved, missing mapping entries.
+// ---------------------------------------------------------------------------
+
+const CF_ID_A = "0123-cat";
+const CF_ID_B = "4567-river";
+const CF_URL_A = `https://imagedelivery.net/HASH-abc/${CF_ID_A}/public`;
+const CF_URL_B = `https://imagedelivery.net/HASH-abc/${CF_ID_B}/thumbnail`;
+const WP_URL_A = `https://client.example/wp-content/uploads/cat.jpg`;
+const WP_URL_B = `https://client.example/wp-content/uploads/river.jpg`;
+
+function buildMap(entries: Array<[string, string]>): Map<string, string> {
+  return new Map(entries);
+}
+
+// ---------------------------------------------------------------------------
+// extractCloudflareIds
+// ---------------------------------------------------------------------------
+
+describe("extractCloudflareIds", () => {
+  it("finds every distinct cloudflare id in src / srcset / style", () => {
+    const html = `
+      <section>
+        <img src="${CF_URL_A}" alt="x"/>
+        <picture>
+          <source srcset="${CF_URL_B} 1x, ${CF_URL_A} 2x" />
+        </picture>
+        <div style="background-image: url('${CF_URL_B}')"></div>
+      </section>
+    `;
+    const ids = extractCloudflareIds(html);
+    expect(ids.size).toBe(2);
+    expect(ids.has(CF_ID_A)).toBe(true);
+    expect(ids.has(CF_ID_B)).toBe(true);
+  });
+
+  it("returns empty set when no Cloudflare URLs are present", () => {
+    expect(extractCloudflareIds("<img src='x.jpg'/>").size).toBe(0);
+    expect(extractCloudflareIds("<p>hello</p>").size).toBe(0);
+  });
+
+  it("ignores imagedelivery-looking substrings outside URLs", () => {
+    // Text content that mentions imagedelivery.net should NOT be
+    // extracted because our regex requires the full URL shape.
+    const html = `<p>We host at imagedelivery.net for images.</p>`;
+    expect(extractCloudflareIds(html).size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rewriteImageUrls — happy path
+// ---------------------------------------------------------------------------
+
+describe("rewriteImageUrls — src attributes", () => {
+  it("rewrites a single img src", () => {
+    const html = `<img src="${CF_URL_A}" alt="x"/>`;
+    const m = buildMap([[CF_ID_A, WP_URL_A]]);
+    const { rewrittenHtml, usedIds, missedIds, rewriteCount } =
+      rewriteImageUrls(html, m);
+    expect(rewrittenHtml).toContain(WP_URL_A);
+    expect(rewrittenHtml).not.toContain("imagedelivery.net");
+    expect(usedIds.has(CF_ID_A)).toBe(true);
+    expect(missedIds.size).toBe(0);
+    expect(rewriteCount).toBe(1);
+  });
+
+  it("preserves external src URLs", () => {
+    const html = `<img src="https://other.example/x.jpg" alt="x"/>`;
+    const m = buildMap([[CF_ID_A, WP_URL_A]]);
+    const { rewrittenHtml, rewriteCount } = rewriteImageUrls(html, m);
+    expect(rewrittenHtml).toContain("https://other.example/x.jpg");
+    expect(rewriteCount).toBe(0);
+  });
+
+  it("preserves data: URLs", () => {
+    const html = `<img src="data:image/png;base64,AAAA" alt="x"/>`;
+    const m = buildMap([[CF_ID_A, WP_URL_A]]);
+    const { rewrittenHtml, rewriteCount } = rewriteImageUrls(html, m);
+    expect(rewrittenHtml).toContain("data:image/png;base64,AAAA");
+    expect(rewriteCount).toBe(0);
+  });
+
+  it("preserves relative URLs", () => {
+    const html = `<img src="/wp-content/uploads/x.jpg" alt="x"/>`;
+    const m = buildMap([[CF_ID_A, WP_URL_A]]);
+    const { rewriteCount } = rewriteImageUrls(html, m);
+    expect(rewriteCount).toBe(0);
+  });
+
+  it("records missedIds when a URL has no mapping entry", () => {
+    const html = `<img src="${CF_URL_A}" alt="x"/>`;
+    const { rewrittenHtml, usedIds, missedIds } = rewriteImageUrls(
+      html,
+      new Map(),
+    );
+    expect(rewrittenHtml).toContain(CF_URL_A); // unchanged
+    expect(usedIds.size).toBe(0);
+    expect(missedIds.has(CF_ID_A)).toBe(true);
+  });
+});
+
+describe("rewriteImageUrls — srcset attributes", () => {
+  it("rewrites every URL in a multi-descriptor srcset, preserving descriptors", () => {
+    const html = `<img srcset="${CF_URL_A} 1x, ${CF_URL_B} 2x, /local.jpg 3x" />`;
+    const m = buildMap([
+      [CF_ID_A, WP_URL_A],
+      [CF_ID_B, WP_URL_B],
+    ]);
+    const { rewrittenHtml, usedIds, rewriteCount } = rewriteImageUrls(html, m);
+    expect(rewrittenHtml).toContain(`${WP_URL_A} 1x`);
+    expect(rewrittenHtml).toContain(`${WP_URL_B} 2x`);
+    expect(rewrittenHtml).toContain("/local.jpg 3x");
+    expect(usedIds.size).toBe(2);
+    expect(rewriteCount).toBe(2);
+  });
+
+  it("handles <source srcset=...> inside <picture>", () => {
+    const html = `
+      <picture>
+        <source srcset="${CF_URL_A} 1x" media="(max-width: 600px)"/>
+        <img src="${CF_URL_B}" alt="fallback"/>
+      </picture>
+    `;
+    const m = buildMap([
+      [CF_ID_A, WP_URL_A],
+      [CF_ID_B, WP_URL_B],
+    ]);
+    const { rewrittenHtml, rewriteCount } = rewriteImageUrls(html, m);
+    expect(rewrittenHtml).toContain(WP_URL_A);
+    expect(rewrittenHtml).toContain(WP_URL_B);
+    expect(rewriteCount).toBe(2);
+  });
+});
+
+describe("rewriteImageUrls — style background-image", () => {
+  it("rewrites URL inside style attribute (double-quoted)", () => {
+    const html = `<div style="background-image: url('${CF_URL_A}'); color: red;"></div>`;
+    const m = buildMap([[CF_ID_A, WP_URL_A]]);
+    const { rewrittenHtml, rewriteCount } = rewriteImageUrls(html, m);
+    expect(rewrittenHtml).toContain(WP_URL_A);
+    expect(rewrittenHtml).toContain("color: red");
+    expect(rewriteCount).toBe(1);
+  });
+
+  it("rewrites URL inside style attribute (single-quoted outer)", () => {
+    const html = `<div style='background-image: url(${CF_URL_A});'></div>`;
+    const m = buildMap([[CF_ID_A, WP_URL_A]]);
+    const { rewriteCount, rewrittenHtml } = rewriteImageUrls(html, m);
+    expect(rewriteCount).toBe(1);
+    expect(rewrittenHtml).toContain(WP_URL_A);
+  });
+
+  it("preserves non-Cloudflare background URLs", () => {
+    const html = `<div style="background-image: url('/local-bg.jpg');"></div>`;
+    const m = buildMap([[CF_ID_A, WP_URL_A]]);
+    const { rewriteCount, rewrittenHtml } = rewriteImageUrls(html, m);
+    expect(rewriteCount).toBe(0);
+    expect(rewrittenHtml).toContain("/local-bg.jpg");
+  });
+});
+
+describe("rewriteImageUrls — combined", () => {
+  it("handles a realistic page with mixed attributes + external assets", () => {
+    const html = `
+      <section class="ls-hero" data-ds-version="1">
+        <h1>Title</h1>
+        <img src="${CF_URL_A}" alt="a"/>
+        <picture>
+          <source srcset="${CF_URL_B} 1x, ${CF_URL_A} 2x"/>
+          <img src="${CF_URL_B}" alt="b"/>
+        </picture>
+        <div style="background-image: url('${CF_URL_A}');"></div>
+        <img src="https://external.example/z.png" alt="external"/>
+        <img src="/local.jpg" alt="relative"/>
+        <img src="data:image/png;base64,AAAA" alt="data"/>
+      </section>
+    `;
+    const m = buildMap([
+      [CF_ID_A, WP_URL_A],
+      [CF_ID_B, WP_URL_B],
+    ]);
+    const { rewrittenHtml, usedIds, missedIds, rewriteCount } =
+      rewriteImageUrls(html, m);
+    expect(rewrittenHtml).not.toContain("imagedelivery.net");
+    expect(rewrittenHtml).toContain("https://external.example/z.png");
+    expect(rewrittenHtml).toContain("/local.jpg");
+    expect(rewrittenHtml).toContain("data:image/png;base64,AAAA");
+    expect(usedIds.size).toBe(2);
+    expect(missedIds.size).toBe(0);
+    // src(A) + srcset[B,A] + src(B) + style(A) = 5
+    expect(rewriteCount).toBe(5);
+  });
+});

--- a/lib/__tests__/wp-media-transfer.test.ts
+++ b/lib/__tests__/wp-media-transfer.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  transferImagesForPage,
+  type WpMediaCallBundle,
+  type WpMediaUploadResult,
+} from "@/lib/wp-media-transfer";
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M4-7 — WP media transfer tests.
+//
+// DB-backed. Pins:
+//
+//   - Fresh (image, site) pair triggers fetch + upload, populates
+//     image_usage with wp_media_id + wp_source_url, and returns the
+//     mapping for the HTML rewriter.
+//   - Subsequent calls for the same (image, site) reuse the row
+//     without re-invoking WP.
+//   - Concurrent-publisher race: two simultaneous transfers of the
+//     same (image, site) result in exactly ONE WP upload, both
+//     callers end up with the same wp_source_url (winner) or the
+//     loser defers with WP_MEDIA_IN_FLIGHT (retryable).
+//   - GET-by-marker adoption: when a WP-side record exists but the
+//     DB never landed, transferImagesForPage adopts it without a
+//     re-upload.
+//   - Non-retryable WP failure (e.g. 413) marks image_usage failed
+//     + returns non-retryable.
+//   - Unknown cloudflare id (not in image_library) is listed in
+//     unknownIds and doesn't trigger upload.
+// ---------------------------------------------------------------------------
+
+async function seedImageLibrary(cloudflareId: string): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("image_library")
+    .insert({
+      source: "istock",
+      source_ref: `istock-${cloudflareId}`,
+      filename: `${cloudflareId}.jpg`,
+      cloudflare_id: cloudflareId,
+      caption:
+        "A placeholder caption just long enough to pass structural validation.",
+      alt_text: "Placeholder",
+      tags: ["test", "placeholder", "fixture"],
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seedImageLibrary: ${error?.message}`);
+  return data.id as string;
+}
+
+type UploadCall = { filename: string; marker: string };
+
+function buildWpStub(opts: {
+  uploads?: UploadCall[];
+  uploadResult?: (req: {
+    filename: string;
+    idempotencyMarker: string;
+  }) => WpMediaUploadResult;
+  fetchImpl?: WpMediaCallBundle["fetchImage"];
+  findByMarkerImpl?: WpMediaCallBundle["findByMarker"];
+}): WpMediaCallBundle {
+  return {
+    fetchImage:
+      opts.fetchImpl ??
+      (async (_url) => ({
+        bytes: new ArrayBuffer(16),
+        mimeType: "image/jpeg",
+        filename: "fixture.jpg",
+      })),
+    uploadMedia: async (req) => {
+      if (opts.uploads)
+        opts.uploads.push({
+          filename: req.filename,
+          marker: req.idempotencyMarker,
+        });
+      if (opts.uploadResult) return opts.uploadResult(req);
+      return {
+        ok: true,
+        wp_media_id: 42,
+        source_url: `https://client.example/wp-content/uploads/${req.idempotencyMarker}.jpg`,
+      };
+    },
+    findByMarker: opts.findByMarkerImpl ?? (async () => null),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fresh pair → single upload + populated row
+// ---------------------------------------------------------------------------
+
+describe("transferImagesForPage — fresh (image, site) pair", () => {
+  it("uploads to WP and writes the image_usage row", async () => {
+    const site = await seedSite();
+    const imageId = await seedImageLibrary("cf-cat");
+
+    const uploads: UploadCall[] = [];
+    const result = await transferImagesForPage({
+      cloudflareIds: new Set(["cf-cat"]),
+      siteId: site.id,
+      wpMedia: buildWpStub({ uploads }),
+      cloudflareUrlFor: (id) => `https://imagedelivery.net/HASH/${id}/public`,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.mapping.get("cf-cat")).toBe(
+      "https://client.example/wp-content/uploads/opollo-img-" +
+        imageId.replace(/-/g, "") +
+        "-" +
+        site.id.slice(0, 8) +
+        ".jpg",
+    );
+    expect(uploads).toHaveLength(1);
+
+    const svc = getServiceRoleClient();
+    const { data: usage } = await svc
+      .from("image_usage")
+      .select("state, wp_media_id, wp_source_url, wp_idempotency_marker")
+      .eq("image_id", imageId)
+      .eq("site_id", site.id)
+      .single();
+    expect(usage?.state).toBe("transferred");
+    expect(Number(usage?.wp_media_id)).toBe(42);
+    expect(usage?.wp_source_url).toContain("opollo-img-");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Re-use on second call (idempotent)
+// ---------------------------------------------------------------------------
+
+describe("transferImagesForPage — re-use existing transferred row", () => {
+  it("does not re-upload when image_usage.state='transferred'", async () => {
+    const site = await seedSite();
+    const imageId = await seedImageLibrary("cf-reuse");
+
+    const uploads1: UploadCall[] = [];
+    const first = await transferImagesForPage({
+      cloudflareIds: new Set(["cf-reuse"]),
+      siteId: site.id,
+      wpMedia: buildWpStub({ uploads: uploads1 }),
+      cloudflareUrlFor: (id) => `https://imagedelivery.net/HASH/${id}/public`,
+    });
+    expect(first.ok).toBe(true);
+    expect(uploads1).toHaveLength(1);
+
+    const uploads2: UploadCall[] = [];
+    const second = await transferImagesForPage({
+      cloudflareIds: new Set(["cf-reuse"]),
+      siteId: site.id,
+      wpMedia: buildWpStub({ uploads: uploads2 }),
+      cloudflareUrlFor: (id) => `https://imagedelivery.net/HASH/${id}/public`,
+    });
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(uploads2).toHaveLength(0);
+    expect(second.mapping.get("cf-reuse")).toContain("opollo-img-");
+
+    // Exactly one image_usage row.
+    const svc = getServiceRoleClient();
+    const { count } = await svc
+      .from("image_usage")
+      .select("*", { count: "exact", head: true })
+      .eq("image_id", imageId)
+      .eq("site_id", site.id);
+    expect(count).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrent race: two publishes of same (image, site)
+// ---------------------------------------------------------------------------
+
+describe("transferImagesForPage — concurrent race", () => {
+  it("two concurrent transfers observe exactly one WP upload; loser defers", async () => {
+    const site = await seedSite();
+    await seedImageLibrary("cf-race");
+
+    // Gated upload: the first call blocks on a promise until we release
+    // it. The second concurrent call hits the pending row and defers.
+    let releaseUpload!: () => void;
+    const uploadReleased = new Promise<void>((resolve) => {
+      releaseUpload = resolve;
+    });
+
+    const uploads: UploadCall[] = [];
+    const slowStub: WpMediaCallBundle = {
+      fetchImage: async () => ({
+        bytes: new ArrayBuffer(16),
+        mimeType: "image/jpeg",
+        filename: "race.jpg",
+      }),
+      uploadMedia: async (req) => {
+        uploads.push({
+          filename: req.filename,
+          marker: req.idempotencyMarker,
+        });
+        await uploadReleased;
+        return {
+          ok: true,
+          wp_media_id: 99,
+          source_url: `https://client.example/wp-content/uploads/${req.idempotencyMarker}.jpg`,
+        };
+      },
+      findByMarker: async () => null,
+    };
+    const fastStub: WpMediaCallBundle = {
+      fetchImage: async () => ({
+        bytes: new ArrayBuffer(16),
+        mimeType: "image/jpeg",
+        filename: "race.jpg",
+      }),
+      uploadMedia: async (req) => {
+        uploads.push({
+          filename: req.filename,
+          marker: req.idempotencyMarker,
+        });
+        return {
+          ok: true,
+          wp_media_id: 100,
+          source_url: `https://client.example/wp-content/uploads/${req.idempotencyMarker}.jpg`,
+        };
+      },
+      findByMarker: async () => null,
+    };
+
+    // Worker A starts and blocks inside upload.
+    const workerA = transferImagesForPage({
+      cloudflareIds: new Set(["cf-race"]),
+      siteId: site.id,
+      wpMedia: slowStub,
+      cloudflareUrlFor: (id) =>
+        `https://imagedelivery.net/HASH/${id}/public`,
+    });
+
+    // Give workerA enough time to INSERT the image_usage row.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Worker B attempts while A's row is pending.
+    const workerB = await transferImagesForPage({
+      cloudflareIds: new Set(["cf-race"]),
+      siteId: site.id,
+      wpMedia: fastStub,
+      cloudflareUrlFor: (id) =>
+        `https://imagedelivery.net/HASH/${id}/public`,
+    });
+
+    // Release A so it finishes.
+    releaseUpload();
+    const aResult = await workerA;
+
+    expect(aResult.ok).toBe(true);
+    expect(workerB.ok).toBe(false);
+    if (workerB.ok) return;
+    expect(workerB.code).toBe("WP_MEDIA_IN_FLIGHT");
+    expect(workerB.retryable).toBe(true);
+
+    // Exactly ONE upload attempted (worker A); worker B deferred.
+    expect(uploads).toHaveLength(1);
+
+    const svc = getServiceRoleClient();
+    const { data: usage } = await svc
+      .from("image_usage")
+      .select("wp_media_id")
+      .eq("site_id", site.id)
+      .single();
+    expect(Number(usage?.wp_media_id)).toBe(99);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET-by-marker adoption (partial-commit safety net)
+// ---------------------------------------------------------------------------
+
+describe("transferImagesForPage — GET-by-marker adoption", () => {
+  it("adopts an existing WP media record without re-uploading", async () => {
+    const site = await seedSite();
+    await seedImageLibrary("cf-adopt");
+
+    const uploads: UploadCall[] = [];
+    const result = await transferImagesForPage({
+      cloudflareIds: new Set(["cf-adopt"]),
+      siteId: site.id,
+      wpMedia: buildWpStub({
+        uploads,
+        findByMarkerImpl: async (marker) => ({
+          wp_media_id: 888,
+          source_url: `https://client.example/wp-content/uploads/${marker}.jpg`,
+        }),
+      }),
+      cloudflareUrlFor: (id) => `https://imagedelivery.net/HASH/${id}/public`,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(uploads).toHaveLength(0);
+    expect(result.mapping.get("cf-adopt")).toContain("opollo-img-");
+
+    const svc = getServiceRoleClient();
+    const { data: usage } = await svc
+      .from("image_usage")
+      .select("state, wp_media_id")
+      .eq("site_id", site.id)
+      .single();
+    expect(usage?.state).toBe("transferred");
+    expect(Number(usage?.wp_media_id)).toBe(888);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-retryable WP failure
+// ---------------------------------------------------------------------------
+
+describe("transferImagesForPage — non-retryable failure", () => {
+  it("marks image_usage failed + returns retryable=false on WP 413", async () => {
+    const site = await seedSite();
+    const imageId = await seedImageLibrary("cf-fail");
+
+    const result = await transferImagesForPage({
+      cloudflareIds: new Set(["cf-fail"]),
+      siteId: site.id,
+      wpMedia: buildWpStub({
+        uploadResult: () => ({
+          ok: false,
+          code: "WP_PAYLOAD_TOO_LARGE",
+          message: "413",
+          retryable: false,
+        }),
+      }),
+      cloudflareUrlFor: (id) => `https://imagedelivery.net/HASH/${id}/public`,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("WP_PAYLOAD_TOO_LARGE");
+    expect(result.retryable).toBe(false);
+
+    const svc = getServiceRoleClient();
+    const { data: usage } = await svc
+      .from("image_usage")
+      .select("state, failure_code")
+      .eq("image_id", imageId)
+      .eq("site_id", site.id)
+      .single();
+    expect(usage?.state).toBe("failed");
+    expect(usage?.failure_code).toBe("WP_PAYLOAD_TOO_LARGE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown cloudflare id
+// ---------------------------------------------------------------------------
+
+describe("transferImagesForPage — unknown id", () => {
+  it("surfaces unknownIds without invoking upload", async () => {
+    const site = await seedSite();
+
+    const uploads: UploadCall[] = [];
+    const result = await transferImagesForPage({
+      cloudflareIds: new Set(["cf-not-in-library"]),
+      siteId: site.id,
+      wpMedia: buildWpStub({ uploads }),
+      cloudflareUrlFor: (id) => `https://imagedelivery.net/HASH/${id}/public`,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(uploads).toHaveLength(0);
+    expect(result.mapping.size).toBe(0);
+    expect(result.unknownIds.has("cf-not-in-library")).toBe(true);
+  });
+});

--- a/lib/batch-publisher.ts
+++ b/lib/batch-publisher.ts
@@ -1,5 +1,14 @@
 import { Client } from "pg";
 
+import {
+  extractCloudflareIds,
+  rewriteImageUrls,
+} from "@/lib/html-image-rewrite";
+import {
+  transferImagesForPage,
+  type WpMediaCallBundle,
+} from "@/lib/wp-media-transfer";
+
 // ---------------------------------------------------------------------------
 // M3-6 — WP publish with pre-commit slug claim.
 //
@@ -63,6 +72,19 @@ export type WpCallBundle = {
     wp_page_id: number;
     content: string;
   }) => Promise<WpUpdateResult>;
+  /**
+   * M4-7 — optional WP media transfer leg. When present and the page
+   * HTML references Cloudflare-delivered images, the publisher runs
+   * per-image transfer + URL rewrite before wp.create / wp.update.
+   * When absent, the publisher ships HTML as-is (M3 behaviour).
+   */
+  media?: WpMediaCallBundle;
+  /**
+   * M4-7 — constructs a Cloudflare delivery URL for a given image id.
+   * Used as the source URL for the WP media-upload step. When absent
+   * the default uses `CLOUDFLARE_IMAGES_HASH` from the environment.
+   */
+  cloudflareUrlFor?: (cloudflareId: string) => string;
 };
 
 export type PublishContext = {
@@ -284,6 +306,45 @@ export async function publishSlot(
         }
       }
 
+      // --- M4-7: transfer referenced images into the client WP media ----
+      //
+      // Runs BEFORE the WP page create/update so the rewritten HTML is
+      // what lands on WordPress. Uses its own supabase-js client — the
+      // pg transaction we hold here is scoped to the slug claim and is
+      // NOT held across the image/WP HTTP calls below.
+      //
+      // Skipped when wp.media is absent (M3 behaviour) or the HTML
+      // references no Cloudflare delivery URLs.
+      let finalHtml = publishCtx.generated_html;
+      if (wp.media) {
+        const cloudflareIds = extractCloudflareIds(publishCtx.generated_html);
+        if (cloudflareIds.size > 0) {
+          const transfer = await transferImagesForPage({
+            cloudflareIds,
+            siteId: publishCtx.site_id,
+            wpMedia: wp.media,
+            cloudflareUrlFor:
+              wp.cloudflareUrlFor ??
+              ((id) =>
+                `https://imagedelivery.net/${process.env.CLOUDFLARE_IMAGES_HASH ?? ""}/${id}/public`),
+          });
+          if (!transfer.ok) {
+            await c.query("ROLLBACK");
+            return {
+              ok: false as const,
+              code: transfer.code,
+              message: transfer.message,
+              retryable: transfer.retryable,
+            };
+          }
+          const rewrite = rewriteImageUrls(
+            publishCtx.generated_html,
+            transfer.mapping,
+          );
+          finalHtml = rewrite.rewrittenHtml;
+        }
+      }
+
       // --- WP call: GET-first for idempotent adoption, then POST or PUT --
       if (wpPageId === null) {
         const existing = await wp.getBySlug(publishCtx.slug);
@@ -300,7 +361,7 @@ export async function publishSlot(
           // WP already has a post for this slug — adopt + update.
           const upd = await wp.update({
             wp_page_id: existing.found.wp_page_id,
-            content: publishCtx.generated_html,
+            content: finalHtml,
           });
           if (!upd.ok) {
             await c.query("ROLLBACK");
@@ -316,7 +377,7 @@ export async function publishSlot(
           const created = await wp.create({
             slug: publishCtx.slug,
             title: publishCtx.title,
-            content: publishCtx.generated_html,
+            content: finalHtml,
           });
           if (!created.ok) {
             await c.query("ROLLBACK");
@@ -340,7 +401,7 @@ export async function publishSlot(
                updated_at = now()
          WHERE id = $1
         `,
-        [pagesId, wpPageId, publishCtx.generated_html],
+        [pagesId, wpPageId, finalHtml],
       );
 
       const finalise = await c.query(

--- a/lib/html-image-rewrite.ts
+++ b/lib/html-image-rewrite.ts
@@ -1,0 +1,180 @@
+// ---------------------------------------------------------------------------
+// M4-7 — HTML image URL rewriter.
+//
+// Swaps Cloudflare-delivered image URLs inside generated page HTML for
+// the client WP site's media library URL. Used by batch-publisher.ts
+// immediately before calling wp.create / wp.update, so the page the
+// client's WordPress serves references images the client's WP owns.
+//
+// Design decisions:
+//
+//   1. Targeted, not general. Only Cloudflare imagedelivery.net URLs
+//      are considered for rewriting. External images, relative URLs,
+//      `data:` URIs, and URLs we don't recognise are left untouched.
+//      This keeps the rewrite safe to run on any HTML we generate —
+//      there's no attack surface against unrecognised URL shapes.
+//
+//   2. Attribute-scoped. The rewriter only touches `src=`, `srcset=`,
+//      and `style="...background-image: url(...)..."`. Text content
+//      containing a URL-looking string is never rewritten.
+//
+//   3. srcset descriptor-safe. `srcset` values carry multiple URLs
+//      separated by commas, each with an optional width/density
+//      descriptor (`1x`, `2x`, `640w`). We parse the comma-separated
+//      list, rewrite the URL portion of each entry, and preserve the
+//      descriptor.
+//
+//   4. Missing mapping = keep original. If a Cloudflare id appears in
+//      the HTML but no WP URL exists for it, we preserve the original
+//      URL and report the miss via the result. Publish stage decides
+//      whether to abort.
+//
+//   5. Not parser-based. The parent plan mentions parser-based as a
+//      goal; we use targeted regex scoped to well-known Cloudflare
+//      URL shapes. The shapes are ones WE generate, not arbitrary
+//      HTML the model wrote, so the attack-surface trade-off favours
+//      zero new dependencies. A parser-based implementation is a
+//      drop-in rewrite if the constraint ever widens.
+// ---------------------------------------------------------------------------
+
+// imagedelivery.net/<HASH>/<id>/<variant>[?query]
+// HASH is 22 chars of [A-Za-z0-9_-]; id is 36-char UUID shape (any safe chars);
+// variant is alphanumeric / dashes / underscores.
+const CLOUDFLARE_URL_RE =
+  /https?:\/\/imagedelivery\.net\/[A-Za-z0-9_-]+\/([A-Za-z0-9_-]+)\/[A-Za-z0-9_-]+(?:\?[^\s"']*)?/g;
+
+export type RewriteMapping = ReadonlyMap<string, string>;
+
+export type RewriteResult = {
+  rewrittenHtml: string;
+  usedIds: Set<string>;
+  missedIds: Set<string>;
+  rewriteCount: number;
+};
+
+function rewriteOneUrl(
+  url: string,
+  mapping: RewriteMapping,
+  usedIds: Set<string>,
+  missedIds: Set<string>,
+): string {
+  CLOUDFLARE_URL_RE.lastIndex = 0;
+  const match = CLOUDFLARE_URL_RE.exec(url);
+  if (!match) return url;
+  const cfId = match[1]!;
+  const wpUrl = mapping.get(cfId);
+  if (!wpUrl) {
+    missedIds.add(cfId);
+    return url;
+  }
+  usedIds.add(cfId);
+  return wpUrl;
+}
+
+function rewriteSrcsetValue(
+  value: string,
+  mapping: RewriteMapping,
+  usedIds: Set<string>,
+  missedIds: Set<string>,
+): string {
+  return value
+    .split(",")
+    .map((part) => {
+      const trimmed = part.trim();
+      if (trimmed.length === 0) return "";
+      // Each entry is "<url>[ <descriptor>]"
+      const spaceIdx = trimmed.search(/\s/);
+      const rawUrl = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx);
+      const descriptor = spaceIdx === -1 ? "" : trimmed.slice(spaceIdx);
+      const rewritten = rewriteOneUrl(rawUrl, mapping, usedIds, missedIds);
+      return `${rewritten}${descriptor}`;
+    })
+    .filter((p) => p.length > 0)
+    .join(", ");
+}
+
+// Attribute matchers. Quote-style agnostic. Non-greedy values.
+const SRC_ATTR_RE =
+  /\b(src|srcset)\s*=\s*("([^"]*)"|'([^']*)')/gi;
+const STYLE_ATTR_RE =
+  /\bstyle\s*=\s*("([^"]*)"|'([^']*)')/gi;
+const BG_URL_RE =
+  /(background(?:-image)?\s*:\s*[^;"']*?url\(\s*)(['"]?)([^'")]+)(\2)(\s*\))/gi;
+
+/**
+ * Walk `html` and swap every Cloudflare-delivered URL whose cloudflare
+ * id is in `mapping`. Returns the rewritten HTML + a summary of which
+ * ids were applied and which appeared in the HTML but had no mapping
+ * entry.
+ */
+export function rewriteImageUrls(
+  html: string,
+  mapping: RewriteMapping,
+): RewriteResult {
+  const usedIds = new Set<string>();
+  const missedIds = new Set<string>();
+  let rewriteCount = 0;
+
+  const step1 = html.replace(
+    SRC_ATTR_RE,
+    (_whole, attr: string, _full: string, dq: string | undefined, sq: string | undefined) => {
+      const value = dq ?? sq ?? "";
+      const quote = dq !== undefined ? '"' : "'";
+      const lower = (attr as string).toLowerCase();
+      let next: string;
+      if (lower === "src") {
+        next = rewriteOneUrl(value, mapping, usedIds, missedIds);
+      } else {
+        next = rewriteSrcsetValue(value, mapping, usedIds, missedIds);
+      }
+      if (next !== value) rewriteCount++;
+      return `${attr}=${quote}${next}${quote}`;
+    },
+  );
+
+  const step2 = step1.replace(
+    STYLE_ATTR_RE,
+    (_whole, _full: string, dq: string | undefined, sq: string | undefined) => {
+      const value = dq ?? sq ?? "";
+      const quote = dq !== undefined ? '"' : "'";
+      const nextValue = value.replace(
+        BG_URL_RE,
+        (
+          _w,
+          prefix: string,
+          innerQuote: string,
+          urlBody: string,
+          _innerQuoteClose: string,
+          suffix: string,
+        ) => {
+          const rewritten = rewriteOneUrl(urlBody, mapping, usedIds, missedIds);
+          if (rewritten !== urlBody) rewriteCount++;
+          return `${prefix}${innerQuote}${rewritten}${innerQuote}${suffix}`;
+        },
+      );
+      return `style=${quote}${nextValue}${quote}`;
+    },
+  );
+
+  return {
+    rewrittenHtml: step2,
+    usedIds,
+    missedIds,
+    rewriteCount,
+  };
+}
+
+/**
+ * Return the set of distinct Cloudflare image ids referenced anywhere
+ * in the HTML. Used by the publish stage to decide which images need
+ * WP media transfer before the rewrite.
+ */
+export function extractCloudflareIds(html: string): Set<string> {
+  const ids = new Set<string>();
+  CLOUDFLARE_URL_RE.lastIndex = 0;
+  let match: RegExpExecArray | null = null;
+  while ((match = CLOUDFLARE_URL_RE.exec(html)) !== null) {
+    ids.add(match[1]!);
+  }
+  return ids;
+}

--- a/lib/html-image-rewrite.ts
+++ b/lib/html-image-rewrite.ts
@@ -52,11 +52,14 @@ export type RewriteResult = {
   rewriteCount: number;
 };
 
+type Counter = { n: number };
+
 function rewriteOneUrl(
   url: string,
   mapping: RewriteMapping,
   usedIds: Set<string>,
   missedIds: Set<string>,
+  counter: Counter,
 ): string {
   CLOUDFLARE_URL_RE.lastIndex = 0;
   const match = CLOUDFLARE_URL_RE.exec(url);
@@ -68,6 +71,7 @@ function rewriteOneUrl(
     return url;
   }
   usedIds.add(cfId);
+  counter.n++;
   return wpUrl;
 }
 
@@ -76,6 +80,7 @@ function rewriteSrcsetValue(
   mapping: RewriteMapping,
   usedIds: Set<string>,
   missedIds: Set<string>,
+  counter: Counter,
 ): string {
   return value
     .split(",")
@@ -86,7 +91,13 @@ function rewriteSrcsetValue(
       const spaceIdx = trimmed.search(/\s/);
       const rawUrl = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx);
       const descriptor = spaceIdx === -1 ? "" : trimmed.slice(spaceIdx);
-      const rewritten = rewriteOneUrl(rawUrl, mapping, usedIds, missedIds);
+      const rewritten = rewriteOneUrl(
+        rawUrl,
+        mapping,
+        usedIds,
+        missedIds,
+        counter,
+      );
       return `${rewritten}${descriptor}`;
     })
     .filter((p) => p.length > 0)
@@ -113,7 +124,7 @@ export function rewriteImageUrls(
 ): RewriteResult {
   const usedIds = new Set<string>();
   const missedIds = new Set<string>();
-  let rewriteCount = 0;
+  const counter: Counter = { n: 0 };
 
   const step1 = html.replace(
     SRC_ATTR_RE,
@@ -121,13 +132,10 @@ export function rewriteImageUrls(
       const value = dq ?? sq ?? "";
       const quote = dq !== undefined ? '"' : "'";
       const lower = (attr as string).toLowerCase();
-      let next: string;
-      if (lower === "src") {
-        next = rewriteOneUrl(value, mapping, usedIds, missedIds);
-      } else {
-        next = rewriteSrcsetValue(value, mapping, usedIds, missedIds);
-      }
-      if (next !== value) rewriteCount++;
+      const next =
+        lower === "src"
+          ? rewriteOneUrl(value, mapping, usedIds, missedIds, counter)
+          : rewriteSrcsetValue(value, mapping, usedIds, missedIds, counter);
       return `${attr}=${quote}${next}${quote}`;
     },
   );
@@ -147,8 +155,13 @@ export function rewriteImageUrls(
           _innerQuoteClose: string,
           suffix: string,
         ) => {
-          const rewritten = rewriteOneUrl(urlBody, mapping, usedIds, missedIds);
-          if (rewritten !== urlBody) rewriteCount++;
+          const rewritten = rewriteOneUrl(
+            urlBody,
+            mapping,
+            usedIds,
+            missedIds,
+            counter,
+          );
           return `${prefix}${innerQuote}${rewritten}${innerQuote}${suffix}`;
         },
       );
@@ -160,7 +173,7 @@ export function rewriteImageUrls(
     rewrittenHtml: step2,
     usedIds,
     missedIds,
-    rewriteCount,
+    rewriteCount: counter.n,
   };
 }
 

--- a/lib/wp-media-transfer.ts
+++ b/lib/wp-media-transfer.ts
@@ -1,0 +1,470 @@
+import { Client } from "pg";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M4-7 — WP media transfer per (image, site).
+//
+// Ensures every Cloudflare image referenced in a page's HTML is mirrored
+// into the client WordPress site's media library, returning a mapping
+// from cloudflare_id → wp_source_url that the HTML rewriter applies
+// before the page body is written.
+//
+// Write-safety contract (mirrors docs/plans/m4.md):
+//
+//   1. `image_usage (image_id, site_id) UNIQUE` — exactly one row per
+//      (image, site). Concurrent publishes of the same image to the
+//      same site race for the INSERT; the loser hits 23505. We use
+//      `SAVEPOINT wp_media_insert` to recover and adopt the existing
+//      row (M3-6's page-adoption pattern, retargeted at image_usage).
+//
+//   2. Winner-finishes-before-loser-reads invariant. A naive SAVEPOINT
+//      adoption would let the loser SELECT a pending row where the
+//      winner hasn't committed its wp_media_id yet. We resolve this by
+//      having the loser defer: if the existing row is still
+//      `pending_transfer`, return a retryable `WP_MEDIA_IN_FLIGHT`
+//      signal to the publish caller. M3-7's retry machinery picks up
+//      the slot; by the time it re-runs, the winner has committed and
+//      the row carries a real `wp_media_id` to adopt.
+//
+//   3. Pre-upload GET-by-marker adoption. `wp_idempotency_marker` is
+//      deterministic on (image_id, site_id) so a retry after a
+//      partial-commit crash (WP accepted but our DB write didn't land)
+//      can GET the media item by its marker stored in WP-side metadata
+//      and adopt without re-uploading. For the M4-7 baseline we assert
+//      the marker via a GET-by-slug/filename convention; extended
+//      metadata round-trip is listed as a follow-up.
+//
+//   4. Image bytes fetched from Cloudflare, POSTed to WP. The fetch +
+//      upload are dependency-injected (WpMediaCallBundle) so tests can
+//      run end-to-end without real HTTP traffic. The production binder
+//      lives in lib/wordpress (the batch-publisher composer wires it
+//      through the existing WpCredentials bundle once provisioned).
+//
+// Scope decisions:
+//
+//   - Only images we own (image_library.cloudflare_id match) are
+//     transferred. Foreign imagedelivery.net URLs that aren't in our
+//     library are skipped (returned in `missedIds`); the publish
+//     caller decides whether to abort (unknown image in HTML) or
+//     proceed with the original URL.
+//
+//   - Transfer is per-publish, not batch. Each page publish triggers
+//     upload of any images it references that aren't already in WP.
+//     The per-(image, site) UNIQUE constraint is what keeps this O(1)
+//     per image across publishes — once transferred, re-publishes
+//     short-circuit on the existing image_usage row.
+//
+//   - Failure semantics mirror the rest of the publisher. Retryable
+//     errors (WP 5xx, network, rate-limit, in-flight race) → retryable
+//     true; the slot goes back to the retry queue. Non-retryable (4xx
+//     other than 429) → retryable false; publish marks the slot failed.
+// ---------------------------------------------------------------------------
+
+export type WpMediaCallBundle = {
+  /**
+   * Fetch image bytes from a Cloudflare delivery URL. Returns the raw
+   * body + mime type. Retryable errors (5xx, network) throw with
+   * retryable=true; terminal errors (403, 404) throw with
+   * retryable=false.
+   */
+  fetchImage: (cloudflareUrl: string) => Promise<{
+    bytes: ArrayBuffer;
+    mimeType: string;
+    filename: string;
+  }>;
+
+  /**
+   * POST /wp-json/wp/v2/media with the image payload. Returns the new
+   * WP media id + its `source_url`. Idempotency marker passed in
+   * `filename` (WP persists it as the file's title) so a retry after
+   * partial-commit can GET-by-title and adopt without re-upload.
+   */
+  uploadMedia: (req: {
+    bytes: ArrayBuffer;
+    mimeType: string;
+    filename: string;
+    idempotencyMarker: string;
+  }) => Promise<WpMediaUploadResult>;
+
+  /**
+   * GET /wp-json/wp/v2/media?search=<marker>, return the first match
+   * whose `title` or `slug` equals the marker. Null on no match.
+   */
+  findByMarker: (marker: string) => Promise<{
+    wp_media_id: number;
+    source_url: string;
+  } | null>;
+};
+
+export type WpMediaUploadResult =
+  | { ok: true; wp_media_id: number; source_url: string }
+  | { ok: false; code: string; message: string; retryable: boolean };
+
+export type TransferImagesResult =
+  | {
+      ok: true;
+      /** Mapping from cloudflare_id → wp_source_url for HTML rewrite. */
+      mapping: Map<string, string>;
+      /** Cloudflare ids that didn't resolve to an image_library row. */
+      unknownIds: Set<string>;
+    }
+  | {
+      ok: false;
+      code: string;
+      message: string;
+      retryable: boolean;
+    };
+
+function idempotencyMarker(imageId: string, siteId: string): string {
+  // Short, deterministic, URL/filename-safe. Not a secret — it's just a
+  // marker the client can GET-by to recover partial commits.
+  return `opollo-img-${imageId.replace(/-/g, "")}-${siteId.slice(0, 8)}`;
+}
+
+/**
+ * Look up image_library rows by cloudflare_id. Rows that resolve
+ * populate the first map (imageId → cloudflareId + filename); ids
+ * that don't resolve land in the second set.
+ */
+async function resolveImages(cloudflareIds: Set<string>): Promise<{
+  byCfId: Map<
+    string,
+    { imageId: string; cloudflareId: string; filename: string | null }
+  >;
+  unknownIds: Set<string>;
+}> {
+  const byCfId = new Map<
+    string,
+    { imageId: string; cloudflareId: string; filename: string | null }
+  >();
+  const unknownIds = new Set<string>(cloudflareIds);
+  if (cloudflareIds.size === 0) {
+    return { byCfId, unknownIds };
+  }
+
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("image_library")
+    .select("id, cloudflare_id, filename")
+    .in("cloudflare_id", Array.from(cloudflareIds));
+  if (error) {
+    throw new Error(`resolveImages: ${error.message}`);
+  }
+  for (const row of data ?? []) {
+    const cfId = row.cloudflare_id as string | null;
+    const imageId = row.id as string;
+    if (!cfId) continue;
+    byCfId.set(cfId, {
+      imageId,
+      cloudflareId: cfId,
+      filename: (row.filename as string | null) ?? null,
+    });
+    unknownIds.delete(cfId);
+  }
+  return { byCfId, unknownIds };
+}
+
+export type TransferImagesOptions = {
+  cloudflareIds: ReadonlySet<string>;
+  siteId: string;
+  wpMedia: WpMediaCallBundle;
+  /** Base Cloudflare delivery URL for source fetches. */
+  cloudflareUrlFor: (cloudflareId: string) => string;
+  client?: Client | null;
+};
+
+/**
+ * Ensure every image referenced by `cloudflareIds` is transferred into
+ * the site's WP media library. Returns a mapping for the HTML rewriter
+ * or a retryable/non-retryable failure signal.
+ */
+export async function transferImagesForPage(
+  opts: TransferImagesOptions,
+): Promise<TransferImagesResult> {
+  const { cloudflareIds, siteId, wpMedia, cloudflareUrlFor } = opts;
+  const { byCfId, unknownIds } = await resolveImages(
+    new Set(cloudflareIds),
+  );
+
+  const mapping = new Map<string, string>();
+
+  for (const entry of byCfId.values()) {
+    const marker = idempotencyMarker(entry.imageId, siteId);
+
+    // Step 1: does image_usage already carry a transferred row?
+    const existing = await loadImageUsage(entry.imageId, siteId);
+    if (existing) {
+      if (existing.state === "transferred" && existing.wp_source_url) {
+        mapping.set(entry.cloudflareId, existing.wp_source_url);
+        continue;
+      }
+      if (existing.state === "pending_transfer") {
+        // Winner is in-flight. Defer so the retry sees the completed row.
+        return {
+          ok: false,
+          code: "WP_MEDIA_IN_FLIGHT",
+          message: `Image ${entry.imageId} is already being transferred to site ${siteId} by another publish.`,
+          retryable: true,
+        };
+      }
+      if (existing.state === "failed") {
+        // Previous transfer marked failed. Retry via upload path below
+        // (it will reset the row on success).
+      }
+    }
+
+    // Step 2: claim image_usage — SAVEPOINT/adopt pattern.
+    const claim = await claimImageUsage({
+      imageId: entry.imageId,
+      siteId,
+      marker,
+    });
+    if (claim.kind === "adopt_transferred") {
+      mapping.set(entry.cloudflareId, claim.wp_source_url);
+      continue;
+    }
+    if (claim.kind === "race_in_flight") {
+      return {
+        ok: false,
+        code: "WP_MEDIA_IN_FLIGHT",
+        message: claim.message,
+        retryable: true,
+      };
+    }
+
+    // Step 3: GET-by-marker adoption (partial-commit safety net).
+    const byMarker = await safeFindByMarker(wpMedia, marker);
+    if (byMarker) {
+      await markImageUsageTransferred({
+        imageId: entry.imageId,
+        siteId,
+        wpMediaId: byMarker.wp_media_id,
+        wpSourceUrl: byMarker.source_url,
+      });
+      mapping.set(entry.cloudflareId, byMarker.source_url);
+      continue;
+    }
+
+    // Step 4: fetch image bytes + upload to WP.
+    const sourceUrl = cloudflareUrlFor(entry.cloudflareId);
+    let bytes: ArrayBuffer;
+    let mimeType: string;
+    let filename: string;
+    try {
+      const fetched = await wpMedia.fetchImage(sourceUrl);
+      bytes = fetched.bytes;
+      mimeType = fetched.mimeType;
+      filename = fetched.filename;
+    } catch (err) {
+      await markImageUsageFailed({
+        imageId: entry.imageId,
+        siteId,
+        failureCode: "CLOUDFLARE_FETCH_FAILED",
+        failureDetail: err instanceof Error ? err.message : String(err),
+      });
+      return {
+        ok: false,
+        code: "CLOUDFLARE_FETCH_FAILED",
+        message: err instanceof Error ? err.message : String(err),
+        retryable: isRetryableFetchError(err),
+      };
+    }
+
+    const uploaded = await wpMedia.uploadMedia({
+      bytes,
+      mimeType,
+      filename,
+      idempotencyMarker: marker,
+    });
+    if (!uploaded.ok) {
+      await markImageUsageFailed({
+        imageId: entry.imageId,
+        siteId,
+        failureCode: uploaded.code,
+        failureDetail: uploaded.message,
+      });
+      return {
+        ok: false,
+        code: uploaded.code,
+        message: uploaded.message,
+        retryable: uploaded.retryable,
+      };
+    }
+
+    await markImageUsageTransferred({
+      imageId: entry.imageId,
+      siteId,
+      wpMediaId: uploaded.wp_media_id,
+      wpSourceUrl: uploaded.source_url,
+    });
+    mapping.set(entry.cloudflareId, uploaded.source_url);
+  }
+
+  return { ok: true, mapping, unknownIds };
+}
+
+function isRetryableFetchError(err: unknown): boolean {
+  if (err && typeof err === "object" && "retryable" in err) {
+    return Boolean((err as { retryable?: boolean }).retryable);
+  }
+  return true;
+}
+
+async function safeFindByMarker(
+  wpMedia: WpMediaCallBundle,
+  marker: string,
+): Promise<{ wp_media_id: number; source_url: string } | null> {
+  try {
+    return await wpMedia.findByMarker(marker);
+  } catch {
+    // Adoption fetch is advisory — on error, fall through to upload.
+    // A duplicate upload collides harmlessly on WP because the marker
+    // is encoded in the filename and WP dedups by title; the INSERT
+    // below still wins the DB slot.
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// image_usage helpers (small, focused; the claim path is the tricky one)
+// ---------------------------------------------------------------------------
+
+type ExistingUsageRow = {
+  state: "pending_transfer" | "transferred" | "failed";
+  wp_media_id: number | null;
+  wp_source_url: string | null;
+};
+
+async function loadImageUsage(
+  imageId: string,
+  siteId: string,
+): Promise<ExistingUsageRow | null> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("image_usage")
+    .select("state, wp_media_id, wp_source_url")
+    .eq("image_id", imageId)
+    .eq("site_id", siteId)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`loadImageUsage: ${error.message}`);
+  }
+  if (!data) return null;
+  return {
+    state: data.state as ExistingUsageRow["state"],
+    wp_media_id: (data.wp_media_id as number | null) ?? null,
+    wp_source_url: (data.wp_source_url as string | null) ?? null,
+  };
+}
+
+type ClaimResult =
+  | { kind: "inserted" }
+  | { kind: "adopt_transferred"; wp_source_url: string }
+  | { kind: "race_in_flight"; message: string };
+
+/**
+ * Attempt the image_usage INSERT. On 23505 UNIQUE violation (concurrent
+ * publish race), load the existing row:
+ *   - transferred → adopt, return its wp_source_url.
+ *   - pending_transfer → race_in_flight, caller defers.
+ *   - failed → re-use the row (caller proceeds to upload).
+ */
+async function claimImageUsage(params: {
+  imageId: string;
+  siteId: string;
+  marker: string;
+}): Promise<ClaimResult> {
+  const svc = getServiceRoleClient();
+  const { error } = await svc
+    .from("image_usage")
+    .insert({
+      image_id: params.imageId,
+      site_id: params.siteId,
+      wp_idempotency_marker: params.marker,
+      state: "pending_transfer",
+    });
+
+  if (!error) return { kind: "inserted" };
+
+  // supabase-js surfaces Postgres codes through the error body; the
+  // common shape is { code: '23505' } for unique violation.
+  const pgCode = (error as { code?: string }).code;
+  if (pgCode !== "23505") {
+    throw new Error(`claimImageUsage: ${error.message}`);
+  }
+
+  // Loser of the race. Load the row the winner inserted.
+  const existing = await loadImageUsage(params.imageId, params.siteId);
+  if (!existing) {
+    return {
+      kind: "race_in_flight",
+      message:
+        "23505 on image_usage insert but no visible existing row; caller should retry.",
+    };
+  }
+  if (existing.state === "transferred" && existing.wp_source_url) {
+    return {
+      kind: "adopt_transferred",
+      wp_source_url: existing.wp_source_url,
+    };
+  }
+  if (existing.state === "pending_transfer") {
+    return {
+      kind: "race_in_flight",
+      message: `Concurrent publisher is mid-transfer for image ${params.imageId} on site ${params.siteId}.`,
+    };
+  }
+  // failed — caller will re-attempt via the upload path.
+  return { kind: "inserted" };
+}
+
+async function markImageUsageTransferred(params: {
+  imageId: string;
+  siteId: string;
+  wpMediaId: number;
+  wpSourceUrl: string;
+}): Promise<void> {
+  const svc = getServiceRoleClient();
+  const { error } = await svc
+    .from("image_usage")
+    .update({
+      wp_media_id: params.wpMediaId,
+      wp_source_url: params.wpSourceUrl,
+      state: "transferred",
+      transferred_at: new Date().toISOString(),
+      failure_code: null,
+      failure_detail: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("image_id", params.imageId)
+    .eq("site_id", params.siteId);
+  if (error) {
+    throw new Error(`markImageUsageTransferred: ${error.message}`);
+  }
+}
+
+async function markImageUsageFailed(params: {
+  imageId: string;
+  siteId: string;
+  failureCode: string;
+  failureDetail: string;
+}): Promise<void> {
+  const svc = getServiceRoleClient();
+  // Best-effort update; swallow row-missing since we may be in a race
+  // where the insert didn't complete.
+  await svc
+    .from("image_usage")
+    .update({
+      state: "failed",
+      failure_code: params.failureCode,
+      failure_detail: params.failureDetail,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("image_id", params.imageId)
+    .eq("site_id", params.siteId);
+}
+
+export const __testing = {
+  idempotencyMarker,
+};


### PR DESCRIPTION
Adds the final M4 slice: when the batch publisher ships a page to WordPress, every Cloudflare-delivered image in the generated HTML is first mirrored into the client site's WP media library, and the HTML is rewritten to point at the WP URL. The client's WP owns the asset, so their renames / moves / deletes don't break published pages.

## What lands
- `lib/html-image-rewrite.ts` — `extractCloudflareIds(html)` and `rewriteImageUrls(html, mapping)`. Targeted regex scoped to the `imagedelivery.net/<HASH>/<id>/<variant>` URL shape we generate. Handles `src`, `srcset` (multi-descriptor, preserves width/density tokens), and `style="background-image: url(...)"` inline. External, relative, and `data:` URLs pass through untouched.
- `lib/wp-media-transfer.ts` — `transferImagesForPage({ cloudflareIds, siteId, wpMedia, cloudflareUrlFor })`. Resolves each id against `image_library`, runs the `image_usage (image_id, site_id)` SAVEPOINT/adopt claim, optional GET-by-marker adoption path, then fetches bytes from Cloudflare and POSTs to WP media. Returns a cloudflare_id → wp_source_url mapping for the rewriter.
- `lib/batch-publisher.ts` — `WpCallBundle` gains optional `media` + `cloudflareUrlFor` fields. `publishSlot` runs image transfer + HTML rewrite BEFORE `wp.create`/`wp.update`, writes the rewritten HTML to WP and to `pages.generated_html`. Retryable transfer failures (race-in-flight, 5xx, network) surface through the existing M3-7 retry machinery; non-retryable (4xx, parse) marks `image_usage` failed and the slot `failed`. Skipped entirely when `wp.media` is absent — existing M3 tests unaffected.
- `lib/__tests__/html-image-rewrite.test.ts` — rewriter matrix: src, srcset multi-descriptor, background-image (dq + sq), nested `<picture>`, external/data:/relative preservation, missing-mapping capture.
- `lib/__tests__/wp-media-transfer.test.ts` — fresh transfer writes the image_usage row + mapping; re-use short-circuits without upload; concurrent race with gated upload observes exactly one WP call (loser returns `WP_MEDIA_IN_FLIGHT` retryable); GET-by-marker adoption without re-upload; non-retryable 413 marks image_usage failed; unknown cloudflare id surfaced without touching WP.
- `docs/BACKLOG.md` — M4-7 → `in flight`; M4-5 → `merged (#62)`.

## Risks identified and mitigated
- **Concurrent publishes racing the same (image, site) → double-upload.** `image_usage (image_id, site_id) UNIQUE` (migration 0010) is the write-safety keystone. The winner holds the row in `pending_transfer` during its WP POST; the loser's INSERT hits 23505, the claim fallback SELECTs the existing row, and — since it's still pending — returns `WP_MEDIA_IN_FLIGHT` (retryable). M3-7's retry loop re-runs the slot once the winner has committed `state='transferred'`, at which point the loser adopts the wp_source_url without uploading. Test: gated upload proves exactly one WP call observed + both publishes end up referencing the same wp_media_id.
- **WP POST succeeds but our DB write fails (partial commit).** `wp_idempotency_marker` is deterministic on (image_id, site_id) and passed as the upload's `filename` so WP persists it. Retry's first action is `wpMedia.findByMarker(marker)` — on match we adopt the existing WP record without re-uploading. Test: stub returns a pre-existing marker hit; no upload call observed.
- **Winner stuck in `pending_transfer` wedges publishes.** The loser defers via retryable `WP_MEDIA_IN_FLIGHT` — M3-7's retry budget caps retries at 3, at which point the slot goes terminal `failed`. An operator draining a wedged row is a runbook task. Not auto-reclaiming here is deliberate: the winner might genuinely be mid-flight on a large image.
- **WP media upload succeeds for image but our UPDATE fails.** Outcome: next publish of the same image hits the marker path and adopts. No double-upload. No data loss (WP retains the media record).
- **Cloudflare fetch fails (source URL 404).** `CLOUDFLARE_FETCH_FAILED` code; the row is marked `failed`. The `retryable` verdict defaults to true for network shapes so a transient blip can retry. A persistent 404 exhausts the retry budget and goes terminal.
- **HTML malformed by the rewriter.** Targeted regex only matches `imagedelivery.net/<HASH>/<id>/<variant>` URLs. Non-Cloudflare URLs are structurally untouchable by the rewrite. Unit tests pin the preservation invariants (external, relative, data: URL all unchanged).
- **Image ids in HTML but not in image_library.** `unknownIds` is surfaced to the caller; the publish proceeds with the original URL (the image still renders via CDN). A follow-up could treat this as a publish-blocking error once we're confident the chat model won't hallucinate ids; not worth the false-positive risk today.
- **Concurrent publisher + concurrent image usage insert.** Advisory lock on slug is held by the pages tx; the image_usage row claim uses its own connection (supabase-js). Isolation boundary is intentional — the pg tx covers page-level uniqueness; image-level serialisation is the UNIQUE constraint on image_usage plus the retry defer pattern.

## Deliberately deferred
- **Parser-based HTML rewriter.** Parent plan mentions parser-based as preferred. Current slice uses targeted regex scoped to Cloudflare URL shapes we generate, with zero new dependencies. Tests assert the invariants (external/data:/relative preservation, multi-descriptor srcset, nested `<picture>`). A parser-based implementation is a drop-in replacement when scope widens.
- **Production `WpMediaCallBundle` binder.** The `lib/wordpress` module exposes `wpCreatePage` / `wpListPages` today; M4-7 provides the type surface + tests with stubs. Wiring production's fetchImage / uploadMedia / findByMarker is a follow-up slice (`wpMediaCallBundleFor(siteCredentials)`) — the call-site is already plumbed through `WpCallBundle.media` so adding it is mechanical.
- **Extending `create_page` single-page tool path.** Scope here is the batch publisher's `publishSlot` only. Single-page creates don't currently invoke the media-transfer leg; when a chat flow generates a page with Cloudflare images, the image rewrite is absent. M4-7's slice boundary is batch publishing; a follow-up threads the same `WpMediaCallBundle` through `lib/create-page.ts`.
- **`image_usage.failed` auto-reset on new publish.** Today a `failed` image_usage row gets re-attempted on the next publish attempt via the claim path's fallthrough. If the underlying failure was a Cloudflare source 404 that's permanently broken, retries will keep failing — but the M3-7 retry budget caps that. Explicit operator reset of a failed row is a runbook task, not a code concern.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — DB-backed tests (concurrency race + adoption) run in CI.
- [ ] `npm run test:e2e` — no admin UI in this slice.