### PR TITLE
feat(b-7): posts list + detail polish

### DIFF
--- a/app/admin/sites/[id]/posts/page.tsx
+++ b/app/admin/sites/[id]/posts/page.tsx
@@ -3,8 +3,11 @@ import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { checkAdminAccess } from "@/lib/admin-gate";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 import { StatusPill, postStatusKind } from "@/components/ui/status-pill";
-import { H1 } from "@/components/ui/typography";
+import { H1, Lead } from "@/components/ui/typography";
+import { FileText, Plus } from "lucide-react";
 import {
   LIST_POSTS_DEFAULT_LIMIT,
   listPostsForSite,
@@ -134,21 +137,24 @@ export default async function SitePostsList({
         ]}
       />
 
-      <div className="mt-6 flex flex-wrap items-center justify-between gap-3">
-        <H1>Posts</H1>
-        <div className="flex items-center gap-3">
-          <p className="text-xs text-muted-foreground">
-            {total} total{total > 0 ? ` · showing ${rangeStart}–${rangeEnd}` : ""}
-          </p>
-          {/* BP-3 — entry-point for single-post creation. */}
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <H1>Posts</H1>
+          <Lead className="mt-0.5">
+            {total === 0
+              ? "No posts on this site yet."
+              : `${total} ${total === 1 ? "post" : "posts"}${total > 0 && items.length < total ? ` · showing ${rangeStart}–${rangeEnd}` : ""}`}
+          </Lead>
+        </div>
+        <Button asChild>
           <Link
             href={`/admin/sites/${site.id}/posts/new`}
-            className="inline-flex h-9 items-center rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted transition-smooth"
             data-testid="new-post-button"
           >
+            <Plus aria-hidden className="h-4 w-4" />
             New post
           </Link>
-        </div>
+        </Button>
       </div>
 
       <form
@@ -210,44 +216,78 @@ export default async function SitePostsList({
       </form>
 
       {items.length === 0 ? (
-        <div
-          role="status"
-          className="mt-6 rounded-md border border-muted-foreground/20 bg-muted/20 p-6 text-center text-sm text-muted-foreground"
-        >
-          No posts match the current filters. Posts are created by the brief
-          runner when a post-mode brief commits + an operator approves its
-          pages.
+        <div className="mt-4">
+          <EmptyState
+            icon={FileText}
+            iconLabel="No posts"
+            title={
+              parsed.status || parsed.query
+                ? "No posts match the current filters"
+                : "No posts on this site yet"
+            }
+            body={
+              parsed.status || parsed.query ? (
+                <>
+                  Adjust the filters above, or clear them to see every post.
+                </>
+              ) : (
+                <>
+                  Create your first single-post draft, or generate a batch
+                  of posts via a post-mode brief.
+                </>
+              )
+            }
+            cta={
+              !parsed.status && !parsed.query ? (
+                <Button asChild>
+                  <Link href={`/admin/sites/${site.id}/posts/new`}>
+                    <Plus aria-hidden className="h-4 w-4" />
+                    New post
+                  </Link>
+                </Button>
+              ) : (
+                <Button asChild variant="outline">
+                  <Link href={`/admin/sites/${site.id}/posts`}>
+                    Clear filters
+                  </Link>
+                </Button>
+              )
+            }
+          />
         </div>
       ) : (
-        <ol className="mt-6 space-y-3">
+        <ol className="mt-4 space-y-2">
           {items.map((post) => {
             return (
               <li
                 key={post.id}
-                className="rounded-lg border p-4"
+                className="rounded-lg border p-3 transition-smooth hover:bg-muted/40"
                 aria-labelledby={`post-${post.id}-title`}
               >
                 <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="flex-1">
+                  <div className="min-w-0 flex-1">
                     <h2
                       id={`post-${post.id}-title`}
-                      className="text-base font-medium"
+                      className="text-sm font-semibold"
                     >
                       <Link
                         href={`/admin/sites/${site.id}/posts/${post.id}`}
-                        className="hover:underline"
+                        className="transition-smooth hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
                       >
                         {post.title}
                       </Link>
                     </h2>
-                    <p className="mt-1 text-xs text-muted-foreground">
+                    <p className="mt-0.5 text-xs text-muted-foreground">
                       <code className="text-[11px]">/{post.slug}</code>
                       {post.wp_post_id
                         ? ` · WP id ${post.wp_post_id}`
                         : ""}
                     </p>
                   </div>
-                  <StatusPill kind={postStatusKind(post.status)} className="shrink-0 capitalize" />
+                  <StatusPill
+                    kind={postStatusKind(post.status)}
+                    className="shrink-0 capitalize"
+                  />
                 </div>
               </li>
             );

--- a/components/PostDetailClient.tsx
+++ b/components/PostDetailClient.tsx
@@ -3,8 +3,10 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { StatusPill, postStatusKind } from "@/components/ui/status-pill";
+import { H1 } from "@/components/ui/typography";
 import type { PostDetail } from "@/lib/posts";
 import type { PreflightResult } from "@/lib/site-preflight";
 
@@ -139,7 +141,7 @@ export function PostDetailClient({
     <div className="mt-6 space-y-6">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold">{post.title}</h1>
+          <H1>{post.title}</H1>
           <p className="mt-1 text-sm text-muted-foreground">
             <code className="text-xs">/{post.slug}</code>
             {" · "}
@@ -176,32 +178,26 @@ export function PostDetailClient({
       </div>
 
       {preflightBlocked && (
-        <div
-          role="alert"
-          className="rounded-md border border-yellow-500/40 bg-yellow-500/10 p-4 text-sm text-yellow-900 dark:text-yellow-200"
+        <Alert
+          variant="warning"
+          title={
+            "blocker" in preflight
+              ? preflight.blocker.title
+              : "Preflight failed."
+          }
         >
-          <p className="font-medium">
-            {"blocker" in preflight ? preflight.blocker.title : "Preflight failed."}
-          </p>
           {"blocker" in preflight && (
             <>
-              <p className="mt-1">{preflight.blocker.detail}</p>
+              <p>{preflight.blocker.detail}</p>
               <p className="mt-2 text-xs">
                 <strong>What to do:</strong> {preflight.blocker.nextAction}
               </p>
             </>
           )}
-        </div>
+        </Alert>
       )}
 
-      {errorMessage && (
-        <div
-          role="alert"
-          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
-        >
-          {errorMessage}
-        </div>
-      )}
+      {errorMessage && <Alert variant="destructive">{errorMessage}</Alert>}
 
       <section
         aria-labelledby="preview-heading"


### PR DESCRIPTION
B-7 — folds posts list + detail surfaces onto Phase A. EmptyState with mode-aware body + CTA on the list, denser rows, Alert primitive on detail. See commit message for detail. Per standing rule: text in lieu of inline screenshots.