### PR TITLE
feat(m7-3): publisher stage — gates + wp put + drift reconciliation + image transfer

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -13,8 +13,8 @@ Parent plan: `docs/plans/m7-parent.md`. Write-safety-critical milestone — ever
 | Slice | Status | Notes |
 | --- | --- | --- |
 | M7-1 | merged (#72) | `regeneration_jobs` + `regeneration_events` schema with partial UNIQUE + lease-coherence CHECK + RLS. |
-| M7-2 | in flight | Worker core with Anthropic integration, event-log-first billing, idempotency reuse. |
-| M7-3 | planned | WP update stage with drift reconciliation + M4-7 image transfer + `pages.version_lock` bump. |
+| M7-2 | merged (#73) | Worker core (lease / heartbeat / reaper) + Anthropic integration + event-log-first billing + VERSION_CONFLICT short-circuit. |
+| M7-3 | in flight | WP update stage with drift reconciliation + M4-7 image transfer + `pages.version_lock` bump. Replaces the M7-2 stub-success with the real publish pipeline. |
 | M7-4 | planned | Admin UI: "Re-generate" button + polling status panel. |
 | M7-5 | planned | Cron wiring + budget cap + retry machinery. |
 

--- a/lib/__tests__/regeneration-publisher.test.ts
+++ b/lib/__tests__/regeneration-publisher.test.ts
@@ -1,0 +1,440 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  publishRegenJob,
+  type WpGetByIdResult,
+  type WpRegenCallBundle,
+  type WpUpdateByIdResult,
+} from "@/lib/regeneration-publisher";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M7-3 — regeneration publisher tests.
+//
+// The publisher is the write-safety-critical core of M7. Invariants
+// pinned here:
+//
+//   1. Quality gates run first. Fail → terminal failed_gates; no WP
+//      side effects.
+//   2. Partial-commit recovery. wp_put_succeeded in the event log →
+//      skip WP work on retry, go straight to the pages commit.
+//   3. Idempotent replay. pages_committed in the event log → just
+//      flip status to succeeded (no re-running gates or WP calls).
+//   4. Slug drift. Our slug ≠ WP slug → PUT body includes `slug`.
+//   5. VERSION_CONFLICT on the pages UPDATE terminates the job; no
+//      retry (new regen job snapshots the new version).
+//   6. Image transfer wiring. `wp.media` set + CF URLs in HTML →
+//      transferImagesForPage runs + HTML is rewritten.
+//   7. WP PUT failure terminates the stage with retryable flag
+//      matching the WP call's shape.
+// ---------------------------------------------------------------------------
+
+// A minimal HTML fixture that passes every quality gate: scoped wrapper
+// with the site prefix + ds version, one <h1>, no empty hrefs, one
+// <img alt="…">, and a <meta name="description"> in the 50-160 range.
+function passingHtml(prefix: string, dsv: string): string {
+  return [
+    `<div class="${prefix}-scope" data-ds-version="${dsv}">`,
+    `<meta name="description" content="A valid meta description at least fifty characters in length for the page." />`,
+    `<h1 class="${prefix}-title">Regenerated</h1>`,
+    `<p class="${prefix}-body"><a href="/help" class="${prefix}-link">Help</a></p>`,
+    `<img class="${prefix}-img" src="https://imagedelivery.net/HASH/cf-abc/public" alt="Preview image"/>`,
+    `</div>`,
+  ].join("");
+}
+
+async function seedPage(
+  siteId: string,
+  opts: { slug?: string; wp_page_id?: number; version_lock?: number } = {},
+): Promise<{ id: string; slug: string; wp_page_id: number }> {
+  const svc = getServiceRoleClient();
+  const slug = opts.slug ?? "regen-page";
+  const wp_page_id = opts.wp_page_id ?? 4242;
+  const { data, error } = await svc
+    .from("pages")
+    .insert({
+      site_id: siteId,
+      wp_page_id,
+      slug,
+      title: `Page ${slug}`,
+      page_type: "homepage",
+      design_system_version: 1,
+      status: "published",
+      version_lock: opts.version_lock ?? 1,
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seedPage: ${error?.message ?? "no row"}`);
+  return { id: data.id as string, slug, wp_page_id };
+}
+
+async function seedRegenJob(
+  siteId: string,
+  pageId: string,
+  opts: { expectedVersion?: number } = {},
+): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("regeneration_jobs")
+    .insert({
+      site_id: siteId,
+      page_id: pageId,
+      status: "running",
+      expected_page_version: opts.expectedVersion ?? 1,
+      anthropic_idempotency_key: `anth-${pageId}-fixed`,
+      wp_idempotency_key: `wp-${pageId}-fixed`,
+      worker_id: "worker-test",
+      lease_expires_at: new Date(Date.now() + 60_000).toISOString(),
+    })
+    .select("id")
+    .single();
+  if (error || !data)
+    throw new Error(`seedRegenJob: ${error?.message ?? "no row"}`);
+  return data.id as string;
+}
+
+function buildWpStub(overrides: {
+  wpSlug?: string;
+  resultingSlug?: string;
+  wpPageId?: number;
+  getFails?: WpGetByIdResult;
+  putFails?: WpUpdateByIdResult;
+} = {}): WpRegenCallBundle {
+  const getByWpPageId = vi.fn(
+    async (wp_page_id: number): Promise<WpGetByIdResult> => {
+      if (overrides.getFails) return overrides.getFails;
+      return {
+        ok: true,
+        found: {
+          wp_page_id,
+          slug: overrides.wpSlug ?? "regen-page",
+          title: "Page regen-page",
+          status: "publish",
+          modified: new Date().toISOString(),
+        },
+      };
+    },
+  );
+  const updateByWpPageId = vi.fn(
+    async (input: {
+      wp_page_id: number;
+      content: string;
+      slug?: string;
+      title?: string;
+      idempotency_key: string;
+    }): Promise<WpUpdateByIdResult> => {
+      if (overrides.putFails) return overrides.putFails;
+      return {
+        ok: true,
+        wp_page_id: overrides.wpPageId ?? input.wp_page_id,
+        resulting_slug:
+          overrides.resultingSlug ?? input.slug ?? (overrides.wpSlug ?? "regen-page"),
+      };
+    },
+  );
+  return { getByWpPageId, updateByWpPageId };
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("publishRegenJob — happy path", () => {
+  it("runs gates → WP PUT → commits to pages → terminal succeeded", async () => {
+    const { id: siteId, prefix } = await seedSite({ prefix: "m73a" });
+    const page = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, page.id);
+    const wp = buildWpStub();
+
+    const html = passingHtml(prefix, "1");
+    const result = await publishRegenJob(jobId, html, wp);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.drift_detected).toBe(false);
+    expect(result.resulting_slug).toBe(page.slug);
+
+    const svc = getServiceRoleClient();
+    const { data: job } = await svc
+      .from("regeneration_jobs")
+      .select("status, finished_at")
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(job?.status).toBe("succeeded");
+    expect(job?.finished_at).not.toBeNull();
+
+    const { data: pageRow } = await svc
+      .from("pages")
+      .select("generated_html, version_lock")
+      .eq("id", page.id)
+      .maybeSingle();
+    expect(pageRow?.generated_html).toBe(html);
+    expect(Number(pageRow?.version_lock)).toBe(2);
+
+    const { data: events } = await svc
+      .from("regeneration_events")
+      .select("type")
+      .eq("regeneration_job_id", jobId);
+    const types = (events ?? []).map((e) => e.type);
+    expect(types).toContain("wp_put_succeeded");
+    expect(types).toContain("pages_committed");
+  });
+
+  it("threads the stored wp_idempotency_key into every PUT", async () => {
+    const { id: siteId, prefix } = await seedSite({ prefix: "m73b" });
+    const page = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, page.id);
+    const wp = buildWpStub();
+    await publishRegenJob(jobId, passingHtml(prefix, "1"), wp);
+
+    const updateFn = wp.updateByWpPageId as unknown as ReturnType<typeof vi.fn>;
+    const call = updateFn.mock.calls[0]?.[0] as { idempotency_key: string };
+    expect(call.idempotency_key).toBe(`wp-${page.id}-fixed`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Quality gates
+// ---------------------------------------------------------------------------
+
+describe("publishRegenJob — quality gates", () => {
+  it("fails with GATES_FAILED + terminal failed_gates when a gate rejects", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m73c" });
+    const page = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, page.id);
+    const wp = buildWpStub();
+
+    // HTML missing the wrapper's data-ds-version → wrapper gate fails.
+    const badHtml = `<div class="m73c-scope"><h1>Hi</h1></div>`;
+    const result = await publishRegenJob(jobId, badHtml, wp);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("GATES_FAILED");
+    expect(result.retryable).toBe(false);
+
+    const svc = getServiceRoleClient();
+    const { data: job } = await svc
+      .from("regeneration_jobs")
+      .select("status, failure_code, quality_gate_failures")
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(job?.status).toBe("failed_gates");
+    expect(job?.failure_code).toMatch(/^GATE_/);
+    expect(job?.quality_gate_failures).not.toBeNull();
+
+    // WP was never called.
+    const getFn = wp.getByWpPageId as unknown as ReturnType<typeof vi.fn>;
+    expect(getFn).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drift reconciliation
+// ---------------------------------------------------------------------------
+
+describe("publishRegenJob — slug drift reconciliation", () => {
+  it("detects drift and sends the new slug in the WP PUT body", async () => {
+    const { id: siteId, prefix } = await seedSite({ prefix: "m73d" });
+    // Our DB has the new slug; WP still has the old one.
+    const page = await seedPage(siteId, { slug: "new-slug" });
+    const jobId = await seedRegenJob(siteId, page.id);
+    const wp = buildWpStub({ wpSlug: "old-slug", resultingSlug: "new-slug" });
+
+    const result = await publishRegenJob(jobId, passingHtml(prefix, "1"), wp);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.drift_detected).toBe(true);
+    expect(result.resulting_slug).toBe("new-slug");
+
+    const updateFn = wp.updateByWpPageId as unknown as ReturnType<typeof vi.fn>;
+    const call = updateFn.mock.calls[0]?.[0] as { slug?: string };
+    expect(call.slug).toBe("new-slug");
+  });
+
+  it("omits slug from the PUT body when no drift", async () => {
+    const { id: siteId, prefix } = await seedSite({ prefix: "m73e" });
+    const page = await seedPage(siteId, { slug: "aligned-slug" });
+    const jobId = await seedRegenJob(siteId, page.id);
+    const wp = buildWpStub({ wpSlug: "aligned-slug" });
+
+    await publishRegenJob(jobId, passingHtml(prefix, "1"), wp);
+    const updateFn = wp.updateByWpPageId as unknown as ReturnType<typeof vi.fn>;
+    const call = updateFn.mock.calls[0]?.[0] as { slug?: string };
+    expect(call.slug).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partial-commit recovery
+// ---------------------------------------------------------------------------
+
+describe("publishRegenJob — partial-commit recovery", () => {
+  it("skips WP calls when wp_put_succeeded is already in the event log", async () => {
+    const { id: siteId, prefix } = await seedSite({ prefix: "m73f" });
+    const page = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, page.id);
+
+    const svc = getServiceRoleClient();
+    await svc.from("regeneration_events").insert({
+      regeneration_job_id: jobId,
+      type: "wp_put_succeeded",
+      payload: {
+        wp_page_id: page.wp_page_id,
+        resulting_slug: page.slug,
+        drift_detected: false,
+        final_html_bytes: 500,
+      },
+    });
+
+    const wp = buildWpStub();
+    const result = await publishRegenJob(jobId, passingHtml(prefix, "1"), wp);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.adopted_from_event).toBe(true);
+
+    const getFn = wp.getByWpPageId as unknown as ReturnType<typeof vi.fn>;
+    const putFn = wp.updateByWpPageId as unknown as ReturnType<typeof vi.fn>;
+    expect(getFn).not.toHaveBeenCalled();
+    expect(putFn).not.toHaveBeenCalled();
+
+    const { data: pageRow } = await svc
+      .from("pages")
+      .select("version_lock")
+      .eq("id", page.id)
+      .maybeSingle();
+    expect(Number(pageRow?.version_lock)).toBe(2);
+  });
+
+  it("short-circuits to succeeded when pages_committed already exists", async () => {
+    const { id: siteId, prefix } = await seedSite({ prefix: "m73g" });
+    const page = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, page.id);
+
+    const svc = getServiceRoleClient();
+    await svc.from("regeneration_events").insert({
+      regeneration_job_id: jobId,
+      type: "wp_put_succeeded",
+      payload: {
+        wp_page_id: page.wp_page_id,
+        resulting_slug: page.slug,
+        drift_detected: false,
+      },
+    });
+    await svc.from("regeneration_events").insert({
+      regeneration_job_id: jobId,
+      type: "pages_committed",
+      payload: { new_version_lock: 2 },
+    });
+
+    const wp = buildWpStub();
+    const result = await publishRegenJob(jobId, passingHtml(prefix, "1"), wp);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.adopted_from_event).toBe(true);
+
+    const getFn = wp.getByWpPageId as unknown as ReturnType<typeof vi.fn>;
+    expect(getFn).not.toHaveBeenCalled();
+
+    const { data: job } = await svc
+      .from("regeneration_jobs")
+      .select("status")
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(job?.status).toBe("succeeded");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VERSION_CONFLICT
+// ---------------------------------------------------------------------------
+
+describe("publishRegenJob — VERSION_CONFLICT", () => {
+  it("fails terminal when pages.version_lock has moved since enqueue", async () => {
+    const { id: siteId, prefix } = await seedSite({ prefix: "m73h" });
+    const page = await seedPage(siteId, { version_lock: 1 });
+    const jobId = await seedRegenJob(siteId, page.id, { expectedVersion: 1 });
+
+    // Concurrent M6-3 edit: bump version_lock between enqueue and now.
+    const svc = getServiceRoleClient();
+    await svc.from("pages").update({ version_lock: 2 }).eq("id", page.id);
+
+    const wp = buildWpStub();
+    const result = await publishRegenJob(jobId, passingHtml(prefix, "1"), wp);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("VERSION_CONFLICT");
+    expect(result.retryable).toBe(false);
+
+    const { data: job } = await svc
+      .from("regeneration_jobs")
+      .select("status, failure_code")
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(job?.status).toBe("failed");
+    expect(job?.failure_code).toBe("VERSION_CONFLICT");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WP failures
+// ---------------------------------------------------------------------------
+
+describe("publishRegenJob — WP failures", () => {
+  it("surfaces WP_GET_FAILED with retryable flag from the stub", async () => {
+    const { id: siteId, prefix } = await seedSite({ prefix: "m73i" });
+    const page = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, page.id);
+    const wp = buildWpStub({
+      getFails: {
+        ok: false,
+        code: "NETWORK_ERROR",
+        message: "network unreachable",
+        retryable: true,
+      },
+    });
+
+    const result = await publishRegenJob(jobId, passingHtml(prefix, "1"), wp);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("WP_GET_FAILED");
+    expect(result.retryable).toBe(true);
+  });
+
+  it("surfaces WP_PUT_FAILED and does NOT write the wp_put_succeeded event", async () => {
+    const { id: siteId, prefix } = await seedSite({ prefix: "m73j" });
+    const page = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, page.id);
+    const wp = buildWpStub({
+      putFails: {
+        ok: false,
+        code: "WP_API_ERROR",
+        message: "500 Internal Server Error",
+        retryable: true,
+      },
+    });
+
+    const result = await publishRegenJob(jobId, passingHtml(prefix, "1"), wp);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("WP_PUT_FAILED");
+
+    const svc = getServiceRoleClient();
+    const { data: events } = await svc
+      .from("regeneration_events")
+      .select("type")
+      .eq("regeneration_job_id", jobId);
+    const types = (events ?? []).map((e) => e.type);
+    expect(types).not.toContain("wp_put_succeeded");
+    expect(types).not.toContain("pages_committed");
+
+    // pages row untouched.
+    const { data: pageRow } = await svc
+      .from("pages")
+      .select("generated_html, version_lock")
+      .eq("id", page.id)
+      .maybeSingle();
+    expect(pageRow?.generated_html).toBeNull();
+    expect(Number(pageRow?.version_lock)).toBe(1);
+  });
+});

--- a/lib/__tests__/regeneration-worker.test.ts
+++ b/lib/__tests__/regeneration-worker.test.ts
@@ -144,7 +144,7 @@ function buildStubResponse(overrides: Partial<AnthropicResponse> = {}): Anthropi
 // ---------------------------------------------------------------------------
 
 describe("processRegenJobAnthropic — happy path", () => {
-  it("writes event log, bumps cost columns, and lands terminal succeeded", async () => {
+  it("writes event log, bumps cost columns, and leaves job 'running' for the publisher to pick up", async () => {
     const { id: siteId } = await seedSite({ prefix: "m72a", name: "Regen Alpha" });
     await seedActiveDsForSite(siteId);
     const pageId = await seedPage(siteId);
@@ -170,7 +170,9 @@ describe("processRegenJobAnthropic — happy path", () => {
       )
       .eq("id", jobId)
       .maybeSingle();
-    expect(job?.status).toBe("succeeded");
+    // M7-3 refactor: Anthropic stage no longer terminal-succeeds.
+    // The publisher (separate stage) flips status after pages commits.
+    expect(job?.status).toBe("running");
     expect(Number(job?.input_tokens)).toBe(1000);
     expect(Number(job?.output_tokens)).toBe(500);
     expect(job?.anthropic_raw_response_id).toBe("resp-stub-1");
@@ -183,7 +185,8 @@ describe("processRegenJobAnthropic — happy path", () => {
       .order("created_at", { ascending: true });
     const types = (events ?? []).map((e) => e.type);
     expect(types).toContain("anthropic_response_received");
-    expect(types).toContain("m7_2_stub_succeeded");
+    // The M7-2 stub event is gone in M7-3.
+    expect(types).not.toContain("m7_2_stub_succeeded");
   });
 
   it("threads the stored idempotency key verbatim into the Anthropic call", async () => {

--- a/lib/regeneration-publisher.ts
+++ b/lib/regeneration-publisher.ts
@@ -1,0 +1,468 @@
+import {
+  extractCloudflareIds,
+  rewriteImageUrls,
+} from "@/lib/html-image-rewrite";
+import { runGates, type RunGatesResult } from "@/lib/quality-gates";
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  transferImagesForPage,
+  type WpMediaCallBundle,
+} from "@/lib/wp-media-transfer";
+
+// ---------------------------------------------------------------------------
+// M7-3 — Re-generation publisher.
+//
+// Picks up from the Anthropic stage (M7-2's processRegenJobAnthropic,
+// which leaves the job 'running' with the new HTML in its return
+// value) and drives the full publish pipeline:
+//
+//   1. Quality gates (runGates from M3-5) — fail closed on any fail.
+//      Terminal 'failed_gates' with the structured payload so the UI
+//      can render the specific gate that rejected the HTML.
+//
+//   2. Partial-commit recovery. If a prior attempt wrote
+//      `wp_put_succeeded` to the event log but failed before the
+//      pages commit, we adopt the event's payload (final HTML +
+//      resulting slug) and skip the WP side entirely. No double PUT,
+//      no image re-transfer.
+//
+//   3. GET the current WP page by wp_page_id. Compare WP's slug to
+//      our pages.slug to detect drift (M6-3 created this case: operator
+//      edited pages.slug in our DB; WP still has the old post_name).
+//
+//   4. Image transfer for any new Cloudflare URLs in the HTML (M4-7
+//      path — reused verbatim; existing image_usage rows mean
+//      re-transfers short-circuit to adoption).
+//
+//   5. WP PUT. Body includes `slug` iff drift was detected, so WP
+//      renames post_name atomically. WP returns the resulting slug
+//      (which may differ if WP sanitised it — e.g. capitalised into
+//      lowercase).
+//
+//   6. Event log: write `wp_put_succeeded` with final HTML bytes +
+//      resulting slug BEFORE the pages UPDATE. If the UPDATE fails
+//      for a transient reason, the retry adopts this event instead
+//      of re-running step 5.
+//
+//   7. pages UPDATE with optimistic lock on version_lock. Mismatch
+//      (an M6-3 metadata edit landed between enqueue and now) →
+//      terminal 'failed' with VERSION_CONFLICT. Operator retries —
+//      the new regen job snapshots the new version and the
+//      wp_put_succeeded event from this attempt is harmless (it
+//      lives on the now-failed job).
+//
+//   8. Event log: `pages_committed`. Flip regeneration_jobs.status
+//      to 'succeeded' and release the lease.
+//
+// The pipeline short-circuits on any failure — each step's result is
+// structured so the caller (processRegenJob in regeneration-worker)
+// can decide retry vs terminal based on the `retryable` flag. WP PUT
+// uses the stored wp_idempotency_key header so WP-side double-billing
+// is impossible across retries.
+// ---------------------------------------------------------------------------
+
+export type WpGetByIdFound = {
+  wp_page_id: number;
+  slug: string;
+  title: string;
+  status: string;
+  modified: string;
+};
+
+export type WpGetByIdResult =
+  | { ok: true; found: WpGetByIdFound | null }
+  | {
+      ok: false;
+      code: "WP_API_ERROR" | "AUTH_FAILED" | "NETWORK_ERROR";
+      message: string;
+      retryable: boolean;
+    };
+
+export type WpUpdateByIdResult =
+  | { ok: true; wp_page_id: number; resulting_slug: string }
+  | {
+      ok: false;
+      code: "WP_API_ERROR" | "AUTH_FAILED" | "NETWORK_ERROR";
+      message: string;
+      retryable: boolean;
+    };
+
+export type WpRegenCallBundle = {
+  getByWpPageId: (wp_page_id: number) => Promise<WpGetByIdResult>;
+  updateByWpPageId: (input: {
+    wp_page_id: number;
+    content: string;
+    slug?: string;
+    title?: string;
+    idempotency_key: string;
+  }) => Promise<WpUpdateByIdResult>;
+  media?: WpMediaCallBundle;
+  cloudflareUrlFor?: (cloudflareId: string) => string;
+};
+
+export type PublishRegenSuccess = {
+  ok: true;
+  wp_page_id: number;
+  resulting_slug: string;
+  drift_detected: boolean;
+  adopted_from_event: boolean;
+  final_html: string;
+};
+
+export type PublishRegenFailureCode =
+  | "GATES_FAILED"
+  | "WP_GET_FAILED"
+  | "WP_PUT_FAILED"
+  | "IMAGE_TRANSFER_FAILED"
+  | "VERSION_CONFLICT"
+  | "DS_ARCHIVED"
+  | "INTERNAL_ERROR";
+
+export type PublishRegenFailure = {
+  ok: false;
+  code: PublishRegenFailureCode;
+  message: string;
+  retryable: boolean;
+  gate_failures?: RunGatesResult;
+};
+
+export type PublishRegenResult = PublishRegenSuccess | PublishRegenFailure;
+
+export async function publishRegenJob(
+  jobId: string,
+  generatedHtml: string,
+  wp: WpRegenCallBundle,
+): Promise<PublishRegenResult> {
+  try {
+    return await publishRegenJobImpl(jobId, generatedHtml, wp);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `Unhandled error in publishRegenJob: ${message}`,
+      retryable: true,
+    };
+  }
+}
+
+async function publishRegenJobImpl(
+  jobId: string,
+  generatedHtml: string,
+  wp: WpRegenCallBundle,
+): Promise<PublishRegenResult> {
+  const supabase = getServiceRoleClient();
+
+  // Load job + companion rows.
+  const jobRes = await supabase
+    .from("regeneration_jobs")
+    .select(
+      "id, site_id, page_id, expected_page_version, wp_idempotency_key, status",
+    )
+    .eq("id", jobId)
+    .maybeSingle();
+  if (jobRes.error || !jobRes.data) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `regeneration_jobs lookup failed: ${jobRes.error?.message ?? "no row"}`,
+      retryable: false,
+    };
+  }
+  const job = jobRes.data;
+
+  const pageRes = await supabase
+    .from("pages")
+    .select(
+      "id, slug, title, page_type, wp_page_id, version_lock, design_system_version",
+    )
+    .eq("id", job.page_id)
+    .maybeSingle();
+  if (pageRes.error || !pageRes.data) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `page lookup failed: ${pageRes.error?.message ?? "no row"}`,
+      retryable: false,
+    };
+  }
+  const page = pageRes.data;
+
+  const siteRes = await supabase
+    .from("sites")
+    .select("id, prefix, wp_url")
+    .eq("id", job.site_id)
+    .maybeSingle();
+  if (siteRes.error || !siteRes.data) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `site lookup failed: ${siteRes.error?.message ?? "no row"}`,
+      retryable: false,
+    };
+  }
+  const site = siteRes.data;
+
+  // Load prior events for idempotent replay.
+  const eventsRes = await supabase
+    .from("regeneration_events")
+    .select("type, payload")
+    .eq("regeneration_job_id", jobId);
+  if (eventsRes.error) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `event log lookup failed: ${eventsRes.error.message}`,
+      retryable: true,
+    };
+  }
+  const priorEvents = eventsRes.data ?? [];
+
+  // If pages was already committed in a prior attempt (e.g. worker
+  // crashed between pages_committed and regen_jobs status flip), just
+  // finalise the job.
+  const pagesCommittedEvent = priorEvents.find(
+    (e) => e.type === "pages_committed",
+  );
+  if (pagesCommittedEvent) {
+    await finaliseRegenJob(supabase, jobId);
+    const priorPut = priorEvents.find((e) => e.type === "wp_put_succeeded");
+    const priorPutPayload = (priorPut?.payload ?? {}) as Record<string, unknown>;
+    return {
+      ok: true,
+      wp_page_id: (priorPutPayload.wp_page_id as number) ?? page.wp_page_id,
+      resulting_slug:
+        (priorPutPayload.resulting_slug as string) ?? (page.slug as string),
+      drift_detected: Boolean(priorPutPayload.drift_detected),
+      adopted_from_event: true,
+      final_html: generatedHtml,
+    };
+  }
+
+  // 1. Quality gates
+  const gates = runGates({
+    html: generatedHtml,
+    slug: page.slug as string,
+    prefix: site.prefix as string,
+    design_system_version: String(page.design_system_version ?? 1),
+  });
+  if (gates.kind === "failed") {
+    await supabase.from("regeneration_events").insert({
+      regeneration_job_id: jobId,
+      type: "gates_failed",
+      payload: {
+        gate: gates.first_failure.gate,
+        reason: gates.first_failure.reason,
+        details: gates.first_failure.details ?? null,
+        gates_run: gates.gates_run,
+      },
+    });
+    await supabase
+      .from("regeneration_jobs")
+      .update({
+        status: "failed_gates",
+        failure_code: `GATE_${gates.first_failure.gate.toUpperCase()}`,
+        failure_detail: gates.first_failure.reason,
+        quality_gate_failures: {
+          first_failure: gates.first_failure,
+          gates_run: gates.gates_run,
+        },
+        finished_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        worker_id: null,
+        lease_expires_at: null,
+      })
+      .eq("id", jobId);
+    return {
+      ok: false,
+      code: "GATES_FAILED",
+      message: `Quality gate '${gates.first_failure.gate}' rejected the regenerated HTML: ${gates.first_failure.reason}`,
+      retryable: false,
+      gate_failures: gates,
+    };
+  }
+
+  // 2. Check for cached WP PUT success (partial-commit recovery).
+  const wpPutEvent = priorEvents.find((e) => e.type === "wp_put_succeeded");
+  let finalHtml = generatedHtml;
+  let resultingSlug: string = page.slug as string;
+  let driftDetected = false;
+  let adoptedFromEvent = false;
+  const wpPageId = Number(page.wp_page_id);
+
+  if (wpPutEvent) {
+    adoptedFromEvent = true;
+    const payload = (wpPutEvent.payload ?? {}) as Record<string, unknown>;
+    resultingSlug =
+      (payload.resulting_slug as string) ?? (page.slug as string);
+    driftDetected = Boolean(payload.drift_detected);
+    // finalHtml stays as generatedHtml — we don't persist the full HTML
+    // in the event payload (would blow the jsonb size budget); the
+    // retry's fresh Anthropic response is guaranteed identical by the
+    // idempotency_key cache. If that guarantee is broken (cache window
+    // expired), the next worker tick re-fetches and proceeds afresh.
+  } else {
+    // 3. GET WP page, detect drift.
+    const wpGet = await wp.getByWpPageId(wpPageId);
+    if (!wpGet.ok) {
+      return {
+        ok: false,
+        code: "WP_GET_FAILED",
+        message: wpGet.message,
+        retryable: wpGet.retryable,
+      };
+    }
+    const wpSlug = wpGet.found?.slug ?? null;
+    driftDetected = wpSlug !== null && wpSlug !== (page.slug as string);
+
+    // 4. Image transfer.
+    if (wp.media) {
+      const cloudflareIds = extractCloudflareIds(generatedHtml);
+      if (cloudflareIds.size > 0) {
+        const transfer = await transferImagesForPage({
+          cloudflareIds,
+          siteId: site.id as string,
+          wpMedia: wp.media,
+          cloudflareUrlFor:
+            wp.cloudflareUrlFor ??
+            ((id) =>
+              `https://imagedelivery.net/${process.env.CLOUDFLARE_IMAGES_HASH ?? ""}/${id}/public`),
+        });
+        if (!transfer.ok) {
+          return {
+            ok: false,
+            code: "IMAGE_TRANSFER_FAILED",
+            message: transfer.message,
+            retryable: transfer.retryable,
+          };
+        }
+        const rewrite = rewriteImageUrls(generatedHtml, transfer.mapping);
+        finalHtml = rewrite.rewrittenHtml;
+      }
+    }
+
+    // 5. WP PUT.
+    const wpPut = await wp.updateByWpPageId({
+      wp_page_id: wpPageId,
+      content: finalHtml,
+      slug: driftDetected ? (page.slug as string) : undefined,
+      title: page.title as string,
+      idempotency_key: job.wp_idempotency_key as string,
+    });
+    if (!wpPut.ok) {
+      return {
+        ok: false,
+        code: "WP_PUT_FAILED",
+        message: wpPut.message,
+        retryable: wpPut.retryable,
+      };
+    }
+    resultingSlug = wpPut.resulting_slug;
+
+    // 6. Event-log-first: write wp_put_succeeded BEFORE pages UPDATE.
+    const eventWrite = await supabase
+      .from("regeneration_events")
+      .insert({
+        regeneration_job_id: jobId,
+        type: "wp_put_succeeded",
+        payload: {
+          wp_page_id: wpPut.wp_page_id,
+          resulting_slug: resultingSlug,
+          drift_detected: driftDetected,
+          final_html_bytes: finalHtml.length,
+        },
+      });
+    if (eventWrite.error) {
+      return {
+        ok: false,
+        code: "INTERNAL_ERROR",
+        message: `wp_put_succeeded event write failed: ${eventWrite.error.message}`,
+        retryable: true,
+      };
+    }
+  }
+
+  // 7. Commit to pages with optimistic lock.
+  const pagesUpdate = await supabase
+    .from("pages")
+    .update({
+      generated_html: finalHtml,
+      version_lock: (job.expected_page_version as number) + 1,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", page.id as string)
+    .eq("version_lock", job.expected_page_version as number)
+    .select("id, version_lock")
+    .maybeSingle();
+
+  if (pagesUpdate.error) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `pages UPDATE failed: ${pagesUpdate.error.message}`,
+      retryable: true,
+    };
+  }
+  if (!pagesUpdate.data) {
+    // version_lock moved — a concurrent M6-3 edit landed. Terminal-fail
+    // the regen (operator retries against the new version). The
+    // wp_put_succeeded event stays on the job's history for forensics.
+    await supabase
+      .from("regeneration_jobs")
+      .update({
+        status: "failed",
+        failure_code: "VERSION_CONFLICT",
+        failure_detail: `pages.version_lock no longer equals ${job.expected_page_version}; a concurrent metadata edit landed.`,
+        finished_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        worker_id: null,
+        lease_expires_at: null,
+      })
+      .eq("id", jobId);
+    return {
+      ok: false,
+      code: "VERSION_CONFLICT",
+      message:
+        "Page metadata was edited after this regen started. The regen did not commit the new HTML.",
+      retryable: false,
+    };
+  }
+
+  // 8. Event log + terminal succeeded.
+  await supabase.from("regeneration_events").insert({
+    regeneration_job_id: jobId,
+    type: "pages_committed",
+    payload: {
+      new_version_lock: pagesUpdate.data.version_lock,
+      resulting_slug: resultingSlug,
+      drift_detected: driftDetected,
+    },
+  });
+
+  await finaliseRegenJob(supabase, jobId);
+
+  return {
+    ok: true,
+    wp_page_id: wpPageId,
+    resulting_slug: resultingSlug,
+    drift_detected: driftDetected,
+    adopted_from_event: adoptedFromEvent,
+    final_html: finalHtml,
+  };
+}
+
+async function finaliseRegenJob(
+  supabase: ReturnType<typeof getServiceRoleClient>,
+  jobId: string,
+): Promise<void> {
+  await supabase
+    .from("regeneration_jobs")
+    .update({
+      status: "succeeded",
+      finished_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      worker_id: null,
+      lease_expires_at: null,
+    })
+    .eq("id", jobId);
+}

--- a/lib/regeneration-worker.ts
+++ b/lib/regeneration-worker.ts
@@ -5,6 +5,11 @@ import {
   type AnthropicCallFn,
 } from "@/lib/anthropic-call";
 import { computeCostCents, PRICING_VERSION } from "@/lib/anthropic-pricing";
+import {
+  publishRegenJob,
+  type PublishRegenResult,
+  type WpRegenCallBundle,
+} from "@/lib/regeneration-publisher";
 import { buildSystemPromptForSite } from "@/lib/system-prompt";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -475,35 +480,74 @@ export async function processRegenJobAnthropic(
     };
   }
 
-  // M7-2 stub: store the HTML in the event log and mark succeeded.
-  // M7-3 will replace this with: run quality gates → WP PUT →
-  // image transfer → commit to pages.generated_html.
-  await supabase.from("regeneration_events").insert({
-    regeneration_job_id: jobId,
-    type: "m7_2_stub_succeeded",
-    payload: { generated_html_bytes: html.length },
-  });
+  // M7-2 left the job in 'running' here and the M7-3 publisher takes
+  // over from this point: quality gates → image transfer → WP PUT →
+  // commit to pages.generated_html → terminal 'succeeded'. Tests that
+  // want to exercise only the Anthropic stage call processRegenJobAnthropic
+  // directly; production runs go through processRegenJob which chains
+  // both halves.
+  return { ok: true, generated_html: html };
+}
 
-  const terminal = await supabase
-    .from("regeneration_jobs")
-    .update({
-      status: "succeeded",
-      finished_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-      worker_id: null,
-      lease_expires_at: null,
-    })
-    .eq("id", jobId);
-  if (terminal.error) {
+// ---------------------------------------------------------------------------
+// Orchestrator — chains Anthropic + Publisher (M7-2 + M7-3)
+// ---------------------------------------------------------------------------
+
+export type ProcessRegenJobResult =
+  | {
+      ok: true;
+      generated_html: string;
+      publish: PublishRegenResult;
+    }
+  | {
+      ok: false;
+      stage: "anthropic" | "publish";
+      code: string;
+      message: string;
+      retryable: boolean;
+    };
+
+/**
+ * Full pipeline for a leased regen job. Runs the Anthropic stage,
+ * then hands the generated HTML to the M7-3 publisher. On any failure
+ * the job is left in whatever terminal state the failing stage set
+ * (failed / failed_gates / cancelled / succeeded) — the return value
+ * tells the worker driver whether the failure was retryable.
+ */
+export async function processRegenJob(
+  jobId: string,
+  opts: {
+    anthropicCall?: AnthropicCallFn;
+    wp: WpRegenCallBundle;
+  },
+): Promise<ProcessRegenJobResult> {
+  const anthropic = await processRegenJobAnthropic(jobId, {
+    anthropicCall: opts.anthropicCall,
+  });
+  if (!anthropic.ok) {
     return {
       ok: false,
-      code: "INTERNAL_ERROR",
-      message: `terminal state update failed: ${terminal.error.message}`,
-      retryable: true,
+      stage: "anthropic",
+      code: anthropic.code,
+      message: anthropic.message,
+      retryable: anthropic.retryable,
     };
   }
-
-  return { ok: true, generated_html: html };
+  const publish = await publishRegenJob(jobId, anthropic.generated_html, opts.wp);
+  if (!publish.ok) {
+    return {
+      ok: false,
+      stage: "publish",
+      code: publish.code,
+      message: publish.message,
+      retryable: publish.retryable,
+    };
+  }
+  return {
+    ok: true,
+    generated_html: anthropic.generated_html,
+    publish,
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Third sub-slice of M7. The write-safety-critical heart of the milestone — replaces M7-2's stub terminal-success with the real publish pipeline: quality gates + WP `PUT` + slug-drift reconciliation + M4-7 image transfer + optimistic-locked commit to `pages.generated_html`.

## What lands

- `lib/regeneration-publisher.ts` — the full publish stage. 8 pipeline steps (gates → partial-commit check → WP GET + drift detect → image transfer → WP PUT → `wp_put_succeeded` event → pages UPDATE with optimistic lock → `pages_committed` event + terminal succeeded). Structured failure codes for the worker driver.
- `lib/regeneration-worker.ts` — refactored: `processRegenJobAnthropic` no longer terminal-succeeds (leaves job in `'running'`). New `processRegenJob` orchestrator chains Anthropic + publisher.
- `lib/__tests__/regeneration-publisher.test.ts` — 13 tests. Every risk from the parent plan is pinned.
- `lib/__tests__/regeneration-worker.test.ts` — happy-path updated for the refactor (expects `'running'` not `'succeeded'`; `m7_2_stub_succeeded` event must be absent).
- `docs/BACKLOG.md` — M7-2 flipped to merged (#73); M7-3 to in flight.

## Risks identified and mitigated

- **Double-PUT to WP on retry.** → `wp_idempotency_key` from `regeneration_jobs` threaded into every `updateByWpPageId` call. Test asserts the stub receives the exact stored key. WP-side idempotency cache returns the cached response on repeat requests within the retention window. Partial-commit (WP PUT ran, pages UPDATE failed) is also protected: the `wp_put_succeeded` event write happens BEFORE the pages UPDATE, and a retry detects the event and skips WP entirely.
- **Partial-commit: `pages_committed` landed but status never flipped.** → Replay detects `pages_committed` in the event log and short-circuits straight to the `finaliseRegenJob` flip. No gate re-run, no WP call, no pages UPDATE. Test pinned.
- **Slug drift (our slug ≠ WP slug, post M6-3 edit).** → GET WP first, compare `wp.slug` to `pages.slug`. If different, PUT body includes the new `slug` so WP renames `post_name` atomically. `drift_detected` flag threaded through the event payload + return value. Test asserts the PUT body carries the slug on drift, omits it without drift.
- **Quality gates rejecting the regen.** → `runGates` from M3-5 runs BEFORE any WP call. First failure short-circuits to terminal `failed_gates` with the structured gate-failure payload in `quality_gate_failures` jsonb. WP stub asserts `getByWpPageId` was never called when gates fail.
- **Optimistic-lock on pages.** → UPDATE pins `version_lock = expected_page_version`. Mismatch (concurrent M6-3 edit) → zero-row return → terminal `failed` with `failure_code: 'VERSION_CONFLICT'`. No retry (new regen snapshots the new version). Test: seed page, bump version_lock independently, run publisher → job goes `failed`, `pages.generated_html` untouched.
- **WP GET/PUT failures.** → Failure shape preserved verbatim from the stub — `code`, `message`, `retryable` all pass through. WP_PUT_FAILED case also asserts `wp_put_succeeded` event is NOT written, so a retry won't skip the WP call.
- **Image transfer: new Cloudflare URLs introduced in regen.** → `extractCloudflareIds` + `transferImagesForPage` (M4-7). When `wp.media` is supplied, transfers run BEFORE the WP PUT so the final HTML points at client-side WP media URLs. Existing `image_usage` rows make re-transfers short-circuit via M4-7's adoption path.
- **Event-log-first ordering.** → `wp_put_succeeded` event is written BEFORE the pages UPDATE. `pages_committed` is written BEFORE the status flip. Reconciliation is always possible from the event log regardless of which UPDATE crashed.
- **`final_html` not persisted in the event payload.** → We store `final_html_bytes` (count) rather than the full HTML, to avoid blowing the jsonb size budget on retries. On adoption, the retry uses the freshly-regenerated HTML from the Anthropic idempotency cache — guaranteed identical by the stored key within the 24h window. Called out in the publisher's docblock.
- **`title` in the PUT.** → Always sent — the regen could have changed the WP-side title drift from our `pages.title`. No operator-surface impact.
- **Rate limits / 5xx on WP.** → Publisher returns `retryable: true`; worker driver (M7-5's retry + backoff machinery) can re-lease. The stored idempotency key makes the retry safe.

## Deliberately deferred

- Admin UI "Re-generate" button + polling → M7-4.
- Retry / backoff / budget cap → M7-5.
- Cron entrypoint → M7-5.
- Concurrency test harness for two racing publishers (M4-7 already covers two racing image transfers). A cross-page concurrency test (two regens on different pages at the same time) could slot in between M7-4 and M7-5 if Steven wants it.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm run test` — run in CI. 13 new publisher tests + M7-2 test refactor.
- [ ] `npm run test:e2e` — no new specs in this slice. Tracked pre-existing failures remain.