### PR TITLE
feat(optimiser-10): diagnostics endpoint, env docs, credential provisioning runbook

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -176,3 +176,39 @@ ISTOCK_SEED_CAP_CENTS=
 # change the baseline, write a forward migration that alters the default.
 # Per-site overrides go through the /admin/sites/[id]/budget PATCH route.
 # See docs/ENV_AUDIT_2026-04-24.md finding #2.
+
+# --- Optimiser module (feat/optimiser) ------------------------------------
+# Provisioning runbook: docs/runbook/optimiser-credentials.md
+# Verify: GET /api/optimiser/diagnostics or /optimiser/diagnostics (admin)
+
+# Google Ads OAuth client + Opollo MCC developer token. All three required
+# together; missing any one → daily Ads sync skips with `skipped: true`.
+# Provision steps in the runbook above.
+GOOGLE_ADS_CLIENT_ID=
+GOOGLE_ADS_CLIENT_SECRET=
+GOOGLE_ADS_DEVELOPER_TOKEN=
+
+# GA4 OAuth client. Either GA4_* or the GOOGLE_OAUTH_* fallback pair must
+# be set for GA4 sync. Empty → GA4 sync skips.
+GA4_CLIENT_ID=
+GA4_CLIENT_SECRET=
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+
+# PageSpeed Insights API key (free tier, 25k queries/day). Single
+# Opollo-wide key — Clarity is the only Phase 1 source that uses
+# per-client tokens. Empty → PSI sync skips silently.
+PAGESPEED_API_KEY=
+
+# Optimiser email transport. Phase 1 ships a no-op + log_only fallback;
+# `noop` (or unset) means digests are dropped with a structured log line.
+# `log_only` writes the recipient + subject to the logs without sending.
+# `sendgrid` / `postmark` / `resend` will land alongside the operator
+# decision on which provider to adopt.
+OPTIMISER_EMAIL_PROVIDER=
+
+# Phase 1.5 toggle: M12/M13 brief_shape='import' availability. When the
+# Site Builder ships the import shape, flip this to `true` and
+# planPageImport routes to the auto path; default is the manual rebuild
+# fallback.
+OPT_AUTO_IMPORT_ENABLED=

--- a/app/api/optimiser/diagnostics/route.ts
+++ b/app/api/optimiser/diagnostics/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { runDiagnostics } from "@/lib/optimiser/diagnostics";
+
+// GET /api/optimiser/diagnostics — admin-only operator surface.
+//
+// Reports per-source provisioning status (env vars, connected clients,
+// last sync, last error) plus module-wide checks (schema, master key,
+// cron secret, email provider). Operators hit this after each Opollo-
+// wide credential is provisioned to confirm the system saw the change.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(): Promise<NextResponse> {
+  const access = await checkAdminAccess({ requiredRoles: ["admin"] });
+  if (access.kind === "redirect") {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "UNAUTHORIZED", message: "Admin access required" },
+      },
+      { status: 401 },
+    );
+  }
+  const report = await runDiagnostics();
+  return NextResponse.json({ ok: true, data: report });
+}

--- a/app/optimiser/diagnostics/page.tsx
+++ b/app/optimiser/diagnostics/page.tsx
@@ -1,0 +1,158 @@
+import { redirect } from "next/navigation";
+
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { runDiagnostics } from "@/lib/optimiser/diagnostics";
+
+export const metadata = { title: "Optimiser · Diagnostics" };
+export const dynamic = "force-dynamic";
+
+export default async function OptimiserDiagnosticsPage() {
+  const access = await checkAdminAccess({ requiredRoles: ["admin"] });
+  if (access.kind === "redirect") redirect(access.to);
+  const report = await runDiagnostics();
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Optimiser diagnostics
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Operator wiring check. Generated{" "}
+          {new Date(report.generated_at).toLocaleString()}.
+        </p>
+      </header>
+
+      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
+        <h2 className="text-lg font-medium">Module</h2>
+        <ModuleRow
+          label="Schema reachable"
+          ok={report.module.schema_reachable}
+          detail={report.module.schema_error}
+        />
+        <ModuleRow
+          label="OPOLLO_MASTER_KEY set"
+          ok={report.module.master_key_set}
+          detail={
+            report.module.master_key_set
+              ? undefined
+              : "Required for credential encryption."
+          }
+        />
+        <ModuleRow
+          label="CRON_SECRET set"
+          ok={report.module.cron_secret_set}
+          detail={
+            report.module.cron_secret_set
+              ? undefined
+              : "Required for sync + email-digest cron handlers."
+          }
+        />
+        <ModuleRow
+          label={`Email provider: ${report.module.email_provider}`}
+          ok={true}
+          detail={
+            report.module.email_provider === "noop"
+              ? "OPTIMISER_EMAIL_PROVIDER unset — digests are no-op + logged."
+              : undefined
+          }
+        />
+        <p className="pt-2 text-sm text-muted-foreground">
+          Clients: {report.module.client_count} ·{" "}
+          {report.module.onboarded_count} onboarded
+        </p>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-medium">Data sources</h2>
+        {report.sources.map((s) => (
+          <article
+            key={s.source}
+            className="space-y-2 rounded-lg border border-border bg-card p-6"
+          >
+            <header className="flex items-center justify-between">
+              <h3 className="font-medium">
+                {s.source.replace("_", " ")}
+              </h3>
+              <span
+                className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${
+                  s.env.configured
+                    ? "border-emerald-200 bg-emerald-50 text-emerald-900"
+                    : "border-red-200 bg-red-50 text-red-900"
+                }`}
+              >
+                {s.env.configured ? "env configured" : "env missing"}
+              </span>
+            </header>
+            {!s.env.configured && (
+              <p className="text-sm text-red-900">
+                Missing: {s.env.missing.join(", ")}
+              </p>
+            )}
+            {s.source !== "anthropic" && (
+              <ul className="space-y-1 text-sm">
+                <li>
+                  <span className="text-muted-foreground">Connected clients: </span>
+                  <span className="font-mono">{s.connected_clients}</span>
+                </li>
+                <li>
+                  <span className="text-muted-foreground">Clients in error: </span>
+                  <span
+                    className={`font-mono ${s.clients_in_error > 0 ? "text-red-700" : ""}`}
+                  >
+                    {s.clients_in_error}
+                  </span>
+                </li>
+                <li>
+                  <span className="text-muted-foreground">
+                    Last successful sync:{" "}
+                  </span>
+                  <span className="font-mono">
+                    {s.last_successful_sync_at
+                      ? new Date(s.last_successful_sync_at).toLocaleString()
+                      : "(never)"}
+                  </span>
+                </li>
+                {s.last_error && (
+                  <li className="text-red-700">
+                    <span>Last error: </span>
+                    <span className="font-mono">{s.last_error.code}</span>
+                    {s.last_error.message && (
+                      <> — {s.last_error.message}</>
+                    )}
+                    <> at {new Date(s.last_error.at).toLocaleString()}</>
+                  </li>
+                )}
+              </ul>
+            )}
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}
+
+function ModuleRow({
+  label,
+  ok,
+  detail,
+}: {
+  label: string;
+  ok: boolean;
+  detail?: string;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 text-sm">
+      <div>
+        <p className="font-medium">{label}</p>
+        {detail && <p className="text-muted-foreground">{detail}</p>}
+      </div>
+      <span
+        aria-hidden
+        className={`mt-1 inline-block size-2.5 rounded-full ${
+          ok ? "bg-emerald-500" : "bg-red-500"
+        }`}
+      />
+    </div>
+  );
+}

--- a/app/optimiser/layout.tsx
+++ b/app/optimiser/layout.tsx
@@ -15,6 +15,7 @@ const NAV = [
   { href: "/optimiser/proposals", label: "Proposals" },
   { href: "/optimiser/change-log", label: "Change log" },
   { href: "/optimiser/onboarding", label: "Onboarding" },
+  { href: "/optimiser/diagnostics", label: "Diagnostics" },
 ];
 
 export default async function OptimiserLayout({

--- a/docs/runbook/optimiser-credentials.md
+++ b/docs/runbook/optimiser-credentials.md
@@ -1,0 +1,121 @@
+# Optimiser — credential provisioning runbook
+
+This runbook walks an operator through provisioning every Opollo-wide credential the Optimiser module needs. Per-client credentials (Ads OAuth refresh tokens, GA4 property IDs, Clarity API tokens) are entered through the onboarding wizard at `/optimiser/onboarding/<client_id>` and don't need shell access.
+
+After each section's "Set the env var" step, hit `/optimiser/diagnostics` (admin-only) and confirm the diagnostic flips from "env missing" to "env configured". The endpoint also reports per-client connector status — the truth source for whether a sync has actually run successfully.
+
+## Source of truth
+
+- **Code surface:** `lib/optimiser/diagnostics.ts:runDiagnostics`
+- **UI surface:** `/optimiser/diagnostics` (admin role required)
+- **Module spec:** `docs/Optimisation_Engine_Spec_v1.5.docx`
+
+## 1. Google Ads (refresh-token OAuth + MCC developer token)
+
+### What you need
+1. **Opollo MCC developer token.** Apply once for the agency-level MCC at https://ads.google.com → Tools → API Center. Approval typically takes 24-48h. Store in `GOOGLE_ADS_DEVELOPER_TOKEN`.
+2. **OAuth client.** Google Cloud Console → APIs & Services → Credentials → Create OAuth client ID → Web application. Add `https://<deploy-host>/api/optimiser/oauth/ads/callback` to "Authorised redirect URIs" for each environment (production, preview, local dev).
+3. **Client ID + secret** from the OAuth client → store in `GOOGLE_ADS_CLIENT_ID` / `GOOGLE_ADS_CLIENT_SECRET`.
+
+### Set the env vars
+Production / preview: Vercel project settings → Environment Variables. Local dev: `.env.local`.
+
+```
+GOOGLE_ADS_CLIENT_ID=<from oauth client>
+GOOGLE_ADS_CLIENT_SECRET=<from oauth client>
+GOOGLE_ADS_DEVELOPER_TOKEN=<from MCC>
+```
+
+### Verify
+1. `/optimiser/diagnostics` → google_ads section reports `env configured`.
+2. Open `/optimiser/onboarding/<a-client-id>` → step 2 → "Sign in with Google" should redirect to `accounts.google.com`. If it redirects back with `error=ads_oauth_not_configured`, the env vars haven't reached the runtime.
+3. After OAuth, paste the customer_id and click Verify. The verifier calls `searchStream` with `LIMIT 1` against the customer; ≥ 1 active campaign → green.
+
+### Operational notes
+- The developer token covers all Opollo-managed Ads accounts (standard MCC pattern). One token, many clients.
+- Refresh tokens are stored encrypted (AES-256-GCM via `OPOLLO_MASTER_KEY`) in `opt_client_credentials`. Rotation runbook lives in `docs/RUNBOOK.md` → "Master key rotation" — same key, same rotation path.
+
+## 2. GA4 (refresh-token OAuth)
+
+### What you need
+1. **OAuth client.** Same Google Cloud project as the Ads OAuth client (or a separate one — both work). The optimiser accepts either `GA4_CLIENT_ID`/`_SECRET` or `GOOGLE_OAUTH_CLIENT_ID`/`_SECRET` as a fallback so a single shared client can drive both flows.
+2. Enable **Google Analytics Data API v1beta** for the Cloud project (Console → Library → search "analyticsdata").
+3. Add `https://<deploy-host>/api/optimiser/oauth/ga4/callback` to the OAuth client's "Authorised redirect URIs".
+
+### Set the env vars
+```
+GA4_CLIENT_ID=<from oauth client>
+GA4_CLIENT_SECRET=<from oauth client>
+```
+Or, if reusing the Ads OAuth client:
+```
+GOOGLE_OAUTH_CLIENT_ID=<shared>
+GOOGLE_OAUTH_CLIENT_SECRET=<shared>
+```
+
+### Verify
+1. `/optimiser/diagnostics` → ga4 section reports `env configured`.
+2. Open `/optimiser/onboarding/<a-client-id>` → step 4 → "Sign in with Google" → consent → enter property_id → "Verify". The verifier runs a 7-day `runReport` with `sessions` + `conversions` metrics; ≥ 1 row → green. Zero rows → "no rows" warning. Zero conversions but rows → "GA4 has no conversions configured" soft warning (not blocking).
+
+## 3. Microsoft Clarity (per-client API token; no Opollo-wide env)
+
+Clarity is the only Phase 1 source that uses per-project tokens. There is no Opollo-wide env var — the operator copies each client's project token into the onboarding wizard step 3.
+
+### Get the token
+For each client's Clarity project: Clarity dashboard → Settings → Data Export. Generate a project API token. Copy + paste into `/optimiser/onboarding/<client_id>` step 3.
+
+### Snippet install
+The wizard's step 3 also displays the Clarity JS snippet. Two options:
+1. Engineering injects via the Site Builder's WordPress connector (preferred for Site-Builder-managed sites).
+2. Send the client an email with the snippet to add manually (template in the wizard).
+
+### Verify
+Click "Verify install" — the verifier calls Clarity's `project-live-insights` endpoint expecting at least one session in the last 24h. If zero sessions, the wizard shows "Waiting for first Clarity session." This is normal until the snippet has been live for ~10 minutes of real traffic.
+
+## 4. PageSpeed Insights (free-tier API key)
+
+### What you need
+1. Google Cloud Console → APIs & Services → Library → enable **PageSpeed Insights API**.
+2. Credentials → Create credentials → API key → restrict to PageSpeed Insights API + (optionally) HTTP referrer match for `*.opollo.com`.
+
+### Set the env var
+```
+PAGESPEED_API_KEY=<from credentials>
+```
+
+### Verify
+- `/optimiser/diagnostics` → pagespeed section reports `env configured`.
+- Wait for the next `/api/cron/optimiser-sync-pagespeed` tick (Mondays 06:00 UTC by default — see `vercel.json`). Or call the endpoint manually with the cron secret for an immediate run.
+- After a tick, `/optimiser` page browser shows LCP / mobile speed metrics on rows.
+
+PSI quota: 25,000 queries/day on the free tier. Phase 1 needs much less (one query per managed page per week × 2 strategies).
+
+## 5. Anthropic (LLM hybrid alignment scoring + brief construction in 1.5)
+
+The optimiser shares the existing `ANTHROPIC_API_KEY`. Documented in this file's `.env.local.example`. No additional setup beyond the existing one.
+
+### Verify
+- `/optimiser/diagnostics` → anthropic section reports `env configured`.
+- The LLM hybrid pass for `ad_to_page_match` and `intent_match` runs on every score-pages cron tick. Recent calls land in `opt_llm_usage`; the diagnostic doesn't surface that table directly today (Phase 1.5 will add a per-client cost panel).
+
+## 6. Email transport (TBD per spec §9.11.4)
+
+Phase 1 ships a no-op + log_only fallback. When the operator chooses a provider:
+
+```
+OPTIMISER_EMAIL_PROVIDER=sendgrid|postmark|resend
+```
+
+Each provider needs its own API key env var; that lands in a follow-up PR alongside the chosen provider's SDK adoption. Until then, digests render correctly but are not sent — the recipient + subject + byte-count appear in the logs.
+
+## 7. Cron secret + master key (already provisioned for the rest of the codebase)
+
+The optimiser reuses the existing `CRON_SECRET` and `OPOLLO_MASTER_KEY`. If either is unset, `/optimiser/diagnostics` flags it red — the optimiser will not function without both.
+
+## What "ready to onboard a real client" looks like
+
+`/optimiser/diagnostics` should report:
+- Module: schema reachable (green), master key + cron secret set (green), email provider set or `noop` if intentional
+- Sources: every section showing `env configured`. `connected clients = 0` is expected before the first onboarding completes.
+
+When the first client onboards, the per-source `connected_clients` count increments and `last_successful_sync_at` populates within 24h of onboarding completion.

--- a/lib/optimiser/diagnostics.ts
+++ b/lib/optimiser/diagnostics.ts
@@ -1,0 +1,232 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { OptCredentialSource } from "./types";
+
+// ---------------------------------------------------------------------------
+// Operator diagnostics for the optimiser module. Slice 10 surface — the
+// "is this thing wired up correctly" check that runs after each
+// credential is provisioned.
+//
+// Reports four things per data source:
+//   1. Whether the env vars the source needs are set
+//   2. Whether at least one client has connected credentials for it
+//   3. Whether a successful sync has happened in the last 24h
+//   4. Whether the most recent sync attempt errored (with the error code)
+//
+// Plus module-wide checks: schema reachable, LLM key set, master key set.
+// ---------------------------------------------------------------------------
+
+export type EnvCheck = {
+  name: string;
+  required: string[];
+  optional?: string[];
+  /** TRUE if every required var is set (non-empty). */
+  configured: boolean;
+  /** Names of required vars that are missing. */
+  missing: string[];
+};
+
+export type SourceDiagnostic = {
+  source: OptCredentialSource | "anthropic";
+  env: EnvCheck;
+  /** Number of clients with status='connected' for this source.
+   * Anthropic + system entries leave this 0 — they're not per-client. */
+  connected_clients: number;
+  /** Most-recent successful sync across all clients. */
+  last_successful_sync_at: string | null;
+  /** Most-recent error across all clients. */
+  last_error: { code: string; message: string; at: string } | null;
+  /** Number of clients whose status is currently 'expired' /
+   * 'misconfigured' / 'disconnected'. */
+  clients_in_error: number;
+};
+
+export type ModuleDiagnostic = {
+  schema_reachable: boolean;
+  schema_error?: string;
+  master_key_set: boolean;
+  cron_secret_set: boolean;
+  email_provider: string;
+  client_count: number;
+  onboarded_count: number;
+};
+
+export type DiagnosticsReport = {
+  module: ModuleDiagnostic;
+  sources: SourceDiagnostic[];
+  generated_at: string;
+};
+
+const SOURCE_ENV: Record<
+  OptCredentialSource | "anthropic",
+  { required: string[]; optional?: string[] }
+> = {
+  google_ads: {
+    required: [
+      "GOOGLE_ADS_CLIENT_ID",
+      "GOOGLE_ADS_CLIENT_SECRET",
+      "GOOGLE_ADS_DEVELOPER_TOKEN",
+    ],
+  },
+  ga4: {
+    required: ["GA4_CLIENT_ID", "GA4_CLIENT_SECRET"],
+    optional: ["GOOGLE_OAUTH_CLIENT_ID", "GOOGLE_OAUTH_CLIENT_SECRET"],
+  },
+  clarity: {
+    // Clarity uses per-client tokens; no Opollo-wide env needed.
+    required: [],
+  },
+  pagespeed: {
+    required: ["PAGESPEED_API_KEY"],
+  },
+  anthropic: {
+    required: ["ANTHROPIC_API_KEY"],
+  },
+};
+
+function checkEnv(source: OptCredentialSource | "anthropic"): EnvCheck {
+  const cfg = SOURCE_ENV[source];
+  const missing: string[] = [];
+  for (const key of cfg.required) {
+    const v = process.env[key];
+    if (!v || v.trim().length === 0) missing.push(key);
+  }
+  // For GA4, accept the GOOGLE_OAUTH_* fallback pair as a substitute.
+  if (source === "ga4" && missing.length === cfg.required.length) {
+    const fallback = (cfg.optional ?? []).every(
+      (k) => (process.env[k] ?? "").trim().length > 0,
+    );
+    if (fallback) {
+      return {
+        name: source,
+        required: cfg.required,
+        optional: cfg.optional,
+        configured: true,
+        missing: [],
+      };
+    }
+  }
+  return {
+    name: source,
+    required: cfg.required,
+    optional: cfg.optional,
+    configured: missing.length === 0,
+    missing,
+  };
+}
+
+export async function runDiagnostics(): Promise<DiagnosticsReport> {
+  const supabase = getServiceRoleClient();
+
+  let schemaReachable = true;
+  let schemaError: string | undefined;
+  let clientCount = 0;
+  let onboardedCount = 0;
+  try {
+    const { data, error, count } = await supabase
+      .from("opt_clients")
+      .select("id, onboarded_at", { count: "exact" })
+      .is("deleted_at", null);
+    if (error) throw new Error(error.message);
+    clientCount = count ?? (data?.length ?? 0);
+    onboardedCount = (data ?? []).filter((r) => r.onboarded_at).length;
+  } catch (err) {
+    schemaReachable = false;
+    schemaError = err instanceof Error ? err.message : String(err);
+  }
+
+  const sources: SourceDiagnostic[] = [];
+  const sourceList: Array<OptCredentialSource | "anthropic"> = [
+    "google_ads",
+    "ga4",
+    "clarity",
+    "pagespeed",
+    "anthropic",
+  ];
+  for (const source of sourceList) {
+    sources.push(await diagnoseSource(source));
+  }
+
+  return {
+    module: {
+      schema_reachable: schemaReachable,
+      schema_error: schemaError,
+      master_key_set:
+        (process.env.OPOLLO_MASTER_KEY ?? "").trim().length > 0,
+      cron_secret_set:
+        (process.env.CRON_SECRET ?? "").trim().length >= 16,
+      email_provider:
+        process.env.OPTIMISER_EMAIL_PROVIDER?.trim() || "noop",
+      client_count: clientCount,
+      onboarded_count: onboardedCount,
+    },
+    sources,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+async function diagnoseSource(
+  source: OptCredentialSource | "anthropic",
+): Promise<SourceDiagnostic> {
+  const env = checkEnv(source);
+  if (source === "anthropic") {
+    return {
+      source,
+      env,
+      connected_clients: 0,
+      last_successful_sync_at: null,
+      last_error: null,
+      clients_in_error: 0,
+    };
+  }
+
+  const supabase = getServiceRoleClient();
+  let connectedClients = 0;
+  let clientsInError = 0;
+  let lastSuccessfulSyncAt: string | null = null;
+  let lastError: SourceDiagnostic["last_error"] = null;
+
+  try {
+    const { data } = await supabase
+      .from("opt_client_credentials")
+      .select(
+        "status, last_synced_at, last_attempted_at, last_error_code, last_error_message",
+      )
+      .eq("source", source);
+    for (const row of data ?? []) {
+      if (row.status === "connected") connectedClients += 1;
+      else clientsInError += 1;
+      if (
+        row.last_synced_at &&
+        (!lastSuccessfulSyncAt ||
+          (row.last_synced_at as string) > lastSuccessfulSyncAt)
+      ) {
+        lastSuccessfulSyncAt = row.last_synced_at as string;
+      }
+      if (
+        row.last_error_code &&
+        row.last_attempted_at &&
+        (!lastError || (row.last_attempted_at as string) > lastError.at)
+      ) {
+        lastError = {
+          code: row.last_error_code as string,
+          message: (row.last_error_message as string | null) ?? "",
+          at: row.last_attempted_at as string,
+        };
+      }
+    }
+  } catch {
+    // Schema unreachable — module diagnostic already captures the
+    // root cause; per-source fields stay zero.
+  }
+
+  return {
+    source,
+    env,
+    connected_clients: connectedClients,
+    last_successful_sync_at: lastSuccessfulSyncAt,
+    last_error: lastError,
+    clients_in_error: clientsInError,
+  };
+}

--- a/lib/optimiser/index.ts
+++ b/lib/optimiser/index.ts
@@ -172,3 +172,12 @@ export type {
   LlmAlignmentResult,
   LlmSubscoreResult,
 } from "./llm-alignment";
+
+// Slice 10 surface
+export { runDiagnostics } from "./diagnostics";
+export type {
+  DiagnosticsReport,
+  ModuleDiagnostic,
+  SourceDiagnostic,
+  EnvCheck,
+} from "./diagnostics";


### PR DESCRIPTION
## Summary
- `/api/optimiser/diagnostics` (admin-only JSON) + `/optimiser/diagnostics` (admin-only HTML view) — single \"is this thing wired up correctly\" check covering env vars, connected clients per source, last successful sync, last error.
- `.env.local.example` gets a new optimiser section.
- `docs/runbook/optimiser-credentials.md` — provisioning steps for every Opollo-wide credential the optimiser needs, each section ending with a Verify step that points back to the diagnostics page.

## Plan (sub-slice)
**Stack base.** `optimiser/slice-9-e2e-tests`.

**Why a dedicated diagnostics surface.** Slice 1's `/api/optimiser/health` is a liveness probe for monitors; it doesn't tell the operator which credentials are missing or which sync paths haven't fired. The diagnostics endpoint is the missing piece — operator hits it after each provisioning step to confirm the system saw the change.

**Admin-only.** Operators can read the page-browser / proposals surfaces; provisioning is a privileged decision (rotating master keys, setting OAuth client secrets), so the diagnostics endpoint is admin-only via `checkAdminAccess({requiredRoles: ['admin']})`.

## Risks identified and mitigated
- **Schema unreachability** — module-level check captures it; per-source diagnostics fall through with zero values rather than 500ing.
- **Env-var checks side-effect free** — synchronous `process.env` reads only; safe on cold start.
- **GA4 fallback** — accepts either `GA4_*` or `GOOGLE_OAUTH_*` pair so a single shared OAuth client can drive both Ads and GA4.
- **Runbook drift** — entries reference stable surfaces. If a route shape changes, the same PR updates the runbook (CLAUDE.md \"RUNBOOK is load-bearing\" rule).

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (1 new API route + 1 new page)
- [ ] End-to-end against a populated DB: `/optimiser/diagnostics` will report green/red exactly as expected once a fresh deploy has the env vars set; manual confirmation deferred to the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)