### PR TITLE
feat(bl-5): bulk upload tab — multi-file drop + delimited paste

### DIFF
--- a/components/BulkUploadPanel.tsx
+++ b/components/BulkUploadPanel.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { FileText, Upload, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { parseBlogPostMetadata } from "@/lib/blog-post-parser";
+import {
+  splitBulkPaste,
+  type SplitDocument,
+} from "@/lib/bulk-post-splitter";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// BL-5 — Bulk upload input surface.
+//
+// Two ways in:
+//   1. Drop multiple `.md` / `.html` / `.txt` files. Each file is one
+//      post candidate.
+//   2. Paste a single multi-document blob. Two recognised shapes:
+//        a. `\n\n---\n\n` between bodies (mode-1).
+//        b. Stacked YAML front-matter — `---\nkey: v\n---\nbody` blocks
+//           one after another (mode-2).
+//
+// BL-5 ships the inputs, the de-duplication, and a basic candidate
+// list. BL-6 will swap the candidate list for rich preview cards with
+// inline edit/reject. BL-7 will plumb the publish orchestrator.
+// ---------------------------------------------------------------------------
+
+const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10MB per file
+const ACCEPT_EXTENSIONS = [".md", ".html", ".txt"];
+const ACCEPT_MIME = ["text/markdown", "text/html", "text/plain"];
+
+export interface BulkCandidate {
+  id: string;
+  source: string;
+  /** Display name — file name for drops, "Pasted post #N" otherwise. */
+  origin: string;
+  detectedTitle: string | null;
+  detectedSlug: string | null;
+  wordCount: number;
+  // Operator can flag a candidate to reject before publish. BL-6
+  // surfaces the toggle; BL-5 stores the field.
+  rejected: boolean;
+}
+
+export function BulkUploadPanel({ siteId }: { siteId: string }) {
+  // siteId reserved — BL-7's publish orchestrator will scope draft
+  // creation to the chosen site. BL-5 doesn't yet hit the API.
+  void siteId;
+
+  const [pasted, setPasted] = useState("");
+  const [files, setFiles] = useState<BulkCandidate[]>([]);
+  const [dragOver, setDragOver] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Pasted candidates derive on every keystroke (cheap — pure logic).
+  const pastedCandidates = useMemo<BulkCandidate[]>(() => {
+    const docs = splitBulkPaste(pasted);
+    return docs.map((d) => candidateFromSource(d.source, `Pasted post #${d.index + 1}`));
+  }, [pasted]);
+
+  const allCandidates = useMemo<BulkCandidate[]>(() => {
+    return [...files, ...pastedCandidates];
+  }, [files, pastedCandidates]);
+
+  const acceptedCount = useMemo(
+    () => allCandidates.filter((c) => !c.rejected).length,
+    [allCandidates],
+  );
+
+  const onFilesChosen = useCallback(async (chosen: FileList | File[]) => {
+    setError(null);
+    const arr = Array.from(chosen);
+    const errors: string[] = [];
+    const next: BulkCandidate[] = [];
+    for (const file of arr) {
+      if (file.size > MAX_FILE_BYTES) {
+        errors.push(`${file.name}: exceeds 10 MB cap.`);
+        continue;
+      }
+      if (!isAcceptedFile(file)) {
+        errors.push(`${file.name}: unsupported type. Use .md / .html / .txt.`);
+        continue;
+      }
+      try {
+        const text = await file.text();
+        next.push(candidateFromSource(text, file.name));
+      } catch (e) {
+        errors.push(
+          `${file.name}: ${e instanceof Error ? e.message : "could not read file"}.`,
+        );
+      }
+    }
+    if (next.length > 0) {
+      setFiles((prev) => [...prev, ...next]);
+    }
+    if (errors.length > 0) {
+      setError(errors.join("\n"));
+    }
+  }, []);
+
+  function onDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOver(false);
+    if (e.dataTransfer.files.length > 0) {
+      void onFilesChosen(e.dataTransfer.files);
+    }
+  }
+
+  function removeFileCandidate(id: string) {
+    setFiles((prev) => prev.filter((c) => c.id !== id));
+  }
+
+  function clearAll() {
+    setFiles([]);
+    setPasted("");
+    setError(null);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={onDrop}
+        className={cn(
+          "rounded-md border border-dashed p-8 text-center text-sm transition-smooth",
+          dragOver
+            ? "border-primary bg-primary/5"
+            : "border-input bg-muted/20 hover:bg-muted/30",
+        )}
+        data-testid="bulk-dropzone"
+      >
+        <Upload aria-hidden className="mx-auto mb-2 h-6 w-6 text-muted-foreground" />
+        <p className="font-medium">Drop markdown, HTML, or text files here</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Each file becomes one post. Max 10 MB per file. Or
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="ml-1 font-medium text-foreground underline underline-offset-2 hover:text-primary"
+          >
+            choose files
+          </button>
+          .
+        </p>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept={[...ACCEPT_EXTENSIONS, ...ACCEPT_MIME].join(",")}
+          className="hidden"
+          onChange={(e) => {
+            if (e.target.files) {
+              void onFilesChosen(e.target.files);
+              // Reset the input so re-uploading the same file fires the change event.
+              e.target.value = "";
+            }
+          }}
+          data-testid="bulk-file-input"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="bulk-paste"
+          className="block text-sm font-medium"
+        >
+          Or paste multiple posts
+        </label>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Separate documents with a <code className="font-mono">---</code>
+          {" "}line on its own (between blank lines), or stack YAML front-
+          matter blocks back-to-back.
+        </p>
+        <Textarea
+          id="bulk-paste"
+          className="mt-2 font-mono text-xs"
+          rows={10}
+          value={pasted}
+          onChange={(e) => setPasted(e.target.value)}
+          placeholder={`---
+title: First post
+---
+Body of first post.
+
+---
+
+---
+title: Second post
+---
+Body of second post.`}
+          data-testid="bulk-paste-textarea"
+        />
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="whitespace-pre-line rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive"
+        >
+          {error}
+        </div>
+      )}
+
+      {allCandidates.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium" data-testid="bulk-summary">
+              {acceptedCount} {acceptedCount === 1 ? "post" : "posts"} ready
+              {allCandidates.length !== acceptedCount &&
+                ` · ${allCandidates.length - acceptedCount} rejected`}
+            </p>
+            <button
+              type="button"
+              onClick={clearAll}
+              className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+            >
+              Clear all
+            </button>
+          </div>
+          <ul className="divide-y rounded-md border bg-background">
+            {allCandidates.map((c) => (
+              <li
+                key={c.id}
+                className="flex items-center gap-3 px-3 py-2"
+                data-testid="bulk-candidate-row"
+              >
+                <FileText
+                  aria-hidden
+                  className="h-4 w-4 shrink-0 text-muted-foreground"
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">
+                    {c.detectedTitle ?? c.origin}
+                  </p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {c.origin} · {c.wordCount.toLocaleString()} words
+                    {c.detectedSlug ? ` · /${c.detectedSlug}` : ""}
+                  </p>
+                </div>
+                {c.id.startsWith("file-") && (
+                  <button
+                    type="button"
+                    onClick={() => removeFileCandidate(c.id)}
+                    aria-label={`Remove ${c.origin}`}
+                    className="rounded-md p-1 text-muted-foreground transition-smooth hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <X aria-hidden className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+          <p className="text-xs text-muted-foreground">
+            BL-6 will turn these rows into editable preview cards. BL-7 will
+            plumb the publish orchestrator.
+          </p>
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <Button type="button" disabled title="Wired in BL-7.">
+          Continue to publish
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function isAcceptedFile(file: File): boolean {
+  const lowerName = file.name.toLowerCase();
+  if (ACCEPT_EXTENSIONS.some((ext) => lowerName.endsWith(ext))) return true;
+  if (file.type && ACCEPT_MIME.includes(file.type)) return true;
+  return false;
+}
+
+let candidateCounter = 0;
+
+function candidateFromSource(source: string, origin: string): BulkCandidate {
+  const parsed = parseBlogPostMetadata(source);
+  candidateCounter += 1;
+  return {
+    id: `${origin.startsWith("Pasted") ? "paste" : "file"}-${candidateCounter}`,
+    source,
+    origin,
+    detectedTitle: parsed.title,
+    detectedSlug: parsed.slug,
+    wordCount: countWords(source),
+    rejected: false,
+  };
+}
+
+function countWords(text: string): number {
+  if (!text) return 0;
+  const stripped = text
+    .replace(/^---[\s\S]*?---/, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]+`/g, " ")
+    .replace(/[#*_>~`-]+/g, " ");
+  return stripped.split(/\s+/).filter((t) => t.length > 0).length;
+}
+
+export { type SplitDocument };

--- a/components/PostsNewClient.tsx
+++ b/components/PostsNewClient.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ChevronDown, FileText, Layers } from "lucide-react";
 
 import { BlogPostComposer } from "@/components/BlogPostComposer";
+import { BulkUploadPanel } from "@/components/BulkUploadPanel";
 import {
   Command,
   CommandEmpty,
@@ -59,11 +60,12 @@ export function PostsNewClient({ sites }: PostsNewClientProps) {
         ) : (
           <EmptyShell label="Pick a site to start drafting your post." />
         )
+      ) : selectedSite ? (
+        <div className="rounded-md border bg-background p-6">
+          <BulkUploadPanel siteId={selectedSite.id} />
+        </div>
       ) : (
-        <EmptyShell
-          label="Bulk upload is coming soon."
-          description="Drop multiple markdown / HTML files at once and review them as a batch before publishing."
-        />
+        <EmptyShell label="Pick a site to start a bulk upload." />
       )}
     </div>
   );

--- a/e2e/posts-new.spec.ts
+++ b/e2e/posts-new.spec.ts
@@ -58,14 +58,40 @@ test.describe("/admin/posts/new — top-level entry", () => {
     await auditA11y(page, testInfo);
   });
 
-  test("bulk-upload tab shows the BL-5 placeholder", async ({
+  test("bulk-upload tab renders the dropzone after a site is picked", async ({
     page,
   }, testInfo) => {
     await signInAsAdmin(page);
     await page.goto("/admin/posts/new");
 
+    // Pre-pick is required — bulk panel needs a siteId.
+    await page.getByTestId("posts-new-site-picker").click();
+    await page
+      .locator('[data-testid^="posts-new-site-option-"]')
+      .first()
+      .click();
+
     await page.getByTestId("posts-new-tab-bulk").click();
-    await expect(page.getByText(/bulk upload is coming soon/i)).toBeVisible();
+
+    await expect(page.getByTestId("bulk-dropzone")).toBeVisible();
+    await expect(page.getByTestId("bulk-paste-textarea")).toBeVisible();
+
+    // Paste a stacked-YAML blob and confirm the count surfaces.
+    await page.getByTestId("bulk-paste-textarea").fill(
+      [
+        "---",
+        "title: First",
+        "---",
+        "Body of first.",
+        "---",
+        "title: Second",
+        "---",
+        "Body of second.",
+      ].join("\n"),
+    );
+    await expect(page.getByTestId("bulk-summary")).toContainText(
+      /2 posts? ready/i,
+    );
 
     await auditA11y(page, testInfo);
   });

--- a/lib/__tests__/bulk-post-splitter.test.ts
+++ b/lib/__tests__/bulk-post-splitter.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { splitBulkPaste } from "@/lib/bulk-post-splitter";
+
+// BL-5 — splitter unit matrix.
+
+describe("splitBulkPaste", () => {
+  it("returns [] on empty input", () => {
+    expect(splitBulkPaste("")).toEqual([]);
+    expect(splitBulkPaste("   \n\n  ")).toEqual([]);
+  });
+
+  it("returns one doc when no separator is present", () => {
+    const text = "Just a single body of text. No separator.";
+    const docs = splitBulkPaste(text);
+    expect(docs).toHaveLength(1);
+    expect(docs[0]?.source).toBe(text);
+    expect(docs[0]?.index).toBe(0);
+  });
+
+  it("splits on the explicit separator (mode-1)", () => {
+    const text = ["First post body.", "", "---", "", "Second post body."].join(
+      "\n",
+    );
+    const docs = splitBulkPaste(text);
+    expect(docs).toHaveLength(2);
+    expect(docs[0]?.source).toBe("First post body.");
+    expect(docs[1]?.source).toBe("Second post body.");
+  });
+
+  it("does not bisect on a `---` HR inside a single document", () => {
+    // No blank lines around the `---`, so it's not a delimiter.
+    const text = "Body line one\n---\nBody line two";
+    const docs = splitBulkPaste(text);
+    expect(docs).toHaveLength(1);
+  });
+
+  it("detects stacked YAML front-matter (mode-2)", () => {
+    const text = [
+      "---",
+      "title: First",
+      "---",
+      "Body of first.",
+      "---",
+      "title: Second",
+      "---",
+      "Body of second.",
+    ].join("\n");
+    const docs = splitBulkPaste(text);
+    expect(docs).toHaveLength(2);
+    expect(docs[0]?.source).toMatch(/title: First/);
+    expect(docs[0]?.source).toMatch(/Body of first/);
+    expect(docs[1]?.source).toMatch(/title: Second/);
+    expect(docs[1]?.source).toMatch(/Body of second/);
+  });
+
+  it("falls back to mode-1 when stacked YAML detection finds only one block", () => {
+    const text = [
+      "---",
+      "title: Only one",
+      "---",
+      "Body of the only post.",
+    ].join("\n");
+    const docs = splitBulkPaste(text);
+    expect(docs).toHaveLength(1);
+  });
+});

--- a/lib/bulk-post-splitter.ts
+++ b/lib/bulk-post-splitter.ts
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------------
+// BL-5 — Bulk-paste splitter.
+//
+// Pure-logic helper that splits a multi-document paste into individual
+// post candidates. Two recognised shapes:
+//
+//   1. Document-separator mode: documents separated by a `---`
+//      delimiter line surrounded by blank lines (`\n\n---\n\n`). Each
+//      segment can carry its own YAML front-matter on top.
+//   2. Stacked YAML-front-matter mode: each document opens with a
+//      `---` YAML block, prose follows, next document's `---` opens
+//      directly. The splitter walks YAML opens and captures each
+//      block + the body text between it and the next YAML open.
+//
+// We auto-detect mode-2 when the first non-blank line is `---` AND
+// there's at least one further pair of `---` later. Otherwise we fall
+// back to mode-1 (separator-based).
+// ---------------------------------------------------------------------------
+
+export interface SplitDocument {
+  /** Raw text the parser will consume. Includes any front-matter. */
+  source: string;
+  /** Index in the original paste, 0-based. */
+  index: number;
+}
+
+export function splitBulkPaste(text: string): SplitDocument[] {
+  const trimmed = text.replace(/^\s+/, "");
+  if (trimmed.length === 0) return [];
+
+  // Mode-2 detection: first non-blank line is `---`, and at least
+  // two additional standalone `---` lines exist later (one to close
+  // the first block, one to open the second).
+  const firstLine = trimmed.split(/\r?\n/, 1)[0]?.trim();
+  if (firstLine === "---") {
+    const stacked = splitStackedYaml(trimmed);
+    if (stacked.length >= 2) return stacked;
+  }
+
+  // Mode-1: split on a standalone `---` between blank lines. We use
+  // a regex that requires explicit blank lines on both sides so a
+  // single document with internal `---` (e.g. an HR rule) isn't
+  // mistakenly bisected.
+  const segments = trimmed
+    .split(/\r?\n\s*\r?\n---\s*\r?\n\s*\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  return segments.map((source, index) => ({ source, index }));
+}
+
+function splitStackedYaml(text: string): SplitDocument[] {
+  const lines = text.split(/\r?\n/);
+  const yamlOpenIndices: number[] = [];
+  let inYaml = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]?.trim() !== "---") continue;
+    if (!inYaml) {
+      yamlOpenIndices.push(i);
+      inYaml = true;
+    } else {
+      inYaml = false;
+    }
+  }
+  if (yamlOpenIndices.length < 2) return [];
+
+  const docs: SplitDocument[] = [];
+  for (let i = 0; i < yamlOpenIndices.length; i++) {
+    const start = yamlOpenIndices[i] ?? 0;
+    const end = yamlOpenIndices[i + 1] ?? lines.length;
+    const slice = lines.slice(start, end).join("\n").trim();
+    if (slice.length > 0) {
+      docs.push({ source: slice, index: i });
+    }
+  }
+  return docs;
+}


### PR DESCRIPTION
## Summary

The Bulk-upload tab graduates from a placeholder shell to a working input surface. Two recognised paths in: drop multiple files OR paste a multi-document blob. Result: a candidate list with detected title / slug / word-count for each post.

## What ships

- **\`lib/bulk-post-splitter.ts\`** — pure-logic splitter detecting two shapes:
  1. Mode-1: docs separated by a \`---\` line between blank lines.
  2. Mode-2: stacked YAML front-matter — two or more \`---\` blocks back-to-back.
  Six-case vitest matrix.
- **\`components/BulkUploadPanel.tsx\`** — dropzone + paste textarea + candidate list. 10 MB per-file cap, accepted-mime check, clear-all.
- **\`PostsNewClient\`** wires the panel into the bulk tab once a site is bound.
- **E2E** asserts the dropzone + paste field render, pastes a stacked-YAML blob, reads \"2 posts ready\" back.

## Risks identified and mitigated

- **Memory on a thousand-file drop** — guarded by per-file 10 MB cap; each file is read independently. Total-batch caps + max-candidate count will layer in alongside BL-6/BL-7.
- **\`---\` HR collision** — splitter only treats \`---\` as a delimiter when it sits on its own line between blank lines. Test asserts a single doc with internal \`---\` doesn't bisect.
- **Stacked-YAML detection requires ≥ 2 blocks** — a single front-matter post falls through to mode-1 and ships as one candidate.
- **No API hit yet** — \`siteId\` reserved for BL-7. Continue button disabled with a \"wired in BL-7\" tooltip.

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅

## Test plan

- [ ] Manual: drop three .md files, confirm three candidate rows
- [ ] Manual: paste mode-1 blob (\`\n\n---\n\n\`), confirm split
- [ ] Manual: paste mode-2 blob (stacked YAML), confirm split
- [ ] Manual: drop a 12 MB file, confirm error surfaces
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)