### PR TITLE
test(audit): drive recovery email link through /api/auth/callback (PR 4/4)

### DIFF
--- a/e2e/auth-passwords.spec.ts
+++ b/e2e/auth-passwords.spec.ts
@@ -262,3 +262,112 @@ test.describe.serial("M14-5 account-security change-password", () => {
     user.password = newPassword;
   });
 });
+
+// ---------------------------------------------------------------------------
+// Recovery email link → /api/auth/callback PKCE hop (audit fix-pass PR 4).
+//
+// AUDIT.md (2026-04-26) §1 flagged that the existing "reset-password
+// updates the password when a session is active" test (above, lines
+// 137-177) deliberately skips the email-link hop — it signs in via
+// /login, navigates directly to /auth/reset-password, and validates
+// only the form behaviour. That leaves the actual production path
+// uncovered: an operator clicks the recovery link in their inbox →
+// browser follows the verify URL → redirect chain ends at our
+// /api/auth/callback?code=...&next=/auth/reset-password → cookie
+// session is set → /auth/reset-password renders the form. If
+// Supabase's redirectTo allowlist is misconfigured, the verify URL
+// 302s to an error page instead of our callback, and the production
+// flow silently breaks.
+//
+// This test drives the full chain. We use auth.admin.generateLink to
+// produce the same action_link the email would contain, navigate it
+// with Playwright (which follows redirects), and assert the session
+// lands on /auth/reset-password with a working form. If the local
+// Supabase project is configured for implicit-flow rather than PKCE,
+// the redirect will deliver tokens in the URL fragment instead of a
+// `code` query param — the cookie-based session won't be set, the
+// /auth/reset-password page will render in its no-session "link
+// expired" state, and this test will fail. That failure is the
+// signal the audit was asking for.
+//
+// Uses its own throwaway user, separate from the user the existing
+// describe.serial block above mutates — so the two are independent.
+// ---------------------------------------------------------------------------
+
+test.describe.serial("M14-5 recovery email-link callback hop (audit PR 4)", () => {
+  let user: TestUser;
+
+  test.beforeAll(async () => {
+    user = await createTestUser("recovery-link");
+  });
+
+  test.afterAll(async () => {
+    if (user) await deleteTestUser(user.id);
+  });
+
+  test("generated recovery link redirects through /api/auth/callback to a working reset form", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+
+    const svc = serviceClient();
+
+    // Build the same redirectTo the production /api/auth/forgot-password
+    // route uses (lib/auth-helpers.ts::buildAuthRedirectUrl shape):
+    // <origin>/api/auth/callback?next=%2Fauth%2Freset-password.
+    // Origin is the Playwright base URL; for a local CI run that's
+    // http://localhost:3000.
+    const origin = new URL(page.url() || "http://localhost:3000").origin;
+    const redirectTo = `${origin}/api/auth/callback?next=%2Fauth%2Freset-password`;
+
+    // generateLink mirrors what svc.auth.resetPasswordForEmail would
+    // produce — same template, same redirect, same token validity
+    // window — but returns the action_link to us directly instead of
+    // sending it via email. Drives the entire production hop chain.
+    const { data, error } = await svc.auth.admin.generateLink({
+      type: "recovery",
+      email: user.email,
+      options: { redirectTo },
+    });
+    if (error || !data?.properties?.action_link) {
+      throw new Error(
+        `generateLink(recovery) failed: ${error?.message ?? "no action_link"}`,
+      );
+    }
+    const actionLink = data.properties.action_link;
+
+    // Navigate. Playwright follows the verify → callback redirect
+    // chain. End state: /auth/reset-password with a session cookie.
+    await page.goto(actionLink);
+    await page.waitForURL(/\/auth\/reset-password/, { timeout: 15_000 });
+
+    // Negative assertion: we did NOT land on the no-session "link
+    // expired" surface. That would mean the redirect chain delivered
+    // tokens in a URL fragment (implicit flow) and our cookie-based
+    // /api/auth/callback never ran — the audit's exact concern.
+    await expect(
+      page.getByRole("heading", { name: /reset link expired/i }),
+    ).toHaveCount(0);
+
+    // Positive assertion: the form is rendered with both password
+    // fields, meaning the auth context is established server-side.
+    await expect(page.getByLabel(/^new password$/i)).toBeVisible();
+    await expect(page.getByLabel(/confirm new password/i)).toBeVisible();
+
+    // Drive the rotation through the form to confirm the session cookie
+    // really does authenticate the /api/auth/reset-password POST.
+    const newPassword = "recovery-link-pwd-12-strong";
+    await page.getByLabel(/^new password$/i).fill(newPassword);
+    await page.getByLabel(/confirm new password/i).fill(newPassword);
+    await page.getByRole("button", { name: /update password/i }).click();
+    await page.waitForURL(/\/admin\/sites/);
+
+    // Sign out then verify the new password is the live credential.
+    await page.getByRole("button", { name: /sign out/i }).click();
+    await page.waitForURL(/\/login/);
+    await signInViaForm(page, user.email, newPassword);
+    await expect(page).toHaveURL(/\/admin\/sites/);
+
+    user.password = newPassword;
+  });
+});


### PR DESCRIPTION
## Audit fix-pass — PR 4 of 4 (closes the fix-pass)

Closes the HIGH finding from AUDIT.md (2026-04-26) §1 about the password-reset E2E skipping the actual email-link hop. Sequenced after PR 3 (#161 merged).

## Scope

The existing `e2e/auth-passwords.spec.ts:137-177` "reset-password updates the password when a session is active" test deliberately skips the callback hop. It signs in via `/login` and navigates directly to `/auth/reset-password` — covers form behaviour but leaves the production path uncovered:

> operator clicks recovery link in inbox → browser follows verify URL → redirect chain ends at `/api/auth/callback?code=...&next=/auth/reset-password` → `exchangeCodeForSession` sets cookie → `/auth/reset-password` renders.

If Supabase's `redirectTo` allowlist is misconfigured, the verify URL 302s to an error page instead of our callback and the production flow silently breaks.

### What this PR adds

A new test in its own `describe.serial` block, with its own throwaway user (`recovery-link` suffix). Drives:

1. `auth.admin.generateLink({ type: 'recovery', email, options: { redirectTo } })` — produces the same `action_link` the email would contain.
2. `page.goto(actionLink)` — Playwright follows the verify → callback redirect chain.
3. `await page.waitForURL(/\/auth\/reset-password/)` — confirms we land on the form, not on `/auth-error`.
4. **Negative assertion** `toHaveCount(0)` on the "reset link expired" heading — if Supabase delivers tokens in a URL fragment (implicit flow) rather than a query-string code, the cookie session never sets and the no-session surface renders. That's the audit's exact concern; the test fails and surfaces it.
5. Drives the form (set new password → submit → `/admin/sites`) — confirms the cookie session really does authenticate the `/api/auth/reset-password` POST.
6. Sign out + sign in with new password — confirms credential rotation actually committed.

### Why a new test rather than extending the existing one

The existing test (lines 137-177) mutates `user.password` and is part of a chain (`describe.serial`) that depends on prior state. Adding the email-link hop to the same test would either break the chain or duplicate user-creation logic. Independent test with its own user is cleaner.

## Risks identified and mitigated

- **Local-Supabase implicit-flow** — the existing test's comment (line 142-150) says local Supabase's `admin.generateLink({type:'recovery'})` returns an implicit-flow verify URL. If that's still true, this new test will fail. **That failure IS the signal the audit was asking for** — the production path is broken under that configuration. Resolution path: configure Supabase to use PKCE for recovery flows (`flowType: 'pkce'` on the auth client config), OR extend `/api/auth/callback` to also handle implicit-flow tokens (server-side fragment parsing isn't possible — would need a thin client-side handler). Either way, the test failing is the correct outcome until the production path is verified working.
- **Test isolation** — uses a fresh `createTestUser("recovery-link")` in `beforeAll` and `deleteTestUser` in `afterAll`. No shared state with the existing block.
- **No production code change** — purely additive E2E coverage. Zero risk to runtime behavior.
- **Origin resolution** — uses `page.url() || "http://localhost:3000"` to derive the origin; matches Playwright's `baseURL` when set, falls back to localhost. The `redirectTo` template matches what `lib/auth-helpers.ts::buildAuthRedirectUrl` produces in the production `forgot-password` route.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] CI E2E run drives the new test successfully — OR fails with a signal that local Supabase needs PKCE config (in which case treat as a separate ops fix, not a same-failure-twice loop)
- [ ] Manual post-merge: trigger a real recovery email to a test address, click the link, confirm the production hop chain lands on `/auth/reset-password` with a working form

🤖 Generated with [Claude Code](https://claude.com/claude-code)