### PR TITLE
feat(b-9): pages list + detail polish

### DIFF
--- a/app/admin/sites/[id]/pages/[pageId]/page.tsx
+++ b/app/admin/sites/[id]/pages/[pageId]/page.tsx
@@ -3,8 +3,9 @@ import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { EditPageMetadataButton } from "@/components/EditPageMetadataButton";
+import { Alert } from "@/components/ui/alert";
 import { StatusPill, postStatusKind } from "@/components/ui/status-pill";
-import { H1 } from "@/components/ui/typography";
+import { H1, H3 } from "@/components/ui/typography";
 import { PageHtmlPreview } from "@/components/PageHtmlPreview";
 import { RegenHistoryPanel } from "@/components/RegenHistoryPanel";
 import { RegenerateButton } from "@/components/RegenerateButton";
@@ -92,12 +93,9 @@ export default async function PageDetail({
   if (!result.ok) {
     if (result.error.code === "NOT_FOUND") notFound();
     return (
-      <div
-        role="alert"
-        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-      >
-        Failed to load page: {result.error.message}
-      </div>
+      <Alert variant="destructive" title="Failed to load page">
+        {result.error.message}
+      </Alert>
     );
   }
 
@@ -224,12 +222,12 @@ export default async function PageDetail({
       </section>
 
       <section className="mt-8">
-        <h2 className="text-sm font-semibold">
+        <H3>
           Re-generation history{" "}
-          <span className="text-xs text-muted-foreground">
+          <span className="text-xs font-normal text-muted-foreground">
             ({regenJobs.length})
           </span>
-        </h2>
+        </H3>
         <p className="text-xs text-muted-foreground">
           Each row is one operator-triggered re-run against the current design
           system. Cost + tokens come from Anthropic; failures carry their

--- a/app/admin/sites/[id]/pages/page.tsx
+++ b/app/admin/sites/[id]/pages/page.tsx
@@ -3,7 +3,8 @@ import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { PagesTable } from "@/components/PagesTable";
-import { H1 } from "@/components/ui/typography";
+import { Alert } from "@/components/ui/alert";
+import { H1, Lead } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import {
   LIST_PAGES_DEFAULT_LIMIT,
@@ -95,12 +96,9 @@ export default async function SitePagesList({
   if (!siteRes.ok) {
     if (siteRes.error.code === "NOT_FOUND") notFound();
     return (
-      <div
-        role="alert"
-        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-      >
-        Failed to load site: {siteRes.error.message}
-      </div>
+      <Alert variant="destructive" title="Failed to load site">
+        {siteRes.error.message}
+      </Alert>
     );
   }
   const site = siteRes.data.site;
@@ -119,12 +117,9 @@ export default async function SitePagesList({
 
   if (!result.ok) {
     return (
-      <div
-        role="alert"
-        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-      >
-        Failed to load pages: {result.error.message}
-      </div>
+      <Alert variant="destructive" title="Failed to load pages">
+        {result.error.message}
+      </Alert>
     );
   }
 
@@ -146,15 +141,16 @@ export default async function SitePagesList({
 
       <div className="mt-4 flex items-start justify-between gap-4">
         <div>
-          <H1>Pages for {site.name}</H1>
-          <p className="text-sm text-muted-foreground">
-            Every page generated for this site. Click a row for the detail
-            view. Editing content itself still happens in WordPress admin.
-          </p>
+          <H1>Pages</H1>
+          <Lead className="mt-0.5">
+            {total === 0
+              ? `No pages generated for ${site.name} yet.`
+              : `${total} ${total === 1 ? "page" : "pages"} generated for ${site.name}.`}
+          </Lead>
         </div>
         <Link
           href={`/admin/sites/${params.id}`}
-          className="text-xs text-muted-foreground hover:text-foreground"
+          className="text-xs text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
         >
           ← Site detail
         </Link>


### PR DESCRIPTION
B-9 — Alert primitive on error states, Lead with count on list, H3 on history section. PagesTable status pills already shipped in A-4. Per standing rule: text in lieu of inline screenshots.