### PR TITLE
fix(security): add role authorization to design-systems and sites/register mutation routes

### DIFF
--- a/app/api/design-systems/[id]/activate/route.ts
+++ b/app/api/design-systems/[id]/activate/route.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { activateDesignSystem } from "@/lib/design-systems";
 import {
   parseBodyWith,
@@ -17,6 +18,9 @@ const BodySchema = z.object({
 // archives any currently-active DS for the same site, atomically, via the
 // activate_design_system RPC from 0003_m1b_rpcs.sql.
 export async function POST(req: Request, ctx: { params: { id: string } }) {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;
 

--- a/app/api/design-systems/[id]/archive/route.ts
+++ b/app/api/design-systems/[id]/archive/route.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { archiveDesignSystem } from "@/lib/design-systems";
 import {
   parseBodyWith,
@@ -17,6 +18,9 @@ const BodySchema = z.object({
 // When the target was the site's active DS, the success payload contains
 // warnings[] noting the site now has no active design system (per §M1b Q6).
 export async function POST(req: Request, ctx: { params: { id: string } }) {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;
 

--- a/app/api/design-systems/[id]/components/[cid]/route.ts
+++ b/app/api/design-systems/[id]/components/[cid]/route.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { requireAdminForApi } from "@/lib/admin-api-gate";
 import {
   UpdateDesignComponentSchema,
   deleteComponent,
@@ -30,6 +31,9 @@ const PatchBodySchema = UpdateDesignComponentSchema.and(
 );
 
 export async function PATCH(req: Request, ctx: RouteContext) {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
   const dsParam = validateUuidParam(ctx.params.id, "id");
   if (!dsParam.ok) return dsParam.response;
   const cidParam = validateUuidParam(ctx.params.cid, "cid");
@@ -62,6 +66,9 @@ export async function PATCH(req: Request, ctx: RouteContext) {
 // expected_version_lock rides as a query param per the M1e plan (DELETE
 // with a body is unreliable across proxies).
 export async function DELETE(req: Request, ctx: RouteContext) {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
   const dsParam = validateUuidParam(ctx.params.id, "id");
   if (!dsParam.ok) return dsParam.response;
   const cidParam = validateUuidParam(ctx.params.cid, "cid");

--- a/app/api/design-systems/[id]/components/route.ts
+++ b/app/api/design-systems/[id]/components/route.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { requireAdminForApi } from "@/lib/admin-api-gate";
 import {
   CreateDesignComponentSchema,
   createComponent,
@@ -36,6 +37,9 @@ const CreateBodySchema = CreateDesignComponentSchema.omit({
 });
 
 export async function POST(req: Request, ctx: RouteContext) {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;
 

--- a/app/api/design-systems/[id]/templates/[tid]/route.ts
+++ b/app/api/design-systems/[id]/templates/[tid]/route.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { requireAdminForApi } from "@/lib/admin-api-gate";
 import {
   UpdateDesignTemplateSchema,
   deleteTemplate,
@@ -30,6 +31,9 @@ const PatchBodySchema = UpdateDesignTemplateSchema.and(
 // elsewhere after a template already referenced it could otherwise leave a
 // dangling ref; this route refuses such writes at the admin layer.
 export async function PATCH(req: Request, ctx: RouteContext) {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
   const dsParam = validateUuidParam(ctx.params.id, "id");
   if (!dsParam.ok) return dsParam.response;
   const tidParam = validateUuidParam(ctx.params.tid, "tid");
@@ -55,6 +59,9 @@ export async function PATCH(req: Request, ctx: RouteContext) {
 
 // DELETE /api/design-systems/[id]/templates/[tid]?expected_version_lock=N
 export async function DELETE(req: Request, ctx: RouteContext) {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
   const dsParam = validateUuidParam(ctx.params.id, "id");
   if (!dsParam.ok) return dsParam.response;
   const tidParam = validateUuidParam(ctx.params.tid, "tid");

--- a/app/api/design-systems/[id]/templates/route.ts
+++ b/app/api/design-systems/[id]/templates/route.ts
@@ -1,3 +1,4 @@
+import { requireAdminForApi } from "@/lib/admin-api-gate";
 import {
   CreateDesignTemplateSchema,
   createTemplate,
@@ -33,6 +34,9 @@ const CreateBodySchema = CreateDesignTemplateSchema.omit({
 });
 
 export async function POST(req: Request, ctx: RouteContext) {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;
 

--- a/app/api/sites/[id]/design-systems/route.ts
+++ b/app/api/sites/[id]/design-systems/route.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { requireAdminForApi } from "@/lib/admin-api-gate";
 import {
   createDesignSystem,
   listDesignSystems,
@@ -35,6 +36,9 @@ const CreateBodySchema = z.object({
 });
 
 export async function POST(req: Request, ctx: RouteContext) {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;
 

--- a/app/api/sites/register/route.ts
+++ b/app/api/sites/register/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 
+import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { createSite } from "@/lib/sites";
 import {
   RegisterSiteInputSchema,
@@ -12,6 +13,9 @@ import {
 export const runtime = "nodejs";
 
 export async function POST(req: Request) {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
   let body: unknown;
   try {
     body = await req.json();

--- a/lib/__tests__/api-design-systems-auth.test.ts
+++ b/lib/__tests__/api-design-systems-auth.test.ts
@@ -47,6 +47,13 @@ vi.mock("@/lib/auth", async () => {
   };
 });
 
+// sites/register calls revalidatePath("/admin/sites") on success, which
+// needs Next.js's static-generation store. Stubbing it out lets the
+// operator-allow test hit the lib layer without a Next.js runtime.
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
 import { POST as activateRoute } from "@/app/api/design-systems/[id]/activate/route";
 import { POST as archiveRoute } from "@/app/api/design-systems/[id]/archive/route";
 import { POST as createComponentRoute } from "@/app/api/design-systems/[id]/components/route";
@@ -368,9 +375,11 @@ describe("role gate — operator is allowed (representative routes)", () => {
 
     const res = await createTemplateRoute(
       jsonReq(`http://t/api/design-systems/${ds.data.id}/templates`, {
-        name: "home",
-        content_schema: minimalComponentContentSchema(),
+        page_type: "homepage",
+        name: "homepage-default",
         composition: minimalComposition(),
+        required_fields: { hero: ["headline"] },
+        is_default: true,
       }),
       { params: { id: ds.data.id } },
     );

--- a/lib/__tests__/api-design-systems-auth.test.ts
+++ b/lib/__tests__/api-design-systems-auth.test.ts
@@ -1,0 +1,395 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+import { __resetAuthKillSwitchCacheForTests } from "@/lib/auth-kill-switch";
+
+import { seedAuthUser } from "./_auth-helpers";
+import { minimalComponentContentSchema, minimalComposition, seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// Security audit §1 Findings 1 + 2 — role gate on every design-systems
+// mutation and on sites/register. Middleware only authenticates; the
+// handlers now also authorize. This file pins:
+//
+//   - FEATURE_SUPABASE_AUTH unset → gate allows through (flag-off bypass),
+//     so existing tests in api-design-systems.test.ts etc. keep working.
+//   - Flag on + viewer → 403 FORBIDDEN on every mutating handler.
+//   - Flag on + operator → not 403 (the allow path; exact success code is
+//     covered by per-route feature tests, not duplicated here).
+//
+// Mock pattern lifted directly from lib/__tests__/admin-api-gate.test.ts.
+// ---------------------------------------------------------------------------
+
+const mockState = vi.hoisted(() => ({
+  client: null as SupabaseClient | null,
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    createRouteAuthClient: () => {
+      if (!mockState.client) {
+        throw new Error(
+          "api-design-systems-auth.test: mockState.client not set before requireAdminForApi",
+        );
+      }
+      return mockState.client;
+    },
+  };
+});
+
+import { POST as activateRoute } from "@/app/api/design-systems/[id]/activate/route";
+import { POST as archiveRoute } from "@/app/api/design-systems/[id]/archive/route";
+import { POST as createComponentRoute } from "@/app/api/design-systems/[id]/components/route";
+import {
+  DELETE as deleteComponentRoute,
+  PATCH as patchComponentRoute,
+} from "@/app/api/design-systems/[id]/components/[cid]/route";
+import { POST as createTemplateRoute } from "@/app/api/design-systems/[id]/templates/route";
+import {
+  DELETE as deleteTemplateRoute,
+  PATCH as patchTemplateRoute,
+} from "@/app/api/design-systems/[id]/templates/[tid]/route";
+import { POST as createDesignSystemRoute } from "@/app/api/sites/[id]/design-systems/route";
+import { POST as registerSiteRoute } from "@/app/api/sites/register/route";
+
+import { createComponent } from "@/lib/components";
+import { createDesignSystem } from "@/lib/design-systems";
+
+function anonClient(): SupabaseClient {
+  const url = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error(
+      "api-design-systems-auth.test: SUPABASE_URL and SUPABASE_ANON_KEY must be set",
+    );
+  }
+  return createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function signedInClient(email: string): Promise<SupabaseClient> {
+  const client = anonClient();
+  const { error } = await client.auth.signInWithPassword({
+    email,
+    password: "test-password-1234",
+  });
+  if (error) throw new Error(`signedInClient: ${error.message}`);
+  return client;
+}
+
+function jsonReq(url: string, body?: unknown, method = "POST"): Request {
+  return new Request(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+// Viewer tests don't need a real DS — the gate runs before param
+// validation, so any UUID-shaped string gets 403'd first.
+const FAKE_DS_ID = "00000000-0000-0000-0000-000000000001";
+const FAKE_CID = "00000000-0000-0000-0000-000000000002";
+const FAKE_TID = "00000000-0000-0000-0000-000000000003";
+const FAKE_SITE_ID = "00000000-0000-0000-0000-000000000004";
+
+// Every mutating handler in the role-gate scope. Each entry invokes the
+// route with a minimally-valid request; under a viewer session the gate
+// returns 403 before the body is parsed.
+const MUTATING_CASES: ReadonlyArray<{
+  name: string;
+  call: () => Promise<Response>;
+}> = [
+  {
+    name: "POST /api/design-systems/[id]/activate",
+    call: () =>
+      activateRoute(
+        jsonReq(`http://t/api/design-systems/${FAKE_DS_ID}/activate`, {
+          expected_version_lock: 1,
+        }),
+        { params: { id: FAKE_DS_ID } },
+      ),
+  },
+  {
+    name: "POST /api/design-systems/[id]/archive",
+    call: () =>
+      archiveRoute(
+        jsonReq(`http://t/api/design-systems/${FAKE_DS_ID}/archive`, {
+          expected_version_lock: 1,
+        }),
+        { params: { id: FAKE_DS_ID } },
+      ),
+  },
+  {
+    name: "POST /api/design-systems/[id]/components",
+    call: () =>
+      createComponentRoute(
+        jsonReq(`http://t/api/design-systems/${FAKE_DS_ID}/components`, {}),
+        { params: { id: FAKE_DS_ID } },
+      ),
+  },
+  {
+    name: "PATCH /api/design-systems/[id]/components/[cid]",
+    call: () =>
+      patchComponentRoute(
+        jsonReq(
+          `http://t/api/design-systems/${FAKE_DS_ID}/components/${FAKE_CID}`,
+          { expected_version_lock: 1 },
+          "PATCH",
+        ),
+        { params: { id: FAKE_DS_ID, cid: FAKE_CID } },
+      ),
+  },
+  {
+    name: "DELETE /api/design-systems/[id]/components/[cid]",
+    call: () =>
+      deleteComponentRoute(
+        new Request(
+          `http://t/api/design-systems/${FAKE_DS_ID}/components/${FAKE_CID}?expected_version_lock=1`,
+          { method: "DELETE" },
+        ),
+        { params: { id: FAKE_DS_ID, cid: FAKE_CID } },
+      ),
+  },
+  {
+    name: "POST /api/design-systems/[id]/templates",
+    call: () =>
+      createTemplateRoute(
+        jsonReq(`http://t/api/design-systems/${FAKE_DS_ID}/templates`, {}),
+        { params: { id: FAKE_DS_ID } },
+      ),
+  },
+  {
+    name: "PATCH /api/design-systems/[id]/templates/[tid]",
+    call: () =>
+      patchTemplateRoute(
+        jsonReq(
+          `http://t/api/design-systems/${FAKE_DS_ID}/templates/${FAKE_TID}`,
+          { expected_version_lock: 1 },
+          "PATCH",
+        ),
+        { params: { id: FAKE_DS_ID, tid: FAKE_TID } },
+      ),
+  },
+  {
+    name: "DELETE /api/design-systems/[id]/templates/[tid]",
+    call: () =>
+      deleteTemplateRoute(
+        new Request(
+          `http://t/api/design-systems/${FAKE_DS_ID}/templates/${FAKE_TID}?expected_version_lock=1`,
+          { method: "DELETE" },
+        ),
+        { params: { id: FAKE_DS_ID, tid: FAKE_TID } },
+      ),
+  },
+  {
+    name: "POST /api/sites/[id]/design-systems",
+    call: () =>
+      createDesignSystemRoute(
+        jsonReq(`http://t/api/sites/${FAKE_SITE_ID}/design-systems`, {
+          tokens_css: "",
+          base_styles: "",
+        }),
+        { params: { id: FAKE_SITE_ID } },
+      ),
+  },
+  {
+    name: "POST /api/sites/register",
+    call: () =>
+      registerSiteRoute(
+        jsonReq(`http://t/api/sites/register`, {
+          name: "Test",
+          wp_url: "https://example.test",
+          wp_user: "wp",
+          wp_app_password: "hunter2hunter2",
+        }),
+      ),
+  },
+];
+
+const ENV_KEYS = ["FEATURE_SUPABASE_AUTH"] as const;
+let originalEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  originalEnv = {};
+  for (const k of ENV_KEYS) originalEnv[k] = process.env[k];
+  mockState.client = null;
+  __resetAuthKillSwitchCacheForTests();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = originalEnv[k];
+    }
+  }
+  mockState.client = null;
+  __resetAuthKillSwitchCacheForTests();
+});
+
+describe("role gate — FEATURE_SUPABASE_AUTH off (bypass)", () => {
+  // Proves existing tests in api-design-systems.test.ts and peers, which
+  // run with the flag unset, still work — the gate allows through with
+  // user: null and the route proceeds to its own validation / lib calls.
+  it("activate route processes its body when the flag is off", async () => {
+    delete process.env.FEATURE_SUPABASE_AUTH;
+    mockState.client = anonClient();
+    const res = await activateRoute(
+      jsonReq(`http://t/api/design-systems/${FAKE_DS_ID}/activate`, {
+        expected_version_lock: 1,
+      }),
+      { params: { id: FAKE_DS_ID } },
+    );
+    // Gate passed (no 403); route then 404s because the DS doesn't
+    // exist. We care that it is NOT 401/403 — the gate got out of the way.
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(403);
+  });
+});
+
+describe("role gate — viewer is denied on every mutating route", () => {
+  beforeEach(async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    const viewer = await seedAuthUser({ role: "viewer" });
+    mockState.client = await signedInClient(viewer.email);
+  });
+
+  it.each(MUTATING_CASES)("$name → 403 FORBIDDEN", async ({ call }) => {
+    const res = await call();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+});
+
+describe("role gate — operator is allowed (representative routes)", () => {
+  // Operator is the minimum role for every mutation under this slice. We
+  // cover one real mutation per surface (design-systems activate, component
+  // create, template create, site register) to prove the allow path; the
+  // other handlers share the same gate call and are already pinned by
+  // the viewer deny tests above.
+
+  beforeEach(async () => {
+    process.env.FEATURE_SUPABASE_AUTH = "true";
+    const operator = await seedAuthUser({ role: "operator" });
+    mockState.client = await signedInClient(operator.email);
+  });
+
+  it("activate route reaches the lib layer (200 on valid payload)", async () => {
+    // Restore the real auth module for the service-role calls that
+    // seedSite + createDesignSystem make; leave the mocked
+    // createRouteAuthClient in place so the gate still sees the operator.
+    const site = await seedSite();
+    const ds = await createDesignSystem({
+      site_id: site.id,
+      version: 1,
+      tokens_css: "",
+      base_styles: "",
+    });
+    if (!ds.ok) throw new Error("seed DS failed");
+
+    const res = await activateRoute(
+      jsonReq(`http://t/api/design-systems/${ds.data.id}/activate`, {
+        expected_version_lock: ds.data.version_lock,
+      }),
+      { params: { id: ds.data.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("components POST reaches the lib layer (creates on valid payload)", async () => {
+    const site = await seedSite();
+    const ds = await createDesignSystem({
+      site_id: site.id,
+      version: 1,
+      tokens_css: "",
+      base_styles: "",
+    });
+    if (!ds.ok) throw new Error("seed DS failed");
+
+    const res = await createComponentRoute(
+      jsonReq(`http://t/api/design-systems/${ds.data.id}/components`, {
+        name: "hero-centered",
+        variant: "default",
+        category: "hero",
+        html_template: "<section>{{headline}}</section>",
+        css: `.${site.prefix}-hero { padding: 2rem; }`,
+        content_schema: minimalComponentContentSchema(),
+      }),
+      { params: { id: ds.data.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("templates POST reaches the lib layer (creates on valid payload)", async () => {
+    const site = await seedSite();
+    const ds = await createDesignSystem({
+      site_id: site.id,
+      version: 1,
+      tokens_css: "",
+      base_styles: "",
+    });
+    if (!ds.ok) throw new Error("seed DS failed");
+    await createComponent({
+      design_system_id: ds.data.id,
+      name: "hero-centered",
+      variant: null,
+      category: "hero",
+      html_template: "<section>{{headline}}</section>",
+      css: `.${site.prefix}-hero {}`,
+      content_schema: minimalComponentContentSchema(),
+    });
+    await createComponent({
+      design_system_id: ds.data.id,
+      name: "footer-default",
+      variant: null,
+      category: "footer",
+      html_template: "<footer></footer>",
+      css: `.${site.prefix}-footer {}`,
+      content_schema: minimalComponentContentSchema(),
+    });
+
+    const res = await createTemplateRoute(
+      jsonReq(`http://t/api/design-systems/${ds.data.id}/templates`, {
+        name: "home",
+        content_schema: minimalComponentContentSchema(),
+        composition: minimalComposition(),
+      }),
+      { params: { id: ds.data.id } },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("sites/register reaches the lib layer (creates on valid payload)", async () => {
+    const res = await registerSiteRoute(
+      jsonReq(`http://t/api/sites/register`, {
+        name: "Operator Test Site",
+        wp_url: "https://op.example.test",
+        wp_user: "admin",
+        wp_app_password: "hunter2hunter2",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes two **High** findings from the Security & Secrets audit (Prompt 1 of 3). Both are **privilege-escalation** bugs, not unauth IDORs — middleware already authenticates these routes; the handlers simply never checked role.

- **Finding 1** — nine mutating handlers under `app/api/design-systems/**` and the sibling `app/api/sites/[id]/design-systems` POST trusted only middleware's signed-in check. A `viewer` could activate/archive/create/patch/delete any site's design system.
- **Finding 2** — `POST /api/sites/register` had the same gap. A signed-in viewer could create sites, firing the `create_tenant_budget_for_site` SECURITY DEFINER trigger and amplifying spam/cost exposure.

Every handler now calls `requireAdminForApi({ roles: ["admin", "operator"] })` before param validation — same shape as every peer admin route (`/api/sites/[id]` PATCH/DELETE, `/api/admin/batch` POST, `/api/admin/sites/[id]/pages/[pageId]/regenerate` POST, etc.).

## Commits

1. `ad1c9b5` — seven design-systems mutation handlers + the `sites/[id]/design-systems` POST sibling.
2. `9095f99` — `sites/register` POST.
3. `5e91e5e` — `lib/__tests__/api-design-systems-auth.test.ts` pins viewer→403 on every mutating route and operator→allow on representative routes. Also pins the flag-off bypass so existing tests in `api-design-systems.test.ts` etc. keep working unchanged.

## Scope notes

- **`/api/design-systems/[id]/preview` GET intentionally left ungated.** Read-only; viewers are legitimate UI readers. Gating it would regress the admin-preview UX they already use. If we later decide viewers should not see previews, that's a product-policy slice with UI-side coordination, not a security regression.
- **`admin + operator`, not admin-only.** Consistent with `/api/sites/[id]` PATCH/DELETE and `/api/admin/batch` POST. Operators create and edit sites in normal product flow; admin-only would be asymmetric with site edit/archive.
- **One scope addition beyond the audit's original list:** `app/api/sites/[id]/design-systems` POST was discovered during Step 1 exploration — same class of finding as the `/api/design-systems/**` routes, bundled in to keep the fix coherent.

## Risks identified and mitigated

- **Write-safety hotspot:** none of these routes move money or mutate identity. The gate change is structural — it turns 200 into 403 for viewers who should not have been reaching these paths anyway.
- **Backward compat:** flag-off bypass preserved by `requireAdminForApi`'s existing contract (returns `allow` with `user: null` when `FEATURE_SUPABASE_AUTH` is off or kill-switch is on). Existing unit tests, which run with the flag unset, continue to exercise the happy path. Pinned by the first test in the new file.
- **Deliberately deferred:** preview GET route (rationale above) and RLS null-safety hardening (audit Finding 5 — belongs in the M3 migration slice, not a hotfix).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] `npm run test` — unit tests require `supabase start` (Docker not running locally); validated via CI instead
- [ ] CI green on this PR before merge

## Related

Full audit report in local plan file; the two closed findings are §1 Findings 1 + 2 there. Steps 2–5 (rate limiting, server-only guards, `.env.example` reconciliation, BACKLOG entry for RLS hardening) follow in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)