### PR TITLE
feat(rs-4): live polling infrastructure + run-surface auto-update

### DIFF
--- a/app/api/briefs/[brief_id]/run/snapshot/route.ts
+++ b/app/api/briefs/[brief_id]/run/snapshot/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import {
+  estimateBriefRunCost,
+  getBriefWithPages,
+  type BriefPageRow,
+  type BriefRow,
+  type BriefRunSnapshot,
+} from "@/lib/briefs";
+import { validateUuidParam } from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// RS-4 — GET /api/briefs/[brief_id]/run/snapshot
+//
+// Polled every 4s by the BriefRunClient via the lib/use-poll.ts hook.
+// Returns the live state needed to drive the run surface without
+// router.refresh()ing the whole page (and re-running every server
+// component on the route).
+//
+// Shape:
+//   {
+//     ok: true,
+//     data: {
+//       brief: { id, status, version_lock, ... },
+//       pages: BriefPageRow[],
+//       active_run: BriefRunSnapshot | null,
+//       remaining_budget_cents: number,
+//       estimate_cents: number,
+//     },
+//     timestamp: ISO8601
+//   }
+//
+// Auth: admin OR operator session (operator can drive runs end-to-end
+// in M12; admin-only would lock them out of the live view they have a
+// CTA for). Same role gate as the parent /run endpoint.
+//
+// Cache: no-store. Polling is the cache; never serve a stale row from
+// a CDN or browser cache.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface BriefRunSnapshotPayload {
+  brief: BriefRow;
+  pages: BriefPageRow[];
+  active_run: BriefRunSnapshot | null;
+  remaining_budget_cents: number;
+  estimate_cents: number;
+}
+
+function jsonNoStore(body: unknown, status: number): NextResponse {
+  return NextResponse.json(body, {
+    status,
+    headers: { "cache-control": "no-store" },
+  });
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { brief_id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const briefIdCheck = validateUuidParam(params.brief_id, "brief_id");
+  if (!briefIdCheck.ok) return briefIdCheck.response;
+  const briefId = briefIdCheck.value;
+
+  const briefResult = await getBriefWithPages(briefId);
+  if (!briefResult.ok) {
+    return jsonNoStore(
+      {
+        ok: false,
+        error: briefResult.error,
+        timestamp: new Date().toISOString(),
+      },
+      briefResult.error.code === "NOT_FOUND" ? 404 : 500,
+    );
+  }
+
+  const { brief, pages } = briefResult.data;
+  const svc = getServiceRoleClient();
+
+  const runRes = await svc
+    .from("brief_runs")
+    .select(
+      "id, brief_id, status, current_ordinal, content_summary, run_cost_cents, failure_code, failure_detail, cancel_requested_at, started_at, finished_at, version_lock, created_at, updated_at",
+    )
+    .eq("brief_id", brief.id)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (runRes.error) {
+    logger.error("brief_run.snapshot.read_failed", {
+      brief_id: brief.id,
+      error: runRes.error.message,
+    });
+    return jsonNoStore(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to read run state.",
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      500,
+    );
+  }
+  const activeRun = (runRes.data ?? null) as BriefRunSnapshot | null;
+
+  const estimate = await estimateBriefRunCost(brief.id);
+
+  const budget = await svc
+    .from("tenant_cost_budgets")
+    .select("monthly_cap_cents, monthly_usage_cents")
+    .eq("site_id", brief.site_id)
+    .maybeSingle();
+  const cap = Number(budget.data?.monthly_cap_cents ?? 0);
+  const usage = Number(budget.data?.monthly_usage_cents ?? 0);
+  const remainingBudgetCents = Math.max(0, cap - usage);
+
+  const data: BriefRunSnapshotPayload = {
+    brief,
+    pages,
+    active_run: activeRun,
+    remaining_budget_cents: remainingBudgetCents,
+    estimate_cents: estimate.ok ? estimate.estimate_cents : 0,
+  };
+
+  return jsonNoStore(
+    { ok: true, data, timestamp: new Date().toISOString() },
+    200,
+  );
+}

--- a/components/BriefRunClient.tsx
+++ b/components/BriefRunClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -14,6 +13,22 @@ import type {
   BriefRunSnapshot,
 } from "@/lib/briefs";
 import { wrapForPreview } from "@/lib/preview-iframe-wrapper";
+import { usePoll } from "@/lib/use-poll";
+
+// RS-4 — payload shape returned by /api/briefs/[brief_id]/run/snapshot.
+// Mirrored locally so this component doesn't import from the route file.
+interface RunSnapshotPayload {
+  brief: BriefRow;
+  pages: BriefPageRow[];
+  active_run: BriefRunSnapshot | null;
+  remaining_budget_cents: number;
+  estimate_cents: number;
+}
+
+interface RunSnapshotEnvelope {
+  ok: boolean;
+  data?: RunSnapshotPayload;
+}
 
 // ---------------------------------------------------------------------------
 // M12-5 — /admin/sites/[id]/briefs/[brief_id]/run client component.
@@ -112,11 +127,11 @@ const ERROR_TRANSLATIONS: Record<string, string> = {
 export function BriefRunClient({
   siteId,
   siteName,
-  brief,
-  pages,
-  activeRun,
-  estimateCents,
-  remainingBudgetCents,
+  brief: initialBrief,
+  pages: initialPages,
+  activeRun: initialActiveRun,
+  estimateCents: initialEstimateCents,
+  remainingBudgetCents: initialRemainingBudgetCents,
 }: {
   siteId: string;
   siteName: string;
@@ -126,12 +141,27 @@ export function BriefRunClient({
   estimateCents: number;
   remainingBudgetCents: number;
 }) {
-  const router = useRouter();
   const [controlState, setControlState] = useState<ControlState>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [reviseOpen, setReviseOpen] = useState<string | null>(null); // page id
   const [reviseNote, setReviseNote] = useState("");
+
+  // RS-4 — poll the snapshot endpoint every 4s. The initial server-render
+  // hydrates the surface; live updates flow in via `polled.data`. After
+  // every successful mutation (start / approve / revise / cancel) we call
+  // `refresh` so the UI doesn't wait up to 4s for the next tick.
+  const polled = usePoll<RunSnapshotEnvelope>(
+    `/api/briefs/${initialBrief.id}/run/snapshot`,
+  );
+
+  const live = polled.data?.ok ? polled.data.data : undefined;
+  const brief = live?.brief ?? initialBrief;
+  const pages = live?.pages ?? initialPages;
+  const activeRun = live?.active_run ?? initialActiveRun;
+  const remainingBudgetCents =
+    live?.remaining_budget_cents ?? initialRemainingBudgetCents;
+  const estimateCents = live?.estimate_cents ?? initialEstimateCents;
 
   const sortedPages = useMemo(
     () => [...pages].sort((a, b) => a.ordinal - b.ordinal),
@@ -169,7 +199,7 @@ export function BriefRunClient({
       if (res.ok && payload.ok) {
         setControlState("idle");
         setConfirmOpen(false);
-        router.refresh();
+        void polled.refresh();
         return;
       }
       if (payload.error?.code === "CONFIRMATION_REQUIRED") {
@@ -205,7 +235,7 @@ export function BriefRunClient({
       };
       if (res.ok && payload.ok) {
         setControlState("idle");
-        router.refresh();
+        void polled.refresh();
         return;
       }
       setErrorMessage(
@@ -243,7 +273,7 @@ export function BriefRunClient({
       };
       if (res.ok && payload.ok) {
         setControlState("idle");
-        router.refresh();
+        void polled.refresh();
         return;
       }
       setErrorMessage(
@@ -288,7 +318,7 @@ export function BriefRunClient({
         setControlState("idle");
         setReviseOpen(null);
         setReviseNote("");
-        router.refresh();
+        void polled.refresh();
         return;
       }
       setErrorMessage(
@@ -318,6 +348,19 @@ export function BriefRunClient({
                 {" — "}
                 <RunStatusPill status={activeRun.status} />
               </>
+            )}
+            {/* RS-4 — discreet stale indicator. Only renders when the
+                last successful poll is more than 8s old (intervalMs * 2),
+                so a single late tick doesn't flicker the badge. */}
+            {polled.isStale && (
+              <span
+                role="status"
+                className="ml-2 inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+                title="Live updates paused — retrying"
+              >
+                <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+                Reconnecting…
+              </span>
             )}
           </p>
         </div>

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,18 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## Component test infra — jsdom + @testing-library/react (opened 2026-04-27 by RS-1 / RS-4)
+
+**What:** Add `jsdom` (or `happy-dom`), `@testing-library/react`, and a vitest project split (or `environmentMatchGlobs`) so we can run hook + component tests under `lib/__tests__/` (or a new `components/__tests__/`).
+
+**Why deferred:** RS-1 (`Composer`) and RS-4 (`usePoll`) both wanted unit-level coverage and the parent plan called for it, but adding the full DOM-test stack is its own architectural decision (env split, ~30 MB devDeps, vitest config rewrite, deciding whether the existing `lib/__tests__` Supabase setup runs for component files too). Out of scope for the UX overhaul slices — they ship behind E2E + manual smoke instead.
+
+**Trigger to pick it up:** the next slice that needs to test a hook with non-trivial state transitions (e.g. RS-6 cost-ticker count-up animation, BP-4 image-picker keyboard nav), OR a regression in `Composer` / `usePoll` that's hard to reproduce manually.
+
+**Rough scope:** ~½ day. Config split, two example tests (one hook, one component), CI-mode config so the new runner doesn't require `supabase start`.
+
+---
+
 ## Legacy path-A row retire trigger (path B, opened 2026-04-29 by PB-6)
 
 **Tags:** `path-b`, `cleanup`, `data-migration`

--- a/lib/use-poll.ts
+++ b/lib/use-poll.ts
@@ -1,0 +1,164 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// RS-4 — generic polling hook.
+//
+// Polls `url` every `intervalMs` (default 4000) and exposes the latest
+// snapshot. Pauses while the tab is hidden (visibilitychange listener)
+// and triggers an immediate fetch when the tab becomes visible again.
+//
+// Contract:
+//   - `data`        latest successful payload, or `null` before first
+//                   fetch lands.
+//   - `error`       Error from the most recent failed fetch; cleared on
+//                   the next success. Polling continues on error so a
+//                   transient network blip doesn't park the UI.
+//   - `isStale`     `true` once `lastFetchAt + intervalMs * 2` has
+//                   elapsed without a successful fetch. Drives the
+//                   "reconnecting…" indicator.
+//   - `isFetching`  in-flight indicator for the current cycle.
+//   - `refresh`     manual trigger; mutations call it after a successful
+//                   POST so the UI updates without waiting for the next
+//                   tick.
+//
+// Single in-flight fetch per hook instance — late responses from
+// previous ticks are aborted on a new tick to prevent out-of-order
+// updates.
+//
+// Pass `null` for `url` to disable polling without unmounting the hook
+// (useful when the brief isn't committed yet).
+// ---------------------------------------------------------------------------
+
+export interface UsePollOptions {
+  intervalMs?: number;
+  enabled?: boolean;
+}
+
+export interface UsePollResult<T> {
+  data: T | null;
+  error: Error | null;
+  isStale: boolean;
+  isFetching: boolean;
+  refresh: () => Promise<void>;
+}
+
+const DEFAULT_INTERVAL_MS = 4000;
+
+export function usePoll<T>(
+  url: string | null,
+  options: UsePollOptions = {},
+): UsePollResult<T> {
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const enabled = options.enabled ?? true;
+
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isFetching, setIsFetching] = useState(false);
+  const [isStale, setIsStale] = useState(false);
+
+  // Refs avoid re-creating doFetch on every state change (which would
+  // restart the interval).
+  const urlRef = useRef(url);
+  urlRef.current = url;
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+  const inFlightRef = useRef<AbortController | null>(null);
+  const lastFetchAtRef = useRef<number>(0);
+
+  const doFetch = useCallback(async (): Promise<void> => {
+    const currentUrl = urlRef.current;
+    if (!currentUrl || !enabledRef.current) return;
+
+    if (inFlightRef.current) inFlightRef.current.abort();
+    const ctrl = new AbortController();
+    inFlightRef.current = ctrl;
+    setIsFetching(true);
+    try {
+      const res = await fetch(currentUrl, {
+        signal: ctrl.signal,
+        cache: "no-store",
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = (await res.json()) as T;
+      if (ctrl.signal.aborted) return;
+      setData(json);
+      setError(null);
+      setIsStale(false);
+      lastFetchAtRef.current = Date.now();
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      const err = e instanceof Error ? e : new Error(String(e));
+      setError(err);
+    } finally {
+      if (!ctrl.signal.aborted) setIsFetching(false);
+    }
+  }, []);
+
+  // Interval polling + visibility-aware pause.
+  useEffect(() => {
+    if (!url || !enabled) return;
+
+    let cancelled = false;
+    let timerId: ReturnType<typeof setTimeout> | null = null;
+
+    function schedule() {
+      if (cancelled) return;
+      timerId = setTimeout(async () => {
+        if (cancelled) return;
+        if (
+          typeof document !== "undefined" &&
+          document.visibilityState === "hidden"
+        ) {
+          // Tab hidden → skip this tick but keep the loop alive so the
+          // moment the tab returns we resume on the next interval.
+          schedule();
+          return;
+        }
+        await doFetch();
+        schedule();
+      }, intervalMs);
+    }
+
+    function onVisibility() {
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState === "visible"
+      ) {
+        // Immediate refresh on tab return so the operator doesn't wait
+        // up to `intervalMs` for the first update.
+        void doFetch();
+      }
+    }
+
+    // Initial fetch then schedule.
+    void doFetch();
+    schedule();
+
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      cancelled = true;
+      if (timerId !== null) clearTimeout(timerId);
+      document.removeEventListener("visibilitychange", onVisibility);
+      if (inFlightRef.current) inFlightRef.current.abort();
+    };
+    // doFetch is stable (empty deps); intervalMs / url / enabled changes
+    // do reset the loop intentionally.
+  }, [url, enabled, intervalMs, doFetch]);
+
+  // Stale detection — runs a cheap timer that flips `isStale` once the
+  // last successful fetch is more than 2 * intervalMs in the past.
+  useEffect(() => {
+    if (!enabled) return;
+    const id = setInterval(() => {
+      if (lastFetchAtRef.current === 0) return;
+      const stale = Date.now() - lastFetchAtRef.current > intervalMs * 2;
+      setIsStale((current) => (current === stale ? current : stale));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [enabled, intervalMs]);
+
+  return { data, error, isStale, isFetching, refresh: doFetch };
+}


### PR DESCRIPTION
## Summary

RS-4 of the run-surface UX overhaul (parent: PR #213).

Drops \`router.refresh()\` from the run surface in favour of a 4s polling loop against a typed snapshot endpoint. The operator sees state transitions, per-page status flips, and cost ticks without manual reload.

## What ships

- **\`lib/use-poll.ts\`** — generic visibility-aware polling hook. Pauses on \`document.visibilityState === \"hidden\"\`, refetches immediately on tab return, aborts in-flight fetches on URL/tick rotation, surfaces \`isStale\` once the last successful tick is more than \`intervalMs * 2\` in the past. \`Cache-Control: no-store\`.
- **\`app/api/briefs/[brief_id]/run/snapshot/route.ts\`** — GET endpoint returning \`{ brief, pages, active_run, remaining_budget_cents, estimate_cents }\`. Admin OR operator role (matches the parent \`/run\` endpoint). \`Cache-Control: no-store\`.
- **\`components/BriefRunClient.tsx\`** — consumes \`usePoll\`. Initial server props hydrate; once the first poll lands, all reads flow through the polled snapshot. The four \`router.refresh()\` calls (start / approve / revise / cancel) become \`void polled.refresh()\` so a successful mutation paints the new state immediately. Discreet \"Reconnecting…\" badge appears when \`isStale\`.

## Risks identified and mitigated

- **Polling load** — 4s × concurrent operators = small read-only SELECT against the existing \`brief_runs (brief_id, created_at)\` index path. Acceptable per parent risk audit.
- **Auth surface** — snapshot route reuses \`requireAdminForApi(['admin', 'operator'])\` and reads only the brief's own data via \`brief.site_id\`.
- **Race / ordering** — single in-flight fetch enforced by \`AbortController\`. Out-of-order updates can't land.
- **SSR continuity** — initial render still uses server-fetched props; polled data layers on top.
- **Stale flicker** — 1 Hz timer + \`intervalMs * 2\` threshold prevents single-tick blips from flapping the badge.
- **Component-test infra** (jsdom + testing-library) absent in this repo. RS-4 ships behind E2E + manual smoke; BACKLOG entry added with trigger conditions.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean; snapshot route present in manifest
- [ ] Manual: start a run, observe pill / pages / cost auto-update; pull the laptop offline, confirm \"Reconnecting…\" surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)