### PR TITLE
feat(m11-4): enforce 500KB generated_html cap as a quality gate

### DIFF
--- a/components/PageHtmlPreview.tsx
+++ b/components/PageHtmlPreview.tsx
@@ -1,3 +1,5 @@
+import { HTML_SIZE_MAX_BYTES, estimateHtmlBytes } from "@/lib/html-size";
+
 // ---------------------------------------------------------------------------
 // M6-2 — Tier-2 static HTML preview.
 //
@@ -7,19 +9,14 @@
 // operator-authored brief can't execute. `allow-same-origin` is off
 // too; we don't need it for static HTML + our design-system CSS.
 //
-// Rendering cap: if generated_html exceeds 500KB we show a size
-// warning + a download link rather than inlining — keeps the admin
-// page responsive on pathological rows.
+// Rendering cap: if generated_html exceeds HTML_SIZE_MAX_BYTES (500KB)
+// we show a size warning + a download link rather than inlining —
+// keeps the admin page responsive on pathological rows.
+//
+// The cap is also enforced as a quality gate at write-time (M11-4)
+// so this branch should rarely be reached in production; both sides
+// import the same constant so they can never drift.
 // ---------------------------------------------------------------------------
-
-const INLINE_HTML_MAX_BYTES = 500 * 1024;
-
-function estimateBytes(html: string): number {
-  // Byte-length estimate without spawning Buffer / TextEncoder on the
-  // server render hot path. Approximation is fine — we only need to
-  // gate the "inline vs. download" decision.
-  return html.length;
-}
 
 export function PageHtmlPreview({ html }: { html: string | null }) {
   if (!html) {
@@ -33,14 +30,14 @@ export function PageHtmlPreview({ html }: { html: string | null }) {
     );
   }
 
-  if (estimateBytes(html) > INLINE_HTML_MAX_BYTES) {
+  if (estimateHtmlBytes(html) > HTML_SIZE_MAX_BYTES) {
     return (
       <div
         className="flex h-64 w-full flex-col items-center justify-center gap-2 rounded-md border bg-muted/30 p-6 text-sm text-muted-foreground"
         data-testid="page-html-preview-too-large"
       >
         <p>
-          Generated HTML is larger than {INLINE_HTML_MAX_BYTES / 1024}KB — inline
+          Generated HTML is larger than {HTML_SIZE_MAX_BYTES / 1024}KB — inline
           preview skipped to keep the admin page responsive.
         </p>
         <p className="text-xs">
@@ -55,7 +52,7 @@ export function PageHtmlPreview({ html }: { html: string | null }) {
       <div className="flex items-center justify-between border-b px-3 py-2 text-xs text-muted-foreground">
         <span>Preview (static, design-system CSS only)</span>
         <span className="font-mono">
-          {(estimateBytes(html) / 1024).toFixed(1)} KB
+          {(estimateHtmlBytes(html) / 1024).toFixed(1)} KB
         </span>
       </div>
       {/*

--- a/lib/__tests__/quality-gates.test.ts
+++ b/lib/__tests__/quality-gates.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from "vitest";
 import {
   ALL_GATES,
   gateHtmlBasics,
+  gateHtmlSize,
   gateMetaDescription,
   gateScopePrefix,
   gateSlugKebab,
   gateWrapper,
+  HTML_SIZE_MAX_BYTES,
   runGates,
   type GateContext,
 } from "@/lib/quality-gates";
@@ -278,17 +280,18 @@ describe("runGates", () => {
   });
 
   it("short-circuits on first failure and names the gate", () => {
-    // Wrapper missing → fails at the FIRST gate, later gates never run.
+    // Wrapper missing → html_size passes (tiny body), then wrapper
+    // fails; later gates never run.
     const r = runGates(ctx({ html: "<section><h1>x</h1></section>" }));
     expect(r.kind).toBe("failed");
     if (r.kind !== "failed") return;
     expect(r.first_failure.gate).toBe("wrapper");
-    expect(r.gates_run).toEqual(["wrapper"]);
+    expect(r.gates_run).toEqual(["html_size", "wrapper"]);
   });
 
   it("runs multiple gates in order when earlier ones pass", () => {
-    // Valid wrapper, valid scope prefix, but zero h1 → fails at
-    // html_basics (third gate).
+    // Valid size, valid wrapper, valid scope prefix, but zero h1 →
+    // fails at html_basics (fourth gate).
     const r = runGates(
       ctx({
         html:
@@ -298,6 +301,53 @@ describe("runGates", () => {
     expect(r.kind).toBe("failed");
     if (r.kind !== "failed") return;
     expect(r.first_failure.gate).toBe("html_basics");
-    expect(r.gates_run).toEqual(["wrapper", "scope_prefix", "html_basics"]);
+    expect(r.gates_run).toEqual([
+      "html_size",
+      "wrapper",
+      "scope_prefix",
+      "html_basics",
+    ]);
+  });
+
+  it("short-circuits at html_size before the regex-heavy gates touch an oversized payload", () => {
+    // Payload well over the 500KB cap. Even though the wrapper is
+    // missing and every other gate would fail, the runner must stop
+    // at html_size so we don't waste CPU scanning a 1MB string.
+    const oversize = "<section>" + "a".repeat(HTML_SIZE_MAX_BYTES + 1) + "</section>";
+    const r = runGates(ctx({ html: oversize }));
+    expect(r.kind).toBe("failed");
+    if (r.kind !== "failed") return;
+    expect(r.first_failure.gate).toBe("html_size");
+    expect(r.gates_run).toEqual(["html_size"]);
+    expect(r.first_failure.details?.code).toBe("HTML_TOO_LARGE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gateHtmlSize (M11-4)
+// ---------------------------------------------------------------------------
+
+describe("gateHtmlSize", () => {
+  it("passes for a comfortably-sized HTML payload", () => {
+    const r = gateHtmlSize(ctx({ html: validHtml() }));
+    expect(r.kind).toBe("pass");
+  });
+
+  it("passes at exactly the cap (boundary)", () => {
+    const atCap = "a".repeat(HTML_SIZE_MAX_BYTES);
+    const r = gateHtmlSize(ctx({ html: atCap }));
+    expect(r.kind).toBe("pass");
+  });
+
+  it("fails one byte over the cap with HTML_TOO_LARGE details", () => {
+    const overCap = "a".repeat(HTML_SIZE_MAX_BYTES + 1);
+    const r = gateHtmlSize(ctx({ html: overCap }));
+    expect(r.kind).toBe("fail");
+    if (r.kind !== "fail") return;
+    expect(r.gate).toBe("html_size");
+    expect(r.details?.code).toBe("HTML_TOO_LARGE");
+    expect(r.details?.actual_bytes).toBe(HTML_SIZE_MAX_BYTES + 1);
+    expect(r.details?.cap_bytes).toBe(HTML_SIZE_MAX_BYTES);
+    expect(r.reason).toMatch(/over/i);
   });
 });

--- a/lib/html-size.ts
+++ b/lib/html-size.ts
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------------
+// M11-4 — shared HTML size cap.
+//
+// 500KB ceiling on generated_html at both the render and write sides.
+// Historically the render-side cap was a constant duplicated inside
+// components/PageHtmlPreview.tsx; M11-4 hoists it here so the write-
+// path quality gate and the render path can never drift.
+//
+// The cap is a defensive guard against pathological generations — real
+// LeadSource-scale pages observed through M3 and M7 are 30–150KB.
+// 500KB is ~3× the tail, generous enough that legitimate 40-section
+// landing pages pass cleanly and tight enough that an accidentally
+// quadratic prompt doesn't silently ship.
+// ---------------------------------------------------------------------------
+
+export const HTML_SIZE_MAX_BYTES = 500 * 1024;
+
+export type HtmlSizeCheckResult =
+  | { ok: true }
+  | {
+      ok: false;
+      code: "HTML_TOO_LARGE";
+      actual_bytes: number;
+      cap_bytes: number;
+    };
+
+/**
+ * Byte-length estimate for an HTML string. We use the JS string length
+ * rather than a precise UTF-8 byte count — the cap is a rough guard,
+ * not a precise storage limit, and the string length is strictly less
+ * than the UTF-8 byte length for non-ASCII content (so any string that
+ * passes the JS-length cap also passes the UTF-8-byte cap).
+ */
+export function estimateHtmlBytes(html: string): number {
+  return html.length;
+}
+
+export function checkHtmlSize(html: string): HtmlSizeCheckResult {
+  const actual_bytes = estimateHtmlBytes(html);
+  if (actual_bytes > HTML_SIZE_MAX_BYTES) {
+    return {
+      ok: false,
+      code: "HTML_TOO_LARGE",
+      actual_bytes,
+      cap_bytes: HTML_SIZE_MAX_BYTES,
+    };
+  }
+  return { ok: true };
+}

--- a/lib/quality-gates.ts
+++ b/lib/quality-gates.ts
@@ -1,3 +1,8 @@
+import {
+  HTML_SIZE_MAX_BYTES,
+  checkHtmlSize,
+} from "@/lib/html-size";
+
 // ---------------------------------------------------------------------------
 // M3-5 — Runtime quality gates.
 //
@@ -23,6 +28,17 @@
 //                             hyphens, no leading/trailing hyphen.
 //   meta_description   meta[name=description] content length is
 //                             50–160 chars.
+//
+// Added in M11-4:
+//
+//   html_size          Runs first so pathological mis-generations
+//                             short-circuit before the regex-heavy
+//                             gates scan a 1MB string. 500KB cap
+//                             matches the render-side cap in
+//                             components/PageHtmlPreview.tsx (both
+//                             import HTML_SIZE_MAX_BYTES from
+//                             lib/html-size so the numbers can never
+//                             drift).
 //
 // Gates deferred to a follow-up slice (M3-5b), with reasons:
 //
@@ -54,6 +70,7 @@ export type GateFail = {
 export type GateResult = GatePass | GateFail | GateSkip;
 
 export type GateName =
+  | "html_size"
   | "wrapper"
   | "scope_prefix"
   | "html_basics"
@@ -102,6 +119,26 @@ function countTagOccurrences(html: string, tag: string): number {
 // ---------------------------------------------------------------------------
 // Gate implementations
 // ---------------------------------------------------------------------------
+
+/**
+ * M11-4: reject generations whose HTML exceeds HTML_SIZE_MAX_BYTES
+ * (500KB). Runs first so oversized payloads short-circuit before the
+ * regex-heavy gates scan them.
+ */
+export const gateHtmlSize: GateFn = (ctx) => {
+  const res = checkHtmlSize(ctx.html);
+  if (res.ok) return { kind: "pass", gate: "html_size" };
+  return {
+    kind: "fail",
+    gate: "html_size",
+    reason: `Generated HTML is ${res.actual_bytes} bytes, over the ${res.cap_bytes}-byte cap.`,
+    details: {
+      code: "HTML_TOO_LARGE",
+      actual_bytes: res.actual_bytes,
+      cap_bytes: res.cap_bytes,
+    },
+  };
+};
 
 /** HC-2: outermost element has data-ds-version matching the site's active DS. */
 export const gateWrapper: GateFn = (ctx) => {
@@ -270,12 +307,17 @@ function validateMetaLen(content: string): GateResult {
 // ---------------------------------------------------------------------------
 
 export const ALL_GATES: Array<{ name: GateName; fn: GateFn }> = [
+  { name: "html_size", fn: gateHtmlSize },
   { name: "wrapper", fn: gateWrapper },
   { name: "scope_prefix", fn: gateScopePrefix },
   { name: "html_basics", fn: gateHtmlBasics },
   { name: "slug_kebab", fn: gateSlugKebab },
   { name: "meta_description", fn: gateMetaDescription },
 ];
+
+// Re-export HTML_SIZE_MAX_BYTES so callers who import only the gates
+// can read the cap constant without pulling a second module.
+export { HTML_SIZE_MAX_BYTES };
 
 export type RunGatesResult =
   | { kind: "passed"; gates_run: GateName[] }


### PR DESCRIPTION
Closes audit gap #9 and finishes the M6 parent plan's risk #5 claim. M6-2 already had a 500KB cap on the render side (`components/PageHtmlPreview.tsx`), but no matching write-time guard — a pathological mis-generation could still persist to `pages.generated_html` and silently bloat the admin surface.

## What lands

- **`lib/html-size.ts`** — single source of truth for `HTML_SIZE_MAX_BYTES` (500KB) + `estimateHtmlBytes()` + `checkHtmlSize()` helper. Render side + write side both import from here so the numbers can't drift.
- **`lib/quality-gates.ts`** — new `gateHtmlSize` wired in as the FIRST gate in `ALL_GATES` so oversized payloads short-circuit before the regex-heavy gates touch them. Re-exports `HTML_SIZE_MAX_BYTES`.
- **`components/PageHtmlPreview.tsx`** — swaps its local constant + local helper for the shared module.
- **`lib/__tests__/quality-gates.test.ts`** — updated `gates_run` order to include `html_size` at the head; new describe block pins the gate's boundary behaviour (at-cap pass, one-byte-over fail with `HTML_TOO_LARGE` code, oversized-short-circuit before the wrapper gate runs).

## Why a gate rather than a publisher check

The parent plan described M11-4 as a publisher-level check. Gating is a cleaner fit: it runs at the same point in the pipeline (between Anthropic and publisher), already feeds the existing `failed_gates` failure code, and gets event-log tracking for free. Both the batch worker and the regen worker run `runGates()`, so one change covers both surfaces. The gate's `first_failure.details.code = 'HTML_TOO_LARGE'` gives operators the clear code the task called for.

## Risks identified and mitigated

- **False-rejecting a legitimate 40-section landing page.** → 500KB matches the render-side cap already running in production; real LeadSource pages through M3/M7 are 30–150KB. Tests pin the boundary at exactly `HTML_SIZE_MAX_BYTES` as passing.
- **Two places, one number — drift risk.** → Render + gate both import from `lib/html-size`. No constant copy.
- **Gate ordering regresses existing tests.** → Updated `runGates` `gates_run` assertions to put `html_size` at the head. New assertion proves `runGates` stops at `html_size` when the payload is oversized, so regex-heavy gates aren't fed a 1MB string.
- **Pathological input causes DoS in the gate itself.** → The gate is a single `.length` check — sub-microsecond; no regex.

## Deliberately deferred

- Auditor-suggested "publisher-level HTML_TOO_LARGE error code". The gate pattern reaches the same operator signal without introducing a parallel error-code path. If a future slice wants a separate code, the gate detail already carries it.
- Retroactive rejection of existing rows over-cap. No such rows exist today on LeadSource-scale batches; the gate only fires for new generations.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — runs in CI.
- [ ] `npm run test:e2e` — runs in CI.