### PR TITLE
fix(scripts): include generated_html + has_html flags in brief-page diagnostic

### DIFF
--- a/scripts/diagnose-prod.ts
+++ b/scripts/diagnose-prod.ts
@@ -236,7 +236,7 @@ async function diagnoseBriefPage(
   const pageRes = await rdb
     .from("brief_pages")
     .select(
-      "id, brief_id, ordinal, title, slug_hint, mode, page_status, current_pass_kind, current_pass_number, page_cost_cents, quality_flag, approved_at, version_lock, source_span_start, source_span_end, word_count, draft_html, critique_log, deleted_at, created_at, updated_at",
+      "id, brief_id, ordinal, title, slug_hint, mode, page_status, current_pass_kind, current_pass_number, page_cost_cents, quality_flag, approved_at, version_lock, source_span_start, source_span_end, word_count, draft_html, generated_html, critique_log, deleted_at, created_at, updated_at",
     )
     .eq("id", pageId)
     .maybeSingle();
@@ -245,15 +245,19 @@ async function diagnoseBriefPage(
   const page = pageRes.data as Record<string, unknown>;
 
   const draftHtml = (page.draft_html as string | null | undefined) ?? null;
+  const generatedHtml = (page.generated_html as string | null | undefined) ?? null;
   const critiqueLog = (page.critique_log as unknown[] | null | undefined) ?? null;
   const draftHtmlLen = draftHtml ? draftHtml.length : 0;
+  const generatedHtmlLen = generatedHtml ? generatedHtml.length : 0;
   const critiqueEntries = Array.isArray(critiqueLog) ? critiqueLog.length : 0;
 
-  // Strip the bulky fields from the JSON payload — they're rarely
-  // useful at full size in a diagnostic dump and they bloat stdout.
-  // The lengths above are the diagnostic signal.
+  // Strip the bulky HTML/critique fields from the JSON payload — they're
+  // rarely useful at full size in a diagnostic dump and they bloat stdout.
+  // The lengths + presence flags below are the diagnostic signal.
   const slim: Record<string, unknown> = { ...page };
   slim.draft_html = draftHtml === null ? null : `<${draftHtmlLen} chars>`;
+  slim.generated_html =
+    generatedHtml === null ? null : `<${generatedHtmlLen} chars>`;
   slim.critique_log = critiqueLog === null ? null : `<${critiqueEntries} entries>`;
 
   summary([
@@ -267,7 +271,8 @@ async function diagnoseBriefPage(
     `  page_cost_cents:       ${page.page_cost_cents ?? 0}`,
     `  quality_flag:          ${page.quality_flag ?? "<null>"}`,
     `  approved_at:           ${page.approved_at ?? "<null>"}`,
-    `  draft_html length:     ${draftHtmlLen}`,
+    `  has_html:              ${draftHtmlLen > 0} (draft_html ${draftHtmlLen} chars)`,
+    `  has_generated_html:    ${generatedHtml !== null} (${generatedHtmlLen} chars)`,
     `  critique_log entries:  ${critiqueEntries}`,
     `  version_lock:          ${page.version_lock}`,
     `  updated_at:            ${page.updated_at} (age ${fmtAge(ageSeconds(page.updated_at as string))})`,
@@ -279,7 +284,10 @@ async function diagnoseBriefPage(
     data: {
       page: slim,
       derived: {
+        has_html: draftHtmlLen > 0,
+        has_generated_html: generatedHtml !== null,
         draft_html_length: draftHtmlLen,
+        generated_html_length: generatedHtmlLen,
         critique_log_entries: critiqueEntries,
       },
     },


### PR DESCRIPTION
## Tiny additive fix on top of #186

Tab 3's `scripts/diagnose-prod.ts` (PR #186) shipped the `brief-page` subcommand SELECTing `draft_html` but not `generated_html`. The two are distinct lifecycle signals — `draft_html` is the runner's working output; `generated_html` is what gets populated on approval and what the publish path reads. A complete brief-page diagnosis needs both.

Caught while running the diagnostic during the UAT smoke 1 stuck-page investigation for brief_pages id `dcbdf7d5-b867-443b-afdf-f60a28f968aa`. The page was at `awaiting_review` with `draft_html` populated (10430 chars) but **no** `generated_html` — the expected pre-approval state, but the script couldn't surface that distinction.

## Change

- Add `generated_html` to the SELECT.
- Compute `generatedHtmlLen` alongside `draftHtmlLen`.
- Surface two boolean flags in both human summary and JSON payload's `derived` section:
  - `has_html` — `draft_html` non-null AND length > 0
  - `has_generated_html` — `generated_html` non-null

The slim payload still strips the bulky HTML field from the JSON output (replaced with `<N chars>`) — only the lengths and presence flags travel.

## Risks identified and mitigated

- **Read-only invariant unchanged** — same `.select()` path, no new write surface. The Proxy's BLOCKED_BUILDER_METHODS list isn't touched.
- **No conflict with Tab 3** — additive change to a function Tab 3 just shipped. If parallel session is editing the same function, this conflicts on merge — easy resolution.
- **Output stability** — JSON shape adds two new keys to `data.derived` and one new key (`generated_html`) to `data.page`. No existing keys removed/renamed. jq pipelines that addressed `data.derived.draft_html_length` still work.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] Ran end-to-end against production for brief_pages `dcbdf7d5-b867-443b-afdf-f60a28f968aa` — output shows `has_html: true (10430 chars)` and `has_generated_html: false (0 chars)`, matching the awaiting_review pre-approval state.
- [ ] CI green
- [ ] Auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)