### PR TITLE
feat(bp-6): image-by-url tab + ssrf guard

### DIFF
--- a/app/api/admin/images/fetch-url/route.ts
+++ b/app/api/admin/images/fetch-url/route.ts
@@ -1,0 +1,261 @@
+import { randomUUID } from "node:crypto";
+
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import {
+  CloudflareCallError,
+  deliveryUrl,
+  uploadImageFromBytes,
+} from "@/lib/cloudflare-images";
+import { logger } from "@/lib/logger";
+import { assertSafeUrl, SsrfBlockedError } from "@/lib/ssrf-guard";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/images/fetch-url — BP-6.
+//
+// Body: { url }
+// Server: assertSafeUrl (SSRF guard) → HEAD probe (size + content-type)
+//   → GET (10 MB cap, 30s timeout) → uploadImageFromBytes →
+//   image_library insert. Returns the new row + delivery_url for
+//   auto-select.
+//
+// Auth: admin OR operator.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_BYTES = 10 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 30_000;
+const ALLOWED_MIME_PREFIX = "image/";
+
+const BodySchema = z.object({
+  url: z.string().url().max(2048),
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: {
+        code,
+        message,
+        retryable: code === "UPSTREAM_RETRYABLE",
+        ...(details ? { details } : {}),
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status, headers: { "cache-control": "no-store" } },
+  );
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: ctrl.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const body = await req.json().catch(() => null);
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return errorJson("VALIDATION_FAILED", "Body must be { url: string }.", 400);
+  }
+  const url = parsed.data.url;
+
+  try {
+    await assertSafeUrl(url);
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      logger.warn("image.fetch_url.ssrf_blocked", {
+        url,
+        reason: err.reason,
+        ...(err.details ?? {}),
+      });
+      return errorJson(
+        "URL_BLOCKED",
+        "That URL points to an internal or unsupported address.",
+        400,
+        { reason: err.reason },
+      );
+    }
+    throw err;
+  }
+
+  // HEAD probe — cheap rejection for oversize / wrong-type.
+  let headRes: Response;
+  try {
+    headRes = await fetchWithTimeout(
+      url,
+      { method: "HEAD" },
+      FETCH_TIMEOUT_MS,
+    );
+  } catch (err) {
+    return errorJson(
+      "FETCH_FAILED",
+      `HEAD probe failed: ${err instanceof Error ? err.message : String(err)}`,
+      502,
+    );
+  }
+  if (!headRes.ok) {
+    return errorJson(
+      "FETCH_FAILED",
+      `Source server returned ${headRes.status} on HEAD.`,
+      502,
+    );
+  }
+  const contentType = headRes.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().startsWith(ALLOWED_MIME_PREFIX)) {
+    return errorJson(
+      "UNSUPPORTED_TYPE",
+      `URL serves "${contentType || "unknown"}" — not an image.`,
+      415,
+    );
+  }
+  const contentLength = Number(headRes.headers.get("content-length") ?? "0");
+  if (Number.isFinite(contentLength) && contentLength > MAX_BYTES) {
+    return errorJson(
+      "FILE_TOO_LARGE",
+      `Source advertises ${Math.round(contentLength / 1024 / 1024)} MB — over the 10 MB cap.`,
+      413,
+    );
+  }
+
+  // GET the bytes.
+  let getRes: Response;
+  try {
+    getRes = await fetchWithTimeout(url, { method: "GET" }, FETCH_TIMEOUT_MS);
+  } catch (err) {
+    return errorJson(
+      "FETCH_FAILED",
+      `GET failed: ${err instanceof Error ? err.message : String(err)}`,
+      502,
+    );
+  }
+  if (!getRes.ok) {
+    return errorJson(
+      "FETCH_FAILED",
+      `Source server returned ${getRes.status} on GET.`,
+      502,
+    );
+  }
+  const bytes = new Uint8Array(await getRes.arrayBuffer());
+  if (bytes.byteLength === 0) {
+    return errorJson("FETCH_FAILED", "Source returned an empty body.", 502);
+  }
+  if (bytes.byteLength > MAX_BYTES) {
+    // HEAD may have been honest about size, then GET returned more
+    // (chunked, no content-length). Hard cap regardless.
+    return errorJson(
+      "FILE_TOO_LARGE",
+      `Fetched body is ${Math.round(bytes.byteLength / 1024 / 1024)} MB — over the 10 MB cap.`,
+      413,
+    );
+  }
+
+  // Upload to Cloudflare.
+  const cloudflareId = `opollo/url/${randomUUID()}`;
+  const filename = (() => {
+    try {
+      const u = new URL(url);
+      const last = u.pathname.split("/").filter(Boolean).pop();
+      return last ?? cloudflareId;
+    } catch {
+      return cloudflareId;
+    }
+  })();
+  let cfRecord;
+  try {
+    cfRecord = await uploadImageFromBytes({
+      id: cloudflareId,
+      bytes,
+      filename,
+      contentType: getRes.headers.get("content-type") ?? contentType,
+    });
+  } catch (err) {
+    if (err instanceof CloudflareCallError) {
+      logger.error("image.fetch_url.cloudflare_failed", {
+        cloudflare_id: cloudflareId,
+        cf_code: err.code,
+        retryable: err.retryable,
+      });
+      return errorJson(
+        err.retryable ? "UPSTREAM_RETRYABLE" : "UPSTREAM_REJECTED",
+        `Cloudflare upload failed (${err.code}).`,
+        err.retryable ? 502 : 400,
+      );
+    }
+    return errorJson("INTERNAL_ERROR", "Cloudflare upload failed.", 500);
+  }
+
+  const supabase = getServiceRoleClient();
+  const ins = await supabase
+    .from("image_library")
+    .insert({
+      cloudflare_id: cfRecord.id,
+      filename,
+      source: "upload" as const,
+      source_ref: url,
+      bytes: bytes.byteLength,
+      created_by: gate.user?.id ?? null,
+    })
+    .select(
+      "id, cloudflare_id, filename, caption, alt_text, tags, source, source_ref, width_px, height_px, bytes, deleted_at, created_at",
+    )
+    .single();
+
+  if (ins.error) {
+    if (ins.error.code === "23505") {
+      const existing = await supabase
+        .from("image_library")
+        .select(
+          "id, cloudflare_id, filename, caption, alt_text, tags, source, source_ref, width_px, height_px, bytes, deleted_at, created_at",
+        )
+        .eq("cloudflare_id", cfRecord.id)
+        .maybeSingle();
+      if (existing.data) {
+        return NextResponse.json(
+          {
+            ok: true,
+            data: { ...existing.data, delivery_url: deliveryUrl(cfRecord.id) },
+            timestamp: new Date().toISOString(),
+          },
+          { status: 200, headers: { "cache-control": "no-store" } },
+        );
+      }
+    }
+    return errorJson(
+      "INTERNAL_ERROR",
+      "Image fetched but failed to save in library.",
+      500,
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { ...ins.data, delivery_url: deliveryUrl(cfRecord.id) },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 201, headers: { "cache-control": "no-store" } },
+  );
+}

--- a/components/ImagePickerModal.tsx
+++ b/components/ImagePickerModal.tsx
@@ -212,15 +212,7 @@ export function ImagePickerModal({
         )}
 
         {tab === "url" && (
-          <div className="mt-4 rounded-lg border-2 border-dashed border-muted bg-muted/30 p-6 text-sm text-muted-foreground">
-            <p className="font-medium text-foreground">
-              Paste-URL coming in BP-6
-            </p>
-            <p className="mt-1">
-              Paste a public image URL — server fetches, runs SSRF guards,
-              uploads to Cloudflare, and auto-selects.
-            </p>
-          </div>
+          <UrlTab onFetched={(image) => handleSelect(image)} />
         )}
       </DialogContent>
     </Dialog>
@@ -332,6 +324,82 @@ function UploadTab({
             Pushing to Cloudflare…
           </span>
         )}
+      </div>
+      {error && (
+        <div
+          role="alert"
+          className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive"
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UrlTab({
+  onFetched,
+}: {
+  onFetched: (image: ImagePickerEntry) => void;
+}) {
+  const [url, setUrl] = useState("");
+  const [fetching, setFetching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFetch() {
+    setError(null);
+    if (!url.trim()) {
+      setError("Paste an image URL.");
+      return;
+    }
+    setFetching(true);
+    try {
+      const res = await fetch("/api/admin/images/fetch-url", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url: url.trim() }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: ImagePickerEntry }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (payload?.ok) {
+        onFetched(payload.data);
+        return;
+      }
+      setError(
+        payload?.ok === false
+          ? payload.error.message
+          : `Fetch failed (HTTP ${res.status}).`,
+      );
+    } catch (err) {
+      setError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setFetching(false);
+    }
+  }
+
+  return (
+    <div className="mt-4 rounded-lg border p-4 text-sm">
+      <p className="font-medium">Fetch image from URL</p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Paste a public image URL. Server fetches, validates the type +
+        size, and uploads to the library. 30s timeout; 10 MB cap.
+        Internal IPs are blocked.
+      </p>
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <Input
+          type="url"
+          inputMode="url"
+          placeholder="https://example.com/image.jpg"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          disabled={fetching}
+          className="min-w-0 flex-1"
+        />
+        <Button type="button" onClick={handleFetch} disabled={fetching}>
+          {fetching ? "Fetching…" : "Fetch"}
+        </Button>
       </div>
       {error && (
         <div

--- a/lib/__tests__/ssrf-guard.test.ts
+++ b/lib/__tests__/ssrf-guard.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { assertSafeUrl, SsrfBlockedError } from "@/lib/ssrf-guard";
+
+// BP-6 — SSRF guard tests. Pure logic + injectable lookup so we don't
+// hit real DNS during the test run.
+
+const okLookup = async () => ({ address: "93.184.216.34", family: 4 });
+
+describe("assertSafeUrl — scheme guard", () => {
+  it("rejects ftp://", async () => {
+    await expect(
+      assertSafeUrl("ftp://example.com/foo.jpg"),
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+  it("rejects file://", async () => {
+    await expect(
+      assertSafeUrl("file:///etc/passwd"),
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+  it("accepts https", async () => {
+    const r = await assertSafeUrl("https://example.com/foo.jpg", {
+      lookupImpl: okLookup,
+    });
+    expect(r.resolvedIp).toBe("93.184.216.34");
+  });
+});
+
+describe("assertSafeUrl — hostname blocklist", () => {
+  it("blocks localhost", async () => {
+    await expect(
+      assertSafeUrl("https://localhost/foo.jpg"),
+    ).rejects.toMatchObject({ reason: "hostname_blocked" });
+  });
+  it("blocks metadata.google.internal", async () => {
+    await expect(
+      assertSafeUrl("https://metadata.google.internal/computeMetadata/v1/"),
+    ).rejects.toMatchObject({ reason: "hostname_blocked" });
+  });
+  it("blocks *.internal heuristic", async () => {
+    await expect(
+      assertSafeUrl("https://prod-db.svc.internal/foo.jpg"),
+    ).rejects.toMatchObject({ reason: "hostname_blocked" });
+  });
+});
+
+describe("assertSafeUrl — IPv4 literal blocks", () => {
+  it("blocks 127.0.0.1", async () => {
+    await expect(
+      assertSafeUrl("https://127.0.0.1/foo.jpg"),
+    ).rejects.toMatchObject({ reason: "ip_blocked" });
+  });
+  it("blocks 10.0.0.5", async () => {
+    await expect(
+      assertSafeUrl("https://10.0.0.5/foo.jpg"),
+    ).rejects.toMatchObject({ reason: "ip_blocked" });
+  });
+  it("blocks 172.20.5.1 (RFC1918 mid-range)", async () => {
+    await expect(
+      assertSafeUrl("https://172.20.5.1/foo.jpg"),
+    ).rejects.toMatchObject({ reason: "ip_blocked" });
+  });
+  it("blocks 169.254.169.254 (AWS/GCP metadata)", async () => {
+    await expect(
+      assertSafeUrl("https://169.254.169.254/latest/meta-data/"),
+    ).rejects.toMatchObject({ reason: "ip_blocked" });
+  });
+  it("blocks 0.0.0.0", async () => {
+    await expect(
+      assertSafeUrl("https://0.0.0.0/foo.jpg"),
+    ).rejects.toMatchObject({ reason: "ip_blocked" });
+  });
+  it("accepts 8.8.8.8 (public)", async () => {
+    const r = await assertSafeUrl("https://8.8.8.8/foo.jpg");
+    expect(r.resolvedIp).toBe("8.8.8.8");
+  });
+});
+
+describe("assertSafeUrl — DNS resolution blocks", () => {
+  it("blocks hostnames resolving to private IP", async () => {
+    await expect(
+      assertSafeUrl("https://attacker.example/foo.jpg", {
+        lookupImpl: async () => ({ address: "10.5.5.5", family: 4 }),
+      }),
+    ).rejects.toMatchObject({ reason: "ip_blocked" });
+  });
+  it("blocks hostnames resolving to loopback", async () => {
+    await expect(
+      assertSafeUrl("https://attacker.example/foo.jpg", {
+        lookupImpl: async () => ({ address: "127.0.0.5", family: 4 }),
+      }),
+    ).rejects.toMatchObject({ reason: "ip_blocked" });
+  });
+  it("surfaces DNS failures as SsrfBlockedError", async () => {
+    await expect(
+      assertSafeUrl("https://nope.invalid/foo.jpg", {
+        lookupImpl: async () => {
+          throw new Error("ENOTFOUND");
+        },
+      }),
+    ).rejects.toMatchObject({ reason: "dns_failed" });
+  });
+});
+
+describe("assertSafeUrl — IPv6", () => {
+  it("blocks ::1 loopback literal", async () => {
+    await expect(
+      assertSafeUrl("https://[::1]/foo.jpg"),
+    ).rejects.toMatchObject({ reason: "ip_blocked" });
+  });
+  it("blocks fe80:: link-local literal", async () => {
+    await expect(
+      assertSafeUrl("https://[fe80::1]/foo.jpg"),
+    ).rejects.toMatchObject({ reason: "ip_blocked" });
+  });
+  it("blocks fc00:: unique-local resolution", async () => {
+    await expect(
+      assertSafeUrl("https://attacker.example/foo.jpg", {
+        lookupImpl: async () => ({ address: "fc00::1", family: 6 }),
+      }),
+    ).rejects.toMatchObject({ reason: "ip_blocked" });
+  });
+});

--- a/lib/ssrf-guard.ts
+++ b/lib/ssrf-guard.ts
@@ -1,0 +1,183 @@
+import { lookup } from "node:dns/promises";
+
+// ---------------------------------------------------------------------------
+// BP-6 — SSRF guard for operator-supplied image URLs.
+//
+// Block list:
+//   • IPv4 loopback        127.0.0.0/8
+//   • IPv4 unspecified     0.0.0.0/8
+//   • IPv4 private         10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+//   • IPv4 link-local      169.254.0.0/16  (covers EC2/GCP metadata IPs)
+//   • IPv6 loopback        ::1
+//   • IPv6 link-local      fe80::/10
+//   • IPv6 unique-local    fc00::/7
+//   • Hostnames            localhost, *.internal (heuristic for cloud metadata)
+//
+// Vercel runtime egress is internet-only by default but the guard is
+// belt-and-suspenders for self-hosted deploys.
+//
+// `assertSafeUrl` resolves the hostname AT CALL TIME and throws if the
+// resolved IP is in the blocklist. DNS rebinding is mitigated as long
+// as the caller uses the URL within the same `assertSafeUrl + fetch`
+// pair — for higher-assurance protection, a follow-up could resolve
+// + connect via the resolved IP directly with a Host header. Captured
+// in the parent plan's risk audit.
+// ---------------------------------------------------------------------------
+
+export class SsrfBlockedError extends Error {
+  constructor(
+    message: string,
+    readonly reason:
+      | "scheme"
+      | "hostname_blocked"
+      | "ip_blocked"
+      | "dns_failed",
+    readonly details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "SsrfBlockedError";
+  }
+}
+
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "metadata.google.internal",
+]);
+
+function isHostnameBlocked(host: string): boolean {
+  const lower = host.toLowerCase();
+  if (BLOCKED_HOSTNAMES.has(lower)) return true;
+  // Heuristic: corporate/cloud internal TLDs.
+  if (lower.endsWith(".internal") || lower.endsWith(".local")) return true;
+  return false;
+}
+
+function isPrivateIPv4(ip: string): boolean {
+  // ip is a dotted quad like "10.1.2.3"
+  const parts = ip.split(".").map((s) => Number.parseInt(s, 10));
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) {
+    return true; // unparseable → treat as blocked, fail closed
+  }
+  const [a, b] = parts;
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 0) return true; // 0.0.0.0/8 unspecified
+  if (a === 10) return true; // 10.0.0.0/8 private
+  if (a === 172 && b !== undefined && b >= 16 && b <= 31) return true; // 172.16/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local + metadata
+  return false;
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  if (lower === "::1") return true; // loopback
+  if (lower === "::") return true; // unspecified
+  if (lower.startsWith("fe80:")) return true; // link-local fe80::/10
+  // unique-local fc00::/7 — first byte 0xfc or 0xfd
+  if (lower.startsWith("fc") || lower.startsWith("fd")) {
+    // sanity: hex digit before colon
+    if (lower.length >= 3 && (lower[2] === ":" || /[0-9a-f]/.test(lower[2] ?? ""))) {
+      return true;
+    }
+  }
+  // IPv4-mapped IPv6 (::ffff:10.0.0.1) — re-check the IPv4 part.
+  const v4MappedMatch = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(lower);
+  if (v4MappedMatch) return isPrivateIPv4(v4MappedMatch[1] ?? "");
+  return false;
+}
+
+// Lookup-impl typed loosely so tests can stub it.
+type LookupImpl = (hostname: string) => Promise<{ address: string; family: number }>;
+
+const defaultLookup: LookupImpl = async (hostname: string) => {
+  const r = await lookup(hostname);
+  return { address: r.address, family: r.family };
+};
+
+export interface AssertSafeUrlOptions {
+  lookupImpl?: LookupImpl;
+}
+
+/**
+ * Throws SsrfBlockedError if the URL targets a non-https scheme, a
+ * blocked hostname, or resolves to a private/loopback/link-local IP.
+ * Returns the resolved IP on success so callers can log it.
+ */
+export async function assertSafeUrl(
+  rawUrl: string,
+  opts: AssertSafeUrlOptions = {},
+): Promise<{ resolvedIp: string; family: 4 | 6 }> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new SsrfBlockedError(
+      `URL is not parseable: ${rawUrl}`,
+      "scheme",
+      { url: rawUrl },
+    );
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new SsrfBlockedError(
+      `URL scheme "${parsed.protocol}" not allowed; use https.`,
+      "scheme",
+      { scheme: parsed.protocol },
+    );
+  }
+  const hostname = parsed.hostname;
+  if (isHostnameBlocked(hostname)) {
+    throw new SsrfBlockedError(
+      `Hostname "${hostname}" is on the SSRF blocklist.`,
+      "hostname_blocked",
+      { hostname },
+    );
+  }
+
+  // Some operators paste a URL whose hostname is already an IP literal —
+  // skip the DNS step and validate the literal directly.
+  const isIPv4Literal = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname);
+  const isIPv6Literal = hostname.startsWith("[") && hostname.endsWith("]");
+  if (isIPv4Literal) {
+    if (isPrivateIPv4(hostname)) {
+      throw new SsrfBlockedError(
+        `IP literal ${hostname} resolves to a private/loopback/link-local range.`,
+        "ip_blocked",
+        { hostname, ip: hostname },
+      );
+    }
+    return { resolvedIp: hostname, family: 4 };
+  }
+  if (isIPv6Literal) {
+    const stripped = hostname.slice(1, -1);
+    if (isPrivateIPv6(stripped)) {
+      throw new SsrfBlockedError(
+        `IPv6 literal ${stripped} resolves to a private/loopback/link-local range.`,
+        "ip_blocked",
+        { hostname, ip: stripped },
+      );
+    }
+    return { resolvedIp: stripped, family: 6 };
+  }
+
+  let resolved: { address: string; family: number };
+  try {
+    resolved = await (opts.lookupImpl ?? defaultLookup)(hostname);
+  } catch (err) {
+    throw new SsrfBlockedError(
+      `DNS lookup failed for ${hostname}.`,
+      "dns_failed",
+      { hostname, error: err instanceof Error ? err.message : String(err) },
+    );
+  }
+  const family = resolved.family === 6 ? 6 : 4;
+  const blocked =
+    family === 4 ? isPrivateIPv4(resolved.address) : isPrivateIPv6(resolved.address);
+  if (blocked) {
+    throw new SsrfBlockedError(
+      `Hostname ${hostname} resolves to ${resolved.address} (private/loopback/link-local).`,
+      "ip_blocked",
+      { hostname, ip: resolved.address, family },
+    );
+  }
+  return { resolvedIp: resolved.address, family };
+}


### PR DESCRIPTION
## Summary

BP-6 of the blog-post workflow plan (parent: PR #214). Closes the image-picker triad started in BP-4.

## What ships

- **\`lib/ssrf-guard.ts\`** — \`assertSafeUrl(url, opts)\`. Resolves the hostname and throws \`SsrfBlockedError\` if scheme isn't http(s), hostname is blocklisted (\`localhost\`, \`*.internal\`, \`metadata.google.internal\`), or the resolved IPv4/IPv6 is in a private/loopback/link-local range (incl. 169.254.0.0/16 covering EC2/GCP metadata IPs and IPv6 \`::1\` / \`fe80::/10\` / \`fc00::/7\` / IPv4-mapped). Lookup is injectable for testing.
- **\`lib/__tests__/ssrf-guard.test.ts\`** — 17 cases across scheme, hostname, IPv4 literal, IPv6 literal, DNS-resolved private IP, DNS failure.
- **\`app/api/admin/images/fetch-url/route.ts\`** — POST { url }. SSRF guard → HEAD probe (size + content-type) → GET (10 MB cap, 30s timeout) → \`uploadImageFromBytes\` → \`image_library\` insert. Returns the row + \`delivery_url\` for picker auto-select. 23505 idempotency-replay returns existing row.
- **\`components/ImagePickerModal.tsx\`** — Paste URL tab is now functional.

## Risks identified and mitigated

- **SSRF** — blocklist covers RFC1918, loopback, link-local, IPv6 private ranges, IPv4-mapped IPv6, common cloud metadata hostnames. Vercel egress is internet-only by default; guard is belt-and-suspenders for self-hosted.
- **DNS rebinding** — \`assertSafeUrl\` resolves at call time. Higher-assurance protection (resolve + connect via raw IP with Host header) deferred per parent plan.
- **Large file DoS** — HEAD content-length + GET-time hard cap + 30s AbortController timeout.
- **Wrong type DoS** — \`image/*\` MIME guard at HEAD.
- **Idempotency** — \`opollo/url/<uuid>\` cloudflare_id; 23505 returns existing row.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean; \`/api/admin/images/fetch-url\` present
- [ ] \`npm run test -- ssrf-guard\` — 17 cases, runs in CI under supabase setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)