### PR TITLE
fix(m12-5): align CONFIRMATION_REQUIRED test status code with errorCodeToStatus

### DIFF
--- a/lib/__tests__/briefs-run-routes.test.ts
+++ b/lib/__tests__/briefs-run-routes.test.ts
@@ -125,7 +125,11 @@ describe("POST /api/briefs/[brief_id]/run — start run", () => {
       }),
       { params: { brief_id: briefId } },
     );
-    expect(first.status).toBe(429);
+    // CONFIRMATION_REQUIRED maps to 403 per lib/tool-schemas.ts
+    // errorCodeToStatus (shared with the FORBIDDEN code class). The
+    // client reads the error.code field, not the HTTP status, to open
+    // the confirmation modal — see BriefRunClient.handleStartRun.
+    expect(first.status).toBe(403);
     const firstBody = (await first.json()) as {
       ok: boolean;
       error: { code: string };


### PR DESCRIPTION
Main went red after #148 merged. briefs-run-routes.test.ts asserted `expect(first.status).toBe(429)` on the CONFIRMATION_REQUIRED path, but lib/tool-schemas.ts::errorCodeToStatus maps CONFIRMATION_REQUIRED to 403 (grouped with FORBIDDEN in the same case fallthrough).

One-line test fix. No runtime change — BriefRunClient keys on payload.error.code, not HTTP status, so the confirm-modal UX is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)