### PR TITLE
feat(bl-9): microinteractions polish on the post-composer surface

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -789,7 +789,10 @@ function ReadingChip({ text }: { text: string }) {
   return (
     <span
       data-testid="post-reading-chip"
-      className="text-xs text-muted-foreground"
+      // BL-9 — fade-in the first time the chip surfaces. Re-runs on
+      // remount only (text changes don't re-trigger because React
+      // doesn't add the class on re-render of an already-mounted node).
+      className="opollo-fade-in text-xs text-muted-foreground"
     >
       {words.toLocaleString()} {words === 1 ? "word" : "words"} ·{" "}
       {minutes} min read
@@ -929,7 +932,7 @@ function AdvancedDisclosure({
       {open && (
         <div
           data-testid="post-advanced-panel"
-          className="border-t p-4"
+          className="opollo-slide-up border-t p-4"
         >
           {children}
         </div>

--- a/components/BulkUploadPanel.tsx
+++ b/components/BulkUploadPanel.tsx
@@ -364,7 +364,7 @@ Body of second post.`}
             </button>
           </div>
           <ul className="space-y-2">
-            {allCandidates.map((c) => (
+            {allCandidates.map((c, idx) => (
               <BulkCandidateCard
                 key={c.id}
                 candidate={c}
@@ -375,6 +375,7 @@ Body of second post.`}
                     : undefined
                 }
                 runDisabled={running}
+                staggerIndex={idx}
               />
             ))}
           </ul>
@@ -508,11 +509,13 @@ function BulkCandidateCard({
   onChange,
   onRemove,
   runDisabled,
+  staggerIndex,
 }: {
   candidate: BulkCandidate;
   onChange: (patch: Partial<BulkCandidate>) => void;
   onRemove?: () => void;
   runDisabled?: boolean;
+  staggerIndex?: number;
 }) {
   const [previewOpen, setPreviewOpen] = useState(false);
   const slugIsValid =
@@ -527,10 +530,19 @@ function BulkCandidateCard({
     candidate.rejected || candidate.status === "saving" || runDisabled === true;
   const savedReadOnly = candidate.status === "saved";
 
+  // BL-9 — stagger-fade the first 6 cards as they appear, capped to
+  // avoid a long sweep that delays the operator. Cards beyond the 6th
+  // fall back to opollo-fade-in with no stagger.
+  const staggerClass =
+    staggerIndex !== undefined && staggerIndex > 0 && staggerIndex <= 6
+      ? `opollo-stagger-in-${staggerIndex}`
+      : "";
+
   return (
     <li
       className={cn(
-        "rounded-md border bg-background transition-smooth",
+        "opollo-fade-in rounded-md border bg-background transition-smooth",
+        staggerClass,
         candidate.rejected && "opacity-50",
         candidate.status === "saved" && "border-success/40",
         candidate.status === "failed" && "border-destructive/40",
@@ -688,7 +700,10 @@ function CandidateStatusBadge({ candidate }: { candidate: BulkCandidate }) {
           href={candidate.editUrl ?? "#"}
           target="_blank"
           rel="noreferrer"
-          className="rounded border border-success/40 bg-success/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-success transition-smooth hover:bg-success/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          // BL-9 — pop-in lands the saved state with a small bounce
+          // so the operator's eye registers the success without
+          // needing to read the badge.
+          className="opollo-pop-in rounded border border-success/40 bg-success/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-success transition-smooth hover:bg-success/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           data-testid="bulk-candidate-saved-link"
         >
           Saved · open


### PR DESCRIPTION
## Summary

Five low-touch animation passes that lift the surface from \"shipped\" to \"feels alive\". All built on the A-3 / A-2 motion primitives so they respect the reduced-motion media query through globals.css.

## What ships

- **AdvancedDisclosure panel** — \`opollo-slide-up\` on open. Reads as \"the options panel grew out of the toggle\" rather than snapping in.
- **ReadingChip** — \`opollo-fade-in\` on first appearance so the figures don't materialise abruptly.
- **BulkCandidateCard** — \`opollo-fade-in\` plus \`opollo-stagger-in-N\` (capped at index 6) so a five-card paste reveals one by one in 50ms steps. Cards beyond the 6th fade-in with no stagger.
- **Saved-status badge** — \`opollo-pop-in\` on the saved transition. Lands with a small bounce so the operator's eye registers success without needing to read it.

## Risks identified and mitigated

- **Reduced-motion respect** — globals.css already wraps each animation in a \`prefers-reduced-motion\` guard. No new animation primitives added.
- **Stagger cap at 6** — beyond that the delay becomes obtrusive on a large paste. Token config has 8 stagger steps; cap keeps a 30-card paste from waiting 1.5s for the last card.
- **Hover-scale on primary buttons** was tempting but rejected — \`active:translate-y-px\` from R1-4 already gives a tactile press, and scale would compete with the disabled-state opacity shift.

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅

## Test plan

- [ ] Manual: open the More options disclosure, confirm slide-up
- [ ] Manual: type into composer, confirm reading chip fade-in
- [ ] Manual: paste 5 docs, confirm staggered card reveal
- [ ] Manual: trigger bulk publish, confirm saved badge pop-in
- [ ] Manual: enable prefers-reduced-motion in OS, confirm no animations
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)