### PR TITLE
docs(m14-6): auth flow diagram + M2 retroactive gap note

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,0 +1,203 @@
+# Auth — flows + surfaces
+
+Canonical map of every auth path in Opollo Site Builder. Updated after M14 completed the self-service recovery surfaces. If you add a new auth entry point or change a redirect, update this doc in the same PR.
+
+## Milestones the surfaces ship from
+
+- **M2** — foundation: Supabase-backed sessions, role matrix (admin / operator / viewer), admin gate (`lib/admin-gate.ts`, `lib/admin-api-gate.ts`), kill switch, revoke flow, invite flow.
+- **M14-1** — permanent operator admin-reset endpoint, emergency-key-gated.
+- **M14-2** — canonical auth-redirect helper + Supabase dashboard Site URL / Redirect URLs documentation.
+- **M14-3** — self-service forgot-password + reset-password flow.
+- **M14-4** — logged-in account-security password change (current-password-verified).
+- **M14-5** — Playwright coverage of M14-3 + M14-4.
+
+## Flows (mermaid)
+
+### Login (M2)
+
+```mermaid
+flowchart LR
+    A[User on /login] --> B[Submit email + password]
+    B --> C[loginAction server action]
+    C -->|valid| D[Set session cookie]
+    D --> E[Redirect to /admin/sites]
+    C -->|invalid| F["Generic 'Invalid email or password' alert"]
+    F --> A
+```
+
+- Entry: `/login` (`app/login/page.tsx` → `LoginForm`)
+- Server action: `app/login/actions.ts::loginAction`
+- Redirect target: `?next=<path>` or `/admin/sites`
+- Forgot-password link under the Sign In button (M14-3 addition) → `/auth/forgot-password`
+
+### Forgot password (M14-3)
+
+```mermaid
+flowchart TD
+    A[User on /login] --> B[Click 'Forgot password?']
+    B --> C[/auth/forgot-password]
+    C --> D[Submit email]
+    D --> E[POST /api/auth/forgot-password]
+    E -->|rate limiter| F{5/email/hour?}
+    F -->|OK| G[supabase.auth.resetPasswordForEmail<br/>redirectTo = NEXT_PUBLIC_SITE_URL/api/auth/callback<br/>?next=%2Fauth%2Freset-password]
+    F -->|Denied| H["429 RATE_LIMITED → 'Too many reset requests'"]
+    G --> I["Success envelope '(if an account exists, a link has been sent)'"]
+    I --> J[User opens email]
+    J --> K[Click recovery link]
+    K --> L[Supabase /auth/v1/verify]
+    L --> M[/api/auth/callback?code=&lt;pkce&gt;]
+    M --> N[exchangeCodeForSession + set cookie]
+    N --> O[Redirect to /auth/reset-password]
+    O --> P[Enter new password + confirm]
+    P --> Q[POST /api/auth/reset-password]
+    Q --> R[Policy check + supabase.auth.updateUser]
+    R --> S[Redirect to /admin/sites, signed in]
+```
+
+**No-enumeration contract:** `/api/auth/forgot-password` returns a success envelope whether or not the email is registered. Supabase failures are logged at warn but do not change the response shape.
+
+**Expired / invalid link:** if the user lands on `/auth/reset-password` with no active session (link expired, already used, PKCE mismatch), the page renders a "Reset link expired" state with a "Request a new link" CTA back to `/auth/forgot-password`. Invalid codes hitting `/api/auth/callback` redirect to `/auth-error?reason=exchange_failed`.
+
+### Logged-in password change (M14-4)
+
+```mermaid
+flowchart TD
+    A[User on /account/security] --> B[Submit current + new + confirm]
+    B --> C[POST /api/account/change-password]
+    C --> D{Current password verify}
+    D -->|Ephemeral anon client signInWithPassword| E{OK?}
+    E -->|No| F[403 INCORRECT_CURRENT_PASSWORD]
+    E -->|Yes| G[validatePassword new]
+    G -->|Weak| H[422 PASSWORD_WEAK]
+    G -->|Same as current| I[422 SAME_PASSWORD]
+    G -->|OK| J[supabase.auth.updateUser]
+    J -->|Error| K[422 UPDATE_FAILED / SAME_PASSWORD]
+    J -->|Success| L[200 + 'Password updated' status]
+```
+
+The current-password probe uses an ephemeral anon client with `persistSession: false` and `autoRefreshToken: false` — it's a credential-validity check, not a sign-in. The user's existing session is never touched. A session hijacker with a stolen cookie cannot complete the flow without the original password.
+
+Rate limiter: existing `login` bucket keyed on `user:<user_id>` (10/60s).
+
+### Admin reset (M14-1) — ops break-glass
+
+```mermaid
+flowchart LR
+    A[Locked-out admin] --> B[Ops operator curls endpoint]
+    B --> C[POST /api/ops/reset-admin-password]
+    C --> D{OPOLLO_EMERGENCY_KEY match?}
+    D -->|Timing-safe compare fail| E[401 UNAUTHORIZED]
+    D -->|Pass| F{opollo_users.role = admin?}
+    F -->|Not admin| G[403 FORBIDDEN]
+    F -->|Admin| H[supabase.auth.admin.updateUserById]
+    H --> I[200 + note 'sessions not revoked']
+```
+
+- Endpoint: `/api/ops/reset-admin-password` (permanent; not a one-off)
+- Auth: `OPOLLO_EMERGENCY_KEY` header (`X-Opollo-Emergency-Key` or `Authorization: Bearer <key>`)
+- Scope guard: target must be `opollo_users.role = 'admin'`, preventing emergency-key compromise from cascading into full tenant takeover
+- Does NOT revoke existing sessions — chain with `POST /api/emergency {"action":"revoke_user"}` if the lockout is suspected compromise
+- Full runbook: `docs/RUNBOOK.md` § "Admin locked out"
+
+### Invite (M2)
+
+```mermaid
+flowchart TD
+    A[Admin on /admin/users] --> B[Click Invite]
+    B --> C[POST /api/admin/users/invite]
+    C --> D[supabase.auth.admin.generateLink type=invite]
+    D --> E[action_link returned]
+    E --> F[Admin shares link with invitee]
+    F --> G[Invitee clicks link]
+    G --> H[/api/auth/callback?code=&lt;pkce&gt;]
+    H --> I[exchangeCodeForSession + set cookie]
+    I --> J[Redirect to ?next= or /]
+```
+
+The invite endpoint's `redirectTo` flows through `lib/auth-redirect.ts::buildAuthRedirectUrl` (M14-2) — canonical `NEXT_PUBLIC_SITE_URL` when set, request origin as fallback. Invites are NOT expirable or revocable in M14; see BACKLOG "Invite TTL + revocation."
+
+### Logout (M2)
+
+```mermaid
+flowchart LR
+    A[User clicks 'Sign out'] --> B[POST /logout]
+    B --> C[supabase.auth.signOut]
+    C --> D[Cookies cleared via SSR client setAll]
+    D --> E[Redirect to /login]
+```
+
+### Kill switch (M2c) — full-app break-glass
+
+```mermaid
+flowchart LR
+    A[Supabase auth down] --> B[Operator curls /api/emergency]
+    B --> C["{action: 'kill_switch_on'}"]
+    C --> D[opollo_config.auth_kill_switch = 'on']
+    D --> E[Middleware falls back to Basic Auth]
+```
+
+- Runbook: `docs/RUNBOOK.md` § "Auth is broken"
+- `kill_switch_off` reverses; propagation is ≤5s per serverless instance.
+
+## Middleware gate summary
+
+`middleware.ts` runs on every request and routes to one of:
+
+1. **Public path** (`PUBLIC_PATHS` set): proceed without session check.
+   - `/login`, `/logout`, `/auth-error`, `/api/emergency`, `/api/health`, `/auth/forgot-password`, `/auth/reset-password`.
+   - Also prefix-public: `/api/auth/*`, `/api/cron/*`.
+2. **Kill switch on**: Basic Auth path (bypasses Supabase).
+3. **Supabase auth on + no session**: 401 for API / redirect `/login?next=<path>` for HTML.
+4. **Supabase auth on + wrong role**: 403 FORBIDDEN.
+5. **Supabase auth on + revoked user**: 401 UNAUTHORIZED (revocation stamped on `opollo_users.revoked_at`).
+6. **Supabase auth on + valid session**: proceed.
+
+## Role matrix
+
+| Role | Read | Write (own scope) | Write (any scope) | Admin routes |
+| --- | --- | --- | --- | --- |
+| viewer | ✓ | ✗ | ✗ | ✗ |
+| operator | ✓ | ✓ | ✗ | some (per-route) |
+| admin | ✓ | ✓ | ✓ | ✓ |
+
+Source of truth: `supabase/migrations/0005_m2b_rls_policies.sql` at the DB layer; `lib/admin-gate.ts` + `lib/admin-api-gate.ts` at the app layer.
+
+## Password policy (M14)
+
+- Minimum 12 characters (NIST SP 800-63B § 5.1.1.2 — length beats character-class rules at equivalent friction).
+- Maximum 256 characters.
+- No whitespace-only.
+- No complexity / composition rules.
+- Source of truth: `lib/password-policy.ts`. Used server-side by M14-1 (`/api/ops/reset-admin-password`), M14-3 (`/api/auth/reset-password`), and M14-4 (`/api/account/change-password`). Client-side strength hint via `passwordStrengthHint()` in M14-3 and M14-4 forms.
+
+## Auth-redirect helper (M14-2)
+
+`lib/auth-redirect.ts::buildAuthRedirectUrl(path, req?)` — single source of truth for auth `redirectTo` URLs. Priority:
+
+1. `NEXT_PUBLIC_SITE_URL` env (canonical, spoofing-immune).
+2. Request origin fallback.
+3. Throw `AuthRedirectBaseUnavailable` when neither is available (server actions, cron).
+
+Any new auth route that issues a link must use this helper AND register the final URL in the Supabase dashboard's Redirect URLs allowlist — see `docs/RUNBOOK.md` § "Supabase Auth URL configuration".
+
+## Structured logging (M14)
+
+Every password-setting surface logs via `lib/logger.ts` with `{ request_id, user_id, email, outcome }`. **The password itself is never serialised into log payloads** — unit tests in each route's `*-route.test.ts` file assert this explicitly with a serialise-and-grep check.
+
+Event names:
+
+- `ops_reset_admin_password_success` / `*_unauthorized` / `*_not_found` / `*_wrong_role` / `*_update_failed` / `*_internal_error`
+- `forgot_password_requested` / `*_rate_limited` / `*_supabase_error` / `*_internal_error`
+- `reset_password_success` / `*_unauthenticated` / `*_supabase_error` / `*_internal_error`
+- `change_password_success` / `*_incorrect_current` / `*_rate_limited` / `*_supabase_error` / `*_unauthenticated` / `*_internal_error` / `*_missing_email`
+
+## What's NOT in scope
+
+Deferred to BACKLOG post-M14:
+
+- **Invite TTL + revocation.** Pick up trigger: admin mistakenly invites the wrong email and can't revoke.
+- **Session expiry pre-warning.** Pick up trigger: operator loses mid-workflow state because of an expiry they didn't see coming.
+- **MFA.** Its own milestone.
+- **"Remember me" toggle.** Cookie sessions already persist.
+- **Account deletion / GDPR export.** No public-user surface yet.
+- **Email verification on signup.** Admin-invite-only today.

--- a/docs/plans/m14-parent.md
+++ b/docs/plans/m14-parent.md
@@ -149,11 +149,11 @@ Every new page M14-3 + M14-4 add goes through `auditA11y()` in its E2E spec per 
 ## Sub-slice status tracker
 
 - [x] M14-1 — admin reset endpoint (merged, PR #113)
-- [ ] `fix(e2e)` briefs-review spec — pre-existing flake on main; ship before M14-2 so the suite is green
-- [ ] M14-2 — Supabase redirect configuration
-- [ ] M14-3 — forgot password flow (BLOCKED on M14-2)
-- [ ] M14-4 — account security page (BLOCKED on M14-3)
-- [ ] M14-5 — E2E coverage (BLOCKED on M14-4)
-- [ ] M14-6 — docs + auth flow diagram (BLOCKED on M14-5)
+- [x] `fix(e2e)` briefs-review spec (merged, PR #114 + PR #115 fixme)
+- [x] M14-2 — Supabase redirect configuration (merged, PR #116)
+- [x] M14-3 — forgot password flow (merged, PR #117)
+- [x] M14-4 — account security page (merged, PR #118)
+- [x] M14-5 — E2E coverage (merged, PR #119 + PR #120 public-paths fix + PR #121 email-flow rework)
+- [x] M14-6 — docs + auth flow diagram (this PR)
 
 **Auto-continue rule:** silence at sub-slice boundaries = proceed, per the CLAUDE.md "Auto-continue" rule. **Explicit halt at M14-6 → M12-2:** after M14-6 merges, auto-continue halts. Steven tests the full reset flow end-to-end — request reset, receive email, set new password, log in with new, verify old rejected, exercise the logged-in password-change flow — and posts an explicit "resume M12-2" signal. Only then does M12-2 pick up. Silence at the M14-6 → M12-2 boundary is NOT a proceed signal.

--- a/docs/plans/m2-parent.md
+++ b/docs/plans/m2-parent.md
@@ -2,7 +2,16 @@
 
 ## Status
 
-Shipped. Backfilled during M11-6 (audit close-out 2026-04-22) so the risk audit has a single source of truth.
+Shipped, completed in M14. Backfilled during M11-6 (audit close-out 2026-04-22); retrospective note added 2026-04-24 after M14.
+
+M2 shipped the foundation — Supabase-backed sessions, role matrix, admin gate, kill switch, invite flow — but it did NOT ship self-service recovery. Specifically, M2 left these gaps, all of which became painful when `hi@opollo.com` locked out:
+
+- **No "Forgot password?" path.** A user who forgot their password had no way to recover it — the login form's only feedback on a bad password was a generic error.
+- **No `/account/security` page.** A signed-in user had no way to rotate their own password.
+- **No permanent operator recovery tool.** If Supabase's email flow was misconfigured or unreachable, a locked-out admin had no path back in short of a one-off database edit.
+- **Supabase dashboard redirect URLs never documented.** The production dashboard's Site URL had drifted to `localhost:3000`, so every auth email (if any were ever sent) would have landed at the wrong host.
+
+M14 closed all four. M2 is still the correct foundation — the role matrix, admin gate, emergency kill switch, and invite flow are all in use unchanged. The "auth is shipped" framing in this plan's original wording predated self-service recovery being a requirement; the door was held by admin-only invite flow until M14 added the self-service paths. See `docs/AUTH.md` for the post-M14 flow diagram.
 
 ## What it is
 


### PR DESCRIPTION
Closes M14. Ships `docs/AUTH.md` — canonical map of every auth surface with mermaid flow diagrams — and backfills `docs/plans/m2-parent.md` with a retroactive note naming the four gaps M2 left that M14 closed.

## What lands
- `docs/AUTH.md` (new) — mermaid flow diagrams for: login / logout (M2), forgot-password → reset-password (M14-3), logged-in password change (M14-4), admin break-glass reset (M14-1), invite (M2), kill switch (M2c). Plus middleware public-paths summary, role matrix, password policy, auth-redirect helper rules, structured-logging event names, and the deferred-to-BACKLOG list.
- `docs/plans/m2-parent.md` — "Status" section updated with the four specific gaps M14 closed (forgot-password, account security, permanent operator recovery, Supabase dashboard redirect docs). The original risk audit stays intact — the gaps were framing, not correctness.
- `docs/plans/m14-parent.md` — sub-slice tracker flipped to all checked.

## Risks identified and mitigated
- **Documentation drift.** A flow diagram that goes stale is worse than no diagram. The file's header makes the maintenance rule explicit: "If you add a new auth entry point or change a redirect, update this doc in the same PR."
- **Revealing sensitive implementation.** Nothing sensitive — no real URLs, no secrets, no internal-only endpoints. The emergency-key-gated admin reset is already documented in the runbook; AUTH.md just cross-links it.

## Deliberately deferred
- **Turning the mermaid into an interactive graph.** The static diagrams render on GitHub (native mermaid support); no tooling to add.
- **"Auth on-call" runbook consolidation.** The existing `docs/RUNBOOK.md` has the individual entries (auth broken, admin locked out, Supabase URL config). A single unified "auth on-call" doc could cross-link them more tightly; leaving that for when the current structure actually causes confusion.

## Self-test
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [ ] `npm run test` + `npm run test:e2e` — run in CI; no code changes in this PR.

## After this merges

**Explicit halt per Steven's 2026-04-23 ordering call.** Silence is NOT a proceed signal at the M14-6 → M12-2 boundary. Post-merge:

1. Steven tests the full reset flow end-to-end: request reset, follow email link, set new password, sign in, verify old password rejected, exercise the logged-in password-change flow.
2. Steven gives an explicit "resume M12-2" signal before any further work starts.

M12-2 (briefs) and M13 (blog posts) stay paused until that signal lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)