### PR TITLE
fix(recover-stuck-brief-page): refuse wipe of structurally-complete draft

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -109,25 +109,9 @@ The replacement: populate the post's WP REST `excerpt` field from a brief-side e
 
 ---
 
-## scripts/recover-stuck-brief-page.ts wipes draft_html unconditionally (caught 2026-04-28)
+## ~~scripts/recover-stuck-brief-page.ts wipes draft_html unconditionally~~ (shipped PR pending — 2026-04-29)
 
-**Tags:** `bug`, `ops-tooling`, `recovery-script`, `data-loss`
-
-**What:** `scripts/recover-stuck-brief-page.ts` always sets `draft_html = NULL` and `critique_log = []` regardless of whether the existing draft is salvageable. During the 2026-04-28 incident pipeline test, this destroyed a structurally-complete 23,201-char `draft_html` that PR #188's gate had successfully retried — the recovery was run on a page that was already in a usable `awaiting_review` state, and the wipe left no audit trail / restore path inside the application. Postgres `UPDATE` does not preserve old row versions; PITR via Supabase dashboard was the only restore option.
-
-**Why deferred:** the immediate workaround (raise daily budget + re-recover + let runner regenerate) recovered cleanly, and the tenant cap-bump is a one-line operator action. No active incident needs this fix today.
-
-**Trigger:** before the next time the recovery script is used in anger, OR as part of the M16 ops-tooling pass. Whichever comes first.
-
-**Scope** (any one of these would be sufficient; combine as needed):
-
-- **Refuse to wipe if structurally complete.** Pre-flight check: if existing `draft_html` passes `isHtmlStructurallyComplete()` (lib/brief-runner.ts), abort the recovery with a clear message ("page is already complete; pass --force-wipe to override"). The `--force-wipe` opt-in puts the destructive choice in the operator's hands.
-- **Preserve previous draft as a backup column.** Add `brief_pages.previous_draft_html text` (nullable, no CHECK) and have the recovery script copy the current `draft_html` into it before NULLing. Single-slot backup; next recovery overwrites. One column, one migration; no audit-table sprawl.
-- **Stamp a `recovery_events` row** before wiping, with `{page_id, prior_draft_html, prior_critique_log, recovered_at, recovered_by}`. Heavier but gives full history; useful if recoveries become routine.
-
-**Size:** Small (~30 min for the structural-complete refuse + `--force-wipe` flag, no schema). Medium (~90 min) if the backup column or audit-events table land too.
-
-**Reference incident:** site `cdb5b15f-971d-4979-a18d-c3fd75a1c3ac`, page `dcbdf7d5-b867-443b-afdf-f60a28f968aa`. Recovery at 2026-04-27T23:14 UTC blew away a clean doc that PR #188 had produced; required a budget-cap bump + re-recover + regen cycle to restore.
+**Resolved:** Structural-completeness pre-flight + `--force-wipe` opt-in (option 1 from the original entry — smallest scope sufficient). Recovery now refuses to destroy a salvageable draft unless the operator explicitly opts in. The backup column / `recovery_events` table options stay deferred — they'd add schema surface for a single-incident scenario; the opt-in flag is the right floor.
 
 ---
 

--- a/scripts/recover-stuck-brief-page.ts
+++ b/scripts/recover-stuck-brief-page.ts
@@ -57,10 +57,13 @@
 
 import { createClient } from "@supabase/supabase-js";
 
+import { runFragmentStructuralCheck } from "../lib/brief-runner";
+
 type CliArgs = {
   pageId?: string;
   dryRun: boolean;
   confirm: boolean;
+  forceWipe: boolean;
 };
 
 function die(msg: string, code: number = 1): never {
@@ -69,12 +72,13 @@ function die(msg: string, code: number = 1): never {
 }
 
 function parseArgs(argv: readonly string[]): CliArgs {
-  const args: CliArgs = { dryRun: false, confirm: false };
+  const args: CliArgs = { dryRun: false, confirm: false, forceWipe: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--page-id") args.pageId = argv[++i];
     else if (a === "--dry-run") args.dryRun = true;
     else if (a === "--confirm") args.confirm = true;
+    else if (a === "--force-wipe") args.forceWipe = true;
     else if (a === "--help" || a === "-h") {
       printUsage();
       process.exit(0);
@@ -94,6 +98,10 @@ function printUsage(): void {
       "  --page-id <uuid>   Required. brief_pages.id of the stuck page.",
       "  --dry-run          Print the targeted state; no DB writes.",
       "  --confirm          Required for real runs (opt-in guard).",
+      "  --force-wipe       Required when the existing draft_html is structurally",
+      "                     complete (would otherwise abort with WIPE_BLOCKED).",
+      "                     The wipe is irreversible — Postgres UPDATE doesn't",
+      "                     preserve old row versions; PITR is the only restore.",
       "",
       "Required env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY",
       "",
@@ -192,6 +200,39 @@ async function main(): Promise<number> {
       "",
     ].join("\n"),
   );
+
+  // BACKLOG-fix (2026-04-29): refuse to wipe a structurally-complete
+  // draft_html unless the operator passes --force-wipe. The wipe is
+  // irreversible (Postgres UPDATE doesn't preserve old row versions;
+  // PITR via dashboard is the only restore). Reference incident: page
+  // dcbdf7d5-... 2026-04-27T23:14 UTC blew away a clean 23,201-char
+  // doc that PR #188's gate had successfully retried. This guard
+  // forces an explicit operator decision rather than a silent wipe.
+  const completeness = runFragmentStructuralCheck(page.draft_html ?? "");
+  if (completeness.ok && !args.forceWipe) {
+    process.stderr.write(
+      [
+        "",
+        "WIPE_BLOCKED — existing draft_html is structurally complete.",
+        `  Length: ${(page.draft_html ?? "").length} chars`,
+        "  This recovery would destroy a salvageable draft. The wipe is",
+        "  irreversible (PITR is the only restore path).",
+        "",
+        "  If you really want to wipe (e.g. operator decided to re-generate",
+        "  from scratch), pass --force-wipe alongside --confirm. Otherwise:",
+        "    - Leave the page as-is and let the operator approve it.",
+        "    - Or use the admin UI's Revise-with-note flow to regenerate",
+        "      without losing the current draft.",
+        "",
+      ].join("\n"),
+    );
+    return 4;
+  }
+  if (completeness.ok && args.forceWipe) {
+    process.stderr.write(
+      "WARNING: --force-wipe acknowledged. Destroying a structurally-complete draft_html.\n",
+    );
+  }
 
   if (args.dryRun) {
     process.stdout.write("Dry-run — no DB writes performed.\n");


### PR DESCRIPTION
## Summary

Closes the BACKLOG entry "recover-stuck-brief-page.ts wipes draft_html unconditionally" caught during the 2026-04-28 incident pipeline test. Recovery now refuses to destroy a salvageable draft unless the operator explicitly opts in via \`--force-wipe\`.

## What lands

- \`scripts/recover-stuck-brief-page.ts\`: \`--force-wipe\` flag + \`runFragmentStructuralCheck\` pre-flight. If the existing \`draft_html\` is structurally complete, the script exits with code 4 (\`WIPE_BLOCKED\`) and a clear message naming the salvageable draft + the alternative paths (leave as-is for operator approval, or use Revise-with-note).
- \`docs/BACKLOG.md\`: entry retired with strikethrough.

## Risks identified and mitigated

- **Operator hits WIPE_BLOCKED on a legitimately-stuck page.** Use case: page is in \`failed\` state with a complete-but-wrong draft. Mitigation: \`--force-wipe\` is the explicit override. Error message names the flag.
- **Pre-flight false negative — fragment passes the structural check but is still bad.** The fragment check is intentionally minimal (no chrome leaks, has data-opollo, balanced styles). It can't tell semantic quality from structural completeness. Operator-judged false negatives are addressed by the same \`--force-wipe\` path.
- **Cross-subsystem import.** Script imports \`runFragmentStructuralCheck\` from \`@/lib/brief-runner\` — pure logic, no DB / no side effects. Same boundary as PB-4 / PB-5.

## Deliberately NOT shipped (per the BACKLOG entry's options)

- Backup column (\`brief_pages.previous_draft_html\`) — schema surface for a single-incident scenario.
- \`recovery_events\` audit table — heavier still; useful only if recoveries become routine.

The opt-in flag is the right floor. If recoveries DO become routine, escalate to one of the heavier options.

## Test plan

- [x] \`npm run lint\` ✓
- [x] \`npm run typecheck\` ✓
- [ ] CI: untouched (script is CLI-only, no unit-test surface in the repo today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)