### PR TITLE
test(m15-7): integration tests for app/api/tools/* routes

### DIFF
--- a/lib/__tests__/_tools-route-helpers.ts
+++ b/lib/__tests__/_tools-route-helpers.ts
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------
+// Shared request-builder helpers for app/api/tools/* route integration tests.
+//
+// Imported by tools-{route}-route.test.ts files. Does NOT import from
+// _helpers.ts or _auth-helpers.ts (those require a Supabase client).
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a POST Request with a JSON body.  url defaults to a generic tools
+ * path — individual test files may override with the real path if needed.
+ */
+export function makeJsonRequest(
+  body: unknown,
+  url = "http://localhost:3000/api/tools/test",
+): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Build a POST Request whose body is NOT valid JSON.  The route's try/catch
+ * around req.json() should fall back to `{}` and forward that to the executor.
+ */
+export function makeMalformedRequest(
+  url = "http://localhost:3000/api/tools/test",
+): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "not json at all",
+  });
+}
+
+/**
+ * A minimal RateLimitResult that looks "denied".  Shape mirrors the
+ * Extract<RateLimitResult, { ok: false }> union arm from lib/rate-limit.ts.
+ */
+export const RATE_LIMIT_DENIED = {
+  ok: false as const,
+  limit: 120,
+  remaining: 0 as const,
+  reset: Date.now() + 60_000,
+  retryAfterSec: 30,
+};
+
+/**
+ * A minimal RateLimitResult that looks "allowed".
+ */
+export const RATE_LIMIT_ALLOWED = {
+  ok: true as const,
+  limit: 120,
+  remaining: 119,
+  reset: 0,
+};
+
+/** Minimal success envelope shape reused across test fixtures. */
+export function makeSuccessEnvelope<T>(data: T) {
+  return {
+    ok: true as const,
+    data,
+    validation: { passed: true as const, checks: [] as string[] },
+    ds_version: "1.0.0",
+    timestamp: "2026-04-24T00:00:00.000Z",
+  };
+}
+
+/** Minimal error envelope for VALIDATION_FAILED (→ 400). */
+export function makeValidationErrorEnvelope(message = "bad input") {
+  return {
+    ok: false as const,
+    error: {
+      code: "VALIDATION_FAILED" as const,
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and retry.",
+    },
+    timestamp: "2026-04-24T00:00:00.000Z",
+  };
+}

--- a/lib/__tests__/tools-create-page-route.test.ts
+++ b/lib/__tests__/tools-create-page-route.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// M15-7 Phase 3b — integration tests for app/api/tools/create_page/route.ts
+//
+// Pins current session-optional, rate-limited behaviour.  Per M15-4
+// finding #3, create_page is a write route that currently lacks an admin
+// gate — intentional drift signal for a future fix slice.
+// ---------------------------------------------------------------------------
+
+const mockExecuteCreatePage = vi.hoisted(() => vi.fn());
+const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockCheckRateLimit = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/create-page", () => ({
+  executeCreatePage: mockExecuteCreatePage,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: () => ({}),
+  getCurrentUser: mockGetCurrentUser,
+}));
+
+vi.mock("@/lib/rate-limit", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/rate-limit")>(
+      "@/lib/rate-limit",
+    );
+  return { ...actual, checkRateLimit: mockCheckRateLimit };
+});
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({ getAll: () => [], set: () => {} }),
+  headers: () => new Headers(),
+}));
+
+import { POST } from "@/app/api/tools/create_page/route";
+import {
+  makeJsonRequest,
+  makeMalformedRequest,
+  makeSuccessEnvelope,
+  makeValidationErrorEnvelope,
+  RATE_LIMIT_DENIED,
+} from "./_tools-route-helpers";
+
+beforeEach(() => {
+  mockExecuteCreatePage.mockReset();
+  mockGetCurrentUser.mockReset().mockResolvedValue(null);
+  mockCheckRateLimit.mockReset().mockResolvedValue({ ok: true, limit: 120, remaining: 119, reset: 0 });
+});
+
+const VALID_BODY = {
+  title: "My Test Page",
+  slug: "my-test-page",
+  content: "x".repeat(200),
+  meta_description: "y".repeat(50),
+  template_type: "generic",
+  ds_version: "1.0.0",
+};
+
+describe("POST /api/tools/create_page", () => {
+  it("200 — passes executor's success envelope through verbatim", async () => {
+    const envelope = makeSuccessEnvelope({
+      page_id: 42,
+      preview_url: "https://wp.example.com/?p=42",
+      admin_url: "https://wp.example.com/wp-admin/post.php?post=42",
+      slug: "my-test-page",
+      status: "draft",
+    });
+    mockExecuteCreatePage.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+    expect(mockExecuteCreatePage).toHaveBeenCalledOnce();
+    expect(mockExecuteCreatePage).toHaveBeenCalledWith(VALID_BODY);
+  });
+
+  it("400 — executor error envelope, status from errorCodeToStatus", async () => {
+    const envelope = makeValidationErrorEnvelope("title too short");
+    mockExecuteCreatePage.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest({ title: "x" }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+  });
+
+  it("malformed JSON body → executor receives {} fallback", async () => {
+    const envelope = makeSuccessEnvelope({ page_id: 1, slug: "fallback", status: "draft", preview_url: "", admin_url: "" });
+    mockExecuteCreatePage.mockResolvedValue(envelope);
+
+    const res = await POST(makeMalformedRequest());
+
+    expect(mockExecuteCreatePage).toHaveBeenCalledWith({});
+    expect(res.status).toBe(200);
+  });
+
+  it("429 — rate-limit denial; executor is never called", async () => {
+    mockCheckRateLimit.mockResolvedValue(RATE_LIMIT_DENIED);
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(mockExecuteCreatePage).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/tools-delete-page-route.test.ts
+++ b/lib/__tests__/tools-delete-page-route.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// M15-7 Phase 3b — integration tests for app/api/tools/delete_page/route.ts
+//
+// delete_page is a destructive write route that currently has no admin gate
+// (M15-4 finding #3).  These tests pin that behaviour as an intentional
+// drift signal for a future auth-tightening fix slice.
+// ---------------------------------------------------------------------------
+
+const mockExecuteDeletePage = vi.hoisted(() => vi.fn());
+const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockCheckRateLimit = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/delete-page", () => ({
+  executeDeletePage: mockExecuteDeletePage,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: () => ({}),
+  getCurrentUser: mockGetCurrentUser,
+}));
+
+vi.mock("@/lib/rate-limit", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/rate-limit")>(
+      "@/lib/rate-limit",
+    );
+  return { ...actual, checkRateLimit: mockCheckRateLimit };
+});
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({ getAll: () => [], set: () => {} }),
+  headers: () => new Headers(),
+}));
+
+import { POST } from "@/app/api/tools/delete_page/route";
+import {
+  makeJsonRequest,
+  makeMalformedRequest,
+  makeSuccessEnvelope,
+  makeValidationErrorEnvelope,
+  RATE_LIMIT_DENIED,
+} from "./_tools-route-helpers";
+
+beforeEach(() => {
+  mockExecuteDeletePage.mockReset();
+  mockGetCurrentUser.mockReset().mockResolvedValue(null);
+  mockCheckRateLimit.mockReset().mockResolvedValue({ ok: true, limit: 120, remaining: 119, reset: 0 });
+});
+
+const VALID_BODY = { page_id: 99, user_confirmed: true };
+
+describe("POST /api/tools/delete_page", () => {
+  it("200 — passes executor's success envelope through verbatim", async () => {
+    const envelope = makeSuccessEnvelope({ page_id: 99, status: "trash" as const });
+    mockExecuteDeletePage.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+    expect(mockExecuteDeletePage).toHaveBeenCalledOnce();
+    expect(mockExecuteDeletePage).toHaveBeenCalledWith(VALID_BODY);
+  });
+
+  it("400 — executor error envelope, status from errorCodeToStatus", async () => {
+    const envelope = makeValidationErrorEnvelope("user_confirmed must be true");
+    mockExecuteDeletePage.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest({ page_id: 1 }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+  });
+
+  it("malformed JSON body → executor receives {} fallback", async () => {
+    const envelope = makeSuccessEnvelope({ page_id: 0, status: "trash" as const });
+    mockExecuteDeletePage.mockResolvedValue(envelope);
+
+    const res = await POST(makeMalformedRequest());
+
+    expect(mockExecuteDeletePage).toHaveBeenCalledWith({});
+    expect(res.status).toBe(200);
+  });
+
+  it("429 — rate-limit denial; executor is never called", async () => {
+    mockCheckRateLimit.mockResolvedValue(RATE_LIMIT_DENIED);
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(mockExecuteDeletePage).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/tools-get-page-route.test.ts
+++ b/lib/__tests__/tools-get-page-route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// M15-7 Phase 3b — integration tests for app/api/tools/get_page/route.ts
+// ---------------------------------------------------------------------------
+
+const mockExecuteGetPage = vi.hoisted(() => vi.fn());
+const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockCheckRateLimit = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/get-page", () => ({
+  executeGetPage: mockExecuteGetPage,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: () => ({}),
+  getCurrentUser: mockGetCurrentUser,
+}));
+
+vi.mock("@/lib/rate-limit", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/rate-limit")>(
+      "@/lib/rate-limit",
+    );
+  return { ...actual, checkRateLimit: mockCheckRateLimit };
+});
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({ getAll: () => [], set: () => {} }),
+  headers: () => new Headers(),
+}));
+
+import { POST } from "@/app/api/tools/get_page/route";
+import {
+  makeJsonRequest,
+  makeMalformedRequest,
+  makeSuccessEnvelope,
+  makeValidationErrorEnvelope,
+  RATE_LIMIT_DENIED,
+} from "./_tools-route-helpers";
+
+beforeEach(() => {
+  mockExecuteGetPage.mockReset();
+  mockGetCurrentUser.mockReset().mockResolvedValue(null);
+  mockCheckRateLimit.mockReset().mockResolvedValue({ ok: true, limit: 120, remaining: 119, reset: 0 });
+});
+
+const VALID_BODY = { page_id: 7 };
+
+describe("POST /api/tools/get_page", () => {
+  it("200 — passes executor's success envelope through verbatim", async () => {
+    const envelope = makeSuccessEnvelope({
+      page_id: 7,
+      title: "Sample Page",
+      slug: "sample-page",
+      content: "<p>Hello world</p>",
+      meta_description: "A sample page for testing purposes here.",
+      status: "draft",
+      parent_id: null,
+      modified_date: "2026-04-01T00:00:00Z",
+    });
+    mockExecuteGetPage.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+    expect(mockExecuteGetPage).toHaveBeenCalledOnce();
+    expect(mockExecuteGetPage).toHaveBeenCalledWith(VALID_BODY);
+  });
+
+  it("400 — executor error envelope, status from errorCodeToStatus", async () => {
+    const envelope = makeValidationErrorEnvelope("page_id must be a positive integer");
+    mockExecuteGetPage.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest({ page_id: -1 }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+  });
+
+  it("malformed JSON body → executor receives {} fallback", async () => {
+    const envelope = makeSuccessEnvelope({ page_id: 0, title: "", slug: "", content: "", meta_description: "", status: "draft", parent_id: null, modified_date: "" });
+    mockExecuteGetPage.mockResolvedValue(envelope);
+
+    const res = await POST(makeMalformedRequest());
+
+    expect(mockExecuteGetPage).toHaveBeenCalledWith({});
+    expect(res.status).toBe(200);
+  });
+
+  it("429 — rate-limit denial; executor is never called", async () => {
+    mockCheckRateLimit.mockResolvedValue(RATE_LIMIT_DENIED);
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(mockExecuteGetPage).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/tools-list-pages-route.test.ts
+++ b/lib/__tests__/tools-list-pages-route.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// M15-7 Phase 3b — integration tests for app/api/tools/list_pages/route.ts
+// ---------------------------------------------------------------------------
+
+const mockExecuteListPages = vi.hoisted(() => vi.fn());
+const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockCheckRateLimit = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/list-pages", () => ({
+  executeListPages: mockExecuteListPages,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: () => ({}),
+  getCurrentUser: mockGetCurrentUser,
+}));
+
+vi.mock("@/lib/rate-limit", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/rate-limit")>(
+      "@/lib/rate-limit",
+    );
+  return { ...actual, checkRateLimit: mockCheckRateLimit };
+});
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({ getAll: () => [], set: () => {} }),
+  headers: () => new Headers(),
+}));
+
+import { POST } from "@/app/api/tools/list_pages/route";
+import {
+  makeJsonRequest,
+  makeMalformedRequest,
+  makeSuccessEnvelope,
+  makeValidationErrorEnvelope,
+  RATE_LIMIT_DENIED,
+} from "./_tools-route-helpers";
+
+beforeEach(() => {
+  mockExecuteListPages.mockReset();
+  mockGetCurrentUser.mockReset().mockResolvedValue(null);
+  mockCheckRateLimit.mockReset().mockResolvedValue({ ok: true, limit: 120, remaining: 119, reset: 0 });
+});
+
+const VALID_BODY = { status: "draft" };
+
+describe("POST /api/tools/list_pages", () => {
+  it("200 — passes executor's success envelope through verbatim", async () => {
+    const envelope = makeSuccessEnvelope({
+      pages: [
+        {
+          page_id: 5,
+          title: "Draft Page",
+          slug: "draft-page",
+          status: "draft",
+          parent_id: null,
+          modified_date: "2026-04-01T00:00:00Z",
+        },
+      ],
+    });
+    mockExecuteListPages.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+    expect(mockExecuteListPages).toHaveBeenCalledOnce();
+    expect(mockExecuteListPages).toHaveBeenCalledWith(VALID_BODY);
+  });
+
+  it("400 — executor error envelope, status from errorCodeToStatus", async () => {
+    const envelope = makeValidationErrorEnvelope("invalid status value");
+    mockExecuteListPages.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest({ status: "unknown-status" }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+  });
+
+  it("malformed JSON body → executor receives {} fallback", async () => {
+    const envelope = makeSuccessEnvelope({ pages: [] });
+    mockExecuteListPages.mockResolvedValue(envelope);
+
+    const res = await POST(makeMalformedRequest());
+
+    expect(mockExecuteListPages).toHaveBeenCalledWith({});
+    expect(res.status).toBe(200);
+  });
+
+  it("429 — rate-limit denial; executor is never called", async () => {
+    mockCheckRateLimit.mockResolvedValue(RATE_LIMIT_DENIED);
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(mockExecuteListPages).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/tools-publish-page-route.test.ts
+++ b/lib/__tests__/tools-publish-page-route.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// M15-7 Phase 3b — integration tests for app/api/tools/publish_page/route.ts
+//
+// publish_page is a write route (draft → publish) that currently has no admin
+// gate (M15-4 finding #3).  Tests pin current session-optional behaviour as
+// an intentional drift signal for a future auth-tightening fix slice.
+// ---------------------------------------------------------------------------
+
+const mockExecutePublishPage = vi.hoisted(() => vi.fn());
+const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockCheckRateLimit = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/publish-page", () => ({
+  executePublishPage: mockExecutePublishPage,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: () => ({}),
+  getCurrentUser: mockGetCurrentUser,
+}));
+
+vi.mock("@/lib/rate-limit", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/rate-limit")>(
+      "@/lib/rate-limit",
+    );
+  return { ...actual, checkRateLimit: mockCheckRateLimit };
+});
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({ getAll: () => [], set: () => {} }),
+  headers: () => new Headers(),
+}));
+
+import { POST } from "@/app/api/tools/publish_page/route";
+import {
+  makeJsonRequest,
+  makeMalformedRequest,
+  makeSuccessEnvelope,
+  makeValidationErrorEnvelope,
+  RATE_LIMIT_DENIED,
+} from "./_tools-route-helpers";
+
+beforeEach(() => {
+  mockExecutePublishPage.mockReset();
+  mockGetCurrentUser.mockReset().mockResolvedValue(null);
+  mockCheckRateLimit.mockReset().mockResolvedValue({ ok: true, limit: 120, remaining: 119, reset: 0 });
+});
+
+const VALID_BODY = { page_id: 55 };
+
+describe("POST /api/tools/publish_page", () => {
+  it("200 — passes executor's success envelope through verbatim", async () => {
+    const envelope = makeSuccessEnvelope({
+      page_id: 55,
+      status: "publish",
+      published_url: "https://wp.example.com/my-page/",
+    });
+    mockExecutePublishPage.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+    expect(mockExecutePublishPage).toHaveBeenCalledOnce();
+    expect(mockExecutePublishPage).toHaveBeenCalledWith(VALID_BODY);
+  });
+
+  it("400 — executor error envelope, status from errorCodeToStatus", async () => {
+    const envelope = makeValidationErrorEnvelope("page_id must be a positive integer");
+    mockExecutePublishPage.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest({ page_id: 0 }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+  });
+
+  it("malformed JSON body → executor receives {} fallback", async () => {
+    const envelope = makeSuccessEnvelope({ page_id: 0, status: "publish", published_url: "" });
+    mockExecutePublishPage.mockResolvedValue(envelope);
+
+    const res = await POST(makeMalformedRequest());
+
+    expect(mockExecutePublishPage).toHaveBeenCalledWith({});
+    expect(res.status).toBe(200);
+  });
+
+  it("429 — rate-limit denial; executor is never called", async () => {
+    mockCheckRateLimit.mockResolvedValue(RATE_LIMIT_DENIED);
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(mockExecutePublishPage).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/tools-search-images-route.test.ts
+++ b/lib/__tests__/tools-search-images-route.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// M15-7 Phase 3b — integration tests for app/api/tools/search_images/route.ts
+//
+// Pins the current "session-optional, rate-limited" behaviour.  Per M15-4
+// finding #3 the route currently has no admin gate — when that ships these
+// tests will need to update (intentional drift signal).
+//
+// External dependencies mocked: executeSearchImages, getCurrentUser,
+// checkRateLimit.  No Supabase / Anthropic / WP at runtime.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be declared before vi.mock calls.
+// ---------------------------------------------------------------------------
+
+const mockExecuteSearchImages = vi.hoisted(() => vi.fn());
+const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockCheckRateLimit = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/search-images", () => ({
+  executeSearchImages: mockExecuteSearchImages,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: () => ({}),
+  getCurrentUser: mockGetCurrentUser,
+}));
+
+// Keep rateLimitExceeded from the actual module so the 429 envelope shape
+// is real; only checkRateLimit is mocked.
+vi.mock("@/lib/rate-limit", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/rate-limit")>(
+      "@/lib/rate-limit",
+    );
+  return { ...actual, checkRateLimit: mockCheckRateLimit };
+});
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({ getAll: () => [], set: () => {} }),
+  headers: () => new Headers(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import route AFTER all vi.mock declarations.
+// ---------------------------------------------------------------------------
+import { POST } from "@/app/api/tools/search_images/route";
+import {
+  makeJsonRequest,
+  makeMalformedRequest,
+  makeSuccessEnvelope,
+  makeValidationErrorEnvelope,
+  RATE_LIMIT_DENIED,
+} from "./_tools-route-helpers";
+
+beforeEach(() => {
+  mockExecuteSearchImages.mockReset();
+  mockGetCurrentUser.mockReset().mockResolvedValue(null);
+  mockCheckRateLimit.mockReset().mockResolvedValue({ ok: true, limit: 120, remaining: 119, reset: 0 });
+});
+
+describe("POST /api/tools/search_images", () => {
+  it("200 — passes executor's success envelope through verbatim", async () => {
+    const envelope = makeSuccessEnvelope({ images: [], total: 0 });
+    mockExecuteSearchImages.mockResolvedValue(envelope);
+
+    const req = makeJsonRequest({ query: "sunset" });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+    expect(mockExecuteSearchImages).toHaveBeenCalledOnce();
+    expect(mockExecuteSearchImages).toHaveBeenCalledWith({ query: "sunset" });
+  });
+
+  it("400 — error envelope from executor, status from errorCodeToStatus", async () => {
+    const envelope = makeValidationErrorEnvelope("missing query or tags");
+    mockExecuteSearchImages.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest({ limit: 5 }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+  });
+
+  it("malformed JSON body → executor receives {} fallback", async () => {
+    const envelope = makeSuccessEnvelope({ images: [] });
+    mockExecuteSearchImages.mockResolvedValue(envelope);
+
+    const res = await POST(makeMalformedRequest());
+
+    expect(mockExecuteSearchImages).toHaveBeenCalledWith({});
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+  });
+
+  it("429 — rate-limit denial short-circuits; executor is never called", async () => {
+    mockCheckRateLimit.mockResolvedValue(RATE_LIMIT_DENIED);
+
+    const res = await POST(makeJsonRequest({ query: "beach" }));
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(mockExecuteSearchImages).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/tools-update-page-route.test.ts
+++ b/lib/__tests__/tools-update-page-route.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// M15-7 Phase 3b — integration tests for app/api/tools/update_page/route.ts
+//
+// update_page is a write route that currently has no admin gate (M15-4
+// finding #3).  Tests pin current session-optional behaviour as an
+// intentional drift signal for a future auth-tightening fix slice.
+// ---------------------------------------------------------------------------
+
+const mockExecuteUpdatePage = vi.hoisted(() => vi.fn());
+const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockCheckRateLimit = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/update-page", () => ({
+  executeUpdatePage: mockExecuteUpdatePage,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: () => ({}),
+  getCurrentUser: mockGetCurrentUser,
+}));
+
+vi.mock("@/lib/rate-limit", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/rate-limit")>(
+      "@/lib/rate-limit",
+    );
+  return { ...actual, checkRateLimit: mockCheckRateLimit };
+});
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({ getAll: () => [], set: () => {} }),
+  headers: () => new Headers(),
+}));
+
+import { POST } from "@/app/api/tools/update_page/route";
+import {
+  makeJsonRequest,
+  makeMalformedRequest,
+  makeSuccessEnvelope,
+  makeValidationErrorEnvelope,
+  RATE_LIMIT_DENIED,
+} from "./_tools-route-helpers";
+
+beforeEach(() => {
+  mockExecuteUpdatePage.mockReset();
+  mockGetCurrentUser.mockReset().mockResolvedValue(null);
+  mockCheckRateLimit.mockReset().mockResolvedValue({ ok: true, limit: 120, remaining: 119, reset: 0 });
+});
+
+const VALID_BODY = {
+  page_id: 11,
+  title: "Updated Title Here",
+  change_scope: "minor_edit",
+};
+
+describe("POST /api/tools/update_page", () => {
+  it("200 — passes executor's success envelope through verbatim", async () => {
+    const envelope = makeSuccessEnvelope({
+      page_id: 11,
+      status: "draft",
+      modified_date: "2026-04-24T00:00:00Z",
+    });
+    mockExecuteUpdatePage.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+    expect(mockExecuteUpdatePage).toHaveBeenCalledOnce();
+    expect(mockExecuteUpdatePage).toHaveBeenCalledWith(VALID_BODY);
+  });
+
+  it("400 — executor error envelope, status from errorCodeToStatus", async () => {
+    const envelope = makeValidationErrorEnvelope("change_scope is required");
+    mockExecuteUpdatePage.mockResolvedValue(envelope);
+
+    const res = await POST(makeJsonRequest({ page_id: 11, title: "x" }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual(envelope);
+  });
+
+  it("malformed JSON body → executor receives {} fallback", async () => {
+    const envelope = makeSuccessEnvelope({ page_id: 0, status: "draft", modified_date: "" });
+    mockExecuteUpdatePage.mockResolvedValue(envelope);
+
+    const res = await POST(makeMalformedRequest());
+
+    expect(mockExecuteUpdatePage).toHaveBeenCalledWith({});
+    expect(res.status).toBe(200);
+  });
+
+  it("429 — rate-limit denial; executor is never called", async () => {
+    mockCheckRateLimit.mockResolvedValue(RATE_LIMIT_DENIED);
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(mockExecuteUpdatePage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Phase 3b of the M15-7 consolidated fix pass — closes the tools-route test coverage gap identified in `docs/TEST_COVERAGE_AUDIT_2026-04-24.md` finding #3.
- Adds 7 test files (one per tool route) + a shared `_tools-route-helpers.ts` module; 28 tests total (4 per route).
- No production code changes — tests only.

## What ships

**New files:**
- `lib/__tests__/_tools-route-helpers.ts` — shared `makeJsonRequest`, `makeMalformedRequest`, fixture builders (`makeSuccessEnvelope`, `makeValidationErrorEnvelope`, `RATE_LIMIT_DENIED`).
- `lib/__tests__/tools-{create,delete,get,list,publish,search-images,update}-page-route.test.ts` — one file per route.

**Per route (4 tests × 7 routes = 28 tests):**
1. Happy path — 200; executor's success envelope passed through verbatim; executor called once with parsed body.
2. Executor error — VALIDATION_FAILED → 400 via `errorCodeToStatus`; envelope preserved verbatim (no extra sanitisation at route layer).
3. Malformed JSON body — route's `try/catch` fallback delivers `{}` to executor; 200 with executor's envelope.
4. Rate-limit denial — 429 without invoking the executor.

**Mocking approach:** `vi.hoisted` + `vi.mock` per the pattern established in `lib/__tests__/chat-route.test.ts` (Phase 3a / PR #133). `rateLimitExceeded` is kept from the real module so the 429 envelope shape is authentic; only `checkRateLimit` is mocked.

## Risks identified and mitigated

This PR is test-only with no write-safety hotspots. The one intentional design note:

- **Session-optional write routes (publish_page, update_page, delete_page):** these routes currently accept unauthenticated requests — the tests pin that _current_ behaviour, not the desired end-state. Per M15-4 finding #3, an admin gate should be added in a future slice. When that lands the tests will need to update — the deliberate test-follows-code drift is the signal.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (all 7 tool routes visible in the build manifest)
- [ ] CI Vitest run — 28 new tests across 7 files (no Supabase / Anthropic / WP required; all external deps mocked)

## Not in scope

- Executor internals (`lib/{create,delete,get,list,publish,update}-page.ts`, `lib/search-images.ts`) — separate coverage concern, not in the M15-7 plan.
- Phase 3c (`lib/wordpress.ts` tests) — next PR in the sequence.
- Auth-gating write routes — future fix slice per M15-4 finding #3.

Closes finding #3 from `docs/TEST_COVERAGE_AUDIT_2026-04-24.md` (tools routes had zero dedicated tests). Refs M15-6 finding #3 (same gap, pre-audit label).