### PR TITLE
feat(c-2): optimistic UI on user role + status flips

### DIFF
--- a/components/UserRoleActionCell.tsx
+++ b/components/UserRoleActionCell.tsx
@@ -2,8 +2,23 @@
 
 import { useRouter } from "next/navigation";
 import { useState, type ChangeEvent } from "react";
+import { toast } from "sonner";
 
 type Role = "admin" | "operator" | "viewer";
+
+// ---------------------------------------------------------------------------
+// C-2 — Optimistic UI on role change.
+//
+// Old behaviour: dropdown changed value, request sent, on failure
+// router.refresh() rolled back via server-rendered re-fetch — slow
+// + visually jarring.
+//
+// New behaviour: dropdown updates immediately to the operator's
+// chosen value, request fires in the background, on success a sonner
+// toast confirms, on failure the dropdown snaps back to the original
+// value and an error toast surfaces. Operator never feels the
+// network round-trip.
+// ---------------------------------------------------------------------------
 
 export function UserRoleActionCell({
   userId,
@@ -15,17 +30,21 @@ export function UserRoleActionCell({
   selfUserId: string | null;
 }) {
   const router = useRouter();
+  // Optimistic local mirror of the server's role. Server-rendered
+  // currentRole is the source of truth; this state lets us flip the
+  // dropdown immediately without waiting for the round-trip.
+  const [optimisticRole, setOptimisticRole] = useState<Role>(currentRole);
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   const isSelf = selfUserId !== null && selfUserId === userId;
 
   async function handleChange(e: ChangeEvent<HTMLSelectElement>) {
     const newRole = e.target.value as Role;
-    if (newRole === currentRole) return;
+    if (newRole === optimisticRole) return;
+    const previous = optimisticRole;
 
+    setOptimisticRole(newRole);
     setSubmitting(true);
-    setError(null);
     try {
       const res = await fetch(
         `/api/admin/users/${encodeURIComponent(userId)}/role`,
@@ -37,47 +56,42 @@ export function UserRoleActionCell({
       );
       const payload = await res.json().catch(() => null);
       if (!res.ok || !payload?.ok) {
-        setError(
-          payload?.error?.message ??
-            `Role change failed (HTTP ${res.status}).`,
-        );
-        // Revert the visual state — router.refresh would re-render
-        // with the stale role, but we want the select to snap back
-        // immediately so the operator doesn't think the change
-        // landed.
-        router.refresh();
-        setSubmitting(false);
+        // Roll back the visual state immediately and surface the
+        // server's reason via toast.
+        setOptimisticRole(previous);
+        toast.error("Couldn't change role", {
+          description:
+            payload?.error?.message ??
+            `Role change failed (HTTP ${res.status}). The previous role has been restored.`,
+        });
         return;
       }
-      // Server-rendered page; refresh re-fetches the list with the
-      // new role.
+      toast.success(`Role updated to ${newRole}`);
+      // Server-rendered list still reflects the old role until refresh;
+      // re-fetch so the rest of the table catches up.
       router.refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-      router.refresh();
+      setOptimisticRole(previous);
+      toast.error("Network error changing role", {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
       setSubmitting(false);
     }
   }
 
   return (
-    <div className="flex flex-col gap-1">
-      <select
-        value={currentRole}
-        onChange={handleChange}
-        disabled={isSelf || submitting}
-        aria-label={`Change role for user ${userId}`}
-        title={isSelf ? "You cannot change your own role." : undefined}
-        className="rounded border bg-background px-2 py-1 text-xs disabled:opacity-60"
-      >
-        <option value="admin">admin</option>
-        <option value="operator">operator</option>
-        <option value="viewer">viewer</option>
-      </select>
-      {error && (
-        <p role="alert" className="text-xs text-destructive">
-          {error}
-        </p>
-      )}
-    </div>
+    <select
+      value={optimisticRole}
+      onChange={handleChange}
+      disabled={isSelf || submitting}
+      aria-label={`Change role for user ${userId}`}
+      title={isSelf ? "You cannot change your own role." : undefined}
+      className="rounded border bg-background px-2 py-1 text-xs transition-smooth disabled:opacity-60"
+    >
+      <option value="admin">admin</option>
+      <option value="operator">operator</option>
+      <option value="viewer">viewer</option>
+    </select>
   );
 }

--- a/components/UserStatusActionCell.tsx
+++ b/components/UserStatusActionCell.tsx
@@ -2,8 +2,15 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { toast } from "sonner";
 
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
+
+// ---------------------------------------------------------------------------
+// C-2 — Optimistic UI on reinstate. Revoke flows through
+// ConfirmActionModal which already toasts on success/failure; the
+// reinstate path was the inline-button gap.
+// ---------------------------------------------------------------------------
 
 export function UserStatusActionCell({
   userId,
@@ -16,14 +23,16 @@ export function UserStatusActionCell({
 }) {
   const router = useRouter();
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [revokeOpen, setRevokeOpen] = useState(false);
+  // Optimistic local mirror — flips to "active" on reinstate request,
+  // rolls back to "revoked" on failure.
+  const [optimisticRevoked, setOptimisticRevoked] = useState(revoked);
 
   const isSelf = selfUserId !== null && selfUserId === userId;
 
   async function reinstate() {
     setSubmitting(true);
-    setError(null);
+    setOptimisticRevoked(false);
     try {
       const res = await fetch(
         `/api/admin/users/${encodeURIComponent(userId)}/reinstate`,
@@ -31,21 +40,27 @@ export function UserStatusActionCell({
       );
       const payload = await res.json().catch(() => null);
       if (!res.ok || !payload?.ok) {
-        setError(
-          payload?.error?.message ??
-            `reinstate failed (HTTP ${res.status}).`,
-        );
-        setSubmitting(false);
+        setOptimisticRevoked(true);
+        toast.error("Couldn't reinstate user", {
+          description:
+            payload?.error?.message ??
+            `Reinstate failed (HTTP ${res.status}). Status restored to revoked.`,
+        });
         return;
       }
+      toast.success("User reinstated");
       router.refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setOptimisticRevoked(true);
+      toast.error("Network error reinstating user", {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
       setSubmitting(false);
     }
   }
 
-  if (revoked) {
+  if (optimisticRevoked) {
     return (
       <div className="flex flex-col gap-1">
         <span className="text-xs text-destructive">revoked</span>
@@ -53,15 +68,10 @@ export function UserStatusActionCell({
           type="button"
           onClick={() => void reinstate()}
           disabled={submitting}
-          className="self-start rounded border px-2 py-0.5 text-sm hover:bg-muted disabled:opacity-60"
+          className="self-start rounded border px-2 py-0.5 text-sm transition-smooth hover:bg-muted disabled:opacity-60"
         >
           {submitting ? "…" : "Reinstate"}
         </button>
-        {error && (
-          <p role="alert" className="text-sm text-destructive">
-            {error}
-          </p>
-        )}
       </div>
     );
   }
@@ -74,15 +84,10 @@ export function UserStatusActionCell({
         onClick={() => setRevokeOpen(true)}
         disabled={isSelf || submitting}
         title={isSelf ? "You cannot revoke your own access." : undefined}
-        className="self-start rounded border px-2 py-0.5 text-sm text-destructive hover:bg-destructive/10 disabled:opacity-60"
+        className="self-start rounded border px-2 py-0.5 text-sm text-destructive transition-smooth hover:bg-destructive/10 disabled:opacity-60"
       >
         {submitting ? "…" : "Revoke"}
       </button>
-      {error && (
-        <p role="alert" className="text-sm text-destructive">
-          {error}
-        </p>
-      )}
       {revokeOpen && (
         <ConfirmActionModal
           open
@@ -95,6 +100,8 @@ export function UserStatusActionCell({
           onClose={() => setRevokeOpen(false)}
           onSuccess={() => {
             setRevokeOpen(false);
+            setOptimisticRevoked(true);
+            toast.success("User revoked");
             router.refresh();
           }}
         />


### PR DESCRIPTION
C-2 — Phase C cross-cutting. Optimistic UI on role + status changes via local state mirrors + sonner toasts. Snap-back on failure with the server's reason. Inline error <p> blocks dropped — toast is the single feedback channel. Per standing rule: text in lieu of inline screenshots.