### PR TITLE
feat(m14-3): forgot-password + reset-password end-to-end flow

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,145 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { buildAuthRedirectUrl } from "@/lib/auth-redirect";
+import { logger } from "@/lib/logger";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/auth/forgot-password — M14-3.
+//
+// Triggers a Supabase password-reset email for `email`. The email's
+// link points at /api/auth/callback?next=/auth/reset-password which
+// exchanges the PKCE code for a session and lands the user on the
+// reset form.
+//
+// Response contract: this endpoint ALWAYS returns a success-shaped
+// response for any syntactically-valid email, regardless of whether
+// that email is actually registered. Rationale: a different response
+// for "email exists" vs "email doesn't exist" lets anyone enumerate
+// the admin roster by hitting this endpoint with every email they're
+// curious about. The cost is that a legit user who typos their email
+// doesn't get explicit feedback — they see "if that email is in our
+// system, you'll get a link shortly," which matches every
+// well-behaved SaaS flow.
+//
+// Rate limiter: `password_reset` bucket, keyed on the normalised
+// email address. 5 requests per email per hour. A single email being
+// flooded is the attack shape this bucket stops; IP-based limiting
+// is in the `login` + `auth_callback` buckets for the other shapes.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+
+const BodySchema = z.object({
+  email: z.string().email().max(320),
+});
+
+function jsonError(
+  code: string,
+  message: string,
+  status: number,
+  retryable = false,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+function successEnvelope(email: string): NextResponse {
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        email,
+        note: "If an account exists for this email, a reset link has been sent. Check your inbox (and spam folder) for the next few minutes.",
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Provide a valid email address.",
+          details: { issues: parsed.error.issues },
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const email = parsed.data.email.trim().toLowerCase();
+
+  const rl = await checkRateLimit("password_reset", `email:${email}`);
+  if (!rl.ok) {
+    logger.warn("forgot_password_rate_limited", { email });
+    return rateLimitExceeded(rl);
+  }
+
+  const redirectTo = buildAuthRedirectUrl(
+    "/api/auth/callback?next=%2Fauth%2Freset-password",
+    req,
+  );
+
+  const svc = getServiceRoleClient();
+
+  try {
+    const { error } = await svc.auth.resetPasswordForEmail(email, {
+      redirectTo,
+    });
+    if (error) {
+      // Log at warn — Supabase failures here (rate-limited upstream,
+      // invalid template config, etc.) are ops-relevant — but still
+      // return the success envelope so the response shape doesn't
+      // leak whether the email is registered. The specific failure
+      // reason is in the structured log.
+      logger.warn("forgot_password_supabase_error", {
+        email,
+        error: error.message,
+      });
+      return successEnvelope(email);
+    }
+
+    logger.info("forgot_password_requested", { email });
+    return successEnvelope(email);
+  } catch (err) {
+    // Unexpected failures (network / library crash) are the one case
+    // we surface as a 500 instead of masking behind the success
+    // envelope. A silent 500 would let an attacker distinguish "real
+    // error" from "email not registered" if the auth service is
+    // degraded — but surfacing a 500 here is about ops signal, not
+    // enumeration. Caller sees a generic retryable error.
+    logger.error("forgot_password_internal_error", {
+      email,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return jsonError(
+      "INTERNAL_ERROR",
+      "Password reset request failed. Please try again.",
+      500,
+      true,
+    );
+  }
+}

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,0 +1,142 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
+import { logger } from "@/lib/logger";
+import { validatePassword } from "@/lib/password-policy";
+
+// ---------------------------------------------------------------------------
+// POST /api/auth/reset-password — M14-3.
+//
+// Sets a new password for the currently authenticated user. Called
+// from the /auth/reset-password page after the PKCE code exchange
+// (via /api/auth/callback) has already landed a session cookie.
+//
+// Auth contract: there MUST be an active Supabase session. This
+// endpoint does not accept a raw recovery token — that was already
+// redeemed by /api/auth/callback. If there's no session, return 401
+// with a message pointing at forgot-password.
+//
+// Password policy: shared with M14-1 and M14-4 via lib/password-policy.
+// Server-side validation runs on every call; client-side strength UI
+// is additive but never authoritative.
+//
+// Logging: info on success, warn on auth/validation failures. Never
+// log the password itself.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+
+const BodySchema = z.object({
+  new_password: z.string().min(1).max(512),
+});
+
+function jsonError(
+  code: string,
+  message: string,
+  status: number,
+  retryable = false,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Provide a new password.",
+          details: { issues: parsed.error.issues },
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const policy = validatePassword(parsed.data.new_password);
+  if (!policy.ok) {
+    return jsonError("PASSWORD_WEAK", policy.message, 422, true);
+  }
+
+  const supabase = createRouteAuthClient();
+  const user = await getCurrentUser(supabase);
+  if (!user) {
+    logger.warn("reset_password_unauthenticated", {
+      outcome: "no_session",
+    });
+    return jsonError(
+      "UNAUTHORIZED",
+      "Your reset link has expired. Request a new one from the forgot-password page.",
+      401,
+    );
+  }
+
+  try {
+    const { error } = await supabase.auth.updateUser({
+      password: parsed.data.new_password,
+    });
+    if (error) {
+      const code = error.message.includes("same_password")
+        ? "SAME_PASSWORD"
+        : "UPDATE_FAILED";
+      const message =
+        code === "SAME_PASSWORD"
+          ? "New password must be different from your current password."
+          : `Password update failed: ${error.message}`;
+      logger.warn("reset_password_supabase_error", {
+        user_id: user.id,
+        email: user.email,
+        error: error.message,
+        code,
+      });
+      return jsonError(code, message, 422, true);
+    }
+
+    logger.info("reset_password_success", {
+      user_id: user.id,
+      email: user.email,
+      outcome: "reset",
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        data: {
+          user_id: user.id,
+          note: "Password updated. You remain signed in.",
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    logger.error("reset_password_internal_error", {
+      user_id: user.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return jsonError(
+      "INTERNAL_ERROR",
+      "Password update failed. Please try again.",
+      500,
+      true,
+    );
+  }
+}

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,0 +1,31 @@
+import { ForgotPasswordForm } from "@/components/ForgotPasswordForm";
+
+// ---------------------------------------------------------------------------
+// /auth/forgot-password — M14-3.
+//
+// Simple static-ish page: form → POST /api/auth/forgot-password →
+// confirmation copy. No session gating — anyone (signed in or not)
+// can request a reset link for any email. The API route is where
+// rate limiting + no-enumeration semantics live.
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-static";
+
+export default function ForgotPasswordPage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-6 p-6">
+      <div className="w-full text-center">
+        <h1 className="text-xl font-semibold">Forgot your password?</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Enter your email and we&apos;ll send you a reset link.
+        </p>
+      </div>
+      <ForgotPasswordForm />
+      <div className="text-center text-xs text-muted-foreground">
+        <a href="/login" className="underline hover:no-underline">
+          Back to sign in
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -1,0 +1,59 @@
+import { ResetPasswordForm } from "@/components/ResetPasswordForm";
+import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
+
+// ---------------------------------------------------------------------------
+// /auth/reset-password — M14-3.
+//
+// Landing page after the email link → /api/auth/callback PKCE exchange.
+// A successful exchange sets a session cookie and redirects the
+// browser here. This page checks for the session; if present, it
+// renders the password form; otherwise it renders the "expired link"
+// state with a "Request a new link" CTA.
+//
+// force-dynamic because the session check has to run per-request.
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+export default async function ResetPasswordPage() {
+  const supabase = createRouteAuthClient();
+  const user = await getCurrentUser(supabase);
+
+  if (!user) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-6 p-6">
+        <div className="w-full text-center">
+          <h1 className="text-xl font-semibold">Reset link expired</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            This reset link has expired or was already used. Request a new link
+            to continue.
+          </p>
+        </div>
+        <a
+          href="/auth/forgot-password"
+          className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Request a new link
+        </a>
+        <a
+          href="/login"
+          className="text-xs text-muted-foreground underline hover:no-underline"
+        >
+          Back to sign in
+        </a>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-6 p-6">
+      <div className="w-full text-center">
+        <h1 className="text-xl font-semibold">Set a new password</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Choose a strong password. Minimum 12 characters.
+        </p>
+      </div>
+      <ResetPasswordForm userEmail={user.email} />
+    </main>
+  );
+}

--- a/components/ForgotPasswordForm.tsx
+++ b/components/ForgotPasswordForm.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+// ---------------------------------------------------------------------------
+// M14-3 — /auth/forgot-password form.
+//
+// Submits to POST /api/auth/forgot-password. The API route's contract
+// is no-enumeration: the response shape is identical whether the email
+// is registered or not. The form always renders the same success copy
+// after a 200, directing the user to check their inbox (and spam).
+// ---------------------------------------------------------------------------
+
+type FormState = "idle" | "submitting" | "success" | "error";
+
+export function ForgotPasswordForm() {
+  const [email, setEmail] = useState("");
+  const [state, setState] = useState<FormState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (state === "submitting") return;
+    setState("submitting");
+    setErrorMessage(null);
+
+    try {
+      const res = await fetch("/api/auth/forgot-password", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+
+      if (res.ok && payload?.ok) {
+        setState("success");
+        return;
+      }
+
+      const code = payload?.ok === false ? payload.error.code : "INTERNAL_ERROR";
+      const fallback =
+        payload?.ok === false
+          ? payload.error.message
+          : `Request failed (HTTP ${res.status}).`;
+      const translated =
+        code === "RATE_LIMITED"
+          ? "Too many reset requests for this email. Try again in a bit."
+          : code === "VALIDATION_FAILED"
+            ? "Please enter a valid email address."
+            : fallback;
+      setErrorMessage(translated);
+      setState("error");
+    } catch (err) {
+      setErrorMessage(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      setState("error");
+    }
+  }
+
+  if (state === "success") {
+    return (
+      <div
+        role="status"
+        className="w-full rounded-md border border-primary/40 bg-primary/5 p-4 text-sm"
+      >
+        <p className="font-medium">Check your email.</p>
+        <p className="mt-1 text-muted-foreground">
+          If an account exists for <span className="font-mono">{email}</span>,
+          you&apos;ll receive a reset link shortly. The link expires in 60
+          minutes, so act soon. Don&apos;t forget to check your spam folder.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex w-full flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <label htmlFor="forgot-email" className="text-sm font-medium">
+          Email
+        </label>
+        <Input
+          id="forgot-email"
+          name="email"
+          type="email"
+          required
+          autoComplete="email"
+          autoFocus
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          suppressHydrationWarning
+        />
+      </div>
+
+      {errorMessage && (
+        <p role="alert" className="text-sm text-destructive">
+          {errorMessage}
+        </p>
+      )}
+
+      <Button type="submit" disabled={state === "submitting" || email.length === 0}>
+        {state === "submitting" ? "Sending…" : "Send reset link"}
+      </Button>
+    </form>
+  );
+}

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -73,6 +73,15 @@ export function LoginForm({ next }: { next: string }) {
       )}
 
       <SubmitButton />
+
+      <p className="text-center text-xs text-muted-foreground">
+        <a
+          href="/auth/forgot-password"
+          className="underline hover:no-underline"
+        >
+          Forgot password?
+        </a>
+      </p>
     </form>
   );
 }

--- a/components/ResetPasswordForm.tsx
+++ b/components/ResetPasswordForm.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  PASSWORD_MIN_LENGTH,
+  passwordStrengthHint,
+  validatePassword,
+} from "@/lib/password-policy";
+
+// ---------------------------------------------------------------------------
+// M14-3 — /auth/reset-password form.
+//
+// Rendered only when a session is present (page.tsx gates the "expired
+// link" state). Client-side password policy feedback is live on every
+// keystroke via passwordStrengthHint(); the server-side validator in
+// lib/password-policy.ts is the authoritative check and runs again in
+// /api/auth/reset-password before the updateUser call.
+//
+// After success: router.replace("/admin/sites") — the user is already
+// authenticated (the recovery callback set the session), so sending
+// them directly to the admin surface is the obvious landing.
+// ---------------------------------------------------------------------------
+
+type FormState = "idle" | "submitting" | "success" | "error";
+
+export function ResetPasswordForm({ userEmail }: { userEmail: string | null }) {
+  const router = useRouter();
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [state, setState] = useState<FormState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const hint = useMemo(() => passwordStrengthHint(password), [password]);
+  const mismatch = confirm.length > 0 && confirm !== password;
+  const canSubmit =
+    state === "idle" &&
+    password.length >= PASSWORD_MIN_LENGTH &&
+    confirm === password;
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (state === "submitting") return;
+
+    // Client-side belt + braces. Server re-validates.
+    const policy = validatePassword(password);
+    if (!policy.ok) {
+      setErrorMessage(policy.message);
+      setState("error");
+      return;
+    }
+    if (password !== confirm) {
+      setErrorMessage("The two passwords don't match.");
+      setState("error");
+      return;
+    }
+
+    setState("submitting");
+    setErrorMessage(null);
+
+    try {
+      const res = await fetch("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ new_password: password }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+
+      if (res.ok && payload?.ok) {
+        setState("success");
+        // Refresh the router so the admin layout re-fetches with the
+        // session — then push to the landing.
+        router.refresh();
+        router.replace("/admin/sites");
+        return;
+      }
+
+      const code =
+        payload?.ok === false ? payload.error.code : "INTERNAL_ERROR";
+      const fallback =
+        payload?.ok === false
+          ? payload.error.message
+          : `Request failed (HTTP ${res.status}).`;
+      const translated =
+        code === "UNAUTHORIZED"
+          ? "Your reset link has expired. Request a new one."
+          : code === "SAME_PASSWORD"
+            ? "New password must be different from your current password."
+            : fallback;
+      setErrorMessage(translated);
+      setState("error");
+    } catch (err) {
+      setErrorMessage(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      setState("error");
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex w-full flex-col gap-4">
+      {userEmail && (
+        <p className="text-xs text-muted-foreground">
+          Signed in as <span className="font-mono">{userEmail}</span>
+        </p>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="reset-password" className="text-sm font-medium">
+          New password
+        </label>
+        <Input
+          id="reset-password"
+          name="new_password"
+          type="password"
+          required
+          autoComplete="new-password"
+          autoFocus
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          suppressHydrationWarning
+        />
+        {hint && (
+          <p className="text-xs text-muted-foreground">{hint}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="reset-password-confirm" className="text-sm font-medium">
+          Confirm new password
+        </label>
+        <Input
+          id="reset-password-confirm"
+          name="confirm"
+          type="password"
+          required
+          autoComplete="new-password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          suppressHydrationWarning
+        />
+        {mismatch && (
+          <p className="text-xs text-destructive">Passwords don&apos;t match.</p>
+        )}
+      </div>
+
+      {errorMessage && (
+        <p role="alert" className="text-sm text-destructive">
+          {errorMessage}
+        </p>
+      )}
+
+      <Button type="submit" disabled={!canSubmit}>
+        {state === "submitting" ? "Updating…" : "Update password"}
+      </Button>
+    </form>
+  );
+}

--- a/lib/__tests__/forgot-password-route.test.ts
+++ b/lib/__tests__/forgot-password-route.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// M14-3 — POST /api/auth/forgot-password.
+//
+// Unit-level test with a mocked service-role client + mocked rate
+// limiter. The assertion matrix:
+//
+//   1. Missing / malformed email → 400 VALIDATION_FAILED.
+//   2. Rate-limit exceeded → 429 RATE_LIMITED, no supabase call.
+//   3. Valid email → 200 success envelope + resetPasswordForEmail called.
+//   4. Supabase error → 200 success envelope still (no-enumeration
+//      guarantee), but warn-level log emitted.
+//   5. Email is lowercased before both the rate-limit identifier and
+//      the Supabase call.
+//   6. redirectTo is built via buildAuthRedirectUrl → passes through to
+//      supabase.
+//   7. Log payload never contains the email as an unhashed value ---
+//      logger.info("forgot_password_requested") receives { email } with
+//      the lowercased address.
+// ---------------------------------------------------------------------------
+
+const mockState = vi.hoisted(() => ({
+  resetResult: { error: null as { message: string } | null },
+  resetCalls: [] as Array<{
+    email: string;
+    options: { redirectTo: string };
+  }>,
+  rateLimitOk: true,
+  rateLimitCalls: [] as Array<{ name: string; identifier: string }>,
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({
+    auth: {
+      resetPasswordForEmail: async (
+        email: string,
+        options: { redirectTo: string },
+      ) => {
+        mockState.resetCalls.push({ email, options });
+        return mockState.resetResult;
+      },
+    },
+  }),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: async (name: string, identifier: string) => {
+    mockState.rateLimitCalls.push({ name, identifier });
+    if (mockState.rateLimitOk) {
+      return { ok: true, limit: 5, remaining: 4, reset: 0 };
+    }
+    return {
+      ok: false,
+      limit: 5,
+      remaining: 0,
+      reset: Date.now() + 60_000,
+      retryAfterSec: 60,
+    };
+  },
+  rateLimitExceeded: () =>
+    new Response(
+      JSON.stringify({ ok: false, error: { code: "RATE_LIMITED" } }),
+      { status: 429, headers: { "content-type": "application/json" } },
+    ),
+}));
+
+const loggerCalls = vi.hoisted(() => ({
+  info: [] as Array<[string, Record<string, unknown> | undefined]>,
+  warn: [] as Array<[string, Record<string, unknown> | undefined]>,
+  error: [] as Array<[string, Record<string, unknown> | undefined]>,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: () => {},
+    info: (msg: string, fields?: Record<string, unknown>) =>
+      loggerCalls.info.push([msg, fields]),
+    warn: (msg: string, fields?: Record<string, unknown>) =>
+      loggerCalls.warn.push([msg, fields]),
+    error: (msg: string, fields?: Record<string, unknown>) =>
+      loggerCalls.error.push([msg, fields]),
+  },
+}));
+
+import { POST as forgotPasswordPOST } from "@/app/api/auth/forgot-password/route";
+
+const originalEnvUrl = process.env.NEXT_PUBLIC_SITE_URL;
+
+beforeEach(() => {
+  mockState.resetResult = { error: null };
+  mockState.resetCalls = [];
+  mockState.rateLimitOk = true;
+  mockState.rateLimitCalls = [];
+  loggerCalls.info.length = 0;
+  loggerCalls.warn.length = 0;
+  loggerCalls.error.length = 0;
+  process.env.NEXT_PUBLIC_SITE_URL = "https://opollo.vercel.app";
+});
+
+afterEach(() => {
+  if (originalEnvUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  } else {
+    process.env.NEXT_PUBLIC_SITE_URL = originalEnvUrl;
+  }
+  vi.restoreAllMocks();
+});
+
+function makeRequest(body: unknown): Request {
+  return new Request("https://opollo.vercel.app/api/auth/forgot-password", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/forgot-password: validation", () => {
+  it("returns 400 when body has no email", async () => {
+    const res = await forgotPasswordPOST(makeRequest({}) as never);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+    expect(mockState.resetCalls).toHaveLength(0);
+  });
+
+  it("returns 400 when email is malformed", async () => {
+    const res = await forgotPasswordPOST(
+      makeRequest({ email: "not-an-email" }) as never,
+    );
+    expect(res.status).toBe(400);
+    expect(mockState.resetCalls).toHaveLength(0);
+  });
+
+  it("returns 400 when body is not JSON", async () => {
+    const req = new Request(
+      "https://opollo.vercel.app/api/auth/forgot-password",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not-json",
+      },
+    );
+    const res = await forgotPasswordPOST(req as never);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/auth/forgot-password: rate limit", () => {
+  it("returns 429 when the limiter denies", async () => {
+    mockState.rateLimitOk = false;
+    const res = await forgotPasswordPOST(
+      makeRequest({ email: "hi@opollo.com" }) as never,
+    );
+    expect(res.status).toBe(429);
+    expect(mockState.resetCalls).toHaveLength(0);
+    const warn = loggerCalls.warn.find(
+      ([msg]) => msg === "forgot_password_rate_limited",
+    );
+    expect(warn).toBeDefined();
+  });
+
+  it("keys the limiter on the normalised email", async () => {
+    await forgotPasswordPOST(
+      makeRequest({ email: "HI@Opollo.COM" }) as never,
+    );
+    expect(mockState.rateLimitCalls).toEqual([
+      { name: "password_reset", identifier: "email:hi@opollo.com" },
+    ]);
+  });
+});
+
+describe("POST /api/auth/forgot-password: happy path", () => {
+  it("returns 200 with a success envelope", async () => {
+    const res = await forgotPasswordPOST(
+      makeRequest({ email: "hi@opollo.com" }) as never,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.email).toBe("hi@opollo.com");
+  });
+
+  it("calls supabase.auth.resetPasswordForEmail exactly once", async () => {
+    await forgotPasswordPOST(
+      makeRequest({ email: "hi@opollo.com" }) as never,
+    );
+    expect(mockState.resetCalls).toHaveLength(1);
+    expect(mockState.resetCalls[0].email).toBe("hi@opollo.com");
+    expect(mockState.resetCalls[0].options.redirectTo).toContain(
+      "/api/auth/callback",
+    );
+    expect(mockState.resetCalls[0].options.redirectTo).toContain(
+      "next=%2Fauth%2Freset-password",
+    );
+  });
+
+  it("normalises email to lowercase for the supabase call", async () => {
+    await forgotPasswordPOST(
+      makeRequest({ email: "HI@Opollo.COM" }) as never,
+    );
+    expect(mockState.resetCalls[0].email).toBe("hi@opollo.com");
+  });
+
+  it("logs the request at info level", async () => {
+    await forgotPasswordPOST(
+      makeRequest({ email: "hi@opollo.com" }) as never,
+    );
+    const info = loggerCalls.info.find(
+      ([msg]) => msg === "forgot_password_requested",
+    );
+    expect(info).toBeDefined();
+  });
+});
+
+describe("POST /api/auth/forgot-password: no-enumeration on supabase errors", () => {
+  it("returns 200 even when supabase returns an error (no enumeration)", async () => {
+    mockState.resetResult = { error: { message: "User not found" } };
+    const res = await forgotPasswordPOST(
+      makeRequest({ email: "ghost@opollo.com" }) as never,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("logs the supabase error at warn level for ops visibility", async () => {
+    mockState.resetResult = { error: { message: "Template not found" } };
+    await forgotPasswordPOST(
+      makeRequest({ email: "hi@opollo.com" }) as never,
+    );
+    const warn = loggerCalls.warn.find(
+      ([msg]) => msg === "forgot_password_supabase_error",
+    );
+    expect(warn).toBeDefined();
+    expect(warn?.[1]?.error).toBe("Template not found");
+  });
+});

--- a/lib/__tests__/password-policy.test.ts
+++ b/lib/__tests__/password-policy.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PASSWORD_MIN_LENGTH,
+  passwordStrengthHint,
+  validatePassword,
+} from "@/lib/password-policy";
+
+describe("validatePassword", () => {
+  it("accepts a 12-character password", () => {
+    const result = validatePassword("dodecakepass");
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a longer password", () => {
+    const result = validatePassword("correct horse battery staple");
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects an 11-character password with TOO_SHORT", () => {
+    const result = validatePassword("elevenchars");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toContain("TOO_SHORT");
+    expect(result.message).toMatch(/at least 12/);
+  });
+
+  it("rejects an empty password with EMPTY + TOO_SHORT", () => {
+    const result = validatePassword("");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toContain("EMPTY");
+    expect(result.message).toBe("Password is required.");
+  });
+
+  it("rejects whitespace-only passwords", () => {
+    const result = validatePassword("            ");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toContain("WHITESPACE_ONLY");
+  });
+
+  it("rejects passwords longer than 256 chars", () => {
+    const result = validatePassword("a".repeat(257));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.issues).toContain("TOO_LONG");
+  });
+
+  it("uses the exported PASSWORD_MIN_LENGTH", () => {
+    expect(PASSWORD_MIN_LENGTH).toBe(12);
+  });
+});
+
+describe("passwordStrengthHint", () => {
+  it("returns null when the password meets the policy", () => {
+    expect(passwordStrengthHint("dodecakepass")).toBeNull();
+  });
+
+  it("prompts for initial input when empty", () => {
+    expect(passwordStrengthHint("")).toBe("Enter a password.");
+  });
+
+  it("reports characters remaining when short", () => {
+    expect(passwordStrengthHint("short")).toBe("7 more characters needed.");
+  });
+
+  it("uses singular when 1 character remains", () => {
+    expect(passwordStrengthHint("elevenchars")).toBe("1 more character needed.");
+  });
+});

--- a/lib/__tests__/reset-password-route.test.ts
+++ b/lib/__tests__/reset-password-route.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// M14-3 — POST /api/auth/reset-password.
+//
+// Unit-level test with a mocked auth client + mocked getCurrentUser.
+// Assertion matrix:
+//
+//   1. Missing / malformed body → 400 VALIDATION_FAILED.
+//   2. Weak password (< 12 chars) → 422 PASSWORD_WEAK, updateUser NOT called.
+//   3. No session → 401 UNAUTHORIZED, updateUser NOT called.
+//   4. supabase.auth.updateUser returns "same_password" → 422 SAME_PASSWORD.
+//   5. supabase.auth.updateUser returns a generic error → 422 UPDATE_FAILED.
+//   6. Happy path → 200 + updateUser called once with the new password.
+//   7. Password never appears in any logger invocation.
+// ---------------------------------------------------------------------------
+
+const mockState = vi.hoisted(() => ({
+  user: null as { id: string; email: string | null } | null,
+  updateResult: { error: null as { message: string } | null },
+  updateCalls: [] as Array<{ attributes: { password: string } }>,
+}));
+
+vi.mock("@/lib/auth", async () => ({
+  createRouteAuthClient: () => ({
+    auth: {
+      updateUser: async (attributes: { password: string }) => {
+        mockState.updateCalls.push({ attributes });
+        return mockState.updateResult;
+      },
+    },
+  }),
+  getCurrentUser: async () => mockState.user,
+}));
+
+const loggerCalls = vi.hoisted(() => ({
+  info: [] as Array<[string, Record<string, unknown> | undefined]>,
+  warn: [] as Array<[string, Record<string, unknown> | undefined]>,
+  error: [] as Array<[string, Record<string, unknown> | undefined]>,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: () => {},
+    info: (msg: string, fields?: Record<string, unknown>) =>
+      loggerCalls.info.push([msg, fields]),
+    warn: (msg: string, fields?: Record<string, unknown>) =>
+      loggerCalls.warn.push([msg, fields]),
+    error: (msg: string, fields?: Record<string, unknown>) =>
+      loggerCalls.error.push([msg, fields]),
+  },
+}));
+
+import { POST as resetPasswordPOST } from "@/app/api/auth/reset-password/route";
+
+const USER_UUID = "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa";
+const VALID_PASSWORD = "correct-horse-battery-staple";
+
+beforeEach(() => {
+  mockState.user = { id: USER_UUID, email: "hi@opollo.com" };
+  mockState.updateResult = { error: null };
+  mockState.updateCalls = [];
+  loggerCalls.info.length = 0;
+  loggerCalls.warn.length = 0;
+  loggerCalls.error.length = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeRequest(body: unknown): Request {
+  return new Request("https://opollo.vercel.app/api/auth/reset-password", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/reset-password: validation", () => {
+  it("returns 400 when body has no new_password", async () => {
+    const res = await resetPasswordPOST(makeRequest({}) as never);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 422 PASSWORD_WEAK when password is shorter than 12 chars", async () => {
+    const res = await resetPasswordPOST(
+      makeRequest({ new_password: "short-11-ch" }) as never,
+    );
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error.code).toBe("PASSWORD_WEAK");
+    expect(mockState.updateCalls).toHaveLength(0);
+  });
+
+  it("returns 400 when body is not JSON", async () => {
+    const req = new Request(
+      "https://opollo.vercel.app/api/auth/reset-password",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not-json",
+      },
+    );
+    const res = await resetPasswordPOST(req as never);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/auth/reset-password: session gating", () => {
+  it("returns 401 when no session is present", async () => {
+    mockState.user = null;
+    const res = await resetPasswordPOST(
+      makeRequest({ new_password: VALID_PASSWORD }) as never,
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.code).toBe("UNAUTHORIZED");
+    expect(mockState.updateCalls).toHaveLength(0);
+  });
+});
+
+describe("POST /api/auth/reset-password: supabase errors", () => {
+  it("returns 422 SAME_PASSWORD when supabase rejects same-password", async () => {
+    mockState.updateResult = {
+      error: { message: "same_password: New password must be different" },
+    };
+    const res = await resetPasswordPOST(
+      makeRequest({ new_password: VALID_PASSWORD }) as never,
+    );
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error.code).toBe("SAME_PASSWORD");
+  });
+
+  it("returns 422 UPDATE_FAILED on a generic supabase error", async () => {
+    mockState.updateResult = { error: { message: "random failure" } };
+    const res = await resetPasswordPOST(
+      makeRequest({ new_password: VALID_PASSWORD }) as never,
+    );
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error.code).toBe("UPDATE_FAILED");
+  });
+});
+
+describe("POST /api/auth/reset-password: happy path", () => {
+  it("returns 200 and calls updateUser exactly once", async () => {
+    const res = await resetPasswordPOST(
+      makeRequest({ new_password: VALID_PASSWORD }) as never,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.user_id).toBe(USER_UUID);
+
+    expect(mockState.updateCalls).toHaveLength(1);
+    expect(mockState.updateCalls[0].attributes.password).toBe(VALID_PASSWORD);
+  });
+
+  it("logs the success event with user_id and email (no password)", async () => {
+    await resetPasswordPOST(
+      makeRequest({ new_password: VALID_PASSWORD }) as never,
+    );
+    const success = loggerCalls.info.find(
+      ([msg]) => msg === "reset_password_success",
+    );
+    expect(success).toBeDefined();
+    const [, fields] = success as [string, Record<string, unknown>];
+    expect(fields.user_id).toBe(USER_UUID);
+    expect(fields.email).toBe("hi@opollo.com");
+  });
+
+  it("never logs the password in any logger invocation", async () => {
+    await resetPasswordPOST(
+      makeRequest({ new_password: VALID_PASSWORD }) as never,
+    );
+    const all = [
+      ...loggerCalls.info,
+      ...loggerCalls.warn,
+      ...loggerCalls.error,
+    ];
+    expect(JSON.stringify(all)).not.toContain(VALID_PASSWORD);
+  });
+});

--- a/lib/password-policy.ts
+++ b/lib/password-policy.ts
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------------
+// M14-3 — shared password policy.
+//
+// One source of truth for password strength across every surface that
+// sets a password: the admin reset endpoint (M14-1), the forgot-password
+// flow (M14-3), and the account-security page (M14-4).
+//
+// Policy: 12-character minimum, no complexity class requirements.
+// Length beats character-class rules for equivalent UX friction
+// (NIST SP 800-63B §5.1.1.2), and every extra rule creates a new way
+// for a legit password to be rejected for reasons the user can't
+// reason about.
+//
+// The helper is pure — no network, no crypto — so the same code runs
+// client-side for live feedback AND server-side as the gate.
+// ---------------------------------------------------------------------------
+
+export const PASSWORD_MIN_LENGTH = 12;
+export const PASSWORD_MAX_LENGTH = 256;
+
+export type PasswordIssue =
+  | "TOO_SHORT"
+  | "TOO_LONG"
+  | "WHITESPACE_ONLY"
+  | "EMPTY";
+
+export type PasswordValidationResult =
+  | { ok: true }
+  | { ok: false; issues: PasswordIssue[]; message: string };
+
+/**
+ * Validate a candidate password against the shared policy.
+ *
+ * Returns `{ ok: true }` when every rule passes. Otherwise returns an
+ * `issues` list (machine-readable) plus a human-readable `message` the
+ * UI can render without further translation.
+ */
+export function validatePassword(raw: string): PasswordValidationResult {
+  const issues: PasswordIssue[] = [];
+
+  if (raw.length === 0) {
+    issues.push("EMPTY");
+  } else if (raw.trim().length === 0) {
+    issues.push("WHITESPACE_ONLY");
+  }
+
+  if (raw.length < PASSWORD_MIN_LENGTH) {
+    issues.push("TOO_SHORT");
+  }
+  if (raw.length > PASSWORD_MAX_LENGTH) {
+    issues.push("TOO_LONG");
+  }
+
+  if (issues.length === 0) return { ok: true };
+
+  return {
+    ok: false,
+    issues,
+    message: messageForIssues(issues),
+  };
+}
+
+function messageForIssues(issues: PasswordIssue[]): string {
+  if (issues.includes("EMPTY")) {
+    return "Password is required.";
+  }
+  if (issues.includes("WHITESPACE_ONLY")) {
+    return "Password cannot be only whitespace.";
+  }
+  if (issues.includes("TOO_SHORT")) {
+    return `Password must be at least ${PASSWORD_MIN_LENGTH} characters.`;
+  }
+  if (issues.includes("TOO_LONG")) {
+    return `Password must be ${PASSWORD_MAX_LENGTH} characters or fewer.`;
+  }
+  return "Password is invalid.";
+}
+
+/**
+ * Short, UI-friendly strength hint. Cheap enough to compute on every
+ * keystroke in a Client Component. Returns `null` when the password
+ * meets the policy — callers render the "OK" state however they want.
+ */
+export function passwordStrengthHint(raw: string): string | null {
+  if (raw.length === 0) return "Enter a password.";
+  if (raw.length < PASSWORD_MIN_LENGTH) {
+    const remaining = PASSWORD_MIN_LENGTH - raw.length;
+    return `${remaining} more character${remaining === 1 ? "" : "s"} needed.`;
+  }
+  return null;
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -34,7 +34,8 @@ export type LimiterName =
   | "login"
   | "auth_callback"
   | "invite"
-  | "register";
+  | "register"
+  | "password_reset";
 
 type LimiterConfig = {
   requests: number;
@@ -42,14 +43,22 @@ type LimiterConfig = {
 };
 
 const CONFIGS: Record<LimiterName, LimiterConfig> = {
-  chat:          { requests: 120, window: "60 s" },
-  batch:         { requests: 30,  window: "60 s" },
-  regen:         { requests: 60,  window: "60 s" },
-  tools:         { requests: 120, window: "60 s" },
-  login:         { requests: 10,  window: "60 s" },
-  auth_callback: { requests: 10,  window: "60 s" },
-  invite:        { requests: 20,  window: "1 h" },
-  register:      { requests: 20,  window: "1 h" },
+  chat:           { requests: 120, window: "60 s" },
+  batch:          { requests: 30,  window: "60 s" },
+  regen:          { requests: 60,  window: "60 s" },
+  tools:          { requests: 120, window: "60 s" },
+  login:          { requests: 10,  window: "60 s" },
+  auth_callback:  { requests: 10,  window: "60 s" },
+  invite:         { requests: 20,  window: "1 h" },
+  register:       { requests: 20,  window: "1 h" },
+  // M14-3: forgot-password per-email bucket. 5 requests per email per
+  // hour caps both accidental user mashing and a compromised sender
+  // from email-bombing a specific address. Identifier convention:
+  // "email:<normalised_email>" — IP-based limiting is intentionally
+  // NOT used here because a single legitimate user behind a CGNAT
+  // shouldn't be throttled because of an unrelated user on the same
+  // IP, and an attacker rotating IPs wouldn't be slowed by it.
+  password_reset: { requests: 5,   window: "1 h" },
 };
 
 export type RateLimitResult =


### PR DESCRIPTION
Ships the full self-service password-reset surface. "Forgot password?" on `/login` → `/auth/forgot-password` → Supabase email → `/auth/reset-password` → back in. No-enumeration response contract, 5-requests-per-email-per-hour rate limiter, 12-character password floor enforced client + server, expired-link UX that points the user back to forgot-password instead of leaving them at a raw Supabase error.

## What lands

### New API routes
- `app/api/auth/forgot-password/route.ts` — POST, body `{ email }`. Calls `supabase.auth.resetPasswordForEmail` with a `redirectTo` built via the M14-2 helper. Always returns 200 for any syntactically-valid email, regardless of whether it's registered — that's the no-enumeration guarantee. Rate-limited via the new `password_reset` bucket (5/email/hour). Structured logs: `forgot_password_requested` (info), `forgot_password_rate_limited` (warn), `forgot_password_supabase_error` (warn), `forgot_password_internal_error` (error).
- `app/api/auth/reset-password/route.ts` — POST, body `{ new_password }`. Requires an active session (the `/api/auth/callback` PKCE exchange is what puts the user there). Runs `validatePassword()` from the shared policy, calls `supabase.auth.updateUser`. Error codes: `VALIDATION_FAILED`, `PASSWORD_WEAK`, `UNAUTHORIZED`, `SAME_PASSWORD`, `UPDATE_FAILED`, `INTERNAL_ERROR` — each has a translated UI message.

### New pages
- `app/auth/forgot-password/page.tsx` — static-rendered shell + `<ForgotPasswordForm>`. No session check; anyone can request a reset.
- `app/auth/reset-password/page.tsx` — force-dynamic, gets the session, renders either the password form (authenticated, via the recovery callback) or the "Request a new link" CTA (no session / expired). No raw Supabase error codes reach the UI.

### New client components
- `components/ForgotPasswordForm.tsx` — email input + success confirmation; surfaces RATE_LIMITED and VALIDATION_FAILED as translated copy.
- `components/ResetPasswordForm.tsx` — new password + confirm password with live strength hint via `passwordStrengthHint()`. Client-side policy check runs on submit as belt + braces; server revalidates. On success: `router.refresh()` then `router.replace("/admin/sites")` — the session is already live from the callback.

### Shared policy + login change
- `lib/password-policy.ts` — single source of truth for password rules. `validatePassword()` + `passwordStrengthHint()` + constants `PASSWORD_MIN_LENGTH` (12) + `PASSWORD_MAX_LENGTH` (256). Pure, no I/O — reusable client + server, ready for M14-4 to consume.
- `lib/rate-limit.ts` — new `password_reset` bucket, 5 requests per email per hour. Identifier convention `email:<normalised_email>`.
- `components/LoginForm.tsx` — "Forgot password?" link below the Sign In button. Matches the existing login form styling.

## Risks identified and mitigated

- **Email enumeration via response-shape differences.** API returns 200 for every syntactically-valid email. Supabase errors (rate-limited upstream, unregistered email) are logged at warn but don't change the response. Unit test `returns 200 even when supabase returns an error (no enumeration)` pins this contract.
- **Rate-limit bypass via email rotation.** The limiter is keyed on the email, not the IP, so an attacker flooding one email can't shift buckets by swapping IP. An attacker rotating emails IS NOT slowed by this bucket — but that's a different attack (abuse of the email SEND rather than abuse of a single user's flow). Supabase's own per-sender rate limits cover that.
- **Session hijacker uses reset-password as a covert password-change.** If an attacker has somehow gotten a session cookie, yes, this endpoint lets them change the password without knowing the current one. That's by design — the endpoint's contract is "you already proved identity via the recovery email link." The mitigation for session-hijack-as-password-change is M14-4's account-security page, which verifies current-password before calling `updateUser`. Users who want to change a known password should use that surface.
- **Password logged in plain text.** Unit test `never logs the password in any logger invocation` asserts the entire JSON-stringified log payload doesn't contain the password. Route code never passes `new_password` to logger.
- **Recovery link expired or malformed.** The page renders the "Request a new link" CTA instead of a raw Supabase error. The callback handler (`/api/auth/callback`) already redirects to `/auth-error?reason=exchange_failed` on malformed tokens; this slice doesn't change that path.
- **Weak password slips past client-side check.** Server re-validates on every submit via the same `validatePassword()`. Client is advisory, server is authoritative.
- **Invite redirectTo allowlist drift.** `/auth/forgot-password` and `/auth/reset-password` are already on the allowlist per M14-2's runbook — Steven already has the dashboard entries registered. No new dashboard step needed.

## Deliberately deferred

- **Multi-region / preview-env testing.** `NEXT_PUBLIC_SITE_URL` on preview deploys is unset; the helper falls back to request origin, which means preview emails will redirect to the preview host. That's correct behaviour for testing on previews, but Supabase's allowlist needs the preview wildcard (`https://*-opollo.vercel.app/*`) already registered per M14-2.
- **Password history / "can't reuse last N."** Not in scope.
- **E2E spec.** M14-5 is the dedicated E2E slice. Hand-testable via:
  1. Click "Forgot password?" on `/login`
  2. Enter admin email, submit
  3. Check inbox for email (requires Supabase SMTP configured, or copy the action_link from the Supabase dashboard's magic-link inspector)
  4. Click the link → lands on `/auth/reset-password` with session
  5. Enter new 12+ char password, confirm, submit
  6. Land on `/admin/sites` signed in

## Self-test
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean, new routes + pages registered in the server manifest
- [ ] `npm run test` — runs in CI, 29 new unit tests across password-policy / forgot-password-route / reset-password-route

🤖 Generated with [Claude Code](https://claude.com/claude-code)