### PR TITLE
feat(pb-9): runner max_tokens reset 16384 -> 4096

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -32,35 +32,6 @@ The replacement: populate the post's WP REST `excerpt` field from a brief-side e
 
 ---
 
-## brief-runner max_tokens=16384 collides with Anthropic org rate limit of 4,000 output tokens/min on Sonnet 4.6 (caught 2026-04-28)
-
-**Tags:** `bug`, `runner`, `rate-limit`, `m13`
-
-**What:** PR #188 raised `RUNNER_MAX_TOKENS` 4096 → 16384 to prevent the truncated-HTML black-box bug. That works for the *content* problem, but a single Anthropic call can now request up to 16K output tokens — quadruple the org's per-minute cap of 4,000 tokens/min on Sonnet 4.6. UAT smoke 1 retry on page `dcbdf7d5-...` hit this on a `visual_revise` pass after four prior text passes had already succeeded. Anthropic returned `429 rate_limit_error`; runner caught it in `processPagePassLoop` and marked the page `failed` with `failure_code='ANTHROPIC_ERROR'` even though the prior pass's `draft_html` was structurally complete and already persisted.
-
-Effect: any reasonably-sized brief run will sporadically fail mid-cycle whenever the per-minute window is already partially spent (concurrent runs, prior burst, etc.). The runner's existing failure path doesn't preserve partial progress — the operator sees a `failed` page even though the doc on disk is fine. Compounds with the recovery-wipe BACKLOG entry below (recovery destroys the partial-success doc).
-
-**Why deferred:** workaround for the live incident was a `failed → awaiting_review` status flip on a single page (one authorized UPDATE). Acceptable while UAT smoke 1 is the only running brief; will recur on every multi-brief day.
-
-**Trigger:** before the next major model swap, OR when rate-limit incidents recur in production. Whichever comes first.
-
-**Scope** (any one alone is partial mitigation; combine for full coverage):
-
-- **Per-call output throttle.** Cap `max_tokens` requested at `min(RUNNER_MAX_TOKENS, available_per_minute_budget)` where `available_per_minute_budget` is read from the previous response's `anthropic-ratelimit-output-tokens-remaining` header (Anthropic returns this on every response). When the per-minute window is fresh (4,000 available), use the full 16,384; when burst is spent, throttle to ≤4,000 and let the runner make multiple smaller calls instead of one big one.
-- **Pre-check rate-limit headers + back off.** Before firing a pass, read the cached `anthropic-ratelimit-output-tokens-reset` from the most recent response. If the next call's projected token count exceeds the remaining budget, sleep until reset (max 60s) before firing. Adds ~30s/page in the worst case but prevents 429s entirely.
-- **Sleep between large pass calls.** Cheapest: hardcode a 15s sleep between any two consecutive passes that each requested > 4,000 max_tokens. Doesn't read headers, doesn't adapt — but kills the burst pattern that triggers the limit. Adds 60–90s to a typical anchor cycle (4 passes × 15s).
-
-**Other notes:**
-
-- Anthropic does also rate-limit *input* tokens (~80,000/min on Sonnet 4.6). The system prompt + content_summary + previous_draft on a re-pass is multi-thousand tokens; cumulative bursts could trip that too. Whatever fix lands should at minimum log the rate-limit headers (output + input + requests) on every successful response so the operator-facing diagnostic surface (`scripts/diagnose-prod.ts`) can see the ceiling proximity.
-- A "preserve partial success" companion fix (so the runner doesn't mark a page `failed` when the previous pass produced a structurally complete doc) reduces the operator pain even without solving the rate limit. Smaller, more local change. Worth pairing.
-
-**Size:** Small (~1 hour) for the cheapest mitigation (sleep between large passes + log headers). Medium (~3 hours) for the per-call throttle reading response headers. Large if the partial-success preservation lands too.
-
-**Reference incident:** site `cdb5b15f-971d-4979-a18d-c3fd75a1c3ac`, page `dcbdf7d5-b867-443b-afdf-f60a28f968aa`. Rate limit fired 2026-04-28T04:37 UTC after 4 successful passes. `failure_detail` raw on the brief_runs row: `429 ... rate_limit_error: This request would exceed your organization's rate limit of 4,000 output tokens per minute (org: e1027476-...).`
-
----
-
 ## scripts/recover-stuck-brief-page.ts wipes draft_html unconditionally (caught 2026-04-28)
 
 **Tags:** `bug`, `ops-tooling`, `recovery-script`, `data-loss`

--- a/lib/brief-runner.ts
+++ b/lib/brief-runner.ts
@@ -127,18 +127,24 @@ export const STANDARD_TEXT_PASSES = 3; // draft, self_critique, revise
 // inserted before briefs.text_model existed (migration 0020 default
 // covers new rows).
 export const RUNNER_MODEL = "claude-sonnet-4-6";
-// Bumped 2026-04-28 from 4096 after UAT smoke 1 surfaced silent
-// truncation: every text-pass response on brief_pages.dcbdf7d5... hit
-// exactly 4096 output tokens, leaving draft_html truncated mid-CSS
-// (no <body>, no closing tags). Realistic Claude-generated landing
-// pages with full inline CSS routinely exceed 3K tokens; 4K is too
-// tight a cap. 16K gives 4x headroom while staying well under the
-// model's 64K (Sonnet/Haiku 4.x) / 32K (Opus 4.x) per-response cap.
-// The structural-completeness gate added in this same PR is the
-// belt: any future truncation that still slips through (e.g. a
-// future model with a smaller cap) gets surfaced as
-// capped_with_issues rather than rendering a black-box iframe.
-export const RUNNER_MAX_TOKENS = 16384;
+// PB-9 (2026-04-29): reset 16384 -> 4096 after path-B fragment rework
+// (PR #194) made path-A full-document outputs obsolete. Path-B
+// fragments are typically 2K-6K chars (~500-1500 tokens), so 4K is
+// comfortable headroom — and it sits at the org's per-minute output
+// cap on Sonnet 4.6 instead of 4x over it. Resolves BACKLOG entry
+// "brief-runner max_tokens=16384 collides with Anthropic org rate
+// limit of 4,000 output tokens/min on Sonnet 4.6".
+//
+// The fragment-shape gate from PR #194 plus the truncation banner
+// from PR #189 stay as belts: any rare fragment that exceeds 4K is
+// surfaced as a quality_flag rather than silently rendering as a
+// blank/styled-empty iframe.
+//
+// Pre-2026-04-28 history: 4096 was the original cap, raised to 16384
+// during the path-A truncation incident on page dcbdf7d5-... . That
+// incident was a content-shape problem, not a cap problem; path-B
+// fixes it at the source.
+export const RUNNER_MAX_TOKENS = 4096;
 
 // Cap on brief_runs.content_summary length. Parent plan §Running-summary
 // budget says ~2k tokens; we measure in chars (4 chars ≈ 1 token average)


### PR DESCRIPTION
## Summary

PB-9 from the parent plan (PR #193). Lowers \`RUNNER_MAX_TOKENS\` 16384 → 4096 now that path-B fragments (PR #194) replace path-A full documents. Fragment outputs are typically 2K–6K chars (~500–1500 tokens), so 4K is comfortable headroom AND sits at the org's per-minute output cap on Sonnet 4.6 instead of 4x over it.

Retires the BACKLOG entry "brief-runner max_tokens=16384 collides with Anthropic org rate limit of 4,000 output tokens/min on Sonnet 4.6" — deleted in this PR.

## What lands

- \`lib/brief-runner.ts\` — \`RUNNER_MAX_TOKENS = 4096\`. Updated comment with the path-B rationale + reference to the rate-limit BACKLOG entry it resolves.
- \`docs/BACKLOG.md\` — rate-limit conflict entry removed.

## Risks identified and mitigated

- **A path-B fragment occasionally exceeds 4096 tokens (long-form post).** The fragment-shape gate (PR #194) catches it; the truncation banner (PR #189) flags it visually. Surfaces as a \`quality_flag\` rather than silent rendering. Same belts as before, just rarely triggered.
- **Existing tests assumed 16384 cap.** None of the brief-runner tests assert against \`max_tokens\` specifically — they pass mock \`AnthropicCallFn\`s that ignore the value. Verified via \`grep "RUNNER_MAX_TOKENS\|16384" lib/__tests__/brief-runner*.test.ts\` returning zero matches.

## Deliberately deferred

- The other rate-limit mitigations (per-call throttle reading response headers, pre-check + back off, inter-call sleep) — no longer needed at 4K cap. Re-open if path-B fragments grow.

## Test plan

- [x] \`npm run lint\` ✓
- [x] \`npm run typecheck\` ✓
- [ ] CI: existing brief-runner suite passes against the lower cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)