### PR TITLE
feat(m6-4): de-jargon design-system authoring form labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,39 +227,16 @@ detail. Pick up on a cleanup slice that naturally lives in M6 (Per-Page
 Iteration UI, where admin UX polish fits), or earlier if a sibling slice
 happens to be in the same file.
 
-### High — remove scope_prefix from the Add Site form
-**Surface:** `components/AddSiteModal.tsx` line ~211 "Scope prefix" field.
-**Problem:** A solo-dev operator adding a client site shouldn't have to
-understand CSS-scoping strategy. The field leaks `sites.prefix` into the UX.
-**Fix:** auto-generate server-side at site creation. Algorithm:
-1. Lower-case, ASCII-slugify the site name; keep only `[a-z0-9]`.
-2. Take the first 2–4 characters.
-3. If that prefix already exists in `sites.prefix`, append a single digit
-   (2, 3, …) until unique, capped at length 4.
-4. If still colliding past `<prefix>9`, fall back to `<prefix>` + base-36
-   counter.
+### ~~High — remove scope_prefix from the Add Site form~~ (shipped in M2d)
+M2d's UX cleanup removed the Scope prefix field from `AddSiteModal.tsx`;
+`lib/sites.createSite` now auto-generates via `generateUniquePrefix` when the
+caller doesn't supply one.
 
-Hide the field from the form entirely. `lib/sites.createSite` accepts
-`prefix` today; flip it to optional + server-compute when absent.
-
-### Medium — jargon in design-system authoring forms
-Audited 2026-04; current offenders:
-
-- `components/TemplateFormModal.tsx`:
-  - "Composition (JSON array)" → "Template composition"
-  - "required_fields (JSON)" → "Required fields per component"
-  - "seo_defaults JSON (optional)" → "SEO defaults (optional)"
-- `components/ComponentFormModal.tsx`:
-  - "content_schema (JSON)" → "Content shape (JSON Schema)"
-  - "image_slots JSON (optional)" → "Image slots (optional)"
-- `components/CreateDesignSystemModal.tsx`:
-  - "tokens.css" / "base-styles.css" — keep the filenames (designers write
-    CSS; the names are accurate), but add a one-line sub-label explaining
-    what each section controls.
-
-Design-system authoring is a developer surface, so full de-jargoning isn't
-the goal — just hide the raw column names. JSON editing UX itself
-(`<Textarea>` with JSON.parse in onBlur) can survive.
+### ~~Medium — jargon in design-system authoring forms~~ (shipped in M6-4)
+The three form labels listed here all shipped in M6-4 — see
+`components/TemplateFormModal.tsx`, `components/ComponentFormModal.tsx`, and
+`components/CreateDesignSystemModal.tsx` for the updated copy + the two
+sub-labels under `tokens.css` / `base-styles.css`.
 
 ### Low — admin-surface labels that expose IDs
 Scan done 2026-04, none found on the primary surfaces:

--- a/components/ComponentFormModal.tsx
+++ b/components/ComponentFormModal.tsx
@@ -369,7 +369,7 @@ export function ComponentFormModal({
           </div>
 
           <div>
-            <Label htmlFor="cf-schema">content_schema (JSON)</Label>
+            <Label htmlFor="cf-schema">Content shape (JSON Schema)</Label>
             <textarea
               id="cf-schema"
               className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
@@ -382,7 +382,7 @@ export function ComponentFormModal({
           </div>
 
           <div>
-            <Label htmlFor="cf-image-slots">image_slots JSON (optional)</Label>
+            <Label htmlFor="cf-image-slots">Image slots (optional)</Label>
             <textarea
               id="cf-image-slots"
               className="mt-1 h-20 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"

--- a/components/CreateDesignSystemModal.tsx
+++ b/components/CreateDesignSystemModal.tsx
@@ -168,6 +168,10 @@ export function CreateDesignSystemModal({
         <form onSubmit={handleSubmit} className="mt-4 space-y-3">
           <div>
             <Label htmlFor="ds-tokens">tokens.css</Label>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Design tokens (colours, spacing, typography) as CSS custom
+              properties on the scope wrapper.
+            </p>
             <textarea
               id="ds-tokens"
               className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
@@ -183,6 +187,10 @@ export function CreateDesignSystemModal({
 
           <div>
             <Label htmlFor="ds-base-styles">base-styles.css</Label>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Baseline component styles (containers, typography reset,
+              primitives) that every page inherits.
+            </p>
             <textarea
               id="ds-base-styles"
               className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"

--- a/components/TemplateFormModal.tsx
+++ b/components/TemplateFormModal.tsx
@@ -392,7 +392,7 @@ export function TemplateFormModal({
           </div>
 
           <div>
-            <Label htmlFor="tf-composition">Composition (JSON array)</Label>
+            <Label htmlFor="tf-composition">Template composition</Label>
             <textarea
               id="tf-composition"
               className="mt-1 h-48 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
@@ -411,7 +411,7 @@ export function TemplateFormModal({
           </div>
 
           <div>
-            <Label htmlFor="tf-required">required_fields (JSON)</Label>
+            <Label htmlFor="tf-required">Required fields per component</Label>
             <textarea
               id="tf-required"
               className="mt-1 h-24 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
@@ -424,7 +424,7 @@ export function TemplateFormModal({
           </div>
 
           <div>
-            <Label htmlFor="tf-seo">seo_defaults JSON (optional)</Label>
+            <Label htmlFor="tf-seo">SEO defaults (optional)</Label>
             <textarea
               id="tf-seo"
               className="mt-1 h-20 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -14,8 +14,8 @@ Parent plan: `docs/plans/m6-parent.md`. Sub-slice status tracker:
 | --- | --- | --- |
 | M6-1 | merged (#68) | `/admin/sites/[id]/pages` list + `lib/pages.ts` data layer + Pages link on site detail. |
 | M6-2 | merged (#69) | `/admin/sites/[id]/pages/[pageId]` detail + Tier-2 static preview + Tier-3 WP admin link. |
-| M6-3 | in flight | Metadata edit modal (title + slug) + `PATCH /api/admin/sites/[id]/pages/[pageId]` with version_lock + UNIQUE_VIOLATION. |
-| M6-4 | planned | UX-debt cleanup: de-jargon the design-system authoring forms per CLAUDE.md backlog. |
+| M6-3 | merged (#70) | Metadata edit modal (title + slug) + `PATCH /api/admin/sites/[id]/pages/[pageId]` with version_lock + UNIQUE_VIOLATION. |
+| M6-4 | in flight | UX-debt cleanup: de-jargon the design-system authoring forms per CLAUDE.md backlog. |
 
 No new env vars.
 

--- a/lib/__tests__/ux-debt-labels.test.ts
+++ b/lib/__tests__/ux-debt-labels.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// M6-4 — UX-debt de-jargon regression fence.
+//
+// Label changes have no behaviour surface, so a render test is overkill.
+// Instead, assert the old raw-column-name strings are gone from the
+// design-system authoring modals and the new operator-friendly copy is
+// present. If someone reverts a label in a future edit, this trips.
+//
+// Not testing CreateDesignSystemModal's filenames (tokens.css /
+// base-styles.css) — those are deliberately preserved. We DO assert
+// the sub-label text landed.
+// ---------------------------------------------------------------------------
+
+function readComponent(filename: string): string {
+  return readFileSync(
+    resolve(__dirname, "..", "..", "components", filename),
+    "utf8",
+  );
+}
+
+describe("UX-debt labels — de-jargon pass (M6-4)", () => {
+  describe("TemplateFormModal.tsx", () => {
+    const src = readComponent("TemplateFormModal.tsx");
+
+    it("replaces 'Composition (JSON array)' with 'Template composition'", () => {
+      expect(src).not.toContain("Composition (JSON array)");
+      expect(src).toContain("Template composition");
+    });
+
+    it("replaces 'required_fields (JSON)' with 'Required fields per component'", () => {
+      expect(src).not.toContain("required_fields (JSON)");
+      expect(src).toContain("Required fields per component");
+    });
+
+    it("replaces 'seo_defaults JSON (optional)' with 'SEO defaults (optional)'", () => {
+      expect(src).not.toContain("seo_defaults JSON (optional)");
+      expect(src).toContain("SEO defaults (optional)");
+    });
+  });
+
+  describe("ComponentFormModal.tsx", () => {
+    const src = readComponent("ComponentFormModal.tsx");
+
+    it("replaces 'content_schema (JSON)' with 'Content shape (JSON Schema)'", () => {
+      expect(src).not.toContain("content_schema (JSON)");
+      expect(src).toContain("Content shape (JSON Schema)");
+    });
+
+    it("replaces 'image_slots JSON (optional)' with 'Image slots (optional)'", () => {
+      expect(src).not.toContain("image_slots JSON (optional)");
+      expect(src).toContain("Image slots (optional)");
+    });
+  });
+
+  describe("CreateDesignSystemModal.tsx", () => {
+    const src = readComponent("CreateDesignSystemModal.tsx");
+
+    it("keeps tokens.css as the Label (designers write CSS; filename is accurate)", () => {
+      expect(src).toContain(">tokens.css<");
+    });
+
+    it("keeps base-styles.css as the Label", () => {
+      expect(src).toContain(">base-styles.css<");
+    });
+
+    it("adds a sub-label explaining what tokens.css controls", () => {
+      expect(src).toContain("Design tokens");
+    });
+
+    it("adds a sub-label explaining what base-styles.css controls", () => {
+      expect(src).toContain("Baseline component styles");
+    });
+  });
+});


### PR DESCRIPTION
Fourth and final sub-slice of M6. Pure-copy swaps on the design-system authoring modals per CLAUDE.md "Backlog — UX debt → Medium". Zero behaviour change, zero schema change — just hiding raw column names from operator-facing strings.

## What lands

- `components/TemplateFormModal.tsx` — "Composition (JSON array)" → "Template composition", "required_fields (JSON)" → "Required fields per component", "seo_defaults JSON (optional)" → "SEO defaults (optional)".
- `components/ComponentFormModal.tsx` — "content_schema (JSON)" → "Content shape (JSON Schema)", "image_slots JSON (optional)" → "Image slots (optional)".
- `components/CreateDesignSystemModal.tsx` — filenames `tokens.css` / `base-styles.css` preserved (designers write CSS; the names are accurate), but each gets a one-line sub-label explaining what the section controls ("Design tokens (colours, spacing, typography)..." / "Baseline component styles (containers, typography reset, primitives)...").
- `CLAUDE.md` — strikes through the Medium UX-debt entry (shipped here) and the already-stale High entry (M2d handled `scope_prefix` auto-generation; the backlog had drifted from reality).
- `lib/__tests__/ux-debt-labels.test.ts` — source-level assertions that the old jargon strings are absent and the new labels are present. Catches a future revert without requiring a jsdom render setup.
- `docs/BACKLOG.md` — M6-3 flipped to merged (#70); M6-4 to in flight.

## Risks identified and mitigated

- **Accidentally changing behaviour beyond labels.** → Diff is limited to `<Label>` string literals plus a new `<p>` sub-label in CreateDesignSystemModal. No form-submit paths, no JSX structure changes, no schema. Unit test asserts the exact string changes.
- **Regressing to the old jargon on a future edit.** → Source-level regex fence in `ux-debt-labels.test.ts` trips on the old strings landing anywhere in the modal files.
- **Sub-label text leaking design-system-specific detail.** → The two sub-labels describe the concept (design tokens, baseline component styles) rather than the concrete CSS custom-property names, so they stay correct across design systems.
- **Breaking the design-system E2E spec.** → There isn't one — the design-system authoring modals pre-date the E2E infrastructure. If Steven wants E2E coverage for this surface, it's a dedicated slice (out of scope here).

## Deliberately deferred

- E2E coverage for the design-system authoring modals themselves. They pre-date the Playwright setup and have been stable behaviourally; a dedicated slice can add E2E when there's time.
- Any further de-jargon pass — the Low-priority CLAUDE.md backlog entry already notes that admin surfaces are clean; no additional offenders on the primary surfaces.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — run in CI. Includes the new `ux-debt-labels.test.ts`.
- [ ] `npm run test:e2e` — run in CI. Tracked pre-existing sites + users + images-edit failures remain; no new specs in this slice.

---

M6 parent milestone wraps with this merge. Next up per the roadmap: **M7 — single-page re-generation + WP publish drift reconciliation** (write-safety-critical; parent plan to be drafted at that boundary).