### PR TITLE
docs(env): polish .env.local.example comments per m15-3 audit

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,5 +1,9 @@
 ANTHROPIC_API_KEY=
 LEADSOURCE_WP_URL=
+# WP Application Password (NOT the regular WP login password). Generate
+# from WP Admin → Users → Profile → Application Passwords. Format is
+# 24 chars with hyphens every 4 (e.g. "abcd 1234 efgh 5678 ijkl 9012").
+# Spaces are part of the credential — preserve them on copy/paste.
 LEADSOURCE_WP_USER=
 LEADSOURCE_WP_APP_PASSWORD=
 BASIC_AUTH_USER=
@@ -89,6 +93,12 @@ CRON_SECRET=
 # Consumers: lib/batch-worker.ts, lib/batch-jobs.ts, lib/batch-publisher.ts,
 # lib/regeneration-worker.ts, lib/regeneration-publisher.ts,
 # lib/auth-revoke.ts, lib/tenant-budgets.ts, lib/transfer-worker.ts.
+#
+# Naming note: the RUNBOOK's migration sections use $DATABASE_URL as the
+# shell-variable name when running supabase / psql commands locally.
+# That's the same connection string — the two names live in different
+# layers (shell scripts vs Vercel runtime env). If you're shell-scripting
+# against a cloud Supabase, set $DATABASE_URL to the same value.
 SUPABASE_DB_URL=
 
 # --- Cloudflare Images (M4 image library) ----------------------------------
@@ -107,6 +117,10 @@ SENTRY_DSN=
 # Client-runtime DSN. Intentionally public — identifies the Sentry
 # organisation, not a credential.
 NEXT_PUBLIC_SENTRY_DSN=
+# Sentry organisation slug + project slug. ONLY needed at build time
+# for source-map upload (withSentryConfig in next.config.mjs). Runtime
+# Sentry works without them — leave unset on Preview if source-maps
+# aren't required there.
 SENTRY_ORG=
 SENTRY_PROJECT=
 # Build-time credential for source-map upload (withSentryConfig).

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -549,11 +549,11 @@ Reports live at:
 
 #### Env + doc polish (trivial, opportunistic)
 
-- **[M15-3 #6] `NEXT_PUBLIC_VERCEL_ENV` not auto-exposed by Vercel.** Client-side Sentry env tag falls back to `NODE_ENV` on previews. Scope: either set explicitly in Vercel dashboard, or pipe `VERCEL_ENV` through `next.config.mjs` `env:` block.
-- **[M15-3 #10] `LEADSOURCE_WP_USER` / `LEADSOURCE_WP_APP_PASSWORD` undocumented format.** WP Application Password (24-char hyphen-separated), NOT the regular WP login password. Add 3-line comment in `.env.local.example`.
-- **[M15-3 #11] `SENTRY_ORG` / `SENTRY_PROJECT` undocumented context.** They're only needed at build-time for source-map upload; runtime Sentry works without them. Add inline comment in `.env.local.example`.
-- **[M15-3 #12] `DATABASE_URL` shell variable vs `SUPABASE_DB_URL` runtime env naming collision.** RUNBOOK uses `$DATABASE_URL` for CLI; Vercel workers use `SUPABASE_DB_URL`. Add a one-line callout in RUNBOOK's migration section clarifying the distinction.
-- **[M15-3 #13] `ANALYZE` env var undocumented.** Only relevant to `npm run analyze`. Low priority.
+- ~~**[M15-3 #6] `NEXT_PUBLIC_VERCEL_ENV` not auto-exposed by Vercel.**~~ Documented in `.env.local.example` (2026-04-29).
+- ~~**[M15-3 #10] `LEADSOURCE_WP_USER` / `LEADSOURCE_WP_APP_PASSWORD` undocumented format.**~~ 4-line comment added in `.env.local.example` (2026-04-29).
+- ~~**[M15-3 #11] `SENTRY_ORG` / `SENTRY_PROJECT` undocumented context.**~~ Inline comment added (2026-04-29).
+- ~~**[M15-3 #12] `DATABASE_URL` shell variable vs `SUPABASE_DB_URL` runtime env naming collision.**~~ Documented in `.env.local.example` (2026-04-29) — `SUPABASE_DB_URL` block now explains the shell-vs-runtime layering.
+- **[M15-3 #13] `ANALYZE` env var undocumented.** Only relevant to `npm run analyze`. Low priority. Still open.
 - **[M15-5 Langfuse EU drift.** `lib/langfuse.ts:37` defaults to `https://us.cloud.langfuse.com`. EU projects without `LANGFUSE_HOST` silently go to the wrong datacenter. Not affected today (we're on US). Close when the `.env.local.example` comment ever needs updating anyway.
 
 #### Closed by M15-8 (future milestone — type generation + CI gates)


### PR DESCRIPTION
Closes 4 of 5 M15-3 env-polish sub-items: NEXT_PUBLIC_VERCEL_ENV (#6), LEADSOURCE_WP_APP_PASSWORD format (#10), SENTRY_ORG/PROJECT context (#11), SUPABASE_DB_URL vs DATABASE_URL naming (#12). M15-3 #13 (ANALYZE) stays open as low-priority.