### PR TITLE
fix(audit): hide soft-deleted rows from authenticated reads (PR 3/4)

### DIFF
--- a/supabase/migrations/0024_audit_soft_delete_rls.sql
+++ b/supabase/migrations/0024_audit_soft_delete_rls.sql
@@ -1,0 +1,74 @@
+-- ---------------------------------------------------------------------------
+-- 0024 — soft-delete RLS leakage fix.
+--
+-- AUDIT.md (2026-04-26) §3 RLS spot-check, soft-delete leakage findings.
+-- Promoted from MEDIUM to HIGH on 2026-04-27 by the fix-pass review —
+-- UAT testers deleting and restoring content is exactly the surface that
+-- catches this.
+--
+-- Five user-facing read policies (briefs, brief_pages, brief_runs,
+-- site_conventions, posts) authorize on role only — they do NOT filter
+-- `deleted_at IS NULL`. Soft-deleted rows therefore stay visible to any
+-- authenticated user via direct SELECT against the table. The application
+-- layer (lib/posts.ts, lib/briefs.ts) does filter by `deleted_at IS NULL`
+-- on its happy paths, but those use the service-role client which bypasses
+-- RLS entirely — the protective filter is at the app layer, not the DB.
+-- A direct authenticated query (e.g. via supabase-js client.from("posts").
+-- select()) bypasses the app layer and exposes everything.
+--
+-- Fix: drop + recreate each read policy with the same role check, plus
+-- `AND deleted_at IS NULL`. Admin-recovery surfaces that need to see
+-- soft-deleted rows must use the service-role client (which they already
+-- do for the happy path).
+--
+-- Tables affected:
+--   - briefs            (0013:325-327)
+--   - brief_pages       (0013:339-341)
+--   - brief_runs        (0013:353-355)
+--   - site_conventions  (0013:367-369)
+--   - posts             (0019:178-180)
+-- ---------------------------------------------------------------------------
+
+BEGIN;
+
+DROP POLICY IF EXISTS briefs_read ON briefs;
+CREATE POLICY briefs_read ON briefs
+  FOR SELECT TO authenticated
+  USING (
+    public.auth_role() IN ('admin', 'operator', 'viewer')
+    AND deleted_at IS NULL
+  );
+
+DROP POLICY IF EXISTS brief_pages_read ON brief_pages;
+CREATE POLICY brief_pages_read ON brief_pages
+  FOR SELECT TO authenticated
+  USING (
+    public.auth_role() IN ('admin', 'operator', 'viewer')
+    AND deleted_at IS NULL
+  );
+
+DROP POLICY IF EXISTS brief_runs_read ON brief_runs;
+CREATE POLICY brief_runs_read ON brief_runs
+  FOR SELECT TO authenticated
+  USING (
+    public.auth_role() IN ('admin', 'operator', 'viewer')
+    AND deleted_at IS NULL
+  );
+
+DROP POLICY IF EXISTS site_conventions_read ON site_conventions;
+CREATE POLICY site_conventions_read ON site_conventions
+  FOR SELECT TO authenticated
+  USING (
+    public.auth_role() IN ('admin', 'operator', 'viewer')
+    AND deleted_at IS NULL
+  );
+
+DROP POLICY IF EXISTS posts_read ON posts;
+CREATE POLICY posts_read ON posts
+  FOR SELECT TO authenticated
+  USING (
+    public.auth_role() IN ('admin', 'operator', 'viewer')
+    AND deleted_at IS NULL
+  );
+
+COMMIT;

--- a/supabase/rollbacks/0024_audit_soft_delete_rls.down.sql
+++ b/supabase/rollbacks/0024_audit_soft_delete_rls.down.sql
@@ -1,0 +1,40 @@
+-- ---------------------------------------------------------------------------
+-- 0024 rollback — restore the original (leaky) read policies WITHOUT the
+-- deleted_at IS NULL filter.
+--
+-- WARNING: applying this rollback re-introduces the soft-delete leakage
+-- documented in AUDIT.md §3. Soft-deleted rows in briefs, brief_pages,
+-- brief_runs, site_conventions, and posts will again be visible to any
+-- authenticated user via direct SELECT. Only roll this back if the
+-- forward migration broke an admin-recovery flow that has not yet been
+-- migrated to service-role access.
+-- ---------------------------------------------------------------------------
+
+BEGIN;
+
+DROP POLICY IF EXISTS briefs_read ON briefs;
+CREATE POLICY briefs_read ON briefs
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator', 'viewer'));
+
+DROP POLICY IF EXISTS brief_pages_read ON brief_pages;
+CREATE POLICY brief_pages_read ON brief_pages
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator', 'viewer'));
+
+DROP POLICY IF EXISTS brief_runs_read ON brief_runs;
+CREATE POLICY brief_runs_read ON brief_runs
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator', 'viewer'));
+
+DROP POLICY IF EXISTS site_conventions_read ON site_conventions;
+CREATE POLICY site_conventions_read ON site_conventions
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator', 'viewer'));
+
+DROP POLICY IF EXISTS posts_read ON posts;
+CREATE POLICY posts_read ON posts
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator', 'viewer'));
+
+COMMIT;


### PR DESCRIPTION
## Audit fix-pass — PR 3 of 4

Closes 5 audit findings from AUDIT.md (2026-04-26) §3, **promoted from MEDIUM to HIGH on 2026-04-27** — UAT testers deleting and restoring content is exactly the surface that catches this. Sequenced after PR 2 (#160 merged).

## Scope

Five user-facing read policies authorize on role only — they do NOT filter `deleted_at IS NULL`. Soft-deleted rows stay visible to any authenticated user via direct SELECT.

The application layer DOES filter on happy paths (e.g. `lib/posts.ts::listPostsForSite` at line 325 calls `.is("deleted_at", null)` when `include_archived` is false), but those code paths use the service-role client which bypasses RLS entirely — the protective filter is at the app layer, not the DB. A direct authenticated query through `supabase-js` from a future surface would bypass the app layer and expose everything.

### Migration 0024 + rollback

| Table | Read policy | Source migration |
|---|---|---|
| `briefs` | `briefs_read` | `0013:325-327` |
| `brief_pages` | `brief_pages_read` | `0013:339-341` |
| `brief_runs` | `brief_runs_read` | `0013:353-355` |
| `site_conventions` | `site_conventions_read` | `0013:367-369` |
| `posts` | `posts_read` | `0019:178-180` |

Drops + recreates each `_read` policy with the same role check, plus `AND deleted_at IS NULL`. Service-role and write policies untouched.

### Admin recovery

Admin-recovery surfaces that need to see soft-deleted rows must use the service-role client. The happy paths already do this (`lib/posts.ts::getServiceRoleClient`). If a future admin-only "trashed items" view needs visibility into soft-deleted rows from the authenticated path, it must explicitly use a separate code path (or relax the policy with an `auth_role() = 'admin'` branch). Choosing the simpler "hide from all authenticated" form to match the audit's exact recommendation.

## Risks identified and mitigated

- **App-layer regression** — `lib/briefs.ts`, `lib/posts.ts`, and the brief-runner all use `getServiceRoleClient()`, which bypasses RLS. Confirmed by grep across `lib/`. No happy path uses `createClient` (anon) for these tables. The fix has no observable behavior change for any current code path.
- **Hidden audit history** — soft-deleted briefs/posts in the audit log become invisible to non-service-role queries. This is the intended security posture: a "deleted" row should look deleted to the operator UI, not just hidden by a `WHERE` clause that a future query might forget. If audit recovery via the UI is needed, build it as an explicit "show deleted" surface using service role.
- **Concurrent reads during DDL** — `DROP POLICY` + `CREATE POLICY` is wrapped in `BEGIN/COMMIT`. Brief invisibility window during the swap is acceptable for a one-time DDL change.
- **Cascade-delete behavior** — none of the affected tables soft-delete via `deleted_at` cascade today; soft-delete is set explicitly by the app layer or admin actions. No cross-table cascade affected by this change.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] CI applies migration cleanly + RLS tests pass
- [ ] Manual post-merge: soft-delete a brief via the admin UI, confirm a fresh authenticated `client.from("briefs").select()` no longer returns it. Service-role query still does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)