### PR TITLE
docs(m13-6a): runbook + backlog + post-mode pattern appendix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,7 @@ Supply-chain scanning runs server-side:
 - Don't loop me in on routine errors — fix and retry
 - Do loop me in on design decisions or scope questions
 - Keep PRs small enough to review in 5 minutes
+- **RUNBOOK is load-bearing for incident response. Code that changes a blocker code, audit event name, or error envelope MUST update the matching `docs/RUNBOOK.md` entry in the same PR.**
 
 ## Performance standards
 - **Lighthouse CI:** every PR runs `.github/workflows/lighthouse.yml`

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,51 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## Site actions dropdown clipped on /admin/sites list (deferred from M13-6a, 2026-04-26)
+
+**Tags:** `ux-polish`
+
+**What:** The actions dropdown on each row of `/admin/sites` is rendered inside a table whose container has `overflow-x-auto` (or similar) for horizontal-scroll-on-narrow. The menu's pop-out is clipped by that overflow context — items below the row's visible bounds are unreachable, particularly on rows near the bottom of a long list where the menu would otherwise extend off-table.
+
+**Why deferred:** Captured live during product walkthrough. Not a write-safety issue and not an incident, but actively annoying. M13-6 is closing out E2E + docs scope; this fits a future UX polish slice cleanly.
+
+**Trigger:** Now-ish — any operator using > 1 menu item on the site list will hit it once the list grows past ~5 rows. Bumps to "high" if site count grows past a screen and the dropdown blocks routine ops.
+
+**Scope:**
+- Two viable shapes; pick whichever fits the existing dropdown component:
+  - **(a) Portal-rendered menu** — migrate the dropdown to a portal (e.g., Radix Popover or headless-ui Menu) so the menu renders outside the overflow context. Cleanest if the rest of the codebase already uses Radix.
+  - **(b) Overflow tweak** — `overflow: visible` on the table container while keeping horizontal scroll on a different scope (e.g., `overflow-x-auto` on a deeper child wrapping just the cell text). Less invasive but easier to break with future CSS changes.
+- Either way: assert with a Playwright test that opens a row in the bottom third of the list, opens the menu, and clicks the bottom-most item — should hit successfully without scroll-jumping.
+
+**Size:** Small — ~30 min for portal solution, ~1 hr for overflow CSS (the latter usually has surprises).
+
+---
+
+## Cloudflare image upload friction → S3 alternative investigation (deferred from M13-6a, 2026-04-26)
+
+**Tags:** `storage`, `audit-target`
+
+**What:** Investigate replacing Cloudflare Images with S3 (+ a thin upload + derivative wrapper) for the Opollo image library. Captured during product readiness review — specific friction points: pricing cliff at higher tier, derivative API ergonomics, debugging when uploads fail mid-flight.
+
+**Why deferred:** M3/M4 shipped Cloudflare Images and it works. Migrating would touch `lib/cloudflare-images.ts`, `image_library` schema, every uploader path (manual upload + iStock + transfer worker), and all generated HTML's image URL rewriting. Whole-day-of-changes work. Not justified until product readiness audit confirms the friction is real for paying operators (vs. internal-team workflow speed-bump that goes away with familiarity).
+
+**Trigger:** Product-readiness audit names this as a top-N migration blocker, OR a paying operator's image volume crosses Cloudflare's pricing cliff in a way S3 + custom derivative pipeline would meaningfully improve. Either signals the migration is paying back the implementation cost.
+
+**Scope:**
+- Comparison matrix:
+  - Per-image cost at three volume tiers (operators today, 5 sites of 30 pages, 50 sites of 30 pages)
+  - Latency on upload + derivative serve (US + EU)
+  - SDK ergonomics (Cloudflare's Images API vs. S3 + Lambda@Edge or Cloudflare R2)
+  - Image-derivative API surface (Cloudflare's variants vs. on-the-fly image proxy)
+  - Debugging story (how do you find a stuck upload?)
+- POC: build an S3-backed `lib/cloudflare-images.ts` adapter behind a feature flag (`OPOLLO_IMAGE_BACKEND=s3`). Run a real upload through it end-to-end.
+- Migration path planning: existing `image_library` rows have Cloudflare-specific URLs in `cloudflare_id`; an S3 migration needs a backfill story OR a dual-read path that resolves either.
+- Decision doc: comparison-matrix-driven recommendation. Ship to BACKLOG-decided once audit completes.
+
+**Size:** Medium-large for the investigation + POC (~1 week). The full migration if approved is its own milestone (~2-3 weeks including the backfill).
+
+---
+
 ## Opollo mu-plugin for one-click Kadence install + theme-mod write (deferred from M13-5c, 2026-04-24)
 
 **What:** A small Opollo-authored WordPress plugin (`opollo-theme-bridge`) that ships a REST endpoint for theme install + activate + theme-mod writes. Would close two M13-5 gaps in one artifact:

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -478,6 +478,154 @@ Log the provisioning date + vendor account IDs somewhere persistent; each rotati
 
 ---
 
+## auth-capability-missing — operator can't publish a post or sync a palette
+
+**Symptom:** publish or appearance-panel button returns a translated banner naming a missing capability. HTTP 403 with `error.code === "PREFLIGHT_BLOCKED"` and `error.details.blocker.code === "AUTH_CAPABILITY_MISSING"`. Specific capability list in `error.details.blocker.missing_capabilities`.
+
+**Impact:** all WP-bound writes for this site are blocked — posts can't publish, palette can't sync. Reads (preflight, dry-run) still work.
+
+**Diagnose:**
+1. Look at `appearance_events` for the latest `preflight_run` row with `details.outcome = 'blocked'` — `details.blocker_code` will be `AUTH_CAPABILITY_MISSING`. Same shape lands in M13-4's posts publish path via the route's translated error envelope.
+2. The capability list this code path checks is pinned in `lib/site-preflight.ts::REQUIRED_PUBLISH_CAPABILITIES` (currently `edit_posts` + `upload_files`). Palette sync needs the same plus the operator's WP user must have `manage_options` for the `/wp/v2/settings` write — that's checked at write-time, not preflight, so a missing `manage_options` surfaces as `WP_API_ERROR` 401 from the sync route, not a preflight blocker.
+3. Cross-reference the actual capability list against what WP returned: hit `/wp-json/wp/v2/users/me?context=edit` with the stored app password. The `capabilities` map is the truth.
+
+**Mitigate:**
+- No mitigation — the operator's WP user genuinely lacks the capability; there's no Opollo-side fix.
+
+**Resolve:**
+- Operator promotes the WP user to Editor (or Administrator if `manage_options` is needed) in WP Admin → Users.
+- Operator regenerates the app password (the old one belongs to the prior role's session in some WP versions) in WP Admin → Profile → Application Passwords.
+- Operator updates Opollo's stored credential via the Edit Site modal — `sites.site_credentials.wp_app_password` (encrypted column) is rewritten.
+- Re-run preflight from the Appearance panel or the post detail page; blocker should clear.
+
+---
+
+## rest-disabled — WP REST returns 404 on /users/me or /themes
+
+**Symptom:** preflight banner with `error.details.blocker.code === "REST_UNREACHABLE"`. Operator-facing copy: "WordPress REST is unreachable. The /wp-json/wp/v2/users/me endpoint returned 404."
+
+**Impact:** every Opollo write to this site is blocked. Detection, sync, publish, unpublish, posts admin — all gated by preflight.
+
+**Diagnose:**
+1. `curl '<wp_url>/wp-json/'` from a developer machine — if 404, REST is disabled site-wide. If 200 but `/wp-json/wp/v2/users/me` 404s, REST is partially blocked (security plugin scoping).
+2. Common causes: iThemes Security's "Disable XML-RPC + REST" feature, WP Hide plugin's REST URL rewrite, Cloudflare WAF rule blocking `/wp-json/*`, an override `.htaccess` rule, or a defunct `rest_authentication_errors` filter in `functions.php`.
+
+**Mitigate:**
+- No Opollo-side mitigation; operator must restore REST.
+
+**Resolve:**
+- Operator disables the REST-blocking plugin or rule:
+  - iThemes Security → Settings → Tweaks → "REST API" set to "Default Access".
+  - WP Hide → Rewrite → restore default `/wp-json/` path.
+  - Cloudflare → WAF → exclude `/wp-json/*` from any blocking rule.
+  - `.htaccess` — remove any `RewriteRule ^wp-json/`.
+- Re-run preflight. The blocker should flip to `REST_AUTH_FAILED` (if creds wrong) or clear entirely.
+
+---
+
+## seo-plugin-missing — post publish blocked because brief declared SEO meta
+
+**Symptom:** post publish gated by a quality-gate failure naming a missing SEO plugin. Operator sees a translated banner: "This post's brief declared SEO meta but no compatible plugin (Yoast / RankMath / SEOPress) is detected on the site."
+
+**Impact:** the specific post can't publish. Other posts on the same site still publish if their briefs don't declare SEO meta.
+
+**Diagnose:**
+1. `lib/seo-plugin-detection.ts` fingerprints the active SEO plugin from `/wp-json/` namespace listing. If the post's brief declared `yoast.*` / `rank_math.*` / `seo_press.*` meta keys, M13-3's post quality gate enforces presence.
+2. Hit `/wp-json/` and look for `wp/v2/types/post` schema fields — Yoast, RankMath, and SEOPress all expose meta fields under a recognizable namespace (`yoast_head_json`, `rank_math_meta`, `_seopress_*`).
+3. Check the brief's source for declared SEO meta — currently exposed via `briefs.brand_voice` / `briefs.design_direction` content; structured SEO meta declaration is BACKLOG.
+
+**Mitigate:**
+- Operator can publish without the SEO meta by editing the brief to remove the SEO directive, then re-running. The post will publish without those meta fields.
+
+**Resolve:**
+- Operator installs one of: Yoast SEO, Rank Math, SEOPress (Steven's preference order: RankMath → Yoast → SEOPress, all free-tier).
+- Operator activates the plugin in WP Admin → Plugins.
+- Re-run preflight from the post detail page; gate should clear.
+- Long term: brief authors should declare which SEO plugin they're targeting upfront so Opollo can preflight at brief-commit time, not publish time. BACKLOG.
+
+---
+
+## kadence-customizer-drift — palette sync hits WP_STATE_DRIFTED
+
+**Symptom:** Appearance panel sync confirm hits 409 `WP_STATE_DRIFTED`. Banner: "WordPress changed between your preview and confirm. We've refreshed the diff — review again before syncing." Diff table shows different "current" colors than the operator saw 30 seconds ago.
+
+**Impact:** sync is blocked but no data loss. Operator's intent is preserved; they need to re-review against the new state.
+
+**Diagnose:**
+1. The drift hash in `lib/kadence-palette-sync.ts::hashPalette` re-reads WP's current palette right before the write. A mismatch with the dry-run's hash triggers the failure.
+2. Common cause: operator (or another team member) opened WP Admin → Customizer → Global Colors and saved a change between Opollo's dry-run and confirm.
+3. Check `appearance_events` for the latest `globals_failed` row with `details.stage = 'drift_check'` — `details.expected_sha` vs `details.actual_sha` confirms the hash mismatch happened at confirm-time.
+
+**Mitigate:**
+- The route automatically re-runs preflight on `WP_STATE_DRIFTED` and surfaces the fresh diff. Operator decides:
+  - Keep their Customizer edits → close the panel without syncing; Opollo's stored DS palette remains source of truth, but Customizer wins for now.
+  - Override Customizer with DS → confirm the new diff (which now reflects the Customizer edits as "current"); sync overwrites them.
+
+**Resolve:**
+- The drift signal is the system working as designed — operator-visible alert prevents silent overwrite.
+- If frequent drift is a workflow problem (multi-author teams stomping each other), the long-term fix is the parent plan's deferred merge-aware sync. BACKLOG candidate alongside the typography+spacing slice.
+
+---
+
+## stuck-brief-run — brief_run row not advancing past 'running'
+
+**Symptom:** Run surface shows a page in `generating` for longer than the lease window (default 60s). Operator clicks Re-check; status doesn't change. Cron logs may show "lease still held by worker_id=X".
+
+**Impact:** that specific brief is paused. Other briefs on the site continue running normally.
+
+**Diagnose:**
+1. `SELECT id, status, worker_id, lease_expires_at, last_heartbeat_at FROM brief_runs WHERE brief_id='<uuid>';` — if `lease_expires_at < now()`, the lease should be reaped on the next cron tick (every minute via `vercel.json`).
+2. `SELECT id, event, details, created_at FROM brief_runs_events WHERE brief_run_id='<uuid>' ORDER BY created_at DESC LIMIT 20;` shows lease/heartbeat history.
+3. Check Vercel cron logs for `process-brief-runner` — if cron is silent, the schedule is broken (verify `vercel.json` deployed and `CRON_SECRET` is set).
+
+**Mitigate:**
+- Manual reaper — under CAS, reset the row:
+  ```sql
+  UPDATE brief_runs
+     SET status = 'queued',
+         worker_id = NULL,
+         lease_expires_at = NULL,
+         updated_at = now(),
+         version_lock = version_lock + 1
+   WHERE id = '<uuid>'
+     AND version_lock = <current_lock>;
+  ```
+  Next cron tick will lease it cleanly.
+- If the row is genuinely corrupt (page state diverged from run state), cancel the run from the UI and re-upload the brief.
+
+**Resolve:**
+- Most stuck-run cases are cron-schedule problems — verify `vercel.json` includes `/api/cron/process-brief-runner` and `CRON_SECRET` is provisioned in the Vercel project. CRON-related diagnostics live in M12-6's runner cron entry.
+- If the worker_id is from a deploy that's been replaced, the new deploy's cron picks up the lease via `FOR UPDATE SKIP LOCKED` once `lease_expires_at` passes. No action needed.
+
+---
+
+## orphan-post-row — brief_page approved but no posts row created
+
+**Symptom:** brief_page status=approved with non-null draft_html, but `/admin/sites/[id]/posts` doesn't show the post. `approveBriefPage`'s response included `failed_bridge_reason` non-null when the operator clicked Approve.
+
+**Impact:** the brief generation succeeded; the post is "stuck" between brief_page and posts table — operator can't publish it from the posts admin because there's no post row.
+
+**Diagnose:**
+1. The bridge in `lib/brief-runner.ts::bridgeApprovedPageToPostIfNeeded` logs `failed_bridge_reason` on every soft failure. Look at the approve route response (network tab on the Approve button click) for the `failed_bridge_reason` field. Common values:
+   - `slug_already_in_use` — another live post on the site already has this slug. UNIQUE violation on `posts(site_id, slug)`.
+   - `existing_lookup_failed` / `insert_failed` — Supabase write error; check supabase logs.
+   - `brief_lookup_failed` — brief vanished (soft-delete race).
+2. `SELECT id, slug, deleted_at FROM posts WHERE site_id='<uuid>' AND slug='<derived-slug>';` — if a row exists but with a different brief origin, the slug collision is real.
+3. The slug derivation: `slug_hint` if non-null on the brief_page, else `slugify(title)`. The slugify shape is in `lib/brief-runner.ts::slugifyForPost`.
+
+**Mitigate:**
+- Operator manually creates the post via `lib/posts.createPost` from a one-off script or admin route, copying `generated_html` + `title` from the approved brief_page.
+
+**Resolve:**
+- For `slug_already_in_use`: edit the brief_page's `slug_hint` to a unique value, then re-approve. The bridge runs again on re-approve and produces a fresh post row. The first failed attempt left the brief_page in approved state, so re-approve will hit the `INVALID_STATE` check from `approveBriefPage` — manually flip the brief_page back to `awaiting_review` first:
+  ```sql
+  UPDATE brief_pages SET page_status = 'awaiting_review', version_lock = version_lock + 1
+   WHERE id = '<uuid>' AND version_lock = <current_lock>;
+  ```
+- For systemic slug collisions (multiple sites generating posts with the same titles): the title-based slug derivation is too coarse. Long-term fix is to scope the slug under the site's prefix, OR include the brief_id in the slug. BACKLOG.
+
+---
+
 ## Adding a new runbook entry
 
 When a live incident surfaces a gap, write it up here the same day. Template:

--- a/docs/patterns/brief-driven-generation.md
+++ b/docs/patterns/brief-driven-generation.md
@@ -167,3 +167,56 @@ As of M12-6, this pattern is in production as the whole-site brief runner:
 - Cron tick at `/api/cron/process-brief-runner` (1-minute Vercel schedule)
 
 M13's post-runner (M13-3) reuses the same runner via the mode dispatch — first cross-reuse. If a third shape lands, audit this doc against the actual diff; promote any stable deltas into the checklist above.
+
+## Post mode (M13)
+
+The first cross-reuse of this pattern is the post-runner. It does **not** fork `lib/brief-runner.ts`; it adds a new entry to the mode dispatch table.
+
+### Mode axis
+
+`briefs.content_type` (CHECK enum `('page','post')`, migration 0021) is the dispatch axis. `resolveRunnerMode(brief)` returns `'page' | 'post'`. `MODE_CONFIGS[mode]` carries the per-mode deltas:
+
+| Knob | `'page'` | `'post'` |
+| --- | --- | --- |
+| Anchor extra cycles | `ANCHOR_EXTRA_CYCLES` (2) | `0` — anchor cycle is disabled. |
+| Mode-specific gates | none | `runPostQualityGates` (meta-description length cap; featured-image / taxonomy hooks plug in here as preflight wiring lands). |
+| Page → output bridge | none (brief_pages is the output). | `bridgeApprovedPageToPostIfNeeded` writes a `posts` row at approval. |
+
+The dispatch is the only mode-aware code path. New mode = new entry; a forked runner-for-posts would drift silently. Asserted by `lib/__tests__/brief-runner-mode.test.ts`: `MODE_CONFIGS.post.anchorExtraCycles === 0`.
+
+### Anchor cycle disabled for posts
+
+The page-mode anchor (page 0 + 2 extra revises + frozen `site_conventions`) presupposes a brand-new site that needs first-time conventions. Posts run against an **already-anchored** site: the running `content_summary` from prior approved posts is the only continuity needed. `MODE_CONFIGS.post.anchorExtraCycles = 0` — text sequence is `draft:0 → self_critique:0 → revise:0` flat, no `revise:1`/`revise:2`. The runner never writes to `site_conventions` on a post run.
+
+### Post-specific quality gates
+
+`runPostQualityGates(draftHtml)` runs **after** the base gate passes. Today: meta-description length capped at `POST_META_DESCRIPTION_MAX` (300, the outer Zod bound). Hook points named in the parent plan land here as their preflight surface arrives — featured-image presence (conditional on M13-3's SEO plugin detection in `lib/seo-plugin-detection.ts`), taxonomy whitelist. Gate failure routes through the same `quality_flag` + `awaiting_review` path as a page failure; no separate state machine.
+
+### brief_page → posts bridge (M13-4)
+
+`approveBriefPage` calls `bridgeApprovedPageToPostIfNeeded` after the brief-page CAS commits. The bridge is the only place `brief_pages` (a generation-time artefact) becomes a `posts` row (the operator's editable surface). Contract:
+
+- **No-op on page-mode briefs.** The bridge reads `briefs.content_type`; `'page'` returns `{ post_id: null }` and the approval looks like a page approval.
+- **Deterministic slug.** `slugifyForPost(slug_hint || title)` — lowercase, `[^a-z0-9]+ → -`, trimmed, capped at 100 chars. Stable across retries; same approval re-run never inserts a duplicate.
+- **Live-slug adoption.** Existing `posts` row matching `(site_id, slug, deleted_at IS NULL)` is adopted and returned; the bridge does **not** overwrite its HTML. Operator's next action is a manual edit or a fresh brief cycle. This is what makes the bridge replay-safe across the whole approval surface, not just within one tick.
+- **Soft-fail on race.** A 23505 on insert (concurrent operator beat us to the slug) returns `{ post_id: null, failed_bridge_reason: 'slug_already_in_use' }`. **Approval itself stays committed** — the brief_page is approved, the post just didn't materialise. Operator sees a UI warning and retries via manual `createPost`.
+- **Never rolls back the approval.** Any bridge failure (brief lookup, existing lookup, insert) is a soft failure. `brief_pages.page_status = 'approved'` is the source of truth; the post row is downstream.
+
+### Publish path (M13-3)
+
+Once a `posts` row exists, the publish lane is independent of the runner. `POST /api/sites/[id]/posts/[post_id]/publish`:
+
+1. Site preflight (`lib/site-preflight.ts`) — REQUIRED_PUBLISH_CAPABILITIES gate; missing capabilities raise blocker codes consumed by the runbook (`auth-capability-missing`, `rest-disabled`, `seo-plugin-missing`).
+2. `wpCreatePost` on first publish; `wpUpdatePost` on re-publish (decided by `posts.wp_post_id IS NULL`).
+3. CAS on `posts.version_lock`. A racing publish trips `VERSION_CONFLICT`; the operator re-reads the row and retries.
+4. Audit event written before the response returns.
+
+Unpublish at `POST /api/sites/[id]/posts/[post_id]/unpublish` mirrors the shape (status flip on WP + CAS on `posts`).
+
+### Kadence palette is independent of post content
+
+M13-5's palette sync mutates `wp_options` (`kadence_blocks_colors`); it does **not** touch post HTML, post markup, or the post-runner. A drifted palette never blocks a post run, and a post run never invalidates a synced palette. The two surfaces share only the `appearance_events` audit table for operator-visible history. If a future change tries to entangle them (e.g. post-render asserting palette freshness), that's a parent-plan-level scope decision, not a runner change.
+
+### What's not in M13
+
+Multi-author authorship, post scheduling (`status='scheduled' + scheduled_for`), and custom post types (CPTs beyond the built-in `'post'`) are all in BACKLOG. Today's runner assumes single-tenant operator authorship + immediate publish + WP core post type only; future axes plug in via the same dispatch table, not a fork.


### PR DESCRIPTION
## Plan (sub-slice of approved M13-6)

M13-6a is the docs-only opener of M13-6. M13-6b (E2E coverage of the posts pipeline + appearance panel) follows on a separate PR with its own halt gate.

### Scope (this PR)

1. **`docs/RUNBOOK.md` — six new operator-workflow entries** for failures M13-3..M13-5 introduced:
   - `auth-capability-missing` — site preflight rejects publish; references `lib/site-preflight.ts::REQUIRED_PUBLISH_CAPABILITIES`.
   - `rest-disabled` — iThemes / WP Hide / Cloudflare WAF blocking REST; recovery steps + diagnostic curl.
   - `seo-plugin-missing` — M13-3 quality-gate fail when no SEO plugin advertises an excerpt slot.
   - `kadence-customizer-drift` — confirm-time hash mismatch; references `lib/kadence-palette-sync.ts::hashPalette` + the snapshot rollback path.
   - `stuck-brief-run` — manual reaper SQL (under lease CAS); references `vercel.json` cron schedule.
   - `orphan-post-row` — bridge soft-fail recovery; references `lib/brief-runner.ts::bridgeApprovedPageToPostIfNeeded` + `slugifyForPost`.
2. **`docs/BACKLOG.md` — two new entries** per parent M13-6 plan:
   - Cloudflare image upload friction → S3 alternative investigation. Tag: `storage`, `audit-target`. Deferred to product-readiness audit.
   - Site actions dropdown clipped on `/admin/sites` list. Tag: `ux-polish`. Options: portal-rendered menu vs `overflow:visible` on parent.
3. **`docs/patterns/brief-driven-generation.md` — "Post mode (M13)" appendix** documenting:
   - `briefs.content_type` dispatch axis + the `MODE_CONFIGS` table.
   - Anchor cycle disabled for posts (already-anchored site; running summary is the only continuity needed).
   - Post-specific quality gates (`runPostQualityGates`; meta-description cap today, featured-image / taxonomy hooks ready).
   - brief_page → posts bridge contract (deterministic slug, live-slug adoption, soft-fail on 23505, never rolls back approval).
   - Publish path: preflight → `wpCreatePost` / `wpUpdatePost` → CAS on `posts.version_lock` → audit event.
   - Palette/posts independence (M13-5 only mutates `wp_options`).
   - What is NOT in M13: multi-author, scheduling, CPTs (BACKLOG).
4. **`CLAUDE.md` — one-line RUNBOOK rule** under "What I care about": code that changes a blocker code / audit event / error envelope MUST update the matching RUNBOOK entry in the same PR.

### Risks identified and mitigated

- **Stale runbook drift** — RUNBOOK rotting next to the code is the only structural risk a docs-only PR can introduce. Mitigated by (a) every new entry naming the exact code reference (file + symbol) so a future grep catches drift, and (b) the new CLAUDE.md rule making RUNBOOK updates a hard requirement on any PR that changes a blocker code, audit event name, or error envelope. The rule sits next to "Keep PRs small enough to review in 5 minutes" — peer-status hygiene rules, not buried.
- **Pattern doc accuracy** — The post-mode appendix was written against the actual code (`lib/brief-runner.ts::resolveRunnerMode`, `MODE_CONFIGS`, `runPostQualityGates`, `bridgeApprovedPageToPostIfNeeded`, `slugifyForPost`) verified by direct read, not from memory of the M13-3/M13-4 plans. Code references include line-anchored function names so a future renamer will trip the docs check.
- **No write-safety hotspots** — Docs-only diff. No billed external calls, no schema changes, no concurrent writers, no race windows. Lint clean.

### Halt

Per parent M13-6 plan, halt after merge. M13-6b (E2E coverage) is the next sub-slice.

## Test plan

- [x] `npm run lint` clean
- [x] No code changes; typecheck/build skipped (docs-only)
- [ ] Reviewer skim of the six RUNBOOK entries for completeness/style consistency with existing entries
- [ ] Reviewer skim of the post-mode pattern appendix vs the actual M13-3/M13-4 code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)