### PR TITLE
feat(m8-3): iStock seed — ISTOCK_SEED_CAP_CENTS env ceiling + capSource traceability

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -13,8 +13,8 @@ Parent plan: `docs/plans/m8-parent.md`. Sub-slice status tracker:
 | Slice | Status | Notes |
 | --- | --- | --- |
 | M8-1 | merged (#79) | `tenant_cost_budgets` schema + auto-create trigger + backfill of existing sites. UNIQUE on site_id. |
-| M8-2 | in flight | Enforcement in `createBatchJob` + `enqueueRegenJob`. `SELECT … FOR UPDATE` + atomic usage increment via `lib/tenant-budgets.ts`. BUDGET_EXCEEDED on overdraw. |
-| M8-3 | planned | iStock seed (M4-5) integration — pre-flight per-tenant cap check. |
+| M8-2 | merged (#80) | Enforcement in `createBatchJob` + `enqueueRegenJob`. `SELECT … FOR UPDATE` + atomic usage increment via `lib/tenant-budgets.ts`. BUDGET_EXCEEDED on overdraw. |
+| M8-3 | in flight | iStock seed (M4-5) integration — `ISTOCK_SEED_CAP_CENTS` env ceiling; effective cap = min(caller, env); `capSource` threaded through result + error. Note: per-tenant doesn't apply (ingest is global, tenant-agnostic); env-var cap replaces it. |
 | M8-4 | planned | `/api/cron/budget-reset` hourly reset cron. Daily + monthly rollover. |
 | M8-5 | planned | Admin UI budget badge on `/admin/sites/[id]` + PATCH endpoint with version_lock. |
 

--- a/lib/__tests__/istock-seed.test.ts
+++ b/lib/__tests__/istock-seed.test.ts
@@ -249,13 +249,13 @@ describe("seedIstockLibrary — budget cap", () => {
   it("throws IngestBudgetError when estimate exceeds the cap", async () => {
     const { rows } = parseIstockCsv(VALID_CSV);
     // estimate = 3 cents; cap = 1 cent → should abort.
-    await expect(
-      seedIstockLibrary({
-        rows,
-        jobIdempotencyKey: "budget-abort",
-        budgetCapCents: 1,
-      }),
-    ).rejects.toBeInstanceOf(IngestBudgetError);
+    const err = await seedIstockLibrary({
+      rows,
+      jobIdempotencyKey: "budget-abort",
+      budgetCapCents: 1,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(IngestBudgetError);
+    expect((err as IngestBudgetError).capSource).toBe("caller");
   });
 
   it("auto-cap is DEFAULT_BUDGET_CAP_MULTIPLIER × estimate, floor 2000 cents", async () => {
@@ -269,5 +269,39 @@ describe("seedIstockLibrary — budget cap", () => {
       2000,
     );
     expect(result.budgetCapCents).toBe(expectedCap);
+  });
+
+  it("M8-3: ISTOCK_SEED_CAP_CENTS env var caps above the caller's value", async () => {
+    const { rows } = parseIstockCsv(VALID_CSV);
+    process.env.ISTOCK_SEED_CAP_CENTS = "2";
+    try {
+      const err = await seedIstockLibrary({
+        rows,
+        jobIdempotencyKey: "env-cap",
+        budgetCapCents: 1000,
+      }).catch((e) => e);
+      expect(err).toBeInstanceOf(IngestBudgetError);
+      // Env cap (2c) is lower than caller (1000c) → env wins.
+      expect((err as IngestBudgetError).capSource).toBe("env");
+      expect((err as IngestBudgetError).budgetCapCents).toBe(2);
+    } finally {
+      delete process.env.ISTOCK_SEED_CAP_CENTS;
+    }
+  });
+
+  it("M8-3: default uses min(2× estimate, env cap)", async () => {
+    const { rows } = parseIstockCsv(VALID_CSV);
+    // Env cap generous so default wins.
+    process.env.ISTOCK_SEED_CAP_CENTS = "1000000";
+    try {
+      const result = await seedIstockLibrary({
+        rows,
+        jobIdempotencyKey: `default-${Date.now()}`,
+      });
+      expect(result.capSource).toBe("default");
+      expect(result.envCapCents).toBe(1000000);
+    } finally {
+      delete process.env.ISTOCK_SEED_CAP_CENTS;
+    }
   });
 });

--- a/lib/istock-seed.ts
+++ b/lib/istock-seed.ts
@@ -199,6 +199,28 @@ export function estimateIngestCost(imageCount: number): CostEstimate {
 }
 
 // ---------------------------------------------------------------------------
+// Env-var ceiling (M8-3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Global cap on one-shot iStock ingests. `ISTOCK_SEED_CAP_CENTS` at
+ * call time; defaults to 10000c ($100) — generously above the 9k-image
+ * catalogue's $63 cost but tight enough to catch a runaway rerun that
+ * multiplies requested_count by 10×.
+ *
+ * Unlike the tenant budgets (M8-1/M8-2) this is process-level, not
+ * per-tenant. The iStock seed ingests into the shared image_library
+ * and isn't scoped to any one site.
+ */
+export function readIstockSeedCapCents(): number {
+  const raw = process.env.ISTOCK_SEED_CAP_CENTS;
+  if (!raw) return 10000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return 10000;
+  return Math.floor(parsed);
+}
+
+// ---------------------------------------------------------------------------
 // Seed
 // ---------------------------------------------------------------------------
 
@@ -217,6 +239,9 @@ export type SeedResult = {
   imagesAdopted: number;
   estimate: CostEstimate;
   budgetCapCents: number;
+  envCapCents: number;
+  effectiveCapCents: number;
+  capSource: "caller" | "env" | "default";
   dryRun: boolean;
   skippedOverBudget: boolean;
 };
@@ -224,13 +249,19 @@ export type SeedResult = {
 export class IngestBudgetError extends Error {
   public readonly estimate: CostEstimate;
   public readonly budgetCapCents: number;
-  constructor(estimate: CostEstimate, budgetCapCents: number) {
+  public readonly capSource: "caller" | "env" | "default";
+  constructor(
+    estimate: CostEstimate,
+    budgetCapCents: number,
+    capSource: "caller" | "env" | "default",
+  ) {
     super(
-      `Estimated cost ${estimate.totalCents} cents exceeds budget cap ${budgetCapCents} cents (${estimate.imageCount} images).`,
+      `Estimated cost ${estimate.totalCents} cents exceeds the ${capSource} budget cap of ${budgetCapCents} cents (${estimate.imageCount} images). Raise the cap via the --budget flag or ISTOCK_SEED_CAP_CENTS env var, or narrow the CSV.`,
     );
     this.name = "IngestBudgetError";
     this.estimate = estimate;
     this.budgetCapCents = budgetCapCents;
+    this.capSource = capSource;
   }
 }
 
@@ -247,15 +278,29 @@ export async function seedIstockLibrary(
   options: SeedOptions,
 ): Promise<SeedResult> {
   const estimate = estimateIngestCost(options.rows.length);
-  const budgetCap =
-    options.budgetCapCents ??
-    Math.max(
-      estimate.totalCents * DEFAULT_BUDGET_CAP_MULTIPLIER,
-      DEFAULT_BUDGET_FLOOR_CENTS,
-    );
+  const envCap = readIstockSeedCapCents();
+  const callerCap = options.budgetCapCents;
+  const defaultCap = Math.max(
+    estimate.totalCents * DEFAULT_BUDGET_CAP_MULTIPLIER,
+    DEFAULT_BUDGET_FLOOR_CENTS,
+  );
+
+  // M8-3: env-var cap is the outer ceiling. Caller's explicit cap
+  // (from --budget flag) applies on top of the env cap but can't
+  // exceed it. When the caller passes nothing, the default cap is
+  // the smaller of 2× estimate or the env cap.
+  let budgetCap: number;
+  let capSource: "caller" | "env" | "default";
+  if (callerCap !== undefined) {
+    budgetCap = Math.min(callerCap, envCap);
+    capSource = callerCap < envCap ? "caller" : "env";
+  } else {
+    budgetCap = Math.min(defaultCap, envCap);
+    capSource = defaultCap < envCap ? "default" : "env";
+  }
 
   if (estimate.totalCents > budgetCap) {
-    throw new IngestBudgetError(estimate, budgetCap);
+    throw new IngestBudgetError(estimate, budgetCap, capSource);
   }
 
   if (options.dryRun) {
@@ -266,6 +311,9 @@ export async function seedIstockLibrary(
       imagesAdopted: 0,
       estimate,
       budgetCapCents: budgetCap,
+      envCapCents: envCap,
+      effectiveCapCents: budgetCap,
+      capSource,
       dryRun: true,
       skippedOverBudget: false,
     };
@@ -404,6 +452,9 @@ export async function seedIstockLibrary(
     imagesAdopted: existingByIstockId.size,
     estimate,
     budgetCapCents: budgetCap,
+    envCapCents: envCap,
+    effectiveCapCents: budgetCap,
+    capSource,
     dryRun: false,
     skippedOverBudget: false,
   };


### PR DESCRIPTION
Third M8 sub-slice. Rescoped from the parent plan's \"per-tenant cap check\": the iStock seed ingests into the shared `image_library` with `transfer_jobs.site_id = NULL` (by design from M4-5). There's no tenant boundary to enforce against. M8-3 instead ships a process-level env-var ceiling that replaces the implicit 2× multiplier as the outer cap.

## What lands

- `readIstockSeedCapCents()` — reads `ISTOCK_SEED_CAP_CENTS` (default 10000c = $100). Generous above the 9k-image catalogue's $63 but tight enough to catch a runaway re-run.
- Effective cap = `min(callerCap, envCap)`. A caller's `--budget` flag can narrow (or widen up to the env ceiling) but never exceed it.
- `SeedResult` gains `envCapCents`, `effectiveCapCents`, `capSource`.
- `IngestBudgetError` gains `capSource` so the thrown message names which cap rejected the estimate.
- 2 new tests: env cap wins when caller is generous; default uses `min(2× estimate, env)`.

## Risks identified and mitigated

- **Operator bypasses the env cap with `--budget 999999`.** → `budgetCap = min(callerCap, envCap)`. The env cap is the ceiling; the caller can only narrow below it. Test pinned.
- **Env var misconfigured (negative / non-numeric).** → `readIstockSeedCapCents` returns the default (10000c) on any non-finite or negative value. No silent bypass.
- **Rescope ambiguity.** → The parent plan said "per-tenant cap check" for M8-3. That doesn't apply to a tenant-agnostic global ingest. Documented in the commit + BACKLOG entry.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — run in CI.