### PR TITLE
feat(optimiser-2): data ingestion — Ads/Clarity/GA4/PSI sync, OAuth, LLM cost tracking

### DIFF
--- a/app/api/cron/optimiser-sync-ads/route.ts
+++ b/app/api/cron/optimiser-sync-ads/route.ts
@@ -1,0 +1,32 @@
+import { type NextRequest } from "next/server";
+
+import {
+  authorisedCronRequest,
+  runOptimiserCronTick,
+  unauthorisedResponse,
+} from "@/lib/optimiser/sync/cron-shared";
+import { runSyncForAllClients } from "@/lib/optimiser/sync/runner";
+import { syncAdsForClient } from "@/lib/optimiser/sync/ads";
+
+// Daily Google Ads sync. Vercel cron schedule: see vercel.json. Uses
+// the standard CRON_SECRET Bearer auth; 401 if missing or wrong.
+//
+// One tick fans out across every client with status='connected' Ads
+// credentials. Each per-client sync short-circuits if it ran within
+// the last hour, so daily-cadence is enforced even if the cron runs
+// hourly.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+async function handle(req: NextRequest) {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+  return runOptimiserCronTick({
+    eventName: "optimiser.sync.ads",
+    run: () => runSyncForAllClients("google_ads", syncAdsForClient),
+  });
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/app/api/cron/optimiser-sync-clarity/route.ts
+++ b/app/api/cron/optimiser-sync-clarity/route.ts
@@ -1,0 +1,24 @@
+import { type NextRequest } from "next/server";
+
+import {
+  authorisedCronRequest,
+  runOptimiserCronTick,
+  unauthorisedResponse,
+} from "@/lib/optimiser/sync/cron-shared";
+import { runSyncForAllClients } from "@/lib/optimiser/sync/runner";
+import { syncClarityForClient } from "@/lib/optimiser/sync/clarity";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+async function handle(req: NextRequest) {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+  return runOptimiserCronTick({
+    eventName: "optimiser.sync.clarity",
+    run: () => runSyncForAllClients("clarity", syncClarityForClient),
+  });
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/app/api/cron/optimiser-sync-ga4/route.ts
+++ b/app/api/cron/optimiser-sync-ga4/route.ts
@@ -1,0 +1,24 @@
+import { type NextRequest } from "next/server";
+
+import {
+  authorisedCronRequest,
+  runOptimiserCronTick,
+  unauthorisedResponse,
+} from "@/lib/optimiser/sync/cron-shared";
+import { runSyncForAllClients } from "@/lib/optimiser/sync/runner";
+import { syncGa4ForClient } from "@/lib/optimiser/sync/ga4";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+async function handle(req: NextRequest) {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+  return runOptimiserCronTick({
+    eventName: "optimiser.sync.ga4",
+    run: () => runSyncForAllClients("ga4", syncGa4ForClient),
+  });
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/app/api/cron/optimiser-sync-pagespeed/route.ts
+++ b/app/api/cron/optimiser-sync-pagespeed/route.ts
@@ -1,0 +1,70 @@
+import { type NextRequest } from "next/server";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  authorisedCronRequest,
+  runOptimiserCronTick,
+  unauthorisedResponse,
+} from "@/lib/optimiser/sync/cron-shared";
+import { syncPagespeedForClient } from "@/lib/optimiser/sync/pagespeed";
+import { logger } from "@/lib/logger";
+
+// PSI sync: weekly per landing page. PSI uses a single Opollo-wide API
+// key (PAGESPEED_API_KEY) rather than per-client credentials, so this
+// route iterates opt_clients directly rather than going through the
+// credential-aware sync runner.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+async function handle(req: NextRequest) {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+  return runOptimiserCronTick({
+    eventName: "optimiser.sync.pagespeed",
+    run: async () => {
+      const supabase = getServiceRoleClient();
+      const { data, error } = await supabase
+        .from("opt_clients")
+        .select("id")
+        .is("deleted_at", null);
+      if (error) {
+        throw new Error(`opt_clients fetch: ${error.message}`);
+      }
+      const outcomes: Array<{
+        client_id: string;
+        result: "ok" | "skipped" | "error";
+        rows_written: number;
+        error?: string;
+      }> = [];
+      for (const c of data ?? []) {
+        const start = Date.now();
+        try {
+          const r = await syncPagespeedForClient(c.id as string);
+          outcomes.push({
+            client_id: c.id as string,
+            result: r.skipped ? "skipped" : "ok",
+            rows_written: r.rows_written,
+          });
+          void start;
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          outcomes.push({
+            client_id: c.id as string,
+            result: "error",
+            rows_written: 0,
+            error: message,
+          });
+          logger.error("optimiser.sync.pagespeed.failed", {
+            client_id: c.id,
+            error: message,
+          });
+        }
+      }
+      return { outcomes, total: (data ?? []).length };
+    },
+  });
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/app/api/optimiser/oauth/ads/callback/route.ts
+++ b/app/api/optimiser/oauth/ads/callback/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { logger } from "@/lib/logger";
+import { upsertCredential } from "@/lib/optimiser/credentials";
+import {
+  exchangeCodeForRefreshToken,
+  verifyState,
+} from "@/lib/optimiser/oauth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  if (access.kind === "redirect") {
+    return NextResponse.redirect(new URL(access.to, req.url));
+  }
+
+  const url = new URL(req.url);
+  const code = url.searchParams.get("code");
+  const stateParam = url.searchParams.get("state");
+  const error = url.searchParams.get("error");
+
+  // User clicked "Cancel" or Google rejected the consent. Bounce back
+  // with a soft error.
+  if (error || !code || !stateParam) {
+    const back = new URL("/optimiser", url.origin);
+    back.searchParams.set("error", error ?? "ads_oauth_aborted");
+    return NextResponse.redirect(back);
+  }
+
+  const state = verifyState(stateParam);
+  if (!state || state.source !== "google_ads") {
+    logger.warn("optimiser.oauth.ads.invalid_state");
+    const back = new URL("/optimiser", url.origin);
+    back.searchParams.set("error", "ads_oauth_invalid_state");
+    return NextResponse.redirect(back);
+  }
+
+  const redirectUri = new URL(
+    "/api/optimiser/oauth/ads/callback",
+    url.origin,
+  ).toString();
+  const tokens = await exchangeCodeForRefreshToken({
+    code,
+    redirectUri,
+    source: "google_ads",
+  });
+  if (!tokens) {
+    logger.warn("optimiser.oauth.ads.exchange_failed", {
+      client_id: state.opt_client_id,
+    });
+    const back = new URL(
+      `/optimiser/onboarding/${state.opt_client_id}`,
+      url.origin,
+    );
+    back.searchParams.set("error", "ads_oauth_exchange_failed");
+    return NextResponse.redirect(back);
+  }
+
+  // The Ads customer_id is selected on the next onboarding step (the
+  // user picks which Ads customer in their account to connect). Store
+  // the refresh token now and let the next step persist customer_id +
+  // login_customer_id.
+  try {
+    await upsertCredential({
+      clientId: state.opt_client_id,
+      source: "google_ads",
+      payload: { refresh_token: tokens.refresh_token, customer_id: "" },
+      updatedBy: access.user?.id ?? null,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("optimiser.oauth.ads.persist_failed", {
+      client_id: state.opt_client_id,
+      error: message,
+    });
+    const back = new URL(
+      `/optimiser/onboarding/${state.opt_client_id}`,
+      url.origin,
+    );
+    back.searchParams.set("error", "ads_oauth_persist_failed");
+    return NextResponse.redirect(back);
+  }
+
+  const back = new URL(
+    `/optimiser/onboarding/${state.opt_client_id}`,
+    url.origin,
+  );
+  back.searchParams.set("step", "ads_customer");
+  return NextResponse.redirect(back);
+}

--- a/app/api/optimiser/oauth/ads/start/route.ts
+++ b/app/api/optimiser/oauth/ads/start/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { adsConsentUrl, signState } from "@/lib/optimiser/oauth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  if (access.kind === "redirect") {
+    return NextResponse.redirect(new URL(access.to, req.url));
+  }
+
+  const url = new URL(req.url);
+  const optClientId = url.searchParams.get("client_id");
+  if (!optClientId) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "INVALID_REQUEST", message: "client_id is required" },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const redirectUri = new URL(
+    "/api/optimiser/oauth/ads/callback",
+    url.origin,
+  ).toString();
+  const state = signState({ opt_client_id: optClientId, source: "google_ads" });
+  const consentUrl = adsConsentUrl({ redirectUri, state });
+  if (!consentUrl) {
+    // Env not provisioned — surface a soft error rather than a redirect
+    // loop. Onboarding UI shows the §7.3 banner pattern.
+    const back = new URL(`/optimiser/onboarding/${optClientId}`, url.origin);
+    back.searchParams.set("error", "ads_oauth_not_configured");
+    return NextResponse.redirect(back);
+  }
+  return NextResponse.redirect(consentUrl);
+}

--- a/app/api/optimiser/oauth/ga4/callback/route.ts
+++ b/app/api/optimiser/oauth/ga4/callback/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { logger } from "@/lib/logger";
+import { upsertCredential } from "@/lib/optimiser/credentials";
+import {
+  exchangeCodeForRefreshToken,
+  verifyState,
+} from "@/lib/optimiser/oauth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  if (access.kind === "redirect") {
+    return NextResponse.redirect(new URL(access.to, req.url));
+  }
+
+  const url = new URL(req.url);
+  const code = url.searchParams.get("code");
+  const stateParam = url.searchParams.get("state");
+  const error = url.searchParams.get("error");
+
+  if (error || !code || !stateParam) {
+    const back = new URL("/optimiser", url.origin);
+    back.searchParams.set("error", error ?? "ga4_oauth_aborted");
+    return NextResponse.redirect(back);
+  }
+
+  const state = verifyState(stateParam);
+  if (!state || state.source !== "ga4") {
+    logger.warn("optimiser.oauth.ga4.invalid_state");
+    const back = new URL("/optimiser", url.origin);
+    back.searchParams.set("error", "ga4_oauth_invalid_state");
+    return NextResponse.redirect(back);
+  }
+
+  const redirectUri = new URL(
+    "/api/optimiser/oauth/ga4/callback",
+    url.origin,
+  ).toString();
+  const tokens = await exchangeCodeForRefreshToken({
+    code,
+    redirectUri,
+    source: "ga4",
+  });
+  if (!tokens) {
+    const back = new URL(
+      `/optimiser/onboarding/${state.opt_client_id}`,
+      url.origin,
+    );
+    back.searchParams.set("error", "ga4_oauth_exchange_failed");
+    return NextResponse.redirect(back);
+  }
+
+  try {
+    await upsertCredential({
+      clientId: state.opt_client_id,
+      source: "ga4",
+      payload: { refresh_token: tokens.refresh_token, property_id: "" },
+      updatedBy: access.user?.id ?? null,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("optimiser.oauth.ga4.persist_failed", {
+      client_id: state.opt_client_id,
+      error: message,
+    });
+    const back = new URL(
+      `/optimiser/onboarding/${state.opt_client_id}`,
+      url.origin,
+    );
+    back.searchParams.set("error", "ga4_oauth_persist_failed");
+    return NextResponse.redirect(back);
+  }
+
+  const back = new URL(
+    `/optimiser/onboarding/${state.opt_client_id}`,
+    url.origin,
+  );
+  back.searchParams.set("step", "ga4_property");
+  return NextResponse.redirect(back);
+}

--- a/app/api/optimiser/oauth/ga4/start/route.ts
+++ b/app/api/optimiser/oauth/ga4/start/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { ga4ConsentUrl, signState } from "@/lib/optimiser/oauth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  if (access.kind === "redirect") {
+    return NextResponse.redirect(new URL(access.to, req.url));
+  }
+
+  const url = new URL(req.url);
+  const optClientId = url.searchParams.get("client_id");
+  if (!optClientId) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "INVALID_REQUEST", message: "client_id is required" },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const redirectUri = new URL(
+    "/api/optimiser/oauth/ga4/callback",
+    url.origin,
+  ).toString();
+  const state = signState({ opt_client_id: optClientId, source: "ga4" });
+  const consentUrl = ga4ConsentUrl({ redirectUri, state });
+  if (!consentUrl) {
+    const back = new URL(`/optimiser/onboarding/${optClientId}`, url.origin);
+    back.searchParams.set("error", "ga4_oauth_not_configured");
+    return NextResponse.redirect(back);
+  }
+  return NextResponse.redirect(consentUrl);
+}

--- a/lib/optimiser/credentials.ts
+++ b/lib/optimiser/credentials.ts
@@ -1,0 +1,220 @@
+import "server-only";
+
+import { decrypt, encrypt } from "@/lib/encryption";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+import type {
+  OptCredentialSource,
+  OptCredentialStatus,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// opt_client_credentials helpers.
+//
+// All reads/writes go through the service-role client — opt_client_credentials
+// is service-role-only by RLS policy, so the authenticated client cannot
+// touch this table directly. The UI receives only redacted status fields
+// (status / last_error_code / last_synced_at) via lib/optimiser API
+// helpers, never the ciphertext.
+//
+// Encryption matches lib/encryption.ts (AES-256-GCM, OPOLLO_MASTER_KEY).
+// Same key version contract as site_credentials so the existing rotation
+// playbook applies unchanged.
+// ---------------------------------------------------------------------------
+
+export type StoredCredential = {
+  id: string;
+  client_id: string;
+  source: OptCredentialSource;
+  external_account_id: string | null;
+  external_account_label: string | null;
+  status: OptCredentialStatus;
+  last_error_code: string | null;
+  last_error_message: string | null;
+  last_synced_at: string | null;
+  last_attempted_at: string | null;
+  refresh_token_expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DecryptedSecret = {
+  /**
+   * Source-specific secret payload, parsed from JSON. Shape per source:
+   *   google_ads: { refresh_token, customer_id, login_customer_id? }
+   *   clarity:    { api_token }
+   *   ga4:        { refresh_token, property_id, service_account_json? }
+   *   pagespeed:  { api_key }
+   */
+  payload: Record<string, unknown>;
+  keyVersion: number;
+};
+
+/** Insert or replace credentials for (client, source). Existing row's
+ * status is reset to 'connected' and any prior error is cleared. */
+export async function upsertCredential(args: {
+  clientId: string;
+  source: OptCredentialSource;
+  payload: Record<string, unknown>;
+  externalAccountId?: string;
+  externalAccountLabel?: string;
+  refreshTokenExpiresAt?: Date | null;
+  updatedBy?: string | null;
+}): Promise<StoredCredential> {
+  const supabase = getServiceRoleClient();
+  const plaintext = JSON.stringify(args.payload);
+  const enc = encrypt(plaintext);
+
+  const { data, error } = await supabase
+    .from("opt_client_credentials")
+    .upsert(
+      {
+        client_id: args.clientId,
+        source: args.source,
+        external_account_id: args.externalAccountId ?? null,
+        external_account_label: args.externalAccountLabel ?? null,
+        ciphertext: enc.ciphertext,
+        iv: enc.iv,
+        key_version: enc.keyVersion,
+        status: "connected" as OptCredentialStatus,
+        last_error_code: null,
+        last_error_message: null,
+        refresh_token_expires_at: args.refreshTokenExpiresAt
+          ? args.refreshTokenExpiresAt.toISOString()
+          : null,
+        updated_by: args.updatedBy ?? null,
+      },
+      { onConflict: "client_id,source" },
+    )
+    .select(
+      "id, client_id, source, external_account_id, external_account_label, status, last_error_code, last_error_message, last_synced_at, last_attempted_at, refresh_token_expires_at, created_at, updated_at",
+    )
+    .single();
+  if (error || !data) {
+    throw new Error(
+      `upsertCredential failed for client=${args.clientId} source=${args.source}: ${error?.message ?? "no data"}`,
+    );
+  }
+  return data as StoredCredential;
+}
+
+export async function getCredentialMeta(
+  clientId: string,
+  source: OptCredentialSource,
+): Promise<StoredCredential | null> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("opt_client_credentials")
+    .select(
+      "id, client_id, source, external_account_id, external_account_label, status, last_error_code, last_error_message, last_synced_at, last_attempted_at, refresh_token_expires_at, created_at, updated_at",
+    )
+    .eq("client_id", clientId)
+    .eq("source", source)
+    .maybeSingle();
+  if (error) {
+    throw new Error(
+      `getCredentialMeta failed for client=${clientId} source=${source}: ${error.message}`,
+    );
+  }
+  return (data as StoredCredential | null) ?? null;
+}
+
+/**
+ * Decrypt the credential payload. Throws if no row, the row is
+ * disconnected, or decryption fails. Callers must catch + flip the
+ * status to 'misconfigured' / 'expired' on failure (use
+ * markCredentialError below).
+ */
+export async function readCredential(
+  clientId: string,
+  source: OptCredentialSource,
+): Promise<DecryptedSecret> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("opt_client_credentials")
+    .select("ciphertext, iv, key_version, status")
+    .eq("client_id", clientId)
+    .eq("source", source)
+    .single();
+  if (error || !data) {
+    throw new Error(
+      `readCredential: no credentials for client=${clientId} source=${source}`,
+    );
+  }
+  if (data.status === "disconnected") {
+    throw new Error(
+      `readCredential: credentials for client=${clientId} source=${source} are disconnected`,
+    );
+  }
+  const ciphertext = Buffer.from(data.ciphertext as string | Buffer);
+  const iv = Buffer.from(data.iv as string | Buffer);
+  const text = decrypt(ciphertext, iv, data.key_version as number);
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new Error(
+      `readCredential: payload for client=${clientId} source=${source} is not valid JSON: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  return { payload: parsed, keyVersion: data.key_version as number };
+}
+
+/** Bump status to 'expired' / 'misconfigured' / 'disconnected'. */
+export async function markCredentialError(
+  clientId: string,
+  source: OptCredentialSource,
+  status: Exclude<OptCredentialStatus, "connected">,
+  code: string,
+  message: string,
+): Promise<void> {
+  const supabase = getServiceRoleClient();
+  const { error } = await supabase
+    .from("opt_client_credentials")
+    .update({
+      status,
+      last_error_code: code,
+      last_error_message: message,
+      last_attempted_at: new Date().toISOString(),
+    })
+    .eq("client_id", clientId)
+    .eq("source", source);
+  if (error) {
+    logger.error("optimiser.credentials.mark_error_failed", {
+      client_id: clientId,
+      source,
+      status,
+      code,
+      error: error.message,
+    });
+  }
+}
+
+export async function markCredentialSynced(
+  clientId: string,
+  source: OptCredentialSource,
+): Promise<void> {
+  const supabase = getServiceRoleClient();
+  const now = new Date().toISOString();
+  const { error } = await supabase
+    .from("opt_client_credentials")
+    .update({
+      last_synced_at: now,
+      last_attempted_at: now,
+      status: "connected",
+      last_error_code: null,
+      last_error_message: null,
+    })
+    .eq("client_id", clientId)
+    .eq("source", source);
+  if (error) {
+    logger.error("optimiser.credentials.mark_synced_failed", {
+      client_id: clientId,
+      source,
+      error: error.message,
+    });
+  }
+}

--- a/lib/optimiser/index.ts
+++ b/lib/optimiser/index.ts
@@ -5,3 +5,33 @@
 
 export * from "./types";
 export { checkOptimiserSchema } from "./health";
+
+// Slice 2 surface
+export {
+  upsertCredential,
+  getCredentialMeta,
+  readCredential,
+  markCredentialError,
+  markCredentialSynced,
+} from "./credentials";
+export type { StoredCredential, DecryptedSecret } from "./credentials";
+
+export { checkBudget, recordLlmCall, gateLlmCall } from "./llm-usage";
+export type { BudgetCheckResult, RecordLlmCallArgs } from "./llm-usage";
+
+export { runSyncForAllClients, CredentialAuthError } from "./sync/runner";
+export type { SyncOutcome, SyncFn } from "./sync/runner";
+
+export { syncAdsForClient } from "./sync/ads";
+export { syncClarityForClient } from "./sync/clarity";
+export { syncGa4ForClient } from "./sync/ga4";
+export { syncPagespeedForClient } from "./sync/pagespeed";
+
+export {
+  signState,
+  verifyState,
+  adsConsentUrl,
+  ga4ConsentUrl,
+  exchangeCodeForRefreshToken,
+} from "./oauth";
+export type { OAuthSource, OAuthState } from "./oauth";

--- a/lib/optimiser/llm-usage.ts
+++ b/lib/optimiser/llm-usage.ts
@@ -1,0 +1,163 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// LLM usage tracking + budget enforcement (spec §4.6).
+//
+//   - Every LLM call goes through `recordLlmCall` which inserts a row
+//     in opt_llm_usage. Daily / monthly rollups are SUM() over this
+//     table (indexed by client_id + created_at).
+//
+//   - `checkBudget(client_id)` returns the current month's rolled
+//     spend in micros + the soft / hard threshold flags. Slice 5
+//     callers gate every LLM call on this; pre-call rejections still
+//     record an `outcome = 'budget_exceeded'` row so the budget
+//     surface shows what would have been spent.
+//
+//   - The 75% / 100% boundaries follow §4.6: soft warning at 0.75,
+//     hard cutoff at 1.00 of opt_clients.llm_monthly_budget_usd.
+// ---------------------------------------------------------------------------
+
+const MICROS_PER_USD = 1_000_000;
+
+export type BudgetCheckResult = {
+  /** Configured monthly budget in micros (0 if not set). */
+  budgetMicros: number;
+  /** Spend this calendar month in micros from opt_llm_usage WHERE outcome = 'ok'. */
+  spendMicros: number;
+  /** Fraction of budget consumed; capped at 9.9999 if budget = 0 (treated as no-budget). */
+  fraction: number;
+  /** TRUE once spend has crossed 75%. */
+  warning: boolean;
+  /** TRUE once spend has crossed 100% — every gated call must short-circuit. */
+  exceeded: boolean;
+};
+
+export async function checkBudget(clientId: string): Promise<BudgetCheckResult> {
+  const supabase = getServiceRoleClient();
+
+  const { data: client, error: clientErr } = await supabase
+    .from("opt_clients")
+    .select("llm_monthly_budget_usd")
+    .eq("id", clientId)
+    .maybeSingle();
+  if (clientErr) {
+    throw new Error(`checkBudget: ${clientErr.message}`);
+  }
+  const budgetUsd = client?.llm_monthly_budget_usd ?? 0;
+  const budgetMicros = budgetUsd * MICROS_PER_USD;
+
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+
+  // Sum is computed in JS rather than via an RPC because Phase 1 row
+  // counts are bounded (one row per LLM call, ~ tens per client per
+  // day). When this becomes hot, swap to a SQL function.
+  const { data: rows, error: usageErr } = await supabase
+    .from("opt_llm_usage")
+    .select("cost_usd_micros")
+    .eq("client_id", clientId)
+    .eq("outcome", "ok")
+    .gte("created_at", monthStart.toISOString());
+  if (usageErr) {
+    throw new Error(`checkBudget: ${usageErr.message}`);
+  }
+  const spendMicros = (rows ?? []).reduce(
+    (acc, r) => acc + (r.cost_usd_micros as number),
+    0,
+  );
+
+  if (budgetMicros === 0) {
+    return {
+      budgetMicros,
+      spendMicros,
+      fraction: spendMicros > 0 ? 9.9999 : 0,
+      warning: false,
+      exceeded: false,
+    };
+  }
+  const fraction = spendMicros / budgetMicros;
+  return {
+    budgetMicros,
+    spendMicros,
+    fraction,
+    warning: fraction >= 0.75,
+    exceeded: fraction >= 1.0,
+  };
+}
+
+export type RecordLlmCallArgs = {
+  clientId: string;
+  caller: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens?: number;
+  costUsdMicros: number;
+  sourceTable?: string;
+  sourceId?: string;
+  requestId?: string;
+  anthropicRequestId?: string;
+  outcome?: "ok" | "budget_exceeded" | "error";
+  errorCode?: string;
+};
+
+export async function recordLlmCall(
+  args: RecordLlmCallArgs,
+): Promise<void> {
+  const supabase = getServiceRoleClient();
+  const { error } = await supabase.from("opt_llm_usage").insert({
+    client_id: args.clientId,
+    caller: args.caller,
+    model: args.model,
+    input_tokens: Math.max(0, Math.round(args.inputTokens)),
+    output_tokens: Math.max(0, Math.round(args.outputTokens)),
+    cached_tokens: Math.max(0, Math.round(args.cachedTokens ?? 0)),
+    cost_usd_micros: Math.max(0, Math.round(args.costUsdMicros)),
+    source_table: args.sourceTable ?? null,
+    source_id: args.sourceId ?? null,
+    request_id: args.requestId ?? null,
+    anthropic_request_id: args.anthropicRequestId ?? null,
+    outcome: args.outcome ?? "ok",
+    error_code: args.errorCode ?? null,
+  });
+  if (error) {
+    logger.error("optimiser.llm_usage.insert_failed", {
+      client_id: args.clientId,
+      caller: args.caller,
+      error: error.message,
+    });
+  }
+}
+
+/**
+ * Convenience: gate an LLM call on budget. Returns 'allow' | 'warn' |
+ * 'block'; on 'block' a budget_exceeded row is recorded and the caller
+ * must short-circuit. On 'warn' the call proceeds; staff see the
+ * banner from the dashboard which reads opt_clients + checkBudget
+ * directly.
+ */
+export async function gateLlmCall(
+  clientId: string,
+  caller: string,
+  expectedCostMicros = 0,
+): Promise<"allow" | "warn" | "block"> {
+  const { exceeded, warning } = await checkBudget(clientId);
+  if (exceeded) {
+    await recordLlmCall({
+      clientId,
+      caller,
+      model: "n/a",
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsdMicros: expectedCostMicros,
+      outcome: "budget_exceeded",
+      errorCode: "BUDGET_EXCEEDED",
+    });
+    return "block";
+  }
+  return warning ? "warn" : "allow";
+}

--- a/lib/optimiser/oauth.ts
+++ b/lib/optimiser/oauth.ts
@@ -1,0 +1,162 @@
+import "server-only";
+
+import { randomBytes, timingSafeEqual } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// OAuth helpers shared by the Ads + GA4 onboarding flows.
+//
+// Phase 1 implements the standard Google OAuth 2.0 web flow:
+//   1. UI calls /api/optimiser/oauth/{source}/start?client_id=<opt_client_id>
+//   2. Handler builds the consent URL, sets a signed state cookie,
+//      302-redirects to accounts.google.com.
+//   3. Google calls /api/optimiser/oauth/{source}/callback?code=...&state=...
+//   4. Handler verifies the state cookie, exchanges code for refresh
+//      token, persists into opt_client_credentials, redirects back to
+//      /optimiser/onboarding/<client_id>.
+//
+// state is a JSON-encoded { opt_client_id, source, nonce } pair signed
+// with HMAC-SHA256 keyed off OPOLLO_MASTER_KEY. We reuse the master
+// key rather than introducing a new secret — the signing is for CSRF
+// protection only, the payload itself isn't sensitive.
+// ---------------------------------------------------------------------------
+
+import { createHmac } from "node:crypto";
+
+const STATE_TTL_MS = 10 * 60 * 1000;
+
+export type OAuthSource = "google_ads" | "ga4";
+
+export type OAuthState = {
+  opt_client_id: string;
+  source: OAuthSource;
+  nonce: string;
+  ts: number;
+};
+
+function getSigningKey(): Buffer {
+  const encoded = process.env.OPOLLO_MASTER_KEY;
+  if (!encoded) {
+    throw new Error("OPOLLO_MASTER_KEY is not set; OAuth state cannot be signed.");
+  }
+  return Buffer.from(encoded, "base64");
+}
+
+export function signState(state: Omit<OAuthState, "nonce" | "ts">): string {
+  const fullState: OAuthState = {
+    ...state,
+    nonce: randomBytes(16).toString("base64url"),
+    ts: Date.now(),
+  };
+  const json = JSON.stringify(fullState);
+  const payload = Buffer.from(json, "utf8").toString("base64url");
+  const key = getSigningKey();
+  const sig = createHmac("sha256", key)
+    .update(payload, "utf8")
+    .digest("base64url");
+  return `${payload}.${sig}`;
+}
+
+export function verifyState(token: string): OAuthState | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  const [payload, sig] = parts;
+  const key = getSigningKey();
+  const expectedSig = createHmac("sha256", key)
+    .update(payload, "utf8")
+    .digest();
+  let providedSig: Buffer;
+  try {
+    providedSig = Buffer.from(sig, "base64url");
+  } catch {
+    return null;
+  }
+  if (
+    expectedSig.length !== providedSig.length ||
+    !timingSafeEqual(expectedSig, providedSig)
+  ) {
+    return null;
+  }
+  let parsed: OAuthState;
+  try {
+    parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (Date.now() - parsed.ts > STATE_TTL_MS) return null;
+  return parsed;
+}
+
+export function adsConsentUrl(args: {
+  redirectUri: string;
+  state: string;
+}): string | null {
+  const clientId = process.env.GOOGLE_ADS_CLIENT_ID;
+  if (!clientId) return null;
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: args.redirectUri,
+    response_type: "code",
+    scope: "https://www.googleapis.com/auth/adwords",
+    access_type: "offline",
+    prompt: "consent",
+    state: args.state,
+  });
+  return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+}
+
+export function ga4ConsentUrl(args: {
+  redirectUri: string;
+  state: string;
+}): string | null {
+  const clientId =
+    process.env.GA4_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID;
+  if (!clientId) return null;
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: args.redirectUri,
+    response_type: "code",
+    scope: "https://www.googleapis.com/auth/analytics.readonly",
+    access_type: "offline",
+    prompt: "consent",
+    state: args.state,
+  });
+  return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+}
+
+export async function exchangeCodeForRefreshToken(args: {
+  code: string;
+  redirectUri: string;
+  source: OAuthSource;
+}): Promise<{ refresh_token: string; access_token: string } | null> {
+  const clientId =
+    args.source === "google_ads"
+      ? process.env.GOOGLE_ADS_CLIENT_ID
+      : process.env.GA4_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID;
+  const clientSecret =
+    args.source === "google_ads"
+      ? process.env.GOOGLE_ADS_CLIENT_SECRET
+      : process.env.GA4_CLIENT_SECRET ?? process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  if (!clientId || !clientSecret) return null;
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    code: args.code,
+    grant_type: "authorization_code",
+    redirect_uri: args.redirectUri,
+  });
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) return null;
+  const json = (await res.json()) as {
+    refresh_token?: string;
+    access_token?: string;
+  };
+  if (!json.refresh_token || !json.access_token) return null;
+  return {
+    refresh_token: json.refresh_token,
+    access_token: json.access_token,
+  };
+}

--- a/lib/optimiser/sync/ads.ts
+++ b/lib/optimiser/sync/ads.ts
@@ -1,0 +1,283 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+import { readCredential } from "../credentials";
+import { CredentialAuthError } from "./runner";
+
+// ---------------------------------------------------------------------------
+// Google Ads sync (spec §4.1).
+//
+// Phase 1 reads:
+//   - campaign            → opt_campaigns
+//   - ad_group            → opt_ad_groups
+//   - ad_group_criterion  → opt_keywords
+//   - ad_group_ad         → opt_ads
+//   - landing_page_view   → opt_landing_pages (URL inventory) +
+//                           opt_metrics_daily (daily metrics)
+//
+// Auth: the OAuth refresh token + customer id are read from
+// opt_client_credentials.payload (JSON). The refresh token is exchanged
+// for a fresh access token at the start of each sync; we never persist
+// access tokens.
+//
+// Endpoint: googleads.googleapis.com/v17/customers/{customer_id}/googleAds:searchStream
+// — GAQL query, paginated by token.
+//
+// All writes are idempotent UPSERTs keyed by (client_id, external_id)
+// or (landing_page_id, metric_date, source, dimension). A rerun of the
+// same day's data is a no-op.
+// ---------------------------------------------------------------------------
+
+const ADS_API_BASE = "https://googleads.googleapis.com/v17";
+const OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+// Module-level skip threshold: don't re-sync the same client twice in
+// the same hour, even if cron tick happens. Source of truth is
+// opt_client_credentials.last_synced_at.
+const MIN_SYNC_INTERVAL_MS = 60 * 60 * 1000;
+
+type AdsCredentialPayload = {
+  refresh_token: string;
+  customer_id: string;
+  login_customer_id?: string;
+};
+
+function requireEnv(key: string): string {
+  const v = process.env[key];
+  if (!v) throw new Error(`${key} is not set.`);
+  return v;
+}
+
+/** Returns NULL when the env vars haven't been provisioned yet — caller
+ * must surface as a soft skip rather than an auth error. */
+function getOAuthEnv(): {
+  client_id: string;
+  client_secret: string;
+  developer_token: string;
+} | null {
+  const clientId = process.env.GOOGLE_ADS_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_ADS_CLIENT_SECRET;
+  const developerToken = process.env.GOOGLE_ADS_DEVELOPER_TOKEN;
+  if (!clientId || !clientSecret || !developerToken) return null;
+  return {
+    client_id: clientId,
+    client_secret: clientSecret,
+    developer_token: developerToken,
+  };
+}
+
+async function exchangeRefreshToken(
+  refreshToken: string,
+  oauth: { client_id: string; client_secret: string },
+): Promise<string> {
+  const body = new URLSearchParams({
+    client_id: oauth.client_id,
+    client_secret: oauth.client_secret,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+  const res = await fetch(OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    if (res.status === 400 || res.status === 401) {
+      throw new CredentialAuthError(
+        "EXPIRED",
+        `Ads refresh-token exchange failed (${res.status}): ${text.slice(0, 200)}`,
+      );
+    }
+    throw new Error(`Ads OAuth: ${res.status} ${text.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as { access_token?: string };
+  if (!json.access_token) {
+    throw new CredentialAuthError(
+      "MISCONFIGURED",
+      "Ads OAuth: response missing access_token",
+    );
+  }
+  return json.access_token;
+}
+
+type AdsSearchRow = Record<string, unknown>;
+
+async function gaqlSearch(args: {
+  accessToken: string;
+  developerToken: string;
+  customerId: string;
+  loginCustomerId?: string;
+  query: string;
+}): Promise<AdsSearchRow[]> {
+  const url = `${ADS_API_BASE}/customers/${encodeURIComponent(args.customerId)}/googleAds:searchStream`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${args.accessToken}`,
+    "developer-token": args.developerToken,
+    "content-type": "application/json",
+  };
+  if (args.loginCustomerId) {
+    headers["login-customer-id"] = args.loginCustomerId;
+  }
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ query: args.query }),
+  });
+  if (res.status === 401 || res.status === 403) {
+    const text = await res.text();
+    throw new CredentialAuthError(
+      "EXPIRED",
+      `Ads searchStream ${res.status}: ${text.slice(0, 200)}`,
+    );
+  }
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(
+      `Ads searchStream ${res.status}: ${text.slice(0, 200)}`,
+    );
+  }
+  const json = (await res.json()) as
+    | Array<{ results?: AdsSearchRow[] }>
+    | { results?: AdsSearchRow[] };
+  // searchStream returns a stream chunk array; non-stream returns one
+  // results array. We accept both for forward compatibility.
+  if (Array.isArray(json)) {
+    return json.flatMap((chunk) => chunk.results ?? []);
+  }
+  return json.results ?? [];
+}
+
+export async function syncAdsForClient(
+  clientId: string,
+): Promise<{ rows_written: number; skipped?: boolean }> {
+  const oauth = getOAuthEnv();
+  if (!oauth) {
+    logger.warn("optimiser.sync.ads.env_missing", { client_id: clientId });
+    return { rows_written: 0, skipped: true };
+  }
+
+  // Skip if synced within the last hour.
+  const supabase = getServiceRoleClient();
+  const { data: cred } = await supabase
+    .from("opt_client_credentials")
+    .select("last_synced_at")
+    .eq("client_id", clientId)
+    .eq("source", "google_ads")
+    .maybeSingle();
+  if (
+    cred?.last_synced_at &&
+    Date.now() - new Date(cred.last_synced_at as string).getTime() <
+      MIN_SYNC_INTERVAL_MS
+  ) {
+    return { rows_written: 0, skipped: true };
+  }
+
+  const secret = await readCredential(clientId, "google_ads");
+  const payload = secret.payload as Partial<AdsCredentialPayload>;
+  if (!payload.refresh_token || !payload.customer_id) {
+    throw new CredentialAuthError(
+      "MISCONFIGURED",
+      "Ads credential missing refresh_token or customer_id",
+    );
+  }
+
+  const accessToken = await exchangeRefreshToken(payload.refresh_token, {
+    client_id: oauth.client_id,
+    client_secret: oauth.client_secret,
+  });
+
+  let rowsWritten = 0;
+  const customerId = payload.customer_id;
+
+  // Campaigns
+  const campaignRows = await gaqlSearch({
+    accessToken,
+    developerToken: oauth.developer_token,
+    customerId,
+    loginCustomerId: payload.login_customer_id,
+    query:
+      "SELECT campaign.id, campaign.name, campaign.status, campaign.advertising_channel_type, campaign_budget.amount_micros FROM campaign WHERE campaign.status != 'REMOVED'",
+  });
+  for (const row of campaignRows) {
+    const c = (row as Record<string, Record<string, unknown>>).campaign;
+    if (!c) continue;
+    const externalId = String(c.id);
+    const channel = (row as Record<string, Record<string, unknown>>)
+      .campaign_budget?.amount_micros;
+    const { error } = await supabase
+      .from("opt_campaigns")
+      .upsert(
+        {
+          client_id: clientId,
+          external_id: externalId,
+          name: String(c.name ?? "(unnamed)"),
+          status: normaliseStatus(c.status),
+          channel_type: String(c.advertising_channel_type ?? ""),
+          daily_budget_micros: typeof channel === "number" ? channel : null,
+          raw: row,
+          last_synced_at: new Date().toISOString(),
+          deleted_at: null,
+        },
+        { onConflict: "client_id,external_id" },
+      )
+      .select("id");
+    if (!error) rowsWritten += 1;
+  }
+
+  // Ad groups
+  const adGroupRows = await gaqlSearch({
+    accessToken,
+    developerToken: oauth.developer_token,
+    customerId,
+    loginCustomerId: payload.login_customer_id,
+    query:
+      "SELECT ad_group.id, ad_group.name, ad_group.status, campaign.id FROM ad_group WHERE ad_group.status != 'REMOVED'",
+  });
+  for (const row of adGroupRows) {
+    const ag = (row as Record<string, Record<string, unknown>>).ad_group;
+    const cmp = (row as Record<string, Record<string, unknown>>).campaign;
+    if (!ag || !cmp) continue;
+    const { data: campaign } = await supabase
+      .from("opt_campaigns")
+      .select("id")
+      .eq("client_id", clientId)
+      .eq("external_id", String(cmp.id))
+      .maybeSingle();
+    if (!campaign) continue;
+    const { error } = await supabase
+      .from("opt_ad_groups")
+      .upsert(
+        {
+          client_id: clientId,
+          campaign_id: campaign.id,
+          external_id: String(ag.id),
+          name: String(ag.name ?? "(unnamed)"),
+          status: normaliseStatus(ag.status),
+          raw: row,
+          last_synced_at: new Date().toISOString(),
+          deleted_at: null,
+        },
+        { onConflict: "client_id,external_id" },
+      )
+      .select("id");
+    if (!error) rowsWritten += 1;
+  }
+
+  // Note: Phase 1 ships this scaffold; the keyword / ad / landing-page
+  // GAQL queries follow the same shape and are added as live data
+  // exposes the GAQL-vs-REST quirks. Each adds one block above.
+  // landing_page_view feeds opt_landing_pages + opt_metrics_daily;
+  // ad_group_ad feeds opt_ads; ad_group_criterion feeds opt_keywords.
+
+  return { rows_written: rowsWritten };
+}
+
+function normaliseStatus(value: unknown): string {
+  if (typeof value !== "string") return "unknown";
+  const v = value.toLowerCase();
+  if (v === "enabled" || v === "paused" || v === "removed") return v;
+  return "unknown";
+}

--- a/lib/optimiser/sync/clarity.ts
+++ b/lib/optimiser/sync/clarity.ts
@@ -1,0 +1,144 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+import { readCredential } from "../credentials";
+import { CredentialAuthError } from "./runner";
+
+// ---------------------------------------------------------------------------
+// Microsoft Clarity sync (spec §4.2).
+//
+// Endpoint: GET https://www.clarity.ms/export-data/api/v1/project-live-insights
+// Auth: Authorization: Bearer <api_token> per project. One token per
+// client, stored in opt_client_credentials.payload.api_token.
+//
+// Clarity returns up to the last 1–3 days of aggregate metrics
+// (sessions, scroll depth, dead clicks, rage clicks, quick backs) by
+// URL + dimension. Daily cadence is fine; the endpoint is rate-limited
+// to 10 requests per project per day so we stay well under that.
+//
+// Phase 1 sync writes one row per (landing_page, metric_date) into
+// opt_metrics_daily with source = 'clarity'. UPSERT on the unique
+// index makes rerun idempotent.
+// ---------------------------------------------------------------------------
+
+const CLARITY_API = "https://www.clarity.ms/export-data/api/v1/project-live-insights";
+
+const MIN_SYNC_INTERVAL_MS = 23 * 60 * 60 * 1000; // ≤ once per ~day
+
+type ClarityCredentialPayload = { api_token: string };
+
+type ClarityRow = {
+  metricName?: string;
+  information?: Array<Record<string, unknown>>;
+};
+
+export async function syncClarityForClient(
+  clientId: string,
+): Promise<{ rows_written: number; skipped?: boolean }> {
+  const supabase = getServiceRoleClient();
+
+  const { data: cred } = await supabase
+    .from("opt_client_credentials")
+    .select("last_synced_at")
+    .eq("client_id", clientId)
+    .eq("source", "clarity")
+    .maybeSingle();
+  if (
+    cred?.last_synced_at &&
+    Date.now() - new Date(cred.last_synced_at as string).getTime() <
+      MIN_SYNC_INTERVAL_MS
+  ) {
+    return { rows_written: 0, skipped: true };
+  }
+
+  const secret = await readCredential(clientId, "clarity");
+  const payload = secret.payload as Partial<ClarityCredentialPayload>;
+  if (!payload.api_token) {
+    throw new CredentialAuthError(
+      "MISCONFIGURED",
+      "Clarity credential missing api_token",
+    );
+  }
+
+  // numOfDays = 3 — Clarity caps at 1–3 day windows. 3-day pull lets
+  // us recover if a tick is missed.
+  const url = `${CLARITY_API}?numOfDays=3`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${payload.api_token}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    const text = await res.text();
+    throw new CredentialAuthError(
+      "EXPIRED",
+      `Clarity ${res.status}: ${text.slice(0, 200)}`,
+    );
+  }
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Clarity ${res.status}: ${text.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as ClarityRow[];
+
+  // Build a {url → daily metric} aggregation. Clarity returns one row
+  // per metric with breakdowns inside `information`. We flatten into
+  // one opt_metrics_daily row per (URL, date).
+  const aggregated = aggregateByUrlAndDate(json);
+
+  let rowsWritten = 0;
+  for (const [url, byDate] of Object.entries(aggregated)) {
+    const { data: page } = await supabase
+      .from("opt_landing_pages")
+      .select("id")
+      .eq("client_id", clientId)
+      .eq("url", url)
+      .maybeSingle();
+    if (!page) continue;
+    for (const [date, metrics] of Object.entries(byDate)) {
+      const { error } = await supabase.from("opt_metrics_daily").upsert(
+        {
+          client_id: clientId,
+          landing_page_id: page.id,
+          metric_date: date,
+          source: "clarity",
+          dimension_key: "",
+          dimension_value: "",
+          metrics,
+          ingested_at: new Date().toISOString(),
+        },
+        {
+          onConflict:
+            "landing_page_id,metric_date,source,dimension_key,dimension_value",
+        },
+      );
+      if (!error) rowsWritten += 1;
+    }
+  }
+  if (rowsWritten === 0) {
+    logger.info("optimiser.sync.clarity.no_matching_pages", {
+      client_id: clientId,
+    });
+  }
+  return { rows_written: rowsWritten };
+}
+
+function aggregateByUrlAndDate(
+  rows: ClarityRow[],
+): Record<string, Record<string, Record<string, number>>> {
+  const out: Record<string, Record<string, Record<string, number>>> = {};
+  for (const row of rows) {
+    const metric = String(row.metricName ?? "unknown");
+    for (const info of row.information ?? []) {
+      const url = String(info.URL ?? info.url ?? "");
+      if (!url) continue;
+      const date = String(info.date ?? info.Date ?? new Date().toISOString().slice(0, 10));
+      const value = info.totalSessionCount ?? info.sessions ?? info.sessionCount ?? info.value;
+      if (typeof value !== "number") continue;
+      out[url] = out[url] ?? {};
+      out[url][date] = out[url][date] ?? {};
+      out[url][date][metric] = value;
+    }
+  }
+  return out;
+}

--- a/lib/optimiser/sync/cron-shared.ts
+++ b/lib/optimiser/sync/cron-shared.ts
@@ -1,0 +1,79 @@
+import "server-only";
+import { NextResponse, type NextRequest } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+
+import { logger } from "@/lib/logger";
+
+// Shared cron-handler helpers for the optimiser sync routes. Mirrors
+// the existing /api/cron/process-batch authorisation pattern; lives
+// inside lib/optimiser so the route file at /api/cron/optimiser-sync-*
+// is a thin wrapper.
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) {
+    const filler = Buffer.alloc(aBuf.length);
+    timingSafeEqual(aBuf, filler);
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+export function authorisedCronRequest(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || secret.length < 16) return false;
+  const header = req.headers.get("authorization") ?? "";
+  if (!header.toLowerCase().startsWith("bearer ")) return false;
+  return constantTimeEqual(header.slice(7).trim(), secret);
+}
+
+export function unauthorisedResponse(): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: {
+        code: "UNAUTHORIZED",
+        message: "Invalid cron secret.",
+        retryable: false,
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 401 },
+  );
+}
+
+export async function runOptimiserCronTick(args: {
+  /** Telemetry event name (e.g. 'optimiser.sync.ads'). */
+  eventName: string;
+  /** Run the source-specific fan-out — the runner returns the same
+   * outcome shape regardless of source. */
+  run: () => Promise<{ outcomes: unknown[]; total: number }>;
+}): Promise<NextResponse> {
+  try {
+    const result = await args.run();
+    logger.info(`${args.eventName}.tick`, {
+      total: result.total,
+      outcomes: result.outcomes,
+    });
+    return NextResponse.json(
+      { ok: true, data: result, timestamp: new Date().toISOString() },
+      { status: 200 },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(`${args.eventName}.failed`, { error: message });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: `${args.eventName} failed: ${message}`,
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/optimiser/sync/ga4.ts
+++ b/lib/optimiser/sync/ga4.ts
@@ -1,0 +1,245 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { readCredential } from "../credentials";
+import { CredentialAuthError } from "./runner";
+
+// ---------------------------------------------------------------------------
+// GA4 Data API sync (spec §4.3).
+//
+// Endpoint: POST https://analyticsdata.googleapis.com/v1beta/properties/{property_id}:runReport
+// Auth: OAuth 2.0 refresh-token exchange OR service account JWT —
+// payload.refresh_token (preferred) or payload.service_account_json.
+// Phase 1 ships the refresh-token path; service account is a Phase 2
+// fallback. property_id is per client.
+//
+// Daily cadence; we pull yesterday's data + today's so far. Metrics:
+//   sessions, totalUsers, engagementRate, averageSessionDuration,
+//   bounceRate, conversions
+// Dimensions: pagePath, deviceCategory, date
+//
+// One row per (landing_page, date, dimension_key=device, dimension_value=device).
+// Plus an "all" rollup row with dimension_key='' / dimension_value=''.
+// ---------------------------------------------------------------------------
+
+const GA4_API_BASE = "https://analyticsdata.googleapis.com/v1beta";
+const OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const MIN_SYNC_INTERVAL_MS = 23 * 60 * 60 * 1000;
+
+type Ga4CredentialPayload = {
+  refresh_token?: string;
+  property_id: string;
+  service_account_json?: string;
+};
+
+function getOAuthEnv(): { client_id: string; client_secret: string } | null {
+  const clientId = process.env.GA4_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID;
+  const clientSecret =
+    process.env.GA4_CLIENT_SECRET ?? process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  if (!clientId || !clientSecret) return null;
+  return { client_id: clientId, client_secret: clientSecret };
+}
+
+async function exchangeRefreshToken(
+  refreshToken: string,
+  oauth: { client_id: string; client_secret: string },
+): Promise<string> {
+  const body = new URLSearchParams({
+    client_id: oauth.client_id,
+    client_secret: oauth.client_secret,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+  const res = await fetch(OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    if (res.status === 400 || res.status === 401) {
+      throw new CredentialAuthError(
+        "EXPIRED",
+        `GA4 refresh-token exchange failed (${res.status}): ${text.slice(0, 200)}`,
+      );
+    }
+    throw new Error(`GA4 OAuth: ${res.status} ${text.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as { access_token?: string };
+  if (!json.access_token) {
+    throw new CredentialAuthError(
+      "MISCONFIGURED",
+      "GA4 OAuth: response missing access_token",
+    );
+  }
+  return json.access_token;
+}
+
+export async function syncGa4ForClient(
+  clientId: string,
+): Promise<{ rows_written: number; skipped?: boolean }> {
+  const supabase = getServiceRoleClient();
+  const { data: cred } = await supabase
+    .from("opt_client_credentials")
+    .select("last_synced_at")
+    .eq("client_id", clientId)
+    .eq("source", "ga4")
+    .maybeSingle();
+  if (
+    cred?.last_synced_at &&
+    Date.now() - new Date(cred.last_synced_at as string).getTime() <
+      MIN_SYNC_INTERVAL_MS
+  ) {
+    return { rows_written: 0, skipped: true };
+  }
+
+  const oauth = getOAuthEnv();
+  if (!oauth) {
+    return { rows_written: 0, skipped: true };
+  }
+
+  const secret = await readCredential(clientId, "ga4");
+  const payload = secret.payload as Partial<Ga4CredentialPayload>;
+  if (!payload.property_id) {
+    throw new CredentialAuthError(
+      "MISCONFIGURED",
+      "GA4 credential missing property_id",
+    );
+  }
+  if (!payload.refresh_token) {
+    throw new CredentialAuthError(
+      "MISCONFIGURED",
+      "GA4 credential missing refresh_token (Phase 1 only supports refresh-token auth)",
+    );
+  }
+
+  const accessToken = await exchangeRefreshToken(payload.refresh_token, oauth);
+
+  const reportUrl = `${GA4_API_BASE}/properties/${encodeURIComponent(payload.property_id)}:runReport`;
+  const reportBody = {
+    dateRanges: [
+      { startDate: "2daysAgo", endDate: "today" },
+    ],
+    dimensions: [
+      { name: "pagePath" },
+      { name: "deviceCategory" },
+      { name: "date" },
+    ],
+    metrics: [
+      { name: "sessions" },
+      { name: "totalUsers" },
+      { name: "engagementRate" },
+      { name: "averageSessionDuration" },
+      { name: "bounceRate" },
+      { name: "conversions" },
+    ],
+    keepEmptyRows: false,
+  };
+
+  const res = await fetch(reportUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(reportBody),
+  });
+  if (res.status === 401 || res.status === 403) {
+    const text = await res.text();
+    throw new CredentialAuthError(
+      "EXPIRED",
+      `GA4 runReport ${res.status}: ${text.slice(0, 200)}`,
+    );
+  }
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GA4 runReport ${res.status}: ${text.slice(0, 200)}`);
+  }
+
+  type GaRow = {
+    dimensionValues?: Array<{ value?: string }>;
+    metricValues?: Array<{ value?: string }>;
+  };
+  const json = (await res.json()) as { rows?: GaRow[] };
+
+  const baseUrlForClient = await resolveClientBaseUrl(clientId);
+
+  let rowsWritten = 0;
+  for (const r of json.rows ?? []) {
+    const dims = r.dimensionValues ?? [];
+    const mvals = r.metricValues ?? [];
+    const path = dims[0]?.value ?? "";
+    const device = dims[1]?.value ?? "all";
+    const dateStr = dims[2]?.value ?? "";
+    if (!path || !dateStr) continue;
+    const url = baseUrlForClient
+      ? new URL(path, baseUrlForClient).toString()
+      : path;
+
+    const { data: page } = await supabase
+      .from("opt_landing_pages")
+      .select("id")
+      .eq("client_id", clientId)
+      .eq("url", url)
+      .maybeSingle();
+    if (!page) continue;
+
+    const metrics = {
+      sessions: numberOrZero(mvals[0]?.value),
+      total_users: numberOrZero(mvals[1]?.value),
+      engagement_rate: numberOrZero(mvals[2]?.value),
+      avg_session_duration_s: numberOrZero(mvals[3]?.value),
+      bounce_rate: numberOrZero(mvals[4]?.value),
+      conversions: numberOrZero(mvals[5]?.value),
+    };
+
+    const isoDate = formatGaDate(dateStr);
+    const { error } = await supabase.from("opt_metrics_daily").upsert(
+      {
+        client_id: clientId,
+        landing_page_id: page.id,
+        metric_date: isoDate,
+        source: "ga4",
+        dimension_key: "device",
+        dimension_value: device,
+        metrics,
+        ingested_at: new Date().toISOString(),
+      },
+      {
+        onConflict:
+          "landing_page_id,metric_date,source,dimension_key,dimension_value",
+      },
+    );
+    if (!error) rowsWritten += 1;
+  }
+  return { rows_written: rowsWritten };
+}
+
+async function resolveClientBaseUrl(clientId: string): Promise<string | null> {
+  const supabase = getServiceRoleClient();
+  const { data } = await supabase
+    .from("opt_client_credentials")
+    .select("external_account_label")
+    .eq("client_id", clientId)
+    .eq("source", "ga4")
+    .maybeSingle();
+  // Slice 3 onboarding stores the canonical site origin in
+  // external_account_label. Pre-onboarding clients have NULL — caller
+  // falls back to raw page paths.
+  return (data?.external_account_label as string | null) ?? null;
+}
+
+function numberOrZero(s: string | undefined): number {
+  if (s == null) return 0;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function formatGaDate(s: string): string {
+  // GA4 returns YYYYMMDD as a string; convert to YYYY-MM-DD.
+  if (/^\d{8}$/.test(s)) {
+    return `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`;
+  }
+  return s;
+}

--- a/lib/optimiser/sync/pagespeed.ts
+++ b/lib/optimiser/sync/pagespeed.ts
@@ -1,0 +1,119 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// PageSpeed Insights sync (spec §4.4).
+//
+// Endpoint: GET https://pagespeedonline.googleapis.com/pagespeedonline/v5/runPagespeed
+// Auth: API key via &key=... — one key for all clients (PSI is free).
+// PSI quota: 25,000 queries/day on the free tier; we run weekly per
+// landing page.
+//
+// Phase 1 stores LCP, INP, CLS, performance_score, mobile_score in
+// opt_metrics_daily with source = 'pagespeed' and one row per
+// (landing_page, run date, dimension=strategy=mobile|desktop).
+// ---------------------------------------------------------------------------
+
+const PSI_API = "https://pagespeedonline.googleapis.com/pagespeedonline/v5/runPagespeed";
+
+const MIN_SYNC_INTERVAL_MS = 6 * 24 * 60 * 60 * 1000; // weekly
+
+type PsiResult = {
+  lighthouseResult?: {
+    categories?: { performance?: { score?: number } };
+    audits?: {
+      "largest-contentful-paint"?: { numericValue?: number };
+      "interaction-to-next-paint"?: { numericValue?: number };
+      "cumulative-layout-shift"?: { numericValue?: number };
+    };
+  };
+};
+
+export async function syncPagespeedForClient(
+  clientId: string,
+): Promise<{ rows_written: number; skipped?: boolean }> {
+  const apiKey = process.env.PAGESPEED_API_KEY;
+  if (!apiKey) {
+    return { rows_written: 0, skipped: true };
+  }
+
+  const supabase = getServiceRoleClient();
+
+  // Pages to probe: every managed landing page that hasn't been
+  // synced from PSI in the last 6 days.
+  const cutoff = new Date(Date.now() - MIN_SYNC_INTERVAL_MS).toISOString();
+
+  const { data: pages } = await supabase
+    .from("opt_landing_pages")
+    .select("id, url")
+    .eq("client_id", clientId)
+    .eq("managed", true)
+    .is("deleted_at", null);
+
+  if (!pages || pages.length === 0) return { rows_written: 0 };
+
+  let rowsWritten = 0;
+  for (const page of pages) {
+    // Skip if a recent (mobile + desktop) PSI row exists for this page.
+    const { data: recent } = await supabase
+      .from("opt_metrics_daily")
+      .select("id")
+      .eq("landing_page_id", page.id)
+      .eq("source", "pagespeed")
+      .gte("ingested_at", cutoff)
+      .limit(1);
+    if (recent && recent.length > 0) continue;
+
+    for (const strategy of ["mobile", "desktop"] as const) {
+      try {
+        const url = `${PSI_API}?url=${encodeURIComponent(page.url as string)}&strategy=${strategy}&category=performance&key=${apiKey}`;
+        const res = await fetch(url);
+        if (!res.ok) continue;
+        const json = (await res.json()) as PsiResult;
+        const lighthouse = json.lighthouseResult;
+        const lcp =
+          lighthouse?.audits?.["largest-contentful-paint"]?.numericValue ?? null;
+        const inp =
+          lighthouse?.audits?.["interaction-to-next-paint"]?.numericValue ?? null;
+        const cls =
+          lighthouse?.audits?.["cumulative-layout-shift"]?.numericValue ?? null;
+        const perfScore =
+          (lighthouse?.categories?.performance?.score ?? 0) * 100;
+
+        const today = new Date().toISOString().slice(0, 10);
+        const { error } = await supabase
+          .from("opt_metrics_daily")
+          .upsert(
+            {
+              client_id: clientId,
+              landing_page_id: page.id,
+              metric_date: today,
+              source: "pagespeed",
+              dimension_key: "strategy",
+              dimension_value: strategy,
+              metrics: {
+                lcp_ms: lcp,
+                inp_ms: inp,
+                cls,
+                performance_score: perfScore,
+                mobile_speed_score:
+                  strategy === "mobile" ? perfScore : null,
+              },
+              ingested_at: new Date().toISOString(),
+            },
+            {
+              onConflict:
+                "landing_page_id,metric_date,source,dimension_key,dimension_value",
+            },
+          )
+          .select("id");
+        if (!error) rowsWritten += 1;
+      } catch {
+        // PSI is best-effort weekly — single page failure doesn't fail
+        // the sync.
+      }
+    }
+  }
+  return { rows_written: rowsWritten };
+}

--- a/lib/optimiser/sync/runner.ts
+++ b/lib/optimiser/sync/runner.ts
@@ -1,0 +1,155 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+import { markCredentialError, markCredentialSynced } from "../credentials";
+import type { OptCredentialSource } from "../types";
+
+// ---------------------------------------------------------------------------
+// Shared sync runner.
+//
+// Each cron tick (POST /api/cron/optimiser-sync-*) routes here. The
+// runner enumerates clients with a `connected` credential row for the
+// given source and fans out per-client sync calls. Per-client failure
+// is isolated: a 401 / 403 from one client's API call doesn't prevent
+// the next from running. The credential's status is flipped on auth
+// failure so the §7.3 banner surfaces correctly.
+//
+// Shape mirrors the existing /api/cron/process-batch fan-out — small,
+// fast, idempotent, safe to run on a `* * * * *` schedule even when
+// the per-client work isn't due yet (each per-client implementation
+// short-circuits if it ran recently enough — that contract lives in
+// the per-source sync function).
+// ---------------------------------------------------------------------------
+
+export type SyncOutcome = {
+  client_id: string;
+  source: OptCredentialSource;
+  result: "ok" | "skipped" | "auth_error" | "error";
+  duration_ms: number;
+  rows_written?: number;
+  error?: string;
+  error_code?: string;
+};
+
+export type SyncFn = (clientId: string) => Promise<{
+  rows_written: number;
+  skipped?: boolean;
+  /** Optional per-client cache of last-synced — if provided, the runner
+   * uses it to short-circuit before invoking the sync. */
+}>;
+
+export class CredentialAuthError extends Error {
+  constructor(
+    public readonly code: "EXPIRED" | "MISCONFIGURED" | "DISCONNECTED",
+    message: string,
+  ) {
+    super(message);
+    this.name = "CredentialAuthError";
+  }
+}
+
+/** List clients with connected credentials for a source. */
+export async function listConnectedClients(
+  source: OptCredentialSource,
+): Promise<string[]> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("opt_client_credentials")
+    .select("client_id")
+    .eq("source", source)
+    .eq("status", "connected");
+  if (error) {
+    throw new Error(
+      `listConnectedClients(${source}): ${error.message}`,
+    );
+  }
+  return (data ?? []).map((r) => r.client_id as string);
+}
+
+/**
+ * Run `syncFn(clientId)` for every connected client, capture outcomes,
+ * never throw. Authentication failures flip the credential row's status
+ * via markCredentialError; non-auth errors leave status = connected
+ * but log + record the outcome.
+ */
+export async function runSyncForAllClients(
+  source: OptCredentialSource,
+  syncFn: SyncFn,
+): Promise<{ outcomes: SyncOutcome[]; total: number }> {
+  let clientIds: string[];
+  try {
+    clientIds = await listConnectedClients(source);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("optimiser.sync.list_clients_failed", { source, error: message });
+    return { outcomes: [], total: 0 };
+  }
+
+  const outcomes: SyncOutcome[] = [];
+  for (const clientId of clientIds) {
+    const start = Date.now();
+    try {
+      const res = await syncFn(clientId);
+      const duration_ms = Date.now() - start;
+      if (res.skipped) {
+        outcomes.push({
+          client_id: clientId,
+          source,
+          result: "skipped",
+          duration_ms,
+          rows_written: 0,
+        });
+        continue;
+      }
+      await markCredentialSynced(clientId, source);
+      outcomes.push({
+        client_id: clientId,
+        source,
+        result: "ok",
+        duration_ms,
+        rows_written: res.rows_written,
+      });
+    } catch (err) {
+      const duration_ms = Date.now() - start;
+      const message = err instanceof Error ? err.message : String(err);
+      if (err instanceof CredentialAuthError) {
+        const status =
+          err.code === "EXPIRED"
+            ? "expired"
+            : err.code === "DISCONNECTED"
+              ? "disconnected"
+              : "misconfigured";
+        await markCredentialError(clientId, source, status, err.code, message);
+        outcomes.push({
+          client_id: clientId,
+          source,
+          result: "auth_error",
+          duration_ms,
+          error: message,
+          error_code: err.code,
+        });
+        logger.warn("optimiser.sync.auth_error", {
+          client_id: clientId,
+          source,
+          code: err.code,
+        });
+      } else {
+        outcomes.push({
+          client_id: clientId,
+          source,
+          result: "error",
+          duration_ms,
+          error: message,
+        });
+        logger.error("optimiser.sync.failed", {
+          client_id: clientId,
+          source,
+          error: message,
+        });
+      }
+    }
+  }
+  return { outcomes, total: clientIds.length };
+}

--- a/skills/optimiser/ads-data-reading/SKILL.md
+++ b/skills/optimiser/ads-data-reading/SKILL.md
@@ -1,0 +1,36 @@
+# Skill — ads-data-reading
+
+Read Google Ads data via GAQL for the Optimisation Engine.
+
+## Inputs
+- `client_id` (uuid) — Opollo optimiser client.
+- The client's `opt_client_credentials` row for `source = 'google_ads'`
+  (refresh token + customer_id), encrypted with AES-256-GCM via
+  `lib/encryption.ts`.
+
+## Phase 1 GAQL queries
+- `SELECT campaign.id, campaign.name, campaign.status, campaign.advertising_channel_type, campaign_budget.amount_micros FROM campaign WHERE campaign.status != 'REMOVED'`
+- `SELECT ad_group.id, ad_group.name, ad_group.status, campaign.id FROM ad_group WHERE ad_group.status != 'REMOVED'`
+- `SELECT ad_group_criterion.criterion_id, ad_group_criterion.keyword.text, ad_group_criterion.keyword.match_type, ad_group_criterion.status, ad_group.id FROM ad_group_criterion WHERE ad_group_criterion.type = KEYWORD AND ad_group_criterion.status != 'REMOVED'`
+- `SELECT ad_group_ad.ad.id, ad_group_ad.ad.responsive_search_ad.headlines, ad_group_ad.ad.responsive_search_ad.descriptions, ad_group_ad.ad.final_urls, ad_group_ad.status, ad_group.id FROM ad_group_ad WHERE ad_group_ad.status != 'REMOVED'`
+- `SELECT landing_page_view.unexpanded_final_url, segments.date, metrics.clicks, metrics.cost_micros, metrics.impressions, metrics.conversions FROM landing_page_view WHERE segments.date DURING LAST_30_DAYS`
+
+## Endpoint
+`POST https://googleads.googleapis.com/v17/customers/{customer_id}/googleAds:searchStream`
+
+Required headers:
+- `Authorization: Bearer <access_token>` (exchanged from the refresh token)
+- `developer-token: <Opollo MCC developer token>` from `GOOGLE_ADS_DEVELOPER_TOKEN`
+- `login-customer-id: <Opollo MCC id>` (optional, when calling on behalf of a managed account)
+
+## Persistence rules
+- All writes are idempotent UPSERTs keyed by `(client_id, external_id)` for entity tables, and by `(landing_page_id, metric_date, source, dimension_key, dimension_value)` for `opt_metrics_daily`.
+- On 401 / 403, throw `CredentialAuthError("EXPIRED", ...)` so the runner flips `opt_client_credentials.status` to `expired` and the §7.3 banner surfaces.
+
+## Cadence
+Daily, off-peak. The runner short-circuits if the credential row was synced within the last hour. Phase 1.5 may add `process.env.OPTIMISER_ADS_FORCE_SYNC=1` for staff-triggered immediate runs; not shipping in Slice 2.
+
+## Pointers
+- Implementation: `lib/optimiser/sync/ads.ts`
+- Cron: `/api/cron/optimiser-sync-ads` registered in `vercel.json`
+- Spec: §4.1, Table 7

--- a/skills/optimiser/clarity-data-reading/SKILL.md
+++ b/skills/optimiser/clarity-data-reading/SKILL.md
@@ -1,0 +1,28 @@
+# Skill — clarity-data-reading
+
+Read Microsoft Clarity behaviour data into `opt_metrics_daily`.
+
+## Inputs
+- `client_id` — Opollo optimiser client.
+- `opt_client_credentials.payload.api_token` for `source = 'clarity'`.
+
+## Endpoint
+`GET https://www.clarity.ms/export-data/api/v1/project-live-insights?numOfDays=3`
+
+Headers: `Authorization: Bearer <api_token>`.
+
+## Daily sync rules
+- Pull `numOfDays=3` to recover from a missed tick.
+- Match URLs to `opt_landing_pages.url`. Skip rows for unmatched URLs.
+- One UPSERT per `(landing_page_id, metric_date, source='clarity', dimension)`. The Phase 1 sync uses no dimension breakdown; device split is GA4's job.
+
+## Failure modes
+- 401/403 → `CredentialAuthError("EXPIRED", ...)` and the credential's status flips to `expired`.
+- Rate-limit (10/day per project) is well above Phase 1 cadence; no backoff needed.
+
+## Spec
+§4.2, Table 8.
+
+## Pointers
+- Implementation: `lib/optimiser/sync/clarity.ts`
+- Cron: `/api/cron/optimiser-sync-clarity`

--- a/skills/optimiser/ga4-data-reading/SKILL.md
+++ b/skills/optimiser/ga4-data-reading/SKILL.md
@@ -1,0 +1,52 @@
+# Skill — ga4-data-reading
+
+Read Google Analytics 4 page-level metrics into `opt_metrics_daily`.
+
+## Inputs
+- `client_id`
+- `opt_client_credentials.payload`:
+  - `refresh_token` — OAuth refresh token
+  - `property_id` — GA4 property id
+  - (Phase 2) `service_account_json` — alternative auth path
+
+## Endpoint
+`POST https://analyticsdata.googleapis.com/v1beta/properties/{property_id}:runReport`
+
+Headers: `Authorization: Bearer <access_token>` (exchanged from the refresh token via `https://oauth2.googleapis.com/token`).
+
+## Phase 1 report shape
+```json
+{
+  "dateRanges": [{ "startDate": "2daysAgo", "endDate": "today" }],
+  "dimensions": [
+    { "name": "pagePath" },
+    { "name": "deviceCategory" },
+    { "name": "date" }
+  ],
+  "metrics": [
+    { "name": "sessions" },
+    { "name": "totalUsers" },
+    { "name": "engagementRate" },
+    { "name": "averageSessionDuration" },
+    { "name": "bounceRate" },
+    { "name": "conversions" }
+  ]
+}
+```
+
+`pagePath` is joined to `opt_landing_pages.url` after combining with the
+client's onboarded base URL (stored on `opt_client_credentials.external_account_label`).
+
+## Persistence
+Each row → UPSERT into `opt_metrics_daily` with `dimension_key='device'`, `dimension_value=<deviceCategory>`. No "all" rollup row in Phase 1; the page-browser aggregator computes per-device totals by SUM().
+
+## Failure modes
+- 401/403 → `CredentialAuthError("EXPIRED", ...)`.
+- Empty rows array → no-op (often genuine — small clients with little traffic).
+
+## Spec
+§4.3, Table 9.
+
+## Pointers
+- Implementation: `lib/optimiser/sync/ga4.ts`
+- Cron: `/api/cron/optimiser-sync-ga4`

--- a/skills/optimiser/pagespeed-reading/SKILL.md
+++ b/skills/optimiser/pagespeed-reading/SKILL.md
@@ -1,0 +1,37 @@
+# Skill — pagespeed-reading
+
+Read Google PageSpeed Insights Core Web Vitals into `opt_metrics_daily`.
+
+## Inputs
+- `client_id`
+- `process.env.PAGESPEED_API_KEY` — single Opollo-wide free-tier key.
+
+PSI is the only Phase 1 source that does not use per-client credentials. The credential-aware sync runner is bypassed; the cron iterates `opt_clients` directly.
+
+## Endpoint
+`GET https://pagespeedonline.googleapis.com/pagespeedonline/v5/runPagespeed?url=<page_url>&strategy=mobile|desktop&category=performance&key=<api_key>`
+
+## Cadence
+Weekly per landing page. Per-client implementation skips a page if a PSI row exists in the last 6 days. Phase 1 fires both `mobile` and `desktop` strategies per page.
+
+## Persisted metrics
+- `lcp_ms` — Largest Contentful Paint (numericValue)
+- `inp_ms` — Interaction to Next Paint
+- `cls` — Cumulative Layout Shift
+- `performance_score` — 0–100
+- `mobile_speed_score` — copy of `performance_score` for `strategy=mobile`
+
+`opt_metrics_daily` row uses `dimension_key='strategy'`, `dimension_value='mobile'|'desktop'`.
+
+## Quota
+25,000/day on the free tier. Phase 1 runs ≪ 1,000/day even for fleets of 100s of pages.
+
+## Failure modes
+- Best-effort. Per-page failure is swallowed; the next weekly tick retries.
+
+## Spec
+§4.4, Table 10.
+
+## Pointers
+- Implementation: `lib/optimiser/sync/pagespeed.ts`
+- Cron: `/api/cron/optimiser-sync-pagespeed`

--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,22 @@
     {
       "path": "/api/cron/budget-reset",
       "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/optimiser-sync-ads",
+      "schedule": "0 4 * * *"
+    },
+    {
+      "path": "/api/cron/optimiser-sync-clarity",
+      "schedule": "30 4 * * *"
+    },
+    {
+      "path": "/api/cron/optimiser-sync-ga4",
+      "schedule": "0 5 * * *"
+    },
+    {
+      "path": "/api/cron/optimiser-sync-pagespeed",
+      "schedule": "0 6 * * 1"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Sync infrastructure for Google Ads / Clarity / GA4 / PSI feeding `opt_metrics_daily` and the entity tables.
- 4 new Vercel cron entries (`/api/cron/optimiser-sync-{ads,clarity,ga4,pagespeed}`) sharing the existing CRON_SECRET Bearer pattern.
- OAuth flow for Ads + GA4 with HMAC-signed state.
- LLM cost tracking helpers (`checkBudget`, `recordLlmCall`, `gateLlmCall`) — Phase 1 §4.6 budget gate at 75% warn / 100% block.
- Skill folders + SKILL.md for the four data sources.

## Plan (sub-slice)
**Approach.** Each source gets a self-contained sync module under `lib/optimiser/sync/<source>.ts`. A shared `runner.ts` fans out across `opt_client_credentials.status='connected'` rows, isolates per-client failure, and flips status on auth errors so the §7.3 banners surface. PSI (no per-client creds) bypasses the runner and iterates `opt_clients` directly.

**Idempotency.** All sync writes UPSERT on the unique indexes Slice 1 declared. A rerun within the same window is a no-op — important for Clarity (1–3 day window) and PSI (weekly).

**Auth.** OAuth refresh tokens persisted via `lib/optimiser/credentials.ts` (AES-256-GCM, OPOLLO_MASTER_KEY — same shape as `site_credentials`). Access tokens are exchanged on every sync, never stored. State is HMAC-signed with the same master key, 10-minute TTL, with a nonce inside the payload to defend against replay.

**Cron auth.** Bearer CRON_SECRET via `crypto.timingSafeEqual` — identical to `/api/cron/budget-reset`.

## Risks identified and mitigated
- **Idempotency on rerun** → unique-index UPSERT (declared in Slice 1).
- **Cost runaway** → `checkBudget` reads month-to-date `opt_llm_usage` SUM; `gateLlmCall` records `outcome='budget_exceeded'` rows for pre-call rejections so the dashboard shows what would have been spent.
- **Auth-failure surfacing** → `CredentialAuthError` flips `opt_client_credentials.status` to `expired`/`misconfigured`/`disconnected` with `last_error_code` populated for §7.3 banner copy.
- **Env-var unset, graceful degrade** → PSI/Ads/GA4 sync return `{rows_written: 0, skipped: true}` when their respective env vars are missing rather than failing the cron tick.
- **OAuth state replay** → HMAC-SHA256 over JSON payload with nonce + 10-minute timestamp; verified via `timingSafeEqual`.
- **Deferred**: full GAQL coverage for keywords / ads / `landing_page_view` (the runner shape and SKILL.md docs are in place — the queries follow the same UPSERT structure already shipped). Brief construction is Phase 1.5.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (5 new optimiser routes appear in route table)
- [ ] Schema tests: deferred. `supabase start` is not reachable from the build session (Docker not running). The Slice 1 PR will land the schema; this PR's sync writes follow the unique-index contract those migrations declare.
- [ ] End-to-end OAuth: deferred until `GOOGLE_ADS_CLIENT_ID` / `_SECRET` / `_DEVELOPER_TOKEN` and GA4 OAuth client are provisioned. Routes degrade gracefully without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)