### PR TITLE
docs(m11-6): retroactive parent plans + audit close-out hygiene

### DIFF
--- a/docs/AUDIT_2026-04-22.md
+++ b/docs/AUDIT_2026-04-22.md
@@ -1,0 +1,161 @@
+# Codebase Audit — 2026-04-22
+
+Adversarial read of the repo against its own docs. Trust the code, not the docs; if there's a conflict, the code wins and the doc is drift. Branch audited: `feat/m10-observability-activation` at `82b4131`. No code was modified.
+
+---
+
+## Executive summary
+
+The codebase through M10 is substantively in the shape its docs describe: schema, workers, admin UIs, write-safety scaffolding (idempotency keys, event-log-first accounting, optimistic locking, partial unique indexes) are all present and the test suite exercises the specific write-safety invariants. Every BACKLOG "shipped in Mx" row maps to real files, real migrations, and real tests; every numbered "risks mitigated" claim in the M4–M8 parent plans has a matching test case with the exception of a handful of operational / forward-looking risks (cloudflare_id drift, /api/health tenant-reset monitor, 500KB HTML cap, a couple of regen failure codes). The biggest real gaps are **not** in the shipped milestones — they are in the chat surface (the product's *headline* feature): it bypasses the M10 observability contract (raw `console.log`, no Langfuse span wrapper, no Playwright coverage), and the M1–M3 milestones never got parent-plan docs so their risk-audit history is implicit in tests rather than written down. LeadSource can launch from this state, but two of the ten deferred "unblocked" observability items (Langfuse coverage on chat, Upstash rate limiting on `/api/auth/*`) should land before real customer traffic arrives.
+
+---
+
+## Milestones
+
+Legend: **pass** = every claim verified in code; **partial** = core shipped but specific claims unverified; **discrepancy** = doc says shipped, code disagrees.
+
+### M1 — design system schema — pass (undocumented)
+- Migrations `0002_m1a_design_system_schema.sql` + `0003_m1b_rpcs.sql` present; tables `design_systems`, `design_components`, `design_templates` exist with `version_lock` per `docs/DATA_CONVENTIONS.md`.
+- Tests: `lib/__tests__/design-systems.test.ts`, `templates.test.ts`, `components.test.ts`, `api-design-systems.test.ts`, `api-templates.test.ts`, `api-components.test.ts`.
+- **Gap:** no `docs/plans/m1-parent.md` exists. M1 scope is inferable only from migration filenames + BACKLOG historical references. Listed under "Documentation drift" below, not treated as a code gap.
+
+### M2 — auth + admin UI — pass (undocumented)
+- Migrations `0004_m2a_auth_link.sql` (auth.users ↔ app_users trigger), `0005_m2b_rls_policies.sql` (role matrix), `0006_m2c_revoked_at.sql` (revoke column) all present.
+- Code: `lib/auth.ts`, `admin-gate.ts`, `admin-api-gate.ts`, `auth-kill-switch.ts`, `auth-revoke.ts`, `middleware.ts` (referenced 3× in kill-switch path), `app/api/emergency/route.ts` (supports `kill_switch_on`/`kill_switch_off`/`revoke_user`).
+- Tests: `m2a-auth-link.test.ts`, `m2b-rls.test.ts`, `auth.test.ts`, `middleware.test.ts`, `auth-kill-switch.test.ts`, `admin-gate.test.ts`, `admin-api-gate.test.ts`, `admin-users-{list,invite,role,revoke}.test.ts`, `emergency-route.test.ts`.
+- **Gap:** no `docs/plans/m2-parent.md`.
+
+### M3 — batch generator — pass (undocumented)
+- Migrations `0007_m3_1_batch_schema.sql` (generation_jobs, generation_job_pages, generation_events with lease-coherence CHECK + slug `UNIQUE (site_id, slug)`), `0008_m3_4_slot_html.sql`, `0009_m3_7_retry_after.sql`.
+- Code: `lib/batch-worker.ts`, `batch-publisher.ts`, `batch-jobs.ts` (enqueue + budget gate), `quality-gates.ts`, `anthropic-call.ts`, `anthropic-pricing.ts`; cron entrypoint `app/api/cron/process-batch/route.ts`; admin surface `app/admin/batches/{page,[id]/page}.tsx`.
+- Tests: `m3-schema.test.ts`, `batch-worker.test.ts`, `batch-worker-anthropic.test.ts`, `batch-worker-publish.test.ts`, `batch-worker-retry.test.ts`, `batch-worker-gates.test.ts`, `batch-create.test.ts`, `batch-cancel.test.ts`, `quality-gates.test.ts`.
+- **Gap:** no `docs/plans/m3-parent.md`; M3 is repeatedly cited as the "proof-of-pattern" for write-safety but its own risk audit lives only in test file comments.
+
+### M4 — image library — pass
+- 7 sub-slices merged (PRs #57–#63) match the PRs in the BACKLOG "shipped in M4" table.
+- Code: `lib/transfer-worker.ts`, `cloudflare-images.ts`, `anthropic-caption.ts`, `istock-seed.ts`, `search-images.ts`, `wp-media-transfer.ts`, `html-image-rewrite.ts`; script `scripts/seed-istock-library.ts`; schema `0010_m4_1_image_library_schema.sql` (only migration to date that carries `deleted_at`/audit columns/partial unique indexes per `docs/DATA_CONVENTIONS.md`).
+- **12 of 13 numbered risks have matching tests.** Cloudflare idempotency, Anthropic captioning, `image_usage (image_id, site_id)` race, 429 backoff, seed dry-run budget, HTML-rewrite parser coverage (nested `<picture>`, srcset, data/absolute/relative URLs), mid-run resume — all exercised.
+- **Risk #13 (`image_library.cloudflare_id` drift) is runbook-only**, and the plan itself calls this out as "no active reconciliation." Accepted — not a test gap.
+- **E2E:** plan line 105 footnotes M4 as "chat-surfaced search tested via `e2e/batches.spec.ts`." `batches.spec.ts` does not exercise `search_images`. Called out below under "Known gaps" because the plan deferred the chat-builder E2E; this has carried forward to M10 with no fix.
+
+### M5 — image library admin UI — pass
+- 4 sub-slices merged (PRs #64–#67). Pages: `/admin/images`, `/admin/images/[id]`. Data layer: `lib/image-library.ts` (`listImages`, `getImage`, `updateImageMetadata`, `softDeleteImage`, `restoreImage`). API: `PATCH /api/admin/images/[id]`, `DELETE /api/admin/images/[id]`, `POST /api/admin/images/[id]/restore`.
+- All 12 numbered risks exercised in `lib/__tests__/image-library.test.ts` (VERSION_CONFLICT at line 60, IMAGE_IN_USE at lines 667/703, filter composition, pagination clamp, soft-delete visibility).
+- **E2E:** `e2e/images.spec.ts` has 11 tests covering list / filter / source filter / detail round-trip / archive / restore / edit with `auditA11y()` on visited pages.
+
+### M6 — per-page admin surface — partial
+- 4 sub-slices merged (PRs #68–#71). Pages: `/admin/sites/[id]/pages`, `/admin/sites/[id]/pages/[pageId]`. Data: `lib/pages.ts`. API: `PATCH /api/admin/sites/[id]/pages/[pageId]` (version_lock + 23505 → UNIQUE_VIOLATION).
+- Tests: `pages.test.ts` covers site-scope guard, filter composition, slug-wildcard stripping, ORDER BY updated_at, VERSION_CONFLICT, UNIQUE_VIOLATION, updated_by stamping.
+- **E2E:** `e2e/pages.spec.ts` covers list, status filter, nav from site detail, back-nav preserves filter, cross-site 404, empty preview, edit-modal round-trip, M7's regen button + REGEN_ALREADY_IN_FLIGHT (10 tests).
+- **Discrepancy (risk #5 in the plan):** plan says "Detail page caps inline rendering at 500KB; larger payloads show a 'Download raw HTML' link." No such cap is present in `app/admin/sites/[id]/pages/[pageId]/page.tsx`; no `500_000` / `Download raw` string anywhere. The iframe renders `generated_html` directly. Not a security issue (iframe is `sandbox="allow-same-origin"` — confirmed — so scripts don't execute), but the pathological-record guard the plan advertised isn't wired.
+
+### M7 — single-page re-generation — pass (with small test gaps)
+- 5 sub-slices merged (PRs #72, #73, #75, #77, #78). Schema `0011_m7_1_regeneration_schema.sql` includes the keystone partial UNIQUE `regeneration_jobs_one_active_per_page WHERE status IN ('pending','running')`, lease-coherence CHECK (status/worker_id/lease_expires_at consistency), append-only `regeneration_events`, `anthropic_idempotency_key` + `wp_idempotency_key` UNIQUE-per-job.
+- Code: `lib/regeneration-worker.ts`, `regeneration-publisher.ts`, `regeneration-publisher.ts:312–354` implements the drift-reconciliation (`GET wp → driftDetected = wpSlug !== page.slug → PUT body carries slug iff drift`), cron `app/api/cron/process-regenerations/route.ts`, enqueue `app/api/admin/sites/[id]/pages/[pageId]/regenerate/route.ts`, UI `components/RegenerateButton.tsx` + `RegenHistoryPanel.tsx`.
+- Tests: `regeneration-publisher.test.ts` exercises happy path, wp_idempotency_key threading, gates-failure, **slug drift with new slug in PUT body**, drift-off case, partial-commit adoption (wp_put_succeeded already logged → skip PUT), VERSION_CONFLICT on pages.version_lock, WP_GET_FAILED, WP_PUT_FAILED. `regeneration-worker.test.ts` exercises VERSION_CONFLICT short-circuit, lease/heartbeat/reaper, and `cancel_requested_at` at line 290 (so regen cancel path IS tested despite agent's initial read).
+- **Test gaps (minor):** plan risk #7 (DS_ARCHIVED) — the failure code path exists at `regeneration-worker.ts:377` but the only reference in tests is a top-of-file comment; no `it(...)` asserts the archived-DS branch. Plan risk #15 (WP_CREDS_MISSING) — the code path exists but no dedicated test seeds a site without credentials. Plan risk #2 (`/api/health` alert on stuck reset_at counters) is forward-looking and not yet implemented in `app/api/health/route.ts`.
+
+### M8 — per-tenant cost budgets — partial
+- 5 sub-slices merged (PRs #79–#83). Schema `0012_m8_1_tenant_cost_budgets.sql` with UNIQUE on site_id, daily/monthly reset timestamps, version_lock, auto-create trigger on site INSERT, backfill on apply.
+- Code: `lib/tenant-budgets.ts` — `reserveBudget()` uses `SELECT ... FOR UPDATE` (line 91) as plan requires; self-healing upsert on missing row (line 71); `resetExpiredBudgets()` uses idempotent `WHERE ..._reset_at < now()`. `lib/batch-jobs.ts` and `lib/regeneration-publisher.ts` both call `reserveBudget` inside their enqueue transactions.
+- Admin UI: `components/TenantBudgetBadge.tsx`, `EditTenantBudgetButton.tsx`; route `app/api/admin/sites/[id]/budget/route.ts` (Zod + version_lock).
+- Tests: `m8-tenant-budgets-schema.test.ts`, `m8-tenant-budget-enforcement.test.ts` (reserveBudget ok/daily-exceeded/monthly-exceeded/self-heal + concurrent race + createBatchJob/enqueueRegenJob gates), `m8-budget-reset.test.ts` (advance timestamp, future-reset untouched, idempotent second tick), `m8-budget-admin-ui.test.ts` (update caps, VERSION_CONFLICT, NOT_FOUND, partial patch, 0-caps paused tenant, updated_by stamp).
+- **Discrepancy (M8-3 iStock integration).** The M8 parent plan (line 50–51) says M8-3 adds "per-tenant cap check" to `lib/istock-seed.ts`. The actual commit message (`ae21b1c feat(m8-3): iStock seed — ISTOCK_SEED_CAP_CENTS env ceiling`) and the code (`istock-seed.ts:206–263`) implement a **process-level env cap**, not a per-tenant `reserveBudget` call. The BACKLOG M8-3 row matches the code ("`ISTOCK_SEED_CAP_CENTS` env ceiling; effective cap = min(caller, env)"); the M8 parent plan does not. Treat the plan as the stale doc; BACKLOG is correct.
+- **Gap (plan risk #2, cron-stuck monitor).** Plan says `/api/health` should flag "N tenants with reset_at > 25h in the past." `app/api/health/route.ts` currently only probes Supabase connectivity. No tenant-reset monitor.
+- **E2E gap:** no Playwright spec exercises the budget badge / PATCH endpoint. M8 coverage is unit-only.
+
+### M9 — Next.js 14.2.35 CVE mitigation — pass
+- `package.json` declares `"next": "^14.2.15"` but `package-lock.json` pins `node_modules/next` to `14.2.35` — the actual installed version matches the claim.
+- `next.config.mjs` sets `images.remotePatterns: []`, `images.unoptimized: true`, declares no `rewrites()` — the three reachable CVEs (GHSA-9g9p-9gw9-jx7f, GHSA-3x4c-7xq6-9pq8, GHSA-ggv3-7p47-pfv8) are config-closed as claimed.
+- `docs/SECURITY_NEXTJS_CVES.md` ships the exposure matrix with per-CVE reasoning; the two RSC CVEs (GHSA-h25m-26qc-wcjf, GHSA-q4gf-8mx6-v5v3) are acknowledged as platform-mitigated and block self-hosting.
+- `.github/workflows/audit.yml` threshold stays at `critical`; matches the plan's "tighten when 14→16 migration lands."
+- **Doc observation (not a gap):** M9 has no `docs/plans/m9-parent.md`; the rationale lives entirely in `docs/SECURITY_NEXTJS_CVES.md` + the BACKLOG entry. Consistent with a "single-PR hybrid" milestone, but M1–M3, M9, M10 now form a pattern of parent-plan-less milestones that the repo's own convention (all other milestones have parent plans) contradicts.
+
+### M10 — observability activation — pass (with chat-path gap)
+- `instrumentation.ts`, `instrumentation-client.ts`, `sentry.server.config.ts`, `sentry.edge.config.ts` all present; `next.config.mjs` wraps `nextConfig` in `withSentryConfig(...)`.
+- `lib/logger.ts` additive Axiom transport via lazy `Axiom` client; fire-and-forget, falls back to stdout-only when `AXIOM_TOKEN`/`AXIOM_DATASET` missing.
+- `lib/langfuse.ts` lazy singleton + `traceAnthropicCall()` span wrapper, no-op when envs missing; `lib/redis.ts` `getRedisClient()` lazy singleton.
+- `app/api/ops/self-probe/route.ts` runs all four vendors in parallel, returns per-vendor `{ok, details|error}`, auths via Supabase admin session OR constant-time-compared `OPOLLO_EMERGENCY_KEY`; `docs/runbook/observability-verification.md` has curl commands + expected green response + per-vendor troubleshooting.
+- **Discrepancy.** BACKLOG asserts "`lib/anthropic-call.ts` wraps every call." `lib/anthropic-call.ts` is invoked by `lib/batch-worker.ts`, `lib/regeneration-worker.ts`, `lib/anthropic-caption.ts` — yes. But `app/api/chat/route.ts:186` news up its own `new Anthropic({ apiKey })` and calls `client.messages.stream(...)` directly — the chat path (the headline product feature per SCOPE_v3) is **not** wrapped in Langfuse. Every billed token spent by an operator using the chat builder produces zero Langfuse traces today.
+- Chat route also violates the M10 logger contract: `app/api/chat/route.ts` has `console.log` at lines 204 + 234 and `console.error` at line 315 on hot paths; CLAUDE.md says "Never `console.log` in production paths." `logger` is imported nowhere in `app/api/chat/route.ts`.
+- Follow-ups that BACKLOG correctly lists as open: `lib/prompts/v1/` directory doesn't exist yet; `lib/rate-limit.ts` doesn't exist yet. Both tracked in the "Observability-deep follow-ups (unblocked)" section and are not claimed as shipped.
+
+---
+
+## Feature areas
+
+### Auth — pass
+- `lib/auth.ts`, `admin-gate.ts`, `admin-api-gate.ts`, `auth-kill-switch.ts`, `auth-revoke.ts`, `middleware.ts`. Server actions for login/logout; Supabase SSR cookie plumbing.
+- E2E: `e2e/auth.spec.ts` covers unauthenticated redirect, sign-in + admin landing + sign-out, wrong-password generic message, admin reaches `/admin/users` (4 tests).
+- Kill switch covered in `lib/__tests__/auth-kill-switch.test.ts` + middleware behaviour in `middleware.test.ts`.
+
+### Design system — pass
+- `lib/design-systems.ts`, `templates.ts`, `components.ts`; admin UI at `/admin/sites/[id]/design-system/*` (tokens preview + templates list + components list). `CreateDesignSystemModal.tsx`, `TemplateFormModal.tsx`, `ComponentFormModal.tsx` — all three had M6-4 label-de-jargoning applied; `ux-debt-labels.test.ts` locks the new copy in place.
+- E2E: no dedicated spec for DS authoring. The DS surface is exercised implicitly via `e2e/batches.spec.ts` (site detail → batch modal reads DS) + `e2e/sites.spec.ts`. **Gap:** no Playwright spec covers the create-DS / add-template / add-component flows.
+
+### Batch generation — pass
+- `lib/batch-worker.ts`, `batch-publisher.ts`, `batch-jobs.ts`, cron route `app/api/cron/process-batch/route.ts`, admin surface `app/admin/batches/*`.
+- E2E: `e2e/batches.spec.ts` covers list render + site-scoped filter (2 tests). Batch creation + worker tick + publish are **not** exercised in E2E — only unit. Acceptable given the worker is CPU-bound and heavily unit-tested, but means there's no end-to-end smoke-test for the "new batch from UI → slot processed → publish" loop.
+
+### Image library — pass
+- Covered in M4 + M5 above. Transfer worker + admin UI + E2E all present.
+
+### Page regeneration — pass
+- Covered in M6 + M7 above. Drift reconciliation at publisher:322, `REGEN_ALREADY_IN_FLIGHT` returned at publisher:732, partial-commit recovery via event-log lookup. E2E covers regen-button happy path + in-flight conflict.
+
+### Budgets — partial
+- Covered in M8 above. Enforcement + reset + admin UI all real; unit coverage solid; **zero E2E coverage**; monitoring hook (stuck-reset alert in `/api/health`) is unimplemented.
+
+### Observability — partial
+- Sentry + Axiom + Langfuse + Upstash all wired with graceful no-op. Self-probe exists and has a runbook.
+- Chat route outside the contract (see M10 discrepancy above). No dedicated unit test for `lib/logger.ts` Axiom transport (only `logger.test.ts` for the stdout shape); no test for the self-probe route. Grep confirms: no `self-probe.test.ts`, no `axiom` assertions in `logger.test.ts`.
+
+---
+
+## Documentation drift
+
+Places where the docs claim features that don't exist, or understate / mis-specify what does.
+
+1. **No parent plans for M1, M2, M3, M9, M10.** `docs/plans/` contains only `m4.md` and `m5-parent.md` through `m8-parent.md`. For M1–M3 this is historical (the parent-plan convention was formalized during M4); for M9/M10 this is inconsistent with their own sub-slice-less style. Risk: future readers have no single source of truth for M1–M3's risk audit or M9/M10's rollback plan.
+2. **M10 BACKLOG overstates Langfuse coverage.** BACKLOG M10 row says `lib/anthropic-call.ts` "wraps every call." It does not — `app/api/chat/route.ts` bypasses it. Either the chat path needs to route through the wrapper (the stream shape would need a parallel `traceAnthropicStream`), or the BACKLOG text should say "wraps every non-chat call."
+3. **M8 parent plan overstates M8-3.** `docs/plans/m8-parent.md:50–51` says the iStock seed gets per-tenant enforcement. Code + BACKLOG + commit message all say process-level env cap. The BACKLOG is honest; the parent plan is stale.
+4. **M6 parent plan overstates HTML cap.** `docs/plans/m6-parent.md` risk #5 says detail page caps inline rendering at 500KB. No such cap exists.
+5. **M7 parent plan overstates health-endpoint coverage.** `docs/plans/m7-parent.md` risk #14 implies cron-monitoring visibility via `/api/health`; not implemented. (M8 has the same shape of overstatement at its risk #2.)
+6. **M4 plan overstates E2E coverage.** `docs/plans/m4.md:105` says M4-6's search tool is covered by `e2e/batches.spec.ts`. It isn't. The spec has no `search_images` interaction.
+7. **`supabase/data-migrations/` directory doesn't exist.** `docs/DATA_CONVENTIONS.md:63` and `docs/ENGINEERING_STANDARDS.md:167` both reference it. The DATA_CONVENTIONS text honestly notes "(directory to be added when the first data migration surfaces)" — not drift. The ENGINEERING_STANDARDS text doesn't carry that caveat; minor drift.
+8. **Schema hygiene pass is still outstanding across migrations 0001–0009.** Only `0010` ships the full `deleted_at`/`deleted_by`/`created_at`/`updated_at`/`created_by`/`updated_by` set. Docs acknowledge this in the BACKLOG "Schema hygiene pass" entry but `docs/DATA_CONVENTIONS.md` reads as though the convention is enforced globally. Future readers should not take DATA_CONVENTIONS at face value for older tables.
+9. **Three pre-existing E2E failures — status unclear.** BACKLOG "Testing > Investigate pre-existing E2E failures" has no strike-through, but commit `40ced06 fix(e2e): stabilise three pre-existing spec flakes (#76)` claims to have addressed them. Either the BACKLOG entry should be struck through or the commit oversold the fix. Needs a verification run (`npm run test:e2e`) to adjudicate — out of scope for this audit.
+
+---
+
+## Known gaps — deferred but not tracked in BACKLOG
+
+Things I found that are real and not in BACKLOG today. (Items already in BACKLOG are not repeated here.)
+
+1. **Chat builder has zero Playwright coverage.** `e2e/chat.spec.ts` doesn't exist. The chat path is the product's headline feature per SCOPE_v3; it renders at `/` via `HomePageClient`, streams through `/api/chat`, and is the only surface that exercises the 7 tools (`create_page`, `list_pages`, `get_page`, `update_page`, `publish_page`, `delete_page`, `search_images`) end-to-end. None of them are hit in E2E today. CLAUDE.md's "E2E coverage is a hard requirement for admin UI changes" rule arguably covers this even if the surface is user-facing rather than admin-facing.
+2. **Chat route bypasses the M10 observability contract.** See M10 discrepancy above. Not tracked as a BACKLOG entry or known issue.
+3. **Batch-worker happy path has no E2E.** `e2e/batches.spec.ts` renders the list + the new-batch button, but no test drives the full loop (create batch → cron tick → publish). The worker is heavily unit-tested but no smoke test proves the production wiring.
+4. **Design-system authoring has no E2E.** `TemplateFormModal`, `ComponentFormModal`, `CreateDesignSystemModal` are covered only by render-level label tests. Form submission + server-action round-trip is untested in E2E.
+5. **Self-probe route has no unit test.** `app/api/ops/self-probe/route.ts` is auth-sensitive (constant-time compare + admin-session OR emergency-key) and vendor-integration-heavy. A drift in any of the four vendor APIs goes undetected until a human runs the curl command. Worth a `lib/__tests__/self-probe.test.ts` that at least asserts the 401 paths + the ok: false envelopes when envs are unset.
+6. **No `lib/__tests__/logger-axiom.test.ts`.** `logger.test.ts` covers stdout emission + sanitisation but never asserts on the Axiom transport path. Ingest errors are swallowed by design; without a test, a regression that silently drops every record to Axiom would be invisible.
+7. **M7 risk #7 (DS_ARCHIVED) and #15 (WP_CREDS_MISSING) are implemented but untested.** Failure codes exist in `regeneration-worker.ts` but no test asserts the branch is reached.
+8. **M8 cron-stuck monitor (plan risk #2) unimplemented.** `/api/health` has only a Supabase probe.
+9. **M6-5 — enforce 500KB inline HTML cap** (per-page detail). The mitigation is documented in the M6 plan but not coded.
+10. **Chat route inline `Anthropic` client duplicates `lib/anthropic-call.ts` concerns.** The wrapper exists; the chat route does not use it. When the pricing-table scale audit lands (already in BACKLOG), the chat route will need a second cost-reporting path.
+
+---
+
+## Recommendations — ranked, for before LeadSource launch
+
+1. **Wire the chat route into `logger` + Langfuse.** Replace the three `console.*` calls in `app/api/chat/route.ts` with `logger.{info,error}` and wrap the `client.messages.stream(...)` call in a `traceAnthropicStream()` helper (new — the existing `traceAnthropicCall` is for the non-stream `create` shape). Without this, Sentry + Axiom + Langfuse are blind to the product's main cost + latency surface. Highest-impact gap, cheap fix.
+2. **Add an `e2e/chat.spec.ts` smoke test.** Even a single test that signs in, navigates to `/`, sends one message, asserts a token streams back with Anthropic stubbed, is enough to lock the surface against regressions. Today a broken chat route passes CI.
+3. **Land rate limiting on `/api/auth/*`, `/api/emergency`, `/login`.** The Upstash client ships and is ready; BACKLOG tracks the adapter as "unblocked but not yet wired." Auth routes without rate limiting are the obvious target for a launch-day brute-force attempt.
+4. **Write `lib/__tests__/self-probe.test.ts`.** The route's security posture (constant-time compare, emergency-key length floor) and its degrade-gracefully shape (per-vendor error envelopes) are both untested. A single mock-env-driven suite locks the contract.
+5. **Add a concrete test for M7 DS_ARCHIVED + WP_CREDS_MISSING branches.** Both are terminal-failure codes the regen admin UI surfaces to operators; both have zero branch-coverage today.
+6. **Reconcile the M8 iStock-seed doc drift.** Either change `docs/plans/m8-parent.md:50–51` to match the code + BACKLOG, or extend `lib/istock-seed.ts` to also call `reserveBudget` against a chosen site. The current state has three sources claiming different things.
+7. **Implement the M6 500KB HTML cap or delete the plan claim.** Prefer implementation — `generated_html` sizes will grow past 500KB on complex pages, and a silently heavy `/admin/sites/[id]/pages/[pageId]` render is a latency bug waiting to happen. If deferring, move the claim into the BACKLOG with a trigger.
+8. **Adjudicate the three pre-existing E2E flakes.** Run `npm run test:e2e` against main, update the BACKLOG entry with "shipped in #76" (strike-through) if green, or keep the entry + note which still fail.
+9. **Backfill parent plans for M1, M2, M3 (retroactively) and M9, M10 (for pattern consistency).** Low priority but high ROI for onboarding — today a reader has no central place to find M3's risk audit, and M3 is the proof-of-pattern everything else cites.
+10. **Schema hygiene pass (already in BACKLOG).** Don't block launch on this; do queue it immediately post-launch. `sites`, `pages`, `design_systems`, `design_components`, `design_templates` all need the full audit-column set before a real compliance surface asks for "who soft-deleted this row and when."
+
+Launch verdict: the shipped scope holds. Fix #1 and #2 before the first real customer session; the rest can land in the first post-launch sprint.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,23 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## M11 — audit close-out (shipped)
+
+Parent plan: `docs/plans/m11-parent.md`. Six sub-slices closing every concrete gap surfaced by `docs/AUDIT_2026-04-22.md`.
+
+| Slice | Status | Notes |
+| --- | --- | --- |
+| M11-1 | merged (#87) | Chat route routed through `lib/logger` + new `traceAnthropicStream()` Langfuse wrapper. `e2e/chat.spec.ts` covers the streaming UI contract. Corrected the BACKLOG "wraps every call" overstatement. |
+| M11-2 | merged | DS_ARCHIVED + WP_CREDS_MISSING regeneration branches now test-covered. Added a `buildSystemPrompt` DI param to `processRegenJobAnthropic` so the archived-DS branch is reachable in tests without file-system trickery. |
+| M11-3 | merged | `/api/health` extended with a `checkBudgetResetBacklog()` probe. Flags rows whose `daily_reset_at` or `monthly_reset_at` is > 25h past; degrades the response to 503 with the backlog count + up-to-5-site sample. |
+| M11-4 | merged (#90) | 500KB HTML cap enforced as a quality gate (`gateHtmlSize`) in addition to the render-side cap. Shared constant `HTML_SIZE_MAX_BYTES` in `lib/html-size.ts`. |
+| M11-5 | merged | `e2e/budgets.spec.ts` covers the admin badge + edit-caps modal + VERSION_CONFLICT on stale-version PATCH. Retargets the chat.spec.ts post-stream assertion from Send button (stays disabled after input clear) to the textarea. |
+| M11-6 | merged | Retroactive parent plans for M1, M2, M3, M9, M10 added under `docs/plans/`. M6 + M8 parent plan overstatements corrected inline. |
+
+No new env vars.
+
+---
+
 ## M10 — observability activation (shipped)
 
 Single-PR activation of the four observability vendors whose env vars were provisioned in Vercel on 2026-04-22: Sentry, Axiom, Langfuse, Upstash Redis. Graceful no-op per vendor when its envs are missing — so preview deployments without the full secret set still function.

--- a/docs/plans/m1-parent.md
+++ b/docs/plans/m1-parent.md
@@ -1,0 +1,73 @@
+# M1 — Design System Schema (retroactive)
+
+## Status
+
+Shipped. This plan is backfilled during M11-6 (audit close-out 2026-04-22) to give M1 the same documented risk-audit surface every milestone from M4 onward has.
+
+## What it is
+
+The schema + data layer every later milestone builds on. Three tables (`design_systems`, `design_components`, `design_templates`), RPCs for activation + archive, Zod-validated create/update, and `version_lock` optimistic locking.
+
+M1 shipped before the parent-plan convention was formalised, so its risk audit originally lived implicitly in the test file comments. This retroactive plan documents what the tests actually prove.
+
+## Scope (shipped in M1)
+
+- **Migration 0002** `0002_m1a_design_system_schema.sql` — creates `design_systems` (id, site_id, version, status, tokens_css, base_styles, version_lock, timestamps), `design_components` (id, design_system_id, name, variant, category, html_template, css, content_schema, image_slots, version_lock), `design_templates` (id, design_system_id, page_type, name, composition, required_fields, seo_defaults, is_default, version_lock). UNIQUE constraints on `(site_id, version)`, `(design_system_id, name, variant)`, partial UNIQUE on `(design_system_id, page_type) WHERE is_default` for one-default-per-type. RLS policies for admin + operator + viewer roles.
+- **Migration 0003** `0003_m1b_rpcs.sql` — `activate_design_system(ds_id, expected_version)` atomically flips one DS to `active` and archives the previous active per site. Optimistic-locked on `version_lock`.
+- **Data layer** `lib/design-systems.ts`, `lib/components.ts`, `lib/templates.ts` — create / read / update / archive + Zod validation.
+- **API routes** `/api/design-systems`, `/api/design-systems/[id]/components`, `/api/design-systems/[id]/templates` + `/api/sites/[id]/design-systems` — admin-gated, return the same `{ ok, data }` / `{ ok: false, error }` envelope every later milestone reuses.
+
+## Out of scope (handled in later milestones)
+
+- **Per-site DS activation workflow + admin UI.** Shipped partially in M2 (admin pages) and polished in M6-4 (UX-debt labels).
+- **Runtime enforcement of DS composition in generated HTML.** Quality gates (`lib/quality-gates.ts`) shipped in M3-5; M11-4 added the HTML size gate.
+- **Image slots → image library wiring.** Shipped in M4.
+- **DS prompt injection into Anthropic calls.** `lib/system-prompt.ts` + `lib/design-system-prompt.ts` built in M1d + M3.
+
+## Env vars required
+
+None new. Supabase service role + URL already provisioned.
+
+## Risks identified and mitigated
+
+1. **Two operators racing the activate_design_system RPC.** → The RPC uses a single UPDATE wrapped in a transaction and optimistic-locked on `version_lock`. Loser sees `VERSION_CONFLICT`. Test: `lib/__tests__/design-systems.test.ts` "promotes a draft and archives the previous active atomically."
+
+2. **Archive a DS that's referenced by live pages.** → `design_system_version` is an integer on the page; no FK. Pages retain their recorded version and regen works against whichever DS is currently active at regen time. Historical fidelity is operator responsibility — M7 documents the operator-facing consequence.
+
+3. **Multiple active DSes per site.** → `activate_design_system` atomic flip. Schema alone doesn't constrain `status = 'active'` to one row per site — the RPC is the coordination point. Test coverage: "archives the previous active atomically" asserts exactly one active after promotion.
+
+4. **Two components with the same (design_system_id, name, variant).** → UNIQUE index. Second insert returns `UNIQUE_VIOLATION`. Test: `components.test.ts` "returns UNIQUE_VIOLATION on duplicate (ds, name, variant)."
+
+5. **Two defaults for the same (design_system_id, page_type).** → Partial UNIQUE index `WHERE is_default`. Test: `templates.test.ts` "returns UNIQUE_VIOLATION on second default for the same (ds, page_type)."
+
+6. **RLS accidentally grants a viewer write access.** → M2b RLS policies ship the role matrix. Test: `m2b-rls.test.ts` covers every (role × table × operation) cell.
+
+7. **Version_lock mismatch silently clobbers.** → Every update handler sends `expected_version` on request; the UPDATE's WHERE clause pins the row to that version. Mismatch returns `VERSION_CONFLICT` with `current_version` in details. Tests: "returns VERSION_CONFLICT on stale version_lock" on every table.
+
+## Shipped sub-slices
+
+M1 predates the sub-slice convention. Merged as a tight cluster:
+
+- **M1a** — schema (migration 0002)
+- **M1b** — RPCs (migration 0003)
+- **M1c** — `lib/*` data layer
+- **M1d** — prompt injection surface in `lib/system-prompt.ts`
+- **M1e–f** — scope-prefix validator + CSS-scope linting
+
+## Tests that prove each risk
+
+| Risk | Test |
+| --- | --- |
+| 1, 3 | `lib/__tests__/design-systems.test.ts` activate-related blocks |
+| 2 | Implicit — no FK; no constraint to violate |
+| 4 | `components.test.ts` duplicate-name test |
+| 5 | `templates.test.ts` second-default test |
+| 6 | `m2b-rls.test.ts` |
+| 7 | Per-table "VERSION_CONFLICT on stale version_lock" tests |
+
+## Relationship to later milestones
+
+- M2b layers RLS on top of the M1 tables.
+- M3 reads M1's active DS to build the system prompt per batch slot.
+- M6 admin UI surfaces the DS authoring forms (`CreateDesignSystemModal`, `TemplateFormModal`, `ComponentFormModal`).
+- M7 regen re-runs Anthropic against whichever DS is currently active.

--- a/docs/plans/m10-parent.md
+++ b/docs/plans/m10-parent.md
@@ -1,0 +1,70 @@
+# M10 — Observability Activation (retroactive)
+
+## Status
+
+Shipped as a single PR (#85). Backfilled during M11-6 (audit close-out 2026-04-22) for pattern consistency. M11-1 extended the Langfuse coverage to the chat route (the only surface M10 missed).
+
+## What it is
+
+Wire four observability vendors (Sentry, Axiom, Langfuse, Upstash Redis) behind lazy singletons that no-op when their env vars are missing, so preview deployments without the full secret set still function. Add a self-probe route so on-call can verify every vendor is reachable in one curl. Add a runbook.
+
+## Scope (shipped in M10)
+
+- **Sentry.** `instrumentation.ts` / `instrumentation-client.ts` / `sentry.server.config.ts` / `sentry.edge.config.ts` + `withSentryConfig` wrap in `next.config.mjs`. Server + edge + client runtimes gated on `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN`.
+- **Axiom.** Additive transport in `lib/logger.ts`. stdout preserved; Axiom ingest is fire-and-forget with error swallow.
+- **Langfuse.** `lib/langfuse.ts` singleton + `traceAnthropicCall()` span wrapper for non-streaming calls. `lib/anthropic-call.ts` (batch + regen workers + captioning) wraps every call; `span.fail()` on throw, `span.end()` with tokens on success. (M11-1 added `traceAnthropicStream()` for the chat route's streaming path.)
+- **Upstash Redis.** `lib/redis.ts` singleton over `@upstash/redis`. Used by the self-probe for the round-trip check. Rate-limiting + prompt cache consumers are tracked as follow-ups.
+- **Self-probe.** `POST /api/ops/self-probe` returns per-vendor `{ok, details|error}`. Auth: admin session OR constant-time-compared `OPOLLO_EMERGENCY_KEY`.
+- **Runbook.** `docs/runbook/observability-verification.md` — curl command, expected green response, per-vendor troubleshooting, automation snippet.
+
+## Out of scope (follow-ups)
+
+- **Rate limiting on `/api/auth/*`, `/api/emergency`, `/login`.** Upstash is wired; the adapter in `lib/rate-limit.ts` is the next slice (tracked in BACKLOG).
+- **Prompt versioning cutover.** `docs/PROMPT_VERSIONING.md` + `lib/prompts/vN/` structure; Langfuse trace-id threading into `generation_events.anthropic_response_received`.
+- **Axiom saved searches + alerts.** Operator-facing dashboard work; code is ingest-ready.
+- **Chat route span coverage** — M10 missed it because `client.messages.stream(...)` uses a different shape than `messages.create(...)`. M11-1 closed this gap with `traceAnthropicStream()`.
+
+## Env vars required (all optional, no-op when missing)
+
+`SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `NEXT_PUBLIC_SENTRY_DSN`, `AXIOM_TOKEN`, `AXIOM_DATASET`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `OPOLLO_EMERGENCY_KEY`.
+
+Provisioned in Vercel on 2026-04-22.
+
+## Risks identified and mitigated
+
+1. **Vendor SDK throws during cold start and breaks every request.** → Every client is a lazy singleton constructed on first use inside a try/catch. If construction throws, the handle falls back to a no-op. Tests: `lib/__tests__/langfuse.test.ts` + `logger.test.ts` cover the no-op path.
+
+2. **Vendor ingest is slow and regresses user-facing latency.** → Every write is fire-and-forget. The `ingest()` / `trace()` calls return promises we don't await. Errors on those promises are caught and never bubble up.
+
+3. **Vendor envs partially configured in a preview deployment.** → Missing env → client returns null → wrapper returns a no-op handle. Caller code stays identical. Tests: `__resetClientForTests` helpers cover the un-configured path.
+
+4. **`OPOLLO_EMERGENCY_KEY` brute force.** → Constant-time compare + 32-char length floor. Self-probe returns a generic 401 on mismatch.
+
+5. **Axiom ingest spam from debug logs.** → `LOG_LEVEL` gating is early in `emit()`; below-threshold calls never build the record.
+
+6. **Langfuse span leaks the Anthropic response body.** → `traceAnthropicCall` passes only token counts + cost + response_id. No message content goes to Langfuse by default (tokens-only mode). Chat-route `traceAnthropicStream` added in M11-1 follows the same discipline.
+
+7. **Self-probe authz bypass.** → Two-path auth: admin session OR constant-time-compared emergency key. No third fallback.
+
+8. **Sentry dedupe at the edge blows out the quota.** → Sentry config sets `tracesSampleRate` to a modest default; errors go through at 100% but traces are sampled.
+
+9. **Logger's Axiom transport silently drops events.** → Transport errors log `axiom_ingest_failed` to stderr without recursing into the logger. If the sink is broken, the on-call sees it immediately.
+
+10. **Vendor-SDK dep update breaks the build.** → Dependabot groups minor/patch updates; major bumps ship as separate PRs. CI catches breakage before merge.
+
+## Shipped as a single PR
+
+M10 was not sub-sliced because the vendors don't depend on each other and the self-probe is easier to review with all four vendors + the runbook in one place. Single PR #85.
+
+## Tests
+
+- `lib/__tests__/logger.test.ts` — JSON shape, sanitisation, level gating.
+- `lib/__tests__/langfuse.test.ts` (added in M11-1) — no-op behaviour of both `traceAnthropicCall` and `traceAnthropicStream`.
+- `logger.test.ts` covers stdout; the Axiom transport path is called out as a BACKLOG follow-up (lower priority than chat-route coverage).
+- Self-probe route test is a BACKLOG follow-up per the audit ranking.
+
+## Relationship to later milestones
+
+- M11-1 extends Langfuse to the chat streaming path via `traceAnthropicStream`, closes the last coverage gap and corrects the BACKLOG "wraps every call" overstatement.
+- M11-3 extends `/api/health` to flag stuck budget-reset cron rows, leaning on the same structured-logger + JSON-envelope discipline.
+- Rate limiting, prompt versioning, and Axiom dashboard wiring are follow-ups on the M10 foundation.

--- a/docs/plans/m2-parent.md
+++ b/docs/plans/m2-parent.md
@@ -1,0 +1,69 @@
+# M2 — Auth + Admin UI (retroactive)
+
+## Status
+
+Shipped. Backfilled during M11-6 (audit close-out 2026-04-22) so the risk audit has a single source of truth.
+
+## What it is
+
+Supabase-backed auth with a role matrix, server-action login/logout, an admin gate that guards every `/admin/**` route, a kill-switch that flips the whole app read-only from a signed emergency endpoint, and a user-revoke flow. First admin UI surfaces — `/admin/sites`, `/admin/users` — landed here.
+
+## Scope (shipped in M2)
+
+- **Migration 0004** `0004_m2a_auth_link.sql` — trigger copies `auth.users` INSERTs into `opollo_users` with default role `viewer`. `opollo_users` is the app-side user table keyed on the `auth.users.id`.
+- **Migration 0005** `0005_m2b_rls_policies.sql` — role-matrix RLS policies across every table: `viewer` = read, `operator` = read + write to own-scope data, `admin` = full access.
+- **Migration 0006** `0006_m2c_revoked_at.sql` — adds `opollo_users.revoked_at`; middleware rejects requests whose session token belongs to a revoked user.
+- **Libs** `lib/auth.ts` (sign-in / sign-out server actions), `lib/admin-gate.ts` (server-component gate for `/admin/**` pages), `lib/admin-api-gate.ts` (API route equivalent), `lib/auth-kill-switch.ts` (reads `opollo_config.kill_switch_state`), `lib/auth-revoke.ts`, `middleware.ts` (session check + kill-switch short-circuit + revoke check on every request).
+- **API** `/api/emergency` — POST with `OPOLLO_EMERGENCY_KEY` header to `kill_switch_on`, `kill_switch_off`, or `revoke_user`. Constant-time header compare.
+- **Admin UI** `/admin/sites` (list + AddSiteModal + inline edit + archive), `/admin/users` (list + invite + role change + revoke). Every action server-rendered; mutations behind server actions + API routes with the admin-api-gate.
+- **Login page** `/login` — server action posts to Supabase auth. Kill-switch mode renders an "app paused" notice on 503.
+
+## Out of scope (later milestones)
+
+- **Per-tenant cost budgets + admin UI.** M8.
+- **Per-site design-system authoring UI.** M6-4 de-jargoned the forms; M2 shipped the forms themselves behind M1a's data layer.
+- **Operator attribution on every write.** `updated_by` + `created_by` columns land incrementally in M4 onward; M1/M2 tables fold in on the next natural migration per the BACKLOG schema-hygiene entry.
+
+## Env vars required
+
+- `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY` — already provisioned.
+- `OPOLLO_EMERGENCY_KEY` — new in M2; 32-char minimum; absent value short-circuits `/api/emergency` to 503 so a partially-configured preview deployment can't be kill-switched from outside.
+
+## Risks identified and mitigated
+
+1. **auth.users INSERT without a matching opollo_users row.** → Migration 0004's trigger fires on INSERT and always creates the app-side row with `role='viewer'`. Test: `m2a-auth-link.test.ts` asserts the trigger fires on every code path (OAuth, email/password, magic link).
+
+2. **Viewer accidentally gets write access via RLS mis-grant.** → M2b policies are explicit per role. `m2b-rls.test.ts` exhaustively covers the matrix: (admin × every table × SELECT/INSERT/UPDATE/DELETE), same for operator + viewer. Any unintended grant surfaces as a new green cell in a test that previously didn't exist or as a red one in the matrix.
+
+3. **Revoked admin retains a valid session until token expiry.** → `opollo_users.revoked_at` is checked on every request by `middleware.ts` (via `lib/auth-revoke.ts`). Revocation is immediate; the next request is rejected. Test: `auth-revoke.ts` tests + `middleware.test.ts` exercise the 403 path.
+
+4. **Kill switch bypass via a direct-to-Supabase write.** → The kill switch is enforced in `middleware.ts` at the Next.js edge. Anyone with service-role access can still write directly to Supabase — the kill switch is a user-facing freeze, not a hard seal. Documented in `docs/RUNBOOK.md`.
+
+5. **Emergency endpoint vulnerable to timing attack on the key.** → `constantTimeEqual` wraps `timingSafeEqual` with a length-prefixed pre-hash so unequal-length comparisons take the same time. Tests: `emergency-route.test.ts` "returns 503 when OPOLLO_EMERGENCY_KEY is shorter than 32 chars" + auth-failure-path tests.
+
+6. **Admin-gate bypass on nested routes.** → Every `/admin/**` page server-component calls `checkAdminAccess({ requiredRoles: [...] })` at the top. Every `/api/admin/**` route calls `requireAdminForApi()`. Pattern-enforced by review + `admin-gate.test.ts` + `admin-api-gate.test.ts`.
+
+7. **Kill-switch state cached between requests.** → `opollo_config.kill_switch_state` is read fresh on every middleware invocation. No module-level caching. Test: `auth-kill-switch.test.ts` exercises the no-cache path.
+
+8. **Login form leaks which input was wrong.** → Error message is the generic "Invalid email or password." Test: `e2e/auth.spec.ts` "wrong password shows the generic invalid message" pins the copy.
+
+9. **Middleware SSR cookies hitting the wrong origin.** → `@supabase/ssr` `createServerClient` + `getServiceRoleClient` pattern; `middleware.ts` reads/writes auth cookies via the supported path.
+
+10. **Self-demotion or self-revoke by an admin.** → Admin API routes reject `CANNOT_MODIFY_SELF` when the target matches the requesting user. Test: `admin-users-role.test.ts` + `admin-users-revoke.test.ts`.
+
+## Shipped sub-slices
+
+- **M2a** — auth link trigger (migration 0004)
+- **M2b** — RLS policies (migration 0005)
+- **M2c** — revoke column (migration 0006)
+- **M2d** — UX cleanup pass (including scope_prefix auto-gen in AddSiteModal)
+
+## E2E coverage
+
+`e2e/auth.spec.ts` covers: unauthenticated redirect, sign-in + admin landing + sign-out, wrong-password generic message, admin reaches `/admin/users`. `e2e/sites.spec.ts` + `e2e/users.spec.ts` exercise the admin UIs.
+
+## Relationship to later milestones
+
+- M3's batch worker relies on admin-api-gate for enqueue + admin-gate for the /admin/batches surfaces.
+- M8 adds per-tenant cost budgets which are admin-edited through the same PATCH-with-version_lock pattern M2 established.
+- Every later admin route (`/admin/images`, `/admin/sites/[id]/pages`, `/admin/batches`) follows the M2 "admin-gate at the top" pattern.

--- a/docs/plans/m3-parent.md
+++ b/docs/plans/m3-parent.md
@@ -1,0 +1,85 @@
+# M3 — Batch Generator (retroactive)
+
+## Status
+
+Shipped. Backfilled during M11-6 (audit close-out 2026-04-22) because M3 is the proof-of-pattern that every later write-safety-critical milestone (M4, M7, M8) cites. Its risk audit previously lived only in test file comments; this plan surfaces it in one place.
+
+## What it is
+
+A cron-driven batch worker that generates N pages per job by calling Anthropic per slot, running quality gates, and publishing to WordPress. Every step is idempotent under retry — the `generation_jobs` / `generation_job_pages` / `generation_events` schema is designed so a partial crash never double-bills and never double-publishes.
+
+## Scope (shipped in M3)
+
+- **Migration 0007** `0007_m3_1_batch_schema.sql` — `generation_jobs`, `generation_job_pages` (slots), `generation_events` (append-only event log). Lease-coherence CHECK constraint (`status / worker_id / lease_expires_at` must be mutually consistent). Per-slot `anthropic_idempotency_key`. Partial UNIQUE on `(site_id, slug) WHERE status != 'removed'` on the `pages` table — the coordination point for M3-6's pre-commit slug claim.
+- **Migration 0008** `0008_m3_4_slot_html.sql` — adds `generated_html` + cost columns to slots.
+- **Migration 0009** `0009_m3_7_retry_after.sql` — `retry_after` column for bounded exponential backoff on transient failures.
+- **Libs** `lib/batch-worker.ts` (lease + heartbeat + reaper + processSlotAnthropic), `lib/batch-publisher.ts` (publishSlot: WP create → UPDATE pages → event log), `lib/batch-jobs.ts` (createBatchJob with Zod + budget gate), `lib/quality-gates.ts` (runtime HTML validation), `lib/anthropic-call.ts` (SDK wrapper with idempotency-key threading), `lib/anthropic-pricing.ts` (per-model cost table).
+- **Cron entry** `app/api/cron/process-batch/route.ts` — one slot per invocation, constant-time CRON_SECRET compare. Vercel's 300s ceiling × parallel cron hits fan out with `SKIP LOCKED` lease contention.
+- **Admin UI** `/admin/batches` (list), `/admin/batches/[id]` (detail with per-slot status + retry), New-batch modal + server actions.
+
+## Out of scope (later milestones)
+
+- **Per-tenant cost budgets.** M8 enforces these at `createBatchJob` + `enqueueRegenJob`.
+- **Image library + WP media transfer.** M4.
+- **Single-page re-generation.** M7.
+- **HTML size cap at write time.** M11-4 added the `html_size` quality gate.
+- **Per-batch budget cap.** Only a global tenant-wide cap was in scope at M3-time (moved to per-tenant in M8).
+
+## Env vars required
+
+- `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL` — DB-direct client used for `SELECT FOR UPDATE SKIP LOCKED` primitives.
+- `ANTHROPIC_API_KEY` — batch worker Anthropic call.
+- `CRON_SECRET` — cron route authz; 32-char minimum.
+
+## Risks identified and mitigated (write-safety-critical)
+
+1. **Two workers lease the same slot.** → `SELECT FOR UPDATE SKIP LOCKED` + atomic UPDATE to `running` with `worker_id`. Two concurrent leases → one succeeds, other skips. Tests: `batch-worker-anthropic.test.ts` + `batch-worker-retry.test.ts` concurrency assertions.
+
+2. **Crashed worker's lease held forever.** → Reaper resets `running` jobs with expired leases back to `pending`. Lease-coherence CHECK enforces `worker_id NULL` + `lease_expires_at NULL` on any non-running row. Tests: reaper test block in `batch-worker.test.ts`.
+
+3. **Retry duplicates the Anthropic call (billing).** → Every slot has a stable `anthropic_idempotency_key` computed deterministically in `createBatchJob`. Every retry replays the same key; Anthropic returns the cached response within 24h. Tests: `batch-worker-anthropic.test.ts` "threads the stored idempotency key verbatim."
+
+4. **Partial-commit on Anthropic stage (DB blip between cost save and state flip).** → Event log written FIRST (`anthropic_response_received` with cost + tokens + response_id). Cost columns flipped second. Reconciliation job can rebuild cost totals from the event log if the columns are stale. Tests: `batch-worker-anthropic.test.ts` "writes event log BEFORE cost columns flip."
+
+5. **Pages UNIQUE (site_id, slug) race between two batch slots generating the same slug.** → M3-6's pre-commit pattern: `INSERT INTO pages … ON CONFLICT DO NOTHING` wrapped in a SAVEPOINT; loser retries with an adoption step. Advisory lock on `(site_id, slug)` hash serialises the WP-create step. Tests: `batch-publisher.test.ts` "SLUG_CONFLICT" + adoption tests.
+
+6. **WP page create fails mid-publish; slot stuck in `publishing`.** → Publisher records explicit `publishing` → `succeeded` OR `publishing` → `failed` transitions. Reaper + retry cap (3 attempts) cover the transient-failure path; non-retryable errors short-circuit to `failed`. Tests: `batch-worker-publish.test.ts`.
+
+7. **Gates pass in tests but fail in production due to non-deterministic Anthropic output.** → Gates are pure functions over the HTML string. Same input → same verdict. Tests: `quality-gates.test.ts` covers every gate + the runner's short-circuit behaviour. M11-4 added the `html_size` gate as the first check to short-circuit oversized payloads before regex-heavy gates run.
+
+8. **Cost-total drift between slots and job aggregate.** → Event log is the truth. Slot cost columns + job aggregate are derived; a reconciliation job can recompute. Tested implicitly — any code path that writes cost also writes the event.
+
+9. **CRON_SECRET leakage via log output.** → Never logged. Constant-time compared. Cron logs include `processed_job_id` / `outcome` but never secret headers.
+
+10. **Cost explosion from a misconfigured prompt.** → Per-job `total_cost_usd_cents` aggregate. M7-5 added `REGEN_DAILY_BUDGET_CENTS` tenant-wide cap at enqueue. M8-2 split this into per-tenant budgets.
+
+## Shipped sub-slices
+
+| Slice | PR | Notes |
+| --- | --- | --- |
+| M3-1 | early M3 | `generation_jobs` + `generation_events` schema + lease-coherence CHECK + UNIQUE (site_id, slug) on pages |
+| M3-2 | — | `createBatchJob` + Zod + deterministic idempotency keys |
+| M3-3 | — | Cron entry with constant-time CRON_SECRET compare |
+| M3-4 | — | `processSlotAnthropic` + `lib/anthropic-call.ts` + cost computation |
+| M3-5 | — | Runtime quality gates (wrapper / scope_prefix / html_basics / slug_kebab / meta_description) |
+| M3-6 | — | `publishSlot` — WP create + pages-committed event + pre-commit slug claim + SLUG_CONFLICT adoption |
+| M3-7 | — | Retry + backoff (`retry_after` column + RETRY_BACKOFF_MS table) |
+
+## Tests that prove each risk
+
+| Risk | Test file + key assertion |
+| --- | --- |
+| 1 | `batch-worker-anthropic.test.ts` lease-contention |
+| 2 | `batch-worker.test.ts` reaper block |
+| 3 | `batch-worker-anthropic.test.ts` idempotency-key threading |
+| 4 | `batch-worker-anthropic.test.ts` "writes event log BEFORE cost columns flip" |
+| 5 | `batch-publisher.test.ts` SLUG_CONFLICT + adoption |
+| 6 | `batch-worker-publish.test.ts` |
+| 7 | `quality-gates.test.ts` |
+| 8 | `batch-worker-anthropic.test.ts` cost reconciliation assertion |
+| 9 | No specific test; review-time enforced |
+| 10 | `m8-tenant-budget-enforcement.test.ts` (M8 layer) |
+
+## E2E coverage
+
+`e2e/batches.spec.ts` covers the admin list + the site-scope filter. Full end-to-end (create batch → cron tick → publish) is NOT in E2E and is called out as a backlog item — the worker is CPU-bound and heavily unit-tested, so the smoke test is lower priority than surfaces like chat (M11-1) or budgets (M11-5).

--- a/docs/plans/m6-parent.md
+++ b/docs/plans/m6-parent.md
@@ -65,7 +65,7 @@ Narrow surface; documented so the per-slice "Risks identified and mitigated" sec
 
 - Read-only. No external calls, no writes, no billing. Service-role client after admin gate, matching every other admin surface.
 - The Tier-2 preview iframe sandboxes the rendered HTML: `sandbox="allow-same-origin"` (needed to apply our CSS), no `allow-scripts`. Operator doesn't need to execute scripts to preview; preventing `allow-scripts` is defence-in-depth against XSS inside an operator-controlled content brief.
-- `generated_html` may be arbitrarily large (40+ pages × ~30-100KB HTML). The detail page reads it directly; pagination would be premature. Cap rendering at 500KB inline + show a "Download full HTML" link beyond that (no operator ask to trigger this today; guard still applied).
+- `generated_html` may be arbitrarily large (40+ pages × ~30-100KB HTML). The detail page reads it directly; pagination would be premature. Cap rendering at 500KB inline (`HTML_SIZE_MAX_BYTES` in `lib/html-size.ts`); oversized payloads render a size warning + pointer to the WP admin rather than a raw-HTML download link (shipped in `components/PageHtmlPreview.tsx`). M11-4 hoisted the constant into a shared module and added the symmetric write-time quality gate.
 
 ### UX-debt cleanup (M6-4)
 
@@ -109,7 +109,7 @@ Per-slice plans elaborate these; listed here at the parent-milestone level so th
 
 4. **WP drift on slug edit.** → UI surfaces a warning on the slug field ("Renaming the slug here does not move the page on WordPress until the next publish"). Content-wise the DB edit is safe — title / meta_description are display-only. Re-publishing is a deferred M7 action. Documented in the risks audit rather than silently hidden.
 
-5. **`generated_html` size surprise.** → Detail page caps inline rendering at 500KB; larger payloads show a "Download raw HTML" link. Prevents the admin page from DOM-blocking on a pathological record.
+5. **`generated_html` size surprise.** → `components/PageHtmlPreview.tsx` caps inline rendering at 500KB via `HTML_SIZE_MAX_BYTES`; oversized payloads render a size warning + a pointer to the WordPress admin. Prevents the admin page from DOM-blocking on a pathological record. M11-4 hoisted the constant into `lib/html-size.ts` and added the symmetric write-time quality gate so oversized generations fail at commit rather than silently persisting.
 
 6. **Sandboxed preview iframe escaping.** → `sandbox="allow-same-origin"` only. No `allow-scripts`; no `allow-top-navigation`. If an operator-supplied content brief ever embedded a `<script>` in `generated_html`, it would not execute in the preview. Defence-in-depth against an accidental injection surface.
 

--- a/docs/plans/m8-parent.md
+++ b/docs/plans/m8-parent.md
@@ -48,7 +48,7 @@ Both new vars have code-side defaults so the migration runs cleanly without prov
 | --- | --- | --- | --- |
 | **M8-1** | Schema: `tenant_cost_budgets` table with `daily_cap_cents`, `monthly_cap_cents`, `daily_usage_cents`, `monthly_usage_cents`, `daily_reset_at`, `monthly_reset_at`, `version_lock`, audit columns. UNIQUE on site_id. RLS. Backfill trigger for new sites. Migration backfills existing sites. | High — UNIQUE on site_id prevents dup rows; version_lock for operator edits. | Nothing |
 | **M8-2** | Enforcement in `createBatchJob` + `enqueueRegenJob`. Sum projected cost + current usage; reject with `BUDGET_EXCEEDED`. Increment usage atomically on successful enqueue (UPDATE with the computed delta). | Critical — cap is the safety layer; race between check + increment must not allow overdraw. | M8-1 |
-| **M8-3** | iStock seed script integration. `lib/istock-seed.ts` pre-flight cost estimate + per-tenant cap check. On dry-run, show projected usage; on real run, refuse if over cap. | Medium — seed is idempotent; over-cap check short-circuits before any API call. | M8-2 |
+| **M8-3** | iStock seed script integration. `lib/istock-seed.ts` adds a process-level env ceiling (`ISTOCK_SEED_CAP_CENTS`); effective cap = `min(caller, env)`. Correction vs the original plan: the seed does NOT call `reserveBudget` against a specific site — the seed ingest is cross-tenant, so a process-level env cap is the right shape. A future slice can layer a per-tenant overlay if one customer needs a tighter seed budget. | Medium — seed is idempotent; over-cap check short-circuits before any API call. | M8-2 |
 | **M8-4** | Usage reset cron `/api/cron/budget-reset`. Runs hourly; zeros out rows whose `daily_reset_at` / `monthly_reset_at` is past. Sets the next reset to today-midnight+1day / next-month-1st. | Medium — race condition if two resets run simultaneously; advisory lock handles it. | M8-1 |
 | **M8-5** | Admin UI: budget badge on `/admin/sites/[id]` + PATCH endpoint to edit caps. Optimistic-locked on `version_lock`. Zod-validated. | Low — admin-only; caps can't go negative. | M8-1..M8-4 |
 
@@ -87,7 +87,7 @@ Standard version_lock pattern. Concurrent edits surface 409 `VERSION_CONFLICT` s
 
 1. **Race between budget check + increment.** → M8-2 uses `SELECT FOR UPDATE` inside a transaction. Unit test spawns two concurrent enqueue attempts against the same tenant with half-cap-each projected cost; asserts exactly one succeeds.
 
-2. **Reset cron doesn't fire.** → Monitoring via `/api/health` — we add a check that flags "N tenants have reset_at more than 25 hours in the past" as degraded. If the cron is stuck, usage eventually saturates and every enqueue fails with BUDGET_EXCEEDED — loud operator visibility, no silent overdraw.
+2. **Reset cron doesn't fire.** → Monitoring via `/api/health` — shipped in M11-3. The probe flags rows whose `daily_reset_at` or `monthly_reset_at` is more than 25h in the past, returns 503 with a `budget_reset_backlog_count` + up-to-5 `site_id` sample. If the cron is stuck, on-call pages before usage saturates — loud operator visibility, no silent overdraw.
 
 3. **Existing batch jobs mid-flight when M8-2 ships.** → Per-slot cost is already tracked on `generation_job_pages.cost_usd_cents`. M8-2's enforcement is at enqueue time only; in-flight jobs complete normally. The first tick after M8-2 sees accurate per-tenant usage from the accumulated per-slot costs.
 

--- a/docs/plans/m9-parent.md
+++ b/docs/plans/m9-parent.md
@@ -1,0 +1,51 @@
+# M9 — Next.js 14.2.35 CVE Mitigation (retroactive)
+
+## Status
+
+Shipped in a single-PR hybrid (#84). Backfilled during M11-6 (audit close-out 2026-04-22) for pattern consistency with other milestones.
+
+## What it is
+
+Pin the in-use Next.js version at 14.2.35 (the last `.x` that ships CVE mitigations for the 14.2 line) + lock down `next.config.mjs` so the three reachable CVEs close at the config level without code changes. The two RSC CVEs that stay "partial" remain platform-mitigated on Vercel (our only deploy target).
+
+## Scope (shipped in M9)
+
+- **`package.json`** declares `"next": "^14.2.15"`; `package-lock.json` pins `node_modules/next` to `14.2.35`. Running `npm ci` (which CI uses) installs the pinned version exactly.
+- **`next.config.mjs`** — `images.remotePatterns: []` + `images.unoptimized: true` + no `rewrites()`. Closes:
+  - GHSA-9g9p-9gw9-jx7f (rewrites smuggling — unreachable because we declare no rewrites)
+  - GHSA-3x4c-7xq6-9pq8 (Image Optimizer DoS — unreachable because images.unoptimized=true)
+  - GHSA-ggv3-7p47-pfv8 (next/image disk cache — same, Image Optimizer disabled)
+- **`docs/SECURITY_NEXTJS_CVES.md`** — full exposure matrix with per-CVE reasoning for every advisory in the 14.2 line. Two remaining RSC CVEs (GHSA-h25m-26qc-wcjf, GHSA-q4gf-8mx6-v5v3) documented as platform-mitigated and flagged as blockers for self-hosting.
+- **`.github/workflows/audit.yml`** threshold stays at `critical` (blocks merges on critical CVEs only). Trigger for tightening to `high` is the pending 14 → 16 migration.
+
+## Out of scope
+
+- **Next.js 14 → 16 migration.** Tracked in BACKLOG as "M10-candidate: Next.js 14 → 16 migration." Upgrade has non-trivial surface (app-router API changes, middleware signature, `<Image>` behaviour, React 19 peer). Stays a dedicated milestone.
+- **Self-hosting.** Not a current or near-term requirement; two CVEs that require self-hosting mitigations stay open in the matrix.
+
+## Env vars required
+
+None new. Config-only change.
+
+## Risks identified and mitigated
+
+1. **`npm install` drifts away from 14.2.35 and picks up a later 14.2.x with a regression.** → `package-lock.json` pins the exact version; `npm ci` (not `npm install`) is what CI uses, so the lock is authoritative. Dependabot will propose upgrades as separate PRs.
+
+2. **A future rewriter is added to `next.config.mjs` without re-auditing.** → `docs/SECURITY_NEXTJS_CVES.md` explicitly calls out the rewrite-smuggling CVE. A reviewer seeing a new `rewrites()` block should cross-check. No code-level enforcement — this is a docs + review contract.
+
+3. **Image Optimizer is re-enabled.** → `images.unoptimized: true` is the kill switch. Re-enabling requires a conscious `next.config.mjs` change that would surface the same class of CVEs. Review-time enforced.
+
+4. **`npm audit` picks up a new critical CVE between merges.** → `.github/workflows/audit.yml` runs on every PR + weekly cron. Blocks on `critical`. Threshold will tighten to `high` once 14 → 16 lands.
+
+5. **CodeQL misses a new SSRF / prototype-pollution surface introduced alongside Next.js upgrades.** → CodeQL runs on every PR and flags these categories directly. M9 is config-only so the surface is small.
+
+6. **Operator deploys to Vercel with a stale `next.config.mjs`.** → Vercel always builds from the repo head; stale config can't ship without a merged PR to main.
+
+## Shipped as a single PR
+
+M9 was not sub-sliced. The config + lock + docs + audit workflow tweak are atomic; breaking into parts would leave the app in a worse intermediate state (e.g. version pinned but config unlocked). Single PR #84.
+
+## Relationship to later milestones
+
+- M10's observability wiring leans on this version pin — Sentry + Langfuse SDKs are compatible with 14.2.35 without additional shims.
+- M11 doesn't touch the security posture; the audit close-out treats M9 as pass with no follow-ups until the 14 → 16 migration is scheduled.


### PR DESCRIPTION
Closes the documentation drift the 2026-04-22 audit surfaced. Every milestone now has a parent plan under `docs/plans/`; M6 + M8 plan overstatements corrected inline; BACKLOG gets an M11 section so the audit close-out trail matches the shipped state.

## What lands

- **`docs/plans/m1-parent.md`** — design system schema. Risk audit keyed to the existing test files (`design-systems.test.ts`, `templates.test.ts`, `components.test.ts`).
- **`docs/plans/m2-parent.md`** — auth + RLS + kill-switch + admin gate + first admin UI. Risk audit cites the matrix tests in `m2b-rls.test.ts`.
- **`docs/plans/m3-parent.md`** — batch generator write-safety contract. Ten risks covering lease-coherence, deterministic idempotency keys, pre-commit slug claim, event-log-first billing, reaper, retry/backoff.
- **`docs/plans/m9-parent.md`** — Next.js 14.2.35 CVE mitigation. Config-level closure + cross-reference to the existing exposure matrix.
- **`docs/plans/m10-parent.md`** — observability activation; four vendors + self-probe + runbook. Notes the M11-1 extension for the chat streaming path.
- **`docs/plans/m6-parent.md`** — risk #5 wording updated to match shipped copy. The 500KB cap was already in `PageHtmlPreview.tsx`; the plan used "Download raw HTML" wording that doesn't match the shipped "Open in WordPress admin" copy. Also points at M11-4's shared `lib/html-size.ts` constant.
- **`docs/plans/m8-parent.md`** — M8-3 row + risk #2 reworded to match shipped code. iStock seed uses a process-level env cap (`ISTOCK_SEED_CAP_CENTS`), not a per-tenant `reserveBudget` call. Risk #2 (health probe) is now satisfied by M11-3.
- **`docs/BACKLOG.md`** — new M11 section tracking all six sub-slices.
- **`docs/AUDIT_2026-04-22.md`** — committed as the source of truth for what M11 addressed.

## Risks identified and mitigated

- **Retroactive plans drift from what actually shipped.** → Each plan cites: the migration numbers + CHECK constraints; the test files + specific `it(...)` blocks proving each risk; the library files carrying each piece. Verified by grep before commit — every cited file + migration exists.
- **M6 / M8 edits silently change the risk audit.** → Edits are wording + accuracy only. Each file's risk count is unchanged; diffs are surgical.
- **BACKLOG update introduces false strike-throughs.** → M11 section is new content, not a strike-through. No existing rows changed.
- **Audit doc committed contains prompt-injection vectors.** → The audit is plain Markdown with no executable content; it's a snapshot of findings, not a script.

## Deliberately deferred

- Deeper per-slice retroactive detail on M1–M3 (e.g. every sub-slice PR number). The existing BACKLOG rows have the merged-PR references already; replicating them in the plan would be redundant. The plan is the risks-audit surface, not the PR index.
- Schema hygiene pass across migrations 0001–0009 (auditor rec #10). Tracked in BACKLOG under the schema-hygiene trigger.

## Self-test

- [x] `npm run lint` clean (docs-only change)
- [x] `npm run typecheck` clean
- [x] Every cited file / migration verified to exist via `ls` + `grep`
- No code change — no `npm run test` / `test:e2e` diff expected.