### PR TITLE
feat(pb-3): preview iframe wraps path-b fragments with shim stylesheet

### DIFF
--- a/components/BriefRunClient.tsx
+++ b/components/BriefRunClient.tsx
@@ -13,6 +13,7 @@ import type {
   BriefRow,
   BriefRunSnapshot,
 } from "@/lib/briefs";
+import { wrapForPreview } from "@/lib/preview-iframe-wrapper";
 
 // ---------------------------------------------------------------------------
 // M12-5 — /admin/sites/[id]/briefs/[brief_id]/run client component.
@@ -588,8 +589,15 @@ function PagePreview({
             // preview. draft_html is Claude-generated and already passes
             // the runner's quality gates, but belt-and-suspenders: render
             // it in a constrained frame.
+            //
+            // PB-3 (2026-04-29): wrapForPreview wraps path-B fragments in
+            // a synthetic doc with a shim stylesheet that approximates
+            // WP/Kadence defaults so the operator sees STYLED content
+            // for visual review rather than unstyled raw HTML. Path-A
+            // documents (claim completeness via DOCTYPE / <html opener)
+            // are passed through unchanged. See lib/preview-iframe-wrapper.ts.
             sandbox=""
-            srcDoc={html}
+            srcDoc={wrapForPreview(html)}
             className="mt-2 h-96 w-full rounded border"
             title={`Preview of ${page.title}`}
           />

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,32 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## Preview iframe — fetch customer theme CSS for high-fidelity preview (path B, opened 2026-04-29 by PB-3)
+
+**Tags:** `path-b`, `m13`, `preview`, `ux`
+
+**What:** PB-3 (`lib/preview-iframe-wrapper.ts`) inlines a generic shim stylesheet that approximates WP/Kadence Blocks defaults. The operator sees STYLED content for visual review, but the styling is NOT pixel-accurate to the customer's actual published page (font face / palette / spacing rhythm / button shapes all differ).
+
+For high-fidelity preview, fetch the customer's actual theme CSS bundle and inline it into the synthetic wrapper instead of (or alongside) the shim. Two server-side fetch shapes worth considering:
+
+- **At server-render time**: `BriefRunPage` fetches `https://<customer-wp>/wp-content/themes/<active-theme>/style.css` + Kadence Blocks CSS bundle, passes the concatenated CSS as a prop to `BriefRunClient`. No CSP impact (server-side fetch). Cost: one extra HTTP round-trip per page render. Mitigation: cache the CSS in Supabase Storage keyed by `(site_id, theme_slug, css_sha256)`.
+- **Operator-triggered snapshot**: a "Refresh theme preview CSS" button in the Appearance panel writes a snapshot row. Iframe wrapper reads the latest snapshot. Operator controls freshness explicitly.
+
+**Why deferred:** PB-3's shim gives visual review just enough fidelity to validate content + structure + image placement. Pixel-accuracy doesn't block the path-B rebuild from shipping. Customer feedback will tell us whether the shim is "close enough" or whether the gap is a regular operator pain.
+
+**Trigger:** when an operator complains the preview doesn't match production well enough to approve confidently, OR when the M13 sync surface adds the snapshot capability for other reasons.
+
+**Scope:**
+- Add the snapshot table or storage bucket if the operator-triggered shape lands.
+- `lib/wp-theme-snapshot.ts`: fetch + store + retrieve helper.
+- `BriefRunPage` (server component): on render, attach the latest snapshot's CSS to the props handed to `BriefRunClient`.
+- `lib/preview-iframe-wrapper.ts`: take an optional `themeCss` parameter; inline it after the shim.
+- E2E: visual snapshot test comparing iframe render to production.
+
+**Size:** Medium (~3–5 hours for the snapshot path; another hour for E2E).
+
+---
+
 ## Post meta description via WP excerpt (path B, opened 2026-04-29 by PB-1)
 
 **Tags:** `path-b`, `m13`, `posts`, `seo`

--- a/lib/__tests__/preview-iframe-wrapper.test.ts
+++ b/lib/__tests__/preview-iframe-wrapper.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { wrapForPreview } from "@/lib/preview-iframe-wrapper";
+
+// ---------------------------------------------------------------------------
+// PB-3 (2026-04-29) — preview-iframe wrapper unit tests.
+//
+// Two contracts pinned:
+//   1. Path-A documents (have <!DOCTYPE> or <html opener) are passed
+//      through unchanged. Legacy / evidence pages (e.g. dcbdf7d5...)
+//      keep rendering exactly as they did before path B landed.
+//   2. Path-B fragments are wrapped in a synthetic document that
+//      includes the shim stylesheet so the iframe shows styled
+//      content for visual review.
+// ---------------------------------------------------------------------------
+
+describe("wrapForPreview — empty / nullish input", () => {
+  it("returns empty string for null", () => {
+    expect(wrapForPreview(null)).toBe("");
+  });
+  it("returns empty string for undefined", () => {
+    expect(wrapForPreview(undefined)).toBe("");
+  });
+  it("returns empty string for empty string", () => {
+    expect(wrapForPreview("")).toBe("");
+  });
+  it("returns empty string for whitespace-only", () => {
+    expect(wrapForPreview("   \n\t ")).toBe("");
+  });
+});
+
+describe("wrapForPreview — path-A passthrough", () => {
+  it("returns DOCTYPE-prefixed input unchanged", () => {
+    const doc =
+      '<!DOCTYPE html><html><head></head><body><p>x</p></body></html>';
+    expect(wrapForPreview(doc)).toBe(doc);
+  });
+  it("returns <html>-opening input unchanged (no DOCTYPE)", () => {
+    const doc = '<html lang="en"><body><p>x</p></body></html>';
+    expect(wrapForPreview(doc)).toBe(doc);
+  });
+  it("is case-insensitive on the completeness markers", () => {
+    const doc = '<!doctype HTML><HTML><BODY>x</BODY></HTML>';
+    expect(wrapForPreview(doc)).toBe(doc);
+  });
+});
+
+describe("wrapForPreview — path-B fragment wrapping", () => {
+  const FRAGMENT = '<section data-opollo class="ls-hero"><h1>Hi</h1></section>';
+
+  it("wraps a fragment in a synthetic <!DOCTYPE>...</html> shell", () => {
+    const out = wrapForPreview(FRAGMENT);
+    expect(out.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(out).toContain('<html lang="en">');
+    expect(out).toContain('<meta charset="UTF-8">');
+    expect(out).toContain('<meta name="viewport"');
+    expect(out).toContain("<style>");
+    expect(out).toContain("</style>");
+    expect(out).toContain("<body>");
+    expect(out).toContain(FRAGMENT);
+    expect(out).toContain("</body>");
+    expect(out.endsWith("</html>")).toBe(true);
+  });
+
+  it("includes the shim stylesheet body { ... } rule", () => {
+    const out = wrapForPreview(FRAGMENT);
+    expect(out).toContain("body {");
+    expect(out).toContain("font-family:");
+  });
+
+  it("includes scoped [data-opollo] rules", () => {
+    const out = wrapForPreview(FRAGMENT);
+    expect(out).toContain("[data-opollo]");
+    expect(out).toContain("--ds-color-primary");
+  });
+
+  it("preserves the fragment's exact bytes within the wrapper body", () => {
+    const out = wrapForPreview(FRAGMENT);
+    // Confirm the fragment appears verbatim, not escaped or transformed.
+    expect(out).toContain(FRAGMENT);
+  });
+
+  it("wraps a multi-section fragment", () => {
+    const multi =
+      '<section data-opollo><h1>Hero</h1></section>\n<section data-opollo><p>Features.</p></section>';
+    const out = wrapForPreview(multi);
+    expect(out).toContain(multi);
+    expect(out).toContain("<style>");
+  });
+
+  it("wraps a bare fragment lacking data-opollo (defensive)", () => {
+    // The runner gate prevents this in production, but the wrapper
+    // shouldn't crash on unmarked content — it just renders it
+    // unstyled (CSS is scoped to [data-opollo]).
+    const out = wrapForPreview("<section><h1>Bare</h1></section>");
+    expect(out).toContain("<section><h1>Bare</h1></section>");
+    expect(out).toContain("<style>");
+  });
+});

--- a/lib/preview-iframe-wrapper.ts
+++ b/lib/preview-iframe-wrapper.ts
@@ -1,0 +1,139 @@
+// ---------------------------------------------------------------------------
+// PB-3 (2026-04-29) — Preview iframe wrapper.
+//
+// The runner emits path-B body fragments (PB-1, PR #194). The preview
+// iframe in BriefRunClient (and any future preview surface) used to
+// render the fragment directly via `srcDoc={html}`, which produced an
+// unstyled raw rendering — useless for visual review because the host
+// WP theme's CSS isn't applied.
+//
+// This helper wraps the fragment in a synthetic HTML document with a
+// shimmed default stylesheet that approximates WP/Kadence Blocks
+// defaults: sensible body font, basic typography, and CSS variables
+// scoped to [data-opollo] that the design system can read. The shim
+// is NOT pixel-perfect to the customer's actual published page, but
+// it lets the operator visually review content + structure + image
+// placement against a reasonable baseline.
+//
+// Higher fidelity (fetching the customer's actual theme CSS bundle
+// and inlining it) is a follow-up — see BACKLOG entry "Preview
+// iframe — fetch customer theme CSS for high-fidelity preview".
+//
+// Path-A passthrough: documents that claim completeness (have
+// <!DOCTYPE> or an <html opener) are returned unchanged. Path-A is
+// retained for backwards compatibility with legacy generations and
+// for the dcbdf7d5-... evidence page.
+//
+// Pure logic — no DOM, no network. Safe in any runtime.
+// ---------------------------------------------------------------------------
+
+const SHIM_STYLESHEET = `
+  /* Path-B preview shim. Approximates WP/Kadence Blocks defaults
+     so a fragment renders styled-enough for visual review. NOT
+     pixel-accurate to the customer's published page. */
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+      Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+    font-size: 16px;
+    line-height: 1.6;
+    color: #1f2937;
+    background: #ffffff;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  [data-opollo] {
+    /* Container width approximates the typical WP theme content area. */
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+    /* Design-system token defaults — actual values come from the
+       theme + M13 sync in production. These are sensible fallbacks. */
+    --ds-color-primary: #2563eb;
+    --ds-color-text: #1f2937;
+    --ds-color-muted: #6b7280;
+    --ds-color-bg: #ffffff;
+    --ds-color-bg-alt: #f9fafb;
+    --ds-radius: 0.5rem;
+    --ds-spacing: 1rem;
+  }
+  [data-opollo] + [data-opollo] {
+    border-top: 1px solid #e5e7eb;
+  }
+  [data-opollo] h1 {
+    font-size: 2.25rem;
+    font-weight: 700;
+    margin: 0 0 1rem;
+    line-height: 1.2;
+  }
+  [data-opollo] h2 {
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin: 1.5rem 0 0.75rem;
+    line-height: 1.3;
+  }
+  [data-opollo] h3 {
+    font-size: 1.375rem;
+    font-weight: 600;
+    margin: 1.25rem 0 0.5rem;
+    line-height: 1.4;
+  }
+  [data-opollo] p { margin: 0 0 1rem; }
+  [data-opollo] a {
+    color: var(--ds-color-primary);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  [data-opollo] a:hover { text-decoration: none; }
+  [data-opollo] img {
+    max-width: 100%;
+    height: auto;
+    border-radius: var(--ds-radius);
+  }
+  [data-opollo] ul, [data-opollo] ol {
+    margin: 0 0 1rem;
+    padding-left: 1.5rem;
+  }
+`;
+
+/**
+ * Returns the html string ready to feed into an iframe srcdoc.
+ *
+ * - For path-A documents (have <!DOCTYPE> or <html opener): returns
+ *   the input unchanged. Legacy / evidence pages render as before.
+ * - For path-B fragments: wraps in a synthetic doc with the shim
+ *   stylesheet. The fragment becomes the iframe body's content.
+ *
+ * Empty / nullish input returns an empty string so the caller can
+ * branch on truthiness.
+ */
+export function wrapForPreview(html: string | null | undefined): string {
+  if (!html) return "";
+  const trimmed = html.trim();
+  if (trimmed.length === 0) return "";
+
+  const claimsCompleteness =
+    /<!DOCTYPE\s+html\b/i.test(trimmed) || /<html[\s>]/i.test(trimmed);
+  if (claimsCompleteness) {
+    // Path-A: render unchanged. Document carries its own chrome and CSS.
+    return html;
+  }
+
+  // Path-B: synthetic wrapper around the fragment.
+  return [
+    "<!DOCTYPE html>",
+    '<html lang="en">',
+    "<head>",
+    '<meta charset="UTF-8">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1.0">',
+    "<style>",
+    SHIM_STYLESHEET,
+    "</style>",
+    "</head>",
+    "<body>",
+    html,
+    "</body>",
+    "</html>",
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary

PB-3 from the parent plan (PR #193). Lowest-risk variant per the standing autonomous-run rule: a synthetic-doc wrapper with a shim stylesheet that approximates WP/Kadence Blocks defaults. Operator sees STYLED content for visual review rather than unstyled raw HTML.

## What lands

- \`lib/preview-iframe-wrapper.ts\` (NEW): pure \`wrapForPreview(html)\` helper. Wraps path-B fragments in a synthetic doc with a shim stylesheet (sensible body font, basic typography, scoped \`[data-opollo]\` selectors, default DS token CSS variables). Path-A documents (claim completeness via \`<!DOCTYPE>\` / \`<html opener\`) are passed through unchanged for backwards compat with legacy generations and the \`dcbdf7d5-...\` evidence page.
- \`components/BriefRunClient.tsx\`: iframe \`srcDoc\` now uses \`wrapForPreview(html)\`. Truncation banner from PR #189 stays. Sandbox stays \`""\` (most restrictive).
- \`lib/__tests__/preview-iframe-wrapper.test.ts\` (NEW): 13-case matrix — empty/null, path-A passthrough (3 cases), path-B wrapping (6 cases including shim contents + multi-section + bare-fragment defensive case).
- \`docs/BACKLOG.md\`: "Preview iframe — fetch customer theme CSS for high-fidelity preview" entry. Trigger: operator complains the preview doesn't match production well enough.

## Risks identified and mitigated

- **Shim stylesheet vs. real customer theme.** The shim approximates Kadence Blocks defaults; pixel-accuracy is NOT a goal. Operator sees content + structure + image placement against a sane baseline. Higher-fidelity preview is in BACKLOG.
- **CSP.** No changes. The synthetic wrapper is inline; no external CSS / no cross-origin fetches; no \`connect-src\` widening. Sandbox stays \`""\`.
- **Path-A regression.** \`wrapForPreview\` detects \`<!DOCTYPE>\` / \`<html opener\` and returns input unchanged — legacy pages render byte-identically to before. Two test cases pin this.
- **Bare fragment without \`data-opollo\` (defensive).** Wrapper still produces a valid doc, just with the scoped CSS not applying. Test pins the defensive shape so a future runner regression doesn't crash the preview.
- **CSS specificity collisions with operator-edited content.** The shim is scoped to \`[data-opollo]\` so it can't bleed onto other content. Operator-edited fragment that drops \`data-opollo\` falls back to browser defaults — visible degradation, not silent.

## Deliberately deferred

- **Customer theme CSS fetch + inline.** BACKLOG entry; trigger is operator complaint or explicit visual-fidelity requirement.
- **Preview-iframe contract pattern doc.** The header comment block in \`lib/preview-iframe-wrapper.ts\` documents the contract; promoting to \`docs/patterns/\` waits until a second preview surface needs the same wrapper (M14 page-preview, etc.).

## Test plan

- [x] \`npm run lint\` ✓
- [x] \`npm run typecheck\` ✓
- [ ] CI: 13 wrapper tests pass.
- [ ] Manual visual: open the brief run surface for any active page; expand "Show rendered preview"; expect a styled fragment (not raw HTML) within the iframe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)