### PR TITLE
feat(p1-2): /admin/email-test dev surface

### DIFF
--- a/app/admin/email-test/page.tsx
+++ b/app/admin/email-test/page.tsx
@@ -1,0 +1,54 @@
+import { notFound, redirect } from "next/navigation";
+
+import { EmailTestForm } from "@/components/EmailTestForm";
+import { Alert } from "@/components/ui/alert";
+import { H1, Lead } from "@/components/ui/typography";
+import { checkAdminAccess } from "@/lib/admin-gate";
+
+// AUTH-FOUNDATION P1.2 — /admin/email-test.
+//
+// Dev-only diagnostic surface for the SendGrid wrapper. Operator can
+// fire a one-shot send through the same code path the runtime uses
+// (lib/email/sendgrid.ts) without dropping to the CLI. Phase 3 will
+// replace the NODE_ENV gate with a super_admin role check.
+//
+// Defence in depth:
+//   1. NODE_ENV gate fronts the page (notFound in prod).
+//   2. Admin auth gate behind it (admin OR operator role).
+//   3. The API route /api/admin/email-test re-checks NODE_ENV and
+//      auth so a route-level fetch from a logged-in admin in prod
+//      still 404s.
+
+export const dynamic = "force-dynamic";
+
+export default async function EmailTestPage() {
+  if (process.env.NODE_ENV === "production") notFound();
+
+  const access = await checkAdminAccess({
+    requiredRoles: ["admin", "operator"],
+    insufficientRoleRedirectTo: "/",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <H1>SendGrid wrapper test</H1>
+      <Lead className="mt-1">
+        Fire a one-shot test email through{" "}
+        <code className="font-mono text-sm">lib/email/sendgrid.ts</code>. Same
+        code path as the runtime uses — invites, login challenges, every
+        transactional send.
+      </Lead>
+
+      <Alert className="mt-6">
+        Dev-only surface, gated on{" "}
+        <code className="font-mono text-xs">NODE_ENV !== &quot;production&quot;</code>.
+        Phase 3 replaces this with a super_admin role check.
+      </Alert>
+
+      <div className="mt-6">
+        <EmailTestForm />
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/email-test/route.ts
+++ b/app/api/admin/email-test/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { sendEmail } from "@/lib/email/sendgrid";
+import { renderBaseEmail } from "@/lib/email/templates/base";
+
+// AUTH-FOUNDATION P1.2 — POST /api/admin/email-test.
+//
+// Backs /admin/email-test. Dev-only by env gate; admin/operator gate
+// behind that. Phase 3 will replace the env gate with a super_admin
+// role check (the API route + the page move together).
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z
+  .object({
+    to: z.string().email().max(320),
+    subject: z.string().min(1).max(200),
+    body: z.string().min(1).max(8000),
+  })
+  .strict();
+
+function deny(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    { ok: false, error: { code, message } },
+    { status },
+  );
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  if (process.env.NODE_ENV === "production") {
+    return deny(
+      "NOT_AVAILABLE_IN_PROD",
+      "Email-test endpoint is dev-only.",
+      404,
+    );
+  }
+
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
+  let parsed: z.infer<typeof BodySchema>;
+  try {
+    const json = await req.json();
+    parsed = BodySchema.parse(json);
+  } catch (err) {
+    return deny(
+      "VALIDATION_FAILED",
+      err instanceof Error ? err.message : "Invalid request body.",
+      400,
+    );
+  }
+
+  const { html, text } = renderBaseEmail({
+    heading: parsed.subject,
+    bodyHtml: `<p style="margin:0 0 12px 0;font-size:14px;line-height:1.5;color:#0f172a;">${escape(parsed.body)}</p>`,
+    bodyText: parsed.body,
+    footerNote:
+      "This is a P1 smoke-test email triggered from /admin/email-test.",
+  });
+
+  const result = await sendEmail({
+    to: parsed.to,
+    subject: parsed.subject,
+    html,
+    text,
+  });
+
+  if (result.ok) {
+    return NextResponse.json({ ok: true, messageId: result.messageId });
+  }
+  return NextResponse.json(
+    { ok: false, error: result.error },
+    { status: result.error.code === "SENDGRID_REJECTED" ? 400 : 502 },
+  );
+}
+
+function escape(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/components/EmailTestForm.tsx
+++ b/components/EmailTestForm.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+// AUTH-FOUNDATION P1.2 — Dev-only client form for /admin/email-test.
+// Result panel reads back the SendGrid X-Message-Id on success or the
+// typed error code/message on failure.
+
+type Result =
+  | { kind: "idle" }
+  | { kind: "sending" }
+  | { kind: "ok"; messageId: string }
+  | { kind: "err"; code: string; message: string };
+
+export function EmailTestForm() {
+  const [to, setTo] = useState("");
+  const [subject, setSubject] = useState(
+    "Opollo SendGrid wrapper smoke test",
+  );
+  const [body, setBody] = useState(
+    "If you're reading this, the SendGrid wrapper, base template, and email_log audit are working end-to-end.",
+  );
+  const [result, setResult] = useState<Result>({ kind: "idle" });
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setResult({ kind: "sending" });
+    try {
+      const res = await fetch("/api/admin/email-test", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ to: to.trim(), subject, body }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; messageId: string }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (payload?.ok) {
+        setResult({ kind: "ok", messageId: payload.messageId });
+      } else {
+        setResult({
+          kind: "err",
+          code: payload?.ok === false ? payload.error.code : "UNKNOWN",
+          message:
+            payload?.ok === false
+              ? payload.error.message
+              : `HTTP ${res.status}`,
+        });
+      }
+    } catch (err) {
+      setResult({
+        kind: "err",
+        code: "NETWORK",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const sending = result.kind === "sending";
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="email-test-to" className="block text-sm font-medium">
+          To
+        </label>
+        <Input
+          id="email-test-to"
+          type="email"
+          required
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+          disabled={sending}
+          placeholder="hi@opollo.com"
+          className="mt-1"
+          data-testid="email-test-to"
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="email-test-subject"
+          className="block text-sm font-medium"
+        >
+          Subject
+        </label>
+        <Input
+          id="email-test-subject"
+          required
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+          disabled={sending}
+          maxLength={200}
+          className="mt-1"
+          data-testid="email-test-subject"
+        />
+      </div>
+      <div>
+        <label htmlFor="email-test-body" className="block text-sm font-medium">
+          Body (plaintext)
+        </label>
+        <Textarea
+          id="email-test-body"
+          required
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          disabled={sending}
+          rows={6}
+          className="mt-1"
+          data-testid="email-test-body"
+        />
+      </div>
+
+      {result.kind === "ok" && (
+        <Alert data-testid="email-test-success">
+          Sent. SendGrid message id:{" "}
+          <code className="font-mono text-xs">{result.messageId}</code>
+        </Alert>
+      )}
+      {result.kind === "err" && (
+        <Alert variant="destructive" data-testid="email-test-error">
+          <strong>{result.code}</strong> — {result.message}
+        </Alert>
+      )}
+
+      <div className="flex justify-end">
+        <Button type="submit" disabled={sending} data-testid="email-test-submit">
+          {sending ? "Sending…" : "Send test email"}
+        </Button>
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary

Second sub-PR of AUTH-FOUNDATION phase 1. In-app counterpart to the CLI smoke test so a logged-in operator can fire a one-shot SendGrid send without dropping to the terminal. Phase 3 will replace the \`NODE_ENV\` gate with a super_admin role check (page + route move together).

## What ships

- **\`app/admin/email-test/page.tsx\`** — server component, NODE_ENV gate (notFound in prod), admin/operator role gate behind it.
- **\`components/EmailTestForm.tsx\`** — client form with to/subject/body, result panel that reads back the SendGrid X-Message-Id on success or the typed error code/message on failure.
- **\`app/api/admin/email-test/route.ts\`** — re-checks NODE_ENV + admin gate (defence in depth so a logged-in admin in prod fetching the route directly still gets 404). Zod-validated body. Surfaces SendGrid 4xx as 400, 5xx/network as 502.

## Risks identified and mitigated

- **Production exposure** — both the page and the route check NODE_ENV independently; either would block a prod request alone.
- **Spam vector** if the gate ever loosens — the existing \`email_log\` audit captures every send, so abuse is post-hoc detectable. Phase 3's super_admin gate further narrows the trust boundary.
- **E2E coverage** intentionally skipped — the page renders only when \`NODE_ENV !== production\`; CI's screenshot harness runs against a production build so the page would 404 in fixtures. The CLI smoke-test script (\`scripts/send-test-email.ts\`) covers the same underlying code path with deterministic assertions.

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅

## Test plan

- [ ] Local: visit \`/admin/email-test\` in dev mode, send to hi@opollo.com
- [ ] Confirm \`email_log\` captures the row with \`sendgrid_message_id\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)