### PR TITLE
feat(optimiser-8): wire LLM hybrid pass for ad_to_page_match + intent_match

### DIFF
--- a/lib/optimiser/index.ts
+++ b/lib/optimiser/index.ts
@@ -164,3 +164,11 @@ export type { EmailPayload, SendResult } from "./email/send";
 
 export { planDigests, sendDigest } from "./email/digests";
 export type { DigestKind, DigestDecision, DigestSendResult } from "./email/digests";
+
+// Slice 8 surface
+export { scoreAlignmentLlm } from "./llm-alignment";
+export type {
+  LlmAlignmentInputs,
+  LlmAlignmentResult,
+  LlmSubscoreResult,
+} from "./llm-alignment";

--- a/lib/optimiser/llm-alignment.ts
+++ b/lib/optimiser/llm-alignment.ts
@@ -1,0 +1,360 @@
+import "server-only";
+
+import { defaultAnthropicCall, type AnthropicCallFn } from "@/lib/anthropic-call";
+import { computeCostCents } from "@/lib/anthropic-pricing";
+import { logger } from "@/lib/logger";
+
+import { gateLlmCall, recordLlmCall } from "./llm-usage";
+import type { PageSnapshot } from "./page-content-analysis";
+
+// ---------------------------------------------------------------------------
+// LLM-augmented sub-scoring for alignment (spec §8 "rules + LLM hybrid").
+//
+// Slice 5 shipped rules-only. Slice 8 wires the LLM augmentation for the
+// two sub-scores that genuinely need semantic judgement:
+//
+//   1. ad_to_page_match — does the ad's headline + description match
+//      the landing page's above-fold content? Token overlap (rules)
+//      misses "managed IT services" ≈ "IT support" ≈ "managed IT
+//      solutions"; LLM closes the semantic gap.
+//
+//   2. intent_match — informational vs. transactional vs. navigational
+//      classification of the top search terms vs. the page type. The
+//      rules pass uses lexical signals ("how to" / "buy"); LLM
+//      classifies the corpus as a whole.
+//
+// Keyword relevance, CTA consistency, and offer clarity stay rules-
+// only — the deterministic checks are accurate enough on those and an
+// LLM call would burn budget for marginal lift.
+//
+// Budget enforcement (spec §4.6):
+//   - Every call goes through gateLlmCall(clientId, caller).
+//   - 75% warn → call still proceeds, dashboard banner reads from
+//     checkBudget independently.
+//   - 100% block → both sub-scores fall back to rules-only and the
+//     confidence_factor's signal sub-factor is multiplied by 0.7 by
+//     the caller (lib/optimiser/score-pages-job.ts wires this).
+//
+// Caching (spec §7.3 — "alignment scores cached per (ad group, page
+// version, behaviour-data window)"): the caller checks
+// opt_alignment_scores.input_fingerprint against the freshly-computed
+// fingerprint. Match → skip scoring entirely, reuse the existing row.
+// This keeps Phase 1 LLM cost predictable: one call per (ad group,
+// page version) per behaviour window, not one per cron tick.
+// ---------------------------------------------------------------------------
+
+const LLM_MODEL = "claude-sonnet-4-6";
+
+export type LlmSubscoreResult = {
+  /** 0–100. Always set, even on fallback. */
+  score: number;
+  /** One-line rationale for the review pane. */
+  rationale: string;
+  /** TRUE if the value was produced by the LLM; FALSE if budget /
+   * error fallback. The caller penalises the confidence signal when
+   * source = 'rules_fallback'. */
+  source: "llm" | "rules_fallback";
+  /** Fallback reason when source = 'rules_fallback'. */
+  fallback_reason?: "budget_exceeded" | "llm_error" | "parse_failed";
+};
+
+export type LlmAlignmentInputs = {
+  clientId: string;
+  adGroupId: string;
+  landingPageId: string;
+  snapshot: PageSnapshot;
+  adHeadlines: string[];
+  adDescriptions: string[];
+  searchTerms: string[];
+  /** Rules-derived score the LLM call returned to (for fallback). */
+  rulesAdToPageMatch: number;
+  rulesIntentMatch: number;
+  /** Test injection point — production paths leave undefined. */
+  callFn?: AnthropicCallFn;
+};
+
+export type LlmAlignmentResult = {
+  ad_to_page_match: LlmSubscoreResult;
+  intent_match: LlmSubscoreResult;
+  /** TRUE if either sub-score fell back to rules. The caller multiplies
+   * the alignment confidence's signal sub-factor by 0.7 when this is true. */
+  fallback_engaged: boolean;
+};
+
+const ADP_SYSTEM = `You are an alignment-scoring assistant for a landing-page optimisation engine.
+
+You score how closely a Google Ads ad's headlines + descriptions match the landing page's above-fold content. Return a JSON object only — no prose, no markdown fences.
+
+Rubric (0–100):
+- 90–100: Ad and page convey the same value proposition, audience, and product/service. Wording differs but meaning aligns.
+- 70–89: Same domain and audience; some specific claims in the ad aren't reflected on the page.
+- 50–69: Same broad category, different specifics. Visitor would feel a noticeable shift.
+- 30–49: Mismatched audience or offer specifics. Likely to bounce.
+- 0–29: Different product or audience entirely.
+
+Output schema:
+{
+  "score": <integer 0-100>,
+  "rationale": "<one-sentence reason, no quotes>"
+}`;
+
+const INTENT_SYSTEM = `You classify search-term intent and assess whether a landing page satisfies it.
+
+Possible intents: "informational" (user wants to learn), "transactional" (user wants to buy / sign up / book), "navigational" (user wants a specific brand or page).
+
+Score 0–100 for how well the page satisfies the dominant intent of the search-term sample.
+
+Rubric:
+- 90–100: Intent and page type match cleanly (transactional intent + form-led conversion page; informational intent + content-led page).
+- 60–89: Generally aligned, with mismatched secondary signals.
+- 30–59: Partial overlap — the page may serve a related but different intent.
+- 0–29: Page actively works against the dominant intent.
+
+Output schema:
+{
+  "score": <integer 0-100>,
+  "intent": "informational" | "transactional" | "navigational" | "mixed",
+  "rationale": "<one-sentence reason, no quotes>"
+}`;
+
+const ADP_INPUT_TEMPLATE = (
+  ad_headlines: string[],
+  ad_descriptions: string[],
+  page: PageSnapshot,
+) =>
+  `Ad headlines:
+${ad_headlines.slice(0, 5).map((h) => `- ${truncate(h, 90)}`).join("\n")}
+
+Ad descriptions:
+${ad_descriptions.slice(0, 3).map((d) => `- ${truncate(d, 180)}`).join("\n")}
+
+Landing page:
+- Title: ${truncate(page.title ?? "(missing)", 120)}
+- H1: ${truncate(page.h1 ?? "(missing)", 120)}
+- H2s:
+${(page.h2s ?? []).slice(0, 5).map((h) => `  - ${truncate(h, 120)}`).join("\n")}
+- Primary CTA: ${truncate(page.primary_cta?.text ?? "(missing)", 80)}
+- Hero excerpt: ${truncate(page.hero_excerpt ?? "(missing)", 600)}
+
+Score the ad-to-page match per the rubric. Return JSON only.`;
+
+const INTENT_INPUT_TEMPLATE = (
+  search_terms: string[],
+  page: PageSnapshot,
+) =>
+  `Top search terms (sorted by impressions, may be empty):
+${(search_terms.length === 0 ? ["(none — no search-term data yet)"] : search_terms.slice(0, 30).map((t) => `- ${truncate(t, 120)}`)).join("\n")}
+
+Landing page:
+- Title: ${truncate(page.title ?? "(missing)", 120)}
+- H1: ${truncate(page.h1 ?? "(missing)", 120)}
+- Primary CTA verb: ${page.primary_cta?.verb ?? "(none)"}
+- Has form: ${page.has_form ? "yes" : "no"}
+- Form field count: ${page.form_field_count}
+
+Classify the dominant intent of the search-term sample and score how well the page satisfies it. Return JSON only.`;
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + "…";
+}
+
+export async function scoreAlignmentLlm(
+  inputs: LlmAlignmentInputs,
+): Promise<LlmAlignmentResult> {
+  const callFn = inputs.callFn ?? defaultAnthropicCall;
+  const gate = await gateLlmCall(inputs.clientId, "alignment_scoring");
+  if (gate === "block") {
+    // Budget exceeded — return rules-only with a fallback flag.
+    return {
+      ad_to_page_match: {
+        score: inputs.rulesAdToPageMatch,
+        rationale: "Budget exhausted — rules-only fallback.",
+        source: "rules_fallback",
+        fallback_reason: "budget_exceeded",
+      },
+      intent_match: {
+        score: inputs.rulesIntentMatch,
+        rationale: "Budget exhausted — rules-only fallback.",
+        source: "rules_fallback",
+        fallback_reason: "budget_exceeded",
+      },
+      fallback_engaged: true,
+    };
+  }
+
+  const [adp, intent] = await Promise.all([
+    scoreOne({
+      callFn,
+      clientId: inputs.clientId,
+      caller: "alignment_scoring",
+      system: ADP_SYSTEM,
+      user: ADP_INPUT_TEMPLATE(
+        inputs.adHeadlines,
+        inputs.adDescriptions,
+        inputs.snapshot,
+      ),
+      idempotencyKey: `${inputs.adGroupId}:${inputs.landingPageId}:adp:${behaviourBucket()}`,
+      sourceTable: "opt_alignment_scores",
+      sourceId: undefined,
+      rulesScore: inputs.rulesAdToPageMatch,
+      expectKeys: ["score", "rationale"],
+    }),
+    scoreOne({
+      callFn,
+      clientId: inputs.clientId,
+      caller: "alignment_scoring",
+      system: INTENT_SYSTEM,
+      user: INTENT_INPUT_TEMPLATE(inputs.searchTerms, inputs.snapshot),
+      idempotencyKey: `${inputs.adGroupId}:${inputs.landingPageId}:intent:${behaviourBucket()}`,
+      sourceTable: "opt_alignment_scores",
+      sourceId: undefined,
+      rulesScore: inputs.rulesIntentMatch,
+      expectKeys: ["score", "rationale"],
+    }),
+  ]);
+
+  return {
+    ad_to_page_match: adp,
+    intent_match: intent,
+    fallback_engaged:
+      adp.source === "rules_fallback" || intent.source === "rules_fallback",
+  };
+}
+
+/** Behaviour bucket = the 7-day window the rolling metrics are reading
+ * from. Same bucket within a week → same idempotency key → Anthropic's
+ * server-side cache returns the original response without billing
+ * twice. */
+function behaviourBucket(): string {
+  const now = new Date();
+  const start = Date.UTC(2026, 0, 1);
+  const week = Math.floor((now.getTime() - start) / (7 * 24 * 60 * 60 * 1000));
+  return `w${week}`;
+}
+
+type ScoreOneArgs = {
+  callFn: AnthropicCallFn;
+  clientId: string;
+  caller: string;
+  system: string;
+  user: string;
+  idempotencyKey: string;
+  sourceTable: string;
+  sourceId?: string;
+  rulesScore: number;
+  expectKeys: string[];
+};
+
+async function scoreOne(args: ScoreOneArgs): Promise<LlmSubscoreResult> {
+  let response;
+  try {
+    response = await args.callFn({
+      model: LLM_MODEL,
+      max_tokens: 200,
+      system: args.system,
+      messages: [{ role: "user", content: args.user }],
+      idempotency_key: args.idempotencyKey,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn("optimiser.llm_alignment.call_failed", {
+      client_id: args.clientId,
+      caller: args.caller,
+      error: message,
+    });
+    await recordLlmCall({
+      clientId: args.clientId,
+      caller: args.caller,
+      model: LLM_MODEL,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsdMicros: 0,
+      outcome: "error",
+      errorCode: "LLM_ERROR",
+    });
+    return {
+      score: args.rulesScore,
+      rationale: "LLM call failed — rules-only fallback.",
+      source: "rules_fallback",
+      fallback_reason: "llm_error",
+    };
+  }
+
+  const { cents } = computeCostCents(response.model, response.usage);
+  await recordLlmCall({
+    clientId: args.clientId,
+    caller: args.caller,
+    model: response.model,
+    inputTokens: response.usage.input_tokens,
+    outputTokens: response.usage.output_tokens,
+    cachedTokens: response.usage.cache_read_input_tokens ?? 0,
+    costUsdMicros: cents * 10_000, // cents → micros
+    anthropicRequestId: response.id,
+    sourceTable: args.sourceTable,
+    sourceId: args.sourceId,
+  });
+
+  const text = response.content.map((b) => b.text).join("\n").trim();
+  const parsed = parseJsonResponse(text);
+  if (!parsed || !args.expectKeys.every((k) => k in parsed)) {
+    logger.warn("optimiser.llm_alignment.parse_failed", {
+      client_id: args.clientId,
+      caller: args.caller,
+      response_id: response.id,
+      raw: text.slice(0, 200),
+    });
+    return {
+      score: args.rulesScore,
+      rationale: "LLM response could not be parsed — rules-only fallback.",
+      source: "rules_fallback",
+      fallback_reason: "parse_failed",
+    };
+  }
+
+  const score = clampScore(parsed.score);
+  const rationale =
+    typeof parsed.rationale === "string"
+      ? parsed.rationale.slice(0, 280)
+      : "(no rationale)";
+  return {
+    score,
+    rationale,
+    source: "llm",
+  };
+}
+
+function parseJsonResponse(text: string): Record<string, unknown> | null {
+  // Strip optional markdown fences.
+  const cleaned = text
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/i, "")
+    .trim();
+  try {
+    const parsed = JSON.parse(cleaned);
+    if (typeof parsed === "object" && parsed !== null) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // try to find the first {...} block.
+    const m = cleaned.match(/\{[\s\S]*\}/);
+    if (m) {
+      try {
+        const parsed = JSON.parse(m[0]);
+        if (typeof parsed === "object" && parsed !== null) {
+          return parsed as Record<string, unknown>;
+        }
+      } catch {
+        // fall through
+      }
+    }
+  }
+  return null;
+}
+
+function clampScore(v: unknown): number {
+  if (typeof v !== "number" || !Number.isFinite(v)) return 0;
+  if (v < 0) return 0;
+  if (v > 100) return 100;
+  return Math.round(v);
+}

--- a/lib/optimiser/score-pages-job.ts
+++ b/lib/optimiser/score-pages-job.ts
@@ -5,6 +5,7 @@ import { logger } from "@/lib/logger";
 
 import { scoreAlignment } from "./alignment-scoring";
 import { suppressedPlaybooksFor } from "./client-memory";
+import { scoreAlignmentLlm } from "./llm-alignment";
 import { computeReliability } from "./data-reliability";
 import { evaluateAndPersistPage } from "./healthy-state";
 import { rollupForPage } from "./metrics-aggregation";
@@ -159,46 +160,119 @@ async function scoreAndProposeForPage(args: {
   const adGroupId = adsForPage?.[0]?.ad_group_id as string | null;
   let alignmentScore: number | null = null;
   let alignmentSubscores: Record<string, number> | null = null;
+  let llmFallbackEngaged = false;
 
   if (adGroupId) {
-    const { data: keywordRows } = await supabase
-      .from("opt_keywords")
-      .select("text, match_type")
-      .eq("ad_group_id", adGroupId)
-      .is("deleted_at", null)
-      .limit(20);
+    const [{ data: keywordRows }, { data: adGroupRow }] = await Promise.all([
+      supabase
+        .from("opt_keywords")
+        .select("text, match_type")
+        .eq("ad_group_id", adGroupId)
+        .is("deleted_at", null)
+        .limit(20),
+      supabase
+        .from("opt_ad_groups")
+        .select("raw")
+        .eq("id", adGroupId)
+        .maybeSingle(),
+    ]);
     const headlines: string[] = [];
     const descriptions: string[] = [];
     for (const ad of adsForPage ?? []) {
       headlines.push(...((ad.headlines ?? []) as string[]));
       descriptions.push(...((ad.descriptions ?? []) as string[]));
     }
-    const result = scoreAlignment({
+    const topSearchTerms = extractTopSearchTerms(adGroupRow?.raw);
+    const rulesResult = scoreAlignment({
       snapshot,
       keywords: (keywordRows ?? []) as Array<{ text: string; match_type?: string }>,
       ad_headlines: headlines,
       ad_descriptions: descriptions,
+      search_terms: topSearchTerms,
     });
-    alignmentScore = result.composite;
-    alignmentSubscores = result.subscores as unknown as Record<string, number>;
 
-    await supabase.from("opt_alignment_scores").upsert(
-      {
-        client_id: args.clientId,
-        ad_group_id: adGroupId,
-        landing_page_id: args.landingPageId,
-        score: result.composite,
-        keyword_relevance: result.subscores.keyword_relevance,
-        ad_to_page_match: result.subscores.ad_to_page_match,
-        cta_consistency: result.subscores.cta_consistency,
-        offer_clarity: result.subscores.offer_clarity,
-        intent_match: result.subscores.intent_match,
-        rationale: result.rationale,
-        input_fingerprint: result.input_fingerprint,
-        computed_at: new Date().toISOString(),
-      },
-      { onConflict: "ad_group_id,landing_page_id" },
-    );
+    // Cache check: if the existing row's input_fingerprint matches and
+    // it's < 24h old, reuse the row and skip the LLM call entirely.
+    const { data: existing } = await supabase
+      .from("opt_alignment_scores")
+      .select("score, ad_to_page_match, intent_match, input_fingerprint, computed_at, rationale")
+      .eq("ad_group_id", adGroupId)
+      .eq("landing_page_id", args.landingPageId)
+      .maybeSingle();
+    const cacheFresh =
+      existing &&
+      existing.input_fingerprint === rulesResult.input_fingerprint &&
+      existing.computed_at &&
+      Date.now() - new Date(existing.computed_at as string).getTime() <
+        24 * 60 * 60 * 1000;
+
+    if (cacheFresh && existing) {
+      alignmentScore = existing.score as number;
+      alignmentSubscores = {
+        keyword_relevance: rulesResult.subscores.keyword_relevance,
+        ad_to_page_match: existing.ad_to_page_match as number,
+        cta_consistency: rulesResult.subscores.cta_consistency,
+        offer_clarity: rulesResult.subscores.offer_clarity,
+        intent_match: existing.intent_match as number,
+      };
+      // No LLM call → no fallback flag; the cached row already
+      // captured whatever the original LLM verdict was.
+    } else {
+      // Fresh inputs (or no prior row). Run the LLM hybrid pass on
+      // ad_to_page_match + intent_match only; keep keyword_relevance,
+      // cta_consistency, and offer_clarity as rules-based.
+      const llm = await scoreAlignmentLlm({
+        clientId: args.clientId,
+        adGroupId,
+        landingPageId: args.landingPageId,
+        snapshot,
+        adHeadlines: headlines,
+        adDescriptions: descriptions,
+        searchTerms: topSearchTerms,
+        rulesAdToPageMatch: rulesResult.subscores.ad_to_page_match,
+        rulesIntentMatch: rulesResult.subscores.intent_match,
+      });
+      llmFallbackEngaged = llm.fallback_engaged;
+
+      const merged = {
+        ...rulesResult.subscores,
+        ad_to_page_match: llm.ad_to_page_match.score,
+        intent_match: llm.intent_match.score,
+      };
+      const composite = recomputeComposite(merged);
+      alignmentScore = composite;
+      alignmentSubscores = merged as unknown as Record<string, number>;
+
+      const augmentedRationale = [
+        ...rulesResult.rationale,
+        {
+          subscore: "ad_to_page_match",
+          note: `LLM (${llm.ad_to_page_match.source}): ${llm.ad_to_page_match.rationale}`,
+        },
+        {
+          subscore: "intent_match",
+          note: `LLM (${llm.intent_match.source}): ${llm.intent_match.rationale}`,
+        },
+      ];
+
+      await supabase.from("opt_alignment_scores").upsert(
+        {
+          client_id: args.clientId,
+          ad_group_id: adGroupId,
+          landing_page_id: args.landingPageId,
+          score: composite,
+          keyword_relevance: merged.keyword_relevance,
+          ad_to_page_match: merged.ad_to_page_match,
+          cta_consistency: merged.cta_consistency,
+          offer_clarity: merged.offer_clarity,
+          intent_match: merged.intent_match,
+          rationale: augmentedRationale,
+          input_fingerprint: rulesResult.input_fingerprint,
+          computed_at: new Date().toISOString(),
+        },
+        { onConflict: "ad_group_id,landing_page_id" },
+      );
+    }
   }
 
   // 3. Rollup + reliability + healthy state.
@@ -227,6 +301,12 @@ async function scoreAndProposeForPage(args: {
     if (!evaluation.fired) continue;
     firedPlaybookIds.push(playbook.id);
     try {
+      // §8 LLM hybrid: when the LLM call fell back to rules, penalise
+      // the confidence signal sub-factor by 0.7 so the proposal
+      // priority reflects the lower-quality signal.
+      const adjustedMagnitude = llmFallbackEngaged
+        ? evaluation.magnitude * 0.7
+        : evaluation.magnitude;
       const r = await generateProposal({
         clientId: args.clientId,
         landingPageId: args.landingPageId,
@@ -236,7 +316,7 @@ async function scoreAndProposeForPage(args: {
         alignmentScore,
         alignmentSubscores,
         triggerEvidence: evaluation.reasons,
-        triggerMagnitude: evaluation.magnitude,
+        triggerMagnitude: adjustedMagnitude,
         suppressed: args.suppressed,
       });
       if (r.inserted) proposalsGenerated += 1;
@@ -297,4 +377,45 @@ function inferAdCtaVerb(
     }
   }
   return null;
+}
+
+const SUBSCORE_WEIGHTS = {
+  keyword_relevance: 0.25,
+  ad_to_page_match: 0.25,
+  cta_consistency: 0.15,
+  offer_clarity: 0.2,
+  intent_match: 0.15,
+} as const;
+
+function recomputeComposite(s: {
+  keyword_relevance: number;
+  ad_to_page_match: number;
+  cta_consistency: number;
+  offer_clarity: number;
+  intent_match: number;
+}): number {
+  return Math.round(
+    s.keyword_relevance * SUBSCORE_WEIGHTS.keyword_relevance +
+      s.ad_to_page_match * SUBSCORE_WEIGHTS.ad_to_page_match +
+      s.cta_consistency * SUBSCORE_WEIGHTS.cta_consistency +
+      s.offer_clarity * SUBSCORE_WEIGHTS.offer_clarity +
+      s.intent_match * SUBSCORE_WEIGHTS.intent_match,
+  );
+}
+
+function extractTopSearchTerms(raw: unknown): string[] {
+  if (!raw || typeof raw !== "object") return [];
+  const top = (raw as { top_search_terms?: unknown }).top_search_terms;
+  if (!Array.isArray(top)) return [];
+  return top
+    .map((entry) => {
+      if (typeof entry === "string") return entry;
+      if (entry && typeof entry === "object") {
+        const t = (entry as { term?: unknown }).term;
+        if (typeof t === "string") return t;
+      }
+      return null;
+    })
+    .filter((s): s is string => typeof s === "string" && s.length > 0)
+    .slice(0, 30);
 }

--- a/skills/optimiser/alignment-scoring/SKILL.md
+++ b/skills/optimiser/alignment-scoring/SKILL.md
@@ -5,27 +5,43 @@ Score the alignment between an ad group's keywords + ad copy and a landing page 
 ## Inputs
 - `PageSnapshot` (from `page-content-analysis`)
 - `keywords[]`, `ad_headlines[]`, `ad_descriptions[]` from the ad group
-- Optional `search_terms[]` for intent classification
+- Optional `search_terms[]` for intent classification (Slice 7+ writes top 30 per ad group into `opt_ad_groups.raw.top_search_terms`)
 
 ## Sub-scores
-1. **keyword_relevance** — top 5 keywords' tokens vs. tokens in (H1, H2s, primary CTA). `hits / 5 × 100`.
-2. **ad_to_page_match** — ad headline + description tokens vs. (H1, H2s, hero excerpt). Set overlap × 1.4, capped at 1.0.
-3. **cta_consistency** — page CTA verb vs. ad CTA verb. Match = 100; both are conversion verbs but differ = 50; differ + non-conversion = 25.
-4. **offer_clarity** — heuristic detection of "offer-shaped phrase" above the fold + CTA above the fold. Both = 90; CTA only = 65; offer only = 50; neither = 25.
-5. **intent_match** — informational vs. transactional classification of search-term sample (or unknown) vs. page transactional signals (form + transactional CTA verb).
+1. **keyword_relevance** — top 5 keywords' tokens vs. tokens in (H1, H2s, primary CTA). `hits / 5 × 100`. _Rules-based._
+2. **ad_to_page_match** — ad headline + description tokens vs. (H1, H2s, hero excerpt). _Rules + LLM hybrid (Slice 8)._
+3. **cta_consistency** — page CTA verb vs. ad CTA verb. _Rules-based._
+4. **offer_clarity** — heuristic detection of "offer-shaped phrase" above the fold + CTA above the fold. _Rules-based._
+5. **intent_match** — informational / transactional / navigational classification of the search-term sample vs. page transactional signals. _Rules + LLM hybrid (Slice 8)._
 
 ## Composite
 Weighted: keyword_relevance ×0.25, ad_to_page_match ×0.25, cta_consistency ×0.15, offer_clarity ×0.20, intent_match ×0.15.
 
-## Phase 1 = rules-only
-Phase 1 ships deterministic rules-only scoring. The spec calls for "rules + LLM hybrid"; the LLM augmentation pass for `keyword_relevance` (semantic equivalence — "managed IT" ≈ "IT support"), `ad_to_page_match` (semantic gap detection), and `intent_match` (LLM classification of search-term intent) is gated on `lib/optimiser/llm-usage.ts:gateLlmCall` and lands as a follow-up. The deterministic baseline is reproducible and lets Phase 1 generate proposals on high-signal cases without LLM cost.
+## LLM hybrid (Slice 8)
+The two sub-scores that need semantic judgement (`ad_to_page_match`, `intent_match`) call `claude-sonnet-4-6` via `lib/anthropic-call.ts`. The other three stay rules-only because deterministic checks are accurate enough on those.
+
+**Budget gate (§4.6).** Every call goes through `gateLlmCall(clientId, "alignment_scoring")` from `lib/optimiser/llm-usage.ts`. On `block` (100% of monthly budget consumed), both LLM sub-scores fall back to the rules-derived values, the result carries `fallback_engaged: true`, and the caller in `score-pages-job.ts` multiplies the playbook trigger magnitude by 0.7 — so the resulting proposal's confidence signal sub-factor is penalised, reflecting the lower-quality scoring.
+
+**Caching (§7.3).** Score-pages-job checks `opt_alignment_scores` for an existing row by `(ad_group_id, landing_page_id)`. If `input_fingerprint` matches the freshly-computed fingerprint AND `computed_at` is < 24h old, the cached row is reused and no LLM call is made. Anthropic's server-side idempotency cache (24h) absorbs any same-bucket re-runs that slip through; the `idempotency_key` carries `<ad_group>:<page>:<subscore>:w<iso_week>`.
+
+**LLM error fallback.** On HTTP error or unparseable response, the affected sub-score falls back to the rules-derived value with `source: 'rules_fallback'` and the fallback flag propagates into the confidence penalty as above.
+
+## Cost recording
+Every LLM call writes one `opt_llm_usage` row with:
+- `caller: 'alignment_scoring'`
+- `model: 'claude-sonnet-4-6'` (resolved from the response, not the request — handles model upgrades cleanly)
+- `cost_usd_micros` from `lib/anthropic-pricing.ts:computeCostCents`
+- `outcome: 'ok' | 'error' | 'budget_exceeded'`
+
+Pre-call rejections (budget exhausted) write a single `outcome='budget_exceeded'` row per scoring pass so the dashboard surface can show "what would have been spent."
 
 ## Output persisted on `opt_alignment_scores`
-Composite + 5 subscores + `rationale` (per-subscore notes) + `input_fingerprint` (cache key for skip-recompute). UPSERT on `(ad_group_id, landing_page_id)`.
+Composite + 5 subscores + `rationale` (per-subscore notes — including LLM rationale for ad_to_page_match and intent_match) + `input_fingerprint` (cache key for skip-recompute). UPSERT on `(ad_group_id, landing_page_id)`.
 
 ## Spec
 §8, Table 17.
 
 ## Pointers
-- `lib/optimiser/alignment-scoring.ts:scoreAlignment`
+- `lib/optimiser/alignment-scoring.ts:scoreAlignment` (rules pass)
+- `lib/optimiser/llm-alignment.ts:scoreAlignmentLlm` (LLM hybrid pass)
 - Caller: `lib/optimiser/score-pages-job.ts`


### PR DESCRIPTION
## Summary
Wires the §8 \"rules + LLM hybrid\" alignment scoring that Slice 5 stubbed. `ad_to_page_match` and `intent_match` now call Claude Sonnet 4.6 for semantic judgement; the other three sub-scores stay rules-only. Budget-gated, cached, and graceful-degrade on failure.

## Plan (sub-slice)
**Stack base.** `optimiser/slice-7-gaql-completion`.

**Why these two.** The other three sub-scores have deterministic rubrics that don't benefit from semantic LLM input — keyword string matching, CTA verb extraction, offer-shaped phrase detection. Spending budget on them would burn money for marginal lift. Ad-to-page match needs to recognise \"managed IT services\" ≈ \"IT support\"; intent match needs to classify a corpus of search terms — both are semantic-judgement problems.

**Caching strategy.** `score-pages-job` checks the existing `opt_alignment_scores` row before scoring. Match on `input_fingerprint` + `computed_at < 24h` → reuse row, no LLM call. Idempotency key on the LLM call uses an ISO-week bucket so Anthropic's 24h server-side cache catches anything that slips past.

**Fallback semantics.** When `gateLlmCall` returns `block` (100% budget), or the LLM call errors, or the response is unparseable, the affected sub-score returns `source: 'rules_fallback'` with the rules-derived value. The caller sees `fallback_engaged: true` and multiplies the playbook trigger magnitude by 0.7, which propagates through `confidence.signal × 0.7 → priority_score × 0.7`. Proposals still generate — they just sort lower.

## Risks identified and mitigated
- **Cost runaway** → `gateLlmCall` pre-flights; mid-pass budget exhaustion handled by per-call try/catch with `outcome='error'` rows.
- **Cache freshness** → 24h TTL + `input_fingerprint` match. Behaviour-bucket idempotency key adds Anthropic-side caching.
- **Parse robustness** → strip markdown fences + first-`{...}` regex fallback; failures cleanly drop to rules with `fallback_reason='parse_failed'`.
- **Concurrency** → two parallel LLM calls via `Promise.all`; each writes its own `opt_llm_usage` row; one upsert on `opt_alignment_scores` after both return.
- **Model upgrades** → cost recording uses `response.model`, not the request model, so a server-side model swap doesn't break the pricing match.
- **Backward compatibility** → Slice 5's rules-only path still works for pages without an ad-group join.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] Live LLM verification: Slice 9's E2E specs will mock the call layer; manual end-to-end against a populated DB + provisioned ANTHROPIC_API_KEY deferred to operator post-provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)