### PR TITLE
docs(claude): auto-handle out-of-date PRs during monitoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,17 @@ The bootstrap prompt Steven pastes into a second tab lives in `docs/PARALLELISM_
 ## Enabling auto-merge on every PR
 Every PR must have GitHub auto-merge armed at creation time. Call `mcp__github__enable_pr_auto_merge` (with `mergeMethod: "SQUASH"`) immediately after `create_pull_request` — it is not enabled implicitly. Without that call, the PR sits in the mergeable state until someone clicks the button in the UI, breaking the self-driving loop.
 
+## PR auto-merge monitoring
+
+When monitoring a PR with auto-merge armed, handle the "out-of-date with base branch" state, not just merged/failed. Specifically:
+
+1. If a polled PR shows state OPEN with mergeable=BEHIND (or equivalent signal that the branch is behind main), run `gh pr update-branch <PR>` automatically.
+2. If update-branch fails due to merge conflict, stop and report — do not force it.
+3. If update-branch succeeds, continue polling; CI will re-run and auto-merge fires when green.
+4. Apply this to every PR being monitored, including ones stacked behind other PRs that just merged.
+
+This prevents the failure mode where PR A merges, PR B becomes behind main, and the monitor waits forever because auto-merge can't fire on a behind-main branch.
+
 ## Self-audit is the review; proceed without external gate
 Self-audit is the first AND the final layer for planning. Once a plan has a populated **"Risks identified and mitigated"** section (see below for what that must contain), proceed directly to implementation. Do NOT post plans to Steven or Claude.ai as a review gate — not for parent milestones, not for sub-slices.
 


### PR DESCRIPTION
## Summary

Adds a new CLAUDE.md section, **"PR auto-merge monitoring"**, that requires future sessions to detect the BEHIND-base state during PR polling and call `gh pr update-branch` automatically. Conflict still escalates to Steven; the update-only-when-clean path is the default.

## Incident that taught the rule

Today's cleanup session merged PR #106 (release-please config rename). That immediately left the already-armed PR #107 (deferred-dependabot-majors) BEHIND main. Auto-merge cannot fire on a behind-main branch — it waits for the branch to be up-to-date before consuming the "auto" intent. The session caught the state on the next poll and nudged manually, but a monitor watching only for MERGED/CLOSED would have waited forever.

The new section codifies the nudge so stacked-PR flows don't hang.

## Content added (11 lines under a new H2)

```markdown
## PR auto-merge monitoring

When monitoring a PR with auto-merge armed, handle the "out-of-date
with base branch" state, not just merged/failed. Specifically:

1. If a polled PR shows state OPEN with mergeable=BEHIND (or
   equivalent signal that the branch is behind main), run
   `gh pr update-branch <PR>` automatically.
2. If update-branch fails due to merge conflict, stop and report —
   do not force it.
3. If update-branch succeeds, continue polling; CI will re-run and
   auto-merge fires when green.
4. Apply this to every PR being monitored, including ones stacked
   behind other PRs that just merged.

This prevents the failure mode where PR A merges, PR B becomes
behind main, and the monitor waits forever because auto-merge can't
fire on a behind-main branch.
```

## Placement rationale

Lives immediately after "Enabling auto-merge on every PR" — both rules govern the auto-merge loop. Arm at creation; nudge when stacked-merge order leaves a branch behind. Adjacent placement makes the two-step contract readable in one glance.

## Risks identified and mitigated

- **`update-branch` could silently rewrite merge-conflict resolution.** → Rule #2 explicitly stops and reports on conflict rather than forcing. `gh pr update-branch` doesn't force by default, but the rule is in English for future-me.
- **Rule could fire on an intentionally-behind branch.** → Rule only triggers when auto-merge is armed (that's the implicit `if a polled PR` context — monitors are set up on PRs *we* armed). Human-armed or stacked-by-design branches aren't in scope.
- **Rate-limiting `update-branch` during flaps.** → No tight loop — the rule fires once per poll interval, and each fire triggers CI re-run which pushes the next poll window out. No retry storm.

## Apply-the-rule-to-itself

Per the prompt, if this PR goes BEHIND main before it merges, I'll update-branch and continue. Auto-merge is armed at creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)