### PR TITLE
feat(m15): schema defense-in-depth — version_lock CHECKs + cancel updated_at + Zod↔DB sync

### DIFF
--- a/app/api/admin/batch/[id]/cancel/route.ts
+++ b/app/api/admin/batch/[id]/cancel/route.ts
@@ -115,12 +115,14 @@ export async function POST(
   // Flip job status + set cancel_requested_at. No ELSE — we just
   // overwrite whatever status we read, since the guard above limited
   // the set to {queued, running, partial}.
+  const now = new Date().toISOString();
   const { error: jobErr } = await svc
     .from("generation_jobs")
     .update({
       status: "cancelled",
-      cancel_requested_at: new Date().toISOString(),
-      finished_at: new Date().toISOString(),
+      cancel_requested_at: now,
+      finished_at: now,
+      updated_at: now,
     })
     .eq("id", jobId);
   if (jobErr) {
@@ -141,7 +143,8 @@ export async function POST(
       state: "skipped",
       last_error_code: "CANCELLED",
       last_error_message: "Batch was cancelled.",
-      finished_at: new Date().toISOString(),
+      finished_at: now,
+      updated_at: now,
       retry_after: null,
     })
     .eq("job_id", jobId)

--- a/lib/__tests__/zod-schema-db-sync.test.ts
+++ b/lib/__tests__/zod-schema-db-sync.test.ts
@@ -1,0 +1,143 @@
+import { Client } from "pg";
+import { describe, expect, it, afterAll } from "vitest";
+
+import { UpdateDesignComponentSchema } from "@/lib/components";
+import { UpdateDesignSystemSchema } from "@/lib/design-systems";
+import { UpdateDesignTemplateSchema } from "@/lib/templates";
+
+// ---------------------------------------------------------------------------
+// M15 defense-in-depth — Zod ↔ DB column sync (Schema audit finding #11).
+//
+// Three update paths do `.update({ ...parsed.data, version_lock: ... })`
+// where `parsed.data` is the output of a Zod `.parse()` on request body:
+//
+//   - updateDesignSystem  / UpdateDesignSystemSchema  / design_systems
+//   - updateComponent     / UpdateDesignComponentSchema / design_components
+//   - updateTemplate      / UpdateDesignTemplateSchema  / design_templates
+//
+// If a developer adds a field to the Zod schema without migrating the
+// matching table column, the next PATCH with that field in the body
+// fails at runtime with PGRST204 (column not found). Lint + typecheck
+// both pass because Zod keys are strings, not a type of the DB schema.
+//
+// These tests read the live table's column list from information_schema
+// and assert every Zod-schema key is present. Zod's inner type has to
+// be unwrapped because `.refine()` wraps the shape in a ZodEffects — we
+// reach through to the underlying ZodObject.
+// ---------------------------------------------------------------------------
+
+const DB_URL =
+  process.env.SUPABASE_DB_URL ??
+  "postgresql://postgres:postgres@127.0.0.1:54322/postgres";
+
+let pgClient: Client | null = null;
+
+async function getClient(): Promise<Client> {
+  if (pgClient) return pgClient;
+  pgClient = new Client({ connectionString: DB_URL });
+  await pgClient.connect();
+  return pgClient;
+}
+
+afterAll(async () => {
+  if (pgClient) {
+    await pgClient.end();
+    pgClient = null;
+  }
+});
+
+async function columnsFor(table: string): Promise<Set<string>> {
+  const client = await getClient();
+  const res = await client.query<{ column_name: string }>(
+    `SELECT column_name
+       FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1`,
+    [table],
+  );
+  return new Set(res.rows.map((r) => r.column_name));
+}
+
+// Unwrap a `.refine()` wrapper so we can read the underlying shape keys.
+// Zod exposes the inner schema on `._def.schema` for ZodEffects instances;
+// a plain ZodObject exposes the shape via `.shape`.
+function zodKeys(schema: unknown): string[] {
+  // ZodEffects → unwrap
+  const inner =
+    (schema as { _def?: { schema?: unknown } })._def?.schema ?? schema;
+  const shape = (inner as { shape?: Record<string, unknown> }).shape;
+  if (!shape) {
+    throw new Error(
+      "zodKeys: could not read schema shape — Zod internals changed?",
+    );
+  }
+  return Object.keys(shape);
+}
+
+async function hasCheckConstraint(
+  table: string,
+  constraint: string,
+): Promise<boolean> {
+  const client = await getClient();
+  const res = await client.query<{ exists: boolean }>(
+    `SELECT EXISTS(
+       SELECT 1
+         FROM pg_constraint c
+         JOIN pg_class t ON t.oid = c.conrelid
+         JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE n.nspname = 'public'
+          AND t.relname = $1
+          AND c.conname = $2
+          AND c.contype = 'c'
+     ) AS exists`,
+    [table, constraint],
+  );
+  return res.rows[0]?.exists === true;
+}
+
+describe("version_lock CHECK constraints (migration 0015)", () => {
+  // Per M15 schema audit finding #9 — five tables shipped without the
+  // `CHECK (version_lock >= 1)` their siblings carry. 0015 adds them.
+  it.each([
+    ["image_library", "image_library_version_lock_positive"],
+    ["briefs", "briefs_version_lock_positive"],
+    ["brief_pages", "brief_pages_version_lock_positive"],
+    ["brief_runs", "brief_runs_version_lock_positive"],
+    ["site_conventions", "site_conventions_version_lock_positive"],
+  ])("%s has %s", async (table, constraint) => {
+    expect(await hasCheckConstraint(table, constraint)).toBe(true);
+  });
+});
+
+describe("Zod ↔ DB column sync (defense-in-depth)", () => {
+  it("UpdateDesignSystemSchema keys ⊆ design_systems columns", async () => {
+    const zodFields = zodKeys(UpdateDesignSystemSchema);
+    const dbCols = await columnsFor("design_systems");
+    for (const field of zodFields) {
+      expect(dbCols.has(field), `design_systems missing column: ${field}`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("UpdateDesignComponentSchema keys ⊆ design_components columns", async () => {
+    const zodFields = zodKeys(UpdateDesignComponentSchema);
+    const dbCols = await columnsFor("design_components");
+    for (const field of zodFields) {
+      expect(
+        dbCols.has(field),
+        `design_components missing column: ${field}`,
+      ).toBe(true);
+    }
+  });
+
+  it("UpdateDesignTemplateSchema keys ⊆ design_templates columns", async () => {
+    const zodFields = zodKeys(UpdateDesignTemplateSchema);
+    const dbCols = await columnsFor("design_templates");
+    for (const field of zodFields) {
+      expect(
+        dbCols.has(field),
+        `design_templates missing column: ${field}`,
+      ).toBe(true);
+    }
+  });
+});

--- a/supabase/migrations/0015_m15_version_lock_checks.sql
+++ b/supabase/migrations/0015_m15_version_lock_checks.sql
@@ -1,0 +1,35 @@
+-- 0015 — M15 schema defense-in-depth: version_lock CHECK constraints.
+--
+-- Five tables were shipped with `version_lock int NOT NULL DEFAULT 1` but
+-- without the `CHECK (version_lock >= 1)` constraint their siblings carry
+-- (design_systems, design_components, design_templates, pages,
+-- tenant_cost_budgets). Surfaced by the M15-2 schema audit (finding #9).
+--
+-- Why it matters: an off-by-one bug in an optimistic-lock bump that wrote
+-- version_lock = 0 would be silently accepted on the 5 tables without
+-- this CHECK and rejected on the 5 with it. The constraint is defense-in-
+-- depth against that asymmetry.
+--
+-- Safe to add: the app never writes version_lock < 1 deliberately. Any
+-- existing row already satisfies the predicate (schema default is 1,
+-- all writes increment monotonically).
+
+ALTER TABLE image_library
+  ADD CONSTRAINT image_library_version_lock_positive
+  CHECK (version_lock >= 1);
+
+ALTER TABLE briefs
+  ADD CONSTRAINT briefs_version_lock_positive
+  CHECK (version_lock >= 1);
+
+ALTER TABLE brief_pages
+  ADD CONSTRAINT brief_pages_version_lock_positive
+  CHECK (version_lock >= 1);
+
+ALTER TABLE brief_runs
+  ADD CONSTRAINT brief_runs_version_lock_positive
+  CHECK (version_lock >= 1);
+
+ALTER TABLE site_conventions
+  ADD CONSTRAINT site_conventions_version_lock_positive
+  CHECK (version_lock >= 1);

--- a/supabase/rollbacks/0015_m15_version_lock_checks.down.sql
+++ b/supabase/rollbacks/0015_m15_version_lock_checks.down.sql
@@ -1,0 +1,16 @@
+-- Rollback for 0015_m15_version_lock_checks.sql
+
+ALTER TABLE image_library
+  DROP CONSTRAINT IF EXISTS image_library_version_lock_positive;
+
+ALTER TABLE briefs
+  DROP CONSTRAINT IF EXISTS briefs_version_lock_positive;
+
+ALTER TABLE brief_pages
+  DROP CONSTRAINT IF EXISTS brief_pages_version_lock_positive;
+
+ALTER TABLE brief_runs
+  DROP CONSTRAINT IF EXISTS brief_runs_version_lock_positive;
+
+ALTER TABLE site_conventions
+  DROP CONSTRAINT IF EXISTS site_conventions_version_lock_positive;


### PR DESCRIPTION
Three fixes from the M15-2 schema audit, grouped as defense-in-depth. No user-facing behavior change.

## What lands

### 1. Migration 0015 — `CHECK (version_lock >= 1)` on 5 tables (audit #9)
Adds the constraint to `image_library`, `briefs`, `brief_pages`, `brief_runs`, `site_conventions`. These tables shipped with `version_lock int NOT NULL DEFAULT 1` but without the sibling CHECK that design_systems / design_components / design_templates / pages / tenant_cost_budgets carry. Defense-in-depth against an off-by-one bug in an optimistic-lock bump silently writing `version_lock = 0`.

Migration is additive and safe — every existing row has `version_lock >= 1` by construction (schema default = 1; all writes increment monotonically). Rollback provided at `supabase/rollbacks/0015_m15_version_lock_checks.down.sql`.

### 2. Batch-cancel `updated_at` fix (audit #3)
`/api/admin/batch/[id]/cancel/route.ts` now stamps `updated_at: now` on both update paths:
- `generation_jobs` status flip
- `generation_job_pages` pending→skipped sweep

Pre-fix: cancel updated status + finished_at + cancel_requested_at, but left `updated_at` stale. Audit timelines keyed on `updated_at` missed the cancel event.

### 3. Zod ↔ DB column-sync tests (audit #11)
New `lib/__tests__/zod-schema-db-sync.test.ts` covers the three `.update({ ...parsed.data, version_lock })` spread sites:
- `updateDesignSystem` / `UpdateDesignSystemSchema` / `design_systems`
- `updateComponent` / `UpdateDesignComponentSchema` / `design_components`
- `updateTemplate` / `UpdateDesignTemplateSchema` / `design_templates`

Each test reads `information_schema.columns` for the table and asserts every Zod key is present. Catches the class of drift where a Zod field added without a migration would PGRST204 at runtime (lint + typecheck both pass otherwise).

Same file pins the migration: asserts the 5 new CHECK constraints exist in `pg_constraint`.

## Risks identified and mitigated
- **CHECK constraint rejects an existing row.** Can't happen — schema default is 1, and all application writes increment from there. Verified by inspection of every `version_lock` writer across the codebase.
- **Zod-sync test breaks when Zod internals change.** The helper `zodKeys()` unwraps `.refine()` via `_def.schema`. If Zod changes that shape, the helper throws a clear error rather than silently passing. Documented inline.
- **`updated_at` now set to a value equal to finished_at on the same UPDATE.** Desired — the audit timeline entry is the cancel moment.

## Deliberately deferred
- **Lease-coherent CHECK tightening (audit #10).** Needs row-scan + in-place remediation before the migration is safe on live queue tables. BACKLOG'd in a follow-up PR per Steven's decision.
- **Generated Supabase types (audit #1).** Shipping as its own PR per Steven's accelerate call.

## Self-test
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean on the staged files (local tree has unrelated untracked work from a sibling session)
- [ ] `npm run test` — runs in CI. Expected: 3 new Zod-sync tests + 5 new CHECK-constraint tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)