### PR TITLE
feat(m12-5): run surface + start/cancel/revise routes + model-tier commit form

### DIFF
--- a/app/admin/sites/[id]/briefs/[brief_id]/run/page.tsx
+++ b/app/admin/sites/[id]/briefs/[brief_id]/run/page.tsx
@@ -1,0 +1,143 @@
+import { notFound } from "next/navigation";
+
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { BriefRunClient } from "@/components/BriefRunClient";
+import {
+  estimateBriefRunCost,
+  getBriefWithPages,
+  type BriefRunSnapshot,
+} from "@/lib/briefs";
+import { getSite } from "@/lib/sites";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// /admin/sites/[id]/briefs/[brief_id]/run — M12-5 run surface.
+//
+// Server Component. Fetches:
+//   - site (for breadcrumb + prefix)
+//   - brief + brief_pages (for the page list + per-page preview)
+//   - active brief_run row, if any (for status + cost rollup)
+//   - pre-flight estimate (estimate_cents + page_count)
+//   - tenant remaining monthly budget
+//
+// Hands everything to <BriefRunClient /> which owns the control buttons
+// + polling / revalidation while a run is in flight.
+
+export const dynamic = "force-dynamic";
+
+export default async function BriefRunPage({
+  params,
+}: {
+  params: { id: string; brief_id: string };
+}) {
+  const [siteResult, briefResult] = await Promise.all([
+    getSite(params.id),
+    getBriefWithPages(params.brief_id),
+  ]);
+
+  if (!siteResult.ok) {
+    if (siteResult.error.code === "NOT_FOUND") notFound();
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+      >
+        Failed to load site: {siteResult.error.message}
+      </div>
+    );
+  }
+  if (!briefResult.ok) {
+    if (briefResult.error.code === "NOT_FOUND") notFound();
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+      >
+        Failed to load brief: {briefResult.error.message}
+      </div>
+    );
+  }
+
+  if (briefResult.data.brief.site_id !== params.id) notFound();
+
+  const site = siteResult.data.site;
+  const { brief, pages } = briefResult.data;
+
+  if (brief.status !== "committed") {
+    // The run surface is only meaningful once the brief is committed.
+    // Bounce the operator back to the review surface where they can
+    // commit.
+    return (
+      <main className="mx-auto max-w-5xl p-6">
+        <Breadcrumbs
+          crumbs={[
+            { label: "Sites", href: "/admin/sites" },
+            { label: site.name, href: `/admin/sites/${site.id}` },
+            { label: "Briefs", href: `/admin/sites/${site.id}` },
+            { label: brief.title },
+          ]}
+        />
+        <div
+          role="status"
+          className="mt-6 rounded-md border border-yellow-500/40 bg-yellow-500/10 p-4 text-sm text-yellow-900 dark:text-yellow-200"
+        >
+          <p className="font-medium">This brief isn&apos;t committed yet.</p>
+          <p className="mt-1">
+            <a
+              className="underline hover:no-underline"
+              href={`/admin/sites/${site.id}/briefs/${brief.id}/review`}
+            >
+              Review and commit
+            </a>{" "}
+            before starting a generation run.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const svc = getServiceRoleClient();
+  const runRes = await svc
+    .from("brief_runs")
+    .select(
+      "id, brief_id, status, current_ordinal, content_summary, run_cost_cents, failure_code, failure_detail, cancel_requested_at, started_at, finished_at, version_lock, created_at, updated_at",
+    )
+    .eq("brief_id", brief.id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const activeRun = (runRes.data ?? null) as BriefRunSnapshot | null;
+
+  const estimate = await estimateBriefRunCost(brief.id);
+
+  const budget = await svc
+    .from("tenant_cost_budgets")
+    .select("monthly_cap_cents, monthly_usage_cents")
+    .eq("site_id", site.id)
+    .maybeSingle();
+  const cap = Number(budget.data?.monthly_cap_cents ?? 0);
+  const usage = Number(budget.data?.monthly_usage_cents ?? 0);
+  const remainingBudgetCents = Math.max(0, cap - usage);
+
+  return (
+    <main className="mx-auto max-w-5xl p-6">
+      <Breadcrumbs
+        crumbs={[
+          { label: "Sites", href: "/admin/sites" },
+          { label: site.name, href: `/admin/sites/${site.id}` },
+          { label: "Briefs", href: `/admin/sites/${site.id}` },
+          { label: brief.title, href: `/admin/sites/${site.id}/briefs/${brief.id}/review` },
+          { label: "Run" },
+        ]}
+      />
+      <BriefRunClient
+        siteId={site.id}
+        siteName={site.name}
+        brief={brief}
+        pages={pages}
+        activeRun={activeRun}
+        estimateCents={estimate.ok ? estimate.estimate_cents : 0}
+        remainingBudgetCents={remainingBudgetCents}
+      />
+    </main>
+  );
+}

--- a/app/api/briefs/[brief_id]/cancel/route.ts
+++ b/app/api/briefs/[brief_id]/cancel/route.ts
@@ -1,0 +1,157 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { validateUuidParam } from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M12-5 — POST /api/briefs/[brief_id]/cancel
+//
+// Halts the active brief_run for this brief. Leaves generated brief_pages
+// in place (per parent plan: "cancel halts the runner and leaves
+// generated pages in place — no destructive cleanup"). Operator can still
+// approve any page already at awaiting_review after cancel, and can
+// start a fresh run once the current one is cancelled (the partial
+// UNIQUE index brief_runs_one_active_per_brief only guards the
+// non-terminal slot).
+//
+// Idempotent by design: a cancel on a brief with no active run, or on
+// a run already cancelled, returns 200 + { already_cancelled: true }.
+// Two operator tabs clicking cancel simultaneously both see success.
+//
+// Body: empty (cancellation is a scoped verb; no cancel-with-reason
+// flow today — operator notes live on brief_pages via /revise).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function envelope(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { brief_id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const idCheck = validateUuidParam(params.brief_id, "brief_id");
+  if (!idCheck.ok) return idCheck.response;
+
+  const svc = getServiceRoleClient();
+
+  const briefLookup = await svc
+    .from("briefs")
+    .select("id, site_id")
+    .eq("id", idCheck.value)
+    .is("deleted_at", null)
+    .maybeSingle();
+  if (briefLookup.error) {
+    return envelope("INTERNAL_ERROR", "Failed to look up brief.", 500);
+  }
+  if (!briefLookup.data) {
+    return envelope("NOT_FOUND", `No brief ${idCheck.value}.`, 404);
+  }
+  const siteId = briefLookup.data.site_id as string;
+
+  const runLookup = await svc
+    .from("brief_runs")
+    .select("id, status, version_lock")
+    .eq("brief_id", idCheck.value)
+    .in("status", ["queued", "running", "paused"])
+    .maybeSingle();
+  if (runLookup.error) {
+    logger.error("briefs.cancel.run_lookup_failed", {
+      brief_id: idCheck.value,
+      error: runLookup.error,
+    });
+    return envelope("INTERNAL_ERROR", "Failed to look up active run.", 500);
+  }
+  if (!runLookup.data) {
+    // Idempotent: no active run is a successful no-op.
+    return NextResponse.json(
+      {
+        ok: true,
+        data: { already_cancelled: true },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }
+
+  const runSnap = runLookup.data as {
+    id: string;
+    status: string;
+    version_lock: number;
+  };
+
+  const nowIso = new Date().toISOString();
+  const update = await svc
+    .from("brief_runs")
+    .update({
+      status: "cancelled",
+      cancel_requested_at: nowIso,
+      finished_at: nowIso,
+      lease_expires_at: null,
+      worker_id: null,
+      updated_at: nowIso,
+      updated_by: gate.user?.id ?? null,
+      version_lock: runSnap.version_lock + 1,
+    })
+    .eq("id", runSnap.id)
+    .eq("version_lock", runSnap.version_lock)
+    .select("id, status")
+    .maybeSingle();
+
+  if (update.error) {
+    logger.error("briefs.cancel.update_failed", {
+      brief_run_id: runSnap.id,
+      error: update.error,
+    });
+    return envelope("INTERNAL_ERROR", "Failed to cancel run.", 500);
+  }
+  if (!update.data) {
+    // CAS miss — another tab beat us to cancel. Re-read and treat as
+    // idempotent success.
+    return NextResponse.json(
+      {
+        ok: true,
+        data: { already_cancelled: true },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }
+
+  revalidatePath(`/admin/sites/${siteId}/briefs/${idCheck.value}/run`);
+  revalidatePath(`/admin/sites/${siteId}/briefs/${idCheck.value}/review`);
+  revalidatePath(`/admin/sites/${siteId}`);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        brief_run_id: runSnap.id,
+        status: update.data.status,
+        already_cancelled: false,
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/briefs/[brief_id]/commit/route.ts
+++ b/app/api/briefs/[brief_id]/commit/route.ts
@@ -3,6 +3,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { ANTHROPIC_MODEL_ALLOWLIST } from "@/lib/anthropic-pricing";
 import { commitBrief } from "@/lib/briefs";
 import {
   parseBodyWith,
@@ -15,11 +16,9 @@ import { logger } from "@/lib/logger";
 
 // ---------------------------------------------------------------------------
 // M12-1 — POST /api/briefs/[brief_id]/commit.
-// M12-2 — accepts optional brand_voice + design_direction in the body;
-//         those fields are persisted atomically with the committed
-//         transition. Both are nullable strings capped at 4 KB. Omitted
-//         fields preserve whatever value is currently on the row
-//         (don't-touch semantics — see commitBrief input docs).
+// M12-2 — accepts optional brand_voice + design_direction in the body.
+// M12-5 — accepts optional text_model + visual_model (allowlist-validated)
+//         so the operator can pick per-brief tiers on the review surface.
 //
 // Body:
 //   {
@@ -27,6 +26,8 @@ import { logger } from "@/lib/logger";
 //     page_hash: string,
 //     brand_voice?: string | null,
 //     design_direction?: string | null,
+//     text_model?: string,        // must be in ANTHROPIC_MODEL_ALLOWLIST
+//     visual_model?: string,      // must be in ANTHROPIC_MODEL_ALLOWLIST
 //   }
 //
 // Freezes the brief's page list under optimistic-concurrency. Idempotent
@@ -42,6 +43,13 @@ export const dynamic = "force-dynamic";
 // the wrong thing into the wrong field.
 const VOICE_DIRECTION_MAX_BYTES = 4096;
 
+const ModelSchema = z
+  .string()
+  .refine(
+    (v) => ANTHROPIC_MODEL_ALLOWLIST.includes(v),
+    { message: "Unknown model id. Pick from the operator form's dropdown." },
+  );
+
 const CommitBodySchema = z.object({
   expected_version_lock: z.number().int().nonnegative(),
   page_hash: z.string().min(32).max(256),
@@ -55,6 +63,8 @@ const CommitBodySchema = z.object({
     .max(VOICE_DIRECTION_MAX_BYTES)
     .nullable()
     .optional(),
+  text_model: ModelSchema.optional(),
+  visual_model: ModelSchema.optional(),
 });
 
 export async function POST(
@@ -78,6 +88,8 @@ export async function POST(
     committedBy: gate.user?.id ?? null,
     brandVoice: parsed.data.brand_voice,
     designDirection: parsed.data.design_direction,
+    textModel: parsed.data.text_model,
+    visualModel: parsed.data.visual_model,
   });
 
   if (!result.ok) {

--- a/app/api/briefs/[brief_id]/pages/[page_id]/revise/route.ts
+++ b/app/api/briefs/[brief_id]/pages/[page_id]/revise/route.ts
@@ -1,0 +1,230 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import {
+  parseBodyWith,
+  readJsonBody,
+  validateUuidParam,
+} from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M12-5 — POST /api/briefs/[brief_id]/pages/[page_id]/revise
+//
+// Operator sees the awaiting_review preview, decides the page needs
+// another pass with a specific note, and submits. This route:
+//
+//   1. Appends the note to brief_pages.operator_notes (preserves
+//      prior notes across multiple revise cycles).
+//   2. Resets the page to page_status='pending', current_pass_kind=null,
+//      current_pass_number=0, draft_html=null, quality_flag=null. The
+//      runner re-enters from the top on its next tick. critique_log is
+//      preserved — the note carries context, not the prior drafts.
+//   3. Re-queues the brief_run at this page's ordinal (mirrors
+//      approveBriefPage's re-queue shape).
+//
+// The runner's PageContext carries operator_notes into the draft /
+// critique / revise prompts (wired in this PR's brief-runner change).
+//
+// Body:
+//   {
+//     expected_version_lock: int,      // CAS against brief_pages
+//     note: string (1..2000 chars)     // the operator's feedback
+//   }
+//
+// Error cases:
+//   VALIDATION_FAILED (400) — malformed body / non-UUID params / empty note
+//   NOT_FOUND (404)         — unknown page / brief_id mismatch
+//   INVALID_STATE (409)     — page not in awaiting_review (can't revise
+//                             a page that's still generating or already
+//                             approved; cancel first)
+//   VERSION_CONFLICT (409)  — expected_version_lock stale
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const ReviseBodySchema = z.object({
+  expected_version_lock: z.number().int().nonnegative(),
+  note: z.string().min(1).max(2000),
+});
+
+function envelope(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+function appendNote(existing: string | null, next: string, at: string): string {
+  const stamped = `[${at}] ${next.trim()}`;
+  if (!existing || existing.trim() === "") return stamped;
+  return `${existing.trim()}\n\n${stamped}`;
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { brief_id: string; page_id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const briefIdCheck = validateUuidParam(params.brief_id, "brief_id");
+  if (!briefIdCheck.ok) return briefIdCheck.response;
+  const pageIdCheck = validateUuidParam(params.page_id, "page_id");
+  if (!pageIdCheck.ok) return pageIdCheck.response;
+
+  const body = await readJsonBody(req);
+  const parsed = parseBodyWith(ReviseBodySchema, body);
+  if (!parsed.ok) return parsed.response;
+
+  const svc = getServiceRoleClient();
+
+  const pageLookup = await svc
+    .from("brief_pages")
+    .select(
+      "id, brief_id, ordinal, page_status, operator_notes, version_lock",
+    )
+    .eq("id", pageIdCheck.value)
+    .is("deleted_at", null)
+    .maybeSingle();
+  if (pageLookup.error) {
+    logger.error("briefs.revise.page_lookup_failed", {
+      page_id: pageIdCheck.value,
+      error: pageLookup.error,
+    });
+    return envelope("INTERNAL_ERROR", "Failed to look up brief_page.", 500);
+  }
+  if (!pageLookup.data) {
+    return envelope(
+      "NOT_FOUND",
+      `No brief_page ${pageIdCheck.value}.`,
+      404,
+    );
+  }
+  const page = pageLookup.data as {
+    id: string;
+    brief_id: string;
+    ordinal: number;
+    page_status: string;
+    operator_notes: string | null;
+    version_lock: number;
+  };
+
+  if (page.brief_id !== briefIdCheck.value) {
+    return envelope(
+      "NOT_FOUND",
+      `Brief_page ${pageIdCheck.value} does not belong to brief ${briefIdCheck.value}.`,
+      404,
+    );
+  }
+  if (page.page_status !== "awaiting_review") {
+    return envelope(
+      "INVALID_STATE",
+      `Page is in status '${page.page_status}', not 'awaiting_review'. Cancel the run to edit a page that's still generating; approved pages are read-only.`,
+      409,
+    );
+  }
+
+  const nowIso = new Date().toISOString();
+  const nextNotes = appendNote(page.operator_notes, parsed.data.note, nowIso);
+
+  // CAS reset under version_lock. Clears draft state so the runner
+  // re-enters from the top; critique_log stays so the operator still
+  // sees history; quality_flag is cleared so the fresh run can set its
+  // own.
+  const upd = await svc
+    .from("brief_pages")
+    .update({
+      page_status: "pending",
+      current_pass_kind: null,
+      current_pass_number: 0,
+      draft_html: null,
+      quality_flag: null,
+      operator_notes: nextNotes,
+      updated_at: nowIso,
+      updated_by: gate.user?.id ?? null,
+      version_lock: parsed.data.expected_version_lock + 1,
+    })
+    .eq("id", page.id)
+    .eq("version_lock", parsed.data.expected_version_lock)
+    .select("id")
+    .maybeSingle();
+  if (upd.error) {
+    logger.error("briefs.revise.update_failed", {
+      page_id: page.id,
+      error: upd.error,
+    });
+    return envelope("INTERNAL_ERROR", "Failed to re-queue page.", 500);
+  }
+  if (!upd.data) {
+    return envelope(
+      "VERSION_CONFLICT",
+      "Page was edited while you were reviewing. Refresh and retry.",
+      409,
+    );
+  }
+
+  // Re-queue the run at this page's ordinal so the next tick picks it up.
+  // Similar shape to approveBriefPage's re-queue — idempotent if the run
+  // is already queued.
+  const runRes = await svc
+    .from("brief_runs")
+    .select("id, status, version_lock")
+    .eq("brief_id", page.brief_id)
+    .in("status", ["paused", "running", "queued"])
+    .maybeSingle();
+  if (runRes.data) {
+    const runSnap = runRes.data as {
+      id: string;
+      status: string;
+      version_lock: number;
+    };
+    await svc
+      .from("brief_runs")
+      .update({
+        status: "queued",
+        current_ordinal: page.ordinal,
+        updated_at: nowIso,
+        version_lock: runSnap.version_lock + 1,
+      })
+      .eq("id", runSnap.id)
+      .eq("version_lock", runSnap.version_lock);
+  }
+
+  // Bust the run surface so the operator sees the pending transition.
+  const briefLookup = await svc
+    .from("briefs")
+    .select("site_id")
+    .eq("id", briefIdCheck.value)
+    .maybeSingle();
+  const siteId = (briefLookup.data?.site_id as string | undefined) ?? null;
+  if (siteId) {
+    revalidatePath(
+      `/admin/sites/${siteId}/briefs/${briefIdCheck.value}/run`,
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        page_id: page.id,
+        page_status: "pending",
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/briefs/[brief_id]/run/route.ts
+++ b/app/api/briefs/[brief_id]/run/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { estimateBriefRunCost, startBriefRun } from "@/lib/briefs";
+import {
+  parseBodyWith,
+  readJsonBody,
+  respond,
+  validateUuidParam,
+} from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// M12-5 — run control surface.
+//
+//   GET  /api/briefs/[brief_id]/run
+//     Returns the pre-flight estimate for the operator UI:
+//       { estimate_cents, page_count, remaining_budget_cents }
+//     No side effects. Used by the run-surface page to render the
+//     confirmation dialog copy BEFORE the operator clicks start.
+//
+//   POST /api/briefs/[brief_id]/run
+//     Body: { confirmed?: boolean }
+//     Wraps lib/briefs.startBriefRun. Returns:
+//       200 + { brief_run_id, estimate_cents, remaining_budget_cents }
+//       429 + CONFIRMATION_REQUIRED when estimate > 50% remaining budget
+//            (operator re-submits with confirmed: true to proceed)
+//       409 + BRIEF_RUN_ALREADY_ACTIVE when a run is already in flight
+//       400 + VALIDATION_FAILED for non-committed brief / malformed body
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const StartRunBodySchema = z.object({
+  confirmed: z.boolean().optional(),
+});
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { brief_id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const idCheck = validateUuidParam(params.brief_id, "brief_id");
+  if (!idCheck.ok) return idCheck.response;
+
+  const estimate = await estimateBriefRunCost(idCheck.value);
+  if (!estimate.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: estimate.code, message: estimate.message, retryable: false },
+        timestamp: new Date().toISOString(),
+      },
+      { status: estimate.code === "NOT_FOUND" ? 404 : 500 },
+    );
+  }
+
+  // Also fetch remaining tenant budget so the UI can render the comparison.
+  const svc = getServiceRoleClient();
+  const briefLookup = await svc
+    .from("briefs")
+    .select("site_id")
+    .eq("id", idCheck.value)
+    .maybeSingle();
+  const siteId = briefLookup.data?.site_id as string | undefined;
+  let remainingBudgetCents = 0;
+  if (siteId) {
+    const budget = await svc
+      .from("tenant_cost_budgets")
+      .select("monthly_cap_cents, monthly_usage_cents")
+      .eq("site_id", siteId)
+      .maybeSingle();
+    if (budget.data) {
+      const cap = Number(budget.data.monthly_cap_cents ?? 0);
+      const usage = Number(budget.data.monthly_usage_cents ?? 0);
+      remainingBudgetCents = Math.max(0, cap - usage);
+    }
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        estimate_cents: estimate.estimate_cents,
+        page_count: estimate.page_count,
+        remaining_budget_cents: remainingBudgetCents,
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { brief_id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const idCheck = validateUuidParam(params.brief_id, "brief_id");
+  if (!idCheck.ok) return idCheck.response;
+
+  const body = await readJsonBody(req);
+  const parsed = parseBodyWith(StartRunBodySchema, body);
+  if (!parsed.ok) return parsed.response;
+
+  const result = await startBriefRun({
+    briefId: idCheck.value,
+    startedBy: gate.user?.id ?? null,
+    confirmed: parsed.data.confirmed,
+  });
+
+  if (!result.ok) {
+    logger.warn("briefs.run.start_failed", {
+      brief_id: idCheck.value,
+      code: result.error.code,
+    });
+    return respond(result);
+  }
+
+  // Bust the review + run surfaces so the post-start read sees the queued row.
+  const svc = getServiceRoleClient();
+  const lookup = await svc
+    .from("briefs")
+    .select("site_id")
+    .eq("id", idCheck.value)
+    .maybeSingle();
+  const siteId = (lookup.data?.site_id as string | undefined) ?? null;
+  if (siteId) {
+    revalidatePath(`/admin/sites/${siteId}/briefs/${idCheck.value}/review`);
+    revalidatePath(`/admin/sites/${siteId}/briefs/${idCheck.value}/run`);
+    revalidatePath(`/admin/sites/${siteId}`);
+  }
+
+  return respond(result);
+}

--- a/components/BriefReviewClient.tsx
+++ b/components/BriefReviewClient.tsx
@@ -8,6 +8,32 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import type { BriefPageRow, BriefRow } from "@/lib/briefs";
 
+// Operator-facing labels for the Anthropic model allowlist. Kept
+// inline (not imported from lib/anthropic-pricing) because the display
+// copy is UI concern, not a data contract. If a new model is added to
+// the allowlist, this table gets a new row in the same PR.
+const MODEL_OPTIONS: Array<{
+  value: string;
+  label: string;
+  hint: string;
+}> = [
+  {
+    value: "claude-haiku-4-5-20251001",
+    label: "Haiku (fastest, cheapest)",
+    hint: "Best for simple copy or straightforward layouts. ~5-10× cheaper than Opus.",
+  },
+  {
+    value: "claude-sonnet-4-6",
+    label: "Sonnet (balanced — default)",
+    hint: "Default for both text and visual. Good quality, moderate cost.",
+  },
+  {
+    value: "claude-opus-4-7",
+    label: "Opus (highest quality, most expensive)",
+    hint: "Reserve for complex-judgment briefs. ~5× the cost of Sonnet.",
+  },
+];
+
 // ---------------------------------------------------------------------------
 // M12-1 — client component for the brief-review page.
 //
@@ -105,6 +131,16 @@ export function BriefReviewClient({
   const [designDirection, setDesignDirection] = useState<string>(
     brief.design_direction ?? "",
   );
+  // M12-5 — operator picks model tiers at commit time. Default to the
+  // value the server committed the brief with; fall back to Sonnet when
+  // a pre-M12-4 row somehow has no value (defensive — migration 0020
+  // fills everything with 'claude-sonnet-4-6').
+  const [textModel, setTextModel] = useState<string>(
+    brief.text_model ?? "claude-sonnet-4-6",
+  );
+  const [visualModel, setVisualModel] = useState<string>(
+    brief.visual_model ?? "claude-sonnet-4-6",
+  );
 
   const isReadOnly = brief.status === "committed";
   const isFailed = brief.status === "failed_parse";
@@ -171,6 +207,8 @@ export function BriefReviewClient({
           page_hash: hash,
           brand_voice: voiceValue,
           design_direction: directionValue,
+          text_model: textModel,
+          visual_model: visualModel,
         }),
       });
       const payload = (await res.json()) as {
@@ -325,6 +363,72 @@ export function BriefReviewClient({
       )}
 
       {(brief.status === "parsed" || brief.status === "committed") && (
+        <section aria-labelledby="model-tier-heading" className="rounded-lg border p-4">
+          <div className="mb-3">
+            <h2 id="model-tier-heading" className="text-lg font-medium">
+              Model tier
+            </h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Pick the Claude model for text generation and for the visual
+              review critique. Sonnet is the default for both — Opus is
+              reserved for complex-judgment briefs. See the cost estimate on
+              the run surface before starting.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <label
+                htmlFor="text-model-select"
+                className="block text-xs font-medium text-muted-foreground"
+              >
+                Text model (draft / critique / revise passes)
+              </label>
+              <select
+                id="text-model-select"
+                className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm disabled:opacity-50"
+                value={textModel}
+                onChange={(e) => setTextModel(e.target.value)}
+                disabled={isReadOnly}
+              >
+                {MODEL_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {MODEL_OPTIONS.find((o) => o.value === textModel)?.hint ?? ""}
+              </p>
+            </div>
+            <div>
+              <label
+                htmlFor="visual-model-select"
+                className="block text-xs font-medium text-muted-foreground"
+              >
+                Visual critique model
+              </label>
+              <select
+                id="visual-model-select"
+                className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm disabled:opacity-50"
+                value={visualModel}
+                onChange={(e) => setVisualModel(e.target.value)}
+                disabled={isReadOnly}
+              >
+                {MODEL_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {MODEL_OPTIONS.find((o) => o.value === visualModel)?.hint ?? ""}
+              </p>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {(brief.status === "parsed" || brief.status === "committed") && (
         <section aria-label="Page list">
           <div className="mb-3 flex items-center justify-between">
             <h2 className="text-lg font-medium">Page list</h2>
@@ -441,21 +545,25 @@ export function BriefReviewClient({
         >
           <div className="flex items-start justify-between gap-4">
             <div>
-              <p className="font-medium">This brief is locked in.</p>
+              <p className="font-medium">This brief is committed.</p>
               <p className="mt-1 text-muted-foreground">
-                Page generation will be available soon — we&apos;ll email you when it&apos;s ready.
+                You&apos;re ready to run the generator. The run surface shows
+                the cost estimate, approval controls, and visual critique per
+                page.
               </p>
             </div>
-            <Button
-              asChild
-              variant="outline"
-              size="sm"
-              className="shrink-0"
-            >
-              <a href={`/admin/sites/${siteId}`}>
-                Back to briefs
-              </a>
-            </Button>
+            <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
+              <Button asChild variant="outline" size="sm">
+                <a href={`/admin/sites/${siteId}`}>Back to briefs</a>
+              </Button>
+              <Button asChild size="sm">
+                <a
+                  href={`/admin/sites/${siteId}/briefs/${brief.id}/run`}
+                >
+                  Open run surface →
+                </a>
+              </Button>
+            </div>
           </div>
         </div>
       )}

--- a/components/BriefRunClient.tsx
+++ b/components/BriefRunClient.tsx
@@ -1,0 +1,785 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type {
+  BriefPageCritiqueEntry,
+  BriefPageQualityFlag,
+  BriefPageRow,
+  BriefPageStatus,
+  BriefRow,
+  BriefRunSnapshot,
+} from "@/lib/briefs";
+
+// ---------------------------------------------------------------------------
+// M12-5 — /admin/sites/[id]/briefs/[brief_id]/run client component.
+//
+// Owns the run-control state machine + three operator actions:
+//   - Start run (with CONFIRMATION_REQUIRED dialog if cost > 50% budget)
+//   - Approve current page (advances runner to the next ordinal)
+//   - Revise with note (captures operator feedback + re-queues the page)
+//   - Cancel run (idempotent, leaves generated pages in place)
+//
+// Renders:
+//   - Run status + cost rollup banner
+//   - Per-page list with status pill + quality_flag badge
+//   - Expanded preview on the current "awaiting_review" page:
+//       * sanitized draft_html in an iframe sandbox
+//       * last visual_critique text (if present)
+//       * approve / revise buttons
+//
+// VERSION_CONFLICT on any action surfaces inline — matches M8-5's
+// budget-editor shape. Operator refreshes to pick up the server state.
+// ---------------------------------------------------------------------------
+
+function centsToUsd(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+type ControlState = "idle" | "starting" | "confirming" | "cancelling" | "acting";
+
+const STATUS_LABELS: Record<
+  BriefPageStatus,
+  { label: string; cls: string }
+> = {
+  pending: { label: "Pending", cls: "bg-muted text-muted-foreground" },
+  generating: {
+    label: "Generating",
+    cls: "bg-primary/10 text-primary animate-pulse",
+  },
+  awaiting_review: {
+    label: "Awaiting review",
+    cls: "bg-yellow-500/10 text-yellow-900 dark:text-yellow-200",
+  },
+  approved: { label: "Approved", cls: "bg-emerald-500/10 text-emerald-700" },
+  failed: { label: "Failed", cls: "bg-destructive/10 text-destructive" },
+  skipped: { label: "Skipped", cls: "bg-muted text-muted-foreground" },
+};
+
+const QUALITY_FLAG_COPY: Record<
+  BriefPageQualityFlag,
+  { label: string; hint: string; cls: string }
+> = {
+  cost_ceiling: {
+    label: "Cost ceiling hit",
+    hint:
+      "The visual review halted before converging because this page hit its per-page cost ceiling. The current draft is the best version the runner produced within budget.",
+    cls: "bg-orange-500/10 text-orange-900 dark:text-orange-200",
+  },
+  capped_with_issues: {
+    label: "Capped with issues",
+    hint:
+      "The 2-iteration visual review cap was reached while the critique still flagged severity-high issues. Review the critique notes below before approving.",
+    cls: "bg-orange-500/10 text-orange-900 dark:text-orange-200",
+  },
+};
+
+const RUN_STATUS_LABELS: Record<
+  BriefRunSnapshot["status"],
+  { label: string; cls: string }
+> = {
+  queued: { label: "Queued", cls: "bg-primary/10 text-primary" },
+  running: {
+    label: "Running",
+    cls: "bg-primary/10 text-primary animate-pulse",
+  },
+  paused: {
+    label: "Awaiting your review",
+    cls: "bg-yellow-500/10 text-yellow-900 dark:text-yellow-200",
+  },
+  succeeded: { label: "Complete", cls: "bg-emerald-500/10 text-emerald-700" },
+  failed: { label: "Failed", cls: "bg-destructive/10 text-destructive" },
+  cancelled: { label: "Cancelled", cls: "bg-muted text-muted-foreground" },
+};
+
+const ERROR_TRANSLATIONS: Record<string, string> = {
+  CONFIRMATION_REQUIRED:
+    "This run's estimated cost exceeds 50% of your remaining monthly budget. Confirm to proceed.",
+  BRIEF_RUN_ALREADY_ACTIVE:
+    "There's already an active run for this brief. Cancel it before starting a new one.",
+  VERSION_CONFLICT:
+    "Another tab changed this page while you were reviewing. Refresh to see the latest state, then retry.",
+  INVALID_STATE:
+    "This action isn't available for the page's current state. Refresh and retry.",
+  NOT_FOUND:
+    "We couldn't find the brief or page. It may have been deleted — refresh to confirm.",
+};
+
+export function BriefRunClient({
+  siteId,
+  siteName,
+  brief,
+  pages,
+  activeRun,
+  estimateCents,
+  remainingBudgetCents,
+}: {
+  siteId: string;
+  siteName: string;
+  brief: BriefRow;
+  pages: BriefPageRow[];
+  activeRun: BriefRunSnapshot | null;
+  estimateCents: number;
+  remainingBudgetCents: number;
+}) {
+  const router = useRouter();
+  const [controlState, setControlState] = useState<ControlState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [reviseOpen, setReviseOpen] = useState<string | null>(null); // page id
+  const [reviseNote, setReviseNote] = useState("");
+
+  const sortedPages = useMemo(
+    () => [...pages].sort((a, b) => a.ordinal - b.ordinal),
+    [pages],
+  );
+
+  const isRunTerminal =
+    activeRun?.status === "succeeded" ||
+    activeRun?.status === "failed" ||
+    activeRun?.status === "cancelled";
+
+  const isRunActive =
+    activeRun !== null && !isRunTerminal; // queued | running | paused
+
+  const canStartRun = !activeRun || isRunTerminal;
+
+  function errorFor(code: string, fallback: string): string {
+    return ERROR_TRANSLATIONS[code] ?? fallback;
+  }
+
+  async function handleStartRun(confirmed: boolean) {
+    setControlState("starting");
+    setErrorMessage(null);
+    try {
+      const res = await fetch(`/api/briefs/${brief.id}/run`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ confirmed }),
+      });
+      const payload = (await res.json()) as {
+        ok: boolean;
+        data?: unknown;
+        error?: { code: string; message: string };
+      };
+      if (res.ok && payload.ok) {
+        setControlState("idle");
+        setConfirmOpen(false);
+        router.refresh();
+        return;
+      }
+      if (payload.error?.code === "CONFIRMATION_REQUIRED") {
+        setConfirmOpen(true);
+        setControlState("idle");
+        return;
+      }
+      setErrorMessage(
+        errorFor(
+          payload.error?.code ?? "INTERNAL_ERROR",
+          payload.error?.message ?? `Start failed (HTTP ${res.status}).`,
+        ),
+      );
+      setControlState("idle");
+    } catch (err) {
+      setErrorMessage(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      setControlState("idle");
+    }
+  }
+
+  async function handleCancel() {
+    setControlState("cancelling");
+    setErrorMessage(null);
+    try {
+      const res = await fetch(`/api/briefs/${brief.id}/cancel`, {
+        method: "POST",
+      });
+      const payload = (await res.json()) as {
+        ok: boolean;
+        error?: { code: string; message: string };
+      };
+      if (res.ok && payload.ok) {
+        setControlState("idle");
+        router.refresh();
+        return;
+      }
+      setErrorMessage(
+        errorFor(
+          payload.error?.code ?? "INTERNAL_ERROR",
+          payload.error?.message ?? `Cancel failed (HTTP ${res.status}).`,
+        ),
+      );
+      setControlState("idle");
+    } catch (err) {
+      setErrorMessage(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      setControlState("idle");
+    }
+  }
+
+  async function handleApprove(page: BriefPageRow) {
+    setControlState("acting");
+    setErrorMessage(null);
+    try {
+      const res = await fetch(
+        `/api/briefs/${brief.id}/pages/${page.id}/approve`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            expected_version_lock: page.version_lock,
+          }),
+        },
+      );
+      const payload = (await res.json()) as {
+        ok: boolean;
+        error?: { code: string; message: string };
+      };
+      if (res.ok && payload.ok) {
+        setControlState("idle");
+        router.refresh();
+        return;
+      }
+      setErrorMessage(
+        errorFor(
+          payload.error?.code ?? "INTERNAL_ERROR",
+          payload.error?.message ?? `Approve failed (HTTP ${res.status}).`,
+        ),
+      );
+      setControlState("idle");
+    } catch (err) {
+      setErrorMessage(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      setControlState("idle");
+    }
+  }
+
+  async function handleRevise(page: BriefPageRow) {
+    if (!reviseNote.trim()) {
+      setErrorMessage("Add a note describing what to change.");
+      return;
+    }
+    setControlState("acting");
+    setErrorMessage(null);
+    try {
+      const res = await fetch(
+        `/api/briefs/${brief.id}/pages/${page.id}/revise`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            expected_version_lock: page.version_lock,
+            note: reviseNote,
+          }),
+        },
+      );
+      const payload = (await res.json()) as {
+        ok: boolean;
+        error?: { code: string; message: string };
+      };
+      if (res.ok && payload.ok) {
+        setControlState("idle");
+        setReviseOpen(null);
+        setReviseNote("");
+        router.refresh();
+        return;
+      }
+      setErrorMessage(
+        errorFor(
+          payload.error?.code ?? "INTERNAL_ERROR",
+          payload.error?.message ?? `Revise failed (HTTP ${res.status}).`,
+        ),
+      );
+      setControlState("idle");
+    } catch (err) {
+      setErrorMessage(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      setControlState("idle");
+    }
+  }
+
+  return (
+    <div className="mt-6 space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">{brief.title}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Run surface for <span className="font-medium">{siteName}</span>
+            {activeRun && (
+              <>
+                {" — "}
+                <RunStatusPill status={activeRun.status} />
+              </>
+            )}
+          </p>
+        </div>
+        {isRunActive && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleCancel}
+            disabled={controlState !== "idle"}
+          >
+            {controlState === "cancelling" ? "Cancelling…" : "Cancel run"}
+          </Button>
+        )}
+      </div>
+
+      {errorMessage && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {errorMessage}
+        </div>
+      )}
+
+      <section
+        aria-labelledby="cost-heading"
+        className="rounded-lg border p-4"
+      >
+        <h2 id="cost-heading" className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          Cost
+        </h2>
+        <div className="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div>
+            <p className="text-xs text-muted-foreground">Estimate</p>
+            <p className="font-mono text-lg">{centsToUsd(estimateCents)}</p>
+            <p className="text-xs text-muted-foreground">
+              {sortedPages.length} page{sortedPages.length === 1 ? "" : "s"} ·{" "}
+              {brief.text_model} / {brief.visual_model}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Remaining this month</p>
+            <p className="font-mono text-lg">
+              {centsToUsd(remainingBudgetCents)}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Spent on this run</p>
+            <p className="font-mono text-lg">
+              {centsToUsd(Number(activeRun?.run_cost_cents ?? 0))}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {canStartRun && (
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            onClick={() => handleStartRun(false)}
+            disabled={controlState !== "idle"}
+          >
+            {controlState === "starting" ? "Starting…" : "Start run"}
+          </Button>
+        </div>
+      )}
+
+      {activeRun?.status === "failed" && activeRun.failure_code && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          <p className="font-medium">
+            Run failed: <code className="text-xs">{activeRun.failure_code}</code>
+          </p>
+          {activeRun.failure_detail && (
+            <p className="mt-1">{activeRun.failure_detail}</p>
+          )}
+        </div>
+      )}
+
+      <section aria-label="Pages">
+        <h2 className="text-lg font-medium">Pages</h2>
+        <ol className="mt-3 space-y-3">
+          {sortedPages.map((page) => {
+            const isExpanded =
+              page.page_status === "awaiting_review" ||
+              page.page_status === "failed" ||
+              page.page_status === "approved";
+            return (
+              <li
+                key={page.id}
+                className="rounded-lg border p-4"
+                aria-labelledby={`page-${page.id}-title`}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3
+                      id={`page-${page.id}-title`}
+                      className="text-base font-medium"
+                    >
+                      {page.ordinal + 1}. {page.title}
+                    </h3>
+                    <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+                      <PageStatusPill status={page.page_status} />
+                      {page.quality_flag && (
+                        <QualityFlagBadge flag={page.quality_flag} />
+                      )}
+                      <span className="text-muted-foreground">
+                        Cost:{" "}
+                        <span className="font-mono">
+                          {centsToUsd(Number(page.page_cost_cents ?? 0))}
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                {isExpanded && (
+                  <PagePreview
+                    page={page}
+                    briefId={brief.id}
+                    isCurrentAwaitingReview={
+                      page.page_status === "awaiting_review"
+                    }
+                    controlState={controlState}
+                    onApprove={() => handleApprove(page)}
+                    onRevise={() => setReviseOpen(page.id)}
+                  />
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+
+      {confirmOpen && (
+        <ConfirmationModal
+          estimateCents={estimateCents}
+          remainingBudgetCents={remainingBudgetCents}
+          onCancel={() => setConfirmOpen(false)}
+          onConfirm={() => handleStartRun(true)}
+          submitting={controlState === "starting"}
+        />
+      )}
+
+      {reviseOpen && (
+        <ReviseModal
+          note={reviseNote}
+          onNoteChange={setReviseNote}
+          onCancel={() => {
+            setReviseOpen(null);
+            setReviseNote("");
+          }}
+          onConfirm={() => {
+            const page = sortedPages.find((p) => p.id === reviseOpen);
+            if (page) handleRevise(page);
+          }}
+          submitting={controlState === "acting"}
+        />
+      )}
+    </div>
+  );
+}
+
+function RunStatusPill({
+  status,
+}: {
+  status: BriefRunSnapshot["status"];
+}) {
+  const l = RUN_STATUS_LABELS[status];
+  return (
+    <span
+      className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${l.cls}`}
+    >
+      {l.label}
+    </span>
+  );
+}
+
+function PageStatusPill({ status }: { status: BriefPageStatus }) {
+  const l = STATUS_LABELS[status];
+  return (
+    <span
+      className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${l.cls}`}
+    >
+      {l.label}
+    </span>
+  );
+}
+
+function QualityFlagBadge({ flag }: { flag: BriefPageQualityFlag }) {
+  const c = QUALITY_FLAG_COPY[flag];
+  return (
+    <span
+      className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${c.cls}`}
+      title={c.hint}
+    >
+      ⚠ {c.label}
+    </span>
+  );
+}
+
+function PagePreview({
+  page,
+  isCurrentAwaitingReview,
+  controlState,
+  onApprove,
+  onRevise,
+}: {
+  page: BriefPageRow;
+  briefId: string;
+  isCurrentAwaitingReview: boolean;
+  controlState: ControlState;
+  onApprove: () => void;
+  onRevise: () => void;
+}) {
+  const html = page.generated_html ?? page.draft_html ?? "";
+  const lastVisualCritique = useMemo(() => {
+    const log = (page.critique_log ?? []) as BriefPageCritiqueEntry[];
+    return [...log]
+      .reverse()
+      .find((e) => e.pass_kind === "visual_critique");
+  }, [page.critique_log]);
+
+  return (
+    <div className="mt-4 space-y-3">
+      {html ? (
+        <details className="group">
+          <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+            Show rendered preview
+          </summary>
+          <iframe
+            // Sandbox prevents scripts, plugins, forms, popups from the
+            // preview. draft_html is Claude-generated and already passes
+            // the runner's quality gates, but belt-and-suspenders: render
+            // it in a constrained frame.
+            sandbox=""
+            srcDoc={html}
+            className="mt-2 h-96 w-full rounded border"
+            title={`Preview of ${page.title}`}
+          />
+        </details>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          No draft HTML yet.
+        </p>
+      )}
+
+      {lastVisualCritique && (
+        <VisualCritiqueBlock entry={lastVisualCritique} />
+      )}
+
+      {page.operator_notes && page.operator_notes.trim() !== "" && (
+        <details className="group">
+          <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+            Your past notes
+          </summary>
+          <pre className="mt-2 whitespace-pre-wrap rounded border bg-muted p-2 text-xs">
+            {page.operator_notes}
+          </pre>
+        </details>
+      )}
+
+      {isCurrentAwaitingReview && (
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onRevise}
+            disabled={controlState !== "idle"}
+          >
+            Revise with note
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={onApprove}
+            disabled={controlState !== "idle"}
+          >
+            {controlState === "acting" ? "Working…" : "Approve this page"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VisualCritiqueBlock({ entry }: { entry: BriefPageCritiqueEntry }) {
+  // critique_log output is the VisualCritique object — see lib/visual-review.
+  const critique = entry.output as {
+    issues: Array<{ category: string; severity: string; note: string }>;
+    overall_notes?: string;
+  };
+  if (!critique || !Array.isArray(critique.issues)) return null;
+  return (
+    <div className="rounded border bg-muted/50 p-3 text-sm">
+      <p className="font-medium">Visual critique</p>
+      {critique.issues.length === 0 ? (
+        <p className="mt-1 text-xs text-muted-foreground">No issues flagged.</p>
+      ) : (
+        <ul className="mt-2 space-y-1 text-xs">
+          {critique.issues.map((issue, i) => (
+            <li key={i} className="flex gap-2">
+              <span
+                className={`inline-flex shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase ${
+                  issue.severity === "high"
+                    ? "bg-destructive/10 text-destructive"
+                    : "bg-muted text-muted-foreground"
+                }`}
+              >
+                {issue.severity}
+              </span>
+              <span>
+                <span className="font-medium">{issue.category}:</span>{" "}
+                {issue.note}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {critique.overall_notes && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          {critique.overall_notes}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ConfirmationModal({
+  estimateCents,
+  remainingBudgetCents,
+  onCancel,
+  onConfirm,
+  submitting,
+}: {
+  estimateCents: number;
+  remainingBudgetCents: number;
+  onCancel: () => void;
+  onConfirm: () => void;
+  submitting: boolean;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-run-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !submitting) onCancel();
+      }}
+    >
+      <div className="w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="confirm-run-title" className="text-lg font-semibold">
+          This run will spend a lot of your monthly budget
+        </h2>
+        <div className="mt-3 space-y-3 text-sm text-muted-foreground">
+          <p>
+            Estimated cost:{" "}
+            <span className="font-mono font-semibold text-foreground">
+              {centsToUsd(estimateCents)}
+            </span>
+            . Remaining monthly budget:{" "}
+            <span className="font-mono font-semibold text-foreground">
+              {centsToUsd(remainingBudgetCents)}
+            </span>
+            .
+          </p>
+          <p>
+            This is more than half of what&apos;s left this month. The run can
+            still be cancelled mid-flight; generated pages stay in place.
+          </p>
+        </div>
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onCancel}
+            disabled={submitting}
+          >
+            Keep reviewing
+          </Button>
+          <Button type="button" onClick={onConfirm} disabled={submitting}>
+            {submitting ? "Starting…" : "Start anyway"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ReviseModal({
+  note,
+  onNoteChange,
+  onCancel,
+  onConfirm,
+  submitting,
+}: {
+  note: string;
+  onNoteChange: (s: string) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+  submitting: boolean;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="revise-note-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !submitting) onCancel();
+      }}
+    >
+      <div className="w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg">
+        <h2 id="revise-note-title" className="text-lg font-semibold">
+          Revise this page with a note
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          The runner re-enters this page from the top. Your note goes into
+          the prompt for every pass.
+        </p>
+        <div className="mt-4">
+          <label
+            htmlFor="revise-note-input"
+            className="block text-xs font-medium text-muted-foreground"
+          >
+            Note for the generator
+          </label>
+          <Textarea
+            id="revise-note-input"
+            className="mt-1"
+            rows={5}
+            value={note}
+            onChange={(e) => onNoteChange(e.target.value)}
+            placeholder="e.g. The hero section is too dense. Break into a headline + single CTA with generous whitespace underneath."
+            maxLength={2000}
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            {note.length} / 2000 characters
+          </p>
+        </div>
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onCancel}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={onConfirm}
+            disabled={submitting || note.trim() === ""}
+          >
+            {submitting ? "Re-queueing…" : "Re-queue with note"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/e2e/briefs-run-surface.spec.ts
+++ b/e2e/briefs-run-surface.spec.ts
@@ -1,0 +1,174 @@
+import { createClient } from "@supabase/supabase-js";
+import { expect, test } from "@playwright/test";
+
+import { E2E_TEST_SITE_PREFIX } from "./fixtures";
+import { auditA11y, signInAsAdmin } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// M12-5 — run surface E2E.
+//
+// Covers the UI rendering path only — actually starting a run spends
+// Anthropic tokens (even with Sonnet), and the runner's multi-pass
+// flow requires a real worker loop. That end-to-end coverage lands in
+// M12-6 per the parent plan's testing strategy row.
+//
+// This spec asserts:
+//   1. After a brief is in `status='committed'`, the run surface renders
+//      at /admin/sites/[id]/briefs/[brief_id]/run
+//   2. Cost estimate + "Start run" button are visible
+//   3. Pages render with status pills
+//   4. auditA11y on the page
+//
+// A fresh committed brief is seeded directly via the service-role client
+// to avoid coupling to the flagged-fixme commit flow in briefs-review.spec.
+// ---------------------------------------------------------------------------
+
+function supabaseServiceClient() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error(
+      "SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY must be set for the E2E suite.",
+    );
+  }
+  return createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function seedCommittedBriefDirectly(opts: {
+  siteId: string;
+  pageCount: number;
+}): Promise<{ briefId: string }> {
+  const svc = supabaseServiceClient();
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const briefRes = await svc
+    .from("briefs")
+    .insert({
+      site_id: opts.siteId,
+      title: `E2E run surface ${unique}`,
+      status: "committed",
+      source_storage_path: `e2e-run/${unique}.md`,
+      source_mime_type: "text/markdown",
+      source_size_bytes: 256,
+      source_sha256: "0".repeat(64),
+      upload_idempotency_key: `e2e-run-${unique}`,
+      committed_at: new Date().toISOString(),
+      committed_page_hash: "e".repeat(64),
+      brand_voice: "Warm and direct.",
+      design_direction: "Clean editorial.",
+    })
+    .select("id")
+    .single();
+  if (briefRes.error || !briefRes.data) {
+    throw new Error(`seedCommittedBriefDirectly: ${briefRes.error?.message}`);
+  }
+  const briefId = briefRes.data.id as string;
+  for (let i = 0; i < opts.pageCount; i++) {
+    await svc.from("brief_pages").insert({
+      brief_id: briefId,
+      ordinal: i,
+      title: `Page ${i + 1}`,
+      mode: "full_text",
+      source_text: `Content for page ${i + 1}.`,
+      word_count: 4,
+    });
+  }
+  return { briefId };
+}
+
+async function findTestSite(): Promise<{ id: string }> {
+  const svc = supabaseServiceClient();
+  const { data, error } = await svc
+    .from("sites")
+    .select("id")
+    .eq("prefix", E2E_TEST_SITE_PREFIX)
+    .maybeSingle();
+  if (error || !data) {
+    throw new Error(
+      `E2E test site not found (prefix ${E2E_TEST_SITE_PREFIX}): ${error?.message ?? "no row"}`,
+    );
+  }
+  return { id: data.id as string };
+}
+
+test.describe("M12-5 briefs — run surface", () => {
+  test.beforeEach(async ({ page }) => {
+    await signInAsAdmin(page);
+  });
+
+  test("run surface renders cost estimate + start CTA for a committed brief", async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(30_000);
+    const site = await findTestSite();
+    const { briefId } = await seedCommittedBriefDirectly({
+      siteId: site.id,
+      pageCount: 2,
+    });
+
+    await page.goto(`/admin/sites/${site.id}/briefs/${briefId}/run`);
+
+    // Brief title visible.
+    await expect(
+      page.getByRole("heading", { level: 1, name: /E2E run surface/ }),
+    ).toBeVisible();
+
+    // Cost panel: estimate + remaining + spent.
+    await expect(page.getByRole("heading", { name: /^cost$/i })).toBeVisible();
+    await expect(page.getByText(/Estimate/i)).toBeVisible();
+    await expect(page.getByText(/Remaining this month/i)).toBeVisible();
+
+    // Start CTA visible (no active run).
+    await expect(
+      page.getByRole("button", { name: /^start run$/i }),
+    ).toBeVisible();
+
+    // Page list renders with ordinal + title.
+    await expect(page.getByRole("heading", { name: /^pages$/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /1\. Page 1/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /2\. Page 2/i })).toBeVisible();
+
+    await auditA11y(page, testInfo);
+  });
+
+  test("run surface redirects the operator when brief is not committed", async ({
+    page,
+  }) => {
+    test.setTimeout(30_000);
+    const site = await findTestSite();
+    const svc = supabaseServiceClient();
+
+    // Seed a parsed-but-not-committed brief.
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const briefRes = await svc
+      .from("briefs")
+      .insert({
+        site_id: site.id,
+        title: `E2E parsed-only ${unique}`,
+        status: "parsed",
+        source_storage_path: `e2e-parsed/${unique}.md`,
+        source_mime_type: "text/markdown",
+        source_size_bytes: 64,
+        source_sha256: "0".repeat(64),
+        upload_idempotency_key: `e2e-parsed-${unique}`,
+      })
+      .select("id")
+      .single();
+    if (briefRes.error || !briefRes.data) {
+      throw new Error(`seed parsed brief: ${briefRes.error?.message}`);
+    }
+    const briefId = briefRes.data.id as string;
+
+    await page.goto(`/admin/sites/${site.id}/briefs/${briefId}/run`);
+
+    // The server component renders a "commit first" banner with a link
+    // back to the review surface.
+    await expect(
+      page.getByText(/this brief isn't committed yet/i),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /review and commit/i }),
+    ).toBeVisible();
+  });
+});

--- a/lib/__tests__/briefs-run-routes.test.ts
+++ b/lib/__tests__/briefs-run-routes.test.ts
@@ -1,0 +1,532 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// M12-5 — unit tests for the three new run-surface routes:
+//   POST /api/briefs/[brief_id]/run     (start run + CONFIRMATION_REQUIRED)
+//   POST /api/briefs/[brief_id]/cancel  (idempotent cancel)
+//   POST /api/briefs/[brief_id]/pages/[page_id]/revise  (revise with note)
+//
+// Runs with FEATURE_SUPABASE_AUTH off so requireAdminForApi allows.
+// ---------------------------------------------------------------------------
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { POST as startRunPOST, GET as startRunGET } from "@/app/api/briefs/[brief_id]/run/route";
+import { POST as cancelPOST } from "@/app/api/briefs/[brief_id]/cancel/route";
+import { POST as revisePOST } from "@/app/api/briefs/[brief_id]/pages/[page_id]/revise/route";
+
+const ENV_KEYS = ["FEATURE_SUPABASE_AUTH"] as const;
+let origEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  origEnv = {};
+  for (const k of ENV_KEYS) origEnv[k] = process.env[k];
+  delete process.env.FEATURE_SUPABASE_AUTH;
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (origEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = origEnv[k];
+  }
+});
+
+async function seedCommittedBriefWithPages(
+  siteId: string,
+  pageCount: number,
+): Promise<{ briefId: string; pageIds: string[] }> {
+  const svc = getServiceRoleClient();
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const briefRes = await svc
+    .from("briefs")
+    .insert({
+      site_id: siteId,
+      title: `run-routes-test ${unique}`,
+      status: "committed",
+      source_storage_path: `run-routes/${unique}.md`,
+      source_mime_type: "text/markdown",
+      source_size_bytes: 128,
+      source_sha256: "0".repeat(64),
+      upload_idempotency_key: `run-routes-${unique}`,
+      committed_at: new Date().toISOString(),
+      committed_page_hash: "e".repeat(64),
+    })
+    .select("id")
+    .single();
+  if (briefRes.error || !briefRes.data) {
+    throw new Error(`seed brief: ${briefRes.error?.message}`);
+  }
+  const briefId = briefRes.data.id as string;
+  const pageIds: string[] = [];
+  for (let i = 0; i < pageCount; i++) {
+    const r = await svc
+      .from("brief_pages")
+      .insert({
+        brief_id: briefId,
+        ordinal: i,
+        title: `Page ${i}`,
+        mode: "full_text",
+        source_text: `Content for page ${i}.`,
+        word_count: 3,
+      })
+      .select("id")
+      .single();
+    if (r.error || !r.data) throw new Error(`seed page ${i}: ${r.error?.message}`);
+    pageIds.push(r.data.id as string);
+  }
+  return { briefId, pageIds };
+}
+
+describe("POST /api/briefs/[brief_id]/run — start run", () => {
+  it("happy path: 200 with brief_run_id + estimate_cents", async () => {
+    const site = await seedSite();
+    const { briefId } = await seedCommittedBriefWithPages(site.id, 2);
+
+    const req = new Request(`http://localhost/api/briefs/${briefId}/run`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const res = await startRunPOST(req, { params: { brief_id: briefId } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data?: {
+        brief_run_id: string;
+        estimate_cents: number;
+        remaining_budget_cents: number;
+      };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data?.brief_run_id).toBeTruthy();
+    expect(body.data?.estimate_cents).toBeGreaterThan(0);
+  });
+
+  it("CONFIRMATION_REQUIRED (429) when estimate > 50% of remaining budget; re-submit with confirmed:true succeeds", async () => {
+    const site = await seedSite();
+    const svc = getServiceRoleClient();
+    const { briefId } = await seedCommittedBriefWithPages(site.id, 2);
+    await svc
+      .from("tenant_cost_budgets")
+      .update({
+        monthly_cap_cents: 100,
+        monthly_usage_cents: 0,
+      })
+      .eq("site_id", site.id);
+
+    const first = await startRunPOST(
+      new Request(`http://localhost/api/briefs/${briefId}/run`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      { params: { brief_id: briefId } },
+    );
+    expect(first.status).toBe(429);
+    const firstBody = (await first.json()) as {
+      ok: boolean;
+      error: { code: string };
+    };
+    expect(firstBody.ok).toBe(false);
+    expect(firstBody.error.code).toBe("CONFIRMATION_REQUIRED");
+
+    const second = await startRunPOST(
+      new Request(`http://localhost/api/briefs/${briefId}/run`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ confirmed: true }),
+      }),
+      { params: { brief_id: briefId } },
+    );
+    expect(second.status).toBe(200);
+  });
+
+  it("BRIEF_RUN_ALREADY_ACTIVE (409) on a second start", async () => {
+    const site = await seedSite();
+    const { briefId } = await seedCommittedBriefWithPages(site.id, 2);
+    const first = await startRunPOST(
+      new Request(`http://localhost/api/briefs/${briefId}/run`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      { params: { brief_id: briefId } },
+    );
+    expect(first.status).toBe(200);
+    const second = await startRunPOST(
+      new Request(`http://localhost/api/briefs/${briefId}/run`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      { params: { brief_id: briefId } },
+    );
+    expect(second.status).toBe(409);
+    const body = (await second.json()) as { ok: boolean; error: { code: string } };
+    expect(body.error.code).toBe("BRIEF_RUN_ALREADY_ACTIVE");
+  });
+
+  it("GET returns estimate + remaining_budget + page_count without side effects", async () => {
+    const site = await seedSite();
+    const { briefId } = await seedCommittedBriefWithPages(site.id, 3);
+    const res = await startRunGET(
+      new Request(`http://localhost/api/briefs/${briefId}/run`),
+      { params: { brief_id: briefId } },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: {
+        estimate_cents: number;
+        page_count: number;
+        remaining_budget_cents: number;
+      };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data.page_count).toBe(3);
+    expect(body.data.estimate_cents).toBeGreaterThan(0);
+    // GET doesn't insert a run row.
+    const svc = getServiceRoleClient();
+    const runs = await svc
+      .from("brief_runs")
+      .select("id")
+      .eq("brief_id", briefId);
+    expect(runs.data?.length ?? 0).toBe(0);
+  });
+});
+
+describe("POST /api/briefs/[brief_id]/cancel", () => {
+  it("idempotent: returns already_cancelled:true when no active run", async () => {
+    const site = await seedSite();
+    const { briefId } = await seedCommittedBriefWithPages(site.id, 1);
+    const res = await cancelPOST(
+      new Request(`http://localhost/api/briefs/${briefId}/cancel`, {
+        method: "POST",
+      }),
+      { params: { brief_id: briefId } },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { already_cancelled?: boolean };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data.already_cancelled).toBe(true);
+  });
+
+  it("cancels an active run and leaves brief_pages rows untouched", async () => {
+    const site = await seedSite();
+    const svc = getServiceRoleClient();
+    const { briefId, pageIds } = await seedCommittedBriefWithPages(site.id, 2);
+    await svc
+      .from("brief_runs")
+      .insert({ brief_id: briefId, status: "running" });
+
+    // Also mark one page as approved (simulating mid-run progress).
+    await svc
+      .from("brief_pages")
+      .update({
+        page_status: "approved",
+        draft_html: "<p>hi</p>",
+        generated_html: "<p>hi</p>",
+        approved_at: new Date().toISOString(),
+      })
+      .eq("id", pageIds[0]!);
+
+    const res = await cancelPOST(
+      new Request(`http://localhost/api/briefs/${briefId}/cancel`, {
+        method: "POST",
+      }),
+      { params: { brief_id: briefId } },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { status?: string; already_cancelled?: boolean };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data.already_cancelled).toBe(false);
+    expect(body.data.status).toBe("cancelled");
+
+    const after = await svc
+      .from("brief_runs")
+      .select("status, cancel_requested_at, finished_at")
+      .eq("brief_id", briefId)
+      .single();
+    expect(after.data?.status).toBe("cancelled");
+    expect(after.data?.cancel_requested_at).not.toBeNull();
+
+    // Approved page still in place.
+    const page = await svc
+      .from("brief_pages")
+      .select("page_status, generated_html")
+      .eq("id", pageIds[0]!)
+      .single();
+    expect(page.data?.page_status).toBe("approved");
+    expect(page.data?.generated_html).toBe("<p>hi</p>");
+  });
+
+  it("NOT_FOUND (404) for an unknown brief id", async () => {
+    const fake = "00000000-0000-4000-8000-000000000000";
+    const res = await cancelPOST(
+      new Request(`http://localhost/api/briefs/${fake}/cancel`, {
+        method: "POST",
+      }),
+      { params: { brief_id: fake } },
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/briefs/[brief_id]/pages/[page_id]/revise", () => {
+  async function seedAwaitingReviewPage(
+    siteId: string,
+  ): Promise<{
+    briefId: string;
+    pageId: string;
+    pageVersionLock: number;
+  }> {
+    const svc = getServiceRoleClient();
+    const { briefId, pageIds } = await seedCommittedBriefWithPages(siteId, 1);
+    const pageId = pageIds[0]!;
+    await svc
+      .from("brief_pages")
+      .update({
+        draft_html: "<section><h1>First draft</h1></section>",
+      })
+      .eq("id", pageId);
+    const upd = await svc
+      .from("brief_pages")
+      .update({ page_status: "awaiting_review" })
+      .eq("id", pageId)
+      .select("version_lock")
+      .single();
+    return {
+      briefId,
+      pageId,
+      pageVersionLock: upd.data!.version_lock as number,
+    };
+  }
+
+  it("happy path: appends note, resets to pending, clears draft_html", async () => {
+    const site = await seedSite();
+    const { briefId, pageId, pageVersionLock } = await seedAwaitingReviewPage(
+      site.id,
+    );
+
+    const res = await revisePOST(
+      new Request(
+        `http://localhost/api/briefs/${briefId}/pages/${pageId}/revise`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            expected_version_lock: pageVersionLock,
+            note: "Make the hero punchier.",
+          }),
+        },
+      ),
+      { params: { brief_id: briefId, page_id: pageId } },
+    );
+    expect(res.status).toBe(200);
+
+    const svc = getServiceRoleClient();
+    const after = await svc
+      .from("brief_pages")
+      .select(
+        "page_status, current_pass_kind, current_pass_number, draft_html, operator_notes, quality_flag",
+      )
+      .eq("id", pageId)
+      .single();
+    expect(after.data?.page_status).toBe("pending");
+    expect(after.data?.current_pass_kind).toBeNull();
+    expect(after.data?.current_pass_number).toBe(0);
+    expect(after.data?.draft_html).toBeNull();
+    expect(after.data?.quality_flag).toBeNull();
+    expect(after.data?.operator_notes).toContain("Make the hero punchier.");
+  });
+
+  it("INVALID_STATE (409) when page is not in awaiting_review", async () => {
+    const site = await seedSite();
+    const { briefId, pageIds } = await seedCommittedBriefWithPages(site.id, 1);
+    const pageId = pageIds[0]!;
+    // Leave as pending (default).
+    const res = await revisePOST(
+      new Request(
+        `http://localhost/api/briefs/${briefId}/pages/${pageId}/revise`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ expected_version_lock: 0, note: "x" }),
+        },
+      ),
+      { params: { brief_id: briefId, page_id: pageId } },
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("INVALID_STATE");
+  });
+
+  it("VERSION_CONFLICT (409) on stale expected_version_lock", async () => {
+    const site = await seedSite();
+    const { briefId, pageId, pageVersionLock } = await seedAwaitingReviewPage(
+      site.id,
+    );
+    const res = await revisePOST(
+      new Request(
+        `http://localhost/api/briefs/${briefId}/pages/${pageId}/revise`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            expected_version_lock: pageVersionLock + 5,
+            note: "stale",
+          }),
+        },
+      ),
+      { params: { brief_id: briefId, page_id: pageId } },
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VERSION_CONFLICT");
+  });
+
+  it("NOT_FOUND (404) on brief_id/page_id mismatch", async () => {
+    const site = await seedSite();
+    const { pageId, pageVersionLock } = await seedAwaitingReviewPage(site.id);
+    const { briefId: otherBriefId } = await seedAwaitingReviewPage(site.id);
+    const res = await revisePOST(
+      new Request(
+        `http://localhost/api/briefs/${otherBriefId}/pages/${pageId}/revise`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            expected_version_lock: pageVersionLock,
+            note: "mismatch",
+          }),
+        },
+      ),
+      { params: { brief_id: otherBriefId, page_id: pageId } },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("VALIDATION_FAILED (400) on empty note", async () => {
+    const site = await seedSite();
+    const { briefId, pageId, pageVersionLock } = await seedAwaitingReviewPage(
+      site.id,
+    );
+    const res = await revisePOST(
+      new Request(
+        `http://localhost/api/briefs/${briefId}/pages/${pageId}/revise`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            expected_version_lock: pageVersionLock,
+            note: "",
+          }),
+        },
+      ),
+      { params: { brief_id: briefId, page_id: pageId } },
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("commit route — model-tier persistence", () => {
+  it("persists text_model + visual_model when supplied on commit", async () => {
+    const { POST: commitPOST } = await import(
+      "@/app/api/briefs/[brief_id]/commit/route"
+    );
+    const { POST: uploadBriefPOST } = await import(
+      "@/app/api/briefs/upload/route"
+    );
+
+    // Seed a parsed brief via the upload route so we have a realistic
+    // version_lock + page_hash to commit with.
+    const site = await seedSite({ prefix: "mt1a" });
+    const svc = getServiceRoleClient();
+
+    const form = new FormData();
+    form.append("site_id", site.id);
+    form.append(
+      "file",
+      new Blob(["## Home\n\nHome copy.\n\n## About\n\nAbout copy.\n"], {
+        type: "text/markdown",
+      }),
+      "brief.md",
+    );
+    const uploadRes = await uploadBriefPOST(
+      new Request("http://localhost/api/briefs/upload", {
+        method: "POST",
+        body: form,
+      }),
+    );
+    const uploadBody = (await uploadRes.json()) as {
+      data: { brief_id: string };
+    };
+    const briefId = uploadBody.data.brief_id;
+
+    const brief = await svc
+      .from("briefs")
+      .select("version_lock")
+      .eq("id", briefId)
+      .single();
+    const pages = await svc
+      .from("brief_pages")
+      .select("ordinal, title, mode, source_text")
+      .eq("brief_id", briefId)
+      .order("ordinal");
+
+    const { computePageHash } = await import("@/lib/briefs");
+    const hash = computePageHash(pages.data ?? []);
+
+    const commitRes = await commitPOST(
+      new Request(`http://localhost/api/briefs/${briefId}/commit`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          expected_version_lock: brief.data!.version_lock,
+          page_hash: hash,
+          text_model: "claude-opus-4-7",
+          visual_model: "claude-haiku-4-5-20251001",
+        }),
+      }),
+      { params: { brief_id: briefId } },
+    );
+    expect(commitRes.status).toBe(200);
+
+    const after = await svc
+      .from("briefs")
+      .select("text_model, visual_model")
+      .eq("id", briefId)
+      .single();
+    expect(after.data?.text_model).toBe("claude-opus-4-7");
+    expect(after.data?.visual_model).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("rejects non-allowlisted model strings with VALIDATION_FAILED (400)", async () => {
+    const { POST: commitPOST } = await import(
+      "@/app/api/briefs/[brief_id]/commit/route"
+    );
+    const fake = "00000000-0000-4000-8000-000000000000";
+    const res = await commitPOST(
+      new Request(`http://localhost/api/briefs/${fake}/commit`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          expected_version_lock: 0,
+          page_hash: "x".repeat(64),
+          text_model: "definitely-not-a-model",
+        }),
+      }),
+      { params: { brief_id: fake } },
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/lib/brief-runner.ts
+++ b/lib/brief-runner.ts
@@ -465,8 +465,15 @@ function systemPromptFor(ctx: PageContext): string {
 }
 
 function userPromptForDraft(ctx: PageContext): string {
+  // M12-5 — operator_notes surface here. Captured by the "revise with
+  // note" action; present only when the operator flipped this page back
+  // to pending with feedback. Empty for fresh runs.
+  const operatorNotesBlock =
+    ctx.page.operator_notes && ctx.page.operator_notes.trim() !== ""
+      ? `\n<operator_notes>\n${ctx.page.operator_notes}\n</operator_notes>`
+      : "";
   return [
-    `<page_spec>\nTitle: ${ctx.page.title}\nMode: ${ctx.page.mode}\nOrdinal: ${ctx.page.ordinal}\n\n${ctx.page.source_text}\n</page_spec>`,
+    `<page_spec>\nTitle: ${ctx.page.title}\nMode: ${ctx.page.mode}\nOrdinal: ${ctx.page.ordinal}\n\n${ctx.page.source_text}\n</page_spec>${operatorNotesBlock}`,
     "",
     "Produce the page's HTML. Respond with the HTML only.",
   ].join("\n");

--- a/lib/briefs.ts
+++ b/lib/briefs.ts
@@ -65,6 +65,32 @@ export type BriefPageStatus =
   | "failed"
   | "skipped";
 
+// M12-5 — client-safe snapshot of the brief_runs row. Subset of the
+// server-only BriefRunRow in lib/brief-runner.ts; the columns the run
+// surface page reads + the client component renders.
+export type BriefRunSnapshot = {
+  id: string;
+  brief_id: string;
+  status:
+    | "queued"
+    | "running"
+    | "paused"
+    | "succeeded"
+    | "failed"
+    | "cancelled";
+  current_ordinal: number | null;
+  content_summary: string;
+  run_cost_cents: number;
+  failure_code: string | null;
+  failure_detail: string | null;
+  cancel_requested_at: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+  version_lock: number;
+  created_at: string;
+  updated_at: string;
+};
+
 export type BriefPagePassKind =
   | "draft"
   | "self_critique"
@@ -541,6 +567,11 @@ export type CommitBriefInput = {
   // null by the runner.
   brandVoice?: string | null;
   designDirection?: string | null;
+  // M12-5 — operator-chosen model tier per brief. `undefined` preserves
+  // the migration default (sonnet). DB CHECK validates the value against
+  // the allowlist; the runner has an app-layer guard too.
+  textModel?: string;
+  visualModel?: string;
 };
 
 export type CommitBriefData = {
@@ -681,6 +712,12 @@ async function commitBriefImpl(
   }
   if (input.designDirection !== undefined) {
     updatePatch.design_direction = input.designDirection;
+  }
+  if (input.textModel !== undefined) {
+    updatePatch.text_model = input.textModel;
+  }
+  if (input.visualModel !== undefined) {
+    updatePatch.visual_model = input.visualModel;
   }
 
   const update = await svc


### PR DESCRIPTION
## Summary

M12-5 lands the operator-facing surface for the brief runner shipped in M12-3/M12-4. Post-commit, the operator opens **/admin/sites/[id]/briefs/[brief_id]/run** and sees a cost estimate, per-page preview, approval controls, and a cancel button. This slice is the wire-up between the M12-4 data layer (cost columns, quality_flag, model tiers) and the actual admin UI.

Implements parent plan §M12-5 sub-slice + the M12-4 amendment's UI-layer obligations (model tiers, CONFIRMATION_REQUIRED, quality_flag rendering).

## What ships

**Extended brief review (`BriefReviewClient.tsx`)**
- Model-tier selects for `briefs.text_model` + `briefs.visual_model` (Haiku / Sonnet / Opus, Sonnet default). Zod-validated against `ANTHROPIC_MODEL_ALLOWLIST` in the commit route — single source of truth shared with the DB CHECK in migration 0020.
- Post-commit footer replaced: direct `Open run surface →` CTA.

**Run surface (`/admin/sites/[id]/briefs/[brief_id]/run`)**
- Server page fetches brief + pages + latest `brief_run` + estimate + remaining tenant budget.
- Client renders: cost panel, run status, per-page cards with status pills + `quality_flag` badges, expanded preview of `draft_html` in `<iframe sandbox=\"\">`, last `visual_critique` entry with severity-colored issues, and action buttons.

**New routes**
- `POST /api/briefs/[brief_id]/run` — wraps `startBriefRun`. Returns 429 `CONFIRMATION_REQUIRED` when estimate > 50% remaining budget; 409 `BRIEF_RUN_ALREADY_ACTIVE` on double-start.
- `GET /api/briefs/[brief_id]/run` — read-only pre-flight (`estimate_cents`, `page_count`, `remaining_budget_cents`). No side effects.
- `POST /api/briefs/[brief_id]/cancel` — idempotent halt. CAS update to `cancelled`, leaves `brief_pages` intact.
- `POST /api/briefs/[brief_id]/pages/[page_id]/revise` — operator note path. Appends to `operator_notes`, resets page to `pending`, clears `draft_html` + `quality_flag` under CAS, re-queues the run.

**Runner thread (`lib/brief-runner.ts`)**
- `userPromptForDraft` injects an `<operator_notes>` block when the page has non-empty `operator_notes`, so a re-queued page picks up feedback on its next draft pass.

## Sub-slice plan (per the parallelism/autonomy rules in CLAUDE.md)

Executed end-to-end against the approved M12 parent plan. Plan is the description above; no separate planning doc.

## Risks identified and mitigated

| Risk | Mitigation | Test |
| --- | --- | --- |
| **Operator double-starts a run** | DB partial UNIQUE `brief_runs_one_active_per_brief` returns 23505 → route translates to 409 `BRIEF_RUN_ALREADY_ACTIVE` | `briefs-run-routes.test.ts` — BRIEF_RUN_ALREADY_ACTIVE on a second start |
| **Operator silently blows 80% of budget on a big run** | Pre-flight check in `startBriefRun`: estimate > 50% remaining → 429 `CONFIRMATION_REQUIRED` with `estimate_cents` + `remaining_budget_cents` in details. UI renders a modal: \"This run will spend a lot of your monthly budget.\" | `briefs-run-routes.test.ts` — CONFIRMATION_REQUIRED + re-submit with confirmed:true |
| **Model drift via ops-layer UPDATE** | DB CHECK pins the allowlist (migration 0020). Commit route also Zod-validates against `ANTHROPIC_MODEL_ALLOWLIST` at the edge so a client posting a bad value gets 400 before the DB ever sees it. | `briefs-run-routes.test.ts` — non-allowlisted model returns VALIDATION_FAILED (400) |
| **Two operator tabs approving/cancelling the same page** | Approve route already checks `version_lock` CAS (M12-3). Revise route does the same. Cancel is idempotent — second cancel returns 200 `already_cancelled: true`; concurrent cancels both succeed. | `briefs-run-routes.test.ts` — VERSION_CONFLICT on revise + idempotent cancel paths |
| **Cancel destroys generated pages** | Cancel UPDATEs `brief_runs.status` only. `brief_pages` are not touched. Seeded test approves a page, cancels the run, asserts `generated_html` survives. | `briefs-run-routes.test.ts` — cancel-leaves-approved-page-intact |
| **Revise-with-note loses the operator's feedback across retries** | `operator_notes` is appended (timestamped) across multiple revise cycles, not overwritten. Runner injects the full `operator_notes` into every draft pass. | `briefs-run-routes.test.ts` — happy-path asserts operator_notes contains the note + draft_html cleared |
| **Revise on a mid-generation page corrupts state** | Route requires `page_status === 'awaiting_review'`. Other states → 409 `INVALID_STATE`. | `briefs-run-routes.test.ts` — INVALID_STATE on pending page |
| **draft_html contains an iframe-breaking XSS** | Preview wrapped in `<iframe sandbox=\"\">` (no scripts, no forms, no top navigation). Belt-and-suspenders: the runner's quality gate already strips `<script>` tags. | Defense-in-depth — not directly tested here but the sandbox attribute is a structural mitigation |

## Deferred to M12-6 (per parent plan testing strategy)

- Full end-to-end run through the runner tick (start → generate → approve → approve → cancel → publish). Requires a runner loop + Anthropic call; E2E spec in this PR covers only the UI rendering path.
- Live screenshot re-render on the approve surface (parent plan mentions \"re-renders from current draft_html on demand\"). Deferred — the visual_critique entry in `critique_log` carries the operator-legible summary.
- Pattern doc `docs/patterns/brief-driven-generation.md` ships in M12-6 per the parent plan.

## Known wrinkle flagged earlier (not a regression in this PR)

`lib/visual-review.ts`'s `critiqueBriefPageVisually` inline doc at lines 258-259 claims \"CRITIQUE_PARSE_FAILED does NOT burn an iteration; the runner retries once or commits with a quality_flag.\" Actual runner behavior on parse failure is a warning-and-exit — no retry, no quality_flag, proceeds to `awaiting_review` with whatever critique_log entries already landed. Not changing runner semantics in this PR; the run surface does the right thing either way (operator sees the incomplete critique_log and decides). Flagging for a follow-up doc/runner cleanup.

## Test plan

- [ ] CI green across lint + typecheck + build + Vitest + Playwright
- [ ] `briefs-run-routes.test.ts` happy + error paths for all three new routes + commit model-tier persistence
- [ ] `e2e/briefs-run-surface.spec.ts` run surface renders + auditA11y + non-committed-brief redirect banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)