### PR TITLE
chore(infra): wire process-transfer cron (1-min schedule) — DO NOT MERGE without prod count check

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,10 @@
       "schedule": "* * * * *"
     },
     {
+      "path": "/api/cron/process-transfer",
+      "schedule": "* * * * *"
+    },
+    {
       "path": "/api/cron/budget-reset",
       "schedule": "0 * * * *"
     }


### PR DESCRIPTION
## Wiring PR — DO NOT auto-merge

Auto-merge intentionally **NOT** armed on this PR. Per Steven's instruction (2026-04-27): production `transfer_job_items` must be inspected for pre-existing pending rows before this cron starts processing. Once Steven confirms the count and resolves any stranded rows, he merges manually.

## Scope

One file changed: `vercel.json` adds a fifth cron entry for `/api/cron/process-transfer` with a 1-minute schedule, same pattern as `process-batch`, `process-regenerations`, `process-brief-runner`.

The route handler at `app/api/cron/process-transfer/route.ts` and the worker at `lib/transfer-worker.ts` are already deployed and complete — Bearer-`CRON_SECRET` auth, lease/heartbeat/SKIP-LOCKED queue, dispatches `cloudflare_ingest` and `wp_media_transfer` job types. The only thing missing was the schedule entry.

## Precondition: prod count check (Steven runs)

Run via Supabase Studio SQL editor (production project) or `psql` with the prod `DATABASE_URL`. The two queries to run:

```sql
-- 1. Pending items waiting for a worker to pick them up.
--    These are what'll start processing the moment the cron deploys.
SELECT
  state,
  COUNT(*) AS row_count,
  MIN(created_at) AS oldest,
  MAX(created_at) AS newest
FROM transfer_job_items
WHERE state IN ('pending', 'leased', 'uploading', 'captioning', 'publishing')
GROUP BY state
ORDER BY state;

-- 2. Parent jobs in non-terminal status — sanity check that pending
--    items belong to jobs the operator actually wants drained.
SELECT
  j.id,
  j.type,
  j.status,
  j.requested_count,
  j.succeeded_count,
  j.failed_count,
  j.skipped_count,
  j.created_at
FROM transfer_jobs j
WHERE j.status IN ('pending', 'processing')
ORDER BY j.created_at;
```

### If results show 0 rows
Merge this PR. The cron starts processing only future jobs (next iStock seed run, next admin-triggered transfer).

### If results show pending/in-flight items from prior seed runs

Three options:

**A. Drain (let the cron process them).** Best if the items reflect work the operator still wants done (e.g. a half-completed iStock seed). Just merge — cron picks them up next minute. Watch `transfer_events` for any failures during the drain.

**B. Cancel (mark them terminal so cron skips them).** Best if items are stale/abandoned and you don't want Cloudflare uploads + Anthropic captioning bills hitting now. Run before merging:

```sql
-- Mark stranded items as skipped. Use the parent job IDs from query 2
-- above to scope this to the abandoned jobs only — do NOT blanket-update
-- the whole table.
UPDATE transfer_job_items
SET
  state = 'skipped',
  failure_code = 'cron_unwired_pre_2026_04_27',
  failure_detail = 'Marked skipped during cron wiring; original job pre-dates the schedule.',
  worker_id = NULL,
  lease_expires_at = NULL,
  updated_at = now()
WHERE transfer_job_id IN ('<job-uuid-1>', '<job-uuid-2>')  -- fill in
  AND state IN ('pending', 'leased', 'uploading', 'captioning', 'publishing');

-- Mark parent jobs cancelled so they don't appear active.
UPDATE transfer_jobs
SET
  status = 'cancelled',
  cancel_requested_at = now(),
  finished_at = now(),
  updated_at = now()
WHERE id IN ('<job-uuid-1>', '<job-uuid-2>')
  AND status IN ('pending', 'processing');
```

Then merge.

**C. Hybrid — drain some, cancel others.** Run query 2 to see job timestamps + counts; cancel anything genuinely stale, drain anything still relevant.

## Risks identified and mitigated

- **Cron starts processing the moment the deploy lands** — that's exactly why the count check is gated before merge. Auto-merge intentionally NOT armed.
- **Cost surprise on drain** — Cloudflare upload is cheap (~$0 per image at our volume); Anthropic captioning is the cost driver (~$0.01-0.03 per image with claude-haiku). At realistic seed sizes (1k-9k items) that's $10-300 if all run. Acceptable for a green-lit drain; not acceptable for a surprise drain. Steven's go/no-go on (A) vs (B) per item count answers this.
- **Bearer auth** — `/api/cron/process-transfer` is already Bearer-`CRON_SECRET` protected (handled by the existing route). Vercel cron auto-injects this; matches the other 4 cron routes. No env var change needed.
- **No code change** — pure JSON. Lint/typecheck/build don't touch vercel.json. Trusting CI to validate.

## Test plan

- [x] vercel.json shape matches the 4 existing cron entries (verified — same `path`/`schedule` keys, same `* * * * *` schedule)
- [ ] Steven runs the prod count queries
- [ ] Steven decides A/B/C path for any pre-existing rows
- [ ] Steven manually merges this PR
- [ ] Post-deploy: `transfer_events` audit log shows the worker picking up items as expected (or staying idle if no work in queue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)