### PR TITLE
fix(audit): kadence-mapper test inputs match parser's per-line contract

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,29 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## Existing CI E2E suite has been red since at least PR #149 (deferred from audit triage, 2026-04-27)
+
+**Tags:** `e2e`, `ci`, `audit`
+
+**What:** The `E2E` GitHub Actions workflow (Playwright against `supabase start` + `next dev`) has been failing on `main` continuously since commit `cbc1127` (PR #149, 2026-04-24 10:59 UTC) — predates the M13 work. Auto-merge on every PR since has fired despite this, because branch protection doesn't gate on E2E. Distinct from the unit-test failures fixed in PRs #166 / 167 / 168 — those traced to specific m13-* PRs and have known root causes; this E2E redness is older and uninvestigated.
+
+**Why deferred:** Audit triage scope was the 19 vitest failures introduced by m13 PRs. Diagnosing the E2E failure requires reading the failed Playwright report (different log shape, different fixtures, different stack), and the four unit-test clusters were the higher-leverage fix — they cover the same write-paths at the route layer. Risk is acceptable while no paying customer hits the WP-publish path.
+
+**Trigger:** Pick this up when ANY of:
+- First paying customer onboards (the unit-layer mocks stop being a sufficient safety net once a real operator hits these paths).
+- A WP-talking write-path regression escapes both unit + manual smoke.
+- Auto-merge is tightened to require the E2E check to pass (would block all future PRs until E2E is green).
+
+**Scope:**
+- Pull the most recent failed E2E artifact from CI; identify whether the failure is in setup (supabase migrations, env), in the test itself (selector drift, timing), or in a real regression.
+- If setup or test drift: fix in place.
+- If a real regression: bisect against `cbc1127` to find the offending change.
+- Document outcome in the PR; if root cause spans multiple PRs, peel into separate fixes.
+
+**Size:** Unknown — could be a 30-min fixture fix or a multi-day bisect. Read the artifact first to size.
+
+---
+
 ## Staging-environment E2E for sync confirm + actual WP publish (deferred from M13-6b, 2026-04-26)
 
 **Tags:** `e2e`, `staging`, `wp-integration`

--- a/lib/__tests__/kadence-mapper.test.ts
+++ b/lib/__tests__/kadence-mapper.test.ts
@@ -93,8 +93,13 @@ describe("parsePaletteTokens", () => {
   });
 
   it("preserves alpha in #RGBA and #RRGGBBAA", () => {
+    // Multi-line: parser requires one declaration per line (DECLARATION_RE
+    // anchors on `^\s*--`).
     const tokens = parsePaletteTokens(
-      `.scope { --x-a: #abcd; --x-b: #aabbccdd; }`,
+      `.scope {
+        --x-a: #abcd;
+        --x-b: #aabbccdd;
+      }`,
       "x",
     );
     expect(tokens[0]?.color).toBe("#AABBCCDD");
@@ -137,7 +142,12 @@ describe("parsePaletteTokens", () => {
   });
 
   it("handles property names without matching the prefix — label falls back to full name", () => {
-    const tokens = parsePaletteTokens(`.scope { --random-thing: #111222; }`, "ls");
+    const tokens = parsePaletteTokens(
+      `.scope {
+        --random-thing: #111222;
+      }`,
+      "ls",
+    );
     expect(tokens[0]?.label).toBe("Random thing");
   });
 


### PR DESCRIPTION
## Summary

Cluster B of the M13 audit triage. Two `parsePaletteTokens` tests fed the parser single-line CSS:

```ts
parsePaletteTokens(`.scope { --x-a: #abcd; --x-b: #aabbccdd; }`, "x")
```

…but the parser's `DECLARATION_RE` anchors with `^\s*--` — it only matches lines whose **first** non-whitespace token is a CSS custom property. The passing tests elsewhere in this file all use the multi-line shape that matches the parser's documented "one declaration per line" contract (`lib/kadence-mapper.ts:93-99`). These two were inconsistent with the rest of the file.

## Impl-vs-test call: **test bug, not impl bug**

Both behaviors the tests intend to cover are real and already implemented:

- **Alpha hex preservation** — `normalizeHex` (`lib/kadence-mapper.ts:117-131`) expands `#RGBA` to `#RRGGBBAA` and uppercases. Verified by reading the function.
- **Label fallback when prefix doesn't match** — `labelFromPropertyName` (`lib/kadence-mapper.ts:137-145`) returns the un-prefixed property name title-cased. Verified by reading the function.

The tests never reached either branch because the regex never matched the line. Rewriting the inputs to multi-line is the smaller, safer fix vs. relaxing the parser to accept inline declarations (which would be a real behavior change with no production caller asking for it).

The parser's per-line contract matches the seed-file format the production design systems emit (`seed/leadsource/tokens.css` is multi-line). If a future DS lands with inline declarations, hardening the parser is its own slice — no production caller would benefit today.

Also adds a BACKLOG entry for the existing E2E suite redness (predates M13; out of scope for this triage; picked up at first paying customer).

## Risks identified and mitigated

- **Risk: I'm covering a real impl bug by changing the test.** Read both functions end-to-end and confirmed they handle the cases the tests assert on. Spot-checked with the input format other passing tests use — same parsing, behavior matches expectations.
- **Risk: BACKLOG entry conflicts with the existing M13-6b E2E entry.** That entry is about *adding* staging-WP E2E coverage for sync-confirm + actual-publish round-trips. The new entry is about *the existing suite being red since PR #149*. Different scope, different trigger.

## Test plan

- [x] `npm run lint` ✓
- [x] `npm run typecheck` ✓
- [ ] CI: `kadence-mapper.test.ts` 2 failing → 0 failing
- [ ] CI: total failing tests drops 15 → 13

Out of scope: kadence-palette-sync-lib (Cluster C) — separate PR with full risks audit since it's a real write-path logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)