### PR TITLE
feat(m13-1): posts schema + content_type axis + lib/posts.ts

### DIFF
--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -25,6 +25,28 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 - Notes: M12-1 shipped four tables (briefs / brief_pages / brief_runs / site_conventions) in 0013 — site_conventions is a table, NOT a JSONB column on briefs as the parent plan originally proposed. M12-2 builds on that consolidated shape. Runner + Claude-inferred defaults for voice/direction land in M12-3; M12-2 ships empty-string defaults + operator-fills form.
 ---
 
+---
+## Session M13-plumbing
+- Started: 2026-04-24
+- Branch: feat/m13-1-posts-schema (first PR), then feat/m13-2-wp-posts-wrapper (second PR, same worktree rebased off main)
+- Slice: M13-1 posts schema + content_type axis + lib/posts.ts; then M13-2 WP REST posts wrapper (wpCreatePost / wpUpdatePost / wpGetPostBySlug / wpDeletePost) + SEO plugin detection + post-error translations. Running in parallel with the M12-4 session on another terminal per docs/plans/m13-parent.md §Dependency on M12 — "M13-1 and M13-2 are orthogonal to M12 and can ship in parallel with M12-1/M12-2".
+- Files claimed:
+  - supabase/migrations/0019_m13_1_posts_schema.sql (new)
+  - supabase/rollbacks/0019_m13_1_posts_schema.down.sql (new)
+  - lib/posts.ts (new)
+  - lib/__tests__/posts.test.ts (new)
+  - lib/__tests__/m13-1-schema.test.ts (new)
+  - lib/wordpress.ts (M13-2 — additive only; new wpCreatePost / wpUpdatePost / wpGetPostBySlug / wpDeletePost alongside existing page wrappers; existing page functions untouched)
+  - lib/seo-plugin-detection.ts (new — M13-2)
+  - lib/error-translations.ts (new — M13-2, scoped to the post-related REST failures M13 surfaces)
+  - lib/__tests__/wordpress-posts.test.ts (new — M13-2)
+  - lib/__tests__/seo-plugin-detection.test.ts (new — M13-2)
+  - lib/__tests__/error-translations.test.ts (new — M13-2)
+- Migration number reserved: 0019
+- Expected completion: two PRs back-to-back, same day; auto-merge on green CI
+- Notes: Worktree-isolated at `.claude/worktrees/m13-1-posts-schema` to avoid HEAD races with the other session (see MEMORY.md "Parallel sessions, single clone"). Explicitly DOES NOT modify `lib/brief-runner.ts`, `lib/visual-review.ts`, `lib/anthropic-call.ts`, or `docs/plans/m12-parent.md` — these are in-flight M12 territory. Session stops after M13-2 merges; M13-3 onward hard-blocks on M12-3.
+---
+
 ## Hot-shared files (always check before claiming)
 
 Even with no other session active, assume these files are "hot" and coordinate explicitly if touching them while another session is in flight:
@@ -56,6 +78,7 @@ When a session starts a migration, reserve the number here before writing the fi
 
 - 0013 — M12-1 briefs schema: `briefs`, `brief_pages`, `brief_runs`, `site_conventions` + `site-briefs` Storage bucket. Executing on `feat/m12-1-briefs-schema`.
 - 0017 — M12-2 brand_voice + design_direction columns on briefs. Executing on `feat/m12-2-brand-voice-site-conventions`.
+- 0019 — M13-1 posts schema: `posts` table with `content_type='post'` CHECK, nullable `wp_post_id`, partial UNIQUE `(site_id, wp_post_id) WHERE wp_post_id IS NOT NULL`, soft-delete + audit + `version_lock`, RLS matching M2b. Executing on `feat/m13-1-posts-schema`.
 
 ## Claim block template
 

--- a/lib/__tests__/m13-1-schema.test.ts
+++ b/lib/__tests__/m13-1-schema.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M13-1 schema tests — posts table constraints.
+//
+// Pins the invariants lib/posts.ts + the M13-3 runner + the M13-4
+// admin surface rely on:
+//
+//   - content_type CHECK: only 'post' accepted.
+//   - version_lock CHECK: >= 1 at insert, >= 1 after update.
+//   - design_system_version CHECK: >= 1.
+//   - status CHECK: 'draft' | 'published' | 'scheduled'.
+//   - posts_published_at_coherent: status='published' requires
+//     published_at NOT NULL.
+//   - Partial UNIQUE (site_id, wp_post_id) WHERE wp_post_id IS NOT NULL:
+//     NULL is distinct (many drafts coexist); published collisions blow
+//     up with 23505.
+//   - Partial UNIQUE (site_id, slug) WHERE deleted_at IS NULL: two live
+//     posts on the same site cannot share a slug; soft-deleted rows
+//     don't contend.
+//   - FK site_id ON DELETE CASCADE.
+//   - FK author_id / created_by / updated_by / deleted_by /
+//     last_edited_by SET NULL on opollo_users delete.
+//   - FK template_id SET NULL on design_templates delete.
+// ---------------------------------------------------------------------------
+
+function randomSlug(suffix: string): string {
+  return `m13-1-${suffix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function insertPost(opts: {
+  site_id: string;
+  slug?: string;
+  title?: string;
+  status?: string;
+  wp_post_id?: number | null;
+  content_type?: string;
+  design_system_version?: number;
+  version_lock?: number;
+  published_at?: string | null;
+  author_id?: string | null;
+  deleted_at?: string | null;
+  allowError?: boolean;
+}): Promise<{ id: string | null; error: { code?: string; message: string } | null }> {
+  const svc = getServiceRoleClient();
+  const row: Record<string, unknown> = {
+    site_id: opts.site_id,
+    slug: opts.slug ?? randomSlug("slug"),
+    title: opts.title ?? "Test Post",
+    status: opts.status ?? "draft",
+    design_system_version: opts.design_system_version ?? 1,
+  };
+  if (opts.content_type !== undefined) row.content_type = opts.content_type;
+  if (opts.wp_post_id !== undefined) row.wp_post_id = opts.wp_post_id;
+  if (opts.version_lock !== undefined) row.version_lock = opts.version_lock;
+  if (opts.published_at !== undefined) row.published_at = opts.published_at;
+  if (opts.author_id !== undefined) row.author_id = opts.author_id;
+  if (opts.deleted_at !== undefined) row.deleted_at = opts.deleted_at;
+
+  const { data, error } = await svc
+    .from("posts")
+    .insert(row)
+    .select("id")
+    .single();
+  if (error) {
+    if (opts.allowError) {
+      return {
+        id: null,
+        error: { code: error.code, message: error.message },
+      };
+    }
+    throw new Error(`insertPost failed: ${error.message}`);
+  }
+  return { id: data.id as string, error: null };
+}
+
+// ---------------------------------------------------------------------------
+// CHECK constraints
+// ---------------------------------------------------------------------------
+
+describe("posts — content_type CHECK", () => {
+  it("accepts content_type='post' (the default)", async () => {
+    const site = await seedSite({ name: "CT1", prefix: "ct1p" });
+    const res = await insertPost({ site_id: site.id });
+    expect(res.id).not.toBeNull();
+  });
+
+  it("rejects content_type='page'", async () => {
+    const site = await seedSite({ name: "CT2", prefix: "ct2p" });
+    const res = await insertPost({
+      site_id: site.id,
+      content_type: "page",
+      allowError: true,
+    });
+    expect(res.error?.message).toMatch(/content_type/i);
+  });
+
+  it("rejects content_type='video'", async () => {
+    const site = await seedSite({ name: "CT3", prefix: "ct3p" });
+    const res = await insertPost({
+      site_id: site.id,
+      content_type: "video",
+      allowError: true,
+    });
+    expect(res.error).not.toBeNull();
+  });
+});
+
+describe("posts — status CHECK", () => {
+  it("accepts 'draft'", async () => {
+    const site = await seedSite({ name: "ST1", prefix: "st1p" });
+    const res = await insertPost({ site_id: site.id, status: "draft" });
+    expect(res.id).not.toBeNull();
+  });
+
+  it("accepts 'published' when published_at is also set", async () => {
+    const site = await seedSite({ name: "ST2", prefix: "st2p" });
+    const res = await insertPost({
+      site_id: site.id,
+      status: "published",
+      published_at: new Date().toISOString(),
+    });
+    expect(res.id).not.toBeNull();
+  });
+
+  it("accepts 'scheduled' (forward-facing; scheduler not wired yet)", async () => {
+    const site = await seedSite({ name: "ST3", prefix: "st3p" });
+    const res = await insertPost({ site_id: site.id, status: "scheduled" });
+    expect(res.id).not.toBeNull();
+  });
+
+  it("rejects an invalid status value", async () => {
+    const site = await seedSite({ name: "ST4", prefix: "st4p" });
+    const res = await insertPost({
+      site_id: site.id,
+      status: "trash",
+      allowError: true,
+    });
+    expect(res.error).not.toBeNull();
+  });
+});
+
+describe("posts — posts_published_at_coherent CHECK", () => {
+  it("rejects status='published' with NULL published_at", async () => {
+    const site = await seedSite({ name: "PC1", prefix: "pc1p" });
+    const res = await insertPost({
+      site_id: site.id,
+      status: "published",
+      published_at: null,
+      allowError: true,
+    });
+    expect(res.error?.message).toMatch(/published_at_coherent|published_at/i);
+  });
+
+  it("allows status='draft' with NULL published_at", async () => {
+    const site = await seedSite({ name: "PC2", prefix: "pc2p" });
+    const res = await insertPost({
+      site_id: site.id,
+      status: "draft",
+      published_at: null,
+    });
+    expect(res.id).not.toBeNull();
+  });
+
+  it("allows status='scheduled' with NULL published_at", async () => {
+    const site = await seedSite({ name: "PC3", prefix: "pc3p" });
+    const res = await insertPost({
+      site_id: site.id,
+      status: "scheduled",
+      published_at: null,
+    });
+    expect(res.id).not.toBeNull();
+  });
+});
+
+describe("posts — version_lock + design_system_version CHECK", () => {
+  it("rejects version_lock < 1", async () => {
+    const site = await seedSite({ name: "V1", prefix: "v1p" });
+    const res = await insertPost({
+      site_id: site.id,
+      version_lock: 0,
+      allowError: true,
+    });
+    expect(res.error?.message).toMatch(/version_lock/i);
+  });
+
+  it("rejects design_system_version < 1", async () => {
+    const site = await seedSite({ name: "V2", prefix: "v2p" });
+    const res = await insertPost({
+      site_id: site.id,
+      design_system_version: 0,
+      allowError: true,
+    });
+    expect(res.error?.message).toMatch(/design_system_version/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partial UNIQUE indexes
+// ---------------------------------------------------------------------------
+
+describe("posts — (site_id, wp_post_id) partial UNIQUE treats NULL as distinct", () => {
+  it("allows multiple drafts with NULL wp_post_id", async () => {
+    const site = await seedSite({ name: "WU1", prefix: "wu1p" });
+    const a = await insertPost({ site_id: site.id, wp_post_id: null });
+    const b = await insertPost({ site_id: site.id, wp_post_id: null });
+    expect(a.id).not.toBeNull();
+    expect(b.id).not.toBeNull();
+  });
+
+  it("rejects two published posts with the same (site_id, wp_post_id)", async () => {
+    const site = await seedSite({ name: "WU2", prefix: "wu2p" });
+    const wpId = 12345;
+    const a = await insertPost({
+      site_id: site.id,
+      wp_post_id: wpId,
+      status: "published",
+      published_at: new Date().toISOString(),
+    });
+    expect(a.id).not.toBeNull();
+    const b = await insertPost({
+      site_id: site.id,
+      wp_post_id: wpId,
+      status: "published",
+      published_at: new Date().toISOString(),
+      allowError: true,
+    });
+    expect(b.error?.code).toBe("23505");
+  });
+
+  it("allows the same wp_post_id across different sites", async () => {
+    const siteA = await seedSite({ name: "WU3A", prefix: "wu3a" });
+    const siteB = await seedSite({ name: "WU3B", prefix: "wu3b" });
+    const a = await insertPost({
+      site_id: siteA.id,
+      wp_post_id: 777,
+      status: "published",
+      published_at: new Date().toISOString(),
+    });
+    const b = await insertPost({
+      site_id: siteB.id,
+      wp_post_id: 777,
+      status: "published",
+      published_at: new Date().toISOString(),
+    });
+    expect(a.id).not.toBeNull();
+    expect(b.id).not.toBeNull();
+  });
+});
+
+describe("posts — (site_id, slug) partial UNIQUE ignores soft-deleted rows", () => {
+  it("rejects two live posts sharing a slug on the same site", async () => {
+    const site = await seedSite({ name: "SU1", prefix: "su1p" });
+    const slug = randomSlug("dup");
+    const a = await insertPost({ site_id: site.id, slug });
+    expect(a.id).not.toBeNull();
+    const b = await insertPost({
+      site_id: site.id,
+      slug,
+      allowError: true,
+    });
+    expect(b.error?.code).toBe("23505");
+  });
+
+  it("permits reuse of a slug after the original is soft-deleted", async () => {
+    const site = await seedSite({ name: "SU2", prefix: "su2p" });
+    const slug = randomSlug("reuse");
+    const a = await insertPost({
+      site_id: site.id,
+      slug,
+      deleted_at: new Date().toISOString(),
+    });
+    expect(a.id).not.toBeNull();
+    const b = await insertPost({ site_id: site.id, slug });
+    expect(b.id).not.toBeNull();
+  });
+
+  it("allows the same slug on different sites", async () => {
+    const siteA = await seedSite({ name: "SU3A", prefix: "su3a" });
+    const siteB = await seedSite({ name: "SU3B", prefix: "su3b" });
+    const slug = randomSlug("shared");
+    const a = await insertPost({ site_id: siteA.id, slug });
+    const b = await insertPost({ site_id: siteB.id, slug });
+    expect(a.id).not.toBeNull();
+    expect(b.id).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Foreign keys
+// ---------------------------------------------------------------------------
+
+describe("posts — foreign keys", () => {
+  it("cascades posts on site delete", async () => {
+    const site = await seedSite({ name: "FK1", prefix: "fk1p" });
+    const a = await insertPost({ site_id: site.id });
+    const svc = getServiceRoleClient();
+    const del = await svc.from("sites").delete().eq("id", site.id);
+    expect(del.error).toBeNull();
+
+    const read = await svc
+      .from("posts")
+      .select("id")
+      .eq("id", a.id as string)
+      .maybeSingle();
+    expect(read.error).toBeNull();
+    expect(read.data).toBeNull();
+  });
+});

--- a/lib/__tests__/posts.test.ts
+++ b/lib/__tests__/posts.test.ts
@@ -125,10 +125,10 @@ describe("createPost", () => {
   it("allows the same slug across different sites", async () => {
     const siteA = await seedSite({ name: "CA", prefix: "cpa" });
     const siteB = await seedSite({ name: "CB", prefix: "cpb" });
-    await seedPost(siteA.id, { slug: "shared", title: "A" });
+    await seedPost(siteA.id, { slug: "shared", title: "Site A post" });
     const res = await createPost({
       site_id: siteB.id,
-      title: "B",
+      title: "Site B post",
       slug: "shared",
       design_system_version: 1,
     });

--- a/lib/__tests__/posts.test.ts
+++ b/lib/__tests__/posts.test.ts
@@ -1,0 +1,654 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createPost,
+  getPost,
+  LIST_POSTS_DEFAULT_LIMIT,
+  listPostsForSite,
+  POST_CONTENT_TYPE,
+  softDeletePost,
+  updatePostMetadata,
+} from "@/lib/posts";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser } from "./_auth-helpers";
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M13-1 — lib/posts.ts unit + integration tests.
+//
+// Pins the invariants the /admin/sites/[id]/posts surface (M13-4) will
+// rely on:
+//
+//   1. createPost stamps content_type='post' regardless of caller input.
+//   2. Site scope — a post belonging to site B never leaks via site A.
+//   3. Filter composition (status + author_id + q) ANDs.
+//   4. Pagination + total match.
+//   5. getPost requires BOTH site_id + post_id; cross-site NOT_FOUND.
+//   6. updatePostMetadata bumps version_lock, stamps last_edited_by.
+//   7. VERSION_CONFLICT on stale expected_version.
+//   8. UNIQUE_VIOLATION on slug collision within the same site (live
+//      posts only — soft-deleted rows must not contend).
+//   9. NOT_FOUND on archived post edit (deleted_at set).
+//   10. softDeletePost marks deleted_at, bumps version_lock, excludes
+//       from default list + detail reads.
+//   11. Transitioning status → 'published' stamps published_at.
+// ---------------------------------------------------------------------------
+
+type Seed = {
+  slug: string;
+  title: string;
+  excerpt?: string | null;
+  status?: "draft" | "published" | "scheduled";
+  wp_post_id?: number | null;
+  author_id?: string | null;
+  createdAtOffsetMs?: number;
+};
+
+async function seedPost(
+  siteId: string,
+  seed: Seed,
+): Promise<string> {
+  const svc = getServiceRoleClient();
+  const now = Date.now();
+  const updatedAt = new Date(
+    now + (seed.createdAtOffsetMs ?? 0),
+  ).toISOString();
+  const row: Record<string, unknown> = {
+    site_id: siteId,
+    content_type: POST_CONTENT_TYPE,
+    wp_post_id: seed.wp_post_id ?? null,
+    slug: seed.slug,
+    title: seed.title,
+    excerpt: seed.excerpt ?? null,
+    design_system_version: 1,
+    status: seed.status ?? "draft",
+    author_id: seed.author_id ?? null,
+    updated_at: updatedAt,
+  };
+  if (seed.status === "published") {
+    row.published_at = updatedAt;
+  }
+  const { data, error } = await svc
+    .from("posts")
+    .insert(row)
+    .select("id")
+    .single();
+  if (error || !data) {
+    throw new Error(`seedPost: ${error?.message ?? "no row"}`);
+  }
+  return data.id as string;
+}
+
+// ---------------------------------------------------------------------------
+// createPost
+// ---------------------------------------------------------------------------
+
+describe("createPost", () => {
+  it("creates a draft post with content_type='post' and version_lock=1", async () => {
+    const site = await seedSite({ name: "C1", prefix: "cp1" });
+    const user = await seedAuthUser({ role: "operator" });
+    const res = await createPost({
+      site_id: site.id,
+      title: "Hello world",
+      slug: "hello-world",
+      excerpt: "A first post",
+      design_system_version: 1,
+      created_by: user.id,
+      content_brief: { topic: "greetings" },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.content_type).toBe("post");
+    expect(res.data.status).toBe("draft");
+    expect(res.data.wp_post_id).toBeNull();
+    expect(res.data.version_lock).toBe(1);
+    expect(res.data.excerpt).toBe("A first post");
+    expect(res.data.published_at).toBeNull();
+  });
+
+  it("surfaces UNIQUE_VIOLATION on slug collision within the same site", async () => {
+    const site = await seedSite({ name: "C2", prefix: "cp2" });
+    await seedPost(site.id, { slug: "taken", title: "First" });
+    const res = await createPost({
+      site_id: site.id,
+      title: "Second",
+      slug: "taken",
+      design_system_version: 1,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("UNIQUE_VIOLATION");
+    expect(res.error.details?.attempted_slug).toBe("taken");
+  });
+
+  it("allows the same slug across different sites", async () => {
+    const siteA = await seedSite({ name: "CA", prefix: "cpa" });
+    const siteB = await seedSite({ name: "CB", prefix: "cpb" });
+    await seedPost(siteA.id, { slug: "shared", title: "A" });
+    const res = await createPost({
+      site_id: siteB.id,
+      title: "B",
+      slug: "shared",
+      design_system_version: 1,
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects a title shorter than the minimum with VALIDATION_FAILED", async () => {
+    const site = await seedSite({ name: "C3", prefix: "cp3" });
+    const res = await createPost({
+      site_id: site.id,
+      title: "Hi",
+      slug: "hi",
+      design_system_version: 1,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("rejects an invalid slug format with VALIDATION_FAILED", async () => {
+    const site = await seedSite({ name: "C4", prefix: "cp4" });
+    const res = await createPost({
+      site_id: site.id,
+      title: "Valid title",
+      slug: "Bad Slug!",
+      design_system_version: 1,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listPostsForSite — site scope + filters + pagination
+// ---------------------------------------------------------------------------
+
+describe("listPostsForSite — site scoping", () => {
+  it("returns only rows belonging to the given site", async () => {
+    const siteA = await seedSite({ name: "LA", prefix: "la1" });
+    const siteB = await seedSite({ name: "LB", prefix: "lb1" });
+    const aId = await seedPost(siteA.id, { slug: "a-hi", title: "A hi" });
+    const bId = await seedPost(siteB.id, { slug: "b-hi", title: "B hi" });
+
+    const res = await listPostsForSite(siteA.id);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const ids = res.data.items.map((i) => i.id);
+    expect(ids).toContain(aId);
+    expect(ids).not.toContain(bId);
+    expect(res.data.total).toBe(1);
+  });
+
+  it("excludes soft-deleted posts by default", async () => {
+    const site = await seedSite({ name: "LD", prefix: "ld1" });
+    const liveId = await seedPost(site.id, { slug: "live", title: "Live" });
+    const archivedId = await seedPost(site.id, {
+      slug: "gone",
+      title: "Gone",
+    });
+    const svc = getServiceRoleClient();
+    await svc
+      .from("posts")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("id", archivedId);
+
+    const res = await listPostsForSite(site.id);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const ids = res.data.items.map((i) => i.id);
+    expect(ids).toContain(liveId);
+    expect(ids).not.toContain(archivedId);
+    expect(res.data.total).toBe(1);
+  });
+
+  it("includes soft-deleted posts when include_archived=true", async () => {
+    const site = await seedSite({ name: "LDi", prefix: "ldi1" });
+    const archivedId = await seedPost(site.id, {
+      slug: "gone-2",
+      title: "Gone again",
+    });
+    const svc = getServiceRoleClient();
+    await svc
+      .from("posts")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("id", archivedId);
+
+    const res = await listPostsForSite(site.id, { include_archived: true });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toContain(archivedId);
+  });
+});
+
+describe("listPostsForSite — filter composition", () => {
+  it("applies status filter", async () => {
+    const site = await seedSite({ name: "LS", prefix: "ls1" });
+    const draftId = await seedPost(site.id, {
+      slug: "d",
+      title: "Draft",
+      status: "draft",
+    });
+    await seedPost(site.id, {
+      slug: "p",
+      title: "Pub",
+      status: "published",
+    });
+    const res = await listPostsForSite(site.id, { status: "draft" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([draftId]);
+  });
+
+  it("applies author_id filter", async () => {
+    const site = await seedSite({ name: "LAu", prefix: "lau1" });
+    const alice = await seedAuthUser({ role: "operator" });
+    const bob = await seedAuthUser({ role: "operator" });
+    const aliceId = await seedPost(site.id, {
+      slug: "alice",
+      title: "Alice",
+      author_id: alice.id,
+    });
+    await seedPost(site.id, {
+      slug: "bob",
+      title: "Bob",
+      author_id: bob.id,
+    });
+    const res = await listPostsForSite(site.id, { author_id: alice.id });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([aliceId]);
+  });
+
+  it("applies free-text search on title + slug (ILIKE)", async () => {
+    const site = await seedSite({ name: "LQ", prefix: "lq1" });
+    const matchId = await seedPost(site.id, {
+      slug: "kadence-guide",
+      title: "Kadence tuning guide",
+    });
+    await seedPost(site.id, { slug: "intro", title: "Intro" });
+    const res = await listPostsForSite(site.id, { query: "kadence" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([matchId]);
+  });
+
+  it("strips ILIKE wildcards from operator input", async () => {
+    const site = await seedSite({ name: "LW", prefix: "lw1" });
+    const matchId = await seedPost(site.id, {
+      slug: "kadence",
+      title: "Kadence",
+    });
+    await seedPost(site.id, { slug: "intro", title: "Intro" });
+    const res = await listPostsForSite(site.id, { query: "kadence*" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([matchId]);
+  });
+});
+
+describe("listPostsForSite — pagination + ordering", () => {
+  it("orders by updated_at desc", async () => {
+    const site = await seedSite({ name: "LO", prefix: "lo1" });
+    const oldId = await seedPost(site.id, {
+      slug: "old",
+      title: "Old",
+      createdAtOffsetMs: -60_000,
+    });
+    const newId = await seedPost(site.id, {
+      slug: "new",
+      title: "New",
+      createdAtOffsetMs: -1_000,
+    });
+    const res = await listPostsForSite(site.id);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.items.map((i) => i.id)).toEqual([newId, oldId]);
+  });
+
+  it("windows results + reports total", async () => {
+    const site = await seedSite({ name: "LP", prefix: "lp1" });
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      ids.push(
+        await seedPost(site.id, {
+          slug: `p-${i}`,
+          title: `Post ${i}`,
+          createdAtOffsetMs: i * 1000,
+        }),
+      );
+    }
+    const pg1 = await listPostsForSite(site.id, { limit: 2, offset: 0 });
+    expect(pg1.ok).toBe(true);
+    if (!pg1.ok) return;
+    expect(pg1.data.items.map((i) => i.id)).toEqual([ids[4], ids[3]]);
+    expect(pg1.data.total).toBe(5);
+
+    const pg2 = await listPostsForSite(site.id, { limit: 2, offset: 2 });
+    expect(pg2.ok).toBe(true);
+    if (!pg2.ok) return;
+    expect(pg2.data.items.map((i) => i.id)).toEqual([ids[2], ids[1]]);
+  });
+
+  it("defaults to LIST_POSTS_DEFAULT_LIMIT when limit omitted", async () => {
+    const site = await seedSite({ name: "LD2", prefix: "ld2" });
+    await seedPost(site.id, { slug: "only", title: "Only" });
+    const res = await listPostsForSite(site.id);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.limit).toBe(LIST_POSTS_DEFAULT_LIMIT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPost — cross-site guard + NOT_FOUND + detail shape
+// ---------------------------------------------------------------------------
+
+describe("getPost — site scope guard", () => {
+  it("returns NOT_FOUND when the post belongs to another site", async () => {
+    const siteA = await seedSite({ name: "GA", prefix: "gxa" });
+    const siteB = await seedSite({ name: "GB", prefix: "gxb" });
+    const postB = await seedPost(siteB.id, { slug: "b-home", title: "B" });
+    const res = await getPost(siteA.id, postB);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns detail when scope matches", async () => {
+    const site = await seedSite({ name: "GS", prefix: "gxs" });
+    const postId = await seedPost(site.id, {
+      slug: "home",
+      title: "Home",
+    });
+    const res = await getPost(site.id, postId);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.id).toBe(postId);
+    expect(res.data.site_name).toBe("GS");
+    expect(res.data.site_wp_url).toBe("https://gxs.test");
+    expect(res.data.content_type).toBe("post");
+    expect(res.data.version_lock).toBe(1);
+  });
+
+  it("returns NOT_FOUND for an archived post by default", async () => {
+    const site = await seedSite({ name: "GD", prefix: "gxd" });
+    const postId = await seedPost(site.id, {
+      slug: "archived",
+      title: "Archived",
+    });
+    const svc = getServiceRoleClient();
+    await svc
+      .from("posts")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("id", postId);
+    const res = await getPost(site.id, postId);
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns archived post when include_archived=true", async () => {
+    const site = await seedSite({ name: "GDi", prefix: "gxdi" });
+    const postId = await seedPost(site.id, {
+      slug: "archived-2",
+      title: "Archived 2",
+    });
+    const svc = getServiceRoleClient();
+    await svc
+      .from("posts")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("id", postId);
+    const res = await getPost(site.id, postId, { include_archived: true });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.deleted_at).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updatePostMetadata — happy paths + error paths
+// ---------------------------------------------------------------------------
+
+describe("updatePostMetadata — happy path", () => {
+  it("updates title + slug + excerpt and bumps version_lock", async () => {
+    const site = await seedSite({ name: "U1", prefix: "u1p" });
+    const postId = await seedPost(site.id, {
+      slug: "orig",
+      title: "Original title",
+    });
+    const res = await updatePostMetadata(site.id, postId, {
+      expected_version: 1,
+      patch: {
+        title: "Rewritten title",
+        slug: "rewritten",
+        excerpt: "New excerpt",
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.title).toBe("Rewritten title");
+    expect(res.data.slug).toBe("rewritten");
+    expect(res.data.excerpt).toBe("New excerpt");
+    expect(res.data.version_lock).toBe(2);
+  });
+
+  it("stamps last_edited_by when updated_by is supplied", async () => {
+    const site = await seedSite({ name: "U2", prefix: "u2p" });
+    const postId = await seedPost(site.id, {
+      slug: "attrib",
+      title: "Attrib",
+    });
+    const user = await seedAuthUser({ role: "operator" });
+    const res = await updatePostMetadata(site.id, postId, {
+      expected_version: 1,
+      updated_by: user.id,
+      patch: { title: "Edited title" },
+    });
+    expect(res.ok).toBe(true);
+
+    const svc = getServiceRoleClient();
+    const readBack = await svc
+      .from("posts")
+      .select("last_edited_by, updated_by")
+      .eq("id", postId)
+      .maybeSingle();
+    expect(readBack.data?.last_edited_by).toBe(user.id);
+    expect(readBack.data?.updated_by).toBe(user.id);
+  });
+
+  it("stamps published_at when transitioning status to published", async () => {
+    const site = await seedSite({ name: "U3", prefix: "u3p" });
+    const postId = await seedPost(site.id, {
+      slug: "pub-me",
+      title: "Draft",
+    });
+    const res = await updatePostMetadata(site.id, postId, {
+      expected_version: 1,
+      patch: { status: "published" },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.status).toBe("published");
+    expect(res.data.published_at).not.toBeNull();
+  });
+
+  it("accepts an excerpt-only patch without touching title or slug", async () => {
+    const site = await seedSite({ name: "U4", prefix: "u4p" });
+    const postId = await seedPost(site.id, {
+      slug: "keep",
+      title: "Keep",
+      excerpt: "Old excerpt",
+    });
+    const res = await updatePostMetadata(site.id, postId, {
+      expected_version: 1,
+      patch: { excerpt: "New excerpt only" },
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.excerpt).toBe("New excerpt only");
+    expect(res.data.slug).toBe("keep");
+    expect(res.data.title).toBe("Keep");
+  });
+});
+
+describe("updatePostMetadata — error paths", () => {
+  it("returns VERSION_CONFLICT on stale expected_version", async () => {
+    const site = await seedSite({ name: "E1", prefix: "e1p" });
+    const postId = await seedPost(site.id, {
+      slug: "conflict",
+      title: "Original",
+    });
+    await updatePostMetadata(site.id, postId, {
+      expected_version: 1,
+      patch: { title: "Round one" },
+    });
+    const res = await updatePostMetadata(site.id, postId, {
+      expected_version: 1,
+      patch: { title: "Stale clobber" },
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VERSION_CONFLICT");
+    expect(res.error.details?.current_version).toBe(2);
+  });
+
+  it("returns UNIQUE_VIOLATION when slug collides on the same site", async () => {
+    const site = await seedSite({ name: "E2", prefix: "e2p" });
+    await seedPost(site.id, { slug: "taken", title: "First" });
+    const secondId = await seedPost(site.id, {
+      slug: "free",
+      title: "Second",
+    });
+    const res = await updatePostMetadata(site.id, secondId, {
+      expected_version: 1,
+      patch: { slug: "taken" },
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("UNIQUE_VIOLATION");
+    expect(res.error.details?.attempted_slug).toBe("taken");
+  });
+
+  it("allows the same slug to exist on a different site", async () => {
+    const siteA = await seedSite({ name: "EA", prefix: "eapa" });
+    const siteB = await seedSite({ name: "EB", prefix: "eapb" });
+    await seedPost(siteA.id, { slug: "shared", title: "A" });
+    const bPost = await seedPost(siteB.id, {
+      slug: "original",
+      title: "B",
+    });
+    const res = await updatePostMetadata(siteB.id, bPost, {
+      expected_version: 1,
+      patch: { slug: "shared" },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("returns NOT_FOUND when the post doesn't exist under the site", async () => {
+    const site = await seedSite({ name: "E3", prefix: "e3p" });
+    const res = await updatePostMetadata(
+      site.id,
+      "00000000-0000-0000-0000-000000000000",
+      { expected_version: 1, patch: { title: "nope" } },
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns NOT_FOUND on archived post", async () => {
+    const site = await seedSite({ name: "E4", prefix: "e4p" });
+    const postId = await seedPost(site.id, {
+      slug: "gone",
+      title: "Gone",
+    });
+    const svc = getServiceRoleClient();
+    await svc
+      .from("posts")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("id", postId);
+    const res = await updatePostMetadata(site.id, postId, {
+      expected_version: 1,
+      patch: { title: "can't edit" },
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("NOT_FOUND");
+    expect(res.error.details?.archived).toBe(true);
+  });
+
+  it("rejects an invalid slug in the patch with VALIDATION_FAILED", async () => {
+    const site = await seedSite({ name: "E5", prefix: "e5p" });
+    const postId = await seedPost(site.id, {
+      slug: "clean",
+      title: "Clean",
+    });
+    const res = await updatePostMetadata(site.id, postId, {
+      expected_version: 1,
+      patch: { slug: "BAD SLUG" },
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VALIDATION_FAILED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// softDeletePost
+// ---------------------------------------------------------------------------
+
+describe("softDeletePost", () => {
+  it("marks deleted_at + bumps version_lock and excludes from default reads", async () => {
+    const site = await seedSite({ name: "S1", prefix: "s1p" });
+    const user = await seedAuthUser({ role: "operator" });
+    const postId = await seedPost(site.id, { slug: "rm", title: "Remove me" });
+    const res = await softDeletePost(site.id, postId, {
+      expected_version: 1,
+      deleted_by: user.id,
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.data.version_lock).toBe(2);
+    expect(res.data.deleted_at).toBeTruthy();
+
+    const list = await listPostsForSite(site.id);
+    expect(list.ok).toBe(true);
+    if (!list.ok) return;
+    expect(list.data.items.map((i) => i.id)).not.toContain(postId);
+  });
+
+  it("frees the slug for a new live post after soft-delete", async () => {
+    const site = await seedSite({ name: "S2", prefix: "s2p" });
+    const archivedId = await seedPost(site.id, {
+      slug: "slot",
+      title: "Archived",
+    });
+    await softDeletePost(site.id, archivedId, { expected_version: 1 });
+    const res = await createPost({
+      site_id: site.id,
+      title: "Fresh",
+      slug: "slot",
+      design_system_version: 1,
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("returns VERSION_CONFLICT on stale expected_version", async () => {
+    const site = await seedSite({ name: "S3", prefix: "s3p" });
+    const postId = await seedPost(site.id, {
+      slug: "bumped",
+      title: "Bumped",
+    });
+    await updatePostMetadata(site.id, postId, {
+      expected_version: 1,
+      patch: { title: "Bumped once" },
+    });
+    const res = await softDeletePost(site.id, postId, { expected_version: 1 });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error.code).toBe("VERSION_CONFLICT");
+  });
+});

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,0 +1,709 @@
+import { z } from "zod";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// M13-1 — per-site posts data layer.
+//
+// Mirrors lib/pages.ts for the generative columns + admin-list /
+// detail / metadata-edit shape, and adds post-specific fields
+// (excerpt, published_at, author_id, scheduled status). Backed by
+// the `posts` table introduced in migration 0019.
+//
+// The `content_type` axis is a schema assertion, not a dispatch
+// discriminator at this layer: every row in `posts` is CHECK'd to
+// `content_type = 'post'` at the DB. The runner's mode='post'
+// branch (landing in M13-3) writes here; pages keep writing to
+// lib/pages.ts.
+//
+// All list / detail reads are site-scoped by construction — a post
+// belonging to site B fetched via site A's URL returns NOT_FOUND
+// (see getPost). Soft-deleted rows (`deleted_at IS NOT NULL`) are
+// excluded by default; admin archive views pass `include_archived`.
+// ---------------------------------------------------------------------------
+
+export const POST_CONTENT_TYPE = "post" as const;
+
+export const LIST_POSTS_MAX_LIMIT = 100;
+export const LIST_POSTS_DEFAULT_LIMIT = 50;
+
+export const POST_TITLE_MIN = 3;
+export const POST_TITLE_MAX = 200;
+export const POST_SLUG_MAX = 100;
+export const POST_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const POST_EXCERPT_MAX = 300;
+
+export type PostStatus = "draft" | "published" | "scheduled";
+export type PostContentType = typeof POST_CONTENT_TYPE;
+
+// ---------------------------------------------------------------------------
+// Zod schemas. Tightened at the DB layer by the 0019 CHECKs; these
+// schemas are the app-layer mirror that API routes / runner helpers
+// validate against before hitting PostgREST.
+// ---------------------------------------------------------------------------
+
+export const PostStatusSchema = z.enum(["draft", "published", "scheduled"]);
+
+export const PostContentTypeSchema = z.literal(POST_CONTENT_TYPE);
+
+export const PostMetadataPatchSchema = z
+  .object({
+    title: z.string().min(POST_TITLE_MIN).max(POST_TITLE_MAX).optional(),
+    slug: z.string().max(POST_SLUG_MAX).regex(POST_SLUG_RE).optional(),
+    excerpt: z.string().max(POST_EXCERPT_MAX).nullable().optional(),
+    status: PostStatusSchema.optional(),
+  })
+  .strict();
+
+export type PostMetadataPatch = z.infer<typeof PostMetadataPatchSchema>;
+
+export const CreatePostInputSchema = z
+  .object({
+    site_id: z.string().uuid(),
+    title: z.string().min(POST_TITLE_MIN).max(POST_TITLE_MAX),
+    slug: z.string().max(POST_SLUG_MAX).regex(POST_SLUG_RE),
+    excerpt: z.string().max(POST_EXCERPT_MAX).nullable().optional(),
+    author_id: z.string().uuid().nullable().optional(),
+    template_id: z.string().uuid().nullable().optional(),
+    design_system_version: z.number().int().min(1),
+    content_brief: z.unknown().optional(),
+    content_structured: z.unknown().optional(),
+    generated_html: z.string().nullable().optional(),
+    created_by: z.string().uuid().nullable().optional(),
+  })
+  .strict();
+
+export type CreatePostInput = z.infer<typeof CreatePostInputSchema>;
+
+export type ListPostsForSiteParams = {
+  status?: PostStatus;
+  query?: string;
+  author_id?: string;
+  limit?: number;
+  offset?: number;
+  include_archived?: boolean;
+};
+
+export type PostListItem = {
+  id: string;
+  site_id: string;
+  content_type: PostContentType;
+  wp_post_id: number | null;
+  slug: string;
+  title: string;
+  excerpt: string | null;
+  status: PostStatus;
+  published_at: string | null;
+  author_id: string | null;
+  template_id: string | null;
+  design_system_version: number;
+  updated_at: string;
+  created_at: string;
+};
+
+export type PostDetail = PostListItem & {
+  content_brief: unknown;
+  content_structured: unknown;
+  generated_html: string | null;
+  last_edited_by: string | null;
+  version_lock: number;
+  deleted_at: string | null;
+  template_name: string | null;
+  site_name: string;
+  site_wp_url: string;
+};
+
+export type ListPostsForSiteResult = {
+  items: PostListItem[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+export type UpdatePostMetadataInput = {
+  expected_version: number;
+  updated_by?: string | null;
+  patch: PostMetadataPatch;
+};
+
+export type SoftDeletePostInput = {
+  expected_version: number;
+  deleted_by?: string | null;
+};
+
+const LIGHT_POST_FIELDS =
+  "id, site_id, content_type, wp_post_id, slug, title, excerpt, status, published_at, author_id, template_id, design_system_version, updated_at, created_at";
+
+const DETAIL_POST_FIELDS =
+  "id, site_id, content_type, wp_post_id, slug, title, excerpt, status, published_at, author_id, template_id, design_system_version, updated_at, created_at, content_brief, content_structured, generated_html, last_edited_by, version_lock, deleted_at";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function internalError(
+  message: string,
+  details?: Record<string, unknown>,
+): ApiResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      details,
+      retryable: false,
+      suggested_action: "Check Supabase connectivity and server logs.",
+    },
+    timestamp: now(),
+  };
+}
+
+function clampLimit(raw: number | undefined): number {
+  if (raw === undefined || !Number.isFinite(raw)) return LIST_POSTS_DEFAULT_LIMIT;
+  const rounded = Math.floor(raw);
+  if (rounded < 1) return 1;
+  if (rounded > LIST_POSTS_MAX_LIMIT) return LIST_POSTS_MAX_LIMIT;
+  return rounded;
+}
+
+function clampOffset(raw: number | undefined): number {
+  if (raw === undefined || !Number.isFinite(raw)) return 0;
+  const rounded = Math.floor(raw);
+  return rounded < 0 ? 0 : rounded;
+}
+
+function escapeIlikeLiteral(value: string): string {
+  return value.replace(/[%_*]/g, "");
+}
+
+function rowToListItem(row: Record<string, unknown>): PostListItem {
+  return {
+    id: row.id as string,
+    site_id: row.site_id as string,
+    content_type: POST_CONTENT_TYPE,
+    wp_post_id:
+      row.wp_post_id === null || row.wp_post_id === undefined
+        ? null
+        : typeof row.wp_post_id === "number"
+          ? row.wp_post_id
+          : Number(row.wp_post_id),
+    slug: row.slug as string,
+    title: row.title as string,
+    excerpt: (row.excerpt as string | null) ?? null,
+    status: row.status as PostStatus,
+    published_at: (row.published_at as string | null) ?? null,
+    author_id: (row.author_id as string | null) ?? null,
+    template_id: (row.template_id as string | null) ?? null,
+    design_system_version: row.design_system_version as number,
+    updated_at: row.updated_at as string,
+    created_at: row.created_at as string,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createPost
+// ---------------------------------------------------------------------------
+
+export async function createPost(
+  input: CreatePostInput,
+): Promise<ApiResponse<PostListItem & { version_lock: number }>> {
+  try {
+    const parsed = CreatePostInputSchema.safeParse(input);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "createPost input failed validation.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+          suggested_action: "Fix the invalid fields and retry.",
+        },
+        timestamp: now(),
+      };
+    }
+    return await createPostImpl(parsed.data);
+  } catch (err) {
+    return internalError(
+      `Unhandled error in createPost: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function createPostImpl(
+  input: CreatePostInput,
+): Promise<ApiResponse<PostListItem & { version_lock: number }>> {
+  const supabase = getServiceRoleClient();
+  const insertRow: Record<string, unknown> = {
+    site_id: input.site_id,
+    content_type: POST_CONTENT_TYPE,
+    title: input.title,
+    slug: input.slug,
+    design_system_version: input.design_system_version,
+    status: "draft" as PostStatus,
+  };
+  if (input.excerpt !== undefined) insertRow.excerpt = input.excerpt;
+  if (input.author_id !== undefined) insertRow.author_id = input.author_id;
+  if (input.template_id !== undefined) insertRow.template_id = input.template_id;
+  if (input.content_brief !== undefined) insertRow.content_brief = input.content_brief;
+  if (input.content_structured !== undefined) {
+    insertRow.content_structured = input.content_structured;
+  }
+  if (input.generated_html !== undefined) insertRow.generated_html = input.generated_html;
+  if (input.created_by !== undefined) insertRow.created_by = input.created_by;
+
+  const res = await supabase
+    .from("posts")
+    .insert(insertRow)
+    .select(`${LIGHT_POST_FIELDS}, version_lock`)
+    .single();
+
+  if (res.error) {
+    if (res.error.code === "23505") {
+      return {
+        ok: false,
+        error: {
+          code: "UNIQUE_VIOLATION",
+          message: `Slug "${input.slug}" is already used by another live post on this site.`,
+          details: {
+            site_id: input.site_id,
+            attempted_slug: input.slug,
+            postgres_code: "23505",
+          },
+          retryable: true,
+          suggested_action: "Pick a different slug, or archive the conflicting post first.",
+        },
+        timestamp: now(),
+      };
+    }
+    return internalError("Failed to create post.", { supabase_error: res.error });
+  }
+  const row = res.data as Record<string, unknown>;
+  return {
+    ok: true,
+    data: {
+      ...rowToListItem(row),
+      version_lock: typeof row.version_lock === "number" ? row.version_lock : 1,
+    },
+    timestamp: now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// listPostsForSite
+// ---------------------------------------------------------------------------
+
+export async function listPostsForSite(
+  siteId: string,
+  params: ListPostsForSiteParams = {},
+): Promise<ApiResponse<ListPostsForSiteResult>> {
+  try {
+    return await listPostsForSiteImpl(siteId, params);
+  } catch (err) {
+    return internalError(
+      `Unhandled error in listPostsForSite: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function listPostsForSiteImpl(
+  siteId: string,
+  params: ListPostsForSiteParams,
+): Promise<ApiResponse<ListPostsForSiteResult>> {
+  const limit = clampLimit(params.limit);
+  const offset = clampOffset(params.offset);
+  const supabase = getServiceRoleClient();
+  const includeArchived = params.include_archived === true;
+
+  let dataQuery = supabase
+    .from("posts")
+    .select(LIGHT_POST_FIELDS)
+    .eq("site_id", siteId)
+    .order("updated_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+  if (!includeArchived) dataQuery = dataQuery.is("deleted_at", null);
+  if (params.status) dataQuery = dataQuery.eq("status", params.status);
+  if (params.author_id) dataQuery = dataQuery.eq("author_id", params.author_id);
+  if (params.query && params.query.trim().length > 0) {
+    const escaped = escapeIlikeLiteral(params.query.trim());
+    dataQuery = dataQuery.or(
+      `title.ilike.*${escaped}*,slug.ilike.*${escaped}*`,
+    );
+  }
+  const dataRes = await dataQuery;
+  if (dataRes.error) {
+    return internalError("Failed to list posts.", { supabase_error: dataRes.error });
+  }
+
+  let countQuery = supabase
+    .from("posts")
+    .select("id", { count: "exact", head: true })
+    .eq("site_id", siteId);
+  if (!includeArchived) countQuery = countQuery.is("deleted_at", null);
+  if (params.status) countQuery = countQuery.eq("status", params.status);
+  if (params.author_id) countQuery = countQuery.eq("author_id", params.author_id);
+  if (params.query && params.query.trim().length > 0) {
+    const escaped = escapeIlikeLiteral(params.query.trim());
+    countQuery = countQuery.or(
+      `title.ilike.*${escaped}*,slug.ilike.*${escaped}*`,
+    );
+  }
+  const countRes = await countQuery;
+  if (countRes.error) {
+    return internalError("Failed to count posts.", { supabase_error: countRes.error });
+  }
+
+  const items = ((dataRes.data ?? []) as Record<string, unknown>[]).map(rowToListItem);
+  return {
+    ok: true,
+    data: { items, total: countRes.count ?? 0, limit, offset },
+    timestamp: now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getPost
+// ---------------------------------------------------------------------------
+
+export async function getPost(
+  siteId: string,
+  postId: string,
+  opts: { include_archived?: boolean } = {},
+): Promise<ApiResponse<PostDetail>> {
+  try {
+    return await getPostImpl(siteId, postId, opts);
+  } catch (err) {
+    return internalError(
+      `Unhandled error in getPost: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function getPostImpl(
+  siteId: string,
+  postId: string,
+  opts: { include_archived?: boolean },
+): Promise<ApiResponse<PostDetail>> {
+  const supabase = getServiceRoleClient();
+  let postQuery = supabase
+    .from("posts")
+    .select(DETAIL_POST_FIELDS)
+    .eq("id", postId)
+    .eq("site_id", siteId);
+  if (!opts.include_archived) postQuery = postQuery.is("deleted_at", null);
+  const postRes = await postQuery.maybeSingle();
+
+  if (postRes.error) {
+    return internalError("Failed to fetch post.", { supabase_error: postRes.error });
+  }
+  if (!postRes.data) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `No post found with id ${postId} under site ${siteId}.`,
+        details: { site_id: siteId, post_id: postId },
+        retryable: false,
+        suggested_action:
+          "Verify both ids. Cross-site access via URL manipulation returns NOT_FOUND.",
+      },
+      timestamp: now(),
+    };
+  }
+  const row = postRes.data as Record<string, unknown>;
+  const base = rowToListItem(row);
+
+  const [templateRes, siteRes] = await Promise.all([
+    row.template_id
+      ? supabase
+          .from("design_templates")
+          .select("name")
+          .eq("id", row.template_id as string)
+          .maybeSingle()
+      : Promise.resolve({ data: null, error: null }),
+    supabase
+      .from("sites")
+      .select("name, wp_url")
+      .eq("id", siteId)
+      .maybeSingle(),
+  ]);
+
+  if (templateRes.error) {
+    return internalError("Failed to fetch template.", { supabase_error: templateRes.error });
+  }
+  if (siteRes.error) {
+    return internalError("Failed to fetch site.", { supabase_error: siteRes.error });
+  }
+  const siteRow = siteRes.data as { name: string; wp_url: string } | null;
+
+  return {
+    ok: true,
+    data: {
+      ...base,
+      content_brief: row.content_brief ?? null,
+      content_structured: row.content_structured ?? null,
+      generated_html: (row.generated_html as string | null) ?? null,
+      last_edited_by: (row.last_edited_by as string | null) ?? null,
+      version_lock: typeof row.version_lock === "number" ? row.version_lock : 1,
+      deleted_at: (row.deleted_at as string | null) ?? null,
+      template_name: (templateRes.data as { name: string } | null)?.name ?? null,
+      site_name: siteRow?.name ?? "—",
+      site_wp_url: siteRow?.wp_url ?? "",
+    },
+    timestamp: now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// updatePostMetadata — optimistic-locked title / slug / excerpt / status
+// ---------------------------------------------------------------------------
+
+export async function updatePostMetadata(
+  siteId: string,
+  postId: string,
+  input: UpdatePostMetadataInput,
+): Promise<ApiResponse<PostListItem & { version_lock: number }>> {
+  try {
+    const parsed = PostMetadataPatchSchema.safeParse(input.patch);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "updatePostMetadata patch failed validation.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+          suggested_action: "Fix the invalid fields and retry.",
+        },
+        timestamp: now(),
+      };
+    }
+    return await updatePostMetadataImpl(siteId, postId, {
+      ...input,
+      patch: parsed.data,
+    });
+  } catch (err) {
+    return internalError(
+      `Unhandled error in updatePostMetadata: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function updatePostMetadataImpl(
+  siteId: string,
+  postId: string,
+  input: UpdatePostMetadataInput,
+): Promise<ApiResponse<PostListItem & { version_lock: number }>> {
+  const supabase = getServiceRoleClient();
+
+  const updateRow: Record<string, unknown> = {
+    updated_at: now(),
+    version_lock: input.expected_version + 1,
+  };
+  if (input.updated_by !== undefined) {
+    updateRow.last_edited_by = input.updated_by;
+    updateRow.updated_by = input.updated_by;
+  }
+  if ("title" in input.patch) updateRow.title = input.patch.title;
+  if ("slug" in input.patch) updateRow.slug = input.patch.slug;
+  if ("excerpt" in input.patch) updateRow.excerpt = input.patch.excerpt;
+  if ("status" in input.patch) {
+    updateRow.status = input.patch.status;
+    // Transitioning into 'published' must carry a published_at so the
+    // `posts_published_at_coherent` CHECK holds.
+    if (input.patch.status === "published") {
+      updateRow.published_at = now();
+    }
+  }
+
+  const res = await supabase
+    .from("posts")
+    .update(updateRow)
+    .eq("id", postId)
+    .eq("site_id", siteId)
+    .eq("version_lock", input.expected_version)
+    .is("deleted_at", null)
+    .select(`${LIGHT_POST_FIELDS}, version_lock`)
+    .maybeSingle();
+
+  if (res.error) {
+    if (res.error.code === "23505") {
+      return {
+        ok: false,
+        error: {
+          code: "UNIQUE_VIOLATION",
+          message: `Slug "${input.patch.slug}" is already used by another live post on this site.`,
+          details: {
+            site_id: siteId,
+            attempted_slug: input.patch.slug ?? null,
+            postgres_code: "23505",
+          },
+          retryable: true,
+          suggested_action:
+            "Pick a different slug, or archive the conflicting post first.",
+        },
+        timestamp: now(),
+      };
+    }
+    return internalError("Failed to update post metadata.", { supabase_error: res.error });
+  }
+
+  if (!res.data) {
+    return await disambiguateMissingUpdate(siteId, postId, input.expected_version);
+  }
+
+  const row = res.data as Record<string, unknown>;
+  const base = rowToListItem(row);
+  return {
+    ok: true,
+    data: {
+      ...base,
+      version_lock: typeof row.version_lock === "number" ? row.version_lock : 1,
+    },
+    timestamp: now(),
+  };
+}
+
+// Zero-row UPDATE disambiguation — NOT_FOUND vs VERSION_CONFLICT vs
+// already-archived. Runs a follow-up SELECT scoped to the site.
+async function disambiguateMissingUpdate(
+  siteId: string,
+  postId: string,
+  expectedVersion: number,
+): Promise<ApiResponse<PostListItem & { version_lock: number }>> {
+  const supabase = getServiceRoleClient();
+  const existsRes = await supabase
+    .from("posts")
+    .select("id, version_lock, deleted_at")
+    .eq("id", postId)
+    .eq("site_id", siteId)
+    .maybeSingle();
+  if (existsRes.error) {
+    return internalError("Failed to re-check post after update.", {
+      supabase_error: existsRes.error,
+    });
+  }
+  if (!existsRes.data) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `No post found with id ${postId} under site ${siteId}.`,
+        details: { site_id: siteId, post_id: postId },
+        retryable: false,
+        suggested_action: "Verify both ids.",
+      },
+      timestamp: now(),
+    };
+  }
+  if (existsRes.data.deleted_at) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Post ${postId} has been archived and can't be edited.`,
+        details: { site_id: siteId, post_id: postId, archived: true },
+        retryable: false,
+        suggested_action: "Restore the archived post first, then retry the edit.",
+      },
+      timestamp: now(),
+    };
+  }
+  return {
+    ok: false,
+    error: {
+      code: "VERSION_CONFLICT",
+      message:
+        "Another operator changed this post since you opened the editor. Reload to see the latest.",
+      details: {
+        post_id: postId,
+        current_version: existsRes.data.version_lock,
+        expected_version: expectedVersion,
+      },
+      retryable: true,
+      suggested_action:
+        "Reload the post to pick up the latest metadata and redo your changes.",
+    },
+    timestamp: now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// softDeletePost — soft-delete is the only delete path per
+// docs/DATA_CONVENTIONS.md. Sets deleted_at + deleted_by, optimistic-
+// locked against expected_version to prevent a stale archive from
+// clobbering a concurrent edit.
+// ---------------------------------------------------------------------------
+
+export async function softDeletePost(
+  siteId: string,
+  postId: string,
+  input: SoftDeletePostInput,
+): Promise<ApiResponse<{ id: string; version_lock: number; deleted_at: string }>> {
+  try {
+    return await softDeletePostImpl(siteId, postId, input);
+  } catch (err) {
+    return internalError(
+      `Unhandled error in softDeletePost: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function softDeletePostImpl(
+  siteId: string,
+  postId: string,
+  input: SoftDeletePostInput,
+): Promise<ApiResponse<{ id: string; version_lock: number; deleted_at: string }>> {
+  const supabase = getServiceRoleClient();
+  const deletedAt = now();
+  const res = await supabase
+    .from("posts")
+    .update({
+      deleted_at: deletedAt,
+      deleted_by: input.deleted_by ?? null,
+      updated_at: deletedAt,
+      version_lock: input.expected_version + 1,
+    })
+    .eq("id", postId)
+    .eq("site_id", siteId)
+    .eq("version_lock", input.expected_version)
+    .is("deleted_at", null)
+    .select("id, version_lock, deleted_at")
+    .maybeSingle();
+
+  if (res.error) {
+    return internalError("Failed to soft-delete post.", { supabase_error: res.error });
+  }
+  if (!res.data) {
+    const disambiguated = await disambiguateMissingUpdate(
+      siteId,
+      postId,
+      input.expected_version,
+    );
+    if (disambiguated.ok) {
+      // Shouldn't happen — if the row exists with the expected version
+      // and isn't archived, the UPDATE above would have matched. Map
+      // to INTERNAL_ERROR so the caller sees a distinct signal.
+      return internalError(
+        "softDeletePost: UPDATE returned zero rows but follow-up SELECT matched.",
+        { site_id: siteId, post_id: postId },
+      );
+    }
+    return disambiguated as unknown as ApiResponse<{
+      id: string;
+      version_lock: number;
+      deleted_at: string;
+    }>;
+  }
+  return {
+    ok: true,
+    data: {
+      id: res.data.id as string,
+      version_lock:
+        typeof res.data.version_lock === "number" ? res.data.version_lock : 1,
+      deleted_at: res.data.deleted_at as string,
+    },
+    timestamp: now(),
+  };
+}

--- a/supabase/migrations/0019_m13_1_posts_schema.sql
+++ b/supabase/migrations/0019_m13_1_posts_schema.sql
@@ -1,0 +1,193 @@
+-- 0019 — M13-1 posts schema.
+-- Reference: docs/plans/m13-parent.md §M13-1.
+--
+-- Design decisions encoded here:
+--
+-- 1. Dedicated `posts` table mirrors `pages` for the generative columns
+--    (content_brief, content_structured, generated_html,
+--    design_system_version) and adds post-specific fields (excerpt,
+--    published_at, author_id). The runner's `mode: 'page' | 'post'`
+--    dispatch in M13-3 writes here when mode = 'post'. Sharing the
+--    pages shape by field convention keeps the runner's per-mode
+--    helpers near-symmetric; forking into a single "content" table
+--    would have forced a content_type discriminator throughout every
+--    M6/M7 query that currently assumes pages-only.
+--
+-- 2. content_type is CHECK-constrained to 'post'. The axis is legible
+--    without a JOIN: any row in `posts` is a post by schema assertion.
+--    Pages do not get the column in this migration — they are "post-
+--    negative" by table identity. If posts + pages unify later, the
+--    CHECK widens to IN ('page', 'post') and a data-migration backfills
+--    the pages side.
+--
+-- 3. wp_post_id is nullable. A post is created as a draft inside
+--    Opollo before WordPress assigns an id; the M13-4 publish action
+--    writes wp_post_id + status='published' in one UPDATE. The partial
+--    UNIQUE `(site_id, wp_post_id) WHERE wp_post_id IS NOT NULL`
+--    mirrors M3-1's posts-side equivalent: NULL is distinct, so many
+--    drafts coexist, but once published the pair must be unique.
+--
+-- 4. (site_id, slug) partial UNIQUE `WHERE deleted_at IS NULL`. A post
+--    belongs to a site's URL namespace; two live posts with the same
+--    slug would be a 404 or a random-winner at the WP side. Soft-
+--    deleted rows don't contend. M3-1's `pages_site_slug_unique` is
+--    the cross-slice precedent; we take the partial flavour here so
+--    restoring a soft-deleted post from archive doesn't trip on a
+--    new live sibling.
+--
+-- 5. status CHECK accepts 'draft' | 'published' | 'scheduled'. The
+--    'scheduled' value lands in the schema NOW so M13-5 can ship the
+--    scheduler surface without a follow-up migration. The parent plan
+--    §Out-of-scope explicitly defers wiring scheduled publish to the
+--    runner — the CHECK is forward-facing only today.
+--
+-- 6. Soft-delete + audit columns + version_lock per
+--    docs/DATA_CONVENTIONS.md. RLS mirrors M2b: service-role-all +
+--    role-band reads for authenticated + operator/admin writes.
+--
+-- Write-safety hotspots addressed:
+--   - content_type CHECK — runner assertion: writing a mode='post' row
+--     with any other content_type value fails at the schema layer, not
+--     in a hypothetical app-layer invariant.
+--   - wp_post_id partial UNIQUE — two publishes racing the same WP post
+--     id under the same site blow up with 23505; the lib layer maps it
+--     to UNIQUE_VIOLATION instead of the raw Postgres error.
+--   - slug partial UNIQUE — no two live posts share a slug within a
+--     site; M13-4's slug-rename edit surfaces UNIQUE_VIOLATION exactly
+--     as pages does today.
+--   - version_lock — optimistic concurrency on operator metadata edits
+--     (title / slug / excerpt / status). Caller passes expected_version;
+--     a stale expected_version returns zero rows and the lib layer
+--     surfaces VERSION_CONFLICT. Constraint `version_lock >= 1`
+--     matches M15's schema defense-in-depth.
+--   - published_at coherence — CHECK forbids status='published' with
+--     NULL published_at so a "published but never published at" row is
+--     schema-impossible.
+
+-- ----------------------------------------------------------------------------
+-- posts
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE posts (
+  id                     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  site_id                uuid NOT NULL
+    REFERENCES sites(id) ON DELETE CASCADE,
+
+  -- Runner assertion key. A post row is always content_type='post';
+  -- CHECK gives schema-level proof the runner dispatched correctly.
+  content_type           text NOT NULL DEFAULT 'post'
+    CHECK (content_type = 'post'),
+
+  -- WP link. NULL until first publish assigns the WP id; then frozen.
+  wp_post_id             bigint,
+
+  slug                   text NOT NULL,
+  title                  text NOT NULL,
+
+  -- Blog-specific fields. excerpt is WP's post excerpt (feeds + SEO);
+  -- published_at records when this specific post was published to WP
+  -- (coherence-constrained below against status).
+  excerpt                text,
+  published_at           timestamptz,
+
+  -- The WP author — opollo_users row that authored the post.
+  -- SET NULL on user delete so historical provenance survives user
+  -- deprovisioning (matches `created_by` semantics in DATA_CONVENTIONS).
+  author_id              uuid
+    REFERENCES opollo_users(id) ON DELETE SET NULL,
+
+  template_id            uuid
+    REFERENCES design_templates(id) ON DELETE SET NULL,
+
+  -- Snapshot of the design system version the runner used. Not a FK
+  -- so a design system can be archived while the post keeps a
+  -- legible record of what it was generated against (same rationale
+  -- as `pages.design_system_version`).
+  design_system_version  integer NOT NULL
+    CHECK (design_system_version >= 1),
+
+  -- Generative columns — operator-facing brief and the structured
+  -- content + final HTML produced by the runner. `content_structured`
+  -- is the intermediate jsonb the runner writes on every pass;
+  -- `generated_html` is the promoted final output.
+  content_brief          jsonb,
+  content_structured     jsonb,
+  generated_html         text,
+
+  status                 text NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft', 'published', 'scheduled')),
+
+  last_edited_by         uuid
+    REFERENCES opollo_users(id) ON DELETE SET NULL,
+
+  version_lock           integer NOT NULL DEFAULT 1
+    CHECK (version_lock >= 1),
+
+  -- Audit columns per DATA_CONVENTIONS.md.
+  created_at             timestamptz NOT NULL DEFAULT now(),
+  updated_at             timestamptz NOT NULL DEFAULT now(),
+  deleted_at             timestamptz,
+  created_by             uuid REFERENCES opollo_users(id) ON DELETE SET NULL,
+  updated_by             uuid REFERENCES opollo_users(id) ON DELETE SET NULL,
+  deleted_by             uuid REFERENCES opollo_users(id) ON DELETE SET NULL,
+
+  -- Published rows must have a published_at timestamp.
+  CONSTRAINT posts_published_at_coherent
+    CHECK (status <> 'published' OR published_at IS NOT NULL)
+);
+
+-- Partial UNIQUE on (site_id, wp_post_id) WHERE wp_post_id IS NOT NULL
+-- — NULL is distinct, so many drafts coexist before WP assigns an id;
+-- published posts have exactly one (site_id, wp_post_id) pair.
+CREATE UNIQUE INDEX posts_site_wp_post_unique
+  ON posts (site_id, wp_post_id)
+  WHERE wp_post_id IS NOT NULL;
+
+-- Partial UNIQUE on (site_id, slug) WHERE deleted_at IS NULL — two
+-- live posts on the same site cannot share a slug. Soft-deleted rows
+-- don't contend, so archiving-and-restoring-later is safe.
+CREATE UNIQUE INDEX posts_site_slug_live_unique
+  ON posts (site_id, slug)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX idx_posts_site_status
+  ON posts (site_id, status)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX idx_posts_site_updated
+  ON posts (site_id, updated_at DESC)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX idx_posts_author
+  ON posts (author_id)
+  WHERE author_id IS NOT NULL AND deleted_at IS NULL;
+
+-- ----------------------------------------------------------------------------
+-- Row Level Security — posts.
+-- Shape: service-role-all + authenticated read for all role bands +
+-- authenticated write for admin/operator. Viewers read-only. Matches
+-- the M12-1 RLS template which is itself a direct descendant of M2b.
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE posts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON posts
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY posts_read ON posts
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator', 'viewer'));
+
+CREATE POLICY posts_insert ON posts
+  FOR INSERT TO authenticated
+  WITH CHECK (public.auth_role() IN ('admin', 'operator'));
+
+CREATE POLICY posts_update ON posts
+  FOR UPDATE TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator'))
+  WITH CHECK (public.auth_role() IN ('admin', 'operator'));
+
+CREATE POLICY posts_delete ON posts
+  FOR DELETE TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator'));

--- a/supabase/rollbacks/0019_m13_1_posts_schema.down.sql
+++ b/supabase/rollbacks/0019_m13_1_posts_schema.down.sql
@@ -1,0 +1,21 @@
+-- Rollback for 0019_m13_1_posts_schema.sql.
+-- Drops the M13-1 posts table + RLS policies.
+-- Does NOT restore row data. Intended for local dev / CI reset.
+--
+-- Reverse order of creation so FK/policy dependencies unwind cleanly.
+
+DROP POLICY IF EXISTS posts_delete      ON posts;
+DROP POLICY IF EXISTS posts_update      ON posts;
+DROP POLICY IF EXISTS posts_insert      ON posts;
+DROP POLICY IF EXISTS posts_read        ON posts;
+DROP POLICY IF EXISTS service_role_all  ON posts;
+
+ALTER TABLE IF EXISTS posts DISABLE ROW LEVEL SECURITY;
+
+DROP INDEX IF EXISTS idx_posts_author;
+DROP INDEX IF EXISTS idx_posts_site_updated;
+DROP INDEX IF EXISTS idx_posts_site_status;
+DROP INDEX IF EXISTS posts_site_slug_live_unique;
+DROP INDEX IF EXISTS posts_site_wp_post_unique;
+
+DROP TABLE IF EXISTS posts;


### PR DESCRIPTION
## Summary
- New `posts` table (migration 0019) mirroring `pages` for generative columns (`content_brief`, `content_structured`, `generated_html`, `design_system_version`) plus blog-specific fields (`excerpt`, `published_at`, `author_id`). `content_type` CHECK-constrained to `'post'` gives the M13-3 runner a schema-level dispatch assertion.
- `lib/posts.ts` CRUD helpers mirror `lib/pages.ts` with Zod schemas, optimistic-locked `updatePostMetadata`, and explicit `softDeletePost`. Tests cover site scope, filter composition, `VERSION_CONFLICT`, `UNIQUE_VIOLATION`, archived disambiguation, and slug reuse after soft-delete.
- Orthogonal to M12 per `docs/plans/m13-parent.md` §Dependency on M12 — ships in parallel with the M12-4 session on another terminal. Touches no M12 file (`lib/brief-runner.ts`, `lib/visual-review.ts`, `lib/anthropic-call.ts`, `docs/plans/m12-parent.md` all untouched). Worktree-isolated at `.claude/worktrees/m13-1-posts-schema` to avoid HEAD races per MEMORY.md "Parallel sessions, single clone".

## Plan (sub-slice)

Posts are a first-class sibling of pages, not a column on pages:

1. Separate table means M6/M7's pages-only queries keep their type/shape guarantees. If the two unify later, `content_type` widens to IN ('page', 'post') via a follow-up data-migration.
2. `content_type` CHECK `'post'` is the runner's row-level assertion key — `mode='post'` in M13-3's dispatch table writes here; a misrouted write trips the CHECK rather than silently ending up in `pages`.
3. `wp_post_id` is nullable — drafts live in Opollo before WP assigns an id; the partial UNIQUE `(site_id, wp_post_id) WHERE wp_post_id IS NOT NULL` treats NULL as distinct so many drafts coexist, while published posts must be unique.
4. `(site_id, slug)` is partial-UNIQUE `WHERE deleted_at IS NULL` — two live posts can't collide, but a soft-deleted slug can be reused. Follows M3-1's `pages_site_slug_unique` precedent (upgraded to the partial flavour for the soft-delete-restore case).
5. `status` CHECK accepts `'draft' | 'published' | 'scheduled'`. `'scheduled'` lands in the schema now so M13-5 ships without a follow-up migration (scheduler wiring is explicitly deferred per parent plan §Out of scope).
6. `posts_published_at_coherent` CHECK — `status='published'` requires `published_at IS NOT NULL`. `updatePostMetadata` auto-stamps `published_at` on a `status → 'published'` transition so callers can't accidentally violate it.
7. Soft-delete + audit + `version_lock` per `docs/DATA_CONVENTIONS.md`. RLS matches M2b (service-role-all + role-band reads + admin/operator writes).

## Risks identified and mitigated

| Risk | Mitigation |
| --- | --- |
| Runner mode regression writes a `content_type='page'` row into `posts`. | `content_type = 'post'` CHECK — schema rejects the insert; covered by `m13-1-schema.test.ts` "rejects content_type='page'/='video'". |
| Two concurrent publishes race the same WP post id (M13-4). | Partial UNIQUE `(site_id, wp_post_id) WHERE wp_post_id IS NOT NULL` — second publish blows up with `23505`; lib layer surfaces `UNIQUE_VIOLATION`. Test: "rejects two published posts with the same (site_id, wp_post_id)". |
| Operator renames a slug to collide with an existing live post. | Partial UNIQUE `(site_id, slug) WHERE deleted_at IS NULL` — `updatePostMetadata` catches `23505` and returns `UNIQUE_VIOLATION` with the attempted slug in details. Test: "returns UNIQUE_VIOLATION when slug collides on the same site". |
| Archived post is silently "restored" by re-editing with a stale expected_version. | `updatePostMetadata` predicates on `deleted_at IS NULL`; the zero-row disambiguator returns `NOT_FOUND` with `archived: true` in details. Test: "returns NOT_FOUND on archived post". |
| Stale edit clobbers a concurrent update. | `version_lock` optimistic concurrency — predicated UPDATE + zero-row disambiguator returns `VERSION_CONFLICT` with `current_version` in details. Test: "returns VERSION_CONFLICT on stale expected_version". |
| Row marked `status='published'` without a `published_at` timestamp. | `posts_published_at_coherent` CHECK + `updatePostMetadata` auto-stamps `published_at = now()` on status transitions to `'published'`. Tests: schema-level rejection + happy-path stamping. |
| Soft-deleted post's slug blocks new post creation forever. | Partial UNIQUE is `WHERE deleted_at IS NULL` — soft-deleted rows don't contend. Test: "permits reuse of a slug after the original is soft-deleted" + "frees the slug for a new live post after soft-delete". |
| Cross-site access via URL manipulation. | `getPost` and `updatePostMetadata` predicate on BOTH `site_id` and `id`; cross-site lookup returns `NOT_FOUND`. Tests: two cross-site-guard tests. |

Gaps deliberately deferred: published-post immutability (handled at the admin surface in M13-4), WP→Opollo drift reconciliation for posts (parallel to M7-5's page flavour, out of scope for M13-1), post revision history (BACKLOG).

## Test plan
- [ ] CI: typecheck, lint, build pass locally (confirmed in worktree).
- [ ] CI: `vitest run lib/__tests__/posts.test.ts` — createPost happy + UNIQUE_VIOLATION + VALIDATION_FAILED paths, list site-scope + filter composition + pagination, getPost cross-site guard + archived flag, updatePostMetadata happy + VERSION_CONFLICT + UNIQUE_VIOLATION + NOT_FOUND-on-archived, softDeletePost happy + slug-reuse + VERSION_CONFLICT.
- [ ] CI: `vitest run lib/__tests__/m13-1-schema.test.ts` — content_type / status / version_lock / design_system_version CHECKs, posts_published_at_coherent, both partial UNIQUEs, site FK CASCADE.
- [ ] Migration runs clean on a fresh `supabase db reset`; rollback 0019.down.sql drops policies + indexes + table in reverse order.

## Follow-up

M13-2 (WordPress REST posts wrapper + SEO plugin detection + post-error translations) opens next as a separate PR on the same worktree. M13-3 onward hard-blocks on M12-3 per the parent plan and does NOT ship in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)