### PR TITLE
feat(bl-1): top-level /admin/posts/new route + Post a blog nav

### DIFF
--- a/app/admin/posts/new/page.tsx
+++ b/app/admin/posts/new/page.tsx
@@ -1,0 +1,60 @@
+import { redirect } from "next/navigation";
+
+import { Alert } from "@/components/ui/alert";
+import { H1, Lead } from "@/components/ui/typography";
+import { PostsNewClient } from "@/components/PostsNewClient";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { listSites } from "@/lib/sites";
+
+// BL-1 — Top-level "Post a blog" entry point.
+//
+// Distinct from /admin/sites/[id]/posts/new (which lives inside a
+// chosen site). This route lets an operator land directly from the
+// sidebar, pick a site, and start drafting. The site picker is the
+// first thing they see; the composer surfaces only after a site is
+// chosen, which keeps the form from spelling out columns the operator
+// hasn't decided on yet.
+
+export const dynamic = "force-dynamic";
+
+export default async function PostsNewPage() {
+  const access = await checkAdminAccess({
+    requiredRoles: ["admin", "operator"],
+    insufficientRoleRedirectTo: "/",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  const result = await listSites();
+  if (!result.ok) {
+    return (
+      <div className="mx-auto max-w-4xl">
+        <Alert variant="destructive">
+          Failed to load sites: {result.error.message}
+        </Alert>
+      </div>
+    );
+  }
+
+  // Filter to sites the operator can actually publish into. Removed
+  // sites are already excluded by listSites; we additionally drop
+  // pending_pairing (no WP credentials yet) so the picker doesn't
+  // present sites that will fail at publish time.
+  const sites = result.data.sites.filter(
+    (s) => s.status !== "pending_pairing",
+  );
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <H1>Post a blog</H1>
+      <Lead className="mt-1">
+        Pick a site, then paste or drop your post. Metadata pre-fills from
+        front-matter, inline labels, or the first heading — every value is
+        editable before save.
+      </Lead>
+
+      <div className="mt-6">
+        <PostsNewClient sites={sites} />
+      </div>
+    </div>
+  );
+}

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -11,6 +11,7 @@ import {
   KeyRound,
   LogOut,
   Menu,
+  PenSquare,
   Settings,
   Users,
   Workflow,
@@ -112,6 +113,12 @@ export function AdminSidebar({
 
   const navLinks: NavLink[] = [
     { label: "Sites", href: "/admin/sites", icon: Globe, testId: "nav-sites" },
+    {
+      label: "Post a blog",
+      href: "/admin/posts/new",
+      icon: PenSquare,
+      testId: "nav-post-blog",
+    },
     {
       label: "Batches",
       href: "/admin/batches",

--- a/components/PostsNewClient.tsx
+++ b/components/PostsNewClient.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, FileText, Layers } from "lucide-react";
+
+import { BlogPostComposer } from "@/components/BlogPostComposer";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import type { SiteListItem } from "@/lib/tool-schemas";
+import { cn } from "@/lib/utils";
+
+// BL-1 — Client shell for /admin/posts/new.
+//
+// Two responsibilities:
+//   1. A site picker that gates the composer. The composer needs a
+//      siteId; until the operator picks one we render a quiet shell.
+//   2. A tabs row with "Single post" + "Bulk upload". Bulk is a
+//      parked stub today (BL-5 fills it). Tabs ride above the picker
+//      so the operator sees the available modes before committing to
+//      a site.
+
+type Mode = "single" | "bulk";
+
+interface PostsNewClientProps {
+  sites: SiteListItem[];
+}
+
+export function PostsNewClient({ sites }: PostsNewClientProps) {
+  const [mode, setMode] = useState<Mode>("single");
+  const [siteId, setSiteId] = useState<string | null>(null);
+
+  const selectedSite = sites.find((s) => s.id === siteId) ?? null;
+
+  return (
+    <div className="space-y-6">
+      <ModeTabs mode={mode} onModeChange={setMode} />
+
+      <SitePicker
+        sites={sites}
+        value={selectedSite}
+        onChange={(s) => setSiteId(s?.id ?? null)}
+      />
+
+      {mode === "single" ? (
+        selectedSite ? (
+          <div className="rounded-md border bg-background p-6">
+            <BlogPostComposer siteId={selectedSite.id} />
+          </div>
+        ) : (
+          <EmptyShell label="Pick a site to start drafting your post." />
+        )
+      ) : (
+        <EmptyShell
+          label="Bulk upload is coming soon."
+          description="Drop multiple markdown / HTML files at once and review them as a batch before publishing."
+        />
+      )}
+    </div>
+  );
+}
+
+function ModeTabs({
+  mode,
+  onModeChange,
+}: {
+  mode: Mode;
+  onModeChange: (next: Mode) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Post creation mode"
+      className="inline-flex items-center gap-1 rounded-md border bg-muted/40 p-1"
+    >
+      <ModeTab
+        id="single"
+        active={mode === "single"}
+        onClick={() => onModeChange("single")}
+        icon={FileText}
+        label="Single post"
+      />
+      <ModeTab
+        id="bulk"
+        active={mode === "bulk"}
+        onClick={() => onModeChange("bulk")}
+        icon={Layers}
+        label="Bulk upload"
+      />
+    </div>
+  );
+}
+
+function ModeTab({
+  id,
+  active,
+  onClick,
+  icon: Icon,
+  label,
+}: {
+  id: Mode;
+  active: boolean;
+  onClick: () => void;
+  icon: typeof FileText;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      data-testid={`posts-new-tab-${id}`}
+      className={cn(
+        "relative inline-flex h-8 items-center gap-1.5 rounded px-3 text-sm font-medium transition-smooth focus:outline-none focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        active
+          ? "bg-background text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      <Icon aria-hidden className="h-3.5 w-3.5" />
+      {label}
+    </button>
+  );
+}
+
+function SitePicker({
+  sites,
+  value,
+  onChange,
+}: {
+  sites: SiteListItem[];
+  value: SiteListItem | null;
+  onChange: (next: SiteListItem | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  if (sites.length === 0) {
+    return (
+      <div
+        role="status"
+        className="rounded-md border bg-muted/40 px-4 py-3 text-sm text-muted-foreground"
+      >
+        No sites available. Pair a WordPress install in
+        <code className="mx-1 font-mono text-xs">/admin/sites</code>
+        before posting.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <label
+        htmlFor="posts-new-site-picker"
+        className="block text-sm font-medium"
+      >
+        Site
+      </label>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            id="posts-new-site-picker"
+            type="button"
+            data-testid="posts-new-site-picker"
+            className="flex h-10 w-full max-w-md items-center justify-between rounded-md border bg-background px-3 text-sm transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            aria-haspopup="listbox"
+            aria-expanded={open}
+          >
+            <span className={value ? "" : "text-muted-foreground"}>
+              {value ? value.name : "Pick a site…"}
+            </span>
+            <ChevronDown
+              aria-hidden
+              className="ml-2 h-4 w-4 text-muted-foreground"
+            />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          sideOffset={4}
+          className="w-[var(--radix-popover-trigger-width)] p-0"
+        >
+          <Command>
+            <CommandInput placeholder="Search sites by name or URL" />
+            <CommandList>
+              <CommandEmpty>No sites match.</CommandEmpty>
+              {sites.map((s) => (
+                <CommandItem
+                  key={s.id}
+                  value={`${s.name} ${s.wp_url}`}
+                  onSelect={() => {
+                    onChange(s);
+                    setOpen(false);
+                  }}
+                  data-testid={`posts-new-site-option-${s.id}`}
+                >
+                  <span className="flex-1 truncate">{s.name}</span>
+                  <span className="ml-2 shrink-0 truncate text-xs text-muted-foreground">
+                    {hostnameOf(s.wp_url)}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {value && (
+        <p className="text-xs text-muted-foreground">
+          Posting to <span className="font-medium text-foreground">{value.name}</span>{" "}
+          ({hostnameOf(value.wp_url)}).
+        </p>
+      )}
+    </div>
+  );
+}
+
+function EmptyShell({
+  label,
+  description,
+}: {
+  label: string;
+  description?: string;
+}) {
+  return (
+    <div className="rounded-md border border-dashed bg-muted/20 px-6 py-12 text-center text-sm">
+      <p className="font-medium">{label}</p>
+      {description && (
+        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+      )}
+    </div>
+  );
+}
+
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}

--- a/e2e/posts-new.spec.ts
+++ b/e2e/posts-new.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+
+import { auditA11y, signInAsAdmin } from "./helpers";
+
+// BL-1 — Top-level /admin/posts/new entry point.
+//
+// Scope:
+//   1. Sidebar nav has a "Post a blog" entry.
+//   2. /admin/posts/new renders with the site picker + tab row.
+//   3. The composer is gated until a site is picked; picking a site
+//      reveals it.
+//   4. The Bulk-upload tab shows its placeholder shell (BL-5 fills it).
+
+test.describe("/admin/posts/new — top-level entry", () => {
+  test("sidebar nav links to the route and the page renders", async ({
+    page,
+  }, testInfo) => {
+    await signInAsAdmin(page);
+
+    // Nav entry exists and is reachable.
+    const navLink = page.getByTestId("nav-post-blog").first();
+    await expect(navLink).toBeVisible();
+    await navLink.click();
+    await page.waitForURL(/\/admin\/posts\/new$/);
+
+    // Tabs row + site picker present before any composer is rendered.
+    await expect(
+      page.getByRole("tab", { name: /single post/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("tab", { name: /bulk upload/i }),
+    ).toBeVisible();
+    await expect(page.getByTestId("posts-new-site-picker")).toBeVisible();
+
+    // Composer is gated — the empty-state copy fronts the surface.
+    await expect(
+      page.getByText(/pick a site to start drafting/i),
+    ).toBeVisible();
+
+    await auditA11y(page, testInfo);
+  });
+
+  test("picking a site reveals the composer", async ({ page }, testInfo) => {
+    await signInAsAdmin(page);
+    await page.goto("/admin/posts/new");
+
+    await page.getByTestId("posts-new-site-picker").click();
+    // The seed contains at least one site (the E2E test site).
+    const firstOption = page
+      .locator('[data-testid^="posts-new-site-option-"]')
+      .first();
+    await expect(firstOption).toBeVisible();
+    await firstOption.click();
+
+    // Composer textarea appears once a site is bound.
+    await expect(page.locator("#post-composer-input")).toBeVisible();
+
+    await auditA11y(page, testInfo);
+  });
+
+  test("bulk-upload tab shows the BL-5 placeholder", async ({
+    page,
+  }, testInfo) => {
+    await signInAsAdmin(page);
+    await page.goto("/admin/posts/new");
+
+    await page.getByTestId("posts-new-tab-bulk").click();
+    await expect(page.getByText(/bulk upload is coming soon/i)).toBeVisible();
+
+    await auditA11y(page, testInfo);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the blog-posting workstream (BL-1 → BL-9). Adds a top-level entry point so an operator can land directly from the sidebar, pick a site, and start drafting — no detour through the site list. Coexists with `/admin/sites/[id]/posts/new` (untouched).

## What ships

- `app/admin/posts/new/page.tsx` — server component, admin/operator gate, server-side `listSites()` filtered to publishable status, hands them to the client shell.
- `components/PostsNewClient.tsx` — Single / Bulk tabs above a `cmdk`-backed site picker. Bulk is a parked stub that BL-5 fills. Single renders `BlogPostComposer` once a site is bound; until then the surface reads as a quiet empty shell that names the next action ("Pick a site to start drafting").
- `components/AdminSidebar.tsx` — new "Post a blog" entry between Sites and Batches. `PenSquare` icon, `nav-post-blog` testId.
- `e2e/posts-new.spec.ts` — three tests (nav reachability, site-picker → composer reveal, bulk placeholder), each runs `auditA11y`.

## Risks identified and mitigated

- **Sites list could leak removed/pending sites into the picker** — server filter drops `pending_pairing` (no WP creds yet) on top of `listSites`'s default exclusion of `removed`. Operator can't pick a site they can't publish to.
- **Composer reuse** — `BlogPostComposer` already accepts a `siteId` prop, no changes needed. The site-scoped route is untouched.
- **Empty sites edge** — picker shows a quiet status panel pointing at `/admin/sites` instead of a blank dropdown.

## Quality gates

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run build` ✅ (new route: `2.25 kB / 212 kB First Load JS`)

## Test plan

- [ ] Manual: land on `/admin/posts/new`, verify site picker + tabs render before composer
- [ ] Manual: pick a site, confirm composer appears with that site context
- [ ] Manual: switch to Bulk tab, confirm placeholder copy
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)