### PR TITLE
docs(pb-6): legacy path-a data — leave-as-is dual-path decision

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,31 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## Legacy path-A row retire trigger (path B, opened 2026-04-29 by PB-6)
+
+**Tags:** `path-b`, `cleanup`, `data-migration`
+
+**What:** PB-6 chose "leave-as-is dual-path" — path-A rows (full HTML docs in `pages.generated_html` / `posts.generated_html` / `brief_pages.draft_html` / `brief_pages.generated_html`) coexist with path-B fragments. Publish + preview both branch via the `claimsCompleteness` heuristic in `lib/preview-iframe-wrapper.ts`. See `docs/plans/path-b-legacy-data-decision.md` for the trade-off rationale.
+
+When path-A rows become stale enough or visually disruptive enough, retire by running option 1 from the parent plan: schema migration adds `legacy_path_a boolean` column (backfill default true, new rows default false); publish path refuses path-A unless the operator explicitly approves a regen.
+
+**Why deferred:** zero-cost, zero-risk leave-as-is is the right default while path B is rolling out and the customer base is still small. Premature retirement adds runtime branches + operator banners + regen cost for content that's working today.
+
+**Trigger:** all path-A rows are older than the customer's data-retention threshold (typically 90 days for unpublished drafts, indefinite for published pages), OR an operator complains a published path-A page is now visually inconsistent with the rest of the site and wants Opollo to regen.
+
+**Scope:**
+- `scripts/diagnose-prod.ts`: add `legacy-row-counts` subcommand (per-table count of rows matching the path-A heuristic). ~30-line read-only addition.
+- Schema migration: add `legacy_path_a boolean` to the four tables; backfill default true via heuristic; new rows default false (runner sets the column on insert).
+- Publish path branch: refuse path-A unless `legacy_path_a` operator-approved-regen flow runs.
+- Operator-facing banner in BriefRunClient + page detail / post detail surfaces.
+- E2E for the regen-on-publish flow.
+
+**Size:** Medium (~3–5 hours for the survey + schema + branch; another hour or two for the operator-facing UX).
+
+**Reference:** `docs/plans/path-b-legacy-data-decision.md` — the current dual-path decision and its retire criteria.
+
+---
+
 ## Path-B publish gate on Kadence sync drift (path B, opened 2026-04-29 by PB-8)
 
 **Tags:** `path-b`, `m13`, `publish`, `feature-flag`

--- a/docs/plans/path-b-legacy-data-decision.md
+++ b/docs/plans/path-b-legacy-data-decision.md
@@ -1,0 +1,48 @@
+# Path-B legacy data migration — decision (2026-04-29)
+
+## Decision
+
+**Leave-as-is dual-path.** Existing path-A rows in `pages.generated_html`, `posts.generated_html`, `brief_pages.draft_html`, and `brief_pages.generated_html` keep their full-document HTML. New runs (post-PR #194) emit path-B fragments. Both shapes coexist on disk indefinitely; the publish path forwards whatever the column holds, and the preview iframe handles both via the `claimsCompleteness` heuristic in `lib/preview-iframe-wrapper.ts` (PR #199).
+
+## Why
+
+Per the standing autonomous-run rule (lowest-risk default), the three options from the parent plan (`docs/plans/path-b-migration-parent.md` §PB-6) trade as:
+
+| Option | Risk | Operator effort | Cost | Reversible? |
+|---|---|---|---|---|
+| 1. Regenerate-on-next-publish | Medium — adds `legacy_path_a boolean` column + runtime branch + operator-facing banner | High — every legacy page needs an explicit regen | Per-page Anthropic cost × N | Yes (drop the column) |
+| 2. Lossy extraction backfill | High — jsdom-based extractor strips inline CSS; some pages will look wrong post-migration | None for the first batch (operator confirms) | One-time cron cost | No (original bytes overwritten) |
+| 3. Leave-as-is dual-path (chosen) | Low — no migration writes; existing publishes keep working byte-identically | None | None up-front | Yes (run option 1 or 2 later) |
+
+Option 3 is the only choice with zero data-loss risk, zero up-front cost, and zero operator action. The cost is permanent runtime branching — but that branching is already in place (PR #189 truncation banner + PR #199 preview wrapper both key off `claimsCompleteness`). Adding nothing is the cheapest way to satisfy PB-6.
+
+## Implementation
+
+**Code changes shipped this PR**: none. The publish path (`lib/wordpress.ts::wpCreatePage` etc.) already forwards `content` byte-identically to WP REST regardless of shape (verified by PB-7's regression suite, PR #196). The preview iframe (`components/BriefRunClient.tsx` → `lib/preview-iframe-wrapper.ts`) already detects path-A vs path-B and wraps appropriately.
+
+**Code changes deliberately deferred**: a one-time row-count survey, a `legacy_path_a` boolean column, an operator-facing banner. All wait for the retire trigger.
+
+## Retire trigger
+
+Drop dual-path support when:
+
+- All path-A rows are older than the customer's data-retention threshold (typically 90 days for unpublished drafts, indefinite for published pages — check current site retention policies before retiring), OR
+- Operator complaint surfaces a published path-A page that's now visually inconsistent with the rest of the (now path-B) site, AND the operator wants Opollo to regen it for them.
+
+When the retire trigger fires, run option 1 (regenerate-on-next-publish) — schema migration adds `legacy_path_a` column with backfill default true; new rows default false; publish path refuses path-A unless explicitly approved by the operator. The BACKLOG entry "Legacy path-A row retire trigger" tracks this.
+
+## Row-count survey (deferred)
+
+A row-count snapshot would inform retirement timing but is not required for the leave-as-is choice. When the retire trigger fires, run via `scripts/diagnose-prod.ts`:
+
+```sh
+# Sketch — actual subcommand to be added when survey runs:
+SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
+  npx tsx scripts/diagnose-prod.ts legacy-row-counts
+```
+
+Expected shape: per-table counts of rows whose `generated_html` / `draft_html` matches the path-A heuristic (`content LIKE '<!DOCTYPE%' OR content LIKE '<html%'`). A small `legacy-row-counts` subcommand can be added then; it's a 30-line addition to the read-only diagnostic CLI.
+
+## Live evidence preserved
+
+Page `dcbdf7d5-b867-443b-afdf-f60a28f968aa` (26,286-char path-A `draft_html`) stays untouched per the rescope directive. Operator can publish it as-is to validate the dual-path publish behaviour.

--- a/docs/plans/path-b-migration-parent.md
+++ b/docs/plans/path-b-migration-parent.md
@@ -410,16 +410,14 @@ PB-6 is last so the decision is informed by real path-B output and real cost dat
 
 ## Sub-slice status tracker
 
-(filled in as PRs land)
-
 | Slice | PR | Merged | Notes |
 |---|---|---|---|
-| PB-1 + PB-2 | — | — | — |
-| PB-3 | — | — | — |
-| PB-4 | — | — | — |
-| PB-5 | — | — | — |
-| PB-6 (decision) | — | — | — |
-| PB-6 (impl) | — | — | — |
-| PB-7 | — | — | — |
-| PB-8 | — | — | — |
-| PB-9 | — | — | — |
+| PB-1 + PB-2 | #194 | 2026-04-28 | Brief-runner emits fragments; `runFragmentStructuralCheck` replaces path-A structural gate. |
+| PB-3 | #199 | 2026-04-28 | Lowest-risk variant: shim stylesheet in `lib/preview-iframe-wrapper.ts`. Customer-CSS fetch deferred to BACKLOG ("Preview iframe — fetch customer theme CSS for high-fidelity preview"). |
+| PB-4 | #197 | 2026-04-28 | M3 batch worker: prompt + fragment-structural gate added. |
+| PB-5 | #198 | 2026-04-28 | M7 regen worker: prompt + fragment-structural gate added. |
+| PB-6 (decision) | #201 | 2026-04-28 | "Leave-as-is dual-path" — see `docs/plans/path-b-legacy-data-decision.md`. Retire trigger captured in BACKLOG. |
+| PB-6 (impl) | — | (deferred) | Implementation deferred per the leave-as-is choice. Retire trigger in BACKLOG. |
+| PB-7 | #196 | 2026-04-28 | Regression test: WP wrappers forward fragment content unchanged. No production code change. |
+| PB-8 | #200 | 2026-04-28 | Docs-only: M13 sync drift severity bumped to "content bug" in RUNBOOK. Hard publish gate behind `FEATURE_PATH_B_PUBLISH_GATE` deferred to BACKLOG. |
+| PB-9 | #195 | 2026-04-28 | `RUNNER_MAX_TOKENS` 16384 → 4096; rate-limit BACKLOG entry retired. |


### PR DESCRIPTION
## Summary

PB-6 from the parent plan (PR #193). Per the standing autonomous-run rule (lowest-risk default), chose option 3 from the parent plan's three migration shapes: **leave-as-is dual-path**. Both path-A and path-B shapes coexist on disk indefinitely; publish + preview branch via the \`claimsCompleteness\` heuristic that PR #189 + PR #199 already keyed off.

Closes the path-B migration parent plan — all 9 sub-slices accounted for.

## What lands

- \`docs/plans/path-b-legacy-data-decision.md\` (NEW): captures the option trade-offs (regenerate-on-next-publish vs lossy extraction vs leave-as-is), the leave-as-is rationale, and the retire trigger.
- \`docs/BACKLOG.md\`: "Legacy path-A row retire trigger" entry tracks the future cleanup. When the trigger fires, run option 1 (regenerate-on-next-publish).
- \`docs/plans/path-b-migration-parent.md\`: status tracker filled in across all 9 sub-slices.

## Why this is zero-code

- Publish path: \`lib/wordpress.ts::wpCreatePage / wpCreatePost / wpUpdatePage / wpUpdatePost\` forwards \`content\` byte-identically regardless of shape. Verified by PB-7's regression suite (PR #196).
- Preview iframe: \`lib/preview-iframe-wrapper.ts::wrapForPreview\` (PR #199) detects path-A vs path-B and wraps appropriately.

## Risks identified and mitigated

- **Permanent runtime branching cost.** The two-shape branch lives in `wrapForPreview` already; no new code surface. Documented in the decision doc as the explicit cost.
- **Operator confusion (preview shows path-A unstyled, path-B styled).** Both shapes render in the iframe; path-A renders as it always did, path-B renders against the shim stylesheet. Mental model: "old pages look like they did before, new pages look styled." Operator-visible; intentional.
- **Stale path-A rows accumulate.** BACKLOG entry tracks the retire trigger. When it fires, run option 1 with the operator-confirmed regen flow.

## Test plan

- [x] \`npm run lint\` ✓ (docs-only)
- [x] \`npm run typecheck\` ✓ (docs-only)

## Path-B parent-plan close-out

All 9 sub-slices merged today (2026-04-28). The full sequence: #194 (PB-1+2), #195 (PB-9), #196 (PB-7), #197 (PB-4), #198 (PB-5), #199 (PB-3), #200 (PB-8), this PR (PB-6 decision). PB-6 implementation deferred to the BACKLOG entry's trigger.

Live evidence: page \`dcbdf7d5-...\` preserved as path-A reference. Operator can publish it as-is to validate the dual-path behaviour end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)