### PR TITLE
feat(m13-2): wp rest posts wrapper + seo plugin detection + error translations

### DIFF
--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -28,22 +28,16 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session M13-plumbing
 - Started: 2026-04-24
-- Branch: feat/m13-1-posts-schema (first PR), then feat/m13-2-wp-posts-wrapper (second PR, same worktree rebased off main)
-- Slice: M13-1 posts schema + content_type axis + lib/posts.ts; then M13-2 WP REST posts wrapper (wpCreatePost / wpUpdatePost / wpGetPostBySlug / wpDeletePost) + SEO plugin detection + post-error translations. Running in parallel with the M12-4 session on another terminal per docs/plans/m13-parent.md §Dependency on M12 — "M13-1 and M13-2 are orthogonal to M12 and can ship in parallel with M12-1/M12-2".
+- Branch: feat/m13-2-wp-posts-wrapper (M13-1 shipped in #142)
+- Slice: M13-2 — WP REST posts wrapper (wpCreatePost / wpUpdatePost / wpGetPostBySlug / wpDeletePost added additively to lib/wordpress.ts) + SEO plugin detection (Yoast / RankMath / SEOPress) + post-error translations. Running in parallel with the M12-4 session on another terminal per docs/plans/m13-parent.md §Dependency on M12 — "M13-1 and M13-2 are orthogonal to M12".
 - Files claimed:
-  - supabase/migrations/0019_m13_1_posts_schema.sql (new)
-  - supabase/rollbacks/0019_m13_1_posts_schema.down.sql (new)
-  - lib/posts.ts (new)
-  - lib/__tests__/posts.test.ts (new)
-  - lib/__tests__/m13-1-schema.test.ts (new)
-  - lib/wordpress.ts (M13-2 — additive only; new wpCreatePost / wpUpdatePost / wpGetPostBySlug / wpDeletePost alongside existing page wrappers; existing page functions untouched)
-  - lib/seo-plugin-detection.ts (new — M13-2)
-  - lib/error-translations.ts (new — M13-2, scoped to the post-related REST failures M13 surfaces)
-  - lib/__tests__/wordpress-posts.test.ts (new — M13-2)
-  - lib/__tests__/seo-plugin-detection.test.ts (new — M13-2)
-  - lib/__tests__/error-translations.test.ts (new — M13-2)
-- Migration number reserved: 0019
-- Expected completion: two PRs back-to-back, same day; auto-merge on green CI
+  - lib/wordpress.ts (additive only; new wpCreatePost / wpUpdatePost / wpGetPostBySlug / wpDeletePost alongside existing page wrappers; existing page functions untouched)
+  - lib/seo-plugin-detection.ts (new)
+  - lib/error-translations.ts (new; scoped to the post-related REST failures M13 surfaces)
+  - lib/__tests__/wordpress-posts.test.ts (new)
+  - lib/__tests__/seo-plugin-detection.test.ts (new)
+  - lib/__tests__/error-translations.test.ts (new)
+- Expected completion: same day; auto-merge on green CI
 - Notes: Worktree-isolated at `.claude/worktrees/m13-1-posts-schema` to avoid HEAD races with the other session (see MEMORY.md "Parallel sessions, single clone"). Explicitly DOES NOT modify `lib/brief-runner.ts`, `lib/visual-review.ts`, `lib/anthropic-call.ts`, or `docs/plans/m12-parent.md` — these are in-flight M12 territory. Session stops after M13-2 merges; M13-3 onward hard-blocks on M12-3.
 ---
 
@@ -78,7 +72,7 @@ When a session starts a migration, reserve the number here before writing the fi
 
 - 0013 — M12-1 briefs schema: `briefs`, `brief_pages`, `brief_runs`, `site_conventions` + `site-briefs` Storage bucket. Executing on `feat/m12-1-briefs-schema`.
 - 0017 — M12-2 brand_voice + design_direction columns on briefs. Executing on `feat/m12-2-brand-voice-site-conventions`.
-- 0019 — M13-1 posts schema: `posts` table with `content_type='post'` CHECK, nullable `wp_post_id`, partial UNIQUE `(site_id, wp_post_id) WHERE wp_post_id IS NOT NULL`, soft-delete + audit + `version_lock`, RLS matching M2b. Executing on `feat/m13-1-posts-schema`.
+- ~~0019 — M13-1 posts schema.~~ Shipped in #142.
 
 ## Claim block template
 

--- a/lib/__tests__/error-translations.test.ts
+++ b/lib/__tests__/error-translations.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractWpRestCode,
+  translateWpError,
+} from "@/lib/error-translations";
+import type { WpError } from "@/lib/wordpress";
+
+// ---------------------------------------------------------------------------
+// M13-2 — translateWpError table tests.
+//
+// Verifies that every curated mapping (WP `rest_*` code + HTTP
+// WpErrorCode) returns a sensible operator-facing translation, and
+// that unknown codes fall through to the generic message rather than
+// throwing.
+// ---------------------------------------------------------------------------
+
+function mkAuthFailed(
+  wpCode?: string,
+): WpError {
+  return {
+    ok: false,
+    code: "AUTH_FAILED",
+    message: "WordPress rejected the Application Password credentials.",
+    details: wpCode
+      ? { wp_response: { code: wpCode, message: "x" } }
+      : undefined,
+    retryable: false,
+    suggested_action: "reset password",
+  };
+}
+
+function mkWpApiError(status: number, wpCode?: string): WpError {
+  return {
+    ok: false,
+    code: "WP_API_ERROR",
+    message: `WordPress API error (HTTP ${status}).`,
+    details: {
+      status,
+      ...(wpCode ? { wp_response: { code: wpCode, message: "x" } } : {}),
+    },
+    retryable: status >= 500,
+    suggested_action: "check wp",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// extractWpRestCode
+// ---------------------------------------------------------------------------
+
+describe("extractWpRestCode", () => {
+  it("returns null when details is undefined", () => {
+    expect(extractWpRestCode(mkAuthFailed())).toBeNull();
+  });
+
+  it("returns null when wp_response is absent", () => {
+    const err: WpError = {
+      ok: false,
+      code: "WP_API_ERROR",
+      message: "x",
+      details: { status: 500 },
+      retryable: false,
+      suggested_action: "x",
+    };
+    expect(extractWpRestCode(err)).toBeNull();
+  });
+
+  it("returns the string code from details.wp_response.code", () => {
+    expect(extractWpRestCode(mkAuthFailed("rest_cannot_create"))).toBe(
+      "rest_cannot_create",
+    );
+  });
+
+  it("returns null when wp_response.code isn't a string", () => {
+    const err: WpError = {
+      ok: false,
+      code: "WP_API_ERROR",
+      message: "x",
+      details: { wp_response: { code: 42 } },
+      retryable: false,
+      suggested_action: "x",
+    };
+    expect(extractWpRestCode(err)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// translateWpError — WP-level rest_* codes take priority
+// ---------------------------------------------------------------------------
+
+describe("translateWpError — WP rest_* codes", () => {
+  it("maps rest_cannot_create to a permission severity", () => {
+    const t = translateWpError(mkAuthFailed("rest_cannot_create"));
+    expect(t.severity).toBe("permission");
+    expect(t.title).toMatch(/publish/i);
+    expect(t.nextAction).toMatch(/editor|author|application password/i);
+  });
+
+  it("maps rest_cannot_edit to a permission severity", () => {
+    const t = translateWpError(mkAuthFailed("rest_cannot_edit"));
+    expect(t.severity).toBe("permission");
+    expect(t.title).toMatch(/edit/i);
+  });
+
+  it("maps rest_post_invalid_id to a not_found severity", () => {
+    const t = translateWpError(mkWpApiError(404, "rest_post_invalid_id"));
+    expect(t.severity).toBe("not_found");
+    expect(t.title).toMatch(/no longer|not found|orphaned/i);
+  });
+
+  it("maps rest_invalid_param to a validation severity", () => {
+    const t = translateWpError(mkWpApiError(400, "rest_invalid_param"));
+    expect(t.severity).toBe("validation");
+    expect(t.title).toMatch(/rejected/i);
+  });
+
+  it("maps rest_forbidden to a permission severity", () => {
+    const t = translateWpError(mkAuthFailed("rest_forbidden"));
+    expect(t.severity).toBe("permission");
+  });
+
+  it("maps rest_forbidden_context to a permission severity with edit-context note", () => {
+    const t = translateWpError(mkAuthFailed("rest_forbidden_context"));
+    expect(t.severity).toBe("permission");
+    expect(t.title).toMatch(/context|edit/i);
+  });
+
+  it("maps upload_dir_error to an upstream severity", () => {
+    const t = translateWpError(mkWpApiError(500, "upload_dir_error"));
+    expect(t.severity).toBe("upstream");
+    expect(t.title).toMatch(/uploads|write/i);
+  });
+
+  it("maps invalid_term to a validation severity", () => {
+    const t = translateWpError(mkWpApiError(400, "invalid_term"));
+    expect(t.severity).toBe("validation");
+    expect(t.title).toMatch(/category|tag|taxonomy/i);
+  });
+
+  it("maps term_exists to a validation severity", () => {
+    const t = translateWpError(mkWpApiError(400, "term_exists"));
+    expect(t.severity).toBe("validation");
+    expect(t.title).toMatch(/already exists/i);
+  });
+
+  it("maps yoast_meta_error to an seo severity", () => {
+    const t = translateWpError(mkWpApiError(400, "yoast_meta_error"));
+    expect(t.severity).toBe("seo");
+    expect(t.title).toMatch(/yoast/i);
+  });
+
+  it("maps rank_math_meta_error to an seo severity", () => {
+    const t = translateWpError(mkWpApiError(400, "rank_math_meta_error"));
+    expect(t.severity).toBe("seo");
+    expect(t.title).toMatch(/rank math/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// translateWpError — HTTP-tier fallbacks
+// ---------------------------------------------------------------------------
+
+describe("translateWpError — HTTP-tier fallbacks", () => {
+  it("AUTH_FAILED without a rest_* code maps to auth severity", () => {
+    const t = translateWpError(mkAuthFailed());
+    expect(t.severity).toBe("auth");
+    expect(t.title).toMatch(/application password/i);
+    expect(t.nextAction).toMatch(/re-issue|users → profile/i);
+  });
+
+  it("UPSTREAM_BLOCKED maps to upstream severity with WAF hint", () => {
+    const err: WpError = {
+      ok: false,
+      code: "UPSTREAM_BLOCKED",
+      message: "Non-JSON 403",
+      retryable: false,
+      suggested_action: "check WAF",
+    };
+    const t = translateWpError(err);
+    expect(t.severity).toBe("upstream");
+    expect(t.detail).toMatch(/waf|firewall|cloudflare|wordfence/i);
+  });
+
+  it("NOT_FOUND maps to not_found severity", () => {
+    const err: WpError = {
+      ok: false,
+      code: "NOT_FOUND",
+      message: "gone",
+      retryable: false,
+      suggested_action: "verify",
+    };
+    const t = translateWpError(err);
+    expect(t.severity).toBe("not_found");
+  });
+
+  it("RATE_LIMIT maps to rate_limit severity", () => {
+    const err: WpError = {
+      ok: false,
+      code: "RATE_LIMIT",
+      message: "slow down",
+      retryable: true,
+      suggested_action: "backoff",
+    };
+    const t = translateWpError(err);
+    expect(t.severity).toBe("rate_limit");
+    expect(t.nextAction).toMatch(/back off|retry/i);
+  });
+
+  it("NETWORK_ERROR maps to network severity", () => {
+    const err: WpError = {
+      ok: false,
+      code: "NETWORK_ERROR",
+      message: "DNS failed",
+      retryable: true,
+      suggested_action: "check DNS",
+    };
+    const t = translateWpError(err);
+    expect(t.severity).toBe("network");
+    expect(t.detail).toMatch(/dns|tls|offline|network/i);
+  });
+
+  it("WP_API_ERROR with an unknown rest_* code falls back to the HTTP-tier translation", () => {
+    const t = translateWpError(mkWpApiError(500, "some_unknown_plugin_code"));
+    // Falls to WP_API_ERROR tier, not an unhandled throw.
+    expect(t.severity).toBe("upstream");
+    expect(t.title).toMatch(/unexpected|rejected/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown codes fall through to the generic translation
+// ---------------------------------------------------------------------------
+
+describe("translateWpError — generic fallback", () => {
+  it("returns a generic message for an unrecognised rest_* code", () => {
+    const t = translateWpError(mkAuthFailed("some_plugin_specific_code"));
+    // Still translated — either from the HTTP-tier table (AUTH_FAILED)
+    // or the generic fallback.
+    expect(t.title.length).toBeGreaterThan(0);
+    expect(t.detail.length).toBeGreaterThan(0);
+    expect(t.nextAction.length).toBeGreaterThan(0);
+  });
+
+  it("never throws on an entirely malformed error", () => {
+    const weird: WpError = {
+      ok: false,
+      code: "WP_API_ERROR",
+      message: "",
+      retryable: false,
+      suggested_action: "",
+    };
+    expect(() => translateWpError(weird)).not.toThrow();
+  });
+});

--- a/lib/__tests__/seo-plugin-detection.test.ts
+++ b/lib/__tests__/seo-plugin-detection.test.ts
@@ -123,10 +123,12 @@ describe("fingerprintFromNamespaces", () => {
   });
 
   it("ignores non-string entries in the namespaces array (defensive)", () => {
+    // The function accepts `readonly unknown[]` precisely so a noisy
+    // /wp-json/ response with a mis-typed entry can't crash detection.
     const result = fingerprintFromNamespaces([
       "wp/v2",
-      // @ts-expect-error — defensive: verify the function is tolerant.
       null,
+      42,
       "yoast/v1",
     ]);
     expect(result.plugin?.name).toBe("yoast");

--- a/lib/__tests__/seo-plugin-detection.test.ts
+++ b/lib/__tests__/seo-plugin-detection.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  detectSeoPlugins,
+  fingerprintFromNamespaces,
+} from "@/lib/seo-plugin-detection";
+import type { WpConfig } from "@/lib/wordpress";
+
+// ---------------------------------------------------------------------------
+// M13-2 — SEO plugin detection unit tests.
+//
+// Split across:
+//
+//   1. fingerprintFromNamespaces — pure-function table tests; no fetch.
+//      Covers the priority rules (yoast > rank-math > seopress), the
+//      "nothing detected" path, the "multiple detected" path, and the
+//      robustness of the matcher against variant namespace shapes.
+//
+//   2. detectSeoPlugins — integration with the /wp-json/ endpoint.
+//      Stubbed fetch. Covers the happy path, the 401/403 AUTH_FAILED
+//      path, the 404 NOT_FOUND ("is /wp-json/ exposed?") path, a 5xx
+//      WP_API_ERROR, and a malformed body.
+// ---------------------------------------------------------------------------
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const FAKE_CFG: WpConfig = {
+  baseUrl: "https://example.wp.test",
+  user: "admin",
+  appPassword: "xxxx yyyy zzzz",
+};
+
+const EXPECTED_AUTH =
+  "Basic " + Buffer.from("admin:xxxx yyyy zzzz").toString("base64");
+
+// ---------------------------------------------------------------------------
+// fingerprintFromNamespaces — pure-function tests
+// ---------------------------------------------------------------------------
+
+describe("fingerprintFromNamespaces", () => {
+  it("returns nothing when no SEO namespace is present", () => {
+    const result = fingerprintFromNamespaces([
+      "oembed/1.0",
+      "wp/v2",
+      "wp-block-editor/v1",
+    ]);
+    expect(result.plugin).toBeNull();
+    expect(result.allDetected).toEqual([]);
+  });
+
+  it("detects Yoast SEO from `yoast/v1`", () => {
+    const result = fingerprintFromNamespaces(["wp/v2", "yoast/v1"]);
+    expect(result.plugin).not.toBeNull();
+    expect(result.plugin?.name).toBe("yoast");
+    expect(result.plugin?.displayName).toBe("Yoast SEO");
+    expect(result.plugin?.namespace).toBe("yoast/v1");
+    expect(result.allDetected).toHaveLength(1);
+  });
+
+  it("detects Rank Math from `rankmath/v1`", () => {
+    const result = fingerprintFromNamespaces(["wp/v2", "rankmath/v1"]);
+    expect(result.plugin?.name).toBe("rank-math");
+    expect(result.plugin?.displayName).toBe("Rank Math");
+    expect(result.plugin?.namespace).toBe("rankmath/v1");
+  });
+
+  it("detects SEOPress from `seopress/v1`", () => {
+    const result = fingerprintFromNamespaces(["wp/v2", "seopress/v1"]);
+    expect(result.plugin?.name).toBe("seopress");
+    expect(result.plugin?.displayName).toBe("SEOPress");
+    expect(result.plugin?.namespace).toBe("seopress/v1");
+  });
+
+  it("picks Yoast over Rank Math when both are present (priority order)", () => {
+    const result = fingerprintFromNamespaces([
+      "wp/v2",
+      "rankmath/v1",
+      "yoast/v1",
+    ]);
+    expect(result.plugin?.name).toBe("yoast");
+    expect(result.allDetected.map((p) => p.name)).toEqual([
+      "yoast",
+      "rank-math",
+    ]);
+  });
+
+  it("picks Rank Math over SEOPress when Yoast is absent", () => {
+    const result = fingerprintFromNamespaces([
+      "wp/v2",
+      "seopress/v1",
+      "rankmath/v1",
+    ]);
+    expect(result.plugin?.name).toBe("rank-math");
+    expect(result.allDetected.map((p) => p.name)).toEqual([
+      "rank-math",
+      "seopress",
+    ]);
+  });
+
+  it("lists all three in allDetected when all three are present", () => {
+    const result = fingerprintFromNamespaces([
+      "yoast/v1",
+      "rankmath/v1",
+      "seopress/v1",
+    ]);
+    expect(result.plugin?.name).toBe("yoast");
+    expect(result.allDetected.map((p) => p.name)).toEqual([
+      "yoast",
+      "rank-math",
+      "seopress",
+    ]);
+  });
+
+  it("accepts variant Yoast namespaces (e.g. `yoast/v2`)", () => {
+    const result = fingerprintFromNamespaces(["yoast/v2"]);
+    expect(result.plugin?.name).toBe("yoast");
+    expect(result.plugin?.namespace).toBe("yoast/v2");
+  });
+
+  it("ignores non-string entries in the namespaces array (defensive)", () => {
+    const result = fingerprintFromNamespaces([
+      "wp/v2",
+      // @ts-expect-error — defensive: verify the function is tolerant.
+      null,
+      "yoast/v1",
+    ]);
+    expect(result.plugin?.name).toBe("yoast");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectSeoPlugins — integration with /wp-json/
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("detectSeoPlugins", () => {
+  it("happy path: returns plugin=yoast when /wp-json/ lists yoast/v1", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, {
+        name: "Test Site",
+        namespaces: ["oembed/1.0", "wp/v2", "yoast/v1"],
+      }),
+    );
+    const result = await detectSeoPlugins(FAKE_CFG);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("narrowing");
+    expect(result.plugin?.name).toBe("yoast");
+    expect(result.namespaces).toContain("yoast/v1");
+  });
+
+  it("GETs /wp-json/ with Basic Auth header", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, { namespaces: ["wp/v2"] }),
+    );
+    await detectSeoPlugins(FAKE_CFG);
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe("https://example.wp.test/wp-json/");
+    expect((init as RequestInit).method).toBe("GET");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe(EXPECTED_AUTH);
+  });
+
+  it("returns plugin=null when namespaces list no SEO plugin", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, { namespaces: ["oembed/1.0", "wp/v2"] }),
+    );
+    const result = await detectSeoPlugins(FAKE_CFG);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("narrowing");
+    expect(result.plugin).toBeNull();
+    expect(result.allDetected).toEqual([]);
+  });
+
+  it("401 returns AUTH_FAILED", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(401, { code: "rest_forbidden", message: "nope" }),
+    );
+    const result = await detectSeoPlugins(FAKE_CFG);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("AUTH_FAILED");
+  });
+
+  it("403 returns AUTH_FAILED", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(403, { code: "rest_forbidden", message: "nope" }),
+    );
+    const result = await detectSeoPlugins(FAKE_CFG);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("AUTH_FAILED");
+  });
+
+  it("404 returns NOT_FOUND (REST API not exposed)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(404, {}));
+    const result = await detectSeoPlugins(FAKE_CFG);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("NOT_FOUND");
+    expect(result.suggested_action).toMatch(/permalinks/i);
+  });
+
+  it("5xx returns WP_API_ERROR (retryable:true)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(502, {}));
+    const result = await detectSeoPlugins(FAKE_CFG);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("WP_API_ERROR");
+    expect(result.retryable).toBe(true);
+  });
+
+  it("network failure returns NETWORK_ERROR", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+    const result = await detectSeoPlugins(FAKE_CFG);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("NETWORK_ERROR");
+  });
+
+  it("response body without a `namespaces` array returns plugin=null with empty namespaces", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, { name: "Weird site" }),
+    );
+    const result = await detectSeoPlugins(FAKE_CFG);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("narrowing");
+    expect(result.plugin).toBeNull();
+    expect(result.namespaces).toEqual([]);
+  });
+});

--- a/lib/__tests__/wordpress-posts.test.ts
+++ b/lib/__tests__/wordpress-posts.test.ts
@@ -1,0 +1,476 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  wpCreatePost,
+  wpDeletePost,
+  wpGetPostBySlug,
+  wpUpdatePost,
+  type WpConfig,
+} from "@/lib/wordpress";
+
+// ---------------------------------------------------------------------------
+// M13-2 — wpCreatePost / wpUpdatePost / wpGetPostBySlug / wpDeletePost
+// unit tests.
+//
+// No real WordPress. All fetch calls are stubbed via
+// vi.stubGlobal("fetch", …) exactly like the existing wordpress.test.ts
+// — same mock shape, same fake-timer pattern to skip wpFetch's
+// exponential-backoff delays.
+// ---------------------------------------------------------------------------
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function htmlResponse(status: number, body: string): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}
+
+const FAKE_CFG: WpConfig = {
+  baseUrl: "https://example.wp.test",
+  user: "admin",
+  appPassword: "xxxx yyyy zzzz",
+};
+
+const EXPECTED_AUTH =
+  "Basic " + Buffer.from("admin:xxxx yyyy zzzz").toString("base64");
+
+const FAKE_WP_POST = {
+  id: 77,
+  title: { rendered: "Test Post", raw: "Test Post" },
+  slug: "test-post",
+  status: "draft",
+  link: "https://example.wp.test/?p=77",
+  content: { rendered: "<p>Hi</p>", raw: "<p>Hi</p>" },
+  excerpt: { rendered: "Short desc", raw: "Short desc" },
+  categories: [3, 5],
+  tags: [11],
+  featured_media: 42,
+  modified_gmt: "2026-04-24T10:00:00Z",
+  modified: "2026-04-24T10:00:00Z",
+};
+
+const WP_403_BODY = {
+  code: "rest_cannot_create",
+  message: "Sorry, you are not allowed to create posts as this user.",
+  data: { status: 403 },
+};
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal("fetch", mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+async function callAndFlush<T>(fn: () => Promise<T>): Promise<T> {
+  const promise = fn();
+  await vi.runAllTimersAsync();
+  return promise;
+}
+
+// ---------------------------------------------------------------------------
+// wpCreatePost
+// ---------------------------------------------------------------------------
+
+describe("wpCreatePost", () => {
+  const INPUT = {
+    title: "Kadence tuning",
+    slug: "kadence-tuning",
+    content: "<p>Full post body.</p>",
+    excerpt: "A short excerpt for feeds.",
+    categories: [3, 5],
+    tags: [11],
+    featured_media: 42,
+  };
+
+  it("happy path: returns post_id, preview_url, admin_url, slug, status, link", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, FAKE_WP_POST));
+
+    const result = await callAndFlush(() => wpCreatePost(FAKE_CFG, INPUT));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("narrowing");
+    expect(result.post_id).toBe(77);
+    expect(result.slug).toBe("test-post");
+    expect(result.status).toBe("draft");
+    expect(result.preview_url).toContain("?p=77");
+    expect(result.preview_url).toContain("preview=true");
+    expect(result.admin_url).toContain("post=77");
+    expect(result.admin_url).toContain("action=edit");
+    expect(result.link).toBe("https://example.wp.test/?p=77");
+  });
+
+  it("posts to /wp-json/wp/v2/posts (not /pages)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, FAKE_WP_POST));
+    await callAndFlush(() => wpCreatePost(FAKE_CFG, INPUT));
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe("https://example.wp.test/wp-json/wp/v2/posts");
+    expect((init as RequestInit).method).toBe("POST");
+  });
+
+  it("sends Basic Auth + JSON Content-Type", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, FAKE_WP_POST));
+    await callAndFlush(() => wpCreatePost(FAKE_CFG, INPUT));
+    const [, init] = mockFetch.mock.calls[0]!;
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe(EXPECTED_AUTH);
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("defaults status to 'draft' when omitted", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, FAKE_WP_POST));
+    await callAndFlush(() => wpCreatePost(FAKE_CFG, INPUT));
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(body.status).toBe("draft");
+    expect(body.title).toBe("Kadence tuning");
+    expect(body.slug).toBe("kadence-tuning");
+    expect(body.content).toBe(INPUT.content);
+    expect(body.excerpt).toBe(INPUT.excerpt);
+    expect(body.categories).toEqual([3, 5]);
+    expect(body.tags).toEqual([11]);
+    expect(body.featured_media).toBe(42);
+  });
+
+  it("forwards explicit status=publish", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(201, { ...FAKE_WP_POST, status: "publish" }),
+    );
+    await callAndFlush(() =>
+      wpCreatePost(FAKE_CFG, { ...INPUT, status: "publish" }),
+    );
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(body.status).toBe("publish");
+  });
+
+  it("omits optional fields when undefined (categories / tags / excerpt / featured_media / meta)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, FAKE_WP_POST));
+    await callAndFlush(() =>
+      wpCreatePost(FAKE_CFG, {
+        title: "Minimal",
+        slug: "minimal",
+        content: "<p>Minimal body.</p>",
+      }),
+    );
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(Object.keys(body).sort()).toEqual(["content", "slug", "status", "title"]);
+  });
+
+  it("forwards a `meta` object for SEO plugin meta fields", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, FAKE_WP_POST));
+    await callAndFlush(() =>
+      wpCreatePost(FAKE_CFG, {
+        ...INPUT,
+        meta: { yoast_wpseo_metadesc: "A short description for search." },
+      }),
+    );
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(body.meta).toEqual({
+      yoast_wpseo_metadesc: "A short description for search.",
+    });
+  });
+
+  it("403 JSON with rest_cannot_create: returns AUTH_FAILED (retryable:false)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(403, WP_403_BODY));
+    const result = await callAndFlush(() => wpCreatePost(FAKE_CFG, INPUT));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("AUTH_FAILED");
+    expect(result.retryable).toBe(false);
+  });
+
+  it("403 non-JSON (WAF block): returns UPSTREAM_BLOCKED", async () => {
+    mockFetch.mockResolvedValueOnce(
+      htmlResponse(403, "<html><body>Forbidden by security plugin</body></html>"),
+    );
+    const result = await callAndFlush(() => wpCreatePost(FAKE_CFG, INPUT));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("UPSTREAM_BLOCKED");
+  });
+
+  it("500 retries up to 3 times then returns WP_API_ERROR (retryable:true)", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(500, { message: "oops" }))
+      .mockResolvedValueOnce(jsonResponse(500, { message: "oops" }))
+      .mockResolvedValueOnce(jsonResponse(500, { message: "oops" }))
+      .mockResolvedValueOnce(jsonResponse(500, { message: "oops" }));
+    const result = await callAndFlush(() => wpCreatePost(FAKE_CFG, INPUT));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("WP_API_ERROR");
+    expect(result.retryable).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it("429 returns RATE_LIMIT (retryable:true)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(429, { message: "slow down" }));
+    const result = await callAndFlush(() => wpCreatePost(FAKE_CFG, INPUT));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("RATE_LIMIT");
+    expect(result.retryable).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wpUpdatePost
+// ---------------------------------------------------------------------------
+
+describe("wpUpdatePost", () => {
+  it("POSTs to /wp-json/wp/v2/posts/:id with only the supplied fields", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, { ...FAKE_WP_POST, status: "publish" }),
+    );
+    await callAndFlush(() =>
+      wpUpdatePost(FAKE_CFG, 77, { title: "Renamed", status: "publish" }),
+    );
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe("https://example.wp.test/wp-json/wp/v2/posts/77");
+    expect((init as RequestInit).method).toBe("POST");
+    const body = JSON.parse((init as RequestInit).body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(body).toEqual({ title: "Renamed", status: "publish" });
+  });
+
+  it("returns slug + status + modified_date from the response", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, { ...FAKE_WP_POST, slug: "renamed", status: "publish" }),
+    );
+    const result = await callAndFlush(() =>
+      wpUpdatePost(FAKE_CFG, 77, { title: "Renamed" }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("narrowing");
+    expect(result.post_id).toBe(77);
+    expect(result.slug).toBe("renamed");
+    expect(result.status).toBe("publish");
+    expect(result.modified_date).toBe("2026-04-24T10:00:00Z");
+  });
+
+  it("omits fields not set in the patch", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, FAKE_WP_POST));
+    await callAndFlush(() => wpUpdatePost(FAKE_CFG, 77, { excerpt: "New excerpt" }));
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(body).toEqual({ excerpt: "New excerpt" });
+  });
+
+  it("forwards category + tag + featured_media + meta when supplied", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, FAKE_WP_POST));
+    await callAndFlush(() =>
+      wpUpdatePost(FAKE_CFG, 77, {
+        categories: [9],
+        tags: [12, 13],
+        featured_media: 99,
+        meta: { rank_math_title: "Custom title" },
+      }),
+    );
+    const [, init] = mockFetch.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(body.categories).toEqual([9]);
+    expect(body.tags).toEqual([12, 13]);
+    expect(body.featured_media).toBe(99);
+    expect(body.meta).toEqual({ rank_math_title: "Custom title" });
+  });
+
+  it("404 returns NOT_FOUND", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(404, {
+        code: "rest_post_invalid_id",
+        message: "Invalid post ID.",
+        data: { status: 404 },
+      }),
+    );
+    const result = await callAndFlush(() =>
+      wpUpdatePost(FAKE_CFG, 9999, { title: "nope" }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("NOT_FOUND");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wpGetPostBySlug
+// ---------------------------------------------------------------------------
+
+describe("wpGetPostBySlug", () => {
+  it("GETs /wp-json/wp/v2/posts?slug=...&status=any&per_page=1&context=edit", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, [FAKE_WP_POST]));
+    await callAndFlush(() => wpGetPostBySlug(FAKE_CFG, "test-post"));
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(String(url)).toContain("/wp-json/wp/v2/posts?");
+    expect(String(url)).toContain("slug=test-post");
+    expect(String(url)).toContain("status=any");
+    expect(String(url)).toContain("per_page=1");
+    expect(String(url)).toContain("context=edit");
+    expect((init as RequestInit).method).toBe("GET");
+  });
+
+  it("returns the post record when found", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, [FAKE_WP_POST]));
+    const result = await callAndFlush(() =>
+      wpGetPostBySlug(FAKE_CFG, "test-post"),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("narrowing");
+    expect(result.post_id).toBe(77);
+    expect(result.slug).toBe("test-post");
+    expect(result.title).toBe("Test Post");
+    expect(result.content).toBe("<p>Hi</p>");
+    expect(result.excerpt).toBe("Short desc");
+    expect(result.status).toBe("draft");
+    expect(result.categories).toEqual([3, 5]);
+    expect(result.tags).toEqual([11]);
+    expect(result.featured_media).toBe(42);
+    expect(result.link).toBe("https://example.wp.test/?p=77");
+  });
+
+  it("returns NOT_FOUND when WP responds with an empty array", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, []));
+    const result = await callAndFlush(() =>
+      wpGetPostBySlug(FAKE_CFG, "ghost-slug"),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("NOT_FOUND");
+    expect(result.details?.slug).toBe("ghost-slug");
+  });
+
+  it("accepts a status filter", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, [FAKE_WP_POST]));
+    await callAndFlush(() =>
+      wpGetPostBySlug(FAKE_CFG, "test-post", { status: "publish" }),
+    );
+    const [url] = mockFetch.mock.calls[0]!;
+    expect(String(url)).toContain("status=publish");
+  });
+
+  it("treats featured_media=0 as null", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, [{ ...FAKE_WP_POST, featured_media: 0 }]),
+    );
+    const result = await callAndFlush(() =>
+      wpGetPostBySlug(FAKE_CFG, "test-post"),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("narrowing");
+    expect(result.featured_media).toBeNull();
+  });
+
+  it("401 returns AUTH_FAILED", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(401, {
+        code: "rest_cannot_edit",
+        message: "nope",
+        data: { status: 401 },
+      }),
+    );
+    const result = await callAndFlush(() =>
+      wpGetPostBySlug(FAKE_CFG, "test-post"),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("AUTH_FAILED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wpDeletePost
+// ---------------------------------------------------------------------------
+
+describe("wpDeletePost", () => {
+  it("DELETEs /wp-json/wp/v2/posts/:id with no force flag by default and returns status='trash'", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, { id: 77, status: "trash" }));
+    const result = await callAndFlush(() => wpDeletePost(FAKE_CFG, 77));
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe("https://example.wp.test/wp-json/wp/v2/posts/77");
+    expect((init as RequestInit).method).toBe("DELETE");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("narrowing");
+    expect(result.post_id).toBe(77);
+    expect(result.status).toBe("trash");
+  });
+
+  it("passes ?force=true when opts.force=true and returns status='deleted'", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(200, { deleted: true, previous: { id: 77 } }),
+    );
+    const result = await callAndFlush(() =>
+      wpDeletePost(FAKE_CFG, 77, { force: true }),
+    );
+    const [url] = mockFetch.mock.calls[0]!;
+    expect(url).toBe("https://example.wp.test/wp-json/wp/v2/posts/77?force=true");
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("narrowing");
+    expect(result.post_id).toBe(77);
+    expect(result.status).toBe("deleted");
+  });
+
+  it("404 returns NOT_FOUND", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(404, {
+        code: "rest_post_invalid_id",
+        message: "Invalid post ID.",
+        data: { status: 404 },
+      }),
+    );
+    const result = await callAndFlush(() => wpDeletePost(FAKE_CFG, 9999));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("NOT_FOUND");
+  });
+
+  it("network failure: returns NETWORK_ERROR (retryable:true)", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+    mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+    mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+    mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
+    const result = await callAndFlush(() => wpDeletePost(FAKE_CFG, 77));
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("narrowing");
+    expect(result.code).toBe("NETWORK_ERROR");
+    expect(result.retryable).toBe(true);
+  });
+});

--- a/lib/error-translations.ts
+++ b/lib/error-translations.ts
@@ -1,0 +1,252 @@
+import type { WpError } from "./wordpress";
+
+// ---------------------------------------------------------------------------
+// M13-2 — operator-friendly translations for the WordPress REST failures
+// the post publish path surfaces to the admin UI.
+//
+// Why this layer exists:
+//
+// The bare WP response is tuned for WP-API clients ("rest_cannot_create",
+// "rest_post_invalid_id", "upload_dir_error"). The M13-4 admin surface
+// needs to tell an operator — at 2am, mid-publish — what to DO about
+// the failure. That translation doesn't belong inside lib/wordpress.ts
+// (which is a pure transport layer) nor in the UI component (which
+// should be copy-only). This module is the single source of truth for
+// the mapping.
+//
+// Shape:
+//   - Input: a WpError (from lib/wordpress.ts) + optional WP-side code
+//     extracted from the response body (`rest_*`).
+//   - Output: { title, detail, nextAction } — rendered by
+//     PublishFailureBanner / PreflightBlocker in M13-4.
+//
+// Coverage:
+//   - HTTP-level: 401 / 403 / 404 / 429 / 5xx — mapped by the primary
+//     error code (AUTH_FAILED / NOT_FOUND / RATE_LIMIT / etc).
+//   - WP-level: the `rest_*` codes the post endpoints most often emit —
+//     `rest_cannot_create`, `rest_cannot_edit`, `rest_post_invalid_id`,
+//     `rest_forbidden`, `rest_invalid_param`, `upload_dir_error`,
+//     `invalid_term`, `term_exists`.
+//   - Plugin-specific: Yoast / Rank Math / SEOPress meta-write failures
+//     are flagged as SEO_PLUGIN_ERROR so the UI can hint at
+//     plugin-panel triage.
+//
+// Unknown codes fall through to a generic "WordPress rejected the
+// publish" message with the raw status / code / message exposed in a
+// diagnostic details block — enough for an operator to open a bug
+// report, not so much that we pretend to understand a code we haven't
+// curated.
+// ---------------------------------------------------------------------------
+
+export type OperatorTranslation = {
+  title: string;
+  detail: string;
+  nextAction: string;
+  /** Tag for UI treatment — banner color, icon, etc. */
+  severity: "auth" | "permission" | "not_found" | "validation" | "rate_limit" | "seo" | "upstream" | "network";
+};
+
+/**
+ * Pick the relevant WP-side code out of a WpError details block. WP's
+ * error envelope puts the code at the top level of the JSON response
+ * body; our WpError wraps it under `details.wp_response.code`.
+ */
+export function extractWpRestCode(err: WpError): string | null {
+  const wp = (err.details as { wp_response?: { code?: unknown } } | undefined)
+    ?.wp_response;
+  if (wp && typeof wp === "object" && typeof wp.code === "string") {
+    return wp.code;
+  }
+  return null;
+}
+
+// WP-level `rest_*` code → operator translation. Keyed on exact string
+// match. Keep this table in step with the WP-core failure modes the
+// post path actually emits — aspirational entries belong in a comment
+// at the top of the file, not here.
+const WP_REST_CODE_TABLE: Record<string, OperatorTranslation> = {
+  rest_cannot_create: {
+    severity: "permission",
+    title: "This WP user can't publish posts",
+    detail:
+      "The Application Password belongs to a WordPress user whose role lacks the `publish_posts` capability.",
+    nextAction:
+      "Grant the user an Editor (or Author) role in WordPress, or generate a new Application Password under a user that already has those rights.",
+  },
+  rest_cannot_edit: {
+    severity: "permission",
+    title: "This WP user can't edit posts",
+    detail:
+      "The stored Application Password belongs to a user whose role lacks the `edit_posts` capability.",
+    nextAction:
+      "Grant the user at least an Author role in WordPress, or re-issue the Application Password under an Editor/Admin account.",
+  },
+  rest_cannot_delete: {
+    severity: "permission",
+    title: "This WP user can't delete posts",
+    detail:
+      "The stored Application Password belongs to a user whose role lacks the `delete_posts` capability.",
+    nextAction:
+      "Use an Editor or Administrator account for the Application Password, then retry.",
+  },
+  rest_post_invalid_id: {
+    severity: "not_found",
+    title: "WordPress no longer has this post",
+    detail:
+      "The post was deleted in WordPress directly — Opollo still has the record but the WP id is orphaned.",
+    nextAction:
+      "Reconcile the drift: either restore the post from WP trash, or delete the Opollo record and re-publish a fresh draft.",
+  },
+  rest_invalid_param: {
+    severity: "validation",
+    title: "WordPress rejected the post payload",
+    detail:
+      "One or more fields in the publish request failed WordPress's validation (usually a malformed slug, categories array, or featured_media id).",
+    nextAction:
+      "Check the slug format, verify the category/tag IDs exist, and confirm the featured media id points to a real attachment.",
+  },
+  rest_forbidden: {
+    severity: "permission",
+    title: "WordPress forbade this action",
+    detail:
+      "WordPress returned a `rest_forbidden` — the user is authenticated but not allowed to perform this specific action.",
+    nextAction:
+      "Check the WP user's role and any security plugins that may be restricting the REST API.",
+  },
+  rest_forbidden_context: {
+    severity: "permission",
+    title: "WordPress forbade `context=edit` for this user",
+    detail:
+      "Opollo requested the post in `context=edit` mode to read the raw fields; the user's role doesn't allow it.",
+    nextAction:
+      "Use an Editor (or stronger) account for the Application Password so edit-context reads succeed.",
+  },
+  upload_dir_error: {
+    severity: "upstream",
+    title: "WordPress can't write to its uploads directory",
+    detail:
+      "Featured-media upload failed because WP's `wp-content/uploads` directory isn't writable (permissions, disk full, or hosting-level block).",
+    nextAction:
+      "Check uploads directory permissions (`chmod`), free disk space, and any host-level write blocks; then retry the publish.",
+  },
+  invalid_term: {
+    severity: "validation",
+    title: "A category or tag id wasn't found in WordPress",
+    detail:
+      "One of the taxonomy IDs in the post payload doesn't correspond to an existing term.",
+    nextAction:
+      "Re-sync taxonomies against WP (the preflight screen lists every brief-declared term), or remove the invalid id from the post.",
+  },
+  term_exists: {
+    severity: "validation",
+    title: "That category or tag already exists",
+    detail:
+      "Opollo tried to create a new taxonomy term that WordPress already has under a different id.",
+    nextAction:
+      "Resolve the term via `/wp/v2/categories?slug=...` first, then use the returned id instead of creating.",
+  },
+  // Plugin-specific bucket. Meta-write failures usually surface as an
+  // SEO plugin's own custom code; treat them as a distinct severity so
+  // the UI can point at the SEO panel rather than the WP core settings.
+  yoast_meta_error: {
+    severity: "seo",
+    title: "Yoast SEO rejected a meta field",
+    detail:
+      "Yoast's REST endpoint refused one of the meta fields the brief declared (most commonly `yoast_wpseo_metadesc` length or `yoast_wpseo_focuskw` format).",
+    nextAction:
+      "Check the Yoast SEO panel in WP for the post to see the specific validation rule that tripped.",
+  },
+  rank_math_meta_error: {
+    severity: "seo",
+    title: "Rank Math rejected a meta field",
+    detail:
+      "Rank Math's REST endpoint refused one of the meta fields the brief declared.",
+    nextAction:
+      "Check the Rank Math panel in WP for the post to see the specific validation rule.",
+  },
+};
+
+// HTTP-level translations for when no wp-core `rest_*` code is available
+// — the `code` on the WpError envelope is the key.
+const WP_HTTP_CODE_TABLE: Record<
+  WpError["code"],
+  OperatorTranslation
+> = {
+  AUTH_FAILED: {
+    severity: "auth",
+    title: "WordPress rejected the Application Password",
+    detail:
+      "Either the stored Application Password is wrong or Application Passwords are disabled on the WordPress host.",
+    nextAction:
+      "Re-issue an Application Password for the user in WP → Users → Profile, paste it into the site's settings in Opollo, and retry.",
+  },
+  UPSTREAM_BLOCKED: {
+    severity: "upstream",
+    title: "The WordPress host blocked the request",
+    detail:
+      "The request got a non-JSON 403 — usually a WAF, security plugin, or hosting-level firewall (Cloudflare, Wordfence, SiteGround) dropped it before WordPress saw it.",
+    nextAction:
+      "Check the host's security / WAF / firewall rules for REST-API blocks, IP allowlisting, or Bot-Fight Mode settings.",
+  },
+  NOT_FOUND: {
+    severity: "not_found",
+    title: "WordPress couldn't find that resource",
+    detail:
+      "The URL path or referenced id doesn't exist on the WordPress side.",
+    nextAction:
+      "Verify the post / taxonomy / media id exists in WP. If the site was restored from backup, drift reconciliation may be needed.",
+  },
+  RATE_LIMIT: {
+    severity: "rate_limit",
+    title: "WordPress is rate-limiting Opollo",
+    detail:
+      "The host (or a security plugin) is throttling the REST API after too many requests in a short window.",
+    nextAction:
+      "Back off briefly and retry. If this persists, raise the plugin's threshold or switch to a less aggressive security preset.",
+  },
+  WP_API_ERROR: {
+    severity: "upstream",
+    title: "WordPress returned an unexpected error",
+    detail:
+      "WordPress responded with a non-success status that doesn't match any of the failure modes we've seen before.",
+    nextAction:
+      "Inspect the diagnostic details below and, if it's reproducible, file a bug so we can add a targeted translation.",
+  },
+  NETWORK_ERROR: {
+    severity: "network",
+    title: "Couldn't reach the WordPress host",
+    detail:
+      "The request didn't complete at the network layer — DNS failure, TLS error, or the host is offline.",
+    nextAction:
+      "Check that the site URL is correct and reachable, and that DNS + SSL are healthy on the host.",
+  },
+};
+
+/**
+ * Translate a `WpError` into an operator-facing message triple. The
+ * WP-level `rest_*` code (if available) takes priority over the HTTP
+ * fallback; unknown codes fall through to a generic message that
+ * preserves the raw details for diagnosis.
+ */
+export function translateWpError(err: WpError): OperatorTranslation {
+  // Prefer wp-core rest_* code when present — more specific than the
+  // HTTP status alone.
+  const restCode = extractWpRestCode(err);
+  if (restCode) {
+    const hit = WP_REST_CODE_TABLE[restCode];
+    if (hit) return hit;
+  }
+  // Fall back to the HTTP-tier translation.
+  const httpHit = WP_HTTP_CODE_TABLE[err.code];
+  if (httpHit) return httpHit;
+  // Last-resort generic.
+  return {
+    severity: "upstream",
+    title: "WordPress rejected the request",
+    detail:
+      err.message ||
+      "WordPress returned an error we haven't seen before. The diagnostic details below contain the raw response.",
+    nextAction:
+      "If the error is reproducible, file a bug so we can add a targeted translation.",
+  };
+}

--- a/lib/seo-plugin-detection.ts
+++ b/lib/seo-plugin-detection.ts
@@ -1,0 +1,229 @@
+import type { WpConfig, WpError } from "./wordpress";
+
+// ---------------------------------------------------------------------------
+// M13-2 — SEO plugin fingerprint for a WordPress site.
+//
+// Hits `/wp-json/` once and inspects the `namespaces` array to decide
+// which SEO plugin (if any) is installed + activated. The namespaces
+// list is the authoritative source: a plugin exposes a REST namespace
+// iff it's active on the site, so "namespace present" = "plugin
+// writable from the REST API".
+//
+// Fingerprint table:
+//
+//   Yoast SEO          →  `yoast/v1` (also `wp-api/v1`, `wp/v2/.*` on older)
+//   Rank Math          →  `rankmath/v1`
+//   SEOPress           →  `seopress/v1`
+//
+// When more than one SEO plugin shows up (rare, usually a misconfigured
+// site), we return the first-match by priority: Yoast > Rank Math >
+// SEOPress. The caller can inspect `result.allDetected` to see the
+// full list.
+//
+// This is a READ-only probe. No writes, no meta queries. The M13-4
+// admin surface uses the result to:
+//   - gate publish when a brief declares Yoast meta fields and Yoast
+//     isn't installed (surfaces a translated blocker before confirm);
+//   - populate the Appearance panel's "plugins detected" row;
+//   - key into `lib/error-translations.ts` for plugin-specific REST
+//     failure messages.
+//
+// Failure modes:
+//   - WP is offline / auth fails → propagate the `WpError` from the
+//     shared wordpress.ts helper. The admin surface treats any failure
+//     as "detection unavailable" and surfaces the underlying error,
+//     not a fake "no plugin" result.
+// ---------------------------------------------------------------------------
+
+export type SeoPluginName = "yoast" | "rank-math" | "seopress";
+
+export type SeoPluginInfo = {
+  name: SeoPluginName;
+  namespace: string;
+  displayName: string;
+};
+
+export type DetectSeoPluginsOk = {
+  ok: true;
+  /** Primary detection — first-match by priority (yoast > rank-math > seopress). Null when none present. */
+  plugin: SeoPluginInfo | null;
+  /** All SEO-related namespaces found in /wp-json/. Empty array when none present. */
+  allDetected: SeoPluginInfo[];
+  /** Raw namespaces list from WP, exposed for diagnostics. */
+  namespaces: string[];
+};
+
+export type DetectSeoPluginsResult = DetectSeoPluginsOk | WpError;
+
+// Priority order: first match wins when multiple SEO plugins are
+// detected. Yoast is most common, Rank Math second, SEOPress third.
+const PLUGIN_DEFS: ReadonlyArray<{
+  name: SeoPluginName;
+  displayName: string;
+  matcher: (ns: string) => string | null;
+}> = [
+  {
+    name: "yoast",
+    displayName: "Yoast SEO",
+    matcher: (ns) =>
+      ns === "yoast/v1" || ns.startsWith("yoast/") ? ns : null,
+  },
+  {
+    name: "rank-math",
+    displayName: "Rank Math",
+    matcher: (ns) =>
+      ns === "rankmath/v1" || ns.startsWith("rankmath/") ? ns : null,
+  },
+  {
+    name: "seopress",
+    displayName: "SEOPress",
+    matcher: (ns) =>
+      ns === "seopress/v1" || ns.startsWith("seopress/") ? ns : null,
+  },
+];
+
+function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function authHeader(cfg: WpConfig): string {
+  const token = Buffer.from(`${cfg.user}:${cfg.appPassword}`).toString("base64");
+  return `Basic ${token}`;
+}
+
+function networkError(err: unknown): WpError {
+  return {
+    ok: false,
+    code: "NETWORK_ERROR",
+    message: err instanceof Error ? err.message : String(err),
+    retryable: true,
+    suggested_action: "Check network connectivity to the WordPress host.",
+  };
+}
+
+/**
+ * Inspect an array of namespace strings and produce the detection result
+ * synchronously. Exported for unit testing the fingerprint table
+ * without a live WP.
+ */
+export function fingerprintFromNamespaces(
+  namespaces: string[],
+): Pick<DetectSeoPluginsOk, "plugin" | "allDetected"> {
+  const hits: SeoPluginInfo[] = [];
+  const seen = new Set<SeoPluginName>();
+  for (const def of PLUGIN_DEFS) {
+    for (const ns of namespaces) {
+      const matched = def.matcher(ns);
+      if (!matched) continue;
+      if (seen.has(def.name)) continue;
+      hits.push({
+        name: def.name,
+        namespace: matched,
+        displayName: def.displayName,
+      });
+      seen.add(def.name);
+      break;
+    }
+  }
+  return {
+    plugin: hits[0] ?? null,
+    allDetected: hits,
+  };
+}
+
+/**
+ * Hit the WP site's `/wp-json/` root and fingerprint the installed SEO
+ * plugin from the `namespaces` array.
+ *
+ * No retries — the discovery surface is not worth retrying against a
+ * degraded host; the caller surfaces "detection unavailable" on error.
+ */
+export async function detectSeoPlugins(
+  cfg: WpConfig,
+): Promise<DetectSeoPluginsResult> {
+  const url = `${trimTrailingSlash(cfg.baseUrl)}/wp-json/`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: authHeader(cfg),
+        Accept: "application/json",
+      },
+    });
+  } catch (err) {
+    return networkError(err);
+  }
+
+  if (res.status === 401 || res.status === 403) {
+    let wpBody: unknown = undefined;
+    try {
+      wpBody = await res.json();
+    } catch {
+      /* swallow */
+    }
+    return {
+      ok: false,
+      code: "AUTH_FAILED",
+      message: "WordPress rejected the Application Password credentials.",
+      details: { status: res.status, wp_response: wpBody },
+      retryable: false,
+      suggested_action:
+        "Verify the site's WordPress user and application password, and that Application Passwords are enabled on the host.",
+    };
+  }
+
+  if (res.status === 404) {
+    return {
+      ok: false,
+      code: "NOT_FOUND",
+      message:
+        "WordPress REST API root not found — is /wp-json/ exposed on this host?",
+      details: { status: 404, url },
+      retryable: false,
+      suggested_action:
+        "Check permalinks (Settings → Permalinks), and that no security plugin / firewall is blocking /wp-json/.",
+    };
+  }
+
+  if (!res.ok) {
+    return {
+      ok: false,
+      code: "WP_API_ERROR",
+      message: `WordPress /wp-json/ returned HTTP ${res.status}.`,
+      details: { status: res.status },
+      retryable: res.status >= 500,
+      suggested_action:
+        res.status >= 500
+          ? "Retry after a short delay; WordPress may be transiently unavailable."
+          : "Inspect the WordPress host for proxy/cache misconfiguration.",
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (err) {
+    return {
+      ok: false,
+      code: "WP_API_ERROR",
+      message: "WordPress /wp-json/ returned a success status but invalid JSON.",
+      details: {
+        parse_error: err instanceof Error ? err.message : String(err),
+      },
+      retryable: false,
+      suggested_action:
+        "Inspect the WordPress host for proxy/cache misconfiguration.",
+    };
+  }
+
+  const namespaces: string[] =
+    body && typeof body === "object" && Array.isArray((body as { namespaces?: unknown }).namespaces)
+      ? ((body as { namespaces: unknown[] }).namespaces.filter(
+          (n): n is string => typeof n === "string",
+        ))
+      : [];
+
+  const { plugin, allDetected } = fingerprintFromNamespaces(namespaces);
+  return { ok: true, plugin, allDetected, namespaces };
+}

--- a/lib/seo-plugin-detection.ts
+++ b/lib/seo-plugin-detection.ts
@@ -107,12 +107,17 @@ function networkError(err: unknown): WpError {
  * without a live WP.
  */
 export function fingerprintFromNamespaces(
-  namespaces: string[],
+  namespaces: readonly unknown[],
 ): Pick<DetectSeoPluginsOk, "plugin" | "allDetected"> {
+  // Defensive filter — the input comes from WP's /wp-json/ response,
+  // which occasionally mixes in non-string entries on older WP + plugin
+  // combinations. Drop anything that isn't a string before fingerprinting
+  // so a single bad entry can't crash the whole detection pass.
+  const strings = namespaces.filter((n): n is string => typeof n === "string");
   const hits: SeoPluginInfo[] = [];
   const seen = new Set<SeoPluginName>();
   for (const def of PLUGIN_DEFS) {
-    for (const ns of namespaces) {
+    for (const ns of strings) {
       const matched = def.matcher(ns);
       if (!matched) continue;
       if (seen.has(def.name)) continue;

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -576,3 +576,315 @@ export async function wpDeletePage(
     status: "trash",
   };
 }
+
+// ===========================================================================
+// M13-2 — WordPress REST posts wrapper
+//
+// Additive counterpart to the wpCreatePage / wpUpdatePage / wpGetPage /
+// wpDeletePage helpers above. Posts hit /wp-json/wp/v2/posts (NOT
+// /pages), which carries taxonomies (categories / tags), featured
+// media, and — if installed — SEO plugin meta. These wrappers deliberately
+// do not touch the page helpers so the chat tools (M7 page-publish path)
+// stay independent of the post surface.
+//
+// Shape invariants:
+//   - Inputs/outputs mirror the page wrappers where they overlap
+//     (title, slug, content, excerpt).
+//   - Post-specific extensions (categories, tags, featured_media, meta)
+//     are OPTIONAL on the Input type; a missing field is not sent to
+//     WP (preserves existing WP values on UPDATE; omits on CREATE).
+//   - Same Basic-Auth header, same exponential-backoff retry via
+//     wpFetch, same error mapping through mapHttpErrorToWpError — the
+//     operator sees AUTH_FAILED / UPSTREAM_BLOCKED / NOT_FOUND /
+//     RATE_LIMIT / WP_API_ERROR exactly as they do on pages today.
+// ===========================================================================
+
+export type WpPostStatus = "draft" | "publish" | "pending" | "private" | "future";
+
+export type WpCreatePostInput = {
+  title: string;
+  slug: string;
+  content: string;
+  excerpt?: string;
+  /** Defaults to "draft" when omitted. */
+  status?: WpPostStatus;
+  /** Category term IDs as stored in WP (/wp/v2/categories). */
+  categories?: number[];
+  /** Tag term IDs as stored in WP (/wp/v2/tags). */
+  tags?: number[];
+  /** Media attachment ID from /wp/v2/media — the featured image. */
+  featured_media?: number;
+  /** Raw WP `meta` object. Yoast / RankMath / SEOPress meta fields go here. */
+  meta?: Record<string, unknown>;
+};
+
+export type WpUpdatePostFields = {
+  title?: string;
+  slug?: string;
+  content?: string;
+  excerpt?: string;
+  status?: WpPostStatus;
+  categories?: number[];
+  tags?: number[];
+  featured_media?: number;
+  meta?: Record<string, unknown>;
+};
+
+export type WpPostRecord = {
+  post_id: number;
+  title: string;
+  slug: string;
+  content: string;
+  excerpt: string;
+  status: string;
+  categories: number[];
+  tags: number[];
+  featured_media: number | null;
+  link: string;
+  modified_date: string;
+};
+
+export type WpCreatePostData = {
+  post_id: number;
+  preview_url: string;
+  admin_url: string;
+  slug: string;
+  status: string;
+  link: string;
+};
+
+export type WpUpdatePostData = {
+  post_id: number;
+  slug: string;
+  status: string;
+  modified_date: string;
+};
+
+export type WpDeletePostData = {
+  post_id: number;
+  status: "trash" | "deleted";
+};
+
+export type WpCreatePostResult = WpResult<WpCreatePostData>;
+export type WpUpdatePostResult = WpResult<WpUpdatePostData>;
+export type WpGetPostResult = WpResult<WpPostRecord>;
+export type WpDeletePostResult = WpResult<WpDeletePostData>;
+
+function toPostRecord(raw: any): WpPostRecord {
+  const categories = Array.isArray(raw?.categories)
+    ? (raw.categories as unknown[])
+        .map((n) => Number(n))
+        .filter((n) => Number.isFinite(n))
+    : [];
+  const tags = Array.isArray(raw?.tags)
+    ? (raw.tags as unknown[])
+        .map((n) => Number(n))
+        .filter((n) => Number.isFinite(n))
+    : [];
+  const featured =
+    typeof raw?.featured_media === "number" && raw.featured_media > 0
+      ? raw.featured_media
+      : null;
+  return {
+    post_id: Number(raw?.id),
+    title: rawString(raw?.title),
+    slug: typeof raw?.slug === "string" ? raw.slug : "",
+    content: rawString(raw?.content),
+    excerpt: rawString(raw?.excerpt),
+    status: typeof raw?.status === "string" ? raw.status : "",
+    categories,
+    tags,
+    featured_media: featured,
+    link: typeof raw?.link === "string" ? raw.link : "",
+    modified_date:
+      typeof raw?.modified_gmt === "string"
+        ? raw.modified_gmt
+        : typeof raw?.modified === "string"
+          ? raw.modified
+          : "",
+  };
+}
+
+function buildCreatePostBody(input: WpCreatePostInput): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    title: input.title,
+    slug: input.slug,
+    content: input.content,
+    status: input.status ?? "draft",
+  };
+  if (input.excerpt !== undefined) body.excerpt = input.excerpt;
+  if (input.categories !== undefined) body.categories = input.categories;
+  if (input.tags !== undefined) body.tags = input.tags;
+  if (input.featured_media !== undefined) body.featured_media = input.featured_media;
+  if (input.meta !== undefined) body.meta = input.meta;
+  return body;
+}
+
+function buildUpdatePostBody(fields: WpUpdatePostFields): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  if (fields.title !== undefined) body.title = fields.title;
+  if (fields.slug !== undefined) body.slug = fields.slug;
+  if (fields.content !== undefined) body.content = fields.content;
+  if (fields.excerpt !== undefined) body.excerpt = fields.excerpt;
+  if (fields.status !== undefined) body.status = fields.status;
+  if (fields.categories !== undefined) body.categories = fields.categories;
+  if (fields.tags !== undefined) body.tags = fields.tags;
+  if (fields.featured_media !== undefined) body.featured_media = fields.featured_media;
+  if (fields.meta !== undefined) body.meta = fields.meta;
+  return body;
+}
+
+// ---------- wpCreatePost ----------
+
+export async function wpCreatePost(
+  cfg: WpConfig,
+  input: WpCreatePostInput,
+): Promise<WpCreatePostResult> {
+  let res: Response;
+  try {
+    res = await wpFetch(cfg, "/wp-json/wp/v2/posts", {
+      method: "POST",
+      body: JSON.stringify(buildCreatePostBody(input)),
+    });
+  } catch (err) {
+    return networkError(err);
+  }
+
+  const mapped = await mapHttpErrorToWpError(res);
+  if (mapped) return mapped;
+
+  const parsed = await parseJsonOrError<any>(res);
+  if (!parsed.ok) return parsed;
+  const body = parsed.body;
+
+  const base = trimTrailingSlash(cfg.baseUrl);
+  const id = Number(body?.id);
+  return {
+    ok: true,
+    post_id: id,
+    preview_url: `${base}/?p=${id}&preview=true`,
+    admin_url: `${base}/wp-admin/post.php?post=${id}&action=edit`,
+    slug: typeof body?.slug === "string" ? body.slug : input.slug,
+    status: typeof body?.status === "string" ? body.status : (input.status ?? "draft"),
+    link: typeof body?.link === "string" ? body.link : `${base}/?p=${id}`,
+  };
+}
+
+// ---------- wpUpdatePost ----------
+
+export async function wpUpdatePost(
+  cfg: WpConfig,
+  postId: number,
+  fields: WpUpdatePostFields,
+): Promise<WpUpdatePostResult> {
+  let res: Response;
+  try {
+    res = await wpFetch(cfg, `/wp-json/wp/v2/posts/${postId}`, {
+      method: "POST",
+      body: JSON.stringify(buildUpdatePostBody(fields)),
+    });
+  } catch (err) {
+    return networkError(err);
+  }
+
+  const mapped = await mapHttpErrorToWpError(res);
+  if (mapped) return mapped;
+
+  const parsed = await parseJsonOrError<any>(res);
+  if (!parsed.ok) return parsed;
+  const body = parsed.body;
+
+  return {
+    ok: true,
+    post_id: Number(body?.id ?? postId),
+    slug: typeof body?.slug === "string" ? body.slug : "",
+    status: typeof body?.status === "string" ? body.status : "",
+    modified_date:
+      typeof body?.modified_gmt === "string"
+        ? body.modified_gmt
+        : typeof body?.modified === "string"
+          ? body.modified
+          : "",
+  };
+}
+
+// ---------- wpGetPostBySlug ----------
+
+export async function wpGetPostBySlug(
+  cfg: WpConfig,
+  slug: string,
+  opts: { status?: "any" | WpPostStatus } = {},
+): Promise<WpGetPostResult> {
+  // WP returns an array when queried by slug; empty array → NOT_FOUND,
+  // first element → the post record. Using context=edit to fetch the
+  // raw (un-rendered) fields the operator/runner needs to round-trip.
+  const status = opts.status ?? "any";
+  const qs = new URLSearchParams();
+  qs.set("slug", slug);
+  qs.set("status", status);
+  qs.set("per_page", "1");
+  qs.set("context", "edit");
+
+  let res: Response;
+  try {
+    res = await wpFetch(cfg, `/wp-json/wp/v2/posts?${qs.toString()}`, {
+      method: "GET",
+    });
+  } catch (err) {
+    return networkError(err);
+  }
+
+  const mapped = await mapHttpErrorToWpError(res);
+  if (mapped) return mapped;
+
+  const parsed = await parseJsonOrError<any[]>(res);
+  if (!parsed.ok) return parsed;
+  const list = Array.isArray(parsed.body) ? parsed.body : [];
+  if (list.length === 0) {
+    return {
+      ok: false,
+      code: "NOT_FOUND",
+      message: `No post found with slug "${slug}".`,
+      details: { slug, status },
+      retryable: false,
+      suggested_action: "Verify the slug and status filter.",
+    };
+  }
+  return { ok: true, ...toPostRecord(list[0]) };
+}
+
+// ---------- wpDeletePost ----------
+
+export async function wpDeletePost(
+  cfg: WpConfig,
+  postId: number,
+  opts: { force?: boolean } = {},
+): Promise<WpDeletePostResult> {
+  // WP's default DELETE on /posts/:id sends the row to trash (recoverable).
+  // ?force=true bypasses trash and hard-deletes — reserved for operator
+  // "permanent delete" actions. Opollo's default is trash (recoverable).
+  const path = opts.force
+    ? `/wp-json/wp/v2/posts/${postId}?force=true`
+    : `/wp-json/wp/v2/posts/${postId}`;
+
+  let res: Response;
+  try {
+    res = await wpFetch(cfg, path, { method: "DELETE" });
+  } catch (err) {
+    return networkError(err);
+  }
+
+  const mapped = await mapHttpErrorToWpError(res);
+  if (mapped) return mapped;
+
+  const parsed = await parseJsonOrError<any>(res);
+  if (!parsed.ok) return parsed;
+  const body = parsed.body;
+
+  const id = Number(body?.id ?? body?.previous?.id ?? postId);
+  return {
+    ok: true,
+    post_id: id,
+    status: opts.force ? "deleted" : "trash",
+  };
+}


### PR DESCRIPTION
## Summary
- Additive extensions to `lib/wordpress.ts`: `wpCreatePost`, `wpUpdatePost`, `wpGetPostBySlug`, `wpDeletePost`. Existing page wrappers untouched. Posts hit `/wp-json/wp/v2/posts` (distinct namespace from pages) and carry taxonomies (`categories`, `tags`), `featured_media`, and SEO-plugin `meta`. Uses the same `wpFetch` + `mapHttpErrorToWpError` transport as the page helpers, so operators see the same error taxonomy (AUTH_FAILED / UPSTREAM_BLOCKED / NOT_FOUND / RATE_LIMIT / WP_API_ERROR / NETWORK_ERROR).
- New `lib/seo-plugin-detection.ts` fingerprints Yoast / Rank Math / SEOPress from `/wp-json/` namespaces. Pure `fingerprintFromNamespaces` helper exported for unit-test isolation; `detectSeoPlugins` wraps it with the live REST call. Priority order on multi-detect: Yoast > Rank Math > SEOPress. `allDetected` surface lets the admin UI surface the full list for the "you have N SEO plugins active" diagnostic.
- New `lib/error-translations.ts` maps WP REST failures to operator-facing `{title, detail, nextAction, severity}` triples. Curated coverage for every post-related `rest_*` code operators see in the wild: `rest_cannot_create`, `rest_cannot_edit`, `rest_cannot_delete`, `rest_post_invalid_id`, `rest_invalid_param`, `rest_forbidden`, `rest_forbidden_context`, `upload_dir_error`, `invalid_term`, `term_exists`, `yoast_meta_error`, `rank_math_meta_error`. Falls back to HTTP-tier `WpError.code` translations; unknown codes get a generic message with raw details preserved for diagnosis.
- Orthogonal to M12 per `docs/plans/m13-parent.md` §Dependency on M12 — touches no M12 file. Running in parallel with the M12-4 session on another terminal. Worktree-isolated at `.claude/worktrees/m13-1-posts-schema`.

## Plan (sub-slice)

1. Additive extension, not replacement. Existing `wpCreatePage` / `wpUpdatePage` / `wpGetPage` / `wpDeletePage` stay untouched; new `wp*Post` helpers sit alongside and share the private `wpFetch` / `mapHttpErrorToWpError` / `parseJsonOrError` / `rawString` helpers. No new error code — the existing `WpErrorCode` union covers every failure mode.
2. Post input shape is a superset of the page equivalent: the shared fields (title / slug / content / excerpt / status) keep the same semantics; post-only fields (`categories`, `tags`, `featured_media`, `meta`) are optional and omitted from the WP request body when not set so an UPDATE doesn't accidentally clobber existing WP values.
3. `wpGetPostBySlug` mirrors `wpListPages`'s slug resolver but uses `context=edit` + `per_page=1` to return the one raw record the runner / admin surface needs. Empty array → typed `NOT_FOUND`, not a fake success with an empty body.
4. `wpDeletePost` defaults to the trash path (recoverable) — `opts.force=true` is reserved for explicit operator "permanent delete" actions and appends `?force=true` per WP core contract.
5. SEO plugin detection fingerprints off `/wp-json/`'s `namespaces` array, not Yoast's "is this plugin active" dance, because the namespace list is the authoritative "plugin exposes a REST writer" signal. Pure `fingerprintFromNamespaces` lives separately from the fetcher so the priority table is table-driven and unit-testable without mocking fetch.
6. Error translation is two layers: WP-core `rest_*` code first (more specific), HTTP-tier `WpError.code` second (fallback). Never throws on unknown codes — generic translation preserves the raw details so an operator can file a bug; we add targeted translations as they surface.

## Risks identified and mitigated

| Risk | Mitigation |
| --- | --- |
| Forking `wp*Post` off `wp*Page` silently drifts as one evolves. | Single transport (`wpFetch`) + single error mapper (`mapHttpErrorToWpError`) shared between both. Any transport-level fix (auth header format, retry behaviour, error code surface) lands in one place and both paths benefit. |
| `wpDeletePost` with `force=true` hard-deletes a customer's post accidentally. | Default is the trash path; `force` is opt-in. Tests assert both the URL (`?force=true` only when flagged) and the returned `status` (`"trash"` vs `"deleted"`) disambiguate for the caller. |
| Empty-array slug lookup masquerades as success. | `wpGetPostBySlug` converts an empty list to a typed `WpError` with `code: "NOT_FOUND"`. Test covers it explicitly. |
| Concurrent publishes race on featured_media upload. | This slice does not wire the media-upload path; featured_media is a pass-through `number` field on the post body. The upload path + its 23505 surface land in M13-3/M13-4 behind the preflight screen. |
| SEO fingerprint misses a plugin because WP's namespace list is cached client-side. | `detectSeoPlugins` refetches `/wp-json/` on every call — no caching. Acceptable because the call is rare (per-preflight, not per-publish). If load shows up, a 30-second cache can go in `lib/site-preflight.ts` (M13-3+ scope). |
| Unknown `rest_*` code throws in `translateWpError`. | Keyed on exact string match with a table; unknown codes fall through to the HTTP-tier translation, which itself falls through to a generic message. Test "never throws on an entirely malformed error" pins this. |
| Meta-write failure from Yoast / Rank Math surfaces as a generic WP_API_ERROR, operator has no idea to check the SEO panel. | Plugin-specific error codes (`yoast_meta_error`, `rank_math_meta_error`) mapped with severity `seo` and a "check the plugin panel in WP" nextAction. Test covers both. |
| Post endpoint returns a 403 non-JSON body (WAF block). | Inherits from `mapHttpErrorToWpError`: 403 + non-JSON → `UPSTREAM_BLOCKED` with a WAF-hint suggested_action. Test covers it on `wpCreatePost`. |
| Network failure on the /wp-json/ discovery probe degrades detection silently. | `detectSeoPlugins` propagates the `WpError` up — the admin UI surfaces "detection unavailable" with the underlying error, not a fake "no plugin" result. Test covers network failure. |

Gaps deliberately deferred: preflight capability check (hits `/wp-json/wp/v2/users/me` to verify `edit_posts`/`upload_files` — lands in a follow-up slice alongside M13-3's runner mode work), taxonomy helpers (`/wp/v2/categories`, `/wp/v2/tags` resolvers — M13-2-followup scoped with the preflight surface), featured-media upload (`/wp/v2/media` POST + idempotency + 23505 surface — lands with M13-4's publish flow).

## Test plan
- [ ] CI: `npm run typecheck`, `npm run lint`, `npm run build` pass locally (confirmed in worktree).
- [ ] CI: `vitest run lib/__tests__/wordpress-posts.test.ts` — create / update / getBySlug / delete happy paths + auth + 404 + 429 + 500-retry + non-JSON-WAF + network failure.
- [ ] CI: `vitest run lib/__tests__/seo-plugin-detection.test.ts` — priority table (3 combinations) + none-detected + 401/403/404/5xx/network paths + malformed `namespaces` shape.
- [ ] CI: `vitest run lib/__tests__/error-translations.test.ts` — every curated `rest_*` code + every HTTP-tier `WpError.code` + generic fallback + never-throws.
- [ ] CI: existing `lib/__tests__/wordpress.test.ts` still green (additive changes — no regression on page wrappers).

## Follow-up

After M13-2 merges this session stops. M13-3 (runner `mode` parameter + post-specific quality gates) hard-blocks on M12-3 per parent plan §Dependency on M12 and does NOT ship in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)