### PR TITLE
feat(p1-1): sendgrid foundation — email_log + wrapper + base template + CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,13 @@ security-observability-baseline sub-PR and fail-fast CI is how they stay true.
   in-memory logger without Axiom token, etc.). Hard-requiring an env
   var at cold-start is reserved for secrets that are operationally
   guaranteed (Supabase URL, service role key).
+- **Transactional email** ships through `lib/email/sendgrid.ts` and
+  `lib/email/templates/base.ts` only. Direct `@sendgrid/mail` imports
+  outside those two files are a code-review block. Every send writes
+  a row to `email_log` (success or failure). Required env vars:
+  `SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL`, `SENDGRID_FROM_NAME`.
+  Smoke-test the wrapper from prod with
+  `npx tsx scripts/send-test-email.ts <to-email>`.
 
 ## E2E coverage is a hard requirement for admin UI changes
 Every PR that adds or substantially changes an admin-facing route, form, or action MUST include a Playwright spec for its happy path. Specs live in `e2e/*.spec.ts`; run locally with `npm run test:e2e` (requires `supabase start`).

--- a/lib/email/sendgrid.ts
+++ b/lib/email/sendgrid.ts
@@ -1,0 +1,196 @@
+import "server-only";
+
+import sgMail from "@sendgrid/mail";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// AUTH-FOUNDATION P1 — SendGrid send wrapper.
+//
+// Single typed entrypoint for every transactional email Opollo sends.
+// Phases 2-4 (invites, login challenges) consume this. Direct
+// @sendgrid/mail calls outside this module are a code-review block.
+//
+// Behaviour:
+//   - Lazy SendGrid auth (first call sets the key) so importing the
+//     module doesn't crash builds when SENDGRID_API_KEY is unset
+//     (preview deploys without prod secrets, etc.).
+//   - One-retry on 5xx (network blip / SendGrid degradation), 250ms
+//     backoff. 4xx is operator error (bad address, rejected sender) —
+//     no retry, surface immediately.
+//   - Every attempt is logged to email_log (success and failure) so
+//     the operator can audit deliverability without reading server
+//     logs. Logging failures DON'T fail the send — the email landed,
+//     the audit is best-effort.
+// ---------------------------------------------------------------------------
+
+let authConfigured = false;
+
+function configureSendGrid(): void {
+  if (authConfigured) return;
+  const key = process.env.SENDGRID_API_KEY;
+  if (!key) {
+    throw new Error(
+      "SENDGRID_API_KEY is not set. Add it to Vercel env vars (and reload the dev server locally).",
+    );
+  }
+  sgMail.setApiKey(key);
+  authConfigured = true;
+}
+
+function fromAddress(): { email: string; name: string } {
+  const email = process.env.SENDGRID_FROM_EMAIL;
+  const name = process.env.SENDGRID_FROM_NAME ?? "Opollo Site Builder";
+  if (!email) {
+    throw new Error(
+      "SENDGRID_FROM_EMAIL is not set. Expected `noreply@opollo.com` per the AUTH-FOUNDATION brief.",
+    );
+  }
+  return { email, name };
+}
+
+export interface SendEmailInput {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+  /** Optional Reply-To override. Defaults to the From address. */
+  replyTo?: string;
+}
+
+export type SendEmailResult =
+  | { ok: true; messageId: string }
+  | {
+      ok: false;
+      error: {
+        code:
+          | "SENDGRID_REJECTED"
+          | "SENDGRID_5XX"
+          | "SENDGRID_NETWORK"
+          | "SENDGRID_UNCONFIGURED"
+          | "SENDGRID_UNKNOWN";
+        message: string;
+        statusCode?: number;
+      };
+    };
+
+export async function sendEmail(input: SendEmailInput): Promise<SendEmailResult> {
+  let result: SendEmailResult;
+  try {
+    configureSendGrid();
+  } catch (err) {
+    result = {
+      ok: false,
+      error: {
+        code: "SENDGRID_UNCONFIGURED",
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+    await writeEmailLog(input, result);
+    return result;
+  }
+
+  const from = fromAddress();
+  const message = {
+    to: input.to,
+    from: { email: from.email, name: from.name },
+    replyTo: input.replyTo,
+    subject: input.subject,
+    html: input.html,
+    text: input.text,
+  };
+
+  // First attempt + one retry on 5xx. 4xx surfaces immediately.
+  result = await attemptSend(message);
+  if (!result.ok && result.error.code === "SENDGRID_5XX") {
+    logger.warn("sendgrid 5xx — retrying once after 250ms", {
+      to: input.to,
+      subject: input.subject,
+      status: result.error.statusCode,
+    });
+    await new Promise((r) => setTimeout(r, 250));
+    result = await attemptSend(message);
+  }
+
+  await writeEmailLog(input, result);
+  return result;
+}
+
+async function attemptSend(
+  message: Parameters<typeof sgMail.send>[0],
+): Promise<SendEmailResult> {
+  try {
+    const [response] = await sgMail.send(message);
+    const messageId =
+      (response.headers["x-message-id"] as string | undefined) ?? "unknown";
+    return { ok: true, messageId };
+  } catch (err) {
+    const errAny = err as {
+      code?: number;
+      response?: { body?: { errors?: Array<{ message?: string }> } };
+      message?: string;
+    };
+    const status = errAny.code;
+    const apiMessage =
+      errAny.response?.body?.errors?.[0]?.message ?? errAny.message ?? "unknown";
+
+    if (typeof status === "number") {
+      if (status >= 500) {
+        return {
+          ok: false,
+          error: {
+            code: "SENDGRID_5XX",
+            message: apiMessage,
+            statusCode: status,
+          },
+        };
+      }
+      return {
+        ok: false,
+        error: {
+          code: "SENDGRID_REJECTED",
+          message: apiMessage,
+          statusCode: status,
+        },
+      };
+    }
+
+    return {
+      ok: false,
+      error: {
+        code: "SENDGRID_NETWORK",
+        message: apiMessage,
+      },
+    };
+  }
+}
+
+async function writeEmailLog(
+  input: SendEmailInput,
+  result: SendEmailResult,
+): Promise<void> {
+  try {
+    const supabase = getServiceRoleClient();
+    const row = {
+      to_email: input.to,
+      subject: input.subject,
+      status: result.ok ? "sent" : "failed",
+      sendgrid_message_id: result.ok ? result.messageId : null,
+      error_code: result.ok ? null : result.error.code,
+      error_message: result.ok ? null : result.error.message,
+    };
+    const { error } = await supabase.from("email_log").insert(row);
+    if (error) {
+      logger.error("email_log insert failed", {
+        supabase_error: error.message,
+        to: input.to,
+      });
+    }
+  } catch (err) {
+    // Never let an audit-write failure break the send-result return.
+    logger.error("email_log unhandled write error", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/lib/email/templates/base.ts
+++ b/lib/email/templates/base.ts
@@ -1,0 +1,125 @@
+import "server-only";
+
+// ---------------------------------------------------------------------------
+// AUTH-FOUNDATION P1 — Base email template.
+//
+// Single HTML + plaintext shell that every transactional message wraps
+// itself in. Plain string interpolation — no @react-email, no
+// templating engine — so the wrapper stays trivially testable and
+// inspectable.
+//
+// HTML structure:
+//   - Outer table (table-based layout because Outlook/Gmail/etc. mangle
+//     div+flex layouts).
+//   - 600px max width, single column, centred. The 600px cap is the
+//     standard email-client viewport width below which nothing reflows.
+//   - Inline CSS only — most clients strip <style> blocks.
+//   - Header: Opollo wordmark (text fallback — no <img> assets shipped
+//     in P1; brand image is a future polish concern that needs a CDN
+//     link, alt text, and dark-mode handling).
+//   - Body: caller-provided HTML, inserted between header + footer.
+//   - Footer: small-print "Opollo, Melbourne AU" + transactional-email
+//     legal note + the boilerplate "you received this because…" line
+//     callers can override.
+//
+// Plaintext: parallel structure, line-wrapped at 72 chars where
+// practical. Some clients show plaintext to screen readers and
+// preview-only inboxes (Apple Mail glance), so the shape mirrors the
+// HTML layout: header line, content, footer.
+// ---------------------------------------------------------------------------
+
+export interface BaseEmailInput {
+  /** The action sentence at the top of the body. e.g. "Approve sign-in to Opollo Site Builder". */
+  heading: string;
+  /** Pre-formatted body HTML. Caller owns the inner markup; the wrapper is structural only. */
+  bodyHtml: string;
+  /** Plaintext mirror of `bodyHtml`. Required — every email ships both representations. */
+  bodyText: string;
+  /** Optional override for the "you received this because…" footer line. Defaults to the generic transactional-notice copy. */
+  footerNote?: string;
+}
+
+const DEFAULT_FOOTER_NOTE =
+  "You received this transactional email because of activity on your Opollo Site Builder account.";
+
+const SUPPORT_NOTE = "Opollo · Melbourne AU";
+
+export function renderBaseEmail(input: BaseEmailInput): {
+  html: string;
+  text: string;
+} {
+  const footerNote = input.footerNote ?? DEFAULT_FOOTER_NOTE;
+  return {
+    html: renderHtml(input.heading, input.bodyHtml, footerNote),
+    text: renderText(input.heading, input.bodyText, footerNote),
+  };
+}
+
+function renderHtml(heading: string, body: string, footerNote: string): string {
+  // Inline CSS only. Indentation is conservative — Gmail strips
+  // leading whitespace in some clients, so logical-block formatting.
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(heading)}</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f5f5f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#0f172a;">
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background-color:#f5f5f5;">
+  <tr>
+    <td align="center" style="padding:24px 16px;">
+      <table role="presentation" width="600" cellspacing="0" cellpadding="0" border="0" style="max-width:600px;width:100%;background-color:#ffffff;border-radius:8px;border:1px solid #e2e8f0;">
+        <tr>
+          <td style="padding:24px 32px 16px 32px;border-bottom:1px solid #e2e8f0;">
+            <span style="font-size:18px;font-weight:600;letter-spacing:-0.01em;color:#0f172a;">Opollo</span>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:32px;">
+            <h1 style="margin:0 0 16px 0;font-size:20px;line-height:1.3;font-weight:600;color:#0f172a;">${escapeHtml(heading)}</h1>
+            ${body}
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:24px 32px;border-top:1px solid #e2e8f0;font-size:12px;line-height:1.5;color:#64748b;">
+            <p style="margin:0 0 8px 0;">${escapeHtml(footerNote)}</p>
+            <p style="margin:0;">${escapeHtml(SUPPORT_NOTE)}</p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>`;
+}
+
+function renderText(heading: string, body: string, footerNote: string): string {
+  // 72-char rule of thumb. Caller's `body` text is left as-is — they
+  // know their content; we add only structural framing.
+  return [
+    "Opollo",
+    "==========",
+    "",
+    heading,
+    "",
+    body,
+    "",
+    "----------",
+    footerNote,
+    SUPPORT_NOTE,
+    "",
+  ].join("\n");
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export { escapeHtml };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-scroll-area": "^1.2.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@sendgrid/mail": "^8.1.6",
         "@sentry/nextjs": "^10.49.0",
         "@supabase/supabase-js": "^2.104.0",
         "@upstash/ratelimit": "^2.0.8",
@@ -4009,6 +4010,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
+      "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.6.tgz",
+      "integrity": "sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.5",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/@sentry-internal/browser-utils": {
       "version": "10.49.0",
       "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.49.0.tgz",
@@ -6230,6 +6269,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
@@ -6291,6 +6336,26 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/axobject-query": {
@@ -6472,7 +6537,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6899,6 +6963,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -7238,6 +7314,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -7272,6 +7357,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-libc": {
@@ -7344,7 +7438,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7502,7 +7595,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7555,7 +7647,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7568,7 +7659,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8395,6 +8485,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -8426,6 +8536,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -8568,7 +8694,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8602,7 +8727,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -8912,7 +9036,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9005,7 +9128,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9018,7 +9140,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -10800,7 +10921,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10871,6 +10991,27 @@
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-scroll-area": "^1.2.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@sendgrid/mail": "^8.1.6",
     "@sentry/nextjs": "^10.49.0",
     "@supabase/supabase-js": "^2.104.0",
     "@upstash/ratelimit": "^2.0.8",

--- a/scripts/send-test-email.ts
+++ b/scripts/send-test-email.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * scripts/send-test-email.ts
+ *
+ * One-shot CLI to verify the SendGrid wrapper end-to-end without
+ * going through the admin UI. The Phase 1 operator gate uses this:
+ *
+ *   SENDGRID_API_KEY=... \
+ *   SENDGRID_FROM_EMAIL=noreply@opollo.com \
+ *   SENDGRID_FROM_NAME="Opollo Site Builder" \
+ *   SUPABASE_URL=... \
+ *   SUPABASE_SERVICE_ROLE_KEY=... \
+ *     npx tsx scripts/send-test-email.ts hi@opollo.com
+ *
+ *   # Or pass a custom subject + body:
+ *   npx tsx scripts/send-test-email.ts hi@opollo.com "Hello" "Body text"
+ *
+ * Exits 0 on success (prints the X-Message-Id), exits 1 on failure
+ * (prints the error code + message). The send is also written to
+ * email_log either way — same as a production send.
+ *
+ * Reuses lib/email/sendgrid.ts so we exercise the exact same code
+ * path the runtime uses. Tweaking the wrapper means re-running this
+ * script confirms the change.
+ */
+
+import { sendEmail } from "@/lib/email/sendgrid";
+import { renderBaseEmail } from "@/lib/email/templates/base";
+
+async function main(): Promise<void> {
+  const [, , to, subjectArg, bodyArg] = process.argv;
+
+  if (!to) {
+    console.error(
+      "Usage: npx tsx scripts/send-test-email.ts <to-email> [subject] [body]",
+    );
+    process.exit(2);
+  }
+
+  const subject = subjectArg ?? "Opollo SendGrid wrapper smoke test";
+  const message =
+    bodyArg ??
+    "If you're reading this, the SendGrid wrapper, base template, and email_log audit are working end-to-end.";
+
+  const { html, text } = renderBaseEmail({
+    heading: subject,
+    bodyHtml: `<p style="margin:0 0 12px 0;font-size:14px;line-height:1.5;color:#0f172a;">${escape(message)}</p>`,
+    bodyText: message,
+    footerNote:
+      "This is a P1 smoke-test email triggered from scripts/send-test-email.ts.",
+  });
+
+  const result = await sendEmail({ to, subject, html, text });
+
+  if (result.ok) {
+    console.error(`✓ Sent. SendGrid message id: ${result.messageId}`);
+    console.log(JSON.stringify({ ok: true, messageId: result.messageId }, null, 2));
+    process.exit(0);
+  } else {
+    console.error(`✗ Failed: ${result.error.code} — ${result.error.message}`);
+    if (result.error.code === "SENDGRID_REJECTED" && result.error.statusCode) {
+      console.error(`  HTTP ${result.error.statusCode} from SendGrid.`);
+    }
+    console.log(JSON.stringify({ ok: false, error: result.error }, null, 2));
+    process.exit(1);
+  }
+}
+
+function escape(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+main().catch((err) => {
+  console.error(`Unhandled error: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/supabase/migrations/0031_email_log.sql
+++ b/supabase/migrations/0031_email_log.sql
@@ -1,0 +1,40 @@
+-- 0031 — AUTH-FOUNDATION P1: SendGrid email log.
+--
+-- Every transactional email send (success and failure) writes a row
+-- here. Phases 2-4 attach to this for invite emails, login-challenge
+-- emails, and operator audit visibility.
+--
+-- Service-role only — no RLS policy is added because all writes come
+-- from server-side lib/email/sendgrid.ts and reads are admin-only via
+-- the /admin/email-test surface (and a future log viewer).
+--
+-- Forward-only.
+
+CREATE TABLE email_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  to_email text NOT NULL,
+  subject text NOT NULL,
+  status text NOT NULL CHECK (status IN ('sent', 'failed')),
+  sendgrid_message_id text,
+  error_code text,
+  error_message text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Inbox-shaped reads ("recent failures", "send history for an address")
+-- benefit from a created_at DESC index. PG can also serve the email
+-- equality probe through the same composite.
+CREATE INDEX email_log_created_at_desc_idx
+  ON email_log (created_at DESC);
+
+CREATE INDEX email_log_to_email_created_at_idx
+  ON email_log (to_email, created_at DESC);
+
+COMMENT ON TABLE email_log IS
+  'Transactional email send log. One row per attempted send (success OR failure). Service-role writes only — no RLS. Added 2026-04-30 (AUTH-FOUNDATION P1).';
+
+COMMENT ON COLUMN email_log.status IS
+  '"sent" = SendGrid accepted (2xx). "failed" = 4xx (rejected) or terminal 5xx after retry.';
+
+COMMENT ON COLUMN email_log.sendgrid_message_id IS
+  'X-Message-Id header SendGrid returns on accept. NULL on failure.';


### PR DESCRIPTION
## Summary

First sub-PR of AUTH-FOUNDATION phase 1. Lays the typed transactional-email infrastructure that phases 2-4 will consume (invites, login challenges).

## What ships

- **Migration 0031** — \`email_log\` table. Service-role only, two indexes for inbox-shape reads.
- **\`@sendgrid/mail\`** dep pinned at ^8.1.6.
- **\`lib/email/sendgrid.ts\`** — single typed \`sendEmail\` wrapper. Lazy auth so module import doesn't crash builds with missing \`SENDGRID_API_KEY\`. One retry on 5xx with 250ms backoff; 4xx surfaces immediately. Every attempt (success + failure) writes a row to \`email_log\`; logging failures don't fail the send.
- **\`lib/email/templates/base.ts\`** — HTML + plaintext shell. 600px max, table-based layout, inline CSS only, mobile-friendly. Plain string interpolation — no template engine. \`escapeHtml\` exported for callers.
- **\`scripts/send-test-email.ts\`** — CLI smoke test. Reuses the same \`sendEmail\` path the runtime takes; exits 0 + prints message id on success, exits 1 + JSON error on failure. Used at the P1 operator gate.
- **CLAUDE.md** — adds the transactional-email convention: route through the wrapper; no direct \`@sendgrid/mail\` imports outside the two files.

## Risks identified and mitigated

- **Cold-start without \`SENDGRID_API_KEY\`** — wrapper throws a typed error captured into the \`SENDGRID_UNCONFIGURED\` result code, written to \`email_log\`, surfaced to the caller without crashing the request.
- **\`email_log\` insert failure during a real send** — caught + logged, never propagated. The email did land; the audit is best-effort.
- **\`@sendgrid/mail\` dependency surface** — limited to two files via the CLAUDE.md rule. Future swap (Postmark, SES) is a one-file change.
- **4xx vs 5xx distinction** — no infinite retry on bad-sender rejections, no immediate fail on transient SendGrid 503s.

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅

## Test plan

- [ ] Migration applies cleanly in staging
- [ ] CLI script prints a SendGrid X-Message-Id (operator gate at end of P1)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)