### PR TITLE
feat(m8-2): per-tenant budget enforcement in createBatchJob + enqueueRegenJob

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -12,8 +12,8 @@ Parent plan: `docs/plans/m8-parent.md`. Sub-slice status tracker:
 
 | Slice | Status | Notes |
 | --- | --- | --- |
-| M8-1 | in flight | `tenant_cost_budgets` schema + auto-create trigger + backfill of existing sites. UNIQUE on site_id. |
-| M8-2 | planned | Enforcement in `createBatchJob` + `enqueueRegenJob`. `SELECT … FOR UPDATE` + atomic usage increment. BUDGET_EXCEEDED on overdraw. |
+| M8-1 | merged (#79) | `tenant_cost_budgets` schema + auto-create trigger + backfill of existing sites. UNIQUE on site_id. |
+| M8-2 | in flight | Enforcement in `createBatchJob` + `enqueueRegenJob`. `SELECT … FOR UPDATE` + atomic usage increment via `lib/tenant-budgets.ts`. BUDGET_EXCEEDED on overdraw. |
 | M8-3 | planned | iStock seed (M4-5) integration — pre-flight per-tenant cap check. |
 | M8-4 | planned | `/api/cron/budget-reset` hourly reset cron. Daily + monthly rollover. |
 | M8-5 | planned | Admin UI budget badge on `/admin/sites/[id]` + PATCH endpoint with version_lock. |

--- a/lib/__tests__/_helpers.ts
+++ b/lib/__tests__/_helpers.ts
@@ -23,6 +23,15 @@ export async function seedSite(overrides?: {
   if (error || !data) {
     throw new Error(`seedSite failed: ${error?.message ?? "no data"}`);
   }
+  // M8-2: raise the auto-created tenant_cost_budgets caps to a generous
+  // ceiling so the wider test suite (which seeds batches with many slots)
+  // doesn't trip the 500c/day default the migration ships with. Tests
+  // that specifically exercise the budget layer (m8-*) set their own
+  // caps explicitly.
+  await supabase
+    .from("tenant_cost_budgets")
+    .update({ daily_cap_cents: 100_000_000, monthly_cap_cents: 100_000_000 })
+    .eq("site_id", data.id);
   return { id: data.id as string, prefix: data.prefix as string };
 }
 

--- a/lib/__tests__/m8-tenant-budget-enforcement.test.ts
+++ b/lib/__tests__/m8-tenant-budget-enforcement.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "vitest";
+import { Client } from "pg";
+
+import { createBatchJob } from "@/lib/batch-jobs";
+import { enqueueRegenJob } from "@/lib/regeneration-publisher";
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  PROJECTED_COST_PER_BATCH_SLOT_CENTS,
+  PROJECTED_COST_PER_REGEN_CENTS,
+  reserveBudget,
+} from "@/lib/tenant-budgets";
+import {
+  activateDesignSystem,
+  createDesignSystem,
+} from "@/lib/design-systems";
+import { createComponent } from "@/lib/components";
+import { createTemplate } from "@/lib/templates";
+
+import {
+  minimalComponentContentSchema,
+  minimalComposition,
+  seedSite,
+} from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M8-2 — enforcement tests.
+//
+// Invariants pinned:
+//
+//   1. reserveBudget rejects when projected + current > cap.
+//   2. Concurrency: two sequential FOR UPDATEs on the same tenant
+//      serialise correctly — second reservation sees the first's
+//      increment. (Full goroutine-style race test requires two
+//      simultaneous pg.Clients; we simulate with interleaved calls
+//      to prove the arithmetic + FOR UPDATE is correct.)
+//   3. createBatchJob rejects with BUDGET_EXCEEDED when slots × per-
+//      slot projection would exceed cap; no job row is created.
+//   4. enqueueRegenJob rejects with BUDGET_EXCEEDED + per-tenant
+//      details. Tenant-wide M7-5 env cap remains the outer ceiling.
+// ---------------------------------------------------------------------------
+
+function requireDbUrl(): string {
+  const url = process.env.SUPABASE_DB_URL;
+  if (!url) throw new Error("SUPABASE_DB_URL not set");
+  return url;
+}
+
+async function withClient<T>(fn: (c: Client) => Promise<T>): Promise<T> {
+  const c = new Client({ connectionString: requireDbUrl() });
+  await c.connect();
+  try {
+    return await fn(c);
+  } finally {
+    await c.end();
+  }
+}
+
+async function setCaps(
+  siteId: string,
+  daily: number,
+  monthly: number = daily * 30,
+): Promise<void> {
+  const svc = getServiceRoleClient();
+  const { error } = await svc
+    .from("tenant_cost_budgets")
+    .update({ daily_cap_cents: daily, monthly_cap_cents: monthly })
+    .eq("site_id", siteId);
+  if (error) throw new Error(`setCaps: ${error.message}`);
+}
+
+async function getUsage(siteId: string) {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("tenant_cost_budgets")
+    .select("daily_usage_cents, monthly_usage_cents")
+    .eq("site_id", siteId)
+    .maybeSingle();
+  if (error) throw new Error(`getUsage: ${error.message}`);
+  return {
+    daily: Number(data?.daily_usage_cents ?? 0),
+    monthly: Number(data?.monthly_usage_cents ?? 0),
+  };
+}
+
+async function seedActiveDsAndTemplate(
+  siteId: string,
+): Promise<{ templateId: string }> {
+  const ds = await createDesignSystem({
+    site_id: siteId,
+    version: 1,
+    tokens_css: "",
+    base_styles: "",
+  });
+  if (!ds.ok) throw new Error(`seed ds: ${ds.error.message}`);
+  for (const name of ["hero-centered", "footer-default"]) {
+    const c = await createComponent({
+      design_system_id: ds.data.id,
+      name,
+      variant: null,
+      category: name.split("-")[0] ?? "misc",
+      html_template: `<section>${name}</section>`,
+      css: ".ls-x {}",
+      content_schema: minimalComponentContentSchema(),
+    });
+    if (!c.ok) throw new Error(`seed component: ${c.error.message}`);
+  }
+  const t = await createTemplate({
+    design_system_id: ds.data.id,
+    page_type: "homepage",
+    name: "homepage-default",
+    composition: minimalComposition(),
+    required_fields: { hero: ["headline"] },
+    is_default: true,
+  });
+  if (!t.ok) throw new Error(`seed template: ${t.error.message}`);
+  const activated = await activateDesignSystem(ds.data.id, ds.data.version_lock);
+  if (!activated.ok) throw new Error(`activate: ${activated.error.message}`);
+  return { templateId: t.data.id };
+}
+
+async function seedPage(siteId: string): Promise<string> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("pages")
+    .insert({
+      site_id: siteId,
+      wp_page_id: Math.floor(Math.random() * 10_000_000),
+      slug: "home",
+      title: "Home",
+      page_type: "homepage",
+      design_system_version: 1,
+      status: "draft",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seedPage: ${error?.message ?? "no row"}`);
+  return data.id as string;
+}
+
+// ---------------------------------------------------------------------------
+// reserveBudget direct tests
+// ---------------------------------------------------------------------------
+
+describe("reserveBudget", () => {
+  it("returns ok + increments usage when projected fits", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m82a" });
+    await setCaps(siteId, 1000);
+
+    await withClient(async (c) => {
+      await c.query("BEGIN");
+      const res = await reserveBudget(c, siteId, 100);
+      expect(res.ok).toBe(true);
+      await c.query("COMMIT");
+    });
+
+    const usage = await getUsage(siteId);
+    expect(usage.daily).toBe(100);
+    expect(usage.monthly).toBe(100);
+  });
+
+  it("rejects with BUDGET_EXCEEDED (daily) when projected pushes past daily cap", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m82b" });
+    await setCaps(siteId, 100, 10000);
+
+    await withClient(async (c) => {
+      await c.query("BEGIN");
+      const res = await reserveBudget(c, siteId, 200);
+      expect(res.ok).toBe(false);
+      if (res.ok) return;
+      expect(res.code).toBe("BUDGET_EXCEEDED");
+      expect(res.period).toBe("daily");
+      expect(res.cap_cents).toBe(100);
+      expect(res.usage_cents).toBe(0);
+      expect(res.projected_cents).toBe(200);
+      await c.query("ROLLBACK");
+    });
+
+    const usage = await getUsage(siteId);
+    expect(usage.daily).toBe(0); // rolled back
+  });
+
+  it("rejects with BUDGET_EXCEEDED (monthly) when monthly cap alone would be exceeded", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m82c" });
+    // Daily cap generous; monthly cap is the blocker.
+    await setCaps(siteId, 10000, 100);
+
+    await withClient(async (c) => {
+      await c.query("BEGIN");
+      const res = await reserveBudget(c, siteId, 200);
+      expect(res.ok).toBe(false);
+      if (res.ok) return;
+      expect(res.code).toBe("BUDGET_EXCEEDED");
+      expect(res.period).toBe("monthly");
+      await c.query("ROLLBACK");
+    });
+  });
+
+  it("self-heals by upserting the budget row when it's missing", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m82d" });
+    // Delete the auto-created row to simulate a manual SQL wipe.
+    const svc = getServiceRoleClient();
+    await svc.from("tenant_cost_budgets").delete().eq("site_id", siteId);
+
+    await withClient(async (c) => {
+      await c.query("BEGIN");
+      const res = await reserveBudget(c, siteId, 10);
+      // Default cap is 500 (per M8-1 defaults); 10 fits comfortably.
+      expect(res.ok).toBe(true);
+      await c.query("COMMIT");
+    });
+
+    const usage = await getUsage(siteId);
+    expect(usage.daily).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createBatchJob integration
+// ---------------------------------------------------------------------------
+
+describe("createBatchJob — budget enforcement", () => {
+  it("rejects with BUDGET_EXCEEDED when slots × projection would exceed cap", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m82e" });
+    const { templateId } = await seedActiveDsAndTemplate(siteId);
+    // Cap at 100c; projection is 30c/slot; 5 slots = 150c → over.
+    await setCaps(siteId, 100);
+
+    const result = await createBatchJob({
+      site_id: siteId,
+      template_id: templateId,
+      slots: Array.from({ length: 5 }, () => ({ inputs: { hero: { headline: "x" } } })),
+      idempotency_key: `k-m82e-${Date.now()}`,
+      created_by: null,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("BUDGET_EXCEEDED");
+    expect(result.error.details?.projected_cents).toBe(5 * PROJECTED_COST_PER_BATCH_SLOT_CENTS);
+
+    // No job row created.
+    const svc = getServiceRoleClient();
+    const { data } = await svc
+      .from("generation_jobs")
+      .select("id")
+      .eq("site_id", siteId);
+    expect(data ?? []).toHaveLength(0);
+
+    // Budget usage untouched (transaction rolled back).
+    const usage = await getUsage(siteId);
+    expect(usage.daily).toBe(0);
+  });
+
+  it("enqueues successfully and increments tenant usage when within cap", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m82f" });
+    const { templateId } = await seedActiveDsAndTemplate(siteId);
+    await setCaps(siteId, 10000);
+
+    const result = await createBatchJob({
+      site_id: siteId,
+      template_id: templateId,
+      slots: [{ inputs: { hero: { headline: "x" } } }],
+      idempotency_key: `k-m82f-${Date.now()}`,
+      created_by: null,
+    });
+    expect(result.ok).toBe(true);
+
+    const usage = await getUsage(siteId);
+    expect(usage.daily).toBe(PROJECTED_COST_PER_BATCH_SLOT_CENTS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enqueueRegenJob integration
+// ---------------------------------------------------------------------------
+
+describe("enqueueRegenJob — budget enforcement", () => {
+  it("rejects with BUDGET_EXCEEDED when the per-tenant daily cap is already at the ceiling", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m82g" });
+    const pageId = await seedPage(siteId);
+    // Cap set to exactly the projection so a single regen overfills.
+    await setCaps(siteId, PROJECTED_COST_PER_REGEN_CENTS - 1);
+
+    const res = await enqueueRegenJob({
+      site_id: siteId,
+      page_id: pageId,
+      created_by: null,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.code).toBe("BUDGET_EXCEEDED");
+    expect(res.details?.period).toBe("daily");
+
+    // No regen job row created.
+    const svc = getServiceRoleClient();
+    const { data } = await svc
+      .from("regeneration_jobs")
+      .select("id")
+      .eq("page_id", pageId);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it("enqueues successfully and increments tenant usage when within cap", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m82h" });
+    const pageId = await seedPage(siteId);
+    await setCaps(siteId, 10000);
+
+    const res = await enqueueRegenJob({
+      site_id: siteId,
+      page_id: pageId,
+      created_by: null,
+    });
+    expect(res.ok).toBe(true);
+
+    const usage = await getUsage(siteId);
+    expect(usage.daily).toBe(PROJECTED_COST_PER_REGEN_CENTS);
+  });
+});

--- a/lib/batch-jobs.ts
+++ b/lib/batch-jobs.ts
@@ -2,6 +2,10 @@ import { createHash } from "node:crypto";
 import { Client } from "pg";
 
 import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  PROJECTED_COST_PER_BATCH_SLOT_CENTS,
+  reserveBudget,
+} from "@/lib/tenant-budgets";
 
 // ---------------------------------------------------------------------------
 // M3-2 — Batch-job creation.
@@ -62,6 +66,7 @@ export type CreateBatchError = {
       | "TEMPLATE_NOT_FOUND"
       | "TEMPLATE_NOT_ACTIVE"
       | "IDEMPOTENCY_KEY_CONFLICT"
+      | "BUDGET_EXCEEDED"
       | "INTERNAL_ERROR";
     message: string;
     details?: Record<string, unknown>;
@@ -303,6 +308,31 @@ export async function createBatchJob(
     }
 
     const job_id = insertJob.rows[0]!.id;
+
+    // M8-2 — reserve the projected cost against the tenant's daily +
+    // monthly budget. Runs inside the same transaction as the job
+    // INSERT so a BUDGET_EXCEEDED rolls back the job atomically.
+    // FOR UPDATE inside reserveBudget serialises concurrent enqueues
+    // against the same tenant.
+    const projectedCents =
+      PROJECTED_COST_PER_BATCH_SLOT_CENTS * input.slots.length;
+    const reservation = await reserveBudget(
+      client,
+      input.site_id,
+      projectedCents,
+    );
+    if (!reservation.ok) {
+      await client.query("ROLLBACK");
+      if (reservation.code === "BUDGET_EXCEEDED") {
+        return errorResult("BUDGET_EXCEEDED", reservation.message, {
+          period: reservation.period,
+          cap_cents: reservation.cap_cents,
+          usage_cents: reservation.usage_cents,
+          projected_cents: reservation.projected_cents,
+        });
+      }
+      return errorResult("INTERNAL_ERROR", reservation.message);
+    }
 
     // Bulk-insert slots. anthropic_idempotency_key / wp_idempotency_key
     // are deterministic on (job_id, slot_index) so every retry of the

--- a/lib/regeneration-publisher.ts
+++ b/lib/regeneration-publisher.ts
@@ -1,9 +1,15 @@
+import { Client } from "pg";
+
 import {
   extractCloudflareIds,
   rewriteImageUrls,
 } from "@/lib/html-image-rewrite";
 import { runGates, type RunGatesResult } from "@/lib/quality-gates";
 import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  PROJECTED_COST_PER_REGEN_CENTS,
+  reserveBudget,
+} from "@/lib/tenant-budgets";
 import {
   transferImagesForPage,
   type WpMediaCallBundle,
@@ -583,6 +589,16 @@ export function readRegenDailyBudgetCents(): number {
  * Caller (the POST route) is responsible for the admin gate and UUID
  * validation. This helper assumes well-formed ids.
  */
+function requireDbUrl(): string {
+  const url = process.env.SUPABASE_DB_URL;
+  if (!url) {
+    throw new Error(
+      "SUPABASE_DB_URL is not set. Required by enqueueRegenJob for the budget reservation transaction.",
+    );
+  }
+  return url;
+}
+
 export async function enqueueRegenJob(
   input: EnqueueRegenJobInput,
 ): Promise<EnqueueRegenJobResult> {
@@ -611,10 +627,9 @@ export async function enqueueRegenJob(
     };
   }
 
-  // Daily budget guard. Sum cost_usd_cents for regen jobs created
-  // today (UTC day boundary). Refuse to enqueue if we'd exceed the
-  // cap. Tenant-wide — per-tenant caps are deferred to the
-  // tenant_cost_budgets backlog entry.
+  // Tenant-wide ceiling (M7-5). Kept as the outer guard above the
+  // per-tenant cap — prevents a new feature from draining every
+  // operator's budget when one tenant happens to have a high cap.
   const cap = readRegenDailyBudgetCents();
   const startOfDay = new Date();
   startOfDay.setUTCHours(0, 0, 0, 0);
@@ -641,30 +656,77 @@ export async function enqueueRegenJob(
       details: {
         cap_cents: cap,
         spent_today_cents: todaySoFar,
+        period: "tenant_wide",
       },
     };
   }
 
-  // Deterministic idempotency keys from the (to-be-minted) job id.
-  // Server-side generated so clients can't influence them.
+  // M8-2 — per-tenant cap + atomic insert inside one transaction.
+  // reserveBudget holds SELECT FOR UPDATE on tenant_cost_budgets;
+  // concurrent enqueues against the same tenant serialise. Rollback
+  // on any failure releases the lock without charging the budget.
   const jobId = crypto.randomUUID();
-  const insertRes = await supabase
-    .from("regeneration_jobs")
-    .insert({
-      id: jobId,
-      site_id: input.site_id,
-      page_id: input.page_id,
-      status: "pending",
-      expected_page_version: pageRes.data.version_lock as number,
-      anthropic_idempotency_key: `ant-regen-${jobId}`,
-      wp_idempotency_key: `wp-regen-${jobId}`,
-      created_by: input.created_by ?? null,
-    })
-    .select("id")
-    .single();
+  const client = new Client({ connectionString: requireDbUrl() });
+  await client.connect();
+  try {
+    await client.query("BEGIN");
 
-  if (insertRes.error) {
-    if (insertRes.error.code === "23505") {
+    const reservation = await reserveBudget(
+      client,
+      input.site_id,
+      PROJECTED_COST_PER_REGEN_CENTS,
+    );
+    if (!reservation.ok) {
+      await client.query("ROLLBACK");
+      if (reservation.code === "BUDGET_EXCEEDED") {
+        return {
+          ok: false,
+          code: "BUDGET_EXCEEDED",
+          message: reservation.message,
+          details: {
+            cap_cents: reservation.cap_cents,
+            usage_cents: reservation.usage_cents,
+            projected_cents: reservation.projected_cents,
+            period: reservation.period,
+          },
+        };
+      }
+      return {
+        ok: false,
+        code: "INTERNAL_ERROR",
+        message: reservation.message,
+      };
+    }
+
+    const insertRes = await client.query<{ id: string }>(
+      `
+      INSERT INTO regeneration_jobs
+        (id, site_id, page_id, status, expected_page_version,
+         anthropic_idempotency_key, wp_idempotency_key, created_by)
+      VALUES ($1, $2, $3, 'pending', $4, $5, $6, $7)
+      RETURNING id
+      `,
+      [
+        jobId,
+        input.site_id,
+        input.page_id,
+        pageRes.data.version_lock as number,
+        `ant-regen-${jobId}`,
+        `wp-regen-${jobId}`,
+        input.created_by ?? null,
+      ],
+    );
+
+    await client.query("COMMIT");
+    return { ok: true, job_id: insertRes.rows[0]!.id };
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      // swallow
+    }
+    const pgErr = err as { code?: string; message?: string };
+    if (pgErr.code === "23505") {
       return {
         ok: false,
         code: "REGEN_ALREADY_IN_FLIGHT",
@@ -676,9 +738,9 @@ export async function enqueueRegenJob(
     return {
       ok: false,
       code: "INTERNAL_ERROR",
-      message: `regeneration_jobs insert failed: ${insertRes.error.message}`,
+      message: `regeneration_jobs insert failed: ${pgErr.message ?? String(err)}`,
     };
+  } finally {
+    await client.end();
   }
-
-  return { ok: true, job_id: insertRes.data.id as string };
 }

--- a/lib/tenant-budgets.ts
+++ b/lib/tenant-budgets.ts
@@ -1,0 +1,186 @@
+import { Client } from "pg";
+
+// ---------------------------------------------------------------------------
+// M8-2 — Per-tenant cost budget enforcement.
+//
+// Two entry points:
+//
+//   reserveBudget(siteId, projectedCents, client)
+//     Wraps a SELECT … FOR UPDATE on tenant_cost_budgets + an atomic
+//     increment. If the projected cost would push either the daily or
+//     monthly usage over its cap, returns
+//     { ok: false, code: 'BUDGET_EXCEEDED', period, cap_cents,
+//       usage_cents, projected_cents } and leaves usage untouched.
+//     Otherwise increments and returns { ok: true }.
+//
+//     The FOR UPDATE holds a row lock for the duration of the caller's
+//     transaction — two simultaneous reservations for the same tenant
+//     serialise. No optimistic retry loops needed.
+//
+//   bumpTenantUsage(siteId, deltaCents, client)
+//     Unconditional increment (no cap check). Called from the reset
+//     cron (M8-4) for adjustments; external callers should prefer
+//     reserveBudget. Exported so a future actual-vs-projected swap
+//     has one place to hook in.
+//
+// Both helpers require a pg.Client inside an open transaction; the
+// caller owns BEGIN/COMMIT. The rationale: reservations need to be
+// rolled back if a downstream INSERT (job / slot) fails, so we can't
+// auto-commit inside the helper.
+//
+// Defense-in-depth upsert: reserveBudget does an INSERT … ON CONFLICT
+// DO NOTHING against tenant_cost_budgets before the SELECT, so a site
+// whose budget row was deleted manually in SQL self-heals on the
+// first reserveBudget call.
+// ---------------------------------------------------------------------------
+
+export type ReserveBudgetOk = { ok: true };
+export type ReserveBudgetFail = {
+  ok: false;
+  code: "BUDGET_EXCEEDED" | "INTERNAL_ERROR";
+  period?: "daily" | "monthly";
+  cap_cents?: number;
+  usage_cents?: number;
+  projected_cents?: number;
+  message: string;
+};
+export type ReserveBudgetResult = ReserveBudgetOk | ReserveBudgetFail;
+
+/**
+ * Reserve `projectedCents` of the site's budget. Caller owns the
+ * transaction. Returns BUDGET_EXCEEDED if either daily or monthly cap
+ * would be exceeded.
+ */
+export async function reserveBudget(
+  client: Client,
+  siteId: string,
+  projectedCents: number,
+): Promise<ReserveBudgetResult> {
+  if (projectedCents < 0) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `reserveBudget called with negative projectedCents (${projectedCents}).`,
+    };
+  }
+
+  // Self-heal if the budget row somehow got deleted. Trigger creates
+  // it on site INSERT; this is belt-and-suspenders.
+  await client.query(
+    `
+    INSERT INTO tenant_cost_budgets (site_id)
+    VALUES ($1)
+    ON CONFLICT (site_id) DO NOTHING
+    `,
+    [siteId],
+  );
+
+  const locked = await client.query<{
+    daily_cap_cents: string;
+    monthly_cap_cents: string;
+    daily_usage_cents: string;
+    monthly_usage_cents: string;
+  }>(
+    `
+    SELECT daily_cap_cents, monthly_cap_cents,
+           daily_usage_cents, monthly_usage_cents
+      FROM tenant_cost_budgets
+     WHERE site_id = $1
+     FOR UPDATE
+    `,
+    [siteId],
+  );
+  const row = locked.rows[0];
+  if (!row) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `tenant_cost_budgets row missing for site ${siteId} after upsert.`,
+    };
+  }
+
+  const dailyCap = Number(row.daily_cap_cents);
+  const monthlyCap = Number(row.monthly_cap_cents);
+  const dailyUsage = Number(row.daily_usage_cents);
+  const monthlyUsage = Number(row.monthly_usage_cents);
+
+  if (dailyUsage + projectedCents > dailyCap) {
+    return {
+      ok: false,
+      code: "BUDGET_EXCEEDED",
+      period: "daily",
+      cap_cents: dailyCap,
+      usage_cents: dailyUsage,
+      projected_cents: projectedCents,
+      message: `Daily budget of ${dailyCap} cents would be exceeded: ${dailyUsage} already used + ${projectedCents} projected.`,
+    };
+  }
+  if (monthlyUsage + projectedCents > monthlyCap) {
+    return {
+      ok: false,
+      code: "BUDGET_EXCEEDED",
+      period: "monthly",
+      cap_cents: monthlyCap,
+      usage_cents: monthlyUsage,
+      projected_cents: projectedCents,
+      message: `Monthly budget of ${monthlyCap} cents would be exceeded: ${monthlyUsage} already used + ${projectedCents} projected.`,
+    };
+  }
+
+  await client.query(
+    `
+    UPDATE tenant_cost_budgets
+       SET daily_usage_cents = daily_usage_cents + $2,
+           monthly_usage_cents = monthly_usage_cents + $2,
+           updated_at = now()
+     WHERE site_id = $1
+    `,
+    [siteId, projectedCents],
+  );
+
+  return { ok: true };
+}
+
+/**
+ * Unconditional usage bump. Skips the cap check — used by reset /
+ * reconciliation paths. Callers that are enqueueing billed work
+ * should use reserveBudget instead.
+ */
+export async function bumpTenantUsage(
+  client: Client,
+  siteId: string,
+  deltaCents: number,
+): Promise<void> {
+  await client.query(
+    `
+    INSERT INTO tenant_cost_budgets (site_id, daily_usage_cents, monthly_usage_cents)
+    VALUES ($1, GREATEST(0, $2), GREATEST(0, $2))
+    ON CONFLICT (site_id) DO UPDATE
+      SET daily_usage_cents = GREATEST(0, tenant_cost_budgets.daily_usage_cents + $2),
+          monthly_usage_cents = GREATEST(0, tenant_cost_budgets.monthly_usage_cents + $2),
+          updated_at = now()
+    `,
+    [siteId, deltaCents],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Projection helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Rough cost projection per batch slot. Opus 4.7 at ~8k tokens output
+ * + ~40k input (cached system prompt + per-slot brief) lands at roughly
+ * 30 cents per page. Conservative — actual costs tend to be lower with
+ * the shared system-prompt cache amortising across the batch.
+ *
+ * Exported so M8-3 (iStock seed) can reuse the shared projection for
+ * its own pre-flight budget check.
+ */
+export const PROJECTED_COST_PER_BATCH_SLOT_CENTS = 30;
+
+/**
+ * Rough cost projection per regen. Single-page regen is roughly the
+ * same shape as one batch slot — same prompt, same token budget.
+ */
+export const PROJECTED_COST_PER_REGEN_CENTS = 30;


### PR DESCRIPTION
Second M8 sub-slice. `reserveBudget` is the shared choke point: both enqueue paths now hold `SELECT FOR UPDATE` on `tenant_cost_budgets` inside their existing INSERT transaction. Concurrent enqueues against the same tenant serialise; cap-exceeded returns `BUDGET_EXCEEDED` with structured period/cap/usage/projected details so the UI can render "daily cap reached, resets at midnight UTC" vs "monthly cap reached".

## What lands

- `lib/tenant-budgets.ts` — new: `reserveBudget`, `bumpTenantUsage`, `PROJECTED_COST_PER_{BATCH_SLOT,REGEN}_CENTS` constants.
- `lib/batch-jobs.ts` — `createBatchJob` reserves `slots × projection` inside the existing transaction; new `BUDGET_EXCEEDED` error code.
- `lib/regeneration-publisher.ts` — `enqueueRegenJob` refactored to `pg.Client` transaction so reservation + INSERT are atomic; M7-5's tenant-wide cap preserved as outer ceiling.
- `lib/__tests__/m8-tenant-budget-enforcement.test.ts` — 10 tests.
- `docs/BACKLOG.md` — tracker flip.

## Risks identified and mitigated

- **Check-then-increment race.** → `SELECT FOR UPDATE` inside one transaction serialises concurrent reservations for the same tenant. No optimistic retry loop; no double-spend window. Unit test covers sequential reservations against the same tenant.
- **Dangling reservation on downstream INSERT failure.** → `reserveBudget` is called inside the existing enqueue transaction. Any failure after the reservation (slot INSERT, regen INSERT, 23505 on `regeneration_jobs_one_active_per_page`) rolls back both the job and the reservation atomically.
- **Missing `tenant_cost_budgets` row.** → Self-healing `INSERT … ON CONFLICT DO NOTHING` before the `SELECT FOR UPDATE`. A manually-deleted row is re-created on the first enqueue.
- **Projection drift over time.** → 30¢ per page is conservative for Opus 4.7 with prompt caching. Under-projection risks one operator draining everyone's cap; over-projection risks false-positive BUDGET_EXCEEDED. Actual-vs-projected swap is noted in the parent plan's deferred section.
- **Tenant-wide cap bypass by per-tenant cap being generous.** → M7-5's `REGEN_DAILY_BUDGET_CENTS` env cap stays as the outer ceiling in `enqueueRegenJob`. Per-tenant caps can only make the enqueue stricter, not looser.
- **BUDGET_EXCEEDED leaking cross-tenant data.** → Response details carry only the caller's site's cap + usage + projection. No cross-tenant data in the error envelope.
- **Slot count × projection overflow bigint.** → 100-slot cap × 30¢ = 3000¢. Well under any reasonable cap. Postgres bigint headroom is 9.2 × 10^18. Not a risk.
- **Pg client leak on failure.** → `finally { await client.end() }` guarantees release on every code path.

## Deliberately deferred

- Actual-vs-projected swap on job terminal → future slice. Requires a new `projected_cost_usd_cents` column on both job tables or a swap helper that reads the projection constant and subtracts it.
- iStock seed pre-flight integration → M8-3.
- Reset cron → M8-4.
- Admin UI badge + PATCH → M8-5.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — run in CI.
- [ ] `npm run test:e2e` — no new specs.