### PR TITLE
fix(security): server-only guards + .env.local.example cleanup

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,10 +9,17 @@ BASIC_AUTH_PASSWORD=
 # Must match LEADSOURCE_WP_URL. Required in both dev and Vercel envs.
 NEXT_PUBLIC_LEADSOURCE_WP_URL=
 
-# Supabase (Week 2+)
+# Supabase (Week 2+). Server-side clients read SUPABASE_URL /
+# SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY via lib/supabase.ts.
+# SUPABASE_DB_URL is the direct Postgres connection string used by
+# workers that open a pg client (batch worker, regen publisher,
+# tenant-budgets, transfer worker, auth-revoke) — typically the
+# "Session" / "Direct connection" pooled URL from Supabase project
+# settings.
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
+SUPABASE_DB_URL=postgresql://postgres:password@host:5432/postgres
 
 # Master encryption key for site credentials (Week 2+).
 # Must decode to exactly 32 bytes. Generate with: openssl rand -base64 32
@@ -54,9 +61,68 @@ FEATURE_SUPABASE_AUTH=
 # too short.
 OPOLLO_EMERGENCY_KEY=
 
-# Cron secret (M3-3). Shared secret between Vercel Cron and
-# /api/cron/process-batch. Vercel sends this as
+# Cron secret (M3-3). Shared secret between Vercel Cron and the
+# /api/cron/* routes (process-batch, process-regenerations,
+# process-transfer, budget-reset). Vercel sends this as
 # `Authorization: Bearer $CRON_SECRET` when the value is set on the
 # project; the route rejects unauthenticated calls with 401. Minimum
 # 16 characters. Generate with `openssl rand -base64 32`.
 CRON_SECRET=
+
+# Cloudflare Images (M4). Account id + API token + delivery-URL hash.
+# Transfer worker + batch publisher use these to upload, fetch metadata,
+# and compose public https://imagedelivery.net/<hash>/<id>/public URLs.
+# Leave unset in dev for a no-op stub; M4 surfaces will return
+# NOT_CONFIGURED instead of crashing.
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_IMAGES_API_TOKEN=
+CLOUDFLARE_IMAGES_HASH=
+
+# Sentry (M10). Server-side DSN + client-side DSN (NEXT_PUBLIC_* is
+# inlined into the browser bundle). Unset = Sentry no-op; both configs
+# guard on DSN presence. ORG / PROJECT / AUTH_TOKEN are only needed at
+# build time for source-map upload via @sentry/nextjs; Vercel sets
+# them from the Sentry integration, local dev can leave blank.
+SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_DSN=
+SENTRY_ORG=
+SENTRY_PROJECT=
+SENTRY_AUTH_TOKEN=
+
+# Langfuse (M10). Cost + latency tracing on every billed Anthropic
+# call via lib/langfuse.ts + lib/anthropic-call.ts's traceAnthropicCall
+# wrapper. Unset = no-op. LANGFUSE_HOST defaults to
+# https://us.cloud.langfuse.com if left blank.
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+LANGFUSE_HOST=
+
+# Axiom (M10). Structured-log transport for lib/logger.ts. Unset =
+# stdout-only (fire-and-forget; ingest errors are swallowed). Both
+# TOKEN and DATASET must be set for the transport to activate.
+AXIOM_TOKEN=
+AXIOM_DATASET=
+
+# Upstash Redis (M10 / rate limiting). REST endpoint used by
+# lib/redis.ts and lib/rate-limit.ts. Unset = rate limiting falls
+# back to the in-memory dev implementation (per-process, not
+# production-safe). Required on Vercel.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# Regen daily budget cap in USD cents (M7). Hard ceiling across all
+# tenants for one calendar day's regeneration spend; enforced by
+# lib/regeneration-publisher.ts before reserveBudget is called.
+# Unset = no global cap (per-tenant caps via tenant_cost_budgets
+# still apply).
+REGEN_DAILY_BUDGET_CENTS=
+
+# iStock seed cap in USD cents (M8-3). Process-level ceiling for
+# one invocation of scripts/seed-istock-library.ts. Effective cap =
+# min(caller-supplied, env). Unset = no env ceiling; the caller-
+# supplied cap is authoritative.
+ISTOCK_SEED_CAP_CENTS=
+
+# Log level override for lib/logger.ts. One of debug | info | warn |
+# error. Default: info in production, debug elsewhere.
+LOG_LEVEL=

--- a/lib/encryption.ts
+++ b/lib/encryption.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import {
   createCipheriv,
   createDecipheriv,

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
 function requireEnv(key: string): string {


### PR DESCRIPTION
## Summary

Two audit follow-ups bundled — small enough to land together.

**Commit 1 — server-only guards on privileged server modules**
- `import "server-only";` at the top of `lib/supabase.ts` (service-role client, bypasses RLS) and `lib/encryption.ts` (`OPOLLO_MASTER_KEY` consumer for AES-256-GCM site-credential encryption).
- Next.js throws a build-time error if either module is pulled into a Client Component bundle — prevents the service-role key or master key from ever being inlined into browser JS via an accidental `"use client"` leak.
- Adds `server-only ^0.0.1` as a direct dep (Next.js recommends it but doesn't ship it transitively).

**Commit 2 — `.env.local.example` sync with real env inventory**
- Example drifted as M4 / M7 / M8 / M10 landed new deps. Adds: `SUPABASE_DB_URL`, Cloudflare Images trio, Sentry (5 vars inc. source-map upload), Langfuse trio, Axiom pair, Upstash Redis REST pair, `REGEN_DAILY_BUDGET_CENTS`, `ISTOCK_SEED_CAP_CENTS`, `LOG_LEVEL`.
- Each block explains what "unset" degrades to, so a new operator doesn't have to grep to find out whether a secret is optional.

## Test plan

- [ ] Typecheck + build pass in CI (server-only import is a first-class Next.js mechanism, no runtime behaviour change).
- [ ] Unit tests pass — no code paths changed beyond the added import line.
- [ ] .env.local.example is docs-only; no runtime risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)