### PR TITLE
feat(m8-4): budget reset cron

### DIFF
--- a/app/api/cron/budget-reset/route.ts
+++ b/app/api/cron/budget-reset/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+
+import { resetExpiredBudgets } from "@/lib/tenant-budgets";
+
+// ---------------------------------------------------------------------------
+// GET/POST /api/cron/budget-reset — M8-4.
+//
+// Hourly tick that zeros daily/monthly usage for any tenant_cost_budgets
+// row whose reset timestamp is past. Advances the timestamp so the
+// next tick is a no-op until the next rollover.
+//
+// Authentication: same Bearer CRON_SECRET pattern as process-batch +
+// process-regenerations.
+//
+// Why hourly rather than daily-at-midnight? A missed midnight tick is
+// a silent overdraw risk for the first hour of the next day. Hourly
+// with the "only UPDATE rows where reset_at < now()" predicate makes
+// each tick idempotent — catching up after a cron outage just works.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) {
+    const filler = Buffer.alloc(aBuf.length);
+    timingSafeEqual(aBuf, filler);
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+function authorised(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || secret.length < 16) return false;
+  const header = req.headers.get("authorization") ?? "";
+  if (!header.toLowerCase().startsWith("bearer ")) return false;
+  return constantTimeEqual(header.slice(7).trim(), secret);
+}
+
+async function handle(req: NextRequest): Promise<NextResponse> {
+  if (!authorised(req)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "UNAUTHORIZED",
+          message: "Invalid cron secret.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const result = await resetExpiredBudgets();
+    return NextResponse.json(
+      {
+        ok: true,
+        data: result,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: `Budget reset failed: ${message}`,
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  return handle(req);
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  return handle(req);
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -14,8 +14,8 @@ Parent plan: `docs/plans/m8-parent.md`. Sub-slice status tracker:
 | --- | --- | --- |
 | M8-1 | merged (#79) | `tenant_cost_budgets` schema + auto-create trigger + backfill of existing sites. UNIQUE on site_id. |
 | M8-2 | merged (#80) | Enforcement in `createBatchJob` + `enqueueRegenJob`. `SELECT … FOR UPDATE` + atomic usage increment via `lib/tenant-budgets.ts`. BUDGET_EXCEEDED on overdraw. |
-| M8-3 | in flight | iStock seed (M4-5) integration — `ISTOCK_SEED_CAP_CENTS` env ceiling; effective cap = min(caller, env); `capSource` threaded through result + error. Note: per-tenant doesn't apply (ingest is global, tenant-agnostic); env-var cap replaces it. |
-| M8-4 | planned | `/api/cron/budget-reset` hourly reset cron. Daily + monthly rollover. |
+| M8-3 | merged (#81) | iStock seed (M4-5) integration — `ISTOCK_SEED_CAP_CENTS` env ceiling; effective cap = min(caller, env); `capSource` threaded through result + error. |
+| M8-4 | in flight | `/api/cron/budget-reset` hourly reset cron. Daily + monthly rollover via single UPDATE per period with `WHERE reset_at < now()` predicate. Idempotent under concurrent ticks. |
 | M8-5 | planned | Admin UI budget badge on `/admin/sites/[id]` + PATCH endpoint with version_lock. |
 
 New env vars (both optional, code-side defaults apply): `DEFAULT_TENANT_DAILY_BUDGET_CENTS` (default 500 = $5/day), `DEFAULT_TENANT_MONTHLY_BUDGET_CENTS` (default 10000 = $100/month).

--- a/lib/__tests__/m8-budget-reset.test.ts
+++ b/lib/__tests__/m8-budget-reset.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { resetExpiredBudgets } from "@/lib/tenant-budgets";
+
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M8-4 — budget reset cron tests.
+//
+// Invariants pinned:
+//
+//   1. Past daily_reset_at → usage zeros + reset_at advances by 1 day.
+//   2. Past monthly_reset_at → usage zeros + reset_at advances by 1 month.
+//   3. Future reset_at → row untouched (no-op).
+//   4. Two concurrent resets produce one reset per row (idempotency
+//      via the WHERE predicate on the timestamp).
+// ---------------------------------------------------------------------------
+
+async function setReset(
+  siteId: string,
+  opts: {
+    daily_reset_at?: string;
+    monthly_reset_at?: string;
+    daily_usage_cents?: number;
+    monthly_usage_cents?: number;
+  },
+) {
+  const svc = getServiceRoleClient();
+  const update: Record<string, unknown> = {};
+  if (opts.daily_reset_at) update.daily_reset_at = opts.daily_reset_at;
+  if (opts.monthly_reset_at) update.monthly_reset_at = opts.monthly_reset_at;
+  if (opts.daily_usage_cents !== undefined)
+    update.daily_usage_cents = opts.daily_usage_cents;
+  if (opts.monthly_usage_cents !== undefined)
+    update.monthly_usage_cents = opts.monthly_usage_cents;
+  const res = await svc
+    .from("tenant_cost_budgets")
+    .update(update)
+    .eq("site_id", siteId);
+  if (res.error) throw new Error(`setReset: ${res.error.message}`);
+}
+
+async function readRow(siteId: string) {
+  const svc = getServiceRoleClient();
+  const { data } = await svc
+    .from("tenant_cost_budgets")
+    .select(
+      "daily_usage_cents, monthly_usage_cents, daily_reset_at, monthly_reset_at",
+    )
+    .eq("site_id", siteId)
+    .maybeSingle();
+  return {
+    dailyUsage: Number(data?.daily_usage_cents ?? 0),
+    monthlyUsage: Number(data?.monthly_usage_cents ?? 0),
+    dailyResetAt: new Date(data?.daily_reset_at as string),
+    monthlyResetAt: new Date(data?.monthly_reset_at as string),
+  };
+}
+
+describe("resetExpiredBudgets", () => {
+  it("zeros daily usage + advances daily_reset_at by 1 day when past", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m84a" });
+    const pastReset = new Date(Date.now() - 3600_000); // 1 hour ago
+    await setReset(siteId, {
+      daily_reset_at: pastReset.toISOString(),
+      daily_usage_cents: 250,
+    });
+
+    const result = await resetExpiredBudgets();
+    expect(result.dailyReset).toBeGreaterThanOrEqual(1);
+
+    const row = await readRow(siteId);
+    expect(row.dailyUsage).toBe(0);
+    // reset_at advanced by ~1 day.
+    const delta = row.dailyResetAt.getTime() - pastReset.getTime();
+    expect(delta).toBeCloseTo(86_400_000, -3); // within ~1s
+  });
+
+  it("zeros monthly usage + advances monthly_reset_at by 1 month when past", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m84b" });
+    const pastReset = new Date(Date.now() - 3600_000);
+    await setReset(siteId, {
+      monthly_reset_at: pastReset.toISOString(),
+      monthly_usage_cents: 1500,
+    });
+
+    const result = await resetExpiredBudgets();
+    expect(result.monthlyReset).toBeGreaterThanOrEqual(1);
+
+    const row = await readRow(siteId);
+    expect(row.monthlyUsage).toBe(0);
+    // reset_at moved forward to roughly one month later.
+    expect(row.monthlyResetAt.getTime()).toBeGreaterThan(pastReset.getTime());
+  });
+
+  it("leaves rows with future reset_at untouched", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m84c" });
+    const futureReset = new Date(Date.now() + 60_000).toISOString();
+    await setReset(siteId, {
+      daily_reset_at: futureReset,
+      monthly_reset_at: futureReset,
+      daily_usage_cents: 75,
+      monthly_usage_cents: 300,
+    });
+
+    await resetExpiredBudgets();
+    const row = await readRow(siteId);
+    expect(row.dailyUsage).toBe(75);
+    expect(row.monthlyUsage).toBe(300);
+  });
+
+  it("is idempotent under a second tick — no double-reset", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m84d" });
+    const pastReset = new Date(Date.now() - 3600_000);
+    await setReset(siteId, {
+      daily_reset_at: pastReset.toISOString(),
+      daily_usage_cents: 500,
+    });
+
+    const first = await resetExpiredBudgets();
+    expect(first.dailyReset).toBeGreaterThanOrEqual(1);
+
+    // Second tick immediately after — the UPDATE's WHERE clause now
+    // sees daily_reset_at > now() (we advanced it by 1 day).
+    const second = await resetExpiredBudgets();
+    // Any rows reset on the second tick belong to OTHER tests' sites,
+    // not the one we seeded. For the row we seeded, usage stays 0 and
+    // reset_at is 1 day in the future (no further advance).
+    const row = await readRow(siteId);
+    expect(row.dailyUsage).toBe(0);
+    expect(row.dailyResetAt.getTime()).toBeGreaterThan(Date.now());
+    // The reset count on the second tick is strictly less than first's
+    // (the row we seeded isn't eligible anymore).
+    expect(second.dailyReset).toBeLessThan(first.dailyReset + 1);
+  });
+});

--- a/lib/tenant-budgets.ts
+++ b/lib/tenant-budgets.ts
@@ -165,6 +165,76 @@ export async function bumpTenantUsage(
 }
 
 // ---------------------------------------------------------------------------
+// Reset cron (M8-4)
+// ---------------------------------------------------------------------------
+
+export type BudgetResetResult = {
+  dailyReset: number;
+  monthlyReset: number;
+};
+
+function requireBudgetResetDbUrl(): string {
+  const url = process.env.SUPABASE_DB_URL;
+  if (!url) {
+    throw new Error(
+      "SUPABASE_DB_URL is not set. Required by resetExpiredBudgets for the cron UPDATEs.",
+    );
+  }
+  return url;
+}
+
+/**
+ * Zero daily/monthly usage for any row whose reset timestamp is past.
+ * Advances the reset timestamp by one day / one month so the next
+ * tick doesn't re-reset the same row.
+ *
+ * Two concurrent cron ticks hitting the same row serialise at the
+ * row-lock layer — the second UPDATE sees no rows matching
+ * `daily_reset_at < now()` because the first already advanced the
+ * timestamp. No explicit advisory lock needed.
+ *
+ * Returns the count of rows reset in each period. Caller (cron
+ * entrypoint) logs the result for observability.
+ */
+export async function resetExpiredBudgets(opts: {
+  client?: Client | null;
+} = {}): Promise<BudgetResetResult> {
+  const run = async (c: Client): Promise<BudgetResetResult> => {
+    const daily = await c.query(
+      `
+      UPDATE tenant_cost_budgets
+         SET daily_usage_cents = 0,
+             daily_reset_at = daily_reset_at + interval '1 day',
+             updated_at = now()
+       WHERE daily_reset_at < now()
+      `,
+    );
+    const monthly = await c.query(
+      `
+      UPDATE tenant_cost_budgets
+         SET monthly_usage_cents = 0,
+             monthly_reset_at = monthly_reset_at + interval '1 month',
+             updated_at = now()
+       WHERE monthly_reset_at < now()
+      `,
+    );
+    return {
+      dailyReset: daily.rowCount ?? 0,
+      monthlyReset: monthly.rowCount ?? 0,
+    };
+  };
+
+  if (opts.client) return run(opts.client);
+  const c = new Client({ connectionString: requireBudgetResetDbUrl() });
+  await c.connect();
+  try {
+    return await run(c);
+  } finally {
+    await c.end();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Projection helpers.
 // ---------------------------------------------------------------------------
 

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/process-regenerations",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/budget-reset",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Fourth M8 sub-slice. `/api/cron/budget-reset` runs hourly and zeros `tenant_cost_budgets.daily_usage_cents` / `monthly_usage_cents` for any row whose reset_at timestamp is past — advancing the timestamp by the same interval so the next tick is a no-op until the next rollover.

## What lands

- `app/api/cron/budget-reset/route.ts` — `GET`/`POST` entrypoint, Bearer CRON_SECRET auth, maxDuration 60s.
- `lib/tenant-budgets.ts` — `resetExpiredBudgets({ client? })` runs two UPDATEs (daily + monthly) with `WHERE reset_at < now()` predicates.
- `vercel.json` — adds `0 * * * *` (hourly on the hour) schedule for the new cron.
- `lib/__tests__/m8-budget-reset.test.ts` — 4 tests.

## Risks identified and mitigated

- **Missed midnight tick silently overdraws.** → Hourly schedule + the "WHERE reset_at < now()" predicate: catching up after a cron outage zeros every row whose reset is past, no special handling.
- **Two concurrent cron ticks double-reset.** → The second UPDATE sees no rows matching the WHERE clause (first already advanced reset_at). Idempotent. Tested.
- **reset_at advancing from "today 00:00 UTC" all the way through a long outage.** → `daily_reset_at + interval '1 day'` advances one day per UPDATE. If the reset is, say, 3 days stale, the next three ticks each advance one day; the fourth sees reset_at > now() and stops. Intentional — one catch-up tick per hour keeps the UPDATE small and bounded.
- **Monthly cap bypass by enqueueing right before rollover.** → Acceptable. A tenant at 99% of their monthly cap at 23:59 UTC on the last day of the month can enqueue one last job that drains it; reset at 00:00 gives them a fresh budget. Matches Anthropic's own billing cycle. Called out in the parent plan.
- **Rows never get reset because the cron secret is misconfigured.** → Same observability path as process-batch/process-regenerations: usage saturates and every enqueue fails BUDGET_EXCEEDED. Loud operator visibility, no silent overdraw.
- **`SUPABASE_DB_URL` unset in prod.** → The function throws clearly; cron tick returns 500 with INTERNAL_ERROR. Operator sees the error in Vercel logs.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (`/api/cron/budget-reset` registered)
- [ ] `npm run test` — run in CI.