### PR TITLE
fix(tests): pin Sonnet on briefs-run-routes seed so CONFIRMATION_REQUIRED still fires

### DIFF
--- a/lib/__tests__/briefs-run-routes.test.ts
+++ b/lib/__tests__/briefs-run-routes.test.ts
@@ -53,6 +53,14 @@ async function seedCommittedBriefWithPages(
       upload_idempotency_key: `run-routes-${unique}`,
       committed_at: new Date().toISOString(),
       committed_page_hash: "e".repeat(64),
+      // UAT-smoke-1: PR #182 flipped briefs.{text,visual}_model column
+      // defaults to Haiku 4.5. The CONFIRMATION_REQUIRED test below
+      // depends on the cost estimate tripping 50% of a 100c budget,
+      // which Haiku rates don't satisfy. Pin Sonnet here so cost
+      // calibration stays the same as when these tests were written;
+      // tests that specifically exercise Haiku semantics override.
+      text_model: "claude-sonnet-4-6",
+      visual_model: "claude-sonnet-4-6",
     })
     .select("id")
     .single();


### PR DESCRIPTION
## Summary

PR #182 follow-up. Default model flipped to Haiku → cost estimate too low → CONFIRMATION_REQUIRED test no longer trips its budget threshold → returns 200 instead of 403. Pin Sonnet on the test's brief seed to decouple the assertion from rate calibration.

## Risks identified and mitigated

- **Risk: future rate changes break this test again.** Pinning Sonnet doesn't actually fix the underlying brittleness; if Sonnet ever gets cheaper, the threshold could stop firing. **Mitigated**: the test's intent is the route's threshold-detection logic, not specific costs. If needed, a follow-up could compute the threshold dynamically — out of scope here.
- **Risk: other test files use the same default and are now broken.** Verified by grep: only `briefs-run-routes.test.ts` lacks an explicit \`text_model\` in its seed helper. \`briefs-start-run.test.ts\` already takes a \`models\` param defaulting to Sonnet; \`brief-runner-visual.test.ts\` seeds Sonnet explicitly; \`brief-runner-mode.test.ts\` ditto. Anchor / concurrency / brief-runner.test.ts / approve-page-route make no cost assertions.

## Self-test

- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean
- [ ] CI: \`briefs-run-routes\` CONFIRMATION_REQUIRED test goes from FAIL to PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)