### PR TITLE
fix(audit): route-test fetch mocks pass through non-WP URLs

### DIFF
--- a/lib/__tests__/appearance-sync-routes.test.ts
+++ b/lib/__tests__/appearance-sync-routes.test.ts
@@ -176,10 +176,12 @@ function mockWp(state: MockWpState) {
         headers: { "content-type": "application/json" },
       });
     }
-    return new Response(JSON.stringify({ error: `unmocked: ${url}` }), {
-      status: 404,
-      headers: { "content-type": "application/json" },
-    });
+    // No WP route match -> pass through to the real fetch. Supabase
+    // REST calls share globalThis.fetch with the WP traffic under
+    // test; swallowing them as "unmocked" 404s makes the route's
+    // appearance_events insert fail and the test asserts on a 500
+    // instead of the real status it expects.
+    return originalFetch(input, init);
   }) as unknown as typeof fetch;
 }
 

--- a/lib/__tests__/posts-publish-routes.test.ts
+++ b/lib/__tests__/posts-publish-routes.test.ts
@@ -62,7 +62,7 @@ type CannedResponse = {
 };
 
 function mockFetch(responses: Record<string, CannedResponse>) {
-  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
     // Find the first matching prefix.
     for (const [needle, resp] of Object.entries(responses)) {
@@ -73,11 +73,11 @@ function mockFetch(responses: Record<string, CannedResponse>) {
         });
       }
     }
-    // Default to 404 if no match — surfaces unexpected calls loudly.
-    return new Response(JSON.stringify({ error: `unmocked: ${url}` }), {
-      status: 404,
-      headers: { "content-type": "application/json" },
-    });
+    // No match -> pass through to the real fetch. Supabase REST calls
+    // share globalThis.fetch with the WP calls under test; swallowing
+    // them as "unmocked" 404s makes the route's first DB query fail and
+    // the test asserts on a 500 instead of the real status it expects.
+    return originalFetch(input, init);
   }) as unknown as typeof fetch;
 }
 


### PR DESCRIPTION
## Summary

Cluster A of the M13 test triage. Two route-test files install a `globalThis.fetch` mock that returned `"unmocked: ${url}"` 404s for any URL not matching their WP-prefix table — but the supabase-js client used by the route handlers shares `globalThis.fetch`, so its REST calls to `http://127.0.0.1:54321/rest/v1/...` were getting swallowed too. Routes saw the fake error on their first DB query and bailed with 500, masking the status code each test was actually asserting on (200 / 403 / 409, etc.).

Both tests now fall through to the captured `originalFetch` when no WP prefix matches. WP traffic stays mocked; supabase calls hit the real local stack `supabase start` already provides.

Affects **13 of the 19 main-branch test failures** captured in CI run [24965428048](https://github.com/opollo5/opollo-site-builder/actions/runs/24965428048):

- `lib/__tests__/posts-publish-routes.test.ts` (PR #151 / m13-4) — 4 tests
- `lib/__tests__/appearance-sync-routes.test.ts` (PR #154 / m13-5c) — 9 tests

## Risks identified and mitigated

- **Regression: silently swallowed assertions.** The previous `unmocked-404` was a fail-loud default. If any test asserted *"we never call URL X"*, that assertion is now silent (the call succeeds via the real fetch). Grep across both files shows no such assertion — every test inspects route response status / body, not call counts on the mocked URL set. **Mitigated**: ripgrep'd `expect(globalThis.fetch).toHaveBeenCalled` / `mockFetch.mock.calls` patterns; none in either file.
- **Local stack drift.** Pass-through requires `supabase start` to be running for the test to succeed. That's already the contract for both files (they use `getServiceRoleClient()` against `127.0.0.1:54321` for fixture seeding). No additional setup demanded.
- **Cross-test interference.** `afterEach` already restores `globalThis.fetch = originalFetch`; the change preserves that contract. Pass-through only applies inside the mock window.

## Test plan

- [x] `npm run lint` ✓
- [x] `npm run typecheck` ✓
- [ ] CI: `posts-publish-routes` + `appearance-sync-routes` go from 13 failing -> 0 failing
- [ ] CI: no other test starts failing (no fall-through-induced flake)

Out of scope: kadence-mapper (Cluster B), kadence-palette-sync-lib (Cluster C), E2E (pre-existing). Each gets its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)