### PR TITLE
feat(bp-4): image picker modal — library tab functional

### DIFF
--- a/app/api/admin/images/list/route.ts
+++ b/app/api/admin/images/list/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { deliveryUrl } from "@/lib/cloudflare-images";
+import {
+  LIST_IMAGES_DEFAULT_LIMIT,
+  LIST_IMAGES_MAX_LIMIT,
+  listImages,
+  type ImageListItem,
+} from "@/lib/image-library";
+
+// ---------------------------------------------------------------------------
+// GET /api/admin/images/list — BP-4.
+//
+// Polled by the image picker modal. Wraps lib/image-library.listImages
+// with FTS search + pagination. Caller pre-computes the Cloudflare
+// delivery URL server-side because the client doesn't have access to
+// CLOUDFLARE_IMAGES_HASH.
+//
+// Query params:
+//   q      — free-text search (caption + alt + filename, FTS)
+//   limit  — capped at LIST_IMAGES_MAX_LIMIT
+//   offset — non-negative integer
+//
+// Auth: admin OR operator (matches the BP-3 entry-point's role policy).
+// Soft-deleted images excluded by default.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export interface ImagePickerEntry extends ImageListItem {
+  delivery_url: string | null;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const url = new URL(req.url);
+  const rawQ = url.searchParams.get("q");
+  const rawLimit = url.searchParams.get("limit");
+  const rawOffset = url.searchParams.get("offset");
+
+  const q = rawQ && rawQ.trim().length > 0 ? rawQ.trim() : undefined;
+  const limit = (() => {
+    if (!rawLimit) return LIST_IMAGES_DEFAULT_LIMIT;
+    const n = Number(rawLimit);
+    if (!Number.isFinite(n) || n < 1) return LIST_IMAGES_DEFAULT_LIMIT;
+    return Math.min(LIST_IMAGES_MAX_LIMIT, Math.floor(n));
+  })();
+  const offset = (() => {
+    if (!rawOffset) return 0;
+    const n = Number(rawOffset);
+    if (!Number.isFinite(n) || n < 0) return 0;
+    return Math.floor(n);
+  })();
+
+  const result = await listImages({ query: q, limit, offset, deleted: false });
+  if (!result.ok) {
+    return NextResponse.json(
+      { ...result },
+      {
+        status: 500,
+        headers: { "cache-control": "no-store" },
+      },
+    );
+  }
+
+  const items: ImagePickerEntry[] = result.data.items.map((item) => ({
+    ...item,
+    delivery_url: item.cloudflare_id ? deliveryUrl(item.cloudflare_id) : null,
+  }));
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        items,
+        total: result.data.total,
+        limit: result.data.limit,
+        offset: result.data.offset,
+      },
+      timestamp: new Date().toISOString(),
+    },
+    {
+      status: 200,
+      headers: { "cache-control": "no-store" },
+    },
+  );
+}

--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -8,6 +8,10 @@ import { Composer, type ComposerValue } from "@/components/Composer";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  ImagePickerModal,
+  type ImagePickerEntry,
+} from "@/components/ImagePickerModal";
+import {
   parseBlogPostMetadata,
   slugify,
   type BlogPostMetadata,
@@ -94,6 +98,11 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const [lastParse, setLastParse] = useState<BlogPostMetadata | null>(null);
+  // BP-4 — featured image is local-only state for now. BP-7 will
+  // persist via posts.featured_image_id and transfer to WP at publish.
+  const [featuredImage, setFeaturedImage] =
+    useState<ImagePickerEntry | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   // Debounced re-parse on every text change. Pure-logic call, but
   // 200ms keeps every keystroke from reflowing four field updates.
@@ -365,12 +374,54 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
         </div>
       </fieldset>
 
-      <div className="rounded-md border-2 border-dashed border-muted bg-muted/30 p-4 text-sm">
-        <p className="font-medium">Featured image</p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Picker lands in BP-4. For now, save as draft and add the image
-          on the post detail page.
-        </p>
+      <div className="rounded-md border p-4 text-sm">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="font-medium">Featured image</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Required at publish (enforced by BP-7&apos;s server-side
+              guard). Selecting here previews; persistence + WP attachment
+              ship in BP-7.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setPickerOpen(true)}
+            disabled={submitting}
+          >
+            {featuredImage ? "Change image" : "Pick image"}
+          </Button>
+        </div>
+        {featuredImage && featuredImage.delivery_url && (
+          <div className="mt-3 flex items-center gap-3">
+            {/* Cloudflare Images delivery URL — no Next/Image to avoid
+                wiring imagedelivery.net into next.config remotePatterns
+                for a thumbnail with explicit w=/h= params already. */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`${featuredImage.delivery_url}/w=120,h=120,fit=cover`}
+              alt={featuredImage.alt_text ?? featuredImage.caption ?? ""}
+              className="h-20 w-20 rounded-md border object-cover"
+            />
+            <div className="min-w-0">
+              <p
+                className="truncate text-sm font-medium"
+                title={featuredImage.caption ?? featuredImage.filename ?? ""}
+              >
+                {featuredImage.caption ?? featuredImage.filename ?? "Untitled"}
+              </p>
+              <button
+                type="button"
+                onClick={() => setFeaturedImage(null)}
+                className="text-xs text-muted-foreground underline hover:text-foreground"
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+        )}
       </div>
 
       {formError && (
@@ -395,10 +446,16 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
         </Button>
       </div>
       <p className="text-xs text-muted-foreground">
-        Start run is disabled until the featured-image picker (BP-4) and
-        run-start gate (BP-8) ship. Save a draft now and the post detail
+        Start run is disabled until BP-7 (featured-image attach) + BP-8
+        (run-start gate) ship. Save a draft now and the post detail
         page will surface the start affordance.
       </p>
+
+      <ImagePickerModal
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onSelect={(image) => setFeaturedImage(image)}
+      />
     </form>
   );
 }

--- a/components/ImagePickerModal.tsx
+++ b/components/ImagePickerModal.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import type { ImageListItem } from "@/lib/image-library";
+
+// ---------------------------------------------------------------------------
+// BP-4 — Image picker modal.
+//
+// Three tabs:
+//   • Library     — search the existing image_library (1,777 stock images
+//                   today + every uploaded / fetched image). FTS via the
+//                   /api/admin/images/list endpoint.
+//   • Upload new  — stub. BP-5 wires multipart → Cloudflare Images.
+//   • Paste URL   — stub. BP-6 wires server-side fetch + SSRF guard.
+//
+// Returns the selected ImagePickerEntry to the caller via onSelect.
+// Modal closes immediately after selection.
+//
+// Wired into BlogPostComposer in this slice as the BP-3 placeholder's
+// replacement; persistence + WP attachment land in BP-7.
+// ---------------------------------------------------------------------------
+
+const SEARCH_DEBOUNCE_MS = 300;
+const PAGE_SIZE = 24;
+
+export interface ImagePickerEntry extends ImageListItem {
+  delivery_url: string | null;
+}
+
+type Tab = "library" | "upload" | "url";
+
+interface ImagePickerModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (image: ImagePickerEntry) => void;
+}
+
+export function ImagePickerModal({
+  open,
+  onClose,
+  onSelect,
+}: ImagePickerModalProps) {
+  const [tab, setTab] = useState<Tab>("library");
+  const [query, setQuery] = useState("");
+  const [items, setItems] = useState<ImagePickerEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inFlightRef = useRef<AbortController | null>(null);
+
+  // Reset state every time the modal opens so a re-open doesn't show
+  // stale results from the previous session.
+  useEffect(() => {
+    if (!open) return;
+    setTab("library");
+    setQuery("");
+    setItems([]);
+    setTotal(0);
+    setOffset(0);
+    setError(null);
+  }, [open]);
+
+  // Debounced fetch on (open, tab=library, query, offset) change.
+  useEffect(() => {
+    if (!open || tab !== "library") return;
+    const ctrl = new AbortController();
+    if (inFlightRef.current) inFlightRef.current.abort();
+    inFlightRef.current = ctrl;
+
+    const id = setTimeout(async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams();
+        if (query.trim().length > 0) params.set("q", query.trim());
+        params.set("limit", String(PAGE_SIZE));
+        params.set("offset", String(offset));
+        const res = await fetch(`/api/admin/images/list?${params}`, {
+          signal: ctrl.signal,
+          cache: "no-store",
+        });
+        if (ctrl.signal.aborted) return;
+        const payload = (await res.json().catch(() => null)) as
+          | {
+              ok: true;
+              data: { items: ImagePickerEntry[]; total: number };
+            }
+          | { ok: false; error: { code: string; message: string } }
+          | null;
+        if (!payload?.ok) {
+          setError(
+            payload?.ok === false
+              ? payload.error.message
+              : `Failed to load images (HTTP ${res.status}).`,
+          );
+          return;
+        }
+        // When offset === 0 the search/query changed — replace.
+        // Otherwise it's "Load more" — append.
+        setItems((prev) =>
+          offset === 0 ? payload.data.items : [...prev, ...payload.data.items],
+        );
+        setTotal(payload.data.total);
+      } catch (e) {
+        if (e instanceof DOMException && e.name === "AbortError") return;
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!ctrl.signal.aborted) setLoading(false);
+      }
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(id);
+      ctrl.abort();
+    };
+  }, [open, tab, query, offset]);
+
+  // Reset offset to 0 whenever the search query changes, so paginating
+  // through the previous query doesn't leak into the new one.
+  useEffect(() => {
+    setOffset(0);
+  }, [query]);
+
+  function handleSelect(image: ImagePickerEntry) {
+    onSelect(image);
+    onClose();
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Pick a featured image</DialogTitle>
+          <DialogDescription>
+            Search the image library, upload a new image, or paste an image
+            URL.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div role="tablist" aria-label="Image source" className="mt-2 flex gap-1 border-b">
+          <TabButton active={tab === "library"} onClick={() => setTab("library")}>
+            Library
+          </TabButton>
+          <TabButton active={tab === "upload"} onClick={() => setTab("upload")}>
+            Upload new
+          </TabButton>
+          <TabButton active={tab === "url"} onClick={() => setTab("url")}>
+            Paste URL
+          </TabButton>
+        </div>
+
+        {tab === "library" && (
+          <div className="mt-4 space-y-3">
+            <Input
+              type="search"
+              placeholder="Search by caption, alt, or filename"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label="Search images"
+            />
+            {error && (
+              <div
+                role="alert"
+                className="rounded-md border border-destructive/40 bg-destructive/10 p-2 text-sm text-destructive"
+              >
+                {error}
+              </div>
+            )}
+            <ImageGrid items={items} onSelect={handleSelect} />
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>
+                {total > 0
+                  ? `Showing ${items.length} of ${total}`
+                  : loading
+                    ? "Loading…"
+                    : "No images match."}
+              </span>
+              {items.length < total && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setOffset(items.length)}
+                  disabled={loading}
+                >
+                  {loading ? "Loading…" : "Load more"}
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {tab === "upload" && (
+          <div className="mt-4 rounded-lg border-2 border-dashed border-muted bg-muted/30 p-6 text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">
+              Upload coming in BP-5
+            </p>
+            <p className="mt-1">
+              Drag-drop or pick a file to push it to Cloudflare Images, then
+              auto-select it. For now, upload via the bulk-upload script and
+              find your image in the Library tab.
+            </p>
+          </div>
+        )}
+
+        {tab === "url" && (
+          <div className="mt-4 rounded-lg border-2 border-dashed border-muted bg-muted/30 p-6 text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">
+              Paste-URL coming in BP-6
+            </p>
+            <p className="mt-1">
+              Paste a public image URL — server fetches, runs SSRF guards,
+              uploads to Cloudflare, and auto-selects.
+            </p>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        "h-10 rounded-t-md px-3 text-sm font-medium transition-smooth",
+        active
+          ? "border-b-2 border-primary text-foreground"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ImageGrid({
+  items,
+  onSelect,
+}: {
+  items: ImagePickerEntry[];
+  onSelect: (image: ImagePickerEntry) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <ul
+      className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4"
+      role="grid"
+      aria-label="Image library"
+    >
+      {items.map((img) => (
+        <li key={img.id} role="gridcell">
+          <button
+            type="button"
+            onClick={() => onSelect(img)}
+            className={cn(
+              "group block w-full overflow-hidden rounded-md border bg-muted text-left",
+              "transition-smooth hover:border-ring hover:shadow-md",
+              "focus:outline-none focus:ring-2 focus:ring-ring",
+            )}
+            aria-label={`Select ${img.caption ?? img.filename ?? img.id}`}
+          >
+            <div className="aspect-square w-full overflow-hidden">
+              {img.delivery_url ? (
+                // Cloudflare delivery URL with explicit w=/h=/fit= sizing.
+                // Plain <img> avoids wiring imagedelivery.net into Next's
+                // image-optimization pipeline for a 200×200 thumbnail.
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={`${img.delivery_url}/w=200,h=200,fit=cover`}
+                  alt={img.alt_text ?? img.caption ?? ""}
+                  loading="lazy"
+                  className="h-full w-full object-cover transition-smooth group-hover:scale-105"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+                  No preview
+                </div>
+              )}
+            </div>
+            {img.caption && (
+              <p
+                className="truncate px-2 py-1 text-xs text-muted-foreground"
+                title={img.caption}
+              >
+                {img.caption}
+              </p>
+            )}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary

BP-4 of the blog-post workflow plan (parent: PR #214).

Modal browser of the \`image_library\` (1,777 stock images today + every uploaded / fetched image once BP-5 / BP-6 land). Wired into BlogPostComposer's featured-image affordance from BP-3.

## What ships

- **\`app/api/admin/images/list/route.ts\`** — GET handler. Wraps \`lib/image-library.listImages\` with FTS search + pagination. Pre-computes the Cloudflare \`deliveryUrl\` server-side. Admin OR operator role. \`Cache-Control: no-store\`.
- **\`components/ImagePickerModal.tsx\`** — Dialog (RS-0) with three tabs:
  - **Library** (functional): 300 ms-debounced search, responsive thumbnail grid (2/3/4 cols), \"Load more\" pagination, single-select.
  - **Upload new** (stub): explanatory message pointing at BP-5.
  - **Paste URL** (stub): explanatory message pointing at BP-6.
- **\`components/BlogPostComposer.tsx\`** — replaces the dashed featured-image placeholder with a \"Pick image\" / \"Change image\" button. Selected image renders as 80×80 preview + caption + Remove. Local state only; persistence + WP attachment land in BP-7.

## Risks identified and mitigated

- **Image library size** — pagination prevents over-fetch (24/page); FTS via \`image_library.search_tsv\`.
- **Cloudflare delivery URL hash** — already public per CF Images design.
- **Soft-deleted images** — filtered via \`deleted: false\` in \`listImages\`.
- **Out-of-order search** — \`AbortController\` aborts previous in-flight request before next.
- **Stale state on re-open** — \`useEffect\` resets tab/query/items/offset when \`open\` flips true.
- **\`no-img-element\`** — explicit ESLint disable with rationale (Cloudflare-Images already optimises; explicit \`w=/h=\` params avoid wiring imagedelivery.net into Next remotePatterns just for thumbnails).

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean; \`/api/admin/images/list\` present
- [ ] Manual: open BlogPostComposer, click \"Pick image\", search, paginate, select; observe preview render with caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)