### PR TITLE
docs(security): reconcile .env.local.example + RLS hardening backlog entry

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -60,3 +60,77 @@ OPOLLO_EMERGENCY_KEY=
 # project; the route rejects unauthenticated calls with 401. Minimum
 # 16 characters. Generate with `openssl rand -base64 32`.
 CRON_SECRET=
+
+# --- Database (workers) ----------------------------------------------------
+# Direct Postgres connection string, used by workers + libs that need
+# SKIP LOCKED / advisory locks / explicit transaction control that the
+# supabase-js REST client can't express. Required in any environment that
+# runs background jobs (cron workers, batch publisher, regen worker). For
+# local dev, `supabase start` prints this as "DB URL"; CI reads it from the
+# same source via `supabase status -o json`.
+# Consumers: lib/batch-worker.ts, lib/batch-jobs.ts, lib/batch-publisher.ts,
+# lib/regeneration-worker.ts, lib/regeneration-publisher.ts,
+# lib/auth-revoke.ts, lib/tenant-budgets.ts, lib/transfer-worker.ts.
+SUPABASE_DB_URL=
+
+# --- Cloudflare Images (M4 image library) ----------------------------------
+# Required for the image library + caption/metadata pipeline. Upload calls
+# use the API token; delivery URLs embed the (non-secret) hash.
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_IMAGES_API_TOKEN=
+# Public delivery-hash path fragment: https://imagedelivery.net/<HASH>/<id>/public
+CLOUDFLARE_IMAGES_HASH=
+
+# --- Observability: Sentry (M10, optional) ---------------------------------
+# All four are optional. Sentry is gated on SENTRY_DSN / NEXT_PUBLIC_SENTRY_DSN;
+# SDKs no-op when unset. Source-map upload runs at build time only when
+# SENTRY_AUTH_TOKEN + SENTRY_ORG + SENTRY_PROJECT are all present.
+SENTRY_DSN=
+# Client-runtime DSN. Intentionally public — identifies the Sentry
+# organisation, not a credential.
+NEXT_PUBLIC_SENTRY_DSN=
+SENTRY_ORG=
+SENTRY_PROJECT=
+# Build-time credential for source-map upload (withSentryConfig).
+SENTRY_AUTH_TOKEN=
+
+# --- Observability: Axiom (M10, optional) ----------------------------------
+# Additive transport in lib/logger.ts. stdout is always the primary sink;
+# Axiom ingest fires in parallel when both vars are set.
+AXIOM_TOKEN=
+AXIOM_DATASET=
+
+# --- Observability: Langfuse (M10, optional) -------------------------------
+# Tracing via traceAnthropicCall() / traceAnthropicStream(). Spans no-op
+# when either key is missing.
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+# Defaults to https://us.cloud.langfuse.com when unset.
+LANGFUSE_HOST=
+
+# --- Rate limiter: Upstash Redis (M10 + security audit, optional) ---------
+# Used by lib/rate-limit.ts named sliding-window buckets (chat, batch,
+# regen, tools, login, auth_callback, invite, register). Fail-open when
+# either var is missing — rate limiting is disabled, requests pass through.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# --- Log level (optional) --------------------------------------------------
+# debug | info | warn | error. Defaults to "info" in production, "debug"
+# in non-prod. Below-threshold calls are O(1) — no string building.
+LOG_LEVEL=
+
+# --- Budget caps (optional; code-side defaults apply) ---------------------
+# Per-day regen spend cap. Per-tenant-site check inside lib/regeneration-
+# publisher.ts. When unset, the regen path reads the tenant_cost_budgets
+# row only (no additional global cap).
+REGEN_DAILY_BUDGET_CENTS=
+# Per-run cap for scripts/seed-leadsource.ts iStock ingest. Guards against
+# a misconfigured seed overspending on stock imagery.
+ISTOCK_SEED_CAP_CENTS=
+# Initial daily / monthly tenant-cost budgets applied to every new site.
+# Defaults: 500c/day (≈$5), 10000c/month (≈$100). Override in Vercel to
+# raise or lower the baseline; per-site overrides still happen via the
+# /admin/sites/[id]/budget PATCH.
+DEFAULT_TENANT_DAILY_BUDGET_CENTS=
+DEFAULT_TENANT_MONTHLY_BUDGET_CENTS=

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -42,6 +42,19 @@ Medium / Low findings from Audit 3 (UI + cross-milestone integration) that are d
 
 Trigger to pick up: next UI polish pass, OR before any admin UI brand-scope change.
 
+### Security audit (2026-04-22 / audit 1 — security & secrets) backlog
+
+All Critical + High findings from the prompt-1 security audit closed by PRs #93 (role gates on design-systems + sites/register), #100 (rate limiting on cost-bearing + auth-adjacent routes), and #102 (server-only guards on node-only lib modules). Finding 6 (.env.local.example drift) closed alongside this entry in the same PR. One Medium deferral:
+
+- **RLS null-safety hardening (Medium, defense-in-depth).** Seven RLS policies across five migration files assume `auth.uid()` is non-NULL for authenticated sessions. PG semantics treat a NULL `USING` clause as not-visible — **no cross-tenant leak today** — but silent denial is the real failure mode during any auth-mechanism cutover. Files:
+  - `supabase/migrations/0004_m2a_auth_link.sql:148` — `public.auth_role()` body
+  - `supabase/migrations/0005_m2b_rls_policies.sql:112-114` — `opollo_users_self_read`
+  - `supabase/migrations/0007_m3_1_batch_schema.sql:125,249,291`
+  - `supabase/migrations/0010_m4_1_image_library_schema.sql:490,500,510`
+  - `supabase/migrations/0011_m7_1_regeneration_schema.sql:177,229`
+
+  Belt-and-braces prefix: `(auth.uid() IS NOT NULL AND ...) OR public.auth_role() = 'admin'`. **Trigger to pick up:** bundle into the next Supabase Auth migration slice — the one the audit calls "M3 auth migration", i.e. the next-after-M2 auth cutover, naming-ambiguous vs. the already-shipped batch-generator M3. Do NOT ship as a hotfix — the policies do not leak today; landing a belt-and-braces prefix outside a wider migration slice is churn for no live risk.
+
 ---
 
 ## M10 — observability activation (shipped)


### PR DESCRIPTION
## Summary

Close-out PR for the security audit (prompt 1 of 3 — security & secrets). Two docs-only commits.

Closes:
- **Audit §1 Finding 6** — `.env.local.example` drift. 21 env vars referenced in code but absent from the example file.
- **Audit 3 #10** (`docs/BACKLOG.md` line 32) — "optional-vars block" tracked under the M11 section. Same item from a different pass.

Defers:
- **Audit §1 Finding 5** — RLS null-safety hardening. Defense-in-depth, not a live leak; tracked with explicit trigger to land in the next Supabase Auth migration slice.

## Commits

### 1. `.env.local.example` — 21 additions across 8 concern groups

| Group | Vars | Required? |
|---|---|---|
| Database | `SUPABASE_DB_URL` | Required for worker paths |
| Cloudflare Images | `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_IMAGES_API_TOKEN`, `CLOUDFLARE_IMAGES_HASH` | Required for M4 image library |
| Sentry | `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` | Optional; SDK no-ops when unset |
| Axiom | `AXIOM_TOKEN`, `AXIOM_DATASET` | Optional; transport no-ops when either missing |
| Langfuse | `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST` | Optional; spans no-op when keys missing |
| Upstash (rate limiter) | `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN` | Optional; rate-limit fails open when missing |
| Logging | `LOG_LEVEL` | Optional; defaults to info (prod) / debug (non-prod) |
| Budget caps | `REGEN_DAILY_BUDGET_CENTS`, `ISTOCK_SEED_CAP_CENTS`, `DEFAULT_TENANT_DAILY_BUDGET_CENTS`, `DEFAULT_TENANT_MONTHLY_BUDGET_CENTS` | Optional; code-side defaults apply |

Every addition verified via `grep process.env.<NAME>` across `lib/`, `app/`, `instrumentation*.ts`, and `next.config.mjs` — no phantom entries.

### 2. `docs/BACKLOG.md` — Security audit subsection under M11

New subsection parallel to "Audit 3 polish backlog". Single entry for the RLS null-safety deferral, listing:
- The seven policies (5 files, exact line numbers)
- The belt-and-braces prefix to apply: `(auth.uid() IS NOT NULL AND ...) OR public.auth_role() = 'admin'`
- Explicit trigger: **next Supabase Auth migration slice**, NOT a hotfix
- Disambiguation: "M3 auth migration" means the next-after-M2 auth cutover, **not** the already-shipped batch-generator M3

## Scope decisions

1. **One PR, two commits.** Both items are docs-only audit close-outs — splitting was pure ceremony.
2. **No CLAUDE.md update.** `.env.local.example` is the canonical env reference; pointing at it from CLAUDE.md would duplicate docs. If a cross-cutting env-vars doc ever makes sense, `docs/ENV_VARS.md` is the right home, not CLAUDE.md.
3. **BACKLOG entry lives under M11** (the audit close-out section), not a new top-level section. One deferral isn't worth its own section; mirroring the existing "Audit 3 polish backlog" subsection preserves the pattern readers already know.

## Risks identified and mitigated

- **Docs drift** — verified every new entry has a live consumer via grep.
- **Spec creep** — resisted expanding the RLS entry beyond the seven audit-named policies. A broader "every policy everywhere should be null-safe" sweep is a different decision for a different time.
- **Naming ambiguity** — the RLS entry explicitly disambiguates "M3 auth migration" to avoid a future reader thinking the audit-era M3 (shipped) closes it.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] CI green (expected first-try; docs-only)
- [ ] Auto-merge OFF per your explicit Option B — manual merge.

## Related

Final close-out of the security audit cycle:
- PR #93 — role gates (Findings 1, 2) — merged
- PR #100 — rate limiting (Findings 3, 4) — merged
- PR #102 — server-only guards (audit §3 Medium) — merged
- This PR — env example reconciliation (Finding 6) + RLS backlog entry (Finding 5 deferral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)