### PR TITLE
fix(m14): add /auth/forgot-password + /auth/reset-password to PUBLIC_PATHS

### DIFF
--- a/lib/__tests__/middleware.test.ts
+++ b/lib/__tests__/middleware.test.ts
@@ -184,6 +184,13 @@ describe("middleware: FEATURE_SUPABASE_AUTH on, no session", () => {
       "/api/auth/callback",
       "/api/auth/login",
       "/api/emergency",
+      // M14-3 password-reset surfaces — added to the public-path set
+      // so unauthenticated users can land on the request form and
+      // the reset page's "expired link" state.
+      "/auth/forgot-password",
+      "/auth/reset-password",
+      "/api/auth/forgot-password",
+      "/api/auth/reset-password",
     ]) {
       const res = await middleware(makeRequest(p));
       expect(res.status).toBe(200);

--- a/middleware.ts
+++ b/middleware.ts
@@ -65,6 +65,14 @@ const PUBLIC_PATHS = new Set<string>([
   // itself doesn't expose sensitive data — just connectivity + build
   // info. See app/api/health/route.ts.
   "/api/health",
+  // M14-3 password-reset surfaces. Both are reachable without a
+  // session — /auth/forgot-password is the entry form, and
+  // /auth/reset-password decides server-side whether to render the
+  // form (recovery session present) or the "link expired" state
+  // (no session). The API counterparts under /api/auth/* are already
+  // covered by the prefix check below.
+  "/auth/forgot-password",
+  "/auth/reset-password",
 ]);
 
 function isPublicPath(pathname: string): boolean {


### PR DESCRIPTION
Unblocks the M14-5 e2e spec. `middleware.ts` PUBLIC_PATHS covered `/login`, `/logout`, `/auth-error`, `/api/emergency`, `/api/health`, and (via prefix) `/api/auth/*` — but never the two new M14-3 **page** routes. Unauthenticated users navigating to `/auth/forgot-password` or `/auth/reset-password` were getting bounced to `/login?next=...` before the page could render.

The M14-5 e2e suite caught it on the forgot-password happy-path test; the expired-link and invalid-code tests in the same `describe.serial` block didn't run (short-circuit on first failure) but would have failed the same way.

## What lands
- `middleware.ts` — adds `/auth/forgot-password` + `/auth/reset-password` to `PUBLIC_PATHS` with a comment explaining why.
- `lib/__tests__/middleware.test.ts` — extends the existing "unauthenticated public paths" loop to cover both new pages + both API routes (`/api/auth/forgot-password`, `/api/auth/reset-password`). Four new assertions in the same loop shape as the existing ones.

## Risks identified and mitigated
- **Unintended exposure of a sensitive page.** Neither page leaks data to an unauthenticated caller. `/auth/forgot-password` is the entry form; `/auth/reset-password` server-checks the session and renders either the password form (recovery session) or the "Request a new link" state (no session). Both are designed to be reachable without an existing session.
- **Missing API routes from the allowlist.** The API routes are already covered by the `/api/auth/*` prefix rule. The unit test additions verify both paths explicitly so a future refactor of the prefix rule can't silently drop them.

## Deliberately deferred
Nothing. This is a one-shot fix for a middleware-gap regression.

## Self-test
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [ ] `npm run test` — runs in CI, middleware.test.ts will fail if either path is accidentally removed from PUBLIC_PATHS
- [ ] `npm run test:e2e` — runs in CI, auth-passwords.spec.ts forgot-password happy path + expired-link + invalid-code tests will now run to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)