### PR TITLE
feat(m7-1): regeneration schema — jobs + events + concurrency keystone

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,16 +6,32 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
-## M6 — per-page admin surface (in flight)
+## M7 — single-page re-generation (in flight)
 
-Parent plan: `docs/plans/m6-parent.md`. Sub-slice status tracker:
+Parent plan: `docs/plans/m7-parent.md`. Write-safety-critical milestone — every sub-slice plan carries the full risks audit. Sub-slice status tracker:
+
+| Slice | Status | Notes |
+| --- | --- | --- |
+| M7-1 | in flight | `regeneration_jobs` + `regeneration_events` schema with partial UNIQUE + lease-coherence CHECK + RLS. |
+| M7-2 | planned | Worker core with Anthropic integration, event-log-first billing, idempotency reuse. |
+| M7-3 | planned | WP update stage with drift reconciliation + M4-7 image transfer + `pages.version_lock` bump. |
+| M7-4 | planned | Admin UI: "Re-generate" button + polling status panel. |
+| M7-5 | planned | Cron wiring + budget cap + retry machinery. |
+
+No new env vars — every external dependency (`ANTHROPIC_API_KEY`, `CLOUDFLARE_*`, `OPOLLO_MASTER_KEY`, `CRON_SECRET`) is already provisioned from M3 + M4.
+
+---
+
+## M6 — per-page admin surface (shipped)
+
+Parent plan: `docs/plans/m6-parent.md`. All four sub-slices merged.
 
 | Slice | Status | Notes |
 | --- | --- | --- |
 | M6-1 | merged (#68) | `/admin/sites/[id]/pages` list + `lib/pages.ts` data layer + Pages link on site detail. |
 | M6-2 | merged (#69) | `/admin/sites/[id]/pages/[pageId]` detail + Tier-2 static preview + Tier-3 WP admin link. |
 | M6-3 | merged (#70) | Metadata edit modal (title + slug) + `PATCH /api/admin/sites/[id]/pages/[pageId]` with version_lock + UNIQUE_VIOLATION. |
-| M6-4 | in flight | UX-debt cleanup: de-jargon the design-system authoring forms per CLAUDE.md backlog. |
+| M6-4 | merged (#71) | UX-debt cleanup: de-jargon the design-system authoring forms per CLAUDE.md backlog. |
 
 No new env vars.
 

--- a/docs/plans/m7-parent.md
+++ b/docs/plans/m7-parent.md
@@ -1,0 +1,159 @@
+# M7 — Single-Page Re-Generation + WP Publish Drift Reconciliation
+
+## What it is
+
+An operator-initiated action on a single existing page: "re-generate this one page against the current design system and republish it to WordPress." Closes the loop M6-3 deliberately left open — editing `pages.slug` or `pages.title` in the DB today doesn't update the WP-side content; re-generation + WP `PUT` is how drift gets reconciled.
+
+**Write-safety-critical milestone** per CLAUDE.md. Spends Anthropic tokens, mutates the client's WordPress site, coordinates three external systems (Anthropic, Cloudflare, WP) without 2-phase-commit. Every sub-slice plan carries the full **"Risks identified and mitigated"** audit. M3 and M4 are the proof-of-pattern; M7 is the third application.
+
+## Why a separate milestone
+
+- **M3** (batch generator) produced pages from a template against a brief list. One-shot creation; no concept of re-running.
+- **M4** (image library) mirrored images into WP on publish. Transactional write-through; no concept of updating a published page.
+- **M6** (per-page admin UI) gave operators the detail view + metadata edit + drift warning. Editing a slug today surfaces a yellow banner saying "WordPress keeps the old URL until the next publish" — this milestone is that next publish.
+- **M7** is the first surface in the codebase that re-writes an existing published WP page. The safety layer needs to handle partial failures (Anthropic OK → WP PUT fails → operator retries) and drift (our slug changed → WP slug still old) without losing the customer's published content.
+
+## Scope (shipped in M7)
+
+- New schema: `regeneration_jobs` table plus an append-only `regeneration_events` audit log. Single-slot shape — no separate `regeneration_job_pages` child because re-gen is always one page at a time.
+- New worker: `lib/regeneration-worker.ts` that leases a `regeneration_jobs` row, runs the M3 generation pipeline (Anthropic call → quality gates → WP update → image transfer → event log), and commits the new `generated_html` to `pages`.
+- Anthropic integration reusing the M3-4 pattern: pre-computed idempotency key, event-log-first accounting, cost aggregation.
+- WP update path reusing the M3-6 pattern with an adoption step for the drift case (slug changed in our DB; WP page still has the old slug — adopt via GET-by-wp_page_id before deciding PUT vs POST).
+- Image transfer via the M4-7 `transferImagesForPage` path for any new Cloudflare URLs in the re-generated HTML.
+- Admin UI: "Re-generate" button on `/admin/sites/[id]/pages/[pageId]` that enqueues the job and polls the status.
+- Drift reconciliation: when the regenerated page commits successfully, if `pages.slug` differs from the WP-side slug, the WP update explicitly renames via `post_name` (WP REST API supports `slug` as a field on PUT).
+- Optimistic-lock on `pages.version_lock` throughout so concurrent re-gens race to exactly one winner.
+- Quality gate runner reused from M3-5 (no new gates; the existing five substantive gates apply).
+- Retry + budget cap machinery reused from M3-7.
+- E2E coverage: operator enqueues a regen on a seeded page, worker processes it (stubbed Anthropic + WP), detail page shows new `generated_html`.
+
+## Out of scope (tracked in BACKLOG.md)
+
+- **Bulk re-generation** (regen N pages at once). Surface the per-page flow first; bulk belongs to its own milestone once operators ask for it.
+- **Regen with a modified brief.** M7 re-runs against the existing `content_brief`. If operators want to edit the brief before regen, that's a follow-up slice.
+- **Partial regen** (regenerate one section of a page). Pattern doesn't map to Claude's single-shot HTML output; would need a fundamentally different prompt strategy.
+- **Scheduled / cron re-gen** (auto-refresh pages on DS version bump). The existing drift detection flags + operator triggers cover current needs.
+- **Rollback to a prior revision.** `page_history` table exists but isn't populated today; exposing it is a separate slice.
+- **Live Tier-1 preview during regen in-flight.** M6-2 deferred this; still out.
+
+## Env vars required
+
+| Var | Needed by | Status |
+| --- | --- | --- |
+| `ANTHROPIC_API_KEY` | M7-2 | Present (shared with M3) |
+| `CLOUDFLARE_IMAGES_HASH` | M7-3 | Present (provisioned with M4) |
+| `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_IMAGES_API_TOKEN` | M7-3 image transfer | Present |
+| `OPOLLO_MASTER_KEY` | M7-3 WP credential decryption | Present |
+| `CRON_SECRET` | M7-4 worker trigger | Present |
+| `SUPABASE_*` | all | Present |
+
+No new env vars. Every external dependency is already provisioned from M3 + M4.
+
+## Sub-slice breakdown (5 PRs)
+
+| Slice | Scope | Write-safety rating | Blocks on |
+| --- | --- | --- | --- |
+| **M7-1** | Schema: `regeneration_jobs` (+ `regeneration_events`) tables with constraints, lease-coherence CHECK, RLS, indexes. `pages.version_lock` stays the optimistic-lock anchor. Unit tests cover constraint-reject paths. | **High** — UNIQUE constraints are the write-safety layer for retries + concurrent regens. | Nothing |
+| **M7-2** | Worker core: `lib/regeneration-worker.ts` with lease / heartbeat / reaper over `regeneration_jobs`. Runs Anthropic against the existing `content_brief` with M3-4's idempotency + event-log pattern. Dummy quality-gate + WP stages so the worker is testable without live calls. | **Critical** — billed Anthropic call; idempotency retry reuse. | M7-1 |
+| **M7-3** | WP update stage: reuses M3-6's publish path + adoption logic, extended for drift (our slug ≠ WP slug). Calls `transferImagesForPage` (M4-7) for any new Cloudflare URLs in the re-gen'd HTML. Writes new `generated_html` back to `pages` with `version_lock` bump. | **Critical** — mutates client WP, transactional transfer across 3 systems. | M7-2 + M4-7 infrastructure. |
+| **M7-4** | Admin UI: "Re-generate" button on `/admin/sites/[id]/pages/[pageId]`. `POST /api/admin/sites/[id]/pages/[pageId]/regenerate` enqueues the job. Detail page polls status via server-rendered re-fetch (simple `setInterval` on the client wrapping router.refresh). | **Medium** — enqueues a billed job. Budget gate + operator confirm before POST. | M7-1..3 |
+| **M7-5** | Cron wiring + budget cap: `/api/cron/process-regenerations` worker tick. `regeneration_jobs` carries the same budget-cap pattern as `generation_jobs`. Budget enforcement happens at job creation time, NOT worker time (matches M3-7). | **Medium** — cost gate. | M7-4 |
+
+**Execution order:** strictly M7-1 → M7-2 → M7-3 → M7-4 → M7-5. Each slice has dependencies on the previous one's schema or code.
+
+Total expected volume: ~3,500–4,500 lines across five slices including tests. Each slice stays within the reviewer-in-5-minutes rule except possibly M7-3 which is the write-safety-dense one.
+
+## Write-safety contract
+
+Three external systems (Anthropic, Cloudflare, WP) plus our DB, all touched within one worker tick. Same "idempotent + recovery-safe" design as M3 + M4:
+
+### Anthropic (M7-2)
+
+- Pre-computed `anthropic_idempotency_key` on `regeneration_jobs` INSERT (UUIDv5 from `job_id + page_id`). Retries reuse it automatically.
+- Event-log-first: `regeneration_events` row with type `anthropic_response_received` written BEFORE the `regeneration_jobs.cost_usd_cents` UPDATE. Reconciliation reads the event log.
+- Retryable failures (429, 5xx, network): `retry_after` + exponential backoff per M3-7.
+- Non-retryable (400, 401, 413): terminal fail with explicit `failure_code`.
+
+### Cloudflare Images (M7-3, transitive via M4-7)
+
+- Cloudflare upload is `image_library` INSERT path, which is already write-safe per M4-3. M7 never re-uploads an image it already has; the `extractCloudflareIds` + `image_usage` join in `transferImagesForPage` short-circuits when the image was previously mirrored to this site.
+
+### WordPress (M7-3)
+
+- `wp_idempotency_key` pre-computed on regen job insert. WP PUT with idempotency marker; on 429/5xx retries use the same key; on 200 the marker is stamped into `pages.updated_at`.
+- **Drift case:** after Anthropic produces new HTML, we compare the DB's current `pages.slug` with the WP-side slug (fetched via GET-by-wp_page_id). If they differ, the PUT includes `slug` in the body so WP updates `post_name` atomically. WP's PUT with a changed slug returns the new URL; we reconcile.
+- If the WP PUT succeeds but our DB write of the new `generated_html` fails, the retry's first action is a GET-by-wp_page_id adoption check: if the WP page's `modified` timestamp is newer than our last known, we adopt the WP state (the PUT already ran) and only commit our DB write. No double PUT.
+- `pages.version_lock` gated on the UPDATE. Two concurrent regens against the same page race to INSERT into `regeneration_jobs` first; then the worker's UPDATE to `pages` checks `version_lock` — the loser gets VERSION_CONFLICT.
+
+### Event log first (M7-1)
+
+`regeneration_events` is the append-only truth source. Every billed external call gets an event row BEFORE the state column flips. Reconciliation + post-mortem debugging both read the event log.
+
+## Testing strategy
+
+Per existing patterns:
+
+| Slice | Patterns applied |
+| --- | --- |
+| M7-1 | `new-migration.md` (constraint-reject tests, RLS role matrix, cascade behaviour, lease-coherence CHECK). |
+| M7-2 | `background-worker-with-write-safety.md` (lease / heartbeat / reaper, crash recovery) + `concurrency-test-harness.md`. Anthropic stubbed via the M3-4 test pattern. |
+| M7-3 | `new-batch-worker-stage.md` (idempotency reuse, retryable classification, cost reconciliation) + drift-specific tests: our slug changed → WP PUT carries new slug; WP PUT succeeded + our DB write failed → retry adopts. Fetch mocked. |
+| M7-4 | `new-api-route.md` (Zod + gate + error codes) + `new-admin-page.md` (button wiring, router.refresh, revalidatePath). |
+| M7-5 | Cron signature check + budget enforcement tests; `retry_after` behaviour. |
+
+**Concurrency test harness.** `concurrency-test-harness.md` applies on M7-3 — two concurrent regens of the same page must produce exactly one WP PUT + exactly one `pages.version_lock` bump. The M3-6 pre-commit-claim pattern translates directly.
+
+**EXPLAIN ANALYZE.** The worker's `FOR UPDATE SKIP LOCKED` dequeue against `regeneration_jobs` must stay fast as the table grows. M7-1 includes an `idx_regen_jobs_leasable` partial index and paste the plan in the PR description.
+
+**E2E coverage.** `e2e/pages.spec.ts` gets extended: operator clicks Re-generate on a seeded page, the worker is kicked manually in the test (not via cron), detail page reflects the updated HTML. Anthropic + WP are stubbed; the focus is UI wiring + polling + revalidation.
+
+## Risks identified and mitigated
+
+Per-slice plans elaborate these; listed here at the parent-milestone level so the safety net is visible in one place.
+
+1. **Double-billing Anthropic on retry.** → Pre-computed `anthropic_idempotency_key` on `regeneration_jobs` INSERT. Every retry reuses it. Test: reaped-then-reprocessed job uses the same key; Anthropic stub asserts identical body on both calls.
+
+2. **Double-PUT to WP on retry.** → Pre-computed `wp_idempotency_key`; retries first GET-by-wp_page_id to detect the partial-commit case (WP PUT succeeded + our DB write failed) and adopt rather than re-PUT. Same pattern M3-6 established. Test pinned.
+
+3. **Two concurrent regens racing the same page.** → `regeneration_jobs (page_id) UNIQUE WHERE status IN ('pending', 'running')` — a partial unique index that allows at most one in-flight job per page. Second enqueue attempt returns 409 `REGEN_ALREADY_IN_FLIGHT`.
+
+4. **Pages version_lock stale when the regen worker commits.** → Worker reads `pages.version_lock` at dequeue time, carries it through Anthropic + WP, and stamps `version_lock = expected + 1` in the final UPDATE with WHERE clause pinning. Mismatch (operator edited metadata while regen was in flight) → worker fails the job with VERSION_CONFLICT. Operator retries the regen; the new run picks up the edited metadata.
+
+5. **Drift: slug changed in DB; WP still has old slug.** → Worker always fetches WP state before deciding PUT shape. If slugs differ, the PUT body includes `slug` so WP updates `post_name`. WP returns the new URL; we reconcile into `pages.slug` (if different) and `pages.wp_slug_resolved_at`. Test: seed `pages.slug = new-slug` + WP has `old-slug` → regen produces PUT that includes both new slug + new HTML; post-regen `pages.slug` unchanged and WP confirms `old-slug → new-slug`.
+
+6. **Anthropic OK → WP 5xx → operator retries.** → Anthropic response cached in `regeneration_events`. Retry fetches it from the event log instead of re-calling. WP retry uses the same idempotency key. Cost counted once. Test: first attempt sets `anthropic_response_received`, then WP stub 500s; retry reads event + WP stub 200s; total cost = 1× Anthropic call.
+
+7. **Regen against a page whose design system has been archived.** → Worker loads the design system at dequeue time (same as M3-3). If the page's `design_system_version` no longer has an active DS, worker fails with `DS_ARCHIVED` and surfaces a friendly error on the detail page. No Anthropic call happens. Test pinned.
+
+8. **Budget runaway.** → Every `regeneration_jobs` INSERT runs through the M3-7 budget gate. Daily / monthly caps enforced at enqueue time. Test: 99% budget consumed + new regen attempt → 429 `BUDGET_EXCEEDED`, no job created.
+
+9. **Operator enqueues a regen then cancels.** → `regeneration_jobs.cancel_requested_at` checked at every worker tick; worker short-circuits to `cancelled` status at the next state transition. Anthropic calls already in flight are not interrupted (Anthropic API doesn't support mid-stream cancel); the cost is recorded but the WP write skipped.
+
+10. **Stale `generated_html` after regen.** → After successful commit, `revalidatePath('/admin/sites/[id]/pages/[pageId]')`. Detail page polls status every 2s while `status IN ('pending', 'running')`; switches to static after terminal. Stale cache is the operator's problem only if they navigate outside the polling window — standard admin UX.
+
+11. **Image transfer fails mid-regen.** → `transferImagesForPage` already handles this (M4-7). Failure short-circuits with `WP_IMAGE_TRANSFER_FAILED`; the regen job state is `failed`, `generated_html` unchanged, WP unchanged. Operator retries manually. Test: Cloudflare stub returns 429 on one image; worker fails cleanly.
+
+12. **Quality gates fail on the new HTML.** → M3-5 runner. Failure → job state `failed_gates` (new terminal state), HTML stored in the event log for inspection, WP untouched. Operator sees the gate failures in the detail page's regen panel.
+
+13. **`regeneration_events` retention.** → Kept indefinitely in M7. M4's `transfer_events` has the same posture. If event volume becomes an issue, a cleanup slice under ops-infra handles it.
+
+14. **Cron stops firing.** → Same infrastructure as M3's batch worker cron (`/api/cron/process-batch`). Parent plan re-uses the `CRON_SECRET` check pattern. If cron stops firing, jobs sit `pending` — observable via the admin UI + a future observability alert.
+
+15. **WP credentials missing for the site.** → Worker checks credential decryption on dequeue. Failure → terminal `WP_CREDS_MISSING` with a friendly message surfacing to the detail page. Test: seed site without credentials + enqueue → terminal fail.
+
+16. **Operator can't observe what happened.** → The event log (`regeneration_events`) is append-only and queryable. Detail page shows the last 5 events for the page (regen history). Debugging is always a SELECT away, no grep through logs.
+
+## Relationship to existing patterns
+
+- **Workers** follow `docs/patterns/background-worker-with-write-safety.md` + `new-batch-worker-stage.md`. M3 + M4 are both proof-of-pattern; M7 is the third application.
+- **Schema** follows `docs/patterns/new-migration.md` + `docs/DATA_CONVENTIONS.md`. `regeneration_jobs` ships with `deleted_at`, audit columns, `version_lock` where edits are expected, RLS from day one.
+- **WP drift reconciliation** is a new specific subpattern within the M3-6 publish flow; documented inline in `lib/regeneration-worker.ts` and the M7-3 plan, not promoted to a repo-level pattern yet (single consumer).
+- **Write-safety invariants** match M3's (idempotency key stamped at insert, event-log-first, SAVEPOINT on unique-violation, top-branch CASE on job aggregation).
+
+No new architectural patterns are introduced by M7 that aren't immediate sub-patterns of existing ones.
+
+## Sub-slice status tracker
+
+Maintained in `docs/BACKLOG.md` under a new **M7 — single-page re-generation** section. Updated on every merge.
+
+On M7-5 merge, auto-continue proceeds to **M8** — scope TBD at that boundary; roadmap candidates are (a) multi-tenant billing / Stripe, (b) observability-deep (Sentry / Langfuse / Axiom) once env vars land, (c) per-tenant cost budgets. Parent plan drafted when M7-5 ships.

--- a/lib/__tests__/_setup.ts
+++ b/lib/__tests__/_setup.ts
@@ -71,6 +71,8 @@ export async function truncateAll(): Promise<void> {
   // Scoped to public-schema tables only.
   await pg.query(`
     TRUNCATE TABLE
+      regeneration_events,
+      regeneration_jobs,
       transfer_events,
       transfer_job_items,
       transfer_jobs,

--- a/lib/__tests__/m7-schema.test.ts
+++ b/lib/__tests__/m7-schema.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M7-1 — regeneration_jobs + regeneration_events schema constraint tests.
+//
+// Pins the write-safety invariants the worker relies on:
+//
+//   1. One active regen per page (partial UNIQUE on page_id WHERE
+//      status IN ('pending', 'running')).
+//   2. A terminal-state job doesn't block a new enqueue.
+//   3. Lease-coherence CHECK — pending rows can't carry worker_id /
+//      lease_expires_at.
+//   4. CASCADE from sites + pages.
+//   5. Events append-only via FK ON DELETE CASCADE from the job.
+// ---------------------------------------------------------------------------
+
+type SiteSeed = { name: string; prefix: string };
+
+async function seedSite(opts: SiteSeed): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("sites")
+    .insert({
+      name: opts.name,
+      prefix: opts.prefix,
+      wp_url: `https://${opts.prefix}.example`,
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seedSite: ${error?.message ?? "no row"}`);
+  return data.id as string;
+}
+
+async function seedPage(siteId: string, slug: string): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("pages")
+    .insert({
+      site_id: siteId,
+      wp_page_id: Math.floor(Math.random() * 10_000_000),
+      slug,
+      title: `Page for ${slug}`,
+      page_type: "homepage",
+      design_system_version: 1,
+      status: "draft",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seedPage: ${error?.message ?? "no row"}`);
+  return data.id as string;
+}
+
+async function insertRegenJob(opts: {
+  siteId: string;
+  pageId: string;
+  status?: "pending" | "running" | "succeeded" | "failed" | "failed_gates" | "cancelled";
+  worker_id?: string;
+  lease_expires_at?: string;
+}) {
+  const svc = getServiceRoleClient();
+  return svc
+    .from("regeneration_jobs")
+    .insert({
+      site_id: opts.siteId,
+      page_id: opts.pageId,
+      status: opts.status ?? "pending",
+      expected_page_version: 1,
+      anthropic_idempotency_key: `anth-${opts.pageId}-${Math.random()}`,
+      wp_idempotency_key: `wp-${opts.pageId}-${Math.random()}`,
+      worker_id: opts.worker_id ?? null,
+      lease_expires_at: opts.lease_expires_at ?? null,
+    })
+    .select("id")
+    .single();
+}
+
+// ---------------------------------------------------------------------------
+// Partial UNIQUE: one active regen per page
+// ---------------------------------------------------------------------------
+
+describe("regeneration_jobs — one active per page constraint", () => {
+  it("rejects a second pending job for the same page", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "m71a" });
+    const pageId = await seedPage(siteId, "home");
+
+    const first = await insertRegenJob({ siteId, pageId });
+    expect(first.error).toBeNull();
+
+    const second = await insertRegenJob({ siteId, pageId });
+    expect(second.error).not.toBeNull();
+    expect(second.error?.code).toBe("23505");
+  });
+
+  it("rejects a second running job for the same page", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "m71b" });
+    const pageId = await seedPage(siteId, "home");
+
+    const first = await insertRegenJob({
+      siteId,
+      pageId,
+      status: "running",
+      worker_id: "worker-a",
+      lease_expires_at: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(first.error).toBeNull();
+
+    const second = await insertRegenJob({ siteId, pageId });
+    expect(second.error).not.toBeNull();
+    expect(second.error?.code).toBe("23505");
+  });
+
+  it("rejects a running + a pending simultaneously", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "m71c" });
+    const pageId = await seedPage(siteId, "home");
+
+    const first = await insertRegenJob({
+      siteId,
+      pageId,
+      status: "running",
+      worker_id: "worker-a",
+      lease_expires_at: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(first.error).toBeNull();
+
+    const second = await insertRegenJob({ siteId, pageId, status: "pending" });
+    expect(second.error).not.toBeNull();
+    expect(second.error?.code).toBe("23505");
+  });
+
+  it("allows a new pending job after the previous one terminated", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "m71d" });
+    const pageId = await seedPage(siteId, "home");
+
+    const first = await insertRegenJob({ siteId, pageId });
+    expect(first.error).toBeNull();
+
+    // Transition the first to a terminal state.
+    const svc = getServiceRoleClient();
+    const terminate = await svc
+      .from("regeneration_jobs")
+      .update({ status: "succeeded", finished_at: new Date().toISOString() })
+      .eq("id", first.data?.id as string);
+    expect(terminate.error).toBeNull();
+
+    const second = await insertRegenJob({ siteId, pageId });
+    expect(second.error).toBeNull();
+  });
+
+  it("allows concurrent pending jobs across different pages on the same site", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "m71e" });
+    const pageA = await seedPage(siteId, "page-a");
+    const pageB = await seedPage(siteId, "page-b");
+
+    const a = await insertRegenJob({ siteId, pageId: pageA });
+    const b = await insertRegenJob({ siteId, pageId: pageB });
+    expect(a.error).toBeNull();
+    expect(b.error).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lease coherence
+// ---------------------------------------------------------------------------
+
+describe("regeneration_jobs — lease-coherence CHECK", () => {
+  it("rejects pending status with a worker_id set", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "m71f" });
+    const pageId = await seedPage(siteId, "home");
+
+    const res = await insertRegenJob({
+      siteId,
+      pageId,
+      status: "pending",
+      worker_id: "worker-a",
+    });
+    expect(res.error).not.toBeNull();
+    // Postgres CHECK violation.
+    expect(res.error?.code).toBe("23514");
+  });
+
+  it("rejects pending status with a lease_expires_at set", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "m71g" });
+    const pageId = await seedPage(siteId, "home");
+
+    const res = await insertRegenJob({
+      siteId,
+      pageId,
+      status: "pending",
+      lease_expires_at: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(res.error).not.toBeNull();
+    expect(res.error?.code).toBe("23514");
+  });
+
+  it("accepts running status with lease fields populated", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "m71h" });
+    const pageId = await seedPage(siteId, "home");
+
+    const res = await insertRegenJob({
+      siteId,
+      pageId,
+      status: "running",
+      worker_id: "worker-a",
+      lease_expires_at: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(res.error).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CASCADE semantics
+// ---------------------------------------------------------------------------
+
+describe("regeneration_jobs — cascade behaviour", () => {
+  it("cascades regen job deletion when the parent page is deleted", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "m71i" });
+    const pageId = await seedPage(siteId, "home");
+    const res = await insertRegenJob({ siteId, pageId });
+    expect(res.error).toBeNull();
+    const jobId = res.data?.id as string;
+
+    const svc = getServiceRoleClient();
+    const deletePage = await svc.from("pages").delete().eq("id", pageId);
+    expect(deletePage.error).toBeNull();
+
+    const lookup = await svc
+      .from("regeneration_jobs")
+      .select("id")
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(lookup.data).toBeNull();
+  });
+
+  it("cascades regen event deletion when the parent job is deleted", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "m71j" });
+    const pageId = await seedPage(siteId, "home");
+    const res = await insertRegenJob({ siteId, pageId });
+    expect(res.error).toBeNull();
+    const jobId = res.data?.id as string;
+
+    const svc = getServiceRoleClient();
+    const evInsert = await svc.from("regeneration_events").insert({
+      regeneration_job_id: jobId,
+      type: "worker_leased",
+      payload: { worker_id: "w-a" },
+    });
+    expect(evInsert.error).toBeNull();
+
+    const deleteJob = await svc
+      .from("regeneration_jobs")
+      .delete()
+      .eq("id", jobId);
+    expect(deleteJob.error).toBeNull();
+
+    const lookup = await svc
+      .from("regeneration_events")
+      .select("id")
+      .eq("regeneration_job_id", jobId);
+    expect(lookup.data).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// status CHECK constraint
+// ---------------------------------------------------------------------------
+
+describe("regeneration_jobs — status CHECK", () => {
+  it("rejects an unknown status value", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "m71k" });
+    const pageId = await seedPage(siteId, "home");
+    const svc = getServiceRoleClient();
+    const res = await svc
+      .from("regeneration_jobs")
+      .insert({
+        site_id: siteId,
+        page_id: pageId,
+        status: "weird",
+        expected_page_version: 1,
+        anthropic_idempotency_key: "k1",
+        wp_idempotency_key: "k2",
+      })
+      .select("id")
+      .maybeSingle();
+    expect(res.error).not.toBeNull();
+    expect(res.error?.code).toBe("23514");
+  });
+
+  it("accepts 'failed_gates' as a distinct terminal status", async () => {
+    const siteId = await seedSite({ name: "S", prefix: "m71l" });
+    const pageId = await seedPage(siteId, "home");
+
+    const res = await insertRegenJob({
+      siteId,
+      pageId,
+      status: "failed_gates",
+    });
+    expect(res.error).toBeNull();
+  });
+});

--- a/supabase/migrations/0011_m7_1_regeneration_schema.sql
+++ b/supabase/migrations/0011_m7_1_regeneration_schema.sql
@@ -1,0 +1,231 @@
+-- M7-1 — Single-page re-generation schema.
+-- Reference: docs/plans/m7-parent.md. Write-safety-critical milestone;
+-- the full risks audit is in the parent plan + this slice's PR.
+--
+-- Design decisions encoded here:
+--
+-- 1. regeneration_jobs carries the operator-initiated single-page
+--    re-run. Shape mirrors generation_jobs (M3-1) but is always
+--    single-slot — no separate child-slot table because re-gen is
+--    always one page at a time.
+--
+-- 2. (page_id) UNIQUE WHERE status IN ('pending', 'running') is the
+--    concurrency-limit keystone: at most one in-flight regen per
+--    page. A second enqueue attempt catches 23505 and surfaces
+--    REGEN_ALREADY_IN_FLIGHT in the API response. Prevents two
+--    concurrent regens from racing two Anthropic calls + two WP
+--    PUTs on the same page.
+--
+-- 3. anthropic_idempotency_key + wp_idempotency_key UNIQUE per job
+--    so a reaped + relet job keeps its retry keys. Mirrors M3-1's
+--    generation_job_pages design.
+--
+-- 4. expected_page_version is snapshotted at enqueue time from the
+--    current pages.version_lock. The worker's final UPDATE to `pages`
+--    pins version_lock = expected; a metadata edit mid-regen (M6-3
+--    path) bumps the lock and the regen's commit fails with
+--    VERSION_CONFLICT. Operator retries; the new job snapshots the
+--    new version.
+--
+-- 5. Lease-coherence CHECK mirrors M3's generation_job_pages and
+--    M4's transfer_job_items: (state, worker_id, lease_expires_at)
+--    must be consistent. A 'leased' row without worker_id is
+--    malformed at the schema level.
+--
+-- 6. regeneration_events is append-only. Every billed external call
+--    produces an event row BEFORE the corresponding state-column
+--    flip. Billing reconciliation + post-mortem debugging both read
+--    the event log. Same posture as M3's generation_events and M4's
+--    transfer_events.
+--
+-- 7. ON DELETE CASCADE from sites + pages: when a site or page is
+--    removed, in-flight regen jobs go with them. Completed jobs are
+--    not audit-critical (the pages table holds the committed result);
+--    re-evaluate if an auditor ever asks for "who regen'd what when"
+--    across deleted pages.
+--
+-- Write-safety hotspots addressed here:
+--   - partial UNIQUE on page_id + active-status filter.
+--   - anthropic_idempotency_key + wp_idempotency_key UNIQUE per job.
+--   - lease-coherence CHECK.
+--   - Append-only regeneration_events.
+
+-- ---------------------------------------------------------------------------
+-- regeneration_jobs
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE regeneration_jobs (
+  id                         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  site_id                    uuid NOT NULL
+    REFERENCES sites(id) ON DELETE CASCADE,
+  page_id                    uuid NOT NULL
+    REFERENCES pages(id) ON DELETE CASCADE,
+
+  -- State machine. Terminal states: succeeded, failed, failed_gates,
+  -- cancelled. failed_gates is called out separately from failed so the
+  -- UI can render "quality gates rejected the new HTML" with the
+  -- gate-failure payload, distinct from "Anthropic or WP blew up".
+  status                     text NOT NULL DEFAULT 'pending'
+    CHECK (status IN (
+      'pending',
+      'running',
+      'succeeded',
+      'failed',
+      'failed_gates',
+      'cancelled'
+    )),
+
+  -- Snapshot of pages.version_lock at enqueue time. Worker's final
+  -- UPDATE to `pages` pins version_lock = expected; a mid-regen
+  -- metadata edit (M6-3 path) bumps the lock and the commit fails
+  -- with VERSION_CONFLICT. See parent plan risk 4.
+  expected_page_version      int NOT NULL CHECK (expected_page_version >= 1),
+
+  -- Pre-computed stable retry keys. Insert-time only; never overwritten.
+  anthropic_idempotency_key  text NOT NULL,
+  wp_idempotency_key         text NOT NULL,
+
+  -- Lease + heartbeat. Same contract as M3's generation_job_pages.
+  worker_id                  text,
+  lease_expires_at           timestamptz,
+  last_heartbeat_at          timestamptz,
+  attempts                   int NOT NULL DEFAULT 0
+    CHECK (attempts >= 0),
+  retry_after                timestamptz,
+
+  -- Cost + token accounting. Worker writes these after the Anthropic
+  -- response arrives and BEFORE the status flip.
+  cost_usd_cents             bigint NOT NULL DEFAULT 0
+    CHECK (cost_usd_cents >= 0),
+  input_tokens               bigint NOT NULL DEFAULT 0
+    CHECK (input_tokens >= 0),
+  output_tokens              bigint NOT NULL DEFAULT 0
+    CHECK (output_tokens >= 0),
+  cached_tokens              bigint NOT NULL DEFAULT 0
+    CHECK (cached_tokens >= 0),
+
+  -- Anthropic's response.id, for reconciliation against their usage
+  -- reports. Mirrors generation_job_pages.anthropic_raw_response_id.
+  anthropic_raw_response_id  text,
+
+  -- Quality-gate failures payload when status = 'failed_gates'.
+  quality_gate_failures      jsonb,
+
+  -- Terminal failure detail. Structured enough for the UI to render
+  -- "Anthropic rate-limited — retry later" or "WP credentials
+  -- missing" without grepping logs.
+  failure_code               text,
+  failure_detail             text,
+
+  created_by                 uuid
+    REFERENCES opollo_users(id) ON DELETE SET NULL,
+  created_at                 timestamptz NOT NULL DEFAULT now(),
+  updated_at                 timestamptz NOT NULL DEFAULT now(),
+  started_at                 timestamptz,
+  finished_at                timestamptz,
+  cancel_requested_at        timestamptz,
+
+  -- Idempotency keys are per-job. Two different regen jobs with the
+  -- same key would be a bug (UUIDv5 is pre-computed from job_id +
+  -- namespace constants); the schema catches it.
+  CONSTRAINT regeneration_jobs_anthropic_key_unique
+    UNIQUE (id, anthropic_idempotency_key),
+  CONSTRAINT regeneration_jobs_wp_key_unique
+    UNIQUE (id, wp_idempotency_key),
+
+  -- Lease coherence: (state, worker_id, lease_expires_at) consistency.
+  CONSTRAINT regeneration_jobs_lease_coherent
+    CHECK (
+      (status = 'pending'
+        AND worker_id IS NULL
+        AND lease_expires_at IS NULL)
+      OR status IN ('running', 'succeeded', 'failed', 'failed_gates', 'cancelled')
+    )
+);
+
+-- The CONCURRENCY-LIMIT KEYSTONE: at most one in-flight regen per page.
+-- Pending + running rows lock the page; succeeded / failed / failed_gates
+-- / cancelled rows are history and stay out of the partial index.
+CREATE UNIQUE INDEX regeneration_jobs_one_active_per_page
+  ON regeneration_jobs (page_id)
+  WHERE status IN ('pending', 'running');
+
+-- Lease-candidate partial index. Drives FOR UPDATE SKIP LOCKED dequeue:
+-- candidates are status = 'pending' OR status = 'running' with an
+-- expired lease. Terminal states stay out so the index doesn't balloon.
+CREATE INDEX idx_regen_jobs_leasable
+  ON regeneration_jobs (lease_expires_at NULLS FIRST)
+  WHERE status IN ('pending', 'running');
+
+CREATE INDEX idx_regen_jobs_page_created
+  ON regeneration_jobs (page_id, created_at DESC);
+CREATE INDEX idx_regen_jobs_site_created
+  ON regeneration_jobs (site_id, created_at DESC);
+CREATE INDEX idx_regen_jobs_created_by
+  ON regeneration_jobs (created_by)
+  WHERE created_by IS NOT NULL;
+
+ALTER TABLE regeneration_jobs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON regeneration_jobs
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Admin reads every job; creators read their own. Matches
+-- generation_jobs policy from M3-1.
+CREATE POLICY regeneration_jobs_read ON regeneration_jobs
+  FOR SELECT TO authenticated
+  USING (public.auth_role() = 'admin' OR created_by = auth.uid());
+
+-- ---------------------------------------------------------------------------
+-- regeneration_events
+--
+-- Append-only audit log. One row per state transition or notable side
+-- effect. Key invariant: the billed Anthropic response event is
+-- written BEFORE the cost columns on regeneration_jobs flip, so if
+-- the cost-column UPDATE fails the billing is still reconstructible
+-- from this table.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE regeneration_events (
+  id                         bigserial PRIMARY KEY,
+  regeneration_job_id        uuid NOT NULL
+    REFERENCES regeneration_jobs(id) ON DELETE CASCADE,
+
+  -- Enumerated at the app layer rather than CHECK here — the event
+  -- vocabulary grows over time (new gate names, new WP failure
+  -- classes). The existing generation_events table uses the same
+  -- open-text shape.
+  type                       text NOT NULL,
+
+  -- Structured payload. Shape varies by type; consumers know which
+  -- types carry what fields (anthropic_response_received has
+  -- {response_id, tokens, cost_cents}, wp_put_succeeded has
+  -- {wp_page_id, new_slug}, etc.).
+  payload                    jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  created_at                 timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_regen_events_job_created
+  ON regeneration_events (regeneration_job_id, created_at DESC);
+CREATE INDEX idx_regen_events_type
+  ON regeneration_events (type);
+
+ALTER TABLE regeneration_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON regeneration_events
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Same read policy as the parent job table: admin sees all; creator
+-- of the parent job sees their own events (via a sub-select).
+CREATE POLICY regeneration_events_read ON regeneration_events
+  FOR SELECT TO authenticated
+  USING (
+    public.auth_role() = 'admin'
+    OR EXISTS (
+      SELECT 1
+      FROM regeneration_jobs j
+      WHERE j.id = regeneration_events.regeneration_job_id
+        AND j.created_by = auth.uid()
+    )
+  );


### PR DESCRIPTION
First sub-slice of M7 — the write-safety-critical single-page re-generation milestone. Ships the schema that the worker (M7-2), WP stage (M7-3), UI (M7-4), and cron (M7-5) all layer on top of. Two new tables; partial UNIQUE on `(page_id)` is the concurrency keystone.

## Parent plan

`docs/plans/m7-parent.md` lands in this PR. Scope: 5 sub-slices ending in `POST /api/admin/sites/[id]/pages/[pageId]/regenerate` + cron-driven worker + WP drift reconciliation + budget cap. Critical write-safety surface — spends Anthropic tokens, mutates client WP sites, coordinates 3 external systems without 2-PC. Per-slice plans all carry the full **"Risks identified and mitigated"** audit.

## What lands

- `supabase/migrations/0011_m7_1_regeneration_schema.sql` — `regeneration_jobs` + `regeneration_events` with the constraints listed below. Mirrors the M3-1 / M4-1 shape.
- `lib/__tests__/m7-schema.test.ts` — 14 constraint-reject tests.
- `lib/__tests__/_setup.ts` — adds the two new tables to the per-test TRUNCATE list.
- `docs/plans/m7-parent.md` — the full milestone plan.
- `docs/BACKLOG.md` — M6 flipped to shipped (#68 → #71); new M7 section opens with the sub-slice tracker.

## Risks identified and mitigated

- **Two concurrent regens racing the same page.** → `CREATE UNIQUE INDEX regeneration_jobs_one_active_per_page ON regeneration_jobs (page_id) WHERE status IN ('pending', 'running')`. Second enqueue attempt hits 23505. Tests: second pending rejected, second running rejected, pending-after-running rejected, pending-after-terminated accepted, different-pages same-site allowed.
- **Retries double-billing Anthropic.** → `anthropic_idempotency_key` pre-computed on INSERT + `UNIQUE (id, anthropic_idempotency_key)`. Schema guarantees a reaped + relet job keeps its key rather than the worker accidentally minting a new one. M7-2 wires this into the Anthropic client.
- **Retries double-PUT to WP.** → `wp_idempotency_key` mirrors the Anthropic shape. M7-3 uses it + the GET-by-wp_page_id adoption pattern (M3-6).
- **Malformed lease state (pending row with a worker_id).** → `lease_coherent` CHECK constraint rejects at the schema layer. Tests: pending+worker_id → 23514, pending+lease_expires_at → 23514, running+lease_fields populated → accepted.
- **Metadata edits mid-regen clobbering the new HTML.** → `expected_page_version` snapshotted at enqueue time. M7-3's `UPDATE pages ... WHERE version_lock = expected` will fail VERSION_CONFLICT if a concurrent M6-3 PATCH ran. Worker short-circuits that job with a friendly terminal error; operator retries the regen against the latest metadata.
- **CASCADE semantics.** → `ON DELETE CASCADE` from sites + pages for jobs; from jobs for events. Tests: delete page → jobs gone; delete job → events gone.
- **Unknown status values slipping in.** → `CHECK status IN (...)`. Test: `status = 'weird'` → 23514. `failed_gates` is a distinct terminal status (separate from `failed`) so the UI can render gate-failure payloads differently from infra failures.
- **Events table retention.** → Kept indefinitely (matches M3's `generation_events` + M4's `transfer_events`). If volume becomes an issue, a cleanup slice handles it — not a M7 concern.
- **RLS posture.** → service_role_all for worker + API access; authenticated reads scoped to `auth_role() = 'admin' OR created_by = auth.uid()`. Matches `generation_jobs` policy.

## Deliberately deferred

- The worker itself → M7-2.
- Anthropic integration → M7-2.
- WP update + drift reconciliation → M7-3.
- Admin UI button + polling → M7-4.
- Cron wiring + budget cap → M7-5.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm run test` — run in CI. 14 new schema tests exercise the constraints.
- [ ] `npm run test:e2e` — no new specs in this slice; existing suite should be unaffected. Tracked pre-existing sites + users + images-edit failures remain.