### PR TITLE
feat(p2-1): test-connection endpoint + capability check

### DIFF
--- a/app/api/sites/test-connection/route.ts
+++ b/app/api/sites/test-connection/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import {
+  checkRateLimit,
+  getClientIp,
+  rateLimitExceeded,
+} from "@/lib/rate-limit";
+import { testWpConnection } from "@/lib/site-test-connection";
+
+// AUTH-FOUNDATION P2.1 — POST /api/sites/test-connection.
+//
+// Pre-save WP credential test. Backs the "Test connection" button on
+// /admin/sites/new and /admin/sites/[id]/edit. Hits the operator's WP
+// at /wp-json/wp/v2/users/me?context=edit with Basic auth and runs
+// the capability check.
+//
+// Body: { url, username, app_password }
+// Returns: { ok: true, user: { display_name, username, roles } }
+//        | { ok: false, error: { code, message } }
+//
+// Admin/operator gated; rate-limited via the test_connection bucket
+// (60/hour) so an operator iterating on a wrong app password isn't
+// blocked but a scan-style abuse is.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z
+  .object({
+    url: z.string().min(1).max(500),
+    username: z.string().min(1).max(100),
+    app_password: z.string().min(1).max(200),
+  })
+  .strict();
+
+export async function POST(req: Request): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const rlId = gate.user ? `user:${gate.user.id}` : `ip:${getClientIp(req)}`;
+  const rl = await checkRateLimit("test_connection", rlId);
+  if (!rl.ok) return rateLimitExceeded(rl);
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = null;
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body must include url, username, and app_password.",
+          details: { issues: parsed.error.issues },
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await testWpConnection(parsed.data);
+  // 200 either way — the API succeeded; the WP connection result is
+  // in the body. The form differentiates on `ok` not on HTTP status.
+  return NextResponse.json(result);
+}

--- a/lib/__tests__/site-test-connection.test.ts
+++ b/lib/__tests__/site-test-connection.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { testWpConnection } from "@/lib/site-test-connection";
+import * as wp from "@/lib/wordpress";
+
+// AUTH-FOUNDATION P2.1 — capability + error mapping unit matrix.
+
+describe("testWpConnection", () => {
+  const originalGetMe = wp.wpGetMe;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.spyOn(wp, "wpGetMe");
+  });
+
+  // -------- happy paths --------
+
+  it("succeeds when roles include administrator", async () => {
+    vi.mocked(wp.wpGetMe).mockResolvedValueOnce({
+      ok: true,
+      user_id: 1,
+      username: "admin",
+      display_name: "Site Admin",
+      roles: ["administrator"],
+      capabilities: {},
+    });
+
+    const result = await testWpConnection({
+      url: "https://example.com",
+      username: "admin",
+      app_password: "abcd efgh ijkl mnop qrst uvwx",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.user.display_name).toBe("Site Admin");
+    expect(result.user.roles).toEqual(["administrator"]);
+  });
+
+  it("succeeds when roles include editor (no admin)", async () => {
+    vi.mocked(wp.wpGetMe).mockResolvedValueOnce({
+      ok: true,
+      user_id: 2,
+      username: "edith",
+      display_name: "Edith",
+      roles: ["editor"],
+      capabilities: {},
+    });
+
+    const result = await testWpConnection({
+      url: "https://example.com",
+      username: "edith",
+      app_password: "anything",
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("succeeds on capabilities.publish_posts even with non-canonical role", async () => {
+    vi.mocked(wp.wpGetMe).mockResolvedValueOnce({
+      ok: true,
+      user_id: 3,
+      username: "ghost",
+      display_name: "",
+      roles: ["custom_publisher"],
+      capabilities: { publish_posts: true },
+    });
+
+    const result = await testWpConnection({
+      url: "https://example.com",
+      username: "ghost",
+      app_password: "x",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Falls back to username when display_name is empty.
+    expect(result.user.display_name).toBe("ghost");
+  });
+
+  // -------- failure paths --------
+
+  it("returns INSUFFICIENT_ROLE when neither role nor capability passes", async () => {
+    vi.mocked(wp.wpGetMe).mockResolvedValueOnce({
+      ok: true,
+      user_id: 4,
+      username: "sub",
+      display_name: "Subscriber",
+      roles: ["subscriber"],
+      capabilities: { read: true },
+    });
+
+    const result = await testWpConnection({
+      url: "https://example.com",
+      username: "sub",
+      app_password: "x",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("INSUFFICIENT_ROLE");
+    expect(result.error.message).toContain("publish");
+  });
+
+  it("translates AUTH_FAILED to a clear message", async () => {
+    vi.mocked(wp.wpGetMe).mockResolvedValueOnce({
+      ok: false,
+      code: "AUTH_FAILED",
+      message: "401",
+      retryable: false,
+      suggested_action: "ignore",
+    });
+
+    const result = await testWpConnection({
+      url: "https://example.com",
+      username: "x",
+      app_password: "wrong",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("AUTH_FAILED");
+    expect(result.error.message).toMatch(/credentials rejected/i);
+  });
+
+  it("translates NOT_FOUND to REST_UNREACHABLE", async () => {
+    vi.mocked(wp.wpGetMe).mockResolvedValueOnce({
+      ok: false,
+      code: "NOT_FOUND",
+      message: "404",
+      retryable: false,
+      suggested_action: "ignore",
+    });
+
+    const result = await testWpConnection({
+      url: "https://example.com",
+      username: "x",
+      app_password: "y",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("REST_UNREACHABLE");
+    expect(result.error.message).toMatch(/REST API not reachable/i);
+  });
+
+  it("translates NETWORK_ERROR to NETWORK", async () => {
+    vi.mocked(wp.wpGetMe).mockResolvedValueOnce({
+      ok: false,
+      code: "NETWORK_ERROR",
+      message: "ECONNREFUSED",
+      retryable: true,
+      suggested_action: "retry",
+    });
+
+    const result = await testWpConnection({
+      url: "https://offline.example.com",
+      username: "x",
+      app_password: "y",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NETWORK");
+    expect(result.error.message).toContain("ECONNREFUSED");
+  });
+
+  // -------- input validation --------
+
+  it("rejects an empty URL", async () => {
+    const result = await testWpConnection({
+      url: "",
+      username: "x",
+      app_password: "y",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("INVALID_URL");
+    expect(originalGetMe).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-http(s) URL", async () => {
+    const result = await testWpConnection({
+      url: "ftp://example.com",
+      username: "x",
+      app_password: "y",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("INVALID_URL");
+  });
+
+  it("rejects an empty app password after whitespace strip", async () => {
+    const result = await testWpConnection({
+      url: "https://example.com",
+      username: "x",
+      app_password: "   \n  ",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("AUTH_FAILED");
+    expect(result.error.message).toMatch(/empty after stripping/i);
+  });
+
+  it("strips whitespace from the WP Application Password format", async () => {
+    let receivedPassword = "";
+    vi.mocked(wp.wpGetMe).mockImplementationOnce(async (cfg) => {
+      receivedPassword = cfg.appPassword;
+      return {
+        ok: true,
+        user_id: 1,
+        username: "admin",
+        display_name: "Admin",
+        roles: ["administrator"],
+        capabilities: {},
+      };
+    });
+
+    await testWpConnection({
+      url: "https://example.com",
+      username: "admin",
+      app_password: "abcd efgh ijkl mnop qrst uvwx",
+    });
+
+    // 24 chars after whitespace strip — matches the WP Application
+    // Password canonical format.
+    expect(receivedPassword).toBe("abcdefghijklmnopqrstuvwx");
+    expect(receivedPassword).toHaveLength(24);
+  });
+
+  it("strips a single trailing slash from the URL before passing to wpGetMe", async () => {
+    let receivedBaseUrl = "";
+    vi.mocked(wp.wpGetMe).mockImplementationOnce(async (cfg) => {
+      receivedBaseUrl = cfg.baseUrl;
+      return {
+        ok: true,
+        user_id: 1,
+        username: "admin",
+        display_name: "Admin",
+        roles: ["administrator"],
+        capabilities: {},
+      };
+    });
+
+    await testWpConnection({
+      url: "https://example.com/",
+      username: "admin",
+      app_password: "x",
+    });
+
+    expect(receivedBaseUrl).toBe("https://example.com");
+  });
+});

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -35,7 +35,8 @@ export type LimiterName =
   | "auth_callback"
   | "invite"
   | "register"
-  | "password_reset";
+  | "password_reset"
+  | "test_connection";
 
 type LimiterConfig = {
   requests: number;
@@ -59,6 +60,11 @@ const CONFIGS: Record<LimiterName, LimiterConfig> = {
   // shouldn't be throttled because of an unrelated user on the same
   // IP, and an attacker rotating IPs wouldn't be slowed by it.
   password_reset: { requests: 5,   window: "1 h" },
+  // AUTH-FOUNDATION P2.1: pre-save WP credential test. Burns when an
+  // operator iterates on a wrong app password during /admin/sites/new
+  // or /admin/sites/[id]/edit; 60/hour comfortably covers that without
+  // letting a logged-in admin scan arbitrary WP installs at scale.
+  test_connection: { requests: 60, window: "1 h" },
 };
 
 export type RateLimitResult =

--- a/lib/site-test-connection.ts
+++ b/lib/site-test-connection.ts
@@ -1,0 +1,177 @@
+import "server-only";
+
+import { wpGetMe, type WpConfig, type WpError } from "@/lib/wordpress";
+
+// AUTH-FOUNDATION P2.1 — Pre-save WP connection test.
+//
+// Used by /admin/sites/new and /admin/sites/[id]/edit before save.
+// Hits GET /wp-json/wp/v2/users/me?context=edit with Basic auth and
+// validates the user has publish capability.
+//
+// Capability check (any one of these passes):
+//   1. roles[] contains 'administrator', OR
+//   2. roles[] contains 'editor', OR
+//   3. capabilities.publish_posts === true
+//
+// (1)+(2) are the canonical roles a publishing operator would have.
+// (3) is the durable capability check — covers Author or any custom
+// role that's been granted publish_posts. We accept any of the three
+// so a custom-role environment isn't rejected by a roles-only check.
+
+const PUBLISH_ROLES = new Set(["administrator", "editor"]);
+
+export interface TestConnectionInput {
+  url: string;
+  username: string;
+  app_password: string;
+}
+
+export interface TestConnectionUser {
+  display_name: string;
+  username: string;
+  roles: string[];
+}
+
+export type TestConnectionResult =
+  | { ok: true; user: TestConnectionUser }
+  | {
+      ok: false;
+      error: {
+        code:
+          | "AUTH_FAILED"
+          | "REST_UNREACHABLE"
+          | "INSUFFICIENT_ROLE"
+          | "NETWORK"
+          | "INVALID_URL"
+          | "WP_ERROR";
+        message: string;
+      };
+    };
+
+export async function testWpConnection(
+  input: TestConnectionInput,
+): Promise<TestConnectionResult> {
+  const url = input.url.trim();
+  if (!url) {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_URL",
+        message: "WordPress URL is required.",
+      },
+    };
+  }
+  // Strip a single trailing slash so the wpFetch path concat doesn't
+  // double up. The form normalises this client-side too; defence in
+  // depth here.
+  const baseUrl = url.replace(/\/+$/, "");
+
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_URL",
+        message: "Could not parse the URL. Use the full https:// origin.",
+      },
+    };
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_URL",
+        message: "URL must use http:// or https://.",
+      },
+    };
+  }
+
+  // WP Application Passwords are 24 chars formatted as "abcd efgh ijkl
+  // mnop qrst uvwx" (4-char groups separated by spaces). Operators
+  // sometimes copy them with surrounding whitespace. Strip both.
+  const appPassword = input.app_password.replace(/\s+/g, "");
+  if (appPassword.length === 0) {
+    return {
+      ok: false,
+      error: {
+        code: "AUTH_FAILED",
+        message: "Application Password is empty after stripping whitespace.",
+      },
+    };
+  }
+
+  const cfg: WpConfig = {
+    baseUrl,
+    user: input.username.trim(),
+    appPassword,
+  };
+
+  const meRes = await wpGetMe(cfg);
+  if (!meRes.ok) {
+    return translateWpError(meRes);
+  }
+
+  const hasPublishRole = meRes.roles.some((r) =>
+    PUBLISH_ROLES.has(r.toLowerCase()),
+  );
+  const hasPublishCap = meRes.capabilities.publish_posts === true;
+  if (!hasPublishRole && !hasPublishCap) {
+    return {
+      ok: false,
+      error: {
+        code: "INSUFFICIENT_ROLE",
+        message: `User authenticated but lacks publish capability. Roles: ${meRes.roles.join(", ") || "(none)"}. Use an administrator or editor account.`,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    user: {
+      display_name: meRes.display_name || meRes.username,
+      username: meRes.username,
+      roles: meRes.roles,
+    },
+  };
+}
+
+function translateWpError(err: WpError): TestConnectionResult {
+  switch (err.code) {
+    case "AUTH_FAILED":
+      return {
+        ok: false,
+        error: {
+          code: "AUTH_FAILED",
+          message:
+            "Credentials rejected. Check the username and Application Password.",
+        },
+      };
+    case "NOT_FOUND":
+      return {
+        ok: false,
+        error: {
+          code: "REST_UNREACHABLE",
+          message:
+            "WP REST API not reachable. Confirm the URL and that the REST API isn't disabled by a security plugin.",
+        },
+      };
+    case "NETWORK_ERROR":
+      return {
+        ok: false,
+        error: {
+          code: "NETWORK",
+          message: `Could not reach the site: ${err.message}`,
+        },
+      };
+    default:
+      return {
+        ok: false,
+        error: {
+          code: "WP_ERROR",
+          message: `${err.code}: ${err.message}`,
+        },
+      };
+  }
+}

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -912,6 +912,10 @@ export type WpGetMeResult =
       ok: true;
       user_id: number;
       username: string;
+      /** Display name from WP (`name` field). Empty string if unset. AUTH-FOUNDATION P2: shown back to the operator on a successful test-connection. */
+      display_name: string;
+      /** Role slugs from WP. Typical values: administrator, editor, author, contributor, subscriber. AUTH-FOUNDATION P2: capability check accepts admin/editor by role too. */
+      roles: string[];
       capabilities: WpUserCapabilities;
     }
   | WpError;
@@ -935,6 +939,8 @@ export async function wpGetMe(cfg: WpConfig): Promise<WpGetMeResult> {
     id?: number;
     username?: string;
     slug?: string;
+    name?: string;
+    roles?: string[];
     capabilities?: Record<string, boolean>;
   }>(res);
   if (!parsed.ok) return parsed;
@@ -944,6 +950,8 @@ export async function wpGetMe(cfg: WpConfig): Promise<WpGetMeResult> {
     ok: true,
     user_id: Number(body?.id ?? 0),
     username: (body?.username ?? body?.slug ?? "") as string,
+    display_name: (body?.name ?? "") as string,
+    roles: Array.isArray(body?.roles) ? (body.roles as string[]) : [],
     capabilities: (body?.capabilities ?? {}) as WpUserCapabilities,
   };
 }


### PR DESCRIPTION
## Summary

First sub-PR of AUTH-FOUNDATION phase 2. Backs the \"Test connection\" button on the new add/edit site flows shipping in P2.2 and P2.3. Pre-save WP credential probe with typed error envelope.

## Audit findings (relevant for the rest of P2)

- \`lib/encryption.ts\` — AES-256-GCM with \`OPOLLO_MASTER_KEY\` exists and is in active use for \`site_credentials\`. **Reusing this**, not Supabase Vault, per the brief's \"if found, use it\" rule.
- \`site_credentials\` already stores encrypted \`wp_app_password\`, \`wp_user\`, \`iv\`, \`key_version\` keyed by \`site_id\`.
- \`lib/wordpress.wpGetMe\` already does \`GET /wp-json/wp/v2/users/me?context=edit\` with Basic auth — extended in this PR to also return \`display_name\` and \`roles\`.

## What ships

- **\`lib/site-test-connection.ts\`** — pure-logic helper. Strips trailing slash from URL, strips whitespace from WP Application Password (operators copy them as \`abcd efgh …\` with spaces; WP expects them concatenated), validates http/https, calls \`wpGetMe\`, runs the capability check (any of: roles[] contains administrator, roles[] contains editor, capabilities.publish_posts === true).
- **\`lib/wordpress.ts\`** — \`wpGetMe\` extended to return \`display_name\` + \`roles\`. Backward-compatible: existing \`lib/site-preflight.ts\` reads only the original three fields.
- **\`lib/rate-limit.ts\`** — new \`test_connection\` bucket: 60 requests/hour per actor.
- **\`app/api/sites/test-connection/route.ts\`** — POST handler, admin/operator gated, Zod-validated body, returns 200 either way (the API succeeded; the WP connection result is in the body's \`ok\` flag).
- **11-case vitest matrix** covering 3 success paths (administrator, editor, custom-role + publish_posts), 4 failure translations (AUTH_FAILED, REST_UNREACHABLE, NETWORK, INSUFFICIENT_ROLE), and input validation + whitespace-strip paths.

## Risks identified and mitigated

- **Error message copy** mirrors the brief's required strings so the form can render them verbatim.
- **Arbitrary URL from a logged-in admin** — rate limit (60/hour) is the abuse cap. Server-side \`wpFetch\` already rejects internal/IP URLs (M14 policy) so an admin can't scan internal infrastructure.
- **Whitespace strip on \`app_password\`** matches what \`wpFetch\` sends to Basic auth, so a successful test mirrors the bytes that a save would persist (no surprise auth-failures after a passing test).

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅
- Vitest suite added (11 cases) — runs in CI

## Test plan

- [ ] CI green (vitest matrix executes)
- [ ] P2.2/P2.3 wire the form to this endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)