### PR TITLE
feat(optimiser-15): brief submission integration — approve actually rebuilds

### DIFF
--- a/app/api/optimiser/proposals/[id]/run-status/route.ts
+++ b/app/api/optimiser/proposals/[id]/run-status/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { reconcileProposalRunStatus } from "@/lib/optimiser/site-builder-bridge/sync-proposal-status";
+
+// OPTIMISER PHASE 1.5 SLICE 15 — GET /api/optimiser/proposals/[id]/run-status.
+//
+// Polled from the proposal review screen after approve. Reconciles
+// the proposal status from the linked brief_run (lazy reconciliation
+// pattern — no cron needed) and returns both states for the UI to
+// render progress.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: NextRequest,
+  ctx: { params: { id: string } },
+): Promise<NextResponse> {
+  const access = await checkAdminAccess({
+    requiredRoles: ["admin", "operator"],
+  });
+  if (access.kind === "redirect") {
+    return NextResponse.json(
+      { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const result = await reconcileProposalRunStatus(ctx.params.id);
+    return NextResponse.json({ ok: true, data: result });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "RECONCILE_FAILED",
+          message: err instanceof Error ? err.message : String(err),
+        },
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/optimiser/proposals.ts
+++ b/lib/optimiser/proposals.ts
@@ -7,6 +7,7 @@ import type { OptProposalCategory, OptProposalStatus, OptRiskLevel } from "./typ
 import { recordRejection } from "./client-memory";
 import { recordChangeLog } from "./change-log";
 import { lintChangeSet, type GuardrailResult } from "./guardrails";
+import { submitBriefForProposal } from "./site-builder-bridge/submit-brief";
 
 // ---------------------------------------------------------------------------
 // opt_proposals DAO + approve/reject/expire helpers.
@@ -115,7 +116,24 @@ export async function getProposalWithEvidence(id: string): Promise<{
 }
 
 export type ApproveResult =
-  | { ok: true; proposal_id: string; brief_submitted: boolean }
+  | {
+      ok: true;
+      proposal_id: string;
+      /**
+       * True when submit-brief succeeded and the proposal is now in
+       * `applying`. False when submit-brief failed but the approval
+       * itself is recorded — staff can retry via the manual handoff.
+       */
+      brief_submitted: boolean;
+      /** Set when brief_submitted = true. */
+      brief_id?: string;
+      /** Set when brief_submitted = true. */
+      brief_run_id?: string;
+      /** Set when brief_submitted = true. */
+      output_mode?: "slice" | "full_page";
+      /** Set when brief_submitted = false. */
+      submit_error?: { code: string; message: string };
+    }
   | {
       ok: false;
       code: "EXPIRED" | "GUARDRAIL_FAILED" | "STATUS_CONFLICT" | "INTERNAL_ERROR";
@@ -215,10 +233,44 @@ export async function approveProposal(args: {
     },
   });
 
-  // Phase 1.5: brief submission. Phase 1 marks the proposal applied
-  // synthetically once the Site Builder brief endpoint is wired up;
-  // here we leave it as `approved` for the manual handoff loop.
-  return { ok: true, proposal_id: args.proposalId, brief_submitted: false };
+  // OPTIMISER-15: brief submission integration.
+  // Approve fires submit-brief synchronously. On success, flip the
+  // proposal to `applying` so the UI starts polling /run-status. On
+  // failure, leave the proposal at `approved` so staff can retry via
+  // the manual handoff (the existing fallback) and surface the error
+  // to the response so the operator sees what went wrong.
+  const submitResult = await submitBriefForProposal({
+    proposalId: args.proposalId,
+    approverUserId: args.approverUserId,
+  });
+  if (!submitResult.ok) {
+    return {
+      ok: true,
+      proposal_id: args.proposalId,
+      brief_submitted: false,
+      submit_error: submitResult.error,
+    };
+  }
+
+  // Flip status approved → applying. CAS on status='approved' so a
+  // race with another submitter doesn't double-fire.
+  await supabase
+    .from("opt_proposals")
+    .update({
+      status: "applying",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", args.proposalId)
+    .eq("status", "approved");
+
+  return {
+    ok: true,
+    proposal_id: args.proposalId,
+    brief_submitted: true,
+    brief_id: submitResult.brief_id,
+    brief_run_id: submitResult.brief_run_id,
+    output_mode: submitResult.output_mode,
+  };
 }
 
 export type RejectResult =

--- a/lib/optimiser/site-builder-bridge/submit-brief.ts
+++ b/lib/optimiser/site-builder-bridge/submit-brief.ts
@@ -1,0 +1,321 @@
+import "server-only";
+
+import { createHash } from "node:crypto";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// OPTIMISER PHASE 1.5 SLICE 15 — Brief submission bridge.
+//
+// Given an APPROVED opt_proposals row, construct a brief + brief_pages
+// + brief_runs triple in the Site Builder schema and link the run
+// back to the proposal via brief_runs.triggered_by_proposal_id.
+//
+// The brief-runner cron (existing) picks up the queued brief_run on
+// its next tick and starts the multi-pass loop. Slice 14's
+// composeFullPage + writeStaticPage are the consumers; the brief-
+// runner integration is a follow-up sub-slice once the operator gate
+// has confirmed the bridge produces correctly-shaped briefs.
+//
+// Hosting-mode routing:
+//   - opt_clients.hosting_mode === 'opollo_subdomain' or
+//     'opollo_cname'  → brief_pages.output_mode = 'full_page'
+//   - opt_clients.hosting_mode === 'client_slice'      → 'slice'
+//
+// The `slice` path preserves backward compatibility with sites that
+// publish into a WordPress install controlled by the client; the
+// `full_page` path produces a self-contained HTML doc written to
+// SiteGround.
+//
+// On any failure the bridge:
+//   - Returns a typed error result without mutating the proposal row
+//     (the approveProposal caller decides whether to revert status).
+//   - Best-effort cleanup of any partially-inserted brief rows so a
+//     retry doesn't accumulate orphaned rows.
+// ---------------------------------------------------------------------------
+
+export interface SubmitBriefInput {
+  proposalId: string;
+  approverUserId: string | null;
+}
+
+export type SubmitBriefResult =
+  | {
+      ok: true;
+      brief_id: string;
+      brief_run_id: string;
+      output_mode: "slice" | "full_page";
+    }
+  | {
+      ok: false;
+      error: { code: string; message: string };
+    };
+
+interface ProposalContext {
+  proposal_id: string;
+  client_id: string;
+  landing_page_id: string;
+  headline: string;
+  change_set: Record<string, unknown>;
+  before_snapshot: Record<string, unknown>;
+  pre_build_reprompt: string | null;
+  triggering_playbook_id: string | null;
+  // Joined from opt_landing_pages
+  page_id: string | null;
+  management_mode: string;
+  // Joined from opt_clients
+  hosting_mode: "opollo_subdomain" | "opollo_cname" | "client_slice";
+  client_slug: string;
+  // Joined from sites (via opt_landing_pages.page_id → pages.site_id)
+  site_id: string | null;
+}
+
+export async function submitBriefForProposal(
+  input: SubmitBriefInput,
+): Promise<SubmitBriefResult> {
+  let context: ProposalContext;
+  try {
+    context = await loadProposalContext(input.proposalId);
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: "PROPOSAL_CONTEXT_FAILED",
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+
+  if (context.management_mode !== "full_automation" || context.page_id === null) {
+    return {
+      ok: false,
+      error: {
+        code: "PAGE_NOT_AUTOMATED",
+        message:
+          "Landing page is not in full_automation mode. Use the manual rebuild fallback or run page-import (Slice 17) first.",
+      },
+    };
+  }
+  if (context.site_id === null) {
+    return {
+      ok: false,
+      error: {
+        code: "SITE_LOOKUP_FAILED",
+        message: "Could not resolve site_id for the landing page's WP page.",
+      },
+    };
+  }
+
+  const outputMode: "slice" | "full_page" =
+    context.hosting_mode === "client_slice" ? "slice" : "full_page";
+  const briefSourceText = renderBriefSourceText(context);
+  const sourceSha = createHash("sha256").update(briefSourceText).digest("hex");
+  const idempotencyKey = `optimiser:proposal:${context.proposal_id}`;
+
+  const supabase = getServiceRoleClient();
+  let briefId: string | null = null;
+  try {
+    // 1. briefs row (status=committed; this is a programmatic brief,
+    //    not an operator upload, so we skip the parsing dance).
+    const { data: briefRow, error: briefErr } = await supabase
+      .from("briefs")
+      .insert({
+        site_id: context.site_id,
+        title: `Optimiser: ${context.headline}`,
+        status: "committed",
+        source_storage_path: `optimiser-virtual/${context.proposal_id}`,
+        source_mime_type: "text/markdown",
+        source_size_bytes: Buffer.byteLength(briefSourceText, "utf8"),
+        source_sha256: sourceSha,
+        upload_idempotency_key: idempotencyKey,
+        parser_mode: "structural",
+        parser_warnings: [],
+        committed_at: new Date().toISOString(),
+        committed_by: input.approverUserId,
+        committed_page_hash: sourceSha,
+        created_by: input.approverUserId,
+        updated_by: input.approverUserId,
+      })
+      .select("id")
+      .single();
+    if (briefErr || !briefRow) {
+      throw new Error(`briefs insert: ${briefErr?.message ?? "no row"}`);
+    }
+    briefId = briefRow.id as string;
+
+    // 2. brief_pages — single page, ordinal 0, output_mode routed.
+    const wordCount = briefSourceText
+      .split(/\s+/)
+      .filter((s) => s.length > 0).length;
+    const { error: pageErr } = await supabase.from("brief_pages").insert({
+      brief_id: briefId,
+      ordinal: 0,
+      title: context.headline,
+      mode: "full_text",
+      source_text: briefSourceText,
+      word_count: wordCount,
+      output_mode: outputMode,
+      operator_notes: context.pre_build_reprompt,
+      created_by: input.approverUserId,
+      updated_by: input.approverUserId,
+    });
+    if (pageErr) {
+      throw new Error(`brief_pages insert: ${pageErr.message}`);
+    }
+
+    // 3. brief_runs — queued, link back to proposal so slice-15's
+    //    sync helper + slice-16's monitor can find it.
+    const { data: runRow, error: runErr } = await supabase
+      .from("brief_runs")
+      .insert({
+        brief_id: briefId,
+        status: "queued",
+        triggered_by_proposal_id: context.proposal_id,
+        created_by: input.approverUserId,
+        updated_by: input.approverUserId,
+      })
+      .select("id")
+      .single();
+    if (runErr || !runRow) {
+      throw new Error(`brief_runs insert: ${runErr?.message ?? "no row"}`);
+    }
+
+    return {
+      ok: true,
+      brief_id: briefId,
+      brief_run_id: runRow.id as string,
+      output_mode: outputMode,
+    };
+  } catch (err) {
+    // Best-effort cleanup. brief_pages + brief_runs cascade off briefs,
+    // so deleting the brief row sweeps everything.
+    if (briefId !== null) {
+      try {
+        await supabase.from("briefs").delete().eq("id", briefId);
+      } catch (cleanupErr) {
+        logger.error("submit-brief: cleanup delete failed", {
+          brief_id: briefId,
+          err:
+            cleanupErr instanceof Error
+              ? cleanupErr.message
+              : String(cleanupErr),
+        });
+      }
+    }
+    return {
+      ok: false,
+      error: {
+        code: "BRIEF_INSERT_FAILED",
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+}
+
+async function loadProposalContext(
+  proposalId: string,
+): Promise<ProposalContext> {
+  const supabase = getServiceRoleClient();
+
+  // Three reads — proposal, landing-page (with optional page join),
+  // and client. Three round-trips is acceptable; this runs once per
+  // approve, not per request hot-path.
+  const proposalRes = await supabase
+    .from("opt_proposals")
+    .select(
+      "id, client_id, landing_page_id, headline, change_set, before_snapshot, pre_build_reprompt, triggering_playbook_id",
+    )
+    .eq("id", proposalId)
+    .is("deleted_at", null)
+    .maybeSingle();
+  if (proposalRes.error) throw new Error(proposalRes.error.message);
+  if (!proposalRes.data) throw new Error("proposal not found");
+
+  const landingRes = await supabase
+    .from("opt_landing_pages")
+    .select("id, management_mode, page_id")
+    .eq("id", proposalRes.data.landing_page_id as string)
+    .maybeSingle();
+  if (landingRes.error) throw new Error(landingRes.error.message);
+  if (!landingRes.data) throw new Error("landing page not found");
+
+  const clientRes = await supabase
+    .from("opt_clients")
+    .select("id, slug, hosting_mode")
+    .eq("id", proposalRes.data.client_id as string)
+    .maybeSingle();
+  if (clientRes.error) throw new Error(clientRes.error.message);
+  if (!clientRes.data) throw new Error("client not found");
+
+  // Resolve site_id: opt_landing_pages.page_id → pages.site_id.
+  let siteId: string | null = null;
+  if (landingRes.data.page_id) {
+    const pageRes = await supabase
+      .from("pages")
+      .select("site_id")
+      .eq("id", landingRes.data.page_id as string)
+      .maybeSingle();
+    if (pageRes.error) throw new Error(pageRes.error.message);
+    siteId = (pageRes.data?.site_id as string | undefined) ?? null;
+  }
+
+  return {
+    proposal_id: proposalRes.data.id as string,
+    client_id: proposalRes.data.client_id as string,
+    landing_page_id: proposalRes.data.landing_page_id as string,
+    headline: proposalRes.data.headline as string,
+    change_set: (proposalRes.data.change_set ?? {}) as Record<string, unknown>,
+    before_snapshot: (proposalRes.data.before_snapshot ?? {}) as Record<
+      string,
+      unknown
+    >,
+    pre_build_reprompt:
+      (proposalRes.data.pre_build_reprompt as string | null) ?? null,
+    triggering_playbook_id:
+      (proposalRes.data.triggering_playbook_id as string | null) ?? null,
+    page_id: (landingRes.data.page_id as string | null) ?? null,
+    management_mode: landingRes.data.management_mode as string,
+    hosting_mode: clientRes.data.hosting_mode as
+      | "opollo_subdomain"
+      | "opollo_cname"
+      | "client_slice",
+    client_slug: clientRes.data.slug as string,
+    site_id: siteId,
+  };
+}
+
+// Render the brief's source_text. The brief-runner reads this verbatim
+// as the generation input. Markdown shape so the existing Anthropic
+// prompt patterns ingest it cleanly.
+function renderBriefSourceText(context: ProposalContext): string {
+  const lines: string[] = [
+    `# ${context.headline}`,
+    "",
+    "## Optimisation context",
+    "",
+    `- Proposal id: ${context.proposal_id}`,
+    `- Triggering playbook: ${context.triggering_playbook_id ?? "(none)"}`,
+    "",
+    "## Change set",
+    "",
+    "```json",
+    JSON.stringify(context.change_set, null, 2),
+    "```",
+    "",
+    "## Before snapshot",
+    "",
+    "```json",
+    JSON.stringify(context.before_snapshot, null, 2),
+    "```",
+  ];
+  if (context.pre_build_reprompt) {
+    lines.push(
+      "",
+      "## Operator notes (pre-build reprompt)",
+      "",
+      context.pre_build_reprompt,
+    );
+  }
+  return lines.join("\n");
+}

--- a/lib/optimiser/site-builder-bridge/sync-proposal-status.ts
+++ b/lib/optimiser/site-builder-bridge/sync-proposal-status.ts
@@ -1,0 +1,117 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// OPTIMISER PHASE 1.5 SLICE 15 — Lazy proposal-status reconciliation.
+//
+// The brief-runner cron tick advances brief_runs.status (queued →
+// running → succeeded | failed). The proposal status (`applying`)
+// needs to follow. Rather than coupling the brief-runner to opt_*
+// (which would add a circular dependency between two domains), this
+// helper reconciles on demand: every poll of GET /run-status calls
+// reconcile(), which reads the latest brief_run and writes the
+// matching opt_proposals.status.
+//
+// State mapping:
+//   brief_runs.status === 'succeeded' → opt_proposals.status = 'applied'
+//   brief_runs.status === 'failed'    → opt_proposals.status = 'applied_then_failed'
+//   anything else                     → no-op (proposal stays 'applying')
+//
+// Idempotent — re-running on a proposal already in 'applied' / 'applied_then_failed'
+// is a noop (the WHERE status='applying' filter blocks the second update).
+// ---------------------------------------------------------------------------
+
+export interface RunStatusResult {
+  proposal_id: string;
+  proposal_status: string;
+  brief_run_id: string | null;
+  brief_run_status: string | null;
+  brief_run_failure_code: string | null;
+  brief_run_failure_detail: string | null;
+}
+
+export async function reconcileProposalRunStatus(
+  proposalId: string,
+): Promise<RunStatusResult> {
+  const supabase = getServiceRoleClient();
+
+  // Find the most-recent brief_run for this proposal. There should
+  // typically be just one; multiple appear only if the operator
+  // re-triggered after an applied_then_failed.
+  const runRes = await supabase
+    .from("brief_runs")
+    .select("id, status, failure_code, failure_detail")
+    .eq("triggered_by_proposal_id", proposalId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (runRes.error) {
+    throw new Error(`brief_runs lookup: ${runRes.error.message}`);
+  }
+
+  const proposalRes = await supabase
+    .from("opt_proposals")
+    .select("id, status")
+    .eq("id", proposalId)
+    .is("deleted_at", null)
+    .maybeSingle();
+  if (proposalRes.error) {
+    throw new Error(`opt_proposals lookup: ${proposalRes.error.message}`);
+  }
+  if (!proposalRes.data) {
+    throw new Error("proposal not found");
+  }
+
+  const currentProposalStatus = proposalRes.data.status as string;
+  const run = runRes.data;
+
+  // No brief_run yet — proposal stays as-is.
+  if (!run) {
+    return {
+      proposal_id: proposalId,
+      proposal_status: currentProposalStatus,
+      brief_run_id: null,
+      brief_run_status: null,
+      brief_run_failure_code: null,
+      brief_run_failure_detail: null,
+    };
+  }
+
+  // Reconcile only when proposal is in `applying` and run is terminal.
+  let nextStatus: string | null = null;
+  if (currentProposalStatus === "applying") {
+    if (run.status === "succeeded") nextStatus = "applied";
+    else if (run.status === "failed") nextStatus = "applied_then_failed";
+  }
+
+  if (nextStatus) {
+    const updRes = await supabase
+      .from("opt_proposals")
+      .update({
+        status: nextStatus,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", proposalId)
+      .eq("status", "applying"); // CAS — only update if still applying
+    if (updRes.error) {
+      logger.error("sync-proposal-status: status update failed", {
+        proposal_id: proposalId,
+        next_status: nextStatus,
+        err: updRes.error.message,
+      });
+    }
+  }
+
+  return {
+    proposal_id: proposalId,
+    proposal_status: nextStatus ?? currentProposalStatus,
+    brief_run_id: run.id as string,
+    brief_run_status: run.status as string,
+    brief_run_failure_code:
+      (run.failure_code as string | null) ?? null,
+    brief_run_failure_detail:
+      (run.failure_detail as string | null) ?? null,
+  };
+}

--- a/supabase/migrations/0053_optimiser_brief_submission.sql
+++ b/supabase/migrations/0053_optimiser_brief_submission.sql
@@ -1,0 +1,57 @@
+-- 0053 — OPTIMISER PHASE 1.5 SLICE 15: brief submission integration.
+--
+-- Two schema additions:
+--
+--   1. opt_proposals.status gains two new values:
+--        - 'applying'             — submit-brief succeeded, brief_run is
+--                                    queued/running, generation in
+--                                    progress.
+--        - 'applied_then_failed'  — brief_run terminated in `failed`
+--                                    state. Operator notified; staff
+--                                    can re-trigger via the proposal
+--                                    review screen.
+--
+--   2. brief_runs.triggered_by_proposal_id — nullable FK back to
+--      opt_proposals. Lets the slice-15 sync helper find the brief_run
+--      that corresponds to a given proposal, and lets the slice-16
+--      staged-rollout monitor know the lineage when a generation
+--      lands. NULL for operator-uploaded briefs (the existing
+--      brief-runner path).
+--
+-- Forward-only. The CHECK constraint on opt_proposals.status is
+-- altered in two steps to satisfy Postgres' constraint-replacement
+-- semantics; the new constraint accepts every value the old one did
+-- plus the two new states.
+
+-- 1. opt_proposals.status enum extension
+ALTER TABLE opt_proposals
+  DROP CONSTRAINT IF EXISTS opt_proposals_status_check;
+
+ALTER TABLE opt_proposals
+  ADD CONSTRAINT opt_proposals_status_check CHECK (status IN (
+    'draft',
+    'pending',
+    'approved',
+    'applying',
+    'applied',
+    'applied_promoted',
+    'applied_then_reverted',
+    'applied_then_failed',
+    'rejected',
+    'expired'
+  ));
+
+COMMENT ON COLUMN opt_proposals.status IS
+  'State machine: draft → pending → approved → applying → applied → applied_promoted | applied_then_reverted | applied_then_failed; OR pending → rejected | expired. `applying` and `applied_then_failed` added 2026-04-30 (OPTIMISER-15) for the brief-submission integration.';
+
+-- 2. brief_runs.triggered_by_proposal_id
+ALTER TABLE brief_runs
+  ADD COLUMN triggered_by_proposal_id uuid
+    REFERENCES opt_proposals(id) ON DELETE SET NULL;
+
+CREATE INDEX brief_runs_triggered_by_proposal_idx
+  ON brief_runs (triggered_by_proposal_id)
+  WHERE triggered_by_proposal_id IS NOT NULL;
+
+COMMENT ON COLUMN brief_runs.triggered_by_proposal_id IS
+  'When this brief_run was triggered by an optimiser proposal approval, this references the opt_proposals row. NULL for operator-uploaded briefs. Set to NULL on proposal delete (history is in opt_change_log; no cascade needed). Added 2026-04-30 (OPTIMISER-15).';

--- a/supabase/rollbacks/0053_optimiser_brief_submission.down.sql
+++ b/supabase/rollbacks/0053_optimiser_brief_submission.down.sql
@@ -1,0 +1,20 @@
+-- Rollback for 0053_optimiser_brief_submission.sql.
+
+DROP INDEX IF EXISTS brief_runs_triggered_by_proposal_idx;
+ALTER TABLE brief_runs DROP COLUMN IF EXISTS triggered_by_proposal_id;
+
+ALTER TABLE opt_proposals
+  DROP CONSTRAINT IF EXISTS opt_proposals_status_check;
+
+-- Restore the original constraint (rolling back to 0041's enum).
+ALTER TABLE opt_proposals
+  ADD CONSTRAINT opt_proposals_status_check CHECK (status IN (
+    'draft',
+    'pending',
+    'approved',
+    'applied',
+    'applied_promoted',
+    'applied_then_reverted',
+    'rejected',
+    'expired'
+  ));


### PR DESCRIPTION
## Summary

Wires up the missing piece in the optimiser → site-builder loop. Before this slice, \"approve proposal\" only flipped the proposal row to \`approved\` and waited for staff to do something manually. Now it constructs a brief + brief_pages + brief_runs triple, lets the existing brief-runner cron pick up the queued run, and reconciles the proposal status as the run completes.

## What ships

- **Migration 0053** — schema additions:
  - \`opt_proposals.status\` enum extended with \`applying\` and \`applied_then_failed\`. State machine: pending → approved → applying → applied | applied_then_failed | applied_promoted | applied_then_reverted.
  - \`brief_runs.triggered_by_proposal_id\` (nullable FK) with a partial index for sync-helper lookups.
- **\`lib/optimiser/site-builder-bridge/submit-brief.ts\`** — joins opt_proposals + opt_landing_pages + opt_clients + pages, routes \`output_mode\` by hosting_mode (client_slice → slice, else → full_page), inserts briefs (status=committed) + brief_pages (ordinal=0) + brief_runs (queued, linked to proposal). Best-effort cleanup of partial inserts on failure.
- **\`lib/optimiser/site-builder-bridge/sync-proposal-status.ts\`** — lazy reconciliation. Reads the linked brief_run, maps succeeded → applied / failed → applied_then_failed / other → no-op. CAS update on status='applying' so re-running is idempotent.
- **\`GET /api/optimiser/proposals/[id]/run-status\`** — admin/operator gated, calls the sync helper, returns proposal_status + brief_run_status for UI polling.
- **\`approveProposal\`** extended to call submit-brief synchronously after the change-log entry. On success: CAS-updates approved → applying. On failure: leaves the proposal at 'approved' and surfaces the submit_error so staff sees what went wrong; manual fallback still works.
- **\`ApproveResult\`** type extended with \`brief_id\` / \`brief_run_id\` / \`output_mode\` (success) and \`submit_error\` (submit failure).

## Risks identified and mitigated

- **Submit-brief failures don't undo the approval** — by design. The proposal sits at 'approved' (not 'applying'), staff sees the error, can retry submit-brief manually, the manual handoff loop still works.
- **Lazy reconciliation has a polling window** — slice 16's monitor cron will also reconcile during its hourly tick. Status update is idempotent.
- **\`brief_runs.triggered_by_proposal_id\`** is ON DELETE SET NULL so a proposal hard-delete doesn't cascade-orphan runs. Audit trail lives in opt_change_log + briefs.title prefix regardless.
- **CAS update on \`status='applying'\`** prevents a race where two pollers reconcile the same terminal run and double-apply the status flip.
- **Idempotency**: \`briefs.upload_idempotency_key = \"optimiser:proposal:{id}\"\` so a submit-brief retry on the same proposal hits the unique constraint and surfaces a clean conflict.

## Deferred

The brief-runner integration with \`composeFullPage\` + \`writeStaticPage\` (slice 14's libraries) is intentionally NOT in this slice. The runner sees full_page-marked brief_pages and routes its post-generation output through the new helpers; that integration lands as a follow-up sub-slice once the operator has confirmed the bridge produces correctly-shaped briefs.

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅

## Test plan

- [ ] Migration applies cleanly in staging
- [ ] Approve a real proposal in staging, watch /run-status reconcile from queued → running → succeeded
- [ ] Verify proposal flips approved → applying → applied
- [ ] Force a brief_run failure, verify proposal flips to applied_then_failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)