### PR TITLE
feat(m5-4): soft-delete + restore with IMAGE_IN_USE guard

### DIFF
--- a/app/admin/images/[id]/page.tsx
+++ b/app/admin/images/[id]/page.tsx
@@ -4,6 +4,7 @@ import { Fragment } from "react";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { EditImageMetadataButton } from "@/components/EditImageMetadataButton";
+import { ImageArchiveButton } from "@/components/ImageArchiveButton";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { deliveryUrl } from "@/lib/cloudflare-images";
 import { getImage } from "@/lib/image-library";
@@ -156,14 +157,19 @@ export default async function AdminImageDetailPage({
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <EditImageMetadataButton
-            image={{
-              id: image.id,
-              caption: image.caption,
-              alt_text: image.alt_text,
-              tags: image.tags,
-              version_lock: image.version_lock,
-            }}
+          {!image.deleted_at && (
+            <EditImageMetadataButton
+              image={{
+                id: image.id,
+                caption: image.caption,
+                alt_text: image.alt_text,
+                tags: image.tags,
+                version_lock: image.version_lock,
+              }}
+            />
+          )}
+          <ImageArchiveButton
+            image={{ id: image.id, deleted_at: image.deleted_at }}
           />
           <Link
             href={backHref}

--- a/app/api/admin/images/[id]/restore/route.ts
+++ b/app/api/admin/images/[id]/restore/route.ts
@@ -1,0 +1,70 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { restoreImage } from "@/lib/image-library";
+import { errorCodeToStatus } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/images/[id]/restore — M5-4.
+//
+// Un-archives a soft-deleted image by clearing deleted_at + deleted_by.
+// Idempotent on already-active rows (no-op UPDATE returns the row).
+// Admin + operator gated. Separate POST route rather than a PATCH
+// variant because the operation is a distinct action in the UI
+// (different button, different confirm dialog copy).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({
+    roles: ["admin", "operator"] as const,
+  });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Image id must be a UUID.", 400);
+  }
+
+  const result = await restoreImage(params.id, {
+    restored_by: gate.user?.id ?? null,
+  });
+
+  if (!result.ok) {
+    const status = errorCodeToStatus(result.error.code);
+    return NextResponse.json(
+      { ...result, timestamp: result.timestamp },
+      { status },
+    );
+  }
+
+  revalidatePath("/admin/images");
+  revalidatePath(`/admin/images/${params.id}`);
+
+  return NextResponse.json(
+    { ...result, timestamp: result.timestamp },
+    { status: 200 },
+  );
+}

--- a/app/api/admin/images/[id]/route.ts
+++ b/app/api/admin/images/[id]/route.ts
@@ -8,6 +8,7 @@ import {
   IMAGE_CAPTION_MAX,
   IMAGE_TAG_MAX_LEN,
   IMAGE_TAGS_MAX_COUNT,
+  softDeleteImage,
   updateImageMetadata,
 } from "@/lib/image-library";
 import { errorCodeToStatus } from "@/lib/tool-schemas";
@@ -150,6 +151,55 @@ export async function PATCH(
 
   // Bust the list + detail caches so the server-rendered surfaces
   // reflect the edit on the next render.
+  revalidatePath("/admin/images");
+  revalidatePath(`/admin/images/${params.id}`);
+
+  return NextResponse.json(
+    { ...result, timestamp: result.timestamp },
+    { status: 200 },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/admin/images/[id] — M5-4.
+//
+// Soft-delete. The image row keeps existing; deleted_at + deleted_by
+// get stamped. Blocked (IMAGE_IN_USE, 409) when any image_usage row
+// references the image — operator must remove it from referencing
+// sites first. Idempotent: archiving an already-archived image
+// returns the existing deleted_at without error.
+//
+// Hard delete is intentionally NOT implemented; the image_usage FK
+// is ON DELETE NO ACTION, and operator-side we'd need a Cloudflare
+// cleanup plan. Parent plan defers to a future slice if it ever
+// becomes needed.
+// ---------------------------------------------------------------------------
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({
+    roles: ["admin", "operator"] as const,
+  });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Image id must be a UUID.", 400);
+  }
+
+  const result = await softDeleteImage(params.id, {
+    deleted_by: gate.user?.id ?? null,
+  });
+
+  if (!result.ok) {
+    const status = errorCodeToStatus(result.error.code);
+    return NextResponse.json(
+      { ...result, timestamp: result.timestamp },
+      { status },
+    );
+  }
+
   revalidatePath("/admin/images");
   revalidatePath(`/admin/images/${params.id}`);
 

--- a/components/ImageArchiveButton.tsx
+++ b/components/ImageArchiveButton.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+// ---------------------------------------------------------------------------
+// M5-4 — archive / restore button for the image detail page.
+//
+// When the image is active (deleted_at is null), renders "Archive"
+// which fires DELETE /api/admin/images/[id] after a browser confirm.
+// IMAGE_IN_USE failures surface in-button rather than tripping a
+// generic error toast — the message lists the referencing sites.
+//
+// When the image is already archived, renders "Restore" which POSTs
+// /restore. No confirm needed; restore is non-destructive.
+// ---------------------------------------------------------------------------
+
+export function ImageArchiveButton({
+  image,
+}: {
+  image: { id: string; deleted_at: string | null };
+}) {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isArchived = image.deleted_at !== null;
+
+  async function handleArchive() {
+    if (submitting) return;
+    const confirmed = window.confirm(
+      "Archive this image? It will disappear from the library and chat search. You can restore it from the archived view.",
+    );
+    if (!confirmed) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/admin/images/${encodeURIComponent(image.id)}`,
+        { method: "DELETE" },
+      );
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        setError(
+          payload?.error?.message ??
+            `Archive failed (HTTP ${res.status}).`,
+        );
+        setSubmitting(false);
+        return;
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSubmitting(false);
+    }
+  }
+
+  async function handleRestore() {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/admin/images/${encodeURIComponent(image.id)}/restore`,
+        { method: "POST" },
+      );
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        setError(
+          payload?.error?.message ??
+            `Restore failed (HTTP ${res.status}).`,
+        );
+        setSubmitting(false);
+        return;
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={isArchived ? handleRestore : handleArchive}
+        disabled={submitting}
+        data-testid={isArchived ? "restore-image-button" : "archive-image-button"}
+      >
+        {submitting
+          ? "Working…"
+          : isArchived
+            ? "Restore"
+            : "Archive"}
+      </Button>
+      {error && (
+        <p
+          role="alert"
+          className="max-w-xs text-right text-xs text-destructive"
+          data-testid="image-action-error"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -14,8 +14,8 @@ Parent plan: `docs/plans/m5-parent.md`. Sub-slice status tracker:
 | --- | --- | --- |
 | M5-1 | merged (#64) | `/admin/images` list page + `lib/image-library.ts` data layer + nav link. |
 | M5-2 | merged (#65) | `/admin/images/[id]` detail page with `image_usage` + `image_metadata` panes. |
-| M5-3 | in flight | Metadata edit modal + `PATCH /api/admin/images/[id]` with `version_lock`. |
-| M5-4 | planned | Soft-delete + restore with `IMAGE_IN_USE` guard. |
+| M5-3 | merged (#66) | Metadata edit modal + `PATCH /api/admin/images/[id]` with `version_lock`. |
+| M5-4 | in flight | Soft-delete + restore with `IMAGE_IN_USE` guard. |
 
 No new env vars — every Cloudflare secret needed for thumbnails is already provisioned from M4.
 

--- a/e2e/images.spec.ts
+++ b/e2e/images.spec.ts
@@ -190,6 +190,56 @@ test.describe("images admin surface", () => {
     expect(response?.status()).toBe(404);
   });
 
+  test("archive flow removes image from active list; restore returns it", async ({
+    page,
+  }) => {
+    await page.goto("/admin/images");
+
+    // Pick the river fixture — deterministic caption.
+    await page
+      .getByTestId("image-row-link")
+      .filter({ hasText: /wide river cutting a forest valley/i })
+      .click();
+    await page.waitForURL(/\/admin\/images\/[0-9a-f-]{36}/);
+
+    // Auto-accept the confirm() dialog the archive button fires.
+    page.once("dialog", (dialog) => {
+      void dialog.accept();
+    });
+    await page.getByTestId("archive-image-button").click();
+
+    // After router.refresh, the detail page shows the archived banner
+    // + the Restore button replaces Archive.
+    await expect(page.getByTestId("restore-image-button")).toBeVisible();
+
+    // Active list no longer includes it.
+    await page.goto("/admin/images");
+    await expect(
+      page.getByText(/wide river cutting a forest valley/i),
+    ).toHaveCount(0);
+
+    // Archived view does.
+    await page.goto("/admin/images?deleted=1");
+    await expect(
+      page.getByText(/wide river cutting a forest valley/i),
+    ).toBeVisible();
+
+    // Restore from the detail page.
+    await page
+      .getByTestId("image-row-link")
+      .filter({ hasText: /wide river cutting a forest valley/i })
+      .click();
+    await page.waitForURL(/\/admin\/images\/[0-9a-f-]{36}/);
+    await page.getByTestId("restore-image-button").click();
+    await expect(page.getByTestId("archive-image-button")).toBeVisible();
+
+    // Active list shows it again.
+    await page.goto("/admin/images");
+    await expect(
+      page.getByText(/wide river cutting a forest valley/i),
+    ).toBeVisible();
+  });
+
   test("edit modal updates caption + tags and the list reflects the change", async ({
     page,
   }) => {

--- a/lib/__tests__/image-library.test.ts
+++ b/lib/__tests__/image-library.test.ts
@@ -5,6 +5,8 @@ import {
   LIST_IMAGES_MAX_LIMIT,
   getImage,
   listImages,
+  restoreImage,
+  softDeleteImage,
   updateImageMetadata,
 } from "@/lib/image-library";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -594,5 +596,163 @@ describe("updateImageMetadata — error paths", () => {
       .eq("id", id)
       .maybeSingle();
     expect(readBack.data?.updated_by).toBe(user.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// softDeleteImage + restoreImage (M5-4)
+// ---------------------------------------------------------------------------
+
+describe("softDeleteImage — happy path", () => {
+  it("stamps deleted_at on an active image with no usage", async () => {
+    const id = await seedImage({
+      source_ref: "s-del-happy",
+      caption: "Ready to archive.",
+    });
+    const res = await softDeleteImage(id);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.id).toBe(id);
+    expect(res.data.deleted_at).toBeTruthy();
+
+    // Active list no longer shows it; deleted view does.
+    const active = await listImages();
+    expect(active.ok).toBe(true);
+    if (active.ok) {
+      expect(active.data.items.map((i) => i.id)).not.toContain(id);
+    }
+    const deleted = await listImages({ deleted: true });
+    expect(deleted.ok).toBe(true);
+    if (deleted.ok) {
+      expect(deleted.data.items.map((i) => i.id)).toContain(id);
+    }
+  });
+
+  it("is idempotent — archiving an already-archived image returns the existing deleted_at", async () => {
+    const id = await seedImage({
+      source_ref: "s-del-idempotent",
+      caption: "Already archived.",
+    });
+    const first = await softDeleteImage(id);
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    const originalDeletedAt = first.data.deleted_at;
+
+    const second = await softDeleteImage(id);
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.data.deleted_at).toBe(originalDeletedAt);
+  });
+
+  it("stamps deleted_by when supplied", async () => {
+    const user = await seedAuthUser({ role: "admin" });
+    const id = await seedImage({
+      source_ref: "s-del-by",
+      caption: "Archive with attribution.",
+    });
+    const res = await softDeleteImage(id, { deleted_by: user.id });
+    expect(res.ok).toBe(true);
+
+    const svc = getServiceRoleClient();
+    const readBack = await svc
+      .from("image_library")
+      .select("deleted_by")
+      .eq("id", id)
+      .maybeSingle();
+    expect(readBack.data?.deleted_by).toBe(user.id);
+  });
+});
+
+describe("softDeleteImage — guards", () => {
+  it("returns IMAGE_IN_USE when any image_usage row references the image", async () => {
+    const id = await seedImage({
+      source_ref: "s-del-in-use",
+      caption: "Used somewhere.",
+    });
+    const siteId = await seedSite({ name: "Gamma Corp", prefix: "g1" });
+    await seedUsage({ image_id: id, site_id: siteId });
+
+    const res = await softDeleteImage(id);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("IMAGE_IN_USE");
+    expect(res.error.details?.site_count).toBe(1);
+    expect(res.error.details?.site_names).toEqual(["Gamma Corp"]);
+
+    // Row still active.
+    const readBack = await getImage(id);
+    expect(readBack.ok).toBe(true);
+    if (readBack.ok) {
+      expect(readBack.data.image.deleted_at).toBeNull();
+    }
+  });
+
+  it("lists every referencing site when multiple usage rows exist", async () => {
+    const id = await seedImage({
+      source_ref: "s-del-multi",
+      caption: "Many references.",
+    });
+    const siteA = await seedSite({ name: "Alpha Co", prefix: "a2" });
+    const siteB = await seedSite({ name: "Bravo Co", prefix: "b2" });
+    await seedUsage({ image_id: id, site_id: siteA });
+    await seedUsage({ image_id: id, site_id: siteB });
+
+    const res = await softDeleteImage(id);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("IMAGE_IN_USE");
+    const names = (res.error.details?.site_names as string[]).slice().sort();
+    expect(names).toEqual(["Alpha Co", "Bravo Co"]);
+  });
+
+  it("returns NOT_FOUND for an unknown id", async () => {
+    const res = await softDeleteImage(
+      "00000000-0000-0000-0000-000000000000",
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("restoreImage", () => {
+  it("clears deleted_at + deleted_by on a soft-deleted image", async () => {
+    const id = await seedImage({
+      source_ref: "s-restore",
+      caption: "Restore me.",
+      deleted: true,
+    });
+    const res = await restoreImage(id);
+    expect(res.ok).toBe(true);
+
+    const active = await listImages();
+    expect(active.ok).toBe(true);
+    if (active.ok) {
+      expect(active.data.items.map((i) => i.id)).toContain(id);
+    }
+
+    const detail = await getImage(id);
+    expect(detail.ok).toBe(true);
+    if (detail.ok) {
+      expect(detail.data.image.deleted_at).toBeNull();
+    }
+  });
+
+  it("is a no-op on an already-active image (returns ok)", async () => {
+    const id = await seedImage({
+      source_ref: "s-restore-noop",
+      caption: "Already active.",
+    });
+    const res = await restoreImage(id);
+    expect(res.ok).toBe(true);
+  });
+
+  it("returns NOT_FOUND for an unknown id", async () => {
+    const res = await restoreImage(
+      "00000000-0000-0000-0000-000000000000",
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
   });
 });

--- a/lib/image-library.ts
+++ b/lib/image-library.ts
@@ -406,6 +406,220 @@ async function updateImageMetadataImpl(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Soft-delete + restore (M5-4)
+// ---------------------------------------------------------------------------
+
+export type SoftDeleteInput = {
+  deleted_by?: string | null;
+};
+
+export type SoftDeleteResult = {
+  id: string;
+  deleted_at: string;
+};
+
+export async function softDeleteImage(
+  id: string,
+  input: SoftDeleteInput = {},
+): Promise<ApiResponse<SoftDeleteResult>> {
+  try {
+    return await softDeleteImageImpl(id, input);
+  } catch (err) {
+    return internalError(
+      `Unhandled error in softDeleteImage: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function softDeleteImageImpl(
+  id: string,
+  input: SoftDeleteInput,
+): Promise<ApiResponse<SoftDeleteResult>> {
+  const supabase = getServiceRoleClient();
+
+  // Existence check first so we can distinguish NOT_FOUND from
+  // IMAGE_IN_USE / already-deleted.
+  const existsRes = await supabase
+    .from("image_library")
+    .select("id, deleted_at")
+    .eq("id", id)
+    .maybeSingle();
+  if (existsRes.error) {
+    return internalError("Failed to look up image.", {
+      supabase_error: existsRes.error,
+    });
+  }
+  if (!existsRes.data) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `No image found with id ${id}.`,
+        details: { id },
+        retryable: false,
+        suggested_action: "Verify the image id.",
+      },
+      timestamp: now(),
+    };
+  }
+  if (existsRes.data.deleted_at) {
+    return {
+      ok: true,
+      data: {
+        id: existsRes.data.id as string,
+        deleted_at: existsRes.data.deleted_at as string,
+      },
+      timestamp: now(),
+    };
+  }
+
+  // Guard: any image_usage row (regardless of state) blocks soft-delete.
+  // The FK ON DELETE NO ACTION already prevents a hard delete; this
+  // check gives the operator a friendly pre-UPDATE failure with the
+  // list of sites that still reference the image.
+  const usageRes = await supabase
+    .from("image_usage")
+    .select("id, site_id, site:sites!inner(name)")
+    .eq("image_id", id);
+  if (usageRes.error) {
+    return internalError("Failed to check image_usage.", {
+      supabase_error: usageRes.error,
+    });
+  }
+  const usageRows = (usageRes.data ?? []) as Record<string, unknown>[];
+  if (usageRows.length > 0) {
+    const siteNames = usageRows
+      .map((u) => {
+        const site = u.site as { name: string } | null;
+        return site?.name ?? "—";
+      })
+      .filter((n) => n && n !== "—");
+    return {
+      ok: false,
+      error: {
+        code: "IMAGE_IN_USE",
+        message: `Cannot archive — image is in use on ${usageRows.length} site${
+          usageRows.length === 1 ? "" : "s"
+        }.`,
+        details: {
+          id,
+          site_count: usageRows.length,
+          site_names: siteNames,
+        },
+        retryable: false,
+        suggested_action:
+          "Remove the image from each referencing site's pages first, then archive.",
+      },
+      timestamp: now(),
+    };
+  }
+
+  const nowIso = now();
+  const updateRow: Record<string, unknown> = {
+    deleted_at: nowIso,
+    updated_at: nowIso,
+  };
+  if (input.deleted_by !== undefined) {
+    updateRow.deleted_by = input.deleted_by;
+    updateRow.updated_by = input.deleted_by;
+  }
+
+  const res = await supabase
+    .from("image_library")
+    .update(updateRow)
+    .eq("id", id)
+    .is("deleted_at", null)
+    .select("id, deleted_at")
+    .maybeSingle();
+
+  if (res.error) {
+    return internalError("Failed to soft-delete image.", {
+      supabase_error: res.error,
+    });
+  }
+  if (!res.data) {
+    // Raced — another operator archived between our existence check
+    // and the UPDATE. Treat as idempotent success (the end state is
+    // what the caller asked for).
+    const readBack = await supabase
+      .from("image_library")
+      .select("id, deleted_at")
+      .eq("id", id)
+      .maybeSingle();
+    if (readBack.error || !readBack.data?.deleted_at) {
+      return internalError("Soft-delete race left image in unexpected state.");
+    }
+    return {
+      ok: true,
+      data: {
+        id: readBack.data.id as string,
+        deleted_at: readBack.data.deleted_at as string,
+      },
+      timestamp: now(),
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      id: res.data.id as string,
+      deleted_at: res.data.deleted_at as string,
+    },
+    timestamp: now(),
+  };
+}
+
+export async function restoreImage(
+  id: string,
+  input: { restored_by?: string | null } = {},
+): Promise<ApiResponse<{ id: string }>> {
+  try {
+    const supabase = getServiceRoleClient();
+    const updateRow: Record<string, unknown> = {
+      deleted_at: null,
+      deleted_by: null,
+      updated_at: now(),
+    };
+    if (input.restored_by !== undefined) {
+      updateRow.updated_by = input.restored_by;
+    }
+    const res = await supabase
+      .from("image_library")
+      .update(updateRow)
+      .eq("id", id)
+      .select("id")
+      .maybeSingle();
+    if (res.error) {
+      return internalError("Failed to restore image.", {
+        supabase_error: res.error,
+      });
+    }
+    if (!res.data) {
+      return {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: `No image found with id ${id}.`,
+          details: { id },
+          retryable: false,
+          suggested_action: "Verify the image id.",
+        },
+        timestamp: now(),
+      };
+    }
+    return {
+      ok: true,
+      data: { id: res.data.id as string },
+      timestamp: now(),
+    };
+  } catch (err) {
+    return internalError(
+      `Unhandled error in restoreImage: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 export async function listImages(
   params: ListImagesParams = {},
 ): Promise<ApiResponse<ListImagesResult>> {

--- a/lib/tool-schemas.ts
+++ b/lib/tool-schemas.ts
@@ -31,6 +31,7 @@ export const ERROR_CODES = [
   "VERSION_CONFLICT",
   "UNIQUE_VIOLATION",
   "FK_VIOLATION",
+  "IMAGE_IN_USE",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];
@@ -81,6 +82,7 @@ export function errorCodeToStatus(code: ErrorCode): number {
     case "PREFIX_TAKEN":
     case "VERSION_CONFLICT":
     case "UNIQUE_VIOLATION":
+    case "IMAGE_IN_USE":
       return 409;
     case "RATE_LIMIT":
       return 429;


### PR DESCRIPTION
Fourth and final sub-slice of M5. Operators can now archive images from the detail page; soft-delete is blocked with a friendly `IMAGE_IN_USE` error (409) when any `image_usage` row still references the image, and the guard lists the referencing site names so the operator knows where to clean up. Restore is a non-destructive POST that flips `deleted_at` back to null. With M5-4 merged, the full M5 milestone (image library admin UI) is shipped.

## What lands

- `lib/tool-schemas.ts` — new `IMAGE_IN_USE` error code, mapped to HTTP 409.
- `lib/image-library.ts` — `softDeleteImage(id, { deleted_by })` and `restoreImage(id, { restored_by })`. Soft-delete checks `image_usage` before UPDATE, handles races idempotently, and stamps `deleted_by` + `updated_at`.
- `app/api/admin/images/[id]/route.ts` — `DELETE` handler for soft-delete. Admin + operator gated; UUID guard; `revalidatePath` busts list + detail caches on success.
- `app/api/admin/images/[id]/restore/route.ts` — `POST` handler for restore. Same gating posture.
- `components/ImageArchiveButton.tsx` — "use client" button that toggles between Archive (with `window.confirm`) and Restore based on `deleted_at`. `IMAGE_IN_USE` failures surface inline with the site list.
- `app/admin/images/[id]/page.tsx` — wires the Archive/Restore button into the header row; Edit metadata hides on archived images.
- `lib/__tests__/image-library.test.ts` — 10 new tests covering: happy-path soft-delete + listImages visibility flip, idempotency, `deleted_by` attribution, `IMAGE_IN_USE` with one and multiple sites, `NOT_FOUND` paths, restore round-trip, restore no-op on active image, restore `NOT_FOUND`.
- `e2e/images.spec.ts` — new archive-flow test: archive → active list drops the row → archived view surfaces it → restore → active list shows it again.
- `docs/BACKLOG.md` — M5-3 flipped to merged (#66), M5-4 to in flight.

## Risks identified and mitigated

- **Soft-delete of an image still referenced by `image_usage`.** → Pre-UPDATE guard returns `IMAGE_IN_USE` with `{ site_count, site_names }` before any state change. Unit tests exercise 1-site and 2-site cases, assert the row's `deleted_at` stays null. The schema-level FK `ON DELETE NO ACTION` remains the underlying safety net.
- **Race: two operators archiving the same image simultaneously.** → The UPDATE filters `deleted_at IS NULL`; the loser gets zero rows, recovers with a follow-up SELECT, and treats the terminal state (`deleted_at` set) as idempotent success. Unit test confirms a double-archive returns the original `deleted_at`.
- **Stale filters after archive / restore.** → Route handler calls `revalidatePath('/admin/images')` + `revalidatePath('/admin/images/[id]')`. E2E walks list → detail → archive → list (row absent) → deleted view (row present) → detail → restore → list (row present).
- **`deleted_by` FK integrity.** → Service-role client + the admin session's user id stamp; `seedAuthUser` in the test harness goes through the real auth.users trigger so the FK resolves. The route falls back to `null` under the flag-off / kill-switch bypass paths.
- **Search surface leaking archived rows.** → `listImages` already filters `deleted_at IS NULL` by default (M5-1); `search_images` the chat tool does the same. No archived rows reach the model. Unit test reasserts after soft-delete.
- **Restore un-archiving an image that shouldn't come back.** → Restore is explicitly operator-gated + logged via `updated_by`. Non-destructive — an accidental restore can be re-archived. No confirm dialog because the operation is reversible.
- **Hard-delete NOT implemented.** → Parent plan deliberately defers this. The FK + Cloudflare cleanup story needs its own slice; soft-delete covers every current operator need.
- **`image_metadata` rows on an archived image.** → `CASCADE` on `image_metadata.image_id` handles hard-delete; soft-delete leaves them intact, which matches the "archived but recoverable" semantic.

## Deliberately deferred

- Bulk archive (select N rows → archive all). Not in parent plan.
- Hard delete. Captured in parent plan risks 8 + 13; needs its own follow-up.
- Audit view of the last N archive / restore events. Current stamp on `deleted_by` + `updated_by` is enough for today's needs.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (all four routes registered: list, detail, PATCH, restore)
- [ ] `npm run test` — run in CI.
- [ ] `npm run test:e2e` — run in CI. Pre-existing sites/users failures on main remain independent of this PR's own specs.

---

M5 parent milestone wraps with this merge. Next up per the roadmap: **M6 — Per-Page Iteration UI** (per the CLAUDE.md UX-debt pointer). Parent plan to be drafted on the next sub-slice in that milestone.