### PR TITLE
feat(p2-3): /admin/sites/[id]/edit with credential rotation

### DIFF
--- a/app/admin/sites/[id]/edit/page.tsx
+++ b/app/admin/sites/[id]/edit/page.tsx
@@ -1,0 +1,75 @@
+import { notFound, redirect } from "next/navigation";
+
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { SiteEditForm } from "@/components/SiteEditForm";
+import { Alert } from "@/components/ui/alert";
+import { H1, Lead } from "@/components/ui/typography";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { getSite } from "@/lib/sites";
+
+// AUTH-FOUNDATION P2.3 — /admin/sites/[id]/edit.
+//
+// Companion to /admin/sites/new. Same field layout, but seeds with the
+// existing site's basics + WP user. Password renders as a placeholder
+// "••••••••• (unchanged)" — empty submit preserves the stored value;
+// a new value re-encrypts and replaces. Test connection without
+// changing the password re-tests the stored credentials via the
+// site_id mode of POST /api/sites/test-connection.
+
+export const dynamic = "force-dynamic";
+
+export default async function EditSitePage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const access = await checkAdminAccess({
+    requiredRoles: ["admin", "operator"],
+    insufficientRoleRedirectTo: "/",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  // Pull credentials for the WP-user pre-fill. The encrypted
+  // app_password is dropped client-side; we never send it down.
+  const result = await getSite(params.id, { includeCredentials: true });
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") notFound();
+    return (
+      <div className="mx-auto max-w-2xl">
+        <Alert variant="destructive">{result.error.message}</Alert>
+      </div>
+    );
+  }
+
+  const site = result.data.site;
+  const creds = result.data.credentials;
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <Breadcrumbs
+        crumbs={[
+          { label: "Sites", href: "/admin/sites" },
+          { label: site.name, href: `/admin/sites/${site.id}` },
+          { label: "Edit" },
+        ]}
+      />
+      <H1 className="mt-2">Edit site</H1>
+      <Lead className="mt-1">
+        Update the basics or rotate the WordPress credentials. The
+        Application Password stays as-is unless you enter a new one.
+      </Lead>
+
+      <div className="mt-6">
+        <SiteEditForm
+          site={{
+            id: site.id,
+            name: site.name,
+            wp_url: site.wp_url,
+            wp_user: creds?.wp_user ?? "",
+          }}
+          hasStoredCredentials={creds !== null}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/api/sites/[id]/route.ts
+++ b/app/api/sites/[id]/route.ts
@@ -1,12 +1,32 @@
 import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
+import { z } from "zod";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
-import { archiveSite, getSite, updateSiteBasics } from "@/lib/sites";
+import {
+  archiveSite,
+  getSite,
+  updateSiteBasics,
+  updateSiteCredentials,
+} from "@/lib/sites";
 import {
   UpdateSiteBasicsSchema,
   errorCodeToStatus,
 } from "@/lib/tool-schemas";
+
+// AUTH-FOUNDATION P2.3 — PATCH body can carry credential rotation
+// alongside basics. Empty/omitted credential fields preserve the
+// stored values; new values are encrypted and replace the row.
+const PatchBodySchema = z
+  .object({
+    name: z.string().min(1).max(100).optional(),
+    wp_url: z.string().url().optional(),
+    wp_user: z.string().min(1).max(100).optional(),
+    wp_app_password: z.string().min(1).max(200).optional(),
+  })
+  .refine((p) => Object.keys(p).length > 0, {
+    message: "At least one field must be provided.",
+  });
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -67,14 +87,15 @@ export async function PATCH(
   } catch {
     body = {};
   }
-  const parsed = UpdateSiteBasicsSchema.safeParse(body);
+  const parsed = PatchBodySchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(
       {
         ok: false,
         error: {
           code: "VALIDATION_FAILED",
-          message: "Body must be { name?, wp_url? } with at least one field.",
+          message:
+            "Body must contain at least one of { name, wp_url, wp_user, wp_app_password }.",
           details: { issues: parsed.error.issues },
           retryable: true,
         },
@@ -84,13 +105,58 @@ export async function PATCH(
     );
   }
 
-  const result = await updateSiteBasics(params.id, parsed.data);
-  if (result.ok) {
+  // Two writes: basics (sites table) + credentials (site_credentials).
+  // Run basics first; if creds fail, basics still landed (operator
+  // can retry the credential rotation independently).
+  const basicsPatch = UpdateSiteBasicsSchema.safeParse({
+    ...(parsed.data.name !== undefined && { name: parsed.data.name }),
+    ...(parsed.data.wp_url !== undefined && { wp_url: parsed.data.wp_url }),
+  });
+  if (basicsPatch.success) {
+    const basicsResult = await updateSiteBasics(params.id, basicsPatch.data);
+    if (!basicsResult.ok) {
+      return NextResponse.json(basicsResult, {
+        status: errorCodeToStatus(basicsResult.error.code),
+      });
+    }
+  }
+
+  if (
+    parsed.data.wp_user !== undefined ||
+    parsed.data.wp_app_password !== undefined
+  ) {
+    const credsResult = await updateSiteCredentials(params.id, {
+      wp_user: parsed.data.wp_user,
+      // Strip whitespace from the WP Application Password — operators
+      // paste them as `abcd efgh …`. Mirror the test-connection
+      // helper's normalisation so a tested-then-saved credential set
+      // stores the same bytes.
+      wp_app_password:
+        parsed.data.wp_app_password !== undefined
+          ? parsed.data.wp_app_password.replace(/\s+/g, "")
+          : undefined,
+    });
+    if (!credsResult.ok) {
+      return NextResponse.json(credsResult, {
+        status: errorCodeToStatus(credsResult.error.code),
+      });
+    }
+  }
+
+  // Re-read the site for the response payload — keeps the wire shape
+  // consistent with the previous PATCH (which returned the SiteRecord).
+  const refreshed = await getSite(params.id, { includeCredentials: false });
+  if (refreshed.ok) {
     revalidatePath("/admin/sites");
     revalidatePath(`/admin/sites/${params.id}`);
   }
-  const status = result.ok ? 200 : errorCodeToStatus(result.error.code);
-  return NextResponse.json(result, { status });
+  const status = refreshed.ok ? 200 : errorCodeToStatus(refreshed.error.code);
+  return NextResponse.json(
+    refreshed.ok
+      ? { ok: true, data: refreshed.data.site, timestamp: new Date().toISOString() }
+      : refreshed,
+    { status },
+  );
 }
 
 export async function DELETE(

--- a/app/api/sites/test-connection/route.ts
+++ b/app/api/sites/test-connection/route.ts
@@ -8,15 +8,24 @@ import {
   rateLimitExceeded,
 } from "@/lib/rate-limit";
 import { testWpConnection } from "@/lib/site-test-connection";
+import { getSite } from "@/lib/sites";
 
-// AUTH-FOUNDATION P2.1 — POST /api/sites/test-connection.
+// AUTH-FOUNDATION P2.1 + P2.3 — POST /api/sites/test-connection.
 //
 // Pre-save WP credential test. Backs the "Test connection" button on
 // /admin/sites/new and /admin/sites/[id]/edit. Hits the operator's WP
 // at /wp-json/wp/v2/users/me?context=edit with Basic auth and runs
 // the capability check.
 //
-// Body: { url, username, app_password }
+// Two body shapes (P2.3 added the second):
+//   1. { url, username, app_password }
+//      Tests the explicit credentials. Used by /admin/sites/new and by
+//      /admin/sites/[id]/edit when the operator typed a new password.
+//   2. { site_id }
+//      Tests the credentials stored for site_id. Used by the edit form
+//      when the operator clicks Test without typing a new password
+//      ("re-test stored creds").
+//
 // Returns: { ok: true, user: { display_name, username, roles } }
 //        | { ok: false, error: { code, message } }
 //
@@ -27,13 +36,17 @@ import { testWpConnection } from "@/lib/site-test-connection";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const BodySchema = z
-  .object({
-    url: z.string().min(1).max(500),
-    username: z.string().min(1).max(100),
-    app_password: z.string().min(1).max(200),
-  })
-  .strict();
+const ExplicitSchema = z.object({
+  url: z.string().min(1).max(500),
+  username: z.string().min(1).max(100),
+  app_password: z.string().min(1).max(200),
+});
+
+const StoredSchema = z.object({
+  site_id: z.string().uuid(),
+});
+
+const BodySchema = z.union([ExplicitSchema, StoredSchema]);
 
 export async function POST(req: Request): Promise<NextResponse> {
   const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
@@ -56,7 +69,8 @@ export async function POST(req: Request): Promise<NextResponse> {
         ok: false,
         error: {
           code: "VALIDATION_FAILED",
-          message: "Body must include url, username, and app_password.",
+          message:
+            "Body must include either { url, username, app_password } or { site_id }.",
           details: { issues: parsed.error.issues },
         },
       },
@@ -64,7 +78,45 @@ export async function POST(req: Request): Promise<NextResponse> {
     );
   }
 
-  const result = await testWpConnection(parsed.data);
+  let testInput: { url: string; username: string; app_password: string };
+
+  if ("site_id" in parsed.data) {
+    const siteResult = await getSite(parsed.data.site_id, {
+      includeCredentials: true,
+    });
+    if (!siteResult.ok) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: siteResult.error.code,
+            message: siteResult.error.message,
+          },
+        },
+        { status: siteResult.error.code === "NOT_FOUND" ? 404 : 500 },
+      );
+    }
+    const creds = siteResult.data.credentials;
+    if (!creds) {
+      return NextResponse.json({
+        ok: false,
+        error: {
+          code: "WP_ERROR",
+          message:
+            "This site has no stored credentials. Provide a username + Application Password to test.",
+        },
+      });
+    }
+    testInput = {
+      url: siteResult.data.site.wp_url,
+      username: creds.wp_user,
+      app_password: creds.wp_app_password,
+    };
+  } else {
+    testInput = parsed.data;
+  }
+
+  const result = await testWpConnection(testInput);
   // 200 either way — the API succeeded; the WP connection result is
   // in the body. The form differentiates on `ok` not on HTTP status.
   return NextResponse.json(result);

--- a/components/SiteActionsMenu.tsx
+++ b/components/SiteActionsMenu.tsx
@@ -4,7 +4,13 @@ import { useRouter } from "next/navigation";
 import { createContext, useContext, useState, useRef, useEffect, ReactNode } from "react";
 
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
-import { EditSiteModal } from "@/components/EditSiteModal";
+
+// AUTH-FOUNDATION P2.3: the per-row Edit action used to open the
+// EditSiteModal (name + wp_url only). It now navigates to
+// /admin/sites/[id]/edit, the unified guided form that supports
+// credential rotation alongside basics. EditSiteModal.tsx is left in
+// place pending a separate cleanup PR once grep confirms no other
+// surface imports it.
 
 type MenuContextType = {
   openMenuId: string | null;
@@ -56,7 +62,6 @@ export function SiteActionsMenu({
 }) {
   const router = useRouter();
   const { openMenuId, setOpenMenuId } = useMenuContext();
-  const [editOpen, setEditOpen] = useState(false);
   const [archiveOpen, setArchiveOpen] = useState(false);
 
   const menuId = `site-actions-${siteId}`;
@@ -91,9 +96,10 @@ export function SiteActionsMenu({
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                setEditOpen(true);
+                router.push(`/admin/sites/${encodeURIComponent(siteId)}/edit`);
                 handleAction();
               }}
+              data-testid="site-edit-action"
             >
               Edit
             </button>
@@ -122,11 +128,6 @@ export function SiteActionsMenu({
         )}
       </div>
 
-      <EditSiteModal
-        open={editOpen}
-        onClose={() => setEditOpen(false)}
-        site={{ id: siteId, name, wp_url: wpUrl }}
-      />
       {archiveOpen && (
         <ConfirmActionModal
           open

--- a/components/SiteEditForm.tsx
+++ b/components/SiteEditForm.tsx
@@ -1,0 +1,484 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+import { CheckCircle2, HelpCircle, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+// AUTH-FOUNDATION P2.3 — Edit form for /admin/sites/[id]/edit.
+//
+// Mirrors SiteCreateForm's layout but with edit-mode semantics:
+//   - Pre-seeds name, wp_url, wp_user from the site record.
+//   - Password field shows the "••••••••• (unchanged)" placeholder
+//     and is NOT pre-filled (we never send the encrypted password
+//     down). passwordTouched tracks whether the operator entered a
+//     new value.
+//   - Test connection has two modes:
+//       a. Operator hasn't changed url/user/password → test STORED
+//          credentials via POST { site_id }.
+//       b. Operator changed any of url/user/password → test EXPLICIT
+//          credentials via POST { url, username, app_password }.
+//          Requires a non-empty password input (the stored password
+//          is bound to the old credential set).
+//   - Save: PATCH /api/sites/[id] with only the fields that changed.
+//     Empty password = no rotation; new password = re-encrypts.
+
+interface ExistingSite {
+  id: string;
+  name: string;
+  wp_url: string;
+  wp_user: string;
+}
+
+interface FormState {
+  name: string;
+  wp_url: string;
+  wp_user: string;
+  wp_app_password: string;
+  passwordTouched: boolean;
+}
+
+type TestResult =
+  | { kind: "idle" }
+  | { kind: "testing" }
+  | {
+      kind: "ok";
+      key: string;
+      user: { display_name: string; username: string; roles: string[] };
+    }
+  | { kind: "err"; code: string; message: string; key: string };
+
+function explicitMode(form: FormState, existing: ExistingSite): boolean {
+  return (
+    form.passwordTouched ||
+    form.wp_url.trim() !== existing.wp_url ||
+    form.wp_user.trim() !== existing.wp_user
+  );
+}
+
+function explicitKey(form: FormState): string {
+  return [form.wp_url.trim(), form.wp_user.trim(), form.wp_app_password]
+    .map((s) => s.replace(/\s+/g, ""))
+    .join("|");
+}
+
+function normaliseUrl(input: string): string {
+  return input.trim().replace(/\/+$/, "");
+}
+
+export function SiteEditForm({
+  site,
+  hasStoredCredentials,
+}: {
+  site: ExistingSite;
+  hasStoredCredentials: boolean;
+}) {
+  const router = useRouter();
+  const [form, setForm] = useState<FormState>({
+    name: site.name,
+    wp_url: site.wp_url,
+    wp_user: site.wp_user,
+    wp_app_password: "",
+    passwordTouched: false,
+  });
+  const [showPassword, setShowPassword] = useState(false);
+  const [testResult, setTestResult] = useState<TestResult>({ kind: "idle" });
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  function setField<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  const isExplicit = explicitMode(form, site);
+  const currentExplicitKey = explicitKey(form);
+
+  // In stored-credentials mode the test result key is `stored:<id>`.
+  // In explicit mode it's the credential triple. Save reads the same.
+  const testPassedForCurrent =
+    testResult.kind === "ok" &&
+    (isExplicit
+      ? testResult.key === currentExplicitKey
+      : testResult.key === `stored:${site.id}`);
+
+  const explicitTestable =
+    isExplicit &&
+    form.wp_url.trim().length > 0 &&
+    form.wp_user.trim().length > 0 &&
+    form.wp_app_password.replace(/\s+/g, "").length > 0;
+
+  const canTest =
+    !submitting &&
+    testResult.kind !== "testing" &&
+    (isExplicit ? explicitTestable : hasStoredCredentials);
+
+  const nameChanged = form.name.trim() !== site.name;
+  const anythingChanged =
+    nameChanged ||
+    form.wp_url.trim() !== site.wp_url ||
+    form.wp_user.trim() !== site.wp_user ||
+    form.passwordTouched;
+
+  // Save gating:
+  //   - If no creds changed (only name and/or wp_url) → no test
+  //     required. PATCH happens with the basics only.
+  //   - If creds changed (url/user/password) → require a passing test
+  //     for the current explicit credential set.
+  const credsChanged =
+    form.wp_url.trim() !== site.wp_url ||
+    form.wp_user.trim() !== site.wp_user ||
+    form.passwordTouched;
+  const canSave =
+    !submitting &&
+    testResult.kind !== "testing" &&
+    anythingChanged &&
+    form.name.trim().length > 0 &&
+    (!credsChanged || testPassedForCurrent);
+
+  async function runTest() {
+    setTestResult({ kind: "testing" });
+    try {
+      const body: Record<string, unknown> = isExplicit
+        ? {
+            url: normaliseUrl(form.wp_url),
+            username: form.wp_user.trim(),
+            app_password: form.wp_app_password,
+          }
+        : { site_id: site.id };
+      const res = await fetch("/api/sites/test-connection", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | {
+            ok: true;
+            user: { display_name: string; username: string; roles: string[] };
+          }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      const key = isExplicit ? currentExplicitKey : `stored:${site.id}`;
+      if (payload?.ok) {
+        setTestResult({ kind: "ok", key, user: payload.user });
+      } else {
+        setTestResult({
+          kind: "err",
+          code: payload?.ok === false ? payload.error.code : "UNKNOWN",
+          message:
+            payload?.ok === false
+              ? payload.error.message
+              : `Test request failed (HTTP ${res.status}).`,
+          key,
+        });
+      }
+    } catch (err) {
+      setTestResult({
+        kind: "err",
+        code: "NETWORK",
+        message: err instanceof Error ? err.message : String(err),
+        key: isExplicit ? currentExplicitKey : `stored:${site.id}`,
+      });
+    }
+  }
+
+  async function handleSave(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!canSave) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const patch: Record<string, string> = {};
+      if (form.name.trim() !== site.name) patch.name = form.name.trim();
+      if (form.wp_url.trim() !== site.wp_url) {
+        patch.wp_url = normaliseUrl(form.wp_url);
+      }
+      if (form.wp_user.trim() !== site.wp_user) patch.wp_user = form.wp_user.trim();
+      if (form.passwordTouched) patch.wp_app_password = form.wp_app_password;
+
+      const res = await fetch(
+        `/api/sites/${encodeURIComponent(site.id)}`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(patch),
+        },
+      );
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (payload?.ok) {
+        toast.success("Site updated", {
+          description: form.passwordTouched
+            ? "Credentials rotated."
+            : "Changes saved.",
+        });
+        router.push(`/admin/sites/${site.id}`);
+        router.refresh();
+        return;
+      }
+      const message =
+        payload?.ok === false
+          ? payload.error.message
+          : `Save failed (HTTP ${res.status}).`;
+      setSubmitError(message);
+    } catch (err) {
+      setSubmitError(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSave} className="space-y-4">
+      <div>
+        <label htmlFor="edit-site-name" className="block text-sm font-medium">
+          Site name
+        </label>
+        <Input
+          id="edit-site-name"
+          required
+          maxLength={100}
+          value={form.name}
+          onChange={(e) => setField("name", e.target.value)}
+          disabled={submitting}
+          className="mt-1"
+          data-testid="site-name"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="edit-site-wp-url" className="block text-sm font-medium">
+          WordPress URL
+        </label>
+        <Input
+          id="edit-site-wp-url"
+          required
+          type="url"
+          inputMode="url"
+          value={form.wp_url}
+          onChange={(e) => setField("wp_url", e.target.value)}
+          disabled={submitting}
+          className="mt-1"
+          data-testid="site-wp-url"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="edit-site-wp-user"
+          className="block text-sm font-medium"
+        >
+          WordPress username
+        </label>
+        <Input
+          id="edit-site-wp-user"
+          required
+          maxLength={100}
+          value={form.wp_user}
+          onChange={(e) => setField("wp_user", e.target.value)}
+          disabled={submitting}
+          autoComplete="off"
+          className="mt-1"
+          data-testid="site-wp-user"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="edit-site-wp-password"
+          className="flex items-center gap-1 text-sm font-medium"
+        >
+          WordPress Application Password
+          <ApplicationPasswordTooltip />
+        </label>
+        <div className="relative mt-1">
+          <Input
+            id="edit-site-wp-password"
+            type={showPassword ? "text" : "password"}
+            value={form.wp_app_password}
+            placeholder={
+              hasStoredCredentials
+                ? "••••••••• (unchanged)"
+                : "Enter Application Password"
+            }
+            onChange={(e) =>
+              setForm((prev) => ({
+                ...prev,
+                wp_app_password: e.target.value,
+                passwordTouched: true,
+              }))
+            }
+            disabled={submitting}
+            autoComplete="off"
+            className="pr-16 font-mono text-sm"
+            data-testid="site-wp-password"
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword((v) => !v)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm px-1"
+            tabIndex={-1}
+          >
+            {showPassword ? "hide" : "show"}
+          </button>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {form.passwordTouched
+            ? "Submitting saves this new Application Password."
+            : "Leave empty to keep the stored Application Password."}
+        </p>
+      </div>
+
+      <div className="rounded-md border bg-muted/30 p-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium">Connection test</p>
+            <p className="text-xs text-muted-foreground">
+              {isExplicit
+                ? "Tests the credentials in the form."
+                : hasStoredCredentials
+                  ? "Tests the stored credentials. Required before saving credential changes."
+                  : "No stored credentials yet — provide a username + password to test."}
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void runTest()}
+            disabled={!canTest}
+            data-testid="site-test-connection"
+          >
+            {testResult.kind === "testing" ? (
+              <>
+                <Loader2 aria-hidden className="h-3.5 w-3.5 animate-spin" />
+                Testing…
+              </>
+            ) : (
+              "Test connection"
+            )}
+          </Button>
+        </div>
+        <TestResultPanel
+          result={testResult}
+          matchesCurrent={testPassedForCurrent}
+        />
+      </div>
+
+      {submitError && (
+        <Alert variant="destructive" data-testid="site-edit-error">
+          {submitError}
+        </Alert>
+      )}
+
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => router.push(`/admin/sites/${site.id}`)}
+          disabled={submitting}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={!canSave} data-testid="site-edit-save">
+          {submitting ? "Saving…" : "Save changes"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function TestResultPanel({
+  result,
+  matchesCurrent,
+}: {
+  result: TestResult;
+  matchesCurrent: boolean;
+}) {
+  if (result.kind === "idle") return null;
+  if (result.kind === "testing") return null;
+
+  if (result.kind === "ok") {
+    return (
+      <div
+        className={cn(
+          "mt-3 rounded-md border p-3 text-sm",
+          matchesCurrent
+            ? "border-success/40 bg-success/10 text-success"
+            : "border-warning/40 bg-warning/10 text-warning",
+        )}
+        data-testid="site-test-result"
+        data-matches-current={matchesCurrent ? "true" : "false"}
+      >
+        <div className="flex items-start gap-2">
+          <CheckCircle2
+            aria-hidden
+            className={cn(
+              "h-4 w-4 shrink-0",
+              matchesCurrent ? "text-success" : "text-warning",
+            )}
+          />
+          <div className="min-w-0">
+            <p className="font-medium">
+              {matchesCurrent
+                ? `Connected as ${result.user.display_name}`
+                : "Credentials changed since last successful test"}
+            </p>
+            <p className="mt-0.5 text-xs">
+              {matchesCurrent
+                ? `WordPress username: ${result.user.username}. Roles: ${
+                    result.user.roles.join(", ") || "(none)"
+                  }`
+                : "Re-run the test before saving."}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+      role="alert"
+      data-testid="site-test-result"
+    >
+      <p className="font-medium">{result.code}</p>
+      <p className="mt-0.5 text-xs">{result.message}</p>
+    </div>
+  );
+}
+
+function ApplicationPasswordTooltip() {
+  return (
+    <span
+      className="group relative inline-flex"
+      tabIndex={0}
+      aria-label="Where to generate a WordPress Application Password"
+    >
+      <HelpCircle
+        aria-hidden
+        className="h-3.5 w-3.5 text-muted-foreground transition-smooth group-hover:text-foreground group-focus:text-foreground"
+      />
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute left-1/2 top-5 z-10 w-72 -translate-x-1/2 rounded-md border bg-popover p-3 text-xs text-popover-foreground opacity-0 shadow-lg transition-smooth group-hover:opacity-100 group-focus:opacity-100"
+      >
+        Generate at{" "}
+        <strong>wp-admin → Users → Profile → Application Passwords</strong>.
+        Name it &quot;Opollo Site Builder&quot;. Paste the generated token
+        here — <strong>not</strong> your WordPress login password.
+        Application Passwords are 24 characters with spaces; the system
+        strips them.
+      </span>
+    </span>
+  );
+}

--- a/e2e/sites.spec.ts
+++ b/e2e/sites.spec.ts
@@ -111,6 +111,57 @@ test.describe("sites CRUD", () => {
     await expect(page.getByTestId("site-create-save")).toBeDisabled();
   });
 
+  test("edit page rotates the WordPress username via the unified form", async ({
+    page,
+  }) => {
+    const seedName = `Edit Target ${Date.now()}`;
+    await createSiteViaForm(page, {
+      name: seedName,
+      url: "https://edit-me.test",
+      user: "wp-old",
+      password: "password-1234",
+    });
+
+    // Navigate via the URL — the actions-menu Edit button on the
+    // sites list lands on the same route.
+    const detailUrl = page.url();
+    const editUrl = `${detailUrl}/edit`;
+    await page.goto(editUrl);
+
+    // Form pre-seeds with the existing values.
+    await expect(page.getByTestId("site-name")).toHaveValue(seedName);
+    await expect(page.getByTestId("site-wp-user")).toHaveValue("wp-old");
+    // Password renders the placeholder, value stays empty.
+    await expect(page.getByTestId("site-wp-password")).toHaveValue("");
+    await expect(page.getByTestId("site-wp-password")).toHaveAttribute(
+      "placeholder",
+      /unchanged/i,
+    );
+
+    // Editing only the name doesn't require a connection test.
+    await page.getByTestId("site-name").fill(`${seedName} (renamed)`);
+    await expect(page.getByTestId("site-edit-save")).toBeEnabled();
+
+    // Now rotate the username — that touches the credential set, so
+    // Save should disable until a passing test for the new key.
+    await page.getByTestId("site-wp-user").fill("wp-new");
+    await page.getByTestId("site-wp-password").fill("rotated-password");
+    await expect(page.getByTestId("site-edit-save")).toBeDisabled();
+
+    await page.getByTestId("site-test-connection").click();
+    await expect(page.getByTestId("site-test-result")).toContainText(
+      /Connected as/i,
+    );
+    await expect(page.getByTestId("site-edit-save")).toBeEnabled();
+
+    await page.getByTestId("site-edit-save").click();
+    // Lands back on the detail page after save.
+    await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}$/);
+    await expect(
+      page.getByRole("heading", { name: `${seedName} (renamed)` }),
+    ).toBeVisible();
+  });
+
   test("archive flow removes the site from the default list", async ({
     page,
   }) => {

--- a/lib/sites.ts
+++ b/lib/sites.ts
@@ -449,6 +449,90 @@ export async function updateSiteBasics(
 }
 
 // ---------------------------------------------------------------------------
+// updateSiteCredentials (AUTH-FOUNDATION P2.3)
+// ---------------------------------------------------------------------------
+
+export async function updateSiteCredentials(
+  id: string,
+  patch: { wp_user?: string; wp_app_password?: string },
+): Promise<ApiResponse<{ updated: boolean }>> {
+  try {
+    if (patch.wp_user === undefined && patch.wp_app_password === undefined) {
+      return { ok: true, data: { updated: false }, timestamp: now() };
+    }
+
+    const supabase = getServiceRoleClient();
+
+    // Confirm the site exists + isn't archived before mutating creds.
+    const siteCheck = await supabase
+      .from("sites")
+      .select("id")
+      .eq("id", id)
+      .neq("status", "removed")
+      .maybeSingle();
+    if (siteCheck.error) {
+      return internalError("Failed to look up site.", {
+        supabase_error: siteCheck.error,
+      });
+    }
+    if (!siteCheck.data) {
+      return {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: `No active site found with id ${id}.`,
+          details: { id },
+          retryable: false,
+          suggested_action:
+            "Verify the site id; removed sites are excluded from credential updates.",
+        },
+        timestamp: now(),
+      };
+    }
+
+    const update: Record<string, unknown> = {};
+    if (patch.wp_user !== undefined) {
+      update.wp_user = patch.wp_user;
+    }
+    if (patch.wp_app_password !== undefined) {
+      try {
+        const enc = encrypt(patch.wp_app_password);
+        update.site_secret_encrypted = toByteaLiteral(enc.ciphertext);
+        update.iv = toByteaLiteral(enc.iv);
+        update.key_version = enc.keyVersion;
+      } catch (err) {
+        return internalError(
+          `Encryption failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    const { error } = await supabase
+      .from("site_credentials")
+      .update(update)
+      .eq("site_id", id);
+    if (error) {
+      return internalError("Failed to update site credentials.", {
+        supabase_error: error,
+      });
+    }
+
+    // Bump the parent sites.updated_at so the list page's "updated"
+    // column reflects the credential rotation.
+    await supabase
+      .from("sites")
+      .update({ updated_at: new Date().toISOString() })
+      .eq("id", id);
+
+    return { ok: true, data: { updated: true }, timestamp: now() };
+  } catch (err) {
+    return internalError(
+      `Unhandled error in updateSiteCredentials: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // updateSiteVoice (RS-2 — site-level brand voice & design direction)
 // ---------------------------------------------------------------------------
 //


### PR DESCRIPTION
## Summary

Sub-PR 3/4 of phase 2. Operators can now rotate WordPress credentials end-to-end through the unified guided form — no DB drop required.

## What ships

- **\`lib/sites.updateSiteCredentials\`** — encrypts new password via the existing AES-256-GCM helper, updates \`site_credentials\`, bumps \`sites.updated_at\`.
- **\`PATCH /api/sites/[id]\`** — body relaxed to accept any subset of \`{ name, wp_url, wp_user, wp_app_password }\`. Basics + creds split into two writes; whitespace stripped from app password to mirror the test-connection helper.
- **\`POST /api/sites/test-connection\`** — extended to accept \`{ site_id }\` for testing stored credentials. Server fetches the site + creds, runs the same \`testWpConnection\` helper.
- **\`/admin/sites/[id]/edit\`** + **\`SiteEditForm\`** — unified guided form mirroring SiteCreateForm. Pre-seeds basics; password renders as \`••••••••• (unchanged)\` placeholder, never pre-filled. \`passwordTouched\` tracks whether the operator entered a new value.
- **Test-connection has two modes**: stored (operator hasn't touched url/user/password → \`POST { site_id }\`) and explicit (any change → \`POST { url, username, app_password }\`, requires non-empty password).
- **Save gating**: editing only the name doesn't require a test pass. Editing url/user/password requires a passing test for the current explicit credential set.
- **\`SiteActionsMenu\`** — Edit action navigates to the new page (was: opened EditSiteModal). Modal file kept, unused.
- **E2E** — new test covers rotate-username + rotate-password + name-only-no-test paths.

## Risks identified and mitigated

- **Stored-creds test mode** reads the encrypted password server-side via \`getSite(includeCredentials=true)\`. Result is fed into \`wpGetMe\` exactly like the explicit path; no special server logic that could leak the bytes.
- **PATCH is not transactional** — basics + creds run sequentially. If basics succeed but creds fail, basics persist and the operator can retry the credential patch independently. A future improvement could wrap both in a Postgres transaction.
- **\"Edit only the name\"** intentionally does NOT require a test pass. E2E asserts this.
- **EditSiteModal kept** — no consumers after this PR; one small follow-up commit will delete the file once grep stays clean across CI runs.

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅ (edit route: 3.13 kB / 186 kB First Load JS)

## Test plan

- [ ] Manual: edit only the name → save works without a connection test
- [ ] Manual: rotate WP user only → must enter password to test, then save
- [ ] Manual: rotate password (URL + user unchanged) → tests against new explicit creds
- [ ] Manual: click Test without typing anything → tests stored credentials
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)