### PR TITLE
feat(m13-5b): ds → kadence palette mapper (pure logic)

### DIFF
--- a/lib/__tests__/_fixtures/tokens-explicit-palette.css
+++ b/lib/__tests__/_fixtures/tokens-explicit-palette.css
@@ -1,0 +1,21 @@
+/*
+ * DS fixture with explicit --acme-palette-N slot naming. The mapper
+ * detects all 8 explicit slots and returns source='explicit' — these
+ * take precedence over any other color tokens in the file.
+ */
+
+.acme-scope {
+  /* Explicit Kadence slot mapping — operator opted into this shape. */
+  --acme-palette-1:   #FF0055;
+  --acme-palette-2:   #FF8800;
+  --acme-palette-3:   #FFCC00;
+  --acme-palette-4:   #22AAFF;
+  --acme-palette-5:   #9922EE;
+  --acme-palette-6:   #22EE88;
+  --acme-palette-7:   #EEEEEE;
+  --acme-palette-8:   #111111;
+
+  /* Extra colors that the mapper should IGNORE when explicit mode is on. */
+  --acme-brand-blue:  #0044CC;
+  --acme-brand-red:   #CC0000;
+}

--- a/lib/__tests__/_fixtures/tokens-leadsource.css
+++ b/lib/__tests__/_fixtures/tokens-leadsource.css
@@ -1,0 +1,38 @@
+/*
+ * Leadsource-shaped DS fixture. Matches the seed/leadsource/tokens.css
+ * structure: brand first, neutrals, type, then non-color values. No
+ * explicit --ls-palette-N names — the mapper falls back to
+ * 'ordered_hex' and takes the first 8 colors in declaration order.
+ */
+
+.ls-scope {
+  /* Brand palette */
+  --ls-blue:          #185FA5;
+  --ls-blue-dark:     #0C447C;
+  --ls-blue-light:    #E6F1FB;
+  --ls-teal:          #1D9E75;
+  --ls-amber:         #BA7517;
+
+  /* Neutrals */
+  --ls-ink:           #1A1A1A;
+  --ls-text:          #2C2C2A;
+  --ls-muted:         #6B6B66;
+  --ls-dim:           #9A9A94;
+  --ls-surface:       #FAFAF6;
+  --ls-surface-2:     #F1EFE8;
+  --ls-border:        #E8E6DE;
+  --ls-border-strong: #D3D1C7;
+  --ls-white:         #FFFFFF;
+
+  /* Gradients — NOT colors; parser skips. */
+  --ls-arc:           linear-gradient(135deg, #185FA5 0%, #1D9E75 50%, #BA7517 100%);
+
+  /* Typography — parser skips (non-color). */
+  --ls-font-sans:     'Inter', sans-serif;
+  --ls-font-display:  'Inter Tight', sans-serif;
+
+  /* Spacing — parser skips (non-color). */
+  --ls-space-xs:      4px;
+  --ls-space-sm:      8px;
+  --ls-space-md:      16px;
+}

--- a/lib/__tests__/_fixtures/tokens-sparse.css
+++ b/lib/__tests__/_fixtures/tokens-sparse.css
@@ -1,0 +1,15 @@
+/*
+ * Sparse DS fixture — only 4 color tokens. Mapper returns
+ * source='insufficient' + slots=[] so the UI surfaces a blocker.
+ */
+
+.xyz-scope {
+  --xyz-primary:  #336699;
+  --xyz-secondary: #99ccff;
+  --xyz-dark:     #222222;
+  --xyz-light:    #f4f4f4;
+
+  /* All non-color values below — parser skips. */
+  --xyz-font-body: 'Georgia', serif;
+  --xyz-space-md:  12px;
+}

--- a/lib/__tests__/kadence-mapper.test.ts
+++ b/lib/__tests__/kadence-mapper.test.ts
@@ -1,0 +1,396 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  KADENCE_PALETTE_SLOT_NAMES,
+  buildPaletteProposal,
+  buildPaletteProposalFromTokensCss,
+  diffPalette,
+  parsePaletteTokens,
+} from "@/lib/kadence-mapper";
+import type { KadencePalette } from "@/lib/kadence-rest";
+
+// ---------------------------------------------------------------------------
+// M13-5b kadence-mapper unit tests.
+//
+// Three fixtures drive the test matrix:
+//   - tokens-leadsource.css:       15+ tokens, no explicit slot names
+//                                  → 'ordered_hex'
+//   - tokens-explicit-palette.css: 8 explicit --acme-palette-N + extras
+//                                  → 'explicit' (ignores the extras)
+//   - tokens-sparse.css:           only 4 color tokens
+//                                  → 'insufficient', slots=[]
+//
+// Parser + proposal + diff are all pure, so no DB + no network.
+// ---------------------------------------------------------------------------
+
+const FIX_DIR = join(__dirname, "_fixtures");
+
+let LEADSOURCE_CSS: string;
+let EXPLICIT_CSS: string;
+let SPARSE_CSS: string;
+
+beforeAll(async () => {
+  LEADSOURCE_CSS = await readFile(
+    join(FIX_DIR, "tokens-leadsource.css"),
+    "utf8",
+  );
+  EXPLICIT_CSS = await readFile(
+    join(FIX_DIR, "tokens-explicit-palette.css"),
+    "utf8",
+  );
+  SPARSE_CSS = await readFile(join(FIX_DIR, "tokens-sparse.css"), "utf8");
+});
+
+// ---------------------------------------------------------------------------
+// parsePaletteTokens
+// ---------------------------------------------------------------------------
+
+describe("parsePaletteTokens", () => {
+  it("extracts every hex-valued custom property in declaration order", () => {
+    const tokens = parsePaletteTokens(LEADSOURCE_CSS, "ls");
+    // Leadsource fixture has 14 hex-valued tokens (5 brand + 9 neutrals)
+    // and skips gradient + font + spacing.
+    expect(tokens).toHaveLength(14);
+    // Declaration order is preserved.
+    expect(tokens[0]).toEqual({
+      name: "--ls-blue",
+      label: "Blue",
+      color: "#185FA5",
+    });
+    expect(tokens[1]?.name).toBe("--ls-blue-dark");
+    expect(tokens[4]?.name).toBe("--ls-amber");
+    expect(tokens[5]?.name).toBe("--ls-ink");
+    expect(tokens[13]?.name).toBe("--ls-white");
+  });
+
+  it("derives a human-readable label from property names sans prefix", () => {
+    const tokens = parsePaletteTokens(LEADSOURCE_CSS, "ls");
+    const byName = new Map(tokens.map((t) => [t.name, t.label]));
+    expect(byName.get("--ls-blue")).toBe("Blue");
+    expect(byName.get("--ls-blue-dark")).toBe("Blue dark");
+    expect(byName.get("--ls-border-strong")).toBe("Border strong");
+  });
+
+  it("expands #RGB shorthand to #RRGGBB and uppercases the result", () => {
+    const tokens = parsePaletteTokens(
+      `
+      .scope {
+        --x-a: #abc;
+        --x-b: #aabbcc;
+        --x-c: #AABBCC;
+      }
+      `,
+      "x",
+    );
+    expect(tokens.map((t) => t.color)).toEqual([
+      "#AABBCC",
+      "#AABBCC",
+      "#AABBCC",
+    ]);
+  });
+
+  it("preserves alpha in #RGBA and #RRGGBBAA", () => {
+    const tokens = parsePaletteTokens(
+      `.scope { --x-a: #abcd; --x-b: #aabbccdd; }`,
+      "x",
+    );
+    expect(tokens[0]?.color).toBe("#AABBCCDD");
+    expect(tokens[1]?.color).toBe("#AABBCCDD");
+  });
+
+  it("skips non-color values (fonts, spacing, gradients)", () => {
+    const tokens = parsePaletteTokens(LEADSOURCE_CSS, "ls");
+    const names = new Set(tokens.map((t) => t.name));
+    expect(names.has("--ls-arc")).toBe(false); // gradient
+    expect(names.has("--ls-font-sans")).toBe(false); // font
+    expect(names.has("--ls-space-xs")).toBe(false); // spacing
+  });
+
+  it("skips rgb() and hsl() functions (they'd need color-space math)", () => {
+    const tokens = parsePaletteTokens(
+      `.scope {
+        --x-a: rgb(255, 0, 0);
+        --x-b: hsl(120, 100%, 50%);
+        --x-c: #FF0000;
+      }`,
+      "x",
+    );
+    // rgb/hsl are recognized as colors but not normalized → dropped.
+    // Only the hex survives.
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]?.name).toBe("--x-c");
+  });
+
+  it("ignores lines inside /* … */ comments", () => {
+    const tokens = parsePaletteTokens(
+      `.scope {
+        /* --commented-out: #000000; */
+        --kept: #FFFFFF;
+      }`,
+      "",
+    );
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]?.name).toBe("--kept");
+  });
+
+  it("handles property names without matching the prefix — label falls back to full name", () => {
+    const tokens = parsePaletteTokens(`.scope { --random-thing: #111222; }`, "ls");
+    expect(tokens[0]?.label).toBe("Random thing");
+  });
+
+  it("returns empty array on empty / whitespace-only input", () => {
+    expect(parsePaletteTokens("", "ls")).toEqual([]);
+    expect(parsePaletteTokens("\n\n  \n", "ls")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPaletteProposal
+// ---------------------------------------------------------------------------
+
+describe("buildPaletteProposal", () => {
+  it("source='ordered_hex' on leadsource fixture: first 8 tokens fill palette1..palette8", () => {
+    const proposal = buildPaletteProposalFromTokensCss({
+      tokens_css: LEADSOURCE_CSS,
+      prefix: "ls",
+    });
+    expect(proposal.source).toBe("ordered_hex");
+    expect(proposal.available_color_count).toBe(14);
+    expect(proposal.slots).toHaveLength(8);
+
+    // Pin the exact mapping — the first 8 leadsource colors in
+    // declaration order.
+    expect(proposal.slots[0]).toEqual({
+      slug: "palette1",
+      name: "Blue",
+      color: "#185FA5",
+    });
+    expect(proposal.slots[1]).toEqual({
+      slug: "palette2",
+      name: "Blue dark",
+      color: "#0C447C",
+    });
+    expect(proposal.slots[4]).toEqual({
+      slug: "palette5",
+      name: "Amber",
+      color: "#BA7517",
+    });
+    expect(proposal.slots[7]).toEqual({
+      slug: "palette8",
+      name: "Muted",
+      color: "#6B6B66",
+    });
+  });
+
+  it("source='explicit' when all 8 --<prefix>-palette-N tokens are present", () => {
+    const proposal = buildPaletteProposalFromTokensCss({
+      tokens_css: EXPLICIT_CSS,
+      prefix: "acme",
+    });
+    expect(proposal.source).toBe("explicit");
+    expect(proposal.slots).toHaveLength(8);
+
+    // Explicit slots win — the --acme-brand-* extras in the file are
+    // ignored even though they're valid hex tokens.
+    expect(proposal.slots[0]).toEqual({
+      slug: "palette1",
+      name: "Palette 1",
+      color: "#FF0055",
+    });
+    expect(proposal.slots[7]).toEqual({
+      slug: "palette8",
+      name: "Palette 8",
+      color: "#111111",
+    });
+  });
+
+  it("source='insufficient' when fewer than 8 color tokens exist", () => {
+    const proposal = buildPaletteProposalFromTokensCss({
+      tokens_css: SPARSE_CSS,
+      prefix: "xyz",
+    });
+    expect(proposal.source).toBe("insufficient");
+    expect(proposal.available_color_count).toBe(4);
+    expect(proposal.slots).toEqual([]);
+  });
+
+  it("falls back to 'ordered_hex' when explicit slots are partial (< 8)", () => {
+    // 7 out of 8 slots declared explicitly → not 'explicit'.
+    const css = `
+      .acme-scope {
+        --acme-palette-1: #111111;
+        --acme-palette-2: #222222;
+        --acme-palette-3: #333333;
+        --acme-palette-4: #444444;
+        --acme-palette-5: #555555;
+        --acme-palette-6: #666666;
+        --acme-palette-7: #777777;
+        /* palette-8 intentionally missing */
+        --acme-extra:     #EEEEEE;
+      }
+    `;
+    const proposal = buildPaletteProposalFromTokensCss({
+      tokens_css: css,
+      prefix: "acme",
+    });
+    expect(proposal.source).toBe("ordered_hex");
+    // Declaration-order fallback: 8 tokens available, takes them in order.
+    expect(proposal.slots).toHaveLength(8);
+    expect(proposal.slots[0]?.color).toBe("#111111"); // --acme-palette-1
+    expect(proposal.slots[7]?.color).toBe("#EEEEEE"); // --acme-extra
+  });
+
+  it("slot names are palette1..palette8 in order", () => {
+    const proposal = buildPaletteProposalFromTokensCss({
+      tokens_css: EXPLICIT_CSS,
+      prefix: "acme",
+    });
+    expect(proposal.slots.map((s) => s.slug)).toEqual(KADENCE_PALETTE_SLOT_NAMES);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// diffPalette
+// ---------------------------------------------------------------------------
+
+describe("diffPalette", () => {
+  it("flags every slot as changed when current palette is empty", () => {
+    const proposal = buildPaletteProposalFromTokensCss({
+      tokens_css: LEADSOURCE_CSS,
+      prefix: "ls",
+    });
+    const current: KadencePalette = { palette: [], source: "empty" };
+    const diff = diffPalette({ current, proposal });
+    expect(diff.entries).toHaveLength(8);
+    expect(diff.any_changes).toBe(true);
+    expect(diff.entries.every((e) => e.changed)).toBe(true);
+    expect(diff.entries[0]?.current).toEqual({ name: null, color: null });
+    expect(diff.entries[0]?.proposed).toEqual({
+      name: "Blue",
+      color: "#185FA5",
+    });
+  });
+
+  it("flags no changes when current palette matches the proposal exactly", () => {
+    const proposal = buildPaletteProposalFromTokensCss({
+      tokens_css: LEADSOURCE_CSS,
+      prefix: "ls",
+    });
+    const current: KadencePalette = {
+      palette: proposal.slots.map((s) => ({
+        slug: s.slug,
+        name: s.name,
+        color: s.color,
+      })),
+      source: "populated",
+    };
+    const diff = diffPalette({ current, proposal });
+    expect(diff.any_changes).toBe(false);
+    expect(diff.entries.every((e) => !e.changed)).toBe(true);
+  });
+
+  it("ignores case differences when comparing hex values (Kadence may return lowercase)", () => {
+    const proposal = buildPaletteProposalFromTokensCss({
+      tokens_css: `
+        .ls-scope {
+          --ls-a: #AABBCC;
+          --ls-b: #DDEEFF;
+          --ls-c: #112233;
+          --ls-d: #445566;
+          --ls-e: #778899;
+          --ls-f: #112244;
+          --ls-g: #556677;
+          --ls-h: #887766;
+        }
+      `,
+      prefix: "ls",
+    });
+    const current: KadencePalette = {
+      palette: proposal.slots.map((s) => ({
+        slug: s.slug,
+        name: s.name,
+        color: s.color.toLowerCase(),
+      })),
+      source: "populated",
+    };
+    const diff = diffPalette({ current, proposal });
+    expect(diff.any_changes).toBe(false);
+  });
+
+  it("flags only the changed slots when the current palette is partially divergent", () => {
+    const proposal = buildPaletteProposalFromTokensCss({
+      tokens_css: LEADSOURCE_CSS,
+      prefix: "ls",
+    });
+    // Current palette matches slots 1-6; 7 + 8 are different.
+    const current: KadencePalette = {
+      palette: proposal.slots.map((s, i) => ({
+        slug: s.slug,
+        name: s.name,
+        color: i < 6 ? s.color : "#000000",
+      })),
+      source: "populated",
+    };
+    const diff = diffPalette({ current, proposal });
+    expect(diff.any_changes).toBe(true);
+    expect(diff.entries.filter((e) => e.changed)).toHaveLength(2);
+    const changedSlots = diff.entries.filter((e) => e.changed).map((e) => e.slot);
+    expect(changedSlots).toEqual(["palette7", "palette8"]);
+  });
+
+  it("returns empty diff + any_changes=false when proposal is 'insufficient'", () => {
+    const proposal = buildPaletteProposalFromTokensCss({
+      tokens_css: SPARSE_CSS,
+      prefix: "xyz",
+    });
+    const current: KadencePalette = {
+      palette: [
+        { slug: "palette1", name: "Old", color: "#ABCDEF" },
+      ],
+      source: "populated",
+    };
+    const diff = diffPalette({ current, proposal });
+    expect(diff.entries).toEqual([]);
+    expect(diff.any_changes).toBe(false);
+  });
+
+  it("treats a missing slot on current as a change (current.color=null)", () => {
+    const proposal = buildPaletteProposalFromTokensCss({
+      tokens_css: LEADSOURCE_CSS,
+      prefix: "ls",
+    });
+    // Current palette has only slots 1 + 2 populated.
+    const current: KadencePalette = {
+      palette: [
+        { slug: "palette1", name: "Blue", color: "#185FA5" },
+        { slug: "palette2", name: "Blue dark", color: "#0C447C" },
+      ],
+      source: "populated",
+    };
+    const diff = diffPalette({ current, proposal });
+    expect(diff.entries[0]?.changed).toBe(false); // matches
+    expect(diff.entries[1]?.changed).toBe(false); // matches
+    // Slots 3-8 missing on current → all changed.
+    expect(diff.entries.slice(2).every((e) => e.changed)).toBe(true);
+    expect(diff.entries[2]?.current.color).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPaletteProposal (direct, from parsed tokens)
+// ---------------------------------------------------------------------------
+
+describe("buildPaletteProposal (from tokens array)", () => {
+  it("composes parse + propose: equivalent to buildPaletteProposalFromTokensCss", () => {
+    const viaFull = buildPaletteProposalFromTokensCss({
+      tokens_css: LEADSOURCE_CSS,
+      prefix: "ls",
+    });
+    const tokens = parsePaletteTokens(LEADSOURCE_CSS, "ls");
+    const viaTokens = buildPaletteProposal({ tokens, prefix: "ls" });
+    expect(viaFull).toEqual(viaTokens);
+  });
+});

--- a/lib/kadence-mapper.ts
+++ b/lib/kadence-mapper.ts
@@ -1,0 +1,320 @@
+import "server-only";
+
+import {
+  KADENCE_PALETTE_SLOT_COUNT,
+  type KadencePalette,
+  type KadencePaletteEntry,
+} from "@/lib/kadence-rest";
+
+// ---------------------------------------------------------------------------
+// M13-5b — DS → Kadence palette mapper.
+//
+// Pure logic. No I/O. Two responsibilities:
+//
+//   1. parsePaletteTokens: read a DS `tokens_css` string, find every
+//      CSS custom property whose value is a color literal, return
+//      them as typed DsTokenEntry records in declaration order.
+//
+//   2. buildPaletteProposal: given parsed tokens + the site's DS
+//      prefix, produce a 8-slot KadencePaletteProposal:
+//        - source 'explicit' when all 8 --<prefix>-palette-N tokens
+//          are present (operator opted into explicit slot mapping)
+//        - source 'ordered_hex' when we fell back to declaration-order
+//          (the first 8 hex-valued tokens fill slots palette1..palette8)
+//        - source 'insufficient' when fewer than 8 color tokens exist
+//          in the DS — caller (UI) surfaces a clear blocker instead of
+//          silently shipping a truncated palette
+//
+//   3. diffPalette: compare a Kadence-current palette (from
+//      lib/kadence-rest::getKadencePalette) against a proposal and
+//      report per-slot changes. Drives the Appearance panel's dry-run
+//      preview table (M13-5e).
+//
+// Rescope note (2026-04-24): palette-only. Typography + spacing
+// globals are BACKLOG per docs/BACKLOG.md §"Kadence typography +
+// spacing globals sync". The parsePaletteTokens regex intentionally
+// skips non-color values — extending to typography/spacing would
+// happen here as additional parsers when the BACKLOG slice ships.
+// ---------------------------------------------------------------------------
+
+/**
+ * Kadence's palette slots are named palette1..palette8. M13-5a pinned
+ * KADENCE_PALETTE_SLOT_COUNT = 8 (the 9th is computed by Kadence from
+ * the other slots).
+ */
+export const KADENCE_PALETTE_SLOT_NAMES = Array.from(
+  { length: KADENCE_PALETTE_SLOT_COUNT },
+  (_, i) => `palette${i + 1}`,
+);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DsTokenEntry = {
+  /** Full property name including leading dashes, e.g. "--ls-blue". */
+  name: string;
+  /** Operator-legible label derived from the property: "Blue" for --ls-blue. */
+  label: string;
+  /** Normalized uppercase #RRGGBB hex (or #RRGGBBAA if alpha present). */
+  color: string;
+};
+
+export type KadencePaletteProposal = {
+  /**
+   * Exactly 8 slots when source !== 'insufficient'; empty array when
+   * 'insufficient'. Callers that care about the `slots` contract MUST
+   * check `source` first.
+   */
+  slots: KadencePaletteEntry[];
+  source: "explicit" | "ordered_hex" | "insufficient";
+  /** Number of color-valued DS tokens parsed. Useful for the 'insufficient' UI copy. */
+  available_color_count: number;
+};
+
+export type PaletteDiffEntry = {
+  slot: string;
+  current: { name: string | null; color: string | null };
+  proposed: { name: string; color: string };
+  /** True iff the proposed color would change the slot's current value. */
+  changed: boolean;
+};
+
+export type PaletteDiff = {
+  entries: PaletteDiffEntry[];
+  /** True iff any entry has changed=true. */
+  any_changes: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+// One CSS custom-property declaration on one line. We only match a
+// minimal subset — no multi-line values, no !important. The DS tokens
+// seed files all emit single-line declarations so we optimize for that
+// shape; a pathological input degrades gracefully (just parses fewer
+// tokens).
+const DECLARATION_RE =
+  /^\s*(--[a-z0-9-]+)\s*:\s*([^;]+?)\s*(?:!important)?\s*;\s*$/i;
+
+// Hex color: #RGB, #RGBA, #RRGGBB, #RRGGBBAA.
+const HEX_RE = /^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+// Parenthesized color function: rgb / rgba / hsl / hsla. We don't
+// compute the resulting hex for non-hex inputs — supporting hsl() or
+// rgb() would require color-space math. For MVP we emit them verbatim
+// as "non-hex" and the caller can reject. The two DS fixtures in-tree
+// both use #hex throughout; color-function support is a BACKLOG
+// candidate if a DS lands with rgb()/hsl().
+const COLOR_FN_RE = /^(rgb|rgba|hsl|hsla)\s*\(/i;
+
+function isColorValue(value: string): boolean {
+  const trimmed = value.trim();
+  return HEX_RE.test(trimmed) || COLOR_FN_RE.test(trimmed);
+}
+
+function normalizeHex(value: string): string | null {
+  const trimmed = value.trim();
+  const m = HEX_RE.exec(trimmed);
+  if (!m) return null;
+  const raw = m[1]!;
+  // Expand #RGB / #RGBA shorthands to #RRGGBB / #RRGGBBAA.
+  if (raw.length === 3 || raw.length === 4) {
+    const expanded = raw
+      .split("")
+      .map((ch) => ch + ch)
+      .join("");
+    return "#" + expanded.toUpperCase();
+  }
+  return "#" + raw.toUpperCase();
+}
+
+function labelFromPropertyName(name: string, prefix: string): string {
+  // --ls-blue-dark   →   "Blue dark"  (strip "--<prefix>-")
+  // --my-primary     →   "My primary" (prefix doesn't match; keep full
+  //                       name sans leading dashes)
+  const strippedDashes = name.replace(/^--/, "");
+  const withoutPrefix =
+    prefix && strippedDashes.startsWith(`${prefix}-`)
+      ? strippedDashes.slice(prefix.length + 1)
+      : strippedDashes;
+  const words = withoutPrefix.replace(/-/g, " ").trim();
+  if (!words) return strippedDashes;
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * Walk the tokens_css string line by line, extract every custom
+ * property whose value parses as a color. Preserves declaration order
+ * (important because buildPaletteProposal's fallback uses order to
+ * pick the first 8 colors).
+ *
+ * Skips color-function values (rgb/hsl) — they land in the output with
+ * `color: ""` and will be filtered by buildPaletteProposal. Caller
+ * wanting full color-space support plugs into the COLOR_FN_RE branch
+ * of isColorValue + adds a normalizer.
+ */
+export function parsePaletteTokens(
+  tokensCss: string,
+  prefix: string,
+): DsTokenEntry[] {
+  const out: DsTokenEntry[] = [];
+  for (const rawLine of tokensCss.split(/\r?\n/)) {
+    const line = rawLine.replace(/\/\*.*?\*\//g, "").trim();
+    if (!line || line.startsWith("//")) continue;
+    const m = DECLARATION_RE.exec(line);
+    if (!m) continue;
+    const [, propName, propValue] = m;
+    if (!propName || !propValue) continue;
+    if (!isColorValue(propValue)) continue;
+    const normalized = normalizeHex(propValue);
+    if (!normalized) continue; // color-function — skip in this slice.
+    out.push({
+      name: propName,
+      label: labelFromPropertyName(propName, prefix),
+      color: normalized,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Proposal builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Does the token set contain all 8 `--<prefix>-palette-N` slots?
+ * When true, they're the authoritative mapping (operator opted in).
+ */
+function findExplicitSlots(
+  tokens: DsTokenEntry[],
+  prefix: string,
+): DsTokenEntry[] | null {
+  const byName = new Map(tokens.map((t) => [t.name, t]));
+  const slots: DsTokenEntry[] = [];
+  for (let i = 1; i <= KADENCE_PALETTE_SLOT_COUNT; i++) {
+    const slotName = `--${prefix}-palette-${i}`;
+    const match = byName.get(slotName);
+    if (!match) return null; // missing a slot — explicit mode off.
+    slots.push(match);
+  }
+  return slots;
+}
+
+/**
+ * Build a Kadence palette proposal from parsed DS tokens. The site's
+ * DS prefix is required for explicit-slot detection + label derivation.
+ *
+ * Preference order:
+ *   1. If all 8 `--<prefix>-palette-N` tokens exist → source='explicit'.
+ *   2. Else if >= 8 hex-valued tokens exist → source='ordered_hex'
+ *      (first 8 in declaration order).
+ *   3. Else → source='insufficient', slots=[] (caller must surface a
+ *      blocker — DS doesn't have enough colors for Kadence sync).
+ */
+export function buildPaletteProposal(opts: {
+  tokens: DsTokenEntry[];
+  prefix: string;
+}): KadencePaletteProposal {
+  const { tokens, prefix } = opts;
+  const colorCount = tokens.length;
+
+  const explicit = findExplicitSlots(tokens, prefix);
+  if (explicit) {
+    return {
+      slots: explicit.map((t, i) => ({
+        slug: KADENCE_PALETTE_SLOT_NAMES[i]!,
+        name: t.label,
+        color: t.color,
+      })),
+      source: "explicit",
+      available_color_count: colorCount,
+    };
+  }
+
+  if (colorCount < KADENCE_PALETTE_SLOT_COUNT) {
+    return {
+      slots: [],
+      source: "insufficient",
+      available_color_count: colorCount,
+    };
+  }
+
+  const first8 = tokens.slice(0, KADENCE_PALETTE_SLOT_COUNT);
+  return {
+    slots: first8.map((t, i) => ({
+      slug: KADENCE_PALETTE_SLOT_NAMES[i]!,
+      name: t.label,
+      color: t.color,
+    })),
+    source: "ordered_hex",
+    available_color_count: colorCount,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Diff
+// ---------------------------------------------------------------------------
+
+function findCurrent(
+  current: KadencePalette,
+  slug: string,
+): KadencePaletteEntry | undefined {
+  return current.palette.find((p) => p.slug === slug);
+}
+
+/**
+ * Compare a Kadence-current palette against a proposal. Returns an
+ * 8-entry diff (one per slot) regardless of how many slots the current
+ * palette has populated. Missing slots in the current palette render
+ * as { current: { name: null, color: null } }; any proposal value
+ * then counts as a change.
+ *
+ * When proposal.source === 'insufficient', diff entries are empty and
+ * any_changes is false — the UI surfaces the blocker copy instead of
+ * a diff table.
+ */
+export function diffPalette(opts: {
+  current: KadencePalette;
+  proposal: KadencePaletteProposal;
+}): PaletteDiff {
+  const { current, proposal } = opts;
+  if (proposal.source === "insufficient" || proposal.slots.length === 0) {
+    return { entries: [], any_changes: false };
+  }
+
+  const entries: PaletteDiffEntry[] = proposal.slots.map((slotEntry) => {
+    const currentEntry = findCurrent(current, slotEntry.slug);
+    const currentColor = currentEntry?.color ?? null;
+    const currentName = currentEntry?.name ?? null;
+    // Case-insensitive hex comparison — Kadence may return lowercase.
+    const changed =
+      currentColor === null ||
+      currentColor.toUpperCase() !== slotEntry.color.toUpperCase();
+    return {
+      slot: slotEntry.slug,
+      current: { name: currentName, color: currentColor },
+      proposed: { name: slotEntry.name, color: slotEntry.color },
+      changed,
+    };
+  });
+  return {
+    entries,
+    any_changes: entries.some((e) => e.changed),
+  };
+}
+
+/**
+ * Convenience composition: parse → propose. Callers that want the
+ * full pipeline (tokens_css → proposal) typically hit this; the
+ * individual functions are exported for testability + future reuse
+ * by the BACKLOG typography/spacing slice.
+ */
+export function buildPaletteProposalFromTokensCss(opts: {
+  tokens_css: string;
+  prefix: string;
+}): KadencePaletteProposal {
+  const tokens = parsePaletteTokens(opts.tokens_css, opts.prefix);
+  return buildPaletteProposal({ tokens, prefix: opts.prefix });
+}


### PR DESCRIPTION
## Summary

M13-5 sub-slice 2 of 5. Pure DS palette → Kadence palette mapper. **No I/O. No write paths. No new database or API surface.** All I/O reads + all mutations remain deferred to M13-5c/d.

## What lands

\`lib/kadence-mapper.ts\` exports three functions:

1. **\`parsePaletteTokens(tokens_css, prefix)\`** — walks a DS \`tokens_css\` string and returns every hex-valued CSS custom property as a typed \`DsTokenEntry\` in declaration order. Skips gradients, fonts, spacing, and color-function values (\`rgb()\` / \`hsl()\` need color-space math — BACKLOG). Strips \`/* ... */\` comments. Label derivation: \`--ls-blue-dark\` → \`"Blue dark"\`.

2. **\`buildPaletteProposal({ tokens, prefix })\`** — produces an 8-slot \`KadencePaletteProposal\` with typed \`source\` field:
   - \`'explicit'\` — all 8 \`--<prefix>-palette-N\` tokens present (operator opted in; takes precedence)
   - \`'ordered_hex'\` — declaration-order fallback: first 8 hex tokens fill \`palette1..palette8\`
   - \`'insufficient'\` — < 8 color tokens; \`slots=[]\` so the UI surfaces a clear blocker instead of silently truncating

3. **\`diffPalette({ current, proposal })\`** — 8-entry diff for the Appearance panel's dry-run preview table (M13-5e). Case-insensitive hex comparison. Missing slot on current counts as a change. Empty diff when proposal is \`'insufficient'\`.

Plus \`buildPaletteProposalFromTokensCss\` — parse+propose composition for the common caller.

Three fixtures under \`lib/__tests__/_fixtures/\`:
- \`tokens-leadsource.css\` — 15+ tokens, no explicit palette-N → \`'ordered_hex'\`
- \`tokens-explicit-palette.css\` — 8 explicit slots + extras to ignore → \`'explicit'\`
- \`tokens-sparse.css\` — 4 colors only → \`'insufficient'\`

## Risks identified and mitigated

Pure-logic slice with zero write-safety hotspots. The three risks below are mapper-correctness risks, not write-safety risks:

| Risk | Mitigation | Test |
| --- | --- | --- |
| Mapper silently ships a truncated palette when the DS has < 8 colors | Third typed source \`'insufficient'\` returns \`slots=[]\`; UI MUST check source before reading slots | \`kadence-mapper.test.ts\` — \`'insufficient'\` path on sparse fixture |
| Operator wants explicit control over slot mapping but the mapper forces declaration-order | \`--<prefix>-palette-1..palette-8\` tokens are detected and take precedence; falls back to ordered_hex only when not all 8 explicit slots exist | \`kadence-mapper.test.ts\` — explicit precedence asserted across 8-complete + 7-of-8 fixtures |
| Case-sensitivity drift between DS emission (\`#AABBCC\`) and Kadence return (\`#aabbcc\`) silently flags every sync as "changed" | Normalized uppercase hex on output; case-insensitive comparison in \`diffPalette\` | \`kadence-mapper.test.ts\` — lowercase-current matches uppercase-proposal, any_changes=false |

## Deliberately deferred

- **Write paths.** M13-5c adds install mutations; M13-5d adds palette sync writes. This slice is reads + pure logic only.
- **Typography + spacing mapping.** Parent plan amendment (M13-5a) moved to BACKLOG. Future slice plugs parsers into this file.
- **Color-function support (\`rgb()\`, \`hsl()\`).** Requires color-space math. BACKLOG candidate if a real DS lands using non-hex color values — the in-tree DS fixtures all use \`#hex\`.

## Halt gate

HALTS after merge per plan. M13-5c (install + activate writes — mutates client WP sites) needs your separate approval before I start.

## Test plan

- [ ] CI green: lint + typecheck + build + Vitest (Playwright unchanged — no UI surface touched)
- [ ] \`kadence-mapper.test.ts\` — 21 pure tests covering parser + proposal + diff across all three fixtures + edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)