### PR TITLE
feat(m5-2): /admin/images/[id] detail page + usage + metadata panes

### DIFF
--- a/app/admin/images/[id]/page.tsx
+++ b/app/admin/images/[id]/page.tsx
@@ -1,0 +1,369 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { Fragment } from "react";
+
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { deliveryUrl } from "@/lib/cloudflare-images";
+import { getImage } from "@/lib/image-library";
+import { formatRelativeTime } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// /admin/images/[id] — M5-2.
+//
+// Per-image detail view. Full metadata, multi-variant preview (public
+// + thumbnail + if configured, additional named variants), the
+// `image_usage` list showing every WP site this image has been
+// mirrored to, and the `image_metadata` k/v pane for EXIF / licensing /
+// model-info rows.
+//
+// Back-link preserves the caller's list-state query params so a
+// return-to-list after inspection lands the operator on the exact
+// same filter / page they came from. The params ride as a single
+// opaque `?from=` blob so we don't have to parse-and-re-emit each
+// filter dimension.
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type RawSearchParams = {
+  [key: string]: string | string[] | undefined;
+};
+
+function resolveBackHref(raw: RawSearchParams): string {
+  const from = typeof raw.from === "string" ? raw.from : null;
+  if (!from) return "/admin/images";
+  // Accept only relative /admin/images paths to defend against open-redirect
+  // style abuse of the `from` parameter.
+  if (!from.startsWith("/admin/images")) return "/admin/images";
+  return from;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null || bytes === undefined) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function usageStateBadge(state: string) {
+  const palette: Record<string, string> = {
+    transferred: "bg-emerald-500/10 text-emerald-700",
+    pending_transfer: "bg-muted text-muted-foreground",
+    failed: "bg-destructive/10 text-destructive",
+  };
+  return (
+    <span
+      className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${
+        palette[state] ?? "bg-muted"
+      }`}
+    >
+      {state.replace(/_/g, " ")}
+    </span>
+  );
+}
+
+function formatJsonValue(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 0);
+  } catch {
+    return String(value);
+  }
+}
+
+export default async function AdminImageDetailPage({
+  params,
+  searchParams,
+}: {
+  params: { id: string };
+  searchParams: RawSearchParams;
+}) {
+  const access = await checkAdminAccess({
+    requiredRoles: ["admin", "operator"],
+    insufficientRoleRedirectTo: "/admin/sites",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  if (!UUID_RE.test(params.id)) notFound();
+
+  const result = await getImage(params.id);
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") notFound();
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+      >
+        Failed to load image: {result.error.message}
+      </div>
+    );
+  }
+
+  const { image, usage, metadata } = result.data;
+  const backHref = resolveBackHref(searchParams);
+
+  const publicUrl = image.cloudflare_id
+    ? deliveryUrl(image.cloudflare_id, "public")
+    : null;
+  const thumbUrl = image.cloudflare_id
+    ? deliveryUrl(image.cloudflare_id, "thumbnail")
+    : null;
+
+  return (
+    <>
+      <Breadcrumbs
+        crumbs={[
+          { label: "Images", href: backHref },
+          { label: image.caption?.slice(0, 60) ?? image.filename ?? image.id },
+        ]}
+      />
+
+      <div className="mt-4 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold">
+            {image.filename ?? "Untitled image"}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Imported {formatDate(image.created_at)}
+            {image.deleted_at && (
+              <>
+                {" · "}
+                <span className="text-destructive">
+                  archived {formatRelativeTime(image.deleted_at)}
+                </span>
+              </>
+            )}
+          </p>
+        </div>
+        <Link
+          href={backHref}
+          className="text-xs text-muted-foreground hover:text-foreground"
+        >
+          ← Back to library
+        </Link>
+      </div>
+
+      <section className="mt-6 grid gap-6 md:grid-cols-[1fr_2fr]">
+        <div className="flex flex-col gap-3">
+          <div className="overflow-hidden rounded-md border bg-muted/30">
+            {publicUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={publicUrl}
+                alt={image.alt_text ?? image.filename ?? "Library image"}
+                className="h-full w-full object-contain"
+                data-testid="image-detail-preview"
+              />
+            ) : (
+              <div className="flex h-64 w-full items-center justify-center text-sm text-muted-foreground">
+                Preview unavailable (no Cloudflare id or delivery hash).
+              </div>
+            )}
+          </div>
+          {thumbUrl && (
+            <div className="flex items-center gap-3 text-xs text-muted-foreground">
+              <span>Thumbnail:</span>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={thumbUrl}
+                alt=""
+                className="h-10 w-10 rounded object-cover"
+              />
+              <a
+                href={thumbUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="hover:underline"
+              >
+                Open
+              </a>
+            </div>
+          )}
+        </div>
+
+        <dl
+          className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm"
+          data-testid="image-detail-fields"
+        >
+          <dt className="text-muted-foreground">Caption</dt>
+          <dd>
+            {image.caption ?? (
+              <span className="text-muted-foreground">(no caption yet)</span>
+            )}
+          </dd>
+          <dt className="text-muted-foreground">Alt text</dt>
+          <dd>
+            {image.alt_text ?? (
+              <span className="text-muted-foreground">(not set)</span>
+            )}
+          </dd>
+          <dt className="text-muted-foreground">Tags</dt>
+          <dd>
+            {image.tags.length === 0 ? (
+              <span className="text-muted-foreground">—</span>
+            ) : (
+              <div className="flex flex-wrap gap-1">
+                {image.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded bg-muted px-2 py-0.5 text-xs"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </dd>
+          <dt className="text-muted-foreground">Source</dt>
+          <dd className="capitalize">
+            {image.source}
+            {image.source_ref && (
+              <span className="ml-2 text-xs text-muted-foreground">
+                ({image.source_ref})
+              </span>
+            )}
+          </dd>
+          <dt className="text-muted-foreground">Dimensions</dt>
+          <dd>
+            {image.width_px && image.height_px
+              ? `${image.width_px}×${image.height_px} px`
+              : "—"}
+          </dd>
+          <dt className="text-muted-foreground">File size</dt>
+          <dd>{formatBytes(image.bytes)}</dd>
+        </dl>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-sm font-semibold">
+          Used on sites{" "}
+          <span className="text-xs text-muted-foreground">
+            ({usage.length})
+          </span>
+        </h2>
+        <p className="text-xs text-muted-foreground">
+          Every WP site this image has been mirrored to via the publish pipeline.
+        </p>
+        <div className="mt-3" data-testid="image-usage-list">
+          {usage.length === 0 ? (
+            <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Not yet used on any site.
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-md border">
+              <table className="w-full text-sm">
+                <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <tr>
+                    <th className="px-4 py-2 font-medium">Site</th>
+                    <th className="px-4 py-2 font-medium">State</th>
+                    <th className="px-4 py-2 font-medium">WP media</th>
+                    <th className="px-4 py-2 font-medium">Transferred</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {usage.map((u) => (
+                    <tr
+                      key={u.id}
+                      className="border-b last:border-b-0"
+                      data-site-id={u.site_id}
+                    >
+                      <td className="px-4 py-3">
+                        <Link
+                          href={`/admin/sites/${u.site_id}`}
+                          className="font-medium hover:underline"
+                        >
+                          {u.site_name}
+                        </Link>
+                        {u.wp_url && (
+                          <div className="text-xs text-muted-foreground">
+                            {u.wp_url}
+                          </div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">{usageStateBadge(u.state)}</td>
+                      <td className="px-4 py-3 text-xs text-muted-foreground">
+                        {u.wp_media_id !== null ? (
+                          u.wp_source_url ? (
+                            <a
+                              href={u.wp_source_url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="hover:underline"
+                            >
+                              #{u.wp_media_id}
+                            </a>
+                          ) : (
+                            `#${u.wp_media_id}`
+                          )
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-xs text-muted-foreground">
+                        {u.transferred_at
+                          ? formatRelativeTime(u.transferred_at)
+                          : "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="text-sm font-semibold">
+          Additional metadata{" "}
+          <span className="text-xs text-muted-foreground">
+            ({metadata.length})
+          </span>
+        </h2>
+        <p className="text-xs text-muted-foreground">
+          EXIF, licensing notes, model info, and any other per-image attributes
+          tracked outside the main row.
+        </p>
+        <div className="mt-3" data-testid="image-metadata-list">
+          {metadata.length === 0 ? (
+            <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+              No additional metadata.
+            </div>
+          ) : (
+            <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 rounded-md border p-4 text-sm">
+              {metadata.map((m) => (
+                <Fragment key={m.key}>
+                  <dt className="font-mono text-xs text-muted-foreground">
+                    {m.key}
+                  </dt>
+                  <dd className="break-all font-mono text-xs">
+                    {formatJsonValue(m.value_jsonb)}
+                  </dd>
+                </Fragment>
+              ))}
+            </dl>
+          )}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/admin/images/page.tsx
+++ b/app/admin/images/page.tsx
@@ -267,7 +267,7 @@ export default async function AdminImagesPage({
       </div>
 
       <div className="mt-3">
-        <ImagesTable items={items} />
+        <ImagesTable items={items} backHref={buildHref(parsed, {})} />
       </div>
     </>
   );

--- a/components/ImagesTable.tsx
+++ b/components/ImagesTable.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { deliveryUrl } from "@/lib/cloudflare-images";
 import type { ImageListItem } from "@/lib/image-library";
 import { formatRelativeTime } from "@/lib/utils";
@@ -63,7 +65,23 @@ function Thumbnail({ item }: { item: ImageListItem }) {
   );
 }
 
-export function ImagesTable({ items }: { items: ImageListItem[] }) {
+type ImagesTableProps = {
+  items: ImageListItem[];
+  /**
+   * Serialised list state for the back-nav (e.g. "/admin/images?q=cat&page=2").
+   * The detail page uses this as its "← Back to library" href so filters
+   * survive a round-trip.
+   */
+  backHref?: string;
+};
+
+function buildDetailHref(id: string, backHref: string | undefined): string {
+  if (!backHref || backHref === "/admin/images") return `/admin/images/${id}`;
+  const params = new URLSearchParams({ from: backHref });
+  return `/admin/images/${id}?${params.toString()}`;
+}
+
+export function ImagesTable({ items, backHref }: ImagesTableProps) {
   if (items.length === 0) {
     return (
       <div className="rounded-md border border-dashed p-8 text-center">
@@ -99,13 +117,17 @@ export function ImagesTable({ items }: { items: ImageListItem[] }) {
                 <Thumbnail item={item} />
               </td>
               <td className="px-4 py-3 align-top">
-                <div className="line-clamp-2 max-w-md text-sm">
+                <Link
+                  href={buildDetailHref(item.id, backHref)}
+                  className="line-clamp-2 block max-w-md text-sm hover:underline"
+                  data-testid="image-row-link"
+                >
                   {item.caption ?? (
                     <span className="text-muted-foreground">
                       (no caption yet)
                     </span>
                   )}
-                </div>
+                </Link>
                 {item.filename && (
                   <div className="mt-1 text-xs text-muted-foreground">
                     {item.filename}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -12,8 +12,8 @@ Parent plan: `docs/plans/m5-parent.md`. Sub-slice status tracker:
 
 | Slice | Status | Notes |
 | --- | --- | --- |
-| M5-1 | in flight | `/admin/images` list page + `lib/image-library.ts` data layer + nav link. |
-| M5-2 | planned | `/admin/images/[id]` detail page with `image_usage` + `image_metadata` panes. |
+| M5-1 | merged (#64) | `/admin/images` list page + `lib/image-library.ts` data layer + nav link. |
+| M5-2 | in flight | `/admin/images/[id]` detail page with `image_usage` + `image_metadata` panes. |
 | M5-3 | planned | Metadata edit modal + `PATCH /api/admin/images/[id]` with `version_lock`. |
 | M5-4 | planned | Soft-delete + restore with `IMAGE_IN_USE` guard. |
 

--- a/e2e/images.spec.ts
+++ b/e2e/images.spec.ts
@@ -150,4 +150,43 @@ test.describe("images admin surface", () => {
       page.getByRole("heading", { name: /image library/i }),
     ).toBeVisible();
   });
+
+  test("list → detail round-trip preserves filter state on back-nav", async ({
+    page,
+  }, testInfo) => {
+    // Start on a filtered list.
+    await page.goto("/admin/images?source=upload");
+    await expect(
+      page.getByText(/operator-uploaded product hero shot/i),
+    ).toBeVisible();
+
+    // Click the caption link to open the detail page.
+    await page
+      .getByTestId("image-row-link")
+      .filter({ hasText: /operator-uploaded product hero shot/i })
+      .click();
+    await page.waitForURL(/\/admin\/images\/[0-9a-f-]{36}/);
+    await expect(
+      page.getByTestId("image-detail-fields"),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /e2e-img-upload\.jpg/ }),
+    ).toBeVisible();
+    await auditA11y(page, testInfo);
+
+    // Back link returns to /admin/images?source=upload (via the
+    // ?from= query param the list writes into each row).
+    await page.getByRole("link", { name: /back to library/i }).click();
+    await page.waitForURL(/\/admin\/images\?source=upload/);
+    await expect(
+      page.getByText(/operator-uploaded product hero shot/i),
+    ).toBeVisible();
+  });
+
+  test("detail page 404s on an unknown UUID", async ({ page }) => {
+    const response = await page.goto(
+      "/admin/images/00000000-0000-0000-0000-000000000000",
+    );
+    expect(response?.status()).toBe(404);
+  });
 });

--- a/lib/__tests__/image-library.test.ts
+++ b/lib/__tests__/image-library.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   LIST_IMAGES_DEFAULT_LIMIT,
   LIST_IMAGES_MAX_LIMIT,
+  getImage,
   listImages,
 } from "@/lib/image-library";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -304,5 +305,152 @@ describe("listImages — row shape", () => {
     expect(item?.width_px).toBe(1024);
     expect(item?.height_px).toBe(768);
     expect(item?.deleted_at).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getImage — detail fetch with usage + metadata joins
+// ---------------------------------------------------------------------------
+
+async function seedSite(opts: { name: string; prefix: string; wp_url?: string }): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("sites")
+    .insert({
+      name: opts.name,
+      prefix: opts.prefix,
+      wp_url: opts.wp_url ?? `https://${opts.prefix}.example`,
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error || !data) {
+    throw new Error(`seedSite: ${error?.message ?? "no row"}`);
+  }
+  return data.id as string;
+}
+
+async function seedUsage(opts: {
+  image_id: string;
+  site_id: string;
+  state?: "pending_transfer" | "transferred" | "failed";
+  wp_media_id?: number | null;
+}): Promise<void> {
+  const svc = getServiceRoleClient();
+  const { error } = await svc.from("image_usage").insert({
+    image_id: opts.image_id,
+    site_id: opts.site_id,
+    state: opts.state ?? "transferred",
+    wp_media_id: opts.wp_media_id ?? 4242,
+    wp_source_url: "https://example.test/wp-content/uploads/x.jpg",
+    wp_idempotency_marker: `m-${opts.site_id}-${opts.image_id}`,
+    transferred_at: new Date().toISOString(),
+  });
+  if (error) throw new Error(`seedUsage: ${error.message}`);
+}
+
+async function seedMetadata(opts: {
+  image_id: string;
+  key: string;
+  value: unknown;
+}): Promise<void> {
+  const svc = getServiceRoleClient();
+  const { error } = await svc.from("image_metadata").insert({
+    image_id: opts.image_id,
+    key: opts.key,
+    value_jsonb: opts.value,
+  });
+  if (error) throw new Error(`seedMetadata: ${error.message}`);
+}
+
+describe("getImage — detail fetch", () => {
+  it("returns NOT_FOUND for an unknown id", async () => {
+    const res = await getImage("00000000-0000-0000-0000-000000000000");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+
+  it("joins image_usage rows with site name + wp_url", async () => {
+    const imageId = await seedImage({
+      source_ref: "s-join",
+      caption: "Join test image.",
+      tags: ["join"],
+    });
+    const siteA = await seedSite({ name: "Site Alpha", prefix: "a1" });
+    const siteB = await seedSite({ name: "Site Bravo", prefix: "b1" });
+    await seedUsage({ image_id: imageId, site_id: siteA, wp_media_id: 101 });
+    await seedUsage({
+      image_id: imageId,
+      site_id: siteB,
+      wp_media_id: 202,
+      state: "pending_transfer",
+    });
+
+    const res = await getImage(imageId);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.usage).toHaveLength(2);
+    const names = res.data.usage.map((u) => u.site_name).sort();
+    expect(names).toEqual(["Site Alpha", "Site Bravo"]);
+    const alphaRow = res.data.usage.find((u) => u.site_name === "Site Alpha");
+    expect(alphaRow?.wp_media_id).toBe(101);
+    expect(alphaRow?.state).toBe("transferred");
+    expect(alphaRow?.wp_url).toBe("https://a1.example");
+  });
+
+  it("returns metadata rows sorted by key", async () => {
+    const imageId = await seedImage({
+      source_ref: "s-meta",
+      caption: "Metadata test.",
+    });
+    await seedMetadata({ image_id: imageId, key: "zebra", value: "last" });
+    await seedMetadata({
+      image_id: imageId,
+      key: "alpha",
+      value: { nested: true },
+    });
+
+    const res = await getImage(imageId);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.metadata.map((m) => m.key)).toEqual(["alpha", "zebra"]);
+    expect(res.data.metadata[0]?.value_jsonb).toEqual({ nested: true });
+  });
+
+  it("returns empty arrays when no usage / metadata rows exist", async () => {
+    const imageId = await seedImage({
+      source_ref: "s-lonely",
+      caption: "Lonely image.",
+    });
+    const res = await getImage(imageId);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.usage).toEqual([]);
+    expect(res.data.metadata).toEqual([]);
+  });
+
+  it("surfaces version_lock for optimistic-concurrency wiring (M5-3)", async () => {
+    const imageId = await seedImage({
+      source_ref: "s-version",
+      caption: "Versioned image.",
+    });
+    const res = await getImage(imageId);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.image.version_lock).toBe(1);
+  });
+
+  it("still fetches soft-deleted images (admin surface)", async () => {
+    const imageId = await seedImage({
+      source_ref: "s-soft-del",
+      caption: "Soft-deleted.",
+      deleted: true,
+    });
+    const res = await getImage(imageId);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.image.id).toBe(imageId);
+    expect(res.data.image.deleted_at).not.toBeNull();
   });
 });

--- a/lib/image-library.ts
+++ b/lib/image-library.ts
@@ -125,6 +125,151 @@ function rowToItem(row: Record<string, unknown>): ImageListItem {
   };
 }
 
+export type ImageUsageSiteRow = {
+  id: string;
+  site_id: string;
+  site_name: string;
+  wp_url: string;
+  wp_media_id: number | null;
+  wp_source_url: string | null;
+  state: "pending_transfer" | "transferred" | "failed";
+  transferred_at: string | null;
+  failure_code: string | null;
+  failure_detail: string | null;
+  created_at: string;
+};
+
+export type ImageMetadataRow = {
+  key: string;
+  value_jsonb: unknown;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ImageDetail = {
+  image: ImageListItem & { version_lock: number };
+  usage: ImageUsageSiteRow[];
+  metadata: ImageMetadataRow[];
+};
+
+const DETAIL_IMAGE_FIELDS =
+  "id, cloudflare_id, filename, caption, alt_text, tags, source, source_ref, width_px, height_px, bytes, deleted_at, created_at, version_lock";
+
+export async function getImage(
+  id: string,
+): Promise<ApiResponse<ImageDetail>> {
+  try {
+    return await getImageImpl(id);
+  } catch (err) {
+    return internalError(
+      `Unhandled error in getImage: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function getImageImpl(
+  id: string,
+): Promise<ApiResponse<ImageDetail>> {
+  const supabase = getServiceRoleClient();
+
+  const imageRes = await supabase
+    .from("image_library")
+    .select(DETAIL_IMAGE_FIELDS)
+    .eq("id", id)
+    .maybeSingle();
+
+  if (imageRes.error) {
+    return internalError("Failed to fetch image.", {
+      supabase_error: imageRes.error,
+    });
+  }
+  if (!imageRes.data) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `No image found with id ${id}.`,
+        details: { id },
+        retryable: false,
+        suggested_action:
+          "Verify the image id. Soft-deleted images are still fetchable; hard-removed ids are not.",
+      },
+      timestamp: now(),
+    };
+  }
+
+  const row = imageRes.data as Record<string, unknown>;
+  const base = rowToItem(row);
+  const image = {
+    ...base,
+    version_lock: typeof row.version_lock === "number" ? row.version_lock : 1,
+  };
+
+  // Usage rows joined to sites so the UI can render the site name
+  // rather than a bare UUID. Service-role query; RLS is not a factor
+  // here since admin-gate has already authorised the caller.
+  const usageRes = await supabase
+    .from("image_usage")
+    .select(
+      "id, site_id, wp_media_id, wp_source_url, state, transferred_at, failure_code, failure_detail, created_at, site:sites!inner(name, wp_url)",
+    )
+    .eq("image_id", id)
+    .order("created_at", { ascending: false });
+
+  if (usageRes.error) {
+    return internalError("Failed to fetch image_usage.", {
+      supabase_error: usageRes.error,
+    });
+  }
+
+  const usage: ImageUsageSiteRow[] = (
+    (usageRes.data ?? []) as Record<string, unknown>[]
+  ).map((u) => {
+    const site = u.site as { name: string; wp_url: string } | null;
+    return {
+      id: u.id as string,
+      site_id: u.site_id as string,
+      site_name: site?.name ?? "—",
+      wp_url: site?.wp_url ?? "",
+      wp_media_id:
+        typeof u.wp_media_id === "number" ? u.wp_media_id : null,
+      wp_source_url: (u.wp_source_url as string | null) ?? null,
+      state: u.state as ImageUsageSiteRow["state"],
+      transferred_at: (u.transferred_at as string | null) ?? null,
+      failure_code: (u.failure_code as string | null) ?? null,
+      failure_detail: (u.failure_detail as string | null) ?? null,
+      created_at: u.created_at as string,
+    };
+  });
+
+  const metaRes = await supabase
+    .from("image_metadata")
+    .select("key, value_jsonb, created_at, updated_at")
+    .eq("image_id", id)
+    .order("key", { ascending: true });
+
+  if (metaRes.error) {
+    return internalError("Failed to fetch image_metadata.", {
+      supabase_error: metaRes.error,
+    });
+  }
+
+  const metadata: ImageMetadataRow[] = (
+    (metaRes.data ?? []) as Record<string, unknown>[]
+  ).map((m) => ({
+    key: m.key as string,
+    value_jsonb: m.value_jsonb,
+    created_at: m.created_at as string,
+    updated_at: m.updated_at as string,
+  }));
+
+  return {
+    ok: true,
+    data: { image, usage, metadata },
+    timestamp: now(),
+  };
+}
+
 export async function listImages(
   params: ListImagesParams = {},
 ): Promise<ApiResponse<ListImagesResult>> {


### PR DESCRIPTION
Second sub-slice of M5. Ships the per-image detail view: large `public` variant preview, full metadata grid (caption / alt / tags / source / dimensions / file size), a joined `image_usage` table showing every WP site this image has been mirrored to (with state + wp_media_id + transferred_at), and an `image_metadata` k/v pane for EXIF / licensing / model-info rows.

List-to-detail is wired through the caption cell; rows now carry a `?from=` query param so back-nav returns the operator to their exact filter state without re-deriving it. Read-only — mutations land in M5-3.

## What lands

- `lib/image-library.ts` — extended with `getImage(id)` + `ImageDetail` / `ImageUsageSiteRow` / `ImageMetadataRow` types. NOT_FOUND error path for unknown UUIDs.
- `app/admin/images/[id]/page.tsx` — server component with breadcrumbs, preview, dt/dd metadata grid, usage table, metadata pane. `notFound()` for invalid UUIDs and missing rows.
- `components/ImagesTable.tsx` — caption cell is now a `<Link>` to the detail page with `?from=` carrying the current list state.
- `app/admin/images/page.tsx` — wires the list's current filter state into `ImagesTable.backHref` so every row's detail link knows how to round-trip.
- `lib/__tests__/image-library.test.ts` — six new `getImage` tests: NOT_FOUND, usage join with site name+wp_url, metadata key-sort, empty joins, version_lock surfacing (for M5-3), soft-deleted image still fetchable.
- `e2e/images.spec.ts` — two new Playwright tests: list → detail round-trip preserves `?source=upload` filter via back-link, 404 on unknown UUID. `auditA11y` on the detail page.
- `docs/BACKLOG.md` — M5-1 flipped to merged (#64), M5-2 to in flight.

## Risks identified and mitigated

- **`?from=` open-redirect abuse.** → `resolveBackHref` only accepts relative paths under `/admin/images`. Any other value falls back to the plain `/admin/images` listing. Anything pointing at an external host or `//evil` gets rejected.
- **Invalid UUID in the route segment.** → `UUID_RE` guard at the top of the page handler returns `notFound()` before hitting the DB, so we never run a failed lookup with a malformed id.
- **Soft-deleted images still need to be reachable from the admin surface.** → `getImage` deliberately does NOT filter `deleted_at IS NULL` (unlike `listImages`' default view). M5-4's restore action will hit the same lookup. Test: soft-deleted image is still fetchable; `deleted_at` surfaces in the header banner.
- **Missing Cloudflare delivery hash in dev.** → `deliveryUrl` returns null; the preview pane shows "Preview unavailable" instead of a broken image. Same graceful-degradation pattern as the list page.
- **Usage table leaking raw DB column names to operators.** → UI headers are "Site" / "State" / "WP media" / "Transferred". `wp_media_id` appears as a link text (`#4242`) rather than a bare integer column.
- **`version_lock` surfaced from `getImage` but not yet used.** → Deliberate. M5-3's PATCH handler reads this number out of the detail page's render tree to stamp the `expected_version` on the optimistic-locked UPDATE. Test pins it at 1 so a regression on insert-default is caught.
- **Read-only slice.** → No mutation paths. PATCH metadata edits land in M5-3; soft-delete / restore in M5-4.

## Deliberately deferred

- Edit metadata button on the detail page → M5-3 wires it to the modal + `PATCH /api/admin/images/[id]`.
- Soft-delete / restore action → M5-4.
- Cloudflare variant drift detection (health probe fetching one known-good id) → captured in the parent plan risk 9; out of scope for this slice.
- `image_metadata` editing UI — surfaced read-only here; no write path planned for M5. If operators need it, a small follow-up adds a JSON editor.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (`/admin/images/[id]` registered)
- [ ] `npm run test` — run in CI.
- [ ] `npm run test:e2e` — run in CI. Pre-existing sites.spec.ts / users.spec.ts failures on main remain; M5-2's own specs are independent.