### PR TITLE
feat(c-3): a11y hardening — skip-link + axe sweep + focus-visible normalization

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -33,8 +33,26 @@ export default async function AdminLayout({
 
   return (
     <div className="min-h-screen bg-background text-foreground">
+      {/* C-3 — skip-to-content link. Visually hidden until focused
+          (Tab from the address bar lands here first), then snaps to
+          the top-left so keyboard / screen-reader users can jump
+          past the AdminNav into the page content. */}
+      <a
+        href="#admin-main"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-md focus:bg-primary focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-primary-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+      >
+        Skip to main content
+      </a>
       <AdminNav user={user} showUsersLink={showUsersLink} />
-      <main className="mx-auto max-w-5xl p-6">{children}</main>
+      <main
+        id="admin-main"
+        // tabIndex=-1 + scroll-mt-16 so the skip-link target is
+        // focusable + lands below the sticky 56px nav header.
+        tabIndex={-1}
+        className="mx-auto max-w-5xl p-6 scroll-mt-16 focus:outline-none"
+      >
+        {children}
+      </main>
       {/* A-6 — admin-wide toaster mount. Consumers call
           `toast.success("…")` / `toast.error("…")` from anywhere in
           the admin tree. */}

--- a/components/BriefRunClient.tsx
+++ b/components/BriefRunClient.tsx
@@ -447,8 +447,8 @@ export function BriefRunClient({
                 tabIndex={-1}
                 className={
                   isAwaitingReview
-                    ? "rounded-lg border-2 border-yellow-500/60 bg-yellow-500/5 p-4 ring-2 ring-yellow-500/20 transition-smooth focus:outline-none focus:ring-yellow-500/40"
-                    : "rounded-lg border p-4 transition-smooth focus:outline-none"
+                    ? "rounded-lg border-2 border-warning/60 bg-warning/5 p-4 ring-2 ring-warning/20 transition-smooth focus-visible:outline-none focus-visible:ring-warning/40"
+                    : "rounded-lg border p-4 transition-smooth focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 }
                 aria-labelledby={`page-${page.id}-title`}
               >

--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { expect, test } from "@playwright/test";
 
-import { signInAsAdmin } from "./helpers";
+import { auditA11y, signInAsAdmin } from "./helpers";
 import { E2E_TEST_SITE_PREFIX } from "./fixtures";
 import { createClient } from "@supabase/supabase-js";
 
@@ -175,6 +175,16 @@ test.describe("A-0 visual regression screenshot harness", () => {
             mask: masks,
             animations: "disabled",
           });
+          // C-3 — run axe-core on every captured route. Findings
+          // attach to the test result; non-blocking by design (the
+          // harness still produces screenshots even if axe surfaces
+          // violations) but visible in the CI run output for triage.
+          // Desktop-viewport pass only — running on both viewports
+          // doubles audit time and rarely finds viewport-specific
+          // a11y issues.
+          if (viewport.name === "desktop") {
+            await auditA11y(page, testInfo);
+          }
           // eslint-disable-next-line no-console
           console.log(
             `  [${viewport.name}] ${route.slug} → ${path.relative(process.cwd(), filePath)}`,


### PR DESCRIPTION
C-3 — final Phase C PR. Skip-to-content link in admin layout (sr-only until focused), axe-core sweep wired into the screenshot harness for every desktop route (non-blocking; findings in CI artifact), focus-visible normalization on the BriefRunClient page card. **This closes Phase C.** Per standing rule: text in lieu of inline screenshots.