### PR TITLE
fix: brief preview truncation banner + diagnose-prod --raw

### DIFF
--- a/components/BriefRunClient.tsx
+++ b/components/BriefRunClient.tsx
@@ -536,6 +536,21 @@ function PagePreview({
   onRevise: () => void;
 }) {
   const html = page.generated_html ?? page.draft_html ?? "";
+  // Belt-and-suspenders: even after the runner's structural gate (PR
+  // #188), an operator-edited or legacy row could still hold a
+  // truncated doc. Surface a banner above the iframe so a black/blank
+  // preview is never silent. Trigger if the doc claims completeness
+  // (<!DOCTYPE / <html opener) AND is missing closing </body> or
+  // </html>. Bare fragments — which never claim to be complete docs —
+  // skip the check.
+  const looksTruncated = useMemo(() => {
+    if (!html) return false;
+    const trimmed = html.trimEnd();
+    const claimsCompleteness =
+      /<!DOCTYPE\s+html\b/i.test(trimmed) || /<html[\s>]/i.test(trimmed);
+    if (!claimsCompleteness) return false;
+    return !/<\/body\s*>/i.test(trimmed) || !/<\/html\s*>$/i.test(trimmed);
+  }, [html]);
   const lastVisualCritique = useMemo(() => {
     const log = (page.critique_log ?? []) as BriefPageCritiqueEntry[];
     return [...log]
@@ -550,6 +565,24 @@ function PagePreview({
           <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
             Show rendered preview
           </summary>
+          {looksTruncated && (
+            <div
+              role="alert"
+              className="mt-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive"
+            >
+              <p className="font-medium">
+                This page&apos;s HTML appears truncated.
+              </p>
+              <p className="mt-1">
+                The doc is missing a closing{" "}
+                <code className="font-mono">&lt;/body&gt;</code> or{" "}
+                <code className="font-mono">&lt;/html&gt;</code> tag, so the
+                preview below may render as a blank or solid-coloured frame.
+                Review the source carefully or click <em>Revise</em> to
+                regenerate.
+              </p>
+            </div>
+          )}
           <iframe
             // Sandbox prevents scripts, plugins, forms, popups from the
             // preview. draft_html is Claude-generated and already passes

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,32 +6,6 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
-## scripts/recover-stuck-brief-page.ts produces a runner-impossible state (caught during UAT smoke 1, 2026-04-28)
-
-**Tags:** `bug`, `ops-tooling`, `recovery-script`
-
-**What:** `scripts/recover-stuck-brief-page.ts` sets `brief_runs.status = 'running'` while clearing `lease_expires_at`, `worker_id`, `started_at`, and `last_heartbeat_at` to NULL. That combination is **impossible** for the runner itself to produce — `leaseBriefRun` (`lib/brief-runner.ts:281-298`) atomically sets `status='running'` AND `lease_expires_at IS NOT NULL` AND `worker_id IS NOT NULL` together. The recovery output is a state that neither subsystem matches:
-
-- **Cron find-work** (`app/api/cron/process-brief-runner/route.ts:85-93`) filters `status = 'queued'` — exact equality, not `IN`. Skips the row.
-- **Reaper** (`lib/brief-runner.ts:354-358`) requires `lease_expires_at IS NOT NULL AND lease_expires_at < now()`. NULL doesn't qualify. Skips the row.
-
-Result: the recovered run sits in limbo forever; cron returns `nothing_queued` even though the row is "ready" by intent.
-
-Caught during UAT smoke 1 recovery for brief_run `053d9a25-f315-4174-8fde-7638edc78514` (page `dcbdf7d5-b867-443b-afdf-f60a28f968aa`). Workaround was a manual SQL re-queue. Diagnosis lives in the conversation log; see also the cron route comment + the `leaseBriefRun` invariant.
-
-**Why deferred:** the UAT BLOCKER (markdown code fence not stripped) takes priority. The recovery-script bug only fires when an operator explicitly runs the script, and the workaround is a ~6-line SQL update that's now well-documented from the diagnosis.
-
-**Trigger:** before the next time anyone other than Steven runs `recover-stuck-brief-page.ts`, OR as part of a "ops-tooling cleanup" slice in M16. Whichever comes first.
-
-**Scope:**
-- Change the recovery script to set `status = 'queued'` (not `'running'`) while still clearing the lease fields. That's the canonical "ready to be re-leased" shape — same UPDATE clause `reapExpiredBriefRuns` produces (`lib/brief-runner.ts:346-351`).
-- Add a unit test covering: feed it a stuck `'running'` row → assert post-state `status='queued'`, `worker_id IS NULL`, `lease_expires_at IS NULL`, `version_lock` incremented.
-- Optional defensive ratchet (separate PR): extend the reaper to also catch the orphan shape `(status='running' AND lease_expires_at IS NULL AND worker_id IS NULL)` so a future recovery-script bug surfaces as auto-recovery rather than a stuck queue. Trade-off: hides recovery mistakes that should ideally surface for diagnosis. Recommend skipping unless the orphan-shape recovery becomes routine.
-- Consider adding a `--dry-run` flag to print the post-state before applying — would have caught this on first run.
-
-**Size:** Small (~30 min for the script fix + test; another ~30 min if the defensive reaper change ships in a paired PR).
-
----
 
 ## Brief upload UX — paste raw text option (deferred from UAT smoke 1, 2026-04-28)
 

--- a/scripts/diagnose-prod.ts
+++ b/scripts/diagnose-prod.ts
@@ -231,7 +231,17 @@ async function diagnoseBriefPage(
   rdb: ReadOnlyClient,
   args: string[],
 ): Promise<unknown> {
-  const pageId = requireUuid(args[0], "<page-id>");
+  // brief-page <page-id> [--raw]
+  // --raw emits the full draft_html + generated_html in stdout instead
+  // of the slimmed `<N chars>` placeholder. Useful for render-bug
+  // investigations (markdown fence, CSS, doctype, max_tokens truncation).
+  const positional: string[] = [];
+  let raw = false;
+  for (const a of args) {
+    if (a === "--raw") raw = true;
+    else positional.push(a);
+  }
+  const pageId = requireUuid(positional[0], "<page-id>");
 
   const pageRes = await rdb
     .from("brief_pages")
@@ -251,14 +261,24 @@ async function diagnoseBriefPage(
   const generatedHtmlLen = generatedHtml ? generatedHtml.length : 0;
   const critiqueEntries = Array.isArray(critiqueLog) ? critiqueLog.length : 0;
 
-  // Strip the bulky HTML/critique fields from the JSON payload — they're
-  // rarely useful at full size in a diagnostic dump and they bloat stdout.
-  // The lengths + presence flags below are the diagnostic signal.
+  // Head + tail previews so structural truncation (no closing </html>,
+  // markdown fence around the doc) is visible from the stderr summary
+  // without --raw.
+  const draftHead = draftHtml ? draftHtml.slice(0, 80) : null;
+  const draftTail = draftHtml ? draftHtml.slice(-80) : null;
+  const generatedHead = generatedHtml ? generatedHtml.slice(0, 80) : null;
+  const generatedTail = generatedHtml ? generatedHtml.slice(-80) : null;
+
+  // Strip / keep bulky fields based on --raw. Default slim because
+  // 10–50KB of HTML in stdout dwarfs the rest of the payload.
   const slim: Record<string, unknown> = { ...page };
-  slim.draft_html = draftHtml === null ? null : `<${draftHtmlLen} chars>`;
-  slim.generated_html =
-    generatedHtml === null ? null : `<${generatedHtmlLen} chars>`;
-  slim.critique_log = critiqueLog === null ? null : `<${critiqueEntries} entries>`;
+  if (!raw) {
+    slim.draft_html = draftHtml === null ? null : `<${draftHtmlLen} chars>`;
+    slim.generated_html =
+      generatedHtml === null ? null : `<${generatedHtmlLen} chars>`;
+    slim.critique_log =
+      critiqueLog === null ? null : `<${critiqueEntries} entries>`;
+  }
 
   summary([
     "── brief-page ──",
@@ -273,9 +293,14 @@ async function diagnoseBriefPage(
     `  approved_at:           ${page.approved_at ?? "<null>"}`,
     `  has_html:              ${draftHtmlLen > 0} (draft_html ${draftHtmlLen} chars)`,
     `  has_generated_html:    ${generatedHtml !== null} (${generatedHtmlLen} chars)`,
+    `  draft_html head:       ${draftHead === null ? "<null>" : JSON.stringify(draftHead)}`,
+    `  draft_html tail:       ${draftTail === null ? "<null>" : JSON.stringify(draftTail)}`,
+    `  generated_html head:   ${generatedHead === null ? "<null>" : JSON.stringify(generatedHead)}`,
+    `  generated_html tail:   ${generatedTail === null ? "<null>" : JSON.stringify(generatedTail)}`,
     `  critique_log entries:  ${critiqueEntries}`,
     `  version_lock:          ${page.version_lock}`,
     `  updated_at:            ${page.updated_at} (age ${fmtAge(ageSeconds(page.updated_at as string))})`,
+    raw ? "  --raw: full HTML included in stdout JSON" : "  (pass --raw to dump full HTML)",
   ]);
 
   return {
@@ -289,6 +314,8 @@ async function diagnoseBriefPage(
         draft_html_length: draftHtmlLen,
         generated_html_length: generatedHtmlLen,
         critique_log_entries: critiqueEntries,
+        draft_html_head: draftHead,
+        generated_html_head: generatedHead,
       },
     },
   };


### PR DESCRIPTION
## Summary

Follow-up to PR #188 (runner structural gate + max_tokens bump + recovery script unstuck). Three orthogonal pieces that #188 didn't include:

1. **components/BriefRunClient.tsx** — red banner above the iframe when `draft_html` / `generated_html` claims completeness (\`<!DOCTYPE\` or \`<html\` opener) but is missing closing \`</body>\` or \`</html>\`. Belt-and-suspenders for legacy / operator-edited rows that bypass the runner gate; gives a real-time signal so a black/blank preview is never silent.

2. **scripts/diagnose-prod.ts** — \`brief-page\` subcommand:
   - \`--raw\` flag dumps full \`draft_html\` + \`generated_html\` in stdout instead of the slimmed \`<N chars>\` placeholder.
   - Summary now shows head/tail snippets so structural truncation (missing closing \`</html>\`, markdown fence around the doc) is visible from the stderr summary without \`--raw\`.

3. **docs/BACKLOG.md** — drops the "scripts/recover-stuck-brief-page.ts produces a runner-impossible state" entry. Fixed in PR #188 (the recovery script now sets \`status='queued'\` so the cron picks it back up).

## Risks identified and mitigated

- **Banner false-positives on bare HTML fragments.** The \`looksTruncated\` check is scope-guarded by \`<!DOCTYPE\` / \`<html\` opener detection — bare \`<section>...\</section\>\` fragments stay untouched. Same scope rule the runner's structural gate uses (consistency).
- **\`--raw\` puts secrets / large payloads on stdout.** \`draft_html\` is operator-visible content, not secret. Volume is the only concern (10–50 KB per call); default stays slim, \`--raw\` is opt-in.
- **No schema or runner code touched.** Zero risk to data path. CI surface is the BriefRunClient snapshot (one new conditional render path) and the diagnose-prod TS check.

## Test plan

- [x] \`npm run lint\` ✓
- [x] \`npm run typecheck\` ✓
- [x] Manually verified \`scripts/diagnose-prod.ts brief-page <id> --raw\` dumps the full HTML and \`(without --raw)\` shows head/tail snippets — used during the 2026-04-28 incident diagnosis to identify the truncation shape.
- [ ] CI: pure-additive component + tooling change, no app-code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)