### PR TITLE
feat(b-1): admin layout + nav polish

### DIFF
--- a/components/AdminNav.tsx
+++ b/components/AdminNav.tsx
@@ -3,9 +3,16 @@
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { useState, useRef, useEffect } from "react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Menu, X } from "lucide-react";
 
 import type { SessionUser } from "@/lib/auth";
+
+// ---------------------------------------------------------------------------
+// B-1 — Admin shell navigation. Sticky top, mobile-collapse, Linear-
+// density. Active-link weight bumped (font-semibold + border-bottom).
+// Focus rings normalized via the standard ring-ring pattern. Hover/
+// focus transitions land via the .transition-smooth motion token.
+// ---------------------------------------------------------------------------
 
 type NavLink = {
   label: string;
@@ -16,6 +23,7 @@ type NavLink = {
 export function AdminNav({ user, showUsersLink }: { user: SessionUser | null; showUsersLink: boolean }) {
   const pathname = usePathname();
   const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const navLinks: NavLink[] = [
@@ -29,6 +37,7 @@ export function AdminNav({ user, showUsersLink }: { user: SessionUser | null; sh
     return pathname === href || pathname.startsWith(href + "/");
   }
 
+  // Close the user menu on any click outside.
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
@@ -42,15 +51,37 @@ export function AdminNav({ user, showUsersLink }: { user: SessionUser | null; sh
     }
   }, [userMenuOpen]);
 
+  // Close the mobile nav on route change so an in-app navigation
+  // doesn't leave the disclosure stuck open.
+  useEffect(() => {
+    setMobileNavOpen(false);
+  }, [pathname]);
+
+  // Escape closes whichever disclosure is open.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      if (userMenuOpen) setUserMenuOpen(false);
+      if (mobileNavOpen) setMobileNavOpen(false);
+    }
+    if (userMenuOpen || mobileNavOpen) {
+      window.addEventListener("keydown", onKey);
+      return () => window.removeEventListener("keydown", onKey);
+    }
+  }, [userMenuOpen, mobileNavOpen]);
+
   return (
-    <header className="border-b">
-      <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 gap-8">
-        {/* Left: Logo + Primary nav */}
+    <header className="sticky top-0 z-30 border-b bg-background/95 backdrop-blur">
+      <div className="mx-auto flex h-14 max-w-7xl items-center justify-between gap-4 px-4">
+        {/* Left: logo + (desktop) primary nav */}
         <div className="flex items-center gap-6">
-          <Link href="/admin/sites" className="font-semibold text-sm whitespace-nowrap">
-            Opollo Site Builder
+          <Link
+            href="/admin/sites"
+            className="text-sm font-semibold whitespace-nowrap transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          >
+            Opollo
           </Link>
-          <nav className="flex items-center gap-1">
+          <nav className="hidden items-center gap-1 sm:flex" aria-label="Primary">
             {navLinks.map(({ label, href, testId }) => {
               const active = isActiveRoute(href);
               return (
@@ -58,9 +89,10 @@ export function AdminNav({ user, showUsersLink }: { user: SessionUser | null; sh
                   key={href}
                   href={href}
                   data-testid={testId}
-                  className={`px-3 py-2 text-xs font-medium transition-colors whitespace-nowrap ${
+                  aria-current={active ? "page" : undefined}
+                  className={`relative h-14 inline-flex items-center px-3 text-xs font-medium whitespace-nowrap transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset ${
                     active
-                      ? "text-foreground border-b-2 border-foreground"
+                      ? "text-foreground font-semibold after:absolute after:inset-x-3 after:bottom-0 after:h-0.5 after:bg-foreground"
                       : "text-muted-foreground hover:text-foreground"
                   }`}
                 >
@@ -71,64 +103,125 @@ export function AdminNav({ user, showUsersLink }: { user: SessionUser | null; sh
           </nav>
         </div>
 
-        {/* Right: User menu dropdown */}
-        <div className="relative" ref={menuRef}>
+        {/* Right: mobile-nav button + user menu */}
+        <div className="flex items-center gap-2">
+          {/* Mobile-only hamburger */}
           <button
-            onClick={() => setUserMenuOpen(!userMenuOpen)}
-            className="flex items-center gap-2 rounded px-3 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-            aria-label="User menu"
-            data-testid="admin-user-menu-button"
+            type="button"
+            onClick={() => setMobileNavOpen((v) => !v)}
+            aria-label={mobileNavOpen ? "Close menu" : "Open menu"}
+            aria-expanded={mobileNavOpen}
+            aria-controls="admin-mobile-nav"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-smooth hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:hidden"
+            data-testid="admin-mobile-nav-button"
           >
-            {user?.email ?? "Admin"}
-            <ChevronDown
-              aria-hidden
-              className={`h-4 w-4 transition-transform ${userMenuOpen ? "rotate-180" : ""}`}
-            />
+            {mobileNavOpen ? (
+              <X aria-hidden className="h-5 w-5" />
+            ) : (
+              <Menu aria-hidden className="h-5 w-5" />
+            )}
           </button>
 
-          {userMenuOpen && (
-            <div
-              className="absolute right-0 top-full mt-1 w-48 rounded-md border bg-background shadow-lg z-50"
-              role="menu"
+          {/* User menu (desktop + mobile) */}
+          <div className="relative" ref={menuRef}>
+            <button
+              onClick={() => setUserMenuOpen(!userMenuOpen)}
+              className="inline-flex h-10 items-center gap-1.5 rounded-md px-3 text-xs text-muted-foreground transition-smooth hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label="User menu"
+              aria-expanded={userMenuOpen}
+              aria-haspopup="menu"
+              data-testid="admin-user-menu-button"
             >
-              {user && (
-                <>
-                  <div className="px-3 py-2 text-xs text-muted-foreground border-b">
-                    {user.email}
+              <span className="hidden max-w-[180px] truncate sm:inline">
+                {user?.email ?? "Admin"}
+              </span>
+              <ChevronDown
+                aria-hidden
+                className={`h-4 w-4 transition-transform ${userMenuOpen ? "rotate-180" : ""}`}
+              />
+            </button>
+
+            {userMenuOpen && (
+              <div
+                className="opollo-fade-in absolute right-0 top-full z-50 mt-1 w-56 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg"
+                role="menu"
+              >
+                {user && (
+                  <div className="border-b px-3 py-2 text-xs text-muted-foreground">
+                    Signed in as
+                    <div className="mt-0.5 truncate font-medium text-foreground">
+                      {user.email}
+                    </div>
                   </div>
+                )}
+                {user && (
                   <Link
                     href="/account/security"
-                    className="block px-3 py-2 text-xs hover:bg-muted text-left"
+                    className="block px-3 py-2 text-xs transition-smooth hover:bg-muted"
                     onClick={() => setUserMenuOpen(false)}
                     data-testid="nav-security"
+                    role="menuitem"
                   >
                     Security
                   </Link>
-                </>
-              )}
-              <Link
-                href="/"
-                className="block px-3 py-2 text-xs hover:bg-muted text-left"
-                onClick={() => setUserMenuOpen(false)}
-                data-testid="nav-back-to-builder"
-              >
-                ← Back to builder
-              </Link>
-              {user && (
-                <form action="/logout" method="POST" className="border-t">
-                  <button
-                    type="submit"
-                    className="w-full px-3 py-2 text-xs hover:bg-muted text-left text-destructive"
-                    data-testid="nav-sign-out"
-                  >
-                    Sign out
-                  </button>
-                </form>
-              )}
-            </div>
-          )}
+                )}
+                <Link
+                  href="/"
+                  className="block px-3 py-2 text-xs transition-smooth hover:bg-muted"
+                  onClick={() => setUserMenuOpen(false)}
+                  data-testid="nav-back-to-builder"
+                  role="menuitem"
+                >
+                  ← Back to builder
+                </Link>
+                {user && (
+                  <form action="/logout" method="POST" className="border-t">
+                    <button
+                      type="submit"
+                      className="block w-full px-3 py-2 text-left text-xs text-destructive transition-smooth hover:bg-destructive/10"
+                      data-testid="nav-sign-out"
+                      role="menuitem"
+                    >
+                      Sign out
+                    </button>
+                  </form>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       </div>
+
+      {/* Mobile-only nav disclosure */}
+      {mobileNavOpen && (
+        <nav
+          id="admin-mobile-nav"
+          className="opollo-fade-in border-t sm:hidden"
+          aria-label="Primary (mobile)"
+        >
+          <ul className="flex flex-col p-2">
+            {navLinks.map(({ label, href, testId }) => {
+              const active = isActiveRoute(href);
+              return (
+                <li key={href}>
+                  <Link
+                    href={href}
+                    data-testid={`${testId}-mobile`}
+                    aria-current={active ? "page" : undefined}
+                    className={`flex h-11 items-center rounded-md px-3 text-sm transition-smooth ${
+                      active
+                        ? "bg-muted font-semibold text-foreground"
+                        : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                    }`}
+                  >
+                    {label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      )}
     </header>
   );
 }

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -1,38 +1,48 @@
 import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 
-// Shared breadcrumb trail for admin detail pages. Each page passes
-// its own crumbs; last one is the current page and renders without
-// a link.
+// ---------------------------------------------------------------------------
+// Shared breadcrumb trail. Last crumb is the current page (renders as
+// plain bold text, no link). B-1 swaps the `›` glyph for ChevronRight
+// + bumps the active-crumb weight to font-medium for slight separation.
+// ---------------------------------------------------------------------------
 
 export type Crumb = { label: string; href?: string };
 
 export function Breadcrumbs({ crumbs }: { crumbs: Crumb[] }) {
   return (
-    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-xs">
+    <nav
+      aria-label="Breadcrumb"
+      className="flex flex-wrap items-center gap-1.5 text-xs"
+    >
       {crumbs.map((c, i) => {
         const isLast = i === crumbs.length - 1;
         return (
-          <span key={i} className="flex items-center gap-1">
+          <span key={i} className="flex items-center gap-1.5">
             {c.href && !isLast ? (
               <Link
                 href={c.href}
-                className="text-muted-foreground hover:text-foreground"
+                className="text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
               >
                 {c.label}
               </Link>
             ) : (
               <span
+                aria-current={isLast ? "page" : undefined}
                 className={
-                  isLast ? "text-foreground" : "text-muted-foreground"
+                  isLast
+                    ? "font-medium text-foreground"
+                    : "text-muted-foreground"
                 }
               >
                 {c.label}
               </span>
             )}
             {!isLast && (
-              <span aria-hidden="true" className="text-muted-foreground">
-                ›
-              </span>
+              <ChevronRight
+                aria-hidden
+                className="h-3 w-3 text-muted-foreground/60"
+              />
             )}
           </span>
         );


### PR DESCRIPTION
## Summary

B-1 of the world-class polish workstream (parent: PR #229). **First Phase B per-screen PR.** Polishes the admin shell — chrome that every other admin route lives inside, so this PR's improvements compound across every subsequent B-* PR.

## ⚠️ Screenshots — operator action needed

The screenshot harness (A-0) cannot run from the autonomous Claude Code context — it requires \`supabase start\` + the local Next.js dev server. Steven runs **\`npm run screenshots\`** against this branch locally to generate before/after PNGs at 1440×900 + 380×844.

The harness will write to \`playwright-screenshots/<viewport>/\` for the surfaces this PR materially changes:
- \`admin-sites-list.png\`
- \`admin-site-detail.png\`
- \`admin-batches-list.png\`
- \`admin-users-list.png\`
- \`admin-images-list.png\`

Per the polish brief, this PR cannot ship without screenshots attached. Auto-merge is armed only because the brief authorizes it on green CI; the visual review gate is operator-side.

If you want the autonomous run to handle screenshots end-to-end, I'll need either (a) supabase CLI in the env, (b) a CI workflow that runs the harness and uploads PNGs as artifacts, or (c) a different verification path.

## What ships

### \`components/AdminNav.tsx\`
- **Sticky header** (\`top-0 z-30\` + \`bg-background/95 backdrop-blur\`). Linear / Vercel pattern.
- **Mobile-collapse**: at <sm, primary nav links fold into a \`Menu\` / \`X\` disclosure; auto-closes on route change + Escape.
- **Mobile nav links at \`h-11\` (44px tap target)** to honour the 380px-floor mobile contract.
- **Active link weight bumped** from \`text-foreground\` to \`font-semibold\` + \`after:absolute after:bg-foreground\` underline.
- **Focus rings normalized** — every focusable element gets the standard \`focus-visible:ring-2 focus-visible:ring-ring\` (replaces ad-hoc mix today).
- Hover/focus uses \`.transition-smooth\` (A-3 token).
- User dropdown gains \`.opollo-fade-in\` entrance + better microcopy (\"Signed in as / <email>\").
- Logo wordmark trimmed to \"Opollo\" — primary nav gets more breathing room at narrow widths.

### \`components/Breadcrumbs.tsx\`
- \`›\` glyph → \`<ChevronRight className=\"h-3 w-3 text-muted-foreground/60\">\` per A-7.
- Active crumb gets \`font-medium\` + \`aria-current=\"page\"\`.
- \`gap-1\` → \`gap-1.5\` for slightly more breathing room.
- \`flex-wrap\` so long crumb chains line-break gracefully on mobile.

## Risks identified and mitigated

- **Sticky header occluding scroll-into-view targets** — RS-5 \`scrollIntoView\` already pads + uses \`focus({ preventScroll: true })\`; 56px header clears.
- **z-index ordering** — nav z-30, ticker z-40, dialogs z-50, toast z-[9999]. Layered correctly.
- **ARIA** — \`aria-current\`, \`aria-expanded\`, \`aria-controls\`, \`aria-haspopup\`, \`aria-label\` added throughout.
- **Focus-trap** — not added (would need Sheet primitive); click-outside + Escape suffice.
- **Reduced-motion** — \`.transition-smooth\` + \`.opollo-fade-in\` zeroed by A-3 contract.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [ ] Manual desktop: nav sticks on scroll, active link bolder, user menu fades in
- [ ] Manual 380px: hamburger toggles disclosure, links 44px tall, no horizontal scroll
- [ ] Manual reduced-motion: no animations; functionality unchanged
- [ ] **Screenshots from \`npm run screenshots\` attached before merge**

🤖 Generated with [Claude Code](https://claude.com/claude-code)