### PR TITLE
fix(m15-7): defense-in-depth — logger routing, err.message sanitization, briefs CAS

### DIFF
--- a/app/api/account/change-password/route.ts
+++ b/app/api/account/change-password/route.ts
@@ -174,7 +174,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       const message =
         code === "SAME_PASSWORD"
           ? "New password must be different from your current password."
-          : `Password update failed: ${error.message}`;
+          : "Password update failed. Please try again or contact support with the request id from the response headers.";
       logger.warn("change_password_supabase_error", {
         user_id: user.id,
         email: user.email,

--- a/app/api/admin/batch/[id]/cancel/route.ts
+++ b/app/api/admin/batch/[id]/cancel/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -64,9 +65,10 @@ export async function POST(
     .eq("id", jobId)
     .maybeSingle();
   if (readErr) {
+    logger.error("admin.batch.cancel.read_failed", { job_id: jobId, error: readErr });
     return errorJson(
       "INTERNAL_ERROR",
-      `Failed to read job: ${readErr.message}`,
+      "Failed to read job. Please try again or contact support with the request id from the response headers.",
       500,
     );
   }
@@ -126,9 +128,10 @@ export async function POST(
     })
     .eq("id", jobId);
   if (jobErr) {
+    logger.error("admin.batch.cancel.update_failed", { job_id: jobId, error: jobErr });
     return errorJson(
       "INTERNAL_ERROR",
-      `Failed to cancel job: ${jobErr.message}`,
+      "Failed to cancel job. Please try again or contact support with the request id from the response headers.",
       500,
     );
   }
@@ -150,9 +153,10 @@ export async function POST(
     .eq("job_id", jobId)
     .eq("state", "pending");
   if (slotsErr) {
+    logger.error("admin.batch.cancel.slots_failed", { job_id: jobId, error: slotsErr });
     return errorJson(
       "INTERNAL_ERROR",
-      `Failed to mark pending slots skipped: ${slotsErr.message}`,
+      "Failed to mark pending slots skipped. Please try again or contact support with the request id from the response headers.",
       500,
     );
   }

--- a/app/api/admin/users/[id]/reinstate/route.ts
+++ b/app/api/admin/users/[id]/reinstate/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -57,9 +58,10 @@ export async function POST(
     .eq("id", userId)
     .maybeSingle();
   if (fetchErr) {
+    logger.error("admin.users.reinstate.fetch_failed", { user_id: userId, error: fetchErr });
     return errorJson(
       "INTERNAL_ERROR",
-      `Failed to read target user: ${fetchErr.message}`,
+      "Failed to read user. Please try again or contact support with the request id from the response headers.",
       500,
     );
   }
@@ -73,9 +75,10 @@ export async function POST(
     ban_duration: "none",
   });
   if (unbanErr) {
+    logger.error("admin.users.reinstate.unban_failed", { user_id: userId, error: unbanErr });
     return errorJson(
       "INTERNAL_ERROR",
-      `Failed to unban user in auth.users: ${unbanErr.message}`,
+      "Failed to unban user. Please try again or contact support with the request id from the response headers.",
       500,
     );
   }
@@ -96,9 +99,10 @@ export async function POST(
     .update({ revoked_at: null })
     .eq("id", userId);
   if (clearErr) {
+    logger.error("admin.users.reinstate.clear_revoked_failed", { user_id: userId, error: clearErr });
     return errorJson(
       "INTERNAL_ERROR",
-      `Failed to clear revoked_at: ${clearErr.message}`,
+      "Failed to reinstate user. Please try again or contact support with the request id from the response headers.",
       500,
     );
   }

--- a/app/api/admin/users/[id]/revoke/route.ts
+++ b/app/api/admin/users/[id]/revoke/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { countActiveAdmins } from "@/lib/auth";
 import { revokeUserSessions } from "@/lib/auth-revoke";
+import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -85,9 +86,10 @@ export async function POST(
     .eq("id", userId)
     .maybeSingle();
   if (fetchErr) {
+    logger.error("admin.users.revoke.fetch_failed", { user_id: userId, error: fetchErr });
     return errorJson(
       "INTERNAL_ERROR",
-      `Failed to read target user: ${fetchErr.message}`,
+      "Failed to read user. Please try again or contact support with the request id from the response headers.",
       500,
     );
   }
@@ -101,9 +103,10 @@ export async function POST(
     // See lib/auth.ts#countActiveAdmins for the definition.
     const adminCount = await countActiveAdmins();
     if (!adminCount.ok) {
+      logger.error("admin.users.revoke.count_failed", { user_id: userId, error: adminCount.error });
       return errorJson(
         "INTERNAL_ERROR",
-        `Failed to count active admins: ${adminCount.error}`,
+        "Failed to count active admins. Please try again or contact support with the request id from the response headers.",
         500,
       );
     }
@@ -120,9 +123,10 @@ export async function POST(
     ban_duration: BAN_FOREVER,
   });
   if (banErr) {
+    logger.error("admin.users.revoke.ban_failed", { user_id: userId, error: banErr });
     return errorJson(
       "INTERNAL_ERROR",
-      `Failed to ban user in auth.users: ${banErr.message}`,
+      "Failed to ban user. Please try again or contact support with the request id from the response headers.",
       500,
     );
   }
@@ -133,10 +137,10 @@ export async function POST(
     // The ban already landed, so the immediate effect is the same even
     // if the session sweep fails. Surface it so operators know to
     // retry, but don't lie about success.
-    const message = err instanceof Error ? err.message : String(err);
+    logger.error("admin.users.revoke.session_sweep_failed", { user_id: userId, error: err });
     return errorJson(
       "INTERNAL_ERROR",
-      `User banned, but session sweep failed: ${message}`,
+      "User banned, but session sweep failed. Please try again or contact support with the request id from the response headers.",
       500,
     );
   }

--- a/app/api/admin/users/[id]/role/route.ts
+++ b/app/api/admin/users/[id]/role/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { countActiveAdmins } from "@/lib/auth";
+import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -120,9 +121,10 @@ export async function PATCH(
     .eq("id", userId)
     .maybeSingle();
   if (fetchErr) {
+    logger.error("admin.users.role.fetch_failed", { user_id: userId, error: fetchErr });
     return errorJson(
       "INTERNAL_ERROR",
-      `Failed to read target user: ${fetchErr.message}`,
+      "Failed to read user. Please try again or contact support with the request id from the response headers.",
       500,
     );
   }
@@ -149,9 +151,10 @@ export async function PATCH(
   if (currentRole === "admin" && targetRole !== "admin") {
     const adminCount = await countActiveAdmins();
     if (!adminCount.ok) {
+      logger.error("admin.users.role.count_failed", { user_id: userId, error: adminCount.error });
       return errorJson(
         "INTERNAL_ERROR",
-        `Failed to count active admins: ${adminCount.error}`,
+        "Failed to count active admins. Please try again or contact support with the request id from the response headers.",
         500,
       );
     }
@@ -169,9 +172,10 @@ export async function PATCH(
     .update({ role: targetRole })
     .eq("id", userId);
   if (updateErr) {
+    logger.error("admin.users.role.update_failed", { user_id: userId, error: updateErr });
     return errorJson(
       "INTERNAL_ERROR",
-      `Failed to update role: ${updateErr.message}`,
+      "Failed to update role. Please try again or contact support with the request id from the response headers.",
       500,
     );
   }

--- a/app/api/admin/users/invite/route.ts
+++ b/app/api/admin/users/invite/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { buildAuthRedirectUrl } from "@/lib/auth-redirect";
+import { logger } from "@/lib/logger";
 import {
   checkRateLimit,
   getClientIp,
@@ -147,9 +148,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         409,
       );
     }
+    logger.error("admin.users.invite.generate_failed", { error });
     return errorJson(
       "INTERNAL_ERROR",
-      `Failed to generate invite: ${error.message}`,
+      "Failed to generate invite. Please try again or contact support with the request id from the response headers.",
       500,
     );
   }

--- a/app/api/admin/users/list/route.ts
+++ b/app/api/admin/users/list/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -42,12 +43,13 @@ export async function GET(): Promise<NextResponse> {
     .order("created_at", { ascending: false });
 
   if (error) {
+    logger.error("admin.users.list.read_failed", { error });
     return NextResponse.json(
       {
         ok: false,
         error: {
           code: "INTERNAL_ERROR",
-          message: `Failed to read opollo_users: ${error.message}`,
+          message: "Failed to read users. Please try again or contact support with the request id from the response headers.",
           retryable: true,
         },
         timestamp: new Date().toISOString(),

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -100,7 +100,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       const message =
         code === "SAME_PASSWORD"
           ? "New password must be different from your current password."
-          : `Password update failed: ${error.message}`;
+          : "Password update failed. Please try again or contact support with the request id from the response headers.";
       logger.warn("reset_password_supabase_error", {
         user_id: user.id,
         email: user.email,

--- a/app/api/briefs/upload/route.ts
+++ b/app/api/briefs/upload/route.ts
@@ -60,9 +60,8 @@ export async function POST(req: Request): Promise<NextResponse> {
   try {
     form = await req.formData();
   } catch (err) {
-    return validationError("Request must be multipart/form-data.", {
-      detail: err instanceof Error ? err.message : String(err),
-    });
+    logger.error("briefs.upload.parse_form_failed", { error: err });
+    return validationError("Request must be multipart/form-data.");
   }
 
   const siteId = form.get("site_id");

--- a/lib/__tests__/system-prompt.test.ts
+++ b/lib/__tests__/system-prompt.test.ts
@@ -384,13 +384,20 @@ describe("buildSystemPromptForSite", () => {
     });
 
     expect(prompt).not.toContain("## Available components");
-    expect(errorSpy).toHaveBeenCalledWith(
-      "[system-prompt] FEATURE_DESIGN_SYSTEM_V2=on but no active design_system for site",
-      expect.objectContaining({
-        site_id: site.id,
-        site_name: "Test",
-        fallback: "legacy_html_blob",
-      }),
+    // Phase 2 of M15-7 routed this through logger.error, which emits one
+    // JSON line to console.error (instead of the old (message, payload)
+    // two-arg call). Parse the JSON and assert on the structured fields
+    // the logger attaches — same invariant, logger-native shape.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [logLine] = errorSpy.mock.calls[0];
+    expect(typeof logLine).toBe("string");
+    const record = JSON.parse(logLine as string);
+    expect(record.level).toBe("error");
+    expect(record.msg).toBe(
+      "system_prompt.resolve_design_system_slot_failed",
     );
+    expect(record.site_id).toBe(site.id);
+    expect(record.site_name).toBe("Test");
+    expect(record.fallback).toBe("legacy_html_blob");
   });
 });

--- a/lib/briefs.ts
+++ b/lib/briefs.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { parseBriefDocument, type BriefPageDraft, type ParserWarning } from "@/lib/brief-parser";
+import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 import type { ApiResponse, ErrorCode } from "@/lib/tool-schemas";
 
@@ -373,6 +374,9 @@ async function uploadBriefImpl(
   }
 
   // 7. Flip briefs.status → parsed + write parser metadata.
+  // CAS on version_lock prevents a concurrent update from silently
+  // winning — matches the pattern used by commitBrief and every other
+  // version_lock-bearing UPDATE in the repo.
   const finalize = await svc
     .from("briefs")
     .update({
@@ -382,11 +386,24 @@ async function uploadBriefImpl(
       version_lock: insert.data.version_lock + 1,
       updated_at: now(),
     })
-    .eq("id", briefId);
+    .eq("id", briefId)
+    .eq("version_lock", insert.data.version_lock)
+    .select("id")
+    .maybeSingle();
   if (finalize.error) {
     return errorEnvelope("INTERNAL_ERROR", "Failed to finalize brief.", {
       details: { supabase_error: finalize.error },
     });
+  }
+  if (!finalize.data) {
+    logger.error("briefs.parse.finalize_version_lock_mismatch", {
+      brief_id: briefId,
+      expected_version_lock: insert.data.version_lock,
+    });
+    return errorEnvelope(
+      "INTERNAL_ERROR",
+      "Brief was modified by a concurrent request during parse. Please retry.",
+    );
   }
 
   return {

--- a/lib/sites.ts
+++ b/lib/sites.ts
@@ -5,6 +5,7 @@ import {
   type SiteRecord,
 } from "@/lib/tool-schemas";
 import { decrypt, encrypt } from "@/lib/encryption";
+import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 export type SiteCredentials = {
@@ -166,15 +167,15 @@ async function rollbackSite(siteId: string): Promise<void> {
     const supabase = getServiceRoleClient();
     const { error } = await supabase.from("sites").delete().eq("id", siteId);
     if (error) {
-      console.error("[sites.createSite] rollback delete failed", {
+      logger.error("sites.createSite.rollback_delete_failed", {
         site_id: siteId,
         error,
       });
     }
   } catch (err) {
-    console.error("[sites.createSite] rollback threw", {
+    logger.error("sites.createSite.rollback_threw", {
       site_id: siteId,
-      err,
+      error: err,
     });
   }
 }

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -7,6 +7,7 @@ import {
 import { listComponents, type DesignComponent } from "@/lib/components";
 import { listTemplates, type DesignTemplate } from "@/lib/templates";
 import { renderRegistryBlock } from "@/lib/design-system-prompt";
+import { logger } from "@/lib/logger";
 
 export type SystemPromptContext = {
   site_name: string;
@@ -129,7 +130,7 @@ export async function loadActiveRegistry(
 } | null> {
   const dsRes = await getActiveDesignSystem(site_id);
   if (!dsRes.ok) {
-    console.error("[system-prompt] getActiveDesignSystem failed", {
+    logger.error("system_prompt.load_active_ds_failed", {
       site_id,
       error: dsRes.error,
     });
@@ -144,17 +145,17 @@ export async function loadActiveRegistry(
   ]);
 
   if (!compRes.ok) {
-    console.error("[system-prompt] listComponents failed", {
+    logger.error("system_prompt.load_components_failed", {
       site_id,
-      ds_id: ds.id,
+      design_system_id: ds.id,
       error: compRes.error,
     });
     return null;
   }
   if (!tmplRes.ok) {
-    console.error("[system-prompt] listTemplates failed", {
+    logger.error("system_prompt.load_templates_failed", {
       site_id,
-      ds_id: ds.id,
+      design_system_id: ds.id,
       error: tmplRes.error,
     });
     return null;
@@ -212,18 +213,15 @@ async function resolveDesignSystemSlot(site: SiteIdentity): Promise<{
 
   const registry = await loadActiveRegistry(site.id);
   if (!registry) {
-    // Flag is on but we have no active DS (or a transient read failure). The
-    // log is deliberately console.error + structured so operators see it
-    // clearly in production — an active-DS miss usually means someone forgot
-    // to activate a seeded design system.
-    console.error(
-      "[system-prompt] FEATURE_DESIGN_SYSTEM_V2=on but no active design_system for site",
-      {
-        site_id: site.id,
-        site_name: site.site_name,
-        fallback: "legacy_html_blob",
-      },
-    );
+    // Flag is on but we have no active DS (or a transient read failure).
+    // An active-DS miss usually means someone forgot to activate a seeded
+    // design system; logger.error routes to both stdout and Axiom so
+    // operators see it in the same place as all other structured events.
+    logger.error("system_prompt.resolve_design_system_slot_failed", {
+      site_id: site.id,
+      site_name: site.site_name,
+      fallback: "legacy_html_blob",
+    });
     return legacy;
   }
 


### PR DESCRIPTION
## Summary

Phase 2 of the M15-7 consolidated fix pass. Closes three clustered classes of finding from the M15 audit series in one PR:

- **Group A (M15-5 finding #5-6):** 6 `console.error` calls routed through `logger.error` in `lib/sites.ts` and `lib/system-prompt.ts`. The logger emits to stdout AND Axiom; `console.error` only hits stdout. Operators now see these events in Axiom alongside all other structured log events.
- **Group B (M15-4 finding #4):** Raw `error.message` text sanitized from HTTP 500/422 response bodies across 9 routes. The full diagnostic is preserved in structured server logs via `logger.error`/`logger.warn`; the client receives a generic message referencing the `x-request-id` header for support correlation.
- **Group C (M15-5 finding #4):** Added `version_lock` CAS guard to the step-7 finalize UPDATE in `lib/briefs.ts:uploadBrief`. The update now uses `.eq("version_lock", insert.data.version_lock)` + `.select("id").maybeSingle()` with a mismatch error path, matching the pattern used by `commitBrief`, `lib/design-systems.ts`, `lib/components.ts`, `lib/templates.ts`, etc.

## What ships

**Group A — `console.error` → `logger.error`:**
- `lib/sites.ts` — `rollbackSite()` delete-failed path + catch path (2 calls)
- `lib/system-prompt.ts` — `loadActiveRegistry()` DS/components/templates failure paths + `resolveDesignSystemSlot()` no-active-DS path (4 calls)

**Group B — `err.message` sanitization:**
- `app/api/admin/users/invite/route.ts` — generate invite failure (1 path)
- `app/api/admin/users/list/route.ts` — read opollo_users failure (1 path)
- `app/api/admin/users/[id]/reinstate/route.ts` — fetch / unban / clear-revoked_at (3 paths)
- `app/api/admin/users/[id]/revoke/route.ts` — fetch / count-admins / ban / session-sweep (4 paths)
- `app/api/admin/users/[id]/role/route.ts` — fetch / count-admins / update (3 paths)
- `app/api/admin/batch/[id]/cancel/route.ts` — read / job-update / slots-update (3 paths)
- `app/api/account/change-password/route.ts` — UPDATE_FAILED branch (1 path; 500 catch was already clean)
- `app/api/auth/reset-password/route.ts` — UPDATE_FAILED branch (1 path; 500 catch was already clean)
- `app/api/briefs/upload/route.ts` — formData parse error `details` field (1 path)

**Group C — briefs CAS:**
- `lib/briefs.ts` step-7 finalize UPDATE: added `.eq("version_lock", insert.data.version_lock)`, `.select("id").maybeSingle()`, and a zero-rows handler that logs `briefs.parse.finalize_version_lock_mismatch` and returns `INTERNAL_ERROR`.

## Risks identified and mitigated

| Risk | Mitigation |
|------|-----------|
| Client code branching on sanitized error message text | Verified before implementation: only `lib/__tests__/rate-limit.test.ts:225` asserts on message text (`/30 seconds/`), and that is NOT in scope for this PR. All admin-users-* tests assert on `body.error.code`, which is unchanged. No E2E test string-matches on any of the sanitized messages. |
| briefs CAS adding a zero-rows false positive | The step-7 UPDATE runs immediately after a successful INSERT in the same request with no intervening async checkpoint — the window for a genuine concurrent mutation is effectively zero today. The guard is still the correct defensive posture for when the flow becomes resumable (e.g., async parse in M12+). |
| logger import adding a circular dependency | `lib/logger` has no imports from `lib/sites`, `lib/system-prompt`, or `lib/briefs`. Build verified clean. |
| Error CODE changes breaking client contracts | No error codes changed. Only message strings and the addition of `logger.error` calls. |

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (all 29 pages generated)
- [ ] CI Vitest suite — admin-users-* tests assert on `body.error.code`, not message text; should be unaffected
- [ ] CI Playwright suite — no E2E test asserts on any of the sanitized message strings

## Not in scope

- `app/api/chat/route.ts` — Phase 3a
- `tools/*` routes — Phase 3b
- `lib/wordpress.ts` — Phase 3c
- `docs/*.md` audit report updates — Phase 4
- `docs/BACKLOG.md` reconciliation — Phase 4
- `lib/__tests__/rate-limit.test.ts:225` message assertion (`/30 seconds/`) — not a leaking internal error; left as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)