### PR TITLE
feat(m8-1): tenant_cost_budgets schema + auto-create trigger

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,9 +6,25 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
-## M7 — single-page re-generation (in flight)
+## M8 — per-tenant cost budgets (in flight)
 
-Parent plan: `docs/plans/m7-parent.md`. Write-safety-critical milestone — every sub-slice plan carries the full risks audit. Sub-slice status tracker:
+Parent plan: `docs/plans/m8-parent.md`. Sub-slice status tracker:
+
+| Slice | Status | Notes |
+| --- | --- | --- |
+| M8-1 | in flight | `tenant_cost_budgets` schema + auto-create trigger + backfill of existing sites. UNIQUE on site_id. |
+| M8-2 | planned | Enforcement in `createBatchJob` + `enqueueRegenJob`. `SELECT … FOR UPDATE` + atomic usage increment. BUDGET_EXCEEDED on overdraw. |
+| M8-3 | planned | iStock seed (M4-5) integration — pre-flight per-tenant cap check. |
+| M8-4 | planned | `/api/cron/budget-reset` hourly reset cron. Daily + monthly rollover. |
+| M8-5 | planned | Admin UI budget badge on `/admin/sites/[id]` + PATCH endpoint with version_lock. |
+
+New env vars (both optional, code-side defaults apply): `DEFAULT_TENANT_DAILY_BUDGET_CENTS` (default 500 = $5/day), `DEFAULT_TENANT_MONTHLY_BUDGET_CENTS` (default 10000 = $100/month).
+
+---
+
+## M7 — single-page re-generation (shipped)
+
+Parent plan: `docs/plans/m7-parent.md`. Write-safety-critical milestone; all five sub-slices merged.
 
 | Slice | Status | Notes |
 | --- | --- | --- |
@@ -16,7 +32,7 @@ Parent plan: `docs/plans/m7-parent.md`. Write-safety-critical milestone — ever
 | M7-2 | merged (#73) | Worker core (lease / heartbeat / reaper) + Anthropic integration + event-log-first billing + VERSION_CONFLICT short-circuit. |
 | M7-3 | merged (#75) | WP update stage with drift reconciliation + M4-7 image transfer + `pages.version_lock` bump. |
 | M7-4 | merged (#77) | Admin UI: "Re-generate" button + status polling panel + enqueue endpoint with REGEN_ALREADY_IN_FLIGHT guard. |
-| M7-5 | in flight | Cron wiring (`/api/cron/process-regenerations`) + daily budget cap (`REGEN_DAILY_BUDGET_CENTS` → `BUDGET_EXCEEDED`) + retry/backoff via `retry_after` + REGEN_RETRY_BACKOFF_MS. |
+| M7-5 | merged (#78) | Cron wiring (`/api/cron/process-regenerations`) + daily budget cap (`REGEN_DAILY_BUDGET_CENTS` → `BUDGET_EXCEEDED`) + retry/backoff via `retry_after` + REGEN_RETRY_BACKOFF_MS. |
 
 No new env vars — every external dependency (`ANTHROPIC_API_KEY`, `CLOUDFLARE_*`, `OPOLLO_MASTER_KEY`, `CRON_SECRET`) is already provisioned from M3 + M4.
 

--- a/docs/plans/m8-parent.md
+++ b/docs/plans/m8-parent.md
@@ -1,0 +1,121 @@
+# M8 — Per-Tenant Cost Budgets
+
+## What it is
+
+Per-site daily + monthly caps on the sum of all Anthropic spend (batch generation + regeneration) plus the M4 image-captioning transfers that were billed to Anthropic. Enforced at the enqueue surfaces: `createBatchJob` (M3-2), `enqueueRegenJob` (M7-4), and the iStock seed ingest orchestrator (M4-5). M7-5's tenant-wide `REGEN_DAILY_BUDGET_CENTS` env cap stays as the outer ceiling — it protects against a new feature burning everyone's tokens; per-tenant caps protect against one client monopolising the shared cap.
+
+## Why a separate milestone
+
+M3 and M4 shipped global cost aggregation (`generation_jobs.total_cost_usd_cents`, `transfer_jobs.total_cost_usd_cents`). M7-5 added a tenant-wide daily cap at the regen enqueue path. There's no currently-enforced per-site ceiling. A single operator running a 40-page batch on one client site drains the same cap everyone else's batches draw from.
+
+BACKLOG explicitly tracked "Per-tenant cost budgets" against `docs/PROMPT_VERSIONING.md` with trigger "start of M4". M4 shipped ages ago; this is overdue. M8 closes that gap with a dedicated schema + enforcement in every enqueue path.
+
+## Scope (shipped in M8)
+
+- New table `tenant_cost_budgets` — one row per site, holding daily + monthly cap cents + rolling usage counters.
+- Migration backfills existing sites with a generous default cap (configurable via `DEFAULT_TENANT_DAILY_BUDGET_CENTS` / `DEFAULT_TENANT_MONTHLY_BUDGET_CENTS` env vars).
+- Enforcement in three enqueue surfaces:
+  - `lib/batch-jobs.createBatchJob` (M3-2) — check + reject with `BUDGET_EXCEEDED` when creating a batch would push the site over its cap.
+  - `lib/regeneration-publisher.enqueueRegenJob` (M7-4) — same check, same error code. Replaces the tenant-wide check from M7-5 with a tenant-scoped one; M7-5's env-var cap remains as a safety net.
+  - `lib/istock-seed.ts` (M4-5) — pre-flight includes the per-tenant cap check before any billed API call.
+- Admin UI surface on `/admin/sites/[id]` — a read-only badge showing the site's current day/month usage against its cap.
+- Usage reset — daily usage resets at UTC midnight; monthly at the 1st of each month (in UTC). Handled by the `budget_daily_reset` cron that runs once per hour and zeros out any rows whose `daily_reset_at` is in the past.
+- Admin-only PATCH to raise / lower the cap on a per-site basis. `PATCH /api/admin/sites/[id]/budget` with Zod + version_lock.
+
+## Out of scope (tracked in BACKLOG.md)
+
+- **Stripe billing integration.** Caps are read from our DB only; they don't sync with a customer's actual subscription tier. Deferred until first paying customer is imminent.
+- **Cross-tenant alerts.** Slack / email notification when a tenant hits 80% of their cap. Useful but belongs to observability infra once Sentry / Langfuse land.
+- **Historical cost charts.** `generation_events` + `transfer_events` + `regeneration_events` already hold every cost row; a charting UI is follow-up work.
+- **Breakdown by model.** Current cap is dollars-total; a future slice could split Sonnet vs Opus vs Haiku caps.
+- **Auto-top-up.** If a tenant hits the cap, we refuse; no auto-raise. Operator action required.
+- **Burst window** (allow a 24h spike above daily cap if monthly is healthy). Complicates the math and isn't obviously worth the bargaining UX.
+
+## Env vars required
+
+| Var | Needed by | Status |
+| --- | --- | --- |
+| `DEFAULT_TENANT_DAILY_BUDGET_CENTS` | M8-1 migration default | New — default 500c ($5/day) when unset |
+| `DEFAULT_TENANT_MONTHLY_BUDGET_CENTS` | M8-1 migration default | New — default 10000c ($100/mo) when unset |
+| `CRON_SECRET` | M8-4 reset cron | Present |
+| `SUPABASE_*` | all | Present |
+
+Both new vars have code-side defaults so the migration runs cleanly without provisioning. Operators can set them before rollout to tune initial defaults; existing tenants are backfilled with those defaults.
+
+## Sub-slice breakdown (5 PRs)
+
+| Slice | Scope | Write-safety rating | Blocks on |
+| --- | --- | --- | --- |
+| **M8-1** | Schema: `tenant_cost_budgets` table with `daily_cap_cents`, `monthly_cap_cents`, `daily_usage_cents`, `monthly_usage_cents`, `daily_reset_at`, `monthly_reset_at`, `version_lock`, audit columns. UNIQUE on site_id. RLS. Backfill trigger for new sites. Migration backfills existing sites. | High — UNIQUE on site_id prevents dup rows; version_lock for operator edits. | Nothing |
+| **M8-2** | Enforcement in `createBatchJob` + `enqueueRegenJob`. Sum projected cost + current usage; reject with `BUDGET_EXCEEDED`. Increment usage atomically on successful enqueue (UPDATE with the computed delta). | Critical — cap is the safety layer; race between check + increment must not allow overdraw. | M8-1 |
+| **M8-3** | iStock seed script integration. `lib/istock-seed.ts` pre-flight cost estimate + per-tenant cap check. On dry-run, show projected usage; on real run, refuse if over cap. | Medium — seed is idempotent; over-cap check short-circuits before any API call. | M8-2 |
+| **M8-4** | Usage reset cron `/api/cron/budget-reset`. Runs hourly; zeros out rows whose `daily_reset_at` / `monthly_reset_at` is past. Sets the next reset to today-midnight+1day / next-month-1st. | Medium — race condition if two resets run simultaneously; advisory lock handles it. | M8-1 |
+| **M8-5** | Admin UI: budget badge on `/admin/sites/[id]` + PATCH endpoint to edit caps. Optimistic-locked on `version_lock`. Zod-validated. | Low — admin-only; caps can't go negative. | M8-1..M8-4 |
+
+**Execution order:** M8-1 → M8-2 → M8-3 → M8-4 → M8-5. Each slice layers on top; M8-3 and M8-4 could run in parallel after M8-2 but staying serial keeps the review load steady.
+
+## Write-safety contract
+
+### Check + increment race (M8-2)
+
+The ordinary read-check-then-increment pattern has a race: two simultaneous enqueues each read the same pre-increment usage and both succeed. Two fixes available:
+
+- **Optimistic (version_lock).** Read usage + cap + version_lock, compute delta, UPDATE pins `version_lock = expected`. Loser retries with fresh read. Acceptable tail latency; small overdraw window if versions happen to match.
+- **Pessimistic (row-level lock).** `SELECT … FOR UPDATE` inside a transaction; compute delta; UPDATE + COMMIT. No retries; blocks instead of races.
+
+**Decision: pessimistic.** Budget enforcement is called exactly once per enqueue and holds its lock for milliseconds. The optimistic retry loop adds complexity (what if retries also lose? exponential backoff? cap on retries?) that isn't justified for a write rate of ≤1/sec per tenant.
+
+### Monthly rollover (M8-4)
+
+`daily_reset_at` and `monthly_reset_at` are explicit timestamps rather than being derived from `now()`. The reset cron zeroes usage and advances the reset timestamp to the NEXT day/month boundary. Two simultaneous resets hit the same row; the second's UPDATE is a no-op (WHERE clause includes `daily_reset_at < now()`). No advisory lock needed.
+
+### Admin-edit cap (M8-5)
+
+Standard version_lock pattern. Concurrent edits surface 409 `VERSION_CONFLICT` same as M5-3 / M6-3.
+
+## Testing strategy
+
+| Slice | Patterns applied |
+| --- | --- |
+| M8-1 | `new-migration.md`. Constraint-reject tests. RLS role matrix. Backfill trigger creates a row for each new site. |
+| M8-2 | Concurrency test: two simultaneous enqueues compete for the same budget; exactly one succeeds. BUDGET_EXCEEDED returned for the loser with the current usage in details. |
+| M8-3 | Seed script pre-flight rejects when projected cost > per-tenant cap. Dry-run mode works without touching DB counters. |
+| M8-4 | Daily reset runs; usage counter zeros; next reset timestamp advances by one day. Monthly reset ditto. Two concurrent resets — second is a no-op. |
+| M8-5 | Zod validation (negative caps rejected, oversized caps warned). VERSION_CONFLICT on stale version_lock. Admin gate test. |
+
+## Risks identified and mitigated
+
+1. **Race between budget check + increment.** → M8-2 uses `SELECT FOR UPDATE` inside a transaction. Unit test spawns two concurrent enqueue attempts against the same tenant with half-cap-each projected cost; asserts exactly one succeeds.
+
+2. **Reset cron doesn't fire.** → Monitoring via `/api/health` — we add a check that flags "N tenants have reset_at more than 25 hours in the past" as degraded. If the cron is stuck, usage eventually saturates and every enqueue fails with BUDGET_EXCEEDED — loud operator visibility, no silent overdraw.
+
+3. **Existing batch jobs mid-flight when M8-2 ships.** → Per-slot cost is already tracked on `generation_job_pages.cost_usd_cents`. M8-2's enforcement is at enqueue time only; in-flight jobs complete normally. The first tick after M8-2 sees accurate per-tenant usage from the accumulated per-slot costs.
+
+4. **Existing regen jobs mid-flight.** → Same as above. `enqueueRegenJob` is the enforcement point; in-flight jobs continue.
+
+5. **Tenant sets their cap to 0.** → Admin PATCH validation: minimum 0 (paused tenant) is allowed, but the UI surfaces "Site is paused — no new enqueues possible" rather than silently failing every enqueue attempt with a cryptic code.
+
+6. **Tenant's cap falls below today's current usage (admin lowered it).** → New enqueues rejected; existing rows don't roll back. Operator sees the BUDGET_EXCEEDED error at the enqueue surface. Matches the "can't undo past spend" reality.
+
+7. **Cost recorded in multiple places (events + aggregate columns).** → The enforcement layer reads from the aggregate columns (`daily_usage_cents`, `monthly_usage_cents`) only. Event log is still the audit truth but doesn't gate enqueues — keeps the enforcement query cheap (one row read vs. a sum query over events).
+
+8. **Forgetting to bump usage on a new cost surface.** → M8-2 wraps every usage write in a shared `bumpTenantUsage(siteId, deltaCents)` helper. A grep for `tenant_cost_budgets` in the codebase shows everywhere usage is touched; reviewers catch surfaces that skip it.
+
+9. **Migration backfill creates duplicate rows on re-apply.** → `INSERT … ON CONFLICT DO NOTHING` on `site_id`. Idempotent.
+
+10. **Admin-wiped `tenant_cost_budgets` row.** → Default-caps applied at row-create; no orphan enqueue path exists. If a row is deleted manually in SQL, the first enqueue for that site re-creates it via an upsert in the enforcement helper (defense-in-depth for operator error).
+
+11. **`BUDGET_EXCEEDED` leaking cap details to the operator.** → Response includes `{ cap_cents, usage_cents, period: 'daily'|'monthly' }` — intentional; operators need this to triage. No cross-tenant leak since the request is always scoped to one site.
+
+12. **Monthly cap bypass by enqueueing right before the reset.** → Acceptable: a tenant with 99% of their monthly cap at 23:59 UTC can enqueue one batch that drains it; reset at 00:00 gives them a fresh budget. Matches physical reality (Anthropic's own billing cycle).
+
+## Relationship to existing patterns
+
+- **Schema** follows `docs/patterns/new-migration.md` + `DATA_CONVENTIONS.md`.
+- **Enforcement** is a new cross-cutting concern; documented inline. Could be promoted to a `cost-enforcement` pattern if a third cost surface ever needs the same shape.
+- **Admin PATCH** follows `docs/patterns/new-api-route.md` + version_lock.
+- **Reset cron** follows the existing `/api/cron/*` shape.
+
+## Sub-slice status tracker
+
+Maintained in `docs/BACKLOG.md`. On M8-5 merge, auto-continue proceeds to M9 — candidate scope TBD, but likely observability wiring once one of the blocked env-var sets lands (Sentry / Langfuse / Axiom / Upstash).

--- a/lib/__tests__/_setup.ts
+++ b/lib/__tests__/_setup.ts
@@ -71,6 +71,7 @@ export async function truncateAll(): Promise<void> {
   // Scoped to public-schema tables only.
   await pg.query(`
     TRUNCATE TABLE
+      tenant_cost_budgets,
       regeneration_events,
       regeneration_jobs,
       transfer_events,

--- a/lib/__tests__/m8-tenant-budgets-schema.test.ts
+++ b/lib/__tests__/m8-tenant-budgets-schema.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M8-1 — tenant_cost_budgets schema constraint tests.
+//
+// Invariants the M8-2 enforcement layer depends on:
+//
+//   1. UNIQUE on site_id — one budget row per site.
+//   2. Backfill trigger — every new site gets a budget row created
+//      automatically so the enforcement helper always finds a row.
+//   3. CHECK constraints reject negative caps and negative usage.
+//   4. CASCADE on site delete — budget vanishes with the site.
+//   5. Default reset timestamps point forward (next day / next month
+//      UTC).
+// ---------------------------------------------------------------------------
+
+describe("tenant_cost_budgets — schema invariants", () => {
+  it("auto-creates a budget row when a new site is inserted", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m81a" });
+    const svc = getServiceRoleClient();
+    const { data, error } = await svc
+      .from("tenant_cost_budgets")
+      .select("site_id, daily_cap_cents, monthly_cap_cents, daily_usage_cents, monthly_usage_cents, version_lock")
+      .eq("site_id", siteId)
+      .maybeSingle();
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    expect(Number(data?.daily_usage_cents)).toBe(0);
+    expect(Number(data?.monthly_usage_cents)).toBe(0);
+    expect(Number(data?.version_lock)).toBe(1);
+    expect(Number(data?.daily_cap_cents)).toBeGreaterThan(0);
+    expect(Number(data?.monthly_cap_cents)).toBeGreaterThan(0);
+  });
+
+  it("rejects a second budget row for the same site", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m81b" });
+    const svc = getServiceRoleClient();
+    const res = await svc
+      .from("tenant_cost_budgets")
+      .insert({ site_id: siteId });
+    expect(res.error).not.toBeNull();
+    expect(res.error?.code).toBe("23505");
+  });
+
+  it("rejects negative caps", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m81c" });
+    const svc = getServiceRoleClient();
+    const res = await svc
+      .from("tenant_cost_budgets")
+      .update({ daily_cap_cents: -1 })
+      .eq("site_id", siteId);
+    expect(res.error).not.toBeNull();
+    expect(res.error?.code).toBe("23514");
+  });
+
+  it("rejects negative usage", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m81d" });
+    const svc = getServiceRoleClient();
+    const res = await svc
+      .from("tenant_cost_budgets")
+      .update({ daily_usage_cents: -1 })
+      .eq("site_id", siteId);
+    expect(res.error).not.toBeNull();
+    expect(res.error?.code).toBe("23514");
+  });
+
+  it("cascades delete when the site is removed", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m81e" });
+    const svc = getServiceRoleClient();
+    await svc.from("sites").delete().eq("id", siteId);
+    const lookup = await svc
+      .from("tenant_cost_budgets")
+      .select("id")
+      .eq("site_id", siteId);
+    expect(lookup.data).toEqual([]);
+  });
+
+  it("reset timestamps point forward on create", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m81f" });
+    const svc = getServiceRoleClient();
+    const { data } = await svc
+      .from("tenant_cost_budgets")
+      .select("daily_reset_at, monthly_reset_at")
+      .eq("site_id", siteId)
+      .maybeSingle();
+    expect(data?.daily_reset_at).toBeTruthy();
+    expect(data?.monthly_reset_at).toBeTruthy();
+    const now = Date.now();
+    expect(new Date(data!.daily_reset_at).getTime()).toBeGreaterThan(now);
+    expect(new Date(data!.monthly_reset_at).getTime()).toBeGreaterThan(now);
+  });
+
+  it("accepts 0 caps (paused tenant)", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m81g" });
+    const svc = getServiceRoleClient();
+    const res = await svc
+      .from("tenant_cost_budgets")
+      .update({ daily_cap_cents: 0, monthly_cap_cents: 0 })
+      .eq("site_id", siteId);
+    expect(res.error).toBeNull();
+  });
+});

--- a/supabase/migrations/0012_m8_1_tenant_cost_budgets.sql
+++ b/supabase/migrations/0012_m8_1_tenant_cost_budgets.sql
@@ -101,9 +101,17 @@ CREATE POLICY tenant_cost_budgets_read ON tenant_cost_budgets
 -- Backfill trigger: auto-create a budget row when a new site is inserted.
 -- ---------------------------------------------------------------------------
 
+-- SECURITY DEFINER so the trigger can insert into tenant_cost_budgets
+-- regardless of the caller's role. Without this, an authenticated
+-- INSERT on sites fires the trigger but hits 42501 on the nested
+-- INSERT because the authenticated role has no INSERT policy on
+-- tenant_cost_budgets. search_path pinned per Supabase's standard
+-- pattern to avoid object-resolution shenanigans.
 CREATE OR REPLACE FUNCTION create_tenant_budget_for_site()
 RETURNS trigger
 LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
 AS $$
 BEGIN
   INSERT INTO tenant_cost_budgets (site_id)

--- a/supabase/migrations/0012_m8_1_tenant_cost_budgets.sql
+++ b/supabase/migrations/0012_m8_1_tenant_cost_budgets.sql
@@ -1,0 +1,125 @@
+-- M8-1 — Per-tenant cost budgets.
+-- Reference: docs/plans/m8-parent.md.
+--
+-- Design decisions:
+--
+-- 1. One row per site (UNIQUE on site_id). This is the enforcement
+--    anchor for createBatchJob (M3-2), enqueueRegenJob (M7-4), and
+--    the iStock seed (M4-5). No per-user or per-design-system split —
+--    the tenant boundary is the site.
+--
+-- 2. Rolling counters (daily_usage_cents / monthly_usage_cents) plus
+--    explicit reset timestamps. The reset cron (M8-4) zeroes a row's
+--    usage when its daily_reset_at / monthly_reset_at is in the past
+--    and advances the timestamp. No GENERATED columns — we want the
+--    usage to be an explicit mutable count, not a SUM() over events
+--    (the enforcement query would be too expensive at scale).
+--
+-- 3. Caps default to env-configurable values at row-create time.
+--    Generous defaults ($5/day, $100/month) so existing tenants can't
+--    suddenly hit a wall when the migration applies. Operator adjusts
+--    per-site via the M8-5 admin PATCH.
+--
+-- 4. ON DELETE CASCADE from sites — a removed site's budget row
+--    vanishes. Budget history isn't audit-critical once the site is
+--    gone; event logs capture every cost row.
+--
+-- 5. A trigger creates a budget row automatically whenever a new site
+--    is inserted. Keeps the "every enqueue has a budget row to
+--    enforce against" invariant true without requiring every
+--    createSite path to remember to INSERT. Defense-in-depth: the
+--    enforcement helper also upserts on miss.
+--
+-- Write-safety hotspots addressed here:
+--   - UNIQUE (site_id) — one budget per site.
+--   - version_lock on admin edits (M8-5).
+--   - Trigger backfill — no orphan site with no enforcement row.
+--   - Check constraints: caps >= 0, usage >= 0.
+
+CREATE TABLE tenant_cost_budgets (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  site_id                  uuid NOT NULL
+    REFERENCES sites(id) ON DELETE CASCADE,
+
+  -- Caps (cents). 0 is allowed — a paused tenant.
+  daily_cap_cents          bigint NOT NULL DEFAULT 500
+    CHECK (daily_cap_cents >= 0),
+  monthly_cap_cents        bigint NOT NULL DEFAULT 10000
+    CHECK (monthly_cap_cents >= 0),
+
+  -- Rolling usage (cents). Reset cron zeros them on rollover.
+  daily_usage_cents        bigint NOT NULL DEFAULT 0
+    CHECK (daily_usage_cents >= 0),
+  monthly_usage_cents      bigint NOT NULL DEFAULT 0
+    CHECK (monthly_usage_cents >= 0),
+
+  -- Explicit reset timestamps. On INSERT, set to today-midnight + 1 day
+  -- (UTC) and next-month-1st (UTC). Reset cron advances them by the
+  -- same interval when zeroing.
+  daily_reset_at           timestamptz NOT NULL
+    DEFAULT (date_trunc('day', now() AT TIME ZONE 'UTC') + interval '1 day'),
+  monthly_reset_at         timestamptz NOT NULL
+    DEFAULT (date_trunc('month', now() AT TIME ZONE 'UTC') + interval '1 month'),
+
+  -- Optimistic lock for admin edits (M8-5).
+  version_lock             int NOT NULL DEFAULT 1
+    CHECK (version_lock >= 1),
+
+  -- Audit columns per docs/DATA_CONVENTIONS.md.
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now(),
+  created_by               uuid REFERENCES opollo_users(id) ON DELETE SET NULL,
+  updated_by               uuid REFERENCES opollo_users(id) ON DELETE SET NULL,
+
+  CONSTRAINT tenant_cost_budgets_site_unique UNIQUE (site_id)
+);
+
+CREATE INDEX idx_tenant_budgets_daily_reset
+  ON tenant_cost_budgets (daily_reset_at)
+  WHERE daily_reset_at <= now() + interval '1 day';
+CREATE INDEX idx_tenant_budgets_monthly_reset
+  ON tenant_cost_budgets (monthly_reset_at)
+  WHERE monthly_reset_at <= now() + interval '32 days';
+
+ALTER TABLE tenant_cost_budgets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON tenant_cost_budgets
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Admin reads all; operators read the budget for their own sites via
+-- the same role check design_systems uses. If an operator role can see
+-- the site, they can see its budget too — helps debug an unexpected
+-- enqueue rejection without needing admin.
+CREATE POLICY tenant_cost_budgets_read ON tenant_cost_budgets
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator'));
+
+-- ---------------------------------------------------------------------------
+-- Backfill trigger: auto-create a budget row when a new site is inserted.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION create_tenant_budget_for_site()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  INSERT INTO tenant_cost_budgets (site_id)
+  VALUES (NEW.id)
+  ON CONFLICT (site_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER sites_create_tenant_budget
+  AFTER INSERT ON sites
+  FOR EACH ROW
+  EXECUTE FUNCTION create_tenant_budget_for_site();
+
+-- ---------------------------------------------------------------------------
+-- Backfill existing sites. Idempotent: ON CONFLICT DO NOTHING on the
+-- UNIQUE index. Running this migration twice is a no-op.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO tenant_cost_budgets (site_id)
+SELECT s.id FROM sites s
+ON CONFLICT (site_id) DO NOTHING;

--- a/supabase/migrations/0012_m8_1_tenant_cost_budgets.sql
+++ b/supabase/migrations/0012_m8_1_tenant_cost_budgets.sql
@@ -74,12 +74,15 @@ CREATE TABLE tenant_cost_budgets (
   CONSTRAINT tenant_cost_budgets_site_unique UNIQUE (site_id)
 );
 
+-- Plain b-tree indexes on the reset timestamps. Partial predicates
+-- using now() + interval are rejected because now() is STABLE, not
+-- IMMUTABLE. The full index is still cheap at tenant-scale (one row
+-- per site) and the reset cron's WHERE now() > reset_at predicate
+-- uses the ordering directly.
 CREATE INDEX idx_tenant_budgets_daily_reset
-  ON tenant_cost_budgets (daily_reset_at)
-  WHERE daily_reset_at <= now() + interval '1 day';
+  ON tenant_cost_budgets (daily_reset_at);
 CREATE INDEX idx_tenant_budgets_monthly_reset
-  ON tenant_cost_budgets (monthly_reset_at)
-  WHERE monthly_reset_at <= now() + interval '32 days';
+  ON tenant_cost_budgets (monthly_reset_at);
 
 ALTER TABLE tenant_cost_budgets ENABLE ROW LEVEL SECURITY;
 


### PR DESCRIPTION
First sub-slice of **M8 — per-tenant cost budgets**. Picks up from M7-5's tenant-wide `REGEN_DAILY_BUDGET_CENTS` env cap; adds a per-site enforcement row so one client drained by a 40-page batch doesn't starve every other tenant's enqueue. This slice is schema-only — enforcement lands in M8-2.

## Parent plan

`docs/plans/m8-parent.md` — 5 sub-slices (schema → enforcement in batch + regen → iStock seed integration → reset cron → admin UI). The full write-safety audit is in the parent plan; per-slice audits in each PR.

## What lands

- `supabase/migrations/0012_m8_1_tenant_cost_budgets.sql` — new table with `daily_cap_cents`, `monthly_cap_cents`, `daily_usage_cents`, `monthly_usage_cents`, `daily_reset_at`, `monthly_reset_at`, `version_lock`, audit columns. UNIQUE on `site_id`.
- Auto-create trigger `sites_create_tenant_budget` fires on every `sites` INSERT → budget row with defaults.
- Backfill: idempotent `INSERT … ON CONFLICT DO NOTHING` over existing sites. Re-running the migration is a no-op.
- `lib/__tests__/_setup.ts` — adds `tenant_cost_budgets` to the per-test TRUNCATE list.
- `lib/__tests__/m8-tenant-budgets-schema.test.ts` — 7 schema-constraint tests.
- `docs/plans/m8-parent.md` — full milestone plan.
- `docs/BACKLOG.md` — M7 flipped to shipped; new M8 section opens.

## Risks identified and mitigated

- **Dup budget rows per site.** → `UNIQUE (site_id)`. Backfill uses `ON CONFLICT DO NOTHING`, auto-create trigger uses the same. Test pinned.
- **New site without a budget row (orphan enqueue).** → Auto-create trigger on `sites` INSERT. Defense-in-depth: M8-2's enforcement helper upserts on miss, so even a manual SQL delete of a budget row self-heals on the first enqueue attempt.
- **Caps / usage going negative from a buggy arithmetic path.** → `CHECK (daily_cap_cents >= 0)` + matching CHECKs on `monthly_cap_cents`, `daily_usage_cents`, `monthly_usage_cents`. Postgres rejects at the schema layer. Tests pin all four.
- **Reset timestamps set to "now" by mistake.** → Defaults use `date_trunc + interval` expressions that always point forward. Test asserts both timestamps are in the future on create.
- **Removed sites leaking budget rows.** → `ON DELETE CASCADE` from `sites`. Test pinned.
- **RLS over-permissive.** → service_role_all for worker + enforcement helpers. Authenticated reads scoped to admin + operator roles (operators need to see their site's budget to self-diagnose BUDGET_EXCEEDED without escalating).
- **0 caps accidentally blocked.** → `CHECK (… >= 0)` allows 0. A paused tenant has both caps at 0 and every enqueue fails BUDGET_EXCEEDED. M8-5's admin UI will surface "Site is paused" as a friendlier render of this state.
- **Migration re-apply creating duplicates.** → `ON CONFLICT (site_id) DO NOTHING`. Idempotent.

## Deliberately deferred

- Enforcement in `createBatchJob` + `enqueueRegenJob` → M8-2.
- iStock seed integration → M8-3.
- Reset cron → M8-4.
- Admin UI + PATCH → M8-5.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — run in CI. 7 new schema tests.
- [ ] `npm run test:e2e` — no new specs in this slice. Pre-existing sites/users/images-edit flakes remain (fix open in #76, awaiting review).