### PR TITLE
feat(a-1): typography primitives + scale documentation

### DIFF
--- a/app/admin/batches/[id]/page.tsx
+++ b/app/admin/batches/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { BatchDetailClient } from "@/components/BatchDetailClient";
+import { H1 } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -167,9 +168,9 @@ export default async function BatchDetailPage({
               ← Batches
             </Link>
           </div>
-          <h1 className="mt-1 text-xl font-semibold">
+          <H1 className="mt-1">
             {site.name} · {tmpl.name}
-          </h1>
+          </H1>
           <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
             <StatusBadge status={job.status as string} />
             <span>

--- a/app/admin/batches/page.tsx
+++ b/app/admin/batches/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 
 import { NewBatchButton } from "@/components/NewBatchButton";
 import type { BatchTemplateOption } from "@/components/NewBatchModal";
+import { H1 } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -196,7 +197,7 @@ export default async function AdminBatchesPage({
     <>
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-xl font-semibold">Batches</h1>
+          <H1>Batches</H1>
           <p className="text-sm text-muted-foreground">
             {siteForButton
               ? `Batches for ${siteForButton.name}.`

--- a/app/admin/images/[id]/page.tsx
+++ b/app/admin/images/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { Fragment } from "react";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { H1 } from "@/components/ui/typography";
 import { EditImageMetadataButton } from "@/components/EditImageMetadataButton";
 import { ImageArchiveButton } from "@/components/ImageArchiveButton";
 import { checkAdminAccess } from "@/lib/admin-gate";
@@ -141,9 +142,9 @@ export default async function AdminImageDetailPage({
 
       <div className="mt-4 flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-xl font-semibold">
+          <H1>
             {image.filename ?? "Untitled image"}
-          </h1>
+          </H1>
           <p className="text-sm text-muted-foreground">
             Imported {formatDate(image.created_at)}
             {image.deleted_at && (

--- a/app/admin/images/page.tsx
+++ b/app/admin/images/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { ImagesTable } from "@/components/ImagesTable";
+import { H1 } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import {
   LIST_IMAGES_DEFAULT_LIMIT,
@@ -144,7 +145,7 @@ export default async function AdminImagesPage({
     <>
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-xl font-semibold">Image library</h1>
+          <H1>Image library</H1>
           <p className="text-sm text-muted-foreground">
             {parsed.deleted
               ? "Archived images (soft-deleted). Restore from the detail view."

--- a/app/admin/sites/[id]/design-system/components/page.tsx
+++ b/app/admin/sites/[id]/design-system/components/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { H1 } from "@/components/ui/typography";
 import { ComponentFormModal, type ComponentFormMode } from "@/components/ComponentFormModal";
 import { ComponentsGrid } from "@/components/ComponentsGrid";
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
@@ -109,7 +110,7 @@ export default function DesignSystemComponentsPage() {
     <>
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-semibold">Components</h1>
+          <H1>Components</H1>
           <p className="text-sm text-muted-foreground">
             Components registered on design system v{selectedDs.version} (
             {selectedDs.status}).

--- a/app/admin/sites/[id]/design-system/page.tsx
+++ b/app/admin/sites/[id]/design-system/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
 import { CreateDesignSystemModal } from "@/components/CreateDesignSystemModal";
 import { DesignSystemsTable } from "@/components/DesignSystemsTable";
+import { H1 } from "@/components/ui/typography";
 import { useDesignSystemLayout } from "@/components/design-system-context";
 import type { DesignSystem } from "@/lib/design-systems";
 
@@ -23,7 +24,7 @@ export default function DesignSystemVersionsPage() {
     <>
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-semibold">Versions</h1>
+          <H1>Versions</H1>
           <p className="text-sm text-muted-foreground">
             One version is active at a time. Edit draft versions before
             activating — activation is atomic and archives the previous active

--- a/app/admin/sites/[id]/design-system/preview/page.tsx
+++ b/app/admin/sites/[id]/design-system/preview/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { H1 } from "@/components/ui/typography";
 import { PreviewGallery } from "@/components/PreviewGallery";
 import {
   resolveSelectedDesignSystem,
@@ -86,7 +87,7 @@ export default function DesignSystemPreviewPage() {
   return (
     <>
       <div>
-        <h1 className="text-xl font-semibold">Preview</h1>
+        <H1>Preview</H1>
         <p className="text-sm text-muted-foreground">
           Read-only metadata view of design system v{selectedDs.version} (
           {selectedDs.status}). Live component rendering lands with M3 — this

--- a/app/admin/sites/[id]/design-system/templates/page.tsx
+++ b/app/admin/sites/[id]/design-system/templates/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { H1 } from "@/components/ui/typography";
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
 import { TemplateFormModal, type TemplateFormMode } from "@/components/TemplateFormModal";
 import { TemplatesTable } from "@/components/TemplatesTable";
@@ -95,7 +96,7 @@ export default function DesignSystemTemplatesPage() {
     <>
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-semibold">Templates</h1>
+          <H1>Templates</H1>
           <p className="text-sm text-muted-foreground">
             Page-type templates on design system v{selectedDs.version} (
             {selectedDs.status}).

--- a/app/admin/sites/[id]/page.tsx
+++ b/app/admin/sites/[id]/page.tsx
@@ -5,6 +5,7 @@ import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { EditTenantBudgetButton } from "@/components/EditTenantBudgetButton";
 import { SiteDetailActions } from "@/components/SiteDetailActions";
 import { TenantBudgetBadge } from "@/components/TenantBudgetBadge";
+import { H1 } from "@/components/ui/typography";
 import { UploadBriefButton } from "@/components/UploadBriefButton";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { listSiteBriefs } from "@/lib/briefs";
@@ -157,7 +158,7 @@ export default async function SiteDetailPage({
               { label: site.name },
             ]}
           />
-          <h1 className="mt-1 text-xl font-semibold">{site.name}</h1>
+          <H1 className="mt-1">{site.name}</H1>
           <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
             <StatusBadge status={site.status} />
             <a

--- a/app/admin/sites/[id]/pages/[pageId]/page.tsx
+++ b/app/admin/sites/[id]/pages/[pageId]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { EditPageMetadataButton } from "@/components/EditPageMetadataButton";
+import { H1 } from "@/components/ui/typography";
 import { PageHtmlPreview } from "@/components/PageHtmlPreview";
 import { RegenHistoryPanel } from "@/components/RegenHistoryPanel";
 import { RegenerateButton } from "@/components/RegenerateButton";
@@ -131,7 +132,7 @@ export default async function PageDetail({
 
       <div className="mt-4 flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <h1 className="truncate text-xl font-semibold">{page.title}</h1>
+          <H1 className="truncate">{page.title}</H1>
           <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
             {statusBadge(page.status)}
             <span className="rounded bg-muted px-2 py-0.5">

--- a/app/admin/sites/[id]/pages/page.tsx
+++ b/app/admin/sites/[id]/pages/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { PagesTable } from "@/components/PagesTable";
+import { H1 } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import {
   LIST_PAGES_DEFAULT_LIMIT,
@@ -145,7 +146,7 @@ export default async function SitePagesList({
 
       <div className="mt-4 flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-xl font-semibold">Pages for {site.name}</h1>
+          <H1>Pages for {site.name}</H1>
           <p className="text-sm text-muted-foreground">
             Every page generated for this site. Click a row for the detail
             view. Editing content itself still happens in WordPress admin.

--- a/app/admin/sites/[id]/posts/new/page.tsx
+++ b/app/admin/sites/[id]/posts/new/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { BlogPostComposer } from "@/components/BlogPostComposer";
+import { H1 } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getSite } from "@/lib/sites";
 
@@ -51,7 +52,7 @@ export default async function BlogPostEntryPage({
           { label: "New post" },
         ]}
       />
-      <h1 className="mt-2 text-xl font-semibold">New blog post</h1>
+      <H1 className="mt-2">New blog post</H1>
       <p className="mt-1 text-sm text-muted-foreground">
         Paste a markdown / HTML / YAML-fronted post. We&apos;ll parse the
         metadata into the fields below — every value is editable before

--- a/app/admin/sites/[id]/posts/page.tsx
+++ b/app/admin/sites/[id]/posts/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { checkAdminAccess } from "@/lib/admin-gate";
+import { H1 } from "@/components/ui/typography";
 import {
   LIST_POSTS_DEFAULT_LIMIT,
   listPostsForSite,
@@ -143,7 +144,7 @@ export default async function SitePostsList({
       />
 
       <div className="mt-6 flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-2xl font-semibold">Posts</h1>
+        <H1>Posts</H1>
         <div className="flex items-center gap-3">
           <p className="text-xs text-muted-foreground">
             {total} total{total > 0 ? ` · showing ${rangeStart}–${rangeEnd}` : ""}

--- a/app/admin/sites/[id]/settings/page.tsx
+++ b/app/admin/sites/[id]/settings/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { SiteVoiceSettingsForm } from "@/components/SiteVoiceSettingsForm";
+import { H1 } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getSite } from "@/lib/sites";
 
@@ -53,7 +54,7 @@ export default async function SiteSettingsPage({
           { label: "Settings" },
         ]}
       />
-      <h1 className="mt-2 text-xl font-semibold">{site.name} — Settings</h1>
+      <H1 className="mt-2">{site.name} — Settings</H1>
       <p className="mt-1 text-sm text-muted-foreground">
         These values pre-populate every new brief. Each brief can still
         override at commit time without changing the site default.

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { InviteUserButton } from "@/components/InviteUserButton";
+import { H1 } from "@/components/ui/typography";
 import { UsersTable } from "@/components/UsersTable";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -43,7 +44,7 @@ export default async function AdminUsersPage() {
     <>
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-semibold">Users</h1>
+          <H1>Users</H1>
           <p className="text-sm text-muted-foreground">
             Everyone with access to this builder. Change a role inline; the
             server blocks self-modification and last-admin demotions.

--- a/app/globals.css
+++ b/app/globals.css
@@ -59,6 +59,29 @@
 }
 
 /* ---------------------------------------------------------------------------
+ * A-1 — Typography scale (documentation block).
+ *
+ * Five tiers via the components/ui/typography.tsx primitives. Tailwind
+ * sizes locked deliberately; do not introduce text-2xl/text-3xl on any
+ * admin surface — those are marketing-page energy and pushed every list
+ * below the operator's fold.
+ *
+ *   <H1>      page heading             text-xl   font-semibold tracking-tight
+ *   <H2>      section heading          text-base font-semibold tracking-tight
+ *   <H3>      sub-section / card       text-sm   font-semibold
+ *   <Eyebrow> small uppercase label    text-xs   font-medium uppercase tracking-wide
+ *                                                 text-muted-foreground
+ *   <Lead>    intro / context line     text-sm   text-muted-foreground
+ *
+ * Body text defaults to text-sm. Metadata + table cells + pills sit at
+ * text-xs. font-mono is reserved for literal data (cloudflare ids,
+ * cost values, code tokens) — not for stylistic accent.
+ *
+ * Reference quality bar: matches Linear's issue view + Vercel's
+ * deployment header. Do not introduce a 6th tier without revisiting.
+ * --------------------------------------------------------------------- */
+
+/* ---------------------------------------------------------------------------
  * RS-0 — Motion primitives.
  *
  * Shared vocabulary for animated state changes (RS-4 status pills, RS-5

--- a/components/ui/typography.tsx
+++ b/components/ui/typography.tsx
@@ -1,0 +1,125 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// A-1 — Typography primitives.
+//
+// Five components cover every text role on an admin surface:
+//
+//   <H1>      page heading             text-xl font-semibold     ~20px
+//   <H2>      section heading          text-base font-semibold   ~16px
+//   <H3>      sub-section / card title text-sm font-semibold     ~14px
+//   <Eyebrow> small uppercase label    text-xs font-medium       ~12px
+//                                      uppercase tracking-wide
+//   <Lead>    intro / context line     text-sm                   ~14px
+//                                      text-muted-foreground
+//
+// Why these tiers (Linear / Vercel / Stripe alignment):
+//
+//   • Page headings on operator surfaces sit at 20px — Linear's issue
+//     view, Vercel's deployment header, Stripe's payment detail. 24px+
+//     reads as marketing-page energy and pushes the rest of the page
+//     below the fold.
+//   • Section headings step down to 16px so they read as "structural
+//     anchor" rather than "second-page heading".
+//   • Sub-section / card titles sit at 14px because cards already use
+//     14px body — the title stays in the same optical line height.
+//   • Eyebrow + Lead are paired companions to H1 (eyebrow above as a
+//     category label; lead below as a one-line context sentence).
+//
+// All five forward `ref` and any HTML element props so they remain
+// drop-in for inline ARIA attributes (aria-labelledby targets, etc.).
+//
+// Sweep notes for follow-up Phase B PRs:
+//
+//   • <h1 className="text-xl font-semibold"> → <H1>
+//   • <h2 className="text-sm font-semibold"> → <H3>   (semantic mismatch
+//     but visual match — section headings in the sidebar are a sub-
+//     section role despite the h2 element)
+//   • <h2 className="text-base font-medium">  → <H2>
+//   • <p className="text-sm text-muted-foreground"> beneath a heading
+//     → <Lead>
+//   • <span className="text-xs font-medium uppercase tracking-wide
+//     text-muted-foreground"> → <Eyebrow>
+//
+// A-1 sweeps the page-heading <h1> pattern. Per-screen <h2> + Lead +
+// Eyebrow folds happen in the matching Phase B PRs (per-screen polish
+// is allowed to consume Phase A primitives but A-1 doesn't try to
+// rewrite every section heading at once).
+// ---------------------------------------------------------------------------
+
+type HeadingProps = React.HTMLAttributes<HTMLHeadingElement>;
+
+export const H1 = React.forwardRef<HTMLHeadingElement, HeadingProps>(
+  function H1({ className, ...props }, ref) {
+    return (
+      <h1
+        ref={ref}
+        className={cn(
+          "text-xl font-semibold tracking-tight text-foreground",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+export const H2 = React.forwardRef<HTMLHeadingElement, HeadingProps>(
+  function H2({ className, ...props }, ref) {
+    return (
+      <h2
+        ref={ref}
+        className={cn(
+          "text-base font-semibold tracking-tight text-foreground",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+export const H3 = React.forwardRef<HTMLHeadingElement, HeadingProps>(
+  function H3({ className, ...props }, ref) {
+    return (
+      <h3
+        ref={ref}
+        className={cn("text-sm font-semibold text-foreground", className)}
+        {...props}
+      />
+    );
+  },
+);
+
+type SpanProps = React.HTMLAttributes<HTMLSpanElement>;
+
+export const Eyebrow = React.forwardRef<HTMLSpanElement, SpanProps>(
+  function Eyebrow({ className, ...props }, ref) {
+    return (
+      <span
+        ref={ref}
+        className={cn(
+          "text-xs font-medium uppercase tracking-wide text-muted-foreground",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+type ParagraphProps = React.HTMLAttributes<HTMLParagraphElement>;
+
+export const Lead = React.forwardRef<HTMLParagraphElement, ParagraphProps>(
+  function Lead({ className, ...props }, ref) {
+    return (
+      <p
+        ref={ref}
+        className={cn("text-sm text-muted-foreground", className)}
+        {...props}
+      />
+    );
+  },
+);


### PR DESCRIPTION
## Summary

A-1 of the world-class polish workstream (parent: PR #229).

Five typography primitives in \`components/ui/typography.tsx\` covering every text role on an admin surface. Page-heading \`<h1>\` sweep across all 15 admin pages.

## What ships

- **\`components/ui/typography.tsx\`** — \`H1\` / \`H2\` / \`H3\` / \`Eyebrow\` / \`Lead\`. Each forwards \`ref\` + HTML attrs so they're drop-in for inline ARIA. Page heading sits at 20px (Linear / Vercel / Stripe alignment, not 24px+ marketing energy) — rationale documented in the file header.
- **\`app/globals.css\`** — type-scale documentation block. Pins the five tiers + body / metadata / mono conventions. Future polish PRs read this before adding \`text-*\` classes.
- **15 admin \`page.tsx\` files** — every \`<h1 className=\"text-xl font-semibold\">…</h1>\` swapped for \`<H1>…</H1>\`. Layout-positioning classes (\`mt-1\`, \`mt-2\`, \`truncate\`) preserved via the H1 \`className\` prop. \`/admin/sites/[id]/posts\` had a one-off \`text-2xl\` that's now back in line.

Per-screen \`<h2>\` + \`Lead\` + \`Eyebrow\` folds happen in the matching Phase B PRs — A-1 deliberately doesn't try to rewrite every section heading at once. Primitive lands first; per-surface adoption follows.

## Risks identified and mitigated

- **Sweep mis-target** — every replacement preserves layout classes via \`className\` prop; only the documented \`tracking-tight\` + \`text-foreground\` bake-in is new.
- **Scale creep** — explicit comment in \`globals.css\` forbids \`text-2xl\` / \`text-3xl\` on admin surfaces.
- **Server vs client compat** — typography.tsx has no client-only React APIs; works in both trees. Verified via build pass.
- **Accessibility** — H1/H2/H3 still render \`<h1>\`/\`<h2>\`/\`<h3>\` semantic elements.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] grep verifies zero \`text-(xl|2xl) font-semibold\` h1 patterns remaining in \`app/admin/\`

## Note on screenshots

A-1 is a Phase A foundation PR — no per-screen visual regression screenshots required (those are Phase B). Visual change is small (\`tracking-tight\` + canonical sizing); verified via build pass + grep coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)