### PR TITLE
feat(pb-5): m7 regen runner emits path-b fragments

### DIFF
--- a/lib/__tests__/regeneration-publisher.test.ts
+++ b/lib/__tests__/regeneration-publisher.test.ts
@@ -31,17 +31,17 @@ import { seedSite } from "./_helpers";
 //      matching the WP call's shape.
 // ---------------------------------------------------------------------------
 
-// A minimal HTML fixture that passes every quality gate: scoped wrapper
-// with the site prefix + ds version, one <h1>, no empty hrefs, one
-// <img alt="…">, and a <meta name="description"> in the 50-160 range.
+// Path-B fragment (PB-5, 2026-04-29). Top-level <section data-opollo>
+// with site prefix + ds version, one <h1>, no empty hrefs, one
+// <img alt="…">. No <meta> — host theme owns it; PR #194 dropped
+// gateMetaDescription from ALL_GATES.
 function passingHtml(prefix: string, dsv: string): string {
   return [
-    `<div class="${prefix}-scope" data-ds-version="${dsv}">`,
-    `<meta name="description" content="A valid meta description at least fifty characters in length for the page." />`,
+    `<section data-opollo class="${prefix}-scope" data-ds-version="${dsv}">`,
     `<h1 class="${prefix}-title">Regenerated</h1>`,
     `<p class="${prefix}-body"><a href="/help" class="${prefix}-link">Help</a></p>`,
     `<img class="${prefix}-img" src="https://imagedelivery.net/HASH/cf-abc/public" alt="Preview image"/>`,
-    `</div>`,
+    `</section>`,
   ].join("");
 }
 

--- a/lib/regeneration-publisher.ts
+++ b/lib/regeneration-publisher.ts
@@ -7,6 +7,7 @@ import {
   rewriteImageUrls,
 } from "@/lib/html-image-rewrite";
 import { LEADSOURCE_FONT_LOAD_HTML } from "@/lib/leadsource-fonts";
+import { runFragmentStructuralCheck } from "@/lib/brief-runner";
 import { runGates, type RunGatesResult } from "@/lib/quality-gates";
 import { getServiceRoleClient } from "@/lib/supabase";
 import {
@@ -248,13 +249,28 @@ async function publishRegenJobImpl(
     };
   }
 
-  // 1. Quality gates
-  const gates = runGates({
-    html: generatedHtml,
-    slug: page.slug as string,
-    prefix: site.prefix as string,
-    design_system_version: String(page.design_system_version ?? 1),
-  });
+  // 1. Quality gates. PB-5 (2026-04-29): fragment-shape check runs
+  // FIRST, before the strict suite. A fragment-shape failure is wrapped
+  // into a synthetic GateOutcome so the existing failure path
+  // (event log + status='failed_gates') handles it uniformly.
+  const fragmentCheck = runFragmentStructuralCheck(generatedHtml);
+  const gates: RunGatesResult = !fragmentCheck.ok
+    ? ({
+        kind: "failed",
+        gates_run: ["fragment_structural"] as Array<string>,
+        first_failure: {
+          kind: "fail",
+          gate: "fragment_structural" as never,
+          reason: fragmentCheck.message,
+          details: { code: fragmentCheck.code },
+        },
+      } as unknown as RunGatesResult)
+    : runGates({
+        html: generatedHtml,
+        slug: page.slug as string,
+        prefix: site.prefix as string,
+        design_system_version: String(page.design_system_version ?? 1),
+      });
   if (gates.kind === "failed") {
     await supabase.from("regeneration_events").insert({
       regeneration_job_id: jobId,

--- a/lib/regeneration-worker.ts
+++ b/lib/regeneration-worker.ts
@@ -680,6 +680,10 @@ function buildRegenUserMessage(
   pageType: string,
   brief: unknown,
 ): string {
+  // Path B (PB-5, 2026-04-29): emit a contiguous fragment of top-level
+  // <section data-opollo …> elements. The host WP theme owns chrome
+  // (DOCTYPE/html/head/body/nav/header/footer) and visual tokens
+  // (palette, fonts, spacing). See docs/INTEGRATION_MODEL_DECISION.md.
   const briefJson = JSON.stringify(brief ?? {}, null, 2);
   return [
     `Re-generate the page "${title}" (slug: ${slug}, type: ${pageType}) against the current design system.`,
@@ -690,7 +694,12 @@ function buildRegenUserMessage(
     briefJson,
     "```",
     "",
-    "Return the full page HTML wrapped in the site's scope div. Follow every hard constraint in the system prompt.",
+    "OUTPUT FORMAT — STRICT REQUIREMENTS:",
+    "1. Output a CONTIGUOUS FRAGMENT of one or more top-level <section> elements. Do NOT emit any of: <!DOCTYPE>, <html>, <head>, <body>, <nav>, <header>, <footer>, <meta>, <link>, <title>, <script>. The host WP theme owns those.",
+    "2. Every top-level <section> MUST carry the data-opollo attribute (presence-only, no value required). The first top-level <section> MUST also carry data-ds-version=\"<DS version from system prompt>\".",
+    "3. Every CSS class must start with the site prefix (per the system prompt).",
+    "4. Inline <style> blocks are permitted ONLY for animation keyframes / scoped utility rules under 200 chars total.",
+    "5. Output raw HTML only. No markdown code fences.",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary

PB-5 from the parent plan (PR #193). Mirrors PB-1+PB-2 (PR #194) and PB-4 (PR #197) for the M7 regen path.

## What lands

- \`lib/regeneration-worker.ts\`: \`buildRegenUserMessage\` rewritten with explicit OUTPUT FORMAT block — forbids chrome, requires \`<section data-opollo>\` with \`data-ds-version\`, caps inline \`<style>\`.
- \`lib/regeneration-publisher.ts\`: \`runFragmentStructuralCheck\` runs FIRST, before \`runGates\`. Fragment-shape failure wrapped into a synthetic \`RunGatesResult\` so the existing \`failed_gates\` event-log + status path handles it uniformly.
- \`lib/__tests__/regeneration-publisher.test.ts\`: \`passingHtml\` fixture rewritten as path-B fragment (\`<section data-opollo>\`), no \`<meta>\` tag.

## Risks identified and mitigated

- **Same synthetic-gate cast as PB-4.** \`gate: "fragment_structural" as never\` plus a cast through \`unknown\`. Sentinel name; not in \`GateName\` union; the event log just records the string. Acceptable for a uniform failure-handling shape.
- **\`runFragmentStructuralCheck\` import from \`@/lib/brief-runner\`.** Same cross-subsystem boundary as PB-4. Pure logic; no DB / no side effects.
- **Idempotency keys are content-shape-agnostic.** Existing \`(brief_id, page_id)\` regen keys unchanged. Re-run with same key returns same Anthropic response (cached); the new gate then evaluates against it.
- **\`<meta name="description">\` removed from passingHtml fixture.** PR #194 dropped \`gateMetaDescription\` from \`ALL_GATES\`, so the strict suite no longer requires it. Removing keeps the fixture path-B-clean (no \`<meta>\` allowed in fragments).

## Test plan

- [x] \`npm run lint\` ✓
- [x] \`npm run typecheck\` ✓
- [ ] CI: regen test suite passes with new fixture + new gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)