### PR TITLE
feat(pb-1+pb-2): brief-runner emits path-b fragments + fragment gate

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,32 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## Post meta description via WP excerpt (path B, opened 2026-04-29 by PB-1)
+
+**Tags:** `path-b`, `m13`, `posts`, `seo`
+
+**What:** PB-1 (path B prompt + gate rework) dropped `<meta name="description">` from the runner's output and made `runPostQualityGates` a no-op. The runner no longer emits a `<head>`, so meta descriptions can never appear in the generated HTML. Posts published in the meantime will fall back to WP's auto-derived excerpt (first 55 words of the body), which is functional but not operator-controlled.
+
+The replacement: populate the post's WP REST `excerpt` field from a brief-side excerpt slot. Either (a) the operator authors an excerpt in the brief markdown ahead of generation, OR (b) the runner generates an excerpt as a structured-output side channel during the visual_revise pass. Either way, the publish path (`lib/wp-rest-posts.ts`) needs to POST the excerpt as a sibling field to `content`. Unit-validate the excerpt length against `POST_META_DESCRIPTION_MAX` (300, currently exported and unused).
+
+**Why deferred:** PB-1's scope is bounded to runner prompt + gate rework. Adding a new brief-authored field + UI surface + WP REST plumbing would more than double the slice. WP's auto-excerpt is a reasonable fallback for the few posts that publish before this lands.
+
+**Trigger:** when an operator complains about a published post's meta description, OR when path-B SEO regression testing surfaces missing-excerpt as a real problem. Whichever comes first.
+
+**Scope:**
+- Brief schema: optional `excerpt` field per post (parser pulls from a `## Excerpt` section in the brief markdown, or an inline frontmatter field).
+- Runner: optionally generates an excerpt as part of the final pass and stores in `posts.excerpt` (column already exists per migration 0019).
+- WP REST: `lib/wp-rest-posts.ts` POSTs `excerpt` alongside `content` on publish.
+- Validate excerpt against `POST_META_DESCRIPTION_MAX` server-side before POST.
+- BriefReviewClient surface: show the excerpt slot, allow inline edits.
+- E2E: extend posts spec to verify excerpt round-trips to WP.
+
+**Size:** Medium (~3 hours runner + WP wiring; another ~2 hours UI + E2E).
+
+**Reference:** `lib/brief-runner.ts::runPostQualityGates` is the no-op seam; `POST_META_DESCRIPTION_MAX` is the validation cap; `posts.excerpt` is the column.
+
+---
+
 ## brief-runner max_tokens=16384 collides with Anthropic org rate limit of 4,000 output tokens/min on Sonnet 4.6 (caught 2026-04-28)
 
 **Tags:** `bug`, `runner`, `rate-limit`, `m13`

--- a/lib/__tests__/brief-runner-anchor.test.ts
+++ b/lib/__tests__/brief-runner-anchor.test.ts
@@ -30,8 +30,8 @@ import { seedSite } from "./_helpers";
 // valid SiteConventionsSchema and persists a row with frozen_at set.
 // ---------------------------------------------------------------------------
 
-// Full-document shell — structural-completeness gate (2026-04-28).
-const ANCHOR_REVISE_OUTPUT = `<!DOCTYPE html><html lang="en"><head><title>Anchor</title></head><body><section><h1>Anchor</h1><p>Final revision.</p></section></body></html>
+// Path-B fragment + JSON-fenced site_conventions tail (PB-1, 2026-04-29).
+const ANCHOR_REVISE_OUTPUT = `<section data-opollo><h1>Anchor</h1><p>Final revision.</p></section>
 
 \`\`\`json
 {
@@ -49,7 +49,7 @@ function makeAnchorStub(record: { last: string | null }): AnthropicCallFn {
     let text: string;
     if (req.idempotency_key.includes(":draft:")) {
       text =
-        '<!DOCTYPE html><html lang="en"><head><title>T</title></head><body><section><h1>Draft</h1><p>First draft.</p></section></body></html>';
+        '<section data-opollo><h1>Draft</h1><p>First draft.</p></section>';
     } else if (req.idempotency_key.includes(":self_critique:")) {
       text = "- Tighten headline\n- Add CTA";
     } else if (req.idempotency_key.endsWith(":revise:2")) {
@@ -57,7 +57,7 @@ function makeAnchorStub(record: { last: string | null }): AnthropicCallFn {
       text = ANCHOR_REVISE_OUTPUT;
     } else {
       text =
-        '<!DOCTYPE html><html lang="en"><head><title>T</title></head><body><section><h1>Revised</h1><p>Intermediate revise.</p></section></body></html>';
+        '<section data-opollo><h1>Revised</h1><p>Intermediate revise.</p></section>';
     }
     record.last = req.idempotency_key;
     const resp: AnthropicResponse = {

--- a/lib/__tests__/brief-runner-concurrency.test.ts
+++ b/lib/__tests__/brief-runner-concurrency.test.ts
@@ -38,8 +38,9 @@ function makeSilentStub(): AnthropicCallFn {
       content: [
         {
           type: "text",
+          // Path-B fragment (PB-1, 2026-04-29).
           text:
-            '<!DOCTYPE html><html lang="en"><head><title>T</title></head><body><section><h1>Quiet</h1><p>Generated.</p></section></body></html>',
+            '<section data-opollo><h1>Quiet</h1><p>Generated.</p></section>',
         },
       ],
       stop_reason: "end_turn",

--- a/lib/__tests__/brief-runner-fragment-gate.test.ts
+++ b/lib/__tests__/brief-runner-fragment-gate.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+
+import { runFragmentStructuralCheck } from "@/lib/brief-runner";
+
+// ---------------------------------------------------------------------------
+// PB-1 (2026-04-29) — runFragmentStructuralCheck matrix.
+//
+// Replaces runStructuralCompletenessCheck (PR #188, path-A) inside
+// runGatesForBriefPage. The new gate validates path-B fragments:
+//   - no host-WP chrome (DOCTYPE, html, head, body, nav, header, footer)
+//   - no head-only or script tags (meta, link, title, script)
+//   - at least one top-level <section data-opollo …>
+//   - inline <style> content total ≤ 200 chars
+// ---------------------------------------------------------------------------
+
+const GOOD_FRAGMENT = `<section data-opollo class="ls-hero" data-ds-version="1">
+  <h1>Hello</h1>
+  <p>World.</p>
+</section>`;
+
+const GOOD_MULTI_SECTION = `<section data-opollo data-ds-version="1"><h1>Hero</h1></section>
+<section data-opollo><p>Features.</p></section>
+<section data-opollo><a href="/cta">CTA</a></section>`;
+
+describe("runFragmentStructuralCheck — happy paths", () => {
+  it("accepts a single-section fragment with the data-opollo marker", () => {
+    expect(runFragmentStructuralCheck(GOOD_FRAGMENT)).toEqual({ ok: true });
+  });
+
+  it("accepts a multi-section fragment", () => {
+    expect(runFragmentStructuralCheck(GOOD_MULTI_SECTION)).toEqual({
+      ok: true,
+    });
+  });
+
+  it("accepts inline <style> content under 200 chars (animation/utility allowance)", () => {
+    const fragment = `<section data-opollo>
+      <style>
+        @keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+      </style>
+      <h1>Hi</h1>
+    </section>`;
+    expect(runFragmentStructuralCheck(fragment)).toEqual({ ok: true });
+  });
+});
+
+describe("runFragmentStructuralCheck — empty / null", () => {
+  it("rejects an empty string", () => {
+    expect(runFragmentStructuralCheck("")).toMatchObject({
+      ok: false,
+      code: "FRAGMENT_EMPTY",
+    });
+  });
+
+  it("rejects whitespace-only", () => {
+    expect(runFragmentStructuralCheck("   \n\t ")).toMatchObject({
+      ok: false,
+      code: "FRAGMENT_EMPTY",
+    });
+  });
+});
+
+describe("runFragmentStructuralCheck — chrome-leak rejections", () => {
+  const cases: Array<{ name: string; html: string; code: string }> = [
+    {
+      name: "DOCTYPE",
+      html: `<!DOCTYPE html><section data-opollo></section>`,
+      code: "FRAGMENT_DOCTYPE_LEAKED",
+    },
+    {
+      name: "<html>",
+      html: `<html><section data-opollo></section></html>`,
+      code: "FRAGMENT_HTML_TAG_LEAKED",
+    },
+    {
+      name: "<head>",
+      html: `<head><title>x</title></head><section data-opollo></section>`,
+      code: "FRAGMENT_HEAD_TAG_LEAKED",
+    },
+    {
+      name: "<body>",
+      html: `<body><section data-opollo></section></body>`,
+      code: "FRAGMENT_BODY_TAG_LEAKED",
+    },
+    {
+      name: "<nav>",
+      html: `<nav><a>menu</a></nav><section data-opollo></section>`,
+      code: "FRAGMENT_NAV_TAG_LEAKED",
+    },
+    {
+      name: "<header>",
+      html: `<header><h1>Site</h1></header><section data-opollo></section>`,
+      code: "FRAGMENT_HEADER_TAG_LEAKED",
+    },
+    {
+      name: "<footer>",
+      html: `<section data-opollo></section><footer>©</footer>`,
+      code: "FRAGMENT_FOOTER_TAG_LEAKED",
+    },
+    {
+      name: "<meta>",
+      html: `<meta name="description" content="x"><section data-opollo></section>`,
+      code: "FRAGMENT_META_TAG_LEAKED",
+    },
+    {
+      name: "<link>",
+      html: `<link rel="stylesheet" href="/x.css"><section data-opollo></section>`,
+      code: "FRAGMENT_LINK_TAG_LEAKED",
+    },
+    {
+      name: "<title>",
+      html: `<title>Page</title><section data-opollo></section>`,
+      code: "FRAGMENT_TITLE_TAG_LEAKED",
+    },
+    {
+      name: "<script>",
+      html: `<script>alert(1)</script><section data-opollo></section>`,
+      code: "FRAGMENT_SCRIPT_TAG_LEAKED",
+    },
+  ];
+  for (const c of cases) {
+    it(`rejects ${c.name}`, () => {
+      expect(runFragmentStructuralCheck(c.html)).toMatchObject({
+        ok: false,
+        code: c.code,
+      });
+    });
+  }
+});
+
+describe("runFragmentStructuralCheck — marker + style limits", () => {
+  it("rejects a fragment without any data-opollo section", () => {
+    const html = `<section><h1>missing marker</h1></section>`;
+    expect(runFragmentStructuralCheck(html)).toMatchObject({
+      ok: false,
+      code: "FRAGMENT_MISSING_DATA_OPOLLO_SECTION",
+    });
+  });
+
+  it("accepts a fragment where data-opollo appears alongside other attributes (any order)", () => {
+    const html = `<section class="ls-hero" data-opollo data-ds-version="3"><h1>x</h1></section>`;
+    expect(runFragmentStructuralCheck(html)).toEqual({ ok: true });
+  });
+
+  it("rejects a fragment whose inline <style> content exceeds 200 chars total", () => {
+    const big = "a".repeat(250);
+    const html = `<section data-opollo><style>.${big} { color: red; }</style></section>`;
+    expect(runFragmentStructuralCheck(html)).toMatchObject({
+      ok: false,
+      code: "FRAGMENT_INLINE_STYLE_OVER_LIMIT",
+    });
+  });
+
+  it("counts inline <style> content across multiple <style> blocks", () => {
+    const block = "x".repeat(120); // 120 + 120 = 240 > 200
+    const html = `<section data-opollo>
+      <style>${block}</style>
+      <style>${block}</style>
+    </section>`;
+    expect(runFragmentStructuralCheck(html)).toMatchObject({
+      ok: false,
+      code: "FRAGMENT_INLINE_STYLE_OVER_LIMIT",
+    });
+  });
+});
+
+describe("runFragmentStructuralCheck — case insensitivity", () => {
+  it("rejects uppercase chrome tags", () => {
+    expect(
+      runFragmentStructuralCheck(`<HTML><section data-opollo></section></HTML>`),
+    ).toMatchObject({
+      ok: false,
+      code: "FRAGMENT_HTML_TAG_LEAKED",
+    });
+  });
+
+  it("accepts a section with mixed-case data-opollo (HTML attrs are case-insensitive)", () => {
+    const html = `<SECTION DATA-OPOLLO><h1>x</h1></SECTION>`;
+    expect(runFragmentStructuralCheck(html)).toEqual({ ok: true });
+  });
+});

--- a/lib/__tests__/brief-runner-mode.test.ts
+++ b/lib/__tests__/brief-runner-mode.test.ts
@@ -33,8 +33,11 @@ import { seedSite } from "./_helpers";
 //   3. resolveRunnerMode falls back to 'page' for unrecognised
 //      content_type values so a mis-migrated row never sends us into
 //      an undefined dispatch entry.
-//   4. runPostQualityGates rejects an over-long meta description
-//      (parent plan §M13-3 "excerpt length cap").
+//   4. runPostQualityGates is a no-op under path B (PB-1, 2026-04-29).
+//      The runner emits content fragments without a <head>, so the
+//      meta-description-in-HTML check can never fire. Post excerpt
+//      population now flows through the WP REST `excerpt` field (see
+//      BACKLOG: "Post meta description via WP excerpt (path B)").
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
@@ -56,13 +59,17 @@ describe("MODE_CONFIGS", () => {
     expect(MODE_CONFIGS.page.runModeSpecificGates("<p>ok</p>")).toBeNull();
   });
 
-  it("post mode routes through runPostQualityGates", () => {
-    // Long meta description should surface a gate failure via the
-    // post-mode dispatch entry.
-    const html = `<html><head><meta name="description" content="${"a".repeat(POST_META_DESCRIPTION_MAX + 1)}"></head><body><p>Hi</p></body></html>`;
-    const gate = MODE_CONFIGS.post.runModeSpecificGates(html);
-    expect(gate).not.toBeNull();
-    expect(gate?.code).toBe("POST_META_DESCRIPTION_TOO_LONG");
+  it("post mode's runModeSpecificGates is a no-op under path B (meta description moved to WP excerpt)", () => {
+    // Path B: the runner emits fragments with no <head>, so the legacy
+    // meta-description-in-HTML gate has nothing to fire on. Even an
+    // input that previously would have failed now returns null.
+    const fragment = `<section data-opollo><h1>Post</h1><p>Body.</p></section>`;
+    expect(MODE_CONFIGS.post.runModeSpecificGates(fragment)).toBeNull();
+    // And the legacy <meta>-bearing input also returns null — see the
+    // BACKLOG entry for the WP REST excerpt wiring that replaces this
+    // surface.
+    const legacy = `<html><head><meta name="description" content="${"a".repeat(POST_META_DESCRIPTION_MAX + 1)}"></head><body><p>Hi</p></body></html>`;
+    expect(MODE_CONFIGS.post.runModeSpecificGates(legacy)).toBeNull();
   });
 });
 
@@ -124,48 +131,28 @@ describe("resolveRunnerMode", () => {
 // Unit — runPostQualityGates
 // ---------------------------------------------------------------------------
 
-describe("runPostQualityGates", () => {
-  it("accepts HTML with no meta description", () => {
-    expect(runPostQualityGates("<p>Body only.</p>")).toBeNull();
+describe("runPostQualityGates (path B no-op)", () => {
+  // Under path B (PB-1, 2026-04-29), the runner emits content fragments
+  // without a <head>, so the meta-description-in-HTML check has nothing
+  // to fire on. The function is preserved as the dispatch-table seam
+  // for future post-specific checks (featured-image, taxonomy whitelist
+  // — see parent plan §M13-3) but currently returns null on every
+  // input. Meta description population for posts will flow through the
+  // WP REST `excerpt` field — see BACKLOG: "Post meta description via
+  // WP excerpt (path B)".
+  it("returns null on a path-B fragment", () => {
+    const fragment = `<section data-opollo><h1>Post</h1><p>Body.</p></section>`;
+    expect(runPostQualityGates(fragment)).toBeNull();
   });
 
-  it("accepts a meta description within the cap", () => {
-    const html = `<html><head><meta name="description" content="Short and sweet."></head><body><p>Body.</p></body></html>`;
-    expect(runPostQualityGates(html)).toBeNull();
-  });
-
-  it("rejects a meta description over POST_META_DESCRIPTION_MAX", () => {
+  it("returns null on legacy path-A HTML even with an over-long meta description", () => {
     const longContent = "x".repeat(POST_META_DESCRIPTION_MAX + 10);
-    const html = `<html><head><meta name="description" content="${longContent}"></head><body><p>Body.</p></body></html>`;
-    const gate = runPostQualityGates(html);
-    expect(gate).not.toBeNull();
-    expect(gate?.code).toBe("POST_META_DESCRIPTION_TOO_LONG");
+    const legacy = `<html><head><meta name="description" content="${longContent}"></head><body><p>Body.</p></body></html>`;
+    expect(runPostQualityGates(legacy)).toBeNull();
   });
 
-  it("accepts a meta description at exactly POST_META_DESCRIPTION_MAX chars", () => {
-    const maxContent = "a".repeat(POST_META_DESCRIPTION_MAX);
-    const html = `<html><head><meta name="description" content="${maxContent}"></head></html>`;
-    expect(runPostQualityGates(html)).toBeNull();
-  });
-
-  it("tolerates attribute-order variants (content= before name=)", () => {
-    const longContent = "x".repeat(POST_META_DESCRIPTION_MAX + 1);
-    const html = `<meta content="${longContent}" name="description">`;
-    const gate = runPostQualityGates(html);
-    expect(gate?.code).toBe("POST_META_DESCRIPTION_TOO_LONG");
-  });
-
-  it("only considers the first meta description tag if multiple are present", () => {
-    const short = "Short desc.";
-    const long = "x".repeat(POST_META_DESCRIPTION_MAX + 10);
-    const html = `<meta name="description" content="${short}"><meta name="description" content="${long}">`;
-    expect(runPostQualityGates(html)).toBeNull();
-  });
-
-  it("ignores other meta tags (e.g. og:description)", () => {
-    const longContent = "x".repeat(POST_META_DESCRIPTION_MAX + 10);
-    const html = `<meta property="og:description" content="${longContent}"><p>Body.</p>`;
-    expect(runPostQualityGates(html)).toBeNull();
+  it("returns null on empty input", () => {
+    expect(runPostQualityGates("")).toBeNull();
   });
 });
 
@@ -186,9 +173,9 @@ function countingStub(record: { count: number; keys: string[] }): AnthropicCallF
     const kind = req.idempotency_key.split(":").at(-2) ?? "";
     let text: string;
     if (kind === "draft" || kind === "revise" || kind === "visual_revise") {
-      // Full-document shell — structural-completeness gate (2026-04-28).
+      // Path-B fragment (PB-1, 2026-04-29).
       text =
-        '<!DOCTYPE html><html lang="en"><head><title>T</title></head><body><section><h1>Post draft</h1><p>Body copy.</p></section></body></html>';
+        '<section data-opollo><h1>Post draft</h1><p>Body copy.</p></section>';
     } else if (kind === "self_critique") {
       text = "- Tighten intro\n- Add CTA";
     } else {

--- a/lib/__tests__/brief-runner-visual.test.ts
+++ b/lib/__tests__/brief-runner-visual.test.ts
@@ -32,10 +32,10 @@ import { seedSite } from "./_helpers";
 
 type RecordedCall = Pick<AnthropicRequest, "idempotency_key" | "model">;
 
-// Full-document shell satisfies the structural-completeness gate
-// (lib/brief-runner.ts::runStructuralCompletenessCheck, 2026-04-28).
+// Path-B fragment (PB-1, 2026-04-29). Satisfies runFragmentStructuralCheck
+// in lib/brief-runner.ts.
 const PLAIN_HTML =
-  '<!DOCTYPE html><html lang="en"><head><title>T</title></head><body><section><h1>Hello</h1><p>World.</p></section></body></html>';
+  '<section data-opollo><h1>Hello</h1><p>World.</p></section>';
 
 function makeTextStub(record: RecordedCall[]): AnthropicCallFn {
   let counter = 0;

--- a/lib/__tests__/brief-runner.test.ts
+++ b/lib/__tests__/brief-runner.test.ts
@@ -34,13 +34,14 @@ import { seedSite } from "./_helpers";
 
 type RecordedCall = Pick<AnthropicRequest, "idempotency_key" | "model">;
 
-// Full-document shells satisfy the structural-completeness gate
-// (lib/brief-runner.ts::runStructuralCompletenessCheck, 2026-04-28).
+// Path-B fragments (PB-1, 2026-04-29). Each fixture is a contiguous
+// fragment of <section data-opollo …> elements with no host chrome.
+// Satisfies runFragmentStructuralCheck in lib/brief-runner.ts.
 const DRAFT_OUTPUT =
-  '<!DOCTYPE html><html lang="en"><head><title>T</title></head><body><section><h1>Hello</h1><p>Draft copy.</p></section></body></html>';
+  '<section data-opollo><h1>Hello</h1><p>Draft copy.</p></section>';
 const CRITIQUE_OUTPUT = "- Make the headline punchier.";
 const REVISE_OUTPUT =
-  '<!DOCTYPE html><html lang="en"><head><title>T</title></head><body><section><h1>Punchier</h1><p>Revised copy.</p></section></body></html>';
+  '<section data-opollo><h1>Punchier</h1><p>Revised copy.</p></section>';
 
 function passTextFor(key: string): string {
   // Key shape: brief:<id>:p<ord>:<kind>:<num>

--- a/lib/brief-runner.ts
+++ b/lib/brief-runner.ts
@@ -550,16 +550,23 @@ type PageContext = {
 function systemPromptFor(ctx: PageContext): string {
   const dsVersion = ctx.designSystemVersion ?? "";
   const prefix = ctx.sitePrefix ?? "";
+  // Path B (PB-1, 2026-04-29): the runner emits BODY FRAGMENTS that
+  // slot into the host WP page's content area. The host theme owns
+  // chrome (DOCTYPE, html, head, body, nav, header, footer) and visual
+  // tokens (palette, fonts, container width). See
+  // docs/INTEGRATION_MODEL_DECISION.md and
+  // docs/plans/path-b-migration-parent.md.
   const parts = [
-    "You are a website page generator. You produce one HTML page at a time against a whole-site brief.",
+    "You are a website page generator. You produce one CONTENT FRAGMENT at a time. The fragment slots into a WordPress page's content area; the host theme provides the surrounding chrome (DOCTYPE, html, head, body, nav, header, footer) and base visual tokens (palette, fonts, spacing).",
     "",
     "OUTPUT FORMAT — STRICT REQUIREMENTS:",
     "1. Output raw HTML only. Do NOT wrap your response in markdown code fences. No ```html, no ```, no triple-backtick fences anywhere around the HTML body.",
-    `2. Wrap the entire page in a single outermost element carrying the attribute data-ds-version="${dsVersion}" exactly. The first opening tag of your response must include this attribute.`,
-    `3. Every CSS class in your HTML must start with the site prefix "${prefix}-" (for example "${prefix}-hero", "${prefix}-cta-button"). Do NOT use Tailwind classes, framework classes, or any class outside the prefix scope.`,
-    "4. Include exactly one <h1> element on the page.",
-    "5. Include a <meta name=\"description\" content=\"...\"> element whose content is between 50 and 160 characters.",
-    "6. Every <img> must have a non-empty alt attribute. No empty hrefs (no href=\"\") and no placeholder href=\"#\".",
+    "2. Output a CONTIGUOUS FRAGMENT of one or more top-level <section> elements. Do NOT emit any of: <!DOCTYPE>, <html>, <head>, <body>, <nav>, <header>, <footer>, <meta>, <link>, <title>, <script>. The host WP theme owns those.",
+    `3. Every top-level <section> MUST carry the data-opollo attribute (presence-only — no value required) so the host theme + admin tooling can identify Opollo content. The first top-level <section> MUST also carry data-ds-version="${dsVersion}" exactly so the design-system version is auditable.`,
+    `4. Every CSS class in your HTML must start with the site prefix "${prefix}-" (for example "${prefix}-hero", "${prefix}-cta-button"). Do NOT use Tailwind classes, framework classes, or any class outside the prefix scope.`,
+    "5. Include exactly one <h1> element across the whole fragment.",
+    "6. Inline <style> blocks are permitted ONLY for animation keyframes / scoped utility rules; total inline-style content across the fragment MUST be under 200 characters. Visual styling (colours, fonts, spacing) inherits from the host theme + design-system tokens applied at the [data-opollo] CSS scope by the theme.",
+    "7. Every <img> must have a non-empty alt attribute. No empty hrefs (no href=\"\") and no placeholder href=\"#\".",
     ctx.brief.brand_voice
       ? `\n<brand_voice>\n${ctx.brief.brand_voice}\n</brand_voice>`
       : "",
@@ -587,7 +594,7 @@ function userPromptForDraft(ctx: PageContext): string {
   return [
     `<page_spec>\nTitle: ${ctx.page.title}\nMode: ${ctx.page.mode}\nOrdinal: ${ctx.page.ordinal}\n\n${ctx.page.source_text}\n</page_spec>${operatorNotesBlock}`,
     "",
-    "Produce the page's HTML following ALL the OUTPUT FORMAT requirements in the system prompt. Output raw HTML only. Do NOT wrap in markdown code fences (no ```html, no ```). Your response must start with the opening tag of the outermost element (which carries the data-ds-version attribute) and end with its closing tag.",
+    "Produce the page's CONTENT FRAGMENT following ALL the OUTPUT FORMAT requirements in the system prompt. Output raw HTML only. Do NOT wrap in markdown code fences (no ```html, no ```). Your response must start with `<section data-opollo` and end with the matching `</section>` of the last top-level section.",
   ].join("\n");
 }
 
@@ -603,7 +610,7 @@ function userPromptForSelfCritique(ctx: PageContext): string {
 
 function userPromptForRevise(ctx: PageContext, isAnchor: boolean): string {
   const anchorInstruction = isAnchor
-    ? "\n\nAfter the HTML's closing tag, on a new line, append a ```json fenced block containing your chosen site_conventions JSON (typographic_scale, section_rhythm, hero_pattern, cta_phrasing, color_role_map, tone_register, additional). The JSON block is the ONLY place ``` fences are allowed in your response. The HTML itself must NOT be wrapped in fences."
+    ? "\n\nAfter the LAST top-level section's closing `</section>`, on a new line, append a ```json fenced block containing your chosen site_conventions JSON (typographic_scale, section_rhythm, hero_pattern, cta_phrasing, color_role_map, tone_register, additional). The JSON block is the ONLY place ``` fences are allowed in your response. The HTML fragment itself must NOT be wrapped in fences."
     : "";
   return [
     `<page_spec>\nTitle: ${ctx.page.title}\nMode: ${ctx.page.mode}\n\n${ctx.page.source_text}\n</page_spec>`,
@@ -612,7 +619,7 @@ function userPromptForRevise(ctx: PageContext, isAnchor: boolean): string {
     "",
     `<critique>\n${ctx.previousCritique ?? ""}\n</critique>`,
     "",
-    `Apply the critique to the draft. Output raw HTML only. Do NOT wrap the HTML in markdown code fences (no \`\`\`html, no \`\`\`). Your response must start with the opening tag of the outermost element (which carries the data-ds-version attribute) and continue from there.${anchorInstruction}`,
+    `Apply the critique to the draft. Output the revised CONTENT FRAGMENT following ALL the OUTPUT FORMAT requirements in the system prompt. Output raw HTML only. Do NOT wrap the HTML in markdown code fences (no \`\`\`html, no \`\`\`). Your response must start with \`<section data-opollo\` and end with the matching \`</section>\` of the last top-level section.${anchorInstruction}`,
   ].join("\n");
 }
 
@@ -624,7 +631,7 @@ function userPromptForVisualRevise(ctx: PageContext): string {
     "",
     `<visual_critique>\n${ctx.previousVisualCritique ?? ""}\n</visual_critique>`,
     "",
-    "Apply the visual critique to the draft. The critique is based on a rendered screenshot; prioritise layout, contrast, whitespace, and CTA prominence fixes. Output raw HTML only. Do NOT wrap the HTML in markdown code fences (no ```html, no ```). Your response must start with the opening tag of the outermost element (which carries the data-ds-version attribute) and continue from there.",
+    "Apply the visual critique to the draft. The critique is based on a rendered screenshot; prioritise layout, contrast, whitespace, and CTA prominence fixes. Output the revised CONTENT FRAGMENT following ALL the OUTPUT FORMAT requirements in the system prompt. Output raw HTML only. Do NOT wrap the HTML in markdown code fences (no ```html, no ```). Your response must start with `<section data-opollo` and end with the matching `</section>` of the last top-level section.",
   ].join("\n");
 }
 
@@ -766,38 +773,30 @@ export function resolveRunnerMode(brief: BriefRow): RunnerMode {
 // the outer Zod bound (POST_EXCERPT_MAX). We gate at the outer bound
 // so the runner rejects obviously-too-long metas but doesn't overfit
 // to one plugin's preference.
+// Path B (PB-1, 2026-04-29): unused in production. Preserved as a
+// constant for any caller that wants to validate operator-supplied
+// excerpt copy server-side before WP REST POST.
 export const POST_META_DESCRIPTION_MAX = 300;
 
 /**
  * Post-specific quality gates (M13-3).
  *
- * Runs on the post's draft_html AFTER the base gate passes. Rejects
- * drafts whose meta description exceeds POST_META_DESCRIPTION_MAX. The
- * other post-specific checks called out in the parent plan
- * (featured-image presence conditional on SEO plugin detection,
- * taxonomy whitelist) plug in here as the M13-4 preflight wiring
- * lands; the function's shape is what the parent plan's "dispatch
- * table" contract is pinning.
+ * Path B (PB-1, 2026-04-29): the meta-description-in-HTML check is
+ * dropped because the runner no longer emits a <head> (the host WP
+ * theme owns chrome). Meta-description population for posts now needs
+ * to flow through the WP REST `excerpt` field on the post — see
+ * BACKLOG entry "Post meta description via WP excerpt (path B)" for
+ * the wiring plan. Until that lands, posts publish without an
+ * Opollo-controlled meta description; WP derives one from the body.
+ *
+ * The function is preserved as the dispatch-table seam for M13's
+ * other post-specific checks (featured-image presence conditional on
+ * SEO plugin, taxonomy whitelist) which plug in as M13-4's preflight
+ * wiring lands.
  */
 export function runPostQualityGates(
-  draftHtml: string,
+  _draftHtml: string,
 ): null | { code: string; message: string } {
-  // Extract the value of every <meta name="description" content="…">
-  // tag, tolerating attribute-order variants (`content=` before `name=`).
-  // On multiple hits, the first wins — WP's excerpt is the first-match
-  // shape in practice. A missing tag is fine: WP derives an excerpt
-  // from the post body if one isn't supplied.
-  const metaRe =
-    /<meta[^>]*\bname\s*=\s*["']description["'][^>]*\bcontent\s*=\s*["']([^"']*)["'][^>]*>|<meta[^>]*\bcontent\s*=\s*["']([^"']*)["'][^>]*\bname\s*=\s*["']description["'][^>]*>/i;
-  const match = metaRe.exec(draftHtml);
-  if (!match) return null;
-  const value = (match[1] ?? match[2] ?? "").trim();
-  if (value.length > POST_META_DESCRIPTION_MAX) {
-    return {
-      code: "POST_META_DESCRIPTION_TOO_LONG",
-      message: `meta name="description" is ${value.length} chars (max ${POST_META_DESCRIPTION_MAX}).`,
-    };
-  }
   return null;
 }
 
@@ -814,6 +813,93 @@ export function runPostQualityGates(
 // Returns null on success. Returns { code, message } on the FIRST
 // missing element so the operator gets a specific, actionable label.
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Fragment structural check (PB-1, 2026-04-29)
+//
+// Path B replacement for runStructuralCompletenessCheck. Validates the
+// shape of a CONTENT FRAGMENT — the runner's path-B output. Rejects
+// any leakage of host-WP chrome (DOCTYPE / html / head / body / nav /
+// header / footer / meta / link / title / script), requires at least
+// one top-level <section data-opollo …>, and caps inline <style>
+// content at 200 chars total.
+//
+// runStructuralCompletenessCheck below is retained for path-A
+// validation (smoke fixtures, retired pages) but no longer wired into
+// runGatesForBriefPage's production path.
+//
+// Returns null on success. Returns { code, message } on the FIRST
+// failure so the operator gets a specific, actionable label.
+// ---------------------------------------------------------------------------
+
+export function runFragmentStructuralCheck(
+  fragment: string,
+): { ok: true } | { ok: false; code: string; message: string } {
+  const trimmed = fragment.trim();
+  if (trimmed.length === 0) {
+    return {
+      ok: false,
+      code: "FRAGMENT_EMPTY",
+      message: "Draft fragment is empty.",
+    };
+  }
+
+  // Forbidden chrome elements. Each row: a regex matching the element's
+  // open tag (case-insensitive), a code, and a one-line failure message.
+  const forbidden: Array<{ re: RegExp; code: string; label: string }> = [
+    { re: /<!DOCTYPE/i, code: "FRAGMENT_DOCTYPE_LEAKED", label: "<!DOCTYPE>" },
+    { re: /<html\b/i, code: "FRAGMENT_HTML_TAG_LEAKED", label: "<html>" },
+    { re: /<head\b/i, code: "FRAGMENT_HEAD_TAG_LEAKED", label: "<head>" },
+    { re: /<body\b/i, code: "FRAGMENT_BODY_TAG_LEAKED", label: "<body>" },
+    { re: /<nav\b/i, code: "FRAGMENT_NAV_TAG_LEAKED", label: "<nav>" },
+    { re: /<header\b/i, code: "FRAGMENT_HEADER_TAG_LEAKED", label: "<header>" },
+    { re: /<footer\b/i, code: "FRAGMENT_FOOTER_TAG_LEAKED", label: "<footer>" },
+    { re: /<meta\b/i, code: "FRAGMENT_META_TAG_LEAKED", label: "<meta>" },
+    { re: /<link\b/i, code: "FRAGMENT_LINK_TAG_LEAKED", label: "<link>" },
+    { re: /<title\b/i, code: "FRAGMENT_TITLE_TAG_LEAKED", label: "<title>" },
+    { re: /<script\b/i, code: "FRAGMENT_SCRIPT_TAG_LEAKED", label: "<script>" },
+  ];
+  for (const f of forbidden) {
+    if (f.re.test(trimmed)) {
+      return {
+        ok: false,
+        code: f.code,
+        message: `Fragment must not contain ${f.label} (host WP theme owns chrome). See docs/INTEGRATION_MODEL_DECISION.md.`,
+      };
+    }
+  }
+
+  // Must contain at least one top-level <section data-opollo …>. The
+  // attribute is presence-only — its value is unused. The check is
+  // tolerant of attribute order and quoting.
+  const hasOpolloSection = /<section\b[^>]*\bdata-opollo\b/i.test(trimmed);
+  if (!hasOpolloSection) {
+    return {
+      ok: false,
+      code: "FRAGMENT_MISSING_DATA_OPOLLO_SECTION",
+      message:
+        "Fragment must include at least one top-level <section data-opollo …>. The attribute is the marker the host theme uses to scope Opollo content.",
+    };
+  }
+
+  // Inline <style> total content must be under 200 chars. Allowance
+  // covers scoped animation-keyframe / utility rules; visual styling
+  // proper inherits from the host theme.
+  const styleBlocks = trimmed.match(/<style\b[^>]*>([\s\S]*?)<\/style>/gi) ?? [];
+  const styleContentTotal = styleBlocks.reduce(
+    (sum, block) => sum + block.replace(/^<style[^>]*>|<\/style>$/gi, "").length,
+    0,
+  );
+  if (styleContentTotal > 200) {
+    return {
+      ok: false,
+      code: "FRAGMENT_INLINE_STYLE_OVER_LIMIT",
+      message: `Inline <style> content totals ${styleContentTotal} chars (max 200). Visual styling belongs on the host theme via M13 sync, not inline.`,
+    };
+  }
+
+  return { ok: true };
+}
 
 export function runStructuralCompletenessCheck(
   draftHtml: string,
@@ -929,18 +1015,15 @@ function runGatesForBriefPage(opts: {
     };
   }
 
-  // Structural-completeness gate (UAT smoke 1, 2026-04-28).
-  // Runs UNCONDITIONALLY — does NOT depend on designSystemVersion or
-  // prefix. PR #181's strict-suite bypass for sites without an active
-  // DS left a hole: a max_tokens-truncated response with no <body>
-  // and no closing tags has SOME HTML tags (passes NOT_HTML above)
-  // but renders as a blank/dark-background iframe in the operator's
-  // preview because the browser's error recovery creates an implicit
-  // empty body that picks up the inline-style background-color rule.
-  // These checks are universal HTML well-formedness — they have
-  // nothing to do with the design-system contract, so they can't be
-  // gated on it.
-  const structural = runStructuralCompletenessCheck(draftHtml);
+  // Fragment structural check (PB-1, 2026-04-29).
+  // Path B: the runner emits content fragments, not complete documents.
+  // This check rejects any leakage of host-WP chrome (DOCTYPE / html /
+  // head / body / nav / header / footer / meta / link / title / script),
+  // requires the data-opollo marker on a top-level section, and caps
+  // inline <style> content. Like the path-A check it replaced, it runs
+  // UNCONDITIONALLY (independent of designSystemVersion / prefix) — the
+  // shape contract holds whether or not a DS is configured.
+  const structural = runFragmentStructuralCheck(draftHtml);
   if (!structural.ok) {
     return {
       ok: false,

--- a/lib/quality-gates.ts
+++ b/lib/quality-gates.ts
@@ -306,13 +306,20 @@ function validateMetaLen(content: string): GateResult {
 // Runner
 // ---------------------------------------------------------------------------
 
+// Path B (PB-1, 2026-04-29): gateMetaDescription dropped from ALL_GATES.
+// Runner now emits content fragments without a <head>, so meta tags
+// can never appear in the HTML. Population for posts will flow through
+// the WP REST `excerpt` field (BACKLOG: "Post meta description via WP
+// excerpt (path B)"). Pages don't need a meta description in WP at
+// all — the theme + SEO plugin handle it. The gate function stays
+// exported for any future caller that needs it, but the production
+// runner never invokes it.
 export const ALL_GATES: Array<{ name: GateName; fn: GateFn }> = [
   { name: "html_size", fn: gateHtmlSize },
   { name: "wrapper", fn: gateWrapper },
   { name: "scope_prefix", fn: gateScopePrefix },
   { name: "html_basics", fn: gateHtmlBasics },
   { name: "slug_kebab", fn: gateSlugKebab },
-  { name: "meta_description", fn: gateMetaDescription },
 ];
 
 // Re-export HTML_SIZE_MAX_BYTES so callers who import only the gates


### PR DESCRIPTION
## Summary

Lockstep PR for PB-1 (prompt rework) + PB-2 (gate rework) per `docs/plans/path-b-migration-parent.md`. The brief runner stops emitting full HTML documents and starts emitting CONTENT FRAGMENTS that slot into a WP page's content area. The host theme owns chrome (DOCTYPE/html/head/body/nav/header/footer) and visual tokens (palette, fonts, spacing).

## What lands

- `lib/brief-runner.ts` — system prompt rewritten; user prompts for draft / revise / visual_revise rewritten; new `runFragmentStructuralCheck` replaces `runStructuralCompletenessCheck` in `runGatesForBriefPage`; `runPostQualityGates` becomes a no-op (BACKLOG entry for the WP excerpt wiring follow-up).
- `lib/quality-gates.ts` — `gateMetaDescription` dropped from `ALL_GATES`. Function still exported.
- `lib/__tests__/brief-runner-fragment-gate.test.ts` (NEW) — 21-case matrix for the new gate.
- `lib/__tests__/brief-runner.test.ts`, `brief-runner-anchor.test.ts`, `brief-runner-concurrency.test.ts`, `brief-runner-mode.test.ts`, `brief-runner-visual.test.ts` — fixtures rewritten path-A → path-B; mode test's meta-description coverage rewritten to expect the new no-op behavior.
- `docs/BACKLOG.md` — "Post meta description via WP excerpt (path B)" entry.

## Risks identified and mitigated

- **Lockstep guarantee.** Splitting PB-1 and PB-2 produces a broken intermediate state (path-B prompts hitting a path-A gate, every page fails). Mitigation: shipped together in one PR. Cannot be split.
- **Test fixtures embedded path-A shapes.** Audited and updated all 5 brief-runner test files. Each fixture now satisfies `runFragmentStructuralCheck`. Brief-runner-mode.test.ts's meta-description coverage was the trickiest — rewritten to expect the no-op behaviour rather than flag-on-too-long.
- **Strict suite (`runGates`) compatibility.** `gateWrapper` already inspects "first opening tag" (was `<html>` in path A; now `<section>`); the system prompt requires `data-ds-version` on the first top-level section, so the gate continues to work unchanged. `gateScopePrefix` keys off class prefix, unchanged. `gateHtmlBasics` checks `<h1>` count + alt text + href; all compatible. Only `gateMetaDescription` had to come out — and was: dropped from `ALL_GATES`.
- **Existing test suite broken because tests were skipping the strict suite (no DS configured).** Confirmed: tests pass `designSystemVersion=""` so the strict suite is skipped, but the structural gate (now `runFragmentStructuralCheck`) DOES run unconditionally. Fixtures updated to satisfy the new structural gate.
- **Path-A retained as escape valve.** `runStructuralCompletenessCheck` and the path-A test file (`brief-runner-structural-gate.test.ts`) remain. Page `dcbdf7d5-...` (preserved per the rescope directive) stays renderable through any future operator-side tooling that needs to validate path-A shape.
- **Meta description regression for posts.** Posts published before the WP-excerpt wiring lands fall back to WP's auto-derived excerpt (first 55 words of body). Functional but not operator-controlled. BACKLOG entry tracks the wiring; trigger is operator complaint or SEO regression test failure.

## Deliberately deferred

- WP REST `excerpt` field plumbing (BACKLOG entry shipped this PR).
- BriefReviewClient excerpt slot UI.
- Strict suite gates (`gateWrapper`, `gateScopePrefix`, `gateHtmlBasics`) checking *every* top-level section in the fragment carries `data-opollo`. Current shape: only required to be present somewhere. Tighten in a follow-up if real-world fragments leak chrome via additional top-level elements.

## Test plan

- [x] `npm run lint` ✓
- [x] `npm run typecheck` ✓
- [ ] CI: brief-runner test suite passes with new fixtures.
- [ ] CI: new fragment-gate test (21 cases) passes.
- [ ] CI: existing structural-gate test (PR #188's suite) still passes — function is preserved.
- [ ] CI: existing quality-gates test passes — runGates assertion auto-reflects the trimmed `ALL_GATES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)