### PR TITLE
chore(security): add server-only guards to encryption and supabase modules

### DIFF
--- a/lib/encryption.ts
+++ b/lib/encryption.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import {
   createCipheriv,
   createDecipheriv,

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
 function requireEnv(key: string): string {


### PR DESCRIPTION
## Summary

Completes the residual gap from closed PR #101. PR #102 shipped `import "server-only"` on 10 worker-side modules but did not touch these two node-only modules:

- `lib/encryption.ts` — uses `node:crypto` for site-credential AES-GCM seal/open; must never ship to a client bundle.
- `lib/supabase.ts` — instantiates the service-role client by reading `SUPABASE_SERVICE_ROLE_KEY` from `process.env`; leaking into a client bundle would embed the key in browser JS.

Vitest alias for `server-only` → `lib/__tests__/_server-only-stub.ts` already configured in `vitest.config.ts`, so unit tests continue to resolve cleanly.

## Risks identified and mitigated

- **Unit tests break when importing either module.** → Vitest's existing alias on `server-only` → `_server-only-stub.ts` covers it. Confirmed the alias is in place in `vitest.config.ts:16-19`.
- **Next.js client bundle accidentally imports either module.** → The whole point of the guard is to make this fail fast at build time. A `use client` file that imports `lib/supabase` will now throw a build-time error with a clear message instead of silently bundling the service-role client into browser JS.
- **Pattern divergence.** → Follows the exact shape of PR #102's 10 guarded modules. Single `import "server-only";` as line 1.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (all routes + middleware compile)
- [ ] `npm run test` — CI (local setup needs supabase CLI on PATH for vitest globalSetup; running in CI instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)