### PR TITLE
feat(bl-8): keyboard shortcuts — ⌘K palette entry, ⌘S save, ⌘Enter publish

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -395,6 +395,27 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
     parentPage !== null &&
     featuredImage !== null;
 
+  // BL-8 — ⌘S / Ctrl+S triggers Save Draft from anywhere on the form.
+  // The browser's "save page" dialog interception is the standard
+  // shortcut operators expect from prose tools.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const isCmdS =
+        (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === "s";
+      if (!isCmdS) return;
+      if (!canSaveDraft) return;
+      e.preventDefault();
+      // Submit via the form so React's onSubmit handler runs (we
+      // ride the same path Save Draft button takes).
+      const formEl = document.getElementById(
+        `blog-post-composer-form-${siteId}`,
+      ) as HTMLFormElement | null;
+      formEl?.requestSubmit();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [canSaveDraft, siteId]);
+
   async function handleSaveDraft(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setFormError(null);
@@ -446,7 +467,11 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
   }
 
   return (
-    <form onSubmit={handleSaveDraft} className="space-y-6">
+    <form
+      id={`blog-post-composer-form-${siteId}`}
+      onSubmit={handleSaveDraft}
+      className="space-y-6"
+    >
       <div>
         <div className="flex items-baseline justify-between gap-2">
           <label
@@ -695,6 +720,17 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
       </div>
 
       <div className="flex flex-wrap items-center justify-end gap-2">
+        <span
+          aria-hidden
+          className="hidden items-center gap-0.5 text-xs text-muted-foreground sm:inline-flex"
+        >
+          <kbd className="rounded border bg-muted px-1 font-mono text-[10px]">
+            ⌘
+          </kbd>
+          <kbd className="rounded border bg-muted px-1 font-mono text-[10px]">
+            S
+          </kbd>
+        </span>
         <Button type="submit" disabled={!canSaveDraft}>
           {submitting ? "Saving…" : "Save draft"}
         </Button>

--- a/components/BulkUploadPanel.tsx
+++ b/components/BulkUploadPanel.tsx
@@ -114,6 +114,28 @@ export function BulkUploadPanel({ siteId }: { siteId: string }) {
     [],
   );
 
+  // BL-8 — ⌘Enter triggers the publish run from anywhere in the bulk
+  // panel. Skipped if the run is already going or there's nothing
+  // to save.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const isCmdEnter =
+        (e.metaKey || e.ctrlKey) &&
+        !e.shiftKey &&
+        !e.altKey &&
+        e.key === "Enter";
+      if (!isCmdEnter) return;
+      const button = document.querySelector<HTMLButtonElement>(
+        '[data-testid="bulk-publish-button"]',
+      );
+      if (!button || button.disabled) return;
+      e.preventDefault();
+      button.click();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
   // BL-7 — sequential publish orchestrator. Iterates accepted, non-
   // saved candidates and POSTs each to /api/sites/[siteId]/posts to
   // create a draft. Sequential so a failing card doesn't blow up the
@@ -368,6 +390,17 @@ Body of second post.`}
             {summary.detail}
           </p>
         )}
+        <span
+          aria-hidden
+          className="hidden items-center gap-0.5 text-xs text-muted-foreground sm:inline-flex"
+        >
+          <kbd className="rounded border bg-muted px-1 font-mono text-[10px]">
+            ⌘
+          </kbd>
+          <kbd className="rounded border bg-muted px-1 font-mono text-[10px]">
+            ↵
+          </kbd>
+        </span>
         <Button
           type="button"
           onClick={() => void runPublish()}

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -7,6 +7,7 @@ import {
   Globe,
   Image as ImageIcon,
   KeyRound,
+  PenSquare,
   Plus,
   Settings,
   Sparkles,
@@ -79,6 +80,13 @@ const NAVIGATE_ITEMS: readonly NavigateItem[] = [
     href: "/admin/sites",
     icon: Globe,
     keywords: "sites wordpress wp manage",
+  },
+  {
+    label: "Post a blog",
+    description: "Start a new post — single or bulk",
+    href: "/admin/posts/new",
+    icon: PenSquare,
+    keywords: "post blog new draft compose write bulk upload",
   },
   {
     label: "Batches",


### PR DESCRIPTION
## Summary

Three small but high-leverage shortcuts that wire the post composer into the operator's muscle-memory keyboard rhythm.

## What ships

- **Command palette gains a \"Post a blog\" entry** (PenSquare icon, between Sites and Batches in the navigate group). ⌘K → \"post\" matches.
- **BlogPostComposer listens for ⌘S / Ctrl+S** and triggers Save Draft via \`form.requestSubmit\` so the same React onSubmit path runs as the button click. Skipped while \`!canSaveDraft\` so an empty form doesn't flash an error. Browser's native \"save page\" dialog is preventDefault'd cleanly.
- **BulkUploadPanel listens for ⌘Enter / Ctrl+Enter** and clicks the publish button (skipped while disabled or running).
- **Inline kbd hints** next to each primary action so the shortcut is discoverable without opening a help drawer.

## Risks identified and mitigated

- **⌘S preventDefault swallows the browser's save shortcut** while the composer is mounted — scoped via a window listener that unmounts with the component, and gated on \`canSaveDraft\` so the form doesn't intercept when there's nothing to save (browser's \"save page\" still works on an empty form).
- **⌘Enter inside the bulk paste textarea fires publish run** rather than inserting a newline. Accepted: most operators don't expect ⌘Enter to be a printable key; matches Linear / Notion submit conventions.
- **Each shortcut gated on the button's disabled state** so a half-filled form doesn't trigger a doomed POST.

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅

## Test plan

- [ ] Manual: ⌘K, type \"post\", Enter — lands on /admin/posts/new
- [ ] Manual: fill composer, ⌘S — saves draft (no browser save dialog)
- [ ] Manual: bulk tab with candidates ready, ⌘Enter — fires run
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)