### PR TITLE
feat(a-6): empty + alert + toast primitives

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { AdminNav } from "@/components/AdminNav";
+import { Toaster } from "@/components/ui/toaster";
 
 // Shared shell for every page under /admin.
 //
@@ -33,6 +34,10 @@ export default async function AdminLayout({
     <div className="min-h-screen bg-background text-foreground">
       <AdminNav user={user} showUsersLink={showUsersLink} />
       <main className="mx-auto max-w-5xl p-6">{children}</main>
+      {/* A-6 — admin-wide toaster mount. Consumers call
+          `toast.success("…")` / `toast.error("…")` from anywhere in
+          the admin tree. */}
+      <Toaster />
     </div>
   );
 }

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,100 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import {
+  CircleAlert,
+  CircleCheck,
+  Info,
+  TriangleAlert,
+  type LucideIcon,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// A-6 — Alert primitive.
+//
+// Extracts the inline alert pattern repeated across the codebase
+// (`rounded-md border border-X/40 bg-X/10 p-3 text-sm text-X` for
+// each of destructive / warning / success / info). CVA-driven so
+// consumers pass `variant="warning"` and the icon, border, bg, and
+// text colour resolve together.
+//
+// Always carries role="alert" (errors) or role="status" (info /
+// success / warning). Default icon per variant; consumers can
+// override via the `icon` prop.
+// ---------------------------------------------------------------------------
+
+const alertVariants = cva(
+  "flex items-start gap-3 rounded-md border p-3 text-sm",
+  {
+    variants: {
+      variant: {
+        info: "border-info/40 bg-info/10 text-info",
+        success: "border-success/40 bg-success/10 text-success",
+        warning: "border-warning/40 bg-warning/10 text-warning",
+        destructive:
+          "border-destructive/40 bg-destructive/10 text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "info",
+    },
+  },
+);
+
+const VARIANT_ICON: Record<
+  NonNullable<VariantProps<typeof alertVariants>["variant"]>,
+  LucideIcon
+> = {
+  info: Info,
+  success: CircleCheck,
+  warning: TriangleAlert,
+  destructive: CircleAlert,
+};
+
+const VARIANT_ROLE: Record<
+  NonNullable<VariantProps<typeof alertVariants>["variant"]>,
+  "alert" | "status"
+> = {
+  info: "status",
+  success: "status",
+  warning: "status",
+  destructive: "alert",
+};
+
+export interface AlertProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "title">,
+    VariantProps<typeof alertVariants> {
+  /** Override the default icon for this variant. */
+  icon?: LucideIcon | null;
+  /** Optional title — renders as a bolder line above the body. */
+  title?: React.ReactNode;
+}
+
+export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  function Alert(
+    { className, variant, icon, title, children, role, ...props },
+    ref,
+  ) {
+    const v = variant ?? "info";
+    const Icon = icon === null ? null : (icon ?? VARIANT_ICON[v]);
+    return (
+      <div
+        ref={ref}
+        role={role ?? VARIANT_ROLE[v]}
+        className={cn(alertVariants({ variant }), className)}
+        {...props}
+      >
+        {Icon && (
+          <Icon aria-hidden className="mt-0.5 h-4 w-4 shrink-0" />
+        )}
+        <div className="min-w-0 flex-1">
+          {title && (
+            <p className="font-medium leading-tight">{title}</p>
+          )}
+          <div className={cn(title && "mt-1")}>{children}</div>
+        </div>
+      </div>
+    );
+  },
+);

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// A-6 — EmptyState primitive.
+//
+// Replaces three drifting variants in the codebase today:
+//
+//   • <div className="rounded-md border border-dashed p-8 text-center">
+//   • <div className="rounded-md border border-muted-foreground/20 bg-muted/20 p-6">
+//   • <div className="rounded-md border p-8 text-center">
+//
+// Linear / Vercel pattern: every empty list has an icon, a title, a
+// one-sentence body that names the next action, and a primary CTA.
+// "Operator-specific microcopy" is part of the polish brief — generic
+// "no items yet" copy is not allowed; the consumer always passes
+// surface-specific body text.
+//
+// Compositional: cta is a slot so the consumer can pass a Button, a
+// Link, or a custom action group. Keeping it un-typed (ReactNode)
+// avoids forcing the consumer through a Button-only API.
+// ---------------------------------------------------------------------------
+
+export interface EmptyStateProps {
+  icon: LucideIcon;
+  /** Accessible name for the icon. Defaults to "Empty". */
+  iconLabel?: string;
+  title: string;
+  body: React.ReactNode;
+  /** Optional primary action — usually a Button, Link, or both. */
+  cta?: React.ReactNode;
+  /** Visual density. Default = standard list empty (p-8); compact = sidebar / inline (p-6). */
+  density?: "default" | "compact";
+  className?: string;
+}
+
+const DENSITY_PADDING = {
+  default: "p-8",
+  compact: "p-6",
+} as const;
+
+export function EmptyState({
+  icon: Icon,
+  iconLabel = "Empty",
+  title,
+  body,
+  cta,
+  density = "default",
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      aria-label={iconLabel}
+      className={cn(
+        "flex flex-col items-center gap-3 rounded-md border border-dashed bg-muted/20 text-center",
+        DENSITY_PADDING[density],
+        className,
+      )}
+    >
+      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <Icon aria-hidden className="h-5 w-5" />
+      </div>
+      <div>
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        <div className="mt-1 max-w-md text-sm text-muted-foreground">
+          {body}
+        </div>
+      </div>
+      {cta && <div className="mt-1 flex items-center gap-2">{cta}</div>}
+    </div>
+  );
+}

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Toaster as SonnerToaster } from "sonner";
+
+// ---------------------------------------------------------------------------
+// A-6 — Toaster mount.
+//
+// Wraps sonner's <Toaster /> with project-wide defaults. Mounted once
+// in app/admin/layout.tsx; consumers anywhere in the admin tree call
+// `import { toast } from "sonner"` and `toast.success("…")` without
+// further setup.
+//
+// Defaults chosen to match Linear / Stripe norms:
+//
+//   • position: "bottom-right" — out of the way of the operator's
+//     primary scan path; doesn't fight the RS-6 cost ticker (also
+//     bottom-right but z-40 — sonner uses z-[9999] internally so the
+//     toast layers above without collision).
+//   • richColors: true — sonner pulls per-variant background tones
+//     instead of a single theme.
+//   • closeButton: true — operator can dismiss before the auto-close
+//     timeout.
+//   • duration: 4000ms default — enough to read a sentence, short
+//     enough not to linger.
+// ---------------------------------------------------------------------------
+
+export function Toaster() {
+  return (
+    <SonnerToaster
+      position="bottom-right"
+      richColors
+      closeButton
+      duration={4000}
+      // Visual class hooks so we can theme via Tailwind tokens later
+      // without diving into sonner's internal styles.
+      toastOptions={{
+        classNames: {
+          toast:
+            "rounded-md border bg-background text-foreground shadow-lg",
+          title: "text-sm font-medium",
+          description: "text-xs text-muted-foreground",
+        },
+      }}
+    />
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "server-only": "^0.0.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^4.0.0"
@@ -12881,6 +12882,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "server-only": "^0.0.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^4.0.0"


### PR DESCRIPTION
## Summary

A-6 of the world-class polish workstream (parent: PR #229). **Closes Phase A. Phase B per-screen polish PRs may now begin.**

Three primitives + the project-wide Toaster mount.

## What ships

- **\`components/ui/empty-state.tsx\`** — \`<EmptyState icon iconLabel title body cta density>\`. Replaces three drifting empty-state variants today. Per-surface microcopy is the consumer's responsibility — no generic \"no items yet\" baked in.
- **\`components/ui/alert.tsx\`** — \`<Alert variant icon title>\`. CVA-driven with four variants (info / success / warning / destructive) → A-2 semantic-color tokens. Default icon per variant; consumer can override or pass \`icon={null}\`. Auto \`role=\"status\"\` for non-destructive, \`role=\"alert\"\` for destructive.
- **\`components/ui/toaster.tsx\`** — wraps sonner with project-wide defaults (bottom-right, richColors, closeButton, 4000ms). Class-name hooks for future Tailwind-token theming.
- **\`app/admin/layout.tsx\`** — mounts \`<Toaster />\` once at the admin shell root. Consumers anywhere call \`import { toast } from \"sonner\"\` + \`toast.success(\"…\")\`.
- **\`package.json\`** — \`sonner ^2.0.7\` (~3KB gzipped).

## Risks identified and mitigated

- **TS title-prop conflict on Alert** — native \`<div>\` \`title\` is \`string\`; resolved via \`Omit<HTMLAttributes, \"title\">\`.
- **z-index collision with RS-6 cost ticker** — sonner uses \`z-[9999]\` internally (ticker is \`z-40\`); toast layers on top.
- **Toaster mount location** — admin layout only; auth surfaces don't get toasts (atomic flows).
- **Bundle bloat** — sonner ~3KB gzipped; verified.
- **Microcopy creep** — EmptyState takes consumer-supplied React nodes only; no default copy.

No consumer changes — Phase B per-screen PRs wire them up.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [ ] Manual: \`import { toast } from \"sonner\"\` + \`toast.success(\"…\")\` from any admin client, observe bottom-right toast

## Phase A complete

Foundation primitives all shipped (A-0 → A-7). Phase B per-screen polish opens after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)