### PR TITLE
feat(b-11): design-system surfaces polish

### DIFF
--- a/app/admin/sites/[id]/design-system/components/page.tsx
+++ b/app/admin/sites/[id]/design-system/components/page.tsx
@@ -3,8 +3,10 @@
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { H1 } from "@/components/ui/typography";
+import { TableSkeleton } from "@/components/ui/skeleton";
+import { H1, Lead } from "@/components/ui/typography";
 import { ComponentFormModal, type ComponentFormMode } from "@/components/ComponentFormModal";
 import { ComponentsGrid } from "@/components/ComponentsGrid";
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
@@ -111,10 +113,10 @@ export default function DesignSystemComponentsPage() {
       <div className="flex items-center justify-between">
         <div>
           <H1>Components</H1>
-          <p className="text-sm text-muted-foreground">
-            Components registered on design system v{selectedDs.version} (
+          <Lead className="mt-0.5">
+            Registered on design system v{selectedDs.version} (
             {selectedDs.status}).
-          </p>
+          </Lead>
         </div>
         <Button
           onClick={() => setFormMode({ kind: "create" })}
@@ -125,22 +127,21 @@ export default function DesignSystemComponentsPage() {
       </div>
 
       <div className="mt-6">
-        {state.status === "loading" && (
-          <div className="rounded-md border p-8 text-center">
-            <p className="text-sm text-muted-foreground">Loading components…</p>
-          </div>
-        )}
+        {state.status === "loading" && <TableSkeleton rows={5} cols={4} />}
 
         {state.status === "error" && (
-          <div
-            className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-            role="alert"
+          <Alert
+            variant="destructive"
+            title="Failed to load components"
+            className="items-center justify-between"
           >
-            <span>{state.message}</span>
-            <Button variant="outline" size="sm" onClick={() => void load()}>
-              Retry
-            </Button>
-          </div>
+            <div className="flex items-center justify-between gap-3">
+              <span>{state.message}</span>
+              <Button variant="outline" size="sm" onClick={() => void load()}>
+                Retry
+              </Button>
+            </div>
+          </Alert>
         )}
 
         {state.status === "ready" && (

--- a/app/admin/sites/[id]/design-system/layout.tsx
+++ b/app/admin/sites/[id]/design-system/layout.tsx
@@ -9,7 +9,9 @@ import {
 } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { CardSkeleton } from "@/components/ui/skeleton";
 import {
   DesignSystemLayoutContext,
   resolveSelectedDesignSystem,
@@ -202,22 +204,17 @@ export default function DesignSystemLayout({
       </div>
 
       <div className="mt-6">
-        {state.status === "loading" && (
-          <div className="rounded-md border p-8 text-center">
-            <p className="text-sm text-muted-foreground">Loading…</p>
-          </div>
-        )}
+        {state.status === "loading" && <CardSkeleton lines={3} />}
 
         {state.status === "error" && (
-          <div
-            className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-            role="alert"
-          >
-            <span>{state.message}</span>
-            <Button variant="outline" size="sm" onClick={() => void load()}>
-              Retry
-            </Button>
-          </div>
+          <Alert variant="destructive" title="Failed to load design system">
+            <div className="flex items-center justify-between gap-3">
+              <span>{state.message}</span>
+              <Button variant="outline" size="sm" onClick={() => void load()}>
+                Retry
+              </Button>
+            </div>
+          </Alert>
         )}
 
         {state.status === "ready" && (

--- a/app/admin/sites/[id]/design-system/preview/page.tsx
+++ b/app/admin/sites/[id]/design-system/preview/page.tsx
@@ -3,8 +3,10 @@
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { H1 } from "@/components/ui/typography";
+import { TableSkeleton } from "@/components/ui/skeleton";
+import { H1, Lead } from "@/components/ui/typography";
 import { PreviewGallery } from "@/components/PreviewGallery";
 import {
   resolveSelectedDesignSystem,
@@ -88,30 +90,25 @@ export default function DesignSystemPreviewPage() {
     <>
       <div>
         <H1>Preview</H1>
-        <p className="text-sm text-muted-foreground">
+        <Lead className="mt-0.5">
           Read-only metadata view of design system v{selectedDs.version} (
           {selectedDs.status}). Live component rendering lands with M3 — this
           page shows raw templates + CSS + field schemas + composition chains.
-        </p>
+        </Lead>
       </div>
 
       <div className="mt-6">
-        {state.status === "loading" && (
-          <div className="rounded-md border p-8 text-center">
-            <p className="text-sm text-muted-foreground">Loading preview…</p>
-          </div>
-        )}
+        {state.status === "loading" && <TableSkeleton rows={6} cols={3} />}
 
         {state.status === "error" && (
-          <div
-            className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-            role="alert"
-          >
-            <span>{state.message}</span>
-            <Button variant="outline" size="sm" onClick={() => void load()}>
-              Retry
-            </Button>
-          </div>
+          <Alert variant="destructive" title="Failed to load preview">
+            <div className="flex items-center justify-between gap-3">
+              <span>{state.message}</span>
+              <Button variant="outline" size="sm" onClick={() => void load()}>
+                Retry
+              </Button>
+            </div>
+          </Alert>
         )}
 
         {state.status === "ready" && (

--- a/app/admin/sites/[id]/design-system/templates/page.tsx
+++ b/app/admin/sites/[id]/design-system/templates/page.tsx
@@ -3,8 +3,10 @@
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { H1 } from "@/components/ui/typography";
+import { TableSkeleton } from "@/components/ui/skeleton";
+import { H1, Lead } from "@/components/ui/typography";
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
 import { TemplateFormModal, type TemplateFormMode } from "@/components/TemplateFormModal";
 import { TemplatesTable } from "@/components/TemplatesTable";
@@ -97,10 +99,10 @@ export default function DesignSystemTemplatesPage() {
       <div className="flex items-center justify-between">
         <div>
           <H1>Templates</H1>
-          <p className="text-sm text-muted-foreground">
+          <Lead className="mt-0.5">
             Page-type templates on design system v{selectedDs.version} (
             {selectedDs.status}).
-          </p>
+          </Lead>
         </div>
         <Button
           onClick={() => setFormMode({ kind: "create" })}
@@ -111,22 +113,17 @@ export default function DesignSystemTemplatesPage() {
       </div>
 
       <div className="mt-6">
-        {state.status === "loading" && (
-          <div className="rounded-md border p-8 text-center">
-            <p className="text-sm text-muted-foreground">Loading templates…</p>
-          </div>
-        )}
+        {state.status === "loading" && <TableSkeleton rows={5} cols={4} />}
 
         {state.status === "error" && (
-          <div
-            className="flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-            role="alert"
-          >
-            <span>{state.message}</span>
-            <Button variant="outline" size="sm" onClick={() => void load()}>
-              Retry
-            </Button>
-          </div>
+          <Alert variant="destructive" title="Failed to load templates">
+            <div className="flex items-center justify-between gap-3">
+              <span>{state.message}</span>
+              <Button variant="outline" size="sm" onClick={() => void load()}>
+                Retry
+              </Button>
+            </div>
+          </Alert>
         )}
 
         {state.status === "ready" && (


### PR DESCRIPTION
B-11 — folds 4 design-system routes (layout + components + templates + preview) onto Skeleton + Alert primitives. Loading state moves from text spinner to layout-reserving skeletons. Per standing rule: text in lieu of inline screenshots.