### PR TITLE
feat(briefs): default model = Haiku 4.5; centralised model registry; freshness runbook

### DIFF
--- a/components/BriefReviewClient.tsx
+++ b/components/BriefReviewClient.tsx
@@ -7,32 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import type { BriefPageRow, BriefRow } from "@/lib/briefs";
-
-// Operator-facing labels for the Anthropic model allowlist. Kept
-// inline (not imported from lib/anthropic-pricing) because the display
-// copy is UI concern, not a data contract. If a new model is added to
-// the allowlist, this table gets a new row in the same PR.
-const MODEL_OPTIONS: Array<{
-  value: string;
-  label: string;
-  hint: string;
-}> = [
-  {
-    value: "claude-haiku-4-5-20251001",
-    label: "Haiku (fastest, cheapest)",
-    hint: "Best for simple copy or straightforward layouts. ~5-10× cheaper than Opus.",
-  },
-  {
-    value: "claude-sonnet-4-6",
-    label: "Sonnet (balanced — default)",
-    hint: "Default for both text and visual. Good quality, moderate cost.",
-  },
-  {
-    value: "claude-opus-4-7",
-    label: "Opus (highest quality, most expensive)",
-    hint: "Reserve for complex-judgment briefs. ~5× the cost of Sonnet.",
-  },
-];
+import { DEFAULT_MODEL_ID, MODEL_OPTIONS } from "@/lib/anthropic-models";
 
 // ---------------------------------------------------------------------------
 // M12-1 — client component for the brief-review page.
@@ -135,14 +110,14 @@ export function BriefReviewClient({
     brief.design_direction ?? "",
   );
   // M12-5 — operator picks model tiers at commit time. Default to the
-  // value the server committed the brief with; fall back to Sonnet when
-  // a pre-M12-4 row somehow has no value (defensive — migration 0020
-  // fills everything with 'claude-sonnet-4-6').
+  // value the server committed the brief with; fall back to the cheap
+  // default (Haiku) when a row has no value, so dev/UAT runs don't
+  // accidentally spend Sonnet/Opus money. Operator opts up explicitly.
   const [textModel, setTextModel] = useState<string>(
-    brief.text_model ?? "claude-sonnet-4-6",
+    brief.text_model ?? DEFAULT_MODEL_ID,
   );
   const [visualModel, setVisualModel] = useState<string>(
-    brief.visual_model ?? "claude-sonnet-4-6",
+    brief.visual_model ?? DEFAULT_MODEL_ID,
   );
 
   const isReadOnly = brief.status === "committed";

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -622,6 +622,62 @@ Keep the Quick-reference table in sync.
 
 ---
 
+## Anthropic releases a new model — adding it to the operator picker
+
+**Symptom:** A new Claude model family ships (e.g. Sonnet 4.7) and operators want to use it on briefs. Currently the model isn't in the picker on the brief review screen, and the runner refuses to call it (rejected by the `ANTHROPIC_MODEL_ALLOWLIST` validator with `INVALID_MODEL`).
+
+**Impact:** None on existing briefs. Operators can't opt INTO the new model until you onboard it.
+
+**Cadence:** Roughly quarterly. Don't onboard a new model the day it ships — let pricing settle and check the rate against `lib/anthropic-pricing.ts:PRICING_TABLE` for surprises.
+
+**Procedure (single PR, three files):**
+
+1. **`lib/anthropic-pricing.ts:PRICING_TABLE`** — add the new entry. Rates from Anthropic's pricing page, in **micro-cents per token** (1 cent = 1000 micro-cents). Example for a hypothetical Sonnet 4.7 at `$1.50` input / `$7.50` output / `$1.875` cache write / `$0.15` cache read per 1M tokens:
+   ```ts
+   "claude-sonnet-4-7": {
+     input: 1.5,           // 1500 cents per 1M = 1_500_000 micro-cents per 1M = 1.5 micro-cents per token
+     output: 7.5,
+     cache_write: 1.875,
+     cache_read: 0.15,
+   },
+   ```
+   Don't mutate existing entries; the `PRICING_VERSION` string at the top of the file pins which table priced any historical run.
+
+2. **`lib/anthropic-models.ts:MODEL_OPTIONS`** — add an operator-facing entry. Pick the right `tier` (haiku / sonnet / opus) based on price relative to the existing tiers. Order in the array drives the picker's display order. Example:
+   ```ts
+   {
+     value: "claude-sonnet-4-7",
+     label: "Sonnet 4.7 (balanced)",
+     hint: "Newer Sonnet generation. Use when Haiku reads thin and Opus is overkill.",
+     tier: "sonnet",
+   },
+   ```
+   The module's load-time check will throw if this id isn't in `ANTHROPIC_MODEL_ALLOWLIST` (which is derived from `PRICING_TABLE` keys), so step 1 must be done first.
+
+3. **`supabase/migrations/00NN_models_<name>.sql`** — extend the `briefs.text_model` and `briefs.visual_model` `CHECK` constraints to accept the new id. Pattern:
+   ```sql
+   ALTER TABLE briefs
+     DROP CONSTRAINT briefs_text_model_check,
+     ADD CONSTRAINT briefs_text_model_check CHECK (text_model IN (
+       'claude-opus-4-7',
+       'claude-sonnet-4-6',
+       'claude-sonnet-4-7',          -- NEW
+       'claude-haiku-4-5-20251001'
+     ));
+   -- repeat for briefs_visual_model_check.
+   ```
+
+**Verify:**
+- `npm run lint` + `npm run typecheck` clean.
+- `npm test -- briefs-upload-route` — model picker round-trips through commit + INSERT without DB CHECK rejection.
+- After deploy: navigate to a brief review page, confirm the new option appears in the picker, and that committing with the new id round-trips through the runner without `INVALID_MODEL`.
+
+**Don't forget:**
+- BACKLOG entry "Model list freshness" — update with the date you last ran this procedure so the next reviewer can see the most-recent cadence point.
+- If the new model deprecates an existing one (Anthropic announces sunset), keep the old id in the allowlist + CHECK until the deprecation date passes — existing briefs reference it.
+
+---
+
 ## CI/CD — Required checks and branch protection
 
 **E2E coverage is now a required check.** As of the E2E stabilisation work (PR #76 + branch-protection promotion), every PR to main must pass `npm run test:e2e` before auto-merge can fire.

--- a/lib/anthropic-models.ts
+++ b/lib/anthropic-models.ts
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------------
+// Anthropic model registry — single source of truth for the operator-
+// facing model picker + the default tier.
+//
+// UAT-smoke-1 — moved out of components/BriefReviewClient.tsx so the
+// list lives next to the pricing table (lib/anthropic-pricing.ts) and
+// the freshness procedure (docs/RUNBOOK.md → "Anthropic releases a
+// new model"). Adding a new model means updating THREE files in the
+// same PR:
+//   1. lib/anthropic-pricing.ts  — PRICING_TABLE entry (rates).
+//   2. lib/anthropic-models.ts   — this file (UI label + tier).
+//   3. supabase/migrations/00NN_models_*.sql — extend the
+//      briefs.text_model / briefs.visual_model CHECK constraints.
+//
+// Tier defaults to 'haiku' for development / UAT / cheap-by-default
+// runs (~5× cheaper than Sonnet). Operators opt INTO Sonnet or Opus
+// when they need higher quality.
+// ---------------------------------------------------------------------------
+
+import { ANTHROPIC_MODEL_ALLOWLIST } from "@/lib/anthropic-pricing";
+
+export type ModelTier = "haiku" | "sonnet" | "opus";
+
+export type ModelOption = {
+  /** Wire id matching the PRICING_TABLE key in lib/anthropic-pricing.ts. */
+  value: string;
+  /** Operator-facing label rendered in the picker. */
+  label: string;
+  /** Operator-facing hint/tooltip. */
+  hint: string;
+  /** Tier classification — drives default selection + sorting. */
+  tier: ModelTier;
+};
+
+export const MODEL_OPTIONS: ReadonlyArray<ModelOption> = Object.freeze([
+  {
+    value: "claude-haiku-4-5-20251001",
+    label: "Haiku (fastest, cheapest — default)",
+    hint: "Default for dev / UAT / simple briefs. ~5× cheaper than Sonnet, ~25× cheaper than Opus.",
+    tier: "haiku",
+  },
+  {
+    value: "claude-sonnet-4-6",
+    label: "Sonnet (balanced)",
+    hint: "Mid-tier. Use for production briefs where Haiku output reads thin.",
+    tier: "sonnet",
+  },
+  {
+    value: "claude-opus-4-7",
+    label: "Opus (highest quality, most expensive)",
+    hint: "Reserve for complex-judgment briefs. ~5× the cost of Sonnet.",
+    tier: "opus",
+  },
+]);
+
+/**
+ * Default model id for fresh brief runs. UAT-smoke-1: Haiku for
+ * cost-control. Operators can opt up to Sonnet/Opus per-brief on the
+ * review surface.
+ */
+export const DEFAULT_MODEL_ID = "claude-haiku-4-5-20251001";
+
+// Defense-in-depth: every option in this UI list must be in the
+// allowlist exported by lib/anthropic-pricing.ts. A drift between the
+// two lists would mean the picker offers a model the runner refuses.
+// Caught at module-load time so the build fails noisily rather than
+// shipping a broken picker. The check runs once per process.
+{
+  const driftedOptions = MODEL_OPTIONS.filter(
+    (o) => !ANTHROPIC_MODEL_ALLOWLIST.includes(o.value),
+  );
+  if (driftedOptions.length > 0) {
+    throw new Error(
+      `lib/anthropic-models.ts: MODEL_OPTIONS drift — ${driftedOptions
+        .map((o) => o.value)
+        .join(
+          ", ",
+        )} not in ANTHROPIC_MODEL_ALLOWLIST. Add to lib/anthropic-pricing.ts:PRICING_TABLE before the option appears in the picker.`,
+    );
+  }
+}

--- a/supabase/migrations/0027_briefs_model_default_haiku.sql
+++ b/supabase/migrations/0027_briefs_model_default_haiku.sql
@@ -1,0 +1,28 @@
+-- 0027 — Default brief model to Haiku 4.5.
+--
+-- Reference: UAT-smoke-1 BACKLOG entry "Default model selection —
+-- currently Sonnet 4.6, should be Haiku 4.5 for dev/test (deferred
+-- from UAT smoke 1, 2026-04-28)".
+--
+-- Migration 0020 set briefs.text_model + briefs.visual_model column
+-- defaults to 'claude-sonnet-4-6'. UAT smoke 1 surfaced the cost: at
+-- ~5× Haiku rates, every dev / UAT / sanity-check run ate Sonnet
+-- money for output the operator didn't need at that quality tier.
+-- Defaults flipped to Haiku — operators opt UP to Sonnet/Opus per-
+-- brief on the review surface.
+--
+-- Behaviour-preserving: existing rows are not touched. Column default
+-- only applies on INSERT when the field is omitted (the upload path
+-- doesn't set it; commit-time selection always sets it explicitly via
+-- the review-screen picker). The CHECK constraint on the allowed
+-- values stays the same — Haiku has been in the allowlist since
+-- migration 0020 shipped.
+
+ALTER TABLE briefs
+  ALTER COLUMN text_model SET DEFAULT 'claude-haiku-4-5-20251001',
+  ALTER COLUMN visual_model SET DEFAULT 'claude-haiku-4-5-20251001';
+
+COMMENT ON COLUMN briefs.text_model IS
+  'Anthropic model used for the text pass loop (draft / self_critique / revise / visual_revise). Default Haiku 4.5 (cheap-by-default for dev/UAT). Operator opts up to Sonnet/Opus per-brief on the review surface. CHECK constraint pins the allowed set; lib/anthropic-pricing.ts has rates.';
+COMMENT ON COLUMN briefs.visual_model IS
+  'Anthropic model used for the multi-modal visual critique pass. Default Haiku 4.5. Sonnet usually enough for production briefs; Opus reserved for complex-judgment briefs.';


### PR DESCRIPTION
## Summary

UAT-smoke-1 follow-up #3 of 3.

1. **Default model = Haiku 4.5.** UI picker defaults flipped from Sonnet 4.6 to Haiku 4.5; migration 0027 updates the `briefs.{text,visual}_model` column defaults to match. ~5× cost reduction on dev/UAT/sanity runs. Operators opt UP to Sonnet/Opus per-brief on the review surface.
2. **Centralised model registry** (`lib/anthropic-models.ts`). MODEL_OPTIONS moved out of the component into a shared module. Module-load drift guard throws if any UI option isn't in `ANTHROPIC_MODEL_ALLOWLIST` (derived from `PRICING_TABLE`).
3. **Freshness runbook entry**. Step-by-step procedure for adding a new model: PRICING_TABLE → MODEL_OPTIONS → CHECK constraint migration. Quarterly cadence.

## Risks identified and mitigated

- **Risk: existing briefs lose access to Sonnet.** No — all three models (Haiku / Sonnet / Opus) remain in the allowlist + picker. Default-only flip; explicit selection still works.
- **Risk: in-flight briefs (status='parsing' / 'parsed' between upload and commit) had their model field stamped with Sonnet by the old DB default and now appear as Sonnet on the review screen.** Correct — that matches what the operator was already going to see; no regression.
- **Risk: drift between MODEL_OPTIONS UI list and ANTHROPIC_MODEL_ALLOWLIST.** The module-load check in `lib/anthropic-models.ts` throws at boot if drift is detected. Build fails noisily rather than shipping a broken picker.
- **Risk: migration 0027 breaks production deployment.** ALTER COLUMN SET DEFAULT is atomic, fast, no rewrites, no constraint changes. Existing rows are untouched. Verified by reading the migration's SQL.
- **Risk: cost projection (`estimateBriefRunCostCents`) uses the new default and miscalculates pre-flight estimates.** No — the estimator takes explicit `text_model` / `visual_model` strings; default selection happens at the UI layer and gets passed through to the estimator. Same flow.
- **Risk: BriefRunClient renders the model id as label.** Confirmed via grep: `BriefRunClient.tsx:358` uses `{brief.text_model}` raw — that displays the Haiku id (`claude-haiku-4-5-20251001`) which is verbose. Acceptable for now (it's a status-line read-only display); if it bothers an operator, swap to the MODEL_OPTIONS label lookup.

## Self-test

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] CI: existing brief tests stay green; module-load drift guard doesn't trip on the existing allowlist.

## Out of scope (deferred)

- Migrating other call sites (chat route, batch worker) to import from `lib/anthropic-models.ts`. Those still use hardcoded `claude-opus-4-7` for chat. Separate slice.
- E2E coverage for the new picker default. The picker itself isn't changing — only the default value. Existing E2E that exercises the picker doesn't assert specific defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)