### PR TITLE
chore: cluster-C diagnostic (DRAFT — do not merge)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,29 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## Existing CI E2E suite has been red since at least PR #149 (deferred from audit triage, 2026-04-27)
+
+**Tags:** `e2e`, `ci`, `audit`
+
+**What:** The `E2E` GitHub Actions workflow (Playwright against `supabase start` + `next dev`) has been failing on `main` continuously since commit `cbc1127` (PR #149, 2026-04-24 10:59 UTC) — predates the M13 work. Auto-merge on every PR since has fired despite this, because branch protection doesn't gate on E2E. Distinct from the unit-test failures fixed in PRs #166 / 167 / 168 — those traced to specific m13-* PRs and have known root causes; this E2E redness is older and uninvestigated.
+
+**Why deferred:** Audit triage scope was the 19 vitest failures introduced by m13 PRs. Diagnosing the E2E failure requires reading the failed Playwright report (different log shape, different fixtures, different stack), and the four unit-test clusters were the higher-leverage fix — they cover the same write-paths at the route layer. Risk is acceptable while no paying customer hits the WP-publish path.
+
+**Trigger:** Pick this up when ANY of:
+- First paying customer onboards (the unit-layer mocks stop being a sufficient safety net once a real operator hits these paths).
+- A WP-talking write-path regression escapes both unit + manual smoke.
+- Auto-merge is tightened to require the E2E check to pass (would block all future PRs until E2E is green).
+
+**Scope:**
+- Pull the most recent failed E2E artifact from CI; identify whether the failure is in setup (supabase migrations, env), in the test itself (selector drift, timing), or in a real regression.
+- If setup or test drift: fix in place.
+- If a real regression: bisect against `cbc1127` to find the offending change.
+- Document outcome in the PR; if root cause spans multiple PRs, peel into separate fixes.
+
+**Size:** Unknown — could be a 30-min fixture fix or a multi-day bisect. Read the artifact first to size.
+
+---
+
 ## Staging-environment E2E for sync confirm + actual WP publish (deferred from M13-6b, 2026-04-26)
 
 **Tags:** `e2e`, `staging`, `wp-integration`

--- a/lib/__tests__/kadence-mapper.test.ts
+++ b/lib/__tests__/kadence-mapper.test.ts
@@ -93,8 +93,13 @@ describe("parsePaletteTokens", () => {
   });
 
   it("preserves alpha in #RGBA and #RRGGBBAA", () => {
+    // Multi-line: parser requires one declaration per line (DECLARATION_RE
+    // anchors on `^\s*--`).
     const tokens = parsePaletteTokens(
-      `.scope { --x-a: #abcd; --x-b: #aabbccdd; }`,
+      `.scope {
+        --x-a: #abcd;
+        --x-b: #aabbccdd;
+      }`,
       "x",
     );
     expect(tokens[0]?.color).toBe("#AABBCCDD");
@@ -137,7 +142,12 @@ describe("parsePaletteTokens", () => {
   });
 
   it("handles property names without matching the prefix — label falls back to full name", () => {
-    const tokens = parsePaletteTokens(`.scope { --random-thing: #111222; }`, "ls");
+    const tokens = parsePaletteTokens(
+      `.scope {
+        --random-thing: #111222;
+      }`,
+      "ls",
+    );
     expect(tokens[0]?.label).toBe("Random thing");
   });
 

--- a/lib/__tests__/kadence-palette-sync-lib.test.ts
+++ b/lib/__tests__/kadence-palette-sync-lib.test.ts
@@ -10,6 +10,11 @@ import { getServiceRoleClient } from "@/lib/supabase";
 
 import { seedSite } from "./_helpers";
 
+// DIAGNOSTIC (cluster-c repro, revert in fix PR): capture global.fetch at
+// file load time so the failing test can detect whether some other test
+// file leaked a mock onto globalThis.fetch.
+const originalFetchAtFileLoad = globalThis.fetch;
+
 // ---------------------------------------------------------------------------
 // M13-5c — unit tests for pure helpers + the CAS-stamping helper.
 //
@@ -104,6 +109,42 @@ describe("stampFirstDetection — CAS + idempotency", () => {
       .select("version_lock, kadence_installed_at")
       .eq("id", site.id)
       .single();
+    // DIAGNOSTIC (cluster-c repro, revert in fix PR): dump everything
+    // we'd need to distinguish schema-cache-stale, fetch-mock-leak,
+    // seedSite race, or a real lib defect.
+    // eslint-disable-next-line no-console
+    console.log(
+      "DEBUG_C1 " +
+        JSON.stringify({
+          site_id: site.id,
+          beforeError: before.error,
+          beforeData: before.data,
+          beforeStatus: before.status,
+          keysOnRow: before.data ? Object.keys(before.data) : null,
+          fetchIsMocked: globalThis.fetch !== originalFetchAtFileLoad,
+          fetchName:
+            typeof globalThis.fetch === "function"
+              ? globalThis.fetch.name
+              : typeof globalThis.fetch,
+        }),
+    );
+    // Also dump the raw row via SELECT * to compare.
+    const star = await svc
+      .from("sites")
+      .select("*")
+      .eq("id", site.id)
+      .single();
+    // eslint-disable-next-line no-console
+    console.log(
+      "DEBUG_C1_STAR " +
+        JSON.stringify({
+          starError: star.error,
+          starKeys: star.data ? Object.keys(star.data).sort() : null,
+          star_kadence_installed_at: star.data
+            ? (star.data as Record<string, unknown>).kadence_installed_at
+            : "<no data>",
+        }),
+    );
     expect(before.data?.kadence_installed_at).toBeNull();
     const origLock = before.data?.version_lock as number;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "pg": "^8.20.0",
         "postcss": "^8.4.47",
         "stylelint": "^17.8.0",
+        "supabase": "^2.95.3",
         "tailwindcss": "^3.4.13",
         "tsx": "^4.21.0",
         "typescript": "^5.6.2",
@@ -1710,6 +1711,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -5807,6 +5821,23 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bin-links": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
+      "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -6069,6 +6100,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -6295,6 +6336,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmd-shim": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
+      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/color-convert": {
@@ -6573,6 +6624,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/data-view-buffer": {
@@ -7711,6 +7772,30 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fetch-retry": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
@@ -7818,6 +7903,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded-parse": {
@@ -10294,6 +10392,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -10462,6 +10573,27 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -10524,6 +10656,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -11321,6 +11463,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -11437,6 +11589,16 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/read-cmd-shim": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/readdirp": {
@@ -12716,6 +12878,69 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/supabase": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.95.3.tgz",
+      "integrity": "sha512-KsAEOmmZsnO8WYP8nI9LhXwLExcGgoPpIUrFnxm56eDsAaeBUiGJRMG6nerMuv/rDvqFByco16Po3IhUnFPpmQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bin-links": "^6.0.0",
+        "https-proxy-agent": "^9.0.0",
+        "node-fetch": "^3.3.2",
+        "tar": "7.5.13"
+      },
+      "bin": {
+        "supabase": "bin/supabase"
+      },
+      "engines": {
+        "npm": ">=8"
+      }
+    },
+    "node_modules/supabase/node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/supabase/node_modules/https-proxy-agent": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
+      "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/supabase/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12921,6 +13146,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/terser": {
@@ -13644,6 +13896,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "pg": "^8.20.0",
     "postcss": "^8.4.47",
     "stylelint": "^17.8.0",
+    "supabase": "^2.95.3",
     "tailwindcss": "^3.4.13",
     "tsx": "^4.21.0",
     "typescript": "^5.6.2",


### PR DESCRIPTION
Throwaway diagnostic branch to surface the actual SELECT shape + fetch-mock state in CI for the kadence-palette-sync-lib test failure.

**This PR will NOT be merged.** Once CI runs, I'll read the diagnostic log via `gh run view --log`, identify the root cause, then revert this branch and ship the targeted fix in a separate PR.