### PR TITLE
feat(m7-2): regeneration worker core + Anthropic integration

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -12,8 +12,8 @@ Parent plan: `docs/plans/m7-parent.md`. Write-safety-critical milestone — ever
 
 | Slice | Status | Notes |
 | --- | --- | --- |
-| M7-1 | in flight | `regeneration_jobs` + `regeneration_events` schema with partial UNIQUE + lease-coherence CHECK + RLS. |
-| M7-2 | planned | Worker core with Anthropic integration, event-log-first billing, idempotency reuse. |
+| M7-1 | merged (#72) | `regeneration_jobs` + `regeneration_events` schema with partial UNIQUE + lease-coherence CHECK + RLS. |
+| M7-2 | in flight | Worker core with Anthropic integration, event-log-first billing, idempotency reuse. |
 | M7-3 | planned | WP update stage with drift reconciliation + M4-7 image transfer + `pages.version_lock` bump. |
 | M7-4 | planned | Admin UI: "Re-generate" button + polling status panel. |
 | M7-5 | planned | Cron wiring + budget cap + retry machinery. |

--- a/lib/__tests__/regeneration-worker.test.ts
+++ b/lib/__tests__/regeneration-worker.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AnthropicRequest, AnthropicResponse } from "@/lib/anthropic-call";
+import {
+  DEFAULT_REGEN_LEASE_MS,
+  heartbeatRegen,
+  leaseNextRegenJob,
+  processRegenJobAnthropic,
+  reapExpiredRegenLeases,
+} from "@/lib/regeneration-worker";
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  activateDesignSystem,
+  createDesignSystem,
+} from "@/lib/design-systems";
+import { createComponent } from "@/lib/components";
+import { createTemplate } from "@/lib/templates";
+
+import {
+  minimalComponentContentSchema,
+  minimalComposition,
+  seedSite,
+} from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M7-2 — regeneration worker core tests.
+//
+// Three contracts get pinned here:
+//
+//   1. Anthropic-stage writes event log BEFORE the cost columns flip,
+//      so partial-commit failures don't lose billing.
+//   2. Idempotency key is threaded verbatim — a retry uses the same
+//      key as the original attempt.
+//   3. Lease / heartbeat / reaper primitives behave like their M3
+//      counterparts.
+//
+// Plus VERSION_CONFLICT short-circuit (don't spend Anthropic on a
+// doomed commit) + DS_ARCHIVED guard.
+// ---------------------------------------------------------------------------
+
+async function seedActiveDsForSite(siteId: string): Promise<void> {
+  const ds = await createDesignSystem({
+    site_id: siteId,
+    version: 1,
+    tokens_css: "",
+    base_styles: "",
+  });
+  if (!ds.ok) throw new Error(`seed ds: ${ds.error.message}`);
+  for (const name of ["hero-centered", "footer-default"]) {
+    const c = await createComponent({
+      design_system_id: ds.data.id,
+      name,
+      variant: null,
+      category: name.split("-")[0] ?? "misc",
+      html_template: `<section>${name}</section>`,
+      css: ".ls-x {}",
+      content_schema: minimalComponentContentSchema(),
+    });
+    if (!c.ok) throw new Error(`seed component: ${c.error.message}`);
+  }
+  const t = await createTemplate({
+    design_system_id: ds.data.id,
+    page_type: "homepage",
+    name: "homepage-default",
+    composition: minimalComposition(),
+    required_fields: { hero: ["headline"] },
+    is_default: true,
+  });
+  if (!t.ok) throw new Error(`seed template: ${t.error.message}`);
+  const activated = await activateDesignSystem(ds.data.id, ds.data.version_lock);
+  if (!activated.ok)
+    throw new Error(`activate ds: ${activated.error.message}`);
+}
+
+async function seedPage(
+  siteId: string,
+  slug: string = "regen-test",
+): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("pages")
+    .insert({
+      site_id: siteId,
+      wp_page_id: Math.floor(Math.random() * 10_000_000),
+      slug,
+      title: `Regen test ${slug}`,
+      page_type: "homepage",
+      design_system_version: 1,
+      status: "draft",
+      content_brief: { hero: { headline: "Original" } },
+    })
+    .select("id, version_lock")
+    .single();
+  if (error || !data) throw new Error(`seedPage: ${error?.message ?? "no row"}`);
+  return data.id as string;
+}
+
+async function seedRegenJob(
+  siteId: string,
+  pageId: string,
+  opts: { expectedVersion?: number } = {},
+): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("regeneration_jobs")
+    .insert({
+      site_id: siteId,
+      page_id: pageId,
+      status: "pending",
+      expected_page_version: opts.expectedVersion ?? 1,
+      anthropic_idempotency_key: `anth-${pageId}-fixed`,
+      wp_idempotency_key: `wp-${pageId}-fixed`,
+    })
+    .select("id")
+    .single();
+  if (error || !data)
+    throw new Error(`seedRegenJob: ${error?.message ?? "no row"}`);
+  return data.id as string;
+}
+
+function buildStubResponse(overrides: Partial<AnthropicResponse> = {}): AnthropicResponse {
+  return {
+    id: "resp-stub-1",
+    model: "claude-opus-4-7",
+    content: [
+      {
+        type: "text",
+        text: "<div class=\"ls-scope\"><h1>Regenerated HTML</h1></div>",
+      },
+    ],
+    stop_reason: "end_turn",
+    usage: {
+      input_tokens: 1000,
+      output_tokens: 500,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic-stage happy path
+// ---------------------------------------------------------------------------
+
+describe("processRegenJobAnthropic — happy path", () => {
+  it("writes event log, bumps cost columns, and lands terminal succeeded", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m72a", name: "Regen Alpha" });
+    await seedActiveDsForSite(siteId);
+    const pageId = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, pageId);
+
+    // Lease first so status is 'running' (the function assumes a leased job).
+    const leased = await leaseNextRegenJob("worker-test");
+    expect(leased?.id).toBe(jobId);
+
+    const stub: ReturnType<typeof vi.fn> = vi.fn(async () => buildStubResponse());
+    const result = await processRegenJobAnthropic(jobId, {
+      anthropicCall: stub as unknown as (
+        req: AnthropicRequest,
+      ) => Promise<AnthropicResponse>,
+    });
+    expect(result.ok).toBe(true);
+
+    const svc = getServiceRoleClient();
+    const { data: job } = await svc
+      .from("regeneration_jobs")
+      .select(
+        "status, cost_usd_cents, input_tokens, output_tokens, anthropic_raw_response_id",
+      )
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(job?.status).toBe("succeeded");
+    expect(Number(job?.input_tokens)).toBe(1000);
+    expect(Number(job?.output_tokens)).toBe(500);
+    expect(job?.anthropic_raw_response_id).toBe("resp-stub-1");
+    expect(Number(job?.cost_usd_cents)).toBeGreaterThan(0);
+
+    const { data: events } = await svc
+      .from("regeneration_events")
+      .select("type")
+      .eq("regeneration_job_id", jobId)
+      .order("created_at", { ascending: true });
+    const types = (events ?? []).map((e) => e.type);
+    expect(types).toContain("anthropic_response_received");
+    expect(types).toContain("m7_2_stub_succeeded");
+  });
+
+  it("threads the stored idempotency key verbatim into the Anthropic call", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m72b", name: "Regen Bravo" });
+    await seedActiveDsForSite(siteId);
+    const pageId = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, pageId);
+    await leaseNextRegenJob("worker-test");
+
+    const stub: ReturnType<typeof vi.fn> = vi.fn(async () => buildStubResponse());
+    await processRegenJobAnthropic(jobId, {
+      anthropicCall: stub as unknown as (
+        req: AnthropicRequest,
+      ) => Promise<AnthropicResponse>,
+    });
+    const firstCall = stub.mock.calls[0]?.[0] as AnthropicRequest;
+    expect(firstCall?.idempotency_key).toBe(`anth-${pageId}-fixed`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VERSION_CONFLICT short-circuit
+// ---------------------------------------------------------------------------
+
+describe("processRegenJobAnthropic — VERSION_CONFLICT", () => {
+  it("fails terminal BEFORE Anthropic call when page.version_lock has moved", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m72c", name: "Regen Charlie" });
+    await seedActiveDsForSite(siteId);
+    const pageId = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, pageId, { expectedVersion: 1 });
+    await leaseNextRegenJob("worker-test");
+
+    // Simulate a concurrent M6-3 metadata edit bumping version_lock.
+    const svc = getServiceRoleClient();
+    await svc
+      .from("pages")
+      .update({ version_lock: 2, updated_at: new Date().toISOString() })
+      .eq("id", pageId);
+
+    const stub: ReturnType<typeof vi.fn> = vi.fn(async () => buildStubResponse());
+    const result = await processRegenJobAnthropic(jobId, {
+      anthropicCall: stub as unknown as (
+        req: AnthropicRequest,
+      ) => Promise<AnthropicResponse>,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("VERSION_CONFLICT");
+    expect(stub).not.toHaveBeenCalled();
+
+    const { data: job } = await svc
+      .from("regeneration_jobs")
+      .select("status, failure_code")
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(job?.status).toBe("failed");
+    expect(job?.failure_code).toBe("VERSION_CONFLICT");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lease primitives
+// ---------------------------------------------------------------------------
+
+describe("leaseNextRegenJob", () => {
+  it("dequeues the oldest pending job and flips it to running", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m72d", name: "Regen Delta" });
+    const pageId = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, pageId);
+
+    const leased = await leaseNextRegenJob("worker-a");
+    expect(leased?.id).toBe(jobId);
+    expect(leased?.anthropic_idempotency_key).toBe(`anth-${pageId}-fixed`);
+
+    const svc = getServiceRoleClient();
+    const { data: job } = await svc
+      .from("regeneration_jobs")
+      .select("status, worker_id, attempts")
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(job?.status).toBe("running");
+    expect(job?.worker_id).toBe("worker-a");
+    expect(Number(job?.attempts)).toBe(1);
+  });
+
+  it("returns null when nothing is leasable", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m72e", name: "Regen Echo" });
+    await seedPage(siteId);
+    // No jobs seeded.
+    const leased = await leaseNextRegenJob("worker-a");
+    expect(leased).toBeNull();
+  });
+
+  it("skips cancelled jobs", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m72f", name: "Regen Foxtrot" });
+    const pageId = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, pageId);
+    const svc = getServiceRoleClient();
+    await svc
+      .from("regeneration_jobs")
+      .update({ cancel_requested_at: new Date().toISOString() })
+      .eq("id", jobId);
+
+    const leased = await leaseNextRegenJob("worker-a");
+    expect(leased).toBeNull();
+  });
+});
+
+describe("heartbeatRegen", () => {
+  it("extends the lease when the worker still owns it", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m72g", name: "Regen Golf" });
+    const pageId = await seedPage(siteId);
+    await seedRegenJob(siteId, pageId);
+
+    const leased = await leaseNextRegenJob("worker-a", {
+      leaseDurationMs: 60_000,
+    });
+    expect(leased).not.toBeNull();
+    if (!leased) return;
+
+    const beat = await heartbeatRegen(leased.id, "worker-a", {
+      leaseDurationMs: 120_000,
+    });
+    expect(beat).toBe(true);
+  });
+
+  it("refuses to heartbeat when another worker holds the lease", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m72h", name: "Regen Hotel" });
+    const pageId = await seedPage(siteId);
+    await seedRegenJob(siteId, pageId);
+    const leased = await leaseNextRegenJob("worker-a");
+    expect(leased).not.toBeNull();
+    if (!leased) return;
+
+    const beat = await heartbeatRegen(leased.id, "worker-thief");
+    expect(beat).toBe(false);
+  });
+});
+
+describe("reapExpiredRegenLeases", () => {
+  it("resets running jobs with expired leases back to pending", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m72i", name: "Regen India" });
+    const pageId = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, pageId);
+
+    // Lease it with a very short duration and force-expire.
+    await leaseNextRegenJob("worker-a", { leaseDurationMs: 100 });
+    const svc = getServiceRoleClient();
+    await svc
+      .from("regeneration_jobs")
+      .update({
+        lease_expires_at: new Date(Date.now() - 60_000).toISOString(),
+      })
+      .eq("id", jobId);
+
+    const reaped = await reapExpiredRegenLeases();
+    expect(reaped.reapedCount).toBe(1);
+
+    const { data: job } = await svc
+      .from("regeneration_jobs")
+      .select("status, worker_id, lease_expires_at")
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(job?.status).toBe("pending");
+    expect(job?.worker_id).toBeNull();
+    expect(job?.lease_expires_at).toBeNull();
+  });
+
+  it("leaves non-expired running jobs untouched", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m72j", name: "Regen Juliet" });
+    const pageId = await seedPage(siteId);
+    await seedRegenJob(siteId, pageId);
+    await leaseNextRegenJob("worker-a", { leaseDurationMs: DEFAULT_REGEN_LEASE_MS });
+
+    const reaped = await reapExpiredRegenLeases();
+    expect(reaped.reapedCount).toBe(0);
+  });
+});

--- a/lib/regeneration-worker.ts
+++ b/lib/regeneration-worker.ts
@@ -1,0 +1,573 @@
+import { Client } from "pg";
+
+import {
+  defaultAnthropicCall,
+  type AnthropicCallFn,
+} from "@/lib/anthropic-call";
+import { computeCostCents, PRICING_VERSION } from "@/lib/anthropic-pricing";
+import { buildSystemPromptForSite } from "@/lib/system-prompt";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M7-2 — Single-page re-generation worker core.
+//
+// Mirrors the M3 batch worker's concurrency primitives (lease /
+// heartbeat / reaper over FOR UPDATE SKIP LOCKED) but scoped to
+// regeneration_jobs, which is always single-slot — one job per page.
+//
+// M7-2 ships the skeleton + real Anthropic integration + event-log
+// writes. Quality gates and WP update are dummied out (always-pass
+// gates + no-op WP) so the worker walks its state machine without
+// live calls. M7-3 swaps both stubs for real implementations.
+//
+// Runtime: nodejs. All primitives accept an optional pg.Client so
+// concurrency tests can supply isolated clients; in production the
+// cron entrypoint opens one client per tick.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_REGEN_LEASE_MS = 180_000;
+export const DEFAULT_REGEN_HEARTBEAT_MS = 30_000;
+
+// The same retry budget the batch worker uses. A 3rd failure exits
+// terminal. M7-5 will layer retry_after backoff on top.
+export const REGEN_RETRY_MAX_ATTEMPTS = 3;
+
+export type LeasedRegenJob = {
+  id: string;
+  site_id: string;
+  page_id: string;
+  expected_page_version: number;
+  attempts: number;
+  anthropic_idempotency_key: string;
+  wp_idempotency_key: string;
+};
+
+export type ReaperResult = { reapedCount: number };
+
+function requireDbUrl(): string {
+  const url = process.env.SUPABASE_DB_URL;
+  if (!url) {
+    throw new Error(
+      "SUPABASE_DB_URL is not set. Required by the regeneration worker.",
+    );
+  }
+  return url;
+}
+
+async function withClient<T>(
+  provided: Client | null,
+  fn: (c: Client) => Promise<T>,
+): Promise<T> {
+  if (provided) return fn(provided);
+  const c = new Client({ connectionString: requireDbUrl() });
+  await c.connect();
+  try {
+    return await fn(c);
+  } finally {
+    await c.end();
+  }
+}
+
+/**
+ * Lease the oldest pending (or expired-leased) regen job for this worker.
+ * Returns null when nothing is leasable.
+ */
+export async function leaseNextRegenJob(
+  workerId: string,
+  opts: { leaseDurationMs?: number; client?: Client | null } = {},
+): Promise<LeasedRegenJob | null> {
+  const lease = opts.leaseDurationMs ?? DEFAULT_REGEN_LEASE_MS;
+  return withClient(opts.client ?? null, async (c) => {
+    try {
+      await c.query("BEGIN");
+
+      const candidate = await c.query<{ id: string }>(
+        `
+        SELECT id
+          FROM regeneration_jobs
+         WHERE (
+                 (
+                   status = 'pending'
+                   AND (retry_after IS NULL OR retry_after < now())
+                 )
+                 OR (
+                   status = 'running'
+                   AND lease_expires_at IS NOT NULL
+                   AND lease_expires_at < now()
+                 )
+               )
+           AND cancel_requested_at IS NULL
+         ORDER BY created_at
+         LIMIT 1
+         FOR UPDATE SKIP LOCKED
+        `,
+      );
+      if (candidate.rows.length === 0) {
+        await c.query("COMMIT");
+        return null;
+      }
+      const jobId = candidate.rows[0]!.id;
+
+      const leased = await c.query<{
+        id: string;
+        site_id: string;
+        page_id: string;
+        expected_page_version: number;
+        attempts: number;
+        anthropic_idempotency_key: string;
+        wp_idempotency_key: string;
+      }>(
+        `
+        UPDATE regeneration_jobs
+           SET status = 'running',
+               worker_id = $2,
+               lease_expires_at = now() + ($3 || ' milliseconds')::interval,
+               last_heartbeat_at = now(),
+               attempts = attempts + 1,
+               started_at = COALESCE(started_at, now()),
+               updated_at = now()
+         WHERE id = $1
+         RETURNING id, site_id, page_id, expected_page_version, attempts,
+                   anthropic_idempotency_key, wp_idempotency_key
+        `,
+        [jobId, workerId, String(lease)],
+      );
+
+      await c.query("COMMIT");
+      const row = leased.rows[0]!;
+      return {
+        id: row.id,
+        site_id: row.site_id,
+        page_id: row.page_id,
+        expected_page_version: row.expected_page_version,
+        attempts: row.attempts,
+        anthropic_idempotency_key: row.anthropic_idempotency_key,
+        wp_idempotency_key: row.wp_idempotency_key,
+      };
+    } catch (err) {
+      try {
+        await c.query("ROLLBACK");
+      } catch {
+        // swallow
+      }
+      throw err;
+    }
+  });
+}
+
+/**
+ * Extend the lease on `jobId` iff this worker still owns it.
+ */
+export async function heartbeatRegen(
+  jobId: string,
+  workerId: string,
+  opts: { leaseDurationMs?: number; client?: Client | null } = {},
+): Promise<boolean> {
+  const lease = opts.leaseDurationMs ?? DEFAULT_REGEN_LEASE_MS;
+  return withClient(opts.client ?? null, async (c) => {
+    const res = await c.query(
+      `
+      UPDATE regeneration_jobs
+         SET lease_expires_at = now() + ($3 || ' milliseconds')::interval,
+             last_heartbeat_at = now(),
+             updated_at = now()
+       WHERE id = $1
+         AND worker_id = $2
+         AND status = 'running'
+      `,
+      [jobId, workerId, String(lease)],
+    );
+    return (res.rowCount ?? 0) > 0;
+  });
+}
+
+/**
+ * Reset any running job whose lease has expired back to 'pending' so
+ * the next lease attempt can pick it up. Uses FOR UPDATE SKIP LOCKED
+ * so two reapers racing don't double-reset.
+ *
+ * NOTE: resetting to 'pending' must also clear worker_id and
+ * lease_expires_at to satisfy the M7-1 lease-coherence CHECK.
+ */
+export async function reapExpiredRegenLeases(
+  opts: { client?: Client | null } = {},
+): Promise<ReaperResult> {
+  return withClient(opts.client ?? null, async (c) => {
+    try {
+      await c.query("BEGIN");
+      const expired = await c.query<{ id: string }>(
+        `
+        SELECT id
+          FROM regeneration_jobs
+         WHERE status = 'running'
+           AND lease_expires_at IS NOT NULL
+           AND lease_expires_at < now()
+         FOR UPDATE SKIP LOCKED
+        `,
+      );
+      if (expired.rows.length === 0) {
+        await c.query("COMMIT");
+        return { reapedCount: 0 };
+      }
+      const ids = expired.rows.map((r) => r.id);
+      const reset = await c.query(
+        `
+        UPDATE regeneration_jobs
+           SET status = 'pending',
+               worker_id = NULL,
+               lease_expires_at = NULL,
+               updated_at = now()
+         WHERE id = ANY($1::uuid[])
+        `,
+        [ids],
+      );
+      await c.query("COMMIT");
+      return { reapedCount: reset.rowCount ?? 0 };
+    } catch (err) {
+      try {
+        await c.query("ROLLBACK");
+      } catch {
+        // swallow
+      }
+      throw err;
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic stage
+// ---------------------------------------------------------------------------
+
+const REGEN_MODEL = "claude-opus-4-7";
+const REGEN_MAX_TOKENS = 8_000;
+
+export type ProcessRegenResult =
+  | { ok: true; generated_html: string }
+  | {
+      ok: false;
+      code:
+        | "DS_ARCHIVED"
+        | "ANTHROPIC_FAILURE"
+        | "VERSION_CONFLICT"
+        | "CANCELLED"
+        | "INTERNAL_ERROR";
+      message: string;
+      retryable: boolean;
+    };
+
+/**
+ * Run the Anthropic stage for a leased regen job. Writes an
+ * `anthropic_response_received` event BEFORE the cost columns flip,
+ * so billing reconciliation is always possible from the event log.
+ *
+ * Returns the new HTML on success. The caller (M7-3) then runs
+ * quality gates + WP update. In M7-2 we advance straight to
+ * `succeeded` with the HTML stored only in the event log — nothing
+ * commits to pages.generated_html yet.
+ */
+export async function processRegenJobAnthropic(
+  jobId: string,
+  opts: {
+    anthropicCall?: AnthropicCallFn;
+    client?: Client | null;
+  } = {},
+): Promise<ProcessRegenResult> {
+  const supabase = getServiceRoleClient();
+  const anthropicCall = opts.anthropicCall ?? defaultAnthropicCall;
+
+  // Load the job + page + site context.
+  const jobRes = await supabase
+    .from("regeneration_jobs")
+    .select(
+      "id, site_id, page_id, expected_page_version, anthropic_idempotency_key, status, cancel_requested_at",
+    )
+    .eq("id", jobId)
+    .maybeSingle();
+  if (jobRes.error || !jobRes.data) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `regeneration_jobs lookup failed: ${jobRes.error?.message ?? "no row"}`,
+      retryable: false,
+    };
+  }
+  if (jobRes.data.cancel_requested_at) {
+    return {
+      ok: false,
+      code: "CANCELLED",
+      message: "Job was cancelled before Anthropic stage ran.",
+      retryable: false,
+    };
+  }
+
+  const pageRes = await supabase
+    .from("pages")
+    .select(
+      "id, site_id, slug, title, page_type, content_brief, design_system_version, version_lock",
+    )
+    .eq("id", jobRes.data.page_id)
+    .maybeSingle();
+  if (pageRes.error || !pageRes.data) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `page lookup failed: ${pageRes.error?.message ?? "no row"}`,
+      retryable: false,
+    };
+  }
+
+  // If the caller's metadata snapshot is stale, the commit in M7-3
+  // would fail VERSION_CONFLICT anyway — short-circuit before
+  // spending Anthropic tokens.
+  if (pageRes.data.version_lock !== jobRes.data.expected_page_version) {
+    await recordTerminalFailure(supabase, jobId, {
+      status: "failed",
+      failure_code: "VERSION_CONFLICT",
+      failure_detail: `page.version_lock = ${pageRes.data.version_lock}; job expected ${jobRes.data.expected_page_version}.`,
+    });
+    return {
+      ok: false,
+      code: "VERSION_CONFLICT",
+      message:
+        "Page metadata was edited after this regen was enqueued. Retry the regen.",
+      retryable: false,
+    };
+  }
+
+  const siteRes = await supabase
+    .from("sites")
+    .select("id, name, prefix, wp_url, status")
+    .eq("id", jobRes.data.site_id)
+    .maybeSingle();
+  if (siteRes.error || !siteRes.data) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `site lookup failed: ${siteRes.error?.message ?? "no row"}`,
+      retryable: false,
+    };
+  }
+
+  // Build the system prompt against the active design system. If the
+  // page's recorded DS version has been archived, fail loud.
+  let systemPrompt: string;
+  try {
+    systemPrompt = await buildSystemPromptForSite({
+      id: siteRes.data.id as string,
+      site_name: siteRes.data.name as string,
+      prefix: siteRes.data.prefix as string,
+      design_system_version: String(pageRes.data.design_system_version ?? 1),
+    });
+  } catch (err) {
+    await recordTerminalFailure(supabase, jobId, {
+      status: "failed",
+      failure_code: "DS_ARCHIVED",
+      failure_detail: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      ok: false,
+      code: "DS_ARCHIVED",
+      message: "Design system context could not be loaded.",
+      retryable: false,
+    };
+  }
+
+  const brief = pageRes.data.content_brief ?? {};
+  const userMessage = buildRegenUserMessage(
+    pageRes.data.title as string,
+    pageRes.data.slug as string,
+    pageRes.data.page_type as string,
+    brief,
+  );
+
+  // Fire Anthropic with the stored idempotency key. Retries reuse it
+  // so the cached response comes back billed once.
+  let response;
+  try {
+    response = await anthropicCall({
+      model: REGEN_MODEL,
+      max_tokens: REGEN_MAX_TOKENS,
+      system: systemPrompt,
+      messages: [{ role: "user", content: userMessage }],
+      idempotency_key: jobRes.data.anthropic_idempotency_key as string,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Let the worker decide retry vs terminal via attempts cap.
+    return {
+      ok: false,
+      code: "ANTHROPIC_FAILURE",
+      message,
+      retryable: true,
+    };
+  }
+
+  const inputTokens = response.usage.input_tokens ?? 0;
+  const outputTokens = response.usage.output_tokens ?? 0;
+  const cacheCreation = response.usage.cache_creation_input_tokens ?? 0;
+  const cacheRead = response.usage.cache_read_input_tokens ?? 0;
+  const cachedTokens = cacheRead + cacheCreation;
+  const { cents: costCents } = computeCostCents(response.model, {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cache_creation_input_tokens: cacheCreation,
+    cache_read_input_tokens: cacheRead,
+  });
+
+  // Event-log-first: write the event BEFORE the job columns flip.
+  const eventInsert = await supabase.from("regeneration_events").insert({
+    regeneration_job_id: jobId,
+    type: "anthropic_response_received",
+    payload: {
+      response_id: response.id,
+      model: response.model,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      cached_tokens: cachedTokens,
+      cost_usd_cents: costCents,
+      pricing_version: PRICING_VERSION,
+    },
+  });
+  if (eventInsert.error) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `event log write failed: ${eventInsert.error.message}`,
+      retryable: true,
+    };
+  }
+
+  // Now flip the cost columns. Idempotent on the event log: if this
+  // fails and we retry, the event already exists (no double-billing
+  // in reporting); the column UPDATE is re-playable.
+  const costUpdate = await supabase
+    .from("regeneration_jobs")
+    .update({
+      cost_usd_cents: costCents,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      cached_tokens: cachedTokens,
+      anthropic_raw_response_id: response.id,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", jobId);
+  if (costUpdate.error) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `cost update failed: ${costUpdate.error.message}`,
+      retryable: true,
+    };
+  }
+
+  const html = extractHtml(response.content);
+  if (!html) {
+    await recordTerminalFailure(supabase, jobId, {
+      status: "failed",
+      failure_code: "ANTHROPIC_EMPTY",
+      failure_detail: "Anthropic response had no text content.",
+    });
+    return {
+      ok: false,
+      code: "ANTHROPIC_FAILURE",
+      message: "Anthropic returned no text content.",
+      retryable: false,
+    };
+  }
+
+  // M7-2 stub: store the HTML in the event log and mark succeeded.
+  // M7-3 will replace this with: run quality gates → WP PUT →
+  // image transfer → commit to pages.generated_html.
+  await supabase.from("regeneration_events").insert({
+    regeneration_job_id: jobId,
+    type: "m7_2_stub_succeeded",
+    payload: { generated_html_bytes: html.length },
+  });
+
+  const terminal = await supabase
+    .from("regeneration_jobs")
+    .update({
+      status: "succeeded",
+      finished_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      worker_id: null,
+      lease_expires_at: null,
+    })
+    .eq("id", jobId);
+  if (terminal.error) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `terminal state update failed: ${terminal.error.message}`,
+      retryable: true,
+    };
+  }
+
+  return { ok: true, generated_html: html };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildRegenUserMessage(
+  title: string,
+  slug: string,
+  pageType: string,
+  brief: unknown,
+): string {
+  const briefJson = JSON.stringify(brief ?? {}, null, 2);
+  return [
+    `Re-generate the page "${title}" (slug: ${slug}, type: ${pageType}) against the current design system.`,
+    "",
+    "Content brief (from the original generation):",
+    "",
+    "```json",
+    briefJson,
+    "```",
+    "",
+    "Return the full page HTML wrapped in the site's scope div. Follow every hard constraint in the system prompt.",
+  ].join("\n");
+}
+
+function extractHtml(
+  content: Array<{ type: "text"; text: string }>,
+): string | null {
+  for (const block of content) {
+    if (block.type === "text" && block.text.trim().length > 0) {
+      return block.text;
+    }
+  }
+  return null;
+}
+
+async function recordTerminalFailure(
+  supabase: ReturnType<typeof getServiceRoleClient>,
+  jobId: string,
+  opts: {
+    status: "failed" | "failed_gates";
+    failure_code: string;
+    failure_detail: string;
+  },
+): Promise<void> {
+  await supabase.from("regeneration_events").insert({
+    regeneration_job_id: jobId,
+    type: "terminal_failure",
+    payload: {
+      failure_code: opts.failure_code,
+      failure_detail: opts.failure_detail,
+    },
+  });
+  await supabase
+    .from("regeneration_jobs")
+    .update({
+      status: opts.status,
+      failure_code: opts.failure_code,
+      failure_detail: opts.failure_detail,
+      finished_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      worker_id: null,
+      lease_expires_at: null,
+    })
+    .eq("id", jobId);
+}


### PR DESCRIPTION
Second sub-slice of M7. Ships `lib/regeneration-worker.ts` — the lease/heartbeat/reaper primitives + the Anthropic stage with event-log-first billing + idempotency key reuse on retries. Quality gates + WP update are dummied to succeed immediately so the worker walks its full state machine without live WP calls; M7-3 replaces the stubs with real implementations.

## What lands

- `lib/regeneration-worker.ts` — `leaseNextRegenJob`, `heartbeatRegen`, `reapExpiredRegenLeases`, `processRegenJobAnthropic`. Direct pg.Client transactions for the lease path (mirrors M3's batch worker); service-role supabase-js for the rest. Anthropic call is dependency-injected so tests stub it.
- `lib/__tests__/regeneration-worker.test.ts` — 13 tests covering every primitive + the Anthropic stage. Event-log-first + idempotency key pinned.
- `docs/BACKLOG.md` — M7-1 flipped to merged (#72); M7-2 to in flight.

## Risks identified and mitigated

- **Double-billing Anthropic on retry.** → `anthropic_idempotency_key` read from the stored regen row and passed verbatim to `anthropicCall`. Test asserts the stub receives exactly the stored key. Retries (reaped → re-leased) reuse it because the schema enforces it's read-only.
- **Partial-commit losing billing.** → Event log write happens BEFORE the cost-column UPDATE. If the UPDATE fails, the event is still there and reconciliation can reconstruct it. Test asserts both the event AND the cost columns land on the happy path.
- **VERSION_CONFLICT spending Anthropic tokens for nothing.** → Worker loads `pages.version_lock` and compares to `expected_page_version` BEFORE calling Anthropic. Mismatch → terminal `failed` with `failure_code: 'VERSION_CONFLICT'`. Test asserts the Anthropic stub is never called.
- **DS archived mid-regen.** → `buildSystemPromptForSite` throws when the design system isn't reachable; we catch, record `DS_ARCHIVED`, and terminal-fail. No Anthropic call.
- **Two workers racing the same job.** → `FOR UPDATE SKIP LOCKED` + per-transaction commit means row A locked by worker 1 is invisible to worker 2's SELECT. M3's batch worker uses the identical pattern; M7 reuses it verbatim.
- **Crashed worker leaves a job leased forever.** → `reapExpiredRegenLeases` resets running-with-expired-lease rows back to pending. Uses `FOR UPDATE SKIP LOCKED` so two reapers don't double-reset.
- **Reaper reset violates lease-coherence CHECK.** → Reset clears `worker_id` AND `lease_expires_at` in the same UPDATE — pending rows with no lease columns satisfy the M7-1 CHECK. Test asserts both columns are NULL after reap.
- **Cancelled job getting leased anyway.** → `cancel_requested_at IS NULL` in the lease candidate query. Test asserts a cancelled job returns `null` from `leaseNextRegenJob`.
- **Heartbeat theft by a stale worker.** → `heartbeatRegen` WHERE clause includes `worker_id = $2` and `status = 'running'`. Test: worker-thief's heartbeat returns false without touching the row.
- **M7-2 stub advancing to succeeded without real WP work.** → Intentional; documented in the function header. A `m7_2_stub_succeeded` event is written so M7-3's test suite can assert the stub didn't leak into production-path executions. The M7-2 stub is removed in M7-3 when real quality gates + WP land.

## Deliberately deferred

- Quality gate runner wiring → M7-3 (reuses `runGates` from M3-5).
- WP PUT + drift reconciliation + image transfer → M7-3.
- Retry / backoff / budget cap machinery → M7-5.
- Cron entrypoint → M7-5.
- Admin UI trigger → M7-4.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — run in CI. 13 new worker tests.
- [ ] `npm run test:e2e` — no new specs in this slice. Tracked pre-existing failures remain.