### PR TITLE
feat(rs-3): auto-advance from committed → run surface

### DIFF
--- a/app/admin/sites/[id]/briefs/[brief_id]/review/page.tsx
+++ b/app/admin/sites/[id]/briefs/[brief_id]/review/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { BriefReviewClient } from "@/components/BriefReviewClient";
@@ -10,6 +10,12 @@ import { getSite } from "@/lib/sites";
 // Server Component. Fetches the brief + its pages server-side and
 // hands them to <BriefReviewClient /> which owns the editable list +
 // commit flow state machine.
+//
+// RS-3: when brief.status === "committed", the operator never sees
+// the review page — we redirect server-side to the run surface so a
+// bookmark, browser-back, or direct link skips the dead intermediate
+// state. Client-side, the commit handler also pushes to /run on
+// success, so the redirect is the safety net for non-flow entries.
 
 export const dynamic = "force-dynamic";
 
@@ -42,6 +48,10 @@ export default async function BriefReviewPage({
   }
 
   if (briefResult.data.brief.site_id !== params.id) notFound();
+
+  if (briefResult.data.brief.status === "committed") {
+    redirect(`/admin/sites/${params.id}/briefs/${params.brief_id}/run`);
+  }
 
   const site = siteResult.data.site;
   const { brief, pages } = briefResult.data;

--- a/components/BriefReviewClient.tsx
+++ b/components/BriefReviewClient.tsx
@@ -22,10 +22,11 @@ import { DEFAULT_MODEL_ID, MODEL_OPTIONS } from "@/lib/anthropic-models";
 //
 //   briefs.status='parsed'        → editable list + "Commit page list" CTA
 //
-//   briefs.status='committed'     → read-only list + post-commit panel
-//                                   with two CTAs: "Back to briefs" and
-//                                   "Open run surface →" (live since
-//                                   M12-5 shipped)
+//   briefs.status='committed'     → operator never sees this page; the
+//                                   /review route redirects to /run
+//                                   server-side, and the commit handler
+//                                   pushes to /run on success (RS-3).
+//                                   The DB-level state still exists.
 //
 //   briefs.status='failed_parse'  → red banner with the failure detail +
 //                                   re-upload suggestion
@@ -243,8 +244,11 @@ export function BriefReviewClient({
         error?: { code: string; message: string };
       };
       if (res.ok && payload.ok) {
-        setCommitState("idle");
-        router.refresh();
+        // RS-3: skip the intermediate "committed" panel — the operator
+        // wants to start the run, not see another OK screen. The /review
+        // route also redirects committed briefs to /run server-side, so
+        // a back-button + reload still lands on the run surface.
+        router.push(`/admin/sites/${siteId}/briefs/${brief.id}/run`);
         return;
       }
       const code = payload.error?.code ?? "INTERNAL_ERROR";
@@ -572,35 +576,11 @@ export function BriefReviewClient({
         </div>
       )}
 
-      {brief.status === "committed" && (
-        <div
-          className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4 text-sm"
-          role="status"
-        >
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <p className="font-medium">This brief is committed.</p>
-              <p className="mt-1 text-muted-foreground">
-                You&apos;re ready to run the generator. The run surface shows
-                the cost estimate, approval controls, and visual critique per
-                page.
-              </p>
-            </div>
-            <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
-              <Button asChild variant="outline" size="sm">
-                <a href={`/admin/sites/${siteId}`}>Back to briefs</a>
-              </Button>
-              <Button asChild size="sm">
-                <a
-                  href={`/admin/sites/${siteId}/briefs/${brief.id}/run`}
-                >
-                  Open run surface →
-                </a>
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* RS-3: removed the post-commit panel. Successful commit pushes
+          the operator straight to /run; the /review route redirects
+          server-side if the operator returns to the URL with status
+          === "committed". The committed state still exists in the DB —
+          just no UI surface for it on this page. */}
 
       {commitState === "confirming" && (
         <CommitConfirmModal

--- a/e2e/briefs-review.spec.ts
+++ b/e2e/briefs-review.spec.ts
@@ -124,8 +124,11 @@ test.describe("M12-1 briefs — upload + review", () => {
     await expect(confirmDialog).toBeVisible();
     await confirmDialog.getByRole("button", { name: /^Commit page list$/i }).click();
 
-    // Page re-renders with the committed state.
-    await expect(page.getByText(/This brief is locked in\./i)).toBeVisible();
+    // RS-3: successful commit redirects straight to the run surface;
+    // the operator never sees the intermediate "committed" panel.
+    await page.waitForURL(
+      /\/admin\/sites\/[0-9a-f-]{36}\/briefs\/[0-9a-f-]{36}\/run$/,
+    );
     await expect(page.getByRole("button", { name: /Commit page list/i })).toHaveCount(0);
   });
 
@@ -175,7 +178,10 @@ test.describe("M12-1 briefs — upload + review", () => {
     await pageA.getByRole("button", { name: /Commit page list/i }).click();
     const dialogA = pageA.getByRole("dialog", { name: /Commit this page list\?/i });
     await dialogA.getByRole("button", { name: /^Commit page list$/i }).click();
-    await expect(pageA.getByText(/This brief is locked in\./i)).toBeVisible();
+    // RS-3: successful commit lands on the run surface.
+    await pageA.waitForURL(
+      /\/admin\/sites\/[0-9a-f-]{36}\/briefs\/[0-9a-f-]{36}\/run$/,
+    );
 
     // B tries to commit without refresh. B's version_lock is stale →
     // ALREADY_EXISTS since A already committed with the matching hash.
@@ -185,9 +191,11 @@ test.describe("M12-1 briefs — upload + review", () => {
     await dialogB.getByRole("button", { name: /^Commit page list$/i }).click();
 
     // Because B's hash matches A's (neither edited), the server treats
-    // this as a successful replay — so the UI should flip to committed
-    // on the next render too. This asserts the idempotent-replay path.
-    await expect(pageB.getByText(/This brief is locked in\./i)).toBeVisible();
+    // this as a successful replay — UI flips to the run surface too.
+    // This asserts the idempotent-replay path.
+    await pageB.waitForURL(
+      /\/admin\/sites\/[0-9a-f-]{36}\/briefs\/[0-9a-f-]{36}\/run$/,
+    );
 
     await contextA.close();
     await contextB.close();


### PR DESCRIPTION
## Summary

RS-3 of the run-surface UX overhaul (parent: PR #213, plan: \`docs/plans/run-surface-ux-overhaul-parent.md\`).

After a successful brief commit the operator wants to start the run, not see another OK screen. Drop the intermediate \"committed\" panel — both the client commit handler and the \`/review\` route now route the operator straight to \`/run\`.

## What ships

- \`components/BriefReviewClient.tsx\`
  - Commit handler: \`router.push(/run)\` on success instead of \`router.refresh()\`.
  - Removed the post-commit panel (the green \"This brief is committed\" block + the two CTAs).
  - Updated state-machine doc comment to reflect the new \`committed\` UI behaviour.
- \`app/admin/sites/[id]/briefs/[brief_id]/review/page.tsx\`
  - Server-side redirect to \`/run\` when \`brief.status === \"committed\"\`. Safety net for bookmarks, browser back, and direct links.
- \`e2e/briefs-review.spec.ts\`
  - Replaced \`/This brief is locked in\./\` assertions with \`waitForURL(/\/run$/)\` for both the happy path and the double-commit (idempotent replay) test.

## Risks identified and mitigated

- **Idempotent-replay path** — server-side commit returns ok for a stale-version replay where the hash matches; the client treats it as a normal success and redirects.
- **Schema-level state preserved** — \`briefs.status='committed'\` still exists; only the UI surface on \`/review\` is gone. Run surface gating logic untouched.
- **Bookmark + back-button** — server redirect catches non-flow entries to \`/review\` for a committed brief.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [ ] \`npm run test:e2e -- briefs-review\` — runs in CI with supabase start

🤖 Generated with [Claude Code](https://claude.com/claude-code)