### PR TITLE
fix(audit): error codes + NEXT_PUBLIC_VERCEL_ENV (PR 1/4)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -111,6 +111,16 @@ SENTRY_ORG=
 SENTRY_PROJECT=
 # Build-time credential for source-map upload (withSentryConfig).
 SENTRY_AUTH_TOKEN=
+# Client-runtime environment tag — Sentry uses it to separate
+# preview vs. production error streams. Vercel sets server-side
+# VERCEL_ENV automatically but does NOT inject NEXT_PUBLIC_VERCEL_ENV
+# into client bundles; an operator must set this explicitly in the
+# Vercel dashboard for both Production and Preview scopes (values
+# `production` / `preview` respectively). When unset, the client SDK
+# falls back to NODE_ENV and tags every preview error as
+# `production`, destroying preview/prod signal separation.
+# Read site: instrumentation-client.ts:18.
+NEXT_PUBLIC_VERCEL_ENV=
 
 # --- Observability: Axiom (M10, optional) ----------------------------------
 # Additive transport in lib/logger.ts. stdout is always the primary sink;

--- a/lib/tool-schemas.ts
+++ b/lib/tool-schemas.ts
@@ -44,6 +44,20 @@ export const ERROR_CODES = [
   "ALREADY_EXISTS",
   "FORBIDDEN",
   "UNAUTHORIZED",
+  // Audit fix-pass 2026-04-27 — promote pre-existing route-emitted
+  // codes into the canonical vocabulary so operator-UI consumers
+  // (AccountSecurityForm, ResetPasswordForm, batch admin) and any
+  // future caller using respond() get a typed code + a canonical
+  // HTTP status. Local jsonError helpers in the affected routes
+  // continue to specify their own status; this expansion is for the
+  // canonical mapping path.
+  "PASSWORD_WEAK",
+  "SAME_PASSWORD",
+  "INCORRECT_CURRENT_PASSWORD",
+  "UPDATE_FAILED",
+  "EMERGENCY_NOT_CONFIGURED",
+  "TEMPLATE_NOT_FOUND",
+  "TEMPLATE_NOT_ACTIVE",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];
@@ -91,8 +105,10 @@ export function errorCodeToStatus(code: ErrorCode): number {
       return 401;
     case "CONFIRMATION_REQUIRED":
     case "FORBIDDEN":
+    case "INCORRECT_CURRENT_PASSWORD":
       return 403;
     case "NOT_FOUND":
+    case "TEMPLATE_NOT_FOUND":
       return 404;
     case "PREFIX_TAKEN":
     case "VERSION_CONFLICT":
@@ -101,6 +117,7 @@ export function errorCodeToStatus(code: ErrorCode): number {
     case "REGEN_ALREADY_IN_FLIGHT":
     case "BRIEF_RUN_ALREADY_ACTIVE":
     case "ALREADY_EXISTS":
+    case "TEMPLATE_NOT_ACTIVE":
       return 409;
     case "BRIEF_TOO_LARGE":
       return 413;
@@ -108,6 +125,8 @@ export function errorCodeToStatus(code: ErrorCode): number {
       return 415;
     case "IDEMPOTENCY_KEY_CONFLICT":
     case "BRIEF_PARSE_FAILED":
+    case "PASSWORD_WEAK":
+    case "SAME_PASSWORD":
       return 422;
     case "RATE_LIMIT":
     case "BUDGET_EXCEEDED":
@@ -116,7 +135,10 @@ export function errorCodeToStatus(code: ErrorCode): number {
     case "WP_API_ERROR":
     case "NETWORK_ERROR":
       return 502;
+    case "EMERGENCY_NOT_CONFIGURED":
+      return 503;
     case "INTERNAL_ERROR":
+    case "UPDATE_FAILED":
       return 500;
   }
 }


### PR DESCRIPTION
## Audit fix-pass — PR 1 of 4

Closes 4 BLOCKER + 1 HIGH from AUDIT.md (2026-04-26). Steven approved sequencing on 2026-04-27.

## Scope

### Error codes (4 BLOCKERs)

Promote 7 pre-existing route-emitted codes into the canonical `ERROR_CODES` vocabulary in `lib/tool-schemas.ts`, with corresponding `errorCodeToStatus` cases:

| Code | Status | Routes that emit it |
|---|---|---|
| `PASSWORD_WEAK` | 422 | `change-password`, `auth/reset-password` |
| `SAME_PASSWORD` | 422 | `change-password`, `auth/reset-password` |
| `INCORRECT_CURRENT_PASSWORD` | 403 | `change-password` |
| `UPDATE_FAILED` | 500 (canonical) | `change-password`, `auth/reset-password` |
| `EMERGENCY_NOT_CONFIGURED` | 503 | `emergency`, `ops/reset-admin-password` |
| `TEMPLATE_NOT_FOUND` | 404 | `admin/batch` (via `lib/batch-jobs`) |
| `TEMPLATE_NOT_ACTIVE` | 409 | `admin/batch` (via `lib/batch-jobs`) |

The operator-UI components (`AccountSecurityForm.tsx:98-102`, `ResetPasswordForm.tsx:93`) already consume these codes via direct string-equality. Promoting to the typed vocabulary:
- Unblocks future callers using `respond()` to get canonical HTTP statuses without hand-rolling `jsonError`.
- Unblocks typed code-to-message translation maps when those land in the operator UI.
- Closes the audit-flagged `unknown` fallback path the moment a typed translation map is wired up.

The local `jsonError` helpers in the affected routes continue to specify their own HTTP status — this PR is additive vocabulary, not a refactor of the helpers themselves. Note one canonical-vs-local mismatch: `UPDATE_FAILED` is canonical 500, but the existing local `jsonError` calls in `change-password` and `reset-password` emit 422. Documented but not changed; the helpers' explicit status takes precedence at those call sites.

### NEXT_PUBLIC_VERCEL_ENV (1 HIGH)

Documented in `.env.local.example` with a comment block explaining:
- The var is read at `instrumentation-client.ts:18` to tag client-side Sentry events with the correct environment.
- Vercel does NOT auto-inject it into client bundles (only server-side `VERCEL_ENV` is automatic).
- Operator must set it explicitly in the Vercel dashboard for both Production and Preview scopes.
- When unset, every preview error tags as `production` via the `NODE_ENV` fallback, destroying signal separation.

**Manual verification required:** confirm both Production and Preview scopes have `NEXT_PUBLIC_VERCEL_ENV` set in the Vercel dashboard (`production` / `preview` respectively) before UAT. I cannot reach the dashboard from this session.

## Risks identified and mitigated

- **TypeScript exhaustiveness on `errorCodeToStatus`** — adding codes to `ERROR_CODES` without adding `case` entries would fail the switch's exhaustiveness check at compile time. All 7 cases are added; typecheck is clean.
- **Existing local `jsonError` calls** — they specify their own HTTP status as a parameter, independent of `errorCodeToStatus`. No behavior change at any existing call site. The local helpers also use `code: string` (not the `ErrorCode` union), so adding to `ERROR_CODES` doesn't gate them either.
- **Operator UI breakage** — components consume codes via string-equality (`code === "PASSWORD_WEAK"`); adding to the union is purely additive and zero-impact on those components.
- **Test fallout** — no test asserts the contents of `ERROR_CODES` directly. Local Vitest run blocked by missing Supabase CLI; CI will validate `change-password-route.test.ts`, `reset-password-route.test.ts`, `emergency-route.test.ts`, `reset-admin-password-route.test.ts`, `batch-create.test.ts`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean (validates exhaustive `errorCodeToStatus` switch)
- [ ] CI test suite green (vitest + e2e)
- [ ] Manual: verify `NEXT_PUBLIC_VERCEL_ENV` set in Vercel dashboard for Production AND Preview before UAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)