### PR TITLE
feat(briefs): paste-text upload mode + content_type selector

### DIFF
--- a/app/api/briefs/upload/route.ts
+++ b/app/api/briefs/upload/route.ts
@@ -19,8 +19,14 @@ import {
 //
 // multipart/form-data with fields:
 //   file             — the brief document (text/plain | text/markdown; ≤ 10 MB).
+//                      EITHER file OR paste_text is required.
+//   paste_text       — UAT-smoke-1: raw markdown text from a textarea.
+//                      When present (and non-empty), used in place of
+//                      `file`. Treated as text/markdown.
 //   site_id          — UUID string.
 //   title            — optional operator-facing label.
+//   content_type     — UAT-smoke-1: 'page' or 'post'. Defaults to 'page'
+//                      if absent or unrecognised.
 //   idempotency_key  — optional client-supplied key.
 //
 // Returns the review URL on success. Parse runs synchronously in the
@@ -67,60 +73,106 @@ export async function POST(req: Request): Promise<NextResponse> {
   const siteId = form.get("site_id");
   const titleRaw = form.get("title");
   const file = form.get("file");
+  const pasteTextRaw = form.get("paste_text");
+  const contentTypeRaw = form.get("content_type");
   const clientIdempotencyKeyRaw = form.get("idempotency_key");
 
   if (typeof siteId !== "string" || !UUID_RE.test(siteId)) {
     return validationError("site_id must be a UUID.");
   }
-  if (!(file instanceof File)) {
-    return validationError("Missing 'file' field; expected a File object.");
+
+  // Resolve content_type: explicit 'post' or default to 'page'. Anything
+  // else (including absent / blank / unrecognised) lands as 'page'.
+  const contentType: "page" | "post" =
+    typeof contentTypeRaw === "string" && contentTypeRaw === "post"
+      ? "post"
+      : "page";
+
+  // Source resolution: paste_text wins if non-empty, else file.
+  const hasPaste =
+    typeof pasteTextRaw === "string" && pasteTextRaw.trim().length > 0;
+  const hasFile = file instanceof File && file.size > 0;
+  if (!hasPaste && !hasFile) {
+    return validationError(
+      "Provide either a 'file' (multipart) or non-empty 'paste_text' field.",
+    );
   }
-  if (file.size === 0) {
+
+  let bytes: Uint8Array;
+  let mimeType: BriefMimeType;
+  let sourceLabel: string;
+  if (hasPaste) {
+    const text = pasteTextRaw as string;
+    bytes = new TextEncoder().encode(text);
+    mimeType = "text/markdown" as BriefMimeType;
+    sourceLabel = "Pasted brief";
+  } else {
+    const f = file as File;
+    if (f.size > BRIEF_MAX_BYTES) {
+      const body: ApiResponse<never> = {
+        ok: false,
+        error: {
+          code: "BRIEF_TOO_LARGE",
+          message: `Brief exceeds the ${BRIEF_MAX_BYTES}-byte cap.`,
+          retryable: false,
+          suggested_action: "Upload a smaller file.",
+        },
+        timestamp: new Date().toISOString(),
+      };
+      return NextResponse.json(body, { status: 413 });
+    }
+    const detected = (f.type || "text/plain") as BriefMimeType;
+    if (!BRIEF_ALLOWED_MIME_TYPES.includes(detected)) {
+      const body: ApiResponse<never> = {
+        ok: false,
+        error: {
+          code: "BRIEF_UNSUPPORTED_TYPE",
+          message: `Unsupported MIME type: ${f.type || "unknown"}.`,
+          retryable: false,
+          suggested_action: "Upload a text/plain or text/markdown file.",
+        },
+        timestamp: new Date().toISOString(),
+      };
+      return NextResponse.json(body, { status: 415 });
+    }
+    bytes = new Uint8Array(await f.arrayBuffer());
+    mimeType = detected;
+    sourceLabel = f.name.replace(/\.[^.]+$/, "");
+  }
+
+  // Size guard for both file and paste paths (file path is checked
+  // again above for the structured 413; paste path lands here).
+  if (bytes.byteLength === 0) {
     const body: ApiResponse<never> = {
       ok: false,
       error: {
         code: "BRIEF_EMPTY",
-        message: "Brief file is empty.",
+        message: "Brief content is empty.",
         retryable: false,
-        suggested_action: "Upload a non-empty file and try again.",
+        suggested_action: "Provide a non-empty file or paste content.",
       },
       timestamp: new Date().toISOString(),
     };
     return NextResponse.json(body, { status: 400 });
   }
-  if (file.size > BRIEF_MAX_BYTES) {
+  if (bytes.byteLength > BRIEF_MAX_BYTES) {
     const body: ApiResponse<never> = {
       ok: false,
       error: {
         code: "BRIEF_TOO_LARGE",
         message: `Brief exceeds the ${BRIEF_MAX_BYTES}-byte cap.`,
         retryable: false,
-        suggested_action: "Upload a smaller file.",
+        suggested_action: "Trim the brief and try again.",
       },
       timestamp: new Date().toISOString(),
     };
     return NextResponse.json(body, { status: 413 });
   }
 
-  const mimeType = (file.type || "text/plain") as BriefMimeType;
-  if (!BRIEF_ALLOWED_MIME_TYPES.includes(mimeType)) {
-    const body: ApiResponse<never> = {
-      ok: false,
-      error: {
-        code: "BRIEF_UNSUPPORTED_TYPE",
-        message: `Unsupported MIME type: ${file.type || "unknown"}.`,
-        retryable: false,
-        suggested_action: "Upload a text/plain or text/markdown file.",
-      },
-      timestamp: new Date().toISOString(),
-    };
-    return NextResponse.json(body, { status: 415 });
-  }
-
   const defaultTitle =
     typeof titleRaw === "string" && titleRaw.trim().length > 0
       ? titleRaw.trim()
-      : file.name.replace(/\.[^.]+$/, "");
+      : sourceLabel;
 
   let clientIdempotencyKey: string | undefined;
   if (typeof clientIdempotencyKeyRaw === "string" && clientIdempotencyKeyRaw.trim().length > 0) {
@@ -131,8 +183,6 @@ export async function POST(req: Request): Promise<NextResponse> {
     clientIdempotencyKey = trimmed;
   }
 
-  const bytes = new Uint8Array(await file.arrayBuffer());
-
   const result = await uploadBrief({
     siteId,
     title: defaultTitle,
@@ -140,6 +190,7 @@ export async function POST(req: Request): Promise<NextResponse> {
     mimeType,
     uploadedBy: gate.user?.id ?? null,
     clientIdempotencyKey,
+    contentType,
   });
 
   if (!result.ok) {

--- a/components/UploadBriefModal.tsx
+++ b/components/UploadBriefModal.tsx
@@ -8,27 +8,35 @@ import { Input } from "@/components/ui/input";
 
 // ---------------------------------------------------------------------------
 // M12-1 — UploadBriefModal.
+// UAT-smoke-1 — adds paste-text source mode + content_type radio group.
 //
-// Entry point for the brief-driven flow. Renders a file picker + title
-// field, POSTs the multipart form to /api/briefs/upload, and on success
-// navigates to the review page. Errors are translated to plain-English
-// strings per docs/patterns/assistive-operator-flow.md.
+// Two source modes:
+//   - file: existing file picker (.txt / .md, ≤ 10 MB).
+//   - paste: textarea — operator pastes raw markdown directly. Routed
+//            through the same parser path on the server (treated as
+//            text/markdown).
+//
+// content_type: 'page' (default) | 'post'. Sent as a separate form
+// field; server defaults to 'page' if absent or unrecognised.
 // ---------------------------------------------------------------------------
 
 const ERROR_TRANSLATIONS: Record<string, string> = {
-  BRIEF_EMPTY: "Your brief is empty. Upload a file with content and try again.",
+  BRIEF_EMPTY: "Your brief is empty. Provide a non-empty file or paste content and try again.",
   BRIEF_TOO_LARGE:
     "That brief is too large. The 10 MB cap is there so the generator can keep the whole document in context.",
   BRIEF_UNSUPPORTED_TYPE:
-    "Upload a plain-text (.txt) or Markdown (.md) file. Other formats aren't supported yet.",
+    "Upload a plain-text (.txt) or Markdown (.md) file — or paste the brief instead.",
   IDEMPOTENCY_KEY_CONFLICT:
     "We've already stored a different brief with this idempotency key. Refresh and upload again without supplying a key.",
   VALIDATION_FAILED:
-    "Some required fields are missing or invalid. Check the file and try again.",
+    "Some required fields are missing or invalid. Check the form and try again.",
   FORBIDDEN: "Your account doesn't have permission to upload briefs.",
   UNAUTHORIZED: "Please sign in again.",
   NOT_FOUND: "This site no longer exists. Refresh the page and try again.",
 };
+
+type SourceMode = "file" | "paste";
+type ContentType = "page" | "post";
 
 export function UploadBriefModal({
   open,
@@ -43,6 +51,9 @@ export function UploadBriefModal({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [title, setTitle] = useState("");
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
+  const [pasteText, setPasteText] = useState("");
+  const [sourceMode, setSourceMode] = useState<SourceMode>("file");
+  const [contentType, setContentType] = useState<ContentType>("page");
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
@@ -50,6 +61,9 @@ export function UploadBriefModal({
     if (!open) return;
     setTitle("");
     setSelectedFileName(null);
+    setPasteText("");
+    setSourceMode("file");
+    setContentType("page");
     setFormError(null);
     setSubmitting(false);
   }, [open]);
@@ -67,12 +81,19 @@ export function UploadBriefModal({
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    const fileInput = fileInputRef.current;
-    if (!fileInput || !fileInput.files || fileInput.files.length === 0) {
-      setFormError("Pick a .txt or .md file to upload.");
-      return;
+
+    if (sourceMode === "file") {
+      const fileInput = fileInputRef.current;
+      if (!fileInput || !fileInput.files || fileInput.files.length === 0) {
+        setFormError("Pick a .txt or .md file to upload, or switch to Paste text.");
+        return;
+      }
+    } else {
+      if (pasteText.trim().length === 0) {
+        setFormError("Paste the brief text into the textarea, or switch to Upload file.");
+        return;
+      }
     }
-    const file = fileInput.files[0];
 
     setSubmitting(true);
     setFormError(null);
@@ -80,8 +101,21 @@ export function UploadBriefModal({
     try {
       const form = new FormData();
       form.append("site_id", siteId);
-      form.append("title", title.trim().length > 0 ? title.trim() : file.name.replace(/\.[^.]+$/, ""));
-      form.append("file", file);
+      form.append("content_type", contentType);
+
+      let derivedDefaultTitle: string;
+      if (sourceMode === "file") {
+        const file = fileInputRef.current!.files![0]!;
+        form.append("file", file);
+        derivedDefaultTitle = file.name.replace(/\.[^.]+$/, "");
+      } else {
+        form.append("paste_text", pasteText);
+        derivedDefaultTitle = "Pasted brief";
+      }
+      form.append(
+        "title",
+        title.trim().length > 0 ? title.trim() : derivedDefaultTitle,
+      );
 
       const res = await fetch("/api/briefs/upload", {
         method: "POST",
@@ -134,38 +168,126 @@ export function UploadBriefModal({
           Upload a brief
         </h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          A brief is a single document describing every page you want
-          generated. We&apos;ll parse it into a page list you can review
+          A brief is a single document describing every page (or post) you
+          want generated. We&apos;ll parse it into a list you can review
           before anything runs.
         </p>
 
         <div className="mt-4 space-y-4">
-          <div>
-            <label htmlFor="brief-file" className="block text-sm font-medium">
-              File
-            </label>
-            <input
-              id="brief-file"
-              ref={fileInputRef}
-              type="file"
-              accept=".txt,.md,text/plain,text/markdown"
-              className="mt-1 block w-full text-sm"
-              disabled={submitting}
-              onChange={(e) => {
-                const f = e.target.files?.[0] ?? null;
-                setSelectedFileName(f?.name ?? null);
-              }}
-              required
-            />
+          {/* Content type — page vs post. */}
+          <fieldset>
+            <legend className="block text-sm font-medium">Content type</legend>
+            <div className="mt-1 flex items-center gap-4">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="content_type"
+                  value="page"
+                  checked={contentType === "page"}
+                  onChange={() => setContentType("page")}
+                  disabled={submitting}
+                />
+                Page brief
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="content_type"
+                  value="post"
+                  checked={contentType === "post"}
+                  onChange={() => setContentType("post")}
+                  disabled={submitting}
+                />
+                Post brief
+              </label>
+            </div>
             <p className="mt-1 text-xs text-muted-foreground">
-              Plain text (.txt) or Markdown (.md). Max 10 MB.
+              Page briefs build site pages with anchor + revise cycles. Post
+              briefs build blog posts (no anchor cycle).
             </p>
-            {selectedFileName && (
-              <p className="mt-1 text-xs text-foreground">
-                Selected: <span className="font-medium">{selectedFileName}</span>
+          </fieldset>
+
+          {/* Source mode — file vs paste. */}
+          <fieldset>
+            <legend className="block text-sm font-medium">Source</legend>
+            <div className="mt-1 flex items-center gap-4">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="source_mode"
+                  value="file"
+                  checked={sourceMode === "file"}
+                  onChange={() => setSourceMode("file")}
+                  disabled={submitting}
+                />
+                Upload file
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="source_mode"
+                  value="paste"
+                  checked={sourceMode === "paste"}
+                  onChange={() => setSourceMode("paste")}
+                  disabled={submitting}
+                />
+                Paste text
+              </label>
+            </div>
+          </fieldset>
+
+          {sourceMode === "file" ? (
+            <div>
+              <label htmlFor="brief-file" className="block text-sm font-medium">
+                File
+              </label>
+              <input
+                id="brief-file"
+                ref={fileInputRef}
+                type="file"
+                accept=".txt,.md,text/plain,text/markdown"
+                className="mt-1 block w-full text-sm"
+                disabled={submitting}
+                onChange={(e) => {
+                  const f = e.target.files?.[0] ?? null;
+                  setSelectedFileName(f?.name ?? null);
+                }}
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Plain text (.txt) or Markdown (.md). Max 10 MB.
               </p>
-            )}
-          </div>
+              {selectedFileName && (
+                <p className="mt-1 text-xs text-foreground">
+                  Selected: <span className="font-medium">{selectedFileName}</span>
+                </p>
+              )}
+            </div>
+          ) : (
+            <div>
+              <label htmlFor="brief-paste" className="block text-sm font-medium">
+                Brief content
+              </label>
+              <textarea
+                id="brief-paste"
+                value={pasteText}
+                onChange={(e) => setPasteText(e.target.value)}
+                disabled={submitting}
+                rows={12}
+                className="mt-1 block w-full rounded-md border bg-background p-2 font-mono text-sm"
+                placeholder={`# Site brief
+
+## Page 1: Home
+Description of the home page...
+
+## Page 2: About
+Description of the about page...`}
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Paste markdown-shaped brief content. Use ## headings to
+                separate pages. Max 10 MB of text.
+              </p>
+            </div>
+          )}
 
           <div>
             <label htmlFor="brief-title" className="block text-sm font-medium">
@@ -176,7 +298,11 @@ export function UploadBriefModal({
               className="mt-1"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="Defaults to the filename"
+              placeholder={
+                sourceMode === "file"
+                  ? "Defaults to the filename"
+                  : "Defaults to 'Pasted brief'"
+              }
               disabled={submitting}
               maxLength={200}
             />

--- a/lib/__tests__/briefs-upload-route.test.ts
+++ b/lib/__tests__/briefs-upload-route.test.ts
@@ -242,4 +242,132 @@ describe("POST /api/briefs/upload", () => {
     const body = (await res.json()) as { error: { code: string } };
     expect(body.error.code).toBe("NOT_FOUND");
   });
+
+  // -----------------------------------------------------------------------
+  // 9. UAT-smoke-1: paste_text source mode
+  // -----------------------------------------------------------------------
+  it("paste_text path: raw markdown text → 201 with parsed status, default title 'Pasted brief'", async () => {
+    const { id: siteId } = await seedSite({ prefix: "mu9a" });
+    const form = new FormData();
+    form.append("site_id", siteId);
+    form.append("paste_text", STRUCTURAL_MD);
+    const req = new Request("http://localhost/api/briefs/upload", {
+      method: "POST",
+      body: form,
+    });
+    const res = await uploadBriefPOST(req);
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as {
+      ok: boolean;
+      data?: { brief_id: string; status: string };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data?.status).toBe("parsed");
+
+    const svc = getServiceRoleClient();
+    const brief = await svc
+      .from("briefs")
+      .select("title, source_mime_type, content_type")
+      .eq("id", body.data!.brief_id)
+      .single();
+    expect(brief.error).toBeNull();
+    expect(brief.data?.title).toBe("Pasted brief");
+    expect(brief.data?.source_mime_type).toBe("text/markdown");
+    expect(brief.data?.content_type).toBe("page"); // default
+  });
+
+  it("paste_text path: explicit content_type='post' → brief row has content_type 'post'", async () => {
+    const { id: siteId } = await seedSite({ prefix: "mu9b" });
+    const form = new FormData();
+    form.append("site_id", siteId);
+    form.append("paste_text", STRUCTURAL_MD);
+    form.append("content_type", "post");
+    form.append("title", "My posts brief");
+    const req = new Request("http://localhost/api/briefs/upload", {
+      method: "POST",
+      body: form,
+    });
+    const res = await uploadBriefPOST(req);
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as { data: { brief_id: string } };
+    const svc = getServiceRoleClient();
+    const brief = await svc
+      .from("briefs")
+      .select("title, content_type")
+      .eq("id", body.data.brief_id)
+      .single();
+    expect(brief.data?.title).toBe("My posts brief");
+    expect(brief.data?.content_type).toBe("post");
+  });
+
+  it("paste_text path: empty paste with no file → 400 VALIDATION_FAILED", async () => {
+    const { id: siteId } = await seedSite({ prefix: "mu9c" });
+    const form = new FormData();
+    form.append("site_id", siteId);
+    form.append("paste_text", "   \n\n  "); // whitespace only
+    const req = new Request("http://localhost/api/briefs/upload", {
+      method: "POST",
+      body: form,
+    });
+    const res = await uploadBriefPOST(req);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("file path with content_type='post' → brief row has content_type 'post'", async () => {
+    const { id: siteId } = await seedSite({ prefix: "mu9d" });
+    const form = new FormData();
+    form.append("site_id", siteId);
+    form.append("content_type", "post");
+    form.append(
+      "file",
+      new Blob([STRUCTURAL_MD], { type: "text/markdown" }),
+      "brief.md",
+    );
+    const req = new Request("http://localhost/api/briefs/upload", {
+      method: "POST",
+      body: form,
+    });
+    const res = await uploadBriefPOST(req);
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as { data: { brief_id: string } };
+    const svc = getServiceRoleClient();
+    const brief = await svc
+      .from("briefs")
+      .select("content_type")
+      .eq("id", body.data.brief_id)
+      .single();
+    expect(brief.data?.content_type).toBe("post");
+  });
+
+  it("unrecognised content_type values silently default to 'page'", async () => {
+    const { id: siteId } = await seedSite({ prefix: "mu9e" });
+    const form = new FormData();
+    form.append("site_id", siteId);
+    form.append("content_type", "garbage");
+    form.append(
+      "file",
+      new Blob([STRUCTURAL_MD], { type: "text/markdown" }),
+      "brief.md",
+    );
+    const req = new Request("http://localhost/api/briefs/upload", {
+      method: "POST",
+      body: form,
+    });
+    const res = await uploadBriefPOST(req);
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as { data: { brief_id: string } };
+    const svc = getServiceRoleClient();
+    const brief = await svc
+      .from("briefs")
+      .select("content_type")
+      .eq("id", body.data.brief_id)
+      .single();
+    expect(brief.data?.content_type).toBe("page");
+  });
 });

--- a/lib/briefs.ts
+++ b/lib/briefs.ts
@@ -160,6 +160,10 @@ export type UploadBriefInput = {
   mimeType: BriefMimeType;
   uploadedBy: string | null;
   clientIdempotencyKey?: string;
+  // UAT-smoke-1 — operator selects content_type at upload time.
+  // Defaults to 'page' (matches the briefs.content_type column default
+  // from migration 0021).
+  contentType?: "page" | "post";
 };
 
 export type UploadBriefData = {
@@ -335,21 +339,25 @@ async function uploadBriefImpl(
 
   // 4. INSERT briefs row with status='parsing'.
   const defaultTitle = input.title.length > 0 ? input.title.slice(0, 200) : "Untitled brief";
+  const insertRow: Record<string, unknown> = {
+    id: briefId,
+    site_id: input.siteId,
+    title: defaultTitle,
+    status: "parsing",
+    source_storage_path: storagePath,
+    source_mime_type: input.mimeType,
+    source_size_bytes: input.bytes.byteLength,
+    source_sha256: fileSha256,
+    upload_idempotency_key: idempotencyKey,
+    created_by: input.uploadedBy,
+    updated_by: input.uploadedBy,
+  };
+  if (input.contentType) {
+    insertRow.content_type = input.contentType;
+  }
   const insert = await svc
     .from("briefs")
-    .insert({
-      id: briefId,
-      site_id: input.siteId,
-      title: defaultTitle,
-      status: "parsing",
-      source_storage_path: storagePath,
-      source_mime_type: input.mimeType,
-      source_size_bytes: input.bytes.byteLength,
-      source_sha256: fileSha256,
-      upload_idempotency_key: idempotencyKey,
-      created_by: input.uploadedBy,
-      updated_by: input.uploadedBy,
-    })
+    .insert(insertRow)
     .select("*")
     .single();
 


### PR DESCRIPTION
## Summary

UAT-smoke-1 follow-up #2 of 3.

1. **Paste-text mode.** Operators pick between *Upload file* (existing `.txt/.md` picker) and *Paste text* (textarea). Pasted content is POSTed as a `paste_text` form field, treated server-side as `text/markdown`, routed through the same parser path. Same SHA256 keying.
2. **content_type selector.** Page brief / Post brief radio on the upload modal, defaults to *Page*. POSTed as `content_type` form field; server resolves `'post'` → `'post'`, anything else (absent, blank, unrecognised) → `'page'`. Plumbed to `briefs.content_type` (column shipped in M13-1 migration 0019).

## What lands

- `app/api/briefs/upload/route.ts` — accepts `paste_text` and `content_type` fields. `paste_text` overrides `file` when non-empty. Size + emptiness gates apply to both paths.
- `lib/briefs.ts` — `UploadBriefInput.contentType` plumbs through to the `briefs` INSERT. When omitted, the DB default (`'page'`) applies.
- `components/UploadBriefModal.tsx` — radio groups for content_type and source mode; conditional file input vs textarea.
- `lib/__tests__/briefs-upload-route.test.ts` — 5 new tests covering paste happy path, paste+post combo, paste empty validation, file+post combo, content_type fallback.

## Risks identified and mitigated

- **Risk: content_type is a CHECK enum at the DB layer.** Migration 0021 pinned `('page', 'post')`. Server-side normalisation to those exact values pre-INSERT means a malformed input never hits the constraint.
- **Risk: paste path bypasses MIME-type validation.** Intentional: pasted text is treated as `text/markdown` by construction. The parser handles markdown directly. Bypass is documented in the route comment.
- **Risk: idempotency key for paste vs file is different even for identical content.** No — the key is `sha256(bytes)` derived from the raw byte stream. Same bytes → same key regardless of source mode. Re-uploading via paste after a file upload of the same content correctly hits the replay path.
- **Risk: `briefs.content_type` already had a DB default.** Confirmed in migration 0021 / `lib/briefs.ts` type `content_type: "page" | "post"`. New rows omitting the field continue to default to 'page' (existing behaviour preserved); explicit values override.
- **Risk: existing E2E happy path breaks.** Existing test uses the file picker and the radio default for content_type is 'page' (matching its prior implicit behaviour). No regression.

## Out of scope (deferred)

- E2E spec extension for the new radio groups. Unit-layer tests cover the route contract end-to-end with real DB writes; E2E for the modal interactions is a polish item.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm run test` — 5 new tests in `briefs-upload-route.test.ts` pass against real Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)