### PR TITLE
fix(audit): add sites.version_lock + logger.error on silent INTERNAL_ERROR

### DIFF
--- a/app/api/sites/[id]/appearance/preflight/route.ts
+++ b/app/api/sites/[id]/appearance/preflight/route.ts
@@ -114,6 +114,11 @@ export async function POST(
     if (ctxRes.code === "WP_REST_UNREACHABLE") {
       return envelope("WP_API_ERROR", ctxRes.message, 502, ctxRes.details);
     }
+    logger.error("appearance.preflight.context_internal_error", {
+      site_id: idCheck.value,
+      ctx_code: ctxRes.code,
+      ctx_message: ctxRes.message,
+    });
     return envelope("INTERNAL_ERROR", ctxRes.message, 500);
   }
 

--- a/app/api/sites/[id]/appearance/rollback-palette/route.ts
+++ b/app/api/sites/[id]/appearance/rollback-palette/route.ts
@@ -12,6 +12,7 @@ import {
   buildPaletteSyncContext,
   rollbackPalette,
 } from "@/lib/kadence-palette-sync";
+import { logger } from "@/lib/logger";
 import { preflightSitePublish } from "@/lib/site-preflight";
 
 // ---------------------------------------------------------------------------
@@ -104,6 +105,11 @@ export async function POST(
     if (ctxRes.code === "WP_REST_UNREACHABLE") {
       return envelope("WP_API_ERROR", ctxRes.message, 502, ctxRes.details);
     }
+    logger.error("appearance.rollback_palette.context_internal_error", {
+      site_id: idCheck.value,
+      ctx_code: ctxRes.code,
+      ctx_message: ctxRes.message,
+    });
     return envelope("INTERNAL_ERROR", ctxRes.message, 500);
   }
 
@@ -145,6 +151,11 @@ export async function POST(
     if (result.code === "WP_WRITE_FAILED") {
       return envelope("WP_API_ERROR", result.message, 502, result.details);
     }
+    logger.error("appearance.rollback_palette.execute_internal_error", {
+      site_id: idCheck.value,
+      result_code: result.code,
+      result_message: result.message,
+    });
     return envelope("INTERNAL_ERROR", result.message, 500);
   }
 

--- a/app/api/sites/[id]/appearance/sync-palette/route.ts
+++ b/app/api/sites/[id]/appearance/sync-palette/route.ts
@@ -13,6 +13,7 @@ import {
   confirmedPaletteSync,
   paletteDryRunFromContext,
 } from "@/lib/kadence-palette-sync";
+import { logger } from "@/lib/logger";
 import { preflightSitePublish } from "@/lib/site-preflight";
 
 // ---------------------------------------------------------------------------
@@ -115,6 +116,11 @@ export async function POST(
     if (ctxRes.code === "WP_REST_UNREACHABLE") {
       return envelope("WP_API_ERROR", ctxRes.message, 502, ctxRes.details);
     }
+    logger.error("appearance.sync_palette.context_internal_error", {
+      site_id: idCheck.value,
+      ctx_code: ctxRes.code,
+      ctx_message: ctxRes.message,
+    });
     return envelope("INTERNAL_ERROR", ctxRes.message, 500);
   }
 
@@ -183,6 +189,11 @@ export async function POST(
     if (result.code === "WP_WRITE_FAILED") {
       return envelope("WP_API_ERROR", result.message, 502, result.details);
     }
+    logger.error("appearance.sync_palette.confirm_internal_error", {
+      site_id: idCheck.value,
+      result_code: result.code,
+      result_message: result.message,
+    });
     return envelope("INTERNAL_ERROR", result.message, 500);
   }
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,29 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## Pattern audit — silent INTERNAL_ERROR fallbacks across all routes (deferred from audit triage, 2026-04-27)
+
+**Tags:** `audit`, `observability`, `discipline`
+
+**What:** The Cluster C audit (PR #169) found that every appearance route had a silent `INTERNAL_ERROR` envelope fallback — `return envelope("INTERNAL_ERROR", ctxRes.message, 500)` with no preceding `logger.error`. That pattern hid a missing-column schema bug from CI logs for ~3 days; production operators saw a 500 toast with zero diagnostic trail. The fix shipped `logger.error` calls at 11 sites across `lib/kadence-palette-sync.ts` and the three appearance routes, but other route handlers in the codebase likely have the same anti-pattern.
+
+**Why deferred:** Cluster C scope was the 12 known failing tests + the immediate fix. A repo-wide sweep is its own slice — could touch 20+ files and would benefit from a lint rule rather than just a manual fix.
+
+**Trigger:** Any of:
+- Another silent-500 incident escapes to production / UAT.
+- Before first paying customer onboards (observability floor for support).
+- A natural pause between milestones where infra/discipline work fits.
+
+**Scope:**
+- Grep the codebase for `envelope\("INTERNAL_ERROR"` and `code: "INTERNAL_ERROR"` returns.
+- For every match, verify either (a) the catch-all has a `logger.error` immediately before it, or (b) the underlying error already gets logged somewhere upstream. Add `logger.error` everywhere case (a) doesn't already hold.
+- Consider an ESLint rule (`no-silent-internal-error`) that flags the pattern. The rule can match returns where `code: "INTERNAL_ERROR"` is set without a `logger.error` call in the same block.
+- Ship as one or more PRs depending on count. Each PR is grep + boilerplate add — small per-file but fans out.
+
+**Size:** Small per-file, possibly 20+ files. ~half a day if no surprises. ESLint rule is its own slice (separate PR, ~1 day) but the manual sweep should land first since it's the diagnostic floor.
+
+---
+
 ## Existing CI E2E suite has been red since at least PR #149 (deferred from audit triage, 2026-04-27)
 
 **Tags:** `e2e`, `ci`, `audit`

--- a/lib/kadence-palette-sync.ts
+++ b/lib/kadence-palette-sync.ts
@@ -138,6 +138,11 @@ export async function buildPaletteSyncContext(
         message: siteRes.error.message,
       };
     }
+    logger.error("kadence_palette_sync.context.get_site_failed", {
+      site_id,
+      get_site_code: siteRes.error.code,
+      get_site_message: siteRes.error.message,
+    });
     return {
       ok: false,
       code: "INTERNAL_ERROR",
@@ -172,6 +177,11 @@ export async function buildPaletteSyncContext(
     .eq("id", site_id)
     .single();
   if (versionRes.error || !versionRes.data) {
+    logger.error("kadence_palette_sync.context.version_lock_read_failed", {
+      site_id,
+      error: versionRes.error ?? null,
+      had_data: Boolean(versionRes.data),
+    });
     return {
       ok: false,
       code: "INTERNAL_ERROR",
@@ -188,6 +198,10 @@ export async function buildPaletteSyncContext(
     .eq("status", "active")
     .maybeSingle();
   if (dsRes.error) {
+    logger.error("kadence_palette_sync.context.design_systems_read_failed", {
+      site_id,
+      error: dsRes.error,
+    });
     return {
       ok: false,
       code: "INTERNAL_ERROR",
@@ -305,9 +319,16 @@ export async function stampFirstDetection(opts: {
     .eq("id", opts.site_id)
     .maybeSingle();
   if (before.error) {
+    logger.error("kadence_palette_sync.stamp.before_select_failed", {
+      site_id: opts.site_id,
+      error: before.error,
+    });
     return { ok: false, code: "INTERNAL_ERROR", message: before.error.message };
   }
   if (!before.data) {
+    logger.error("kadence_palette_sync.stamp.site_vanished", {
+      site_id: opts.site_id,
+    });
     return { ok: false, code: "INTERNAL_ERROR", message: "Site vanished." };
   }
   if (before.data.kadence_installed_at) {
@@ -334,6 +355,11 @@ export async function stampFirstDetection(opts: {
     .select("version_lock")
     .maybeSingle();
   if (upd.error) {
+    logger.error("kadence_palette_sync.stamp.cas_update_failed", {
+      site_id: opts.site_id,
+      expected_version_lock: opts.expected_version_lock,
+      error: upd.error,
+    });
     return { ok: false, code: "INTERNAL_ERROR", message: upd.error.message };
   }
   if (!upd.data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "pg": "^8.20.0",
         "postcss": "^8.4.47",
         "stylelint": "^17.8.0",
+        "supabase": "^2.95.3",
         "tailwindcss": "^3.4.13",
         "tsx": "^4.21.0",
         "typescript": "^5.6.2",
@@ -1710,6 +1711,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -5807,6 +5821,23 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bin-links": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
+      "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -6069,6 +6100,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -6295,6 +6336,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmd-shim": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
+      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/color-convert": {
@@ -6573,6 +6624,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/data-view-buffer": {
@@ -7711,6 +7772,30 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fetch-retry": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
@@ -7818,6 +7903,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded-parse": {
@@ -10294,6 +10392,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -10462,6 +10573,27 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -10524,6 +10656,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -11321,6 +11463,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -11437,6 +11589,16 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/read-cmd-shim": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/readdirp": {
@@ -12716,6 +12878,69 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/supabase": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.95.3.tgz",
+      "integrity": "sha512-KsAEOmmZsnO8WYP8nI9LhXwLExcGgoPpIUrFnxm56eDsAaeBUiGJRMG6nerMuv/rDvqFByco16Po3IhUnFPpmQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bin-links": "^6.0.0",
+        "https-proxy-agent": "^9.0.0",
+        "node-fetch": "^3.3.2",
+        "tar": "7.5.13"
+      },
+      "bin": {
+        "supabase": "bin/supabase"
+      },
+      "engines": {
+        "npm": ">=8"
+      }
+    },
+    "node_modules/supabase/node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/supabase/node_modules/https-proxy-agent": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
+      "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/supabase/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12921,6 +13146,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/terser": {
@@ -13644,6 +13896,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "pg": "^8.20.0",
     "postcss": "^8.4.47",
     "stylelint": "^17.8.0",
+    "supabase": "^2.95.3",
     "tailwindcss": "^3.4.13",
     "tsx": "^4.21.0",
     "typescript": "^5.6.2",

--- a/supabase/migrations/0025_audit_sites_version_lock.sql
+++ b/supabase/migrations/0025_audit_sites_version_lock.sql
@@ -1,0 +1,39 @@
+-- 0025 — Audit fix: add version_lock to sites.
+--
+-- Reference: AUDIT triage, 2026-04-27. PR #154 (m13-5c) shipped
+-- lib/kadence-palette-sync.ts referencing sites.version_lock for CAS
+-- across stampFirstDetection / confirmedPaletteSync / rollbackPalette,
+-- but migration 0022 (m13-5a) added kadence_installed_at +
+-- kadence_globals_synced_at WITHOUT also folding sites into the
+-- version_lock convention. PostgREST therefore returned 42703
+-- ("column sites.version_lock does not exist") on every CAS call,
+-- which the routes swallowed as a silent INTERNAL_ERROR (500).
+--
+-- Production impact: zero. Operator clicks on the Appearance panel
+-- got an error toast but no WP write happened — the lib aborts at
+-- the first SELECT. Verified before this migration via:
+--   SELECT id, kadence_installed_at, kadence_globals_synced_at
+--   FROM sites WHERE kadence_installed_at IS NOT NULL OR
+--   kadence_globals_synced_at IS NOT NULL;  -- 0 rows
+--   SELECT site_id, event FROM appearance_events
+--   WHERE event IN ('install_completed', 'globals_completed');  -- 0 rows
+--
+-- Forward-only: sites is otherwise an older table that predates the
+-- DATA_CONVENTIONS audit columns. This adds JUST version_lock — the
+-- minimum to unblock M13-5 routes. The wider audit/soft-delete fold-in
+-- is intentionally deferred (separate slice; sites is the central
+-- table and a wider change deserves its own PR).
+--
+-- Backfill: NOT NULL DEFAULT 1 means existing rows get version_lock=1
+-- atomically as part of the ALTER. No data migration required. Any
+-- code path that doesn't set the column on UPDATE leaves it at 1
+-- forever, which is fine — the only callers that CAS on it are the
+-- M13-5 routes (which now work correctly), and any future call sites
+-- will read-then-write under CAS.
+
+ALTER TABLE sites
+  ADD COLUMN version_lock integer NOT NULL DEFAULT 1
+    CHECK (version_lock >= 1);
+
+COMMENT ON COLUMN sites.version_lock IS
+  'Optimistic concurrency counter per docs/DATA_CONVENTIONS.md. Incremented on every mutating UPDATE through CAS (eq("version_lock", expected) + version_lock: expected+1). Conflict returns 409 / VERSION_CONFLICT. Added 2026-04-27 (audit fix: M13-5c shipped lib code referencing this column without the schema migration).';


### PR DESCRIPTION
## Summary

Cluster C of the M13 audit triage. The CI diagnostic on PR #168 captured the smoking gun: every CAS call against the `sites` table errored with PostgREST `42703` (`"column sites.version_lock does not exist"`). PR #154 (m13-5c) shipped `lib/kadence-palette-sync.ts` referencing `sites.version_lock` for CAS in `stampFirstDetection`, `confirmedPaletteSync`, and `rollbackPalette` — but migration 0022 (m13-5a) folded only `kadence_installed_at` + `kadence_globals_synced_at` into `sites`; it never added `version_lock`. The lib's lookup errored before any WP write, the routes returned a silent `INTERNAL_ERROR` 500, and the bug hid in plain sight on red CI for ~3 days.

## What lands

- **`supabase/migrations/0025_audit_sites_version_lock.sql`** — adds `version_lock integer NOT NULL DEFAULT 1 CHECK (version_lock >= 1)` to `sites`, matching the convention used by `design_systems` / `posts` / `image_library`.
- **Lib code unchanged.** The lib was correct; the schema was missing the column it referenced.
- **`logger.error` on every silent `INTERNAL_ERROR` fallback (Phase 3 of the audit plan):**
  - `lib/kadence-palette-sync.ts` — 6 sites (`buildPaletteSyncContext` getSite / version_lock / design_systems readers; `stampFirstDetection` before-select / vanished / cas-update).
  - `app/api/sites/[id]/appearance/preflight/route.ts` — 1 site (context fallback).
  - `app/api/sites/[id]/appearance/sync-palette/route.ts` — 2 sites (context fallback + confirm-result fallback).
  - `app/api/sites/[id]/appearance/rollback-palette/route.ts` — 2 sites (context fallback + execute-result fallback).
  - `logger` import added to the two route files that didn't have it.
- **`supabase` as devDependency.** Future devs / CI on a fresh checkout get the CLI via `npm ci`. No behaviour change in CI (`supabase/setup-cli` action still takes precedence on PATH).
- **`docs/BACKLOG.md` entry** for the codebase-wide pattern audit — silent `INTERNAL_ERROR` fallbacks across all routes (this PR seeds the pattern; sweep is its own slice).

## Production impact: zero

Verified pre-fix:
```sql
SELECT id, kadence_installed_at, kadence_globals_synced_at FROM sites
WHERE kadence_installed_at IS NOT NULL OR kadence_globals_synced_at IS NOT NULL;
-- 0 rows

SELECT site_id, event FROM appearance_events
WHERE event IN ('install_completed', 'globals_completed');
-- 0 rows
```
The lib aborts at the first SELECT every time, so no client WP site was mutated. Recovery scope: zero.

## Risks identified and mitigated

- **Risk: schema migration on a hot table.** `sites` is the central tenant table. **Mitigated**: forward-only `ALTER TABLE ... ADD COLUMN ... DEFAULT 1` is atomic in Postgres for fixed-default values; existing rows get `version_lock=1` instantly. No backfill, no downtime, no data migration.
- **Risk: other code expects `sites` to NOT have `version_lock`.** **Mitigated**: grep for `sites.version_lock` shows references only in `lib/kadence-palette-sync.ts` (the lib that was already broken) and the test files that were failing because of the missing column. No code path treats `version_lock` as forbidden on `sites`.
- **Risk: NEW callers will skip the CAS bump.** A row inserted via the existing `sites` insert paths gets `version_lock=1` from the column default, then any future UPDATE that doesn't read-then-CAS just leaves it at 1. The only callers that CAS on it today are the M13-5 routes (which now work). Future call sites will naturally adopt the read-then-CAS pattern; this is an additive forward-compatible change.
- **Risk: regressing on the M2c-2 / M3-7 pattern of "stamp version_lock at insert time."** **Mitigated**: insert paths don't need updating. PostgREST's INSERT with the new column DEFAULT means no app-side code change is needed for the column to populate correctly.
- **Risk: logger.error sites add log noise.** The new lines fire only on actual error conditions (DB errors, CAS misses on non-version-lock columns, etc.). Under normal operation they don't fire. Adds signal, not noise.
- **Risk: silent INTERNAL_ERROR pattern persists elsewhere.** This is an open audit finding, captured in BACKLOG. Not in scope for this PR (would touch ~20+ files). Phase 3 here seeds the discipline for the appearance routes; the sweep is the BACKLOG slice.
- **Risk: production sites already had `version_lock` set by some other path.** **Mitigated**: ALTER TABLE ADD COLUMN with NOT NULL DEFAULT 1 will fail if existing rows have any conflicting state (they don't, because the column doesn't exist). Verified via diagnostic CI run that production has no `kadence_globals_synced_at` set, so no orphan version_lock state.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm test` — verifies in CI. Expected: all 12 Cluster C tests pass; `kadence-palette-sync-lib.test.ts` 3-pack and `appearance-sync-routes.test.ts` 9-pack go from failing to passing.
- [ ] Total failing tests: 13 → 0 (combined with PRs #166 + #167, closes the 19-failure audit triage).

## Closes diagnostic PR

Diagnostic PR #168 will be closed without merge once CI on this PR confirms the diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)