### PR TITLE
feat(m13-3): runner mode dispatch + briefs.content_type + post quality gates

### DIFF
--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -25,6 +25,23 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 - Notes: M12-1 shipped four tables (briefs / brief_pages / brief_runs / site_conventions) in 0013 — site_conventions is a table, NOT a JSONB column on briefs as the parent plan originally proposed. M12-2 builds on that consolidated shape. Runner + Claude-inferred defaults for voice/direction land in M12-3; M12-2 ships empty-string defaults + operator-fills form.
 ---
 
+---
+## Session M13-plumbing
+- Started: 2026-04-24
+- Branch: feat/m13-3-runner-mode (M13-1 shipped in #142; M13-2 in #143)
+- Slice: M13-3 — runner `mode: 'page' | 'post'` dispatch via MODE_CONFIGS + `briefs.content_type` schema column + post-specific quality gates (meta description length cap). Anchor cycle disabled in post mode. No changes to M12-4's visual-review loop.
+- Files claimed:
+  - supabase/migrations/0021_m13_3_briefs_content_type.sql (new)
+  - supabase/rollbacks/0021_m13_3_briefs_content_type.down.sql (new)
+  - lib/briefs.ts (extend BriefRow with content_type — no other changes)
+  - lib/brief-runner.ts (add RunnerMode + MODE_CONFIGS + resolveRunnerMode + runPostQualityGates; thread modeConfig through processPagePassLoop)
+  - lib/__tests__/brief-runner-mode.test.ts (new — dispatch table + resolveRunnerMode + post gate + integration tick)
+  - lib/__tests__/m13-3-schema.test.ts (new — content_type CHECK + default + NOT NULL)
+- Migration number reserved: 0021
+- Expected completion: same day; auto-merge on green CI
+- Notes: Runs only after M12-4 (#141) merged so the visual-review primitive is on main. Does not touch any M12 or M13-1/M13-2 file. M13-4 onward is still deferred to a later session.
+---
+
 ## Hot-shared files (always check before claiming)
 
 Even with no other session active, assume these files are "hot" and coordinate explicitly if touching them while another session is in flight:
@@ -57,6 +74,7 @@ When a session starts a migration, reserve the number here before writing the fi
 - 0013 — M12-1 briefs schema: `briefs`, `brief_pages`, `brief_runs`, `site_conventions` + `site-briefs` Storage bucket. Executing on `feat/m12-1-briefs-schema`.
 - 0017 — M12-2 brand_voice + design_direction columns on briefs. Executing on `feat/m12-2-brand-voice-site-conventions`.
 - ~~0019 — M13-1 posts schema.~~ Shipped in #142.
+- 0021 — M13-3 briefs.content_type column. Executing on `feat/m13-3-runner-mode`.
 
 ## Claim block template
 

--- a/lib/__tests__/brief-runner-mode.test.ts
+++ b/lib/__tests__/brief-runner-mode.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest";
+
+import type { BriefRow } from "@/lib/briefs";
+import type {
+  AnthropicCallFn,
+  AnthropicResponse,
+} from "@/lib/anthropic-call";
+import {
+  MODE_CONFIGS,
+  POST_META_DESCRIPTION_MAX,
+  processBriefRunTick,
+  resolveRunnerMode,
+  runPostQualityGates,
+} from "@/lib/brief-runner";
+import { ANCHOR_EXTRA_CYCLES } from "@/lib/site-conventions";
+import type { VisualRenderFn } from "@/lib/visual-review";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M13-3 — runner mode dispatch + post-specific quality gate tests.
+//
+// Pins the parent plan's risk mitigation for "Runner mode regression:
+// post mode runs anchor cycles anyway. Silent cost blowout.":
+//
+//   1. MODE_CONFIGS.post.anchorExtraCycles === 0 (dispatch-table
+//      invariant — a refactor that flips this back to the page default
+//      trips here).
+//   2. Integration tick on a mode='post' brief runs the standard
+//      3-pass loop (draft + self_critique + revise) and NOT the
+//      anchor-extended 3 + ANCHOR_EXTRA_CYCLES loop.
+//   3. resolveRunnerMode falls back to 'page' for unrecognised
+//      content_type values so a mis-migrated row never sends us into
+//      an undefined dispatch entry.
+//   4. runPostQualityGates rejects an over-long meta description
+//      (parent plan §M13-3 "excerpt length cap").
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Unit — MODE_CONFIGS dispatch table
+// ---------------------------------------------------------------------------
+
+describe("MODE_CONFIGS", () => {
+  it("page mode preserves M12 anchor-cycle behaviour", () => {
+    expect(MODE_CONFIGS.page.mode).toBe("page");
+    expect(MODE_CONFIGS.page.anchorExtraCycles).toBe(ANCHOR_EXTRA_CYCLES);
+  });
+
+  it("post mode disables the anchor cycle entirely", () => {
+    expect(MODE_CONFIGS.post.mode).toBe("post");
+    expect(MODE_CONFIGS.post.anchorExtraCycles).toBe(0);
+  });
+
+  it("page mode's runModeSpecificGates is a no-op", () => {
+    expect(MODE_CONFIGS.page.runModeSpecificGates("<p>ok</p>")).toBeNull();
+  });
+
+  it("post mode routes through runPostQualityGates", () => {
+    // Long meta description should surface a gate failure via the
+    // post-mode dispatch entry.
+    const html = `<html><head><meta name="description" content="${"a".repeat(POST_META_DESCRIPTION_MAX + 1)}"></head><body><p>Hi</p></body></html>`;
+    const gate = MODE_CONFIGS.post.runModeSpecificGates(html);
+    expect(gate).not.toBeNull();
+    expect(gate?.code).toBe("POST_META_DESCRIPTION_TOO_LONG");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit — resolveRunnerMode
+// ---------------------------------------------------------------------------
+
+function makeBrief(overrides: Partial<BriefRow> = {}): BriefRow {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    site_id: "00000000-0000-0000-0000-000000000002",
+    title: "t",
+    status: "committed",
+    source_storage_path: "x",
+    source_mime_type: "text/markdown",
+    source_size_bytes: 1,
+    source_sha256: "0".repeat(64),
+    upload_idempotency_key: "k",
+    parser_mode: "structural",
+    parser_warnings: [],
+    parse_failure_code: null,
+    parse_failure_detail: null,
+    committed_at: null,
+    committed_by: null,
+    committed_page_hash: null,
+    brand_voice: null,
+    design_direction: null,
+    text_model: "claude-sonnet-4-6",
+    visual_model: "claude-sonnet-4-6",
+    content_type: "page",
+    version_lock: 1,
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  };
+}
+
+describe("resolveRunnerMode", () => {
+  it("returns 'page' for a brief with content_type='page'", () => {
+    expect(resolveRunnerMode(makeBrief({ content_type: "page" }))).toBe("page");
+  });
+
+  it("returns 'post' for a brief with content_type='post'", () => {
+    expect(resolveRunnerMode(makeBrief({ content_type: "post" }))).toBe("post");
+  });
+
+  it("falls back to 'page' if an unknown content_type slips through the schema CHECK", () => {
+    // CHECK guards against this at the DB, but a backfill bug could set
+    // the column to something unexpected. Defensive default avoids an
+    // undefined dispatch-table lookup.
+    const brief = makeBrief({
+      content_type: "something-weird" as unknown as "page",
+    });
+    expect(resolveRunnerMode(brief)).toBe("page");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit — runPostQualityGates
+// ---------------------------------------------------------------------------
+
+describe("runPostQualityGates", () => {
+  it("accepts HTML with no meta description", () => {
+    expect(runPostQualityGates("<p>Body only.</p>")).toBeNull();
+  });
+
+  it("accepts a meta description within the cap", () => {
+    const html = `<html><head><meta name="description" content="Short and sweet."></head><body><p>Body.</p></body></html>`;
+    expect(runPostQualityGates(html)).toBeNull();
+  });
+
+  it("rejects a meta description over POST_META_DESCRIPTION_MAX", () => {
+    const longContent = "x".repeat(POST_META_DESCRIPTION_MAX + 10);
+    const html = `<html><head><meta name="description" content="${longContent}"></head><body><p>Body.</p></body></html>`;
+    const gate = runPostQualityGates(html);
+    expect(gate).not.toBeNull();
+    expect(gate?.code).toBe("POST_META_DESCRIPTION_TOO_LONG");
+  });
+
+  it("accepts a meta description at exactly POST_META_DESCRIPTION_MAX chars", () => {
+    const maxContent = "a".repeat(POST_META_DESCRIPTION_MAX);
+    const html = `<html><head><meta name="description" content="${maxContent}"></head></html>`;
+    expect(runPostQualityGates(html)).toBeNull();
+  });
+
+  it("tolerates attribute-order variants (content= before name=)", () => {
+    const longContent = "x".repeat(POST_META_DESCRIPTION_MAX + 1);
+    const html = `<meta content="${longContent}" name="description">`;
+    const gate = runPostQualityGates(html);
+    expect(gate?.code).toBe("POST_META_DESCRIPTION_TOO_LONG");
+  });
+
+  it("only considers the first meta description tag if multiple are present", () => {
+    const short = "Short desc.";
+    const long = "x".repeat(POST_META_DESCRIPTION_MAX + 10);
+    const html = `<meta name="description" content="${short}"><meta name="description" content="${long}">`;
+    expect(runPostQualityGates(html)).toBeNull();
+  });
+
+  it("ignores other meta tags (e.g. og:description)", () => {
+    const longContent = "x".repeat(POST_META_DESCRIPTION_MAX + 10);
+    const html = `<meta property="og:description" content="${longContent}"><p>Body.</p>`;
+    expect(runPostQualityGates(html)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration — mode='post' runs the standard 3-pass loop, no anchor cycles
+//
+// This is the headline risk mitigation: a production mode='post' run
+// MUST NOT fire the anchor-extended pass loop (cost blowout). We seed
+// a committed brief with content_type='post' + one page, stub Anthropic
+// to count calls, and assert the call count is exactly 3 (draft +
+// self_critique + revise) rather than 3 + ANCHOR_EXTRA_CYCLES.
+// ---------------------------------------------------------------------------
+
+function countingStub(record: { count: number; keys: string[] }): AnthropicCallFn {
+  return async (req) => {
+    record.count += 1;
+    record.keys.push(req.idempotency_key);
+    const kind = req.idempotency_key.split(":").at(-2) ?? "";
+    let text: string;
+    if (kind === "draft" || kind === "revise" || kind === "visual_revise") {
+      text = "<section><h1>Post draft</h1><p>Body copy.</p></section>";
+    } else if (kind === "self_critique") {
+      text = "- Tighten intro\n- Add CTA";
+    } else {
+      text = "(stub)";
+    }
+    const resp: AnthropicResponse = {
+      id: `post-${record.count}`,
+      model: req.model,
+      content: [{ type: "text", text }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 100, output_tokens: 50 },
+    };
+    return resp;
+  };
+}
+
+async function seedCommittedPostBrief(siteId: string): Promise<{
+  briefId: string;
+  runId: string;
+  postPageId: string;
+}> {
+  const svc = getServiceRoleClient();
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const briefRes = await svc
+    .from("briefs")
+    .insert({
+      site_id: siteId,
+      title: `post-mode-test ${unique}`,
+      status: "committed",
+      content_type: "post",
+      source_storage_path: `post-mode/${unique}.md`,
+      source_mime_type: "text/markdown",
+      source_size_bytes: 128,
+      source_sha256: "0".repeat(64),
+      upload_idempotency_key: `post-mode-${unique}`,
+      committed_at: new Date().toISOString(),
+      committed_page_hash: "c".repeat(64),
+      brand_voice: "Warm, direct.",
+      design_direction: "Editorial.",
+    })
+    .select("id")
+    .single();
+  if (briefRes.error || !briefRes.data) {
+    throw new Error(`post seed brief: ${briefRes.error?.message}`);
+  }
+  const briefId = briefRes.data.id as string;
+
+  const page = await svc
+    .from("brief_pages")
+    .insert({
+      brief_id: briefId,
+      ordinal: 0,
+      title: "First post",
+      mode: "full_text",
+      source_text: "Full post body copy.",
+      word_count: 4,
+    })
+    .select("id")
+    .single();
+  if (page.error || !page.data) {
+    throw new Error(`post seed page: ${page.error?.message}`);
+  }
+
+  const run = await svc
+    .from("brief_runs")
+    .insert({ brief_id: briefId, status: "queued" })
+    .select("id")
+    .single();
+  if (run.error || !run.data) {
+    throw new Error(`post seed run: ${run.error?.message}`);
+  }
+
+  return {
+    briefId,
+    runId: run.data.id as string,
+    postPageId: page.data.id as string,
+  };
+}
+
+describe("mode='post' — anchor cycles disabled", () => {
+  it("fires only the standard 3-pass text loop (no anchor extra cycles)", async () => {
+    const site = await seedSite();
+    const { runId, postPageId, briefId } = await seedCommittedPostBrief(site.id);
+
+    const rec = { count: 0, keys: [] as string[] };
+    const result = await processBriefRunTick(runId, {
+      anthropicCall: countingStub(rec),
+      workerId: "post-mode-worker",
+      // Stub the render so Playwright isn't required in CI. The visual
+      // critique is still billed (one Anthropic call per iteration) but
+      // we're only counting TEXT passes in the assertion, so the visual
+      // spend doesn't skew the test.
+      visualRender: (async () => ({
+        viewport_png_base64: "UE5HLXN0dWI=",
+        full_page_png_base64: "UE5HLXN0dWI=",
+        viewport_bytes: 64,
+        full_page_bytes: 64,
+      })) satisfies VisualRenderFn,
+    });
+    expect(result.ok).toBe(true);
+
+    // Count text passes only (visual critique passes have kind
+    // 'visual_critique' or 'visual_revise' in the idempotency key).
+    const textPasses = rec.keys.filter((k) => {
+      const kind = k.split(":").at(-2) ?? "";
+      return kind === "draft" || kind === "self_critique" || kind === "revise";
+    });
+    expect(textPasses.length).toBe(3);
+    // Explicit: no revise:1, revise:2 from an anchor cycle
+    expect(rec.keys.some((k) => k.endsWith(":revise:1"))).toBe(false);
+    expect(rec.keys.some((k) => k.endsWith(":revise:2"))).toBe(false);
+
+    // No site_conventions row was frozen — posts don't anchor.
+    const svc = getServiceRoleClient();
+    const conv = await svc
+      .from("site_conventions")
+      .select("id, frozen_at")
+      .eq("brief_id", briefId)
+      .maybeSingle();
+    expect(conv.data).toBeNull();
+
+    // Page ends up in awaiting_review like a page brief would.
+    const pg = await svc
+      .from("brief_pages")
+      .select("page_status")
+      .eq("id", postPageId)
+      .single();
+    expect(pg.data?.page_status).toBe("awaiting_review");
+  });
+});

--- a/lib/__tests__/m13-3-schema.test.ts
+++ b/lib/__tests__/m13-3-schema.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M13-3 schema tests — briefs.content_type CHECK + default.
+//
+// Pins the invariants the runner's MODE_CONFIGS dispatch relies on:
+//
+//   1. CHECK IN ('page','post') — rejects any other value at the schema
+//      layer so a backfill bug can't slip an undefined mode in.
+//   2. DEFAULT 'page' — existing M12 briefs (and any future INSERT that
+//      forgets the column) get the safe page-mode behaviour without a
+//      data-migration.
+//   3. NOT NULL — the runner can assume the column is always present.
+// ---------------------------------------------------------------------------
+
+function unique(suffix: string): string {
+  return `m13-3-schema-${suffix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function insertBrief(opts: {
+  site_id: string;
+  content_type?: string;
+  allowError?: boolean;
+}): Promise<{
+  id: string | null;
+  content_type: string | null;
+  error: { code?: string; message: string } | null;
+}> {
+  const svc = getServiceRoleClient();
+  const row: Record<string, unknown> = {
+    site_id: opts.site_id,
+    title: "Schema test brief",
+    status: "parsed",
+    source_storage_path: `m13-3-schema/${unique("path")}.md`,
+    source_mime_type: "text/markdown",
+    source_size_bytes: 256,
+    source_sha256: "0".repeat(64),
+    upload_idempotency_key: unique("idemp"),
+  };
+  if (opts.content_type !== undefined) row.content_type = opts.content_type;
+
+  const { data, error } = await svc
+    .from("briefs")
+    .insert(row)
+    .select("id, content_type")
+    .single();
+  if (error) {
+    if (opts.allowError) {
+      return {
+        id: null,
+        content_type: null,
+        error: { code: error.code, message: error.message },
+      };
+    }
+    throw new Error(`insertBrief failed: ${error.message}`);
+  }
+  return {
+    id: data.id as string,
+    content_type: data.content_type as string,
+    error: null,
+  };
+}
+
+describe("briefs.content_type — CHECK + default", () => {
+  it("defaults to 'page' when the column is omitted", async () => {
+    const site = await seedSite({ name: "CT1", prefix: "ct1b" });
+    const res = await insertBrief({ site_id: site.id });
+    expect(res.id).not.toBeNull();
+    expect(res.content_type).toBe("page");
+  });
+
+  it("accepts explicit content_type='page'", async () => {
+    const site = await seedSite({ name: "CT2", prefix: "ct2b" });
+    const res = await insertBrief({ site_id: site.id, content_type: "page" });
+    expect(res.id).not.toBeNull();
+    expect(res.content_type).toBe("page");
+  });
+
+  it("accepts explicit content_type='post'", async () => {
+    const site = await seedSite({ name: "CT3", prefix: "ct3b" });
+    const res = await insertBrief({ site_id: site.id, content_type: "post" });
+    expect(res.id).not.toBeNull();
+    expect(res.content_type).toBe("post");
+  });
+
+  it("rejects an unknown content_type via the CHECK constraint", async () => {
+    const site = await seedSite({ name: "CT4", prefix: "ct4b" });
+    const res = await insertBrief({
+      site_id: site.id,
+      content_type: "video",
+      allowError: true,
+    });
+    expect(res.error).not.toBeNull();
+    expect(res.error?.message).toMatch(/content_type/i);
+  });
+
+  it("rejects content_type=NULL (NOT NULL constraint)", async () => {
+    // Sending NULL explicitly. PostgREST serialises undefined by
+    // omitting the key; passing null maps to SQL NULL.
+    const svc = getServiceRoleClient();
+    const site = await seedSite({ name: "CT5", prefix: "ct5b" });
+    const { data, error } = await svc
+      .from("briefs")
+      .insert({
+        site_id: site.id,
+        title: "null-ct",
+        status: "parsed",
+        source_storage_path: `m13-3-schema/${unique("null")}.md`,
+        source_mime_type: "text/markdown",
+        source_size_bytes: 256,
+        source_sha256: "0".repeat(64),
+        upload_idempotency_key: unique("null"),
+        content_type: null,
+      })
+      .select("id")
+      .single();
+    // NOT NULL + default behaviour: PostgREST treats explicit null as
+    // NULL, which the NOT NULL constraint rejects.
+    expect(data).toBeNull();
+    expect(error).not.toBeNull();
+    expect(error?.message).toMatch(/content_type|not-null|null value/i);
+  });
+});

--- a/lib/brief-runner.ts
+++ b/lib/brief-runner.ts
@@ -587,17 +587,114 @@ function nextPassAfter(
 }
 
 // ---------------------------------------------------------------------------
+// Runner mode dispatch (M13-3)
+//
+// `brief.content_type` drives a two-entry dispatch table: 'page' keeps
+// M12's behaviour (anchor cycle on ordinal 0, standard quality gates,
+// anchor-page budget ceiling) verbatim; 'post' disables the anchor
+// cycle entirely (the site is already anchored by M12's page run, so
+// the running content_summary is the only continuity posts need) and
+// layers post-specific quality gates on top of the base ones.
+//
+// Write-safety invariants pinned by the dispatch table:
+//   - Anchor-cycle count is zero for posts. Asserted by
+//     modeConfigFor('post').anchorExtraCycles === 0. A production
+//     anchor cycle on a post mode run would first need the dispatch
+//     table to lie — covered by the unit test in brief-runner-mode.test.ts.
+//   - Content-type assertion: the runner reads brief.content_type and
+//     fails BRIEF_INVALID_CONTENT_TYPE (schema-impossible given the
+//     migration 0021 CHECK, but defense-in-depth) before firing any
+//     billed call.
+//   - New mode = new entry in the dispatch. A forked runner-for-posts
+//     would drift silently; the single dispatch stays in lockstep.
+// ---------------------------------------------------------------------------
+
+export type RunnerMode = "page" | "post";
+
+export type RunnerModeConfig = {
+  mode: RunnerMode;
+  /** Anchor-cycle extra revises. 'page' = ANCHOR_EXTRA_CYCLES; 'post' = 0. */
+  anchorExtraCycles: number;
+  /**
+   * Returns the first failing gate specific to this mode after the base
+   * gate has passed. `null` means all post-specific gates accepted the draft.
+   */
+  runModeSpecificGates: (draftHtml: string) => null | {
+    code: string;
+    message: string;
+  };
+};
+
+export const MODE_CONFIGS: Readonly<Record<RunnerMode, RunnerModeConfig>> = {
+  page: {
+    mode: "page",
+    anchorExtraCycles: ANCHOR_EXTRA_CYCLES,
+    runModeSpecificGates: () => null,
+  },
+  post: {
+    mode: "post",
+    anchorExtraCycles: 0,
+    runModeSpecificGates: runPostQualityGates,
+  },
+} as const;
+
+export function resolveRunnerMode(brief: BriefRow): RunnerMode {
+  return brief.content_type === "post" ? "post" : "page";
+}
+
+// Hard cap on meta-description length — WP excerpt / SEO plugins
+// typically clamp around 155–160; the M13-1 posts layer uses 300 as
+// the outer Zod bound (POST_EXCERPT_MAX). We gate at the outer bound
+// so the runner rejects obviously-too-long metas but doesn't overfit
+// to one plugin's preference.
+export const POST_META_DESCRIPTION_MAX = 300;
+
+/**
+ * Post-specific quality gates (M13-3).
+ *
+ * Runs on the post's draft_html AFTER the base gate passes. Rejects
+ * drafts whose meta description exceeds POST_META_DESCRIPTION_MAX. The
+ * other post-specific checks called out in the parent plan
+ * (featured-image presence conditional on SEO plugin detection,
+ * taxonomy whitelist) plug in here as the M13-4 preflight wiring
+ * lands; the function's shape is what the parent plan's "dispatch
+ * table" contract is pinning.
+ */
+export function runPostQualityGates(
+  draftHtml: string,
+): null | { code: string; message: string } {
+  // Extract the value of every <meta name="description" content="…">
+  // tag, tolerating attribute-order variants (`content=` before `name=`).
+  // On multiple hits, the first wins — WP's excerpt is the first-match
+  // shape in practice. A missing tag is fine: WP derives an excerpt
+  // from the post body if one isn't supplied.
+  const metaRe =
+    /<meta[^>]*\bname\s*=\s*["']description["'][^>]*\bcontent\s*=\s*["']([^"']*)["'][^>]*>|<meta[^>]*\bcontent\s*=\s*["']([^"']*)["'][^>]*\bname\s*=\s*["']description["'][^>]*>/i;
+  const match = metaRe.exec(draftHtml);
+  if (!match) return null;
+  const value = (match[1] ?? match[2] ?? "").trim();
+  if (value.length > POST_META_DESCRIPTION_MAX) {
+    return {
+      code: "POST_META_DESCRIPTION_TOO_LONG",
+      message: `meta name="description" is ${value.length} chars (max ${POST_META_DESCRIPTION_MAX}).`,
+    };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // Quality gate hook
 // ---------------------------------------------------------------------------
 
 /**
- * Minimal gate function for M12-3: ensures draft_html is non-empty and
- * HTML-ish (contains at least one tag). M12-4+ plugs in the existing
- * lib/quality-gates.ts surface (HTML size cap, DS-token whitelist,
- * link integrity) which currently targets batch/regen outputs and
- * needs a thin adapter for brief-runner inputs.
+ * Base gate function: ensures draft_html is non-empty and HTML-ish.
+ * Mode-specific gates layer on top via MODE_CONFIGS; callers invoke
+ * the base gate first, then delegate to the mode config.
  */
-function runGatesForBriefPage(draftHtml: string | null): {
+function runGatesForBriefPage(
+  draftHtml: string | null,
+  modeConfig: RunnerModeConfig = MODE_CONFIGS.page,
+): {
   ok: boolean;
   code?: string;
   message?: string;
@@ -611,6 +708,10 @@ function runGatesForBriefPage(draftHtml: string | null): {
       code: "NOT_HTML",
       message: "Draft does not contain any HTML tags.",
     };
+  }
+  const modeGate = modeConfig.runModeSpecificGates(draftHtml);
+  if (modeGate) {
+    return { ok: false, code: modeGate.code, message: modeGate.message };
   }
   return { ok: true };
 }
@@ -817,7 +918,14 @@ async function processPagePassLoop(
   call: AnthropicCallFn,
   visualRender: VisualRenderFn,
 ): Promise<BriefRunTickResult> {
-  const isAnchor = page.ordinal === 0;
+  const mode = resolveRunnerMode(brief);
+  const modeConfig = MODE_CONFIGS[mode];
+  // M13-3: anchor cycle fires on ordinal 0 ONLY in page mode. In post
+  // mode there is no anchor cycle — the site is already anchored by
+  // M12's page run and posts inherit site_conventions via the frozen
+  // row. A regression that flipped this back to `page.ordinal === 0`
+  // would silently burn ANCHOR_EXTRA_CYCLES of Anthropic spend per post.
+  const isAnchor = modeConfig.anchorExtraCycles > 0 && page.ordinal === 0;
   const ceiling = isAnchor
     ? BRIEF_ANCHOR_PAGE_CEILING_CENTS
     : BRIEF_PAGE_CEILING_CENTS;
@@ -1179,8 +1287,9 @@ async function processPagePassLoop(
     numberToRun = peek.number;
   }
 
-  // All passes done. Run the gate.
-  const gate = runGatesForBriefPage(page.draft_html);
+  // All passes done. Run the base gate + mode-specific gates from the
+  // dispatch table (M13-3).
+  const gate = runGatesForBriefPage(page.draft_html, modeConfig);
   if (!gate.ok) {
     await client.query(
       `

--- a/lib/briefs.ts
+++ b/lib/briefs.ts
@@ -52,6 +52,12 @@ export type BriefRow = {
   // value surfaces as INVALID_MODEL without firing the call.
   text_model: string;
   visual_model: string;
+  // M13-3 — routes the runner's dispatch between 'page' mode (anchor
+  // cycle on ordinal 0, standard quality gates) and 'post' mode
+  // (anchor cycle disabled, post-specific quality gates). Defaults to
+  // 'page' at the schema layer (migration 0021) so every pre-M13
+  // brief folds in unchanged.
+  content_type: "page" | "post";
   version_lock: number;
   created_at: string;
   updated_at: string;

--- a/supabase/migrations/0021_m13_3_briefs_content_type.sql
+++ b/supabase/migrations/0021_m13_3_briefs_content_type.sql
@@ -1,0 +1,39 @@
+-- 0021 — M13-3 briefs.content_type axis.
+-- Reference: docs/plans/m13-parent.md §M13-3.
+--
+-- Additive-only ALTER TABLE. Single column on briefs with CHECK
+-- constraint + default 'page' so existing M12-1/M12-2/M12-3/M12-4
+-- briefs fold in unchanged. The runner's `mode` parameter reads this
+-- column; 'page' preserves existing behavior (anchor cycle on ordinal 0,
+-- standard quality gates), 'post' disables the anchor cycle and runs
+-- the post-specific quality gates.
+--
+-- Why a CHECK-constrained text column (not a PG enum):
+--   docs/DATA_CONVENTIONS.md §Naming. CHECK constraints rewrite in one
+--   ALTER when the enum grows (e.g. future 'product', 'case-study' —
+--   tracked in parent plan §Out of scope). A Postgres ENUM type would
+--   need ALTER TYPE ... ADD VALUE which is not transaction-safe.
+--
+-- Default = 'page' is the safe migration — every row on main right now
+-- is a page brief; no backfill needed. Post briefs will be inserted
+-- with content_type='post' explicitly by the M13-4 upload route.
+--
+-- Write-safety hotspots addressed:
+--   - CHECK IN ('page','post') — rejects unknown values at the schema
+--     layer, so an ops-layer patch or backfill bug can't slip a value
+--     the runner's dispatch table doesn't know how to handle.
+--   - NOT NULL + DEFAULT — existing briefs have a legal value without
+--     a data-migration pass; new inserts that forget the column get
+--     the safe default.
+
+ALTER TABLE briefs
+  ADD COLUMN content_type text NOT NULL DEFAULT 'page'
+    CHECK (content_type IN ('page', 'post'));
+
+-- Partial index on the post subset — the M13-4 admin surface will
+-- filter "post briefs for this site" frequently; page briefs
+-- dominate today, so a full (site_id, content_type) index would
+-- balloon for a predicate the query planner hits rarely.
+CREATE INDEX idx_briefs_site_post_content_type
+  ON briefs (site_id, created_at DESC)
+  WHERE content_type = 'post' AND deleted_at IS NULL;

--- a/supabase/rollbacks/0021_m13_3_briefs_content_type.down.sql
+++ b/supabase/rollbacks/0021_m13_3_briefs_content_type.down.sql
@@ -1,0 +1,7 @@
+-- Rollback for 0021_m13_3_briefs_content_type.sql.
+-- Drops the content_type column + its partial index.
+-- Does NOT attempt to restore row data. Intended for local dev / CI reset.
+
+DROP INDEX IF EXISTS idx_briefs_site_post_content_type;
+
+ALTER TABLE briefs DROP COLUMN IF EXISTS content_type;


### PR DESCRIPTION
## Summary
- Migration 0021 adds `briefs.content_type` (CHECK IN `('page','post')`, NOT NULL, default `'page'`). Every M12 brief on main folds in unchanged; new post briefs insert `content_type='post'` explicitly.
- `lib/brief-runner.ts` gains `RunnerMode` + `MODE_CONFIGS` dispatch table + `resolveRunnerMode(brief)` + `runPostQualityGates`. `processPagePassLoop`'s `isAnchor` derivation now factors mode — post mode runs zero anchor cycles, skips the site_conventions freeze, and uses `BRIEF_PAGE_CEILING_CENTS` rather than the anchor-page ceiling.
- `BriefRow` gains `content_type: 'page' | 'post'`.
- Orthogonal to M13-4+'s WP publish plumbing — M13-3 only changes how the runner iterates, not where the output lands.

## Plan (sub-slice)

The parent plan §M13-3 called for a "dispatch table" on the runner so a new mode is "a new entry in the dispatch, not a new runner". The implementation takes that literally:

1. `MODE_CONFIGS: Record<RunnerMode, RunnerModeConfig>` holds one entry per mode — `{ mode, anchorExtraCycles, runModeSpecificGates }`. Page mode preserves `ANCHOR_EXTRA_CYCLES`; post mode sets it to 0.
2. `processPagePassLoop` reads `resolveRunnerMode(brief)` at entry, derives `modeConfig`, and computes `isAnchor = modeConfig.anchorExtraCycles > 0 && page.ordinal === 0`. Every downstream branch that keyed off `isAnchor` (budget ceiling, `standardCap`, `isAnchorFinalPass`, `nextPassAfter`, the conventions freeze at line 1223) inherits the correct behaviour for both modes without signature changes.
3. Post-specific quality gates layer on top of the base gate. `runGatesForBriefPage` now accepts a `modeConfig` and calls `modeConfig.runModeSpecificGates(draftHtml)` after the base gate passes. Page mode's gates are a no-op; post mode runs `runPostQualityGates` which rejects meta descriptions over `POST_META_DESCRIPTION_MAX` (300 chars, matching `POST_EXCERPT_MAX` in `lib/posts.ts`).
4. `resolveRunnerMode` falls back to `'page'` for unrecognised values. CHECK on the DB column blocks anything other than `'page' | 'post'` at write time, but the default guards against a backfill bug or mis-typed column value at read time.
5. Visual review loop is unchanged. Post mode still runs visual critique per parent plan §Shared-primitives map ("Visual review pass | M12-4 | Applied to rendered post templates"). M13-3 scopes only text-pass behaviour.

## Risks identified and mitigated

| Risk | Mitigation |
| --- | --- |
| **Runner mode regression: post mode runs anchor cycles anyway.** Silent cost blowout at `ANCHOR_EXTRA_CYCLES * Anthropic price per pass` per post. | Structural — `MODE_CONFIGS.post.anchorExtraCycles === 0`. `isAnchor` derivation factors `modeConfig.anchorExtraCycles > 0`, so a misconfigured dispatch entry, not a missed call site, is the only way anchor cycles fire on posts. Unit test in `brief-runner-mode.test.ts` pins the dispatch table value; integration test asserts exactly 3 text passes ran on a mode='post' brief. |
| **Unknown content_type slips through via backfill or manual DB edit.** Runner dispatch lookup returns undefined → crash mid-tick. | Defense-in-depth at read time: `resolveRunnerMode` normalises to `'page'` for anything other than `'post'`. Tested. Schema CHECK on `briefs.content_type` rejects unknown values at write time as the primary guard. |
| **Post mode still freezes site_conventions** (double-writes, violates UNIQUE on `site_conventions.brief_id`). | `if (isAnchor)` at the freeze call already gates — `isAnchor` is false in post mode, so the freeze branch never fires. Integration test asserts no `site_conventions` row exists for a mode='post' brief after the tick. |
| **Budget ceiling drift in post mode.** Using `BRIEF_ANCHOR_PAGE_CEILING_CENTS` on posts would over-reserve; using `BRIEF_PAGE_CEILING_CENTS` on an anchor page would under-reserve. | `ceiling` ternary keys on `isAnchor`, which is now mode-aware. Post mode always uses `BRIEF_PAGE_CEILING_CENTS`; page mode anchor pages use `BRIEF_ANCHOR_PAGE_CEILING_CENTS` exactly as before. |
| **Concurrent runner races on the same post brief.** | Unchanged — the same `leaseBriefRun` + `brief_runs_one_active_per_brief` partial UNIQUE index that already serialises page briefs serialises post briefs. `content_type` doesn't enter the concurrency keystone. |
| **Idempotency key collision between page and post briefs.** | Existing `passIdempotencyKey` includes `briefId`, which is distinct per brief. No change needed — a mode='post' brief and a mode='page' brief never share an idempotency key because they never share a `briefId`. |
| **Post quality gate over-rejects** (legitimate posts with detailed meta descriptions). | `POST_META_DESCRIPTION_MAX = 300` matches `POST_EXCERPT_MAX` in `lib/posts.ts`. Anything longer than that is outside the outer Zod bound too; a stricter SEO-plugin-specific limit (Yoast ~160) plugs in with the M13-4 preflight wiring, not here. |

Gaps deliberately deferred: featured-image presence gate (depends on M13-4's SEO-plugin detection surface + brief-declared featured-media field, neither exists yet), taxonomy whitelist gate (brief_pages doesn't carry per-entry taxonomy fields; deferred until M13-4 pipes them in), Langfuse span-name decoration with mode (spans already fire per pass; adding mode to the name is cosmetic against the structural invariant the unit test pins).

## Test plan
- [ ] CI: `npm run typecheck`, `npm run lint`, `npm run build` pass locally (confirmed in worktree).
- [ ] CI: `vitest run lib/__tests__/m13-3-schema.test.ts` — default 'page', explicit 'page'/'post' accepted, 'video'/NULL rejected.
- [ ] CI: `vitest run lib/__tests__/brief-runner-mode.test.ts` — MODE_CONFIGS dispatch values, resolveRunnerMode fallback, runPostQualityGates cap + variants, integration tick on a mode='post' brief fires exactly 3 text passes with no site_conventions freeze.
- [ ] CI: existing `brief-runner.test.ts` / `brief-runner-anchor.test.ts` / `brief-runner-concurrency.test.ts` / `brief-runner-visual.test.ts` still green (mode change is additive — page mode behaviour is untouched).

## Follow-up

M13-4 (`/admin/sites/[id]/posts` admin surface) is the next slice. It threads `content_type='post'` into the upload route, wires preflight + SEO plugin detection (both shipped in M13-2) into the publish confirm flow, and routes approved drafts to the `posts` table (shipped in M13-1). This is a larger sub-slice that warrants its own planning pass; not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)