### PR TITLE
ci(polish): screenshot harness in github actions

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,104 @@
+name: Screenshots
+
+# Polish workstream visual-regression harness. Captures every admin
+# surface at desktop 1440×900 + mobile 380×844 against an ephemeral
+# local Supabase, uploads the playwright-screenshots/ folder as a
+# downloadable artifact.
+#
+# Per the world-class polish brief (PR #229) the per-screen Phase B
+# PRs and the R-0 operator-review report each need before/after PNGs.
+# This workflow makes them downloadable from every PR's CI run.
+#
+# Triggered:
+#   • pull_request — every Phase B / Phase C PR gets fresh screenshots
+#     for visual review.
+#   • workflow_dispatch — Steven can fire it manually against any
+#     branch (e.g. for the R-0 report PR).
+#   • push to main — captures the post-merge baseline; the artifact on
+#     the latest main run is the reference state.
+#
+# Skipped on forked-repo PRs (same as e2e.yml — secrets would leak).
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: screenshots-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  screenshots:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      # Same setup as e2e.yml — admin gate ON exercises the real auth
+      # flow; deterministic master key for ephemeral encryption.
+      FEATURE_SUPABASE_AUTH: "true"
+      OPOLLO_MASTER_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - uses: actions/cache@v5
+        id: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase local stack
+        run: supabase start
+
+      - name: Read Supabase credentials into env
+        run: |
+          URL=$(supabase status --output json | jq -r '.API_URL')
+          SVC=$(supabase status --output json | jq -r '.SERVICE_ROLE_KEY')
+          ANON=$(supabase status --output json | jq -r '.ANON_KEY')
+          DB=$(supabase status --output json | jq -r '.DB_URL')
+          echo "SUPABASE_URL=$URL" >> "$GITHUB_ENV"
+          echo "SUPABASE_SERVICE_ROLE_KEY=$SVC" >> "$GITHUB_ENV"
+          echo "SUPABASE_ANON_KEY=$ANON" >> "$GITHUB_ENV"
+          echo "SUPABASE_DB_URL=$DB" >> "$GITHUB_ENV"
+
+      - name: Capture screenshots
+        run: npm run screenshots
+
+      - name: Upload screenshot artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-screenshots-${{ github.event.pull_request.number || github.sha }}
+          path: playwright-screenshots
+          retention-days: 30
+          # if-no-files-found: warn rather than error — a partially
+          # broken capture run still gives reviewers something to look
+          # at while we triage the failure.
+          if-no-files-found: warn
+
+      - name: Stop Supabase
+        if: always()
+        run: supabase stop --no-backup || true

--- a/docs/patterns/visual-regression-screenshots.md
+++ b/docs/patterns/visual-regression-screenshots.md
@@ -28,6 +28,30 @@ writes them to `playwright-screenshots/<viewport>/<route-slug>.png`.
 
 ## How to run
 
+### In CI (canonical path)
+
+`.github/workflows/screenshots.yml` runs on every PR + push to main +
+on-demand `workflow_dispatch`. Each run uploads
+`playwright-screenshots/` as an artifact named
+`playwright-screenshots-<pr-number-or-sha>`. Reviewers download from
+the run's "Artifacts" panel, expand the zip, and review the PNGs in
+their image viewer of choice.
+
+The PR description should link to the relevant run + name the
+affected files. Example:
+
+```markdown
+## Screenshots
+
+[Latest screenshot CI run](https://github.com/opollo5/opollo-site-builder/actions/runs/12345)
+
+Surfaces this PR materially changed:
+- `desktop/admin-sites-list.png`
+- `mobile/admin-sites-list.png`
+```
+
+### Locally (when you need to iterate without pushing)
+
 ```bash
 # 1. Local Supabase running (the harness queries the seeded test site).
 supabase start
@@ -41,7 +65,8 @@ The script signs in as the seeded `playwright-admin@opollo.test` user
 and writes PNGs.
 
 Skipped by default in regular CI — `npm run test:e2e` passes a `RUN_SCREENSHOTS=1`
-env-var guard that's only set by the dedicated `npm run screenshots` script.
+env-var guard that's only set by the dedicated `npm run screenshots` script
+(via the workflow above).
 
 ## How to reference in a PR description
 


### PR DESCRIPTION
Wires the A-0 screenshot harness into GitHub Actions per Steven's option 2 approval. Each PR's CI run captures playwright-screenshots/ and uploads as a downloadable artifact so reviewers spot-check visual regressions without needing supabase locally. Models on existing e2e.yml. Sits between Phase B (just closed at B-15) and Phase C (about to open). Per standing rule: text in lieu of inline screenshots (this PR has no UI changes).