### PR TITLE
feat(b-8): blog post entry polish

### DIFF
--- a/app/admin/sites/[id]/posts/new/page.tsx
+++ b/app/admin/sites/[id]/posts/new/page.tsx
@@ -2,7 +2,8 @@ import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { BlogPostComposer } from "@/components/BlogPostComposer";
-import { H1 } from "@/components/ui/typography";
+import { Alert } from "@/components/ui/alert";
+import { H1, Lead } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getSite } from "@/lib/sites";
 
@@ -30,20 +31,15 @@ export default async function BlogPostEntryPage({
   if (!result.ok) {
     if (result.error.code === "NOT_FOUND") notFound();
     return (
-      <main className="mx-auto max-w-3xl p-6">
-        <div
-          role="alert"
-          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-        >
-          {result.error.message}
-        </div>
-      </main>
+      <div className="mx-auto max-w-3xl">
+        <Alert variant="destructive">{result.error.message}</Alert>
+      </div>
     );
   }
   const site = result.data.site;
 
   return (
-    <main className="mx-auto max-w-4xl p-6">
+    <div className="mx-auto max-w-4xl">
       <Breadcrumbs
         crumbs={[
           { label: "Sites", href: "/admin/sites" },
@@ -53,15 +49,15 @@ export default async function BlogPostEntryPage({
         ]}
       />
       <H1 className="mt-2">New blog post</H1>
-      <p className="mt-1 text-sm text-muted-foreground">
+      <Lead className="mt-1">
         Paste a markdown / HTML / YAML-fronted post. We&apos;ll parse the
-        metadata into the fields below — every value is editable before
-        you save the draft.
-      </p>
+        metadata into the fields below — every value is editable before you
+        save the draft.
+      </Lead>
 
       <div className="mt-6">
         <BlogPostComposer siteId={site.id} />
       </div>
-    </main>
+    </div>
   );
 }

--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronDown } from "lucide-react";
 
+import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Composer, type ComposerValue } from "@/components/Composer";
 import {
@@ -453,14 +454,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
         )}
       </div>
 
-      {formError && (
-        <div
-          role="alert"
-          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
-        >
-          {formError}
-        </div>
-      )}
+      {formError && <Alert variant="destructive">{formError}</Alert>}
 
       <div className="flex flex-wrap items-center justify-end gap-2">
         <Button type="submit" disabled={!canSaveDraft}>


### PR DESCRIPTION
B-8 — folds BlogPostComposer error block + entry page shell to A-6 Alert + Lead. Per standing rule: text in lieu of inline screenshots.