### PR TITLE
feat(bp-3): blog-post entry-point page (composer + smart-parsed metadata)

### DIFF
--- a/app/admin/sites/[id]/posts/new/page.tsx
+++ b/app/admin/sites/[id]/posts/new/page.tsx
@@ -1,0 +1,66 @@
+import { notFound, redirect } from "next/navigation";
+
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { BlogPostComposer } from "@/components/BlogPostComposer";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { getSite } from "@/lib/sites";
+
+// /admin/sites/[id]/posts/new — BP-3 entry-point.
+//
+// Operator pastes / drops a post; smart-parser pre-fills metadata
+// fields (BP-1); save-draft creates a draft post in the existing
+// posts table. BP-4 (image picker) and BP-8 (run-start gate) layer on
+// the featured-image flow + the Start-run CTA in later slices.
+
+export const dynamic = "force-dynamic";
+
+export default async function BlogPostEntryPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const access = await checkAdminAccess({
+    requiredRoles: ["admin", "operator"],
+    insufficientRoleRedirectTo: "/",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  const result = await getSite(params.id);
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") notFound();
+    return (
+      <main className="mx-auto max-w-3xl p-6">
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        >
+          {result.error.message}
+        </div>
+      </main>
+    );
+  }
+  const site = result.data.site;
+
+  return (
+    <main className="mx-auto max-w-4xl p-6">
+      <Breadcrumbs
+        crumbs={[
+          { label: "Sites", href: "/admin/sites" },
+          { label: site.name, href: `/admin/sites/${site.id}` },
+          { label: "Posts", href: `/admin/sites/${site.id}/posts` },
+          { label: "New post" },
+        ]}
+      />
+      <h1 className="mt-2 text-xl font-semibold">New blog post</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Paste a markdown / HTML / YAML-fronted post. We&apos;ll parse the
+        metadata into the fields below — every value is editable before
+        you save the draft.
+      </p>
+
+      <div className="mt-6">
+        <BlogPostComposer siteId={site.id} />
+      </div>
+    </main>
+  );
+}

--- a/app/admin/sites/[id]/posts/page.tsx
+++ b/app/admin/sites/[id]/posts/page.tsx
@@ -142,11 +142,21 @@ export default async function SitePostsList({
         ]}
       />
 
-      <div className="mt-6 flex items-center justify-between">
+      <div className="mt-6 flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-2xl font-semibold">Posts</h1>
-        <p className="text-xs text-muted-foreground">
-          {total} total{total > 0 ? ` · showing ${rangeStart}–${rangeEnd}` : ""}
-        </p>
+        <div className="flex items-center gap-3">
+          <p className="text-xs text-muted-foreground">
+            {total} total{total > 0 ? ` · showing ${rangeStart}–${rangeEnd}` : ""}
+          </p>
+          {/* BP-3 — entry-point for single-post creation. */}
+          <Link
+            href={`/admin/sites/${site.id}/posts/new`}
+            className="inline-flex h-9 items-center rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted transition-smooth"
+            data-testid="new-post-button"
+          >
+            New post
+          </Link>
+        </div>
       </div>
 
       <form

--- a/app/api/sites/[id]/posts/route.ts
+++ b/app/api/sites/[id]/posts/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { createPost } from "@/lib/posts";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { errorCodeToStatus } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// POST /api/sites/[id]/posts — BP-3 entry-point save-draft.
+//
+// Body: { title, slug, excerpt?, metadata?, design_system_version? }
+//
+// Creates a draft post for the site. design_system_version defaults to
+// the site's currently-active DS version. Returns the new post id +
+// detail link so the client can router.push() into the post's edit
+// surface.
+//
+// Admin OR operator role.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const BodySchema = z
+  .object({
+    title: z.string().min(1).max(200),
+    slug: z
+      .string()
+      .min(1)
+      .max(100)
+      .regex(/^[a-z0-9-]+$/),
+    excerpt: z.string().max(2000).nullable().optional(),
+    metadata: z.unknown().optional(),
+  })
+  .strict();
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: {
+        code,
+        message,
+        retryable: false,
+        ...(details ? { details } : {}),
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Site id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "Body failed validation.",
+      400,
+      { issues: parsed.error.issues },
+    );
+  }
+
+  // Read the site's active design system version so the post row's
+  // design_system_version snapshots the value the operator authored
+  // against (matches the brief-runner semantics).
+  const svc = getServiceRoleClient();
+  const { data: ds } = await svc
+    .from("design_systems")
+    .select("version")
+    .eq("site_id", params.id)
+    .eq("status", "active")
+    .maybeSingle();
+  const dsVersion = Number(ds?.version ?? 1);
+
+  const result = await createPost({
+    site_id: params.id,
+    title: parsed.data.title,
+    slug: parsed.data.slug,
+    excerpt: parsed.data.excerpt ?? undefined,
+    design_system_version: dsVersion,
+    metadata: parsed.data.metadata,
+    created_by: gate.user?.id ?? null,
+  });
+
+  if (!result.ok) {
+    const status = errorCodeToStatus(result.error.code);
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      status,
+      result.error.details,
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        id: result.data.id,
+        slug: result.data.slug,
+        title: result.data.title,
+        edit_url: `/admin/sites/${params.id}/posts/${result.data.id}`,
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 201 },
+  );
+}

--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Composer, type ComposerValue } from "@/components/Composer";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  parseBlogPostMetadata,
+  slugify,
+  type BlogPostMetadata,
+  type ParseSource,
+} from "@/lib/blog-post-parser";
+
+// ---------------------------------------------------------------------------
+// BP-3 — Blog-post entry-point composer.
+//
+// Composes the RS-1 Composer (paste / drag-drop / + attach) with the
+// BP-1 smart-parser. Each metadata field surfaces the parser's source
+// inline so the operator can see "Auto-filled from YAML title" — same
+// affordance whether they paste markdown, HTML, or a YAML-fenced
+// document.
+//
+// Save-draft posts to /api/sites/[id]/posts and routes to the post's
+// detail page on success. The "Start run" button is disabled with
+// "Featured image required" copy until BP-4 (image picker) and BP-8
+// (run-start gate) wire it.
+// ---------------------------------------------------------------------------
+
+const PARSE_DEBOUNCE_MS = 200;
+
+const SOURCE_HINTS: Record<ParseSource, string> = {
+  yaml: "Auto-filled from YAML front-matter",
+  inline: "Auto-filled from inline label",
+  html: "Auto-filled from HTML meta",
+  h1: "Auto-filled from first heading",
+  first_paragraph: "Auto-filled from first paragraph",
+  derived: "Derived from title",
+  none: "",
+};
+
+const ERROR_TRANSLATIONS: Record<string, string> = {
+  UNIQUE_VIOLATION:
+    "A post with this slug already exists on this site. Pick a different slug.",
+  VALIDATION_FAILED: "Some fields are invalid. Check the form and try again.",
+  FORBIDDEN: "Your account doesn't have permission to create posts on this site.",
+  UNAUTHORIZED: "Please sign in again.",
+  NOT_FOUND: "This site no longer exists. Refresh and try again.",
+};
+
+function SourceHint({ source }: { source: ParseSource }) {
+  if (source === "none") return null;
+  return (
+    <span className="text-xs text-muted-foreground">{SOURCE_HINTS[source]}</span>
+  );
+}
+
+interface FieldState {
+  value: string;
+  source: ParseSource;
+  // True once the operator has typed in this field; locks it from
+  // further parser overwrites so the operator's edit isn't clobbered
+  // by a debounced parse from the textarea below.
+  touched: boolean;
+}
+
+function emptyField(): FieldState {
+  return { value: "", source: "none", touched: false };
+}
+
+function applyParse(
+  current: FieldState,
+  parsed: string | null,
+  source: ParseSource,
+): FieldState {
+  if (current.touched) return current;
+  if (parsed === null) return current;
+  return { value: parsed, source, touched: false };
+}
+
+export function BlogPostComposer({ siteId }: { siteId: string }) {
+  const router = useRouter();
+  const [composerValue, setComposerValue] = useState<ComposerValue>({
+    text: "",
+    file: null,
+  });
+  const [title, setTitle] = useState<FieldState>(emptyField);
+  const [slug, setSlug] = useState<FieldState>(emptyField);
+  const [metaTitle, setMetaTitle] = useState<FieldState>(emptyField);
+  const [metaDescription, setMetaDescription] = useState<FieldState>(emptyField);
+  const [parentPage, setParentPage] = useState(""); // BP-8 will swap for combobox
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [lastParse, setLastParse] = useState<BlogPostMetadata | null>(null);
+
+  // Debounced re-parse on every text change. Pure-logic call, but
+  // 200ms keeps every keystroke from reflowing four field updates.
+  useEffect(() => {
+    if (composerValue.text.length === 0) {
+      setLastParse(null);
+      return;
+    }
+    const id = setTimeout(() => {
+      const parsed = parseBlogPostMetadata(composerValue.text);
+      setLastParse(parsed);
+      setTitle((cur) => applyParse(cur, parsed.title, parsed.source_map.title));
+      setSlug((cur) => applyParse(cur, parsed.slug, parsed.source_map.slug));
+      setMetaTitle((cur) =>
+        applyParse(cur, parsed.meta_title, parsed.source_map.meta_title),
+      );
+      setMetaDescription((cur) =>
+        applyParse(
+          cur,
+          parsed.meta_description,
+          parsed.source_map.meta_description,
+        ),
+      );
+    }, PARSE_DEBOUNCE_MS);
+    return () => clearTimeout(id);
+  }, [composerValue.text]);
+
+  // If the operator clears a touched field, snap it back to the
+  // parsed value rather than leaving the form blank between edits.
+  function setFieldValue(
+    setter: typeof setTitle,
+    value: string,
+    parsedFallback: string | null,
+    source: ParseSource,
+  ) {
+    if (value === "" && parsedFallback) {
+      setter({ value: parsedFallback, source, touched: false });
+    } else {
+      setter({ value, source, touched: true });
+    }
+  }
+
+  const slugIsValid = useMemo(
+    () => /^[a-z0-9-]+$/.test(slug.value) && slug.value.length > 0,
+    [slug.value],
+  );
+  const titleIsValid = title.value.trim().length > 0;
+  const metaDescriptionIsValid =
+    metaDescription.value.trim().length > 0 &&
+    metaDescription.value.length <= 160;
+
+  const canSaveDraft =
+    !submitting &&
+    titleIsValid &&
+    slugIsValid &&
+    composerValue.text.trim().length > 0;
+
+  async function handleSaveDraft(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setFormError(null);
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/sites/${siteId}/posts`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: title.value.trim(),
+          slug: slug.value.trim(),
+          excerpt:
+            metaDescription.value.trim().length > 0
+              ? metaDescription.value.trim()
+              : null,
+          metadata: lastParse ?? null,
+        }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: { id: string; edit_url: string } }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (payload?.ok) {
+        router.push(payload.data.edit_url);
+        return;
+      }
+      const code =
+        payload?.ok === false ? payload.error.code : "INTERNAL_ERROR";
+      const fallback =
+        payload?.ok === false
+          ? payload.error.message
+          : `Save failed (HTTP ${res.status}).`;
+      setFormError(ERROR_TRANSLATIONS[code] ?? fallback);
+    } catch (err) {
+      setFormError(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSaveDraft} className="space-y-6">
+      <div>
+        <label
+          htmlFor="post-composer-input"
+          className="block text-sm font-medium"
+        >
+          Post content
+        </label>
+        <Composer
+          textareaId="post-composer-input"
+          value={composerValue}
+          onChange={setComposerValue}
+          accept=".md,.html,.txt,text/markdown,text/html,text/plain"
+          maxFileBytes={10 * 1024 * 1024}
+          placeholder={`Type, paste, or drop your post.\n\nA YAML front-matter block, inline labels, or HTML meta tags will pre-fill the metadata fields below.`}
+          acceptHint="Markdown, HTML, or plain text. Drag-drop, paste, or use + to attach. Max 10 MB."
+          className="mt-1"
+        />
+      </div>
+
+      <fieldset className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div>
+          <label htmlFor="post-title" className="block text-sm font-medium">
+            Title
+          </label>
+          <Input
+            id="post-title"
+            className="mt-1"
+            value={title.value}
+            onChange={(e) =>
+              setFieldValue(setTitle, e.target.value, lastParse?.title ?? null, "derived")
+            }
+            disabled={submitting}
+            maxLength={200}
+            aria-invalid={!titleIsValid}
+          />
+          <div className="mt-1 flex items-center justify-between gap-2">
+            <SourceHint source={title.source} />
+            {!titleIsValid && (
+              <span className="text-xs text-destructive">Title required.</span>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="post-slug" className="block text-sm font-medium">
+            URL slug
+          </label>
+          <Input
+            id="post-slug"
+            className="mt-1"
+            value={slug.value}
+            onChange={(e) =>
+              setFieldValue(
+                setSlug,
+                e.target.value.toLowerCase(),
+                lastParse?.slug ?? null,
+                lastParse?.source_map.slug ?? "derived",
+              )
+            }
+            onBlur={() => {
+              // Auto-clean on blur so the operator never has to think
+              // about kebab-casing their own input.
+              if (slug.value && !slugIsValid) {
+                setSlug({
+                  value: slugify(slug.value),
+                  source: "derived",
+                  touched: true,
+                });
+              }
+            }}
+            disabled={submitting}
+            maxLength={100}
+            aria-invalid={!slugIsValid}
+          />
+          <div className="mt-1 flex items-center justify-between gap-2">
+            <SourceHint source={slug.source} />
+            {!slugIsValid && slug.value.length > 0 && (
+              <span className="text-xs text-destructive">
+                Lowercase letters, numbers, dashes only.
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <label
+            htmlFor="post-meta-title"
+            className="block text-sm font-medium"
+          >
+            Meta title (SEO)
+          </label>
+          <Input
+            id="post-meta-title"
+            className="mt-1"
+            value={metaTitle.value}
+            onChange={(e) =>
+              setFieldValue(
+                setMetaTitle,
+                e.target.value,
+                lastParse?.meta_title ?? null,
+                lastParse?.source_map.meta_title ?? "derived",
+              )
+            }
+            disabled={submitting}
+            maxLength={200}
+          />
+          <SourceHint source={metaTitle.source} />
+        </div>
+
+        <div>
+          <label
+            htmlFor="post-parent-page"
+            className="block text-sm font-medium"
+          >
+            Parent page
+          </label>
+          <Input
+            id="post-parent-page"
+            className="mt-1"
+            value={parentPage}
+            onChange={(e) => setParentPage(e.target.value)}
+            disabled={submitting}
+            placeholder="(BP-8 will replace this with a WP-page combobox)"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Free-text for now. BP-8 wires the WP /pages picker.
+          </p>
+        </div>
+
+        <div className="md:col-span-2">
+          <label
+            htmlFor="post-meta-description"
+            className="block text-sm font-medium"
+          >
+            Meta description (SEO)
+          </label>
+          <Textarea
+            id="post-meta-description"
+            className="mt-1"
+            rows={3}
+            value={metaDescription.value}
+            onChange={(e) =>
+              setFieldValue(
+                setMetaDescription,
+                e.target.value,
+                lastParse?.meta_description ?? null,
+                lastParse?.source_map.meta_description ?? "derived",
+              )
+            }
+            disabled={submitting}
+            maxLength={400}
+            aria-invalid={
+              metaDescription.value.length > 0 && !metaDescriptionIsValid
+            }
+          />
+          <div className="mt-1 flex items-center justify-between gap-2 text-xs">
+            <SourceHint source={metaDescription.source} />
+            <span
+              className={
+                metaDescription.value.length > 160
+                  ? "text-destructive"
+                  : "text-muted-foreground"
+              }
+            >
+              {metaDescription.value.length}/160
+            </span>
+          </div>
+        </div>
+      </fieldset>
+
+      <div className="rounded-md border-2 border-dashed border-muted bg-muted/30 p-4 text-sm">
+        <p className="font-medium">Featured image</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Picker lands in BP-4. For now, save as draft and add the image
+          on the post detail page.
+        </p>
+      </div>
+
+      {formError && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {formError}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button type="submit" disabled={!canSaveDraft}>
+          {submitting ? "Saving…" : "Save draft"}
+        </Button>
+        <Button
+          type="button"
+          disabled
+          title="Featured image required (BP-4 + BP-8 will wire this)"
+        >
+          Start run
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Start run is disabled until the featured-image picker (BP-4) and
+        run-start gate (BP-8) ship. Save a draft now and the post detail
+        page will surface the start affordance.
+      </p>
+    </form>
+  );
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -71,6 +71,9 @@ export const CreatePostInputSchema = z
     content_structured: z.unknown().optional(),
     generated_html: z.string().nullable().optional(),
     created_by: z.string().uuid().nullable().optional(),
+    // BP-3: parser snapshot (title/slug/meta_*/source_map) for posts
+    // created via the entry-point. NULL otherwise.
+    metadata: z.unknown().optional(),
   })
   .strict();
 
@@ -252,6 +255,7 @@ async function createPostImpl(
   }
   if (input.generated_html !== undefined) insertRow.generated_html = input.generated_html;
   if (input.created_by !== undefined) insertRow.created_by = input.created_by;
+  if (input.metadata !== undefined) insertRow.metadata = input.metadata;
 
   const res = await supabase
     .from("posts")

--- a/supabase/migrations/0029_posts_metadata.sql
+++ b/supabase/migrations/0029_posts_metadata.sql
@@ -1,0 +1,22 @@
+-- 0029 — BP-3: posts.metadata jsonb column for the blog-post entry-point.
+--
+-- The new /admin/sites/[id]/posts/new entry-point parses metadata
+-- (title, slug, meta_title, meta_description, source_map) from the
+-- operator's pasted content via lib/blog-post-parser.ts. The
+-- structured snapshot is persisted alongside the operator-confirmed
+-- title/slug/excerpt so a later debugger can answer "what did the
+-- smart-parser pull vs what did the operator type?" without
+-- re-parsing.
+--
+-- Nullable: legacy posts (created via the brief-runner content_type
+-- ='post' path) carry no parser metadata and stay NULL.
+--
+-- Forward-only. No backfill — operator-confirmed values already live
+-- in title/slug/excerpt; metadata is the parsed-source provenance,
+-- only meaningful for posts created via the new entry-point.
+
+ALTER TABLE posts
+  ADD COLUMN metadata jsonb;
+
+COMMENT ON COLUMN posts.metadata IS
+  'Snapshot of the smart-parser output (title, slug, meta_title, meta_description, source_map) for posts created via the BP-3 entry-point at /admin/sites/[id]/posts/new. NULL for posts created via the brief-runner path. Added 2026-04-27 (BP-3).';


### PR DESCRIPTION
## Summary

BP-3 of the blog-post workflow plan (parent: PR #214). BP-2 was a no-op — RS-1's Composer shipped first, so BP-3 consumes it directly.

New surface at \`/admin/sites/[id]/posts/new\` lets the operator paste a markdown / HTML / YAML-fronted blog post; the BP-1 smart-parser populates metadata fields (title, slug, meta_title, meta_description) with per-field source hints; save-draft creates a posts row.

## What ships

- **\`supabase/migrations/0029_posts_metadata.sql\`** — \`ADD COLUMN posts.metadata jsonb\` (nullable). Snapshot of the parser output; legacy posts (created via brief-runner path) carry NULL.
- **\`lib/posts.ts\`** — \`CreatePostInputSchema\` accepts \`metadata\`; \`createPost\` writes it on insert.
- **\`app/api/sites/[id]/posts/route.ts\`** — POST handler (admin OR operator). Reads the site's active design_system_version. Returns the new post id + edit_url.
- **\`components/BlogPostComposer.tsx\`** — wraps the RS-1 Composer with the metadata form. Debounced 200ms re-parse on every text change. Per-field source hints. Touched fields lock against further parser overwrites; clearing snaps back to the parsed value. Slug auto-clean on blur.
- **\`app/admin/sites/[id]/posts/new/page.tsx\`** — server component, admin OR operator role.
- **\`app/admin/sites/[id]/posts/page.tsx\`** — adds \"New post\" CTA next to the total counter.

## Risks identified and mitigated

- **Schema migration on \`posts\`** — nullable ADD COLUMN; atomic; forward-only.
- **Smart-parser mis-classifications** — per-field source hint surfaces the parsed source; operator edits inline; touched flag protects from mid-typing reflow.
- **Auto-save vs explicit-save** — explicit; no surprise mid-typing.
- **Slug uniqueness** — \`createPost\` surfaces \`UNIQUE_VIOLATION\` (PG 23505) with translated message.
- **Featured image (BP-4) and run-start (BP-8) not yet wired** — explicit disabled \"Start run\" + helper text point at upcoming slices.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean; \`/admin/sites/[id]/posts/new\` and \`/api/sites/[id]/posts\` present
- [ ] Manual: paste a YAML-fronted markdown blob, observe metadata populate; clear a field, confirm parser snaps back; save draft, confirm router push to \`/posts/[id]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)