### PR TITLE
chore: drop dead schema tables (M1 stubs)

### DIFF
--- a/supabase/migrations/0014_drop_dead_schema.sql
+++ b/supabase/migrations/0014_drop_dead_schema.sql
@@ -1,0 +1,14 @@
+-- Drop dead schema tables (M1 stubs never implemented in code)
+-- Audit confirmed no application code references these tables:
+-- - chat_sessions / chat_sessions_archive: conversation state (dead; chat route uses other mechanism)
+-- - pairing_codes: WP plugin initial-pairing (dead; product moved past)
+-- - health_checks: historical probe records (dead; /api/health endpoint is separate)
+-- - page_history: page edit audit trail (dead; no owner on roadmap)
+-- - site_context: cached site metadata (dead; no owner on roadmap)
+
+DROP TABLE IF EXISTS chat_sessions_archive CASCADE;
+DROP TABLE IF EXISTS chat_sessions CASCADE;
+DROP TABLE IF EXISTS pairing_codes CASCADE;
+DROP TABLE IF EXISTS health_checks CASCADE;
+DROP TABLE IF EXISTS page_history CASCADE;
+DROP TABLE IF EXISTS site_context CASCADE;


### PR DESCRIPTION
## Summary

Drop 6 unused tables from M1 that never received code implementation. Schema audit confirmed zero application code references these tables.

## Tables dropped

- **chat_sessions / chat_sessions_archive** — conversation state (chat route uses separate mechanism)
- **pairing_codes** — WP plugin initial-pairing (product moved past)
- **health_checks** — historical probe records (/api/health endpoint is separate)
- **page_history** — page edit audit trail (no owner on roadmap)
- **site_context** — cached site metadata (no owner on roadmap)

## Verification

Code audit (grep all .ts files): **zero references** to any of these tables.
Schema audit document: recommends dropping dead schema to prevent silent rot.
No RLS policies, triggers, or views depend on these tables.

## Migration

Single migration 0014 drops all 6 with CASCADE to clean up any incidental dependencies.
