### PR TITLE
fix(m15-3): env coupling validation + doc-drift cleanup

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -146,9 +146,9 @@ REGEN_DAILY_BUDGET_CENTS=
 # Per-run cap for scripts/seed-leadsource.ts iStock ingest. Guards against
 # a misconfigured seed overspending on stock imagery.
 ISTOCK_SEED_CAP_CENTS=
-# Initial daily / monthly tenant-cost budgets applied to every new site.
-# Defaults: 500c/day (≈$5), 10000c/month (≈$100). Override in Vercel to
-# raise or lower the baseline; per-site overrides still happen via the
-# /admin/sites/[id]/budget PATCH.
-DEFAULT_TENANT_DAILY_BUDGET_CENTS=
-DEFAULT_TENANT_MONTHLY_BUDGET_CENTS=
+# DEFAULT_TENANT_DAILY_BUDGET_CENTS / DEFAULT_TENANT_MONTHLY_BUDGET_CENTS
+# were listed here prior to 2026-04-24, but no code reads them. The M8-1
+# migration hardcodes the column defaults (500c/day, 10000c/month). To
+# change the baseline, write a forward migration that alters the default.
+# Per-site overrides go through the /admin/sites/[id]/budget PATCH route.
+# See docs/ENV_AUDIT_2026-04-24.md finding #2.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -113,7 +113,7 @@ Parent plan: `docs/plans/m8-parent.md`. All five sub-slices merged.
 | M8-4 | merged (#82) | `/api/cron/budget-reset` hourly reset cron. Daily + monthly rollover via single UPDATE per period with `WHERE reset_at < now()` predicate. Idempotent under concurrent ticks. |
 | M8-5 | merged (#83) | Admin UI budget badge on `/admin/sites/[id]` + PATCH endpoint with version_lock. |
 
-New env vars (both optional, code-side defaults apply): `DEFAULT_TENANT_DAILY_BUDGET_CENTS` (default 500 = $5/day), `DEFAULT_TENANT_MONTHLY_BUDGET_CENTS` (default 10000 = $100/month).
+~~New env vars (both optional, code-side defaults apply): `DEFAULT_TENANT_DAILY_BUDGET_CENTS` (default 500 = $5/day), `DEFAULT_TENANT_MONTHLY_BUDGET_CENTS` (default 10000 = $100/month).~~ **2026-04-24 (M15-3):** these env vars were never wired. The M8-1 migration hardcodes the column defaults (500 / 10000); no code reads the env var. Changing the baseline requires a forward migration. Entries also removed from `.env.local.example`.
 
 ---
 
@@ -127,7 +127,7 @@ Parent plan: `docs/plans/m7-parent.md`. Write-safety-critical milestone; all fiv
 | M7-2 | merged (#73) | Worker core (lease / heartbeat / reaper) + Anthropic integration + event-log-first billing + VERSION_CONFLICT short-circuit. |
 | M7-3 | merged (#75) | WP update stage with drift reconciliation + M4-7 image transfer + `pages.version_lock` bump. |
 | M7-4 | merged (#77) | Admin UI: "Re-generate" button + status polling panel + enqueue endpoint with REGEN_ALREADY_IN_FLIGHT guard. |
-| M7-5 | merged (#78) | Cron wiring (`/api/cron/process-regenerations`) + daily budget cap (`REGEN_DAILY_BUDGET_CENTS` → `BUDGET_EXCEEDED`) + retry/backoff via `retry_after` + REGEN_RETRY_BACKOFF_MS. |
+| M7-5 | merged (#78) | Cron wiring (`/api/cron/process-regenerations`) + daily budget cap (`REGEN_DAILY_BUDGET_CENTS` env → `BUDGET_EXCEEDED`) + retry/backoff via `retry_after`. Backoff values live in the `REGEN_RETRY_BACKOFF_MS` code constant in `lib/regeneration-worker.ts`, not an env var. |
 
 No new env vars — every external dependency (`ANTHROPIC_API_KEY`, `CLOUDFLARE_*`, `OPOLLO_MASTER_KEY`, `CRON_SECRET`) is already provisioned from M3 + M4.
 

--- a/docs/ENV_AUDIT_2026-04-24.md
+++ b/docs/ENV_AUDIT_2026-04-24.md
@@ -1,0 +1,297 @@
+# Env Var Audit (M15-3)
+
+**Date:** 2026-04-24
+**Scope:** M1 → M14 (all code surfaces + all documentation references)
+**Method:** Parallel Sonnet sub-agents extracted (a) every `process.env.*` / GitHub Actions `secrets.*` reference across `lib/`, `app/`, `scripts/`, `e2e/`, `middleware.ts`, `next.config.mjs`, `playwright.config.ts`, `vitest.config.ts`, `.github/workflows/*.yml`, and `package.json`, and (b) every env var mentioned in `.env.local.example`, CLAUDE.md, and all `docs/*.md`. Opus cross-referenced the two plus targeted greps for the suspicious cases.
+**Inputs:** Full code scan (55 distinct vars across ~40 files) + full docs scan (40 named vars across 15 docs + `.env.local.example`). Scratch inputs not persisted to disk this round; they were under the 68KB cutoff.
+
+---
+
+## TL;DR
+
+14 findings; none production-breaking today. The class of bug that bit us tonight (schema/env drift between deploy reality and code assumptions) shows up in multiple forms here: **dead env vars in `.env.local.example`**, **env vars in docs that the code never reads**, **env vars the code reads that no docs explain**, and — the most operationally concerning — **a rotation runbook (`OPOLLO_MASTER_KEY_NEXT` zero-downtime flow in `docs/RUNBOOK.md`) that cannot execute as written because the code is not dual-key aware**.
+
+**Escalation flag:** 14 findings, over the 10-threshold — pause for prioritization. **Also pending:** the Vercel env var list. This report covers code ↔ docs cross-reference completely; the code ↔ Vercel leg is incomplete without you pasting the Vercel state. I'll append that as Part 2 if/when you paste.
+
+**I am NOT starting M15-4 until you respond.**
+
+---
+
+## Part 1 — Code ↔ Docs cross-reference
+
+### Findings Summary
+
+| # | Severity | Category | One-line |
+|---|---|---|---|
+| 1 | LIKELY-PROD-BREAKING (for rotation) | Runbook vs code gap | `OPOLLO_MASTER_KEY_NEXT` rotation playbook in `docs/RUNBOOK.md` assumes dual-key decryption logic that `lib/encryption.ts` does not have. Attempting the documented zero-downtime rotation would fail at the "redeploy and verify old values still decrypt" step. |
+| 2 | LATENT-RISK | Dead env vars (docs → no code) | `DEFAULT_TENANT_DAILY_BUDGET_CENTS` + `DEFAULT_TENANT_MONTHLY_BUDGET_CENTS` are in `.env.local.example` and `docs/BACKLOG.md` but no code reads them. The M8 migration hardcodes 500/10000. |
+| 3 | LATENT-RISK | Dead env vars (docs → no code) | `OPOLLO_PROMPT_VERSION` is documented in `docs/PROMPT_VERSIONING.md` as the live prompt-version override, but no code reads it. The doc doesn't flag this as unshipped. |
+| 4 | TECH-DEBT | Name drift in docs | `docs/RUNBOOK.md:396` says `LANGFUSE_BASEURL`. Code + `.env.local.example` use `LANGFUSE_HOST`. RUNBOOK is the typo. |
+| 5 | TECH-DEBT | Doc miscategorization | `docs/BACKLOG.md:130` references `REGEN_RETRY_BACKOFF_MS` as a tunable env var. It's actually a code constant (`lib/regeneration-worker.ts:54`). No code path reads it from env. |
+| 6 | LATENT-RISK | Undocumented code-side var | `instrumentation-client.ts:18` reads `NEXT_PUBLIC_VERCEL_ENV`, but Vercel does NOT auto-expose this to client bundles — it must be explicitly set on the project. If unset, client-side Sentry tags errors with the `NODE_ENV` fallback on every deploy. No docs mention this. |
+| 7 | LATENT-RISK | Cross-system coupling (undefended) | `NEXT_PUBLIC_LEADSOURCE_WP_URL` and `LEADSOURCE_WP_URL` MUST match (per `.env.local.example:10`), but there's no runtime or build-time check. Mismatch silently breaks CSP / preview iframe. |
+| 8 | LATENT-RISK | Cross-system coupling (undefended) | `NEXT_PUBLIC_SITE_URL` value MUST be registered in Supabase Dashboard → Authentication → Redirect URLs allowlist. No check verifies this; drift breaks every auth email flow. |
+| 9 | LATENT-RISK | Graceful-degrade produces broken output | `CLOUDFLARE_IMAGES_HASH` uses `?? ""` fallback in 4 call sites. If unset in production, delivery URLs become `https://imagedelivery.net//<id>/public` (double slash) and 404 silently. Should be hard-required or validated at cold-start. |
+| 10 | TECH-DEBT | Undocumented format | `LEADSOURCE_WP_USER` and `LEADSOURCE_WP_APP_PASSWORD` appear in `.env.local.example` without any inline comment. No docs explain "WP Application Password, not regular password" — a common newbie trap. |
+| 11 | TECH-DEBT | Undocumented context | `SENTRY_ORG` and `SENTRY_PROJECT` appear in `.env.local.example` with no comments. Nothing explains they're only needed at build time for source-map upload, not for runtime Sentry. |
+| 12 | TECH-DEBT | Name confusion | `SUPABASE_DB_URL` (runtime worker env var) vs `DATABASE_URL` (shell variable in RUNBOOK.md migration CLI commands). Different concepts; naming collision. Someone could read the runbook and set `DATABASE_URL` in Vercel by accident. |
+| 13 | TECH-DEBT | Undocumented code-side var | `ANALYZE` env var in `next.config.mjs:8` enables the bundle analyzer at build time. Not documented anywhere. Minor — dev-only. |
+| 14 | LATENT-RISK | No CI gate | No CI check verifies that every `process.env.X` reference has a corresponding `.env.local.example` entry + docs mention. This is the class of drift the audit itself is discovering — M15-8 scopes this. |
+
+---
+
+## Detailed findings
+
+### 1. [LIKELY-PROD-BREAKING, when rotation is attempted] `OPOLLO_MASTER_KEY_NEXT` rotation gap
+
+**What:** `docs/RUNBOOK.md:329-339` documents a zero-downtime master-key rotation procedure:
+
+> 1. Generate new key (`openssl rand -base64 32`).
+> 2. Set `OPOLLO_MASTER_KEY_NEXT` in Vercel env to the new key; leave `OPOLLO_MASTER_KEY` as the old key. Redeploy.
+> 3. Run the rotation migration that re-encrypts all `sites.wp_app_password` rows using `OPOLLO_MASTER_KEY_NEXT`.
+> 4. Swap: `OPOLLO_MASTER_KEY` = new key (previous `_NEXT`). Clear `OPOLLO_MASTER_KEY_NEXT`. Redeploy.
+
+**Reality:** `lib/encryption.ts:36` only reads `OPOLLO_MASTER_KEY`. It has no awareness of `OPOLLO_MASTER_KEY_NEXT`. The `loadMasterKey()` function:
+
+```ts
+const raw = process.env.OPOLLO_MASTER_KEY;
+if (!raw) throw new Error("OPOLLO_MASTER_KEY is not set.");
+```
+
+There is no dual-key decrypt path. After step 2 of the playbook (redeploy with both keys set), the running app still decrypts every `sites.wp_app_password` with the **old** key. There's also no migration in `supabase/migrations/` that re-encrypts using `OPOLLO_MASTER_KEY_NEXT`. The playbook is aspirational, not executable.
+
+**Why it matters:** If you ever actually need to rotate the master key (suspected leak, routine rotation), following the documented procedure will not rotate anything. The app will continue using the old key. The "downtime window: ~0s" claim in the runbook is wrong; real rotation requires downtime (or the dual-key logic that's missing).
+
+**Fix options:**
+- **(a) Build the dual-key logic.** Add `OPOLLO_MASTER_KEY_NEXT` support to `lib/encryption.ts`: decrypt tries the active key first, then `_NEXT` if that fails. Write the re-encrypt migration. Matches the documented playbook. ~1 day of work + careful testing.
+- **(b) Replace the playbook with a bounded-downtime procedure.** Tear down, rotate env var, re-encrypt all rows in a single migration, redeploy. Fits what the code supports today. Downtime = however long the re-encrypt migration takes. ~1 hour to rewrite the runbook + test once.
+
+Option (b) is honest about current state. Option (a) is the better long-term story.
+
+**Severity rationale:** LIKELY-PROD-BREAKING **if a rotation is attempted**. Today there's no active rotation. But this would manifest as "rotation looks like it worked, app keeps decrypting with the old key" — a silent failure state that would be missed until the old key is revoked somewhere upstream, at which point every site's WP credentials become unrecoverable. Worth fixing before any rotation is ever attempted.
+
+---
+
+### 2. [LATENT-RISK] Dead env vars: `DEFAULT_TENANT_{DAILY,MONTHLY}_BUDGET_CENTS`
+
+**What:** Both vars are in `.env.local.example:153-154` with a full comment:
+
+> Initial daily / monthly tenant-cost budgets applied to every new site. Defaults: 500c/day (≈$5), 10000c/month (≈$100). Override in Vercel to raise or lower the baseline; per-site overrides still happen via the /admin/sites/[id]/budget PATCH.
+
+And in `docs/BACKLOG.md:116`:
+
+> New env vars (both optional, code-side defaults apply): `DEFAULT_TENANT_DAILY_BUDGET_CENTS` (default 500 = $5/day), `DEFAULT_TENANT_MONTHLY_BUDGET_CENTS` (default 10000 = $100/month).
+
+**Reality:** Zero code references to `process.env.DEFAULT_TENANT_DAILY_BUDGET_CENTS` or `process.env.DEFAULT_TENANT_MONTHLY_BUDGET_CENTS`. The M8-1 migration (`supabase/migrations/0012_m8_1_tenant_cost_budgets.sql`) hardcodes the defaults at the column level:
+
+```sql
+daily_cap_cents bigint NOT NULL DEFAULT 500,
+monthly_cap_cents bigint NOT NULL DEFAULT 10000,
+```
+
+Setting either env var on Vercel has no effect. The docs claim an override capability that doesn't exist.
+
+**Why it matters:** Not an active bug, but the docs lie. If someone sets `DEFAULT_TENANT_DAILY_BUDGET_CENTS=1000` on Vercel expecting new sites to get $10/day, they'll get $5/day anyway and never know why. Also a clean audit signal: if `.env.local.example` contains docs-only vars, every dev who reads the file has a slightly wrong mental model of what the app supports.
+
+**Fix options:**
+- **(a) Wire the code.** Read the env var in the migration / in a post-insert trigger / in the tenant-budget creation trigger. Match docs.
+- **(b) Delete the docs.** Remove both vars from `.env.local.example` + `docs/BACKLOG.md` comment. Update the trigger-based default to be clearly documented as "500/10000 hardcoded; change via migration."
+
+Option (b) is less work and matches current system behavior. If you want runtime override, (a) is the right path.
+
+---
+
+### 3. [LATENT-RISK] `OPOLLO_PROMPT_VERSION` documented as live, not shipped
+
+**What:** `docs/PROMPT_VERSIONING.md:32,38` describes `OPOLLO_PROMPT_VERSION` as the active mechanism:
+
+> `lib/prompts/index.ts` exposes `resolvePrompt(version?: string)` — reads `OPOLLO_PROMPT_VERSION` env, falls back to latest shipped version. Chat route calls this.
+>
+> `OPOLLO_PROMPT_VERSION` env var controls the active prompt: Unset → latest shipped version. `v1` → force legacy behaviour.
+
+**Reality:** No code reads `process.env.OPOLLO_PROMPT_VERSION`. No file `lib/prompts/index.ts` exists. The prompt-versioning cutover hasn't shipped. The doc itself says later (line 57): "Cutover is its own sub-slice (blocked on `LANGFUSE_*` env provisioning)." But the reader doesn't get that nuance at the top.
+
+**Why it matters:** A reader of `docs/PROMPT_VERSIONING.md` could reasonably conclude this is the live system and try to use the env var. Nothing breaks; nothing changes either. Softer version of finding #2 — the docs describe the future state as if it's the current state.
+
+**Fix:** Add a "**Not yet shipped** — pending cutover slice" banner at the top of `docs/PROMPT_VERSIONING.md`, OR implement the cutover. Same dilemma as #2.
+
+---
+
+### 4. [TECH-DEBT] `LANGFUSE_BASEURL` typo in RUNBOOK
+
+**What:** `docs/RUNBOOK.md:396` reads: "Langfuse: `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, optionally `LANGFUSE_BASEURL` if self-hosted." Nowhere else uses this name. Code reads `LANGFUSE_HOST` (verified at `lib/langfuse.ts:37`). `.env.local.example:127` uses `LANGFUSE_HOST`.
+
+**Why it matters:** An operator following the runbook to set up a self-hosted Langfuse would set `LANGFUSE_BASEURL` in Vercel and Langfuse would never activate (code ignores unknown var, falls back to the default `https://us.cloud.langfuse.com`). Silent misconfig.
+
+**Fix:** One-char edit — RUNBOOK.md line 396 `LANGFUSE_BASEURL` → `LANGFUSE_HOST`.
+
+---
+
+### 5. [TECH-DEBT] `REGEN_RETRY_BACKOFF_MS` miscategorized in BACKLOG
+
+**What:** `docs/BACKLOG.md:130` (M7-5 row) implies `REGEN_RETRY_BACKOFF_MS` is an env var tunable for retry/backoff behavior.
+
+**Reality:** It's a code constant — `export const REGEN_RETRY_BACKOFF_MS: Record<number, number> = { 1: 30_000, 2: 60_000, 3: 120_000 }` at `lib/regeneration-worker.ts:54`. Changing retry backoff requires a code change + deploy, not a Vercel env edit.
+
+**Why it matters:** Minor — only affects anyone trying to tune this under incident pressure. They'd look for the env var, not find it, waste time.
+
+**Fix:** Update `docs/BACKLOG.md:130` to reference the code constant path, or name a separate env var if you want that to be tunable at runtime and implement it.
+
+---
+
+### 6. [LATENT-RISK] `NEXT_PUBLIC_VERCEL_ENV` not auto-exposed
+
+**What:** `instrumentation-client.ts:18` reads `process.env.NEXT_PUBLIC_VERCEL_ENV` with fallback chain `?? process.env.NODE_ENV ?? "development"`. Vercel auto-exposes `VERCEL_ENV` at the system level, but `NEXT_PUBLIC_*` prefixed vars are NOT auto-exposed to client bundles — the operator has to explicitly set `NEXT_PUBLIC_VERCEL_ENV=$VERCEL_ENV` (or a literal value) in the Vercel project's Environment Variables dashboard for each environment.
+
+**Why it matters:** Client-side Sentry errors get tagged with the `NODE_ENV` fallback, which is `"production"` on every Vercel deploy regardless of whether it's production or preview. You lose the ability to filter preview-only client errors in Sentry.
+
+**Fix:** Either (a) add `NEXT_PUBLIC_VERCEL_ENV` to the Vercel dashboard for each environment (cheapest), (b) document the requirement in `.env.local.example`, or (c) rewrite the instrumentation to read `NEXT_PUBLIC_VERCEL_ENV` via `next.config.mjs` `env:` block that pipes `VERCEL_ENV` through.
+
+---
+
+### 7. [LATENT-RISK] `NEXT_PUBLIC_LEADSOURCE_WP_URL` ↔ `LEADSOURCE_WP_URL` undefended coupling
+
+**What:** `.env.local.example:10` says "Must match LEADSOURCE_WP_URL." `lib/security-headers.ts:82` uses `NEXT_PUBLIC_LEADSOURCE_WP_URL` for CSP `connect-src`. Client-side preview iframe uses it for the iframe src. If the two drift:
+- CSP includes the wrong origin → preview iframe blocked by browser.
+- Or the iframe src is one origin and the CSP allows another.
+
+**Why it matters:** Silent bug class — the preview just doesn't render, with no error message pointing at env misconfiguration.
+
+**Fix options:**
+- **(a) Runtime assertion.** Add a startup check (or a health-check probe) that asserts the two values match. Fail loudly at cold-start.
+- **(b) Derive one from the other.** Set `NEXT_PUBLIC_LEADSOURCE_WP_URL` in `next.config.mjs` from `process.env.LEADSOURCE_WP_URL`. Eliminates the drift surface.
+
+Option (b) is cleaner; one env var, always consistent.
+
+---
+
+### 8. [LATENT-RISK] `NEXT_PUBLIC_SITE_URL` ↔ Supabase Dashboard undefended coupling
+
+**What:** `.env.local.example:12-27` explicitly documents this requirement:
+
+> Any value set here MUST also be registered in the Supabase dashboard under Authentication → URL Configuration → Redirect URLs allowlist or Supabase will reject the redirect.
+
+Nothing checks this. If Vercel has `NEXT_PUBLIC_SITE_URL=https://opollo.vercel.app` but Supabase allowlist has only `http://localhost:3000`, every invite + password-reset email link fails at exchange time.
+
+**Why it matters:** This is a recurring operational footgun — every domain change, every new preview environment, every auth-email addition has to be manually mirrored in Supabase. Easy to forget. The M14 series hit this shape of bug.
+
+**Fix:** Self-probe `/api/ops/self-probe` already exists per `app/api/ops/self-probe/route.ts`. Add a check that verifies: for the current `NEXT_PUBLIC_SITE_URL`, Supabase will accept it as a redirect (via the auth admin API's `generateLink` or similar). Make it part of a deploy verification checklist in RUNBOOK.
+
+---
+
+### 9. [LATENT-RISK] `CLOUDFLARE_IMAGES_HASH` silent fallback to malformed URLs
+
+**What:** Four call sites use `?? ""` or `?? null` fallback:
+- `lib/cloudflare-images.ts:127,344`
+- `lib/batch-publisher.ts:332`
+- `lib/regeneration-publisher.ts:338`
+
+If the env var is unset, the delivery URL template renders as `https://imagedelivery.net//<id>/public` (note the double slash). Cloudflare returns 404. The app does not error at cold-start.
+
+**Why it matters:** On a misconfigured production deploy, image library ingestion "succeeds" (upload goes through to Cloudflare) but every generated image URL 404s. No obvious signal — you see blank images on preview pages and have to trace back to env config.
+
+**Fix:** Promote it to hard-required. If `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_IMAGES_API_TOKEN` are hard-required in `lib/cloudflare-images.ts:125-126` (they throw), `CLOUDFLARE_IMAGES_HASH` should be too. Or at minimum add a self-probe assertion.
+
+---
+
+### 10. [TECH-DEBT] `LEADSOURCE_WP_USER` / `LEADSOURCE_WP_APP_PASSWORD` undocumented format
+
+**What:** Both appear in `.env.local.example:3,4` without any inline comment. A WP Application Password (what the code expects) is a 24-char hyphen-separated string generated in WP Admin → Users → Profile → Application Passwords. A regular WP login password will not work. Nothing documents this.
+
+**Why it matters:** Setup-time footgun. A new operator sets the regular WP password and hits 401s on every publish attempt.
+
+**Fix:** 3-line comment in `.env.local.example` explaining: WP Application Password (NOT login password), where to generate it, format.
+
+---
+
+### 11. [TECH-DEBT] `SENTRY_ORG` / `SENTRY_PROJECT` undocumented context
+
+**What:** `.env.local.example:110-111` lists them without inline comments. The only explanation in the codebase is in `docs/RUNBOOK.md:394` ("Source-map upload runs at build time only when `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` + `SENTRY_PROJECT` are all present"). Anyone reading `.env.local.example` alone would not know these are build-time-only vars.
+
+**Fix:** Add a short inline comment in `.env.local.example` near both vars: "Build-time only (source-map upload). Runtime Sentry works without these."
+
+---
+
+### 12. [TECH-DEBT] `DATABASE_URL` shell variable vs `SUPABASE_DB_URL` runtime env
+
+**What:** `docs/RUNBOOK.md:266,282-284,429` uses `$DATABASE_URL` as a shell variable in `supabase db push --db-url "$DATABASE_URL"` commands. This is meant to be a one-off export in the operator's terminal during manual migration runs. `.env.local.example:92` defines `SUPABASE_DB_URL` as the persistent Vercel env var read by workers at runtime.
+
+**Why it matters:** Two similarly-named "Postgres URL" concepts. An operator could read the runbook, see `$DATABASE_URL` used, set `DATABASE_URL` in Vercel, and wonder why nothing works.
+
+**Fix:** RUNBOOK.md is using a conventional shell variable name (`DATABASE_URL` is standard for Postgres/Supabase CLI), which is actually fine — but a one-line callout at the top of the migration section clarifying "This is a shell variable for CLI use, not a Vercel env var — Vercel workers use `SUPABASE_DB_URL`" would save confusion.
+
+---
+
+### 13. [TECH-DEBT] `ANALYZE` env var undocumented
+
+**What:** `next.config.mjs:8` reads `process.env.ANALYZE === "true"` to enable `@next/bundle-analyzer`. Enabled via `npm run analyze` (per `package.json` script). Not documented in `.env.local.example` or any docs.
+
+**Why it matters:** Minor. Only relevant to devs running the analyzer. Most will find it via `package.json` scripts.
+
+**Fix:** Low priority. Add a line in the docs section for local-dev env vars, or leave as-is.
+
+---
+
+### 14. [LATENT-RISK] No CI gate between code env vars and `.env.local.example`
+
+**What:** There is no CI check that fails when a new `process.env.X` is introduced in code without a matching entry in `.env.local.example` or vice versa. The whole class of drift in findings #2, #3, #5, #10, #11 only exists because of this.
+
+**Fix:** M15-8 already scopes this: "Add CI check that fails if any env var referenced in code is missing from docs/ENV.md reference list." Same work.
+
+---
+
+## Supplemental observations (not findings, just signals)
+
+- **Subsystem naming is disciplined.** `SUPABASE_*`, `CLOUDFLARE_*`, `SENTRY_*`, `AXIOM_*`, `LANGFUSE_*`, `OPOLLO_*`, `UPSTASH_*`, `LEADSOURCE_WP_*`, `VERCEL_*`, `NEXT_PUBLIC_*` — every var has a clear namespace. No cross-subsystem collisions (despite my initial suspicion that `OPOLLO_MASTER_KEY` vs `OPOLLO_EMERGENCY_KEY` might be confusing — they're clearly named for different purposes and the docs cover both).
+- **Graceful degradation is consistent.** Observability vendors (Sentry, Axiom, Langfuse) all no-op silently when unset, per CLAUDE.md. Rate limiter (Upstash) fail-open. Basic Auth fallback pass-through. Hard-required set is exactly the right set (Supabase core + WP creds + master key + Anthropic + Cloudflare Images core).
+- **CI env handling is clean.** `.github/workflows/e2e.yml` and `lighthouse.yml` hardcode deterministic test values (`OPOLLO_MASTER_KEY=AAAAA...`) — these are correctly allow-listed in `.gitleaks.toml` per CLAUDE.md.
+- **Test-only env var writes are pervasive.** `lib/__tests__/*` files heavily mutate `process.env` for setup. Well-contained, not a drift risk.
+- **Vercel-injected platform vars (`VERCEL_ENV`, `VERCEL_GIT_COMMIT_SHA`, `VERCEL_DEPLOYMENT_ID`) are read with fallbacks.** Won't break on non-Vercel deploys (e.g., local dev). ✓
+
+---
+
+## Part 2 — Code ↔ Vercel cross-reference (pending)
+
+**Status:** Not yet started. Waiting on the Vercel env var list from you.
+
+**What I need:** A paste of your Vercel project's Environment Variables, grouped by environment (Production / Preview / Development). The names are enough; values are not needed. If easier, `vercel env ls` output piped to a file works. Alternatively, a screenshot of each of the three environment tabs in the Vercel dashboard.
+
+**What this cross-reference will catch:**
+- Env vars referenced by code that are **missing from Vercel** → cold-start failures or feature-unavailable at runtime.
+- Env vars configured in Vercel that **no code reads** → dead Vercel config; cleanup opportunity.
+- Env vars set only in Production but missing from Preview (or vice versa) → inconsistent preview behavior.
+- Env vars set with suspicious values (e.g., `SUPABASE_URL` pointing at the wrong project, `NEXT_PUBLIC_SITE_URL` pointing at an old domain).
+
+The hard-required set from Part 1 gives you the checklist: `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL`, `ANTHROPIC_API_KEY`, `OPOLLO_MASTER_KEY`, `CRON_SECRET`, `OPOLLO_EMERGENCY_KEY`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_IMAGES_API_TOKEN`, `LEADSOURCE_WP_URL`, `LEADSOURCE_WP_USER`, `LEADSOURCE_WP_APP_PASSWORD`, `NEXT_PUBLIC_SITE_URL` — all 14 must be present in Production or the app is broken.
+
+---
+
+## What I did NOT cover in this audit
+
+- **Runtime probe of the Vercel deployment.** I didn't call `/api/ops/self-probe` or any live endpoint to verify env vars are actually set correctly in the running deployment. A self-probe check belongs in M15-4 (endpoint audit).
+- **Secret format / value validation.** I didn't verify any secret is valid (e.g., `ANTHROPIC_API_KEY` starts with `sk-ant-api03-`, `OPOLLO_MASTER_KEY` decodes to 32 bytes). Part 2 with the Vercel paste could cover "names set," not values.
+- **Supabase Dashboard state.** The `NEXT_PUBLIC_SITE_URL` allowlist check (finding #8) requires visibility into Supabase's URL configuration. Out of scope for this audit; flagged for operations.
+- **Env var encryption at rest in Vercel.** Vercel's secret-handling model is trusted; I didn't audit it.
+
+---
+
+## Files produced
+
+- `docs/ENV_AUDIT_2026-04-24.md` (this file)
+- No scratch files this round — both sub-agents returned full output inline (under the persisted-output cutoff).
+
+---
+
+## Awaiting your response
+
+Two asks:
+
+1. **Vercel env var list.** `vercel env ls` output or a paste from the dashboard, so I can do Part 2. If you'd rather defer Part 2 to M15-7 triage, say so.
+2. **Prioritization on the 14 findings.** Same shape as M15-2 — over threshold, pause for triage discussion.
+
+**I am NOT starting M15-4 until you respond.**
+
+Triggers applied:
+- [x] **More than 10 findings** — 14 items.
+- [~] **Production-breaking bug:** finding #1 (`OPOLLO_MASTER_KEY_NEXT` rotation gap) is only production-breaking *if a rotation is attempted today*. It's not breaking anything right now. Calling it LIKELY-PROD-BREAKING for visibility, but not forcing the "urgent flag."
+- [x] **Need external data** — Vercel env var list, see above.

--- a/docs/PROMPT_VERSIONING.md
+++ b/docs/PROMPT_VERSIONING.md
@@ -1,5 +1,7 @@
 # Prompt Versioning
 
+> **Status: not yet shipped.** This file describes the target layout for a future cutover, not the current runtime. As of 2026-04-24, chat still loads `docs/SYSTEM_PROMPT_v1.md` + `docs/TOOL_SCHEMAS_v1.md` directly. The `lib/prompts/` directory, the `resolvePrompt()` helper, and the `OPOLLO_PROMPT_VERSION` env var described below do **not** exist in the codebase yet — setting `OPOLLO_PROMPT_VERSION` on Vercel today has no effect. The cutover is its own sub-slice, pending the `LANGFUSE_*` env provisioning called out later in this doc.
+
 Spec for how system prompts, tool schemas, and evaluation suites are organised in `lib/prompts/`. Target layout once we start routing chat traffic through versioned prompts and measuring with Langfuse.
 
 Current state: prompts live in `docs/SYSTEM_PROMPT_v1.md` and `docs/TOOL_SCHEMAS_v1.md`, loaded at runtime from the `outputFileTracingIncludes` bundle. This file is the migration target — not a rewrite instruction. The cutover PR will be its own sub-slice.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -328,15 +328,19 @@ Some shipped migrations add columns without `NOT NULL DEFAULT`; on a fresh DB th
 
 ### OPOLLO_MASTER_KEY (encrypts `sites.wp_app_password`)
 
-Zero-downtime rotation:
+`lib/encryption.ts` reads a single active key. Rotation requires a write-freeze on `sites.wp_app_password` while every `site_credentials` row is re-encrypted. The `key_version` column on `site_credentials` is in place for a future dual-key zero-downtime path, but the code does not read `OPOLLO_MASTER_KEY_NEXT` today — do not rely on staging a `_NEXT` variable to run in parallel with the old key.
 
-1. `openssl rand -base64 32` → new key.
-2. Set `OPOLLO_MASTER_KEY_NEXT` in Vercel env to the new key; leave `OPOLLO_MASTER_KEY` as the old key. Redeploy.
-3. Run the rotation script (follow-up slice — for now, re-register each site through the Edit Site modal: the app encrypts with the new key on save).
-4. When every site row has been re-encrypted: set `OPOLLO_MASTER_KEY` to the new key, remove `OPOLLO_MASTER_KEY_NEXT`. Redeploy.
-5. Confirm: for every site, `editSiteModal → Save` round-trips successfully.
+1. `openssl rand -base64 32` → new key. Record it in the password manager.
+2. Freeze writes that touch `sites.wp_app_password`:
+   - Confirm no active batch: `SELECT count(*) FROM generation_jobs WHERE status IN ('queued','running');` must be 0. Wait for stragglers or cancel via `POST /api/admin/batch/[id]/cancel`.
+   - Pause the relevant Vercel crons (batch, transfer, regeneration).
+   - Turn on the auth kill switch to block admin UI writes: `POST /api/emergency` with `{"action":"kill_switch_on"}` (see the admin-reset section of this runbook for the curl shape).
+3. Re-encrypt every `site_credentials` row with the new key. Today this is an ad-hoc script run from a trusted machine (not committed): for each row, decrypt `site_secret_encrypted` with the old key, re-encrypt with the new key, write back the new ciphertext + fresh `iv` + bumped `key_version`, atomically per row (`UPDATE ... WHERE id = $1 RETURNING key_version`). Run against a staging clone of the row set first to verify.
+4. Swap the key in Vercel: `OPOLLO_MASTER_KEY` = new key. Redeploy.
+5. Unfreeze: `POST /api/emergency` with `{"action":"kill_switch_off"}`, resume crons.
+6. Confirm: in the admin UI, Edit Site → Save on one site. The round-trip must succeed (app decrypts with new key + re-encrypts back).
 
-**Downtime window:** none if staged. If the rotation script lands, this becomes a single-step rotation.
+**Downtime window:** the write-freeze — at current scale (<5 sites) that is seconds, not minutes. If rotation cadence becomes routine or the site count grows materially, invest in the dual-key code path (`lib/encryption.ts` accepts a staged `OPOLLO_MASTER_KEY_NEXT` and tries both on decrypt). That is a backlog item, not the current procedure. Do not follow an older version of this runbook that describes a zero-downtime `_NEXT` flow — the code does not support it.
 
 ### OPOLLO_EMERGENCY_KEY
 
@@ -393,7 +397,7 @@ For each tool (Sentry / Axiom / Langfuse / Upstash):
 2. **Copy the required env vars** from the vendor dashboard:
    - Sentry: `SENTRY_DSN`, `SENTRY_AUTH_TOKEN` (for source-map upload).
    - Axiom: `AXIOM_TOKEN`, `AXIOM_DATASET`.
-   - Langfuse: `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, optionally `LANGFUSE_BASEURL` if self-hosted.
+   - Langfuse: `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, optionally `LANGFUSE_HOST` if self-hosted (defaults to `https://us.cloud.langfuse.com`; set to `https://cloud.langfuse.com` for EU or to a custom URL for self-host).
    - Upstash: `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`.
 3. **Add them to Vercel** — Settings → Environment Variables. Set all three environments (Production, Preview, Development) unless the vendor is production-only.
 4. **Add to `.env.local.example`** with a comment explaining the default-off behaviour.

--- a/docs/SCHEMA_AUDIT_2026-04-24.md
+++ b/docs/SCHEMA_AUDIT_2026-04-24.md
@@ -1,0 +1,303 @@
+# Schema → Code Audit (M15-2)
+
+**Date:** 2026-04-24
+**Scope:** M1 → M14 (migrations 0001-0013 + all lib/, app/, scripts/, e2e/ code)
+**Method:** Parallel Sonnet sub-agents extracted (a) the canonical post-migration schema from `supabase/migrations/*.sql` and (b) every Supabase query chain in the codebase (`.from()/.select()/.insert()/.update()/.delete()/.eq()/.rpc()` etc. + raw `pg` SQL strings). Opus cross-referenced the two and classified findings.
+**Inputs:** `docs/_audit_scratch/canonical_schema.md` (~1400 lines, 27 tables + 6 RPCs/functions + 4 triggers + 2 enums + 1 storage bucket) and `docs/_audit_scratch/code_queries.md` (~1870 lines, ~212 distinct query chains). Scratch dir to be cleaned up after M15-3..M15-6.
+
+---
+
+## TL;DR
+
+**No new production-breaking schema-to-code mismatches beyond the one already in flight.** The `opollo_users.deleted_at` bug that triggered M15 was fully cleaned up by commit 5cd7667 — every remaining user-lifecycle reference in the codebase uses `revoked_at` correctly. M15-1 is separately handling the `/api/ops/reset-admin-password` endpoint.
+
+However, the audit surfaced **14 latent findings** (past the >10 escalation threshold). None will crash today; several are the same shape of trap that produced the original bug. The single highest-leverage fix is **generated Supabase types + a CI gate that fails on column-not-in-types** (M15-8 already planned). That alone would have caught the original `deleted_at` drift at typecheck time.
+
+**Escalation flag:** count is over 10 — pause for your prioritization before M15-7 scoping. I am NOT starting M15-3 until you review this.
+
+---
+
+## Findings Summary (14 items)
+
+| # | Severity | Category | Milestone | One-line |
+|---|---|---|---|---|
+| 0 | — | (Reference only) | M14-1 / M15-1 | `opollo_users.deleted_at` bug: fixed in 5cd7667; M15-1 in flight on `/api/ops/reset-admin-password`. Not re-flagged. |
+| 1 | LATENT-RISK | Type safety | Cross-cutting | No generated `types/supabase.ts`. Code hand-maintains row types + dynamic `.select("col1,col2")` strings — the exact class of defect that shipped the original bug. |
+| 2 | LATENT-RISK | Dead-in-code schema | M1, M12-1 | 8 tables defined in migrations are never written by production code (schema exists, code doesn't touch them). |
+| 3 | TECH-DEBT | Audit-column drift | M3-1 | `app/api/admin/batch/[id]/cancel` updates `generation_jobs` (Q129) and `generation_job_pages` (Q130) without stamping `updated_at`. Rows keep stale updated_at post-cancel. |
+| 4 | LATENT-RISK | Query performance | M7-1 | `lib/regeneration-worker.ts` daily-budget check (Q105) does a full-table scan of `regeneration_jobs.cost_usd_cents` filtered only by `created_at`. No supporting index; runs on every enqueue. |
+| 5 | TECH-DEBT | Feature gap | M4-1 | `transfer_jobs` schema has `cancel_requested_at` but no cancel API/UI exists — schema is wired for a feature that didn't ship. |
+| 6 | TECH-DEBT | Schema asymmetry | M1 | `chat_sessions_archive` lacks the `DEFAULT now()` on `created_at/updated_at` and the `message_count` CHECK constraint that `chat_sessions` has. (Dead table today — see #2.) |
+| 7 | TECH-DEBT | Schema inconsistency | M1 | `page_history.operator_user_id` is `uuid` with no FK; sibling `updated_by` is `text`. Two audit columns for the same concept at different types. (Dead table today — see #2.) |
+| 8 | TECH-DEBT | Schema inconsistency | M3-1, M4-1, M7-1 | Parallel event tables use different PK types: `generation_events` and `regeneration_events` are `bigserial`; `transfer_events` is `uuid`. |
+| 9 | TECH-DEBT | Missing constraint | M4-1, M12-1 | `image_library.version_lock`, `briefs.version_lock`, `brief_pages.version_lock`, `brief_runs.version_lock`, `site_conventions.version_lock` lack `CHECK (version_lock >= 1)`. Other `version_lock` columns (design_*, pages, tenant_cost_budgets) have it. |
+| 10 | TECH-DEBT | Constraint asymmetry | M3-1, M4-1, M7-1 | `transfer_job_items_lease_coherent` CHECK is stricter than `generation_job_pages_lease_coherent` and `regeneration_jobs_lease_coherent` — M4 also requires `worker_id IS NOT NULL AND lease_expires_at IS NOT NULL` in leased states; M3 and M7 only check the state enum. |
+| 11 | LATENT-RISK | Dynamic columns | M1a | `updateDesignSystem`, `updateComponent`, `updateTemplate` use `{...parsed.data, version_lock}` spread. `parsed.data` comes from a Zod schema. If Zod drifts from DB columns the query fails at runtime, not typecheck. |
+| 12 | LATENT-RISK | RLS asymmetry | M4-1 | `image_usage` SELECT policy excludes `viewer` role; `image_library` and `image_metadata` include it. May be intentional (WP plumbing hidden from viewers), but undocumented. |
+| 13 | LATENT-RISK | RLS documentation | M3-1, M4-1, M7-1, M8-1 | Service-role-only write tables (all generation_*, transfer_*, regeneration_*, tenant_cost_budgets) have no authenticated INSERT/UPDATE/DELETE policies. Intentional (workers use service-role), but a future dev writing an admin surface could hit 42501 with no signal pointing them to the service-role client. |
+| 14 | LATENT-RISK | RLS documentation | M2a | `opollo_config` has no authenticated read policy — intentional to protect `first_admin_email` from enumeration, but undocumented at the schema level. |
+
+---
+
+## Critical finding — reference only
+
+### 0. `opollo_users.deleted_at` bug (M14-1; M15-1 in flight)
+
+- **Schema truth:** `opollo_users` has never had a `deleted_at` column in any of the 13 migrations. The column added in `0006_m2c_revoked_at.sql` is `revoked_at` — semantically a *session-invalidation* timestamp (a new login with `iat > revoked_at` passes the gate without clearing the column), not a deletion marker.
+- **Fix state:** Commit 5cd7667 (`fix(m14-1): opollo_users has no deleted_at column — filter on revoked_at`) resolved the known call site. Grep confirms every remaining `opollo_users` reference in the repo uses `revoked_at`:
+  - `lib/auth.ts:209` — `.select("role,email,revoked_at")`
+  - `lib/auth-revoke.ts:103` — `.update({ revoked_at: ... })`
+  - `app/api/admin/users/list/route.ts:41` — `.select("id, email, display_name, role, created_at, revoked_at")`
+  - `app/api/admin/users/[id]/reinstate/route.ts:56,96` — reads and clears `revoked_at`
+  - `app/api/admin/users/[id]/revoke/route.ts:102` — `.is("revoked_at", null)` guard
+  - `app/api/ops/reset-admin-password/route.ts:146-148` — the M15-1 surface; covered elsewhere.
+- **Action:** None here. M15-1 owns `/api/ops/reset-admin-password`. Listed for completeness.
+
+---
+
+## Detailed findings
+
+### 1. [LATENT-RISK] No generated Supabase types
+
+**What:** The repo has no `types/supabase*.ts`. Row types are hand-written (e.g. `AdminUserRow` in `app/api/admin/users/list/route.ts:25`, `OpolloUserRow` in tests, `DETAIL_PAGE_FIELDS`/`DETAIL_IMAGE_FIELDS` as string constants in `lib/pages.ts` and `lib/image-library.ts`). Column lists in `.select("a, b, c")` are string literals — TypeScript cannot validate them against the schema.
+
+**Why it matters:** This is the root cause of the shape of bug that triggered M15. A query `.select("deleted_at")` against a table that doesn't have `deleted_at` passes lint, typecheck, and most unit tests (if the test mocks the Supabase client). It only fails at runtime against a real database. Every table introduced since M1 has widened the blast radius.
+
+**Fix:** M15-8 already scopes this. `supabase gen types typescript --linked > types/supabase.ts`, commit the file, regenerate on every migration, and use `Database["public"]["Tables"]["opollo_users"]["Row"]` + `.select<"id,email,revoked_at", Pick<..., "id" | "email" | "revoked_at">>()` patterns. Add CI check that fails on schema-vs-types drift.
+
+---
+
+### 2. [LATENT-RISK] Dead-in-code schema (8 tables)
+
+**What:** These tables exist in the schema but no production code writes to or reads from them via either supabase-js or raw `pg`:
+
+| Table | Introduced | Intended purpose |
+|---|---|---|
+| `page_history` | M1 (0001) | Write-once audit log for page operations |
+| `site_context` | M1 (0001) | Site-level snapshot (pages_tree, menus_current, etc.) |
+| `pairing_codes` | M1 (0001) | WP plugin initial-pairing flow |
+| `health_checks` | M1 (0001) | Historical probe records (distinct from `/api/health` liveness) |
+| `chat_sessions` | M1 (0001) | Conversation state persistence |
+| `chat_sessions_archive` | M1 (0001) | Archive partition for chat_sessions |
+| `brief_runs` | M12-1 (0013) | Worker-run state for briefs → pages expansion |
+| `site_conventions` | M12-1 (0013) | Anchor-cycle output per brief |
+
+M1 tables (6) are original-scope stubs that never got code. M12-1 tables (2) are forward-facing schema shipped ahead of the M12-2+ worker.
+
+**Why it matters:** Dead schema rots silently. A future dev may assume these tables are populated and JOIN against them, or a migration may drop a column the code never used, or a RLS policy may go unreviewed. `chat_sessions`/`chat_sessions_archive` in particular are production-facing (chat flow runs today) and their absence from code paths suggests the chat surface is using some other storage — worth confirming that's intentional.
+
+**Fix:** Triage per table:
+- Populate or drop each of the M1 6. Leaning toward drop for `pairing_codes` / `health_checks` / `chat_sessions*` if the product decisions already moved past them; keep `page_history` / `site_context` if they're on the roadmap with an owner.
+- Keep the M12-1 2; they have a planned owner (M12-2+). Add a comment in migration 0013 noting "forward-looking; populated by M12-N worker."
+
+---
+
+### 3. [TECH-DEBT] `updated_at` not stamped on batch-cancel
+
+**Where:** `app/api/admin/batch/[id]/cancel/route.ts:118-125` (Q129) and `app/api/admin/batch/[id]/cancel/route.ts:138-148` (Q130).
+
+**What:** Cancel path updates `generation_jobs` (sets `status="cancelled", cancel_requested_at, finished_at`) and `generation_job_pages` (sets `state="skipped", last_error_code, last_error_message, finished_at, retry_after:null`) without setting `updated_at`. Both tables have `updated_at timestamptz NOT NULL DEFAULT now()`. No trigger auto-maintains it.
+
+**Why it matters:** Rows carry a stale `updated_at` post-cancel. Audit timelines based on that column will miss the cancel. Not crash-inducing.
+
+**Fix:** Add `updated_at: new Date().toISOString()` to both update objects.
+
+---
+
+### 4. [LATENT-RISK] Missing index for daily-budget check
+
+**Where:** `lib/regeneration-worker.ts` `checkDailyBudget` (Q105).
+
+**What:** `await supabase.from("regeneration_jobs").select("cost_usd_cents").gte("created_at", startOfDay.toISOString())` — filters only by `created_at`. `regeneration_jobs` has indexes on `(site_id, created_at DESC)`, `(page_id, created_at DESC)`, and `(created_by)` but none on `created_at` alone. Query planner will pick whichever covering index exists and filter in-memory, or scan the whole table.
+
+**Why it matters:** Fires on every regen enqueue. At current volume it's fine. If regen throughput grows to thousands of jobs/day, this query's cost grows linearly — the "this is slow" signal will arrive mid-incident.
+
+**Fix:** Either (a) add `CREATE INDEX idx_regen_jobs_created_at ON regeneration_jobs (created_at DESC) WHERE status != 'cancelled'` or (b) scope the query to `site_id` as well and use the existing composite index. Option (b) is probably right — daily budget should be per-site anyway, not global.
+
+**Required by CLAUDE.md:** "any new DB query in a code path that runs per-request or per-slot... MUST be EXPLAIN ANALYZE'd against a realistic-volume seed before merge." This query predates the rule but should be retroactively validated.
+
+---
+
+### 5. [TECH-DEBT] No cancel endpoint for transfer_jobs
+
+**What:** `transfer_jobs` has `cancel_requested_at timestamptz` column in its M4-1 schema. No `app/api/admin/transfer*/cancel/route.ts` exists. `generation_jobs` has both the column AND a cancel endpoint. Asymmetric.
+
+**Why it matters:** Either the cancel flow is missing (operator can't stop a stuck ingest/transfer mid-flight), or the column is dead and should be dropped. Likely the former based on symmetry with generation_jobs.
+
+**Fix:** Product decision — either wire an `/api/admin/transfer/[id]/cancel` route or drop the column in a future migration. Flag for M15-4 (endpoint audit) since it's in that territory.
+
+---
+
+### 6. [TECH-DEBT] `chat_sessions_archive` schema drift
+
+**Where:** 0001_initial_schema.sql.
+
+**What:** `chat_sessions` has `messages jsonb NOT NULL DEFAULT '[]'`, `message_count int NOT NULL DEFAULT 0 CHECK (message_count >= 0 AND message_count <= 200)`, `created_at/updated_at NOT NULL DEFAULT now()`. `chat_sessions_archive` has the same columns but NO defaults and NO CHECK. Any archive insert path must supply all four values explicitly.
+
+**Why it matters:** Today: nothing — both tables are dead in code (finding #2). If an archive path gets written later, the drift becomes a footgun.
+
+**Fix:** Either fold it into the table when someone ships the archive flow, or drop both tables in the same cleanup slice.
+
+---
+
+### 7. [TECH-DEBT] `page_history` dual-type user columns
+
+**Where:** 0001_initial_schema.sql.
+
+**What:** `page_history.operator_user_id uuid` (no FK to opollo_users) and `page_history.updated_by text` (free-text, no FK). Two columns that conceptually reference the same "who did this" user, at incompatible types.
+
+**Why it matters:** Today: nothing — table is dead in code. If population arrives later, no one will know which column to fill.
+
+**Fix:** Pick one. If it's an append-only audit log where the user may later be deleted, `updated_by text` with a human-readable handle makes sense and `operator_user_id` should go. If referential integrity matters, keep `operator_user_id` (with FK added) and drop `updated_by`.
+
+---
+
+### 8. [TECH-DEBT] Event-table PK type inconsistency
+
+**What:**
+- `generation_events.id bigserial` (M3-1)
+- `regeneration_events.id bigserial` (M7-1)
+- `transfer_events.id uuid` (M4-1)
+
+Three parallel audit-log tables with different PK types.
+
+**Why it matters:** Hard to standardize tooling on "the event tables." Also means export/partition/rollup queries must branch on table.
+
+**Fix:** Low-priority. If we ever build a unified event stream, this becomes load-bearing. Until then it's cosmetic.
+
+---
+
+### 9. [TECH-DEBT] `version_lock` missing CHECK constraint
+
+**Where:**
+- `image_library.version_lock int NOT NULL DEFAULT 1` (M4-1)
+- `briefs.version_lock int NOT NULL DEFAULT 1` (M12-1)
+- `brief_pages.version_lock int NOT NULL DEFAULT 1` (M12-1)
+- `brief_runs.version_lock int NOT NULL DEFAULT 1` (M12-1)
+- `site_conventions.version_lock int NOT NULL DEFAULT 1` (M12-1)
+
+Comparison — tables WITH the CHECK:
+- `design_systems.version_lock integer NOT NULL DEFAULT 1 CHECK (version_lock >= 1)`
+- `design_components.version_lock integer NOT NULL DEFAULT 1 CHECK (version_lock >= 1)`
+- `design_templates.version_lock integer NOT NULL DEFAULT 1 CHECK (version_lock >= 1)`
+- `pages.version_lock integer NOT NULL DEFAULT 1 CHECK (version_lock >= 1)`
+- `tenant_cost_budgets.version_lock int NOT NULL DEFAULT 1 CHECK (version_lock >= 1)`
+
+**Why it matters:** The application never writes `version_lock = 0` deliberately, but a bug that does (e.g., an off-by-one in an optimistic-lock bump) would be silently accepted on the 5 tables without the CHECK and rejected on the 5 with it.
+
+**Fix:** Add `CHECK (version_lock >= 1)` to all 5 missing tables in a single forward-only migration. Safe — no existing rows violate it.
+
+---
+
+### 10. [TECH-DEBT] Lease-coherent CHECK asymmetry
+
+**Where:**
+- `transfer_job_items_lease_coherent` (M4-1): `(state='pending' AND worker_id IS NULL AND lease_expires_at IS NULL) OR (state IN ('leased','uploading','captioning','publishing') AND worker_id IS NOT NULL AND lease_expires_at IS NOT NULL) OR (state IN ('succeeded','failed','skipped'))`
+- `generation_job_pages_lease_coherent` (M3-1): `(state='pending' AND worker_id IS NULL AND lease_expires_at IS NULL) OR state IN ('leased','generating','validating','publishing','succeeded','failed','skipped')`
+- `regeneration_jobs_lease_coherent` (M7-1): same looser shape as M3.
+
+**Why it matters:** M4 enforces that leased rows ALWAYS have worker_id + lease_expires_at set. M3 and M7 do not — they let a row be in `leased` state with null worker_id, which is an invariant the workers rely on for recovery. This class of bug is the one PR #18's self-audit rule is supposed to catch for write-safety-critical milestones.
+
+**Fix:** Tighten M3 and M7 CHECKs to match M4's form. Requires a forward migration. Needs a sweep of existing rows first to make sure no orphan-leased rows are still in the table.
+
+---
+
+### 11. [LATENT-RISK] Dynamic update spreads
+
+**Where:**
+- `lib/design-systems.ts:208-215` (`updateDesignSystem`, Q26)
+- `lib/components.ts:176-184` (`updateComponent`, Q35)
+- `lib/templates.ts` (`updateTemplate`, Q43)
+
+All three do `.update({ ...parsed.data, version_lock: expected + 1 })` where `parsed.data` is the output of a Zod `.parse()` on request body.
+
+**Why it matters:** If the Zod schema diverges from DB columns (a developer adds `foo_new` to Zod without migrating the table), the next PATCH with `foo_new` in the body fails at runtime with `PGRST204` (column not found). Lint + typecheck both pass.
+
+**Fix:** Short-term — unit tests on the three update paths that assert Zod-schema keys ⊆ DB columns. Long-term — the M15-8 type generation work should surface this via `Database["Tables"][...]["Update"]` typing of the Zod output.
+
+---
+
+### 12. [LATENT-RISK] `image_usage` RLS excludes viewer
+
+**Where:** Migration 0010.
+
+**What:** `image_library` and `image_metadata` allow SELECT for `role IN ('admin','operator','viewer')`. `image_usage` allows SELECT only for `role IN ('admin','operator')` — viewers cannot read usage records.
+
+**Why it matters:** If a viewer-role admin UI lands, it'll render image detail pages correctly until they try to display "used on N sites." This surfaces as a silent empty join, not an RLS denial — the join returns 0 rows instead of erroring.
+
+**Fix:** Either align the policy to include `viewer`, or add a comment on the migration explaining the exclusion (if WP media IDs are considered internal plumbing).
+
+---
+
+### 13. [LATENT-RISK] Service-role-only write tables (undocumented)
+
+**What:** These tables have RLS enabled but no authenticated-role INSERT/UPDATE/DELETE policies (only SELECT + service_role_all):
+- `generation_jobs`, `generation_job_pages`, `generation_events`
+- `transfer_jobs`, `transfer_job_items`, `transfer_events`
+- `regeneration_jobs`, `regeneration_events`
+- `tenant_cost_budgets`
+
+**Why it matters:** All production writes currently use `getServiceRoleClient()` and bypass RLS — the design is coherent. But a future developer writing an admin surface against one of these tables using `createRouteAuthClient()` will get a 42501 error with no hint that "use service-role for this table" is the answer. The same happens if anyone ever exposes these to the browser via a Supabase client.
+
+**Fix:** Add a comment block at the top of each migration noting "writes happen server-side via service-role; authenticated policies are intentionally absent." Same pattern as the existing comment on `opollo_config`.
+
+---
+
+### 14. [LATENT-RISK] `opollo_config` read is admin-only (undocumented)
+
+**Where:** Migration 0004.
+
+**What:** `opollo_config` has RLS enabled with only `service_role_all` — no authenticated SELECT policy at all. Intentional (prevents enumeration of `first_admin_email`), but the reasoning lives only in migration commit history.
+
+**Fix:** Add a comment in the migration. Low effort, high value for the next person to read this table.
+
+---
+
+## Verification evidence — what I checked and did NOT find
+
+| Check | Result |
+|---|---|
+| Column references in `.select()` / `.insert()` / `.update()` against non-existent columns | None found |
+| Column references in `.eq()` / `.filter()` / `.is()` / `.in()` / `.ilike()` / `.order()` against non-existent columns | None found |
+| Table references in `.from()` against tables not in schema | None found |
+| Foreign-table joins (`.select("id, rel:other_table!inner(...)")`) against tables not in schema | None found |
+| RPC calls against functions not defined in schema | None found — only `activate_design_system` is called, and it's defined |
+| Storage buckets referenced in code but not provisioned | None found — only `site-briefs` is used, and it's provisioned in 0013 |
+| Enum values used in code that don't exist in the schema ENUMs | None found (checked `site_status`, `health_status`) |
+| Check-constraint violations in obvious insert/update paths | None found (status transitions, version_lock bumps all consistent) |
+| Stale TypeScript types with `deleted_at?: string \| null` on user-ish rows | None found — no drift there |
+| Code that references `deleted_at` on a table that doesn't have it | None — every `deleted_at` hit is on `image_library`, `briefs`, `brief_pages`, or a test/component that references one of those |
+| Code that uses authenticated clients on service-role-only tables in production | None — all production writes on generation_*/transfer_*/regen_* use service-role |
+
+---
+
+## What I did NOT cover in this audit
+
+- **Runtime query analysis.** The audit is static — it cross-references source code against migration SQL, not the live database. If the production DB has drifted from migrations (manual ALTER TABLE, Supabase dashboard edits), this audit won't catch it. Recommendation: add a CI check that compares the live schema (via `supabase db diff`) against migrations.
+- **Deep raw-`pg` SQL parsing.** Raw `pg.query` usage in `lib/batch-worker.ts`, `lib/batch-publisher.ts`, `lib/transfer-worker.ts`, `lib/tenant-budgets.ts`, `lib/auth-revoke.ts`, `lib/regeneration-publisher.ts`, `lib/batch-jobs.ts` was surveyed but not parsed statement-by-statement. Sample checks (SELECT columns, INSERT columns, UPDATE targets) matched schema, but a query-level parse across these files is a separate slice if warranted.
+- **Migration ordering / rollback verification.** Migration sequence 0001-0013 was treated as canonical. Rollback scripts exist at `supabase/rollbacks/0013_m12_1_briefs_schema.down.sql` but weren't audited for correctness.
+- **`supabase/data-migrations/` folder is empty** — no seed data drift to check.
+- **Live RLS evaluation.** RLS policies are read from migrations; I didn't run them against sample queries to verify they actually admit/reject the expected rows. The M2b/M4/M7/M12 RLS tests do this at test time.
+- **Cross-branch audit.** Only the current checkout (branch `fix/m14-1-opollo-users-deleted-at`) was scanned. If other branches have pending schema changes, they're not in scope.
+
+---
+
+## Files produced
+
+- `docs/SCHEMA_AUDIT_2026-04-24.md` (this file)
+- `docs/_audit_scratch/canonical_schema.md` (~1400 lines; ground-truth schema)
+- `docs/_audit_scratch/code_queries.md` (~1870 lines; every query usage)
+- `docs/_audit_scratch/_extract.js` (one-shot script that decoded the persisted-output JSON; safe to delete after M15-6)
+
+Scratch files are inputs to M15-3..M15-6 as well — keep them around; I'll clean `docs/_audit_scratch/` up after M15-6 lands.
+
+---
+
+## Awaiting your review
+
+I am NOT starting M15-3 (env var audit) until you respond. Triggers for pause:
+- [x] **More than 10 findings** — 14 items, needs prioritization discussion.
+- [ ] Production-breaking bug found — no; the one known case is covered by M15-1.
+- [ ] Need external data — no.
+
+When you respond, the useful signals for me are: (a) which of the 14 items you want escalated into M15-7 immediate fixes vs pushed to BACKLOG, and (b) whether to proceed to M15-3.

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -6,7 +6,26 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 
 <!-- CLAIM BLOCKS BELOW THIS LINE — append on slice start, remove on slice merge -->
 
-_No active claims._
+---
+## Session B
+- Started: 2026-04-24
+- Branch: fix/m15-3-env-audit-actionables
+- Slice: M15-3 env audit + three actionable fixes (dual-key runbook honesty, env coupling validation at boot, doc-drift cleanup)
+- Files claimed:
+  - docs/SCHEMA_AUDIT_2026-04-24.md (M15-2 audit — merged within this PR)
+  - docs/ENV_AUDIT_2026-04-24.md (M15-3 audit — merged within this PR)
+  - docs/_audit_scratch/ (scratch inputs for M15-2..M15-6; removed before merge or in a follow-up)
+  - docs/RUNBOOK.md (master-key rotation section rewrite + LANGFUSE_HOST typo fix)
+  - docs/BACKLOG.md (DEFAULT_TENANT_* strike-through + REGEN_RETRY_BACKOFF_MS reclassify)
+  - docs/PROMPT_VERSIONING.md (not-yet-shipped banner)
+  - .env.local.example (dead DEFAULT_TENANT_* entries commented out)
+  - lib/env-validation.ts (new)
+  - lib/__tests__/env-validation.test.ts (new)
+  - instrumentation.ts (wire validateEnvCouplingOnce into register())
+- Migration number reserved: none
+- Expected completion: same session; auto-merge on green CI; then proceed to M15-4 audit under pause rules
+- Notes: M15-1 is in flight in Session A (`/api/ops/reset-admin-password` fix). Session B stays off that endpoint, the `opollo_users.deleted_at → revoked_at` fix, and any related migration.
+---
 
 ## Hot-shared files (always check before claiming)
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,18 +1,26 @@
 // ---------------------------------------------------------------------------
 // M10 — Sentry server/edge initialisation.
+// M15-3 — env coupling validation at boot.
 //
 // Next.js's canonical pattern as of 15+ (and backported to 14.x by
 // @sentry/nextjs 10.x). The framework calls `register()` once per
 // runtime (Node / Edge); we route to the matching Sentry init file.
 //
 // No-op gate: when SENTRY_DSN is not set, `init()` never runs. Tests
-// and local dev stay quiet without any other conditional. The SDK's
-// own guards would also silently drop without a DSN, but skipping
-// init entirely keeps the bundle tree-shakeable when a deployment
-// deliberately opts out.
+// and local dev stay quiet without any other conditional.
+//
+// Env coupling validation runs on the Node.js runtime only — it uses
+// the shared logger which depends on @axiomhq/js, which we don't try
+// to run on the edge. One warning emission per cold start when a
+// misconfig is detected; silent when everything agrees.
 // ---------------------------------------------------------------------------
 
 export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { validateEnvCouplingOnce } = await import("./lib/env-validation");
+    validateEnvCouplingOnce();
+  }
+
   if (!process.env.SENTRY_DSN) return;
 
   if (process.env.NEXT_RUNTIME === "nodejs") {

--- a/lib/__tests__/env-validation.test.ts
+++ b/lib/__tests__/env-validation.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __resetValidationForTests,
+  validateEnvCoupling,
+  validateEnvCouplingOnce,
+} from "@/lib/env-validation";
+
+// validateEnvCoupling() emits warn-level log lines via the shared logger.
+// The real logger writes JSON to stderr for warn-level calls, so we spy
+// on console.error and parse the captured lines.
+
+let stderr: string[];
+const ENV_KEYS = [
+  "LEADSOURCE_WP_URL",
+  "NEXT_PUBLIC_LEADSOURCE_WP_URL",
+  "NEXT_PUBLIC_SITE_URL",
+  "CLOUDFLARE_IMAGES_HASH",
+  "CLOUDFLARE_ACCOUNT_ID",
+  "CLOUDFLARE_IMAGES_API_TOKEN",
+  "VERCEL_ENV",
+];
+
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  stderr = [];
+  vi.spyOn(console, "error").mockImplementation((line: unknown) => {
+    stderr.push(String(line));
+  });
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  __resetValidationForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+function parse(line: string): Record<string, unknown> {
+  return JSON.parse(line) as Record<string, unknown>;
+}
+
+function warningsFor(check: string): Record<string, unknown>[] {
+  return stderr
+    .map(parse)
+    .filter((rec) => rec.msg === "env_coupling_warning" && rec.check === check);
+}
+
+describe("validateEnvCoupling", () => {
+  it("is silent when no relevant env vars are set", () => {
+    validateEnvCoupling();
+    expect(stderr).toEqual([]);
+  });
+
+  describe("leadsource_wp_url coupling", () => {
+    it("is silent when both server and client URLs match", () => {
+      process.env.LEADSOURCE_WP_URL = "https://wp.example.com";
+      process.env.NEXT_PUBLIC_LEADSOURCE_WP_URL = "https://wp.example.com";
+      validateEnvCoupling();
+      expect(warningsFor("leadsource_wp_url")).toEqual([]);
+    });
+
+    it("warns when only the server URL is set", () => {
+      process.env.LEADSOURCE_WP_URL = "https://wp.example.com";
+      validateEnvCoupling();
+      const warnings = warningsFor("leadsource_wp_url");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].issue).toBe("server_set_client_missing");
+    });
+
+    it("warns when only the client URL is set", () => {
+      process.env.NEXT_PUBLIC_LEADSOURCE_WP_URL = "https://wp.example.com";
+      validateEnvCoupling();
+      const warnings = warningsFor("leadsource_wp_url");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].issue).toBe("client_set_server_missing");
+    });
+
+    it("warns when server and client URLs disagree", () => {
+      process.env.LEADSOURCE_WP_URL = "https://wp.example.com";
+      process.env.NEXT_PUBLIC_LEADSOURCE_WP_URL =
+        "https://different.example.com";
+      validateEnvCoupling();
+      const warnings = warningsFor("leadsource_wp_url");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].issue).toBe("server_client_mismatch");
+      expect(warnings[0].server).toBe("https://wp.example.com");
+      expect(warnings[0].client).toBe("https://different.example.com");
+    });
+  });
+
+  describe("next_public_site_url", () => {
+    it("warns when unset in production", () => {
+      process.env.VERCEL_ENV = "production";
+      validateEnvCoupling();
+      const warnings = warningsFor("next_public_site_url");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].issue).toBe("unset_in_production");
+    });
+
+    it("does not warn when unset outside production", () => {
+      process.env.VERCEL_ENV = "preview";
+      validateEnvCoupling();
+      expect(warningsFor("next_public_site_url")).toEqual([]);
+    });
+
+    it("does not warn when unset with no VERCEL_ENV (local dev)", () => {
+      validateEnvCoupling();
+      expect(warningsFor("next_public_site_url")).toEqual([]);
+    });
+
+    it("warns when http:// in production", () => {
+      process.env.VERCEL_ENV = "production";
+      process.env.NEXT_PUBLIC_SITE_URL = "http://opollo.example.com";
+      validateEnvCoupling();
+      const warnings = warningsFor("next_public_site_url");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].issue).toBe("non_https_in_production");
+      expect(warnings[0].value).toBe("http://opollo.example.com");
+    });
+
+    it("is silent when https:// in production", () => {
+      process.env.VERCEL_ENV = "production";
+      process.env.NEXT_PUBLIC_SITE_URL = "https://opollo.example.com";
+      validateEnvCoupling();
+      expect(warningsFor("next_public_site_url")).toEqual([]);
+    });
+
+    it("is silent when http:// outside production", () => {
+      process.env.VERCEL_ENV = "preview";
+      process.env.NEXT_PUBLIC_SITE_URL = "http://localhost:3000";
+      validateEnvCoupling();
+      expect(warningsFor("next_public_site_url")).toEqual([]);
+    });
+  });
+
+  describe("cloudflare_images_hash", () => {
+    it("is silent when both hash and creds are unset", () => {
+      validateEnvCoupling();
+      expect(warningsFor("cloudflare_images_hash")).toEqual([]);
+    });
+
+    it("warns when account id is set but hash is missing", () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = "test-account";
+      validateEnvCoupling();
+      const warnings = warningsFor("cloudflare_images_hash");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].issue).toBe("hash_missing_while_configured");
+    });
+
+    it("warns when api token is set but hash is missing", () => {
+      process.env.CLOUDFLARE_IMAGES_API_TOKEN = "test-token";
+      validateEnvCoupling();
+      const warnings = warningsFor("cloudflare_images_hash");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].issue).toBe("hash_missing_while_configured");
+    });
+
+    it("is silent when hash is set alongside creds", () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = "test-account";
+      process.env.CLOUDFLARE_IMAGES_API_TOKEN = "test-token";
+      process.env.CLOUDFLARE_IMAGES_HASH = "abc123";
+      validateEnvCoupling();
+      expect(warningsFor("cloudflare_images_hash")).toEqual([]);
+    });
+  });
+
+  describe("validateEnvCouplingOnce", () => {
+    it("runs validation on first call", () => {
+      process.env.LEADSOURCE_WP_URL = "https://wp.example.com";
+      validateEnvCouplingOnce();
+      expect(warningsFor("leadsource_wp_url")).toHaveLength(1);
+    });
+
+    it("is a no-op on subsequent calls", () => {
+      process.env.LEADSOURCE_WP_URL = "https://wp.example.com";
+      validateEnvCouplingOnce();
+      validateEnvCouplingOnce();
+      validateEnvCouplingOnce();
+      expect(warningsFor("leadsource_wp_url")).toHaveLength(1);
+    });
+
+    it("resets after __resetValidationForTests", () => {
+      process.env.LEADSOURCE_WP_URL = "https://wp.example.com";
+      validateEnvCouplingOnce();
+      __resetValidationForTests();
+      validateEnvCouplingOnce();
+      expect(warningsFor("leadsource_wp_url")).toHaveLength(2);
+    });
+  });
+});

--- a/lib/env-validation.ts
+++ b/lib/env-validation.ts
@@ -1,0 +1,116 @@
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// M15-3 — env coupling validation at boot.
+//
+// Surfaces three classes of silent-misconfig from the env audit:
+//   1. LEADSOURCE_WP_URL and NEXT_PUBLIC_LEADSOURCE_WP_URL must agree.
+//      Mismatch silently breaks CSP connect-src / preview iframe.
+//   2. NEXT_PUBLIC_SITE_URL must be set to a https:// origin on Vercel
+//      production. Unset = auth redirects fall back to Host header
+//      (spoof-vulnerable); http:// = Supabase rejects redirect links.
+//   3. CLOUDFLARE_IMAGES_HASH must be set when Cloudflare Images creds
+//      are set. Absent hash produces malformed delivery URLs that 404
+//      silently.
+//
+// Warnings only — the app does not crash. These states can be deliberate
+// in dev / preview (no WP integration configured, etc.) and we don't
+// want boot to fail on a preview deploy.
+// ---------------------------------------------------------------------------
+
+let alreadyValidated = false;
+
+export function validateEnvCouplingOnce(): void {
+  if (alreadyValidated) return;
+  alreadyValidated = true;
+  validateEnvCoupling();
+}
+
+export function validateEnvCoupling(): void {
+  const isProd = process.env.VERCEL_ENV === "production";
+
+  checkLeadSourceWpUrlCoupling();
+  checkNextPublicSiteUrl(isProd);
+  checkCloudflareImagesHash();
+}
+
+function checkLeadSourceWpUrlCoupling(): void {
+  const server = process.env.LEADSOURCE_WP_URL ?? "";
+  const client = process.env.NEXT_PUBLIC_LEADSOURCE_WP_URL ?? "";
+
+  if (!server && !client) return;
+
+  if (server && !client) {
+    logger.warn("env_coupling_warning", {
+      check: "leadsource_wp_url",
+      issue: "server_set_client_missing",
+      detail:
+        "LEADSOURCE_WP_URL is set but NEXT_PUBLIC_LEADSOURCE_WP_URL is not. The client-side preview iframe will be blank until both are set and matching.",
+    });
+    return;
+  }
+
+  if (!server && client) {
+    logger.warn("env_coupling_warning", {
+      check: "leadsource_wp_url",
+      issue: "client_set_server_missing",
+      detail:
+        "NEXT_PUBLIC_LEADSOURCE_WP_URL is set but LEADSOURCE_WP_URL is not. Server-side WP publish will fail.",
+    });
+    return;
+  }
+
+  if (server !== client) {
+    logger.warn("env_coupling_warning", {
+      check: "leadsource_wp_url",
+      issue: "server_client_mismatch",
+      server,
+      client,
+      detail:
+        "LEADSOURCE_WP_URL and NEXT_PUBLIC_LEADSOURCE_WP_URL disagree. CSP connect-src and preview iframe point at different origins; one of them is wrong.",
+    });
+  }
+}
+
+function checkNextPublicSiteUrl(isProd: boolean): void {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "";
+
+  if (isProd && !siteUrl) {
+    logger.warn("env_coupling_warning", {
+      check: "next_public_site_url",
+      issue: "unset_in_production",
+      detail:
+        "NEXT_PUBLIC_SITE_URL is not set on a production deploy. Auth email redirects will fall back to the request Host header, which is spoof-vulnerable. Set it to the production origin (e.g. https://opollo.vercel.app) and register the same value in Supabase Dashboard → Authentication → Redirect URLs allowlist.",
+    });
+    return;
+  }
+
+  if (isProd && siteUrl && !siteUrl.startsWith("https://")) {
+    logger.warn("env_coupling_warning", {
+      check: "next_public_site_url",
+      issue: "non_https_in_production",
+      value: siteUrl,
+      detail:
+        "NEXT_PUBLIC_SITE_URL does not start with https:// on a production deploy. Supabase rejects non-HTTPS redirect URLs in production.",
+    });
+  }
+}
+
+function checkCloudflareImagesHash(): void {
+  const hash = process.env.CLOUDFLARE_IMAGES_HASH ?? "";
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? "";
+  const apiToken = process.env.CLOUDFLARE_IMAGES_API_TOKEN ?? "";
+
+  if (!hash && (accountId || apiToken)) {
+    logger.warn("env_coupling_warning", {
+      check: "cloudflare_images_hash",
+      issue: "hash_missing_while_configured",
+      detail:
+        "CLOUDFLARE_IMAGES_HASH is unset but Cloudflare Images credentials are configured. Delivery URLs will be malformed (https://imagedelivery.net//<id>/public) and 404. Set CLOUDFLARE_IMAGES_HASH from Cloudflare Dashboard → Images → Variants.",
+    });
+  }
+}
+
+export function __resetValidationForTests(): void {
+  alreadyValidated = false;
+}


### PR DESCRIPTION
## Summary

Ships the three actionable items from M15-3 (env var audit, `docs/ENV_AUDIT_2026-04-24.md`). The remaining 11 findings are deferred to the consolidated M15-7 fix pass after audits M15-4/5/6 complete.

Also lands the two audit reports themselves (`docs/SCHEMA_AUDIT_2026-04-24.md` from M15-2 and `docs/ENV_AUDIT_2026-04-24.md` from M15-3) so the fix rationale is reviewable alongside the code.

## What ships

### 1. Master-key rotation runbook honesty (audit finding #1)

`docs/RUNBOOK.md` documented a zero-downtime rotation using `OPOLLO_MASTER_KEY_NEXT`, but `lib/encryption.ts` only reads a single active key. Following the playbook as written would fail silently — the app would keep decrypting with the old key after the documented rotation.

**Decision: option (b) — rewrite the runbook to match code reality.** Rationale:
- Current scale is tiny (<5 sites); a brief write-freeze is acceptable.
- Dual-key decrypt-fallback has its own failure mode: an auth-tag mismatch in AES-GCM can arise from data corruption, not just the wrong key. A dual-key fallback path could silently accept a corrupted row as "wrong key, try next one" and return garbage.
- The `site_credentials.key_version` column stays in place — it's already schema-ready for a future dual-key upgrade. No schema work will be needed when we're ready.
- YAGNI: no rotation is scheduled. We can add the dual-key path in its own slice if rotation cadence becomes routine.

The new runbook section describes a honest brief-downtime rotation: freeze writes (kill switch + pause crons), re-encrypt each row with an ad-hoc script, swap the key in Vercel, unfreeze.

### 2. NEXT_PUBLIC coupling validation at boot (audit findings #7, #8, #9)

New `lib/env-validation.ts` runs once per Node.js cold start (wired via `instrumentation.ts → register()`). Warns through the structured logger when:

- `LEADSOURCE_WP_URL` and `NEXT_PUBLIC_LEADSOURCE_WP_URL` disagree, or only one of the two is set (silent CSP / preview-iframe breakage otherwise)
- `NEXT_PUBLIC_SITE_URL` is unset or uses `http://` on a Vercel production deploy (auth redirect spoofing surface)
- `CLOUDFLARE_IMAGES_HASH` is missing while Cloudflare Images credentials are configured (delivery URLs 404 silently otherwise)

All three are warn-level, never fatal — they can be deliberate in dev/preview. Guarded by a `validateEnvCouplingOnce()` idempotency flag so repeated `register()` invocations in dev hot-reload don't spam logs. Edge runtime skipped to avoid `@axiomhq/js` compat concerns; node cold-start is enough.

Unit tests in `lib/__tests__/env-validation.test.ts` spy on `console.error` (where the logger sends warn-level lines) and assert on the JSON envelope.

### 3. Doc-drift cleanup (audit findings #2, #3, #4, #5)

- `docs/RUNBOOK.md:396` — `LANGFUSE_BASEURL` typo fixed to `LANGFUSE_HOST` (code in `lib/langfuse.ts:37` reads `LANGFUSE_HOST`).
- `.env.local.example` — `DEFAULT_TENANT_DAILY_BUDGET_CENTS` + `DEFAULT_TENANT_MONTHLY_BUDGET_CENTS` removed; no code reads them. The M8-1 migration hardcodes the column defaults (500 / 10000). Replaced with an explanatory comment block.
- `docs/BACKLOG.md` — matching strike-through on the M8 "new env vars" line; `REGEN_RETRY_BACKOFF_MS` relabelled in the M7-5 entry (it's a code constant in `lib/regeneration-worker.ts:54`, not a tunable env var).
- `docs/PROMPT_VERSIONING.md` — "not yet shipped" banner near the top. `OPOLLO_PROMPT_VERSION` and `lib/prompts/index.ts` are described in detail but neither exists in the codebase; a reader could reasonably assume they're live.

## Risks identified and mitigated

- **Validation spam in logs.** Warn-level emits once per cold-start, not per request. Silent when env is correct. Cold-start cadence on Vercel is modest; Axiom ingest impact is negligible.
- **Breaking the existing Sentry init path.** `instrumentation.ts` `register()` now does env validation BEFORE the Sentry DSN check. The validation never throws (warn-only), and the subsequent Sentry block preserves its original SENTRY_DSN gate verbatim. Build confirmed green.
- **False positives in local dev.** The three checks are designed to stay quiet when env vars are cleanly unset (feature off). Only partial configuration triggers warnings. Local dev without WP integration + without Cloudflare + without `NEXT_PUBLIC_SITE_URL` → silent.
- **Claim on runbook rewrite.** The new rotation procedure references an ad-hoc re-encrypt script that isn't committed. This matches current reality (no rotation has ever been run; no script exists). A future rotation slice would add the script. The runbook is explicit that it's ad-hoc today.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (Next.js production build succeeds)
- [ ] `npm run test` — deferred to CI (local Supabase CLI not on PATH)
- [ ] E2E — no admin UI surface changes; existing E2E suite applies unchanged

## Not in scope

- The 14 findings from M15-2 schema audit — all deferred to M15-7.
- The 11 other findings from M15-3 env audit (undocumented `NEXT_PUBLIC_VERCEL_ENV`, undocumented WP Application Password format, `SENTRY_ORG`/`PROJECT` context, etc.) — deferred to M15-7.
- Part 2 of M15-3 (code ↔ Vercel cross-reference) — pending the Vercel env var list paste from @steven.m; will append as a supplement.
- Dual-key master-key rotation implementation — explicitly deferred; schema is ready (`key_version` column), code is not.

After merge: M15-4 (endpoint behavior audit) starts under the same pause-after-audit rules as M15-2 and M15-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)