### PR TITLE
feat(m11-5): budget E2E coverage + stabilise chat.spec.ts assertions

### DIFF
--- a/e2e/budgets.spec.ts
+++ b/e2e/budgets.spec.ts
@@ -115,7 +115,11 @@ test.describe("tenant budget admin surface", () => {
 
     const err = page.getByTestId("edit-tenant-budget-error");
     await expect(err).toBeVisible();
-    await expect(err).toContainText(/version|conflict|stale/i);
+    // The client surfaces the server's VERSION_CONFLICT message as a
+    // human-readable "Another operator changed this budget since you
+    // opened the editor…". Match on load-bearing keywords so the
+    // assertion survives future copy tweaks.
+    await expect(err).toContainText(/another operator|changed|reload/i);
     await expect(
       page.getByRole("dialog", { name: /edit budget caps/i }),
     ).toBeVisible();

--- a/e2e/budgets.spec.ts
+++ b/e2e/budgets.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { auditA11y, signInAsAdmin } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// M11-5 — Tenant budget admin surface smoke test.
+//
+// M8-5 shipped the budget badge + PATCH endpoint with zero Playwright
+// coverage (audit 2026-04-22 M8 partial finding). This spec locks the
+// UI contract:
+//
+//   - Badge renders on /admin/sites/[id] with daily + monthly rows.
+//   - Edit modal opens, updates caps via the PATCH endpoint, badge
+//     reflects the new values after router.refresh().
+//   - Stale-version PATCH surfaces VERSION_CONFLICT inline without
+//     closing the modal.
+//
+// We drive the seeded E2E site (global-setup creates it with the
+// auto-trigger budget row) rather than provisioning a new site per
+// test. Playwright config pins `workers: 1` so serial execution
+// means the cap mutations between tests don't race.
+// ---------------------------------------------------------------------------
+
+async function gotoE2ESiteDetail(page: Page): Promise<string> {
+  await page.goto("/admin/sites");
+  await page
+    .getByRole("link", { name: "E2E Test Site" })
+    .first()
+    .click();
+  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}$/);
+  return page.url();
+}
+
+test.describe("tenant budget admin surface", () => {
+  test.beforeEach(async ({ page }) => {
+    await signInAsAdmin(page);
+  });
+
+  test("budget badge renders on site detail with daily + monthly rows", async ({
+    page,
+  }, testInfo) => {
+    await gotoE2ESiteDetail(page);
+    const badge = page.getByTestId("tenant-budget-badge");
+    await expect(badge).toBeVisible();
+    await expect(badge.getByText(/^Daily$/)).toBeVisible();
+    await expect(badge.getByText(/^Monthly$/)).toBeVisible();
+    await expect(badge.getByText(/^Resets /).first()).toBeVisible();
+    await auditA11y(page, testInfo);
+  });
+
+  test("edit-caps modal updates the daily + monthly caps; badge reflects the new values", async ({
+    page,
+  }) => {
+    await gotoE2ESiteDetail(page);
+    await expect(page.getByTestId("edit-tenant-budget-button")).toBeVisible();
+    await page.getByTestId("edit-tenant-budget-button").click();
+
+    const daily = page.getByLabel(/daily cap/i);
+    const monthly = page.getByLabel(/monthly cap/i);
+    await expect(daily).toBeVisible();
+    await daily.fill("17.50");
+    await monthly.fill("275");
+    await page.getByRole("button", { name: /save caps/i }).click();
+
+    await expect(
+      page.getByRole("dialog", { name: /edit budget caps/i }),
+    ).toHaveCount(0);
+    const badge = page.getByTestId("tenant-budget-badge");
+    await expect(badge).toContainText("/ $17.50");
+    await expect(badge).toContainText("/ $275.00");
+  });
+
+  test("stale-version PATCH surfaces a conflict without closing the modal", async ({
+    page,
+  }) => {
+    const siteUrl = await gotoE2ESiteDetail(page);
+    const siteId = siteUrl.split("/").pop() as string;
+
+    // Open the modal so it captures whatever server-side version_lock
+    // was rendered into the button's props.
+    await page.getByTestId("edit-tenant-budget-button").click();
+
+    // Bump the server-side version while the modal is open. Discover
+    // the current version by retrying expected_version=1..20 until
+    // one succeeds; the first success advances the row by one, which
+    // is enough to stale out the open modal's snapshot.
+    const bumped = await page.evaluate(async (id: string) => {
+      for (let attempt = 1; attempt <= 20; attempt++) {
+        const res = await fetch(
+          `/api/admin/sites/${encodeURIComponent(id)}/budget`,
+          {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              expected_version: attempt,
+              patch: { daily_cap_cents: 100 * attempt + 7 },
+            }),
+          },
+        );
+        if (res.status === 200) {
+          return { succeededAtVersion: attempt };
+        }
+      }
+      throw new Error(
+        "Could not find a matching expected_version within 20 attempts",
+      );
+    }, siteId);
+    expect(bumped.succeededAtVersion).toBeGreaterThan(0);
+
+    // Submit the open modal with its now-stale captured version. The
+    // server rejects with VERSION_CONFLICT and the modal stays open
+    // with an error alert.
+    await page.getByLabel(/daily cap/i).fill("42");
+    await page.getByRole("button", { name: /save caps/i }).click();
+
+    const err = page.getByTestId("edit-tenant-budget-error");
+    await expect(err).toBeVisible();
+    await expect(err).toContainText(/version|conflict|stale/i);
+    await expect(
+      page.getByRole("dialog", { name: /edit budget caps/i }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -86,8 +86,10 @@ test.describe("chat builder", () => {
     await expect(page.getByText("Make me a homepage")).toBeVisible();
     await expect(page.getByText("Hello there")).toBeVisible();
 
-    // Send button returns to enabled state once the stream closes.
-    await expect(page.getByRole("button", { name: /send/i })).toBeEnabled();
+    // Stream closed cleanly: textarea re-enables (the Send button
+    // stays disabled because sendDisabled also checks `!input.trim()`
+    // and HomePageClient clears input on submit).
+    await expect(textarea).toBeEnabled();
   });
 
   test("error path — upstream failure renders an inline error bubble", async ({
@@ -114,7 +116,8 @@ test.describe("chat builder", () => {
     await page.getByRole("button", { name: /send/i }).click();
 
     await expect(page.getByText(/Anthropic upstream failed/)).toBeVisible();
-    // Stream closes cleanly: input re-enables, no hung "…" indicator.
-    await expect(page.getByRole("button", { name: /send/i })).toBeEnabled();
+    // Stream closed cleanly: textarea is enabled again (disabled
+    // only gates on streaming + activeSiteId; no hung "…" indicator).
+    await expect(textarea).toBeEnabled();
   });
 });


### PR DESCRIPTION
Closes the audit M8-partial finding: M8 shipped admin UI + PATCH endpoint with zero Playwright coverage. Also rolls in a chat.spec.ts fix — M11-1's E2E asserted the Send button re-enables after stream close, but `sendDisabled` in HomePageClient also gates on `!input.trim()` and submit clears the input, so the Send button stays disabled after every send. PR #88 and PR #89 both inherited the broken spec from main; this bundles the retarget so the next round of CI is green.

## What lands

- **`e2e/budgets.spec.ts`** — three tests on `/admin/sites/[id]`:
  1. Badge renders with Daily + Monthly rows + reset captions, plus `auditA11y()`.
  2. Edit-caps modal updates both caps, badge reflects the new dollar values after `router.refresh()`.
  3. Stale-version PATCH surfaces VERSION_CONFLICT inline; modal stays open. Uses a bounded retry loop (`expected_version` 1..20) to discover the current version so the test is resilient to whatever state prior tests left.
- **`e2e/chat.spec.ts`** — the two assertions that pinned "Send button enabled after stream close" retarget to "textarea enabled after stream close." Textarea disabled-state is purely a function of `streaming || !activeSiteId`, which is what the test actually wants to pin.

## Risks identified and mitigated

- **Budget spec races the hourly reset cron.** → Tests only read `*_cap_cents` and `*_usage_cents` shapes that the cron doesn't touch; the cron only advances `*_reset_at`. No race.
- **Bounded retry loop is flaky on a pathological starting version.** → Capped at 20 attempts, which covers any state prior tests could leave (each test bumps version by ≤1). Throws with a clear message if it somehow doesn't converge.
- **Serial test ordering.** → Playwright config pins `workers: 1, fullyParallel: false`, so modal-edit tests don't race each other for the budget row.
- **Chat assertion change is a widened regression net.** → Textarea enables when streaming flips to false (same signal as before); Send button state is a richer function that the test shouldn't be pinned to. The new assertion correctly exercises "stream terminated cleanly."

## Deliberately deferred

- **Unit test for the EditTenantBudgetModal client state** — pure UI state + fetch, no server-side coverage value. The E2E exercises it end-to-end.
- **Budget cap-reached error E2E** (enqueue → reserveBudget → BUDGET_EXCEEDED). The M8-2 unit suite already pins this; a UI E2E would require stubbing the batch-create happy path which is out of scope for budget coverage.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — runs in CI.
- [ ] `npm run test:e2e` — runs in CI.