### PR TITLE
feat(optimiser-13): causal deltas + rollback UI + reprompt split (v1.6)

### DIFF
--- a/app/api/cron/optimiser-evaluate-causal-deltas/route.ts
+++ b/app/api/cron/optimiser-evaluate-causal-deltas/route.ts
@@ -1,0 +1,30 @@
+import { type NextRequest } from "next/server";
+
+import {
+  authorisedCronRequest,
+  runOptimiserCronTick,
+  unauthorisedResponse,
+} from "@/lib/optimiser/sync/cron-shared";
+import { runCausalDeltaEvaluationForAllClients } from "@/lib/optimiser/causal/evaluate-deltas";
+
+// Daily post-rollout evaluation at 08:15 UTC. For every applied
+// proposal where the rollout window has closed, computes actual_impact
+// and writes/updates a row in opt_causal_deltas.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+async function handle(req: NextRequest) {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+  return runOptimiserCronTick({
+    eventName: "optimiser.evaluate_causal_deltas",
+    run: async () => {
+      const r = await runCausalDeltaEvaluationForAllClients();
+      return { outcomes: r.outcomes, total: r.total_proposals };
+    },
+  });
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/app/api/optimiser/pages/[id]/rollback/route.ts
+++ b/app/api/optimiser/pages/[id]/rollback/route.ts
@@ -1,0 +1,178 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { logger } from "@/lib/logger";
+import { recordChangeLog } from "@/lib/optimiser/change-log";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// POST /api/optimiser/pages/[id]/rollback — addendum §4.4 + §9.8.6.
+//
+// Rolls a managed page back to a target score-history version. Phase 1
+// surface ships proposal-side bookkeeping: flip the relevant proposal
+// to applied_then_reverted, log the rollback with staff actor id, and
+// trigger a fresh score evaluation against the restored state. The
+// actual Site Builder rollback endpoint call lands in Phase 1.5
+// alongside brief submission.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z.object({
+  target_history_id: z.string().uuid(),
+  reason: z.string().min(1).max(500),
+});
+
+export async function POST(
+  req: NextRequest,
+  ctx: { params: { id: string } },
+): Promise<NextResponse> {
+  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  if (access.kind === "redirect") {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "UNAUTHORIZED", message: "Not authorised" },
+      },
+      { status: 401 },
+    );
+  }
+
+  let body;
+  try {
+    body = Body.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INVALID_BODY",
+          message: err instanceof Error ? err.message : "Invalid body",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getServiceRoleClient();
+  const { data: page } = await supabase
+    .from("opt_landing_pages")
+    .select("id, client_id, page_id")
+    .eq("id", ctx.params.id)
+    .is("deleted_at", null)
+    .maybeSingle();
+  if (!page) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "NOT_FOUND", message: "Page not found" },
+      },
+      { status: 404 },
+    );
+  }
+
+  const { data: target } = await supabase
+    .from("opt_page_score_history")
+    .select("id, page_version, triggering_proposal_id, evaluated_at, composite_score, classification")
+    .eq("id", body.target_history_id)
+    .eq("landing_page_id", ctx.params.id)
+    .maybeSingle();
+  if (!target) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: "Target version not found for this page",
+        },
+      },
+      { status: 404 },
+    );
+  }
+
+  // Flip the proposal that drove the version BEING ROLLED-BACK-FROM
+  // (i.e. the most recent applied proposal for this page) to
+  // applied_then_reverted. The target version's own triggering proposal
+  // is preserved as historical truth.
+  const { data: latestApplied } = await supabase
+    .from("opt_proposals")
+    .select("id, status")
+    .eq("landing_page_id", ctx.params.id)
+    .in("status", ["applied", "applied_promoted"])
+    .order("applied_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (latestApplied) {
+    const { error: flipErr } = await supabase
+      .from("opt_proposals")
+      .update({
+        status: "applied_then_reverted",
+        updated_at: new Date().toISOString(),
+        updated_by: access.user?.id ?? null,
+      })
+      .eq("id", latestApplied.id as string);
+    if (flipErr) {
+      logger.error("optimiser.rollback.flip_failed", {
+        page_id: ctx.params.id,
+        proposal_id: latestApplied.id,
+        error: flipErr.message,
+      });
+    }
+  }
+
+  // Audit-trail row in opt_change_log. The Site Builder's existing
+  // rollback endpoint call lands in Phase 1.5; for Phase 1 the log row
+  // is the truth + the page snapshot stays where it is.
+  await recordChangeLog({
+    clientId: page.client_id as string,
+    proposalId: (latestApplied?.id as string) ?? null,
+    landingPageId: ctx.params.id,
+    event: "manual_rollback",
+    pageVersion: (target.page_version as string | null) ?? null,
+    actorUserId: access.user?.id ?? null,
+    details: {
+      target_history_id: body.target_history_id,
+      target_evaluated_at: target.evaluated_at,
+      target_composite_score: target.composite_score,
+      target_classification: target.classification,
+      reverted_proposal_id: latestApplied?.id ?? null,
+      reason: body.reason,
+      // Phase 1 marker — Phase 1.5 will replace with brief_submission_id.
+      site_builder_rollback_pending: true,
+    },
+  });
+
+  // Re-evaluate the score so the cached current_composite_score on
+  // opt_landing_pages reflects the restored state. Phase 1 ships the
+  // restored composite from the target history row directly; the next
+  // /api/cron/optimiser-evaluate-scores tick will reconcile if data
+  // shifts.
+  const { error: updateErr } = await supabase
+    .from("opt_landing_pages")
+    .update({
+      current_composite_score: target.composite_score as number,
+      current_classification: target.classification as string,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", ctx.params.id);
+  if (updateErr) {
+    logger.error("optimiser.rollback.score_update_failed", {
+      page_id: ctx.params.id,
+      error: updateErr.message,
+    });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    data: {
+      page_id: ctx.params.id,
+      restored_to: {
+        history_id: target.id,
+        composite_score: target.composite_score,
+        classification: target.classification,
+        evaluated_at: target.evaluated_at,
+      },
+    },
+  });
+}

--- a/app/optimiser/pages/[id]/page.tsx
+++ b/app/optimiser/pages/[id]/page.tsx
@@ -5,6 +5,10 @@ import { Button } from "@/components/ui/button";
 import { ScoreBreakdownPanel } from "@/components/optimiser/ScoreBreakdownPanel";
 import { ScoreHistoryTable } from "@/components/optimiser/ScoreHistoryTable";
 import { ScoreSparkline } from "@/components/optimiser/ScoreSparkline";
+import {
+  buildDeltaMapByProposal,
+  listCausalDeltasForPage,
+} from "@/lib/optimiser/causal/read-deltas";
 import { getClient } from "@/lib/optimiser/clients";
 import { getLandingPage } from "@/lib/optimiser/landing-pages";
 import { computeReliability } from "@/lib/optimiser/data-reliability";
@@ -98,6 +102,8 @@ export default async function OptimiserPageDetail({
     limit: 10,
   });
   const history = await listScoreHistory({ landingPageId: page.id, limit: 30 });
+  const causalDeltaRows = await listCausalDeltasForPage(page.id);
+  const causalDeltas = buildDeltaMapByProposal(causalDeltaRows);
 
   return (
     <div className="space-y-6">
@@ -158,7 +164,11 @@ export default async function OptimiserPageDetail({
             />
           )}
         </header>
-        <ScoreHistoryTable history={history} />
+        <ScoreHistoryTable
+          pageId={page.id}
+          history={history}
+          causalDeltas={causalDeltas}
+        />
       </section>
     </div>
   );

--- a/app/optimiser/proposals/[id]/page.tsx
+++ b/app/optimiser/proposals/[id]/page.tsx
@@ -2,7 +2,9 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+import { PastCausalDeltasPanel } from "@/components/optimiser/PastCausalDeltasPanel";
 import { ProposalReview } from "@/components/optimiser/ProposalReview";
+import { listRecentCausalDeltasForPlaybook } from "@/lib/optimiser/causal/read-deltas";
 import { getProposalWithEvidence } from "@/lib/optimiser/proposals";
 import { getLandingPage } from "@/lib/optimiser/landing-pages";
 
@@ -18,6 +20,16 @@ export default async function OptimiserProposalReviewPage({
   if (!proposal) notFound();
   const page = await getLandingPage(proposal.landing_page_id);
 
+  // Past causal deltas for the same playbook on this client — drives
+  // the §4.3 "what happened last time we did this" panel.
+  const pastDeltas = proposal.triggering_playbook_id
+    ? await listRecentCausalDeltasForPlaybook({
+        clientId: proposal.client_id,
+        playbookId: proposal.triggering_playbook_id,
+        limit: 5,
+      })
+    : [];
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
@@ -28,6 +40,10 @@ export default async function OptimiserProposalReviewPage({
           Status: <code>{proposal.status}</code>
         </span>
       </div>
+      <PastCausalDeltasPanel
+        deltas={pastDeltas}
+        playbookId={proposal.triggering_playbook_id}
+      />
       <ProposalReview
         proposal={{
           id: proposal.id,

--- a/components/optimiser/PastCausalDeltasPanel.tsx
+++ b/components/optimiser/PastCausalDeltasPanel.tsx
@@ -1,0 +1,66 @@
+import type { CausalDeltaRow } from "@/lib/optimiser/causal/read-deltas";
+import { summariseDeltasForReviewPanel } from "@/lib/optimiser/causal/read-deltas";
+
+// "What happened last time we did this" panel — addendum §4.3.
+// Server-renderable; consumes the deltas the proposal review page
+// fetches with listRecentCausalDeltasForPlaybook.
+
+export function PastCausalDeltasPanel({
+  deltas,
+  playbookId,
+}: {
+  deltas: CausalDeltaRow[];
+  playbookId: string | null;
+}) {
+  if (!playbookId) return null;
+  const summary = summariseDeltasForReviewPanel(deltas);
+  if (summary.count === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-3 text-sm text-muted-foreground">
+        No prior causal deltas for this playbook on this client yet.
+        Once the first applied proposal of this type accumulates 14 days
+        or 300+ post-rollout sessions, the comparison will appear here.
+      </div>
+    );
+  }
+  const friendly = playbookId.replace(/_/g, " ");
+  const crSummary =
+    summary.avg_cr_pct != null
+      ? `${summary.avg_cr_pct >= 0 ? "+" : ""}${(summary.avg_cr_pct * 100).toFixed(1)}% CR`
+      : null;
+  const scoreSummary =
+    summary.avg_score_delta != null
+      ? `${summary.avg_score_delta >= 0 ? "+" : ""}${summary.avg_score_delta.toFixed(0)} composite pts`
+      : null;
+  const confidenceLabel =
+    summary.avg_confidence == null
+      ? null
+      : summary.avg_confidence >= 0.7
+        ? "high confidence"
+        : summary.avg_confidence >= 0.4
+          ? "moderate confidence"
+          : "low confidence";
+  return (
+    <div className="rounded-md border border-emerald-200 bg-emerald-50/40 p-3 text-sm text-emerald-900">
+      <p>
+        <span className="font-medium">What happened last time:</span>{" "}
+        past {summary.count} {friendly} proposal{summary.count === 1 ? "" : "s"} for this client averaged{" "}
+        {[crSummary, scoreSummary].filter(Boolean).join(" / ")}
+        {confidenceLabel ? ` with ${confidenceLabel}` : ""}.
+      </p>
+      <ul className="mt-2 space-y-1 text-xs text-emerald-800/80">
+        {deltas.slice(0, 3).map((d) => (
+          <li key={d.id}>
+            ·{" "}
+            {d.actual_impact_cr != null
+              ? `${d.actual_impact_cr >= 0 ? "+" : ""}${(d.actual_impact_cr * 100).toFixed(1)}% CR`
+              : d.actual_impact_score != null
+                ? `${d.actual_impact_score >= 0 ? "+" : ""}${d.actual_impact_score} pts`
+                : "no measured impact"}{" "}
+            on {new Date(d.evaluation_window_end).toLocaleDateString()}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/optimiser/ProposalReview.tsx
+++ b/components/optimiser/ProposalReview.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { RepromptForm } from "@/components/optimiser/RepromptForm";
 
 export type ProposalReviewProps = {
   proposal: {
@@ -180,12 +181,7 @@ export function ProposalReview({
         </Section>
 
         <Section title="Pre-build reprompt (optional)">
-          <Textarea
-            value={reprompt}
-            onChange={(e) => setReprompt(e.target.value)}
-            rows={3}
-            placeholder="Augment the brief: 'keep the existing testimonial component' / 'use the centred hero variant' / etc."
-          />
+          <RepromptForm value={reprompt} onChange={setReprompt} />
           <p className="mt-1 text-xs text-muted-foreground">
             Appended to the change set on approve. Phase 1.5 forwards this into the Site Builder brief.
           </p>

--- a/components/optimiser/RepromptForm.tsx
+++ b/components/optimiser/RepromptForm.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+// §9.8.7 reprompt UI split: controlled vs. free.
+// Both modes serialise to a single string the existing pre_build_reprompt
+// field on opt_proposals consumes. Phase 1.5 brief construction parses
+// the structured shape back out for the Site Builder brief.
+
+const PRESERVE_OPTIONS = [
+  { id: "h1", label: "H1" },
+  { id: "hero_copy", label: "Hero copy" },
+  { id: "form_structure", label: "Form structure" },
+  { id: "primary_cta_verb", label: "Primary CTA verb" },
+  { id: "testimonials", label: "Testimonials" },
+  { id: "trust_signals", label: "Trust signals" },
+  { id: "faq", label: "FAQ section" },
+  { id: "footer_cta", label: "Footer CTA" },
+] as const;
+
+export type RepromptValue = string;
+
+export function RepromptForm({
+  value,
+  onChange,
+}: {
+  value: RepromptValue;
+  onChange: (value: RepromptValue) => void;
+}) {
+  const [mode, setMode] = useState<"controlled" | "free">("controlled");
+  const [keep, setKeep] = useState<Record<string, boolean>>({});
+  const [changeOnly, setChangeOnly] = useState("");
+  const [free, setFree] = useState(value);
+
+  // Whenever the controlled inputs change, serialise into the reprompt
+  // string the parent state consumes.
+  const controlledSerialised = useMemo(() => {
+    const keepLabels = PRESERVE_OPTIONS.filter((o) => keep[o.id]).map(
+      (o) => o.label,
+    );
+    const parts: string[] = [];
+    if (keepLabels.length > 0) {
+      parts.push(`Preserve: ${keepLabels.join(", ")}.`);
+    }
+    if (changeOnly.trim()) {
+      parts.push(`Change only: ${changeOnly.trim()}.`);
+    }
+    return parts.join(" ");
+  }, [keep, changeOnly]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 text-sm">
+        <button
+          type="button"
+          onClick={() => {
+            setMode("controlled");
+            onChange(controlledSerialised);
+          }}
+          className={`rounded-md px-3 py-1.5 ${
+            mode === "controlled"
+              ? "bg-primary text-primary-foreground"
+              : "border border-border hover:bg-muted"
+          }`}
+        >
+          Controlled
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setMode("free");
+            onChange(free);
+          }}
+          className={`rounded-md px-3 py-1.5 ${
+            mode === "free"
+              ? "bg-primary text-primary-foreground"
+              : "border border-border hover:bg-muted"
+          }`}
+        >
+          Free reprompt
+        </button>
+        <span className="ml-2 text-xs text-muted-foreground">
+          {mode === "controlled"
+            ? "Pick what to preserve and what to change. Recommended."
+            : "Freeform — lower precision, useful when the structured form doesn't fit."}
+        </span>
+      </div>
+
+      {mode === "controlled" ? (
+        <div className="space-y-3 rounded-md border border-border bg-card p-4">
+          <fieldset>
+            <legend className="text-sm font-medium">Preserve</legend>
+            <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
+              {PRESERVE_OPTIONS.map((opt) => (
+                <label
+                  key={opt.id}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  <input
+                    type="checkbox"
+                    checked={Boolean(keep[opt.id])}
+                    onChange={(e) => {
+                      const next = { ...keep, [opt.id]: e.target.checked };
+                      setKeep(next);
+                      onChange(serialise(next, changeOnly));
+                    }}
+                  />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+          <div>
+            <label className="block text-sm font-medium">Change only</label>
+            <Input
+              value={changeOnly}
+              onChange={(e) => {
+                setChangeOnly(e.target.value);
+                onChange(serialise(keep, e.target.value));
+              }}
+              placeholder="e.g. CTA verb to 'Get a Quote'; trust signal placement"
+              className="mt-1"
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Generated brief:{" "}
+            <code className="font-mono">
+              {controlledSerialised || "(nothing yet)"}
+            </code>
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2 rounded-md border border-border bg-card p-4">
+          <Textarea
+            value={free}
+            onChange={(e) => {
+              setFree(e.target.value);
+              onChange(e.target.value);
+            }}
+            rows={3}
+            placeholder="Augment the brief: 'keep the existing testimonial component' / 'use the centred hero variant' / etc."
+          />
+          <p className="text-xs text-muted-foreground">
+            Both modes route through the Site Builder generation engine —
+            never direct edits.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function serialise(
+  keep: Record<string, boolean>,
+  changeOnly: string,
+): string {
+  const keepLabels = PRESERVE_OPTIONS.filter((o) => keep[o.id]).map(
+    (o) => o.label,
+  );
+  const parts: string[] = [];
+  if (keepLabels.length > 0) {
+    parts.push(`Preserve: ${keepLabels.join(", ")}.`);
+  }
+  if (changeOnly.trim()) {
+    parts.push(`Change only: ${changeOnly.trim()}.`);
+  }
+  return parts.join(" ");
+}
+
+/** Convenience export for callers that want to render the trigger
+ * button independently of the form. Phase 1.5 may use this to embed
+ * the form inline in a sheet/dialog. */
+export function RepromptToggleButton(props: {
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant={props.active ? "default" : "outline"}
+      size="sm"
+      onClick={props.onClick}
+    >
+      Reprompt
+    </Button>
+  );
+}

--- a/components/optimiser/RollbackButton.tsx
+++ b/components/optimiser/RollbackButton.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+// Per-version rollback button + confirmation modal — addendum §4.4.
+// Replaces the disabled placeholder that Slice 12 shipped on the score
+// history table.
+
+export function RollbackButton({
+  pageId,
+  historyId,
+  versionLabel,
+  classification,
+  composite,
+}: {
+  pageId: string;
+  historyId: string;
+  versionLabel: string;
+  classification: string;
+  composite: number;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function confirm() {
+    if (!reason.trim()) {
+      setError("A reason is required for the audit trail.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/optimiser/pages/${pageId}/rollback`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          target_history_id: historyId,
+          reason: reason.trim(),
+        }),
+      });
+      const json = await res.json();
+      if (!json.ok) {
+        setError(json.error?.message ?? "Rollback failed");
+        return;
+      }
+      setOpen(false);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Rollback failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-md border border-border bg-background px-2 py-1 text-xs hover:bg-muted"
+      >
+        Roll back
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={`rollback-${historyId}-title`}
+        >
+          <div className="w-full max-w-md space-y-4 rounded-lg border border-border bg-background p-6 shadow-lg">
+            <header className="space-y-1">
+              <h2
+                id={`rollback-${historyId}-title`}
+                className="text-lg font-semibold"
+              >
+                Roll back to {versionLabel}
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Restoring this version will mark the latest applied proposal
+                as <code className="font-mono text-xs">applied_then_reverted</code>{" "}
+                and re-evaluate the score against the restored content. The
+                full audit trail goes into opt_change_log.
+              </p>
+            </header>
+            <ul className="space-y-1 rounded-md border border-border bg-card p-3 text-sm">
+              <li>
+                <span className="text-muted-foreground">Target composite: </span>
+                <span className="font-mono font-semibold">{composite}</span>{" "}
+                <span className="text-xs text-muted-foreground">
+                  ({classification.replace("_", " ")})
+                </span>
+              </li>
+              <li>
+                <span className="text-muted-foreground">When: </span>
+                <span className="font-mono text-xs">{versionLabel}</span>
+              </li>
+            </ul>
+            <div className="space-y-2">
+              <label
+                htmlFor={`rollback-reason-${historyId}`}
+                className="block text-sm font-medium"
+              >
+                Reason (required for audit trail)
+              </label>
+              <Textarea
+                id={`rollback-reason-${historyId}`}
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                rows={3}
+                placeholder="Why is this rollback being initiated? e.g. 'CR dropped 20% over the last week, restoring last known-good version pending investigation.'"
+              />
+            </div>
+            {error && (
+              <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-900">
+                {error}
+              </div>
+            )}
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpen(false)}
+                disabled={submitting}
+              >
+                Cancel
+              </Button>
+              <Button type="button" onClick={confirm} disabled={submitting}>
+                {submitting ? "Rolling back…" : "Confirm rollback"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/optimiser/ScoreHistoryTable.tsx
+++ b/components/optimiser/ScoreHistoryTable.tsx
@@ -3,17 +3,22 @@ import {
   classificationLabel,
 } from "@/lib/optimiser/scoring/classify";
 import type { ScoreHistoryRow } from "@/lib/optimiser/scoring/score-history";
+import { RollbackButton } from "@/components/optimiser/RollbackButton";
 
 // §4.2 Score history view — full timeline of every score evaluation
-// for a page. Slice 12 ships the table; Slice 13 wires the rollback
-// action via the placeholder button. Tooltip explains the placeholder.
+// for a page. Slice 13 replaces the Slice 12 placeholder with the
+// real rollback action.
 
 export function ScoreHistoryTable({
+  pageId,
   history,
   causalDeltas,
 }: {
+  /** Required for the rollback action button on prior-version rows. */
+  pageId: string;
   history: ScoreHistoryRow[];
-  /** Slice 13 populates this; Slice 12 always passes an empty array. */
+  /** Map of triggering_proposal_id → causal-delta summary, populated by
+   * the Slice 13 server-side fetch on the page detail view. */
   causalDeltas?: Map<
     string,
     { actual_impact_cr?: number | null; actual_impact_score?: number | null }
@@ -48,7 +53,9 @@ export function ScoreHistoryTable({
           {history.map((row, idx) => {
             const colours = classificationBadgeColor(row.classification);
             const isCurrent = idx === 0;
-            const delta = causalDeltas?.get(row.id);
+            const delta =
+              causalDeltas?.get(row.triggering_proposal_id ?? "") ??
+              causalDeltas?.get(row.id);
             return (
               <tr
                 key={row.id}
@@ -99,14 +106,13 @@ export function ScoreHistoryTable({
                 </td>
                 <td className="px-3 py-2">
                   {!isCurrent && (
-                    <button
-                      type="button"
-                      disabled
-                      title="Rollback ships in the next update"
-                      className="rounded-md border border-border bg-muted/40 px-2 py-1 text-xs text-muted-foreground"
-                    >
-                      Roll back
-                    </button>
+                    <RollbackButton
+                      pageId={pageId}
+                      historyId={row.id}
+                      versionLabel={new Date(row.evaluated_at).toLocaleString()}
+                      classification={row.classification}
+                      composite={row.composite_score}
+                    />
                   )}
                 </td>
               </tr>

--- a/lib/optimiser/causal/evaluate-deltas.ts
+++ b/lib/optimiser/causal/evaluate-deltas.ts
@@ -1,0 +1,338 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// Causal delta evaluation (addendum §4.3 + §9.8.5).
+//
+// For every applied proposal where the rollout window has closed:
+//   - 14 days post-rollout (or per-client override on
+//     opt_clients.causal_eval_window_days)  OR
+//   - 300+ sessions on the new version
+// whichever comes first.
+//
+// The evaluator:
+//   1. Pulls the rollout day from opt_change_log (event = 'page_regenerated'
+//      for that proposal_id) — falls back to opt_proposals.applied_at
+//      when the change-log row is missing.
+//   2. Aggregates pre-rollout metrics (matching duration immediately
+//      before rollout) and post-rollout metrics (rollout to now).
+//   3. Computes actual_impact_cr (relative %) and actual_impact_score
+//      (composite delta) where data is available on both sides.
+//   4. UPSERTs into opt_causal_deltas keyed by proposal_id.
+//
+// Side effect: feeds opt_playbooks.seed_impact_min/max_pp via the
+// §9.4.2 calibration loop (Phase 2 activates the loop; Slice 13 ships
+// the writer with `fed_into_calibration` defaulting false so a future
+// loop activation can pick up unconsumed deltas).
+// ---------------------------------------------------------------------------
+
+const POST_ROLLOUT_SESSION_THRESHOLD = 300;
+const DEFAULT_WINDOW_DAYS = 14;
+
+export type CausalDeltaOutcome = {
+  client_id: string;
+  proposals_evaluated: number;
+  proposals_skipped: number;
+  errors: number;
+};
+
+export async function runCausalDeltaEvaluationForAllClients(): Promise<{
+  outcomes: CausalDeltaOutcome[];
+  total_proposals: number;
+}> {
+  const supabase = getServiceRoleClient();
+  const { data: clients, error } = await supabase
+    .from("opt_clients")
+    .select("id, causal_eval_window_days")
+    .is("deleted_at", null);
+  if (error) {
+    throw new Error(`runCausalDeltaEvaluationForAllClients: ${error.message}`);
+  }
+  const outcomes: CausalDeltaOutcome[] = [];
+  let total = 0;
+  for (const client of clients ?? []) {
+    const o = await runForClient({
+      clientId: client.id as string,
+      windowDays:
+        (client.causal_eval_window_days as number | null) ?? DEFAULT_WINDOW_DAYS,
+    });
+    total += o.proposals_evaluated;
+    outcomes.push(o);
+  }
+  return { outcomes, total_proposals: total };
+}
+
+async function runForClient(args: {
+  clientId: string;
+  windowDays: number;
+}): Promise<CausalDeltaOutcome> {
+  const supabase = getServiceRoleClient();
+
+  const { data: applied, error } = await supabase
+    .from("opt_proposals")
+    .select(
+      "id, landing_page_id, applied_at, change_set, expected_impact_min_pp, expected_impact_max_pp, triggering_playbook_id, before_snapshot",
+    )
+    .eq("client_id", args.clientId)
+    .in("status", ["applied", "applied_promoted"])
+    .not("applied_at", "is", null)
+    .is("deleted_at", null);
+  if (error) {
+    logger.error("optimiser.causal.list_failed", {
+      client_id: args.clientId,
+      error: error.message,
+    });
+    return {
+      client_id: args.clientId,
+      proposals_evaluated: 0,
+      proposals_skipped: 0,
+      errors: 1,
+    };
+  }
+
+  let evaluated = 0;
+  let skipped = 0;
+  let errs = 0;
+  const now = Date.now();
+  for (const row of applied ?? []) {
+    try {
+      const appliedAt = new Date(row.applied_at as string).getTime();
+      const windowMs = args.windowDays * 24 * 60 * 60 * 1000;
+      const windowExpired = now - appliedAt >= windowMs;
+      let postSessions = 0;
+      if (!windowExpired) {
+        // Need at least POST_ROLLOUT_SESSION_THRESHOLD sessions on the
+        // new version to evaluate early.
+        postSessions = await countSessionsSince(
+          row.landing_page_id as string,
+          new Date(appliedAt),
+        );
+        if (postSessions < POST_ROLLOUT_SESSION_THRESHOLD) {
+          skipped += 1;
+          continue;
+        }
+      }
+
+      await evaluateProposal({
+        clientId: args.clientId,
+        landingPageId: row.landing_page_id as string,
+        proposalId: row.id as string,
+        appliedAt: new Date(appliedAt),
+        evaluationEnd: new Date(now),
+        changeSet: (row.change_set as Record<string, unknown>) ?? {},
+        expectedImpactMinPp:
+          (row.expected_impact_min_pp as number | null) ?? null,
+        expectedImpactMaxPp:
+          (row.expected_impact_max_pp as number | null) ?? null,
+        triggeringPlaybookId:
+          (row.triggering_playbook_id as string | null) ?? null,
+        beforeSnapshot:
+          (row.before_snapshot as Record<string, unknown>) ?? {},
+      });
+      evaluated += 1;
+    } catch (err) {
+      errs += 1;
+      logger.error("optimiser.causal.failed", {
+        proposal_id: row.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return {
+    client_id: args.clientId,
+    proposals_evaluated: evaluated,
+    proposals_skipped: skipped,
+    errors: errs,
+  };
+}
+
+async function countSessionsSince(
+  landingPageId: string,
+  since: Date,
+): Promise<number> {
+  const supabase = getServiceRoleClient();
+  const { data } = await supabase
+    .from("opt_metrics_daily")
+    .select("metrics")
+    .eq("landing_page_id", landingPageId)
+    .eq("source", "ga4")
+    .gte("metric_date", since.toISOString().slice(0, 10));
+  let total = 0;
+  for (const row of data ?? []) {
+    const m = (row.metrics ?? {}) as { sessions?: number };
+    total += typeof m.sessions === "number" ? m.sessions : 0;
+  }
+  return total;
+}
+
+async function evaluateProposal(args: {
+  clientId: string;
+  landingPageId: string;
+  proposalId: string;
+  appliedAt: Date;
+  evaluationEnd: Date;
+  changeSet: Record<string, unknown>;
+  expectedImpactMinPp: number | null;
+  expectedImpactMaxPp: number | null;
+  triggeringPlaybookId: string | null;
+  beforeSnapshot: Record<string, unknown>;
+}): Promise<void> {
+  const supabase = getServiceRoleClient();
+  const windowDurationMs = args.evaluationEnd.getTime() - args.appliedAt.getTime();
+  const preStart = new Date(args.appliedAt.getTime() - windowDurationMs);
+
+  const [pre, post] = await Promise.all([
+    aggregateWindowMetrics(args.landingPageId, preStart, args.appliedAt),
+    aggregateWindowMetrics(args.landingPageId, args.appliedAt, args.evaluationEnd),
+  ]);
+
+  // CR delta — relative percentage change.
+  let actual_impact_cr: number | null = null;
+  if (pre.cr != null && post.cr != null && pre.cr > 0) {
+    actual_impact_cr = (post.cr - pre.cr) / pre.cr;
+  }
+
+  // Composite-score delta — the proposal's before_snapshot carries the
+  // pre-version composite (Slice 12 stores it on opt_proposals at
+  // generation time; Phase 1.5 brief construction will overwrite when
+  // the rebuild ships). Post-version composite reads from
+  // opt_landing_pages.current_composite_score.
+  const beforeScore =
+    typeof (args.beforeSnapshot as { composite_score?: unknown })
+      .composite_score === "number"
+      ? ((args.beforeSnapshot as { composite_score: number }).composite_score)
+      : null;
+  let actual_impact_score: number | null = null;
+  const { data: pageRow } = await supabase
+    .from("opt_landing_pages")
+    .select("current_composite_score")
+    .eq("id", args.landingPageId)
+    .maybeSingle();
+  const afterScore = (pageRow?.current_composite_score as number | null) ?? null;
+  if (beforeScore != null && afterScore != null) {
+    actual_impact_score = afterScore - beforeScore;
+  }
+
+  // Confidence per §9.4.1 against the post-rollout window only.
+  const confidence = computeWindowConfidence(post);
+
+  const { error } = await supabase
+    .from("opt_causal_deltas")
+    .upsert(
+      {
+        client_id: args.clientId,
+        landing_page_id: args.landingPageId,
+        proposal_id: args.proposalId,
+        change_set: args.changeSet,
+        expected_impact: {
+          min_pp: args.expectedImpactMinPp,
+          max_pp: args.expectedImpactMaxPp,
+        },
+        actual_impact_cr,
+        actual_impact_score,
+        confidence_score: confidence.score,
+        confidence_sample: confidence.sample,
+        confidence_freshness: confidence.freshness,
+        confidence_stability: confidence.stability,
+        confidence_signal: confidence.signal,
+        triggering_playbook_id: args.triggeringPlaybookId,
+        evaluation_window_start: args.appliedAt.toISOString(),
+        evaluation_window_end: args.evaluationEnd.toISOString(),
+      },
+      { onConflict: "proposal_id" },
+    );
+  if (error) {
+    throw new Error(`evaluateProposal upsert: ${error.message}`);
+  }
+}
+
+type WindowMetrics = {
+  sessions: number;
+  conversions: number;
+  cr: number | null;
+  bounce_rate: number | null;
+  bounce_series: number[];
+};
+
+async function aggregateWindowMetrics(
+  landingPageId: string,
+  since: Date,
+  until: Date,
+): Promise<WindowMetrics> {
+  const supabase = getServiceRoleClient();
+  const { data } = await supabase
+    .from("opt_metrics_daily")
+    .select("metric_date, source, metrics")
+    .eq("landing_page_id", landingPageId)
+    .gte("metric_date", since.toISOString().slice(0, 10))
+    .lte("metric_date", until.toISOString().slice(0, 10));
+  let sessions = 0;
+  let conversions = 0;
+  const bounceSeries: number[] = [];
+  for (const row of data ?? []) {
+    const m = (row.metrics ?? {}) as {
+      sessions?: number;
+      conversions?: number;
+      bounce_rate?: number;
+    };
+    if (row.source === "ga4") {
+      sessions += m.sessions ?? 0;
+      conversions += m.conversions ?? 0;
+      if (typeof m.bounce_rate === "number") bounceSeries.push(m.bounce_rate);
+    }
+  }
+  return {
+    sessions,
+    conversions,
+    cr: sessions > 0 ? conversions / sessions : null,
+    bounce_rate:
+      bounceSeries.length > 0
+        ? bounceSeries.reduce((a, b) => a + b, 0) / bounceSeries.length
+        : null,
+    bounce_series: bounceSeries,
+  };
+}
+
+function computeWindowConfidence(window: WindowMetrics): {
+  score: number;
+  sample: number;
+  freshness: number;
+  stability: number;
+  signal: number;
+} {
+  // Mirrors lib/optimiser/confidence.ts's formula but specialised
+  // for the post-rollout window (§9.4.1 applied to the causal-delta
+  // measurement).
+  const sample = Math.min(1, window.sessions / 1000);
+  const freshness = 1; // post-rollout = current, so 1.0
+  let stability = 0.7;
+  if (window.bounce_series.length >= 3) {
+    const mean =
+      window.bounce_series.reduce((a, b) => a + b, 0) /
+      window.bounce_series.length;
+    if (mean > 0) {
+      const variance =
+        window.bounce_series.reduce((acc, v) => acc + (v - mean) ** 2, 0) /
+        window.bounce_series.length;
+      const stddev = Math.sqrt(variance);
+      const cov = Math.abs(stddev / mean);
+      stability = Math.max(0, Math.min(1, 1 - cov));
+    }
+  }
+  const signal = window.conversions >= 30 ? 0.9 : window.conversions >= 10 ? 0.6 : 0.4;
+  const score = sample * freshness * stability * signal;
+  return {
+    score: round3(score),
+    sample: round3(sample),
+    freshness: round3(freshness),
+    stability: round3(stability),
+    signal: round3(signal),
+  };
+}
+
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}

--- a/lib/optimiser/causal/read-deltas.ts
+++ b/lib/optimiser/causal/read-deltas.ts
@@ -1,0 +1,118 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// Reader for the causal-delta UI surfaces (§4.3).
+
+export type CausalDeltaRow = {
+  id: string;
+  client_id: string;
+  landing_page_id: string;
+  proposal_id: string;
+  change_set: Record<string, unknown>;
+  expected_impact: { min_pp?: number | null; max_pp?: number | null };
+  actual_impact_cr: number | null;
+  actual_impact_score: number | null;
+  confidence_score: number | null;
+  triggering_playbook_id: string | null;
+  evaluation_window_start: string;
+  evaluation_window_end: string;
+  created_at: string;
+};
+
+const COLS =
+  "id, client_id, landing_page_id, proposal_id, change_set, expected_impact, actual_impact_cr, actual_impact_score, confidence_score, triggering_playbook_id, evaluation_window_start, evaluation_window_end, created_at";
+
+export async function listCausalDeltasForPage(
+  landingPageId: string,
+): Promise<CausalDeltaRow[]> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("opt_causal_deltas")
+    .select(COLS)
+    .eq("landing_page_id", landingPageId)
+    .order("created_at", { ascending: false });
+  if (error) throw new Error(`listCausalDeltasForPage: ${error.message}`);
+  return (data ?? []) as CausalDeltaRow[];
+}
+
+/**
+ * Read the most recent N causal deltas for a (client, playbook)
+ * combination. Powers the proposal-review "what happened last time
+ * we did this" panel.
+ */
+export async function listRecentCausalDeltasForPlaybook(args: {
+  clientId: string;
+  playbookId: string;
+  limit?: number;
+}): Promise<CausalDeltaRow[]> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("opt_causal_deltas")
+    .select(COLS)
+    .eq("client_id", args.clientId)
+    .eq("triggering_playbook_id", args.playbookId)
+    .order("created_at", { ascending: false })
+    .limit(args.limit ?? 5);
+  if (error)
+    throw new Error(`listRecentCausalDeltasForPlaybook: ${error.message}`);
+  return (data ?? []) as CausalDeltaRow[];
+}
+
+/** Build the proposal-id → delta map the score-history table consumes. */
+export function buildDeltaMapByProposal(
+  deltas: CausalDeltaRow[],
+): Map<
+  string,
+  { actual_impact_cr?: number | null; actual_impact_score?: number | null; confidence_score?: number | null }
+> {
+  const map = new Map();
+  for (const d of deltas) {
+    map.set(d.proposal_id, {
+      actual_impact_cr: d.actual_impact_cr,
+      actual_impact_score: d.actual_impact_score,
+      confidence_score: d.confidence_score,
+    });
+  }
+  return map;
+}
+
+/**
+ * Aggregate the past N deltas for a playbook into a single summary
+ * line: "past 3 CTA-move proposals for this client averaged +1.4% CR
+ * with high confidence".
+ */
+export function summariseDeltasForReviewPanel(
+  deltas: CausalDeltaRow[],
+): {
+  count: number;
+  avg_cr_pct: number | null;
+  avg_score_delta: number | null;
+  avg_confidence: number | null;
+} {
+  if (deltas.length === 0) {
+    return {
+      count: 0,
+      avg_cr_pct: null,
+      avg_score_delta: null,
+      avg_confidence: null,
+    };
+  }
+  const crs = deltas
+    .map((d) => d.actual_impact_cr)
+    .filter((v): v is number => v != null);
+  const scores = deltas
+    .map((d) => d.actual_impact_score)
+    .filter((v): v is number => v != null);
+  const confs = deltas
+    .map((d) => d.confidence_score)
+    .filter((v): v is number => v != null);
+  return {
+    count: deltas.length,
+    avg_cr_pct: crs.length > 0 ? crs.reduce((a, b) => a + b, 0) / crs.length : null,
+    avg_score_delta:
+      scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : null,
+    avg_confidence:
+      confs.length > 0 ? confs.reduce((a, b) => a + b, 0) / confs.length : null,
+  };
+}

--- a/lib/optimiser/index.ts
+++ b/lib/optimiser/index.ts
@@ -228,3 +228,16 @@ export {
   listScoreSparkline,
   type ScoreHistoryRow,
 } from "./scoring/score-history";
+
+// Slice 13 surface — v1.6 causal deltas + rollback
+export {
+  runCausalDeltaEvaluationForAllClients,
+  type CausalDeltaOutcome,
+} from "./causal/evaluate-deltas";
+export {
+  listCausalDeltasForPage,
+  listRecentCausalDeltasForPlaybook,
+  buildDeltaMapByProposal,
+  summariseDeltasForReviewPanel,
+  type CausalDeltaRow,
+} from "./causal/read-deltas";

--- a/skills/optimiser/causal-delta-evaluation/SKILL.md
+++ b/skills/optimiser/causal-delta-evaluation/SKILL.md
@@ -1,0 +1,45 @@
+# Skill — causal-delta-evaluation
+
+Compute and persist the v1.6 causal delta for an applied proposal once the rollout window has closed (addendum §4.3 + §9.8.5).
+
+## When the evaluator fires
+Daily cron `/api/cron/optimiser-evaluate-causal-deltas` (08:15 UTC). For each applied proposal in `opt_proposals`, the evaluator skips unless **either**:
+- 14 days have passed since `applied_at` (or per-client override on `opt_clients.causal_eval_window_days`), **or**
+- The new version has accumulated 300+ post-rollout sessions
+
+whichever comes first.
+
+## Inputs per proposal
+- `opt_proposals` row: `landing_page_id`, `applied_at`, `change_set`, `expected_impact_*`, `triggering_playbook_id`, `before_snapshot.composite_score`
+- `opt_metrics_daily` for the page: pre-window (matching duration immediately before rollout) + post-window (rollout to now)
+- `opt_landing_pages.current_composite_score` — the post-rollout composite
+
+## Computation
+- `actual_impact_cr = (post_cr - pre_cr) / pre_cr` — relative %, NULL when either side has zero sessions
+- `actual_impact_score = post_composite - pre_composite` — absolute composite delta in points, NULL when either side is missing
+- Confidence per §9.4.1 against the post-rollout window:
+  - `sample = min(1, post_sessions / 1000)`
+  - `freshness = 1.0` (post = current)
+  - `stability` from coefficient-of-variation of post-window bounce rate (≥3 days needed)
+  - `signal = 0.4 / 0.6 / 0.9` based on conversion count thresholds (10 / 30)
+  - `score = sample × freshness × stability × signal`
+
+## Persistence
+UPSERT into `opt_causal_deltas` keyed on `proposal_id`. Re-running the evaluator on the same proposal updates the existing row (e.g. once more post-window data has accumulated).
+
+`fed_into_calibration` defaults FALSE so a future Phase 2 calibration loop can pick up unconsumed deltas without re-querying historical data.
+
+## Confidence vs. composite-score confidence
+**Q1.6.2 decision** — kept separate, displayed adjacently. The composite-score's reliability dot reflects "is the data trustworthy at this snapshot"; the causal-delta's confidence reflects "is the measured impact statistically real". Same formula, different windows. Both surfaced in the UI per addendum §4.3.
+
+## Surfaces
+- Score history table (`/optimiser/pages/[id]`): causal-delta column shows `+1.2% CR` or `+9 pts` per row keyed by `triggering_proposal_id`
+- Proposal review screen: "what happened last time we did this" panel queries `listRecentCausalDeltasForPlaybook(client, playbook)` — surfaces past 5 deltas for the same playbook on the same client
+
+## Phase 2 calibration loop hook
+Once A/B tests start producing winner data, `fed_into_calibration` flips TRUE after the row drives a `seed_impact_*` update on `opt_playbooks` per §9.4.2. Phase 1 ships the writer; the loop activates in Phase 2.
+
+## Pointers
+- `lib/optimiser/causal/evaluate-deltas.ts:runCausalDeltaEvaluationForAllClients`
+- `lib/optimiser/causal/read-deltas.ts:listRecentCausalDeltasForPlaybook`
+- Cron route: `/api/cron/optimiser-evaluate-causal-deltas`

--- a/skills/optimiser/score-rollback/SKILL.md
+++ b/skills/optimiser/score-rollback/SKILL.md
@@ -1,0 +1,51 @@
+# Skill — score-rollback
+
+Roll a managed page back to a target score-history version (addendum §4.4 + §9.8.6).
+
+## Endpoint
+`POST /api/optimiser/pages/[id]/rollback`
+
+Body:
+```ts
+{
+  target_history_id: uuid,  // an opt_page_score_history row for this page
+  reason: string,           // required for the audit trail
+}
+```
+
+Authorisation: `admin` or `operator` role per `checkAdminAccess`.
+
+## Flow
+
+1. Look up the target `opt_page_score_history` row + verify it belongs to the page in the URL.
+2. Find the most recent applied / applied_promoted proposal for the page (the one being rolled back FROM).
+3. Flip that proposal to `applied_then_reverted`.
+4. Insert an `opt_change_log` row with `event = 'manual_rollback'`, the staff actor id, target version metadata, and `site_builder_rollback_pending: true` (Phase 1 marker).
+5. Update `opt_landing_pages.current_composite_score` + `current_classification` to the target version's values so the page browser reflects the restored state without waiting for the next cron tick.
+
+## What Phase 1 does NOT do
+
+The Site Builder's rollback endpoint isn't called yet — it lands in Phase 1.5 alongside brief submission. Phase 1's rollback is the **audit trail + score reconciliation**; the actual page bytes don't change. The `site_builder_rollback_pending: true` flag in the change-log details payload is the marker the Phase 1.5 wiring will pick up.
+
+## UI
+
+`components/optimiser/RollbackButton.tsx` — client component opened from each prior-version row in `ScoreHistoryTable`. Confirmation modal shows:
+- Target composite + classification + evaluated_at
+- Reason textarea (required)
+- Confirm / cancel
+
+The current row (latest) doesn't show a rollback button — there's no version newer than current to roll back to.
+
+## Score re-evaluation
+
+Phase 1 surface restores the cached score from the target history row directly. The next `/api/cron/optimiser-evaluate-scores` tick will reconcile against the live page state. Phase 1.5 can swap to a "force re-evaluate" call after the Site Builder rollback completes for tighter ordering.
+
+## Spec
+
+§4.4 (rollback as a first-class UI feature), §9.8.6, `addendum-v1.6.docx`.
+
+## Pointers
+- `app/api/optimiser/pages/[id]/rollback/route.ts`
+- `components/optimiser/RollbackButton.tsx`
+- `components/optimiser/ScoreHistoryTable.tsx` (caller)
+- `lib/optimiser/change-log.ts:recordChangeLog` (audit-trail writer)

--- a/supabase/migrations/0051_opt_causal_deltas.sql
+++ b/supabase/migrations/0051_opt_causal_deltas.sql
@@ -1,0 +1,102 @@
+-- 0051 — Optimiser v1.6: opt_causal_deltas.
+-- Reference: addendum §3.1, §4.3, §9.8.5.
+--
+-- Records the attributed effect of each applied proposal once it
+-- accumulates enough post-rollout data. Powers the "what happened
+-- last time we did this" panel on the proposal review screen and
+-- the causal-delta column on the §4.2 score history view.
+--
+-- Append-only — one row per (proposal, evaluation_window). The
+-- post-rollout cron writes a row when:
+--   - 14 days since rollout (or per-client override on
+--     opt_clients.causal_eval_window_days)  OR
+--   - 300+ sessions on the new version
+-- whichever comes first.
+--
+-- The attributed effect feeds back into opt_playbooks.seed_impact_*
+-- via the §9.4.2 calibration loop.
+
+CREATE TABLE opt_causal_deltas (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id                uuid NOT NULL
+    REFERENCES opt_clients(id) ON DELETE CASCADE,
+  landing_page_id          uuid NOT NULL
+    REFERENCES opt_landing_pages(id) ON DELETE CASCADE,
+  proposal_id              uuid NOT NULL
+    REFERENCES opt_proposals(id) ON DELETE CASCADE,
+
+  -- Snapshot of the structured change set from the proposal at
+  -- approval time. Stored verbatim so the causal-delta UI shows
+  -- exactly what was changed even if the proposal's change_set
+  -- column drifts (it shouldn't, but defensive).
+  change_set               jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Range from the proposal's expected_impact_min/max_pp at approval.
+  -- {"min_pp": 5, "max_pp": 10} shape.
+  expected_impact          jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Measured deltas. NULL if the metric wasn't available on either side
+  -- of the rollout window.
+  --
+  -- actual_impact_cr = (post_cr - pre_cr) / pre_cr — relative %.
+  -- actual_impact_score = post_composite - pre_composite — absolute pts.
+  actual_impact_cr         numeric(8, 5),
+  actual_impact_score      integer,
+
+  -- §9.4.1 confidence sub-factors against the post-rollout window.
+  confidence_score         numeric(4, 3)
+    CHECK (confidence_score IS NULL OR (confidence_score >= 0 AND confidence_score <= 1)),
+  confidence_sample        numeric(4, 3),
+  confidence_freshness     numeric(4, 3),
+  confidence_stability     numeric(4, 3),
+  confidence_signal        numeric(4, 3),
+
+  -- Triggering playbook id (denormalised from opt_proposals so the
+  -- "past N CTA-move proposals" query is a single-table scan).
+  triggering_playbook_id   text REFERENCES opt_playbooks(id) ON DELETE SET NULL,
+
+  -- Pre/post window timestamps. Shape: same duration on each side,
+  -- aligned to the rollout day.
+  evaluation_window_start  timestamptz NOT NULL,
+  evaluation_window_end    timestamptz NOT NULL,
+
+  -- TRUE once this row's actual_impact_cr / actual_impact_score has
+  -- fed the §9.4.2 playbook calibration loop. Phase 1 ships the
+  -- writer; Phase 2 wires the loop.
+  fed_into_calibration     boolean NOT NULL DEFAULT false,
+
+  created_at               timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT opt_causal_deltas_window_coherent CHECK (
+    evaluation_window_end > evaluation_window_start
+  )
+);
+
+-- One causal-delta row per proposal — re-running the evaluation cron
+-- on the same proposal updates the existing row (UPSERT on
+-- proposal_id) rather than appending duplicates. The cron treats it
+-- as a side-effect-of-an-evaluation-window record, not a stream.
+CREATE UNIQUE INDEX opt_causal_deltas_proposal_uniq
+  ON opt_causal_deltas (proposal_id);
+
+CREATE INDEX opt_causal_deltas_client_created_idx
+  ON opt_causal_deltas (client_id, created_at DESC);
+
+CREATE INDEX opt_causal_deltas_landing_page_idx
+  ON opt_causal_deltas (landing_page_id, created_at DESC);
+
+-- Hot-path index for the proposal-review "what happened last time"
+-- panel — joined on (client_id, triggering_playbook_id) ordered by
+-- created_at desc.
+CREATE INDEX opt_causal_deltas_client_playbook_idx
+  ON opt_causal_deltas (client_id, triggering_playbook_id, created_at DESC)
+  WHERE triggering_playbook_id IS NOT NULL;
+
+ALTER TABLE opt_causal_deltas ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON opt_causal_deltas
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY opt_causal_deltas_read ON opt_causal_deltas
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator', 'viewer'));

--- a/supabase/rollbacks/0051_opt_causal_deltas.down.sql
+++ b/supabase/rollbacks/0051_opt_causal_deltas.down.sql
@@ -1,0 +1,9 @@
+-- Rollback for 0051_opt_causal_deltas.sql
+DROP POLICY IF EXISTS opt_causal_deltas_read ON opt_causal_deltas;
+DROP POLICY IF EXISTS service_role_all ON opt_causal_deltas;
+ALTER TABLE IF EXISTS opt_causal_deltas DISABLE ROW LEVEL SECURITY;
+DROP INDEX IF EXISTS opt_causal_deltas_client_playbook_idx;
+DROP INDEX IF EXISTS opt_causal_deltas_landing_page_idx;
+DROP INDEX IF EXISTS opt_causal_deltas_client_created_idx;
+DROP INDEX IF EXISTS opt_causal_deltas_proposal_uniq;
+DROP TABLE IF EXISTS opt_causal_deltas;

--- a/vercel.json
+++ b/vercel.json
@@ -55,6 +55,10 @@
     {
       "path": "/api/cron/optimiser-evaluate-scores",
       "schedule": "45 7 * * *"
+    },
+    {
+      "path": "/api/cron/optimiser-evaluate-causal-deltas",
+      "schedule": "15 8 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Closes the v1.6 build. Adds the causal-delta loop, replaces the Slice 12 rollback placeholder with a real action, and splits the proposal-review reprompt into controlled vs. free modes.

## Plan (sub-slice)
**Stack base.** `optimiser/slice-12-composite-scoring`. Auto-retargets on merge.

**Approach.** Causal evaluation runs daily; for each applied proposal where the rollout window has closed (14d or 300+ post-rollout sessions), the evaluator aggregates pre/post metrics, computes `actual_impact_cr` + `actual_impact_score` + confidence, and UPSERTs into `opt_causal_deltas` keyed by `proposal_id`. The score history view + the proposal review view consume the same row from two angles.

Rollback is Phase 1 audit-trail only — Phase 1.5 wires the actual Site Builder rollback endpoint when brief submission lands. The `site_builder_rollback_pending: true` flag in the change-log details payload is the Phase 1.5 hook.

**Decisions called out**
- **Q1.6.2** — causal-delta confidence and composite-score reliability kept separate, displayed adjacently. Same formula, different windows.
- **Q1.6.3** — per-client measurement-window override via `opt_clients.causal_eval_window_days` (default 14, set in Slice 12 migration).

## Risks identified and mitigated
- **UPSERT keyed on proposal_id** prevents duplicate causal-delta rows; the unique index enforces it at the schema layer.
- **Rollback button only on prior versions** — current row has no rollback target.
- **Reprompt API contract unchanged** — both modes write to the existing `pre_build_reprompt` string field on opt_proposals; Phase 1.5 brief construction parses the structured shape back out.
- **fed_into_calibration default FALSE** so Phase 2 calibration loop can pick up unconsumed deltas.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (1 new cron + 1 new API route)
- [ ] E2E: deferred (issue #272)

🤖 Generated with [Claude Code](https://claude.com/claude-code)