### PR TITLE
feat(m8-5): admin budget badge + PATCH endpoint

### DIFF
--- a/app/admin/sites/[id]/page.tsx
+++ b/app/admin/sites/[id]/page.tsx
@@ -2,11 +2,14 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { EditTenantBudgetButton } from "@/components/EditTenantBudgetButton";
 import { NewBatchButton } from "@/components/NewBatchButton";
 import { SiteActionsMenu } from "@/components/SiteActionsMenu";
+import { TenantBudgetBadge } from "@/components/TenantBudgetBadge";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getSite } from "@/lib/sites";
 import { getServiceRoleClient } from "@/lib/supabase";
+import { getTenantBudget } from "@/lib/tenant-budgets";
 import type { BatchTemplateOption } from "@/components/NewBatchModal";
 
 // /admin/sites/[id] — M2d UX cleanup.
@@ -132,6 +135,12 @@ export default async function SiteDetailPage({
     .order("created_at", { ascending: false })
     .limit(20);
 
+  // M8-5 — tenant budget badge. Admin-only; operators view the
+  // site surface but only admins edit caps. The badge itself is
+  // visible to operators for budget self-diagnosis.
+  const tenantBudget = await getTenantBudget(site.id);
+  const isAdmin = access.user?.role === "admin" || access.user === null;
+
   return (
     <>
       <div className="flex items-start justify-between gap-4">
@@ -247,7 +256,26 @@ export default async function SiteDetailPage({
           </div>
         </section>
 
-        <aside>
+        <aside className="space-y-6">
+          <div>
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold">Budget</h2>
+              {isAdmin && tenantBudget && (
+                <EditTenantBudgetButton
+                  budget={{
+                    site_id: tenantBudget.site_id,
+                    daily_cap_cents: tenantBudget.daily_cap_cents,
+                    monthly_cap_cents: tenantBudget.monthly_cap_cents,
+                    version_lock: tenantBudget.version_lock,
+                  }}
+                />
+              )}
+            </div>
+            <div className="mt-2">
+              <TenantBudgetBadge budget={tenantBudget} />
+            </div>
+          </div>
+
           <h2 className="text-sm font-semibold">Design system</h2>
           <div className="mt-2 rounded-md border p-3 text-xs">
             {ds ? (

--- a/app/api/admin/sites/[id]/budget/route.ts
+++ b/app/api/admin/sites/[id]/budget/route.ts
@@ -1,0 +1,131 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { updateTenantBudget } from "@/lib/tenant-budgets";
+import { errorCodeToStatus } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// PATCH /api/admin/sites/[id]/budget — M8-5.
+//
+// Admin-only. Edit daily / monthly caps on tenant_cost_budgets.
+// Optimistic-locked on version_lock; concurrent edits surface
+// VERSION_CONFLICT (409) with the current server-side version.
+//
+// Caps must be non-negative integers ≤ 10M cents ($100,000). 0 is a
+// valid paused-tenant state.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const MAX_CAP_CENTS = 10_000_000;
+
+const PatchSchema = z
+  .object({
+    daily_cap_cents: z
+      .number()
+      .int()
+      .nonnegative()
+      .max(MAX_CAP_CENTS)
+      .optional(),
+    monthly_cap_cents: z
+      .number()
+      .int()
+      .nonnegative()
+      .max(MAX_CAP_CENTS)
+      .optional(),
+  })
+  .refine(
+    (p) =>
+      p.daily_cap_cents !== undefined || p.monthly_cap_cents !== undefined,
+    { message: "At least one of daily_cap_cents or monthly_cap_cents is required." },
+  );
+
+const BodySchema = z.object({
+  expected_version: z.number().int().min(1),
+  patch: PatchSchema,
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false, ...(details ? { details } : {}) },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Site id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body failed validation.",
+          details: { issues: parsed.error.issues },
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await updateTenantBudget(
+    params.id,
+    parsed.data.expected_version,
+    parsed.data.patch,
+    gate.user?.id ?? null,
+  );
+
+  if (!result.ok) {
+    const status = errorCodeToStatus(
+      result.code === "VERSION_CONFLICT"
+        ? "VERSION_CONFLICT"
+        : result.code === "NOT_FOUND"
+          ? "NOT_FOUND"
+          : "INTERNAL_ERROR",
+    );
+    return errorJson(result.code, result.message, status, result.details);
+  }
+
+  revalidatePath(`/admin/sites/${params.id}`);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: result.budget,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/components/EditTenantBudgetButton.tsx
+++ b/components/EditTenantBudgetButton.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+// ---------------------------------------------------------------------------
+// M8-5 — edit-tenant-budget modal + button.
+//
+// Admin-only. Opens a modal to update daily / monthly caps. Optimistic
+// lock echoed back on submit; VERSION_CONFLICT surfaces the server
+// message and keeps the modal open.
+//
+// Input is in DOLLARS (cleaner for operators) but sent in CENTS over
+// the wire — the modal multiplies on submit and the API stores cents.
+// ---------------------------------------------------------------------------
+
+type BudgetProps = {
+  site_id: string;
+  daily_cap_cents: number;
+  monthly_cap_cents: number;
+  version_lock: number;
+};
+
+function centsToDollars(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+function dollarsToCents(raw: string): number | null {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return Math.round(parsed * 100);
+}
+
+export function EditTenantBudgetButton({
+  budget,
+}: {
+  budget: BudgetProps;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        data-testid="edit-tenant-budget-button"
+      >
+        Edit caps
+      </Button>
+      {open && (
+        <EditTenantBudgetModal
+          budget={budget}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+function EditTenantBudgetModal({
+  budget,
+  onClose,
+}: {
+  budget: BudgetProps;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const [daily, setDaily] = useState(centsToDollars(budget.daily_cap_cents));
+  const [monthly, setMonthly] = useState(
+    centsToDollars(budget.monthly_cap_cents),
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDaily(centsToDollars(budget.daily_cap_cents));
+    setMonthly(centsToDollars(budget.monthly_cap_cents));
+  }, [budget.daily_cap_cents, budget.monthly_cap_cents]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const dailyCents = dollarsToCents(daily);
+    const monthlyCents = dollarsToCents(monthly);
+    if (dailyCents === null || monthlyCents === null) {
+      setError("Caps must be non-negative numbers (dollars, e.g. 5.00).");
+      setSubmitting(false);
+      return;
+    }
+
+    const patch: { daily_cap_cents?: number; monthly_cap_cents?: number } = {};
+    if (dailyCents !== budget.daily_cap_cents) patch.daily_cap_cents = dailyCents;
+    if (monthlyCents !== budget.monthly_cap_cents)
+      patch.monthly_cap_cents = monthlyCents;
+    if (patch.daily_cap_cents === undefined && patch.monthly_cap_cents === undefined) {
+      onClose();
+      return;
+    }
+
+    try {
+      const res = await fetch(
+        `/api/admin/sites/${encodeURIComponent(budget.site_id)}/budget`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            expected_version: budget.version_lock,
+            patch,
+          }),
+        },
+      );
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        setError(
+          payload?.error?.message ?? `Update failed (HTTP ${res.status}).`,
+        );
+        setSubmitting(false);
+        return;
+      }
+      router.refresh();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="edit-budget-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !submitting) onClose();
+      }}
+    >
+      <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="edit-budget-title" className="text-lg font-semibold">
+          Edit budget caps
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Caps are in dollars. 0 pauses all billed work on this site until
+          raised.
+        </p>
+        <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+          <div>
+            <label htmlFor="eb-daily" className="block text-sm font-medium">
+              Daily cap ($)
+            </label>
+            <Input
+              id="eb-daily"
+              type="number"
+              step="0.01"
+              min="0"
+              value={daily}
+              onChange={(e) => setDaily(e.target.value)}
+              disabled={submitting}
+              autoFocus
+            />
+          </div>
+          <div>
+            <label htmlFor="eb-monthly" className="block text-sm font-medium">
+              Monthly cap ($)
+            </label>
+            <Input
+              id="eb-monthly"
+              type="number"
+              step="0.01"
+              min="0"
+              value={monthly}
+              onChange={(e) => setMonthly(e.target.value)}
+              disabled={submitting}
+            />
+          </div>
+          {error && (
+            <p
+              role="alert"
+              className="text-sm text-destructive"
+              data-testid="edit-tenant-budget-error"
+            >
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Saving…" : "Save caps"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/TenantBudgetBadge.tsx
+++ b/components/TenantBudgetBadge.tsx
@@ -1,0 +1,115 @@
+import type { TenantBudget } from "@/lib/tenant-budgets";
+
+// ---------------------------------------------------------------------------
+// M8-5 — tenant budget usage badge.
+//
+// Server-rendered. Two bars (daily + monthly) with current usage vs
+// cap + the next reset time. Cap = 0 renders as "paused" — no enqueue
+// allowed until operator raises the cap.
+// ---------------------------------------------------------------------------
+
+function formatCents(cents: number): string {
+  if (cents === 0) return "$0";
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatResetAt(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function usagePct(usage: number, cap: number): number {
+  if (cap <= 0) return 100;
+  return Math.min(100, Math.round((usage / cap) * 100));
+}
+
+function barClass(pct: number, capped: boolean): string {
+  if (capped) return "bg-muted";
+  if (pct >= 90) return "bg-destructive";
+  if (pct >= 70) return "bg-yellow-500";
+  return "bg-emerald-500";
+}
+
+function Row({
+  label,
+  usage,
+  cap,
+  resetAt,
+}: {
+  label: string;
+  usage: number;
+  cap: number;
+  resetAt: string;
+}) {
+  const pct = usagePct(usage, cap);
+  const paused = cap === 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span className="font-medium">{label}</span>
+        <span className="text-muted-foreground">
+          {paused ? (
+            <span className="text-destructive">Paused</span>
+          ) : (
+            <>
+              {formatCents(usage)} / {formatCents(cap)}
+              <span className="ml-1">({pct}%)</span>
+            </>
+          )}
+        </span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded bg-muted">
+        <div
+          className={`h-full ${barClass(pct, paused)}`}
+          style={{ width: `${paused ? 100 : pct}%` }}
+        />
+      </div>
+      <div className="text-[10px] text-muted-foreground">
+        Resets {formatResetAt(resetAt)}
+      </div>
+    </div>
+  );
+}
+
+export function TenantBudgetBadge({ budget }: { budget: TenantBudget | null }) {
+  if (!budget) {
+    return (
+      <div
+        className="rounded-md border border-dashed p-3 text-xs text-muted-foreground"
+        data-testid="tenant-budget-missing"
+      >
+        No budget row. Every enqueue will self-heal via the tenant-budget
+        upsert in `reserveBudget`.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="space-y-3 rounded-md border p-3"
+      data-testid="tenant-budget-badge"
+    >
+      <Row
+        label="Daily"
+        usage={budget.daily_usage_cents}
+        cap={budget.daily_cap_cents}
+        resetAt={budget.daily_reset_at}
+      />
+      <Row
+        label="Monthly"
+        usage={budget.monthly_usage_cents}
+        cap={budget.monthly_cap_cents}
+        resetAt={budget.monthly_reset_at}
+      />
+    </div>
+  );
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -15,8 +15,8 @@ Parent plan: `docs/plans/m8-parent.md`. Sub-slice status tracker:
 | M8-1 | merged (#79) | `tenant_cost_budgets` schema + auto-create trigger + backfill of existing sites. UNIQUE on site_id. |
 | M8-2 | merged (#80) | Enforcement in `createBatchJob` + `enqueueRegenJob`. `SELECT … FOR UPDATE` + atomic usage increment via `lib/tenant-budgets.ts`. BUDGET_EXCEEDED on overdraw. |
 | M8-3 | merged (#81) | iStock seed (M4-5) integration — `ISTOCK_SEED_CAP_CENTS` env ceiling; effective cap = min(caller, env); `capSource` threaded through result + error. |
-| M8-4 | in flight | `/api/cron/budget-reset` hourly reset cron. Daily + monthly rollover via single UPDATE per period with `WHERE reset_at < now()` predicate. Idempotent under concurrent ticks. |
-| M8-5 | planned | Admin UI budget badge on `/admin/sites/[id]` + PATCH endpoint with version_lock. |
+| M8-4 | merged (#82) | `/api/cron/budget-reset` hourly reset cron. Daily + monthly rollover via single UPDATE per period with `WHERE reset_at < now()` predicate. Idempotent under concurrent ticks. |
+| M8-5 | in flight | Admin UI budget badge on `/admin/sites/[id]` + PATCH endpoint with version_lock. |
 
 New env vars (both optional, code-side defaults apply): `DEFAULT_TENANT_DAILY_BUDGET_CENTS` (default 500 = $5/day), `DEFAULT_TENANT_MONTHLY_BUDGET_CENTS` (default 10000 = $100/month).
 

--- a/lib/__tests__/m8-budget-admin-ui.test.ts
+++ b/lib/__tests__/m8-budget-admin-ui.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  getTenantBudget,
+  updateTenantBudget,
+} from "@/lib/tenant-budgets";
+
+import { seedSite } from "./_helpers";
+import { seedAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// M8-5 — admin budget read/update tests.
+// ---------------------------------------------------------------------------
+
+describe("getTenantBudget", () => {
+  it("returns the budget row for an existing site", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m85a" });
+    const budget = await getTenantBudget(siteId);
+    expect(budget).not.toBeNull();
+    expect(budget?.site_id).toBe(siteId);
+    expect(budget?.version_lock).toBe(1);
+  });
+
+  it("returns null when the budget row doesn't exist", async () => {
+    const result = await getTenantBudget(
+      "00000000-0000-0000-0000-000000000000",
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("updateTenantBudget", () => {
+  it("updates caps and bumps version_lock on the happy path", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m85b" });
+    const before = await getTenantBudget(siteId);
+    if (!before) throw new Error("seeded budget missing");
+
+    const res = await updateTenantBudget(
+      siteId,
+      before.version_lock,
+      { daily_cap_cents: 1234, monthly_cap_cents: 56789 },
+      null,
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.budget.daily_cap_cents).toBe(1234);
+    expect(res.budget.monthly_cap_cents).toBe(56789);
+    expect(res.budget.version_lock).toBe(before.version_lock + 1);
+  });
+
+  it("returns VERSION_CONFLICT when expected_version is stale", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m85c" });
+    const before = await getTenantBudget(siteId);
+    if (!before) throw new Error("seeded budget missing");
+
+    // First edit succeeds, version becomes 2.
+    await updateTenantBudget(
+      siteId,
+      before.version_lock,
+      { daily_cap_cents: 200 },
+      null,
+    );
+    // Stale edit with version=1 fails.
+    const res = await updateTenantBudget(
+      siteId,
+      before.version_lock,
+      { daily_cap_cents: 999 },
+      null,
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.code).toBe("VERSION_CONFLICT");
+    expect(res.details?.current_version).toBe(before.version_lock + 1);
+  });
+
+  it("returns NOT_FOUND when the site has no budget row", async () => {
+    const res = await updateTenantBudget(
+      "00000000-0000-0000-0000-000000000000",
+      1,
+      { daily_cap_cents: 1 },
+      null,
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.code).toBe("NOT_FOUND");
+  });
+
+  it("accepts a partial patch (daily only)", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m85d" });
+    const before = await getTenantBudget(siteId);
+    if (!before) throw new Error("seeded budget missing");
+
+    const res = await updateTenantBudget(
+      siteId,
+      before.version_lock,
+      { daily_cap_cents: 42 },
+      null,
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.budget.daily_cap_cents).toBe(42);
+    // Monthly preserved from default.
+    expect(res.budget.monthly_cap_cents).toBe(before.monthly_cap_cents);
+  });
+
+  it("accepts 0 caps (paused tenant)", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m85e" });
+    const before = await getTenantBudget(siteId);
+    if (!before) throw new Error("seeded budget missing");
+
+    const res = await updateTenantBudget(
+      siteId,
+      before.version_lock,
+      { daily_cap_cents: 0, monthly_cap_cents: 0 },
+      null,
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it("stamps updated_by when supplied", async () => {
+    const { id: siteId } = await seedSite({ prefix: "m85f" });
+    const before = await getTenantBudget(siteId);
+    if (!before) throw new Error("seeded budget missing");
+
+    const user = await seedAuthUser({ role: "admin" });
+    const res = await updateTenantBudget(
+      siteId,
+      before.version_lock,
+      { daily_cap_cents: 500 },
+      user.id,
+    );
+    expect(res.ok).toBe(true);
+
+    const svc = getServiceRoleClient();
+    const { data } = await svc
+      .from("tenant_cost_budgets")
+      .select("updated_by")
+      .eq("site_id", siteId)
+      .maybeSingle();
+    expect(data?.updated_by).toBe(user.id);
+  });
+});

--- a/lib/tenant-budgets.ts
+++ b/lib/tenant-budgets.ts
@@ -1,5 +1,7 @@
 import { Client } from "pg";
 
+import { getServiceRoleClient } from "@/lib/supabase";
+
 // ---------------------------------------------------------------------------
 // M8-2 — Per-tenant cost budget enforcement.
 //
@@ -254,3 +256,154 @@ export const PROJECTED_COST_PER_BATCH_SLOT_CENTS = 30;
  * same shape as one batch slot — same prompt, same token budget.
  */
 export const PROJECTED_COST_PER_REGEN_CENTS = 30;
+
+// ---------------------------------------------------------------------------
+// Read / update for the admin UI (M8-5)
+// ---------------------------------------------------------------------------
+
+export type TenantBudget = {
+  site_id: string;
+  daily_cap_cents: number;
+  monthly_cap_cents: number;
+  daily_usage_cents: number;
+  monthly_usage_cents: number;
+  daily_reset_at: string;
+  monthly_reset_at: string;
+  version_lock: number;
+  created_at: string;
+  updated_at: string;
+};
+
+/**
+ * Read the budget row for a site. Service-role — admin gate runs
+ * above the caller.
+ */
+export async function getTenantBudget(
+  siteId: string,
+): Promise<TenantBudget | null> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("tenant_cost_budgets")
+    .select(
+      "site_id, daily_cap_cents, monthly_cap_cents, daily_usage_cents, monthly_usage_cents, daily_reset_at, monthly_reset_at, version_lock, created_at, updated_at",
+    )
+    .eq("site_id", siteId)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`getTenantBudget: ${error.message}`);
+  }
+  if (!data) return null;
+  return {
+    site_id: data.site_id as string,
+    daily_cap_cents: Number(data.daily_cap_cents),
+    monthly_cap_cents: Number(data.monthly_cap_cents),
+    daily_usage_cents: Number(data.daily_usage_cents),
+    monthly_usage_cents: Number(data.monthly_usage_cents),
+    daily_reset_at: data.daily_reset_at as string,
+    monthly_reset_at: data.monthly_reset_at as string,
+    version_lock: Number(data.version_lock),
+    created_at: data.created_at as string,
+    updated_at: data.updated_at as string,
+  };
+}
+
+export type UpdateTenantBudgetPatch = {
+  daily_cap_cents?: number;
+  monthly_cap_cents?: number;
+};
+
+export type UpdateTenantBudgetResult =
+  | { ok: true; budget: TenantBudget }
+  | {
+      ok: false;
+      code: "NOT_FOUND" | "VERSION_CONFLICT" | "INTERNAL_ERROR";
+      message: string;
+      details?: Record<string, unknown>;
+    };
+
+/**
+ * Admin PATCH to update caps. Optimistic-locked on version_lock.
+ * Mismatch → VERSION_CONFLICT with the current server version in
+ * details. Zod validation (non-negative, integer, max 10M cents) is
+ * the caller's responsibility.
+ */
+export async function updateTenantBudget(
+  siteId: string,
+  expectedVersion: number,
+  patch: UpdateTenantBudgetPatch,
+  updatedBy: string | null,
+): Promise<UpdateTenantBudgetResult> {
+  const svc = getServiceRoleClient();
+
+  const updateRow: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+    version_lock: expectedVersion + 1,
+    updated_by: updatedBy,
+  };
+  if (patch.daily_cap_cents !== undefined) {
+    updateRow.daily_cap_cents = patch.daily_cap_cents;
+  }
+  if (patch.monthly_cap_cents !== undefined) {
+    updateRow.monthly_cap_cents = patch.monthly_cap_cents;
+  }
+
+  const res = await svc
+    .from("tenant_cost_budgets")
+    .update(updateRow)
+    .eq("site_id", siteId)
+    .eq("version_lock", expectedVersion)
+    .select(
+      "site_id, daily_cap_cents, monthly_cap_cents, daily_usage_cents, monthly_usage_cents, daily_reset_at, monthly_reset_at, version_lock, created_at, updated_at",
+    )
+    .maybeSingle();
+
+  if (res.error) {
+    return {
+      ok: false,
+      code: "INTERNAL_ERROR",
+      message: `updateTenantBudget: ${res.error.message}`,
+    };
+  }
+  if (!res.data) {
+    // Zero rows: disambiguate NOT_FOUND vs VERSION_CONFLICT.
+    const exists = await svc
+      .from("tenant_cost_budgets")
+      .select("version_lock")
+      .eq("site_id", siteId)
+      .maybeSingle();
+    if (!exists.data) {
+      return {
+        ok: false,
+        code: "NOT_FOUND",
+        message: `No budget row for site ${siteId}.`,
+      };
+    }
+    return {
+      ok: false,
+      code: "VERSION_CONFLICT",
+      message:
+        "Another operator changed this budget since you opened the editor. Reload to see the latest.",
+      details: {
+        current_version: Number(exists.data.version_lock),
+        expected_version: expectedVersion,
+      },
+    };
+  }
+
+  const row = res.data as Record<string, unknown>;
+  return {
+    ok: true,
+    budget: {
+      site_id: row.site_id as string,
+      daily_cap_cents: Number(row.daily_cap_cents),
+      monthly_cap_cents: Number(row.monthly_cap_cents),
+      daily_usage_cents: Number(row.daily_usage_cents),
+      monthly_usage_cents: Number(row.monthly_usage_cents),
+      daily_reset_at: row.daily_reset_at as string,
+      monthly_reset_at: row.monthly_reset_at as string,
+      version_lock: Number(row.version_lock),
+      created_at: row.created_at as string,
+      updated_at: row.updated_at as string,
+    },
+  };
+}


### PR DESCRIPTION
Fifth and final M8 sub-slice. Operators see tenant usage against cap on the site detail page; admins edit caps via a modal. Closes the M8 milestone.

## What lands

- `lib/tenant-budgets.ts` — `getTenantBudget(siteId)` + `updateTenantBudget(siteId, expectedVersion, patch, updatedBy)`.
- `app/api/admin/sites/[id]/budget/route.ts` — PATCH. Zod-validated (non-negative ints, max $100K). Admin-only gate. `revalidatePath` on success.
- `components/TenantBudgetBadge.tsx` — traffic-light progress bars for daily + monthly.
- `components/EditTenantBudgetButton.tsx` — modal with dollar-input caps. Optimistic lock echoed.
- `app/admin/sites/[id]/page.tsx` — badge in the right aside next to Design system; Edit button only for admin role.
- `lib/__tests__/m8-budget-admin-ui.test.ts` — 6 tests.
- `docs/BACKLOG.md` — M8 closed out.

## Risks identified and mitigated

- **Concurrent cap edits.** → `version_lock` optimistic lock. Same pattern as M5-3 / M6-3. Unit test pinned.
- **Admin UI bypassing gate.** → `requireAdminForApi()` at the top (admin role required; operators can read but not edit). The Edit button is conditionally rendered based on `access.user?.role === "admin"` on the server side.
- **Operator sets cap above the tenant-wide M7-5 env cap.** → Per-tenant cap can only be stricter than the env cap at enforcement time (`reserveBudget` checks the per-tenant cap first; `enqueueRegenJob` keeps the M7-5 env cap as the outer ceiling). No bypass.
- **Cap input in dollars vs storage in cents.** → Modal converts on submit (`dollarsToCents`); invalid input (negative / NaN) rejected with a friendly inline error before the PATCH.
- **0 cap "pausing" tenant.** → Explicitly allowed by the migration CHECK. Badge renders `Paused` in red. Every enqueue fails BUDGET_EXCEEDED until the cap is raised — exactly what pausing should do.

## M8 milestone wrap-up

| Slice | PR | Content |
| --- | --- | --- |
| M8-1 | #79 | `tenant_cost_budgets` schema + auto-create trigger + backfill |
| M8-2 | #80 | reserveBudget + enforcement in createBatchJob + enqueueRegenJob |
| M8-3 | #81 | iStock seed ISTOCK_SEED_CAP_CENTS env ceiling |
| M8-4 | #82 | Hourly budget-reset cron |
| M8-5 | this PR | Badge + PATCH endpoint |

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — run in CI. 6 new tests.