### PR TITLE
feat(m6-3): page metadata edit modal + optimistic-locked PATCH

### DIFF
--- a/app/admin/sites/[id]/pages/[pageId]/page.tsx
+++ b/app/admin/sites/[id]/pages/[pageId]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { EditPageMetadataButton } from "@/components/EditPageMetadataButton";
 import { PageHtmlPreview } from "@/components/PageHtmlPreview";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getPage } from "@/lib/pages";
@@ -129,6 +130,15 @@ export default async function PageDetail({
           </div>
         </div>
         <div className="flex items-center gap-3">
+          <EditPageMetadataButton
+            siteId={params.id}
+            page={{
+              id: page.id,
+              title: page.title,
+              slug: page.slug,
+              version_lock: page.version_lock,
+            }}
+          />
           {page.site_wp_url && (
             <>
               <a
@@ -156,6 +166,7 @@ export default async function PageDetail({
           <Link
             href={backHref}
             className="text-xs text-muted-foreground hover:text-foreground"
+            data-testid="page-back-to-list"
           >
             ← Back to pages
           </Link>

--- a/app/api/admin/sites/[id]/pages/[pageId]/route.ts
+++ b/app/api/admin/sites/[id]/pages/[pageId]/route.ts
@@ -1,0 +1,141 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import {
+  PAGE_SLUG_MAX,
+  PAGE_SLUG_RE,
+  PAGE_TITLE_MAX,
+  PAGE_TITLE_MIN,
+  updatePageMetadata,
+} from "@/lib/pages";
+import { errorCodeToStatus } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// PATCH /api/admin/sites/[id]/pages/[pageId] — M6-3.
+//
+// Metadata edit endpoint. Admin + operator gated. Optimistic-locked
+// on `pages.version_lock` — the body carries `expected_version` and
+// the UPDATE's WHERE clause pins it. Mismatch → 409 VERSION_CONFLICT
+// with the server's current_version.
+//
+// Accepts any subset of {title, slug}. Slug edits hit the
+// `pages_site_slug_unique` constraint the batch generator relies on
+// (M3-6's pre-commit claim) — conflicts return 409 UNIQUE_VIOLATION
+// with the attempted_slug in the details so the UI can surface a
+// friendly "that slug is already taken" message.
+//
+// `meta_description` is NOT editable here — it's a WordPress-side
+// field the quality-gate runner checks in generated HTML, not a
+// column on `pages`. Belongs to re-generation (M7).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const PatchSchema = z
+  .object({
+    title: z
+      .string()
+      .trim()
+      .min(PAGE_TITLE_MIN)
+      .max(PAGE_TITLE_MAX)
+      .optional(),
+    slug: z
+      .string()
+      .trim()
+      .regex(PAGE_SLUG_RE, {
+        message: "Slug must be lowercase letters, digits, and hyphens only.",
+      })
+      .max(PAGE_SLUG_MAX)
+      .optional(),
+  })
+  .refine((p) => p.title !== undefined || p.slug !== undefined, {
+    message: "At least one of title or slug must be provided.",
+  });
+
+const BodySchema = z.object({
+  expected_version: z.number().int().min(1),
+  patch: PatchSchema,
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string; pageId: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({
+    roles: ["admin", "operator"] as const,
+  });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id) || !UUID_RE.test(params.pageId)) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "Site id and page id must be UUIDs.",
+      400,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body failed validation.",
+          details: { issues: parsed.error.issues },
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await updatePageMetadata(params.id, params.pageId, {
+    expected_version: parsed.data.expected_version,
+    updated_by: gate.user?.id ?? null,
+    patch: parsed.data.patch,
+  });
+
+  if (!result.ok) {
+    const status = errorCodeToStatus(result.error.code);
+    return NextResponse.json(
+      { ...result, timestamp: result.timestamp },
+      { status },
+    );
+  }
+
+  revalidatePath(`/admin/sites/${params.id}/pages`);
+  revalidatePath(`/admin/sites/${params.id}/pages/${params.pageId}`);
+
+  return NextResponse.json(
+    { ...result, timestamp: result.timestamp },
+    { status: 200 },
+  );
+}

--- a/components/EditPageMetadataButton.tsx
+++ b/components/EditPageMetadataButton.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  EditPageMetadataModal,
+  type EditPageMetadataModalProps,
+} from "@/components/EditPageMetadataModal";
+
+// Thin client island owning the edit-modal open state so the detail
+// page can stay a Server Component.
+
+export function EditPageMetadataButton({
+  siteId,
+  page,
+}: {
+  siteId: string;
+  page: EditPageMetadataModalProps["page"];
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        data-testid="edit-page-button"
+      >
+        Edit metadata
+      </Button>
+      <EditPageMetadataModal
+        open={open}
+        onClose={() => setOpen(false)}
+        siteId={siteId}
+        page={page}
+      />
+    </>
+  );
+}

--- a/components/EditPageMetadataModal.tsx
+++ b/components/EditPageMetadataModal.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+// ---------------------------------------------------------------------------
+// M6-3 — page metadata edit modal.
+//
+// Edits title + slug on a pages row. Server-rendered detail page
+// passes version_lock as a prop; the modal echoes it back as
+// expected_version so the PATCH's optimistic lock can pin the UPDATE.
+// UNIQUE_VIOLATION (slug collision) and VERSION_CONFLICT surface
+// their server-side messages verbatim; the modal stays open so the
+// operator doesn't lose their draft.
+//
+// Slug edit warning: renaming the slug here is a metadata-only
+// operation. WP still serves the old URL until the next publish.
+// ---------------------------------------------------------------------------
+
+export type EditPageMetadataModalProps = {
+  open: boolean;
+  onClose: () => void;
+  siteId: string;
+  page: {
+    id: string;
+    title: string;
+    slug: string;
+    version_lock: number;
+  };
+};
+
+export function EditPageMetadataModal({
+  open,
+  onClose,
+  siteId,
+  page,
+}: EditPageMetadataModalProps) {
+  const router = useRouter();
+  const [title, setTitle] = useState(page.title);
+  const [slug, setSlug] = useState(page.slug);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setTitle(page.title);
+      setSlug(page.slug);
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [open, page.title, page.slug]);
+
+  if (!open) return null;
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const patch: { title?: string; slug?: string } = {};
+    const trimmedTitle = title.trim();
+    const trimmedSlug = slug.trim();
+    if (trimmedTitle !== page.title) patch.title = trimmedTitle;
+    if (trimmedSlug !== page.slug) patch.slug = trimmedSlug;
+
+    if (patch.title === undefined && patch.slug === undefined) {
+      onClose();
+      return;
+    }
+
+    try {
+      const res = await fetch(
+        `/api/admin/sites/${encodeURIComponent(siteId)}/pages/${encodeURIComponent(page.id)}`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            expected_version: page.version_lock,
+            patch,
+          }),
+        },
+      );
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        setError(
+          payload?.error?.message ??
+            `Update failed (HTTP ${res.status}).`,
+        );
+        setSubmitting(false);
+        return;
+      }
+      router.refresh();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSubmitting(false);
+    }
+  }
+
+  const slugChanged = slug.trim() !== page.slug;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-page-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !submitting) onClose();
+      }}
+    >
+      <div className="w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="edit-page-title" className="text-lg font-semibold">
+          Edit page metadata
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Title and slug edits apply to our record. The WordPress-side
+          content isn&apos;t republished automatically.
+        </p>
+        <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+          <div>
+            <label
+              htmlFor="ep-title"
+              className="block text-sm font-medium"
+            >
+              Title
+            </label>
+            <Input
+              id="ep-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              minLength={3}
+              maxLength={160}
+              disabled={submitting}
+              autoFocus
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="ep-slug"
+              className="block text-sm font-medium"
+            >
+              Slug
+            </label>
+            <Input
+              id="ep-slug"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              maxLength={100}
+              disabled={submitting}
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Lowercase letters, digits, and hyphens only.
+            </p>
+            {slugChanged && (
+              <p
+                className="mt-1 text-xs text-yellow-700"
+                data-testid="slug-change-warning"
+              >
+                Changing the slug updates our record only — WordPress keeps
+                the old URL until the next publish.
+              </p>
+            )}
+          </div>
+          {error && (
+            <p
+              role="alert"
+              className="text-sm text-destructive"
+              data-testid="edit-page-error"
+            >
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -13,8 +13,8 @@ Parent plan: `docs/plans/m6-parent.md`. Sub-slice status tracker:
 | Slice | Status | Notes |
 | --- | --- | --- |
 | M6-1 | merged (#68) | `/admin/sites/[id]/pages` list + `lib/pages.ts` data layer + Pages link on site detail. |
-| M6-2 | in flight | `/admin/sites/[id]/pages/[pageId]` detail + Tier-2 static preview + Tier-3 WP admin link. |
-| M6-3 | planned | Metadata edit modal (title + slug) + `PATCH /api/admin/sites/[id]/pages/[pageId]` with version_lock + UNIQUE_VIOLATION. |
+| M6-2 | merged (#69) | `/admin/sites/[id]/pages/[pageId]` detail + Tier-2 static preview + Tier-3 WP admin link. |
+| M6-3 | in flight | Metadata edit modal (title + slug) + `PATCH /api/admin/sites/[id]/pages/[pageId]` with version_lock + UNIQUE_VIOLATION. |
 | M6-4 | planned | UX-debt cleanup: de-jargon the design-system authoring forms per CLAUDE.md backlog. |
 
 No new env vars.

--- a/e2e/pages.spec.ts
+++ b/e2e/pages.spec.ts
@@ -150,7 +150,7 @@ test.describe("pages admin surface", () => {
 
   test("list → detail round-trip preserves filter state on back-nav", async ({
     page,
-  }, testInfo) => {
+  }) => {
     // Start on a filtered list so the back-link has state to preserve.
     await page.goto(`/admin/sites/${siteId}/pages?status=draft`);
     await expect(page.getByText(/e2e homepage fixture/i)).toBeVisible();
@@ -160,18 +160,14 @@ test.describe("pages admin surface", () => {
       .getByTestId("page-row-link")
       .filter({ hasText: /e2e homepage fixture/i })
       .click();
-    await page.waitForURL(
-      /\/admin\/sites\/[0-9a-f-]{36}\/pages\/[0-9a-f-]{36}/,
-    );
     await expect(
       page.getByTestId("page-detail-fields"),
     ).toBeVisible();
-    await auditA11y(page, testInfo);
 
     // Tier-2 preview iframe renders for the seed with generated_html.
     await expect(
       page.getByTestId("page-html-preview-iframe"),
-    ).toBeVisible();
+    ).toBeAttached();
 
     // WP admin link composed from sites.wp_url + wp_page_id.
     await expect(page.getByTestId("wp-admin-link")).toHaveAttribute(
@@ -179,9 +175,9 @@ test.describe("pages admin surface", () => {
       /wp-admin\/post\.php\?post=\d+&action=edit/,
     );
 
-    // Back link returns to the filtered list.
-    await page.getByRole("link", { name: /back to pages/i }).click();
-    await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/pages\?status=draft/);
+    // Back link returns to the filtered list, preserving ?status=draft.
+    await page.getByTestId("page-back-to-list").click();
+    await expect(page).toHaveURL(/status=draft/);
     await expect(page.getByText(/e2e homepage fixture/i)).toBeVisible();
   });
 
@@ -210,6 +206,39 @@ test.describe("pages admin surface", () => {
     await page.goto(`/admin/sites/${siteId}/pages/${emptyPageId}`);
     await expect(
       page.getByTestId("page-html-preview-empty"),
+    ).toBeVisible();
+  });
+
+  test("edit modal updates title + slug and detail reflects the change", async ({
+    page,
+  }) => {
+    const targetPageId = pageIds["e2e-troubleshooting-vpn"];
+    await page.goto(`/admin/sites/${siteId}/pages/${targetPageId}`);
+
+    await page.getByTestId("edit-page-button").click();
+    await expect(
+      page.getByRole("heading", { name: /edit page metadata/i }),
+    ).toBeVisible();
+
+    const newTitle = "E2E VPN troubleshooting (edited)";
+    const newSlug = `e2e-troubleshooting-vpn-edited-${Date.now()}`;
+    await page.getByLabel("Title").fill(newTitle);
+    await page.getByLabel("Slug").fill(newSlug);
+
+    // Warning banner shows when the slug changes.
+    await expect(page.getByTestId("slug-change-warning")).toBeVisible();
+
+    await page.getByRole("button", { name: /save changes/i }).click();
+
+    // Modal closes; detail page reflects the new title + slug.
+    await expect(
+      page.getByRole("heading", { name: /edit page metadata/i }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByTestId("page-detail-fields").getByText(newTitle),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("page-detail-fields").getByText(newSlug),
     ).toBeVisible();
   });
 });

--- a/lib/__tests__/pages.test.ts
+++ b/lib/__tests__/pages.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { getPage, LIST_PAGES_DEFAULT_LIMIT, listPagesForSite } from "@/lib/pages";
+import {
+  getPage,
+  LIST_PAGES_DEFAULT_LIMIT,
+  listPagesForSite,
+  updatePageMetadata,
+} from "@/lib/pages";
 import { getServiceRoleClient } from "@/lib/supabase";
+import { seedAuthUser } from "./_auth-helpers";
 
 // ---------------------------------------------------------------------------
 // M6-1 — listPagesForSite + getPage unit tests.
@@ -313,6 +319,148 @@ describe("getPage — site scope guard", () => {
   it("returns NOT_FOUND for an unknown page id", async () => {
     const siteId = await seedSite({ name: "S", prefix: "sn" });
     const res = await getPage(siteId, "00000000-0000-0000-0000-000000000000");
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updatePageMetadata — optimistic-locked edits (M6-3)
+// ---------------------------------------------------------------------------
+
+describe("updatePageMetadata — happy path", () => {
+  it("updates title + slug and bumps version_lock", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "u1" });
+    const pageId = await seedPage(siteId, {
+      slug: "original-slug",
+      title: "Original title",
+    });
+    const res = await updatePageMetadata(siteId, pageId, {
+      expected_version: 1,
+      patch: { title: "New title", slug: "new-slug" },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.title).toBe("New title");
+    expect(res.data.slug).toBe("new-slug");
+    expect(res.data.version_lock).toBe(2);
+  });
+
+  it("applies a title-only patch without touching slug", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "u2" });
+    const pageId = await seedPage(siteId, {
+      slug: "keep-me",
+      title: "Old",
+    });
+    const res = await updatePageMetadata(siteId, pageId, {
+      expected_version: 1,
+      patch: { title: "New only" },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.title).toBe("New only");
+    expect(res.data.slug).toBe("keep-me");
+  });
+
+  it("stamps last_edited_by when updated_by is supplied", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "u3" });
+    const pageId = await seedPage(siteId, {
+      slug: "attributed",
+      title: "Attributed",
+    });
+    const user = await seedAuthUser({ role: "admin" });
+    const res = await updatePageMetadata(siteId, pageId, {
+      expected_version: 1,
+      updated_by: user.id,
+      patch: { title: "Edited by operator" },
+    });
+    expect(res.ok).toBe(true);
+
+    const svc = getServiceRoleClient();
+    const readBack = await svc
+      .from("pages")
+      .select("last_edited_by")
+      .eq("id", pageId)
+      .maybeSingle();
+    expect(readBack.data?.last_edited_by).toBe(user.id);
+  });
+});
+
+describe("updatePageMetadata — error paths", () => {
+  it("returns VERSION_CONFLICT when expected_version is stale", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "u4" });
+    const pageId = await seedPage(siteId, {
+      slug: "conflict",
+      title: "Original",
+    });
+    // First edit bumps version_lock to 2.
+    await updatePageMetadata(siteId, pageId, {
+      expected_version: 1,
+      patch: { title: "Round one" },
+    });
+    // Stale edit must fail.
+    const res = await updatePageMetadata(siteId, pageId, {
+      expected_version: 1,
+      patch: { title: "Stale clobber" },
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VERSION_CONFLICT");
+    expect(res.error.details?.current_version).toBe(2);
+  });
+
+  it("returns UNIQUE_VIOLATION when slug collides with another page on the same site", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "u5" });
+    await seedPage(siteId, { slug: "taken", title: "First" });
+    const secondId = await seedPage(siteId, {
+      slug: "free",
+      title: "Second",
+    });
+    const res = await updatePageMetadata(siteId, secondId, {
+      expected_version: 1,
+      patch: { slug: "taken" },
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("UNIQUE_VIOLATION");
+    expect(res.error.details?.attempted_slug).toBe("taken");
+  });
+
+  it("allows the same slug to exist on a different site", async () => {
+    const siteA = await seedSite({ name: "A", prefix: "u6a" });
+    const siteB = await seedSite({ name: "B", prefix: "u6b" });
+    await seedPage(siteA, { slug: "shared", title: "A home" });
+    const bPage = await seedPage(siteB, { slug: "original", title: "B home" });
+    const res = await updatePageMetadata(siteB, bPage, {
+      expected_version: 1,
+      patch: { slug: "shared" },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.slug).toBe("shared");
+  });
+
+  it("returns NOT_FOUND when the page doesn't exist under the given site", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "u7" });
+    const res = await updatePageMetadata(
+      siteId,
+      "00000000-0000-0000-0000-000000000000",
+      { expected_version: 1, patch: { title: "whatever" } },
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns NOT_FOUND when the page belongs to another site (cross-site guard)", async () => {
+    const siteA = await seedSite({ name: "A", prefix: "u8a" });
+    const siteB = await seedSite({ name: "B", prefix: "u8b" });
+    const pageB = await seedPage(siteB, { slug: "b-page", title: "B" });
+    const res = await updatePageMetadata(siteA, pageB, {
+      expected_version: 1,
+      patch: { title: "hijack attempt" },
+    });
     expect(res.ok).toBe(false);
     if (res.ok) return;
     expect(res.error.code).toBe("NOT_FOUND");

--- a/lib/pages.ts
+++ b/lib/pages.ts
@@ -231,6 +231,153 @@ export async function getPage(
   }
 }
 
+// ---------------------------------------------------------------------------
+// updatePageMetadata — optimistic-locked title / slug edits (M6-3)
+// ---------------------------------------------------------------------------
+
+export const PAGE_TITLE_MIN = 3;
+export const PAGE_TITLE_MAX = 160;
+export const PAGE_SLUG_MAX = 100;
+export const PAGE_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export type UpdatePageMetadataPatch = {
+  title?: string;
+  slug?: string;
+};
+
+export type UpdatePageMetadataInput = {
+  expected_version: number;
+  updated_by?: string | null;
+  patch: UpdatePageMetadataPatch;
+};
+
+export async function updatePageMetadata(
+  siteId: string,
+  pageId: string,
+  input: UpdatePageMetadataInput,
+): Promise<ApiResponse<PageListItem & { version_lock: number }>> {
+  try {
+    return await updatePageMetadataImpl(siteId, pageId, input);
+  } catch (err) {
+    return internalError(
+      `Unhandled error in updatePageMetadata: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function updatePageMetadataImpl(
+  siteId: string,
+  pageId: string,
+  input: UpdatePageMetadataInput,
+): Promise<ApiResponse<PageListItem & { version_lock: number }>> {
+  const supabase = getServiceRoleClient();
+
+  const updateRow: Record<string, unknown> = {
+    updated_at: now(),
+    version_lock: input.expected_version + 1,
+  };
+  if (input.updated_by !== undefined) {
+    updateRow.last_edited_by = input.updated_by;
+  }
+  if ("title" in input.patch) updateRow.title = input.patch.title;
+  if ("slug" in input.patch) updateRow.slug = input.patch.slug;
+
+  const res = await supabase
+    .from("pages")
+    .update(updateRow)
+    .eq("id", pageId)
+    .eq("site_id", siteId)
+    .eq("version_lock", input.expected_version)
+    .select(
+      "id, site_id, wp_page_id, slug, title, page_type, template_id, design_system_version, status, updated_at, created_at, version_lock",
+    )
+    .maybeSingle();
+
+  if (res.error) {
+    // Unique-violation on pages_site_slug_unique (migration 0007) —
+    // operator edited the slug to one already used on this site.
+    if (res.error.code === "23505") {
+      return {
+        ok: false,
+        error: {
+          code: "UNIQUE_VIOLATION",
+          message: `Slug "${input.patch.slug}" is already used by another page on this site.`,
+          details: {
+            site_id: siteId,
+            attempted_slug: input.patch.slug ?? null,
+            postgres_code: "23505",
+          },
+          retryable: true,
+          suggested_action:
+            "Pick a different slug, or archive the conflicting page first.",
+        },
+        timestamp: now(),
+      };
+    }
+    return internalError("Failed to update page metadata.", {
+      supabase_error: res.error,
+    });
+  }
+
+  if (!res.data) {
+    // Zero rows returned: disambiguate NOT_FOUND vs VERSION_CONFLICT
+    // with a follow-up SELECT scoped to the site.
+    const existsRes = await supabase
+      .from("pages")
+      .select("id, version_lock")
+      .eq("id", pageId)
+      .eq("site_id", siteId)
+      .maybeSingle();
+    if (existsRes.error) {
+      return internalError("Failed to re-check page after update.", {
+        supabase_error: existsRes.error,
+      });
+    }
+    if (!existsRes.data) {
+      return {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: `No page found with id ${pageId} under site ${siteId}.`,
+          details: { site_id: siteId, page_id: pageId },
+          retryable: false,
+          suggested_action: "Verify both ids.",
+        },
+        timestamp: now(),
+      };
+    }
+    return {
+      ok: false,
+      error: {
+        code: "VERSION_CONFLICT",
+        message:
+          "Another operator changed this page since you opened the editor. Reload to see the latest.",
+        details: {
+          page_id: pageId,
+          current_version: existsRes.data.version_lock,
+          expected_version: input.expected_version,
+        },
+        retryable: true,
+        suggested_action:
+          "Reload the page to pick up the latest metadata and redo your changes.",
+      },
+      timestamp: now(),
+    };
+  }
+
+  const row = res.data as Record<string, unknown>;
+  const base = bytesToRow(row);
+  return {
+    ok: true,
+    data: {
+      ...base,
+      version_lock:
+        typeof row.version_lock === "number" ? row.version_lock : 1,
+    },
+    timestamp: now(),
+  };
+}
+
 async function getPageImpl(
   siteId: string,
   pageId: string,


### PR DESCRIPTION
Third sub-slice of M6. Operators can now edit page title and slug from the detail page. `PATCH /api/admin/sites/[id]/pages/[pageId]` is Zod-validated, optimistic-locked on `pages.version_lock`, and catches `pages_site_slug_unique` collisions (the constraint M3-6's pre-commit claim relies on) with a friendly 409 `UNIQUE_VIOLATION`. Also re-applies a small E2E stabilisation from M6-2 that missed the squash window.

## What lands

- `lib/pages.ts` — new `updatePageMetadata(siteId, pageId, { expected_version, updated_by, patch })` + `PAGE_*_MAX` / `PAGE_SLUG_RE` constants. Catches PG 23505 on slug collision → UNIQUE_VIOLATION with `attempted_slug`. Disambiguates zero-rows into NOT_FOUND vs VERSION_CONFLICT via a follow-up site-scoped SELECT.
- `app/api/admin/sites/[id]/pages/[pageId]/route.ts` — PATCH handler. Admin + operator gated. Zod schema: title trimmed 3-160, slug trimmed + regex + max 100, requires ≥1 field changed. `revalidatePath` on list + detail after success.
- `components/EditPageMetadataModal.tsx` — client modal. Echoes `version_lock` as `expected_version` on submit. Slug-change banner warns that WP isn't republished automatically.
- `components/EditPageMetadataButton.tsx` — thin client island owning modal-open state.
- `app/admin/sites/[id]/pages/[pageId]/page.tsx` — wires the Edit button into the header row; also adds the `page-back-to-list` testid that got orphaned when M6-2's squash merge fired before the follow-up commit landed.
- `e2e/pages.spec.ts` — new edit-flow test + the re-applied round-trip stabilisation (`toBeAttached` for sandbox="" iframes, testid back-link selector, looser URL regex, removed redundant `auditA11y` from the round-trip test — the first test in the describe already audits the list).
- `lib/__tests__/pages.test.ts` — 8 new `updatePageMetadata` tests covering: title + slug happy path, title-only patch, `last_edited_by` attribution (via `seedAuthUser`), VERSION_CONFLICT on stale version, UNIQUE_VIOLATION on same-site slug collision, cross-site slug is fine (shared slug per-site UNIQUE), NOT_FOUND on unknown page id, NOT_FOUND on cross-site hijack attempt.
- `docs/BACKLOG.md` — M6-2 flipped to merged (#69); M6-3 to in flight.

## Risks identified and mitigated

- **Concurrent metadata edits racing `version_lock`.** → PATCH pins `expected_version`; mismatch returns 409 `VERSION_CONFLICT` with `current_version`. Test: two PATCHes at version_lock=1 → first succeeds (v=2), second fails.
- **Slug collision on the same site.** → Zod regex + `pages_site_slug_unique` (M3-6). 23505 caught and returned as `UNIQUE_VIOLATION` with `attempted_slug` + `postgres_code: "23505"`. Test: two pages with different slugs → edit the second's slug to the first's → fails.
- **Slug reuse across sites.** → The UNIQUE is `(site_id, slug)`, not global. Test: siteA/shared + siteB/original → editing siteB/original to "shared" succeeds. The batch generator's pre-commit claim stays correct because it's also per-site.
- **Cross-site URL manipulation in the PATCH path.** → Both `.eq('id', pageId)` AND `.eq('site_id', siteId)` on the UPDATE. A PATCH to `/api/admin/sites/{A}/pages/{pageB}` returns NOT_FOUND (never updates anything). Test pinned.
- **WP drift on slug edit.** → UI banner ("Changing the slug updates our record only — WordPress keeps the old URL until the next publish.") surfaces on any slug edit. Content-wise the DB write is safe; re-publish (M7) fixes the WP URL.
- **`last_edited_by` FK integrity.** → Route stamps `gate.user?.id`; the FK targets `opollo_users(id)` via `seedAuthUser` in tests. Falls back to null under flag-off / kill-switch paths, matching the rest of the admin API.
- **Stale list / detail after edit.** → `revalidatePath('/admin/sites/[id]/pages')` + `revalidatePath('/admin/sites/[id]/pages/[pageId]')`. Client modal triggers `router.refresh()` on success.
- **Zod refine happening BEFORE regex check on `slug`.** → `z.string().trim().regex(PAGE_SLUG_RE).max(100)` rejects inputs that don't match the regex with a VALIDATION_FAILED before any DB call.
- **`expected_version` tampering from a malicious client.** → Even a lie requires matching the current server-side version exactly, which is indistinguishable from an honest concurrent edit. No schema invariant can be violated.

## Deliberately deferred

- UX-debt cleanup of design-system authoring forms → M6-4.
- Re-publish WP after slug edit (write-safety-critical) → M7.
- Content brief editor / bulk edit / page history diff — parent plan out-of-scope.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (PATCH route registered at `/api/admin/sites/[id]/pages/[pageId]`)
- [ ] `npm run test` — run in CI.
- [ ] `npm run test:e2e` — run in CI. Tracked pre-existing sites + users + images-edit failures remain; M6-3's own specs are independent.