### PR TITLE
chore: sync M7 BACKLOG tracker

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -12,9 +12,9 @@ Parent plan: `docs/plans/m7-parent.md`. Write-safety-critical milestone — ever
 
 | Slice | Status | Notes |
 | --- | --- | --- |
-| M7-1 | in flight | `regeneration_jobs` + `regeneration_events` schema with partial UNIQUE + lease-coherence CHECK + RLS. |
-| M7-2 | planned | Worker core with Anthropic integration, event-log-first billing, idempotency reuse. |
-| M7-3 | planned | WP update stage with drift reconciliation + M4-7 image transfer + `pages.version_lock` bump. |
+| M7-1 | merged (#72) | `regeneration_jobs` + `regeneration_events` schema with partial UNIQUE + lease-coherence CHECK + RLS. |
+| M7-2 | merged (#73) | Worker core (lease / heartbeat / reaper) + Anthropic integration + event-log-first billing + VERSION_CONFLICT short-circuit. |
+| M7-3 | planned (next up) | WP update stage with drift reconciliation + M4-7 image transfer + `pages.version_lock` bump. Replaces the M7-2 stub-success with the real publish pipeline. |
 | M7-4 | planned | Admin UI: "Re-generate" button + polling status panel. |
 | M7-5 | planned | Cron wiring + budget cap + retry machinery. |
 


### PR DESCRIPTION
M7-1 (#72) and M7-2 (#73) landed but their own branches' BACKLOG flips didn't reach main (squash picked a stale base). This one-line sync corrects the tracker before M7-3 opens.