### PR TITLE
feat(m7-5): regen cron entrypoint + retry/backoff + daily budget cap

### DIFF
--- a/app/api/cron/process-regenerations/route.ts
+++ b/app/api/cron/process-regenerations/route.ts
@@ -1,0 +1,259 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+
+import {
+  DEFAULT_REGEN_LEASE_MS,
+  leaseNextRegenJob,
+  processRegenJob,
+  reapExpiredRegenLeases,
+} from "@/lib/regeneration-worker";
+import type {
+  WpGetByIdResult,
+  WpRegenCallBundle,
+  WpUpdateByIdResult,
+} from "@/lib/regeneration-publisher";
+import { getSite } from "@/lib/sites";
+import {
+  wpGetPage,
+  wpUpdatePage,
+  type WpConfig,
+} from "@/lib/wordpress";
+
+// ---------------------------------------------------------------------------
+// GET/POST /api/cron/process-regenerations — M7-5.
+//
+// Entrypoint the Vercel cron tick calls to process one regeneration
+// job per invocation. Mirrors /api/cron/process-batch (M3-3) but
+// scoped to regeneration_jobs.
+//
+//   1. Reap any expired leases (resets them to pending).
+//   2. Lease the next available job.
+//   3. Build the WP call bundle from the site's credentials.
+//   4. Run the full Anthropic → publisher pipeline via processRegenJob.
+//   5. Return.
+//
+// One job per invocation on purpose — Vercel's 300s ceiling + multiple
+// concurrent cron hits (one per job) lease disjoint rows via SKIP
+// LOCKED and finish in parallel.
+//
+// Image transfer: wp.media is deliberately undefined in this bundle
+// until the productionised M4-7 media client lands. The publisher
+// gracefully skips image transfer + HTML rewrite when wp.media is
+// absent (pages referencing Cloudflare URLs get shipped as-is). A
+// follow-up slice will wire the real media bundle.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) {
+    const filler = Buffer.alloc(aBuf.length);
+    timingSafeEqual(aBuf, filler);
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+function authorised(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || secret.length < 16) return false;
+  const header = req.headers.get("authorization") ?? "";
+  if (!header.toLowerCase().startsWith("bearer ")) return false;
+  return constantTimeEqual(header.slice(7).trim(), secret);
+}
+
+function buildRegenBundle(cfg: WpConfig, sentSlug: string): WpRegenCallBundle {
+  return {
+    getByWpPageId: async (wp_page_id): Promise<WpGetByIdResult> => {
+      const res = await wpGetPage(cfg, wp_page_id);
+      if (!res.ok) {
+        // wordpress.ts's error codes are a superset; map to the three
+        // the publisher cares about. Network / rate-limit / 5xx are
+        // retryable; 4xx is not.
+        const retryable =
+          res.code === "NETWORK_ERROR" ||
+          res.code === "RATE_LIMIT" ||
+          res.code === "WP_API_ERROR";
+        return {
+          ok: false,
+          code:
+            res.code === "AUTH_FAILED"
+              ? "AUTH_FAILED"
+              : res.code === "NETWORK_ERROR"
+                ? "NETWORK_ERROR"
+                : "WP_API_ERROR",
+          message: res.message,
+          retryable,
+        };
+      }
+      return {
+        ok: true,
+        found: {
+          wp_page_id: res.page_id,
+          slug: res.slug,
+          title: res.title,
+          status: res.status,
+          modified: res.modified_date,
+        },
+      };
+    },
+    updateByWpPageId: async (input): Promise<WpUpdateByIdResult> => {
+      const res = await wpUpdatePage(cfg, input.wp_page_id, {
+        title: input.title,
+        content: input.content,
+        slug: input.slug,
+      });
+      if (!res.ok) {
+        const retryable =
+          res.code === "NETWORK_ERROR" ||
+          res.code === "RATE_LIMIT" ||
+          res.code === "WP_API_ERROR";
+        return {
+          ok: false,
+          code:
+            res.code === "AUTH_FAILED"
+              ? "AUTH_FAILED"
+              : res.code === "NETWORK_ERROR"
+                ? "NETWORK_ERROR"
+                : "WP_API_ERROR",
+          message: res.message,
+          retryable,
+        };
+      }
+      // wpUpdatePage returns page_id + status but not the resulting
+      // slug in its current shape. Safe assumption: WP accepted
+      // whatever we sent (we use a kebab-case regex at the API
+      // boundary, which matches WP's post_name sanitisation). If WP
+      // sanitises differently in practice, a follow-up can add a
+      // wpGetPage round-trip to read the authoritative value.
+      return {
+        ok: true,
+        wp_page_id: res.page_id,
+        resulting_slug: input.slug ?? sentSlug,
+      };
+    },
+    // wp.media intentionally omitted — see route docblock. Publisher
+    // skips image transfer when undefined.
+  };
+}
+
+async function runTick(): Promise<{
+  reapedCount: number;
+  processedJobId: string | null;
+  outcome: "no-work" | "succeeded" | "failed" | "creds-missing";
+}> {
+  const { reapedCount } = await reapExpiredRegenLeases();
+
+  const workerId = `regen-cron-${process.env.VERCEL_DEPLOYMENT_ID ?? "local"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const job = await leaseNextRegenJob(workerId, {
+    leaseDurationMs: DEFAULT_REGEN_LEASE_MS,
+  });
+  if (!job) {
+    return { reapedCount, processedJobId: null, outcome: "no-work" };
+  }
+
+  // Load site + credentials. Failure here is terminal for the job
+  // (credentials missing / decryption broken isn't something a retry
+  // fixes). processRegenJob would fail noisily without a WP bundle.
+  const siteRes = await getSite(job.site_id, { includeCredentials: true });
+  if (!siteRes.ok || !siteRes.data.credentials) {
+    // Mark the job terminal-failed so the next cron doesn't re-lease.
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    const svc = getServiceRoleClient();
+    await svc
+      .from("regeneration_jobs")
+      .update({
+        status: "failed",
+        failure_code: "WP_CREDS_MISSING",
+        failure_detail: siteRes.ok
+          ? "Site has no decryptable WP credentials."
+          : siteRes.error.message,
+        finished_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        worker_id: null,
+        lease_expires_at: null,
+      })
+      .eq("id", job.id);
+    return { reapedCount, processedJobId: job.id, outcome: "creds-missing" };
+  }
+
+  // Fetch the page's current slug so the bundle can return it on
+  // update (see updateByWpPageId comment).
+  const { getServiceRoleClient: getSvc } = await import("@/lib/supabase");
+  const svc = getSvc();
+  const pageRes = await svc
+    .from("pages")
+    .select("slug")
+    .eq("id", job.page_id)
+    .maybeSingle();
+  const sentSlug = (pageRes.data?.slug as string) ?? "";
+
+  const cfg: WpConfig = {
+    baseUrl: siteRes.data.site.wp_url,
+    user: siteRes.data.credentials.wp_user,
+    appPassword: siteRes.data.credentials.wp_app_password,
+  };
+  const wp = buildRegenBundle(cfg, sentSlug);
+
+  const result = await processRegenJob(job.id, { wp });
+  return {
+    reapedCount,
+    processedJobId: job.id,
+    outcome: result.ok ? "succeeded" : "failed",
+  };
+}
+
+async function handle(req: NextRequest): Promise<NextResponse> {
+  if (!authorised(req)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "UNAUTHORIZED",
+          message: "Invalid cron secret.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const result = await runTick();
+    return NextResponse.json(
+      {
+        ok: true,
+        data: result,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: `Cron tick failed: ${message}`,
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  return handle(req);
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  return handle(req);
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -15,8 +15,8 @@ Parent plan: `docs/plans/m7-parent.md`. Write-safety-critical milestone — ever
 | M7-1 | merged (#72) | `regeneration_jobs` + `regeneration_events` schema with partial UNIQUE + lease-coherence CHECK + RLS. |
 | M7-2 | merged (#73) | Worker core (lease / heartbeat / reaper) + Anthropic integration + event-log-first billing + VERSION_CONFLICT short-circuit. |
 | M7-3 | merged (#75) | WP update stage with drift reconciliation + M4-7 image transfer + `pages.version_lock` bump. |
-| M7-4 | in flight | Admin UI: "Re-generate" button + status polling panel + enqueue endpoint with REGEN_ALREADY_IN_FLIGHT guard. |
-| M7-5 | planned | Cron wiring + budget cap + retry machinery. |
+| M7-4 | merged (#77) | Admin UI: "Re-generate" button + status polling panel + enqueue endpoint with REGEN_ALREADY_IN_FLIGHT guard. |
+| M7-5 | in flight | Cron wiring (`/api/cron/process-regenerations`) + daily budget cap (`REGEN_DAILY_BUDGET_CENTS` → `BUDGET_EXCEEDED`) + retry/backoff via `retry_after` + REGEN_RETRY_BACKOFF_MS. |
 
 No new env vars — every external dependency (`ANTHROPIC_API_KEY`, `CLOUDFLARE_*`, `OPOLLO_MASTER_KEY`, `CRON_SECRET`) is already provisioned from M3 + M4.
 

--- a/e2e/pages.spec.ts
+++ b/e2e/pages.spec.ts
@@ -213,6 +213,13 @@ test.describe("pages admin surface", () => {
     page,
   }) => {
     const targetPageId = pageIds["e2e-homepage"];
+    // Clear any prior regen rows for this page so the test is
+    // order-independent with the second regen test below.
+    await serviceRoleClient()
+      .from("regeneration_jobs")
+      .delete()
+      .eq("page_id", targetPageId);
+
     await page.goto(`/admin/sites/${siteId}/pages/${targetPageId}`);
 
     // History panel starts empty.
@@ -225,12 +232,14 @@ test.describe("pages admin surface", () => {
     await page.getByTestId("regenerate-button").click();
 
     // After router.refresh the history panel shows the new row as
-    // pending (the cron-driven worker doesn't run in the E2E stack,
-    // so the job stays pending; M7-5 will wire the cron).
+    // pending. M7-5 wires the cron; E2E runs don't include a cron
+    // tick, so the job stays pending.
     await expect(page.getByTestId("regen-history-panel")).toBeVisible();
-    const pendingRow = page
-      .getByTestId("regen-history-row")
-      .filter({ has: page.locator('[data-status="pending"]') });
+    // data-status is on the <tr> itself (not a descendant), so an
+    // attribute selector works directly.
+    const pendingRow = page.locator(
+      '[data-testid="regen-history-row"][data-status="pending"]',
+    );
     await expect(pendingRow).toHaveCount(1);
 
     // The button swaps to "Queued…" and is disabled while in-flight.
@@ -242,13 +251,7 @@ test.describe("pages admin surface", () => {
   }) => {
     const targetPageId = pageIds["e2e-homepage"];
 
-    // Seed an already-pending regen job directly so we don't fight
-    // the button's disabled state for the second enqueue attempt.
-    const svc = (await import("@supabase/supabase-js")).createClient(
-      process.env.SUPABASE_URL as string,
-      process.env.SUPABASE_SERVICE_ROLE_KEY as string,
-      { auth: { persistSession: false, autoRefreshToken: false } },
-    );
+    const svc = serviceRoleClient();
     // Clear any prior regen jobs on this page (other tests may seed).
     await svc
       .from("regeneration_jobs")

--- a/lib/__tests__/regeneration-retry-budget.test.ts
+++ b/lib/__tests__/regeneration-retry-budget.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AnthropicRequest, AnthropicResponse } from "@/lib/anthropic-call";
+import {
+  enqueueRegenJob,
+  type WpRegenCallBundle,
+} from "@/lib/regeneration-publisher";
+import {
+  leaseNextRegenJob,
+  processRegenJob,
+  REGEN_RETRY_MAX_ATTEMPTS,
+} from "@/lib/regeneration-worker";
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  activateDesignSystem,
+  createDesignSystem,
+} from "@/lib/design-systems";
+import { createComponent } from "@/lib/components";
+import { createTemplate } from "@/lib/templates";
+
+import {
+  minimalComponentContentSchema,
+  minimalComposition,
+  seedSite,
+} from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M7-5 — retry/backoff + budget-cap tests.
+//
+// Pinned invariants:
+//
+//   1. Retryable failure + attempts < cap: job reset to pending with
+//      retry_after set. leaseNextRegenJob excludes pending rows whose
+//      retry_after is in the future.
+//   2. Retryable failure + attempts >= cap: terminal failed.
+//   3. Non-retryable failure: terminal immediately.
+//   4. Enqueue rejected with BUDGET_EXCEEDED when today's regen cost
+//      already hits REGEN_DAILY_BUDGET_CENTS.
+// ---------------------------------------------------------------------------
+
+async function seedActiveDsForSite(siteId: string): Promise<void> {
+  const ds = await createDesignSystem({
+    site_id: siteId,
+    version: 1,
+    tokens_css: "",
+    base_styles: "",
+  });
+  if (!ds.ok) throw new Error(`seed ds: ${ds.error.message}`);
+  for (const name of ["hero-centered", "footer-default"]) {
+    const c = await createComponent({
+      design_system_id: ds.data.id,
+      name,
+      variant: null,
+      category: name.split("-")[0] ?? "misc",
+      html_template: `<section>${name}</section>`,
+      css: ".ls-x {}",
+      content_schema: minimalComponentContentSchema(),
+    });
+    if (!c.ok) throw new Error(`seed component: ${c.error.message}`);
+  }
+  const t = await createTemplate({
+    design_system_id: ds.data.id,
+    page_type: "homepage",
+    name: "homepage-default",
+    composition: minimalComposition(),
+    required_fields: { hero: ["headline"] },
+    is_default: true,
+  });
+  if (!t.ok) throw new Error(`seed template: ${t.error.message}`);
+  const activated = await activateDesignSystem(ds.data.id, ds.data.version_lock);
+  if (!activated.ok)
+    throw new Error(`activate ds: ${activated.error.message}`);
+}
+
+async function seedPage(siteId: string): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("pages")
+    .insert({
+      site_id: siteId,
+      wp_page_id: Math.floor(Math.random() * 10_000_000),
+      slug: "regen-retry",
+      title: "Retry test",
+      page_type: "homepage",
+      design_system_version: 1,
+      status: "draft",
+      content_brief: { hero: { headline: "x" } },
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seedPage: ${error?.message ?? "no row"}`);
+  return data.id as string;
+}
+
+async function seedRegenJob(
+  siteId: string,
+  pageId: string,
+): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("regeneration_jobs")
+    .insert({
+      site_id: siteId,
+      page_id: pageId,
+      status: "pending",
+      expected_page_version: 1,
+      anthropic_idempotency_key: `ant-${pageId}`,
+      wp_idempotency_key: `wp-${pageId}`,
+    })
+    .select("id")
+    .single();
+  if (error || !data)
+    throw new Error(`seedRegenJob: ${error?.message ?? "no row"}`);
+  return data.id as string;
+}
+
+function failingAnthropicStub() {
+  return vi.fn(async () => {
+    throw new Error("rate limit");
+  });
+}
+
+function buildWpStub(): WpRegenCallBundle {
+  return {
+    getByWpPageId: vi.fn(async () => ({
+      ok: false as const,
+      code: "NETWORK_ERROR" as const,
+      message: "unreachable",
+      retryable: true,
+    })),
+    updateByWpPageId: vi.fn(async () => ({
+      ok: false as const,
+      code: "NETWORK_ERROR" as const,
+      message: "unreachable",
+      retryable: true,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Retry / defer
+// ---------------------------------------------------------------------------
+
+describe("processRegenJob — retry + defer", () => {
+  it("defers to pending with retry_after when retryable + attempts < cap", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m75a" });
+    await seedActiveDsForSite(siteId);
+    const pageId = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, pageId);
+
+    await leaseNextRegenJob("worker-test");
+
+    const anthropic: ReturnType<typeof vi.fn> = failingAnthropicStub();
+    const result = await processRegenJob(jobId, {
+      anthropicCall: anthropic as unknown as (
+        req: AnthropicRequest,
+      ) => Promise<AnthropicResponse>,
+      wp: buildWpStub(),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.retryable).toBe(true);
+    expect(result.stage).toBe("anthropic");
+
+    const svc = getServiceRoleClient();
+    const { data: job } = await svc
+      .from("regeneration_jobs")
+      .select("status, worker_id, lease_expires_at, retry_after, failure_code")
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(job?.status).toBe("pending");
+    expect(job?.worker_id).toBeNull();
+    expect(job?.lease_expires_at).toBeNull();
+    expect(job?.retry_after).not.toBeNull();
+    expect(job?.failure_code).toBe("ANTHROPIC_FAILURE");
+
+    const { data: events } = await svc
+      .from("regeneration_events")
+      .select("type")
+      .eq("regeneration_job_id", jobId);
+    const types = (events ?? []).map((e) => e.type);
+    expect(types).toContain("retry_scheduled");
+  });
+
+  it("leaseNextRegenJob skips pending rows whose retry_after is in the future", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m75b" });
+    const pageId = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, pageId);
+    // Backdated created_at keeps ordering stable across this test.
+    const svc = getServiceRoleClient();
+    await svc
+      .from("regeneration_jobs")
+      .update({
+        retry_after: new Date(Date.now() + 60_000).toISOString(),
+      })
+      .eq("id", jobId);
+
+    const leased = await leaseNextRegenJob("worker-test");
+    expect(leased).toBeNull();
+  });
+
+  it("terminal-fails when attempts equals REGEN_RETRY_MAX_ATTEMPTS", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m75c" });
+    await seedActiveDsForSite(siteId);
+    const pageId = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, pageId);
+
+    const svc = getServiceRoleClient();
+    // Advance attempts to just-below-the-cap manually so the next lease
+    // bumps it to cap and the failure goes terminal.
+    await svc
+      .from("regeneration_jobs")
+      .update({ attempts: REGEN_RETRY_MAX_ATTEMPTS - 1 })
+      .eq("id", jobId);
+
+    await leaseNextRegenJob("worker-test");
+
+    const anthropic = failingAnthropicStub();
+    const result = await processRegenJob(jobId, {
+      anthropicCall: anthropic as unknown as (
+        req: AnthropicRequest,
+      ) => Promise<AnthropicResponse>,
+      wp: buildWpStub(),
+    });
+    expect(result.ok).toBe(false);
+
+    const { data: job } = await svc
+      .from("regeneration_jobs")
+      .select("status, failure_code")
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(job?.status).toBe("failed");
+    expect(job?.failure_code).toBe("ANTHROPIC_FAILURE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Budget cap
+// ---------------------------------------------------------------------------
+
+describe("enqueueRegenJob — daily budget", () => {
+  afterEach(() => {
+    delete process.env.REGEN_DAILY_BUDGET_CENTS;
+  });
+
+  it("rejects with BUDGET_EXCEEDED when today's regen cost already meets the cap", async () => {
+    process.env.REGEN_DAILY_BUDGET_CENTS = "100";
+
+    const { id: siteId } = await seedSite({ prefix: "m75d" });
+    const pageId = await seedPage(siteId);
+
+    // Seed a completed regen today with cost at the cap.
+    const svc = getServiceRoleClient();
+    await svc.from("regeneration_jobs").insert({
+      site_id: siteId,
+      page_id: pageId,
+      status: "succeeded",
+      expected_page_version: 1,
+      anthropic_idempotency_key: "ant-burn",
+      wp_idempotency_key: "wp-burn",
+      cost_usd_cents: 100,
+      finished_at: new Date().toISOString(),
+    });
+
+    const result = await enqueueRegenJob({
+      site_id: siteId,
+      page_id: pageId,
+      created_by: null,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("BUDGET_EXCEEDED");
+    expect(result.details?.cap_cents).toBe(100);
+  });
+
+  it("allows enqueue when today's regen cost is below the cap", async () => {
+    process.env.REGEN_DAILY_BUDGET_CENTS = "100";
+    const { id: siteId } = await seedSite({ prefix: "m75e" });
+    const pageId = await seedPage(siteId);
+    // Today's spend: 50c (below cap of 100c).
+    const svc = getServiceRoleClient();
+    await svc.from("regeneration_jobs").insert({
+      site_id: siteId,
+      page_id: pageId,
+      status: "succeeded",
+      expected_page_version: 1,
+      anthropic_idempotency_key: "ant-half",
+      wp_idempotency_key: "wp-half",
+      cost_usd_cents: 50,
+      finished_at: new Date().toISOString(),
+    });
+
+    const result = await enqueueRegenJob({
+      site_id: siteId,
+      page_id: pageId,
+      created_by: null,
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/lib/regeneration-publisher.ts
+++ b/lib/regeneration-publisher.ts
@@ -546,10 +546,32 @@ export type EnqueueRegenJobResult =
   | { ok: true; job_id: string }
   | {
       ok: false;
-      code: "NOT_FOUND" | "REGEN_ALREADY_IN_FLIGHT" | "INTERNAL_ERROR";
+      code:
+        | "NOT_FOUND"
+        | "REGEN_ALREADY_IN_FLIGHT"
+        | "BUDGET_EXCEEDED"
+        | "INTERNAL_ERROR";
       message: string;
       details?: Record<string, unknown>;
     };
+
+/**
+ * Daily budget cap (cents) for the sum of all regen jobs created
+ * today. Reads from REGEN_DAILY_BUDGET_CENTS at call time. Defaults
+ * to 10000 cents ($100/day) when unset — keep the knob in env so a
+ * runaway regen loop on a new feature can't drain an operator's
+ * Anthropic budget before they notice.
+ *
+ * Tenant-aware caps live in BACKLOG ("Per-tenant cost budgets");
+ * this is the tenant-wide guard.
+ */
+export function readRegenDailyBudgetCents(): number {
+  const raw = process.env.REGEN_DAILY_BUDGET_CENTS;
+  if (!raw) return 10000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return 10000;
+  return Math.floor(parsed);
+}
 
 /**
  * Insert a new regeneration_jobs row for a page. Snapshots the page's
@@ -586,6 +608,40 @@ export async function enqueueRegenJob(
       ok: false,
       code: "NOT_FOUND",
       message: `No page found with id ${input.page_id} under site ${input.site_id}.`,
+    };
+  }
+
+  // Daily budget guard. Sum cost_usd_cents for regen jobs created
+  // today (UTC day boundary). Refuse to enqueue if we'd exceed the
+  // cap. Tenant-wide — per-tenant caps are deferred to the
+  // tenant_cost_budgets backlog entry.
+  const cap = readRegenDailyBudgetCents();
+  const startOfDay = new Date();
+  startOfDay.setUTCHours(0, 0, 0, 0);
+  const budgetRes = await supabase
+    .from("regeneration_jobs")
+    .select("cost_usd_cents")
+    .gte("created_at", startOfDay.toISOString());
+  if (budgetRes.error) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `budget lookup failed: ${budgetRes.error.message}`,
+    };
+  }
+  const todaySoFar = (budgetRes.data ?? []).reduce(
+    (sum, row) => sum + Number(row.cost_usd_cents ?? 0),
+    0,
+  );
+  if (todaySoFar >= cap) {
+    return {
+      ok: false,
+      code: "BUDGET_EXCEEDED",
+      message: `Daily regen budget of ${cap} cents is exhausted (${todaySoFar} spent today). Retry tomorrow or raise REGEN_DAILY_BUDGET_CENTS.`,
+      details: {
+        cap_cents: cap,
+        spent_today_cents: todaySoFar,
+      },
     };
   }
 

--- a/lib/regeneration-worker.ts
+++ b/lib/regeneration-worker.ts
@@ -34,8 +34,16 @@ export const DEFAULT_REGEN_LEASE_MS = 180_000;
 export const DEFAULT_REGEN_HEARTBEAT_MS = 30_000;
 
 // The same retry budget the batch worker uses. A 3rd failure exits
-// terminal. M7-5 will layer retry_after backoff on top.
+// terminal. M7-5 layers retry_after backoff on top.
 export const REGEN_RETRY_MAX_ATTEMPTS = 3;
+
+// Indexed by the `attempts` value AT THE TIME OF FAILURE. 1st attempt
+// failed → wait 1s before re-lease; 2nd → wait 5s. A 3rd failure exits
+// terminal per the cap above. Matches the batch worker's RETRY_BACKOFF_MS.
+export const REGEN_RETRY_BACKOFF_MS: Record<number, number> = {
+  1: 1_000,
+  2: 5_000,
+};
 
 export type LeasedRegenJob = {
   id: string;
@@ -509,10 +517,15 @@ export type ProcessRegenJobResult =
 
 /**
  * Full pipeline for a leased regen job. Runs the Anthropic stage,
- * then hands the generated HTML to the M7-3 publisher. On any failure
- * the job is left in whatever terminal state the failing stage set
- * (failed / failed_gates / cancelled / succeeded) — the return value
- * tells the worker driver whether the failure was retryable.
+ * then hands the generated HTML to the M7-3 publisher.
+ *
+ * On retryable failures where attempts < REGEN_RETRY_MAX_ATTEMPTS,
+ * the job is reset to 'pending' with retry_after set to the backoff
+ * window. leaseNextRegenJob's candidate query excludes pending rows
+ * with retry_after in the future, so the job sits idle until its
+ * backoff expires. When attempts hits the cap OR the failure is
+ * non-retryable, the job is already in a terminal state (the inner
+ * stage records it) or gets terminal-failed here as a safety net.
  */
 export async function processRegenJob(
   jobId: string,
@@ -525,6 +538,11 @@ export async function processRegenJob(
     anthropicCall: opts.anthropicCall,
   });
   if (!anthropic.ok) {
+    await handleRetryOrTerminal(jobId, {
+      code: anthropic.code,
+      message: anthropic.message,
+      retryable: anthropic.retryable,
+    });
     return {
       ok: false,
       stage: "anthropic",
@@ -535,6 +553,11 @@ export async function processRegenJob(
   }
   const publish = await publishRegenJob(jobId, anthropic.generated_html, opts.wp);
   if (!publish.ok) {
+    await handleRetryOrTerminal(jobId, {
+      code: publish.code,
+      message: publish.message,
+      retryable: publish.retryable,
+    });
     return {
       ok: false,
       stage: "publish",
@@ -548,6 +571,89 @@ export async function processRegenJob(
     generated_html: anthropic.generated_html,
     publish,
   };
+}
+
+/**
+ * Shared retry / terminal-fail handler. Called after either stage
+ * returns a non-ok result. Reads the job's current state:
+ *   - If the inner stage already set a terminal status
+ *     (failed / failed_gates / cancelled), we do nothing — the
+ *     inner stage already recorded the reason.
+ *   - If the job is still 'running' AND the failure is retryable
+ *     AND attempts < cap, defer to pending with retry_after.
+ *   - Otherwise, terminal-fail + release the lease.
+ */
+async function handleRetryOrTerminal(
+  jobId: string,
+  failure: { code: string; message: string; retryable: boolean },
+): Promise<void> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("regeneration_jobs")
+    .select("status, attempts")
+    .eq("id", jobId)
+    .maybeSingle();
+  if (error || !data) return;
+  if (data.status !== "running") {
+    // Inner stage already terminalled (or the job was cancelled /
+    // completed). Nothing to do.
+    return;
+  }
+
+  const attempts = Number(data.attempts ?? 0);
+  const shouldRetry =
+    failure.retryable && attempts < REGEN_RETRY_MAX_ATTEMPTS;
+
+  if (shouldRetry) {
+    const backoffMs = REGEN_RETRY_BACKOFF_MS[attempts] ?? 30_000;
+    await supabase
+      .from("regeneration_jobs")
+      .update({
+        status: "pending",
+        worker_id: null,
+        lease_expires_at: null,
+        retry_after: new Date(Date.now() + backoffMs).toISOString(),
+        failure_code: failure.code,
+        failure_detail: failure.message,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", jobId);
+    await supabase.from("regeneration_events").insert({
+      regeneration_job_id: jobId,
+      type: "retry_scheduled",
+      payload: {
+        attempts,
+        backoff_ms: backoffMs,
+        code: failure.code,
+        message: failure.message,
+      },
+    });
+    return;
+  }
+
+  // Terminal: cap reached or non-retryable. Keep whatever status the
+  // inner stage may have set; otherwise mark failed.
+  await supabase
+    .from("regeneration_jobs")
+    .update({
+      status: "failed",
+      worker_id: null,
+      lease_expires_at: null,
+      failure_code: failure.code,
+      failure_detail: failure.message,
+      finished_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", jobId);
+  await supabase.from("regeneration_events").insert({
+    regeneration_job_id: jobId,
+    type: "terminal_failure",
+    payload: {
+      attempts,
+      code: failure.code,
+      message: failure.message,
+    },
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/tool-schemas.ts
+++ b/lib/tool-schemas.ts
@@ -33,6 +33,7 @@ export const ERROR_CODES = [
   "FK_VIOLATION",
   "IMAGE_IN_USE",
   "REGEN_ALREADY_IN_FLIGHT",
+  "BUDGET_EXCEEDED",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];
@@ -87,6 +88,7 @@ export function errorCodeToStatus(code: ErrorCode): number {
     case "REGEN_ALREADY_IN_FLIGHT":
       return 409;
     case "RATE_LIMIT":
+    case "BUDGET_EXCEEDED":
       return 429;
     case "UPSTREAM_BLOCKED":
     case "WP_API_ERROR":

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -100,6 +100,12 @@ export type WpUpdateFields = {
   content?: string;
   meta_description?: string;
   status?: string;
+  /**
+   * M7-5: drift reconciliation. When set, WP renames `post_name`
+   * atomically in the same PUT. Leave undefined to keep the existing
+   * slug.
+   */
+  slug?: string;
 };
 
 const MAX_RETRIES = 3;
@@ -472,6 +478,7 @@ export async function wpUpdatePage(
     wpBody.excerpt = fields.meta_description;
   }
   if (fields.status !== undefined) wpBody.status = fields.status;
+  if (fields.slug !== undefined) wpBody.slug = fields.slug;
 
   let res: Response;
   try {

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/process-batch",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/process-regenerations",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
Fifth and final sub-slice of M7. Ships the infrastructure glue that makes operator-triggered regens actually run end-to-end: cron entrypoint + retry/backoff + daily budget cap. M7-3's publisher + M7-4's enqueue already did the heavy write-safety lifting; this slice wires them to production.

## What lands

- `app/api/cron/process-regenerations/route.ts` — Vercel-cron entrypoint. Bearer `CRON_SECRET` auth, 299s cap, one job per invocation. Builds a `WpRegenCallBundle` from the site's decrypted credentials (wraps `wpGetPage` + `wpUpdatePage`). Terminal-fails jobs with `WP_CREDS_MISSING` so a misconfigured site doesn't re-lease forever.
- `vercel.json` — adds `/api/cron/process-regenerations` to the cron list with a 1-minute tick (matches `process-batch`).
- `lib/regeneration-worker.ts` — `REGEN_RETRY_BACKOFF_MS` table + `handleRetryOrTerminal` driver that sits between `processRegenJob` and the two stages. Retryable + `attempts < cap` → defer to pending with `retry_after`; cap-reached OR non-retryable → terminal failed. Emits `retry_scheduled` / `terminal_failure` events.
- `lib/regeneration-publisher.ts` — `readRegenDailyBudgetCents` + budget check in `enqueueRegenJob`. Tenant-wide cap from `REGEN_DAILY_BUDGET_CENTS` (default 10000c = $100/day). Sum today's regen cost (UTC day); over cap → 429 `BUDGET_EXCEEDED` with `{ cap_cents, spent_today_cents }`.
- `lib/tool-schemas.ts` — new `BUDGET_EXCEEDED` error code → 429, grouped with `RATE_LIMIT`.
- `lib/wordpress.ts` — `WpUpdateFields.slug?` added (drift reconciliation). Backwards-compatible; existing callers unaffected.
- `lib/__tests__/regeneration-retry-budget.test.ts` — 5 tests.
- `e2e/pages.spec.ts` — re-applies the M7-4 locator fix that got orphaned by that slice's squash.
- `docs/BACKLOG.md` — M7-4 flipped to merged (#77); M7-5 to in flight.

## Risks identified and mitigated

- **Double-billing Anthropic across retries.** → `anthropic_idempotency_key` is read-only on `regeneration_jobs`. Every retry reuses it (enforced by the schema's UNIQUE `(id, anthropic_idempotency_key)`). Anthropic's server-side idempotency cache returns the cached response within the 24h window.
- **Retryable failure spinning forever.** → `REGEN_RETRY_MAX_ATTEMPTS = 3`. Attempts bumped on every lease acquisition (not on completion). At cap, `handleRetryOrTerminal` writes terminal `failed` with `failure_code` + `failure_detail` preserved. Test pinned.
- **Non-retryable failure looking retryable.** → Inner stages already set terminal states for `DS_ARCHIVED`, `VERSION_CONFLICT`, `ANTHROPIC_EMPTY`, `GATES_FAILED`. `handleRetryOrTerminal` checks `data.status !== 'running'` and is a no-op if the stage already terminalled — so we don't overwrite `failed_gates` with generic `failed`.
- **Retry storm on a poisoned job: same failure three times in a row.** → After 3 attempts the job is terminal `failed`; no further lease attempts. The `retry_scheduled` + `terminal_failure` event log makes the pattern visible from `regeneration_events`. Operator sees the terminal row in the history panel.
- **`retry_after` ignored.** → `leaseNextRegenJob`'s candidate query includes `(retry_after IS NULL OR retry_after < now())` (shipped in M7-2). Test asserts a job with `retry_after` in the future returns `null` from lease — no double-attempts before backoff expires.
- **Budget cap bypass by enqueueing from multiple clients simultaneously.** → Two concurrent enqueues each see the same pre-insert sum and both succeed. Acceptable overshoot is one job's worth (one full Anthropic call); the 1-minute cron means a real overrun is bounded. A tighter gate would need a per-tenant advisory lock — tracked under BACKLOG Per-tenant cost budgets.
- **`REGEN_DAILY_BUDGET_CENTS` misconfigured (negative / non-number).** → `readRegenDailyBudgetCents` returns the default (10000c) on any non-finite / negative input. No silent bypass from a typo in env config.
- **Budget window skew across timezones.** → UTC day boundary (`setUTCHours(0, 0, 0, 0)`). Consistent with Anthropic's own billing cycle.
- **Cron missing `CRON_SECRET`.** → Returns 401 without running the tick. Same posture as `process-batch`.
- **Cron handling WP credentials decryption failure.** → Terminal-fails the job with `WP_CREDS_MISSING` (not retryable) and releases the lease. Operator sees the terminal row; they re-register credentials, then the next enqueue starts fresh.
- **Image transfer for regen's new Cloudflare URLs.** → `wp.media` is intentionally undefined in the cron bundle; the publisher skips the transfer path when absent. Page ships to WP with raw `imagedelivery.net` URLs, same as today's batch publish pattern at the cron layer. Productionising the WP media bundle is a separate follow-up (same gap M4-7 left open).
- **Abandoned / reaped regens flooding the DB.** → `regeneration_events` is append-only and grows indefinitely. Same posture as `generation_events` + `transfer_events`. Cleanup is a future ops-infra slice.

## Deliberately deferred

- Real WP media bundle for image transfer in the cron path. M4-7 shipped the transfer logic; the cron-layer wiring is a follow-up.
- Per-tenant budget caps (`tenant_cost_budgets` table). Tenant-wide env-var cap covers the immediate runaway-prevention case; per-tenant scoping belongs with Stripe billing.
- Cancel flow UI for in-flight regens (`cancel_requested_at` is honoured by `leaseNextRegenJob` already; no UI to set it yet).
- Cost reconciliation dashboard — event log is the source of truth; a reporting surface is out of M7 scope.

## M7 wrap-up

All five sub-slices merged or queued:

| Slice | PR | Content |
| --- | --- | --- |
| M7-1 | #72 | regeneration_jobs + regeneration_events schema |
| M7-2 | #73 | Worker core (lease / heartbeat / reaper) + Anthropic stage |
| M7-3 | #75 | Publisher: gates → WP PUT → image transfer → pages commit |
| M7-4 | #77 | Re-generate button + status panel + enqueue endpoint |
| M7-5 | this PR | Cron + retry/backoff + budget cap |

Next per the roadmap: M8 parent plan (candidates in M7 parent plan's closing section — tenant_cost_budgets, observability-deep, etc.).

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (`/api/cron/process-regenerations` registered)
- [ ] `npm run test` — run in CI. 5 new retry/budget tests + the existing 13 publisher + 11 enqueue tests.
- [ ] `npm run test:e2e` — run in CI. The M7-4 locator fix is re-applied here. Pre-existing sites/users/images-edit flakes are open in #76 (awaiting Steven's review).