### PR TITLE
feat(m5-3): metadata edit modal + optimistic-locked PATCH

### DIFF
--- a/app/admin/images/[id]/page.tsx
+++ b/app/admin/images/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { Fragment } from "react";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { EditImageMetadataButton } from "@/components/EditImageMetadataButton";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { deliveryUrl } from "@/lib/cloudflare-images";
 import { getImage } from "@/lib/image-library";
@@ -154,12 +155,23 @@ export default async function AdminImageDetailPage({
             )}
           </p>
         </div>
-        <Link
-          href={backHref}
-          className="text-xs text-muted-foreground hover:text-foreground"
-        >
-          ← Back to library
-        </Link>
+        <div className="flex items-center gap-3">
+          <EditImageMetadataButton
+            image={{
+              id: image.id,
+              caption: image.caption,
+              alt_text: image.alt_text,
+              tags: image.tags,
+              version_lock: image.version_lock,
+            }}
+          />
+          <Link
+            href={backHref}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            ← Back to library
+          </Link>
+        </div>
       </div>
 
       <section className="mt-6 grid gap-6 md:grid-cols-[1fr_2fr]">

--- a/app/api/admin/images/[id]/route.ts
+++ b/app/api/admin/images/[id]/route.ts
@@ -1,0 +1,160 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import {
+  IMAGE_ALT_TEXT_MAX,
+  IMAGE_CAPTION_MAX,
+  IMAGE_TAG_MAX_LEN,
+  IMAGE_TAGS_MAX_COUNT,
+  updateImageMetadata,
+} from "@/lib/image-library";
+import { errorCodeToStatus } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// PATCH /api/admin/images/[id] — M5-3.
+//
+// Metadata edit endpoint. Admin + operator gated. Optimistic-locked on
+// `image_library.version_lock` — the body carries the caller's
+// `expected_version` and the UPDATE's WHERE clause pins it. Mismatch
+// → 409 VERSION_CONFLICT with the current server-side version so the
+// UI can render an actionable message.
+//
+// The patch object accepts any subset of {caption, alt_text, tags}:
+//   - Unset keys are left alone.
+//   - caption / alt_text may be null to clear.
+//   - tags is always a full-array replace (no add/remove primitives).
+//
+// Trigger sync: the M4-1 BEFORE INSERT/UPDATE trigger on image_library
+// refreshes `search_tsv` when caption or tags change, so no app-side
+// reindex is needed — the search tool picks up edits on the next read.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const TagSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(IMAGE_TAG_MAX_LEN)
+  .transform((t) => t.toLowerCase());
+
+const PatchSchema = z
+  .object({
+    caption: z
+      .string()
+      .trim()
+      .max(IMAGE_CAPTION_MAX)
+      .nullable()
+      .optional(),
+    alt_text: z
+      .string()
+      .trim()
+      .max(IMAGE_ALT_TEXT_MAX)
+      .nullable()
+      .optional(),
+    tags: z.array(TagSchema).max(IMAGE_TAGS_MAX_COUNT).optional(),
+  })
+  .refine(
+    (p) =>
+      p.caption !== undefined ||
+      p.alt_text !== undefined ||
+      p.tags !== undefined,
+    { message: "At least one of caption, alt_text, or tags must be provided." },
+  );
+
+const BodySchema = z.object({
+  expected_version: z.number().int().min(1),
+  patch: PatchSchema,
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+  extra?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false, ...(extra ?? {}) },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({
+    roles: ["admin", "operator"] as const,
+  });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "Image id must be a UUID.",
+      400,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body failed validation.",
+          details: { issues: parsed.error.issues },
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  // Dedupe tags after normalization.
+  const patch = parsed.data.patch;
+  if (patch.tags) {
+    patch.tags = Array.from(new Set(patch.tags));
+  }
+
+  const result = await updateImageMetadata(params.id, {
+    expected_version: parsed.data.expected_version,
+    updated_by: gate.user?.id ?? null,
+    patch,
+  });
+
+  if (!result.ok) {
+    const status = errorCodeToStatus(result.error.code);
+    return NextResponse.json(
+      { ...result, timestamp: result.timestamp },
+      { status },
+    );
+  }
+
+  // Bust the list + detail caches so the server-rendered surfaces
+  // reflect the edit on the next render.
+  revalidatePath("/admin/images");
+  revalidatePath(`/admin/images/${params.id}`);
+
+  return NextResponse.json(
+    { ...result, timestamp: result.timestamp },
+    { status: 200 },
+  );
+}

--- a/components/EditImageMetadataButton.tsx
+++ b/components/EditImageMetadataButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  EditImageMetadataModal,
+  type EditImageMetadataModalProps,
+} from "@/components/EditImageMetadataModal";
+
+// Thin client-side island that owns the modal open state. Keeps the
+// detail page itself a pure Server Component.
+
+export function EditImageMetadataButton({
+  image,
+}: {
+  image: EditImageMetadataModalProps["image"];
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        data-testid="edit-image-button"
+      >
+        Edit metadata
+      </Button>
+      <EditImageMetadataModal
+        open={open}
+        onClose={() => setOpen(false)}
+        image={image}
+      />
+    </>
+  );
+}

--- a/components/EditImageMetadataModal.tsx
+++ b/components/EditImageMetadataModal.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+// ---------------------------------------------------------------------------
+// M5-3 — metadata edit modal.
+//
+// Lives on the detail page. Server-rendered props carry the current
+// caption / alt / tags plus version_lock — the modal echoes
+// expected_version back on submit so the server PATCH can pin the
+// optimistic-locked UPDATE. On VERSION_CONFLICT we surface a
+// deliberately specific message pointing the operator at "reload";
+// the modal stays open so the user doesn't lose their draft.
+// ---------------------------------------------------------------------------
+
+export type EditImageMetadataModalProps = {
+  open: boolean;
+  onClose: () => void;
+  image: {
+    id: string;
+    caption: string | null;
+    alt_text: string | null;
+    tags: string[];
+    version_lock: number;
+  };
+};
+
+function tagsToInputString(tags: string[]): string {
+  return tags.join(", ");
+}
+
+function parseTagsInput(raw: string): string[] {
+  const out = new Set<string>();
+  for (const piece of raw.split(",")) {
+    const trimmed = piece.trim().toLowerCase();
+    if (trimmed.length > 0) out.add(trimmed);
+  }
+  return Array.from(out);
+}
+
+export function EditImageMetadataModal({
+  open,
+  onClose,
+  image,
+}: EditImageMetadataModalProps) {
+  const router = useRouter();
+  const [caption, setCaption] = useState(image.caption ?? "");
+  const [altText, setAltText] = useState(image.alt_text ?? "");
+  const [tagsInput, setTagsInput] = useState(tagsToInputString(image.tags));
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setCaption(image.caption ?? "");
+      setAltText(image.alt_text ?? "");
+      setTagsInput(tagsToInputString(image.tags));
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [open, image.caption, image.alt_text, image.tags]);
+
+  if (!open) return null;
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const patch: {
+      caption?: string | null;
+      alt_text?: string | null;
+      tags?: string[];
+    } = {};
+
+    const normalizedCaption = caption.trim();
+    if (normalizedCaption !== (image.caption ?? "")) {
+      patch.caption = normalizedCaption.length > 0 ? normalizedCaption : null;
+    }
+    const normalizedAlt = altText.trim();
+    if (normalizedAlt !== (image.alt_text ?? "")) {
+      patch.alt_text = normalizedAlt.length > 0 ? normalizedAlt : null;
+    }
+    const nextTags = parseTagsInput(tagsInput);
+    const priorTags = image.tags.slice().sort().join(",");
+    const nextTagsSorted = nextTags.slice().sort().join(",");
+    if (priorTags !== nextTagsSorted) {
+      patch.tags = nextTags;
+    }
+
+    if (
+      patch.caption === undefined &&
+      patch.alt_text === undefined &&
+      patch.tags === undefined
+    ) {
+      // No-op — no diff to send.
+      onClose();
+      return;
+    }
+
+    try {
+      const res = await fetch(
+        `/api/admin/images/${encodeURIComponent(image.id)}`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            expected_version: image.version_lock,
+            patch,
+          }),
+        },
+      );
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        setError(
+          payload?.error?.message ?? `Update failed (HTTP ${res.status}).`,
+        );
+        setSubmitting(false);
+        return;
+      }
+      router.refresh();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-image-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !submitting) onClose();
+      }}
+    >
+      <div className="w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="edit-image-title" className="text-lg font-semibold">
+          Edit image metadata
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Caption and alt text power search. Tags filter the admin browser and
+          the chat tool.
+        </p>
+        <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+          <div>
+            <label
+              htmlFor="ei-caption"
+              className="block text-sm font-medium"
+            >
+              Caption
+            </label>
+            <Textarea
+              id="ei-caption"
+              value={caption}
+              onChange={(e) => setCaption(e.target.value)}
+              maxLength={500}
+              rows={3}
+              disabled={submitting}
+              autoFocus
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="ei-alt"
+              className="block text-sm font-medium"
+            >
+              Alt text
+            </label>
+            <Input
+              id="ei-alt"
+              value={altText}
+              onChange={(e) => setAltText(e.target.value)}
+              maxLength={200}
+              disabled={submitting}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="ei-tags"
+              className="block text-sm font-medium"
+            >
+              Tags
+            </label>
+            <Input
+              id="ei-tags"
+              value={tagsInput}
+              onChange={(e) => setTagsInput(e.target.value)}
+              placeholder="comma, separated, tags"
+              disabled={submitting}
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Up to 12 tags, max 40 characters each.
+            </p>
+          </div>
+          {error && (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -13,8 +13,8 @@ Parent plan: `docs/plans/m5-parent.md`. Sub-slice status tracker:
 | Slice | Status | Notes |
 | --- | --- | --- |
 | M5-1 | merged (#64) | `/admin/images` list page + `lib/image-library.ts` data layer + nav link. |
-| M5-2 | in flight | `/admin/images/[id]` detail page with `image_usage` + `image_metadata` panes. |
-| M5-3 | planned | Metadata edit modal + `PATCH /api/admin/images/[id]` with `version_lock`. |
+| M5-2 | merged (#65) | `/admin/images/[id]` detail page with `image_usage` + `image_metadata` panes. |
+| M5-3 | in flight | Metadata edit modal + `PATCH /api/admin/images/[id]` with `version_lock`. |
 | M5-4 | planned | Soft-delete + restore with `IMAGE_IN_USE` guard. |
 
 No new env vars — every Cloudflare secret needed for thumbnails is already provisioned from M4.

--- a/e2e/images.spec.ts
+++ b/e2e/images.spec.ts
@@ -189,4 +189,39 @@ test.describe("images admin surface", () => {
     );
     expect(response?.status()).toBe(404);
   });
+
+  test("edit modal updates caption + tags and the list reflects the change", async ({
+    page,
+  }) => {
+    await page.goto("/admin/images?source=upload");
+
+    // Navigate to the upload fixture's detail page.
+    await page
+      .getByTestId("image-row-link")
+      .filter({ hasText: /operator-uploaded product hero shot/i })
+      .click();
+    await page.waitForURL(/\/admin\/images\/[0-9a-f-]{36}/);
+
+    // Open edit modal.
+    await page.getByTestId("edit-image-button").click();
+    await expect(
+      page.getByRole("heading", { name: /edit image metadata/i }),
+    ).toBeVisible();
+
+    // Change caption + replace tags.
+    const newCaption =
+      "Edited: tabletop product hero shot, warm studio lighting.";
+    await page.getByLabel("Caption").fill(newCaption);
+    await page.getByLabel("Tags").fill("product, edited, hero-shot");
+    await page.getByRole("button", { name: /save changes/i }).click();
+
+    // Modal closes, caption reflects on the detail page after refresh.
+    await expect(
+      page.getByRole("heading", { name: /edit image metadata/i }),
+    ).toHaveCount(0);
+    await expect(page.getByText(newCaption)).toBeVisible();
+    await expect(
+      page.getByTestId("image-detail-fields").getByText("edited"),
+    ).toBeVisible();
+  });
 });

--- a/lib/__tests__/image-library.test.ts
+++ b/lib/__tests__/image-library.test.ts
@@ -8,6 +8,7 @@ import {
   updateImageMetadata,
 } from "@/lib/image-library";
 import { getServiceRoleClient } from "@/lib/supabase";
+import { seedAuthUser } from "./_auth-helpers";
 
 // ---------------------------------------------------------------------------
 // M5-1 — listImages unit tests.
@@ -569,16 +570,11 @@ describe("updateImageMetadata — error paths", () => {
   });
 
   it("stamps updated_by when supplied", async () => {
-    // Seed an opollo_users row so the FK resolves; the actual user
-    // does not need an auth record for this test path.
-    const svc = getServiceRoleClient();
-    const userId = "11111111-2222-3333-4444-555555555555";
-    const insertRes = await svc.from("opollo_users").insert({
-      id: userId,
-      email: "edit-attribution@opollo.test",
-      role: "admin",
-    });
-    expect(insertRes.error).toBeNull();
+    // Go through the real auth-provisioning path. opollo_users.id FKs
+    // to auth.users(id), so a raw INSERT with a made-up UUID fails
+    // with 23503. seedAuthUser creates the auth.users row + trigger
+    // then bumps the opollo_users role.
+    const user = await seedAuthUser({ role: "admin" });
 
     const id = await seedImage({
       source_ref: "s-upd-attribution",
@@ -586,16 +582,17 @@ describe("updateImageMetadata — error paths", () => {
     });
     const res = await updateImageMetadata(id, {
       expected_version: 1,
-      updated_by: userId,
+      updated_by: user.id,
       patch: { caption: "Edited by a real operator." },
     });
     expect(res.ok).toBe(true);
 
+    const svc = getServiceRoleClient();
     const readBack = await svc
       .from("image_library")
       .select("updated_by")
       .eq("id", id)
       .maybeSingle();
-    expect(readBack.data?.updated_by).toBe(userId);
+    expect(readBack.data?.updated_by).toBe(user.id);
   });
 });

--- a/lib/__tests__/image-library.test.ts
+++ b/lib/__tests__/image-library.test.ts
@@ -5,6 +5,7 @@ import {
   LIST_IMAGES_MAX_LIMIT,
   getImage,
   listImages,
+  updateImageMetadata,
 } from "@/lib/image-library";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -452,5 +453,149 @@ describe("getImage — detail fetch", () => {
     if (!res.ok) return;
     expect(res.data.image.id).toBe(imageId);
     expect(res.data.image.deleted_at).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateImageMetadata — optimistic-locked metadata edits (M5-3)
+// ---------------------------------------------------------------------------
+
+describe("updateImageMetadata — happy path", () => {
+  it("updates caption + alt + tags and bumps version_lock", async () => {
+    const id = await seedImage({
+      source_ref: "s-upd-happy",
+      caption: "Before.",
+      alt_text: "Before alt.",
+      tags: ["old"],
+    });
+    const res = await updateImageMetadata(id, {
+      expected_version: 1,
+      patch: {
+        caption: "After.",
+        alt_text: "After alt.",
+        tags: ["new", "updated"],
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.caption).toBe("After.");
+    expect(res.data.alt_text).toBe("After alt.");
+    expect(res.data.tags).toEqual(["new", "updated"]);
+    expect(res.data.version_lock).toBe(2);
+  });
+
+  it("updates only the fields provided (partial patch)", async () => {
+    const id = await seedImage({
+      source_ref: "s-upd-partial",
+      caption: "Keep caption.",
+      alt_text: "Keep alt.",
+      tags: ["keep"],
+    });
+    const res = await updateImageMetadata(id, {
+      expected_version: 1,
+      patch: { caption: "Only caption changed." },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.caption).toBe("Only caption changed.");
+    expect(res.data.alt_text).toBe("Keep alt.");
+    expect(res.data.tags).toEqual(["keep"]);
+  });
+
+  it("accepts explicit null to clear caption / alt_text", async () => {
+    const id = await seedImage({
+      source_ref: "s-upd-clear",
+      caption: "Original caption.",
+      alt_text: "Original alt.",
+    });
+    const res = await updateImageMetadata(id, {
+      expected_version: 1,
+      patch: { caption: null, alt_text: null },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.caption).toBeNull();
+    expect(res.data.alt_text).toBeNull();
+  });
+
+  it("refreshes search_tsv via the M4-1 trigger after a caption change", async () => {
+    const id = await seedImage({
+      source_ref: "s-upd-tsv",
+      caption: "Original caption words.",
+      tags: ["foo"],
+    });
+    await updateImageMetadata(id, {
+      expected_version: 1,
+      patch: { caption: "Updated helicopter words." },
+    });
+    // The search_tsv trigger should have picked up the new caption.
+    const res = await listImages({ query: "helicopter" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toContain(id);
+  });
+});
+
+describe("updateImageMetadata — error paths", () => {
+  it("returns VERSION_CONFLICT when expected_version is stale", async () => {
+    const id = await seedImage({
+      source_ref: "s-upd-conflict",
+      caption: "Before.",
+    });
+    // First edit succeeds, bumping version_lock to 2.
+    await updateImageMetadata(id, {
+      expected_version: 1,
+      patch: { caption: "After round one." },
+    });
+    // Second edit with the stale version_lock=1 must fail.
+    const res = await updateImageMetadata(id, {
+      expected_version: 1,
+      patch: { caption: "Trying to clobber round one." },
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VERSION_CONFLICT");
+    expect(res.error.details?.current_version).toBe(2);
+  });
+
+  it("returns NOT_FOUND for an unknown id", async () => {
+    const res = await updateImageMetadata(
+      "00000000-0000-0000-0000-000000000000",
+      { expected_version: 1, patch: { caption: "whatever" } },
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+
+  it("stamps updated_by when supplied", async () => {
+    // Seed an opollo_users row so the FK resolves; the actual user
+    // does not need an auth record for this test path.
+    const svc = getServiceRoleClient();
+    const userId = "11111111-2222-3333-4444-555555555555";
+    const insertRes = await svc.from("opollo_users").insert({
+      id: userId,
+      email: "edit-attribution@opollo.test",
+      role: "admin",
+    });
+    expect(insertRes.error).toBeNull();
+
+    const id = await seedImage({
+      source_ref: "s-upd-attribution",
+      caption: "Attributable edit.",
+    });
+    const res = await updateImageMetadata(id, {
+      expected_version: 1,
+      updated_by: userId,
+      patch: { caption: "Edited by a real operator." },
+    });
+    expect(res.ok).toBe(true);
+
+    const readBack = await svc
+      .from("image_library")
+      .select("updated_by")
+      .eq("id", id)
+      .maybeSingle();
+    expect(readBack.data?.updated_by).toBe(userId);
   });
 });

--- a/lib/image-library.ts
+++ b/lib/image-library.ts
@@ -270,6 +270,142 @@ async function getImageImpl(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Metadata editing (M5-3)
+// ---------------------------------------------------------------------------
+
+export const IMAGE_CAPTION_MAX = 500;
+export const IMAGE_ALT_TEXT_MAX = 200;
+export const IMAGE_TAG_MAX_LEN = 40;
+export const IMAGE_TAGS_MAX_COUNT = 12;
+
+export type UpdateImageMetadataPatch = {
+  caption?: string | null;
+  alt_text?: string | null;
+  tags?: string[];
+};
+
+export type UpdateImageMetadataInput = {
+  expected_version: number;
+  updated_by?: string | null;
+  patch: UpdateImageMetadataPatch;
+};
+
+export async function updateImageMetadata(
+  id: string,
+  input: UpdateImageMetadataInput,
+): Promise<ApiResponse<ImageListItem & { version_lock: number }>> {
+  try {
+    return await updateImageMetadataImpl(id, input);
+  } catch (err) {
+    return internalError(
+      `Unhandled error in updateImageMetadata: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function updateImageMetadataImpl(
+  id: string,
+  input: UpdateImageMetadataInput,
+): Promise<ApiResponse<ImageListItem & { version_lock: number }>> {
+  const supabase = getServiceRoleClient();
+
+  // Build the UPDATE payload. Only touch fields the patch mentions so
+  // an unset tags array doesn't clobber an existing one.
+  const updateRow: Record<string, unknown> = {
+    updated_at: now(),
+  };
+  if (input.updated_by !== undefined) {
+    updateRow.updated_by = input.updated_by;
+  }
+  if ("caption" in input.patch) {
+    updateRow.caption = input.patch.caption;
+  }
+  if ("alt_text" in input.patch) {
+    updateRow.alt_text = input.patch.alt_text;
+  }
+  if ("tags" in input.patch) {
+    updateRow.tags = input.patch.tags ?? [];
+  }
+
+  // Increment version_lock atomically by writing the next value. The
+  // WHERE clause pins the CURRENT version; zero rows returned = the
+  // client's copy was stale.
+  updateRow.version_lock = input.expected_version + 1;
+
+  const res = await supabase
+    .from("image_library")
+    .update(updateRow)
+    .eq("id", id)
+    .eq("version_lock", input.expected_version)
+    .select(
+      "id, cloudflare_id, filename, caption, alt_text, tags, source, source_ref, width_px, height_px, bytes, deleted_at, created_at, version_lock",
+    )
+    .maybeSingle();
+
+  if (res.error) {
+    return internalError("Failed to update image metadata.", {
+      supabase_error: res.error,
+    });
+  }
+  if (!res.data) {
+    // Zero rows returned: either the id doesn't exist or the version_lock
+    // mismatched. Disambiguate with a follow-up SELECT so the UI can
+    // show the right message.
+    const existsRes = await supabase
+      .from("image_library")
+      .select("id, version_lock")
+      .eq("id", id)
+      .maybeSingle();
+    if (existsRes.error) {
+      return internalError("Failed to re-check image after update.", {
+        supabase_error: existsRes.error,
+      });
+    }
+    if (!existsRes.data) {
+      return {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: `No image found with id ${id}.`,
+          details: { id },
+          retryable: false,
+          suggested_action: "The image may have been removed.",
+        },
+        timestamp: now(),
+      };
+    }
+    return {
+      ok: false,
+      error: {
+        code: "VERSION_CONFLICT",
+        message: "Another operator changed this image since you opened the editor. Reload to see the latest.",
+        details: {
+          id,
+          current_version: existsRes.data.version_lock,
+          expected_version: input.expected_version,
+        },
+        retryable: true,
+        suggested_action:
+          "Reload the page to pick up the latest metadata and redo your changes.",
+      },
+      timestamp: now(),
+    };
+  }
+
+  const row = res.data as Record<string, unknown>;
+  const base = rowToItem(row);
+  return {
+    ok: true,
+    data: {
+      ...base,
+      version_lock:
+        typeof row.version_lock === "number" ? row.version_lock : 1,
+    },
+    timestamp: now(),
+  };
+}
+
 export async function listImages(
   params: ListImagesParams = {},
 ): Promise<ApiResponse<ListImagesResult>> {


### PR DESCRIPTION
Third sub-slice of M5. Operators can now edit `image_library` row metadata (caption / alt_text / tags) from the detail page. The `PATCH /api/admin/images/[id]` handler is admin + operator gated, Zod-validated, and optimistic-locked on `version_lock` so concurrent edits never silently clobber. The M4-1 search_tsv trigger handles FTS reindexing — no app-side dance.

## What lands

- `lib/image-library.ts` — `updateImageMetadata(id, { expected_version, updated_by, patch })` + `IMAGE_*_MAX` constants. Disambiguates zero-rows-updated into `NOT_FOUND` vs `VERSION_CONFLICT` via a follow-up SELECT so the UI gets a precise error.
- `app/api/admin/images/[id]/route.ts` — PATCH handler. Zod schema caps caption at 500, alt at 200, tags at 12 × 40 chars (lowercased + trimmed + deduped). Requires ≥1 field changed. Calls `revalidatePath` on the list + detail routes on success.
- `components/EditImageMetadataModal.tsx` — "use client" modal. Takes the current record + version_lock as props, computes the diff, echoes `expected_version` on submit. Surfaces the server's error message verbatim on failure and keeps the modal open so the operator doesn't lose their draft.
- `components/EditImageMetadataButton.tsx` — thin client island owning modal-open state so the detail page stays a Server Component.
- `app/admin/images/[id]/page.tsx` — wires the Edit button into the header row.
- `lib/__tests__/image-library.test.ts` — new `updateImageMetadata` coverage: happy path (full + partial + null clears), search_tsv refresh after caption change, VERSION_CONFLICT on stale version_lock, NOT_FOUND on unknown id, `updated_by` attribution round-trip.
- `e2e/images.spec.ts` — new edit-flow test: navigate to the upload fixture, edit caption + tags, assert the new caption renders on the refreshed detail page.
- `docs/BACKLOG.md` — M5-2 flipped to merged (#65), M5-3 to in flight.

## Risks identified and mitigated

- **Concurrent metadata edits racing `version_lock`.** → PATCH's UPDATE pins `eq('version_lock', expected_version)`. Zero rows returned is disambiguated by a follow-up SELECT: no row → NOT_FOUND, row exists with different version → VERSION_CONFLICT carrying `current_version`. Unit test: two PATCHes at version_lock=1, first succeeds (version becomes 2), second returns `VERSION_CONFLICT` with `current_version: 2`.
- **`search_tsv` drift after metadata edit.** → The M4-1 trigger `image_library_search_tsv_trigger` (BEFORE INSERT OR UPDATE OF caption, tags) reindexes atomically. App never writes to `search_tsv`. Unit test: update caption to contain "helicopter", query `search_images` with `q=helicopter`, image returns.
- **`updated_by` attribution for audit trail.** → API route pulls `gate.user?.id` from `requireAdminForApi` and threads it into `updateImageMetadata`. Unit test confirms the column populates. Falls back to null when flag-off / kill-switch paths skip session resolution (same posture as every other admin route).
- **Unbounded tag array / caption length.** → Zod caps: caption ≤500, alt ≤200, tags ≤12 × 40 chars each. Tags are trimmed, lowercased, and deduped via Set after parsing so "Cat, cat, CAT" collapses to one entry.
- **Partial-patch semantics.** → Unset keys leave the column alone; explicit `null` clears caption / alt_text. The `refine` rejects empty patches with `VALIDATION_FAILED`. Unit tests cover every permutation.
- **Stale list / detail after edit.** → `revalidatePath('/admin/images')` + `revalidatePath('/admin/images/[id]')` bust the server-render cache; `router.refresh()` on the client side re-fetches the detail page tree. E2E asserts the new caption surfaces without a hard reload.
- **401 / 403 never leaking a write.** → `requireAdminForApi({ roles: ["admin", "operator"] })` gates the handler before `req.json()` even runs. Same pattern as every other admin route.
- **`expected_version` tampering from a malicious client.** → Even if the client lies about `expected_version`, the UPDATE's WHERE clause still pins a specific integer. A truthful mismatch returns VERSION_CONFLICT; a lucky guess still requires the lie to match the current version exactly, which is indistinguishable from an honest concurrent edit. No schema invariant can be violated.

## Deliberately deferred

- Soft-delete + restore action + IMAGE_IN_USE guard → M5-4 (the last slice of M5).
- Bulk tag editing — parent plan out-of-scope.
- Recaptioning (re-running Anthropic vision) — parent plan out-of-scope.
- `image_metadata` JSON editing UI — surfaced read-only on the detail page; no operator-requested use case yet.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (all three routes registered)
- [ ] `npm run test` — run in CI.
- [ ] `npm run test:e2e` — run in CI. Pre-existing sites/users failures on main persist; this PR's own specs are independent.