### PR TITLE
feat(rs-2): site-level brand voice & design direction defaults

### DIFF
--- a/app/admin/sites/[id]/briefs/[brief_id]/review/page.tsx
+++ b/app/admin/sites/[id]/briefs/[brief_id]/review/page.tsx
@@ -69,6 +69,8 @@ export default async function BriefReviewPage({
       <BriefReviewClient
         siteId={site.id}
         siteName={site.name}
+        siteBrandVoiceDefault={site.brand_voice}
+        siteDesignDirectionDefault={site.design_direction}
         brief={brief}
         initialPages={pages}
       />

--- a/app/admin/sites/[id]/page.tsx
+++ b/app/admin/sites/[id]/page.tsx
@@ -386,6 +386,27 @@ export default async function SiteDetailPage({
               Open Appearance panel →
             </Link>
           </div>
+
+          {/* RS-2 — Settings (brand voice + design direction defaults). */}
+          <div className="rounded-lg border p-4 text-sm">
+            <h2 className="text-base font-medium">Settings</h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Brand voice &amp; design direction defaults that every new brief
+              inherits.
+              {(site.brand_voice || site.design_direction) && (
+                <span className="ml-1 text-emerald-700">Configured.</span>
+              )}
+              {!site.brand_voice && !site.design_direction && (
+                <span className="ml-1 text-muted-foreground">Not set.</span>
+              )}
+            </p>
+            <Link
+              href={`/admin/sites/${site.id}/settings`}
+              className="mt-2 inline-block text-muted-foreground hover:text-foreground"
+            >
+              Open Settings →
+            </Link>
+          </div>
         </aside>
       </div>
     </>

--- a/app/admin/sites/[id]/settings/page.tsx
+++ b/app/admin/sites/[id]/settings/page.tsx
@@ -1,0 +1,84 @@
+import { notFound, redirect } from "next/navigation";
+
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { SiteVoiceSettingsForm } from "@/components/SiteVoiceSettingsForm";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { getSite } from "@/lib/sites";
+
+// /admin/sites/[id]/settings — RS-2.
+//
+// Site-level settings surface. Today: brand voice + design direction
+// defaults that the brief commit form inherits. Future home for site
+// theme overrides, post-mode toggle, etc.
+//
+// Operator role can edit (matches voice/direction's editorial nature
+// and the API gate on /voice).
+
+export const dynamic = "force-dynamic";
+
+export default async function SiteSettingsPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const access = await checkAdminAccess({
+    requiredRoles: ["admin", "operator"],
+    insufficientRoleRedirectTo: "/",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  const result = await getSite(params.id);
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") notFound();
+    return (
+      <main className="mx-auto max-w-3xl p-6">
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        >
+          {result.error.message}
+        </div>
+      </main>
+    );
+  }
+  const site = result.data.site;
+
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <Breadcrumbs
+        crumbs={[
+          { label: "Admin", href: "/admin/sites" },
+          { label: "Sites", href: "/admin/sites" },
+          { label: site.name, href: `/admin/sites/${site.id}` },
+          { label: "Settings" },
+        ]}
+      />
+      <h1 className="mt-2 text-xl font-semibold">{site.name} — Settings</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        These values pre-populate every new brief. Each brief can still
+        override at commit time without changing the site default.
+      </p>
+
+      <section
+        aria-labelledby="voice-heading"
+        className="mt-6 rounded-lg border p-4"
+      >
+        <h2 id="voice-heading" className="text-base font-semibold">
+          Brand voice &amp; design direction
+        </h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Set once for the site; the brief commit form inherits these as
+          defaults.
+        </p>
+        <div className="mt-4">
+          <SiteVoiceSettingsForm
+            siteId={site.id}
+            initialBrandVoice={site.brand_voice}
+            initialDesignDirection={site.design_direction}
+            initialVersionLock={site.version_lock}
+          />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/api/admin/sites/[id]/voice/route.ts
+++ b/app/api/admin/sites/[id]/voice/route.ts
@@ -1,0 +1,131 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { updateSiteVoice } from "@/lib/sites";
+import { errorCodeToStatus } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// PATCH /api/admin/sites/[id]/voice — RS-2.
+//
+// Edit the site-level brand_voice / design_direction defaults. Per-brief
+// overrides on the briefs table still win at commit time.
+//
+// Admin OR operator role: voice/direction copy is editorial, not
+// financial. Operators routinely tune it as part of customer onboarding.
+// (Compare to /budget which is admin-only.)
+//
+// Optimistic-locked on sites.version_lock; concurrent edits surface
+// VERSION_CONFLICT (409) with the current server-side version.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_FIELD_BYTES = 4096;
+
+const PatchSchema = z
+  .object({
+    brand_voice: z
+      .union([z.string().max(MAX_FIELD_BYTES), z.null()])
+      .optional(),
+    design_direction: z
+      .union([z.string().max(MAX_FIELD_BYTES), z.null()])
+      .optional(),
+  })
+  .refine(
+    (p) =>
+      p.brand_voice !== undefined || p.design_direction !== undefined,
+    {
+      message:
+        "At least one of brand_voice or design_direction is required.",
+    },
+  );
+
+const BodySchema = z.object({
+  expected_version_lock: z.number().int().min(1),
+  patch: PatchSchema,
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false, ...(details ? { details } : {}) },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Site id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body failed validation.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await updateSiteVoice(
+    params.id,
+    parsed.data.expected_version_lock,
+    parsed.data.patch,
+  );
+
+  if (!result.ok) {
+    const status = errorCodeToStatus(
+      result.error.code === "VERSION_CONFLICT"
+        ? "VERSION_CONFLICT"
+        : result.error.code === "NOT_FOUND"
+          ? "NOT_FOUND"
+          : "INTERNAL_ERROR",
+    );
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      status,
+      result.error.details,
+    );
+  }
+
+  revalidatePath(`/admin/sites/${params.id}`);
+  revalidatePath(`/admin/sites/${params.id}/settings`);
+
+  return NextResponse.json(
+    { ok: true, data: result.data, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/components/BriefReviewClient.tsx
+++ b/components/BriefReviewClient.tsx
@@ -89,11 +89,15 @@ const ERROR_TRANSLATIONS: Record<string, string> = {
 export function BriefReviewClient({
   siteId,
   siteName,
+  siteBrandVoiceDefault,
+  siteDesignDirectionDefault,
   brief,
   initialPages,
 }: {
   siteId: string;
   siteName: string;
+  siteBrandVoiceDefault: string | null;
+  siteDesignDirectionDefault: string | null;
   brief: BriefRow;
   initialPages: BriefPageRow[];
 }) {
@@ -106,11 +110,27 @@ export function BriefReviewClient({
   const [latestBrief, setLatestBrief] = useState<BriefRow>(brief);
   // M12-2 — brand_voice + design_direction feed the M12-3 runner. Captured
   // pre-commit; editable here while status='parsed', read-only after commit.
+  //
+  // RS-2 — site-level defaults inherit when the brief row has no
+  // override yet. The operator can then "Customize for this brief"
+  // (collapsed by default whenever a site default exists) which keeps
+  // their override on the briefs row, never touching the site row.
   const [brandVoice, setBrandVoice] = useState<string>(
-    brief.brand_voice ?? "",
+    brief.brand_voice ?? siteBrandVoiceDefault ?? "",
   );
   const [designDirection, setDesignDirection] = useState<string>(
-    brief.design_direction ?? "",
+    brief.design_direction ?? siteDesignDirectionDefault ?? "",
+  );
+  const hasSiteDefault =
+    (siteBrandVoiceDefault ?? "").length > 0 ||
+    (siteDesignDirectionDefault ?? "").length > 0;
+  const hasPerBriefOverride =
+    brief.brand_voice !== null || brief.design_direction !== null;
+  // Collapse the editor when site defaults exist AND the brief hasn't
+  // already been overridden — operators land on a clean "inheriting"
+  // state and only expand when they want to deviate.
+  const [voiceOverrideOpen, setVoiceOverrideOpen] = useState<boolean>(
+    !hasSiteDefault || hasPerBriefOverride,
   );
   // M12-5 — operator picks model tiers at commit time. Default to the
   // value the server committed the brief with; fall back to the cheap
@@ -329,16 +349,61 @@ export function BriefReviewClient({
 
       {(brief.status === "parsed" || brief.status === "committed") && (
         <section aria-labelledby="voice-direction-heading" className="rounded-lg border p-4">
-          <div className="mb-3">
-            <h2 id="voice-direction-heading" className="text-lg font-medium">
-              Brand voice &amp; design direction
-            </h2>
-            <p className="mt-1 text-xs text-muted-foreground">
-              These guide every page the generator produces. Optional today;
-              required before the runner ships in M12-3.
-            </p>
+          <div className="mb-3 flex items-start justify-between gap-3">
+            <div>
+              <h2 id="voice-direction-heading" className="text-lg font-medium">
+                Brand voice &amp; design direction
+              </h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {hasSiteDefault && !voiceOverrideOpen
+                  ? "Inheriting from site defaults. Expand to customize for this brief."
+                  : hasSiteDefault
+                    ? "Override values for this brief only. The site defaults below stay unchanged."
+                    : "These guide every page the generator produces. Set once on Site Settings to inherit on every brief."}
+              </p>
+            </div>
+            {hasSiteDefault && !isReadOnly && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setVoiceOverrideOpen((v) => !v)}
+                aria-expanded={voiceOverrideOpen}
+                aria-controls="voice-direction-fields"
+              >
+                {voiceOverrideOpen ? "Use site defaults" : "Customize for this brief"}
+              </Button>
+            )}
           </div>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {hasSiteDefault && !voiceOverrideOpen && (
+            <div className="space-y-2 rounded-md bg-muted/40 p-3 text-sm">
+              {siteBrandVoiceDefault && (
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Brand voice (site default)
+                  </p>
+                  <p className="mt-1 whitespace-pre-wrap">
+                    {siteBrandVoiceDefault}
+                  </p>
+                </div>
+              )}
+              {siteDesignDirectionDefault && (
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Design direction (site default)
+                  </p>
+                  <p className="mt-1 whitespace-pre-wrap">
+                    {siteDesignDirectionDefault}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+          <div
+            id="voice-direction-fields"
+            hidden={hasSiteDefault && !voiceOverrideOpen}
+            className="grid grid-cols-1 gap-4 md:grid-cols-2"
+          >
             <div>
               <label
                 htmlFor="brand-voice-input"

--- a/components/SiteVoiceSettingsForm.tsx
+++ b/components/SiteVoiceSettingsForm.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+// ---------------------------------------------------------------------------
+// RS-2 — site-level brand voice & design direction editor.
+//
+// Reads/writes /api/admin/sites/[id]/voice with optimistic version_lock.
+// Operator sets the values once; brief commit forms inherit them as
+// defaults. Per-brief override still wins at commit time — those values
+// live on the briefs row, not here.
+// ---------------------------------------------------------------------------
+
+const ERROR_TRANSLATIONS: Record<string, string> = {
+  VERSION_CONFLICT:
+    "Another tab updated this site's voice settings. Refresh to see the latest values, then re-apply your edit.",
+  VALIDATION_FAILED:
+    "We couldn't save those values. Check the form and try again.",
+  FORBIDDEN: "Your account doesn't have permission to edit site settings.",
+  UNAUTHORIZED: "Please sign in again.",
+  NOT_FOUND: "This site no longer exists. Refresh the page and try again.",
+};
+
+const FIELD_MAX_BYTES = 4096;
+
+export function SiteVoiceSettingsForm({
+  siteId,
+  initialBrandVoice,
+  initialDesignDirection,
+  initialVersionLock,
+}: {
+  siteId: string;
+  initialBrandVoice: string | null;
+  initialDesignDirection: string | null;
+  initialVersionLock: number;
+}) {
+  const router = useRouter();
+  const [brandVoice, setBrandVoice] = useState(initialBrandVoice ?? "");
+  const [designDirection, setDesignDirection] = useState(
+    initialDesignDirection ?? "",
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSubmitting(true);
+    setFormError(null);
+    setSavedAt(null);
+    try {
+      const res = await fetch(`/api/admin/sites/${siteId}/voice`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          expected_version_lock: initialVersionLock,
+          patch: {
+            // Empty string = clear the value (null) so "operator opened
+            // the field, typed, then cleared" is treated the same as
+            // "explicitly empty".
+            brand_voice: brandVoice.trim() === "" ? null : brandVoice,
+            design_direction:
+              designDirection.trim() === "" ? null : designDirection,
+          },
+        }),
+      });
+      const payload = (await res.json()) as
+        | { ok: true; data: { brand_voice: string | null } }
+        | { ok: false; error: { code: string; message: string } };
+      if (payload.ok) {
+        setSavedAt(new Date().toLocaleTimeString());
+        router.refresh();
+        return;
+      }
+      setFormError(
+        ERROR_TRANSLATIONS[payload.error.code] ?? payload.error.message,
+      );
+    } catch (err) {
+      setFormError(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="site-brand-voice" className="block text-sm font-medium">
+          Brand voice
+        </label>
+        <Textarea
+          id="site-brand-voice"
+          className="mt-1"
+          rows={5}
+          value={brandVoice}
+          onChange={(e) => setBrandVoice(e.target.value)}
+          disabled={submitting}
+          maxLength={FIELD_MAX_BYTES}
+          placeholder="e.g. Warm, confident, plain language. Avoid jargon. Second-person (you / your) by default."
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          How every page on this site should sound. New briefs inherit this as
+          a default. {FIELD_MAX_BYTES.toLocaleString()} characters max.
+        </p>
+      </div>
+
+      <div>
+        <label
+          htmlFor="site-design-direction"
+          className="block text-sm font-medium"
+        >
+          Design direction
+        </label>
+        <Textarea
+          id="site-design-direction"
+          className="mt-1"
+          rows={5}
+          value={designDirection}
+          onChange={(e) => setDesignDirection(e.target.value)}
+          disabled={submitting}
+          maxLength={FIELD_MAX_BYTES}
+          placeholder="e.g. Generous white space. Hero with photo background. Single CTA per section, accent color for emphasis."
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          Visual constraints for the anchor cycle on every brief. New briefs
+          inherit this as a default. {FIELD_MAX_BYTES.toLocaleString()}{" "}
+          characters max.
+        </p>
+      </div>
+
+      {formError && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {formError}
+        </div>
+      )}
+
+      {savedAt && !formError && (
+        <div
+          role="status"
+          className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-3 text-sm text-emerald-700"
+        >
+          Saved at {savedAt}. Reload to see version_lock advance.
+        </div>
+      )}
+
+      <div className="flex items-center justify-end">
+        <Button type="submit" disabled={submitting}>
+          {submitting ? "Saving…" : "Save voice settings"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/lib/sites.ts
+++ b/lib/sites.ts
@@ -448,6 +448,106 @@ export async function updateSiteBasics(
   }
 }
 
+// ---------------------------------------------------------------------------
+// updateSiteVoice (RS-2 — site-level brand voice & design direction)
+// ---------------------------------------------------------------------------
+//
+// Patch the site's brand_voice / design_direction defaults. Operator UX:
+// set once on the Site Settings page, every new brief inherits the
+// values. Per-brief override on briefs.brand_voice / briefs.design_direction
+// still wins at commit time.
+//
+// Optimistic concurrency on sites.version_lock — concurrent edits return
+// VERSION_CONFLICT (409). Either field may be null to clear it; passing
+// undefined leaves the existing value untouched.
+
+export async function updateSiteVoice(
+  id: string,
+  expectedVersionLock: number,
+  patch: { brand_voice?: string | null; design_direction?: string | null },
+): Promise<ApiResponse<SiteRecord>> {
+  try {
+    if (
+      patch.brand_voice === undefined &&
+      patch.design_direction === undefined
+    ) {
+      return internalError("updateSiteVoice called with empty patch.");
+    }
+    const supabase = getServiceRoleClient();
+
+    const updatePatch: Record<string, unknown> = {
+      updated_at: new Date().toISOString(),
+      version_lock: expectedVersionLock + 1,
+    };
+    if (patch.brand_voice !== undefined) {
+      updatePatch.brand_voice = patch.brand_voice;
+    }
+    if (patch.design_direction !== undefined) {
+      updatePatch.design_direction = patch.design_direction;
+    }
+
+    const { data, error } = await supabase
+      .from("sites")
+      .update(updatePatch)
+      .eq("id", id)
+      .eq("version_lock", expectedVersionLock)
+      .neq("status", "removed")
+      .select()
+      .maybeSingle();
+
+    if (error) {
+      return internalError("Failed to update site voice.", {
+        supabase_error: error,
+      });
+    }
+    if (!data) {
+      // Disambiguate NOT_FOUND vs VERSION_CONFLICT — re-read the row.
+      const { data: present } = await supabase
+        .from("sites")
+        .select("version_lock")
+        .eq("id", id)
+        .neq("status", "removed")
+        .maybeSingle();
+      if (!present) {
+        return {
+          ok: false,
+          error: {
+            code: "NOT_FOUND",
+            message: `No active site found with id ${id}.`,
+            details: { id },
+            retryable: false,
+            suggested_action:
+              "Verify the site id; removed sites are excluded.",
+          },
+          timestamp: now(),
+        };
+      }
+      return {
+        ok: false,
+        error: {
+          code: "VERSION_CONFLICT",
+          message:
+            "Another tab updated this site's voice settings. Reload to see the latest values, then re-apply your edit.",
+          details: {
+            id,
+            expected_version_lock: expectedVersionLock,
+            current_version_lock: present.version_lock,
+          },
+          retryable: false,
+          suggested_action:
+            "Reload the Settings page to see the latest version.",
+        },
+        timestamp: now(),
+      };
+    }
+    return { ok: true, data: data as SiteRecord, timestamp: now() };
+  } catch (err) {
+    return internalError(
+      `Unhandled error in updateSiteVoice: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 /**
  * Soft-archive a site. Sets status='removed' so listSites filters it
  * out. The UNIQUE (prefix) WHERE status != 'removed' partial index

--- a/lib/tool-schemas.ts
+++ b/lib/tool-schemas.ts
@@ -183,6 +183,11 @@ export type SiteRecord = {
   plugin_version: string | null;
   created_at: string;
   updated_at: string;
+  // RS-2: site-level defaults. Nullable; brief commit form populates from
+  // these when the operator hasn't set a per-brief override.
+  brand_voice: string | null;
+  design_direction: string | null;
+  version_lock: number;
 };
 
 export type SiteListItem = {

--- a/supabase/migrations/0028_sites_brand_voice_design_direction.sql
+++ b/supabase/migrations/0028_sites_brand_voice_design_direction.sql
@@ -1,0 +1,24 @@
+-- 0028 — RS-2: site-level brand voice + design direction.
+--
+-- Today brand_voice and design_direction live exclusively on the
+-- `briefs` row, so the operator re-types them every brief even though
+-- the values almost never change between briefs of the same site. This
+-- migration moves the *defaults* to the site row; the per-brief
+-- columns stay (operator override still persists per brief).
+--
+-- Both columns are nullable. Existing sites get NULL and continue to
+-- work — the brief-review form falls back to its current "no defaults"
+-- behaviour when the site values are unset.
+--
+-- Forward-only. No backfill: operator sets the site-level value
+-- explicitly via Site Settings.
+
+ALTER TABLE sites
+  ADD COLUMN brand_voice text,
+  ADD COLUMN design_direction text;
+
+COMMENT ON COLUMN sites.brand_voice IS
+  'Site-level default brand voice copy. Inherited by new briefs as the brief-review default; per-brief brand_voice still overrides at commit time. Added 2026-04-27 (RS-2).';
+
+COMMENT ON COLUMN sites.design_direction IS
+  'Site-level default design direction copy. Inherited by new briefs as the brief-review default; per-brief design_direction still overrides at commit time. Added 2026-04-27 (RS-2).';


### PR DESCRIPTION
## Summary

RS-2 of the run-surface UX overhaul (parent: PR #213).

Today \`brand_voice\` + \`design_direction\` live exclusively on the briefs row, so the operator re-types them every brief even though the values almost never change between briefs of the same site. RS-2 lifts the **defaults** to the site row; per-brief override still lives on the briefs row and still wins at commit time.

## What ships

- **\`supabase/migrations/0028_sites_brand_voice_design_direction.sql\`** — \`ADD COLUMN brand_voice text, design_direction text\`. Both nullable. Forward-only, no backfill.
- **\`lib/sites.ts\`** — new \`updateSiteVoice(id, expectedVersionLock, patch)\` with CAS on \`sites.version_lock\`. Returns \`VERSION_CONFLICT\` (409) on concurrent edits, \`NOT_FOUND\` for missing/removed sites.
- **\`lib/tool-schemas.ts\`** — \`SiteRecord\` gains \`brand_voice\` / \`design_direction\` / \`version_lock\` fields.
- **\`app/api/admin/sites/[id]/voice/route.ts\`** — PATCH endpoint, **admin OR operator** role (matches the editorial nature of voice/direction; \`/budget\` stays admin-only as a financial control). 4096-char cap per field; empty string clears (NULL).
- **\`app/admin/sites/[id]/settings/page.tsx\`** — new Settings surface with the voice/direction editor.
- **\`components/SiteVoiceSettingsForm.tsx\`** — client form, optimistic CAS, translates \`VERSION_CONFLICT\` inline.
- **\`app/admin/sites/[id]/page.tsx\`** — new \"Settings\" panel in the aside with \"Configured / Not set\" badge + link.
- **\`components/BriefReviewClient.tsx\`** — defaults populate from site values when the brief row has no per-brief override. When site defaults exist + no override, the editor collapses to a read-only \"Inheriting from site defaults\" preview with a \"Customize for this brief\" toggle. Override stays on the briefs row.
- **\`app/admin/sites/[id]/briefs/[brief_id]/review/page.tsx\`** — passes \`site.brand_voice\` / \`site.design_direction\` into BriefReviewClient.

## Risks identified and mitigated

- **Schema migration on \`sites\`** — nullable ADD COLUMN; atomic; no backfill required.
- **Operator confusion (\"which value is active?\")** — collapsed-state preview shows the site-level value verbatim above the override toggle. Override-state heading copy explicitly says \"for this brief only\".
- **Existing per-brief overrides** — continue to load (\`brief.brand_voice ?? site.brand_voice\`) so already-committed briefs show the operator-set value.
- **Concurrent settings edit + brief upload** — brief form reads site values at SSR; site edits after form-load are stale until refresh. Acceptable.
- **API role policy** — \`/voice\` = admin OR operator (editorial); \`/budget\` stays admin-only (financial). Documented in the route header.
- **UploadBriefModal not changed** — \`brand_voice\` has always been a commit-time field on the brief, not an upload-time field. The inheritance lands visibly in the same surface (BriefReviewClient) it always has.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean; \`/admin/sites/[id]/settings\` and \`/api/admin/sites/[id]/voice\` present
- [ ] Manual: set site voice on Settings → upload brief → confirm review form pre-populates from site defaults → toggle override → commit → confirm site row unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)