### PR TITLE
feat(optimiser-12): composite scoring + score history (v1.6)

### DIFF
--- a/app/api/cron/optimiser-evaluate-scores/route.ts
+++ b/app/api/cron/optimiser-evaluate-scores/route.ts
@@ -1,0 +1,26 @@
+import { type NextRequest } from "next/server";
+
+import {
+  authorisedCronRequest,
+  runOptimiserCronTick,
+  unauthorisedResponse,
+} from "@/lib/optimiser/sync/cron-shared";
+import { runEvaluateScoresForAllClients } from "@/lib/optimiser/scoring/evaluate-scores-job";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+async function handle(req: NextRequest) {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+  return runOptimiserCronTick({
+    eventName: "optimiser.evaluate_scores",
+    run: async () => {
+      const r = await runEvaluateScoresForAllClients();
+      return { outcomes: r.outcomes, total: r.total_pages };
+    },
+  });
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/app/optimiser/clients/[id]/settings/page.tsx
+++ b/app/optimiser/clients/[id]/settings/page.tsx
@@ -1,0 +1,139 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { getClient } from "@/lib/optimiser/clients";
+import {
+  DEFAULT_CONVERSION_COMPONENTS,
+  DEFAULT_SCORE_WEIGHTS,
+  type ConversionComponentsPresent,
+  type ScoreWeights,
+} from "@/lib/optimiser/scoring/types";
+
+// Client settings — addendum §6.2 Q1.6.4. Phase 1 surface is read-only;
+// staff can see the weights + conversion components present + causal
+// window. Phase 2 makes them editable once the calibration loop is
+// landing.
+
+export const metadata = { title: "Optimiser · Client settings" };
+export const dynamic = "force-dynamic";
+
+const WEIGHT_LABELS: Record<keyof ScoreWeights, string> = {
+  alignment: "Alignment",
+  behaviour: "Behaviour",
+  conversion: "Conversion",
+  technical: "Technical",
+};
+
+const WEIGHT_DESCRIPTIONS: Record<keyof ScoreWeights, string> = {
+  alignment:
+    "How well keywords + ads + landing-page copy match. Drives the message-mismatch / CTA-verb / offer-clarity playbooks.",
+  behaviour:
+    "Bounce rate, engagement time, scroll depth, CTA clicks per session. Normalised against this client's other active pages.",
+  conversion:
+    "Conversion rate (×0.50), cost per conversion (×0.30 inverse), revenue per visit (×0.20 if tracked). Where revenue isn't tracked, weight redistributes to CR (×0.65) and CPA (×0.35).",
+  technical:
+    "PageSpeed Insights mobile data: LCP / INP / CLS / mobile speed score. Mobile is dominant traffic for paid landing pages.",
+};
+
+export default async function ClientSettingsPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const client = await getClient(params.id);
+  if (!client) notFound();
+
+  const weights = (client.score_weights as ScoreWeights) ?? DEFAULT_SCORE_WEIGHTS;
+  const componentsPresent =
+    (client.conversion_components_present as ConversionComponentsPresent) ??
+    DEFAULT_CONVERSION_COMPONENTS;
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <p className="text-xs text-muted-foreground">
+            <Link href="/optimiser" className="text-primary underline-offset-4 hover:underline">
+              ← Page browser
+            </Link>
+          </p>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {client.name} — score settings
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Phase 1 surface is read-only. Phase 2 wires the manual override
+            via this page.
+          </p>
+        </div>
+        <Button asChild variant="outline">
+          <Link href={`/optimiser/onboarding/${client.id}`}>
+            Connector settings
+          </Link>
+        </Button>
+      </header>
+
+      <section className="space-y-4 rounded-lg border border-border bg-card p-6">
+        <h2 className="text-lg font-medium">Composite score weights</h2>
+        <p className="text-sm text-muted-foreground">
+          The composite is{" "}
+          <code className="font-mono text-xs">
+            (alignment × {weights.alignment.toFixed(2)}) + (behaviour × {weights.behaviour.toFixed(2)}) + (conversion × {weights.conversion.toFixed(2)}) + (technical × {weights.technical.toFixed(2)})
+          </code>
+          . Defaults are{" "}
+          <code className="font-mono text-xs">0.25 / 0.30 / 0.30 / 0.15</code>.
+        </p>
+        <ul className="space-y-3">
+          {(Object.keys(weights) as Array<keyof ScoreWeights>).map((key) => (
+            <li key={key} className="flex items-start gap-3">
+              <span className="mt-1 inline-block w-16 font-mono text-sm tabular-nums">
+                ×{weights[key].toFixed(2)}
+              </span>
+              <div className="flex-1">
+                <p className="font-medium">{WEIGHT_LABELS[key]}</p>
+                <p className="text-sm text-muted-foreground">
+                  {WEIGHT_DESCRIPTIONS[key]}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
+        <h2 className="text-lg font-medium">Conversion components present</h2>
+        <p className="text-sm text-muted-foreground">
+          Drives the §2.3 redistribution: when revenue tracking is missing,
+          its 0.20 weight folds into CR (×0.65) + CPA (×0.35).
+        </p>
+        <ul className="space-y-1 text-sm">
+          <li>
+            <span className="inline-block w-32 text-muted-foreground">Conversion rate</span>
+            <strong>{componentsPresent.cr ? "tracked" : "not tracked"}</strong>
+          </li>
+          <li>
+            <span className="inline-block w-32 text-muted-foreground">Cost per conversion</span>
+            <strong>{componentsPresent.cpa ? "tracked" : "not tracked"}</strong>
+          </li>
+          <li>
+            <span className="inline-block w-32 text-muted-foreground">Revenue per visit</span>
+            <strong>{componentsPresent.revenue ? "tracked" : "not tracked"}</strong>
+          </li>
+        </ul>
+      </section>
+
+      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
+        <h2 className="text-lg font-medium">Causal-delta measurement window</h2>
+        <p className="text-sm">
+          <span className="font-mono tabular-nums">{client.causal_eval_window_days}</span> days
+        </p>
+        <p className="text-sm text-muted-foreground">
+          After a regenerated page has been live for this many days (or
+          accumulated 300+ sessions on the new version, whichever is sooner),
+          the engine evaluates its actual impact and writes a row to
+          opt_causal_deltas. Lower-traffic B2B clients may extend this; default 14 days.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/app/optimiser/pages/[id]/page.tsx
+++ b/app/optimiser/pages/[id]/page.tsx
@@ -1,0 +1,195 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { ScoreBreakdownPanel } from "@/components/optimiser/ScoreBreakdownPanel";
+import { ScoreHistoryTable } from "@/components/optimiser/ScoreHistoryTable";
+import { ScoreSparkline } from "@/components/optimiser/ScoreSparkline";
+import { getClient } from "@/lib/optimiser/clients";
+import { getLandingPage } from "@/lib/optimiser/landing-pages";
+import { computeReliability } from "@/lib/optimiser/data-reliability";
+import { rollupForPage } from "@/lib/optimiser/metrics-aggregation";
+import {
+  computeBehaviourSubscore,
+  type BehaviourCohortRow,
+} from "@/lib/optimiser/scoring/behaviour-subscore";
+import {
+  computeCompositeScore,
+  lowestContribution,
+} from "@/lib/optimiser/scoring/composite-score";
+import {
+  computeConversionSubscore,
+  costPerConversionFromRollup,
+  type ConversionCohortRow,
+} from "@/lib/optimiser/scoring/conversion-subscore";
+import { computeTechnicalSubscore } from "@/lib/optimiser/scoring/technical-subscore";
+import { listScoreHistory, listScoreSparkline } from "@/lib/optimiser/scoring/score-history";
+import {
+  DEFAULT_CONVERSION_COMPONENTS,
+  DEFAULT_SCORE_WEIGHTS,
+  type ConversionComponentsPresent,
+  type ScoreWeights,
+} from "@/lib/optimiser/scoring/types";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+export const metadata = { title: "Optimiser · Page detail" };
+export const dynamic = "force-dynamic";
+
+export default async function OptimiserPageDetail({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const page = await getLandingPage(params.id);
+  if (!page) notFound();
+  const client = await getClient(page.client_id);
+  if (!client) notFound();
+
+  // Compute the live composite breakdown for the panel. The page row's
+  // cached current_composite_score / current_classification feed the
+  // page browser; the detail panel recomputes against the latest
+  // rollup so the displayed sub-scores match what the user sees in
+  // the metrics columns.
+  const weights = (client.score_weights as ScoreWeights) ?? DEFAULT_SCORE_WEIGHTS;
+  const componentsPresent =
+    (client.conversion_components_present as ConversionComponentsPresent) ??
+    DEFAULT_CONVERSION_COMPONENTS;
+
+  const rollup = await rollupForPage(page.id);
+  const reliability = computeReliability(rollup);
+
+  const cohort = await fetchClientCohort(page.client_id);
+
+  const supabase = getServiceRoleClient();
+  const { data: alignmentRow } = await supabase
+    .from("opt_alignment_scores")
+    .select("score")
+    .eq("landing_page_id", page.id)
+    .order("computed_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const alignmentScore = (alignmentRow?.score as number | null) ?? null;
+
+  const behaviour = computeBehaviourSubscore(rollup, cohort.behaviour);
+  const conversion = page.conversion_n_a
+    ? null
+    : computeConversionSubscore({
+        rollup,
+        cohort: cohort.conversion,
+        componentsPresent,
+        costPerConversionCents: costPerConversionFromRollup(rollup) ?? undefined,
+      });
+  const technical = computeTechnicalSubscore(rollup);
+
+  const composite = computeCompositeScore({
+    subscores: {
+      alignment: alignmentScore,
+      behaviour: behaviour?.score ?? null,
+      conversion: conversion?.score ?? null,
+      technical: technical?.score ?? null,
+    },
+    configuredWeights: weights,
+    conversionNotApplicable: page.conversion_n_a,
+  });
+
+  const dragging = composite ? lowestContribution(composite) : null;
+  const sparkline = await listScoreSparkline({
+    landingPageId: page.id,
+    limit: 10,
+  });
+  const history = await listScoreHistory({ landingPageId: page.id, limit: 30 });
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-1">
+          <p className="text-xs text-muted-foreground">
+            <Link href="/optimiser" className="text-primary underline-offset-4 hover:underline">
+              ← Page browser
+            </Link>{" "}
+            · {client.name}
+          </p>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {page.display_name ?? page.url}
+          </h1>
+          <p className="font-mono text-xs text-muted-foreground">{page.url}</p>
+        </div>
+        <Button asChild variant="outline">
+          <Link
+            href={`/optimiser/clients/${client.id}/settings`}
+          >
+            Score weights
+          </Link>
+        </Button>
+      </header>
+
+      {composite ? (
+        <ScoreBreakdownPanel
+          result={composite}
+          subscores={{
+            alignment: alignmentScore,
+            behaviour: behaviour?.score ?? null,
+            conversion: conversion?.score ?? null,
+            technical: technical?.score ?? null,
+          }}
+          reliability={reliability.reliability}
+          draggingSubscore={dragging}
+        />
+      ) : (
+        <section className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+          Gathering data — composite score available once §9.5 thresholds
+          are met (sessions ≥ 100, freshness ≤ 7 days, behaviour data
+          present).
+        </section>
+      )}
+
+      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
+        <header className="flex items-center justify-between">
+          <h2 className="text-lg font-medium">Score history</h2>
+          {sparkline.length > 0 && (
+            <ScoreSparkline
+              points={sparkline.map((row) => ({
+                value: row.composite_score,
+                classification: row.classification,
+                evaluated_at: row.evaluated_at,
+              }))}
+              width={240}
+              height={56}
+            />
+          )}
+        </header>
+        <ScoreHistoryTable history={history} />
+      </section>
+    </div>
+  );
+}
+
+async function fetchClientCohort(clientId: string): Promise<{
+  behaviour: BehaviourCohortRow[];
+  conversion: ConversionCohortRow[];
+}> {
+  const supabase = getServiceRoleClient();
+  const { data: pages } = await supabase
+    .from("opt_landing_pages")
+    .select("id")
+    .eq("client_id", clientId)
+    .eq("managed", true)
+    .is("deleted_at", null);
+  const behaviour: BehaviourCohortRow[] = [];
+  const conversion: ConversionCohortRow[] = [];
+  for (const p of pages ?? []) {
+    const r = await rollupForPage(p.id as string);
+    behaviour.push({
+      bounce_rate: r.bounce_rate > 0 ? r.bounce_rate : null,
+      avg_engagement_time_s:
+        r.avg_engagement_time_s > 0 ? r.avg_engagement_time_s : null,
+      avg_scroll_depth: r.avg_scroll_depth > 0 ? r.avg_scroll_depth : null,
+    });
+    const cpa = costPerConversionFromRollup(r);
+    conversion.push({
+      conversion_rate: r.conversion_rate > 0 ? r.conversion_rate : null,
+      cost_per_conversion: cpa,
+    });
+  }
+  return { behaviour, conversion };
+}

--- a/components/optimiser/PageBrowser.tsx
+++ b/components/optimiser/PageBrowser.tsx
@@ -11,9 +11,14 @@ import type {
   OptDataReliability,
   OptPageState,
 } from "@/lib/optimiser/types";
+import {
+  classificationBadgeColor,
+  classificationLabel,
+} from "@/lib/optimiser/scoring/classify";
+import type { ScoreClassification } from "@/lib/optimiser/scoring/types";
 
-// Page browser (§9.3). Lists every landing page for the selected
-// client with state + data reliability dot + key metrics.
+// Page browser (§9.3 + addendum §4.1).
+// v1.6 adds the composite-score column + classification badge.
 
 const STATE_PILL: Record<OptPageState, string> = {
   active: "bg-blue-100 text-blue-900 border-blue-200",
@@ -50,6 +55,8 @@ export type PageBrowserProps = {
 
 export function PageBrowser({ client, pages }: PageBrowserProps) {
   const [filterState, setFilterState] = useState<"all" | OptPageState>("all");
+  const [filterClassification, setFilterClassification] =
+    useState<"all" | ScoreClassification>("all");
   const [filterReliability, setFilterReliability] =
     useState<"all" | OptDataReliability>("all");
   const [search, setSearch] = useState("");
@@ -57,6 +64,12 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
   const filtered = useMemo(() => {
     return pages.filter((p) => {
       if (filterState !== "all" && p.state !== filterState) return false;
+      if (
+        filterClassification !== "all" &&
+        p.current_classification !== filterClassification
+      ) {
+        return false;
+      }
       if (filterReliability !== "all" && p.data_reliability !== filterReliability) {
         return false;
       }
@@ -65,9 +78,25 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
       }
       return true;
     });
-  }, [pages, filterState, filterReliability, search]);
+  }, [pages, filterState, filterClassification, filterReliability, search]);
 
-  const counts = useMemo(() => {
+  const classCounts = useMemo(() => {
+    const c: Record<ScoreClassification | "total" | "uncategorised", number> = {
+      total: pages.length,
+      high_performer: 0,
+      optimisable: 0,
+      needs_attention: 0,
+      uncategorised: 0,
+    };
+    for (const p of pages) {
+      const cls = p.current_classification as ScoreClassification | null;
+      if (cls && cls in c) c[cls] += 1;
+      else c.uncategorised += 1;
+    }
+    return c;
+  }, [pages]);
+
+  const stateCounts = useMemo(() => {
     const c: Record<OptPageState | "total", number> = {
       total: pages.length,
       active: 0,
@@ -83,26 +112,26 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex items-center gap-2">
-          <Pill onClick={() => setFilterState("all")} active={filterState === "all"}>
-            All ({counts.total})
-          </Pill>
-          <Pill onClick={() => setFilterState("active")} active={filterState === "active"}>
-            Active ({counts.active})
-          </Pill>
-          <Pill onClick={() => setFilterState("healthy")} active={filterState === "healthy"}>
-            Healthy ({counts.healthy})
+          <Pill onClick={() => setFilterClassification("all")} active={filterClassification === "all"}>
+            All ({classCounts.total})
           </Pill>
           <Pill
-            onClick={() => setFilterState("insufficient_data")}
-            active={filterState === "insufficient_data"}
+            onClick={() => setFilterClassification("high_performer")}
+            active={filterClassification === "high_performer"}
           >
-            Gathering ({counts.insufficient_data})
+            High performers ({classCounts.high_performer})
           </Pill>
           <Pill
-            onClick={() => setFilterState("read_only_external")}
-            active={filterState === "read_only_external"}
+            onClick={() => setFilterClassification("optimisable")}
+            active={filterClassification === "optimisable"}
           >
-            Read-only ({counts.read_only_external})
+            Optimisable ({classCounts.optimisable})
+          </Pill>
+          <Pill
+            onClick={() => setFilterClassification("needs_attention")}
+            active={filterClassification === "needs_attention"}
+          >
+            Needs attention ({classCounts.needs_attention})
           </Pill>
         </div>
         <div className="ml-auto flex items-center gap-2">
@@ -124,6 +153,21 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
             <option value="amber">Amber+</option>
             <option value="red">Red only</option>
           </select>
+          <select
+            value={filterState}
+            onChange={(e) => setFilterState(e.target.value as "all" | OptPageState)}
+            className="rounded-md border border-border bg-background px-2 py-1.5 text-sm"
+          >
+            <option value="all">State: any ({stateCounts.total})</option>
+            <option value="active">Active ({stateCounts.active})</option>
+            <option value="healthy">Healthy ({stateCounts.healthy})</option>
+            <option value="insufficient_data">
+              Gathering ({stateCounts.insufficient_data})
+            </option>
+            <option value="read_only_external">
+              Read-only ({stateCounts.read_only_external})
+            </option>
+          </select>
         </div>
       </div>
 
@@ -133,6 +177,7 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
             <tr>
               <th className="px-3 py-2 w-8"></th>
               <th className="px-3 py-2">Page</th>
+              <th className="px-3 py-2">Score</th>
               <th className="px-3 py-2">State</th>
               <th className="px-3 py-2 text-right">Alignment</th>
               <th className="px-3 py-2 text-right">CR</th>
@@ -145,15 +190,17 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
           <tbody>
             {filtered.length === 0 && (
               <tr>
-                <td colSpan={9} className="px-3 py-8 text-center text-muted-foreground">
+                <td colSpan={10} className="px-3 py-8 text-center text-muted-foreground">
                   No pages match the current filters.
                 </td>
               </tr>
             )}
             {filtered.map((p) => {
               const dot = RELIABILITY_DOT[p.data_reliability];
+              const cls = p.current_classification as ScoreClassification | null;
+              const score = p.current_composite_score as number | null;
               return (
-                <tr key={p.id} className="border-t border-border align-top">
+                <tr key={p.id} className="border-t border-border align-top hover:bg-muted/20">
                   <td className="px-3 py-2">
                     <span
                       title={dot.label}
@@ -162,7 +209,12 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
                     />
                   </td>
                   <td className="px-3 py-2">
-                    <div className="font-mono text-xs">{p.url}</div>
+                    <Link
+                      href={`/optimiser/pages/${p.id}`}
+                      className="font-mono text-xs text-primary underline-offset-4 hover:underline"
+                    >
+                      {p.url}
+                    </Link>
                     {(p.active_technical_alerts ?? []).length > 0 && (
                       <div className="mt-1 flex flex-wrap gap-1">
                         {(p.active_technical_alerts as string[]).map((alert) => (
@@ -174,6 +226,13 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
                           </span>
                         ))}
                       </div>
+                    )}
+                  </td>
+                  <td className="px-3 py-2">
+                    {score != null && cls ? (
+                      <ScoreBadge score={score} classification={cls} />
+                    ) : (
+                      <span className="text-xs text-muted-foreground">—</span>
                     )}
                   </td>
                   <td className="px-3 py-2">
@@ -220,6 +279,13 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
           className="text-primary underline-offset-4 hover:underline"
         >
           settings
+        </Link>{" "}
+        ·{" "}
+        <Link
+          href={`/optimiser/clients/${client.id}/settings`}
+          className="text-primary underline-offset-4 hover:underline"
+        >
+          score weights
         </Link>
       </p>
     </div>
@@ -244,5 +310,24 @@ function Pill({
     >
       {children}
     </Button>
+  );
+}
+
+function ScoreBadge({
+  score,
+  classification,
+}: {
+  score: number;
+  classification: ScoreClassification;
+}) {
+  const colours = classificationBadgeColor(classification);
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-full border px-2 py-0.5 ${colours.bg} ${colours.border} ${colours.text}`}
+      title={classificationLabel(classification)}
+    >
+      <span aria-hidden className={`inline-block size-2 rounded-full ${colours.dot}`} />
+      <span className="font-mono text-sm font-semibold">{score}</span>
+    </span>
   );
 }

--- a/components/optimiser/ScoreBreakdownPanel.tsx
+++ b/components/optimiser/ScoreBreakdownPanel.tsx
@@ -1,0 +1,180 @@
+import {
+  classificationBadgeColor,
+  classificationLabel,
+} from "@/lib/optimiser/scoring/classify";
+import type {
+  CompositeResult,
+  SubscoreBundle,
+} from "@/lib/optimiser/scoring/types";
+
+// Score breakdown panel — addendum §4.1.
+//
+// Server component. Renders:
+//   - Composite score (large) + classification badge + reliability dot
+//   - Four horizontal bars showing each sub-score's weighted contribution
+//   - One-line interpretation pointing at the lowest-contribution sub-score
+
+const PLAYBOOK_HINT_BY_SUBSCORE: Record<
+  keyof SubscoreBundle,
+  { label: string; playbooks: string[] }
+> = {
+  alignment: {
+    label: "Alignment",
+    playbooks: ["Message mismatch", "CTA verb mismatch"],
+  },
+  behaviour: {
+    label: "Behaviour",
+    playbooks: ["Weak above-the-fold", "Form friction"],
+  },
+  conversion: {
+    label: "Conversion",
+    playbooks: ["Offer clarity", "Trust gap"],
+  },
+  technical: {
+    label: "Technical",
+    playbooks: ["Page speed alert"],
+  },
+};
+
+export function ScoreBreakdownPanel({
+  result,
+  subscores,
+  reliability,
+  draggingSubscore,
+}: {
+  result: CompositeResult;
+  subscores: SubscoreBundle;
+  reliability: "green" | "amber" | "red";
+  draggingSubscore: keyof SubscoreBundle | null;
+}) {
+  const colours = classificationBadgeColor(result.classification);
+  const reliabilityColour =
+    reliability === "green"
+      ? "bg-emerald-500"
+      : reliability === "amber"
+        ? "bg-amber-400"
+        : "bg-red-500";
+  return (
+    <section className="space-y-5 rounded-lg border border-border bg-card p-6">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Composite score
+          </p>
+          <p className="mt-1 flex items-center gap-3">
+            <span className="text-4xl font-semibold tabular-nums">
+              {result.composite_score}
+            </span>
+            <span
+              className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm font-medium ${colours.bg} ${colours.border} ${colours.text}`}
+            >
+              <span aria-hidden className={`size-2 rounded-full ${colours.dot}`} />
+              {classificationLabel(result.classification)}
+            </span>
+            <span
+              aria-hidden
+              className={`size-2.5 rounded-full ${reliabilityColour}`}
+              title={`Data reliability: ${reliability}`}
+            />
+          </p>
+        </div>
+      </header>
+
+      <div className="space-y-2">
+        <SubscoreBar
+          label="Alignment"
+          value={subscores.alignment}
+          weight={result.weights_used.alignment}
+          contribution={result.contributions.alignment}
+          highlight={draggingSubscore === "alignment"}
+        />
+        <SubscoreBar
+          label="Behaviour"
+          value={subscores.behaviour}
+          weight={result.weights_used.behaviour}
+          contribution={result.contributions.behaviour}
+          highlight={draggingSubscore === "behaviour"}
+        />
+        <SubscoreBar
+          label="Conversion"
+          value={subscores.conversion}
+          weight={result.weights_used.conversion}
+          contribution={result.contributions.conversion}
+          highlight={draggingSubscore === "conversion"}
+        />
+        <SubscoreBar
+          label="Technical"
+          value={subscores.technical}
+          weight={result.weights_used.technical}
+          contribution={result.contributions.technical}
+          highlight={draggingSubscore === "technical"}
+        />
+      </div>
+
+      {draggingSubscore && (
+        <p className="rounded-md bg-muted/50 p-3 text-sm">
+          <span className="font-medium">What&apos;s dragging this score down:</span>{" "}
+          {PLAYBOOK_HINT_BY_SUBSCORE[draggingSubscore].label} is the
+          weakest sub-score. Two relevant playbooks:{" "}
+          {PLAYBOOK_HINT_BY_SUBSCORE[draggingSubscore].playbooks.join(", ")}.
+        </p>
+      )}
+      {!draggingSubscore && result.classification === "high_performer" && (
+        <p className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-900">
+          Performing within expected range across all sub-scores. No
+          action needed unless a playbook trigger fires.
+        </p>
+      )}
+
+      {result.redistribution_applied && (
+        <p className="text-xs text-muted-foreground">
+          Note: weights redistributed because some sub-scores didn&apos;t
+          have enough data or the page is flagged conversion_n_a.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function SubscoreBar({
+  label,
+  value,
+  weight,
+  contribution,
+  highlight,
+}: {
+  label: string;
+  value: number | null;
+  weight: number;
+  contribution: number;
+  highlight: boolean;
+}) {
+  const pct = value == null ? 0 : Math.max(0, Math.min(100, value));
+  const isUnused = weight === 0;
+  return (
+    <div
+      className={`rounded-md ${
+        highlight ? "border border-amber-200 bg-amber-50/60 p-2" : "p-1"
+      }`}
+    >
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium">{label}</span>
+        <span className="tabular-nums text-muted-foreground">
+          {value == null
+            ? isUnused
+              ? "(not weighted)"
+              : "(insufficient data)"
+            : `${value} (×${weight.toFixed(2)} = ${contribution.toFixed(1)})`}
+        </span>
+      </div>
+      <div className="mt-1 h-2 overflow-hidden rounded-full bg-muted">
+        {value != null && !isUnused && (
+          <div
+            className="h-full rounded-full bg-primary"
+            style={{ width: `${pct}%` }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/optimiser/ScoreHistoryTable.tsx
+++ b/components/optimiser/ScoreHistoryTable.tsx
@@ -1,0 +1,119 @@
+import {
+  classificationBadgeColor,
+  classificationLabel,
+} from "@/lib/optimiser/scoring/classify";
+import type { ScoreHistoryRow } from "@/lib/optimiser/scoring/score-history";
+
+// §4.2 Score history view — full timeline of every score evaluation
+// for a page. Slice 12 ships the table; Slice 13 wires the rollback
+// action via the placeholder button. Tooltip explains the placeholder.
+
+export function ScoreHistoryTable({
+  history,
+  causalDeltas,
+}: {
+  history: ScoreHistoryRow[];
+  /** Slice 13 populates this; Slice 12 always passes an empty array. */
+  causalDeltas?: Map<
+    string,
+    { actual_impact_cr?: number | null; actual_impact_score?: number | null }
+  >;
+}) {
+  if (history.length === 0) {
+    return (
+      <p className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        No score history yet. Daily evaluation produces the first row
+        within 24 hours of onboarding.
+      </p>
+    );
+  }
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/40 text-left">
+          <tr>
+            <th className="px-3 py-2">When</th>
+            <th className="px-3 py-2">Composite</th>
+            <th className="px-3 py-2">Classification</th>
+            <th className="px-3 py-2 text-right">Align</th>
+            <th className="px-3 py-2 text-right">Behav</th>
+            <th className="px-3 py-2 text-right">Conv</th>
+            <th className="px-3 py-2 text-right">Tech</th>
+            <th className="px-3 py-2">Trigger</th>
+            <th className="px-3 py-2">Causal delta</th>
+            <th className="px-3 py-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {history.map((row, idx) => {
+            const colours = classificationBadgeColor(row.classification);
+            const isCurrent = idx === 0;
+            const delta = causalDeltas?.get(row.id);
+            return (
+              <tr
+                key={row.id}
+                className={`border-t border-border ${
+                  isCurrent ? "bg-emerald-50/40" : ""
+                }`}
+              >
+                <td className="px-3 py-2 whitespace-nowrap text-xs text-muted-foreground">
+                  {new Date(row.evaluated_at).toLocaleString()}
+                  {isCurrent && (
+                    <span className="ml-2 text-emerald-700">current</span>
+                  )}
+                </td>
+                <td className="px-3 py-2 font-mono font-semibold">
+                  {row.composite_score}
+                </td>
+                <td className="px-3 py-2">
+                  <span
+                    className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs ${colours.bg} ${colours.border} ${colours.text}`}
+                  >
+                    <span aria-hidden className={`size-1.5 rounded-full ${colours.dot}`} />
+                    {classificationLabel(row.classification)}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-xs">
+                  {row.alignment_subscore ?? "—"}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-xs">
+                  {row.behaviour_subscore ?? "—"}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-xs">
+                  {row.conversion_subscore ?? "—"}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-xs">
+                  {row.technical_subscore ?? "—"}
+                </td>
+                <td className="px-3 py-2 text-xs">
+                  {row.triggering_proposal_id
+                    ? row.change_set_summary ?? row.triggering_proposal_id.slice(0, 8) + "…"
+                    : "—"}
+                </td>
+                <td className="px-3 py-2 text-xs">
+                  {delta?.actual_impact_cr != null
+                    ? `${delta.actual_impact_cr > 0 ? "+" : ""}${(delta.actual_impact_cr * 100).toFixed(1)}% CR`
+                    : delta?.actual_impact_score != null
+                      ? `${delta.actual_impact_score > 0 ? "+" : ""}${delta.actual_impact_score.toFixed(0)} pts`
+                      : "—"}
+                </td>
+                <td className="px-3 py-2">
+                  {!isCurrent && (
+                    <button
+                      type="button"
+                      disabled
+                      title="Rollback ships in the next update"
+                      className="rounded-md border border-border bg-muted/40 px-2 py-1 text-xs text-muted-foreground"
+                    >
+                      Roll back
+                    </button>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/optimiser/ScoreSparkline.tsx
+++ b/components/optimiser/ScoreSparkline.tsx
@@ -1,0 +1,99 @@
+// Tiny SVG sparkline for the page detail panel + page browser hover.
+// Server-renderable (no React state, no event handlers); render-on-the-
+// page input is a small array of {value, classification, evaluated_at}.
+
+import type { ScoreClassification } from "@/lib/optimiser/scoring/types";
+
+export type SparklinePoint = {
+  value: number;
+  classification: ScoreClassification;
+  evaluated_at: string;
+};
+
+const STROKE_BY_CLASS: Record<ScoreClassification, string> = {
+  high_performer: "#10b981",
+  optimisable: "#f59e0b",
+  needs_attention: "#ef4444",
+};
+
+export function ScoreSparkline({
+  points,
+  width = 200,
+  height = 48,
+}: {
+  points: SparklinePoint[];
+  width?: number;
+  height?: number;
+}) {
+  if (points.length === 0) {
+    return (
+      <div
+        style={{ width, height }}
+        className="flex items-center justify-center rounded-md border border-dashed border-border text-xs text-muted-foreground"
+      >
+        no history
+      </div>
+    );
+  }
+  const padding = 4;
+  const innerW = width - padding * 2;
+  const innerH = height - padding * 2;
+  const minScore = 0;
+  const maxScore = 100;
+  const stepX = points.length > 1 ? innerW / (points.length - 1) : 0;
+  const path = points
+    .map((p, i) => {
+      const x = padding + i * stepX;
+      const y =
+        padding +
+        innerH -
+        ((p.value - minScore) / (maxScore - minScore)) * innerH;
+      return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  const last = points[points.length - 1];
+  const lastX = padding + (points.length - 1) * stepX;
+  const lastY =
+    padding +
+    innerH -
+    ((last.value - minScore) / (maxScore - minScore)) * innerH;
+  return (
+    <svg
+      width={width}
+      height={height}
+      role="img"
+      aria-label={`Score sparkline, latest ${last.value}`}
+    >
+      <line
+        x1={padding}
+        x2={width - padding}
+        y1={padding + innerH * 0.2}
+        y2={padding + innerH * 0.2}
+        stroke="#10b98140"
+        strokeDasharray="2 3"
+      />
+      <line
+        x1={padding}
+        x2={width - padding}
+        y1={padding + innerH * 0.4}
+        y2={padding + innerH * 0.4}
+        stroke="#f59e0b40"
+        strokeDasharray="2 3"
+      />
+      <path
+        d={path}
+        fill="none"
+        stroke={STROKE_BY_CLASS[last.classification]}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <circle
+        cx={lastX}
+        cy={lastY}
+        r={3}
+        fill={STROKE_BY_CLASS[last.classification]}
+      />
+    </svg>
+  );
+}

--- a/lib/optimiser/clients.ts
+++ b/lib/optimiser/clients.ts
@@ -23,13 +23,27 @@ export type OptClient = {
   confidence_overrides: Record<string, unknown>;
   data_threshold_overrides: Record<string, unknown>;
   onboarded_at: string | null;
+  // v1.6 additions — composite-score weights + conversion-component
+  // availability + causal-delta measurement window.
+  score_weights: {
+    alignment: number;
+    behaviour: number;
+    conversion: number;
+    technical: number;
+  };
+  conversion_components_present: {
+    cr: boolean;
+    cpa: boolean;
+    revenue: boolean;
+  };
+  causal_eval_window_days: number;
   version_lock: number;
   created_at: string;
   updated_at: string;
 };
 
 const CLIENT_COLUMNS =
-  "id, name, primary_contact_email, cross_client_learning_consent, llm_monthly_budget_usd, hosting_mode, hosting_cname_host, client_slug, staged_rollout_config, confidence_overrides, data_threshold_overrides, onboarded_at, version_lock, created_at, updated_at";
+  "id, name, primary_contact_email, cross_client_learning_consent, llm_monthly_budget_usd, hosting_mode, hosting_cname_host, client_slug, staged_rollout_config, confidence_overrides, data_threshold_overrides, onboarded_at, score_weights, conversion_components_present, causal_eval_window_days, version_lock, created_at, updated_at";
 
 export async function listClients(): Promise<OptClient[]> {
   const supabase = getServiceRoleClient();

--- a/lib/optimiser/index.ts
+++ b/lib/optimiser/index.ts
@@ -181,3 +181,50 @@ export type {
   SourceDiagnostic,
   EnvCheck,
 } from "./diagnostics";
+
+// Slice 12 surface — v1.6 composite scoring
+export {
+  classify,
+  classificationLabel,
+  classificationBadgeColor,
+} from "./scoring/classify";
+export type {
+  ScoreClassification,
+  ScoreWeights,
+  ConversionComponentsPresent,
+  SubscoreBundle,
+  CompositeResult,
+  CompositeConfidence,
+} from "./scoring/types";
+export {
+  DEFAULT_SCORE_WEIGHTS,
+  DEFAULT_CONVERSION_COMPONENTS,
+} from "./scoring/types";
+export {
+  computeBehaviourSubscore,
+  type BehaviourCohortRow,
+  type BehaviourScoreResult,
+} from "./scoring/behaviour-subscore";
+export {
+  computeConversionSubscore,
+  costPerConversionFromRollup,
+  type ConversionCohortRow,
+  type ConversionScoreResult,
+} from "./scoring/conversion-subscore";
+export {
+  computeTechnicalSubscore,
+  type TechnicalScoreResult,
+} from "./scoring/technical-subscore";
+export {
+  computeCompositeScore,
+  lowestContribution,
+} from "./scoring/composite-score";
+export {
+  runEvaluateScoresForAllClients,
+  type EvaluateScoresOutcome,
+} from "./scoring/evaluate-scores-job";
+export {
+  listScoreHistory,
+  listScoreSparkline,
+  type ScoreHistoryRow,
+} from "./scoring/score-history";

--- a/lib/optimiser/landing-pages.ts
+++ b/lib/optimiser/landing-pages.ts
@@ -26,13 +26,22 @@ export type LandingPage = {
   active_technical_alerts: unknown[];
   data_reliability: "green" | "amber" | "red";
   data_reliability_checks: Record<string, unknown>;
+  // v1.6 — composite-score cache columns. NULL until the
+  // /api/cron/optimiser-evaluate-scores tick has run for this page.
+  current_composite_score: number | null;
+  current_classification:
+    | "high_performer"
+    | "optimisable"
+    | "needs_attention"
+    | null;
+  conversion_n_a: boolean;
   version_lock: number;
   created_at: string;
   updated_at: string;
 };
 
 const COLS =
-  "id, client_id, url, display_name, managed, management_mode, page_id, state, state_evaluated_at, state_reasons, spend_30d_usd_cents, sessions_30d, core_offer, page_snapshot, active_technical_alerts, data_reliability, data_reliability_checks, version_lock, created_at, updated_at";
+  "id, client_id, url, display_name, managed, management_mode, page_id, state, state_evaluated_at, state_reasons, spend_30d_usd_cents, sessions_30d, core_offer, page_snapshot, active_technical_alerts, data_reliability, data_reliability_checks, current_composite_score, current_classification, conversion_n_a, version_lock, created_at, updated_at";
 
 export async function listLandingPagesForClient(
   clientId: string,

--- a/lib/optimiser/scoring/behaviour-subscore.ts
+++ b/lib/optimiser/scoring/behaviour-subscore.ts
@@ -1,0 +1,115 @@
+import "server-only";
+
+import type { PageMetricsRollup } from "../metrics-aggregation";
+import { normaliseAgainstPercentiles } from "./percentile";
+
+// Behaviour sub-score — addendum §2.2.2.
+//
+// Aggregates four behaviour signals from Clarity + GA4 into a single
+// 0–100 score, normalised against the client's active-pages 25th–75th
+// percentile range. Comparing within the client's own page cohort is
+// the right baseline — pages within an account should be comparable;
+// cross-account benchmarks aren't.
+//
+// Weights (from Table 1):
+//   bounce_rate          0.30 (lower is better)
+//   avg_engagement_time  0.25 (higher is better)
+//   scroll_depth         0.25 (higher is better)
+//   cta_clicks_per_session 0.20 (higher is better)
+//
+// Where a component's input is unavailable (e.g. no Clarity data for
+// scroll), that component's weight redistributes proportionally
+// across the components that DO have data. The result is undefined
+// (returns NULL) only when the cohort itself is too small (< 2 pages
+// with that component) or when all four inputs are missing.
+
+const COMPONENT_WEIGHTS = {
+  bounce_rate: 0.3,
+  avg_engagement_time_s: 0.25,
+  avg_scroll_depth: 0.25,
+  cta_clicks_per_session: 0.2,
+} as const;
+
+export type BehaviourCohortRow = {
+  bounce_rate?: number | null;
+  avg_engagement_time_s?: number | null;
+  avg_scroll_depth?: number | null;
+  cta_clicks_per_session?: number | null;
+};
+
+export type BehaviourScoreResult = {
+  score: number;
+  components: {
+    bounce_rate: number | null;
+    avg_engagement_time_s: number | null;
+    avg_scroll_depth: number | null;
+    cta_clicks_per_session: number | null;
+  };
+  components_used: number;
+};
+
+export function computeBehaviourSubscore(
+  rollup: PageMetricsRollup,
+  cohort: BehaviourCohortRow[],
+  ctaClicksPerSession?: number,
+): BehaviourScoreResult | null {
+  const componentScores = {
+    bounce_rate: scoreComponent(
+      rollup.bounce_rate > 0 ? rollup.bounce_rate : null,
+      cohort.map((r) => r.bounce_rate ?? null),
+      "lower_is_better",
+    ),
+    avg_engagement_time_s: scoreComponent(
+      rollup.avg_engagement_time_s > 0
+        ? rollup.avg_engagement_time_s
+        : null,
+      cohort.map((r) => r.avg_engagement_time_s ?? null),
+      "higher_is_better",
+    ),
+    avg_scroll_depth: scoreComponent(
+      rollup.avg_scroll_depth > 0 ? rollup.avg_scroll_depth : null,
+      cohort.map((r) => r.avg_scroll_depth ?? null),
+      "higher_is_better",
+    ),
+    cta_clicks_per_session: scoreComponent(
+      typeof ctaClicksPerSession === "number" && ctaClicksPerSession > 0
+        ? ctaClicksPerSession
+        : null,
+      cohort.map((r) => r.cta_clicks_per_session ?? null),
+      "higher_is_better",
+    ),
+  };
+
+  // Sum up weighted contributions, redistributing across the
+  // available components if some are missing.
+  let totalWeight = 0;
+  let weightedSum = 0;
+  for (const [key, weight] of Object.entries(COMPONENT_WEIGHTS) as Array<
+    [keyof typeof COMPONENT_WEIGHTS, number]
+  >) {
+    const componentValue = componentScores[key];
+    if (componentValue == null) continue;
+    weightedSum += componentValue * weight;
+    totalWeight += weight;
+  }
+  if (totalWeight === 0) return null;
+  const composite = Math.round(weightedSum / totalWeight);
+  return {
+    score: Math.max(0, Math.min(100, composite)),
+    components: componentScores,
+    components_used: Object.values(componentScores).filter((v) => v != null)
+      .length,
+  };
+}
+
+function scoreComponent(
+  value: number | null,
+  cohortValues: Array<number | null>,
+  direction: "higher_is_better" | "lower_is_better",
+): number | null {
+  if (value == null) return null;
+  const cohort = cohortValues.filter(
+    (v): v is number => v != null && Number.isFinite(v),
+  );
+  return normaliseAgainstPercentiles(value, cohort, direction);
+}

--- a/lib/optimiser/scoring/classify.ts
+++ b/lib/optimiser/scoring/classify.ts
@@ -1,0 +1,54 @@
+import type { ScoreClassification } from "./types";
+
+// Composite-score classification per addendum §2.3.
+//   80–100 → high_performer  (green)
+//   60–79  → optimisable    (amber)
+//    0–59  → needs_attention (red)
+
+export function classify(score: number): ScoreClassification {
+  if (score >= 80) return "high_performer";
+  if (score >= 60) return "optimisable";
+  return "needs_attention";
+}
+
+export function classificationLabel(c: ScoreClassification): string {
+  switch (c) {
+    case "high_performer":
+      return "High performer";
+    case "optimisable":
+      return "Optimisable";
+    case "needs_attention":
+      return "Needs attention";
+  }
+}
+
+export function classificationBadgeColor(c: ScoreClassification): {
+  bg: string;
+  border: string;
+  text: string;
+  dot: string;
+} {
+  switch (c) {
+    case "high_performer":
+      return {
+        bg: "bg-emerald-100",
+        border: "border-emerald-200",
+        text: "text-emerald-900",
+        dot: "bg-emerald-500",
+      };
+    case "optimisable":
+      return {
+        bg: "bg-amber-100",
+        border: "border-amber-200",
+        text: "text-amber-900",
+        dot: "bg-amber-400",
+      };
+    case "needs_attention":
+      return {
+        bg: "bg-red-100",
+        border: "border-red-200",
+        text: "text-red-900",
+        dot: "bg-red-500",
+      };
+  }
+}

--- a/lib/optimiser/scoring/composite-score.ts
+++ b/lib/optimiser/scoring/composite-score.ts
@@ -1,0 +1,154 @@
+import { classify } from "./classify";
+import {
+  DEFAULT_SCORE_WEIGHTS,
+  type CompositeResult,
+  type ScoreWeights,
+  type SubscoreBundle,
+} from "./types";
+
+// Composite-score assembler — addendum §2.1 + §2.4.
+//
+// Formula:
+//   composite = (alignment × w_a) + (behaviour × w_b)
+//             + (conversion × w_c) + (technical × w_t)
+//
+// Edge cases:
+//   1. conversion_n_a = TRUE  → conversion's 0.30 weight redistributes
+//      equally across alignment / behaviour / technical (so each grows
+//      by 0.10).
+//   2. Any sub-score input unavailable → that sub-score's weight
+//      redistributes proportionally across the available sub-scores.
+//      (Alignment is the canonical case: a brand-new page with no ad
+//      group join has no alignment score; the 0.25 weight folds into
+//      the rest.)
+//   3. Both edge cases combine: if conversion_n_a and alignment is
+//      unavailable, the remaining 0.55 weight (behaviour 0.30 +
+//      technical 0.15 + the redistributed conversion 0.10 each) is
+//      applied to behaviour + technical.
+//
+// `weights_used` in the result is always the post-redistribution
+// weights — what was actually applied — so the persisted history
+// row shows the truth, not the configured defaults.
+
+export function computeCompositeScore(args: {
+  subscores: SubscoreBundle;
+  configuredWeights?: ScoreWeights;
+  conversionNotApplicable?: boolean;
+}): CompositeResult | null {
+  const baseWeights = args.configuredWeights ?? DEFAULT_SCORE_WEIGHTS;
+  let weights: ScoreWeights = { ...baseWeights };
+  let redistribution_applied = false;
+
+  // Step 1: conversion_n_a redistribution (§2.4).
+  if (args.conversionNotApplicable) {
+    const conversionWeight = weights.conversion;
+    const splitTo = ["alignment", "behaviour", "technical"] as const;
+    const each = conversionWeight / splitTo.length;
+    weights = {
+      alignment: weights.alignment + each,
+      behaviour: weights.behaviour + each,
+      conversion: 0,
+      technical: weights.technical + each,
+    };
+    redistribution_applied = true;
+  }
+
+  // Step 2: redistribute weights of unavailable sub-scores
+  // proportionally across the available ones.
+  const availability: Record<keyof SubscoreBundle, boolean> = {
+    alignment: args.subscores.alignment != null && weights.alignment > 0,
+    behaviour: args.subscores.behaviour != null && weights.behaviour > 0,
+    conversion:
+      args.subscores.conversion != null && weights.conversion > 0,
+    technical: args.subscores.technical != null && weights.technical > 0,
+  };
+  const totalAvailable = (Object.keys(availability) as Array<keyof SubscoreBundle>).reduce(
+    (acc, k) => acc + (availability[k] ? weights[k] : 0),
+    0,
+  );
+  if (totalAvailable <= 0) return null;
+  if (totalAvailable < 1.0 - 1e-6) {
+    // Some weight is going unused; rescale the available weights so
+    // they sum to 1.
+    const rescaler = 1 / totalAvailable;
+    const rescaled: ScoreWeights = {
+      alignment: availability.alignment ? weights.alignment * rescaler : 0,
+      behaviour: availability.behaviour ? weights.behaviour * rescaler : 0,
+      conversion: availability.conversion ? weights.conversion * rescaler : 0,
+      technical: availability.technical ? weights.technical * rescaler : 0,
+    };
+    weights = rescaled;
+    redistribution_applied = true;
+  } else {
+    // Drop weights for unavailable sub-scores to 0.
+    weights = {
+      alignment: availability.alignment ? weights.alignment : 0,
+      behaviour: availability.behaviour ? weights.behaviour : 0,
+      conversion: availability.conversion ? weights.conversion : 0,
+      technical: availability.technical ? weights.technical : 0,
+    };
+  }
+
+  const contributions = {
+    alignment:
+      availability.alignment && args.subscores.alignment != null
+        ? args.subscores.alignment * weights.alignment
+        : 0,
+    behaviour:
+      availability.behaviour && args.subscores.behaviour != null
+        ? args.subscores.behaviour * weights.behaviour
+        : 0,
+    conversion:
+      availability.conversion && args.subscores.conversion != null
+        ? args.subscores.conversion * weights.conversion
+        : 0,
+    technical:
+      availability.technical && args.subscores.technical != null
+        ? args.subscores.technical * weights.technical
+        : 0,
+  };
+
+  const composite = Math.round(
+    contributions.alignment +
+      contributions.behaviour +
+      contributions.conversion +
+      contributions.technical,
+  );
+  const clamped = Math.max(0, Math.min(100, composite));
+
+  return {
+    composite_score: clamped,
+    classification: classify(clamped),
+    weights_used: weights,
+    redistribution_applied,
+    contributions: {
+      alignment: round1(contributions.alignment),
+      behaviour: round1(contributions.behaviour),
+      conversion: round1(contributions.conversion),
+      technical: round1(contributions.technical),
+    },
+  };
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+/**
+ * Identify the lowest-weighted-contribution sub-score for the
+ * "What's dragging this score down" hint per addendum §4.1.
+ * Returns NULL if the page is a high_performer (no dragging signal).
+ */
+export function lowestContribution(
+  result: CompositeResult,
+): keyof CompositeResult["contributions"] | null {
+  if (result.classification === "high_performer") return null;
+  const entries = Object.entries(result.contributions) as Array<
+    [keyof CompositeResult["contributions"], number]
+  >;
+  // Filter out zero-weight (redistributed-out) entries.
+  const eligible = entries.filter(([key]) => result.weights_used[key] > 0);
+  if (eligible.length === 0) return null;
+  eligible.sort((a, b) => a[1] - b[1]);
+  return eligible[0][0];
+}

--- a/lib/optimiser/scoring/conversion-subscore.ts
+++ b/lib/optimiser/scoring/conversion-subscore.ts
@@ -1,0 +1,142 @@
+import "server-only";
+
+import type { PageMetricsRollup } from "../metrics-aggregation";
+import { normaliseAgainstPercentiles } from "./percentile";
+import type { ConversionComponentsPresent } from "./types";
+import { DEFAULT_CONVERSION_COMPONENTS } from "./types";
+
+// Conversion sub-score — addendum §2.2.3.
+//
+// Default weights:
+//   conversion_rate     0.50 (higher is better)
+//   cost_per_conversion 0.30 (lower is better)
+//   revenue_per_visit   0.20 (higher is better)
+//
+// Where revenue isn't tracked (most B2B MSP cases — the spec's
+// motivating example), the 0.20 weight redistributes to CR (0.65) and
+// CPA (0.35). Decision Q1.6.1 from the addendum: redistribute to
+// CR + CPA rather than alignment + behaviour. Documented in this
+// slice's PR.
+//
+// `present` is read from opt_clients.conversion_components_present —
+// staff toggle revenue tracking on per-client when ecommerce is wired
+// up. CR and CPA are assumed always present (the scorer returns NULL
+// when both are unavailable for the page even if "present" claims
+// they should be).
+
+const FULL_WEIGHTS = {
+  conversion_rate: 0.5,
+  cost_per_conversion: 0.3,
+  revenue_per_visit: 0.2,
+} as const;
+
+const NO_REVENUE_WEIGHTS = {
+  conversion_rate: 0.65,
+  cost_per_conversion: 0.35,
+  revenue_per_visit: 0,
+} as const;
+
+export type ConversionCohortRow = {
+  conversion_rate?: number | null;
+  cost_per_conversion?: number | null;
+  revenue_per_visit?: number | null;
+};
+
+export type ConversionScoreResult = {
+  score: number;
+  components: {
+    conversion_rate: number | null;
+    cost_per_conversion: number | null;
+    revenue_per_visit: number | null;
+  };
+  /** Effective weights applied (after revenue redistribution). */
+  weights_applied: {
+    conversion_rate: number;
+    cost_per_conversion: number;
+    revenue_per_visit: number;
+  };
+};
+
+export function computeConversionSubscore(args: {
+  rollup: PageMetricsRollup;
+  cohort: ConversionCohortRow[];
+  componentsPresent?: ConversionComponentsPresent;
+  /** Page-level CPA (USD cents). Computed by the caller because
+   * cost_per_conversion = spend / conversions, both rollup fields. */
+  costPerConversionCents?: number;
+  /** Page-level revenue per visit (USD cents). NULL when not tracked. */
+  revenuePerVisitCents?: number;
+}): ConversionScoreResult | null {
+  const present = args.componentsPresent ?? DEFAULT_CONVERSION_COMPONENTS;
+  const useFullWeights = present.revenue && (args.revenuePerVisitCents ?? null) != null;
+  const weights = useFullWeights ? FULL_WEIGHTS : NO_REVENUE_WEIGHTS;
+
+  const components = {
+    conversion_rate: scoreComponent(
+      args.rollup.conversion_rate > 0 ? args.rollup.conversion_rate : null,
+      args.cohort.map((r) => r.conversion_rate ?? null),
+      "higher_is_better",
+    ),
+    cost_per_conversion: scoreComponent(
+      typeof args.costPerConversionCents === "number" &&
+        args.costPerConversionCents > 0
+        ? args.costPerConversionCents
+        : null,
+      args.cohort.map((r) => r.cost_per_conversion ?? null),
+      "lower_is_better",
+    ),
+    revenue_per_visit: useFullWeights
+      ? scoreComponent(
+          typeof args.revenuePerVisitCents === "number" &&
+            args.revenuePerVisitCents > 0
+            ? args.revenuePerVisitCents
+            : null,
+          args.cohort.map((r) => r.revenue_per_visit ?? null),
+          "higher_is_better",
+        )
+      : null,
+  };
+
+  let totalWeight = 0;
+  let weightedSum = 0;
+  for (const [key, weight] of Object.entries(weights) as Array<
+    [keyof typeof FULL_WEIGHTS, number]
+  >) {
+    if (weight === 0) continue;
+    const componentValue = components[key];
+    if (componentValue == null) continue;
+    weightedSum += componentValue * weight;
+    totalWeight += weight;
+  }
+  if (totalWeight === 0) return null;
+  const composite = Math.round(weightedSum / totalWeight);
+  return {
+    score: Math.max(0, Math.min(100, composite)),
+    components,
+    weights_applied: {
+      conversion_rate: weights.conversion_rate,
+      cost_per_conversion: weights.cost_per_conversion,
+      revenue_per_visit: weights.revenue_per_visit,
+    },
+  };
+}
+
+function scoreComponent(
+  value: number | null,
+  cohortValues: Array<number | null>,
+  direction: "higher_is_better" | "lower_is_better",
+): number | null {
+  if (value == null) return null;
+  const cohort = cohortValues.filter(
+    (v): v is number => v != null && Number.isFinite(v),
+  );
+  return normaliseAgainstPercentiles(value, cohort, direction);
+}
+
+/** Helper for callers to compute CPA from the rollup. */
+export function costPerConversionFromRollup(
+  rollup: PageMetricsRollup,
+): number | null {
+  if (rollup.conversions <= 0 || rollup.spend_usd_cents <= 0) return null;
+  return rollup.spend_usd_cents / rollup.conversions;
+}

--- a/lib/optimiser/scoring/evaluate-scores-job.ts
+++ b/lib/optimiser/scoring/evaluate-scores-job.ts
@@ -1,0 +1,286 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+import { computeReliability } from "../data-reliability";
+import { rollupForPage } from "../metrics-aggregation";
+import {
+  computeBehaviourSubscore,
+  type BehaviourCohortRow,
+} from "./behaviour-subscore";
+import {
+  computeCompositeScore,
+  lowestContribution,
+} from "./composite-score";
+import {
+  computeConversionSubscore,
+  costPerConversionFromRollup,
+  type ConversionCohortRow,
+} from "./conversion-subscore";
+import { computeTechnicalSubscore } from "./technical-subscore";
+import {
+  DEFAULT_CONVERSION_COMPONENTS,
+  DEFAULT_SCORE_WEIGHTS,
+  type ConversionComponentsPresent,
+  type ScoreWeights,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Daily score-evaluation job (Slice 12).
+//
+// For each managed page:
+//   1. Compute the 30-day rollup
+//   2. Look up the latest alignment score from opt_alignment_scores
+//   3. Compute behaviour, conversion, technical sub-scores against the
+//      client's active-pages cohort (per-client percentile normalisation)
+//   4. Assemble the composite + classification per addendum §2
+//   5. Update opt_landing_pages.current_composite_score +
+//      current_classification
+//   6. Insert a row into opt_page_score_history
+//
+// Bounded by client; per-client failure isolated.
+// ---------------------------------------------------------------------------
+
+export type EvaluateScoresOutcome = {
+  client_id: string;
+  pages_scored: number;
+  pages_skipped: number;
+  errors: number;
+};
+
+export async function runEvaluateScoresForAllClients(): Promise<{
+  outcomes: EvaluateScoresOutcome[];
+  total_pages: number;
+}> {
+  const supabase = getServiceRoleClient();
+  const { data: clients, error } = await supabase
+    .from("opt_clients")
+    .select(
+      "id, score_weights, conversion_components_present",
+    )
+    .is("deleted_at", null);
+  if (error) {
+    throw new Error(`runEvaluateScoresForAllClients: ${error.message}`);
+  }
+
+  const outcomes: EvaluateScoresOutcome[] = [];
+  let total_pages = 0;
+  for (const client of clients ?? []) {
+    const o = await runForClient({
+      clientId: client.id as string,
+      weights: (client.score_weights as ScoreWeights | null) ??
+        DEFAULT_SCORE_WEIGHTS,
+      componentsPresent:
+        (client.conversion_components_present as
+          | ConversionComponentsPresent
+          | null) ?? DEFAULT_CONVERSION_COMPONENTS,
+    });
+    total_pages += o.pages_scored;
+    outcomes.push(o);
+  }
+  return { outcomes, total_pages };
+}
+
+async function runForClient(args: {
+  clientId: string;
+  weights: ScoreWeights;
+  componentsPresent: ConversionComponentsPresent;
+}): Promise<EvaluateScoresOutcome> {
+  const supabase = getServiceRoleClient();
+  const { data: pages, error } = await supabase
+    .from("opt_landing_pages")
+    .select(
+      "id, conversion_n_a, page_id, management_mode",
+    )
+    .eq("client_id", args.clientId)
+    .eq("managed", true)
+    .is("deleted_at", null);
+  if (error) {
+    logger.error("optimiser.evaluate_scores.list_failed", {
+      client_id: args.clientId,
+      error: error.message,
+    });
+    return {
+      client_id: args.clientId,
+      pages_scored: 0,
+      pages_skipped: 0,
+      errors: 1,
+    };
+  }
+
+  if (!pages || pages.length === 0) {
+    return {
+      client_id: args.clientId,
+      pages_scored: 0,
+      pages_skipped: 0,
+      errors: 0,
+    };
+  }
+
+  // Build the cohort once per client. Each entry is an active-pages
+  // snapshot used by the percentile normalisation.
+  const cohort = await buildClientCohort(args.clientId);
+  let scored = 0;
+  let skipped = 0;
+  let errs = 0;
+
+  for (const page of pages) {
+    try {
+      const result = await evaluatePage({
+        clientId: args.clientId,
+        landingPageId: page.id as string,
+        conversionNotApplicable: Boolean(page.conversion_n_a),
+        weights: args.weights,
+        componentsPresent: args.componentsPresent,
+        behaviourCohort: cohort.behaviour,
+        conversionCohort: cohort.conversion,
+      });
+      if (result.skipped) {
+        skipped += 1;
+      } else {
+        scored += 1;
+      }
+    } catch (err) {
+      errs += 1;
+      logger.error("optimiser.evaluate_scores.failed", {
+        client_id: args.clientId,
+        landing_page_id: page.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return {
+    client_id: args.clientId,
+    pages_scored: scored,
+    pages_skipped: skipped,
+    errors: errs,
+  };
+}
+
+async function evaluatePage(args: {
+  clientId: string;
+  landingPageId: string;
+  conversionNotApplicable: boolean;
+  weights: ScoreWeights;
+  componentsPresent: ConversionComponentsPresent;
+  behaviourCohort: BehaviourCohortRow[];
+  conversionCohort: ConversionCohortRow[];
+}): Promise<{ skipped: boolean }> {
+  const supabase = getServiceRoleClient();
+  const rollup = await rollupForPage(args.landingPageId);
+  const reliability = computeReliability(rollup);
+
+  // §9.5 thresholds: skip score evaluation if the data isn't
+  // sufficient. The healthy-state evaluator already handles the
+  // insufficient_data state; we just don't write a misleading score.
+  if (reliability.reliability === "red") {
+    return { skipped: true };
+  }
+
+  const alignmentScore = await fetchLatestAlignmentScore(args.landingPageId);
+  const behaviour = computeBehaviourSubscore(rollup, args.behaviourCohort);
+  const conversion = args.conversionNotApplicable
+    ? null
+    : computeConversionSubscore({
+        rollup,
+        cohort: args.conversionCohort,
+        componentsPresent: args.componentsPresent,
+        costPerConversionCents: costPerConversionFromRollup(rollup) ?? undefined,
+      });
+  const technical = computeTechnicalSubscore(rollup);
+
+  const composite = computeCompositeScore({
+    subscores: {
+      alignment: alignmentScore,
+      behaviour: behaviour?.score ?? null,
+      conversion: conversion?.score ?? null,
+      technical: technical?.score ?? null,
+    },
+    configuredWeights: args.weights,
+    conversionNotApplicable: args.conversionNotApplicable,
+  });
+  if (!composite) {
+    return { skipped: true };
+  }
+
+  const nowIso = new Date().toISOString();
+
+  const { error: updateErr } = await supabase
+    .from("opt_landing_pages")
+    .update({
+      current_composite_score: composite.composite_score,
+      current_classification: composite.classification,
+      updated_at: nowIso,
+    })
+    .eq("id", args.landingPageId);
+  if (updateErr) {
+    throw new Error(`evaluatePage update: ${updateErr.message}`);
+  }
+
+  const { error: histErr } = await supabase
+    .from("opt_page_score_history")
+    .insert({
+      client_id: args.clientId,
+      landing_page_id: args.landingPageId,
+      composite_score: composite.composite_score,
+      classification: composite.classification,
+      alignment_subscore: alignmentScore,
+      behaviour_subscore: behaviour?.score ?? null,
+      conversion_subscore: conversion?.score ?? null,
+      technical_subscore: technical?.score ?? null,
+      weights_used: composite.weights_used,
+      evaluated_at: nowIso,
+    });
+  if (histErr) {
+    throw new Error(`evaluatePage history insert: ${histErr.message}`);
+  }
+  void lowestContribution; // imported for callers; not needed here.
+
+  return { skipped: false };
+}
+
+async function fetchLatestAlignmentScore(
+  landingPageId: string,
+): Promise<number | null> {
+  const supabase = getServiceRoleClient();
+  const { data } = await supabase
+    .from("opt_alignment_scores")
+    .select("score")
+    .eq("landing_page_id", landingPageId)
+    .order("computed_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return (data?.score as number | null) ?? null;
+}
+
+async function buildClientCohort(clientId: string): Promise<{
+  behaviour: BehaviourCohortRow[];
+  conversion: ConversionCohortRow[];
+}> {
+  const supabase = getServiceRoleClient();
+  const { data: pages } = await supabase
+    .from("opt_landing_pages")
+    .select("id")
+    .eq("client_id", clientId)
+    .eq("managed", true)
+    .is("deleted_at", null);
+  const behaviour: BehaviourCohortRow[] = [];
+  const conversion: ConversionCohortRow[] = [];
+  for (const p of pages ?? []) {
+    const r = await rollupForPage(p.id as string);
+    const cpa = costPerConversionFromRollup(r);
+    behaviour.push({
+      bounce_rate: r.bounce_rate > 0 ? r.bounce_rate : null,
+      avg_engagement_time_s:
+        r.avg_engagement_time_s > 0 ? r.avg_engagement_time_s : null,
+      avg_scroll_depth: r.avg_scroll_depth > 0 ? r.avg_scroll_depth : null,
+    });
+    conversion.push({
+      conversion_rate: r.conversion_rate > 0 ? r.conversion_rate : null,
+      cost_per_conversion: cpa,
+    });
+  }
+  return { behaviour, conversion };
+}

--- a/lib/optimiser/scoring/percentile.ts
+++ b/lib/optimiser/scoring/percentile.ts
@@ -1,0 +1,54 @@
+// Percentile-based normalisation helper for the behaviour and
+// conversion sub-scores. Normalises a value against the client's
+// active-pages 25th–75th percentile range so a B2B page with 90s
+// engagement isn't penalised against a B2C page with 15s engagement.
+//
+// Mapping:
+//   - value at or below p25 → 0
+//   - value at or above p75 → 100
+//   - linear interpolation in between
+//
+// `direction = 'higher_is_better'` follows the rule above.
+// `direction = 'lower_is_better'` (e.g. bounce rate, CPA) inverts:
+//   p25 → 100, p75 → 0.
+
+export type Direction = "higher_is_better" | "lower_is_better";
+
+export function quantile(values: number[], q: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = (sorted.length - 1) * q;
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  const t = idx - lo;
+  return sorted[lo] * (1 - t) + sorted[hi] * t;
+}
+
+export function normaliseAgainstPercentiles(
+  value: number,
+  cohort: number[],
+  direction: Direction,
+): number {
+  if (cohort.length < 2) {
+    // Not enough points to set a useful range. Return a neutral 50
+    // so the sub-score doesn't dominate either direction.
+    return 50;
+  }
+  const p25 = quantile(cohort, 0.25);
+  const p75 = quantile(cohort, 0.75);
+  if (p75 === p25) {
+    // All values in the cohort are identical — no spread to normalise
+    // against. Return 50.
+    return 50;
+  }
+  if (direction === "higher_is_better") {
+    if (value <= p25) return 0;
+    if (value >= p75) return 100;
+    return Math.round(((value - p25) / (p75 - p25)) * 100);
+  }
+  // lower_is_better
+  if (value <= p25) return 100;
+  if (value >= p75) return 0;
+  return Math.round((1 - (value - p25) / (p75 - p25)) * 100);
+}

--- a/lib/optimiser/scoring/score-history.ts
+++ b/lib/optimiser/scoring/score-history.ts
@@ -1,0 +1,58 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ScoreClassification, ScoreWeights } from "./types";
+
+// Score-history reader — powers the sparkline + version timeline (§4.2).
+
+export type ScoreHistoryRow = {
+  id: string;
+  client_id: string;
+  landing_page_id: string;
+  page_version: string | null;
+  composite_score: number;
+  classification: ScoreClassification;
+  alignment_subscore: number | null;
+  behaviour_subscore: number | null;
+  conversion_subscore: number | null;
+  technical_subscore: number | null;
+  weights_used: ScoreWeights;
+  confidence: number | null;
+  triggering_proposal_id: string | null;
+  change_set_summary: string | null;
+  evaluated_at: string;
+  created_at: string;
+};
+
+const COLS =
+  "id, client_id, landing_page_id, page_version, composite_score, classification, alignment_subscore, behaviour_subscore, conversion_subscore, technical_subscore, weights_used, confidence, triggering_proposal_id, change_set_summary, evaluated_at, created_at";
+
+export async function listScoreHistory(args: {
+  landingPageId: string;
+  limit?: number;
+}): Promise<ScoreHistoryRow[]> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("opt_page_score_history")
+    .select(COLS)
+    .eq("landing_page_id", args.landingPageId)
+    .order("evaluated_at", { ascending: false })
+    .limit(args.limit ?? 50);
+  if (error) throw new Error(`listScoreHistory: ${error.message}`);
+  return (data ?? []) as ScoreHistoryRow[];
+}
+
+/**
+ * Return the last N rows ordered ASC by evaluated_at — the shape the
+ * sparkline component expects. Limit is capped at 50.
+ */
+export async function listScoreSparkline(args: {
+  landingPageId: string;
+  limit?: number;
+}): Promise<ScoreHistoryRow[]> {
+  const rows = await listScoreHistory({
+    landingPageId: args.landingPageId,
+    limit: Math.min(args.limit ?? 10, 50),
+  });
+  return rows.slice().reverse();
+}

--- a/lib/optimiser/scoring/technical-subscore.ts
+++ b/lib/optimiser/scoring/technical-subscore.ts
@@ -1,0 +1,130 @@
+import "server-only";
+
+import type { PageMetricsRollup } from "../metrics-aggregation";
+
+// Technical sub-score — addendum §2.2.4.
+//
+// Reads from PageSpeed Insights mobile data already ingested in v1.5.
+// Mobile metrics are weighted because mobile is the dominant traffic
+// source for paid landing pages. Each Core Web Vital maps to 0–100
+// using Google's good / needs improvement / poor thresholds as the
+// 100 / 50 / 0 anchors:
+//
+//   LCP (ms): 0–2500 good / 2500–4000 NI / >4000 poor
+//   INP (ms): 0–200  good /  200–500  NI / >500  poor
+//   CLS:      0–0.1  good /  0.1–0.25 NI / >0.25 poor
+//   Mobile speed score: 0–100 already, taken as-is
+//
+// Weights (Table 3):
+//   LCP                 0.35
+//   INP                 0.25
+//   CLS                 0.20
+//   Mobile speed score  0.20
+//
+// When PSI hasn't measured a page yet, returns NULL so the composite
+// can fall back to redistribution.
+
+const COMPONENT_WEIGHTS = {
+  lcp: 0.35,
+  inp: 0.25,
+  cls: 0.2,
+  mobile_speed: 0.2,
+} as const;
+
+const LCP_GOOD_MS = 2500;
+const LCP_POOR_MS = 4000;
+const INP_GOOD_MS = 200;
+const INP_POOR_MS = 500;
+const CLS_GOOD = 0.1;
+const CLS_POOR = 0.25;
+
+export type TechnicalScoreResult = {
+  score: number;
+  components: {
+    lcp: number | null;
+    inp: number | null;
+    cls: number | null;
+    mobile_speed: number | null;
+  };
+  components_used: number;
+};
+
+export function computeTechnicalSubscore(
+  rollup: PageMetricsRollup,
+  /** Optional INP / CLS values from the most-recent PSI run. The base
+   * rollup currently surfaces LCP + mobile_speed_score; INP and CLS are
+   * read directly off the metrics row when present. */
+  extra?: { inp_ms?: number | null; cls?: number | null },
+): TechnicalScoreResult | null {
+  const components = {
+    lcp: scoreLcp(rollup.lcp_ms),
+    inp: scoreInp(extra?.inp_ms ?? null),
+    cls: scoreCls(extra?.cls ?? null),
+    mobile_speed: scoreMobileSpeed(rollup.mobile_speed_score),
+  };
+
+  let totalWeight = 0;
+  let weightedSum = 0;
+  for (const [key, weight] of Object.entries(COMPONENT_WEIGHTS) as Array<
+    [keyof typeof COMPONENT_WEIGHTS, number]
+  >) {
+    const componentValue = components[key];
+    if (componentValue == null) continue;
+    weightedSum += componentValue * weight;
+    totalWeight += weight;
+  }
+  if (totalWeight === 0) return null;
+  const composite = Math.round(weightedSum / totalWeight);
+  return {
+    score: Math.max(0, Math.min(100, composite)),
+    components,
+    components_used: Object.values(components).filter((v) => v != null).length,
+  };
+}
+
+function scoreLcp(ms: number | null): number | null {
+  if (ms == null || !Number.isFinite(ms) || ms <= 0) return null;
+  return scoreThreshold(ms, LCP_GOOD_MS, LCP_POOR_MS, "lower_is_better");
+}
+
+function scoreInp(ms: number | null): number | null {
+  if (ms == null || !Number.isFinite(ms) || ms <= 0) return null;
+  return scoreThreshold(ms, INP_GOOD_MS, INP_POOR_MS, "lower_is_better");
+}
+
+function scoreCls(value: number | null): number | null {
+  if (value == null || !Number.isFinite(value) || value < 0) return null;
+  return scoreThreshold(value, CLS_GOOD, CLS_POOR, "lower_is_better");
+}
+
+function scoreMobileSpeed(score: number | null): number | null {
+  if (score == null || !Number.isFinite(score)) return null;
+  if (score < 0) return 0;
+  if (score > 100) return 100;
+  return Math.round(score);
+}
+
+/**
+ * Map a metric to 0–100 against Google's good/NI/poor thresholds.
+ * - lower_is_better: value ≤ good → 100, value ≥ poor → 0, linear in between.
+ *   The midpoint (good ↔ poor centre) anchors to 50.
+ * - higher_is_better: inverted.
+ */
+function scoreThreshold(
+  value: number,
+  good: number,
+  poor: number,
+  direction: "lower_is_better" | "higher_is_better",
+): number {
+  if (direction === "lower_is_better") {
+    if (value <= good) return 100;
+    if (value >= poor) return 0;
+    // Linear interpolation between good (→ 100) and poor (→ 0).
+    const t = (value - good) / (poor - good);
+    return Math.round((1 - t) * 100);
+  }
+  if (value >= good) return 100;
+  if (value <= poor) return 0;
+  const t = (value - poor) / (good - poor);
+  return Math.round(t * 100);
+}

--- a/lib/optimiser/scoring/types.ts
+++ b/lib/optimiser/scoring/types.ts
@@ -1,0 +1,70 @@
+// Shared types for the v1.6 composite-scoring system.
+
+export type ScoreClassification =
+  | "high_performer"
+  | "optimisable"
+  | "needs_attention";
+
+export type ScoreWeights = {
+  alignment: number;
+  behaviour: number;
+  conversion: number;
+  technical: number;
+};
+
+export const DEFAULT_SCORE_WEIGHTS: ScoreWeights = {
+  alignment: 0.25,
+  behaviour: 0.3,
+  conversion: 0.3,
+  technical: 0.15,
+};
+
+export type ConversionComponentsPresent = {
+  cr: boolean;
+  cpa: boolean;
+  revenue: boolean;
+};
+
+export const DEFAULT_CONVERSION_COMPONENTS: ConversionComponentsPresent = {
+  cr: true,
+  cpa: true,
+  revenue: false,
+};
+
+/** Per-page snapshot of the four sub-scores. NULL when the inputs
+ * for that sub-score are unavailable; the composite calculator handles
+ * redistribution. */
+export type SubscoreBundle = {
+  alignment: number | null;
+  behaviour: number | null;
+  conversion: number | null;
+  technical: number | null;
+};
+
+export type CompositeResult = {
+  composite_score: number;
+  classification: ScoreClassification;
+  /** Effective weights applied (after any §2.4 redistribution).
+   * Always sums to 1.0. */
+  weights_used: ScoreWeights;
+  /** TRUE if §2.4 redistribution kicked in (conversion_n_a or any
+   * sub-score input unavailable). */
+  redistribution_applied: boolean;
+  /** Per-sub-score weighted contribution (subscore × weight) for the
+   * UI breakdown panel. */
+  contributions: {
+    alignment: number;
+    behaviour: number;
+    conversion: number;
+    technical: number;
+  };
+};
+
+/** Confidence per §9.4.1 — same shape as the proposal-level confidence. */
+export type CompositeConfidence = {
+  score: number;
+  sample: number;
+  freshness: number;
+  stability: number;
+  signal: number;
+};

--- a/skills/optimiser/behaviour-subscore/SKILL.md
+++ b/skills/optimiser/behaviour-subscore/SKILL.md
@@ -1,0 +1,34 @@
+# Skill — behaviour-subscore
+
+Compute the v1.6 Behaviour sub-score per addendum §2.2.2.
+
+## Inputs
+- `PageMetricsRollup` (30-day rollup from `lib/optimiser/metrics-aggregation.ts`)
+- `BehaviourCohortRow[]` — same-shape rollups for the client's other active pages, used as the percentile baseline
+- Optional `cta_clicks_per_session` (Phase 2 wires the Clarity click-map data; Phase 1 leaves it unset → component dropped from the weighted sum)
+
+## Components + weights (Table 1 of the addendum)
+| Component | Weight | Direction | Source |
+|---|---|---|---|
+| Bounce rate | 0.30 | lower is better | GA4 |
+| Avg engagement time | 0.25 | higher is better | GA4 |
+| Scroll depth (avg %) | 0.25 | higher is better | Clarity |
+| CTA clicks per session | 0.20 | higher is better | Clarity click maps / GA4 events |
+
+## Normalisation
+Each component is normalised to 0–100 against the client's active-pages 25th–75th percentile range. Why per-client: a B2B page with 90s engagement isn't penalised against a B2C page with 15s engagement. Why p25/p75: it ignores extreme outliers that would otherwise stretch the scale.
+
+When a cohort has < 2 pages, the helper returns `50` (neutral). When all cohort values are identical, also `50`.
+
+## Missing-component redistribution
+If a component's input is unavailable for the page (e.g. no Clarity data), that component's weight redistributes proportionally across the available components. The sub-score returns NULL only when all four inputs are missing.
+
+## Output
+```ts
+{ score: 0..100, components: { ... }, components_used: 1..4 }
+```
+
+## Pointers
+- `lib/optimiser/scoring/behaviour-subscore.ts:computeBehaviourSubscore`
+- `lib/optimiser/scoring/percentile.ts:normaliseAgainstPercentiles`
+- Caller: `lib/optimiser/scoring/evaluate-scores-job.ts`

--- a/skills/optimiser/composite-score/SKILL.md
+++ b/skills/optimiser/composite-score/SKILL.md
@@ -1,0 +1,51 @@
+# Skill — composite-score
+
+Assemble the v1.6 composite Landing Page Score per addendum §2.1 + §2.4.
+
+## Formula
+```
+composite = (alignment × w_a) + (behaviour × w_b) + (conversion × w_c) + (technical × w_t)
+```
+
+Default weights: `{alignment: 0.25, behaviour: 0.30, conversion: 0.30, technical: 0.15}`. Per-client overrides in `opt_clients.score_weights` (read-only in Phase 1, editable in Phase 2 once calibration data flows).
+
+## Classification (§2.3)
+- 80–100 → `high_performer`  (green)
+- 60–79  → `optimisable`    (amber)
+-  0–59  → `needs_attention` (red)
+
+## Edge cases
+
+### conversion_n_a = TRUE (§2.4)
+Awareness-stage pages without a conversion goal. Conversion's 0.30 weight redistributes equally across alignment / behaviour / technical (each gains 0.10).
+
+### Missing sub-score input
+If a sub-score is NULL (insufficient data, no PSI run yet, no ad group join for alignment), its weight is dropped and the remaining weights rescale to sum to 1. The result still produces a valid composite as long as at least one sub-score is available.
+
+### Both
+When conversion_n_a + alignment is NULL, the remaining weight (now spread across behaviour + technical with redistributed conversion bumps) rescales again. The `redistribution_applied: true` flag is set so the UI can show the "weights redistributed" hint.
+
+## Output
+```ts
+{
+  composite_score: 0..100,
+  classification: "high_performer" | "optimisable" | "needs_attention",
+  weights_used: { ... },        // post-redistribution
+  redistribution_applied: bool,
+  contributions: { ... },       // subscore × weight per axis
+}
+```
+
+## "What's dragging this score down" hint (§4.1)
+`lowestContribution(result)` returns the sub-score with the smallest weighted contribution among non-zero-weight sub-scores. NULL when classification is `high_performer`. The page detail panel uses this to point at two relevant playbooks.
+
+## Persistence
+The score-evaluator cron (`/api/cron/optimiser-evaluate-scores`) writes:
+- `opt_landing_pages.current_composite_score` + `current_classification` (cached for the page browser)
+- One row in `opt_page_score_history` per evaluation, with `weights_used` snapshotted so the timeline reflects the truth even after weights change
+
+## Pointers
+- `lib/optimiser/scoring/composite-score.ts:computeCompositeScore`
+- `lib/optimiser/scoring/composite-score.ts:lowestContribution`
+- `lib/optimiser/scoring/classify.ts`
+- Caller: `lib/optimiser/scoring/evaluate-scores-job.ts`

--- a/skills/optimiser/conversion-subscore/SKILL.md
+++ b/skills/optimiser/conversion-subscore/SKILL.md
@@ -1,0 +1,34 @@
+# Skill — conversion-subscore
+
+Compute the v1.6 Conversion sub-score per addendum §2.2.3.
+
+## Inputs
+- `PageMetricsRollup` (rollup gives CR + spend; CPA is computed by the caller as `spend / conversions`)
+- `ConversionCohortRow[]` — client's active-pages CR / CPA / revenue values for percentile normalisation
+- `ConversionComponentsPresent` — `{ cr: bool, cpa: bool, revenue: bool }` from `opt_clients`. Default: CR + CPA present, revenue not.
+
+## Components + weights (Table 2)
+| Component | Weight (with revenue) | Weight (without revenue) | Direction |
+|---|---|---|---|
+| Conversion rate | 0.50 | 0.65 | higher is better |
+| Cost per conversion | 0.30 | 0.35 | lower is better |
+| Revenue per visit | 0.20 | — | higher is better |
+
+When `componentsPresent.revenue` is false (B2B MSP common case), the 0.20 weight redistributes to CR + CPA per addendum Q1.6.1. The decision to redistribute to CR + CPA (rather than to alignment + behaviour) is documented in the Slice 12 PR description.
+
+## Normalisation
+Same percentile approach as behaviour-subscore: 25th/75th client cohort, with `lower_is_better` inverted for CPA.
+
+## When the score returns NULL
+- The caller has flagged the page `conversion_n_a = TRUE` (composite-score handles redistribution at a higher layer)
+- Both CR and CPA are NULL
+
+## Output
+```ts
+{ score: 0..100, components: { ... }, weights_applied: { ... } }
+```
+
+## Pointers
+- `lib/optimiser/scoring/conversion-subscore.ts:computeConversionSubscore`
+- `lib/optimiser/scoring/conversion-subscore.ts:costPerConversionFromRollup`
+- Caller: `lib/optimiser/scoring/evaluate-scores-job.ts`

--- a/skills/optimiser/technical-subscore/SKILL.md
+++ b/skills/optimiser/technical-subscore/SKILL.md
@@ -1,0 +1,41 @@
+# Skill — technical-subscore
+
+Compute the v1.6 Technical sub-score per addendum §2.2.4.
+
+## Inputs
+- `PageMetricsRollup` (LCP + mobile speed score from PSI)
+- Optional `{ inp_ms, cls }` from the most-recent PSI row
+
+All four come from PageSpeed Insights mobile data — already ingested in v1.5 §4.4.
+
+## Components + weights (Table 3)
+| Component | Weight | Threshold (good → poor) |
+|---|---|---|
+| Largest Contentful Paint | 0.35 | 2500ms → 4000ms |
+| Interaction to Next Paint | 0.25 | 200ms → 500ms |
+| Cumulative Layout Shift | 0.20 | 0.1 → 0.25 |
+| Mobile speed score | 0.20 | (already 0–100) |
+
+## Threshold mapping
+Each Core Web Vital maps to 0–100 by linear interpolation between Google's good and poor thresholds:
+- value ≤ good → 100
+- value ≥ poor → 0
+- linear in between (so the midpoint between good and poor anchors at 50)
+
+Mobile speed score is taken as-is.
+
+## Why mobile only
+Mobile is the dominant traffic source for paid landing pages. Desktop CWV is correlated but not the primary signal.
+
+## When the score returns NULL
+- LCP, INP, CLS are all unavailable AND mobile_speed_score is NULL — this happens when PSI hasn't run yet or the URL was unreachable
+
+## Output
+```ts
+{ score: 0..100, components: { ... }, components_used: 1..4 }
+```
+
+## Pointers
+- `lib/optimiser/scoring/technical-subscore.ts:computeTechnicalSubscore`
+- Cron that populates the underlying PSI data: `/api/cron/optimiser-sync-pagespeed`
+- Caller: `lib/optimiser/scoring/evaluate-scores-job.ts`

--- a/supabase/migrations/0047_opt_page_score_history.sql
+++ b/supabase/migrations/0047_opt_page_score_history.sql
@@ -1,0 +1,89 @@
+-- 0047 — Optimiser v1.6: opt_page_score_history.
+-- Reference: docs/Optimisation_Engine_v1.6_Addendum.docx §3.1, §4.2.
+--
+-- One row per (page, version, evaluation timestamp). Powers the
+-- score-over-time view (§4.2) and the sparkline on the page detail
+-- panel (§4.1).
+--
+-- Append-only — score evaluations are forward-rolling timeline events,
+-- never edited in place. The cron at /api/cron/optimiser-evaluate-
+-- scores writes one row per managed page per day where data is
+-- sufficient.
+--
+-- weights_used is captured per row so a reader can reconstruct exactly
+-- how the composite was computed at the time, even after the client's
+-- opt_clients.score_weights changes.
+
+CREATE TABLE opt_page_score_history (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id                uuid NOT NULL
+    REFERENCES opt_clients(id) ON DELETE CASCADE,
+  landing_page_id          uuid NOT NULL
+    REFERENCES opt_landing_pages(id) ON DELETE CASCADE,
+
+  -- Optional reference to the Site Builder pages row's version.
+  -- NULL for pages still in management_mode='read_only' that don't
+  -- have a Site Builder row.
+  page_version             text,
+
+  composite_score          integer NOT NULL
+    CHECK (composite_score >= 0 AND composite_score <= 100),
+  classification           text NOT NULL
+    CHECK (classification IN ('high_performer', 'optimisable', 'needs_attention')),
+
+  -- Each sub-score 0–100. NULL when the sub-score input was
+  -- unavailable but the composite was still computed via
+  -- redistribution (e.g. conversion_n_a pages skip the conversion
+  -- sub-score and redistribute its 0.30 weight).
+  alignment_subscore       integer
+    CHECK (alignment_subscore IS NULL OR (alignment_subscore >= 0 AND alignment_subscore <= 100)),
+  behaviour_subscore       integer
+    CHECK (behaviour_subscore IS NULL OR (behaviour_subscore >= 0 AND behaviour_subscore <= 100)),
+  conversion_subscore      integer
+    CHECK (conversion_subscore IS NULL OR (conversion_subscore >= 0 AND conversion_subscore <= 100)),
+  technical_subscore       integer
+    CHECK (technical_subscore IS NULL OR (technical_subscore >= 0 AND technical_subscore <= 100)),
+
+  -- Snapshot of opt_clients.score_weights at the time the score was
+  -- computed. Reading this directly avoids ambiguity if the client's
+  -- weights change between evaluations.
+  weights_used             jsonb NOT NULL,
+
+  -- §9.4.1 confidence sub-factors carried through to the score so
+  -- the breakdown panel can show the same number the proposal pane
+  -- shows. NULL when not applicable (e.g. brand-new page with no
+  -- behaviour history).
+  confidence               numeric(4, 3)
+    CHECK (confidence IS NULL OR (confidence >= 0 AND confidence <= 1)),
+
+  -- Optional reference to the proposal that triggered this version,
+  -- for the §4.2 timeline row.
+  triggering_proposal_id   uuid REFERENCES opt_proposals(id) ON DELETE SET NULL,
+
+  -- Free-form summary of the change set behind this version. Mirrored
+  -- from opt_proposals.change_set when triggering_proposal_id is set;
+  -- NULL for the initial baseline row.
+  change_set_summary       text,
+
+  evaluated_at             timestamptz NOT NULL DEFAULT now(),
+  created_at               timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX opt_page_score_history_page_evaluated_idx
+  ON opt_page_score_history (landing_page_id, evaluated_at DESC);
+
+CREATE INDEX opt_page_score_history_client_evaluated_idx
+  ON opt_page_score_history (client_id, evaluated_at DESC);
+
+CREATE INDEX opt_page_score_history_proposal_idx
+  ON opt_page_score_history (triggering_proposal_id)
+  WHERE triggering_proposal_id IS NOT NULL;
+
+ALTER TABLE opt_page_score_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON opt_page_score_history
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY opt_page_score_history_read ON opt_page_score_history
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator', 'viewer'));

--- a/supabase/migrations/0048_opt_score_calibration.sql
+++ b/supabase/migrations/0048_opt_score_calibration.sql
@@ -1,0 +1,48 @@
+-- 0048 — Optimiser v1.6: opt_score_calibration.
+-- Reference: addendum §2.5 + §3.1.
+--
+-- Append-only log of weight changes from the calibration loop. Phase 2
+-- A/B test outcomes drive automatic weight adjustments; Phase 1 staff
+-- can manually override via the client settings page (the writer for
+-- that lands when weights become editable in Phase 2). Phase 1 ships
+-- the table empty.
+--
+-- weight_before / weight_after are full snapshots (the four-key shape)
+-- so a reader can reconstruct the timeline without joining against
+-- opt_clients (which only carries the current values).
+
+CREATE TABLE opt_score_calibration (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id                uuid NOT NULL
+    REFERENCES opt_clients(id) ON DELETE CASCADE,
+
+  weight_before            jsonb NOT NULL,
+  weight_after             jsonb NOT NULL,
+
+  -- 'manual_override' (admin-driven from settings page) |
+  -- 'observed_calibration' (Phase 2 A/B test outcome) |
+  -- 'reset_to_defaults'.
+  trigger                  text NOT NULL DEFAULT 'manual_override'
+    CHECK (trigger IN ('manual_override', 'observed_calibration', 'reset_to_defaults')),
+
+  -- Optional pointer to the test that drove an observed_calibration
+  -- entry. NULL otherwise.
+  source_test_id           uuid,
+
+  notes                    text,
+
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  created_by               uuid REFERENCES auth.users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX opt_score_calibration_client_created_idx
+  ON opt_score_calibration (client_id, created_at DESC);
+
+ALTER TABLE opt_score_calibration ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON opt_score_calibration
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY opt_score_calibration_read ON opt_score_calibration
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator', 'viewer'));

--- a/supabase/migrations/0049_opt_clients_score_weights.sql
+++ b/supabase/migrations/0049_opt_clients_score_weights.sql
@@ -1,0 +1,38 @@
+-- 0049 — Optimiser v1.6: opt_clients column additions for composite scoring.
+-- Reference: addendum §2.1, §2.3, §3.2, §6.2 Q1.6.3.
+--
+-- Three new nullable / defaulted columns. Forward-only, no rewrite.
+-- Existing rows pick up the defaults on read.
+
+ALTER TABLE opt_clients
+  ADD COLUMN score_weights jsonb NOT NULL DEFAULT jsonb_build_object(
+    'alignment', 0.25,
+    'behaviour', 0.30,
+    'conversion', 0.30,
+    'technical', 0.15
+  );
+
+-- Tracks which conversion sub-components are available for the client.
+-- Drives the §2.3 redistribution: when revenue is unavailable, the 0.20
+-- weight folds into CR (0.65) + CPA (0.35). Defaults assume CR + CPA
+-- only — revenue tracking is opt-in via the client settings page.
+ALTER TABLE opt_clients
+  ADD COLUMN conversion_components_present jsonb NOT NULL DEFAULT jsonb_build_object(
+    'cr', true,
+    'cpa', true,
+    'revenue', false
+  );
+
+-- §6.2 Q1.6.3 — per-client override for the causal-delta measurement
+-- window. Default 14 days per addendum §4.3; lower-traffic B2B clients
+-- may extend.
+ALTER TABLE opt_clients
+  ADD COLUMN causal_eval_window_days integer NOT NULL DEFAULT 14
+    CHECK (causal_eval_window_days >= 1 AND causal_eval_window_days <= 90);
+
+COMMENT ON COLUMN opt_clients.score_weights IS
+  'Composite-score sub-score weights per addendum §2.1. JSON object with keys alignment / behaviour / conversion / technical, each in [0,1]. Defaults in §2.1.';
+COMMENT ON COLUMN opt_clients.conversion_components_present IS
+  'Which conversion sub-components are available. Drives the §2.3 redistribution when revenue tracking is missing.';
+COMMENT ON COLUMN opt_clients.causal_eval_window_days IS
+  'Per-client override for the causal-delta measurement window (addendum §4.3 / §6.2 Q1.6.3). Default 14 days.';

--- a/supabase/migrations/0050_opt_landing_pages_composite_score.sql
+++ b/supabase/migrations/0050_opt_landing_pages_composite_score.sql
@@ -1,0 +1,32 @@
+-- 0050 — Optimiser v1.6: opt_landing_pages cached composite-score columns.
+-- Reference: addendum §3.2, §2.4.
+--
+-- Three new columns on opt_landing_pages. Cached so the page browser
+-- renders the green/amber/red badge without joining against
+-- opt_page_score_history every row.
+--
+-- The score-evaluator cron updates these alongside writing the history
+-- row.
+
+ALTER TABLE opt_landing_pages
+  ADD COLUMN current_composite_score integer
+    CHECK (current_composite_score IS NULL OR (current_composite_score >= 0 AND current_composite_score <= 100));
+
+ALTER TABLE opt_landing_pages
+  ADD COLUMN current_classification text
+    CHECK (current_classification IS NULL OR current_classification IN ('high_performer', 'optimisable', 'needs_attention'));
+
+-- Operator flag for awareness-stage pages with no conversion goal.
+-- Set during onboarding (Slice 12 ships read-only display; Phase 2
+-- adds an editable surface). When TRUE, the composite formula
+-- redistributes the 0.30 conversion weight equally across the other
+-- three sub-scores per addendum §2.4.
+ALTER TABLE opt_landing_pages
+  ADD COLUMN conversion_n_a boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN opt_landing_pages.current_composite_score IS
+  'Cached composite score (0-100). Updated by the score-evaluator cron alongside writing opt_page_score_history. NULL when insufficient data per §9.5.';
+COMMENT ON COLUMN opt_landing_pages.current_classification IS
+  'Cached classification label. high_performer (80-100) / optimisable (60-79) / needs_attention (0-59).';
+COMMENT ON COLUMN opt_landing_pages.conversion_n_a IS
+  'Operator flag for pages without a conversion goal. When TRUE the composite redistributes the 0.30 conversion weight per addendum §2.4.';

--- a/supabase/rollbacks/0047_opt_page_score_history.down.sql
+++ b/supabase/rollbacks/0047_opt_page_score_history.down.sql
@@ -1,0 +1,8 @@
+-- Rollback for 0047_opt_page_score_history.sql
+DROP POLICY IF EXISTS opt_page_score_history_read ON opt_page_score_history;
+DROP POLICY IF EXISTS service_role_all ON opt_page_score_history;
+ALTER TABLE IF EXISTS opt_page_score_history DISABLE ROW LEVEL SECURITY;
+DROP INDEX IF EXISTS opt_page_score_history_proposal_idx;
+DROP INDEX IF EXISTS opt_page_score_history_client_evaluated_idx;
+DROP INDEX IF EXISTS opt_page_score_history_page_evaluated_idx;
+DROP TABLE IF EXISTS opt_page_score_history;

--- a/supabase/rollbacks/0048_opt_score_calibration.down.sql
+++ b/supabase/rollbacks/0048_opt_score_calibration.down.sql
@@ -1,0 +1,6 @@
+-- Rollback for 0048_opt_score_calibration.sql
+DROP POLICY IF EXISTS opt_score_calibration_read ON opt_score_calibration;
+DROP POLICY IF EXISTS service_role_all ON opt_score_calibration;
+ALTER TABLE IF EXISTS opt_score_calibration DISABLE ROW LEVEL SECURITY;
+DROP INDEX IF EXISTS opt_score_calibration_client_created_idx;
+DROP TABLE IF EXISTS opt_score_calibration;

--- a/supabase/rollbacks/0049_opt_clients_score_weights.down.sql
+++ b/supabase/rollbacks/0049_opt_clients_score_weights.down.sql
@@ -1,0 +1,4 @@
+-- Rollback for 0049_opt_clients_score_weights.sql
+ALTER TABLE opt_clients DROP COLUMN IF EXISTS causal_eval_window_days;
+ALTER TABLE opt_clients DROP COLUMN IF EXISTS conversion_components_present;
+ALTER TABLE opt_clients DROP COLUMN IF EXISTS score_weights;

--- a/supabase/rollbacks/0050_opt_landing_pages_composite_score.down.sql
+++ b/supabase/rollbacks/0050_opt_landing_pages_composite_score.down.sql
@@ -1,0 +1,4 @@
+-- Rollback for 0050_opt_landing_pages_composite_score.sql
+ALTER TABLE opt_landing_pages DROP COLUMN IF EXISTS conversion_n_a;
+ALTER TABLE opt_landing_pages DROP COLUMN IF EXISTS current_classification;
+ALTER TABLE opt_landing_pages DROP COLUMN IF EXISTS current_composite_score;

--- a/vercel.json
+++ b/vercel.json
@@ -51,6 +51,10 @@
     {
       "path": "/api/cron/optimiser-expire-proposals",
       "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/optimiser-evaluate-scores",
+      "schedule": "45 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
First half of v1.6 from `docs/Optimisation_Engine_v1.6_Addendum.docx`. Adds the composite Landing Page Score (alignment + behaviour + conversion + technical → 0–100), per-page-version score history, page detail view with score breakdown panel + history table, and a read-only client settings page for visible weights.

## Plan (sub-slice)
**Stack base.** Targets `optimiser/slice-10-diagnostics`. Auto-retargets up the chain on merge.

**Approach.** Four sub-score calculators feed a composite assembler, which writes one row per page per day to `opt_page_score_history` and caches `current_composite_score` + `current_classification` on `opt_landing_pages`. Cohort-relative normalisation (client's own active-pages 25–75th percentile) is the right baseline per addendum §2.2.2.

**Decisions called out**
- **Q1.6.1** — when revenue tracking is unavailable, redistribute the 0.20 conversion-component weight to CR (×0.65) + CPA (×0.35). Picked direction A from the addendum.
- **Q1.6.4** — score weights visible to staff on `/optimiser/clients/[id]/settings`. Phase 1 read-only with per-axis explanations; Phase 2 makes them editable.

**Why the rollback button is a placeholder.** Per the brief: "Slice 13 ships the rollback UI; Slice 12 leaves the button as a placeholder that tooltip-explains 'rollback ships in the next update'."

## Risks identified and mitigated
- **Insufficient-data short-circuit** — evaluate-scores-job skips pages with reliability=red so a misleading score is never persisted.
- **Cohort-of-one** — percentile normalisation returns 50 (neutral) when the cohort has < 2 pages or zero spread. Single-page clients don't get trivial 0/100 scores.
- **weights_used snapshotting** — every history row stores the effective weights at evaluation time, so future tuning doesn't rewrite the timeline.
- **§4.1 dragging hint** — only fires for non-`high_performer` pages with a positive-weight sub-score. Otherwise renders a green "performing within expected range" note.
- **Cohort recompute cost** — O(n) per client per tick. Bounded by managed pages count; Phase 1.5 candidate to materialise as a view if it gets hot.
- **vercel.json** — appends one cron entry; existing entries untouched.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (1 new cron + 2 new pages)
- [ ] E2E: deferred. The repo's e2e suite is broken on `main` itself (issue #272); no new specs introduced here that aren't covered by the existing optimiser fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)