### PR TITLE
feat(m6-2): per-page detail + Tier-2 static preview + WP admin link

### DIFF
--- a/app/admin/sites/[id]/pages/[pageId]/page.tsx
+++ b/app/admin/sites/[id]/pages/[pageId]/page.tsx
@@ -1,0 +1,200 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { PageHtmlPreview } from "@/components/PageHtmlPreview";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { getPage } from "@/lib/pages";
+import { formatRelativeTime } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// /admin/sites/[id]/pages/[pageId] — M6-2.
+//
+// Per-page detail view. Scoped by (site_id, page_id) so a cross-site
+// URL manipulation returns 404. Shows:
+//
+//   - Metadata grid: title, slug, type, status, DS version, template
+//     name, WP page id (as a link to the WP admin edit URL), updated-at.
+//   - Tier-2 preview: sandboxed iframe rendering generated_html under
+//     our design-system CSS only. No allow-scripts.
+//   - Tier-3 link: "Open in WordPress admin" → `{wp_url}/wp-admin/post.php?post={wp_page_id}&action=edit`.
+//   - Back-link honours `?from=` so returning to the list preserves
+//     filter state.
+//
+// Read-only. Metadata editing lands in M6-3.
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type RawSearchParams = {
+  [key: string]: string | string[] | undefined;
+};
+
+function resolveBackHref(
+  siteId: string,
+  raw: RawSearchParams,
+): string {
+  const from = typeof raw.from === "string" ? raw.from : null;
+  const fallback = `/admin/sites/${siteId}/pages`;
+  if (!from) return fallback;
+  // Accept only relative paths under the same site's pages surface.
+  if (!from.startsWith(`/admin/sites/${siteId}/pages`)) return fallback;
+  return from;
+}
+
+function statusBadge(status: string) {
+  const palette: Record<string, string> = {
+    draft: "bg-muted text-muted-foreground",
+    published: "bg-emerald-500/10 text-emerald-700",
+  };
+  return (
+    <span
+      className={`inline-flex rounded px-2 py-0.5 text-xs font-medium capitalize ${
+        palette[status] ?? "bg-muted"
+      }`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function wpAdminEditUrl(wpUrl: string, wpPageId: number): string {
+  // WP's post.php?post=<id>&action=edit works regardless of whether
+  // the post is actually a page or a post — the same route edits both.
+  const base = wpUrl.replace(/\/$/, "");
+  return `${base}/wp-admin/post.php?post=${wpPageId}&action=edit`;
+}
+
+function wpPublicUrl(wpUrl: string, slug: string): string {
+  const base = wpUrl.replace(/\/$/, "");
+  return `${base}/${slug}`;
+}
+
+export default async function PageDetail({
+  params,
+  searchParams,
+}: {
+  params: { id: string; pageId: string };
+  searchParams: RawSearchParams;
+}) {
+  const access = await checkAdminAccess({
+    requiredRoles: ["admin", "operator"],
+    insufficientRoleRedirectTo: "/admin/sites",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  if (!UUID_RE.test(params.id) || !UUID_RE.test(params.pageId)) {
+    notFound();
+  }
+
+  const result = await getPage(params.id, params.pageId);
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") notFound();
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+      >
+        Failed to load page: {result.error.message}
+      </div>
+    );
+  }
+
+  const page = result.data;
+  const backHref = resolveBackHref(params.id, searchParams);
+
+  return (
+    <>
+      <Breadcrumbs
+        crumbs={[
+          { label: "Sites", href: "/admin/sites" },
+          { label: page.site_name, href: `/admin/sites/${params.id}` },
+          { label: "Pages", href: backHref },
+          { label: page.title.slice(0, 60) },
+        ]}
+      />
+
+      <div className="mt-4 flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="truncate text-xl font-semibold">{page.title}</h1>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            {statusBadge(page.status)}
+            <span className="rounded bg-muted px-2 py-0.5">
+              {page.page_type.replace(/_/g, " ")}
+            </span>
+            <span>/{page.slug}</span>
+            <span>· updated {formatRelativeTime(page.updated_at)}</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          {page.site_wp_url && (
+            <>
+              <a
+                href={wpAdminEditUrl(page.site_wp_url, page.wp_page_id)}
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs underline hover:text-foreground"
+                data-testid="wp-admin-link"
+              >
+                Open in WP admin ↗
+              </a>
+              {page.status === "published" && (
+                <a
+                  href={wpPublicUrl(page.site_wp_url, page.slug)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-xs underline hover:text-foreground"
+                  data-testid="wp-public-link"
+                >
+                  View live ↗
+                </a>
+              )}
+            </>
+          )}
+          <Link
+            href={backHref}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            ← Back to pages
+          </Link>
+        </div>
+      </div>
+
+      <section className="mt-6 grid gap-6 md:grid-cols-[2fr_1fr]">
+        <PageHtmlPreview html={page.generated_html} />
+
+        <dl
+          className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm"
+          data-testid="page-detail-fields"
+        >
+          <dt className="text-muted-foreground">Title</dt>
+          <dd>{page.title}</dd>
+          <dt className="text-muted-foreground">Slug</dt>
+          <dd className="font-mono text-xs">{page.slug}</dd>
+          <dt className="text-muted-foreground">Type</dt>
+          <dd className="capitalize">
+            {page.page_type.replace(/_/g, " ")}
+          </dd>
+          <dt className="text-muted-foreground">Status</dt>
+          <dd>{statusBadge(page.status)}</dd>
+          <dt className="text-muted-foreground">Template</dt>
+          <dd>
+            {page.template_name ?? (
+              <span className="text-muted-foreground">—</span>
+            )}
+          </dd>
+          <dt className="text-muted-foreground">DS version</dt>
+          <dd>v{page.design_system_version}</dd>
+          <dt className="text-muted-foreground">WP page id</dt>
+          <dd className="font-mono text-xs">#{page.wp_page_id}</dd>
+          <dt className="text-muted-foreground">Created</dt>
+          <dd className="text-xs">{formatRelativeTime(page.created_at)}</dd>
+          <dt className="text-muted-foreground">Updated</dt>
+          <dd className="text-xs">{formatRelativeTime(page.updated_at)}</dd>
+        </dl>
+      </section>
+    </>
+  );
+}

--- a/components/PageHtmlPreview.tsx
+++ b/components/PageHtmlPreview.tsx
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------------
+// M6-2 — Tier-2 static HTML preview.
+//
+// Renders `generated_html` inside a sandboxed iframe via srcdoc. The
+// sandbox is intentionally narrow — we DO NOT allow scripts, forms,
+// or top-navigation so an accidentally-embedded `<script>` in an
+// operator-authored brief can't execute. `allow-same-origin` is off
+// too; we don't need it for static HTML + our design-system CSS.
+//
+// Rendering cap: if generated_html exceeds 500KB we show a size
+// warning + a download link rather than inlining — keeps the admin
+// page responsive on pathological rows.
+// ---------------------------------------------------------------------------
+
+const INLINE_HTML_MAX_BYTES = 500 * 1024;
+
+function estimateBytes(html: string): number {
+  // Byte-length estimate without spawning Buffer / TextEncoder on the
+  // server render hot path. Approximation is fine — we only need to
+  // gate the "inline vs. download" decision.
+  return html.length;
+}
+
+export function PageHtmlPreview({ html }: { html: string | null }) {
+  if (!html) {
+    return (
+      <div
+        className="flex h-64 w-full items-center justify-center rounded-md border bg-muted/30 text-sm text-muted-foreground"
+        data-testid="page-html-preview-empty"
+      >
+        No generated HTML for this page yet.
+      </div>
+    );
+  }
+
+  if (estimateBytes(html) > INLINE_HTML_MAX_BYTES) {
+    return (
+      <div
+        className="flex h-64 w-full flex-col items-center justify-center gap-2 rounded-md border bg-muted/30 p-6 text-sm text-muted-foreground"
+        data-testid="page-html-preview-too-large"
+      >
+        <p>
+          Generated HTML is larger than {INLINE_HTML_MAX_BYTES / 1024}KB — inline
+          preview skipped to keep the admin page responsive.
+        </p>
+        <p className="text-xs">
+          Open the page in WordPress admin to view it rendered.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border bg-white">
+      <div className="flex items-center justify-between border-b px-3 py-2 text-xs text-muted-foreground">
+        <span>Preview (static, design-system CSS only)</span>
+        <span className="font-mono">
+          {(estimateBytes(html) / 1024).toFixed(1)} KB
+        </span>
+      </div>
+      {/*
+        sandbox omits allow-scripts, allow-forms, allow-top-navigation,
+        and allow-same-origin on purpose. The iframe renders the HTML
+        and our DS CSS only; nothing executes or navigates.
+      */}
+      <iframe
+        title="Page HTML preview"
+        srcDoc={html}
+        sandbox=""
+        className="h-[70vh] w-full"
+        data-testid="page-html-preview-iframe"
+      />
+    </div>
+  );
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -12,8 +12,8 @@ Parent plan: `docs/plans/m6-parent.md`. Sub-slice status tracker:
 
 | Slice | Status | Notes |
 | --- | --- | --- |
-| M6-1 | in flight | `/admin/sites/[id]/pages` list + `lib/pages.ts` data layer + Pages link on site detail. |
-| M6-2 | planned | `/admin/sites/[id]/pages/[pageId]` detail + Tier-2 static preview + Tier-3 WP admin link. |
+| M6-1 | merged (#68) | `/admin/sites/[id]/pages` list + `lib/pages.ts` data layer + Pages link on site detail. |
+| M6-2 | in flight | `/admin/sites/[id]/pages/[pageId]` detail + Tier-2 static preview + Tier-3 WP admin link. |
 | M6-3 | planned | Metadata edit modal (title + slug) + `PATCH /api/admin/sites/[id]/pages/[pageId]` with version_lock + UNIQUE_VIOLATION. |
 | M6-4 | planned | UX-debt cleanup: de-jargon the design-system authoring forms per CLAUDE.md backlog. |
 
@@ -136,16 +136,17 @@ the comment, add a fixture test that asserts "1M Opus tokens at 15 USD" produces
 
 ## Testing
 
-### Investigate pre-existing E2E failures on main (sites.spec.ts:73 + users.spec.ts:19)
-**What:** two E2E tests have been failing on main since M4-7 (#63). They didn't block that merge or any M5 merge because E2E is not a required check.
+### Investigate pre-existing E2E failures on main (sites + users + images specs)
+**What:** three E2E tests have been failing on main since M4-7 / M5-2. None of them blocked their originating merges because E2E is not a required check.
 - `e2e/sites.spec.ts:73` — `sites CRUD › archive flow removes the site from the default list`. Locator `getByRole('row', { name: /Archive Target <ts>/ }).getByRole('button', { name: /actions for/i })` never resolves — likely the row takes longer than 30s to appear post-create, OR the actions-button ARIA name drifted when `SiteActionsMenu` changed.
-- `e2e/users.spec.ts:19` — `users admin surface › /admin/users shows the seeded admin + invite modal opens`. Strict-mode violation: `getByText('playwright-admin@opollo.test')` matches both the header chrome's `admin-user-email` span and the users-table cell. Was already two-match before the failure started — something (env flag? session warmup?) flipped behaviour around M4-7.
+- `e2e/users.spec.ts:19` — `users admin surface › /admin/users shows the seeded admin + invite modal opens`. Strict-mode violation: `getByText('playwright-admin@opollo.test')` matches both the header chrome's `admin-user-email` span and the users-table cell.
+- `e2e/images.spec.ts:243` — `images admin surface › edit modal updates caption + tags and the list reflects the change`. Strict-mode violation: `getByText(newCaption)` matches both the Breadcrumbs current-crumb node (which truncates the caption to 60 chars) and the detail-fields dd. Started failing when M5-2 added Breadcrumbs to the image detail page; the M5-3 edit test's post-save assertion was authored before the breadcrumb landed.
 
-**Why deferred:** not regressions from any M5 PR; not worth blocking M5/M6 timelines. Both need a focused PR to repro locally + fix deliberately (likely `getByTestId` in users.spec to dodge strict mode, and waiting on `networkidle` after the site create before hunting the row).
+**Why deferred:** not regressions from any M5/M6 PR; not worth blocking milestone timelines. All three need a focused PR to repro locally + fix deliberately (likely `getByTestId` in users.spec + images.spec to dodge strict mode, and waiting on `networkidle` after the site create before hunting the row).
 
-**Trigger:** pick up between M6 sub-slices if CI attention permits, or at the end of M6 as a standalone slice before M7 (M7 adds write-safety-critical E2E coverage; clean baseline matters).
+**Trigger:** pick up at the end of M6 as a standalone slice before M7 (M7 adds write-safety-critical E2E coverage; clean baseline matters). Could also slot in between M6 sub-slices if it happens to be fast.
 
-**Scope:** ~50 lines total across two specs + any axe-related polish. No lib/ or app/ changes expected.
+**Scope:** ~80 lines across three specs, mostly locator narrowing (`getByTestId` + more-specific text matchers). No lib/ or app/ changes expected.
 
 ### Load testing (k6 / Artillery)
 **What:** scripted soak tests against the batch worker + chat route.

--- a/e2e/pages.spec.ts
+++ b/e2e/pages.spec.ts
@@ -17,6 +17,7 @@ type PageSeed = {
   title: string;
   page_type?: string;
   status?: "draft" | "published";
+  generated_html?: string;
 };
 
 const E2E_PAGE_SEEDS: PageSeed[] = [
@@ -25,6 +26,8 @@ const E2E_PAGE_SEEDS: PageSeed[] = [
     title: "E2E homepage fixture",
     page_type: "homepage",
     status: "draft",
+    generated_html:
+      "<div class=\"e2e-scope\"><h1>E2E homepage fixture</h1><p>Short body copy.</p></div>",
   },
   {
     slug: "e2e-integration-gravity",
@@ -67,7 +70,7 @@ async function lookupTestSiteId(): Promise<string> {
   return data.id as string;
 }
 
-async function seedPages(siteId: string): Promise<void> {
+async function seedPages(siteId: string): Promise<Record<string, string>> {
   const svc = serviceRoleClient();
   // Clear prior fixture rows so slug-UNIQUE constraint doesn't collide
   // across runs.
@@ -77,26 +80,37 @@ async function seedPages(siteId: string): Promise<void> {
     .delete()
     .eq("site_id", siteId)
     .in("slug", slugs);
+  const ids: Record<string, string> = {};
   for (const seed of E2E_PAGE_SEEDS) {
-    const { error } = await svc.from("pages").insert({
-      site_id: siteId,
-      wp_page_id: Math.floor(Math.random() * 10_000_000),
-      slug: seed.slug,
-      title: seed.title,
-      page_type: seed.page_type ?? "homepage",
-      design_system_version: 1,
-      status: seed.status ?? "draft",
-    });
-    if (error) throw new Error(`seedPages insert: ${error.message}`);
+    const { data, error } = await svc
+      .from("pages")
+      .insert({
+        site_id: siteId,
+        wp_page_id: Math.floor(Math.random() * 10_000_000),
+        slug: seed.slug,
+        title: seed.title,
+        page_type: seed.page_type ?? "homepage",
+        design_system_version: 1,
+        status: seed.status ?? "draft",
+        generated_html: seed.generated_html ?? null,
+      })
+      .select("id")
+      .single();
+    if (error || !data) {
+      throw new Error(`seedPages insert: ${error?.message ?? "no row"}`);
+    }
+    ids[seed.slug] = data.id as string;
   }
+  return ids;
 }
 
 test.describe("pages admin surface", () => {
   let siteId: string;
+  let pageIds: Record<string, string> = {};
 
   test.beforeEach(async ({ page }) => {
     siteId = await lookupTestSiteId();
-    await seedPages(siteId);
+    pageIds = await seedPages(siteId);
     await signInAsAdmin(page);
   });
 
@@ -131,6 +145,71 @@ test.describe("pages admin surface", () => {
     await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/pages/);
     await expect(
       page.getByRole("heading", { name: /pages for/i }),
+    ).toBeVisible();
+  });
+
+  test("list → detail round-trip preserves filter state on back-nav", async ({
+    page,
+  }, testInfo) => {
+    // Start on a filtered list so the back-link has state to preserve.
+    await page.goto(`/admin/sites/${siteId}/pages?status=draft`);
+    await expect(page.getByText(/e2e homepage fixture/i)).toBeVisible();
+
+    // Drill into the homepage fixture detail.
+    await page
+      .getByTestId("page-row-link")
+      .filter({ hasText: /e2e homepage fixture/i })
+      .click();
+    await page.waitForURL(
+      /\/admin\/sites\/[0-9a-f-]{36}\/pages\/[0-9a-f-]{36}/,
+    );
+    await expect(
+      page.getByTestId("page-detail-fields"),
+    ).toBeVisible();
+    await auditA11y(page, testInfo);
+
+    // Tier-2 preview iframe renders for the seed with generated_html.
+    await expect(
+      page.getByTestId("page-html-preview-iframe"),
+    ).toBeVisible();
+
+    // WP admin link composed from sites.wp_url + wp_page_id.
+    await expect(page.getByTestId("wp-admin-link")).toHaveAttribute(
+      "href",
+      /wp-admin\/post\.php\?post=\d+&action=edit/,
+    );
+
+    // Back link returns to the filtered list.
+    await page.getByRole("link", { name: /back to pages/i }).click();
+    await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/pages\?status=draft/);
+    await expect(page.getByText(/e2e homepage fixture/i)).toBeVisible();
+  });
+
+  test("detail page 404s on cross-site URL manipulation", async ({
+    page,
+  }) => {
+    // Reuse one of the seeded pages under the REAL site; then request
+    // it under a different-looking UUID that doesn't exist.
+    const response = await page.goto(
+      `/admin/sites/${siteId}/pages/00000000-0000-0000-0000-000000000000`,
+    );
+    expect(response?.status()).toBe(404);
+
+    // Validate the UUID guard also triggers a 404 on a non-UUID string.
+    const badUrlResponse = await page.goto(
+      `/admin/sites/${siteId}/pages/not-a-uuid`,
+    );
+    expect(badUrlResponse?.status()).toBe(404);
+  });
+
+  test("preview pane shows empty-state when generated_html is null", async ({
+    page,
+  }) => {
+    // The Gravity integration fixture is seeded without generated_html.
+    const emptyPageId = pageIds["e2e-integration-gravity"];
+    await page.goto(`/admin/sites/${siteId}/pages/${emptyPageId}`);
+    await expect(
+      page.getByTestId("page-html-preview-empty"),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
Second sub-slice of M6. Ships `/admin/sites/[id]/pages/[pageId]` as a read-only per-page detail view: metadata grid, Tier-2 static HTML preview in a sandboxed iframe, Tier-3 link out to the WordPress admin editor, and when the page is published a "View live" link as well. List row clicks now go somewhere meaningful.

## What lands

- `app/admin/sites/[id]/pages/[pageId]/page.tsx` — server component. Breadcrumbs, header chrome with status + type badges + WP links, two-column layout (preview + metadata grid). UUID guard + `notFound()` on invalid ids and on cross-site misses (via `getPage`'s scope guard from M6-1).
- `components/PageHtmlPreview.tsx` — Tier-2 preview. `<iframe srcDoc={html} sandbox="">` — empty sandbox means no scripts, no forms, no top-navigation, no same-origin. Size cap: inline cuts out at 500KB with a graceful "open in WP admin" nudge.
- `e2e/pages.spec.ts` — three new tests: list → detail round-trip preserves `?status=draft` filter via back-link, `404` on cross-site + non-UUID URL manipulation, empty-state of the preview when `generated_html` is null. `auditA11y` on the detail page.
- `docs/BACKLOG.md` — M6-1 flipped to merged (#68); M6-2 to in flight. The pre-existing E2E failures entry expands to include the `images.spec.ts:243` strict-mode violation the M5-2 breadcrumb introduced.

## Risks identified and mitigated

- **XSS via `generated_html` in the preview iframe.** → `sandbox=""` — no `allow-scripts`, no `allow-same-origin`, no `allow-forms`, no `allow-top-navigation`. Even if an operator-authored brief ever produced `<script>` in the HTML, it wouldn't execute. Defence-in-depth beyond whatever Claude's output produces.
- **Cross-site page lookup.** → `getPage(siteId, pageId)` already requires BOTH ids (shipped in M6-1). M6-2 confirms via an E2E test that a `pageId` under a mismatched `site` returns 404, not the row.
- **Non-UUID in either route segment.** → `UUID_RE` guard on both `params.id` and `params.pageId` returns `notFound()` before any DB call.
- **`from=` open-redirect abuse.** → `resolveBackHref` accepts only paths that start with `/admin/sites/${siteId}/pages`; anything else falls back to the site-scoped pages list root. No risk of redirecting the operator to an external host or another tenant's surface.
- **Huge `generated_html` DOM-blocking the admin page.** → 500KB inline cap; oversized records show a friendly message with a WP-admin nudge rather than inlining.
- **`wp_url` not ending in `/`.** → Both `wpAdminEditUrl` and `wpPublicUrl` strip any trailing slash before concatenating. No double-`//` in the URL.
- **Published page shows a "View live" link that 404s on the client site.** → We compose the URL from `sites.wp_url + '/' + slug`. If WP has a different permalink structure (date-based, category-nested) the live link might 404. This is a minor UX cost — the operator can still use the "Open in WP admin" link to navigate to the real URL. Called out; no code fix until a real client surfaces the mismatch.

## Deliberately deferred

- Metadata edit modal + PATCH route → M6-3.
- Live Tier-1 iframe preview (WP draft URL with preview token) → M7 (tied to re-generation).
- Page version history / diff view → tied to re-generation.
- Viewport switcher + theme switcher → SCOPE_v3 nice-to-haves; out of scope.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (`/admin/sites/[id]/pages/[pageId]` registered)
- [ ] `npm run test` — run in CI.
- [ ] `npm run test:e2e` — run in CI. Pre-existing sites + users + images-edit failures remain (tracked in BACKLOG.md); M6-2's own specs are independent.