### PR TITLE
fix(m15-4): chat SSE error sanitization + LAST_ADMIN revoked_at filter

### DIFF
--- a/app/api/admin/users/[id]/revoke/route.ts
+++ b/app/api/admin/users/[id]/revoke/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { countActiveAdmins } from "@/lib/auth";
 import { revokeUserSessions } from "@/lib/auth-revoke";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -95,19 +96,18 @@ export async function POST(
   }
 
   if (target.role === "admin") {
-    const { count, error: countErr } = await svc
-      .from("opollo_users")
-      .select("id", { count: "exact", head: true })
-      .eq("role", "admin")
-      .is("revoked_at", null);
-    if (countErr) {
+    // Shared counter with /admin/users/[id]/role — both routes must
+    // agree on "active admin" = role='admin' AND revoked_at IS NULL.
+    // See lib/auth.ts#countActiveAdmins for the definition.
+    const adminCount = await countActiveAdmins();
+    if (!adminCount.ok) {
       return errorJson(
         "INTERNAL_ERROR",
-        `Failed to count active admins: ${countErr.message}`,
+        `Failed to count active admins: ${adminCount.error}`,
         500,
       );
     }
-    if ((count ?? 0) <= 1) {
+    if (adminCount.count <= 1) {
       return errorJson(
         "LAST_ADMIN",
         "Refusing to revoke the last active admin. Promote another admin first, or use the emergency route.",

--- a/app/api/admin/users/[id]/role/route.ts
+++ b/app/api/admin/users/[id]/role/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { countActiveAdmins } from "@/lib/auth";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -142,22 +143,22 @@ export async function PATCH(
   }
 
   // Last-admin guard — only matters when demoting away from 'admin'.
+  // Counts via countActiveAdmins() (role='admin' AND revoked_at IS NULL)
+  // so revoked admins don't prop up the count. See docs/ENDPOINT_AUDIT_2026-04-24.md
+  // finding #2 for the prior drift where this route counted revoked admins.
   if (currentRole === "admin" && targetRole !== "admin") {
-    const { count, error: countErr } = await svc
-      .from("opollo_users")
-      .select("id", { count: "exact", head: true })
-      .eq("role", "admin");
-    if (countErr) {
+    const adminCount = await countActiveAdmins();
+    if (!adminCount.ok) {
       return errorJson(
         "INTERNAL_ERROR",
-        `Failed to count admins: ${countErr.message}`,
+        `Failed to count active admins: ${adminCount.error}`,
         500,
       );
     }
-    if ((count ?? 0) <= 1) {
+    if (adminCount.count <= 1) {
       return errorJson(
         "LAST_ADMIN",
-        "Refusing to demote the last remaining admin. Promote another admin first, or use the emergency route.",
+        "Refusing to demote the last remaining active admin. Promote another admin first, or use the emergency route.",
         409,
       );
     }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -27,6 +27,11 @@ import { buildSystemPromptForSite } from "@/lib/system-prompt";
 import { getSite } from "@/lib/sites";
 import { traceAnthropicStream } from "@/lib/langfuse";
 import { logger } from "@/lib/logger";
+import { getRequestContext } from "@/lib/request-context";
+import {
+  buildChatErrorDiagnostic,
+  buildSafeSseErrorPayload,
+} from "@/lib/chat-errors";
 import {
   runWithWpCredentials,
   type WpCredentialsOverride,
@@ -344,29 +349,16 @@ export async function POST(req: Request) {
 
         send("done", { stop_reason: stopReason ?? "unknown" });
       } catch (err) {
+        // Full diagnostic goes to the server logger only. The SSE payload
+        // the browser receives is opaque — static code, static message,
+        // our request_id for support correlation. See
+        // docs/ENDPOINT_AUDIT_2026-04-24.md finding #1 + lib/chat-errors.ts
+        // for the rationale.
         const apiErr = err instanceof Anthropic.APIError ? err : null;
-
-        const diagnostic = {
-          model: MODEL,
-          message: err instanceof Error ? err.message : String(err),
-          name: err instanceof Error ? err.name : undefined,
-          status: apiErr?.status,
-          request_id: apiErr?.requestID,
-          body: apiErr?.error,
-          stack: err instanceof Error ? err.stack : undefined,
-        };
+        const diagnostic = buildChatErrorDiagnostic(err, MODEL, apiErr);
         logger.error("api.chat.streaming_error", diagnostic);
 
-        send("error", {
-          code: "INTERNAL_ERROR",
-          message: diagnostic.message,
-          details: {
-            name: diagnostic.name,
-            status: diagnostic.status,
-            request_id: diagnostic.request_id,
-            body: diagnostic.body,
-          },
-        });
+        send("error", buildSafeSseErrorPayload(getRequestContext().request_id ?? null));
       } finally {
         controller.close();
       }

--- a/docs/ENDPOINT_AUDIT_2026-04-24.md
+++ b/docs/ENDPOINT_AUDIT_2026-04-24.md
@@ -1,0 +1,347 @@
+# Endpoint Behavior Audit (M15-4)
+
+**Date:** 2026-04-24
+**Scope:** All 45 `app/api/**/route.ts` handlers in the repository
+**Method:** Sonnet sub-agent profiled each route (method, auth, rate limit, body parsing, external-service calls, error envelope, logging, known gotchas) + produced aggregate tables (envelope consistency, auth guard matrix, external service error handling, rate-limiting coverage, body validation, stack trace leaks, timeout surface, inconsistencies). Opus verified the two production-breaking items by reading the actual source and classified severity for each finding.
+**Inputs:** `docs/_audit_scratch/code_endpoints.md` (~1700 lines, 45 route profiles + 10 aggregate sections). Scratch dir to be cleaned after M15-6.
+
+---
+
+## 🚨 TL;DR — two production-breaking items found, escalating
+
+**Two active bugs** that meet Steven's "production-breaking" escalation trigger. Both are shipping in production today. Both warrant fixing ahead of the M15-7 batch.
+
+1. **Chat route leaks internal error detail to browser clients** (`app/api/chat/route.ts:349-369`). The SSE `error` event sends raw `err.message`, error class name, and the Anthropic API error body directly to every chat user's browser. An Anthropic rate-limit response exposes quota state; a Supabase error exposes schema/constraint names; any thrown exception leaks its own message. Affects **every chat user, including non-admins**. Severity: production data disclosure.
+
+2. **`admin/users/[id]/role` PATCH can demote the last active admin** (`app/api/admin/users/[id]/role/route.ts:146-149`). The LAST_ADMIN guard counts users by `.eq("role", "admin")` without `.is("revoked_at", null)`. If any revoked admin exists in the DB, the count includes them, and the guard permits demoting the last *active* admin. The sibling `revoke` route gets this filter right (`app/api/admin/users/[id]/revoke/route.ts:98-102`) — `role` is the drift. Severity: safety-invariant bypass under narrow conditions.
+
+**Remaining 17 findings** span likely-production-breaking (tools route auth gaps, error-message leakage across 10+ admin routes, `retryable: true` on validation errors), latent-risk (no external-service timeouts, 30/45 routes with no structured logging, 6 unauthenticated read endpoints), and tech-debt (12 copies of `errorJson()`, 7 copies of `constantTimeEqual`).
+
+**Escalation triggers hit:**
+- [x] **Production-breaking bug found** — 2 items above, do not bury. Flagged urgently at top.
+- [x] **More than 10 findings** — 19 total, pause for prioritization.
+- [ ] Need external data — no.
+
+**I am NOT starting M15-5 until you respond.**
+
+---
+
+## Findings summary (19 items)
+
+| # | Severity | Category | Route(s) | One-line |
+|---|---|---|---|---|
+| 1 | **PROD-BREAKING** | Data disclosure | `chat` | SSE `error` event sends raw `err.message` + Anthropic API error body to browser. |
+| 2 | **PROD-BREAKING** | Safety-invariant bug | `admin/users/[id]/role` | LAST_ADMIN count omits `.is("revoked_at", null)` — could allow demoting last active admin. |
+| 3 | LIKELY-PROD-BREAKING | Auth gap | `tools/publish_page`, `tools/update_page`, `tools/delete_page` | No session required. WP write operations reachable by rate-limited IP when auth is off; viewer-role users can call them when auth is on. |
+| 4 | LIKELY-PROD-BREAKING | Data disclosure | 10+ admin routes | Supabase/postgres `error.message` concatenated into 500 response bodies — schema names, constraint names, column names leak. |
+| 5 | LIKELY-PROD-BREAKING | Retry contract break | 5 routes (`admin/images/[id]`, `admin/sites/[id]/budget`, `admin/sites/[id]/pages/[pageId]`, `admin/users/invite`, `admin/users/[id]/role`) | `retryable: true` on 400 validation errors — clients that honor the flag retry-loop forever on unfixable bad input. |
+| 6 | LATENT-RISK | No timeouts | ~40 routes | Zero `AbortController`/`signal` on any external call. One hanging Anthropic/WP/Supabase/Upstash call holds a Vercel function until the 299s maxDuration. |
+| 7 | LATENT-RISK | Observability gap | ~30 of 45 routes | No structured logging in route handlers. Errors surface only in Vercel raw function logs, never in Axiom. |
+| 8 | LATENT-RISK | Defense-in-depth gap | 6 GET routes (`sites/list`, `sites/[id]`, `sites/[id]/design-systems`, `design-systems/[id]/components`, `design-systems/[id]/templates`, `design-systems/[id]/preview`) | No route-level auth. Relies entirely on middleware. UUID-guessing attacker with no session can read full design system CSS + composition. |
+| 9 | LATENT-RISK | Rate-limiting gap | 9 sensitive routes | No rate limit on user-mgmt (revoke, reinstate, role), budget PATCH, briefs upload (10MB), design-system writes, `sites/list`, `design-systems/[id]/preview`. Abuse/spam surface. |
+| 10 | LATENT-RISK | Body-validation gap | All 7 `tools/*` routes | Route passes `body: unknown` directly to executor. Whether validation happens depends on lib implementation; no route-level Zod. |
+| 11 | LATENT-RISK | Auth model mismatch | All 7 `tools/*` routes | Tools executors call `runWithWpCredentials()` expecting WP creds in AsyncLocalStorage, but the tools routes don't seed that context. Direct POST bypassing chat → silent failure or default-site creds. Needs verification. |
+| 12 | LATENT-RISK | Inconsistent JSON parse | Old-pattern routes | Old pattern: `try { await req.json() } catch { body = {} }` produces confusing "missing fields" error on malformed JSON. New `lib/http.readJsonBody` produces a clear "Request body must be valid JSON." error. Migration incomplete. |
+| 13 | LATENT-RISK | Observability gap | `emergency` route | Uses `console.error` directly (intentional — predates logger, and may be preferred for break-glass where Axiom is the thing that's down). Emergency events do not reach Axiom. Worth formalizing. |
+| 14 | TECH-DEBT | Copypasta | 12+ route files | Each has its own local `errorJson()` helper. `lib/http.ts` has `respond()` / `validationError()`. Migration incomplete. |
+| 15 | TECH-DEBT | Copypasta | 7 route files (4 cron + 3 ops) | Identical 10-line `constantTimeEqual` in each. Any security fix needs a 7-place edit. |
+| 16 | TECH-DEBT | Contract drift | `admin/batch/[id]/cancel` | Returns `code: "INVALID_STATE"` which is not in `ERROR_CODES` in `lib/tool-schemas.ts`. Client-side enum match fails. |
+| 17 | TECH-DEBT | Undocumented auth-scope asymmetry | `admin/sites/[id]/budget` | Admin-only, while sibling `admin/sites/[id]/pages/*` routes allow admin + operator. Probably intentional (budget = financial), but undocumented. |
+| 18 | TECH-DEBT | Envelope outlier | `health` | Response is `{ status, checks, build, timestamp }` — no `ok` field. Clients using `result.ok` to branch will be wrong. Probably fine for a health probe; flag for consistency-conscious review. |
+| 19 | TECH-DEBT | Unhandled sub-call | `health` | `Promise.all([checkSupabase(), checkBudgetResetBacklog()])` has no outer try/catch. If either helper throws (not returns error-shaped), Next.js returns an unstructured 500. |
+
+---
+
+## Urgent — the two production-breaking findings
+
+### 1. Chat route leaks internal error detail to browser clients
+
+**File:** `app/api/chat/route.ts`, lines 346-369
+
+**Code (abridged):**
+```ts
+} catch (err) {
+  const apiErr = err instanceof Anthropic.APIError ? err : null;
+
+  const diagnostic = {
+    model: MODEL,
+    message: err instanceof Error ? err.message : String(err),
+    name: err instanceof Error ? err.name : undefined,
+    status: apiErr?.status,
+    request_id: apiErr?.requestID,
+    body: apiErr?.error,
+    stack: err instanceof Error ? err.stack : undefined,
+  };
+  logger.error("api.chat.streaming_error", diagnostic);
+
+  send("error", {
+    code: "INTERNAL_ERROR",
+    message: diagnostic.message,     // ← raw error message
+    details: {
+      name: diagnostic.name,          // ← error class name
+      status: diagnostic.status,
+      request_id: diagnostic.request_id,
+      body: diagnostic.body,          // ← Anthropic API error body
+    },
+  });
+}
+```
+
+**What leaks:**
+- `message`: raw `err.message`. For an Anthropic `APIError`, this contains the SDK's stringified response (rate-limit info, quota state, model descriptors). For a Supabase/postgres error, it contains SQL error text with table/column/constraint names. For an uncaught `TypeError`, whatever the JS runtime produced.
+- `details.body`: the raw Anthropic error payload. This is the SDK's `error` property — structured, often including request IDs and per-error-type fields.
+- `details.name`: error class name (e.g., `RateLimitError`, `AuthenticationError`).
+
+**Note:** `diagnostic.stack` is *logged* (to Axiom via `logger.error`) but *not* sent in the SSE. That part is clean. The payload shown above IS sent to the browser.
+
+**Who sees it:** every user of the chat interface, including viewer-role users and unauthenticated users when `FEATURE_SUPABASE_AUTH` is off. SSE is a long-lived browser connection; the error event is displayed by whatever client-side code handles `event: error`.
+
+**Why it matters:** standard information-disclosure surface. Not credential leakage, but infrastructure detail: which models we use, our rate-limit state with Anthropic, our database schema. All of which attackers use for reconnaissance.
+
+**Fix options:**
+- **(a) Sanitize the SSE payload.** Keep the full diagnostic in the server log; send only `{ code: "INTERNAL_ERROR", message: "Generation failed. If this persists, contact support.", request_id: diagnostic.request_id }` to the browser. `request_id` is safe (it's ours) and is the key operators need to find the full diagnostic in Axiom.
+- **(b) Classify error and send a safe code per class.** E.g., `ANTHROPIC_RATE_LIMIT` if `apiErr.status === 429`, `ANTHROPIC_AUTH` if 401/403, `INTERNAL_ERROR` otherwise. No free-text message; static per-code copy. More work, but gives clients something actionable.
+
+Recommend (a) for the immediate fix, (b) as a follow-up slice if product wants retry-aware chat UX.
+
+---
+
+### 2. `admin/users/[id]/role` PATCH LAST_ADMIN guard is missing the `revoked_at` filter
+
+**File:** `app/api/admin/users/[id]/role/route.ts`, lines 146-149
+
+**Code:**
+```ts
+const { count, error: countErr } = await svc
+  .from("opollo_users")
+  .select("id", { count: "exact", head: true })
+  .eq("role", "admin");
+// ← missing: .is("revoked_at", null)
+```
+
+**Compare — sibling `revoke` route does it right** (`app/api/admin/users/[id]/revoke/route.ts:98-102`):
+```ts
+const { count, error: countErr } = await svc
+  .from("opollo_users")
+  .select("id", { count: "exact", head: true })
+  .eq("role", "admin")
+  .is("revoked_at", null);   // ← correct
+```
+
+**What breaks:** the guard on line 157 (`if ((count ?? 0) <= 1) return LAST_ADMIN`) checks whether we'd be demoting the last admin. If the DB has, say, 1 active admin + 1 revoked admin, `count` returns 2, the guard passes, and demoting the active admin leaves the system with *zero* active admins — exactly the state the guard is meant to prevent.
+
+**Exploit window:** requires at least one `opollo_users` row with `role='admin'` and `revoked_at IS NOT NULL`. Current DB state unknown from the audit. The `revoke` path sets `revoked_at` without clearing `role`, so any previously-admin user who's been revoked makes the drift live.
+
+**Fix:** add `.is("revoked_at", null)` to the query. One-line change. Also worth auditing the other `count.admin` sites — there might be more.
+
+This is the *same* class of bug (`deleted_at` vs `revoked_at` confusion) that produced the M14-1 incident which kicked off the whole M15 audit series. Same lesson, different route.
+
+**Fix options:**
+- **(a) Add the missing filter.** One-line change. Land now.
+- **(b) Centralize the query.** Create `countActiveAdmins()` in `lib/auth.ts` or similar; both routes call it. Prevents future drift.
+
+Recommend (b) — the root cause is a copypasta of the count query. Fixing both routes to call one helper closes the drift surface.
+
+---
+
+## Likely-production-breaking
+
+### 3. Tools write routes have no session requirement
+
+**Routes:** `app/api/tools/publish_page/route.ts`, `app/api/tools/update_page/route.ts`, `app/api/tools/delete_page/route.ts`
+
+Session is optional (rate-limited by user-id if present, else by IP). When `FEATURE_SUPABASE_AUTH` is off (kill-switch path), any IP that can stay under the `tools` rate limit (120 req/60s shared with 4 other tools routes) can POST a valid body and trigger WP write operations. When auth is on, any role — viewer included — can call them.
+
+**Mitigating factor:** the tools routes also have a latent bug (finding #11) where `runWithWpCredentials()` isn't seeded in the route, so direct calls may fail silently or use default-site creds. Need to trace through `lib/create-page.ts` etc. to confirm what happens to a direct call outside the chat flow. But "the attack doesn't work because of another bug" is not a security argument.
+
+**Fix:** add `requireAdminForApi(['admin', 'operator'])` to the three write routes. The `tools/*` endpoints are internal to the chat flow; no external caller needs them. If there IS an external caller (tests?), switch those to admin-session or a separate internal-auth mechanism.
+
+### 4. Error-message leakage in 500 responses across 10+ admin routes
+
+Every admin route that does `errorJson("INTERNAL_ERROR", `Failed to X: ${err.message}`, 500)` leaks raw Supabase/postgres error text. Found in:
+
+- `admin/users/invite` (1 site)
+- `admin/users/list` (1 site)
+- `admin/users/[id]/reinstate` (3 sites)
+- `admin/users/[id]/revoke` (4 sites)
+- `admin/users/[id]/role` (3 sites)
+- `admin/batch/[id]/cancel` (3 sites)
+- `account/change-password` (1 site)
+- `auth/reset-password` (1 site)
+- `briefs/upload` (formData parse error path)
+
+Supabase errors include table names, constraint names, column names, sometimes row data hints. Postgres `error.message` can include SQL snippets. All of this is reconnaissance gold and violates the CLAUDE.md observability contract ("no leaked stack traces, consistent envelope").
+
+**Fix:** replace each `Failed to X: ${err.message}` with a generic message + `logger.error()` the full diagnostic with the request_id. One-PR fan-out.
+
+### 5. `retryable: true` on validation errors
+
+Routes: `admin/images/[id]`, `admin/sites/[id]/budget`, `admin/sites/[id]/pages/[pageId]`, `admin/users/invite`, `admin/users/[id]/role`.
+
+Pattern: these routes return `{ ok: false, error: { code: "VALIDATION_FAILED", retryable: true, ... } }` on a Zod parse failure. `retryable: true` means "try again with the same input" — wrong for a validation error; correct retry is "try again with fixed input." Clients that auto-retry on `retryable` loop forever.
+
+**Fix:** force `retryable: false` on all `VALIDATION_FAILED` responses. Centralize via `lib/http.validationError()` (which already gets this right). Migrate the 5 holdouts.
+
+---
+
+## Latent-risk (8 items)
+
+### 6. Zero timeouts on external calls
+
+None of the 45 routes configure an `AbortController`, `signal`, or SDK-level timeout on Anthropic, WordPress, Supabase, or Upstash calls. The only exception is `ops/self-probe` which uses `Sentry.flush(5000)`.
+
+**Blast radius:** a hanging Anthropic or WordPress call holds a Vercel function slot until Next.js maxDuration (typically 299s). Under load, draining function concurrency can cascade into timeouts for unrelated requests.
+
+**Fix:** introduce a shared `withTimeout(promise, ms)` helper in `lib/http.ts`. Wrap each external call. Suggested initial values: Anthropic 60s, WordPress 30s, Cloudflare 30s, Supabase 15s. Emit `EXTERNAL_TIMEOUT` on exceedance.
+
+### 7. ~30 of 45 routes have no structured logging
+
+Routes that handle errors without calling `logger.error/warn/info` at all: admin/batch, admin/batch/[id]/cancel, admin/images/[id], admin/images/[id]/restore, admin/sites/[id]/budget, admin/sites/[id]/pages/[pageId], admin/sites/[id]/pages/[pageId]/regenerate, admin/users/list, admin/users/[id]/reinstate, admin/users/[id]/revoke, admin/users/[id]/role, briefs/upload (partial), auth/callback, all design-systems/*, sites/register, sites/[id], sites/[id]/design-systems, sites/list, all 7 tools/*.
+
+Errors on these surfaces appear only in Vercel raw function logs (ephemeral, no index) — not in Axiom's queryable store. Per CLAUDE.md observability contract, production paths should log via `lib/logger`.
+
+**Fix:** on every error-return path in these routes, call `logger.error()` with the error code + request_id + context. Incremental — can be done per-route without breaking anything.
+
+### 8. Defense-in-depth gap: 6 public GET routes
+
+`sites/list`, `sites/[id]`, `sites/[id]/design-systems`, `design-systems/[id]/components`, `design-systems/[id]/templates`, `design-systems/[id]/preview` have no route-level auth. Middleware is the only gate. If middleware matcher is ever misconfigured or the Basic Auth kill-switch flips open, these become anonymous reads.
+
+**Fix:** add `requireAdminForApi()` with whatever role set matches current middleware intent. Cost: one import + one check per route. Value: every route enforces its own auth; middleware becomes a defense layer, not the defense layer.
+
+### 9. Rate-limiting gaps on sensitive admin routes
+
+Routes that should probably be rate-limited but aren't: user-mgmt (revoke/reinstate/role), budget PATCH, briefs upload (accepts up to 10MB), design-system writes, `sites/list`, `design-systems/[id]/preview`. The `rate-limit.ts` file already anticipates more buckets; wiring is just not done.
+
+**Fix:** add named buckets (`user_mgmt`, `admin_write`, `briefs`) and wire each route. Low-cost.
+
+### 10. Tools routes delegate body validation entirely
+
+All 7 `tools/*` routes pass `body: unknown` to the executor with no route-level Zod check. Whether validation happens depends on `lib/create-page.ts` etc. This is fragile — a refactor of a lib function that removes validation silently removes the guard.
+
+**Fix:** add a Zod schema at the route for each tools action. The tool-schemas are already defined in `lib/tool-schemas.ts`; call `parseBodyWith(req, toolSchemas.createPage)`.
+
+### 11. Tools routes don't seed `runWithWpCredentials()` context
+
+Tools executors (`executeCreatePage`, `executePublishPage`, etc.) call `runWithWpCredentials()` expecting site credentials in AsyncLocalStorage. The chat route seeds that context with `getSite()` credentials; the tools routes do not. A direct POST to `/api/tools/publish_page` bypassing chat → either silent failure (no creds, WP publish returns 401 and the executor maps it to an error) or, worse, uses some default-site credentials from a prior request. Needs verification.
+
+**Fix:** two paths — (1) remove the tools routes if they're only used internally by chat (chat calls the executors directly, not through HTTP); or (2) keep the routes and seed the context from the request body's `site_id`. Probably (1) — the tools routes appear vestigial from an earlier architecture where a separate agent front-end called them.
+
+### 12. Malformed JSON behavior inconsistent
+
+Old pattern: `try { body = await req.json() } catch { body = {} }`. A malformed JSON body becomes `{}`, validation then fails with "missing fields" — confusing diagnostic.
+
+New pattern (`lib/http.readJsonBody`): returns `undefined`, `parseBodyWith` emits "Request body must be valid JSON."
+
+**Fix:** migrate old-pattern routes to `readJsonBody` + `parseBodyWith`. Lands alongside the envelope-helper migration (finding #14).
+
+### 13. Emergency route `console.error` doesn't reach Axiom
+
+`app/api/emergency/route.ts:106` uses `console.error("[emergency]", JSON.stringify(...))` with an eslint-disable. Rationale (presumably): the break-glass path must not depend on the logger, since the logger depends on Axiom and Axiom may be the thing that's down.
+
+**Consequence:** emergency route invocations don't flow to Axiom's indexed store. Vercel raw function logs only. Operators investigating a break-glass event have to know to look there.
+
+**Fix options:** (a) dual-log — call both `logger.error` and `console.error`, accepting the cost if logger throws. (b) accept the status quo, add a `docs/RUNBOOK.md` pointer to "where to find emergency events." (c) write emergency events to a dedicated DB table (append-only audit) in addition to stdout.
+
+Recommend (b) for now — it's cheap, and the status quo is defensible.
+
+---
+
+## Tech-debt (6 items)
+
+### 14. 12+ local `errorJson()` helpers
+
+Routes that use an inline `errorJson()` helper (Sub-variant A2 in the envelope analysis) each define their own copy. `lib/http.ts` has `respond()` / `validationError()` for the same purpose (Sub-variant A1). Functionally identical today; fragmentation means a future change to the envelope requires 12 edits.
+
+**Fix:** migrate A2 routes to `lib/http.ts` helpers. Large diff but mechanical.
+
+### 15. `constantTimeEqual` duplicated 7 times
+
+Identical 10-line function in cron/budget-reset, cron/process-batch, cron/process-regenerations, cron/process-transfer, emergency, ops/reset-admin-password, ops/self-probe.
+
+**Fix:** move to `lib/http.ts` (or a new `lib/crypto-compare.ts`); import where needed.
+
+### 16. `INVALID_STATE` error code not in `ERROR_CODES` enum
+
+`admin/batch/[id]/cancel` returns `code: "INVALID_STATE"` on a wrong-state cancel attempt, but `ERROR_CODES` in `lib/tool-schemas.ts` doesn't include it. Client-side enum matching fails silently. Likely no client actually matches on this today, but the contract is broken.
+
+**Fix:** add `"INVALID_STATE"` to the enum, or rename to an existing code.
+
+### 17. Auth-scope asymmetry on `admin/sites/[id]/budget`
+
+Admin-only while sibling `admin/sites/[id]/pages/*` allows admin + operator. Probably intentional (budget caps are financial; operators edit content). Not documented in either route or in CLAUDE.md.
+
+**Fix:** add a comment at the `requireAdminForApi(['admin'])` call explaining why operators are excluded from this specific route.
+
+### 18. `health` envelope non-standard
+
+No `ok` field. Intentional for a health probe shape (`{ status, checks, build, timestamp }`). But any client expecting `result.ok` will be wrong. Marginal — few clients call `/api/health` programmatically.
+
+**Fix:** document in the route-level comment, or align to `{ ok, data: { status, checks, build }, timestamp }`. Low priority.
+
+### 19. `health` route has no outer try/catch
+
+`Promise.all([checkSupabase(), checkBudgetResetBacklog()])` — if a helper throws (not returns error-shaped), Next.js emits an unstructured 500. Probably never happens in practice, but belt-and-braces.
+
+**Fix:** wrap in try/catch; on failure, return a 503 with the standard check-level error surface.
+
+---
+
+## Cross-cutting patterns
+
+### Response-envelope drift
+
+One canonical envelope (`{ ok, error?, data?, timestamp }`), two implementations (A1 via `lib/http.respond()`, A2 via inline `errorJson()` in each route file). 12+ copies of A2. `health` and `self-probe` are documented outliers; `chat` is dual-mode (JSON pre-stream, SSE in-stream). One migration slice could unify A2 → A1.
+
+### Logging gap
+
+~30 of 45 routes have no structured logging. The observability contract says "use `lib/logger`"; the practice says "many routes log nothing." This is the single biggest observability hole in the codebase.
+
+### Timeout gap
+
+Zero `AbortController` usage on external calls. Exactly one explicit timeout anywhere (`Sentry.flush(5000)` in `ops/self-probe`). This is a Vercel-function-concurrency risk, not just a correctness risk — a slow upstream can drain the pool.
+
+### Rate-limit gap
+
+9 sensitive routes without a limiter. The `lib/rate-limit.ts` file's comments anticipate more buckets; wiring is incomplete.
+
+### Copypasta
+
+12 `errorJson()` copies + 7 `constantTimeEqual` copies. Migration-ready: both have canonical homes in `lib/http.ts`.
+
+### Auth-layering
+
+Middleware is the *only* route-level gate on 6 read routes. Defense in depth missing.
+
+---
+
+## What I did NOT cover in this audit
+
+- **Live endpoint probing.** This is static analysis of route handlers. I didn't call any endpoint to verify behavior against a running deployment. The M15-1 in-flight `/api/ops/reset-admin-password` work should exercise one of these paths live; that's their territory.
+- **Middleware-level auth review.** Middleware was read for context but not audited in depth. `middleware.ts` is listed as a "hot-shared" file in `docs/WORK_IN_FLIGHT.md`; changes need the coordination protocol.
+- **Request-handling correctness below the route layer.** The `lib/*.ts` implementations that routes delegate to weren't audited here. If `executeCreatePage()` has its own auth check inside, some of the tools-route findings are less severe than they look. Spot-check when fixing.
+- **M15-5 territory.** Hardcoded URLs, cron timezone/overlap, race conditions, dead code, RLS bypass paths, promise-rejection handling — all belong in the cross-cutting production-risk audit. A few observations here (timeout gap, rate-limit gap) will also surface there; I'll avoid re-flagging.
+
+---
+
+## Files produced
+
+- `docs/ENDPOINT_AUDIT_2026-04-24.md` (this file)
+- `docs/_audit_scratch/code_endpoints.md` (~1700 lines, raw Sonnet output — kept for M15-5/6 reuse)
+- `docs/_audit_scratch/_extract2.js` (one-shot JSON extractor; safe to delete after M15-6)
+
+---
+
+## Awaiting review
+
+Two paths forward:
+
+**Option A — fix the two production-breaking items now** (same shape as the M15-3 fix PR). Small, targeted, ~1 day:
+- Sanitize the chat SSE error payload (finding #1).
+- Add `.is("revoked_at", null)` to `admin/users/[id]/role` LAST_ADMIN count — ideally via a shared `countActiveAdmins()` helper that `revoke` also calls (findings #2 + a latent copypasta cleanup).
+- Add unit tests for both.
+
+**Option B — defer everything to M15-7** and continue through M15-5 + M15-6 first.
+
+Option A matches how you scoped M15-3. The two items are narrow, well-understood, and both reduce a real risk in production today. My recommendation is A, but this is your call given the pause rule.
+
+Same pause question as M15-2 and M15-3: which findings escalate into immediate fixes, and do I proceed to M15-5?

--- a/lib/__tests__/admin-users-revoke.test.ts
+++ b/lib/__tests__/admin-users-revoke.test.ts
@@ -210,6 +210,40 @@ describe("POST /api/admin/users/[id]/revoke: guardrails", () => {
     const body = await res.json();
     expect(body.error.code).toBe("LAST_ADMIN");
   });
+
+  // M15-4 regression. Pinning the sibling invariant from the /role PATCH
+  // route: the LAST_ADMIN count must only include active admins. A
+  // revoked row with role='admin' does not satisfy the floor. Both routes
+  // now share the countActiveAdmins() helper in lib/auth.ts so this
+  // contract cannot drift again.
+  it(
+    "LAST_ADMIN counts only active admins — revoked admins do not prop up the count",
+    async () => {
+      const activeAdmin = await seedAuthUser({ role: "admin" });
+      const revokedAdmin = await seedAuthUser({ role: "admin" });
+
+      const svc = getServiceRoleClient();
+      const { error: revokeErr } = await svc
+        .from("opollo_users")
+        .update({ revoked_at: new Date().toISOString() })
+        .eq("id", revokedAdmin.id);
+      expect(revokeErr).toBeNull();
+
+      delete process.env.FEATURE_SUPABASE_AUTH;
+      mockState.client = anonClient();
+
+      const res = await revokePOST(makeRequest(activeAdmin.id), {
+        params: { id: activeAdmin.id },
+      });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error.code).toBe("LAST_ADMIN");
+
+      // The active admin's revoked_at must still be null — the guard
+      // must short-circuit before any mutation.
+      expect(await readRevokedAt(activeAdmin.id)).toBeNull();
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/lib/__tests__/admin-users-role.test.ts
+++ b/lib/__tests__/admin-users-role.test.ts
@@ -311,6 +311,48 @@ describe("PATCH /api/admin/users/[id]/role: guardrails", () => {
     const body = await res.json();
     expect(body.error.code).toBe("LAST_ADMIN");
   });
+
+  // M15-4 regression. Prior to the fix, the LAST_ADMIN count filtered only
+  // on role='admin' and ignored revoked_at, so a revoked admin row would
+  // pad the count and let the caller demote the last *active* admin. This
+  // test seeds one active admin + one revoked admin, then attempts to
+  // demote the active one. With the fix, count(active)=1 and demotion
+  // must be blocked. Without the fix, count(all-with-admin-role)=2 and
+  // demotion would succeed — that's the bug.
+  it(
+    "LAST_ADMIN counts only active admins — revoked admins do not prop up the count",
+    async () => {
+      const activeAdmin = await seedAuthUser({ role: "admin" });
+      const revokedAdmin = await seedAuthUser({ role: "admin" });
+
+      // Stamp revoked_at on the second admin via service-role. The row
+      // keeps role='admin' but revoked_at is set, so the user cannot
+      // sign in and must not count toward the LAST_ADMIN floor.
+      const svc = getServiceRoleClient();
+      const { error: revokeErr } = await svc
+        .from("opollo_users")
+        .update({ revoked_at: new Date().toISOString() })
+        .eq("id", revokedAdmin.id);
+      expect(revokeErr).toBeNull();
+
+      // Flag-off path — the caller is superuser; targeting the sole
+      // active admin. With the fix, LAST_ADMIN fires (count=1).
+      delete process.env.FEATURE_SUPABASE_AUTH;
+      mockState.client = anonClient();
+
+      const res = await roleRoutePATCH(
+        makeRequest(activeAdmin.id, { role: "operator" }),
+        { params: { id: activeAdmin.id } },
+      );
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error.code).toBe("LAST_ADMIN");
+
+      // And the row was NOT demoted — defensive assertion against the
+      // "error returned but the write already landed" failure mode.
+      expect(await readRole(activeAdmin.id)).toBe("admin");
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/lib/__tests__/chat-errors.test.ts
+++ b/lib/__tests__/chat-errors.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import Anthropic from "@anthropic-ai/sdk";
+
+import {
+  SAFE_CHAT_ERROR_CODE,
+  SAFE_CHAT_ERROR_MESSAGE,
+  buildChatErrorDiagnostic,
+  buildSafeSseErrorPayload,
+} from "@/lib/chat-errors";
+
+// ---------------------------------------------------------------------------
+// M15-4 — chat SSE error sanitization.
+//
+// Pins two invariants:
+//   1. The SSE payload the browser receives is a constant shape regardless
+//      of the underlying error. No raw error message, no Anthropic API
+//      body, no stack trace, no internal file paths.
+//   2. The server-side diagnostic retains the full error context so
+//      operators can debug from Axiom / Vercel logs.
+//
+// Every "forbidden substring" below is something the pre-M15-4 code would
+// have sent to the browser unchanged. The leak regression test asserts
+// none of them appear in the serialized SSE payload.
+// ---------------------------------------------------------------------------
+
+describe("buildSafeSseErrorPayload", () => {
+  it("returns the constant safe shape with the passed request_id", () => {
+    const payload = buildSafeSseErrorPayload("req-abc-123");
+    expect(payload).toEqual({
+      code: "INTERNAL_ERROR",
+      message: SAFE_CHAT_ERROR_MESSAGE,
+      request_id: "req-abc-123",
+    });
+  });
+
+  it("accepts a null request_id for contexts where the id is unavailable", () => {
+    const payload = buildSafeSseErrorPayload(null);
+    expect(payload.request_id).toBeNull();
+    expect(payload.code).toBe(SAFE_CHAT_ERROR_CODE);
+    expect(payload.message).toBe(SAFE_CHAT_ERROR_MESSAGE);
+  });
+
+  it("emits the same static message across different request_ids", () => {
+    const a = buildSafeSseErrorPayload("req-1");
+    const b = buildSafeSseErrorPayload("req-2");
+    expect(a.message).toBe(b.message);
+    expect(a.code).toBe(b.code);
+  });
+});
+
+describe("buildChatErrorDiagnostic — server-side log contract", () => {
+  it("captures the raw error message for an Anthropic APIError", () => {
+    const apiErr = new Anthropic.APIError(
+      429,
+      { error: { type: "rate_limit_exceeded", message: "quota exceeded" } },
+      "Rate limit exceeded",
+      new Headers({ "x-anthropic-request-id": "anth-req-xyz" }),
+    );
+    const diagnostic = buildChatErrorDiagnostic(apiErr, "claude-opus-4-7", apiErr);
+    expect(diagnostic.message).toBe("Rate limit exceeded");
+    expect(diagnostic.status).toBe(429);
+    expect(diagnostic.body).toEqual({
+      error: { type: "rate_limit_exceeded", message: "quota exceeded" },
+    });
+    expect(diagnostic.stack).toBeTypeOf("string");
+  });
+
+  it("captures a plain Error without an Anthropic wrapper", () => {
+    const err = new Error("database connection lost");
+    const diagnostic = buildChatErrorDiagnostic(err, "test-model", null);
+    expect(diagnostic.message).toBe("database connection lost");
+    expect(diagnostic.name).toBe("Error");
+    expect(diagnostic.status).toBeUndefined();
+    expect(diagnostic.body).toBeUndefined();
+    expect(diagnostic.stack).toBeTypeOf("string");
+    expect(diagnostic.model).toBe("test-model");
+  });
+
+  it("stringifies non-Error throws", () => {
+    const diagnostic = buildChatErrorDiagnostic("string thrown", "m", null);
+    expect(diagnostic.message).toBe("string thrown");
+    expect(diagnostic.stack).toBeUndefined();
+    expect(diagnostic.name).toBeUndefined();
+  });
+});
+
+describe("chat SSE error leak regression", () => {
+  // Each case pairs a realistic failure with the substrings that would
+  // have been exposed under the pre-M15-4 payload shape. The safe payload
+  // is built from only the request_id, so by construction none of the
+  // error content can appear — but the test guards against a future
+  // refactor that adds `err` back to the function signature.
+  const cases: Array<{ name: string; err: unknown; forbidden: string[] }> = [
+    {
+      name: "Anthropic rate-limit with internal quota detail",
+      err: new Anthropic.APIError(
+        429,
+        {
+          error: {
+            type: "rate_limit_exceeded",
+            message: "org_abc123 has exceeded its daily quota",
+          },
+        },
+        "429 Too Many Requests",
+        new Headers({ "x-anthropic-request-id": "anth-req-xyz" }),
+      ),
+      forbidden: [
+        "org_abc123",
+        "rate_limit_exceeded",
+        "exceeded its daily quota",
+        "429 Too Many Requests",
+      ],
+    },
+    {
+      name: "Supabase schema error revealing table + column names",
+      err: Object.assign(
+        new Error(
+          'column "deleted_at" of relation "opollo_users" does not exist',
+        ),
+        { code: "42703", details: null, hint: null },
+      ),
+      forbidden: [
+        "deleted_at",
+        "opollo_users",
+        "42703",
+        "does not exist",
+        "relation",
+      ],
+    },
+    {
+      name: "TypeError exposing internal file paths",
+      err: new TypeError(
+        "Cannot read property 'wp_secret' of undefined at /var/task/.next/server/lib/sites.js:234",
+      ),
+      forbidden: [
+        "wp_secret",
+        "/var/task",
+        ".next/server",
+        "sites.js:234",
+      ],
+    },
+  ];
+
+  for (const { name, err: _err, forbidden } of cases) {
+    it(`does not leak: ${name}`, () => {
+      const payload = buildSafeSseErrorPayload("req-leak-test");
+      const serialized = JSON.stringify(payload);
+      for (const substring of forbidden) {
+        expect(serialized).not.toContain(substring);
+      }
+    });
+  }
+
+  it("the safe payload type rejects an error argument at compile time", () => {
+    // This test documents the type-level invariant. The function signature
+    // is (requestId: string | null) => SafeChatSseErrorPayload. Passing an
+    // Error would be a TypeScript error. Runtime version of the check:
+    // calling with only a requestId produces a payload with no error
+    // field.
+    const payload = buildSafeSseErrorPayload("req-abc");
+    expect(Object.keys(payload).sort()).toEqual(
+      ["code", "message", "request_id"].sort(),
+    );
+    // No "error", "err", "details", "body", "stack", "name" keys.
+    const forbiddenKeys = [
+      "error",
+      "err",
+      "details",
+      "body",
+      "stack",
+      "name",
+      "status",
+    ];
+    for (const key of forbiddenKeys) {
+      expect(payload).not.toHaveProperty(key);
+    }
+  });
+});

--- a/lib/__tests__/chat-errors.test.ts
+++ b/lib/__tests__/chat-errors.test.ts
@@ -49,20 +49,30 @@ describe("buildSafeSseErrorPayload", () => {
 });
 
 describe("buildChatErrorDiagnostic — server-side log contract", () => {
-  it("captures the raw error message for an Anthropic APIError", () => {
+  it("captures the full error context for an Anthropic APIError", () => {
     const apiErr = new Anthropic.APIError(
       429,
       { error: { type: "rate_limit_exceeded", message: "quota exceeded" } },
       "Rate limit exceeded",
       new Headers({ "x-anthropic-request-id": "anth-req-xyz" }),
     );
-    const diagnostic = buildChatErrorDiagnostic(apiErr, "claude-opus-4-7", apiErr);
-    expect(diagnostic.message).toBe("Rate limit exceeded");
+    const diagnostic = buildChatErrorDiagnostic(
+      apiErr,
+      "claude-opus-4-7",
+      apiErr,
+    );
+    // The Anthropic SDK composes APIError.message from status + body, so
+    // we assert on substrings rather than equality. The invariant we
+    // care about is "the full error context reaches the server log" —
+    // not the exact serialization.
+    expect(diagnostic.message).toContain("429");
+    expect(diagnostic.message).toContain("rate_limit_exceeded");
     expect(diagnostic.status).toBe(429);
     expect(diagnostic.body).toEqual({
       error: { type: "rate_limit_exceeded", message: "quota exceeded" },
     });
     expect(diagnostic.stack).toBeTypeOf("string");
+    expect(diagnostic.model).toBe("claude-opus-4-7");
   });
 
   it("captures a plain Error without an Anthropic wrapper", () => {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -273,3 +273,35 @@ export async function requireRole(
 // Revocation lives in lib/auth-revoke.ts — it uses a direct Postgres
 // connection (pg) and must never be reachable from the Edge middleware
 // bundle. Import `signOutAuthUser` from "@/lib/auth-revoke" instead.
+
+// ---------------------------------------------------------------------------
+// Active-admin count.
+//
+// Both the /admin/users/[id]/role PATCH and /admin/users/[id]/revoke POST
+// routes need to block operations that would leave the org with zero
+// active admins. "Active" means role='admin' AND revoked_at IS NULL — a
+// revoked admin cannot sign in and does not count. The M15-4 audit found
+// a drift where /role PATCH was counting `role='admin'` only (without the
+// revoked_at filter), which could let an operator demote the last *active*
+// admin if a revoked admin existed on the table. Both call sites now go
+// through this shared helper so the count definition cannot drift again.
+//
+// Returns a discriminated result so callers can distinguish "couldn't
+// count" from "counted zero" without reading error codes. Service-role
+// client, bypasses RLS.
+// ---------------------------------------------------------------------------
+
+export async function countActiveAdmins(): Promise<
+  { ok: true; count: number } | { ok: false; error: string }
+> {
+  const svc = getServiceRoleClient();
+  const { count, error } = await svc
+    .from("opollo_users")
+    .select("id", { count: "exact", head: true })
+    .eq("role", "admin")
+    .is("revoked_at", null);
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+  return { ok: true, count: count ?? 0 };
+}

--- a/lib/chat-errors.ts
+++ b/lib/chat-errors.ts
@@ -1,0 +1,94 @@
+import type { APIError } from "@anthropic-ai/sdk";
+
+// ---------------------------------------------------------------------------
+// M15-4 — chat streaming error sanitization.
+//
+// The chat route runs a Server-Sent Events stream. When it throws mid-stream,
+// we need to (a) log the full diagnostic to our own logger so operators can
+// investigate, and (b) tell the browser client that something broke. The
+// browser payload must NOT contain the raw error message, the raw Anthropic
+// API error body, or any stack trace — those surfaces leak infrastructure
+// detail (model names, quota state, schema names, internal file paths) to
+// every chat user, including non-admins.
+//
+// The safe payload only carries an opaque error code, a static user-facing
+// message, and our internal request_id so support can correlate the browser
+// complaint with the server log entry. See docs/ENDPOINT_AUDIT_2026-04-24.md
+// finding #1 for the leak that triggered this.
+//
+// Design note: `buildSafeSseErrorPayload` INTENTIONALLY does not accept the
+// error. That makes it structurally impossible for a future change to
+// accidentally pipe err.message into the response — the function has
+// nothing to pipe. The diagnostic is produced separately by
+// `buildChatErrorDiagnostic` and is consumed only by the logger.
+// ---------------------------------------------------------------------------
+
+export const SAFE_CHAT_ERROR_CODE = "INTERNAL_ERROR" as const;
+
+export const SAFE_CHAT_ERROR_MESSAGE =
+  "The chat service encountered an internal error. Please try again. " +
+  "If the problem persists, reference this request id when contacting support.";
+
+export interface ChatErrorDiagnostic {
+  model: string;
+  message: string;
+  name: string | undefined;
+  status: number | undefined;
+  anthropic_request_id: string | undefined;
+  body: unknown;
+  stack: string | undefined;
+  // Index signature so logger.error (which expects Record<string, unknown>)
+  // can accept this object without a cast.
+  [key: string]: unknown;
+}
+
+export interface SafeChatSseErrorPayload {
+  code: typeof SAFE_CHAT_ERROR_CODE;
+  message: string;
+  request_id: string | null;
+}
+
+/**
+ * Build the full diagnostic object for the server-side logger. Includes every
+ * piece of context that helps an operator debug the failure — raw error
+ * message, error class name, Anthropic API status + request id, raw API
+ * error body, and the stack trace.
+ *
+ * This output MUST NOT reach the browser. It is consumed exclusively by
+ * `logger.error(...)`, which writes to stdout + (optionally) Axiom.
+ */
+export function buildChatErrorDiagnostic(
+  err: unknown,
+  model: string,
+  anthropicErr: APIError | null,
+): ChatErrorDiagnostic {
+  return {
+    model,
+    message: err instanceof Error ? err.message : String(err),
+    name: err instanceof Error ? err.name : undefined,
+    status: anthropicErr?.status,
+    anthropic_request_id: anthropicErr?.requestID ?? undefined,
+    body: anthropicErr?.error,
+    stack: err instanceof Error ? err.stack : undefined,
+  };
+}
+
+/**
+ * Build the SSE error payload the browser receives. Takes ONLY the
+ * request_id — intentionally does not accept the error itself. The payload
+ * is constant-shape across every failure mode: one opaque code, one static
+ * message, one request_id for correlation.
+ *
+ * The request_id is the same id middleware stamps on every response as
+ * `x-request-id`; clients can read it from the SSE body or the response
+ * header to file a support request.
+ */
+export function buildSafeSseErrorPayload(
+  requestId: string | null,
+): SafeChatSseErrorPayload {
+  return {
+    code: SAFE_CHAT_ERROR_CODE,
+    message: SAFE_CHAT_ERROR_MESSAGE,
+    request_id: requestId,
+  };
+}


### PR DESCRIPTION
## Summary

Ships the two production-breaking items from the M15-4 endpoint audit (`docs/ENDPOINT_AUDIT_2026-04-24.md`). The remaining 17 findings (3 likely-prod-breaking + 8 latent-risk + 6 tech-debt) are deferred to the M15-7 consolidated fix pass after M15-5 and M15-6 complete.

The audit report itself lands in this PR (`docs/ENDPOINT_AUDIT_2026-04-24.md`) so the fix rationale is reviewable alongside the code.

## 🚨 What the audit flagged (both fixed here)

### 1. Chat SSE error event leaked internal detail to every browser client

**Before:** `app/api/chat/route.ts:349-369` sent `err.message`, error class name, and the raw Anthropic API error body to the browser as an SSE `error` event. An Anthropic rate-limit response exposed quota state; a Supabase error exposed schema/constraint names; any thrown exception leaked its own message. This reached every chat user, including non-admins.

**After:** the SSE `error` event carries only `{ code: "INTERNAL_ERROR", message: <static user-facing string>, request_id }`. The full diagnostic — raw `err.message`, error class name, Anthropic status + request id, raw API error body, stack trace — is logged to the structured logger for operator debugging and never reaches the browser.

### 2. `admin/users/[id]/role` LAST_ADMIN count missed `revoked_at` filter

**Before:** `app/api/admin/users/[id]/role/route.ts:146-149` counted admins by `.eq("role", "admin")` with no `.is("revoked_at", null)`. If any revoked admin row existed, the count was too high and the guard let operators demote the last *active* admin. The sibling `/revoke` route got this right; `/role` didn't.

**After:** both routes call a new shared `countActiveAdmins()` helper in `lib/auth.ts`. "Active admin" is defined once, applied everywhere.

This is the same class of bug (`deleted_at` vs `revoked_at` confusion) that shipped as M14-1 and triggered the whole M15 audit series. Centralising the count closes the drift surface.

## What ships

- **`lib/chat-errors.ts`** (new) — two helpers:
  - `buildChatErrorDiagnostic(err, model, apiErr)` — server-log shape (leaky, for Axiom)
  - `buildSafeSseErrorPayload(requestId)` — browser shape (opaque, by construction)
  - The safe-payload builder INTENTIONALLY does not accept the error. That is the structural invariant: no future refactor can leak an error field into the response because the function has nothing to leak.
- **`lib/__tests__/chat-errors.test.ts`** (new) — pins:
  - the constant payload shape (code, message, request_id only — no `error`, `details`, `body`, `stack`, `name`, `status` keys)
  - the diagnostic captures full context (for server-side debugging)
  - leak regression across realistic error shapes (Anthropic rate limit body with internal quota detail, Supabase schema error with table + column names, TypeError with internal file paths)
- **`app/api/chat/route.ts`** — catch block now builds the diagnostic for `logger.error(...)` and sends `buildSafeSseErrorPayload(getRequestContext().request_id ?? null)` to the browser. The `request_id` comes from middleware's AsyncLocalStorage context.
- **`lib/auth.ts`** — adds `countActiveAdmins(): { ok: true; count } | { ok: false; error }`. Discriminated result; service-role; bypasses RLS.
- **`app/api/admin/users/[id]/role/route.ts`** + **`app/api/admin/users/[id]/revoke/route.ts`** — both use `countActiveAdmins()`. Inline count queries removed.
- **`lib/__tests__/admin-users-role.test.ts`** + **`lib/__tests__/admin-users-revoke.test.ts`** — regression test added to each: seeds 1 active admin + 1 revoked admin, attempts to demote/revoke the active one, asserts LAST_ADMIN fires (count=1 after the filter, not 2).

## Risks identified and mitigated

- **Browser clients relying on the old `details` object fields.** The pre-fix SSE payload had `details.name`, `details.status`, `details.request_id`, `details.body`. Post-fix, only `request_id` exists and it's at the top level of the payload. Any browser code that read the old `details.*` fields will now read `undefined`. Acceptable: those fields leaked internal state; losing them is the point. The `request_id` is preserved (at the top level) so support correlation still works.
- **Lost context on production errors.** Operators lose the ability to see the error message in the browser, but the logger output still has everything, keyed by the same `request_id`. Support flow: browser shows `request_id`, operator searches Axiom/Vercel logs for that id, sees the full diagnostic.
- **Shared helper adding a new query per request.** `countActiveAdmins()` is only called on the LAST_ADMIN guard path (demotion or revocation of an admin). Traffic is vanishingly small. No concurrency concerns.
- **Parallel-session race during commit.** HEAD raced with another Claude Code session mid-commit; the commit landed on the wrong branch and the working tree was later clobbered. Cleaned up by re-pointing the branch ref to the correct commit object (the commit itself was intact as a git object). No work lost. Flagged in conversation; the memory note about parallel-session HEAD races held up.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (Next.js production build succeeds)
- [ ] `npm run test` — deferred to CI (local Supabase CLI not on PATH; the admin-users-* integration tests need it)
- [ ] E2E — no admin UI surface changes, no chat UI surface changes beyond the error message; existing E2E suite applies

## Not in scope

- The 17 other findings from M15-4 (tools-route auth gaps, `err.message` leaking across 10+ admin routes, `retryable: true` on validation errors in 5 routes, no external-service timeouts, 30/45 routes with no structured logging, etc.) — deferred to M15-7.
- The 14 M15-2 schema audit findings — parallel session is already shipping some on `feat/m15-schema-defense-in-depth`; rest deferred to M15-7.
- M15-3 remaining findings — deferred to M15-7.

After merge: M15-5 (cross-cutting production-risk audit) begins under the same pause-after-audit rules as M15-2/3/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)