### PR TITLE
fix(e2e): stabilise three pre-existing spec flakes (sites + users + images)

### DIFF
--- a/components/SiteActionsMenu.tsx
+++ b/components/SiteActionsMenu.tsx
@@ -67,6 +67,7 @@ export function SiteActionsMenu({
         <summary
           className="cursor-pointer list-none rounded px-2 py-1 text-muted-foreground hover:bg-muted"
           aria-label={`Actions for ${name}`}
+          data-testid="site-actions-summary"
         >
           ⋯
         </summary>
@@ -87,6 +88,7 @@ export function SiteActionsMenu({
             disabled={archiving}
             className="w-full px-3 py-1.5 text-left text-xs text-destructive hover:bg-destructive/10 disabled:opacity-50"
             onClick={handleArchive}
+            data-testid="site-archive-action"
           >
             {archiving ? "Archiving…" : "Archive"}
           </button>

--- a/e2e/images.spec.ts
+++ b/e2e/images.spec.ts
@@ -269,9 +269,20 @@ test.describe("images admin surface", () => {
     await expect(
       page.getByRole("heading", { name: /edit image metadata/i }),
     ).toHaveCount(0);
-    await expect(page.getByText(newCaption)).toBeVisible();
+    // Scope to the detail-fields dd. M5-2 added a Breadcrumbs row that
+    // also renders the caption (truncated to 60 chars), so a naked
+    // getByText is a strict-mode violation.
     await expect(
-      page.getByTestId("image-detail-fields").getByText("edited"),
+      page.getByTestId("image-detail-fields").getByText(newCaption),
+    ).toBeVisible();
+    // exact: true so we match the "edited" tag <span> specifically;
+    // the capitalised "Edited:" at the start of the caption dd is a
+    // substring hit that caused a strict-mode violation on the first
+    // rebased-on-main run.
+    await expect(
+      page.getByTestId("image-detail-fields").getByText("edited", {
+        exact: true,
+      }),
     ).toBeVisible();
   });
 });

--- a/e2e/sites.spec.ts
+++ b/e2e/sites.spec.ts
@@ -66,21 +66,25 @@ test.describe("sites CRUD", () => {
     await page.getByLabel("WordPress app password").fill("password-1234");
     await page.getByRole("button", { name: /register site/i }).click();
 
-    await expect(page.getByText(disposableName).first()).toBeVisible();
+    // The modal closes + router.refresh re-renders the list. Wait for
+    // the row to appear before hunting the actions menu — prior impl
+    // used `getByText().first()` which didn't wait on the row locator
+    // itself and raced the `<details>` mount.
+    const row = page.getByRole("row", { name: new RegExp(disposableName) });
+    await expect(row).toBeVisible();
 
     // Open the actions menu on the new row and archive.
-    const row = page.getByRole("row", { name: new RegExp(disposableName) });
-    await row.getByRole("button", { name: /actions for/i }).click();
+    // <summary> elements don't always resolve as role=button across
+    // Playwright versions; use the testid we added on the summary.
+    await row.getByTestId("site-actions-summary").click();
 
     // Browser confirm() auto-accept.
     page.once("dialog", (dialog) => {
       void dialog.accept();
     });
-    await row.getByRole("button", { name: /^archive$/i }).click();
+    await row.getByTestId("site-archive-action").click();
 
     // After router.refresh the row should be gone.
-    await expect(
-      page.getByRole("row", { name: new RegExp(disposableName) }),
-    ).toHaveCount(0);
+    await expect(row).toHaveCount(0);
   });
 });

--- a/e2e/users.spec.ts
+++ b/e2e/users.spec.ts
@@ -15,8 +15,14 @@ test.describe("users admin surface", () => {
     await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
     await auditA11y(page, testInfo);
 
-    // The seeded admin row is present.
-    await expect(page.getByText(E2E_ADMIN_EMAIL)).toBeVisible();
+    // The seeded admin row is present. getByText would be a strict-mode
+    // violation because the admin email also renders in the header
+    // chrome's admin-user-email span. Scope the assertion to the users
+    // table row instead.
+    const selfRow = page.getByRole("row", {
+      name: new RegExp(E2E_ADMIN_EMAIL),
+    });
+    await expect(selfRow).toBeVisible();
 
     // Invite button opens the modal (M2d-3 shipped the backend + UI).
     await page.getByRole("button", { name: /invite user/i }).click();


### PR DESCRIPTION
**⚠️ DO NOT MERGE** — opened per Steven's request for review before merge. Per-session instructions: \"open a separate PR fixing the three pre-existing E2E flakes… Do not merge — escalate for my review.\"

Fixes three E2E specs that have been red on main since M4-7 / M5-2. None are required checks, so each milestone has squash-merged over them. Tracked in `docs/BACKLOG.md → Testing → Investigate pre-existing E2E failures on main`.

## What lands

- `components/SiteActionsMenu.tsx` — added `data-testid="site-actions-summary"` to the `<summary>` and `data-testid="site-archive-action"` to the Archive button. No behaviour change.
- `e2e/sites.spec.ts` — archive flow now waits on the row locator itself before drilling into the actions menu; uses the new testids instead of `getByRole("button", { name: /actions for/i })`.
- `e2e/users.spec.ts` — admin-email assertion scoped to the users table row (strict-mode violation came from the admin-user-email header span matching the same text).
- `e2e/images.spec.ts` — post-edit caption assertion scoped to `image-detail-fields` (strict-mode violation came from the Breadcrumbs current-crumb added in M5-2 also rendering the truncated caption).

No lib/ or app/ logic changes. Diff is entirely locator narrowing + two new testids.

## Why these were failing

1. **`sites.spec.ts:73`.** `<summary>` elements have implicit ARIA role "disclosure triangle" in some a11y-tree implementations and "button" in others. Playwright couldn't consistently resolve `getByRole("button", { name: /actions for/i })` against the `<summary aria-label="Actions for {name}">`. The row locator was also racing the `<details>` mount. The test was also flaky before M4-7 but a prior session cleaned up the admin-sites shape just before M4-7 landed and exposed the latent flake.

2. **`users.spec.ts:19`.** `getByText('playwright-admin@opollo.test')` has always matched two elements: the `admin-user-email` header span (landed in M2c) and the users table cell (landed in M2d-1). Under Playwright's strict mode this is a violation. Worked briefly in early M2d because the header span was only rendered after hydration, so the text was single-match in the initial paint — a later refactor moved the email into the SSR output.

3. **`images.spec.ts:243`.** M5-2 introduced Breadcrumbs on the image detail page, rendering the caption (truncated to 60 chars) as the current crumb. The M5-3 edit-flow test asserts `getByText(newCaption)` afterwards, which now matches both the breadcrumb AND the detail-fields dd. Strict mode correctly rejects.

## Why open for review rather than auto-merge

Steven's instruction: \"Do not merge — escalate for my review. Continue M7-4/M7-5 on the fixed baseline.\"

M7-4/M7-5 branches will be cut from main, not from this branch — so the three failures will continue to appear in those PRs' CI until this is reviewed + merged. That's acceptable per the prior six M5/M6 merges; E2E is not a required check.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test:e2e` — run in CI. Expected: the three previously-failing specs pass; no regressions elsewhere.

## After merge

- Strike through the BACKLOG entry \"Investigate pre-existing E2E failures on main\" — the fix this entry tracked is shipped here.
- Future M7-4/M7-5 PRs land on top of this and see clean E2E baselines.