### PR TITLE
test(m11-2): cover DS_ARCHIVED + WP_CREDS_MISSING regeneration branches

### DIFF
--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -86,8 +86,10 @@ test.describe("chat builder", () => {
     await expect(page.getByText("Make me a homepage")).toBeVisible();
     await expect(page.getByText("Hello there")).toBeVisible();
 
-    // Send button returns to enabled state once the stream closes.
-    await expect(page.getByRole("button", { name: /send/i })).toBeEnabled();
+    // Stream closed cleanly: textarea re-enables (the Send button
+    // stays disabled because sendDisabled also checks `!input.trim()`
+    // and HomePageClient clears input on submit).
+    await expect(textarea).toBeEnabled();
   });
 
   test("error path — upstream failure renders an inline error bubble", async ({
@@ -114,7 +116,8 @@ test.describe("chat builder", () => {
     await page.getByRole("button", { name: /send/i }).click();
 
     await expect(page.getByText(/Anthropic upstream failed/)).toBeVisible();
-    // Stream closes cleanly: input re-enables, no hung "…" indicator.
-    await expect(page.getByRole("button", { name: /send/i })).toBeEnabled();
+    // Stream closed cleanly: textarea is enabled again (disabled
+    // only gates on streaming + activeSiteId; no hung "…" indicator).
+    await expect(textarea).toBeEnabled();
   });
 });

--- a/lib/__tests__/cron-process-regenerations-wp-creds.test.ts
+++ b/lib/__tests__/cron-process-regenerations-wp-creds.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { GET } from "@/app/api/cron/process-regenerations/route";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// WP_CREDS_MISSING terminal failure (M11-2 — closes audit gap #7).
+//
+// The cron route marks a leased job terminal-failed with
+// failure_code='WP_CREDS_MISSING' when the site has no decryptable WP
+// credentials row (either `getSite` failed with a site-level code, or
+// the credentials column is null). Without the guard, processRegenJob
+// would fail noisily and the job would retry forever.
+//
+// Pre-M11-2 the branch was implemented at
+// app/api/cron/process-regenerations/route.ts:163 but had zero test
+// coverage. This suite exercises the branch end-to-end by calling
+// the real GET handler against a seeded site that has no wp_credentials
+// row.
+// ---------------------------------------------------------------------------
+
+const VALID_CRON_SECRET = "test-cron-secret-min-16-chars-long";
+
+async function seedRegenJobForSite(siteId: string): Promise<{
+  jobId: string;
+  pageId: string;
+}> {
+  const svc = getServiceRoleClient();
+
+  const { data: page, error: pageErr } = await svc
+    .from("pages")
+    .insert({
+      site_id: siteId,
+      wp_page_id: Math.floor(Math.random() * 10_000_000),
+      slug: "m11-wp-creds",
+      title: "WP-creds-missing test",
+      page_type: "homepage",
+      design_system_version: 1,
+      status: "draft",
+      content_brief: { hero: { headline: "Placeholder" } },
+    })
+    .select("id")
+    .single();
+  if (pageErr || !page) {
+    throw new Error(`seed page failed: ${pageErr?.message ?? "no row"}`);
+  }
+
+  const pageId = page.id as string;
+  const { data: job, error: jobErr } = await svc
+    .from("regeneration_jobs")
+    .insert({
+      site_id: siteId,
+      page_id: pageId,
+      status: "pending",
+      expected_page_version: 1,
+      anthropic_idempotency_key: `anth-${pageId}-m11`,
+      wp_idempotency_key: `wp-${pageId}-m11`,
+    })
+    .select("id")
+    .single();
+  if (jobErr || !job) {
+    throw new Error(`seed job failed: ${jobErr?.message ?? "no row"}`);
+  }
+
+  return { jobId: job.id as string, pageId };
+}
+
+function buildCronRequest(): Request {
+  return new Request("http://localhost/api/cron/process-regenerations", {
+    method: "GET",
+    headers: { authorization: `Bearer ${VALID_CRON_SECRET}` },
+  });
+}
+
+describe("cron/process-regenerations — WP_CREDS_MISSING branch", () => {
+  const originalCronSecret = process.env.CRON_SECRET;
+
+  beforeEach(() => {
+    process.env.CRON_SECRET = VALID_CRON_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalCronSecret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = originalCronSecret;
+    }
+  });
+
+  it("marks the job failed with failure_code='WP_CREDS_MISSING' when the site has no credentials", async () => {
+    const { id: siteId } = await seedSite({
+      prefix: "m11b",
+      name: "Regen WP-Creds-Missing",
+    });
+    // seedSite intentionally does NOT create a `site_wp_credentials`
+    // row, so getSite({ includeCredentials: true }) returns a site
+    // with credentials === null — which is exactly the branch we
+    // want to exercise.
+    const { jobId } = await seedRegenJobForSite(siteId);
+
+    const req = buildCronRequest();
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: {
+        processedJobId: string | null;
+        outcome: string;
+      };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data.processedJobId).toBe(jobId);
+    expect(body.data.outcome).toBe("creds-missing");
+
+    const svc = getServiceRoleClient();
+    const { data: job } = await svc
+      .from("regeneration_jobs")
+      .select(
+        "status, failure_code, failure_detail, worker_id, lease_expires_at, finished_at",
+      )
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(job?.status).toBe("failed");
+    expect(job?.failure_code).toBe("WP_CREDS_MISSING");
+    expect(job?.failure_detail).toMatch(/credential/i);
+    expect(job?.worker_id).toBeNull();
+    expect(job?.lease_expires_at).toBeNull();
+    expect(job?.finished_at).not.toBeNull();
+  });
+});

--- a/lib/__tests__/regeneration-worker.test.ts
+++ b/lib/__tests__/regeneration-worker.test.ts
@@ -365,3 +365,64 @@ describe("reapExpiredRegenLeases", () => {
     expect(reaped.reapedCount).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// DS_ARCHIVED terminal failure (M11-2 — closes audit gap #7).
+//
+// The branch exists in lib/regeneration-worker.ts: if
+// `buildSystemPromptForSite` throws (design system for the page's
+// recorded version is gone), the job is recorded terminal-failed with
+// failure_code = 'DS_ARCHIVED' and the Anthropic call is never made.
+// Pre-M11-2 the branch was implemented but had zero test coverage.
+//
+// Production's `buildSystemPromptForSite` falls back to legacy blocks
+// rather than throwing under normal DB state, so the test uses the
+// M11-2 `buildSystemPrompt` DI param to inject a stub that throws.
+// ---------------------------------------------------------------------------
+
+describe("processRegenJobAnthropic — DS_ARCHIVED", () => {
+  it("records terminal failure with failure_code='DS_ARCHIVED' when the prompt builder throws", async () => {
+    const { id: siteId } = await seedSite({
+      prefix: "m11a",
+      name: "Regen DS-Archived",
+    });
+    // No active DS is seeded; the default buildSystemPromptForSite
+    // would have fallen back to legacy, so we inject a stub that
+    // throws to mirror "DS version has been archived since enqueue."
+    const pageId = await seedPage(siteId);
+    const jobId = await seedRegenJob(siteId, pageId);
+    await leaseNextRegenJob("worker-test");
+
+    const anthropicStub: ReturnType<typeof vi.fn> = vi.fn(async () =>
+      buildStubResponse(),
+    );
+    const promptStub = vi.fn(async () => {
+      throw new Error(
+        "Design system v1 has been archived; no active prompt block available.",
+      );
+    });
+
+    const result = await processRegenJobAnthropic(jobId, {
+      anthropicCall: anthropicStub as unknown as (
+        req: AnthropicRequest,
+      ) => Promise<AnthropicResponse>,
+      buildSystemPrompt: promptStub,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("DS_ARCHIVED");
+    expect(anthropicStub).not.toHaveBeenCalled();
+
+    const svc = getServiceRoleClient();
+    const { data: job } = await svc
+      .from("regeneration_jobs")
+      .select("status, failure_code, failure_detail, finished_at")
+      .eq("id", jobId)
+      .maybeSingle();
+    expect(job?.status).toBe("failed");
+    expect(job?.failure_code).toBe("DS_ARCHIVED");
+    expect(job?.failure_detail).toMatch(/archived/i);
+    expect(job?.finished_at).not.toBeNull();
+  });
+});

--- a/lib/regeneration-worker.ts
+++ b/lib/regeneration-worker.ts
@@ -10,7 +10,16 @@ import {
   type PublishRegenResult,
   type WpRegenCallBundle,
 } from "@/lib/regeneration-publisher";
-import { buildSystemPromptForSite } from "@/lib/system-prompt";
+import {
+  buildSystemPromptForSite,
+  type SiteIdentity,
+} from "@/lib/system-prompt";
+
+// Exposed so tests can stub the prompt builder to assert the
+// DS_ARCHIVED failure branch without relying on flaky file-system
+// state. Default is the real builder; production callers omit the
+// option.
+export type BuildSystemPromptFn = (site: SiteIdentity) => Promise<string>;
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -282,11 +291,14 @@ export async function processRegenJobAnthropic(
   jobId: string,
   opts: {
     anthropicCall?: AnthropicCallFn;
+    buildSystemPrompt?: BuildSystemPromptFn;
     client?: Client | null;
   } = {},
 ): Promise<ProcessRegenResult> {
   const supabase = getServiceRoleClient();
   const anthropicCall = opts.anthropicCall ?? defaultAnthropicCall;
+  const buildSystemPrompt =
+    opts.buildSystemPrompt ?? buildSystemPromptForSite;
 
   // Load the job + page + site context.
   const jobRes = await supabase
@@ -365,7 +377,7 @@ export async function processRegenJobAnthropic(
   // page's recorded DS version has been archived, fail loud.
   let systemPrompt: string;
   try {
-    systemPrompt = await buildSystemPromptForSite({
+    systemPrompt = await buildSystemPrompt({
       id: siteRes.data.id as string,
       site_name: siteRes.data.name as string,
       prefix: siteRes.data.prefix as string,


### PR DESCRIPTION
Closes audit gap #7 (docs/AUDIT_2026-04-22.md known-gaps). The two terminal-failure codes M7 exposes to the admin regen-history UI — `DS_ARCHIVED` and `WP_CREDS_MISSING` — had zero branch coverage. Both branches existed in code; both had no `it(...)` block asserting they're reached.

## What lands

- **`lib/regeneration-worker.ts`** — adds an optional `buildSystemPrompt` DI param to `processRegenJobAnthropic`, mirroring the existing `anthropicCall` shape. Production callers omit it; tests inject a stub to force the DS_ARCHIVED path. No behaviour change.
- **`lib/__tests__/regeneration-worker.test.ts`** — new `DS_ARCHIVED` test injects a throwing prompt-builder stub and asserts: `result.code='DS_ARCHIVED'`, `status='failed'`, `failure_code='DS_ARCHIVED'`, `finished_at` stamped, `anthropicCall` never fired.
- **`lib/__tests__/cron-process-regenerations-wp-creds.test.ts`** — new file exercising the cron route's credentials-missing guard end-to-end. Calls `GET` with a valid CRON_SECRET against a seeded site with no `site_wp_credentials` row; asserts outcome=`creds-missing`, job status=`failed`, `failure_code='WP_CREDS_MISSING'`, `worker_id` + `lease_expires_at` cleared.

## Risks identified and mitigated

- **DS_ARCHIVED was effectively dead-code pre-M11-2** (production's `buildSystemPromptForSite` falls back to legacy blocks rather than throwing). → The new DI param lets the test surface the branch without changing production semantics; the fix to "actually reach this branch in prod" is a separate M7-adjacent decision and is not M11 scope.
- **Cron route test takes a real Next.js handler with a synthetic `Request`.** → The handler's `NextRequest` interface is satisfied by the standard `Request` + header bag; no middleware runs in this codepath. No `NextResponse` mocking needed because the handler uses it only for response construction.
- **CRON_SECRET env mutation leaks between tests.** → `beforeEach`/`afterEach` restore the original value; test file is self-contained.

## Deliberately deferred

- "Make DS_ARCHIVED reachable in production without the DI stub" — sits in M7's scope, not M11's. Current behaviour is that regenerating against an archived DS silently falls back to the site's currently-active DS.
- Covering the remaining M7 plan-risks that aren't in the audit (every other branch listed in `docs/plans/m7-parent.md` is already tested).

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — runs in CI (local Supabase not provisioned on this box).
- [ ] `npm run test:e2e` — runs in CI.