### PR TITLE
fix(m14-1): opollo_users has no deleted_at column — filter on revoked_at

### DIFF
--- a/app/api/ops/reset-admin-password/route.ts
+++ b/app/api/ops/reset-admin-password/route.ts
@@ -129,16 +129,23 @@ export async function POST(req: Request): Promise<NextResponse> {
   const svc = getServiceRoleClient();
 
   try {
-    // Confirm the target is a current (non-deleted) admin. Supabase's
+    // Confirm the target is a current (non-revoked) admin. Supabase's
     // auth.users table is the source of truth for auth identity, but
     // opollo_users is the source of truth for role. The join path:
     // opollo_users.id == auth.users.id; we look up opollo_users by
     // email-equivalent, then use the id to drive the auth admin call.
+    //
+    // opollo_users does NOT carry a deleted_at column today — the
+    // BACKLOG schema-hygiene pass scopes soft-delete to the mutable
+    // content tables (sites / design_systems / pages / etc), not to
+    // the user table. User lifecycle uses revoked_at instead: revoked
+    // admins are refused here so a leaked emergency key can't reset
+    // a banned admin's password as part of a compromise chain.
     const { data: opolloUser, error: opolloErr } = await svc
       .from("opollo_users")
-      .select("id, role, deleted_at")
+      .select("id, role, revoked_at")
       .eq("email", normalizedEmail)
-      .is("deleted_at", null)
+      .is("revoked_at", null)
       .maybeSingle();
 
     if (opolloErr) {

--- a/lib/__tests__/reset-admin-password-route.test.ts
+++ b/lib/__tests__/reset-admin-password-route.test.ts
@@ -21,7 +21,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 type OpolloUserRow = {
   id: string;
   role: string;
-  deleted_at: string | null;
+  revoked_at: string | null;
 };
 
 type LookupResult = {
@@ -36,20 +36,61 @@ type UpdateResult = {
 const mockState = vi.hoisted(() => ({
   lookupResult: null as LookupResult | null,
   lookupCalls: [] as Array<{ column: string; value: string }>,
+  selectColumns: [] as string[],
+  isCalls: [] as Array<{ column: string; value: unknown }>,
   updateResult: { error: null } as UpdateResult,
   updateCalls: [] as Array<{ userId: string; attributes: { password: string } }>,
 }));
+
+// Columns actually present on opollo_users as of migration 0006.
+// If the route .select()s or .is()-filters on anything outside this
+// set, the mock fails loudly — a unit-level tripwire for the
+// "queries a column the table doesn't have" class of bug that
+// shipped in the original M14-1 and only surfaced in production.
+const OPOLLO_USERS_COLUMNS = new Set([
+  "id",
+  "email",
+  "display_name",
+  "role",
+  "created_at",
+  "revoked_at",
+]);
+
+function assertValidColumnList(cols: string): void {
+  for (const col of cols.split(",").map((c) => c.trim()).filter(Boolean)) {
+    if (!OPOLLO_USERS_COLUMNS.has(col)) {
+      throw new Error(
+        `reset-admin-password.test: route selected non-existent opollo_users column "${col}". ` +
+          `Valid columns: ${[...OPOLLO_USERS_COLUMNS].join(", ")}.`,
+      );
+    }
+  }
+}
+
+function assertValidColumn(col: string): void {
+  if (!OPOLLO_USERS_COLUMNS.has(col)) {
+    throw new Error(
+      `reset-admin-password.test: route filtered on non-existent opollo_users column "${col}". ` +
+        `Valid columns: ${[...OPOLLO_USERS_COLUMNS].join(", ")}.`,
+    );
+  }
+}
 
 vi.mock("@/lib/supabase", () => ({
   getServiceRoleClient: () => ({
     from(_table: string) {
       return {
-        select(_cols: string) {
+        select(cols: string) {
+          mockState.selectColumns.push(cols);
+          assertValidColumnList(cols);
           return {
             eq(column: string, value: string) {
+              assertValidColumn(column);
               mockState.lookupCalls.push({ column, value });
               return {
-                is(_col: string, _val: null) {
+                is(col: string, val: unknown) {
+                  assertValidColumn(col);
+                  mockState.isCalls.push({ column: col, value: val });
                   return {
                     maybeSingle: async () => {
                       if (!mockState.lookupResult) {
@@ -141,11 +182,13 @@ beforeEach(() => {
     data: {
       id: ADMIN_UUID,
       role: "admin",
-      deleted_at: null,
+      revoked_at: null,
     },
     error: null,
   };
   mockState.lookupCalls = [];
+  mockState.selectColumns = [];
+  mockState.isCalls = [];
   mockState.updateResult = { error: null };
   mockState.updateCalls = [];
   loggerCalls.info.length = 0;
@@ -328,7 +371,7 @@ describe("POST /api/ops/reset-admin-password: target guard", () => {
 
   it("returns 403 when the matching user is an operator", async () => {
     mockState.lookupResult = {
-      data: { id: ADMIN_UUID, role: "operator", deleted_at: null },
+      data: { id: ADMIN_UUID, role: "operator", revoked_at: null },
       error: null,
     };
     const res = await resetAdminPasswordPOST(
@@ -345,7 +388,7 @@ describe("POST /api/ops/reset-admin-password: target guard", () => {
 
   it("returns 403 when the matching user is a viewer", async () => {
     mockState.lookupResult = {
-      data: { id: ADMIN_UUID, role: "viewer", deleted_at: null },
+      data: { id: ADMIN_UUID, role: "viewer", revoked_at: null },
       error: null,
     };
     const res = await resetAdminPasswordPOST(
@@ -369,6 +412,49 @@ describe("POST /api/ops/reset-admin-password: target guard", () => {
     expect(mockState.lookupCalls).toEqual([
       { column: "email", value: "hi@opollo.com" },
     ]);
+  });
+
+  it("filters on revoked_at (not deleted_at) — opollo_users has no soft-delete column", async () => {
+    // Regression pin: the original M14-1 shipped a query against
+    // opollo_users.deleted_at which is not a column on that table
+    // (soft-delete is scoped to mutable content tables per BACKLOG
+    // schema-hygiene). The mock's `assertValidColumn` fails the
+    // test if any non-existent column is ever selected or filtered.
+    await resetAdminPasswordPOST(
+      makeRequest(
+        { email: "hi@opollo.com", new_password: VALID_PASSWORD },
+        { key: KEY_32 },
+      ),
+    );
+    expect(mockState.isCalls).toEqual([
+      { column: "revoked_at", value: null },
+    ]);
+    expect(mockState.selectColumns).toEqual(["id, role, revoked_at"]);
+  });
+});
+
+describe("POST /api/ops/reset-admin-password: revoked admin is refused", () => {
+  beforeEach(() => {
+    process.env.OPOLLO_EMERGENCY_KEY = KEY_32;
+  });
+
+  it("returns 404 when the matching admin has a non-null revoked_at", async () => {
+    // The route filters `.is('revoked_at', null)` at the query layer,
+    // so a revoked admin surfaces as "no matching row" → NOT_FOUND.
+    // Simulates that by returning `data: null` from the mock — the
+    // same shape Supabase returns when the .is() predicate excludes
+    // every row.
+    mockState.lookupResult = { data: null, error: null };
+    const res = await resetAdminPasswordPOST(
+      makeRequest(
+        { email: "revoked-admin@opollo.com", new_password: VALID_PASSWORD },
+        { key: KEY_32 },
+      ),
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(mockState.updateCalls).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
**Urgent hotfix — unblocks admin recovery.**

Production error from Vercel logs: `column opollo_users.deleted_at does not exist`. `/api/ops/reset-admin-password` returned 500 INTERNAL_ERROR on every real call because the lookup filtered on a column that isn't on the `opollo_users` table.

## Diagnosis

**Schema reality (verified against migrations 0002, 0004, 0006):** `opollo_users` columns are `id`, `email`, `display_name`, `role`, `created_at`, `revoked_at`. No `deleted_at`.

**BACKLOG intent:** the "Schema hygiene pass: soft-delete + audit columns" entry in `docs/BACKLOG.md` explicitly scopes soft-delete to the mutable content tables — `sites`, `design_systems`, `design_components`, `design_templates`, `pages`. `opollo_users` is not in that list. User lifecycle uses `revoked_at` semantics (ban-then-unban), which is a different concept than soft-delete.

So this is **Option A** from your brief: remove the bad `deleted_at` check, don't add a column that isn't planned.

**Audit of every other query:** grepped all `.from("opollo_users")` sites in `app/`, `lib/`, and `e2e/`. The M14-1 route was the *only* offender. Every other query uses valid columns (`id`, `email`, `display_name`, `role`, `created_at`, `revoked_at`). No other fixes needed.

## Why CI didn't catch it

The M14-1 unit test fully mocks `getServiceRoleClient`, so the `.is("deleted_at", null)` chain never hit a real DB. Pure unit mocks don't enforce column existence.

## What lands
- `app/api/ops/reset-admin-password/route.ts` — lookup now filters `.is("revoked_at", null)` and selects `id, role, revoked_at`. Comment updated with the why (links back to the BACKLOG decision). Semantic: a revoked admin surfaces as `NOT_FOUND`, refusing reset — a leaked emergency key must not be usable to reset a banned admin's password.
- `lib/__tests__/reset-admin-password-route.test.ts` — three changes:
  1. Mock's `.select()` / `.eq()` / `.is()` chain now asserts every column name against `OPOLLO_USERS_COLUMNS` (the actual schema column set). Any future typo against opollo_users fails the test loudly at call time instead of silently passing and failing in production.
  2. New explicit test `"filters on revoked_at (not deleted_at) — opollo_users has no soft-delete column"` that pins the exact column names going into the query. Direct regression bookmark for the bug that shipped.
  3. New test `"returns 404 when the matching admin has a non-null revoked_at"` that covers the revoked-admin-is-refused branch.

## Risks identified and mitigated
- **Defeating the revoke-then-reset compromise path.** Semantic change: revoked admins are now refused by this endpoint. Correct behaviour — a leaked emergency key shouldn't rotate a banned admin's password. The runbook's existing guidance to chain with `revoke_user` still works when the lockout is suspected compromise.
- **The tighter mock breaks future legitimate additions.** If a future slice adds a real column to opollo_users, that column must be added to the `OPOLLO_USERS_COLUMNS` set literal. That's by design — it's the tripwire that caught this bug. A 1-line test edit is cheaper than a production outage.
- **No migration needed.** Explicitly verified against BACKLOG intent — `opollo_users` doesn't get soft-delete and isn't planned to.

## Deliberately deferred
- **Promoting the column-set-assertion helper to a shared test utility.** If we hit this bug pattern on another table, extract. One caller now, no abstraction.
- **Integration test against a real Supabase.** The existing `admin-users-*` tests hit a real DB; a parallel integration test for this route would catch the class, but doubles the fixture footprint. Unit-level column assertion covers the specific regression.

## Self-test
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] `npm run test` — runs in CI. Expected: the new `filters on revoked_at` test pins the fix; the `revoked admin returns 404` test covers the new branch.

## After merge
Retry `POST /api/ops/reset-admin-password` with your `OPOLLO_EMERGENCY_KEY` + `{email: "hi@opollo.com", new_password: "<strong>"}`. Should now return 200 + a "password reset" envelope. Runbook recipe in `docs/RUNBOOK.md` § "Admin locked out" still valid — this only changes the implementation, not the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)