### PR TITLE
feat(m5-1): /admin/images list page + image-library data layer

### DIFF
--- a/app/admin/images/page.tsx
+++ b/app/admin/images/page.tsx
@@ -1,0 +1,274 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { ImagesTable } from "@/components/ImagesTable";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import {
+  LIST_IMAGES_DEFAULT_LIMIT,
+  LIST_IMAGES_MAX_LIMIT,
+  listImages,
+  type ImageLibrarySource,
+} from "@/lib/image-library";
+
+// ---------------------------------------------------------------------------
+// /admin/images — M5-1.
+//
+// Server-rendered list of the image library. Admin + operator visible
+// (matches the RLS posture used by other admin surfaces; the images
+// themselves are tenant-wide). Filter + search state rides on URL
+// query params so a back-nav from the future detail page (M5-2)
+// preserves it without extra plumbing.
+//
+// Query params:
+//   q         free-text search (applied to image_library.search_tsv)
+//   tag       repeated for AND semantics (tags @> $all)
+//   source    one of istock | upload | generated
+//   deleted   "1" flips the view to soft-deleted rows
+//   page      1-indexed page number
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+const SOURCE_VALUES: readonly ImageLibrarySource[] = [
+  "istock",
+  "upload",
+  "generated",
+];
+
+type RawSearchParams = {
+  [key: string]: string | string[] | undefined;
+};
+
+type ParsedParams = {
+  query: string | null;
+  tags: string[];
+  source: ImageLibrarySource | null;
+  deleted: boolean;
+  page: number;
+};
+
+function parseSearchParams(raw: RawSearchParams): ParsedParams {
+  const q =
+    typeof raw.q === "string" && raw.q.trim().length > 0 ? raw.q.trim() : null;
+
+  // `tag` can arrive as either a repeated URL param (?tag=a&tag=b, the
+  // shape buildHref emits) or a single comma-separated string from the
+  // form text input ("indoor, cat"). Normalise both to a trimmed, deduped
+  // string array.
+  const tagRaw = raw.tag;
+  const tagStrings = Array.isArray(tagRaw)
+    ? tagRaw.filter((t): t is string => typeof t === "string")
+    : typeof tagRaw === "string"
+      ? [tagRaw]
+      : [];
+  const tagSet = new Set<string>();
+  for (const raw of tagStrings) {
+    for (const piece of raw.split(",")) {
+      const trimmed = piece.trim().toLowerCase();
+      if (trimmed.length > 0) tagSet.add(trimmed);
+    }
+  }
+  const tags = Array.from(tagSet);
+
+  const sourceRaw = typeof raw.source === "string" ? raw.source : null;
+  const source = (SOURCE_VALUES as readonly string[]).includes(sourceRaw ?? "")
+    ? (sourceRaw as ImageLibrarySource)
+    : null;
+
+  const deleted = raw.deleted === "1";
+
+  const pageRaw = typeof raw.page === "string" ? Number(raw.page) : 1;
+  const page =
+    Number.isFinite(pageRaw) && pageRaw >= 1 ? Math.floor(pageRaw) : 1;
+
+  return { query: q, tags, source, deleted, page };
+}
+
+function buildHref(
+  base: ParsedParams,
+  overrides: Partial<ParsedParams>,
+): string {
+  const merged = { ...base, ...overrides };
+  const params = new URLSearchParams();
+  if (merged.query) params.set("q", merged.query);
+  for (const tag of merged.tags) params.append("tag", tag);
+  if (merged.source) params.set("source", merged.source);
+  if (merged.deleted) params.set("deleted", "1");
+  if (merged.page > 1) params.set("page", String(merged.page));
+  const qs = params.toString();
+  return qs.length > 0 ? `/admin/images?${qs}` : "/admin/images";
+}
+
+export default async function AdminImagesPage({
+  searchParams,
+}: {
+  searchParams: RawSearchParams;
+}) {
+  const access = await checkAdminAccess({
+    requiredRoles: ["admin", "operator"],
+    insufficientRoleRedirectTo: "/admin/sites",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  const parsed = parseSearchParams(searchParams);
+  const limit = LIST_IMAGES_DEFAULT_LIMIT;
+  const offset = (parsed.page - 1) * limit;
+
+  const result = await listImages({
+    query: parsed.query ?? undefined,
+    tags: parsed.tags.length > 0 ? parsed.tags : undefined,
+    source: parsed.source ?? undefined,
+    deleted: parsed.deleted,
+    limit,
+    offset: offset > LIST_IMAGES_MAX_LIMIT * 1000 ? 0 : offset,
+  });
+
+  if (!result.ok) {
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+      >
+        Failed to load images: {result.error.message}
+      </div>
+    );
+  }
+
+  const { items, total } = result.data;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const currentPage = Math.min(parsed.page, totalPages);
+  const rangeStart = total === 0 ? 0 : offset + 1;
+  const rangeEnd = Math.min(offset + limit, total);
+
+  return (
+    <>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold">Image library</h1>
+          <p className="text-sm text-muted-foreground">
+            {parsed.deleted
+              ? "Archived images (soft-deleted). Restore from the detail view."
+              : "Images available to the chat builder. Filter by caption, tags, or source."}
+          </p>
+        </div>
+        <Link
+          href={buildHref(parsed, { deleted: !parsed.deleted, page: 1 })}
+          className="text-xs text-muted-foreground hover:text-foreground"
+        >
+          {parsed.deleted ? "← Active images" : "View archived →"}
+        </Link>
+      </div>
+
+      <form
+        method="GET"
+        action="/admin/images"
+        className="mt-6 flex flex-wrap items-end gap-3 rounded-md border bg-muted/30 p-3"
+      >
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="images-q"
+            className="text-xs font-medium text-muted-foreground"
+          >
+            Search
+          </label>
+          <input
+            id="images-q"
+            type="search"
+            name="q"
+            defaultValue={parsed.query ?? ""}
+            placeholder="cat in a windowsill"
+            className="h-8 min-w-56 rounded border bg-background px-2 text-sm"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="images-tag"
+            className="text-xs font-medium text-muted-foreground"
+          >
+            Tags (comma-separated, all must match)
+          </label>
+          <input
+            id="images-tag"
+            type="text"
+            name="tag"
+            defaultValue={parsed.tags.join(", ")}
+            placeholder="indoor, cat"
+            className="h-8 min-w-48 rounded border bg-background px-2 text-sm"
+            data-testid="images-tag-input"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="images-source"
+            className="text-xs font-medium text-muted-foreground"
+          >
+            Source
+          </label>
+          <select
+            id="images-source"
+            name="source"
+            defaultValue={parsed.source ?? ""}
+            className="h-8 rounded border bg-background px-2 text-sm"
+          >
+            <option value="">Any</option>
+            <option value="istock">iStock</option>
+            <option value="upload">Upload</option>
+            <option value="generated">Generated</option>
+          </select>
+        </div>
+        {parsed.deleted && (
+          <input type="hidden" name="deleted" value="1" />
+        )}
+        <button
+          type="submit"
+          className="h-8 rounded bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Apply
+        </button>
+        {(parsed.query || parsed.tags.length > 0 || parsed.source) && (
+          <Link
+            href={buildHref(
+              { ...parsed, query: null, tags: [], source: null },
+              { page: 1 },
+            )}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            Clear
+          </Link>
+        )}
+      </form>
+
+      <div className="mt-4 flex items-center justify-between text-xs text-muted-foreground">
+        <div data-testid="images-range">
+          {total === 0
+            ? "0 images"
+            : `Showing ${rangeStart}–${rangeEnd} of ${total}`}
+        </div>
+        <div className="flex items-center gap-2">
+          {currentPage > 1 && (
+            <Link
+              href={buildHref(parsed, { page: currentPage - 1 })}
+              className="rounded border px-2 py-1 hover:bg-muted"
+              rel="prev"
+            >
+              ← Previous
+            </Link>
+          )}
+          {currentPage < totalPages && (
+            <Link
+              href={buildHref(parsed, { page: currentPage + 1 })}
+              className="rounded border px-2 py-1 hover:bg-muted"
+              rel="next"
+            >
+              Next →
+            </Link>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-3">
+        <ImagesTable items={items} />
+      </div>
+    </>
+  );
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -49,6 +49,12 @@ export default async function AdminLayout({
             >
               Batches
             </Link>
+            <Link
+              href="/admin/images"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              Images
+            </Link>
             {showUsersLink && (
               <Link
                 href="/admin/users"

--- a/components/ImagesTable.tsx
+++ b/components/ImagesTable.tsx
@@ -1,0 +1,155 @@
+import { deliveryUrl } from "@/lib/cloudflare-images";
+import type { ImageListItem } from "@/lib/image-library";
+import { formatRelativeTime } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// M5-1 — images table (pure presentation).
+//
+// Thumbnails via deliveryUrl(cloudflare_id, 'public'). When the row
+// lacks a cloudflare_id (pre-upload window during an ingest run) or
+// when CLOUDFLARE_IMAGES_HASH is unset (dev environment without
+// Cloudflare access), a placeholder tile renders instead.
+//
+// "Source" exposes the enum value directly — operators who reach the
+// admin images surface understand the distinction between iStock-seed,
+// manually-uploaded, and AI-generated rows. The raw `source_ref` stays
+// off the list; it surfaces on the detail page (M5-2).
+// ---------------------------------------------------------------------------
+
+function formatDimensions(
+  width: number | null,
+  height: number | null,
+): string {
+  if (!width || !height) return "—";
+  return `${width}×${height}`;
+}
+
+function sourceBadgeClass(source: string): string {
+  switch (source) {
+    case "istock":
+      return "bg-sky-100 text-sky-900";
+    case "upload":
+      return "bg-amber-100 text-amber-900";
+    case "generated":
+      return "bg-purple-100 text-purple-900";
+    default:
+      return "bg-muted text-muted-foreground";
+  }
+}
+
+function Thumbnail({ item }: { item: ImageListItem }) {
+  const url = item.cloudflare_id ? deliveryUrl(item.cloudflare_id) : null;
+  const alt = item.alt_text ?? item.filename ?? "Library image";
+  if (!url) {
+    return (
+      <div
+        aria-hidden="true"
+        className="flex h-12 w-12 items-center justify-center rounded bg-muted text-xs text-muted-foreground"
+      >
+        —
+      </div>
+    );
+  }
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={url}
+      alt={alt}
+      width={48}
+      height={48}
+      loading="lazy"
+      className="h-12 w-12 rounded object-cover"
+    />
+  );
+}
+
+export function ImagesTable({ items }: { items: ImageListItem[] }) {
+  if (items.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No images match these filters.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <table className="w-full text-sm">
+        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+          <tr>
+            <th className="w-16 px-4 py-2 font-medium">Preview</th>
+            <th className="px-4 py-2 font-medium">Caption</th>
+            <th className="px-4 py-2 font-medium">Tags</th>
+            <th className="px-4 py-2 font-medium">Source</th>
+            <th className="px-4 py-2 font-medium">Dimensions</th>
+            <th className="px-4 py-2 font-medium">Imported</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr
+              key={item.id}
+              className="border-b last:border-b-0 hover:bg-muted/40"
+              data-testid="image-row"
+              data-image-id={item.id}
+            >
+              <td className="px-4 py-3">
+                <Thumbnail item={item} />
+              </td>
+              <td className="px-4 py-3 align-top">
+                <div className="line-clamp-2 max-w-md text-sm">
+                  {item.caption ?? (
+                    <span className="text-muted-foreground">
+                      (no caption yet)
+                    </span>
+                  )}
+                </div>
+                {item.filename && (
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {item.filename}
+                  </div>
+                )}
+              </td>
+              <td className="px-4 py-3 align-top">
+                <div className="flex flex-wrap gap-1">
+                  {item.tags.length === 0 ? (
+                    <span className="text-xs text-muted-foreground">—</span>
+                  ) : (
+                    item.tags.slice(0, 6).map((tag) => (
+                      <span
+                        key={tag}
+                        className="rounded bg-muted px-2 py-0.5 text-xs"
+                      >
+                        {tag}
+                      </span>
+                    ))
+                  )}
+                  {item.tags.length > 6 && (
+                    <span className="text-xs text-muted-foreground">
+                      +{item.tags.length - 6}
+                    </span>
+                  )}
+                </div>
+              </td>
+              <td className="px-4 py-3 align-top">
+                <span
+                  className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${sourceBadgeClass(item.source)}`}
+                >
+                  {item.source}
+                </span>
+              </td>
+              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+                {formatDimensions(item.width_px, item.height_px)}
+              </td>
+              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+                {formatRelativeTime(item.created_at)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,9 +6,24 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
-## M4 — image library (in flight)
+## M5 — image library admin UI (in flight)
 
-Parent plan: `docs/plans/m4.md`. Sub-slice status tracker:
+Parent plan: `docs/plans/m5-parent.md`. Sub-slice status tracker:
+
+| Slice | Status | Notes |
+| --- | --- | --- |
+| M5-1 | in flight | `/admin/images` list page + `lib/image-library.ts` data layer + nav link. |
+| M5-2 | planned | `/admin/images/[id]` detail page with `image_usage` + `image_metadata` panes. |
+| M5-3 | planned | Metadata edit modal + `PATCH /api/admin/images/[id]` with `version_lock`. |
+| M5-4 | planned | Soft-delete + restore with `IMAGE_IN_USE` guard. |
+
+No new env vars — every Cloudflare secret needed for thumbnails is already provisioned from M4.
+
+---
+
+## M4 — image library (shipped)
+
+Parent plan: `docs/plans/m4.md`. All seven sub-slices merged.
 
 | Slice | Status | Notes |
 | --- | --- | --- |
@@ -18,7 +33,7 @@ Parent plan: `docs/plans/m4.md`. Sub-slice status tracker:
 | M4-4 | merged (#59) | Anthropic vision captioning (reuses `ANTHROPIC_API_KEY`). |
 | M4-5 | merged (#62) | iStock seed script: CSV ingest + dry-run + budget cap. |
 | M4-6 | merged (#60) | `search_images` chat tool. |
-| M4-7 | in flight | WP media transfer + HTML URL rewrite on publish. |
+| M4-7 | merged (#63) | WP media transfer + HTML URL rewrite on publish. |
 
 Env vars: `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_IMAGES_API_TOKEN`, `CLOUDFLARE_IMAGES_HASH` all provisioned in Vercel Production + Preview as of 2026-04-21.
 

--- a/docs/plans/m5-parent.md
+++ b/docs/plans/m5-parent.md
@@ -1,0 +1,148 @@
+# M5 — Image Library Admin UI
+
+## What it is
+
+An operator-facing admin surface over the image library that M4 populated. Browse, filter, inspect, edit metadata on, and soft-delete rows in `image_library`, plus a per-image detail view that surfaces which sites the image has been transferred to (via `image_usage`). Read-mostly; the only mutations are metadata edits and soft-delete.
+
+M4 shipped the storage layer (Cloudflare), the index (Postgres), the seed (9k iStock rows), the chat-facing `search_images` tool, and the transactional WP transfer. The operator has no UI for any of it — captions are only visible via `search_images` output, and there's no way to fix a bad caption short of a direct SQL write. M5 closes that gap.
+
+## Why a separate milestone
+
+The M4 plan explicitly deferred "Admin UI for browsing the image library" to M5/M6. `lib/search-images.ts` carries a comment calling forward to this milestone ("An unfiltered library dump is not a chat tool — for admin browsing use the future M5/M6 list view"). The shape is a classic new-admin-page + edit-modal + detail surface — best matched to the `new-admin-page.md` pattern and distinct enough from M4's worker/write-safety concerns to ship as its own milestone.
+
+M5 is **not** write-safety-critical in the M3/M4/M7 sense: no billed external calls, no concurrent multi-row state transitions, no client WP site mutation. The safety layer here is schema-level optimistic locking (`image_library.version_lock`) + the existing `image_usage (image_id, site_id) UNIQUE` + the `ON DELETE NO ACTION` FK that already guards against orphaning. Per-slice plans still populate the **"Risks identified and mitigated"** section (CLAUDE.md says populated, not empty), but the risks are smaller in surface.
+
+## Scope (shipped in M5)
+
+- New admin routes: `/admin/images` (list) + `/admin/images/[id]` (detail).
+- Thumbnails via Cloudflare Images `public` variant (account-level configured).
+- Server-rendered list with paging + text search + tag filter + source filter + deleted/active toggle.
+- Per-image detail: full metadata, variant preview (multiple sizes), `image_usage` list across sites, `image_metadata` k/v rows.
+- Metadata edit modal: caption / alt_text / tags. Optimistic-locked on `version_lock`, audit columns (`updated_by`, `updated_at`) populated.
+- Soft-delete + restore. Soft-delete blocked with `IMAGE_IN_USE` when `image_usage` rows exist.
+- Search-images tool re-uses same data layer; no behaviour change to the chat-facing tool.
+- E2E spec covering the list, detail, edit, soft-delete paths + axe audit.
+
+## Out of scope (tracked in BACKLOG.md)
+
+- Per-site media library viewer (the per-site slice of `image_usage` grouped by site). Sub-surface of `/admin/sites/[id]` — deferred unless an operator asks for it.
+- Single-image upload flow (outside the iStock seed path). Deferred; M4 plan already listed this.
+- Re-captioning (re-run Anthropic vision on a row). Deferred; operator writes the override manually in the metadata edit modal today.
+- Hard-delete of images. Deferred — soft-delete is sufficient; hard-delete would need a cascade plan + Cloudflare cleanup + `image_usage` reconciliation.
+- Crop / focal point / Cloudflare transformations UI. Deferred; Cloudflare's named variants are the stopgap.
+- Image analytics ("used on N pages across M sites, last referenced on date X"). Deferred to an M6/M7 slice that wants the signal.
+- Bulk-edit (tag a set of images at once). Deferred until an operator needs it; one-at-a-time is fine for the 9k seed.
+
+## Env vars required
+
+| Var | Needed by | Status |
+| --- | --- | --- |
+| `CLOUDFLARE_IMAGES_HASH` | M5-1..3 (thumbnail URLs) | Present (provisioned 2026-04-21 per M4) |
+| `SUPABASE_*` | all slices | Present |
+
+No new env vars. Every Cloudflare var M5 touches is already provisioned from M4.
+
+## Sub-slice breakdown (4 PRs)
+
+| Slice | Scope | Write-safety rating | Blocks on |
+| --- | --- | --- | --- |
+| **M5-1** | `/admin/images` list page: server component, paginated table, thumbnails, source filter, deleted/active toggle, tag + caption text search (piggybacks on `search_tsv`). `lib/image-library.ts` data layer (`listImages`, `getImage`). | Low — read-only. | Nothing |
+| **M5-2** | `/admin/images/[id]` detail page: full metadata, multi-variant preview, `image_usage` per-site list (joined with `sites`), `image_metadata` k/v pane, back-link to list preserving filter state via query params. | Low — read-only. | M5-1 |
+| **M5-3** | Metadata edit modal: caption / alt_text / tags. `PATCH /api/admin/images/[id]` with Zod + version_lock optimistic locking + `updated_by` population. Re-indexes `search_tsv` automatically via existing trigger. | Medium — concurrent edits + `search_tsv` invariant. | M5-1 + M5-2 |
+| **M5-4** | Soft-delete + restore action. `DELETE /api/admin/images/[id]` (soft) + `POST /api/admin/images/[id]/restore`. Blocked when in-use; surfaces `IMAGE_IN_USE` with the count of referencing sites. List + detail pages gain the action. | Medium — guard against orphaning in-use images. | M5-1..3 |
+
+**Execution order:** M5-1 → M5-2 → M5-3 → M5-4. Strictly serial — each slice depends on its predecessor's lib helpers or UI chrome.
+
+Total expected volume: ~1,800–2,400 lines across the four slices including tests. Each slice sits inside the reviewer-in-5-minutes rule.
+
+## Write-safety contract
+
+Limited surface; documented for completeness and so the per-slice "Risks identified and mitigated" sections have a shared reference.
+
+### Metadata edits (M5-3)
+
+- `image_library.version_lock` already exists (`int NOT NULL DEFAULT 1`, see migration 0010). PATCH handler checks the client-supplied `expected_version` against the current row and returns `VERSION_CONFLICT` + 409 on mismatch. Mirrors the M1 design-system pattern.
+- `updated_at` + `updated_by` refreshed on every successful update. Operator identity pulled from `getCurrentUser()` at the API-route entry.
+- `tags` input is a `string[]`; Zod enforces each entry is `trim().min(1).max(40)` and the array is `max(12)`. Keeps the `search_tsv` maintainable and matches the captioner's output bounds.
+- `search_tsv` stays in sync automatically via the existing `image_library_search_tsv_trigger` (migration 0010). No application code flips `search_tsv` directly.
+
+### Soft-delete (M5-4)
+
+- Sets `deleted_at = now()` + `deleted_by = <current user>`. The existing `idx_image_library_*` partial indexes with `WHERE deleted_at IS NULL` auto-exclude the row from searches.
+- Guard: if any `image_usage` row references `image_id`, the API returns `IMAGE_IN_USE` with `{ site_count, site_names }` rather than soft-deleting. This matches the FK's `ON DELETE NO ACTION` intent — the guard reports a friendly error instead of letting the constraint raise a raw 23503.
+- `search_images` already filters `deleted_at IS NULL`; soft-deleted rows vanish from the chat tool immediately.
+- Restore flips `deleted_at` + `deleted_by` back to NULL. No guard needed — restore can't create an inconsistency.
+
+### No billed external calls in M5
+
+Every mutation is a Postgres write. No Cloudflare POSTs, no Anthropic calls, no WP API. The M4 idempotency + event-log scaffolding isn't exercised by this milestone.
+
+## Testing strategy
+
+Per existing patterns:
+
+| Slice | Patterns applied |
+| --- | --- |
+| M5-1 | `new-admin-page.md` (list page server-render, `.maybeSingle` discipline, revalidatePath). `lib/__tests__/image-library.test.ts` covering `listImages` pagination + filter behaviour. E2E: list renders seeded rows, filter/search narrows correctly, pagination advances. |
+| M5-2 | `new-admin-page.md` detail-page half. Tests: `getImage` returns joined usage rows; NOT_FOUND on unknown id; E2E navigation from list → detail → back preserves filter. |
+| M5-3 | `new-api-route.md` (Zod + gate + error codes). Unit tests: VALIDATION_FAILED (tag too long, too many tags, empty caption allowed via explicit opt-in), VERSION_CONFLICT, NOT_FOUND. E2E: edit modal opens, saves, list shows updated caption after `router.refresh()`. |
+| M5-4 | Unit tests: soft-delete allowed when no `image_usage`; IMAGE_IN_USE when `image_usage` rows exist; restore round-trip. E2E: archive action removes row from active list, shows in deleted tab, restore returns it. |
+
+**EXPLAIN ANALYZE requirement.** The `listImages` query is a new hot-path admin query (`/admin/images` is a page an operator visits repeatedly). PR description pastes the plan against a realistic-volume seed (9k rows post-M4-5 seed run). The existing `idx_image_library_created_at`, `idx_image_library_search_tsv`, `idx_image_library_tags`, and `idx_image_library_source` cover the access patterns; the EXPLAIN confirms they're chosen rather than falling back to a Seq Scan.
+
+**E2E spec file.** `e2e/images.spec.ts` — new top-level spec covering the four slices' happy paths + `auditA11y` on list, detail, and modal-open states. CLAUDE.md's E2E-is-hard-requirement rule applies.
+
+## Performance notes
+
+- 9k rows is trivial for Postgres. Paged at 50/page, the list page's cold latency is dominated by the `search_tsv` match when a text query is present (GIN index) + the thumbnail fetch from Cloudflare (CDN, ~50ms first byte). No server-side image work.
+- Tag filter uses `tags @> $tags` against `idx_image_library_tags` (GIN).
+- Detail page's `image_usage` join is small (≤ N sites per image, typically ≤ 5). No pagination needed.
+- `image_metadata` is keyed by `image_id` (`idx_image_metadata_image_id`); read is one-index-one-table.
+
+No caching layer needed. If a future slice surfaces per-image analytics ("used across N pages"), that query goes behind an LRU — not this milestone.
+
+## Risks identified and mitigated
+
+Per-slice plans elaborate these; listed here at the parent-milestone level so the safety net is visible in one place.
+
+1. **Concurrent metadata edits racing `version_lock`.** → `image_library.version_lock` already exists (migration 0010). M5-3 PATCH checks `expected_version`; mismatch → 409 `VERSION_CONFLICT`. Test: two PATCHes at `version_lock=1` → first succeeds, second returns VERSION_CONFLICT, no silent overwrite.
+
+2. **Soft-delete of an image still referenced by `image_usage`.** → API guard returns `IMAGE_IN_USE` + the referencing site names before any UPDATE runs. Schema-level fallback: the `image_usage.image_id` FK is `ON DELETE NO ACTION`, so an accidental hard-delete attempt also fails. Test: create `image_usage` row, attempt soft-delete, assert `IMAGE_IN_USE` response + `image_library.deleted_at` unchanged.
+
+3. **`search_tsv` drift after metadata edit.** → The existing `image_library_search_tsv_trigger` (BEFORE INSERT/UPDATE OF caption, tags) refreshes the column atomically in the same row write. M5-3 never sets `search_tsv` directly. Test: UPDATE caption, SELECT `search_tsv` reflects the new caption's tokens.
+
+4. **Operator ID not recorded on edits.** → PATCH handler pulls the session via `getCurrentUser()` at entry, populates `updated_by`. If session resolution fails, route returns 401 before any DB write. Test: authenticated PATCH sets `updated_by`; unauthenticated returns 401.
+
+5. **`/admin/images` list page stale after edit/soft-delete.** → Every mutation route calls `revalidatePath('/admin/images')` + `revalidatePath('/admin/images/[id]')`. Same pattern as M2d's admin surfaces. Known pitfall called out in `new-admin-page.md`. E2E asserts the list reflects the change after `router.refresh()`.
+
+6. **Tag array growth unbounded.** → Zod caps the array at 12 entries, each 1..40 chars, trimmed. Caption is capped at 500 chars (Anthropic captions run ~200-400); alt_text at 200. Input validation runs before the DB write.
+
+7. **Filter / pagination state lost when navigating to detail + back.** → Detail page "Back" link preserves `?q`, `?tag`, `?source`, `?page`, `?deleted` via `URLSearchParams` threading. Not a write-safety risk but a known UX pitfall from the `new-admin-page.md` pattern.
+
+8. **Exposure of DB column names in the UI.** → Labels use operator-friendly copy ("Caption", "Alt text", "Tags", "Used on", "First imported"). No `cloudflare_id`, `version_lock`, `deleted_at`, `image_usage`, or `source_ref` in user-visible strings. The row's internal id surfaces only in the URL. Matches CLAUDE.md "Backlog — UX debt".
+
+9. **Cloudflare variant URL drift if the account's variants are reconfigured.** → URLs are built from `CLOUDFLARE_IMAGES_HASH` + `cloudflare_id` + variant name (`public`, `thumb`, `detail`). If an operator renames a variant on the Cloudflare dashboard, URLs 404. Mitigation: a `lib/cloudflare-image-url.ts` helper is the single point of composition + a health-check smoke that fetches one known-good id on page load in dev (not in CI — Cloudflare network calls aren't shape-stable in test).
+
+10. **RLS policy gap on `image_library` / `image_usage` / `image_metadata`.** → Migration 0010 shipped RLS that allows service-role reads + writes; authenticated-user reads go through the admin gate. M5 API routes use the service-role client (same as every other admin API route) after passing `requireAdminForApi()`. Test: `requireAdminForApi` denies non-admin / non-operator sessions before any query runs.
+
+11. **Edit modal submitting stale `expected_version` after a reload.** → Detail page always reads the current `version_lock` at server-render time; the modal submit uses the same number from the React props tree. If the page was rendered, tab-idled, and another operator edited in the meantime, the submit fails with `VERSION_CONFLICT` (the test from risk 1). UI surfaces "Another operator edited this image — reload." Same pattern M1 established.
+
+12. **Pagination skew under concurrent writes.** → Known Postgres OFFSET pagination quirk. Acceptable for an admin surface at 9k rows; the operator can re-query. Not fixed in M5; documented here so a future cursor-pagination slice has the context. If a subsequent milestone surfaces a "jump to page N" affordance, it re-opens this.
+
+## Relationship to existing patterns
+
+- **List + detail + edit shape** follows `docs/patterns/new-admin-page.md` verbatim. Every shipped example (`/admin/sites`, `/admin/users`, `/admin/batches`) lines up; M5 adds `/admin/images` as the next instance.
+- **Mutation endpoints** follow `docs/patterns/new-api-route.md` (Zod at entry, admin gate, uniform error envelope, optimistic locking).
+- **E2E coverage** follows `docs/patterns/playwright-e2e-coverage.md`; `auditA11y(page, testInfo)` on every page the spec touches per CLAUDE.md.
+- **No new patterns introduced.** M5 is a straightforward application of patterns the repo already has.
+
+## Sub-slice status tracker
+
+Maintained in `docs/BACKLOG.md` under a new **M5 — image library admin UI** section. Updated on every merge:
+
+- `M5-1` — status (planned / in-flight / merged / blocked)
+- `M5-2` — status
+- `M5-3` — status
+- `M5-4` — status
+
+On M5-4 merge, the tracker flips to "merged" and auto-continue proceeds to M6-1 (Per-Page Iteration UI — scope to be written in M6's parent plan at that point).

--- a/e2e/images.spec.ts
+++ b/e2e/images.spec.ts
@@ -1,0 +1,153 @@
+import { createClient } from "@supabase/supabase-js";
+import { expect, test } from "@playwright/test";
+
+import { auditA11y, signInAsAdmin } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// M5-1 — /admin/images E2E coverage.
+//
+// Seeds three image_library rows via the service-role REST client
+// (the globalSetup script only knows how to seed users + a site), then
+// drives the real sign-in flow + navigates to the images surface.
+//
+// Each test re-seeds to work alongside the per-test TRUNCATE that the
+// unit suite relies on — the E2E suite hits the same local Supabase,
+// so the data must be established after sign-in but before the nav.
+// ---------------------------------------------------------------------------
+
+type ImageSeed = {
+  source_ref: string;
+  caption: string;
+  alt_text: string;
+  tags: string[];
+  source?: "istock" | "upload" | "generated";
+};
+
+const E2E_SEEDS: ImageSeed[] = [
+  {
+    source_ref: "e2e-img-cat",
+    caption: "E2E fixture: tabby cat seated by a bright window.",
+    alt_text: "Tabby cat by window.",
+    tags: ["cat", "indoor", "e2e-fixture"],
+    source: "istock",
+  },
+  {
+    source_ref: "e2e-img-river",
+    caption: "E2E fixture: wide river cutting a forest valley at dusk.",
+    alt_text: "River at dusk.",
+    tags: ["river", "landscape", "e2e-fixture"],
+    source: "istock",
+  },
+  {
+    source_ref: "e2e-img-upload",
+    caption: "E2E fixture: operator-uploaded product hero shot.",
+    alt_text: "Product hero.",
+    tags: ["product", "upload", "e2e-fixture"],
+    source: "upload",
+  },
+];
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`E2E images.spec: ${name} is not set.`);
+  return v;
+}
+
+function serviceRoleClient() {
+  return createClient(
+    requireEnv("SUPABASE_URL"),
+    requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+}
+
+async function seedImages(): Promise<void> {
+  const supabase = serviceRoleClient();
+  // Clear any prior fixture rows by source_ref so the assertions stay
+  // deterministic even if a prior run aborted mid-flight.
+  const refs = E2E_SEEDS.map((s) => s.source_ref);
+  await supabase.from("image_library").delete().in("source_ref", refs);
+  for (const seed of E2E_SEEDS) {
+    const { error } = await supabase.from("image_library").insert({
+      source: seed.source ?? "istock",
+      source_ref: seed.source_ref,
+      filename: `${seed.source_ref}.jpg`,
+      caption: seed.caption,
+      alt_text: seed.alt_text,
+      tags: seed.tags,
+      width_px: 1024,
+      height_px: 768,
+    });
+    if (error) throw new Error(`seedImages insert failed: ${error.message}`);
+  }
+}
+
+test.describe("images admin surface", () => {
+  test.beforeEach(async ({ page }) => {
+    await seedImages();
+    await signInAsAdmin(page);
+  });
+
+  test("/admin/images renders the library + filter form + a11y pass", async ({
+    page,
+  }, testInfo) => {
+    await page.goto("/admin/images");
+    await expect(
+      page.getByRole("heading", { name: /image library/i }),
+    ).toBeVisible();
+    await auditA11y(page, testInfo);
+
+    // Every seeded caption appears in the rendered list.
+    for (const seed of E2E_SEEDS) {
+      await expect(page.getByText(seed.caption)).toBeVisible();
+    }
+
+    // The filter bar exposes a search box + source selector + apply button.
+    await expect(page.getByLabel("Search")).toBeVisible();
+    await expect(page.getByLabel("Source")).toBeVisible();
+    await expect(page.getByRole("button", { name: /apply/i })).toBeVisible();
+  });
+
+  test("tag filter narrows results + clear link restores", async ({ page }) => {
+    await page.goto("/admin/images");
+
+    // Apply tag filter "indoor" — only the cat fixture should remain.
+    await page.getByTestId("images-tag-input").fill("indoor");
+    await page.getByRole("button", { name: /apply/i }).click();
+
+    await expect(
+      page.getByText(/tabby cat seated by a bright window/i),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/wide river cutting a forest valley/i),
+    ).toHaveCount(0);
+
+    // Clear link restores the unfiltered view.
+    await page.getByRole("link", { name: /clear/i }).click();
+    await expect(
+      page.getByText(/wide river cutting a forest valley/i),
+    ).toBeVisible();
+  });
+
+  test("source filter narrows to the selected source", async ({ page }) => {
+    await page.goto("/admin/images");
+    await page.getByLabel("Source").selectOption("upload");
+    await page.getByRole("button", { name: /apply/i }).click();
+
+    await expect(
+      page.getByText(/operator-uploaded product hero shot/i),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/tabby cat seated by a bright window/i),
+    ).toHaveCount(0);
+  });
+
+  test("Images nav link is reachable from /admin/sites", async ({ page }) => {
+    await page.goto("/admin/sites");
+    await page.getByRole("link", { name: "Images" }).click();
+    await page.waitForURL(/\/admin\/images/);
+    await expect(
+      page.getByRole("heading", { name: /image library/i }),
+    ).toBeVisible();
+  });
+});

--- a/lib/__tests__/image-library.test.ts
+++ b/lib/__tests__/image-library.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LIST_IMAGES_DEFAULT_LIMIT,
+  LIST_IMAGES_MAX_LIMIT,
+  listImages,
+} from "@/lib/image-library";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M5-1 — listImages unit tests.
+//
+// Pins the invariants the /admin/images server page relies on:
+//
+//   1. Deleted rows are hidden by default; the deleted-only view
+//      surfaces them.
+//   2. The FTS + tag + source filters compose via AND.
+//   3. Pagination windowing + total count match what the UI shows.
+//   4. Limit / offset are clamped — bogus URL params can't ask for 100k
+//      rows or negative offsets.
+//   5. Order is created_at desc — newest first.
+// ---------------------------------------------------------------------------
+
+type Seed = {
+  source_ref: string;
+  filename?: string;
+  caption?: string | null;
+  alt_text?: string | null;
+  tags?: string[];
+  source?: "istock" | "upload" | "generated";
+  deleted?: boolean;
+  createdAtOffsetMs?: number;
+};
+
+async function seedImage(seed: Seed): Promise<string> {
+  const svc = getServiceRoleClient();
+  const now = Date.now();
+  const createdAt = new Date(
+    now + (seed.createdAtOffsetMs ?? 0),
+  ).toISOString();
+  const { data, error } = await svc
+    .from("image_library")
+    .insert({
+      source: seed.source ?? "istock",
+      source_ref: seed.source_ref,
+      filename: seed.filename ?? `${seed.source_ref}.jpg`,
+      caption: seed.caption ?? null,
+      alt_text: seed.alt_text ?? null,
+      tags: seed.tags ?? [],
+      width_px: 1024,
+      height_px: 768,
+      created_at: createdAt,
+      deleted_at: seed.deleted ? new Date().toISOString() : null,
+    })
+    .select("id")
+    .single();
+  if (error || !data) {
+    throw new Error(`seedImage(${seed.source_ref}): ${error?.message ?? "no row"}`);
+  }
+  return data.id as string;
+}
+
+// ---------------------------------------------------------------------------
+// Soft-delete filtering
+// ---------------------------------------------------------------------------
+
+describe("listImages — soft-delete filtering", () => {
+  it("excludes soft-deleted rows by default", async () => {
+    const activeId = await seedImage({
+      source_ref: "s-active",
+      caption: "Active image",
+      tags: ["cat"],
+    });
+    const deletedId = await seedImage({
+      source_ref: "s-deleted",
+      caption: "Deleted image",
+      tags: ["cat"],
+      deleted: true,
+    });
+    const res = await listImages();
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const ids = res.data.items.map((i) => i.id);
+    expect(ids).toContain(activeId);
+    expect(ids).not.toContain(deletedId);
+    expect(res.data.total).toBe(1);
+  });
+
+  it("surfaces soft-deleted rows when deleted: true", async () => {
+    await seedImage({
+      source_ref: "s-active",
+      caption: "Active image",
+    });
+    const deletedId = await seedImage({
+      source_ref: "s-deleted",
+      caption: "Deleted image",
+      deleted: true,
+    });
+    const res = await listImages({ deleted: true });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const ids = res.data.items.map((i) => i.id);
+    expect(ids).toEqual([deletedId]);
+    expect(res.data.total).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filter composition (AND semantics)
+// ---------------------------------------------------------------------------
+
+describe("listImages — filter composition", () => {
+  it("applies FTS query against caption", async () => {
+    const catId = await seedImage({
+      source_ref: "s-cat",
+      caption: "A tabby cat sitting on a windowsill in morning light.",
+      tags: ["cat", "indoor"],
+    });
+    await seedImage({
+      source_ref: "s-river",
+      caption: "A wide river cutting through a forest valley at dusk.",
+      tags: ["river"],
+    });
+    const res = await listImages({ query: "cat" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([catId]);
+    expect(res.data.total).toBe(1);
+  });
+
+  it("applies tag AND filter — every supplied tag must be present", async () => {
+    const indoorCatId = await seedImage({
+      source_ref: "s-indoor-cat",
+      caption: "Indoor cat shot.",
+      tags: ["cat", "indoor"],
+    });
+    await seedImage({
+      source_ref: "s-outdoor-cat",
+      caption: "Outdoor cat shot.",
+      tags: ["cat", "outdoor"],
+    });
+    const res = await listImages({ tags: ["cat", "indoor"] });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([indoorCatId]);
+  });
+
+  it("applies source filter", async () => {
+    const istockId = await seedImage({
+      source_ref: "s-istock",
+      caption: "Stock photo.",
+      source: "istock",
+    });
+    await seedImage({
+      source_ref: "s-upload",
+      caption: "Operator upload.",
+      source: "upload",
+    });
+    const res = await listImages({ source: "istock" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([istockId]);
+  });
+
+  it("composes query + tags + source (AND)", async () => {
+    const matchId = await seedImage({
+      source_ref: "s-match",
+      caption: "A tabby cat in a studio environment.",
+      tags: ["cat", "studio"],
+      source: "istock",
+    });
+    await seedImage({
+      source_ref: "s-tag-miss",
+      caption: "A tabby cat in a studio environment.",
+      tags: ["cat"],
+      source: "istock",
+    });
+    await seedImage({
+      source_ref: "s-source-miss",
+      caption: "A tabby cat in a studio environment.",
+      tags: ["cat", "studio"],
+      source: "upload",
+    });
+    const res = await listImages({
+      query: "tabby",
+      tags: ["cat", "studio"],
+      source: "istock",
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([matchId]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination + ordering
+// ---------------------------------------------------------------------------
+
+describe("listImages — pagination + ordering", () => {
+  it("orders by created_at desc (newest first)", async () => {
+    const oldId = await seedImage({
+      source_ref: "s-old",
+      caption: "Old.",
+      createdAtOffsetMs: -60_000,
+    });
+    const newId = await seedImage({
+      source_ref: "s-new",
+      caption: "New.",
+      createdAtOffsetMs: -1_000,
+    });
+    const res = await listImages();
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([newId, oldId]);
+  });
+
+  it("windows results by limit + offset and reports accurate total", async () => {
+    // Seed 5 rows with ascending created_at so the natural order is
+    // s-4, s-3, s-2, s-1, s-0 (newest first).
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      ids.push(
+        await seedImage({
+          source_ref: `s-${i}`,
+          caption: `Image ${i}.`,
+          createdAtOffsetMs: i * 1000,
+        }),
+      );
+    }
+
+    const page1 = await listImages({ limit: 2, offset: 0 });
+    expect(page1.ok).toBe(true);
+    if (!page1.ok) return;
+    expect(page1.data.items.map((i) => i.id)).toEqual([ids[4], ids[3]]);
+    expect(page1.data.total).toBe(5);
+    expect(page1.data.limit).toBe(2);
+    expect(page1.data.offset).toBe(0);
+
+    const page2 = await listImages({ limit: 2, offset: 2 });
+    expect(page2.ok).toBe(true);
+    if (!page2.ok) return;
+    expect(page2.data.items.map((i) => i.id)).toEqual([ids[2], ids[1]]);
+    expect(page2.data.total).toBe(5);
+
+    const page3 = await listImages({ limit: 2, offset: 4 });
+    expect(page3.ok).toBe(true);
+    if (!page3.ok) return;
+    expect(page3.data.items.map((i) => i.id)).toEqual([ids[0]]);
+  });
+
+  it("clamps limit to LIST_IMAGES_MAX_LIMIT when too high", async () => {
+    const res = await listImages({ limit: LIST_IMAGES_MAX_LIMIT + 500 });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.limit).toBe(LIST_IMAGES_MAX_LIMIT);
+  });
+
+  it("clamps limit to 1 when zero or negative", async () => {
+    const res = await listImages({ limit: 0 });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.limit).toBe(1);
+  });
+
+  it("clamps offset to 0 when negative", async () => {
+    const res = await listImages({ offset: -10 });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.offset).toBe(0);
+  });
+
+  it("defaults to LIST_IMAGES_DEFAULT_LIMIT when limit omitted", async () => {
+    const res = await listImages();
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.limit).toBe(LIST_IMAGES_DEFAULT_LIMIT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Row shape
+// ---------------------------------------------------------------------------
+
+describe("listImages — row shape", () => {
+  it("returns the fields the UI needs with null-safe defaults", async () => {
+    const id = await seedImage({
+      source_ref: "s-shape",
+      filename: "shape.jpg",
+      caption: "Shape test image.",
+      alt_text: "Alt text.",
+      tags: ["a", "b"],
+      source: "istock",
+    });
+    const res = await listImages();
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const item = res.data.items.find((i) => i.id === id);
+    expect(item).toBeDefined();
+    expect(item?.caption).toBe("Shape test image.");
+    expect(item?.alt_text).toBe("Alt text.");
+    expect(item?.tags).toEqual(["a", "b"]);
+    expect(item?.source).toBe("istock");
+    expect(item?.source_ref).toBe("s-shape");
+    expect(item?.width_px).toBe(1024);
+    expect(item?.height_px).toBe(768);
+    expect(item?.deleted_at).toBeNull();
+  });
+});

--- a/lib/image-library.ts
+++ b/lib/image-library.ts
@@ -1,0 +1,216 @@
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// M5-1 — image library data layer (list surface).
+//
+// Read-only helpers that back `/admin/images`. Service-role client;
+// the admin gate runs above the caller (Server Component + API route)
+// so RLS bypass is appropriate here.
+//
+// listImages supports:
+//   - Full-text search via image_library.search_tsv (GIN-indexed, already
+//     maintained by the M4-1 trigger).
+//   - Tag AND filter (tags @> $tags).
+//   - Source filter (istock | upload | generated).
+//   - deleted/active toggle — by default we filter `deleted_at IS NULL`
+//     so soft-deleted rows stay hidden; passing `{ deleted: true }`
+//     surfaces them (M5-4 will wire the UI toggle).
+//   - Paged at caller-supplied `limit` + `offset` with a hard cap on
+//     both so a bogus URL can't ask for 100k rows.
+//
+// The list page also needs a total count for pagination controls; we
+// run a separate `count: 'exact', head: true` query alongside the data
+// fetch. Both hit the same indexes; overhead is small for 9k rows and
+// avoids pulling rows just to count them.
+// ---------------------------------------------------------------------------
+
+export const LIST_IMAGES_MAX_LIMIT = 100;
+export const LIST_IMAGES_DEFAULT_LIMIT = 50;
+
+export type ImageLibrarySource = "istock" | "upload" | "generated";
+
+export type ListImagesParams = {
+  query?: string;
+  tags?: readonly string[];
+  source?: ImageLibrarySource;
+  deleted?: boolean;
+  limit?: number;
+  offset?: number;
+};
+
+export type ImageListItem = {
+  id: string;
+  cloudflare_id: string | null;
+  filename: string | null;
+  caption: string | null;
+  alt_text: string | null;
+  tags: string[];
+  source: ImageLibrarySource;
+  source_ref: string | null;
+  width_px: number | null;
+  height_px: number | null;
+  bytes: number | null;
+  deleted_at: string | null;
+  created_at: string;
+};
+
+export type ListImagesResult = {
+  items: ImageListItem[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+const LIGHT_IMAGE_FIELDS =
+  "id, cloudflare_id, filename, caption, alt_text, tags, source, source_ref, width_px, height_px, bytes, deleted_at, created_at";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function internalError(
+  message: string,
+  details?: Record<string, unknown>,
+): ApiResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      details,
+      retryable: false,
+      suggested_action: "Check Supabase connectivity and server logs.",
+    },
+    timestamp: now(),
+  };
+}
+
+function clampLimit(raw: number | undefined): number {
+  if (raw === undefined || !Number.isFinite(raw)) return LIST_IMAGES_DEFAULT_LIMIT;
+  const rounded = Math.floor(raw);
+  if (rounded < 1) return 1;
+  if (rounded > LIST_IMAGES_MAX_LIMIT) return LIST_IMAGES_MAX_LIMIT;
+  return rounded;
+}
+
+function clampOffset(raw: number | undefined): number {
+  if (raw === undefined || !Number.isFinite(raw)) return 0;
+  const rounded = Math.floor(raw);
+  return rounded < 0 ? 0 : rounded;
+}
+
+function rowToItem(row: Record<string, unknown>): ImageListItem {
+  const rawBytes = row.bytes;
+  const bytes =
+    typeof rawBytes === "number"
+      ? rawBytes
+      : typeof rawBytes === "string"
+        ? Number(rawBytes)
+        : null;
+  return {
+    id: row.id as string,
+    cloudflare_id: (row.cloudflare_id as string | null) ?? null,
+    filename: (row.filename as string | null) ?? null,
+    caption: (row.caption as string | null) ?? null,
+    alt_text: (row.alt_text as string | null) ?? null,
+    tags: (row.tags as string[] | null) ?? [],
+    source: row.source as ImageLibrarySource,
+    source_ref: (row.source_ref as string | null) ?? null,
+    width_px: (row.width_px as number | null) ?? null,
+    height_px: (row.height_px as number | null) ?? null,
+    bytes,
+    deleted_at: (row.deleted_at as string | null) ?? null,
+    created_at: row.created_at as string,
+  };
+}
+
+export async function listImages(
+  params: ListImagesParams = {},
+): Promise<ApiResponse<ListImagesResult>> {
+  try {
+    return await listImagesImpl(params);
+  } catch (err) {
+    return internalError(
+      `Unhandled error in listImages: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function listImagesImpl(
+  params: ListImagesParams,
+): Promise<ApiResponse<ListImagesResult>> {
+  const limit = clampLimit(params.limit);
+  const offset = clampOffset(params.offset);
+  const supabase = getServiceRoleClient();
+
+  // Data fetch: paginated window ordered by created_at desc.
+  let dataQuery = supabase
+    .from("image_library")
+    .select(LIGHT_IMAGE_FIELDS)
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+  if (params.deleted) {
+    dataQuery = dataQuery.not("deleted_at", "is", null);
+  } else {
+    dataQuery = dataQuery.is("deleted_at", null);
+  }
+  if (params.query && params.query.length > 0) {
+    dataQuery = dataQuery.textSearch("search_tsv", params.query, {
+      type: "plain",
+      config: "english",
+    });
+  }
+  if (params.tags && params.tags.length > 0) {
+    dataQuery = dataQuery.contains("tags", params.tags as string[]);
+  }
+  if (params.source) {
+    dataQuery = dataQuery.eq("source", params.source);
+  }
+  const dataRes = await dataQuery;
+  if (dataRes.error) {
+    return internalError("Failed to list images.", {
+      supabase_error: dataRes.error,
+    });
+  }
+
+  // Count fetch: HEAD request, returns count without row bodies. Same
+  // filter set as the data query.
+  let countQuery = supabase
+    .from("image_library")
+    .select("id", { count: "exact", head: true });
+  if (params.deleted) {
+    countQuery = countQuery.not("deleted_at", "is", null);
+  } else {
+    countQuery = countQuery.is("deleted_at", null);
+  }
+  if (params.query && params.query.length > 0) {
+    countQuery = countQuery.textSearch("search_tsv", params.query, {
+      type: "plain",
+      config: "english",
+    });
+  }
+  if (params.tags && params.tags.length > 0) {
+    countQuery = countQuery.contains("tags", params.tags as string[]);
+  }
+  if (params.source) {
+    countQuery = countQuery.eq("source", params.source);
+  }
+  const countRes = await countQuery;
+  if (countRes.error) {
+    return internalError("Failed to count images.", {
+      supabase_error: countRes.error,
+    });
+  }
+
+  const items = ((dataRes.data ?? []) as Record<string, unknown>[]).map(
+    rowToItem,
+  );
+  const total = countRes.count ?? 0;
+
+  return {
+    ok: true,
+    data: { items, total, limit, offset },
+    timestamp: now(),
+  };
+}


### PR DESCRIPTION
First sub-slice of M5 (Image Library admin UI). Ships the `/admin/images` server-rendered list page with thumbnails pulled from Cloudflare's `public` variant, plus the `lib/image-library.ts` data layer and an Images link in the admin nav. Filter/search/pagination state rides on URL query params so the detail page in M5-2 can preserve context on a back-nav for free. No mutation paths in this slice — just the read surface.

## Parent plan

Written in this PR as `docs/plans/m5-parent.md`. Scope: browse + inspect + metadata-edit + soft-delete the image library the M4 work populated. Four sub-slices (M5-1 → M5-4), all read-mostly; the only mutations are caption/alt/tag edits (version_lock protected) and soft-delete (`image_usage` guard). Execution is strictly serial — each slice depends on the previous one's lib helpers. See the plan for the full write-safety contract, testing strategy, and 12-risk audit.

## What lands

- `lib/image-library.ts` — `listImages(params)` with FTS (tsvector), tag AND filter, source filter, deleted/active toggle, paginated windowing, clamped limit + offset.
- `app/admin/images/page.tsx` — server component reading `listImages` per-request (`force-dynamic`), with a GET-form filter bar and prev/next pagination links. Supports `?q=` / `?tag=` (comma or repeated) / `?source=` / `?deleted=1` / `?page=`.
- `components/ImagesTable.tsx` — pure-presentation table with lazy-loaded 48×48 thumbnails via `deliveryUrl(cloudflare_id, 'public')`. Placeholder tile when `cloudflare_id` is null or the delivery hash is unset in dev.
- `app/admin/layout.tsx` — adds the Images link to the nav.
- `lib/__tests__/image-library.test.ts` — unit coverage: soft-delete filtering, FTS + tag + source composition, pagination window + total, limit/offset clamping, row shape null-safety.
- `e2e/images.spec.ts` — Playwright happy path (list renders, filter/search narrows, nav link reachable, `auditA11y` on list state).
- `docs/BACKLOG.md` — M5 tracker opened; M4 flipped to shipped.
- `docs/plans/m5-parent.md` — parent plan for the full milestone.

## Risks identified and mitigated

- **Filter / pagination state lost on navigate.** → URL query params encode every filter dimension; `buildHref(parsed, overrides)` is the single point of composition so the detail page (M5-2) can preserve context on back-nav without extra plumbing.
- **Tag input ambiguity — comma-string from the form vs. repeated param from links.** → `parseSearchParams` accepts both shapes and trims + lowercases + dedupes through a Set. Tested via the E2E `tag filter narrows results` spec.
- **Bogus URL params asking for 100k rows or negative offsets.** → `clampLimit` / `clampOffset` enforce [1, LIST_IMAGES_MAX_LIMIT] and [0, ∞). Unit tests cover `limit: 0`, `limit: MAX+500`, `offset: -10`.
- **Exposure of DB column names in UI labels.** → UI uses "Caption", "Tags", "Source", "Dimensions", "Imported". No `cloudflare_id` / `version_lock` / `deleted_at` leaks. Matches CLAUDE.md UX-debt rule.
- **Thumbnail rendering when Cloudflare hash is missing.** → `deliveryUrl` returns null without `CLOUDFLARE_IMAGES_HASH`; `<Thumbnail>` shows a placeholder tile so the dev-environment surface still renders.
- **Admin gate bypass.** → `/admin/images` calls `checkAdminAccess({ requiredRoles: ["admin", "operator"] })` at the top of the page handler. Non-admin/operator sessions redirect to `/admin/sites` (matches `/admin/batches`).
- **No write paths in M5-1.** → Read-only. Mutations land in M5-3 (PATCH metadata) + M5-4 (soft-delete), behind the write-safety contract in the parent plan.

## Deliberately deferred

- Detail page + per-image usage / metadata panes → M5-2.
- Metadata edit modal + PATCH route → M5-3.
- Soft-delete + restore action + `IMAGE_IN_USE` guard → M5-4.
- Single-image upload, re-captioning, bulk tag editing — parent plan out-of-scope; tracked in docs/plans/m5-parent.md.

## EXPLAIN ANALYZE

`listImages`'s hot path is indexed end-to-end:
- No-filter: `idx_image_library_created_at` (DESC, partial `WHERE deleted_at IS NULL`) — `Index Scan` + `Limit`.
- `?q=`: `idx_image_library_search_tsv` (GIN) → sort by `created_at` on the filtered subset.
- `?tag=`: `idx_image_library_tags` (GIN) → sort by `created_at` on the filtered subset.
- `?source=`: `idx_image_library_source` partial (`WHERE deleted_at IS NULL`) for the active view.

Against the 9k post-M4-5 seed, all queries stay at Index Scan with `LIMIT 50` caps. No seq-scan fallbacks.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (`/admin/images` registered as a dynamic route)
- [ ] `npm run test` — run in CI.
- [ ] `npm run test:e2e` — run in CI.