### PR TITLE
UX polish: brief commit confirmation + site actions menu (WIP)

### DIFF
--- a/components/BriefReviewClient.tsx
+++ b/components/BriefReviewClient.tsx
@@ -439,10 +439,24 @@ export function BriefReviewClient({
           className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4 text-sm"
           role="status"
         >
-          <p className="font-medium">This page list is committed.</p>
-          <p className="mt-1 text-muted-foreground">
-            Starting generation runs becomes available in M12-5.
-          </p>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="font-medium">This brief is locked in.</p>
+              <p className="mt-1 text-muted-foreground">
+                Page generation will be available soon — we&apos;ll email you when it&apos;s ready.
+              </p>
+            </div>
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+              className="shrink-0"
+            >
+              <a href={`/admin/sites/${siteId}`}>
+                Back to briefs
+              </a>
+            </Button>
+          </div>
         </div>
       )}
 

--- a/e2e/briefs-review.spec.ts
+++ b/e2e/briefs-review.spec.ts
@@ -181,7 +181,7 @@ test.describe("M12-1 briefs — upload + review", () => {
     await pageA.getByRole("button", { name: /Commit page list/i }).click();
     const dialogA = pageA.getByRole("dialog", { name: /Commit this page list\?/i });
     await dialogA.getByRole("button", { name: /^Commit page list$/i }).click();
-    await expect(pageA.getByText(/This page list is committed\./i)).toBeVisible();
+    await expect(pageA.getByText(/This brief is locked in\./i)).toBeVisible();
 
     // B tries to commit without refresh. B's version_lock is stale →
     // ALREADY_EXISTS since A already committed with the matching hash.
@@ -193,7 +193,7 @@ test.describe("M12-1 briefs — upload + review", () => {
     // Because B's hash matches A's (neither edited), the server treats
     // this as a successful replay — so the UI should flip to committed
     // on the next render too. This asserts the idempotent-replay path.
-    await expect(pageB.getByText(/This page list is committed\./i)).toBeVisible();
+    await expect(pageB.getByText(/This brief is locked in\./i)).toBeVisible();
 
     await contextA.close();
     await contextB.close();


### PR DESCRIPTION
## Summary

UX polish slice addressing 3 BACKLOG items from M15 UAT prep.

### Status
- ✅ Brief commit confirmation dead-end — remove jargon, add CTA (#e2baa7c)
- 🔄 Site actions menu (mutual exclusion + overflow) — WIP, requires refactor
- 🔄 Admin top navigation redesign — WIP, requires new AdminNav component

### Completed — Brief commit confirmation

**Problem:** After committing a brief, user sees 'This page list is committed. Starting generation runs becomes available in M12-5.' with no button to continue. User is stranded.

**Fix:**
- Replaced dead-end green message with proper confirmation state
- Added primary 'Back to briefs' button linking to parent site briefs list
- Removed internal milestone jargon ('M12-5') from user-facing copy
- New user-friendly message: 'This brief is locked in. Page generation will be available soon — we'll email you when it's ready.'

Fixes the dead-end UX blocker immediately.

### Not yet completed — Site actions menu + Admin top nav

Due to context constraints, the larger refactors for items 1 & 2 were scoped for follow-up in this branch. Both require:
- SiteActionsMenu: Context provider for global menu state + Portal for overflow + smart positioning
- AdminNav: New component with dropdown user menu, active route indicators, responsive hamburger

The brief commit confirmation fix is ready to merge; the other two items should follow in a subsequent commit on this branch.