### PR TITLE
feat(r1): button hierarchy + auth shells + sites density + magenta-mask fix

### DIFF
--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -8,27 +8,35 @@ import { H1, Lead } from "@/components/ui/typography";
 // confirmation copy. No session gating — anyone (signed in or not)
 // can request a reset link for any email. The API route is where
 // rate limiting + no-enumeration semantics live.
+//
+// R1-10 — page wrapped in `bg-canvas` (matches admin shell) and the
+// form sits in a card so the inputs/buttons read against a
+// background, not floating on raw white.
 // ---------------------------------------------------------------------------
 
 export const dynamic = "force-static";
 
 export default function ForgotPasswordPage() {
   return (
-    <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-6 p-6">
-      <div className="w-full text-center">
-        <H1>Forgot your password?</H1>
-        <Lead className="mt-2">
-          Enter your email and we&apos;ll send you a reset link.
-        </Lead>
-      </div>
-      <ForgotPasswordForm />
-      <div className="text-center text-xs text-muted-foreground">
-        <a
-          href="/login"
-          className="underline transition-smooth hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
-        >
-          Back to sign in
-        </a>
+    <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center">
+          <H1>Forgot your password?</H1>
+          <Lead className="mt-2">
+            Enter your email and we&apos;ll send you a reset link.
+          </Lead>
+        </div>
+        <div className="rounded-lg border bg-background p-6 shadow-sm">
+          <ForgotPasswordForm />
+        </div>
+        <p className="text-center text-xs text-muted-foreground">
+          <a
+            href="/login"
+            className="underline transition-smooth hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          >
+            Back to sign in
+          </a>
+        </p>
       </div>
     </main>
   );

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -12,6 +12,10 @@ import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
 // renders the password form; otherwise it renders the "expired link"
 // state with a "Request a new link" CTA.
 //
+// R1-10 — wrapped in bg-canvas + card surface (matches /login and
+// /auth/forgot-password) so inputs/buttons read against a real
+// background.
+//
 // force-dynamic because the session check has to run per-request.
 // ---------------------------------------------------------------------------
 
@@ -23,36 +27,46 @@ export default async function ResetPasswordPage() {
 
   if (!user) {
     return (
-      <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-6 p-6">
-        <div className="w-full text-center">
-          <H1>Reset link expired</H1>
-          <Lead className="mt-2">
-            This reset link has expired or was already used. Request a new
-            link to continue.
-          </Lead>
+      <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
+        <div className="w-full max-w-md space-y-6">
+          <div className="text-center">
+            <H1>Reset link expired</H1>
+            <Lead className="mt-2">
+              This reset link has expired or was already used. Request a new
+              link to continue.
+            </Lead>
+          </div>
+          <div className="rounded-lg border bg-background p-6 text-center shadow-sm">
+            <Button asChild>
+              <a href="/auth/forgot-password">Request a new link</a>
+            </Button>
+          </div>
+          <p className="text-center text-xs text-muted-foreground">
+            <a
+              href="/login"
+              className="underline transition-smooth hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+            >
+              Back to sign in
+            </a>
+          </p>
         </div>
-        <Button asChild>
-          <a href="/auth/forgot-password">Request a new link</a>
-        </Button>
-        <a
-          href="/login"
-          className="text-xs text-muted-foreground underline transition-smooth hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
-        >
-          Back to sign in
-        </a>
       </main>
     );
   }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-6 p-6">
-      <div className="w-full text-center">
-        <H1>Set a new password</H1>
-        <Lead className="mt-2">
-          Choose a strong password. Minimum 12 characters.
-        </Lead>
+    <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center">
+          <H1>Set a new password</H1>
+          <Lead className="mt-2">
+            Choose a strong password. Minimum 12 characters.
+          </Lead>
+        </div>
+        <div className="rounded-lg border bg-background p-6 shadow-sm">
+          <ResetPasswordForm userEmail={user.email} />
+        </div>
       </div>
-      <ResetPasswordForm userEmail={user.email} />
     </main>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -12,7 +12,11 @@
     --popover-foreground: 222.2 84% 4.9%;
     --primary: 222.2 47.4% 11.2%;
     --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
+    /* R1-4 — bumped from 210 40% 96.1% so secondary buttons read
+       against the bg-canvas (220 14% 96%) wash. Now sits ~9 percentage
+       points darker than canvas — visible but still subordinate to
+       primary. */
+    --secondary: 220 13% 87%;
     --secondary-foreground: 222.2 47.4% 11.2%;
     --muted: 210 40% 96.1%;
     --muted-foreground: 215.4 16.3% 46.9%;
@@ -48,7 +52,9 @@
     --popover-foreground: 210 40% 98%;
     --primary: 210 40% 98%;
     --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
+    /* R1-4 — secondary in dark mode lifted slightly so it reads
+       against the dark --background. */
+    --secondary: 217.2 32.6% 25%;
     --secondary-foreground: 210 40% 98%;
     --muted: 217.2 32.6% 17.5%;
     --muted-foreground: 215 20.2% 65.1%;

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -53,12 +53,16 @@ export default async function LoginPage({
   }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-6 p-6">
-      <div className="text-center">
-        <H1>Opollo Site Builder</H1>
-        <Lead className="mt-1">Sign in to continue.</Lead>
+    <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center">
+          <H1>Opollo Site Builder</H1>
+          <Lead className="mt-1">Sign in to continue.</Lead>
+        </div>
+        <div className="rounded-lg border bg-background p-6 shadow-sm">
+          <LoginForm next={next} />
+        </div>
       </div>
-      <LoginForm next={next} />
     </main>
   );
 }

--- a/components/SitesTable.tsx
+++ b/components/SitesTable.tsx
@@ -10,7 +10,7 @@ import { cn, formatRelativeTime } from "@/lib/utils";
 // ---------------------------------------------------------------------------
 // B-2 — Sites list polish.
 //
-// Density: row height tightened to ~44px (px-3 py-2.5). Status cell
+// Density: row height tightened to ~44px (px-3 py-2). Status cell
 // keeps the dot + text pattern (distinct from StatusPill — chosen for
 // the list-density, single-state context).
 // Empty state folded to A-6's EmptyState primitive.
@@ -104,7 +104,7 @@ export function SitesTable({ sites, onCreateClick }: SitesTableProps) {
               key={s.id}
               className="group border-b transition-smooth last:border-b-0 hover:bg-muted/40"
             >
-              <td className="px-3 py-2.5 font-medium">
+              <td className="px-3 py-2 font-medium">
                 <Link
                   href={`/admin/sites/${s.id}`}
                   className="block transition-smooth hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
@@ -113,7 +113,7 @@ export function SitesTable({ sites, onCreateClick }: SitesTableProps) {
                   {s.name}
                 </Link>
               </td>
-              <td className="px-3 py-2.5 text-muted-foreground">
+              <td className="px-3 py-2 text-muted-foreground">
                 <a
                   href={s.wp_url}
                   target="_blank"
@@ -124,16 +124,16 @@ export function SitesTable({ sites, onCreateClick }: SitesTableProps) {
                   {s.wp_url}
                 </a>
               </td>
-              <td className="px-3 py-2.5">
+              <td className="px-3 py-2">
                 <StatusCell status={s.status} />
               </td>
-              <td className="px-3 py-2.5 text-xs text-muted-foreground">
+              <td className="px-3 py-2 text-xs text-muted-foreground">
                 <span data-screenshot-mask>
                   {formatRelativeTime(s.updated_at)}
                 </span>
               </td>
               <td
-                className="px-2 py-2.5 text-right"
+                className="px-2 py-2 text-right"
                 onClick={(e) => e.stopPropagation()}
               >
                 <SiteActionsMenu

--- a/components/UserStatusActionCell.tsx
+++ b/components/UserStatusActionCell.tsx
@@ -60,15 +60,17 @@ export function UserStatusActionCell({
     }
   }
 
+  // R1-11 — sparse-data tables feel less marooned with horizontal
+  // status + action layout (was vertical stack with self-start button).
   if (optimisticRevoked) {
     return (
-      <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-2">
         <span className="text-xs text-destructive">revoked</span>
         <button
           type="button"
           onClick={() => void reinstate()}
           disabled={submitting}
-          className="self-start rounded border px-2 py-0.5 text-sm transition-smooth hover:bg-muted disabled:opacity-60"
+          className="rounded border px-2 py-0.5 text-xs transition-smooth hover:bg-muted disabled:opacity-60"
         >
           {submitting ? "…" : "Reinstate"}
         </button>
@@ -77,14 +79,14 @@ export function UserStatusActionCell({
   }
 
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex items-center gap-2">
       <span className="text-xs text-muted-foreground">active</span>
       <button
         type="button"
         onClick={() => setRevokeOpen(true)}
         disabled={isSelf || submitting}
         title={isSelf ? "You cannot revoke your own access." : undefined}
-        className="self-start rounded border px-2 py-0.5 text-sm text-destructive transition-smooth hover:bg-destructive/10 disabled:opacity-60"
+        className="rounded border px-2 py-0.5 text-xs text-destructive transition-smooth hover:bg-destructive/10 disabled:opacity-60"
       >
         {submitting ? "…" : "Revoke"}
       </button>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,29 +4,44 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
-// B-2 — added `gap-2` to support icon + text composition
-// (`<Plus /> New site`) without consumers spelling out spacing.
-// `transition-colors` → `transition-smooth` (A-3 token) for the
-// canonical hover/focus curve.
+// R1-4 — Linear-style button hierarchy. Primary feels primary; outline
+// reads as a real secondary; ghost is subtle but lights up on hover.
+//
+// Changes from B-2:
+//   • default: shadow-sm + active:translate-y-px gives a tactile press;
+//     hover lifts to shadow.
+//   • outline: border-input bumped to a tone the eye registers against
+//     bg-background OR bg-canvas; hover drops a subtle muted bg under
+//     the border instead of swapping accent (which competed with primary
+//     visually).
+//   • secondary: bg-secondary darkened via the --secondary token
+//     adjustment in globals.css; readable against canvas + cards both.
+//   • ghost: explicit bg-transparent + hover:bg-muted (was hover:bg-
+//     accent which renders the same as muted under the current
+//     palette but is semantically clearer).
+//
+// `gap-2` from B-2 stays — supports icon + text composition.
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-smooth focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow active:translate-y-px",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 hover:shadow active:translate-y-px",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background text-foreground shadow-sm hover:bg-muted/60 hover:border-foreground/20 active:translate-y-px",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 active:translate-y-px",
+        ghost:
+          "bg-transparent text-foreground hover:bg-muted hover:text-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-11 rounded-md px-6",
         icon: "h-10 w-10",
       },
     },

--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -168,11 +168,17 @@ test.describe("A-0 visual regression screenshot harness", () => {
           }
           // Mask "updated N minutes ago" style relative timestamps so a
           // clock tick between PRs doesn't reorder the diff.
+          // R1-9 — override Playwright's default magenta maskColor (which
+          // appeared on the Sites list UPDATED column as bright pink
+          // blocks in operator review). Use a subtle muted gray that
+          // blends with the canvas tint so the screenshot reads as
+          // "this column has dynamic text" rather than "broken styling."
           const masks = await page.locator("[data-screenshot-mask]").all();
           await page.screenshot({
             path: filePath,
             fullPage: true,
             mask: masks,
+            maskColor: "#e5e7eb",
             animations: "disabled",
           });
           // C-3 — run axe-core on every captured route. Findings


### PR DESCRIPTION
Round 1 review feedback bundle (PR #257). Items 4, 9, 10, 11.

## R1-9 — Magenta blocks on Sites UPDATED column
Root cause: Playwright's default `maskColor` is `#FF00FF` (bright magenta). The `data-screenshot-mask` spans on relative timestamps rendered as pink in the screenshot artifacts. Set `maskColor: '#e5e7eb'` (cool gray, near canvas) so masks read as 'dynamic text here' not 'broken styling.'

## R1-10 — Auth surfaces unstyled
`/login`, `/auth/forgot-password`, `/auth/reset-password` now wrap in `bg-canvas` + the form sits in a `rounded-lg border bg-background p-6 shadow-sm` card — matches the admin-shell card pattern. B-15 missed this.

## R1-11 — Sparse-data table density
- SitesTable row padding `py-2.5 → py-2`.
- UserStatusActionCell: vertical stack → horizontal row (status + button inline). Removes ~16px per row.

## R1-4 — Linear-style button hierarchy
- `default` + `destructive`: `shadow-sm + hover:shadow + active:translate-y-px` for tactile press.
- `outline`: explicit text-foreground, hover swaps to muted/60 (was hover:accent which competed with primary).
- `ghost`: explicit bg-transparent + hover:bg-muted.
- `size sm`: h-9 → h-8 + text-xs.
- `--secondary` token bumped from 210 40% 96.1% (invisible against canvas) to 220 13% 87% (visible but subordinate).

## Test plan
- [x] lint / typecheck / build — clean

Per the standing rule: text description in lieu of inline screenshots. Screenshot CI workflow fires on PR open.