### PR TITLE
fix(p1): host-aware gate for /admin/email-test

### DIFF
--- a/app/admin/email-test/page.tsx
+++ b/app/admin/email-test/page.tsx
@@ -4,25 +4,29 @@ import { EmailTestForm } from "@/components/EmailTestForm";
 import { Alert } from "@/components/ui/alert";
 import { H1, Lead } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
+import { isEmailTestAllowed } from "@/lib/email-test-gate";
 
-// AUTH-FOUNDATION P1.2 — /admin/email-test.
+// AUTH-FOUNDATION P1.2 + P1-FIX — /admin/email-test.
 //
-// Dev-only diagnostic surface for the SendGrid wrapper. Operator can
-// fire a one-shot send through the same code path the runtime uses
+// Dev / staging diagnostic surface for the SendGrid wrapper. Operator
+// can fire a one-shot send through the same code path the runtime uses
 // (lib/email/sendgrid.ts) without dropping to the CLI. Phase 3 will
-// replace the NODE_ENV gate with a super_admin role check.
+// replace the host-aware gate with a super_admin role check and the
+// host check goes away.
 //
 // Defence in depth:
-//   1. NODE_ENV gate fronts the page (notFound in prod).
+//   1. Host-aware gate fronts the page (notFound on the prod custom
+//      domain; allowed on local dev, Vercel preview, and the staging
+//      *.vercel.app alias).
 //   2. Admin auth gate behind it (admin OR operator role).
-//   3. The API route /api/admin/email-test re-checks NODE_ENV and
-//      auth so a route-level fetch from a logged-in admin in prod
+//   3. The API route /api/admin/email-test re-checks the same gate so
+//      a route-level fetch from a logged-in admin on the prod domain
 //      still 404s.
 
 export const dynamic = "force-dynamic";
 
 export default async function EmailTestPage() {
-  if (process.env.NODE_ENV === "production") notFound();
+  if (!isEmailTestAllowed()) notFound();
 
   const access = await checkAdminAccess({
     requiredRoles: ["admin", "operator"],
@@ -41,9 +45,10 @@ export default async function EmailTestPage() {
       </Lead>
 
       <Alert className="mt-6">
-        Dev-only surface, gated on{" "}
-        <code className="font-mono text-xs">NODE_ENV !== &quot;production&quot;</code>.
-        Phase 3 replaces this with a super_admin role check.
+        Reachable on local dev + the staging{" "}
+        <code className="font-mono text-xs">*.vercel.app</code> alias only.
+        Blocked on production custom domains. Phase 3 replaces this
+        host-aware gate with a super_admin role check.
       </Alert>
 
       <div className="mt-6">

--- a/app/api/admin/email-test/route.ts
+++ b/app/api/admin/email-test/route.ts
@@ -4,12 +4,14 @@ import { z } from "zod";
 import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { sendEmail } from "@/lib/email/sendgrid";
 import { renderBaseEmail } from "@/lib/email/templates/base";
+import { isEmailTestAllowed } from "@/lib/email-test-gate";
 
-// AUTH-FOUNDATION P1.2 — POST /api/admin/email-test.
+// AUTH-FOUNDATION P1.2 + P1-FIX — POST /api/admin/email-test.
 //
-// Backs /admin/email-test. Dev-only by env gate; admin/operator gate
-// behind that. Phase 3 will replace the env gate with a super_admin
-// role check (the API route + the page move together).
+// Backs /admin/email-test. Host-aware gate (allowed on local dev,
+// Vercel preview, and the staging *.vercel.app alias; blocked on prod
+// custom domains); admin/operator gate behind that. Phase 3 will
+// replace the host gate with a super_admin role check.
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -34,10 +36,10 @@ function deny(
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  if (process.env.NODE_ENV === "production") {
+  if (!isEmailTestAllowed()) {
     return deny(
-      "NOT_AVAILABLE_IN_PROD",
-      "Email-test endpoint is dev-only.",
+      "NOT_AVAILABLE_ON_THIS_HOST",
+      "Email-test endpoint is not available on production custom domains.",
       404,
     );
   }

--- a/lib/email-test-gate.ts
+++ b/lib/email-test-gate.ts
@@ -1,0 +1,42 @@
+import "server-only";
+
+import { headers } from "next/headers";
+
+// AUTH-FOUNDATION P1-FIX — Environment-aware gate for /admin/email-test.
+//
+// The original P1 surface gated on `NODE_ENV !== "production"`. Vercel
+// builds every deployment (preview AND prod) with NODE_ENV=production,
+// so staging at opollo-site-builder.vercel.app 404'd just like real prod.
+// The fix: check the actual request host so the page is reachable on
+// the staging .vercel.app aliases but not on the cut-over prod domain
+// (mgmt.opollo.com).
+//
+// Allow when:
+//   1. Local dev (NODE_ENV !== "production"), OR
+//   2. Vercel preview deploy (PR previews), OR
+//   3. Vercel production build hitting a *.vercel.app host (i.e. the
+//      staging alias on the same project — same env vars as prod, but
+//      a host string that's clearly not a customer-facing domain).
+//
+// Block when:
+//   - Any host that doesn't end in .vercel.app while NODE_ENV=production.
+//     mgmt.opollo.com falls through this branch. Localhost in a prod
+//     build is also blocked (shouldn't happen in practice, but explicit).
+//
+// This is a temporary host-string check. Phase 3 replaces it with a
+// `super_admin` role gate in `lib/admin-gate.ts` and the host hack
+// goes away.
+
+export function isEmailTestAllowed(): boolean {
+  // Local dev always passes.
+  if (process.env.NODE_ENV !== "production") return true;
+
+  // PR preview deploys are inherently non-prod surfaces.
+  if (process.env.VERCEL_ENV === "preview") return true;
+
+  // Production build (VERCEL_ENV === "production"). Use the request
+  // host to disambiguate staging-on-vercel-domain vs real-prod-on-
+  // custom-domain.
+  const host = headers().get("host") ?? "";
+  return host.endsWith(".vercel.app");
+}


### PR DESCRIPTION
## Summary

The original P1.2 gate was \`NODE_ENV !== \"production\"\`. Vercel builds every deployment with \`NODE_ENV=production\` (preview AND prod), so staging at \`opollo-site-builder.vercel.app\` 404'd alongside real prod and the Phase 1 operator gate had no in-app path — only the CLI fallback.

## What ships

\`lib/email-test-gate.ts\` encapsulates a host-aware allowlist used by both the page and the API route.

**Allow when:**
1. Local dev (\`NODE_ENV !== \"production\"\`), OR
2. Vercel preview deploy (\`VERCEL_ENV === \"preview\"\`), OR
3. Vercel production build hitting a \`*.vercel.app\` host (the staging alias on the same project).

**Block** on any non-\`.vercel.app\` host while \`NODE_ENV=production\`. The prod custom domain (\`mgmt.opollo.com\`) falls through this branch.

## Why \`headers().get(\"host\")\` not \`VERCEL_URL\`

\`VERCEL_URL\` is the auto-generated per-deployment URL (\`<project>-<hash>-<scope>.vercel.app\`), not the canonical alias \`opollo-site-builder.vercel.app\`. String-matching \`VERCEL_URL\` is brittle. The request \`Host\` header is what the client actually came in on, which is the right signal here.

## Risks identified and mitigated

- **Page + API route both call \`isEmailTestAllowed()\`** so a route-level fetch from a logged-in admin on the prod domain still 404s.
- **\`*.vercel.app\` allowlist is intentionally broad** — covers both the canonical staging alias and per-deployment URLs (preview comments, hash URLs). Once mgmt.opollo.com is the only customer-facing domain, that domain falls through. If you later add a *.vercel.app subdomain you don't want exposed, the gate needs tightening — Phase 3's super_admin gate replaces this entirely.
- **No new env vars** — the fix is pure code.

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅

## Test plan

- [ ] Visit \`https://opollo-site-builder.vercel.app/admin/email-test\` after merge — page renders
- [ ] Send a test email to hi@opollo.com from the form
- [ ] Confirm \`email_log\` row landed
- [ ] (post-cutover) Visit \`https://mgmt.opollo.com/admin/email-test\` — 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)