### PR TITLE
docs(pb-8): m13 sync drift is a content bug under path b

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,32 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## Path-B publish gate on Kadence sync drift (path B, opened 2026-04-29 by PB-8)
+
+**Tags:** `path-b`, `m13`, `publish`, `feature-flag`
+
+**What:** Under path B, the host theme owns visual tokens (palette, fonts, spacing) — so Kadence palette sync is the visual contract for published Opollo content. Drift between the design-system tokens and the WP palette = published content renders with wrong colours.
+
+PB-8 documented the new severity in `docs/RUNBOOK.md` ("kadence-customizer-drift — palette sync hits WP_STATE_DRIFTED" entry). The next layer is a hard preflight gate: refuse publish on a site whose `kadence_globals_synced_at` is null OR whose stored DS palette doesn't match the last successful WP read. Operator must run sync before publish proceeds.
+
+Implementation should be flag-gated (`FEATURE_PATH_B_PUBLISH_GATE`, default off; flip on per-site as path-B rollouts complete) so existing customers aren't blocked the moment the gate lands.
+
+**Why deferred:** PB-8 surfaced the severity bump in the runbook; the operator-facing visual treatment (red banner in the Appearance panel) and the preflight gate itself widen scope into the M13 surface area. Worth a dedicated slice that touches `app/api/sites/[id]/appearance/preflight/route.ts`, `app/api/sites/[id]/posts/[post_id]/publish/route.ts`, `app/api/sites/[id]/pages/[page_id]/publish/route.ts`, and `components/AppearancePanel.tsx` together with E2E coverage of the gated-publish path.
+
+**Trigger:** when an operator publishes path-B content against a drifted site and gets a visual regression, OR when path-B becomes the default (every new site uses path B) and we want hard guardrails before rollout. Whichever comes first.
+
+**Scope:**
+- Add `FEATURE_PATH_B_PUBLISH_GATE` env-var doc to `.env.local.example`.
+- Extend `lib/site-preflight.ts` with a `checkKadenceSyncFresh(siteId)` helper.
+- Wire the helper into the four publish + preflight routes above. When the flag is on AND the site has a drift state, return `409 KADENCE_SYNC_DRIFT_BLOCKED` with a translated message naming the Appearance panel link.
+- `components/AppearancePanel.tsx`: visual treatment of "out of sync" upgrades from yellow warning to red alert when the flag is on.
+- Sync-drift unit tests bump severity (`expect(...).toBeNull()` → `expect(...).toMatchObject({ code: 'KADENCE_SYNC_DRIFT_BLOCKED' })`).
+- E2E: `e2e/appearance.spec.ts` covers the publish-blocked-on-drift path.
+
+**Size:** Medium (~3–5 hours including E2E + flag plumbing).
+
+---
+
 ## Preview iframe — fetch customer theme CSS for high-fidelity preview (path B, opened 2026-04-29 by PB-3)
 
 **Tags:** `path-b`, `m13`, `preview`, `ux`

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -525,9 +525,11 @@ Log the provisioning date + vendor account IDs somewhere persistent; each rotati
 
 ## kadence-customizer-drift — palette sync hits WP_STATE_DRIFTED
 
+**Severity (path B, post-2026-04-29):** **CONTENT BUG**, not polish. Under path B (decision PR #192), Opollo emits content fragments and the host theme owns visual tokens (palette, fonts, spacing). Kadence palette sync IS the visual contract — drift between the design-system tokens and the WP-side palette means published Opollo content renders with the wrong colours. Treat sync-drift incidents at the same urgency as a runner regression. Prior framing of "polish" is obsolete.
+
 **Symptom:** Appearance panel sync confirm hits 409 `WP_STATE_DRIFTED`. Banner: "WordPress changed between your preview and confirm. We've refreshed the diff — review again before syncing." Diff table shows different "current" colors than the operator saw 30 seconds ago.
 
-**Impact:** sync is blocked but no data loss. Operator's intent is preserved; they need to re-review against the new state.
+**Impact:** sync is blocked but no data loss. Under path B, **any content published while drift is unresolved will render with wrong colours** — the operator should publish nothing else until sync is reconciled. Operator's intent is preserved; they need to re-review against the new state.
 
 **Diagnose:**
 1. The drift hash in `lib/kadence-palette-sync.ts::hashPalette` re-reads WP's current palette right before the write. A mismatch with the dry-run's hash triggers the failure.


### PR DESCRIPTION
## Summary

PB-8 from the parent plan (PR #193). Documents the M13 reframe: under path B, the host theme owns visual tokens (palette, fonts, spacing) — Kadence palette sync IS the visual contract. Drift = published Opollo content renders with wrong colours.

## What lands

- \`docs/RUNBOOK.md\`: \`kadence-customizer-drift\` entry gets a path-B severity note. Sync drift is now a **CONTENT BUG**, not polish. Operator should publish nothing else until reconciled.
- \`docs/BACKLOG.md\`: "Path-B publish gate on Kadence sync drift" entry tracking the hard preflight gate (refuse publish on drift) — feature-flagged behind \`FEATURE_PATH_B_PUBLISH_GATE\`. Deferred to its own slice that touches publish + preflight routes + AppearancePanel + E2E together.

## Risks identified and mitigated

- **Operator publishes path-B content while drifted, gets visual regression.** Surface severity in the runbook so on-call has the right priority. Hard prevention is the BACKLOG follow-up.
- **Severity reframe could surprise an operator who's used to drift being "just a notice".** Banner / panel-copy update pairs with the gate work in the follow-up slice. Today's documentation makes the new framing explicit.

## Deliberately deferred (BACKLOG)

- The hard publish gate behind \`FEATURE_PATH_B_PUBLISH_GATE\` — a dedicated slice with route changes + UI updates + E2E. Trigger: operator hits a drift-related visual regression OR path-B becomes default for new sites.

## Test plan

- [x] \`npm run lint\` ✓ (docs-only)
- [x] \`npm run typecheck\` ✓ (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)