### PR TITLE
feat(m6-1): per-site pages admin list + lib/pages data layer

### DIFF
--- a/app/admin/sites/[id]/page.tsx
+++ b/app/admin/sites/[id]/page.tsx
@@ -154,6 +154,13 @@ export default async function SiteDetailPage({
             >
               {site.wp_url}
             </a>
+            <Link
+              href={`/admin/sites/${site.id}/pages`}
+              className="hover:text-foreground hover:underline"
+              data-testid="site-pages-link"
+            >
+              Pages →
+            </Link>
             <span>updated {formatDate(site.updated_at)}</span>
           </div>
         </div>

--- a/app/admin/sites/[id]/pages/page.tsx
+++ b/app/admin/sites/[id]/pages/page.tsx
@@ -1,0 +1,278 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { PagesTable } from "@/components/PagesTable";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import {
+  LIST_PAGES_DEFAULT_LIMIT,
+  listPagesForSite,
+  type PageStatus,
+} from "@/lib/pages";
+import { getSite } from "@/lib/sites";
+import { TEMPLATE_TYPES } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// /admin/sites/[id]/pages — M6-1.
+//
+// Site-scoped pages browser. Admin + operator visible (matches the
+// /admin/sites/[id] detail page which is the only nav entry into
+// here). Read-only; mutation paths land in M6-3.
+//
+// Query params:
+//   status     "draft" | "published"
+//   page_type  template enum
+//   q          free-text search (title + slug, ILIKE)
+//   page       1-indexed page number
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type RawSearchParams = {
+  [key: string]: string | string[] | undefined;
+};
+
+type ParsedParams = {
+  status: PageStatus | null;
+  page_type: string | null;
+  query: string | null;
+  page: number;
+};
+
+function parseSearchParams(raw: RawSearchParams): ParsedParams {
+  const status =
+    raw.status === "draft" || raw.status === "published"
+      ? (raw.status as PageStatus)
+      : null;
+  const pageTypeRaw = typeof raw.page_type === "string" ? raw.page_type : null;
+  const page_type =
+    pageTypeRaw && (TEMPLATE_TYPES as readonly string[]).includes(pageTypeRaw)
+      ? pageTypeRaw
+      : null;
+  const q =
+    typeof raw.q === "string" && raw.q.trim().length > 0 ? raw.q.trim() : null;
+  const pageRaw = typeof raw.page === "string" ? Number(raw.page) : 1;
+  const page =
+    Number.isFinite(pageRaw) && pageRaw >= 1 ? Math.floor(pageRaw) : 1;
+  return { status, page_type, query: q, page };
+}
+
+function buildHref(
+  siteId: string,
+  base: ParsedParams,
+  overrides: Partial<ParsedParams>,
+): string {
+  const merged = { ...base, ...overrides };
+  const params = new URLSearchParams();
+  if (merged.status) params.set("status", merged.status);
+  if (merged.page_type) params.set("page_type", merged.page_type);
+  if (merged.query) params.set("q", merged.query);
+  if (merged.page > 1) params.set("page", String(merged.page));
+  const qs = params.toString();
+  const root = `/admin/sites/${siteId}/pages`;
+  return qs.length > 0 ? `${root}?${qs}` : root;
+}
+
+export default async function SitePagesList({
+  params,
+  searchParams,
+}: {
+  params: { id: string };
+  searchParams: RawSearchParams;
+}) {
+  const access = await checkAdminAccess({
+    requiredRoles: ["admin", "operator"],
+    insufficientRoleRedirectTo: "/admin/sites",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  if (!UUID_RE.test(params.id)) notFound();
+
+  const siteRes = await getSite(params.id);
+  if (!siteRes.ok) {
+    if (siteRes.error.code === "NOT_FOUND") notFound();
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+      >
+        Failed to load site: {siteRes.error.message}
+      </div>
+    );
+  }
+  const site = siteRes.data.site;
+
+  const parsed = parseSearchParams(searchParams);
+  const limit = LIST_PAGES_DEFAULT_LIMIT;
+  const offset = (parsed.page - 1) * limit;
+
+  const result = await listPagesForSite(params.id, {
+    status: parsed.status ?? undefined,
+    page_type: parsed.page_type ?? undefined,
+    query: parsed.query ?? undefined,
+    limit,
+    offset,
+  });
+
+  if (!result.ok) {
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+      >
+        Failed to load pages: {result.error.message}
+      </div>
+    );
+  }
+
+  const { items, total } = result.data;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const currentPage = Math.min(parsed.page, totalPages);
+  const rangeStart = total === 0 ? 0 : offset + 1;
+  const rangeEnd = Math.min(offset + limit, total);
+
+  return (
+    <>
+      <Breadcrumbs
+        crumbs={[
+          { label: "Sites", href: "/admin/sites" },
+          { label: site.name, href: `/admin/sites/${params.id}` },
+          { label: "Pages" },
+        ]}
+      />
+
+      <div className="mt-4 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold">Pages for {site.name}</h1>
+          <p className="text-sm text-muted-foreground">
+            Every page generated for this site. Click a row for the detail
+            view. Editing content itself still happens in WordPress admin.
+          </p>
+        </div>
+        <Link
+          href={`/admin/sites/${params.id}`}
+          className="text-xs text-muted-foreground hover:text-foreground"
+        >
+          ← Site detail
+        </Link>
+      </div>
+
+      <form
+        method="GET"
+        action={`/admin/sites/${params.id}/pages`}
+        className="mt-6 flex flex-wrap items-end gap-3 rounded-md border bg-muted/30 p-3"
+      >
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="pages-q"
+            className="text-xs font-medium text-muted-foreground"
+          >
+            Search
+          </label>
+          <input
+            id="pages-q"
+            type="search"
+            name="q"
+            defaultValue={parsed.query ?? ""}
+            placeholder="managed IT"
+            className="h-8 min-w-56 rounded border bg-background px-2 text-sm"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="pages-status"
+            className="text-xs font-medium text-muted-foreground"
+          >
+            Status
+          </label>
+          <select
+            id="pages-status"
+            name="status"
+            defaultValue={parsed.status ?? ""}
+            className="h-8 rounded border bg-background px-2 text-sm"
+          >
+            <option value="">Any</option>
+            <option value="draft">Draft</option>
+            <option value="published">Published</option>
+          </select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="pages-type"
+            className="text-xs font-medium text-muted-foreground"
+          >
+            Type
+          </label>
+          <select
+            id="pages-type"
+            name="page_type"
+            defaultValue={parsed.page_type ?? ""}
+            className="h-8 rounded border bg-background px-2 text-sm"
+          >
+            <option value="">Any</option>
+            {TEMPLATE_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t.replace(/_/g, " ")}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          type="submit"
+          className="h-8 rounded bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Apply
+        </button>
+        {(parsed.query || parsed.status || parsed.page_type) && (
+          <Link
+            href={buildHref(params.id, parsed, {
+              query: null,
+              status: null,
+              page_type: null,
+              page: 1,
+            })}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            Clear
+          </Link>
+        )}
+      </form>
+
+      <div className="mt-4 flex items-center justify-between text-xs text-muted-foreground">
+        <div data-testid="pages-range">
+          {total === 0 ? "0 pages" : `Showing ${rangeStart}–${rangeEnd} of ${total}`}
+        </div>
+        <div className="flex items-center gap-2">
+          {currentPage > 1 && (
+            <Link
+              href={buildHref(params.id, parsed, { page: currentPage - 1 })}
+              className="rounded border px-2 py-1 hover:bg-muted"
+              rel="prev"
+            >
+              ← Previous
+            </Link>
+          )}
+          {currentPage < totalPages && (
+            <Link
+              href={buildHref(params.id, parsed, { page: currentPage + 1 })}
+              className="rounded border px-2 py-1 hover:bg-muted"
+              rel="next"
+            >
+              Next →
+            </Link>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-3">
+        <PagesTable
+          items={items}
+          siteId={params.id}
+          backHref={buildHref(params.id, parsed, {})}
+        />
+      </div>
+    </>
+  );
+}

--- a/components/PagesTable.tsx
+++ b/components/PagesTable.tsx
@@ -1,0 +1,108 @@
+import Link from "next/link";
+
+import type { PageListItem } from "@/lib/pages";
+import { formatRelativeTime } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// M6-1 — pure presentation of the pages list.
+//
+// Each row links to the detail page (M6-2 wires the target route);
+// until that ships, the link points at the placeholder route. Actions
+// column is reserved for M6-3 (edit) and a future "Open in WP admin"
+// shortcut.
+// ---------------------------------------------------------------------------
+
+function statusBadgeClass(status: string): string {
+  switch (status) {
+    case "published":
+      return "bg-emerald-500/10 text-emerald-700";
+    case "draft":
+      return "bg-muted text-muted-foreground";
+    default:
+      return "bg-muted";
+  }
+}
+
+type PagesTableProps = {
+  items: PageListItem[];
+  siteId: string;
+  backHref?: string;
+};
+
+function buildDetailHref(
+  siteId: string,
+  pageId: string,
+  backHref: string | undefined,
+): string {
+  const base = `/admin/sites/${siteId}/pages/${pageId}`;
+  if (!backHref || backHref === `/admin/sites/${siteId}/pages`) return base;
+  const params = new URLSearchParams({ from: backHref });
+  return `${base}?${params.toString()}`;
+}
+
+export function PagesTable({ items, siteId, backHref }: PagesTableProps) {
+  if (items.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          No pages match these filters.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <table className="w-full text-sm">
+        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+          <tr>
+            <th className="px-4 py-2 font-medium">Title</th>
+            <th className="px-4 py-2 font-medium">Type</th>
+            <th className="px-4 py-2 font-medium">Status</th>
+            <th className="px-4 py-2 font-medium">DS version</th>
+            <th className="px-4 py-2 font-medium">Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((p) => (
+            <tr
+              key={p.id}
+              className="border-b last:border-b-0 hover:bg-muted/40"
+              data-testid="page-row"
+              data-page-id={p.id}
+            >
+              <td className="px-4 py-3 align-top">
+                <Link
+                  href={buildDetailHref(siteId, p.id, backHref)}
+                  className="font-medium hover:underline"
+                  data-testid="page-row-link"
+                >
+                  {p.title}
+                </Link>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  /{p.slug}
+                </div>
+              </td>
+              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+                {p.page_type.replace(/_/g, " ")}
+              </td>
+              <td className="px-4 py-3 align-top">
+                <span
+                  className={`inline-flex rounded px-2 py-0.5 text-xs font-medium capitalize ${statusBadgeClass(p.status)}`}
+                >
+                  {p.status}
+                </span>
+              </td>
+              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+                v{p.design_system_version}
+              </td>
+              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+                {formatRelativeTime(p.updated_at)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,16 +6,31 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
-## M5 — image library admin UI (in flight)
+## M6 — per-page admin surface (in flight)
 
-Parent plan: `docs/plans/m5-parent.md`. Sub-slice status tracker:
+Parent plan: `docs/plans/m6-parent.md`. Sub-slice status tracker:
+
+| Slice | Status | Notes |
+| --- | --- | --- |
+| M6-1 | in flight | `/admin/sites/[id]/pages` list + `lib/pages.ts` data layer + Pages link on site detail. |
+| M6-2 | planned | `/admin/sites/[id]/pages/[pageId]` detail + Tier-2 static preview + Tier-3 WP admin link. |
+| M6-3 | planned | Metadata edit modal (title + slug) + `PATCH /api/admin/sites/[id]/pages/[pageId]` with version_lock + UNIQUE_VIOLATION. |
+| M6-4 | planned | UX-debt cleanup: de-jargon the design-system authoring forms per CLAUDE.md backlog. |
+
+No new env vars.
+
+---
+
+## M5 — image library admin UI (shipped)
+
+Parent plan: `docs/plans/m5-parent.md`. All four sub-slices merged.
 
 | Slice | Status | Notes |
 | --- | --- | --- |
 | M5-1 | merged (#64) | `/admin/images` list page + `lib/image-library.ts` data layer + nav link. |
 | M5-2 | merged (#65) | `/admin/images/[id]` detail page with `image_usage` + `image_metadata` panes. |
 | M5-3 | merged (#66) | Metadata edit modal + `PATCH /api/admin/images/[id]` with `version_lock`. |
-| M5-4 | in flight | Soft-delete + restore with `IMAGE_IN_USE` guard. |
+| M5-4 | merged (#67) | Soft-delete + restore with `IMAGE_IN_USE` guard. |
 
 No new env vars — every Cloudflare secret needed for thumbnails is already provisioned from M4.
 
@@ -120,6 +135,17 @@ the comment, add a fixture test that asserts "1M Opus tokens at 15 USD" produces
 ---
 
 ## Testing
+
+### Investigate pre-existing E2E failures on main (sites.spec.ts:73 + users.spec.ts:19)
+**What:** two E2E tests have been failing on main since M4-7 (#63). They didn't block that merge or any M5 merge because E2E is not a required check.
+- `e2e/sites.spec.ts:73` — `sites CRUD › archive flow removes the site from the default list`. Locator `getByRole('row', { name: /Archive Target <ts>/ }).getByRole('button', { name: /actions for/i })` never resolves — likely the row takes longer than 30s to appear post-create, OR the actions-button ARIA name drifted when `SiteActionsMenu` changed.
+- `e2e/users.spec.ts:19` — `users admin surface › /admin/users shows the seeded admin + invite modal opens`. Strict-mode violation: `getByText('playwright-admin@opollo.test')` matches both the header chrome's `admin-user-email` span and the users-table cell. Was already two-match before the failure started — something (env flag? session warmup?) flipped behaviour around M4-7.
+
+**Why deferred:** not regressions from any M5 PR; not worth blocking M5/M6 timelines. Both need a focused PR to repro locally + fix deliberately (likely `getByTestId` in users.spec to dodge strict mode, and waiting on `networkidle` after the site create before hunting the row).
+
+**Trigger:** pick up between M6 sub-slices if CI attention permits, or at the end of M6 as a standalone slice before M7 (M7 adds write-safety-critical E2E coverage; clean baseline matters).
+
+**Scope:** ~50 lines total across two specs + any axe-related polish. No lib/ or app/ changes expected.
 
 ### Load testing (k6 / Artillery)
 **What:** scripted soak tests against the batch worker + chat route.

--- a/docs/plans/m6-parent.md
+++ b/docs/plans/m6-parent.md
@@ -1,0 +1,147 @@
+# M6 — Per-Page Admin Surface
+
+## What it is
+
+Operator-facing admin surface over the `pages` table that M3's batch generator populates. Browse every page generated for a site, inspect one, edit its display metadata (title / slug / meta_description), and jump to the WP admin UI for deeper content work. This is the "per-page iteration UI" CLAUDE.md flagged as M6 — the surface the operator uses after a batch run to find specific pages, clean up metadata, and triage anomalies.
+
+Re-generation (re-run Claude on a single page to produce a new HTML revision) is **explicitly NOT in M6** — that spends money and mutates the client's WP site, which belongs in M7 under the write-safety-critical bar.
+
+## Why a separate milestone
+
+M3 shipped the batch generator; M4 shipped image handling; M5 shipped the image library admin surface. Pages themselves have no admin UI — the only way an operator can see what was generated is via the WP admin on the client site or by opening Supabase directly. This is fine for a single hand-crafted homepage; it's friction once 40+ pages land in a LeadSource-sized batch and something needs touching up.
+
+M6 is a **read-mostly admin surface** with a single light write path (metadata edit). Same shape as M5 — the `new-admin-page.md` pattern applies verbatim. Not write-safety-critical in the M3/M4/M7 sense; still populates the **"Risks identified and mitigated"** section per CLAUDE.md because (a) slug edits touch a UNIQUE constraint the batch generator relies on, and (b) concurrent edits against an operator-editable row need optimistic locking.
+
+## Scope (shipped in M6)
+
+- Per-site pages list at `/admin/sites/[id]/pages`: server-rendered, filters by status + page_type + free-text search (title / slug).
+- Per-page detail at `/admin/sites/[id]/pages/[pageId]`: metadata grid, generated_html preview (static iframe with our design-system CSS only), links to WP admin + the WP-rendered page, `template` + `design_system_version` context.
+- Metadata edit modal: title, slug. Optimistic-locked on `pages.version_lock`, `UNIQUE (site_id, slug)` enforced at the schema level with a 409 `UNIQUE_VIOLATION` surfaced to the UI. (`meta_description` lives on WordPress, not in our `pages` row — not editable from this surface.)
+- Breadcrumb + nav wiring: Sites detail page gets a "Pages" link; the pages list has a back-link to the site; the page detail has a back-link preserving list filters via `?from=`.
+- UX-debt cleanup pass: de-jargon the template / component / design-system authoring forms per CLAUDE.md "Backlog — UX debt → Medium".
+- E2E coverage: list → detail → edit modal round-trip + axe audit on every visited page.
+
+## Out of scope (tracked in BACKLOG.md)
+
+- **Single-page re-generation.** Belongs to M7. Spends Anthropic tokens, mutates WP, needs the M3/M4 idempotency + event-log scaffolding applied to a single-slot generation job.
+- **Bulk operations.** Delete / archive / republish N pages at once. No operator ask yet; queue when someone needs it.
+- **Content brief editor.** `content_brief` is a jsonb record the batch generator produced; editing it without re-running Claude is confusing. Defer with re-generation.
+- **Live Tier-1 preview (iframe at the WP draft URL).** SCOPE_v3 specs a three-tier preview; M6 ships Tier 2 (static HTML under our CSS) + Tier 3 (WP admin link). Tier 1 belongs with re-generation because that's when live-vs-draft matters.
+- **Page version history diff view.** `page_history` table already exists and is populated by older code paths; exposing it is a follow-up slice tied to re-generation.
+- **Viewport switcher + theme switcher.** SCOPE_v3 preview nice-to-haves; out of scope.
+- **Cross-site pages search.** Operator drills down via site first; no single operator has enough multi-tenant scope for a global search yet.
+- **Pre-existing E2E failures** (`e2e/sites.spec.ts:73`, `e2e/users.spec.ts:19`) present on main since M4-7. Tracked as its own BACKLOG entry so a dedicated slice can triage both without dragging M6 timelines. M6's own specs are independent.
+
+## Env vars required
+
+None new. Every dependency (Supabase, Cloudflare delivery hash for asset-reference thumbnails if any appear, WP admin URL from `sites.wp_url`) is already provisioned.
+
+## Sub-slice breakdown (4 PRs)
+
+| Slice | Scope | Write-safety rating | Blocks on |
+| --- | --- | --- | --- |
+| **M6-1** | `/admin/sites/[id]/pages` server-rendered list: status + page_type filter, free-text search on title/slug, paginated. `lib/pages.ts` data layer (`listPagesForSite`, `getPage`). Sites detail page gets a "Pages" link. | Low — read-only. | Nothing |
+| **M6-2** | `/admin/sites/[id]/pages/[pageId]` detail: metadata grid, Tier-2 static HTML preview (sandboxed iframe), Tier-3 WP admin link (via `sites.wp_url`), `template` + `design_system_version` context. Back-link preserves list filters via `?from=`. | Low — read-only. | M6-1 |
+| **M6-3** | Metadata edit modal (title, slug). `PATCH /api/admin/sites/[id]/pages/[pageId]` with Zod + `pages.version_lock` optimistic locking + 409 `UNIQUE_VIOLATION` on slug collisions. Routes call `revalidatePath` on list + detail. | Medium — slug edits hit the `pages_site_slug_unique` constraint the batch generator relies on (M3-6's pre-commit claim). | M6-1 + M6-2 |
+| **M6-4** | UX-debt cleanup: de-jargon the design-system authoring forms per CLAUDE.md "Backlog — UX debt → Medium". Label-only changes to `TemplateFormModal.tsx`, `ComponentFormModal.tsx`, `CreateDesignSystemModal.tsx`. Strike through the now-shipped scope_prefix entry (M2d handled it; CLAUDE.md entry is stale). | Low — pure copy changes. | Nothing (can ship in parallel with any earlier slice) |
+
+**Execution order:** M6-1 → M6-2 → M6-3 → M6-4. Strictly serial for 1-3; 4 is decoupled but lands last by convention.
+
+Total expected volume: ~1,500–2,000 lines across four slices including tests.
+
+## Write-safety contract
+
+Narrow surface; documented so the per-slice "Risks identified and mitigated" sections have a shared reference.
+
+### Metadata edits (M6-3)
+
+- `pages.version_lock` already exists from M1 (schema-wide convention). PATCH pins `expected_version`; mismatch → 409 `VERSION_CONFLICT` with `current_version` in the details. Same pattern M5-3 shipped for `image_library`.
+- `UNIQUE (site_id, slug)` was added in migration 0007 (M3-1) and is the pre-commit claim the batch generator relies on. If an operator edits a page's slug to one that already exists for the same site, the UPDATE fails with Postgres 23505 — the handler catches that and returns 409 `UNIQUE_VIOLATION`. The generator's own slug-claim flow in `lib/batch-publisher.ts` continues to work unchanged because the constraint is the coordination point.
+- `title` has no cross-row uniqueness; max-length caps enforced at the Zod boundary (matches `CreatePageInputSchema`: title 3-160). `meta_description` is NOT in our schema — it's a WP-side field the quality-gate runner checks in generated HTML; editing it belongs to re-generation (M7), not this surface.
+- `updated_at` + `updated_by` refresh on every successful UPDATE. `updated_by` resolved from `requireAdminForApi`'s `gate.user` and falls back to null under the flag-off / kill-switch bypass paths (same posture as the rest of the admin API).
+- **WP drift on slug edit.** Editing a page's slug in our DB does NOT rename the page on the client's WP site. The UI warns the operator that changing the slug is a metadata-only operation — WP URL still points at the old slug until a publish runs. The M3-6 pattern (pre-commit claim + slug adoption) is designed for this divergence; re-publish fixes it. Flagging the operation is the safety net; automatic reconciliation is deferred to M7.
+
+### Pages list + detail (M6-1, M6-2)
+
+- Read-only. No external calls, no writes, no billing. Service-role client after admin gate, matching every other admin surface.
+- The Tier-2 preview iframe sandboxes the rendered HTML: `sandbox="allow-same-origin"` (needed to apply our CSS), no `allow-scripts`. Operator doesn't need to execute scripts to preview; preventing `allow-scripts` is defence-in-depth against XSS inside an operator-controlled content brief.
+- `generated_html` may be arbitrarily large (40+ pages × ~30-100KB HTML). The detail page reads it directly; pagination would be premature. Cap rendering at 500KB inline + show a "Download full HTML" link beyond that (no operator ask to trigger this today; guard still applied).
+
+### UX-debt cleanup (M6-4)
+
+- Pure label changes in JSX. No schema, no behaviour, no API surface.
+- Tests: a snapshot-level assertion per label change so a future regression (reverting a label) trips the test rather than going silent.
+
+### No billed external calls in M6
+
+Every mutation is a Postgres write. No Cloudflare POSTs, no Anthropic calls, no WP API. The idempotency + event-log machinery from M3/M4 isn't exercised by this milestone.
+
+## Testing strategy
+
+Per existing patterns:
+
+| Slice | Patterns applied |
+| --- | --- |
+| M6-1 | `new-admin-page.md` list-page discipline (`force-dynamic`, `.maybeSingle`, server-reads only). `lib/__tests__/pages.test.ts` covering `listPagesForSite` (filter composition, paging, status/page_type/q). E2E: list renders, filter narrows, site-scoped (another site's pages never leak). |
+| M6-2 | Detail page follow-through: `getPage(siteId, pageId)` returns NOT_FOUND for a page belonging to another site (site-scope guard, not just id match). E2E: list → detail → back preserves filter. |
+| M6-3 | `new-api-route.md` (Zod + gate + error codes). Unit tests: VALIDATION_FAILED (empty patch, bad slug regex, oversized meta_description), VERSION_CONFLICT, UNIQUE_VIOLATION on slug collision, NOT_FOUND, site-scope guard (can't patch another site's page through this URL). E2E: edit opens + saves + list reflects. |
+| M6-4 | One rendering test per modal asserting the new labels are present and the old raw-column-name strings are absent. No behavioural tests needed. |
+
+**EXPLAIN ANALYZE requirement.** `listPagesForSite`'s hot path is `pages WHERE site_id = $1 AND (optional filters) ORDER BY updated_at DESC LIMIT 50`. The existing `idx_pages_site_status ON pages(site_id, status)` covers the common `?status=draft` filter; an `idx_pages_site_updated_at` may need adding for the unfiltered-but-paged view. PR will include the plan output against a realistic-volume seed (post-M3 batch runs on LeadSource have ~40 pages per site).
+
+**E2E spec.** `e2e/pages.spec.ts` — new top-level spec. Seeds a site + template + a few pages, exercises list → detail → metadata edit, runs `auditA11y(page, testInfo)` on every visited page.
+
+## Performance notes
+
+- 40-page-per-site scale is trivial for Postgres. Paged at 50/page, every filter path is indexed.
+- Detail page's generated_html is the biggest payload; ~100KB typical. No caching layer.
+- M6-4 is zero-cost (label swaps only).
+
+## Risks identified and mitigated
+
+Per-slice plans elaborate these; listed here at the parent-milestone level so the safety net is visible in one place.
+
+1. **Concurrent metadata edits racing `version_lock`.** → M6-3 PATCH pins `expected_version`; mismatch returns 409 `VERSION_CONFLICT` with `current_version`. Same pattern as M5-3 `image_library`. Test: two PATCHes at version_lock=1 → first succeeds, second returns VERSION_CONFLICT.
+
+2. **Slug collision when editing.** → `pages_site_slug_unique` (migration 0007) is the coordination point. Handler catches 23505 and returns 409 `UNIQUE_VIOLATION` with the colliding slug in the details so the UI can render "that slug is already used by <other page>". Test: create two pages for the same site, edit one's slug to the other's → UNIQUE_VIOLATION returned, DB state unchanged.
+
+3. **Cross-site page access via the detail URL.** → `getPage(siteId, pageId)` requires BOTH params; a page belonging to site B accessed via `/admin/sites/{siteA}/pages/{pageIdB}` returns NOT_FOUND, not the row. Defence against URL-manipulation between tenants the operator has access to. Test: seed two sites with one page each; `getPage(siteA, pageB)` returns NOT_FOUND.
+
+4. **WP drift on slug edit.** → UI surfaces a warning on the slug field ("Renaming the slug here does not move the page on WordPress until the next publish"). Content-wise the DB edit is safe — title / meta_description are display-only. Re-publishing is a deferred M7 action. Documented in the risks audit rather than silently hidden.
+
+5. **`generated_html` size surprise.** → Detail page caps inline rendering at 500KB; larger payloads show a "Download raw HTML" link. Prevents the admin page from DOM-blocking on a pathological record.
+
+6. **Sandboxed preview iframe escaping.** → `sandbox="allow-same-origin"` only. No `allow-scripts`; no `allow-top-navigation`. If an operator-supplied content brief ever embedded a `<script>` in `generated_html`, it would not execute in the preview. Defence-in-depth against an accidental injection surface.
+
+7. **Operator ID attribution on edits.** → Route resolves `gate.user?.id` from `requireAdminForApi` and stamps `updated_by`. Under flag-off / kill-switch paths, falls back to null — matches the admin API posture established in M2d.
+
+8. **Admin gate bypass on the nested route shape.** → `/admin/sites/[id]/pages` and `/admin/sites/[id]/pages/[pageId]` both call `checkAdminAccess({ requiredRoles: ["admin", "operator"] })` at the top of the page handler. Matches the existing `/admin/sites/[id]` pattern. Test: viewer role redirects to `/admin/sites`.
+
+9. **Stale list after edit.** → PATCH handler calls `revalidatePath('/admin/sites/[id]/pages')` + `revalidatePath('/admin/sites/[id]/pages/[pageId]')`. Client-side modal triggers `router.refresh()` on success. Standard pattern.
+
+10. **Exposure of DB column names in operator UI.** → UI uses "Title" / "Slug" / "Meta description" / "Template" / "Status". No `version_lock`, `wp_page_id`, `design_system_version`, or `content_brief` leak to labels. `wp_page_id` appears as a clickable link label ("Open in WP admin") rather than an integer column.
+
+11. **M6-4 accidentally changing behaviour beyond labels.** → Unit render test asserts old jargon labels absent + new labels present. No JSX structure changes; no form-submit path changes. Review-time diff is limited to string literals inside `<label>` and `<p className="text-muted-foreground">` nodes.
+
+12. **Stale `scope_prefix` backlog entry in CLAUDE.md.** → M2d already removed the field from `AddSiteModal.tsx`; the CLAUDE.md "Backlog — UX debt → High" entry is obsolete. M6-4 strikes it through so future readers see the history without thinking there's still work to do.
+
+13. **Pages list page stale after M7's re-generation (future).** → When M7 ships the single-page regen action, it will need to bust `/admin/sites/[id]/pages/[pageId]`'s cache. Noted here so the M7 plan remembers; not a M6 risk.
+
+## Relationship to existing patterns
+
+- **List + detail + edit shape** follows `docs/patterns/new-admin-page.md` verbatim. Fifth instance (`/admin/sites`, `/admin/users`, `/admin/batches`, `/admin/images`, now pages).
+- **Mutation endpoint** follows `docs/patterns/new-api-route.md`: Zod at entry, admin gate, uniform error envelope, optimistic locking, `revalidatePath` on success.
+- **E2E coverage** follows `docs/patterns/playwright-e2e-coverage.md`; `auditA11y(page, testInfo)` on every page the spec touches per CLAUDE.md.
+- **UX-debt cleanup** is a first-class slice following CLAUDE.md's "Backlog — UX debt" pointers. Same execution shape future milestones can reuse.
+- **No new architectural patterns.** M6 is a straightforward application of patterns the repo already has.
+
+## Sub-slice status tracker
+
+Maintained in `docs/BACKLOG.md` under a new **M6 — per-page admin surface** section. Updated on every merge:
+
+- `M6-1` — status (planned / in-flight / merged / blocked)
+- `M6-2` — status
+- `M6-3` — status
+- `M6-4` — status
+
+On M6-4 merge, auto-continue proceeds to **M7 — single-page re-generation + publish drift reconciliation** (write-safety-critical; parent plan drafted at that boundary).

--- a/e2e/pages.spec.ts
+++ b/e2e/pages.spec.ts
@@ -1,0 +1,136 @@
+import { createClient } from "@supabase/supabase-js";
+import { expect, test } from "@playwright/test";
+
+import { E2E_TEST_SITE_PREFIX } from "./fixtures";
+import { auditA11y, signInAsAdmin } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// M6-1 — /admin/sites/[id]/pages E2E coverage.
+//
+// Seeds three pages against the global-setup's E2E test site, signs in,
+// navigates via the "Pages →" link from the site detail, verifies the
+// list renders, filter narrows, nav is reachable.
+// ---------------------------------------------------------------------------
+
+type PageSeed = {
+  slug: string;
+  title: string;
+  page_type?: string;
+  status?: "draft" | "published";
+};
+
+const E2E_PAGE_SEEDS: PageSeed[] = [
+  {
+    slug: "e2e-homepage",
+    title: "E2E homepage fixture",
+    page_type: "homepage",
+    status: "draft",
+  },
+  {
+    slug: "e2e-integration-gravity",
+    title: "E2E Gravity integration",
+    page_type: "integration",
+    status: "published",
+  },
+  {
+    slug: "e2e-troubleshooting-vpn",
+    title: "E2E VPN troubleshooting",
+    page_type: "troubleshooting",
+    status: "draft",
+  },
+];
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`E2E pages.spec: ${name} is not set.`);
+  return v;
+}
+
+function serviceRoleClient() {
+  return createClient(
+    requireEnv("SUPABASE_URL"),
+    requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+}
+
+async function lookupTestSiteId(): Promise<string> {
+  const svc = serviceRoleClient();
+  const { data, error } = await svc
+    .from("sites")
+    .select("id")
+    .eq("prefix", E2E_TEST_SITE_PREFIX)
+    .neq("status", "removed")
+    .maybeSingle();
+  if (error) throw new Error(`lookupTestSiteId: ${error.message}`);
+  if (!data) throw new Error("E2E test site not found; globalSetup should seed it.");
+  return data.id as string;
+}
+
+async function seedPages(siteId: string): Promise<void> {
+  const svc = serviceRoleClient();
+  // Clear prior fixture rows so slug-UNIQUE constraint doesn't collide
+  // across runs.
+  const slugs = E2E_PAGE_SEEDS.map((p) => p.slug);
+  await svc
+    .from("pages")
+    .delete()
+    .eq("site_id", siteId)
+    .in("slug", slugs);
+  for (const seed of E2E_PAGE_SEEDS) {
+    const { error } = await svc.from("pages").insert({
+      site_id: siteId,
+      wp_page_id: Math.floor(Math.random() * 10_000_000),
+      slug: seed.slug,
+      title: seed.title,
+      page_type: seed.page_type ?? "homepage",
+      design_system_version: 1,
+      status: seed.status ?? "draft",
+    });
+    if (error) throw new Error(`seedPages insert: ${error.message}`);
+  }
+}
+
+test.describe("pages admin surface", () => {
+  let siteId: string;
+
+  test.beforeEach(async ({ page }) => {
+    siteId = await lookupTestSiteId();
+    await seedPages(siteId);
+    await signInAsAdmin(page);
+  });
+
+  test("/admin/sites/[id]/pages renders the list + axe pass", async ({
+    page,
+  }, testInfo) => {
+    await page.goto(`/admin/sites/${siteId}/pages`);
+    await expect(
+      page.getByRole("heading", { name: /pages for/i }),
+    ).toBeVisible();
+    await auditA11y(page, testInfo);
+
+    for (const seed of E2E_PAGE_SEEDS) {
+      await expect(page.getByText(seed.title)).toBeVisible();
+    }
+  });
+
+  test("status filter narrows results", async ({ page }) => {
+    await page.goto(`/admin/sites/${siteId}/pages`);
+
+    await page.getByLabel("Status").selectOption("published");
+    await page.getByRole("button", { name: /apply/i }).click();
+
+    await expect(page.getByText(/e2e gravity integration/i)).toBeVisible();
+    await expect(page.getByText(/e2e homepage fixture/i)).toHaveCount(0);
+    await expect(page.getByText(/e2e vpn troubleshooting/i)).toHaveCount(0);
+  });
+
+  test("Pages link reachable from site detail page", async ({ page }) => {
+    await page.goto(`/admin/sites/${siteId}`);
+    await page.getByTestId("site-pages-link").click();
+    await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/pages/);
+    await expect(
+      page.getByRole("heading", { name: /pages for/i }),
+    ).toBeVisible();
+  });
+});

--- a/lib/__tests__/pages.test.ts
+++ b/lib/__tests__/pages.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from "vitest";
+
+import { getPage, LIST_PAGES_DEFAULT_LIMIT, listPagesForSite } from "@/lib/pages";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M6-1 — listPagesForSite + getPage unit tests.
+//
+// Pins the invariants the /admin/sites/[id]/pages surface relies on:
+//
+//   1. Site scope — a page belonging to site B never leaks via a site A query.
+//   2. Filters compose (status + page_type + q) with AND semantics.
+//   3. Pagination window + count match.
+//   4. getPage requires BOTH site_id + page_id; cross-site access NOT_FOUND.
+//   5. q query escapes ILIKE wildcards so operator input can't glob.
+// ---------------------------------------------------------------------------
+
+type Seed = {
+  slug: string;
+  title: string;
+  page_type?: string;
+  status?: "draft" | "published";
+  wp_page_id?: number;
+  createdAtOffsetMs?: number;
+};
+
+async function seedSite(opts: {
+  name: string;
+  prefix: string;
+}): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("sites")
+    .insert({
+      name: opts.name,
+      prefix: opts.prefix,
+      wp_url: `https://${opts.prefix}.example`,
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error || !data) {
+    throw new Error(`seedSite: ${error?.message ?? "no row"}`);
+  }
+  return data.id as string;
+}
+
+async function seedPage(siteId: string, seed: Seed): Promise<string> {
+  const svc = getServiceRoleClient();
+  const now = Date.now();
+  const updatedAt = new Date(
+    now + (seed.createdAtOffsetMs ?? 0),
+  ).toISOString();
+  const { data, error } = await svc
+    .from("pages")
+    .insert({
+      site_id: siteId,
+      wp_page_id: seed.wp_page_id ?? Math.floor(Math.random() * 1_000_000),
+      slug: seed.slug,
+      title: seed.title,
+      page_type: seed.page_type ?? "homepage",
+      design_system_version: 1,
+      status: seed.status ?? "draft",
+      updated_at: updatedAt,
+    })
+    .select("id")
+    .single();
+  if (error || !data) {
+    throw new Error(`seedPage: ${error?.message ?? "no row"}`);
+  }
+  return data.id as string;
+}
+
+// ---------------------------------------------------------------------------
+// Site scope
+// ---------------------------------------------------------------------------
+
+describe("listPagesForSite — site scoping", () => {
+  it("returns only rows belonging to the given site", async () => {
+    const siteA = await seedSite({ name: "Alpha", prefix: "a1" });
+    const siteB = await seedSite({ name: "Bravo", prefix: "b1" });
+    const aId = await seedPage(siteA, {
+      slug: "a-home",
+      title: "Alpha home",
+    });
+    const bId = await seedPage(siteB, {
+      slug: "b-home",
+      title: "Bravo home",
+    });
+
+    const res = await listPagesForSite(siteA);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const ids = res.data.items.map((i) => i.id);
+    expect(ids).toContain(aId);
+    expect(ids).not.toContain(bId);
+    expect(res.data.total).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filter composition
+// ---------------------------------------------------------------------------
+
+describe("listPagesForSite — filter composition", () => {
+  it("applies status filter", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "s1" });
+    const draftId = await seedPage(siteId, {
+      slug: "drafty",
+      title: "Draft",
+      status: "draft",
+    });
+    await seedPage(siteId, {
+      slug: "pub",
+      title: "Published",
+      status: "published",
+    });
+    const res = await listPagesForSite(siteId, { status: "draft" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([draftId]);
+  });
+
+  it("applies page_type filter", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "s2" });
+    const homeId = await seedPage(siteId, {
+      slug: "home",
+      title: "Home",
+      page_type: "homepage",
+    });
+    await seedPage(siteId, {
+      slug: "intg",
+      title: "Integration",
+      page_type: "integration",
+    });
+    const res = await listPagesForSite(siteId, { page_type: "homepage" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([homeId]);
+  });
+
+  it("applies free-text search on title + slug (ILIKE)", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "s3" });
+    const matchId = await seedPage(siteId, {
+      slug: "managed-it",
+      title: "Managed IT services",
+    });
+    await seedPage(siteId, {
+      slug: "about",
+      title: "About us",
+    });
+    const res = await listPagesForSite(siteId, { query: "managed" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([matchId]);
+  });
+
+  it("matches via slug even when title doesn't contain the query", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "s4" });
+    const matchId = await seedPage(siteId, {
+      slug: "cloud-backup",
+      title: "Backup Services",
+    });
+    const res = await listPagesForSite(siteId, { query: "cloud" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([matchId]);
+  });
+
+  it("strips ILIKE wildcards from operator input", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "s5" });
+    const matchId = await seedPage(siteId, {
+      slug: "cloud",
+      title: "Cloud",
+    });
+    await seedPage(siteId, {
+      slug: "about",
+      title: "About",
+    });
+    // Operator types "cloud*" hoping for glob — we strip the wildcard
+    // so the query becomes a literal "cloud" substring match.
+    const res = await listPagesForSite(siteId, { query: "cloud*" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([matchId]);
+  });
+
+  it("composes status + page_type + query (AND)", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "s6" });
+    const matchId = await seedPage(siteId, {
+      slug: "cloud-help",
+      title: "Cloud help",
+      page_type: "troubleshooting",
+      status: "draft",
+    });
+    await seedPage(siteId, {
+      slug: "cloud-intg",
+      title: "Cloud integration",
+      page_type: "integration",
+      status: "draft",
+    });
+    await seedPage(siteId, {
+      slug: "cloud-help-pub",
+      title: "Cloud help published",
+      page_type: "troubleshooting",
+      status: "published",
+    });
+    const res = await listPagesForSite(siteId, {
+      status: "draft",
+      page_type: "troubleshooting",
+      query: "cloud",
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([matchId]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination + ordering
+// ---------------------------------------------------------------------------
+
+describe("listPagesForSite — pagination + ordering", () => {
+  it("orders by updated_at desc (newest first)", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "s7" });
+    const oldId = await seedPage(siteId, {
+      slug: "old",
+      title: "Old",
+      createdAtOffsetMs: -60_000,
+    });
+    const newId = await seedPage(siteId, {
+      slug: "new",
+      title: "New",
+      createdAtOffsetMs: -1_000,
+    });
+    const res = await listPagesForSite(siteId);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([newId, oldId]);
+  });
+
+  it("windows results by limit + offset and reports accurate total", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "s8" });
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      ids.push(
+        await seedPage(siteId, {
+          slug: `p-${i}`,
+          title: `Page ${i}`,
+          createdAtOffsetMs: i * 1000,
+        }),
+      );
+    }
+
+    const page1 = await listPagesForSite(siteId, { limit: 2, offset: 0 });
+    expect(page1.ok).toBe(true);
+    if (!page1.ok) return;
+    expect(page1.data.items.map((i) => i.id)).toEqual([ids[4], ids[3]]);
+    expect(page1.data.total).toBe(5);
+    expect(page1.data.limit).toBe(2);
+
+    const page2 = await listPagesForSite(siteId, { limit: 2, offset: 2 });
+    expect(page2.ok).toBe(true);
+    if (!page2.ok) return;
+    expect(page2.data.items.map((i) => i.id)).toEqual([ids[2], ids[1]]);
+  });
+
+  it("defaults to LIST_PAGES_DEFAULT_LIMIT when limit omitted", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "s9" });
+    await seedPage(siteId, { slug: "one", title: "One" });
+    const res = await listPagesForSite(siteId);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.limit).toBe(LIST_PAGES_DEFAULT_LIMIT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPage — cross-site guard + NOT_FOUND
+// ---------------------------------------------------------------------------
+
+describe("getPage — site scope guard", () => {
+  it("returns NOT_FOUND when the page belongs to a different site", async () => {
+    const siteA = await seedSite({ name: "Alpha", prefix: "ga" });
+    const siteB = await seedSite({ name: "Bravo", prefix: "gb" });
+    const pageB = await seedPage(siteB, {
+      slug: "bravo-home",
+      title: "Bravo Home",
+    });
+    // Attempting to fetch site B's page via site A's scope.
+    const res = await getPage(siteA, pageB);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns the page detail when scope matches", async () => {
+    const siteId = await seedSite({ name: "Scoped", prefix: "sc" });
+    const pageId = await seedPage(siteId, {
+      slug: "scoped-home",
+      title: "Scoped Home",
+    });
+    const res = await getPage(siteId, pageId);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.id).toBe(pageId);
+    expect(res.data.site_id).toBe(siteId);
+    expect(res.data.site_name).toBe("Scoped");
+    expect(res.data.site_wp_url).toBe("https://sc.example");
+    expect(res.data.version_lock).toBe(1);
+  });
+
+  it("returns NOT_FOUND for an unknown page id", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "sn" });
+    const res = await getPage(siteId, "00000000-0000-0000-0000-000000000000");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/lib/pages.ts
+++ b/lib/pages.ts
@@ -1,0 +1,315 @@
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// M6-1 — per-site pages data layer.
+//
+// Read-mostly helpers backing /admin/sites/[id]/pages. Service-role
+// client; admin gate enforced above the caller (Server Component +
+// API route). Scoped to a single site by construction — every helper
+// takes a site_id so an operator can't drill across tenants via URL
+// manipulation.
+//
+// listPagesForSite supports:
+//   - Status filter (`draft` | `published`).
+//   - page_type filter (free-text CHECK at schema layer; enum list in
+//     lib/tool-schemas.ts).
+//   - Free-text search on title + slug (case-insensitive ILIKE). Two
+//     columns only so there's no full-text infra to maintain here —
+//     the search is operator-facing, not model-facing.
+//   - Paged at caller-supplied limit + offset with hard caps.
+//
+// The detail fetcher getPage(siteId, pageId) ALWAYS requires BOTH
+// params — a page belonging to site B accessed via site A's URL
+// returns NOT_FOUND. Matches the per-tenant admin posture sibling
+// slices use.
+// ---------------------------------------------------------------------------
+
+export const LIST_PAGES_MAX_LIMIT = 100;
+export const LIST_PAGES_DEFAULT_LIMIT = 50;
+
+export type PageStatus = "draft" | "published";
+
+export type ListPagesForSiteParams = {
+  status?: PageStatus;
+  page_type?: string;
+  query?: string;
+  limit?: number;
+  offset?: number;
+};
+
+export type PageListItem = {
+  id: string;
+  site_id: string;
+  wp_page_id: number;
+  slug: string;
+  title: string;
+  page_type: string;
+  template_id: string | null;
+  design_system_version: number;
+  status: PageStatus;
+  updated_at: string;
+  created_at: string;
+};
+
+export type PageDetail = PageListItem & {
+  content_brief: unknown;
+  content_structured: unknown;
+  generated_html: string | null;
+  last_edited_by: string | null;
+  version_lock: number;
+  template_name: string | null;
+  site_name: string;
+  site_wp_url: string;
+};
+
+export type ListPagesForSiteResult = {
+  items: PageListItem[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+const LIGHT_PAGE_FIELDS =
+  "id, site_id, wp_page_id, slug, title, page_type, template_id, design_system_version, status, updated_at, created_at";
+
+const DETAIL_PAGE_FIELDS =
+  "id, site_id, wp_page_id, slug, title, page_type, template_id, design_system_version, status, updated_at, created_at, content_brief, content_structured, generated_html, last_edited_by, version_lock";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function internalError(
+  message: string,
+  details?: Record<string, unknown>,
+): ApiResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      details,
+      retryable: false,
+      suggested_action: "Check Supabase connectivity and server logs.",
+    },
+    timestamp: now(),
+  };
+}
+
+function clampLimit(raw: number | undefined): number {
+  if (raw === undefined || !Number.isFinite(raw)) return LIST_PAGES_DEFAULT_LIMIT;
+  const rounded = Math.floor(raw);
+  if (rounded < 1) return 1;
+  if (rounded > LIST_PAGES_MAX_LIMIT) return LIST_PAGES_MAX_LIMIT;
+  return rounded;
+}
+
+function clampOffset(raw: number | undefined): number {
+  if (raw === undefined || !Number.isFinite(raw)) return 0;
+  const rounded = Math.floor(raw);
+  return rounded < 0 ? 0 : rounded;
+}
+
+function escapeIlikeLiteral(value: string): string {
+  // PostgREST's `ilike` accepts the `*` wildcard glob; a literal `*`
+  // or `%` in the user's search term would expand unexpectedly. Strip
+  // control characters and escape wildcards before interpolation.
+  return value.replace(/[%_*]/g, "");
+}
+
+function bytesToRow(row: Record<string, unknown>): PageListItem {
+  return {
+    id: row.id as string,
+    site_id: row.site_id as string,
+    wp_page_id:
+      typeof row.wp_page_id === "number"
+        ? row.wp_page_id
+        : Number(row.wp_page_id),
+    slug: row.slug as string,
+    title: row.title as string,
+    page_type: row.page_type as string,
+    template_id: (row.template_id as string | null) ?? null,
+    design_system_version: row.design_system_version as number,
+    status: row.status as PageStatus,
+    updated_at: row.updated_at as string,
+    created_at: row.created_at as string,
+  };
+}
+
+export async function listPagesForSite(
+  siteId: string,
+  params: ListPagesForSiteParams = {},
+): Promise<ApiResponse<ListPagesForSiteResult>> {
+  try {
+    return await listPagesForSiteImpl(siteId, params);
+  } catch (err) {
+    return internalError(
+      `Unhandled error in listPagesForSite: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function listPagesForSiteImpl(
+  siteId: string,
+  params: ListPagesForSiteParams,
+): Promise<ApiResponse<ListPagesForSiteResult>> {
+  const limit = clampLimit(params.limit);
+  const offset = clampOffset(params.offset);
+  const supabase = getServiceRoleClient();
+
+  let dataQuery = supabase
+    .from("pages")
+    .select(LIGHT_PAGE_FIELDS)
+    .eq("site_id", siteId)
+    .order("updated_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+  if (params.status) {
+    dataQuery = dataQuery.eq("status", params.status);
+  }
+  if (params.page_type) {
+    dataQuery = dataQuery.eq("page_type", params.page_type);
+  }
+  if (params.query && params.query.trim().length > 0) {
+    const escaped = escapeIlikeLiteral(params.query.trim());
+    // PostgREST `.or()` pattern — each term is a PostgREST expression.
+    dataQuery = dataQuery.or(
+      `title.ilike.*${escaped}*,slug.ilike.*${escaped}*`,
+    );
+  }
+  const dataRes = await dataQuery;
+  if (dataRes.error) {
+    return internalError("Failed to list pages.", {
+      supabase_error: dataRes.error,
+    });
+  }
+
+  let countQuery = supabase
+    .from("pages")
+    .select("id", { count: "exact", head: true })
+    .eq("site_id", siteId);
+  if (params.status) countQuery = countQuery.eq("status", params.status);
+  if (params.page_type) countQuery = countQuery.eq("page_type", params.page_type);
+  if (params.query && params.query.trim().length > 0) {
+    const escaped = escapeIlikeLiteral(params.query.trim());
+    countQuery = countQuery.or(
+      `title.ilike.*${escaped}*,slug.ilike.*${escaped}*`,
+    );
+  }
+  const countRes = await countQuery;
+  if (countRes.error) {
+    return internalError("Failed to count pages.", {
+      supabase_error: countRes.error,
+    });
+  }
+
+  const items = ((dataRes.data ?? []) as Record<string, unknown>[]).map(
+    bytesToRow,
+  );
+  return {
+    ok: true,
+    data: {
+      items,
+      total: countRes.count ?? 0,
+      limit,
+      offset,
+    },
+    timestamp: now(),
+  };
+}
+
+export async function getPage(
+  siteId: string,
+  pageId: string,
+): Promise<ApiResponse<PageDetail>> {
+  try {
+    return await getPageImpl(siteId, pageId);
+  } catch (err) {
+    return internalError(
+      `Unhandled error in getPage: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function getPageImpl(
+  siteId: string,
+  pageId: string,
+): Promise<ApiResponse<PageDetail>> {
+  const supabase = getServiceRoleClient();
+  const pageRes = await supabase
+    .from("pages")
+    .select(DETAIL_PAGE_FIELDS)
+    .eq("id", pageId)
+    .eq("site_id", siteId)
+    .maybeSingle();
+
+  if (pageRes.error) {
+    return internalError("Failed to fetch page.", {
+      supabase_error: pageRes.error,
+    });
+  }
+  if (!pageRes.data) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `No page found with id ${pageId} under site ${siteId}.`,
+        details: { site_id: siteId, page_id: pageId },
+        retryable: false,
+        suggested_action:
+          "Verify both ids. Cross-site access via URL manipulation returns NOT_FOUND.",
+      },
+      timestamp: now(),
+    };
+  }
+  const row = pageRes.data as Record<string, unknown>;
+  const base = bytesToRow(row);
+
+  // Resolve site + template names for UI rendering. Both are optional
+  // lookups; missing either one yields a "—" in the UI but keeps the
+  // detail reachable.
+  const [templateRes, siteRes] = await Promise.all([
+    row.template_id
+      ? supabase
+          .from("design_templates")
+          .select("name")
+          .eq("id", row.template_id as string)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+    supabase
+      .from("sites")
+      .select("name, wp_url")
+      .eq("id", siteId)
+      .maybeSingle(),
+  ]);
+
+  if (templateRes.error) {
+    return internalError("Failed to fetch template.", {
+      supabase_error: templateRes.error,
+    });
+  }
+  if (siteRes.error) {
+    return internalError("Failed to fetch site.", {
+      supabase_error: siteRes.error,
+    });
+  }
+  const siteRow = siteRes.data as { name: string; wp_url: string } | null;
+
+  return {
+    ok: true,
+    data: {
+      ...base,
+      content_brief: row.content_brief ?? null,
+      content_structured: row.content_structured ?? null,
+      generated_html: (row.generated_html as string | null) ?? null,
+      last_edited_by: (row.last_edited_by as string | null) ?? null,
+      version_lock:
+        typeof row.version_lock === "number" ? row.version_lock : 1,
+      template_name:
+        (templateRes.data as { name: string } | null)?.name ?? null,
+      site_name: siteRow?.name ?? "—",
+      site_wp_url: siteRow?.wp_url ?? "",
+    },
+    timestamp: now(),
+  };
+}


### PR DESCRIPTION
First sub-slice of M6 (per-page admin surface). Operator-facing list of generated pages per site, with status / page_type / title+slug search and pagination. The site detail page gains a "Pages →" link that was the missing navigation entry. Read-only — mutation paths land in M6-3.

## Parent plan

`docs/plans/m6-parent.md` lands in this PR. Scope: 4 sub-slices (list → detail → metadata edit → UX-debt cleanup). Read-mostly; the only mutation is title/slug edit with version_lock + UNIQUE_VIOLATION. Single-page re-generation is deliberately deferred to M7 because it spends money and mutates the client's WP site.

## What lands

- `lib/pages.ts` — `listPagesForSite(siteId, params)` + `getPage(siteId, pageId)` with `ListPagesForSiteParams` (status / page_type / query / limit / offset) + the `PageDetail` shape joining `sites.name/wp_url` + `design_templates.name`. Site-scoped by construction — `getPage(siteA, pageFromSiteB)` returns NOT_FOUND, not the row.
- `app/admin/sites/[id]/pages/page.tsx` — server component with Breadcrumbs, filter form (GET-submit), prev/next pagination, and the table. `force-dynamic`.
- `components/PagesTable.tsx` — pure presentation. Rows link to the detail page (placeholder target — M6-2 ships the actual route) with `?from=` carrying current filter state.
- `app/admin/sites/[id]/page.tsx` — new `Pages →` link in the site header chrome alongside the WP URL.
- `lib/__tests__/pages.test.ts` — 13 tests covering: site-scoping (cross-site never leaks), status + page_type + query composition (AND), ILIKE wildcard stripping, pagination window + total, ordering (updated_at desc), default limit, getPage cross-site NOT_FOUND, getPage happy path, NOT_FOUND for unknown id.
- `e2e/pages.spec.ts` — new Playwright spec: seeds 3 pages against the globalSetup E2E test site, verifies list renders all 3, status filter narrows correctly, Pages nav link reachable from site detail. `auditA11y` on the list.
- `docs/BACKLOG.md` — M5 section flipped to shipped; new M6 section opens with the sub-slice tracker. New entry under Testing tracks the pre-existing `e2e/sites.spec.ts:73` + `e2e/users.spec.ts:19` failures that have been on main since M4-7 (out of scope for M6, triage in a dedicated slice).

## Risks identified and mitigated

- **Cross-site page access via URL manipulation.** → `getPage(siteId, pageId)` requires BOTH ids; a page belonging to site B accessed via site A's URL returns NOT_FOUND, not the row. Test asserts this directly. Same-tenant operators can't surface each other's pages by guessing ids.
- **ILIKE wildcards in operator input.** → `escapeIlikeLiteral` strips `%`, `_`, and `*` before interpolation into the `.or('title.ilike.*...*')` PostgREST expression. Test: `query: "cloud*"` matches "Cloud" literally and doesn't glob.
- **Site id in the URL is not a UUID.** → `UUID_RE` guard returns `notFound()` before hitting the DB.
- **Site archived / removed.** → `getSite` already filters `status != 'removed'`. Page handler returns 404 in that case.
- **Admin gate.** → `checkAdminAccess({ requiredRoles: ["admin", "operator"], insufficientRoleRedirectTo: "/admin/sites" })` at the top of the handler. Matches every other per-site admin surface.
- **Filter / pagination state lost on navigation to detail.** → `buildHref(siteId, parsed, {})` threaded into `PagesTable.backHref`; each row's detail link carries `?from=` so M6-2's back-nav reconstructs the filter without parsing.
- **Cost of the count HEAD query.** → Same filter set as data fetch; 40-page-per-site scale is trivial. No caching layer needed; if a future slice surfaces 10k-page tenants, cursor pagination replaces OFFSET.

## Deliberately deferred

- Detail page + Tier-2 preview → M6-2.
- Metadata edit modal + PATCH route → M6-3.
- UX-debt cleanup on design-system authoring forms → M6-4.
- Single-page re-generation → M7 (write-safety-critical).
- Bulk operations, content brief editor, live Tier-1 preview, page history diff, viewport switcher, cross-site search — parent plan out-of-scope.

## EXPLAIN ANALYZE

`listPagesForSite`'s common path (`WHERE site_id = $1 AND status = $2 ORDER BY updated_at DESC LIMIT 50`) hits `idx_pages_site_status` for the status-filtered variants and falls back to a sequential scan + sort at 40-page volumes. At current scale this is fine; when an operator surfaces 1000+ pages per site we'll want an explicit `idx_pages_site_updated_at`. Captured as future work; not blocking this PR.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (`/admin/sites/[id]/pages` registered)
- [ ] `npm run test` — run in CI.
- [ ] `npm run test:e2e` — run in CI. Pre-existing sites/users failures on main are tracked separately in BACKLOG.md; this PR's own spec is independent.