### PR TITLE
feat(p3-1): super_admin tier + role rename (operator/viewer→admin/user) + invites/audit schema

### DIFF
--- a/app/admin/batches/[id]/page.tsx
+++ b/app/admin/batches/[id]/page.tsx
@@ -48,7 +48,7 @@ export default async function BatchDetailPage({
   params: { id: string };
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/admin/sites",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/batches/page.tsx
+++ b/app/admin/batches/page.tsx
@@ -63,7 +63,7 @@ export default async function AdminBatchesPage({
   searchParams: { site_id?: string };
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/admin/sites",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/email-test/page.tsx
+++ b/app/admin/email-test/page.tsx
@@ -29,7 +29,7 @@ export default async function EmailTestPage() {
   if (!isEmailTestAllowed()) notFound();
 
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/images/[id]/page.tsx
+++ b/app/admin/images/[id]/page.tsx
@@ -96,7 +96,7 @@ export default async function AdminImageDetailPage({
   searchParams: RawSearchParams;
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/admin/sites",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/images/page.tsx
+++ b/app/admin/images/page.tsx
@@ -107,7 +107,7 @@ export default async function AdminImagesPage({
   searchParams: RawSearchParams;
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/admin/sites",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/posts/new/page.tsx
+++ b/app/admin/posts/new/page.tsx
@@ -19,7 +19,7 @@ export const dynamic = "force-dynamic";
 
 export default async function PostsNewPage() {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/sites/[id]/appearance/page.tsx
+++ b/app/admin/sites/[id]/appearance/page.tsx
@@ -40,7 +40,7 @@ export default async function SiteAppearancePage({
   params: { id: string };
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/admin/sites",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/sites/[id]/edit/page.tsx
+++ b/app/admin/sites/[id]/edit/page.tsx
@@ -24,7 +24,7 @@ export default async function EditSitePage({
   params: { id: string };
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/sites/[id]/page.tsx
+++ b/app/admin/sites/[id]/page.tsx
@@ -67,7 +67,7 @@ export default async function SiteDetailPage({
   params: { id: string };
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/sites/[id]/pages/[pageId]/page.tsx
+++ b/app/admin/sites/[id]/pages/[pageId]/page.tsx
@@ -80,7 +80,7 @@ export default async function PageDetail({
   searchParams: RawSearchParams;
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/admin/sites",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/sites/[id]/pages/page.tsx
+++ b/app/admin/sites/[id]/pages/page.tsx
@@ -85,7 +85,7 @@ export default async function SitePagesList({
   searchParams: RawSearchParams;
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/admin/sites",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/sites/[id]/posts/[post_id]/page.tsx
+++ b/app/admin/sites/[id]/posts/[post_id]/page.tsx
@@ -27,7 +27,7 @@ export default async function PostDetailPage({
   params: { id: string; post_id: string };
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/admin/sites",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/sites/[id]/posts/new/page.tsx
+++ b/app/admin/sites/[id]/posts/new/page.tsx
@@ -22,7 +22,7 @@ export default async function BlogPostEntryPage({
   params: { id: string };
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/sites/[id]/posts/page.tsx
+++ b/app/admin/sites/[id]/posts/page.tsx
@@ -79,7 +79,7 @@ export default async function SitePostsList({
   searchParams: RawSearchParams;
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/admin/sites",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/sites/[id]/settings/page.tsx
+++ b/app/admin/sites/[id]/settings/page.tsx
@@ -24,7 +24,7 @@ export default async function SiteSettingsPage({
   params: { id: string };
 }) {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/admin/sites/new/page.tsx
+++ b/app/admin/sites/new/page.tsx
@@ -16,7 +16,7 @@ export const dynamic = "force-dynamic";
 
 export default async function NewSitePage() {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/",
   });
   if (access.kind === "redirect") redirect(access.to);

--- a/app/api/admin/batch/[id]/cancel/route.ts
+++ b/app/api/admin/batch/[id]/cancel/route.ts
@@ -49,7 +49,7 @@ export async function POST(
   _req: Request,
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const jobId = params.id;

--- a/app/api/admin/batch/route.ts
+++ b/app/api/admin/batch/route.ts
@@ -62,7 +62,7 @@ function errorStatusFor(
 }
 
 export async function POST(req: Request): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const rlId = gate.user ? `user:${gate.user.id}` : `ip:${getClientIp(req)}`;

--- a/app/api/admin/email-test/route.ts
+++ b/app/api/admin/email-test/route.ts
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   let parsed: z.infer<typeof BodySchema>;

--- a/app/api/admin/images/[id]/restore/route.ts
+++ b/app/api/admin/images/[id]/restore/route.ts
@@ -40,7 +40,7 @@ export async function POST(
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
   const gate = await requireAdminForApi({
-    roles: ["admin", "operator"] as const,
+    roles: ["super_admin", "admin"] as const,
   });
   if (gate.kind === "deny") return gate.response;
 

--- a/app/api/admin/images/[id]/route.ts
+++ b/app/api/admin/images/[id]/route.ts
@@ -94,7 +94,7 @@ export async function PATCH(
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
   const gate = await requireAdminForApi({
-    roles: ["admin", "operator"] as const,
+    roles: ["super_admin", "admin"] as const,
   });
   if (gate.kind === "deny") return gate.response;
 
@@ -180,7 +180,7 @@ export async function DELETE(
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
   const gate = await requireAdminForApi({
-    roles: ["admin", "operator"] as const,
+    roles: ["super_admin", "admin"] as const,
   });
   if (gate.kind === "deny") return gate.response;
 

--- a/app/api/admin/images/fetch-url/route.ts
+++ b/app/api/admin/images/fetch-url/route.ts
@@ -72,7 +72,7 @@ async function fetchWithTimeout(
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const body = await req.json().catch(() => null);

--- a/app/api/admin/images/list/route.ts
+++ b/app/api/admin/images/list/route.ts
@@ -106,7 +106,7 @@ export interface ImagePickerEntry extends ImageListItem {
 }
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const url = new URL(req.url);

--- a/app/api/admin/images/upload/route.ts
+++ b/app/api/admin/images/upload/route.ts
@@ -49,7 +49,7 @@ function errorJson(
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const form = await req.formData().catch(() => null);

--- a/app/api/admin/sites/[id]/pages/[pageId]/regenerate/route.ts
+++ b/app/api/admin/sites/[id]/pages/[pageId]/regenerate/route.ts
@@ -53,7 +53,7 @@ export async function POST(
   { params }: { params: { id: string; pageId: string } },
 ): Promise<NextResponse> {
   const gate = await requireAdminForApi({
-    roles: ["admin", "operator"] as const,
+    roles: ["super_admin", "admin"] as const,
   });
   if (gate.kind === "deny") return gate.response;
 

--- a/app/api/admin/sites/[id]/pages/[pageId]/route.ts
+++ b/app/api/admin/sites/[id]/pages/[pageId]/route.ts
@@ -82,7 +82,7 @@ export async function PATCH(
   { params }: { params: { id: string; pageId: string } },
 ): Promise<NextResponse> {
   const gate = await requireAdminForApi({
-    roles: ["admin", "operator"] as const,
+    roles: ["super_admin", "admin"] as const,
   });
   if (gate.kind === "deny") return gate.response;
 

--- a/app/api/admin/sites/[id]/voice/route.ts
+++ b/app/api/admin/sites/[id]/voice/route.ts
@@ -69,7 +69,7 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   if (!UUID_RE.test(params.id)) {

--- a/app/api/admin/users/[id]/role/route.ts
+++ b/app/api/admin/users/[id]/role/route.ts
@@ -41,8 +41,11 @@ import { getServiceRoleClient } from "@/lib/supabase";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+// AUTH-FOUNDATION P3 — role rename (operator/viewer → admin/user;
+// super_admin is the new top tier reserved for hi@opollo.com and
+// CANNOT be assigned via this route).
 const RoleSchema = z.object({
-  role: z.enum(["admin", "operator", "viewer"]),
+  role: z.enum(["admin", "user"]),
 });
 
 const UUID_RE =
@@ -93,7 +96,7 @@ export async function PATCH(
         ok: false,
         error: {
           code: "VALIDATION_FAILED",
-          message: "Body must be { role: 'admin' | 'operator' | 'viewer' }.",
+          message: "Body must be { role: 'admin' | 'user' }.",
           details: { issues: parsed.error.issues },
           retryable: false, // VALIDATION_FAILED is not retryable — same input loops forever (M15-4 #5)
         },
@@ -132,7 +135,18 @@ export async function PATCH(
     return errorJson("NOT_FOUND", "No user with that id.", 404);
   }
 
-  const currentRole = target.role as "admin" | "operator" | "viewer";
+  const currentRole = target.role as "super_admin" | "admin" | "user";
+
+  // The DB-level guard_super_admin trigger blocks demoting the
+  // hi@opollo.com row; surface a clean 409 here so the UI doesn't
+  // see a generic 500.
+  if (currentRole === "super_admin") {
+    return errorJson(
+      "SUPER_ADMIN_LOCKED",
+      "Super admin cannot be modified.",
+      409,
+    );
+  }
   if (currentRole === targetRole) {
     return NextResponse.json(
       {

--- a/app/api/admin/users/invite/route.ts
+++ b/app/api/admin/users/invite/route.ts
@@ -30,7 +30,7 @@ import { getServiceRoleClient } from "@/lib/supabase";
 // Side effects: the call creates an auth.users row (email_confirmed_at
 // still null). The handle_new_auth_user trigger from migration 0004
 // fires immediately and inserts the matching opollo_users row with
-// role='viewer', so the invitee shows up in /admin/users as pending
+// role='user', so the invitee shows up in /admin/users as pending
 // before they click the link. After acceptance, the callback exchanges
 // the code for a session and lands them on `next` (default `/`).
 //

--- a/app/api/admin/users/list/route.ts
+++ b/app/api/admin/users/list/route.ts
@@ -27,7 +27,9 @@ export type AdminUserRow = {
   id: string;
   email: string;
   display_name: string | null;
-  role: "admin" | "operator" | "viewer";
+  // AUTH-FOUNDATION P3 — role enum migrated from
+  // (admin, operator, viewer) to (super_admin, admin, user).
+  role: "super_admin" | "admin" | "user";
   created_at: string;
   revoked_at: string | null;
 };

--- a/app/api/briefs/[brief_id]/cancel/route.ts
+++ b/app/api/briefs/[brief_id]/cancel/route.ts
@@ -47,7 +47,7 @@ export async function POST(
   _req: Request,
   { params }: { params: { brief_id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const idCheck = validateUuidParam(params.brief_id, "brief_id");

--- a/app/api/briefs/[brief_id]/commit/route.ts
+++ b/app/api/briefs/[brief_id]/commit/route.ts
@@ -71,7 +71,7 @@ export async function POST(
   req: Request,
   { params }: { params: { brief_id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const idCheck = validateUuidParam(params.brief_id, "brief_id");

--- a/app/api/briefs/[brief_id]/pages/[page_id]/approve/route.ts
+++ b/app/api/briefs/[brief_id]/pages/[page_id]/approve/route.ts
@@ -66,7 +66,7 @@ export async function POST(
   req: Request,
   { params }: { params: { brief_id: string; page_id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const briefIdCheck = validateUuidParam(params.brief_id, "brief_id");

--- a/app/api/briefs/[brief_id]/pages/[page_id]/revise/route.ts
+++ b/app/api/briefs/[brief_id]/pages/[page_id]/revise/route.ts
@@ -77,7 +77,7 @@ export async function POST(
   req: Request,
   { params }: { params: { brief_id: string; page_id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const briefIdCheck = validateUuidParam(params.brief_id, "brief_id");

--- a/app/api/briefs/[brief_id]/pages/route.ts
+++ b/app/api/briefs/[brief_id]/pages/route.ts
@@ -85,7 +85,7 @@ export async function PATCH(
   req: Request,
   { params }: { params: { brief_id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const idCheck = validateUuidParam(params.brief_id, "brief_id");

--- a/app/api/briefs/[brief_id]/run/route.ts
+++ b/app/api/briefs/[brief_id]/run/route.ts
@@ -43,7 +43,7 @@ export async function GET(
   _req: Request,
   { params }: { params: { brief_id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const idCheck = validateUuidParam(params.brief_id, "brief_id");
@@ -101,7 +101,7 @@ export async function POST(
   req: Request,
   { params }: { params: { brief_id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const idCheck = validateUuidParam(params.brief_id, "brief_id");

--- a/app/api/briefs/[brief_id]/run/snapshot/route.ts
+++ b/app/api/briefs/[brief_id]/run/snapshot/route.ts
@@ -63,7 +63,7 @@ export async function GET(
   _req: Request,
   { params }: { params: { brief_id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const briefIdCheck = validateUuidParam(params.brief_id, "brief_id");

--- a/app/api/briefs/upload/route.ts
+++ b/app/api/briefs/upload/route.ts
@@ -59,7 +59,7 @@ function validationError(message: string, details?: Record<string, unknown>): Ne
 }
 
 export async function POST(req: Request): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   let form: FormData;

--- a/app/api/design-systems/[id]/activate/route.ts
+++ b/app/api/design-systems/[id]/activate/route.ts
@@ -18,7 +18,7 @@ const BodySchema = z.object({
 // archives any currently-active DS for the same site, atomically, via the
 // activate_design_system RPC from 0003_m1b_rpcs.sql.
 export async function POST(req: Request, ctx: { params: { id: string } }) {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const param = validateUuidParam(ctx.params.id, "id");

--- a/app/api/design-systems/[id]/archive/route.ts
+++ b/app/api/design-systems/[id]/archive/route.ts
@@ -18,7 +18,7 @@ const BodySchema = z.object({
 // When the target was the site's active DS, the success payload contains
 // warnings[] noting the site now has no active design system (per §M1b Q6).
 export async function POST(req: Request, ctx: { params: { id: string } }) {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const param = validateUuidParam(ctx.params.id, "id");

--- a/app/api/design-systems/[id]/components/[cid]/route.ts
+++ b/app/api/design-systems/[id]/components/[cid]/route.ts
@@ -31,7 +31,7 @@ const PatchBodySchema = UpdateDesignComponentSchema.and(
 );
 
 export async function PATCH(req: Request, ctx: RouteContext) {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const dsParam = validateUuidParam(ctx.params.id, "id");
@@ -66,7 +66,7 @@ export async function PATCH(req: Request, ctx: RouteContext) {
 // expected_version_lock rides as a query param per the M1e plan (DELETE
 // with a body is unreliable across proxies).
 export async function DELETE(req: Request, ctx: RouteContext) {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const dsParam = validateUuidParam(ctx.params.id, "id");

--- a/app/api/design-systems/[id]/components/route.ts
+++ b/app/api/design-systems/[id]/components/route.ts
@@ -37,7 +37,7 @@ const CreateBodySchema = CreateDesignComponentSchema.omit({
 });
 
 export async function POST(req: Request, ctx: RouteContext) {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const param = validateUuidParam(ctx.params.id, "id");

--- a/app/api/design-systems/[id]/templates/[tid]/route.ts
+++ b/app/api/design-systems/[id]/templates/[tid]/route.ts
@@ -31,7 +31,7 @@ const PatchBodySchema = UpdateDesignTemplateSchema.and(
 // elsewhere after a template already referenced it could otherwise leave a
 // dangling ref; this route refuses such writes at the admin layer.
 export async function PATCH(req: Request, ctx: RouteContext) {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const dsParam = validateUuidParam(ctx.params.id, "id");
@@ -59,7 +59,7 @@ export async function PATCH(req: Request, ctx: RouteContext) {
 
 // DELETE /api/design-systems/[id]/templates/[tid]?expected_version_lock=N
 export async function DELETE(req: Request, ctx: RouteContext) {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const dsParam = validateUuidParam(ctx.params.id, "id");

--- a/app/api/design-systems/[id]/templates/route.ts
+++ b/app/api/design-systems/[id]/templates/route.ts
@@ -34,7 +34,7 @@ const CreateBodySchema = CreateDesignTemplateSchema.omit({
 });
 
 export async function POST(req: Request, ctx: RouteContext) {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const param = validateUuidParam(ctx.params.id, "id");

--- a/app/api/optimiser/clients/[id]/ads-customer/route.ts
+++ b/app/api/optimiser/clients/[id]/ads-customer/route.ts
@@ -24,7 +24,7 @@ export async function PUT(
   req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },

--- a/app/api/optimiser/clients/[id]/clarity/route.ts
+++ b/app/api/optimiser/clients/[id]/clarity/route.ts
@@ -18,7 +18,7 @@ export async function PUT(
   req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },

--- a/app/api/optimiser/clients/[id]/ga4-property/route.ts
+++ b/app/api/optimiser/clients/[id]/ga4-property/route.ts
@@ -21,7 +21,7 @@ export async function PUT(
   req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },

--- a/app/api/optimiser/clients/[id]/landing-pages/route.ts
+++ b/app/api/optimiser/clients/[id]/landing-pages/route.ts
@@ -40,7 +40,7 @@ export async function POST(
   req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },
@@ -90,7 +90,7 @@ export async function PATCH(
   req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },

--- a/app/api/optimiser/clients/[id]/onboarded/route.ts
+++ b/app/api/optimiser/clients/[id]/onboarded/route.ts
@@ -10,7 +10,7 @@ export async function POST(
   _req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },

--- a/app/api/optimiser/clients/[id]/route.ts
+++ b/app/api/optimiser/clients/[id]/route.ts
@@ -45,7 +45,7 @@ export async function PATCH(
   req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },

--- a/app/api/optimiser/clients/route.ts
+++ b/app/api/optimiser/clients/route.ts
@@ -32,7 +32,7 @@ export async function GET(): Promise<NextResponse> {
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },

--- a/app/api/optimiser/landing-pages/[id]/import/route.ts
+++ b/app/api/optimiser/landing-pages/[id]/import/route.ts
@@ -14,7 +14,7 @@ export async function POST(
   _req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },

--- a/app/api/optimiser/oauth/ads/callback/route.ts
+++ b/app/api/optimiser/oauth/ads/callback/route.ts
@@ -12,7 +12,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.redirect(new URL(access.to, req.url));
   }

--- a/app/api/optimiser/oauth/ads/start/route.ts
+++ b/app/api/optimiser/oauth/ads/start/route.ts
@@ -7,7 +7,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.redirect(new URL(access.to, req.url));
   }

--- a/app/api/optimiser/oauth/ga4/callback/route.ts
+++ b/app/api/optimiser/oauth/ga4/callback/route.ts
@@ -12,7 +12,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.redirect(new URL(access.to, req.url));
   }

--- a/app/api/optimiser/oauth/ga4/start/route.ts
+++ b/app/api/optimiser/oauth/ga4/start/route.ts
@@ -7,7 +7,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.redirect(new URL(access.to, req.url));
   }

--- a/app/api/optimiser/pages/[id]/rollback/route.ts
+++ b/app/api/optimiser/pages/[id]/rollback/route.ts
@@ -27,7 +27,7 @@ export async function POST(
   req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       {

--- a/app/api/optimiser/pages/import/route.ts
+++ b/app/api/optimiser/pages/import/route.ts
@@ -32,7 +32,7 @@ const BodySchema = z
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
   });
   if (access.kind === "redirect") {
     return NextResponse.json(

--- a/app/api/optimiser/proposals/[id]/approve/route.ts
+++ b/app/api/optimiser/proposals/[id]/approve/route.ts
@@ -16,7 +16,7 @@ export async function POST(
   req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },

--- a/app/api/optimiser/proposals/[id]/create-variant/route.ts
+++ b/app/api/optimiser/proposals/[id]/create-variant/route.ts
@@ -29,7 +29,7 @@ export async function POST(
   req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },

--- a/app/api/optimiser/proposals/[id]/reject/route.ts
+++ b/app/api/optimiser/proposals/[id]/reject/route.ts
@@ -22,7 +22,7 @@ export async function POST(
   req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },

--- a/app/api/optimiser/proposals/[id]/rollback/route.ts
+++ b/app/api/optimiser/proposals/[id]/rollback/route.ts
@@ -15,7 +15,7 @@ export async function POST(
   req: NextRequest,
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator"] });
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin"] });
   if (access.kind === "redirect") {
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "Not authorised" } },

--- a/app/api/optimiser/proposals/[id]/run-status/route.ts
+++ b/app/api/optimiser/proposals/[id]/run-status/route.ts
@@ -18,7 +18,7 @@ export async function GET(
   ctx: { params: { id: string } },
 ): Promise<NextResponse> {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin", "operator"],
+    requiredRoles: ["super_admin", "admin"],
   });
   if (access.kind === "redirect") {
     return NextResponse.json(

--- a/app/api/sites/[id]/appearance/preflight/route.ts
+++ b/app/api/sites/[id]/appearance/preflight/route.ts
@@ -57,7 +57,7 @@ export async function POST(
   _req: Request,
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const idCheck = validateUuidParam(params.id, "id");

--- a/app/api/sites/[id]/appearance/rollback-palette/route.ts
+++ b/app/api/sites/[id]/appearance/rollback-palette/route.ts
@@ -68,7 +68,7 @@ export async function POST(
   req: Request,
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const idCheck = validateUuidParam(params.id, "id");

--- a/app/api/sites/[id]/appearance/sync-palette/route.ts
+++ b/app/api/sites/[id]/appearance/sync-palette/route.ts
@@ -77,7 +77,7 @@ export async function POST(
   req: Request,
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const idCheck = validateUuidParam(params.id, "id");

--- a/app/api/sites/[id]/design-systems/route.ts
+++ b/app/api/sites/[id]/design-systems/route.ts
@@ -36,7 +36,7 @@ const CreateBodySchema = z.object({
 });
 
 export async function POST(req: Request, ctx: RouteContext) {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const param = validateUuidParam(ctx.params.id, "id");

--- a/app/api/sites/[id]/posts/[post_id]/publish/route.ts
+++ b/app/api/sites/[id]/posts/[post_id]/publish/route.ts
@@ -80,7 +80,7 @@ export async function POST(
   req: Request,
   { params }: { params: { id: string; post_id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const siteIdCheck = validateUuidParam(params.id, "id");

--- a/app/api/sites/[id]/posts/[post_id]/unpublish/route.ts
+++ b/app/api/sites/[id]/posts/[post_id]/unpublish/route.ts
@@ -74,7 +74,7 @@ export async function POST(
   req: Request,
   { params }: { params: { id: string; post_id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const siteIdCheck = validateUuidParam(params.id, "id");

--- a/app/api/sites/[id]/posts/route.ts
+++ b/app/api/sites/[id]/posts/route.ts
@@ -64,7 +64,7 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   if (!UUID_RE.test(params.id)) {

--- a/app/api/sites/[id]/route.ts
+++ b/app/api/sites/[id]/route.ts
@@ -74,7 +74,7 @@ export async function PATCH(
   req: Request,
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   if (!UUID_RE.test(params.id)) {
@@ -163,7 +163,7 @@ export async function DELETE(
   _req: Request,
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   if (!UUID_RE.test(params.id)) {

--- a/app/api/sites/[id]/wp-pages/route.ts
+++ b/app/api/sites/[id]/wp-pages/route.ts
@@ -43,7 +43,7 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } },
 ): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   if (!UUID_RE.test(params.id)) {

--- a/app/api/sites/register/route.ts
+++ b/app/api/sites/register/route.ts
@@ -18,7 +18,7 @@ import {
 export const runtime = "nodejs";
 
 export async function POST(req: Request) {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const rlId = gate.user ? `user:${gate.user.id}` : `ip:${getClientIp(req)}`;

--- a/app/api/sites/test-connection/route.ts
+++ b/app/api/sites/test-connection/route.ts
@@ -49,7 +49,7 @@ const StoredSchema = z.object({
 const BodySchema = z.union([ExplicitSchema, StoredSchema]);
 
 export async function POST(req: Request): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const rlId = gate.user ? `user:${gate.user.id}` : `ip:${getClientIp(req)}`;

--- a/app/optimiser/clients/[id]/settings/page.tsx
+++ b/app/optimiser/clients/[id]/settings/page.tsx
@@ -46,9 +46,13 @@ export default async function ClientSettingsPage({
   const client = await getClient(params.id);
   if (!client) notFound();
   // Phase 2 Slice 21 — only admins can toggle assisted approval; the
-  // toggle component renders a read-only badge for operators / viewers.
-  const access = await checkAdminAccess({ requiredRoles: ["admin", "operator", "viewer"] });
-  const isAdmin = access.kind === "allow" && access.user?.role === "admin";
+  // toggle component renders a read-only badge for non-admin viewers.
+  // AUTH-FOUNDATION P3 — open to every authenticated role
+  // (super_admin, admin, user); permission is gated below by isAdmin.
+  const access = await checkAdminAccess({ requiredRoles: ["super_admin", "admin", "user"] });
+  const isAdmin =
+    access.kind === "allow" &&
+    (access.user?.role === "super_admin" || access.user?.role === "admin");
 
   const weights = (client.score_weights as ScoreWeights) ?? DEFAULT_SCORE_WEIGHTS;
   const componentsPresent =

--- a/components/UserRoleActionCell.tsx
+++ b/components/UserRoleActionCell.tsx
@@ -4,7 +4,13 @@ import { useRouter } from "next/navigation";
 import { useState, type ChangeEvent } from "react";
 import { toast } from "sonner";
 
-type Role = "admin" | "operator" | "viewer";
+// AUTH-FOUNDATION P3 — role enum migrated from
+// (admin, operator, viewer) to (super_admin, admin, user).
+// super_admin is the locked top tier; this dropdown only offers
+// admin and user since super_admin can't be assigned via this route
+// (and the row is disabled when the target is already super_admin).
+type Role = "super_admin" | "admin" | "user";
+type AssignableRole = Exclude<Role, "super_admin">;
 
 // ---------------------------------------------------------------------------
 // C-2 — Optimistic UI on role change.
@@ -37,9 +43,10 @@ export function UserRoleActionCell({
   const [submitting, setSubmitting] = useState(false);
 
   const isSelf = selfUserId !== null && selfUserId === userId;
+  const isSuperAdmin = currentRole === "super_admin";
 
   async function handleChange(e: ChangeEvent<HTMLSelectElement>) {
-    const newRole = e.target.value as Role;
+    const newRole = e.target.value as AssignableRole;
     if (newRole === optimisticRole) return;
     const previous = optimisticRole;
 
@@ -80,6 +87,21 @@ export function UserRoleActionCell({
     }
   }
 
+  // super_admin row: render the role as a static label, never a
+  // dropdown. The DB-level guard_super_admin trigger blocks role
+  // changes anyway; surfacing as a dropdown would mislead the
+  // operator into thinking they can demote.
+  if (isSuperAdmin) {
+    return (
+      <span
+        className="inline-flex items-center rounded border border-input bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground"
+        title="Super admin cannot be modified."
+      >
+        super_admin
+      </span>
+    );
+  }
+
   return (
     <select
       value={optimisticRole}
@@ -90,8 +112,7 @@ export function UserRoleActionCell({
       className="rounded border bg-background px-2 py-1 text-xs transition-smooth disabled:opacity-60"
     >
       <option value="admin">admin</option>
-      <option value="operator">operator</option>
-      <option value="viewer">viewer</option>
+      <option value="user">user</option>
     </select>
   );
 }

--- a/lib/__tests__/_auth-helpers.ts
+++ b/lib/__tests__/_auth-helpers.ts
@@ -5,7 +5,8 @@ import { getServiceRoleClient } from "@/lib/supabase";
 // service-role supabase-js client — we want the same HTTP + trigger path
 // the admin API uses, not raw SQL inserts that skip the trigger.
 
-export type TestRole = "admin" | "operator" | "viewer";
+// AUTH-FOUNDATION P3 — role enum migrated to (super_admin, admin, user).
+export type TestRole = "super_admin" | "admin" | "user";
 
 export type SeededAuthUser = {
   id: string;
@@ -60,11 +61,11 @@ export async function cleanupTrackedAuthUsers(): Promise<void> {
 
 /**
  * Creates an auth.users row via the admin API. The
- * handle_new_auth_user trigger (0004 migration) inserts the matching
- * opollo_users row with role='viewer' (or 'admin' if opollo_config's
- * first_admin_email matches). When `overrides.role` is supplied and
- * differs from the trigger's choice, we UPDATE the opollo_users row
- * post-insert so the test gets the requested role.
+ * handle_new_auth_user trigger (0004 + 0057 migrations) inserts the
+ * matching opollo_users row with role='user' (or 'super_admin' if
+ * opollo_config's first_admin_email matches). When `overrides.role`
+ * is supplied and differs from the trigger's choice, we UPDATE the
+ * opollo_users row post-insert so the test gets the requested role.
  *
  * `email_confirm: true` skips Supabase Auth's confirmation flow — we
  * don't want the test harness dealing with inbucket / email links.
@@ -101,8 +102,8 @@ export async function seedAuthUser(overrides?: {
     createdAuthUserIds.add(userId);
   }
 
-  // If a role was requested, reconcile. Default case (viewer) is fine.
-  if (overrides?.role && overrides.role !== "viewer") {
+  // If a role was requested, reconcile. Default case (user) is fine.
+  if (overrides?.role && overrides.role !== "user") {
     const { error: updateErr } = await supabase
       .from("opollo_users")
       .update({ role: overrides.role })
@@ -117,7 +118,7 @@ export async function seedAuthUser(overrides?: {
   return {
     id: userId,
     email,
-    role: overrides?.role ?? "viewer",
+    role: overrides?.role ?? "user",
   };
 }
 

--- a/lib/__tests__/admin-api-gate.test.ts
+++ b/lib/__tests__/admin-api-gate.test.ts
@@ -146,7 +146,7 @@ describe("requireAdminForApi: FEATURE_SUPABASE_AUTH on, kill switch off", () => 
   });
 
   it("returns 403 FORBIDDEN for an operator when admin is required", async () => {
-    const operator = await seedAuthUser({ role: "operator" });
+    const operator = await seedAuthUser({ role: "admin" });
     mockState.client = await signedInClient(operator.email);
 
     const gate = await requireAdminForApi();
@@ -158,7 +158,7 @@ describe("requireAdminForApi: FEATURE_SUPABASE_AUTH on, kill switch off", () => 
   });
 
   it("returns 403 FORBIDDEN for a viewer", async () => {
-    const viewer = await seedAuthUser({ role: "viewer" });
+    const viewer = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(viewer.email);
 
     const gate = await requireAdminForApi();
@@ -179,12 +179,12 @@ describe("requireAdminForApi: FEATURE_SUPABASE_AUTH on, kill switch off", () => 
   });
 
   it("honours a custom roles list (operator allowed when listed)", async () => {
-    const operator = await seedAuthUser({ role: "operator" });
+    const operator = await seedAuthUser({ role: "admin" });
     mockState.client = await signedInClient(operator.email);
 
-    const gate = await requireAdminForApi({ roles: ["admin", "operator"] });
+    const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
     expect(gate.kind).toBe("allow");
     if (gate.kind !== "allow") throw new Error("unreachable");
-    expect(gate.user?.role).toBe("operator");
+    expect(gate.user?.role).toBe("admin");
   });
 });

--- a/lib/__tests__/admin-gate.test.ts
+++ b/lib/__tests__/admin-gate.test.ts
@@ -150,7 +150,7 @@ describe("checkAdminAccess: FEATURE_SUPABASE_AUTH on, kill switch off", () => {
   });
 
   it("redirects viewers to /", async () => {
-    const viewer = await seedAuthUser({ role: "viewer" });
+    const viewer = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(viewer.email);
 
     const result = await checkAdminAccess();
@@ -158,13 +158,13 @@ describe("checkAdminAccess: FEATURE_SUPABASE_AUTH on, kill switch off", () => {
   });
 
   it("allows operators and threads the user through", async () => {
-    const operator = await seedAuthUser({ role: "operator" });
+    const operator = await seedAuthUser({ role: "admin" });
     mockState.client = await signedInClient(operator.email);
 
     const result = await checkAdminAccess();
     expect(result.kind).toBe("allow");
     if (result.kind === "allow") {
-      expect(result.user?.role).toBe("operator");
+      expect(result.user?.role).toBe("admin");
       expect(result.user?.email).toBe(operator.email);
     }
   });
@@ -188,7 +188,7 @@ describe("checkAdminAccess: custom options (M2d-1)", () => {
   });
 
   it("redirects an operator to the insufficientRoleRedirectTo target when admin is required", async () => {
-    const operator = await seedAuthUser({ role: "operator" });
+    const operator = await seedAuthUser({ role: "admin" });
     mockState.client = await signedInClient(operator.email);
 
     const result = await checkAdminAccess({
@@ -210,7 +210,7 @@ describe("checkAdminAccess: custom options (M2d-1)", () => {
   });
 
   it("falls back to the default '/' redirect when no target is supplied", async () => {
-    const operator = await seedAuthUser({ role: "operator" });
+    const operator = await seedAuthUser({ role: "admin" });
     mockState.client = await signedInClient(operator.email);
 
     const result = await checkAdminAccess({ requiredRoles: ["admin"] });

--- a/lib/__tests__/admin-users-invite.test.ts
+++ b/lib/__tests__/admin-users-invite.test.ts
@@ -143,7 +143,7 @@ describe("POST /api/admin/users/invite: auth", () => {
 
   it("returns 403 when caller is operator", async () => {
     process.env.FEATURE_SUPABASE_AUTH = "true";
-    const op = await seedAuthUser({ role: "operator" });
+    const op = await seedAuthUser({ role: "admin" });
     mockState.client = await signedInClient(op.email);
 
     const res = await invitePOST(
@@ -220,7 +220,7 @@ describe("POST /api/admin/users/invite: outcomes", () => {
       // Trigger fired → opollo_users row exists with role='viewer'.
       const row = await readOpolloUserByEmail(inviteEmail);
       expect(row).not.toBeNull();
-      expect(row?.role).toBe("viewer");
+      expect(row?.role).toBe("user");
     } finally {
       await deleteAuthUserByEmail(inviteEmail);
     }
@@ -231,7 +231,7 @@ describe("POST /api/admin/users/invite: outcomes", () => {
     // Seed a second user — that email is now registered in auth.users
     // via the admin API, matching what inviteUserByEmail would collide
     // against.
-    const existing = await seedAuthUser({ role: "viewer" });
+    const existing = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(admin.email);
 
     const res = await invitePOST(

--- a/lib/__tests__/admin-users-list.test.ts
+++ b/lib/__tests__/admin-users-list.test.ts
@@ -104,7 +104,7 @@ describe("GET /api/admin/users/list: auth", () => {
 
   it("returns 403 when the caller is an operator (admin-only)", async () => {
     process.env.FEATURE_SUPABASE_AUTH = "true";
-    const op = await seedAuthUser({ role: "operator" });
+    const op = await seedAuthUser({ role: "admin" });
     mockState.client = await signedInClient(op.email);
 
     const res = await usersListGET();
@@ -115,7 +115,7 @@ describe("GET /api/admin/users/list: auth", () => {
 
   it("returns 403 when the caller is a viewer", async () => {
     process.env.FEATURE_SUPABASE_AUTH = "true";
-    const viewer = await seedAuthUser({ role: "viewer" });
+    const viewer = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(viewer.email);
 
     const res = await usersListGET();
@@ -124,7 +124,7 @@ describe("GET /api/admin/users/list: auth", () => {
 
   it("returns 200 when the flag is off (Basic Auth path)", async () => {
     delete process.env.FEATURE_SUPABASE_AUTH;
-    await seedAuthUser({ role: "viewer" });
+    await seedAuthUser({ role: "user" });
     mockState.client = anonClient();
 
     const res = await usersListGET();
@@ -143,7 +143,7 @@ describe("GET /api/admin/users/list: payload", () => {
     // that ordering by created_at desc is still deterministic because
     // the second insert's now() > the first's.
     await new Promise((r) => setTimeout(r, 10));
-    const viewer = await seedAuthUser({ role: "viewer" });
+    const viewer = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(admin.email);
 
     const res = await usersListGET();
@@ -163,7 +163,7 @@ describe("GET /api/admin/users/list: payload", () => {
 
   it("includes revoked_at on a revoked row", async () => {
     const admin = await seedAuthUser({ role: "admin" });
-    const target = await seedAuthUser({ role: "operator" });
+    const target = await seedAuthUser({ role: "admin" });
 
     const svc = getServiceRoleClient();
     const { error: updateErr } = await svc

--- a/lib/__tests__/admin-users-revoke.test.ts
+++ b/lib/__tests__/admin-users-revoke.test.ts
@@ -131,7 +131,7 @@ afterEach(() => {
 describe("POST /api/admin/users/[id]/revoke: auth + validation", () => {
   it("returns 401 when flag on and no session", async () => {
     process.env.FEATURE_SUPABASE_AUTH = "true";
-    const target = await seedAuthUser({ role: "viewer" });
+    const target = await seedAuthUser({ role: "user" });
     mockState.client = anonClient();
 
     const res = await revokePOST(makeRequest(target.id), {
@@ -142,8 +142,8 @@ describe("POST /api/admin/users/[id]/revoke: auth + validation", () => {
 
   it("returns 403 when caller is operator", async () => {
     process.env.FEATURE_SUPABASE_AUTH = "true";
-    const op = await seedAuthUser({ role: "operator" });
-    const target = await seedAuthUser({ role: "viewer" });
+    const op = await seedAuthUser({ role: "admin" });
+    const target = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(op.email);
 
     const res = await revokePOST(makeRequest(target.id), {
@@ -257,7 +257,7 @@ describe("POST /api/admin/users/[id]/revoke: effects", () => {
 
   it("stamps revoked_at, bans in auth.users, and sweeps sessions", async () => {
     const admin = await seedAuthUser({ role: "admin" });
-    const target = await seedAuthUser({ role: "operator" });
+    const target = await seedAuthUser({ role: "admin" });
     // Seed a refresh token so we can verify it gets swept.
     await signedInClient(target.email);
 
@@ -301,8 +301,8 @@ describe("POST /api/admin/users/[id]/reinstate", () => {
   });
 
   it("requires admin (403 operator)", async () => {
-    const op = await seedAuthUser({ role: "operator" });
-    const target = await seedAuthUser({ role: "viewer" });
+    const op = await seedAuthUser({ role: "admin" });
+    const target = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(op.email);
 
     const res = await reinstatePOST(
@@ -317,7 +317,7 @@ describe("POST /api/admin/users/[id]/reinstate", () => {
 
   it("clears revoked_at and unbans, restoring sign-in", async () => {
     const admin = await seedAuthUser({ role: "admin" });
-    const target = await seedAuthUser({ role: "operator" });
+    const target = await seedAuthUser({ role: "admin" });
     await signedInClient(target.email);
 
     mockState.client = await signedInClient(admin.email);
@@ -355,7 +355,7 @@ describe("POST /api/admin/users/[id]/reinstate", () => {
 
   it("is idempotent on an already-active user with changed: false", async () => {
     const admin = await seedAuthUser({ role: "admin" });
-    const target = await seedAuthUser({ role: "viewer" });
+    const target = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(admin.email);
 
     const res = await reinstatePOST(

--- a/lib/__tests__/admin-users-role.test.ts
+++ b/lib/__tests__/admin-users-role.test.ts
@@ -125,7 +125,7 @@ describe("PATCH /api/admin/users/[id]/role: auth", () => {
     process.env.FEATURE_SUPABASE_AUTH = "true";
     mockState.client = anonClient();
 
-    const user = await seedAuthUser({ role: "viewer" });
+    const user = await seedAuthUser({ role: "user" });
     const res = await roleRoutePATCH(
       makeRequest(user.id, { role: "admin" }),
       { params: { id: user.id } },
@@ -135,8 +135,8 @@ describe("PATCH /api/admin/users/[id]/role: auth", () => {
 
   it("returns 403 when caller is operator", async () => {
     process.env.FEATURE_SUPABASE_AUTH = "true";
-    const op = await seedAuthUser({ role: "operator" });
-    const target = await seedAuthUser({ role: "viewer" });
+    const op = await seedAuthUser({ role: "admin" });
+    const target = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(op.email);
 
     const res = await roleRoutePATCH(
@@ -161,7 +161,7 @@ describe("PATCH /api/admin/users/[id]/role: validation", () => {
     mockState.client = await signedInClient(admin.email);
 
     const res = await roleRoutePATCH(
-      makeRequest("not-a-uuid", { role: "viewer" }),
+      makeRequest("not-a-uuid", { role: "user" }),
       { params: { id: "not-a-uuid" } },
     );
     expect(res.status).toBe(400);
@@ -171,7 +171,7 @@ describe("PATCH /api/admin/users/[id]/role: validation", () => {
 
   it("returns 400 when role is missing", async () => {
     const admin = await seedAuthUser({ role: "admin" });
-    const target = await seedAuthUser({ role: "viewer" });
+    const target = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(admin.email);
 
     const res = await roleRoutePATCH(
@@ -183,7 +183,7 @@ describe("PATCH /api/admin/users/[id]/role: validation", () => {
 
   it("returns 400 when role is an unknown string", async () => {
     const admin = await seedAuthUser({ role: "admin" });
-    const target = await seedAuthUser({ role: "viewer" });
+    const target = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(admin.email);
 
     const res = await roleRoutePATCH(
@@ -195,7 +195,7 @@ describe("PATCH /api/admin/users/[id]/role: validation", () => {
 
   it("returns 400 when body is not JSON", async () => {
     const admin = await seedAuthUser({ role: "admin" });
-    const target = await seedAuthUser({ role: "viewer" });
+    const target = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(admin.email);
 
     const res = await roleRoutePATCH(
@@ -233,7 +233,7 @@ describe("PATCH /api/admin/users/[id]/role: guardrails", () => {
     mockState.client = await signedInClient(admin.email);
 
     const res = await roleRoutePATCH(
-      makeRequest(admin.id, { role: "viewer" }),
+      makeRequest(admin.id, { role: "user" }),
       { params: { id: admin.id } },
     );
     expect(res.status).toBe(409);
@@ -258,7 +258,7 @@ describe("PATCH /api/admin/users/[id]/role: guardrails", () => {
     // still two admins at the moment of the check.
     mockState.client = await signedInClient(admin.email);
     const demote = await roleRoutePATCH(
-      makeRequest(secondAdmin.id, { role: "operator" }),
+      makeRequest(secondAdmin.id, { role: "admin" }),
       { params: { id: secondAdmin.id } },
     );
     expect(demote.status).toBe(200);
@@ -304,7 +304,7 @@ describe("PATCH /api/admin/users/[id]/role: guardrails", () => {
     // State: `admin` is admin; `secondAdmin` is operator. `admin` is
     // the only admin row. Try to demote.
     const res = await roleRoutePATCH(
-      makeRequest(admin.id, { role: "operator" }),
+      makeRequest(admin.id, { role: "admin" }),
       { params: { id: admin.id } },
     );
     expect(res.status).toBe(409);
@@ -341,7 +341,7 @@ describe("PATCH /api/admin/users/[id]/role: guardrails", () => {
       mockState.client = anonClient();
 
       const res = await roleRoutePATCH(
-        makeRequest(activeAdmin.id, { role: "operator" }),
+        makeRequest(activeAdmin.id, { role: "admin" }),
         { params: { id: activeAdmin.id } },
       );
       expect(res.status).toBe(409);
@@ -366,24 +366,24 @@ describe("PATCH /api/admin/users/[id]/role: success", () => {
 
   it("200 with changed:false on a no-op role assignment", async () => {
     const admin = await seedAuthUser({ role: "admin" });
-    const target = await seedAuthUser({ role: "viewer" });
+    const target = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(admin.email);
 
     const res = await roleRoutePATCH(
-      makeRequest(target.id, { role: "viewer" }),
+      makeRequest(target.id, { role: "user" }),
       { params: { id: target.id } },
     );
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.data.changed).toBe(false);
-    expect(body.data.role).toBe("viewer");
-    expect(await readRole(target.id)).toBe("viewer");
+    expect(body.data.role).toBe("user");
+    expect(await readRole(target.id)).toBe("user");
   });
 
   it("promotes viewer → admin", async () => {
     const admin = await seedAuthUser({ role: "admin" });
-    const target = await seedAuthUser({ role: "viewer" });
+    const target = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(admin.email);
 
     const res = await roleRoutePATCH(
@@ -402,10 +402,10 @@ describe("PATCH /api/admin/users/[id]/role: success", () => {
     mockState.client = await signedInClient(admin.email);
 
     const res = await roleRoutePATCH(
-      makeRequest(target.id, { role: "operator" }),
+      makeRequest(target.id, { role: "admin" }),
       { params: { id: target.id } },
     );
     expect(res.status).toBe(200);
-    expect(await readRole(target.id)).toBe("operator");
+    expect(await readRole(target.id)).toBe("admin");
   });
 });

--- a/lib/__tests__/api-design-systems-auth.test.ts
+++ b/lib/__tests__/api-design-systems-auth.test.ts
@@ -269,7 +269,7 @@ describe("role gate — FEATURE_SUPABASE_AUTH off (bypass)", () => {
 describe("role gate — viewer is denied on every mutating route", () => {
   beforeEach(async () => {
     process.env.FEATURE_SUPABASE_AUTH = "true";
-    const viewer = await seedAuthUser({ role: "viewer" });
+    const viewer = await seedAuthUser({ role: "user" });
     mockState.client = await signedInClient(viewer.email);
   });
 
@@ -291,7 +291,7 @@ describe("role gate — operator is allowed (representative routes)", () => {
 
   beforeEach(async () => {
     process.env.FEATURE_SUPABASE_AUTH = "true";
-    const operator = await seedAuthUser({ role: "operator" });
+    const operator = await seedAuthUser({ role: "admin" });
     mockState.client = await signedInClient(operator.email);
   });
 

--- a/lib/__tests__/auth.test.ts
+++ b/lib/__tests__/auth.test.ts
@@ -60,24 +60,24 @@ async function signedInClient(email: string): Promise<SupabaseClient> {
 
 describe("getCurrentUser", () => {
   it("returns id/email/role for a signed-in viewer", async () => {
-    const user = await seedAuthUser({ role: "viewer" });
+    const user = await seedAuthUser({ role: "user" });
     const client = await signedInClient(user.email);
     const result = await getCurrentUser(client);
     expect(result).not.toBeNull();
     expect(result?.id).toBe(user.id);
     expect(result?.email).toBe(user.email);
-    expect(result?.role).toBe("viewer");
+    expect(result?.role).toBe("user");
   });
 
   it("returns the promoted role for admins and operators", async () => {
     const admin = await seedAuthUser({ role: "admin" });
-    const operator = await seedAuthUser({ role: "operator" });
+    const operator = await seedAuthUser({ role: "admin" });
 
     const adminClient = await signedInClient(admin.email);
     const operatorClient = await signedInClient(operator.email);
 
     expect((await getCurrentUser(adminClient))?.role).toBe("admin");
-    expect((await getCurrentUser(operatorClient))?.role).toBe("operator");
+    expect((await getCurrentUser(operatorClient))?.role).toBe("admin");
   });
 
   it("returns null when the client has no session", async () => {
@@ -89,19 +89,19 @@ describe("getCurrentUser", () => {
 
 describe("requireRole", () => {
   it("returns the user when their role matches", async () => {
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     const client = await signedInClient(user.email);
-    const result = await requireRole(client, ["admin", "operator"]);
+    const result = await requireRole(client, ["super_admin", "admin"]);
     expect(result.id).toBe(user.id);
-    expect(result.role).toBe("operator");
+    expect(result.role).toBe("admin");
   });
 
   it("throws AuthError(403) when role does not match", async () => {
-    const user = await seedAuthUser({ role: "viewer" });
+    const user = await seedAuthUser({ role: "user" });
     const client = await signedInClient(user.email);
     let caught: unknown;
     try {
-      await requireRole(client, ["admin", "operator"]);
+      await requireRole(client, ["super_admin", "admin"]);
     } catch (err) {
       caught = err;
     }
@@ -113,7 +113,7 @@ describe("requireRole", () => {
     const client = anonClient();
     let caught: unknown;
     try {
-      await requireRole(client, ["viewer"]);
+      await requireRole(client, ["user"]);
     } catch (err) {
       caught = err;
     }
@@ -125,18 +125,18 @@ describe("requireRole", () => {
 describe("role changes are per-request fresh", () => {
   it("reflects a server-side role demotion on the next getCurrentUser call", async () => {
     // Set up: operator signs in, lib sees them as operator.
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     const client = await signedInClient(user.email);
 
     const before = await getCurrentUser(client);
-    expect(before?.role).toBe("operator");
+    expect(before?.role).toBe("admin");
 
     // An admin (via M2d, via the trigger, via any service-role path)
     // demotes the user to viewer.
     const svc = getServiceRoleClient();
     const { error } = await svc
       .from("opollo_users")
-      .update({ role: "viewer" })
+      .update({ role: "user" })
       .eq("id", user.id);
     expect(error).toBeNull();
 
@@ -144,13 +144,13 @@ describe("role changes are per-request fresh", () => {
     // reflects the new role. No revocation, no re-login. This is the
     // promise that lets M2d skip the sign-out dance for role changes.
     const after = await getCurrentUser(client);
-    expect(after?.role).toBe("viewer");
+    expect(after?.role).toBe("user");
   });
 });
 
 describe("revokeUserSessions — hard revocation", () => {
   it("rejects the user's pre-revocation access token on the next call", async () => {
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     const client = await signedInClient(user.email);
 
     // Sanity: session is live before revocation.
@@ -173,7 +173,7 @@ describe("revokeUserSessions — hard revocation", () => {
   });
 
   it("allows a fresh sign-in after revocation", async () => {
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     await revokeUserSessions(user.id);
 
     // revocation leaves the user enabled — a new sign-in produces a
@@ -183,13 +183,13 @@ describe("revokeUserSessions — hard revocation", () => {
     const client = await signedInClient(user.email);
     const result = await getCurrentUser(client);
     expect(result?.id).toBe(user.id);
-    expect(result?.role).toBe("operator");
+    expect(result?.role).toBe("admin");
   });
 });
 
 describe("signOutAuthUser — soft sweep", () => {
   it("deletes refresh_tokens so silent auto-refresh can't continue", async () => {
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     await signedInClient(user.email);
 
     // Belt check: there's at least one refresh_token row for this user
@@ -210,7 +210,7 @@ describe("signOutAuthUser — soft sweep", () => {
       .select("id,role,revoked_at")
       .eq("id", user.id)
       .maybeSingle();
-    expect(row?.role).toBe("operator");
+    expect(row?.role).toBe("admin");
     expect(row?.revoked_at).toBeNull();
   });
 });

--- a/lib/__tests__/batch-cancel.test.ts
+++ b/lib/__tests__/batch-cancel.test.ts
@@ -140,8 +140,8 @@ let otherOperator: SeededAuthUser;
 beforeEach(async () => {
   process.env.FEATURE_SUPABASE_AUTH = "true";
   admin = await seedAuthUser({ role: "admin" });
-  operator = await seedAuthUser({ role: "operator" });
-  otherOperator = await seedAuthUser({ role: "operator" });
+  operator = await seedAuthUser({ role: "admin" });
+  otherOperator = await seedAuthUser({ role: "admin" });
 });
 
 afterEach(() => {

--- a/lib/__tests__/emergency-route.test.ts
+++ b/lib/__tests__/emergency-route.test.ts
@@ -312,7 +312,7 @@ describe("POST /api/emergency: revoke_user", () => {
   });
 
   it("stamps opollo_users.revoked_at and sweeps refresh tokens", async () => {
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     await signedInClient(user.email);
 
     // Sanity: refresh token exists before revoke.

--- a/lib/__tests__/login-action.test.ts
+++ b/lib/__tests__/login-action.test.ts
@@ -123,7 +123,7 @@ describe("loginAction", () => {
   });
 
   it("returns generic invalid message on wrong password", async () => {
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     const result = await runAction(
       buildFormData({
         email: user.email,
@@ -146,7 +146,7 @@ describe("loginAction", () => {
   });
 
   it("redirects to next on successful sign-in", async () => {
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     const result = await runAction(
       buildFormData({
         email: user.email,
@@ -158,7 +158,7 @@ describe("loginAction", () => {
   });
 
   it("sanitises a malicious next to /admin/sites", async () => {
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     const result = await runAction(
       buildFormData({
         email: user.email,
@@ -170,7 +170,7 @@ describe("loginAction", () => {
   });
 
   it("sanitises a protocol-relative next to /admin/sites", async () => {
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     const result = await runAction(
       buildFormData({
         email: user.email,
@@ -182,7 +182,7 @@ describe("loginAction", () => {
   });
 
   it("defaults next to /admin/sites when omitted", async () => {
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     const result = await runAction(
       buildFormData({
         email: user.email,

--- a/lib/__tests__/m12-1-rls.test.ts
+++ b/lib/__tests__/m12-1-rls.test.ts
@@ -61,11 +61,11 @@ describe("M12-1: RLS matrix for briefs + brief_pages + brief_runs + site_convent
 
   beforeAll(async () => {
     admin = await seedAuthUser({ email: "m12-1-rls-admin@opollo.test", role: "admin", persistent: true });
-    operator = await seedAuthUser({ email: "m12-1-rls-op@opollo.test", role: "operator", persistent: true });
-    viewer = await seedAuthUser({ email: "m12-1-rls-viewer@opollo.test", role: "viewer", persistent: true });
+    operator = await seedAuthUser({ email: "m12-1-rls-op@opollo.test", role: "admin", persistent: true });
+    viewer = await seedAuthUser({ email: "m12-1-rls-viewer@opollo.test", role: "user", persistent: true });
     // seedAuthUser creates an opollo_users row via trigger; for the "no role"
     // user we delete that row each test so public.auth_role() returns NULL.
-    noRole = await seedAuthUser({ email: "m12-1-rls-norole@opollo.test", role: "viewer", persistent: true });
+    noRole = await seedAuthUser({ email: "m12-1-rls-norole@opollo.test", role: "user", persistent: true });
 
     adminClient = buildClient(await signInAs(admin));
     operatorClient = buildClient(await signInAs(operator));
@@ -91,8 +91,8 @@ describe("M12-1: RLS matrix for briefs + brief_pages + brief_runs + site_convent
     // _setup.ts TRUNCATEs opollo_users — re-seed so auth_role() resolves.
     await svc.from("opollo_users").insert([
       { id: admin.id, email: admin.email, role: "admin" },
-      { id: operator.id, email: operator.email, role: "operator" },
-      { id: viewer.id, email: viewer.email, role: "viewer" },
+      { id: operator.id, email: operator.email, role: "admin" },
+      { id: viewer.id, email: viewer.email, role: "user" },
       // Intentionally skip noRole so auth_role() returns NULL for them.
     ]);
 

--- a/lib/__tests__/m12-1-schema.test.ts
+++ b/lib/__tests__/m12-1-schema.test.ts
@@ -72,7 +72,7 @@ describe("M12-1: briefs / brief_pages / brief_runs / site_conventions", () => {
   beforeAll(async () => {
     opUser = await seedAuthUser({
       email: "m12-1-schema-op@opollo.test",
-      role: "operator",
+      role: "admin",
       persistent: true,
     });
   });
@@ -364,7 +364,7 @@ describe("M12-1: briefs / brief_pages / brief_runs / site_conventions", () => {
     await svc.from("opollo_users").insert({
       id: opUser.id,
       email: opUser.email,
-      role: "operator",
+      role: "admin",
     });
 
     const { id: briefId } = await insertBrief({

--- a/lib/__tests__/m2a-auth-link.test.ts
+++ b/lib/__tests__/m2a-auth-link.test.ts
@@ -37,7 +37,7 @@ describe("M2a: handle_new_auth_user trigger", () => {
     const row = await readOpolloUser(user.id);
     expect(row).not.toBeNull();
     expect(row?.email).toBe(user.email);
-    expect(row?.role).toBe("viewer");
+    expect(row?.role).toBe("user");
   });
 
   it("promotes to 'admin' when email matches opollo_config.first_admin_email", async () => {
@@ -53,7 +53,7 @@ describe("M2a: handle_new_auth_user trigger", () => {
     await setFirstAdminEmail("boss@opollo.test");
     const user = await seedAuthUser({ email: "intern@opollo.test" });
     const row = await readOpolloUser(user.id);
-    expect(row?.role).toBe("viewer");
+    expect(row?.role).toBe("user");
   });
 });
 
@@ -107,7 +107,7 @@ describe("M2a: public.auth_role() helper", () => {
   // use a direct pg connection where we can SET LOCAL the claim to
   // simulate an authenticated session.
   it("returns the user's role when called as that user", async () => {
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     const pg = new Client({ connectionString: DB_URL });
     await pg.connect();
     try {
@@ -117,7 +117,7 @@ describe("M2a: public.auth_role() helper", () => {
       // but this is simpler from psql.
       await pg.query(`SET LOCAL "request.jwt.claim.sub" = '${user.id}'`);
       const res = await pg.query("SELECT public.auth_role() AS role");
-      expect(res.rows[0].role).toBe("operator");
+      expect(res.rows[0].role).toBe("admin");
       await pg.query("COMMIT");
     } finally {
       await pg.end();

--- a/lib/__tests__/m2b-rls.test.ts
+++ b/lib/__tests__/m2b-rls.test.ts
@@ -62,12 +62,12 @@ describe("M2b: user-scoped RLS policies", () => {
     });
     operator = await seedAuthUser({
       email: "m2b-operator@opollo.test",
-      role: "operator",
+      role: "admin",
       persistent: true,
     });
     viewer = await seedAuthUser({
       email: "m2b-viewer@opollo.test",
-      role: "viewer",
+      role: "user",
       persistent: true,
     });
 
@@ -84,8 +84,8 @@ describe("M2b: user-scoped RLS policies", () => {
     const svc = getServiceRoleClient();
     await svc.from("opollo_users").insert([
       { id: admin.id, email: admin.email, role: "admin" },
-      { id: operator.id, email: operator.email, role: "operator" },
-      { id: viewer.id, email: viewer.email, role: "viewer" },
+      { id: operator.id, email: operator.email, role: "admin" },
+      { id: viewer.id, email: viewer.email, role: "user" },
     ]);
   });
 
@@ -583,11 +583,11 @@ describe("M2b: user-scoped RLS policies", () => {
     it("admin UPDATE: can promote another user", async () => {
       const { data, error } = await adminClient
         .from("opollo_users")
-        .update({ role: "operator" })
+        .update({ role: "admin" })
         .eq("id", viewer.id)
         .select("id, role");
       expect(error).toBeNull();
-      expect(data?.[0]?.role).toBe("operator");
+      expect(data?.[0]?.role).toBe("admin");
     });
 
     it("operator UPDATE: filtered — no admin_write policy matches", async () => {

--- a/lib/__tests__/m3-schema.test.ts
+++ b/lib/__tests__/m3-schema.test.ts
@@ -406,12 +406,12 @@ describe("M3-1 — RLS policies", () => {
   beforeAll(async () => {
     creator = await seedAuthUser({
       email: "m3-creator@opollo.test",
-      role: "operator",
+      role: "admin",
       persistent: true,
     });
     otherOperator = await seedAuthUser({
       email: "m3-other@opollo.test",
-      role: "operator",
+      role: "admin",
       persistent: true,
     });
     admin = await seedAuthUser({
@@ -421,7 +421,7 @@ describe("M3-1 — RLS policies", () => {
     });
     viewer = await seedAuthUser({
       email: "m3-viewer@opollo.test",
-      role: "viewer",
+      role: "user",
       persistent: true,
     });
 

--- a/lib/__tests__/m4-schema.test.ts
+++ b/lib/__tests__/m4-schema.test.ts
@@ -79,12 +79,12 @@ describe("M4-1: image-library schema", () => {
     });
     operator = await seedAuthUser({
       email: "m4-operator@opollo.test",
-      role: "operator",
+      role: "admin",
       persistent: true,
     });
     viewer = await seedAuthUser({
       email: "m4-viewer@opollo.test",
-      role: "viewer",
+      role: "user",
       persistent: true,
     });
     adminClient = buildClient(await signInAs(admin));
@@ -105,8 +105,8 @@ describe("M4-1: image-library schema", () => {
     const svc = getServiceRoleClient();
     await svc.from("opollo_users").insert([
       { id: admin.id, email: admin.email, role: "admin" },
-      { id: operator.id, email: operator.email, role: "operator" },
-      { id: viewer.id, email: viewer.email, role: "viewer" },
+      { id: operator.id, email: operator.email, role: "admin" },
+      { id: viewer.id, email: viewer.email, role: "user" },
     ]);
   });
 

--- a/lib/__tests__/middleware.test.ts
+++ b/lib/__tests__/middleware.test.ts
@@ -306,7 +306,7 @@ describe("middleware: FEATURE_SUPABASE_AUTH on, valid session", () => {
     await clearKillSwitchRow();
     __resetAuthKillSwitchCacheForTests();
 
-    const user = await seedAuthUser({ role: "viewer" });
+    const user = await seedAuthUser({ role: "user" });
     const cookies = await buildSessionCookies(user.email);
 
     const res = await middleware(makeRequest("/admin/sites", { cookies }));

--- a/lib/__tests__/posts.test.ts
+++ b/lib/__tests__/posts.test.ts
@@ -87,7 +87,7 @@ async function seedPost(
 describe("createPost", () => {
   it("creates a draft post with content_type='post' and version_lock=1", async () => {
     const site = await seedSite({ name: "C1", prefix: "cp1" });
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     const res = await createPost({
       site_id: site.id,
       title: "Hello world",
@@ -244,8 +244,8 @@ describe("listPostsForSite — filter composition", () => {
 
   it("applies author_id filter", async () => {
     const site = await seedSite({ name: "LAu", prefix: "lau1" });
-    const alice = await seedAuthUser({ role: "operator" });
-    const bob = await seedAuthUser({ role: "operator" });
+    const alice = await seedAuthUser({ role: "admin" });
+    const bob = await seedAuthUser({ role: "admin" });
     const aliceId = await seedPost(site.id, {
       slug: "alice",
       title: "Alice",
@@ -441,7 +441,7 @@ describe("updatePostMetadata — happy path", () => {
       slug: "attrib",
       title: "Attrib",
     });
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     const res = await updatePostMetadata(site.id, postId, {
       expected_version: 1,
       updated_by: user.id,
@@ -603,7 +603,7 @@ describe("updatePostMetadata — error paths", () => {
 describe("softDeletePost", () => {
   it("marks deleted_at + bumps version_lock and excludes from default reads", async () => {
     const site = await seedSite({ name: "S1", prefix: "s1p" });
-    const user = await seedAuthUser({ role: "operator" });
+    const user = await seedAuthUser({ role: "admin" });
     const postId = await seedPost(site.id, { slug: "rm", title: "Remove me" });
     const res = await softDeletePost(site.id, postId, {
       expected_version: 1,

--- a/lib/__tests__/reset-admin-password-route.test.ts
+++ b/lib/__tests__/reset-admin-password-route.test.ts
@@ -371,7 +371,7 @@ describe("POST /api/ops/reset-admin-password: target guard", () => {
 
   it("returns 403 when the matching user is an operator", async () => {
     mockState.lookupResult = {
-      data: { id: ADMIN_UUID, role: "operator", revoked_at: null },
+      data: { id: ADMIN_UUID, role: "admin", revoked_at: null },
       error: null,
     };
     const res = await resetAdminPasswordPOST(
@@ -388,7 +388,7 @@ describe("POST /api/ops/reset-admin-password: target guard", () => {
 
   it("returns 403 when the matching user is a viewer", async () => {
     mockState.lookupResult = {
-      data: { id: ADMIN_UUID, role: "viewer", revoked_at: null },
+      data: { id: ADMIN_UUID, role: "user", revoked_at: null },
       error: null,
     };
     const res = await resetAdminPasswordPOST(

--- a/lib/admin-gate.ts
+++ b/lib/admin-gate.ts
@@ -49,7 +49,10 @@ import { isAuthKillSwitchOn } from "@/lib/auth-kill-switch";
 // back to /admin/sites.
 // ---------------------------------------------------------------------------
 
-export const ADMIN_ROLES: readonly Role[] = ["admin", "operator"];
+// AUTH-FOUNDATION P3: trusted-operator surfaces require super_admin
+// OR admin. Migration 0057 mapped the legacy admin+operator pair to
+// super_admin+admin, preserving the same trusted-operator semantics.
+export const ADMIN_ROLES: readonly Role[] = ["super_admin", "admin"];
 
 export type AdminAccessOptions = {
   /** Which roles are allowed. Defaults to ADMIN_ROLES (admin + operator). */

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -32,7 +32,13 @@ import { getServiceRoleClient } from "@/lib/supabase";
 //     middleware path.
 // ---------------------------------------------------------------------------
 
-export type Role = "admin" | "operator" | "viewer";
+// AUTH-FOUNDATION P3 (2026-04-30): role enum migrated from
+// (admin, operator, viewer) to (super_admin, admin, user). Migration
+// 0057 maps existing rows: viewer→user, operator→admin, admin stays
+// admin (with hi@opollo.com promoted to super_admin via the same
+// migration). Trusted-operator gating that previously required
+// admin OR operator now requires super_admin OR admin.
+export type Role = "super_admin" | "admin" | "user";
 
 export type SessionUser = {
   id: string;

--- a/supabase/migrations/0057_auth_foundation_roles_and_invites.sql
+++ b/supabase/migrations/0057_auth_foundation_roles_and_invites.sql
@@ -1,0 +1,240 @@
+-- 0057 — AUTH-FOUNDATION P3: super_admin tier + role rename + invites + audit log.
+--
+-- Replaces the legacy three-role enum (admin, operator, viewer) with the
+-- AUTH-FOUNDATION brief's three-role enum (super_admin, admin, user) and
+-- lays the schema for the custom invite + audit-log flows that supersede
+-- the existing Supabase magic-link invite path.
+--
+-- Changes:
+--
+-- 1. opollo_users.role:
+--      - DROP old CHECK (admin | operator | viewer)
+--      - ADD new CHECK (super_admin | admin | user)
+--      - Map existing rows:
+--          viewer  → user        (1:1)
+--          operator → admin       (consolidate; operators were already
+--                                  trusted-but-not-supreme)
+--          admin   → admin        (kept, will be auto-promoted to
+--                                  super_admin below for hi@opollo.com)
+--      - DEFAULT to 'user' (handle_new_auth_user trigger still sets
+--        super_admin / user explicitly via opollo_config; the column
+--        default is the safety net for direct inserts that bypass the
+--        trigger)
+--
+-- 2. handle_new_auth_user trigger updated:
+--      - first_admin_email → super_admin (was admin)
+--      - everyone else     → user (was viewer)
+--
+-- 3. opollo_config.first_admin_email upserted to 'hi@opollo.com'
+--    (canonical super_admin per the brief)
+--
+-- 4. opollo_users row for hi@opollo.com upserted with role='super_admin'
+--    so the existing bootstrap admin is preserved at the top tier even
+--    if they were created before this migration ran.
+--
+-- 5. New trigger guard_super_admin: prevents DELETE on the
+--    hi@opollo.com row, and prevents UPDATE that changes the role
+--    away from 'super_admin' OR changes the email. This is the
+--    DB-level "super_admin cannot be removed" enforcement from the
+--    brief.
+--
+-- 6. invites table: per-invite tracking with token_hash (sha-256 of
+--    a 32-byte random; raw token only sent in email, never stored).
+--    24-hour expiry; status enum (pending | accepted | expired |
+--    revoked); invited_by FK to opollo_users.
+--
+-- 7. user_audit_log table: append-only audit of user-management
+--    actions. Writes happen IN THE SAME TRANSACTION as the action
+--    (enforced at the application layer via supabase.from(...).insert
+--    + supabase.from('user_audit_log').insert in a wrapped routine).
+--
+-- Forward-only. The app code in lib/auth.ts + lib/admin-gate.ts
+-- updates in lockstep with this migration so main stays green.
+
+-- ----------------------------------------------------------------------------
+-- 1. opollo_users.role enum migration
+-- ----------------------------------------------------------------------------
+
+-- Drop the old CHECK first so the data migration below doesn't trip it.
+ALTER TABLE opollo_users
+  DROP CONSTRAINT IF EXISTS opollo_users_role_check;
+
+-- Map legacy roles. operator → admin (work-day operators continue to
+-- have the admin powers they had); viewer → user (no admin access);
+-- admin stays admin (super_admin promotion happens below).
+UPDATE opollo_users SET role = 'user'  WHERE role = 'viewer';
+UPDATE opollo_users SET role = 'admin' WHERE role = 'operator';
+
+-- Re-add the CHECK with the new enum.
+ALTER TABLE opollo_users
+  ADD CONSTRAINT opollo_users_role_check
+    CHECK (role IN ('super_admin', 'admin', 'user'));
+
+-- Default 'user' for direct inserts that bypass the trigger.
+ALTER TABLE opollo_users
+  ALTER COLUMN role SET DEFAULT 'user';
+
+COMMENT ON COLUMN opollo_users.role IS
+  'AUTH-FOUNDATION P3 enum (added 2026-04-30). super_admin: hi@opollo.com only, undeletable, all powers. admin: invite/remove role=user, no promotions. user: no /admin access. The handle_new_auth_user trigger sets super_admin for the first_admin_email config value and user for everyone else.';
+
+-- ----------------------------------------------------------------------------
+-- 2. handle_new_auth_user trigger update
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.handle_new_auth_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_first_admin_email text;
+  v_role              text;
+BEGIN
+  SELECT value
+    INTO v_first_admin_email
+    FROM public.opollo_config
+    WHERE key = 'first_admin_email';
+
+  IF v_first_admin_email IS NOT NULL AND NEW.email = v_first_admin_email THEN
+    v_role := 'super_admin';
+  ELSE
+    v_role := 'user';
+  END IF;
+
+  INSERT INTO public.opollo_users (id, email, role)
+    VALUES (NEW.id, NEW.email, v_role)
+    ON CONFLICT (id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+-- ----------------------------------------------------------------------------
+-- 3. opollo_config.first_admin_email upsert + super_admin row promotion
+-- ----------------------------------------------------------------------------
+
+INSERT INTO opollo_config (key, value)
+  VALUES ('first_admin_email', 'hi@opollo.com')
+  ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+
+-- If hi@opollo.com already has an opollo_users row (e.g. they were
+-- created via the previous bootstrap as 'admin'), promote them.
+UPDATE opollo_users
+   SET role = 'super_admin'
+ WHERE email = 'hi@opollo.com';
+
+-- ----------------------------------------------------------------------------
+-- 4. guard_super_admin trigger — DB-level "super_admin cannot be removed"
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.guard_super_admin()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- DELETE: block if the row is the hi@opollo.com super_admin.
+  IF (TG_OP = 'DELETE') THEN
+    IF OLD.email = 'hi@opollo.com' AND OLD.role = 'super_admin' THEN
+      RAISE EXCEPTION 'SUPER_ADMIN_LOCKED: hi@opollo.com cannot be deleted';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  -- UPDATE: block role change OR email change on the super_admin row.
+  IF (TG_OP = 'UPDATE') THEN
+    IF OLD.email = 'hi@opollo.com' AND OLD.role = 'super_admin' THEN
+      IF NEW.role <> 'super_admin' THEN
+        RAISE EXCEPTION 'SUPER_ADMIN_LOCKED: hi@opollo.com role cannot be changed';
+      END IF;
+      IF NEW.email <> OLD.email THEN
+        RAISE EXCEPTION 'SUPER_ADMIN_LOCKED: hi@opollo.com email cannot be changed';
+      END IF;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS guard_super_admin_trigger ON opollo_users;
+CREATE TRIGGER guard_super_admin_trigger
+  BEFORE UPDATE OR DELETE ON opollo_users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.guard_super_admin();
+
+-- ----------------------------------------------------------------------------
+-- 5. invites table
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE invites (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email        text NOT NULL,
+  role         text NOT NULL
+    CHECK (role IN ('admin', 'user')),  -- never invite to super_admin
+  token_hash   text NOT NULL UNIQUE,    -- sha256 of 32-byte random; raw token only ever in email
+  invited_by   uuid REFERENCES opollo_users(id) ON DELETE SET NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  expires_at   timestamptz NOT NULL DEFAULT (now() + interval '24 hours'),
+  accepted_at  timestamptz,
+  status       text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'accepted', 'expired', 'revoked'))
+);
+
+-- Inbox-style queries (operator views pending invites for an email,
+-- accept-invite endpoint looks up by token_hash).
+CREATE INDEX invites_email_status_idx ON invites (email, status);
+CREATE INDEX invites_status_expires_idx ON invites (status, expires_at);
+
+-- Partial unique: at most one pending invite per email at a time.
+-- Accepted / expired / revoked rows don't block future invites.
+CREATE UNIQUE INDEX invites_pending_email_uniq
+  ON invites (email)
+  WHERE status = 'pending';
+
+ALTER TABLE invites ENABLE ROW LEVEL SECURITY;
+CREATE POLICY service_role_all ON invites
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE invites IS
+  'AUTH-FOUNDATION P3 invite tracking. token_hash is sha256 of a 32-byte random; the raw token only ever appears in the invite email. 24-hour expiry by default. Added 2026-04-30 (P3.1).';
+
+-- ----------------------------------------------------------------------------
+-- 6. user_audit_log table
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE user_audit_log (
+  id            bigserial PRIMARY KEY,
+  actor_id      uuid REFERENCES opollo_users(id) ON DELETE SET NULL,
+  action        text NOT NULL
+    CHECK (action IN (
+      'invite_sent',
+      'invite_revoked',
+      'invite_accepted',
+      'user_removed',
+      'user_reinstated',
+      'role_changed'
+    )),
+  target_email  text NOT NULL,
+  metadata      jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX user_audit_log_created_idx
+  ON user_audit_log (created_at DESC);
+
+CREATE INDEX user_audit_log_target_idx
+  ON user_audit_log (target_email, created_at DESC);
+
+CREATE INDEX user_audit_log_actor_idx
+  ON user_audit_log (actor_id, created_at DESC);
+
+ALTER TABLE user_audit_log ENABLE ROW LEVEL SECURITY;
+CREATE POLICY service_role_all ON user_audit_log
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE user_audit_log IS
+  'AUTH-FOUNDATION P3 user-management audit. Append-only; writes happen in the same transaction as the action (enforced at the application layer). Read by the /admin/users/audit super-admin viewer. Added 2026-04-30 (P3.1).';

--- a/supabase/rollbacks/0057_auth_foundation_roles_and_invites.down.sql
+++ b/supabase/rollbacks/0057_auth_foundation_roles_and_invites.down.sql
@@ -1,0 +1,65 @@
+-- Rollback for 0057_auth_foundation_roles_and_invites.sql.
+--
+-- Caveats:
+--   - The role rename viewer→user / operator→admin is data-lossy on
+--     the way back: there's no record of which 'user' rows were
+--     originally 'viewer'. This rollback maps user→viewer for ALL
+--     non-super_admin / non-admin rows; if you had genuine 'admin'
+--     rows that came from operator promotions, they stay as admin.
+--   - The super_admin trigger guard is dropped, so hi@opollo.com is
+--     once again deletable.
+--   - invites + user_audit_log rows are dropped along with their
+--     tables — this is intentional; their data only makes sense
+--     under the P3 schema.
+
+DROP TABLE IF EXISTS user_audit_log;
+DROP TABLE IF EXISTS invites;
+
+DROP TRIGGER IF EXISTS guard_super_admin_trigger ON opollo_users;
+DROP FUNCTION IF EXISTS public.guard_super_admin();
+
+-- Restore the original handle_new_auth_user (admin / viewer).
+CREATE OR REPLACE FUNCTION public.handle_new_auth_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  v_first_admin_email text;
+  v_role              text;
+BEGIN
+  SELECT value
+    INTO v_first_admin_email
+    FROM public.opollo_config
+    WHERE key = 'first_admin_email';
+
+  IF v_first_admin_email IS NOT NULL AND NEW.email = v_first_admin_email THEN
+    v_role := 'admin';
+  ELSE
+    v_role := 'viewer';
+  END IF;
+
+  INSERT INTO public.opollo_users (id, email, role)
+    VALUES (NEW.id, NEW.email, v_role)
+    ON CONFLICT (id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Restore the role enum (admin / operator / viewer).
+ALTER TABLE opollo_users
+  DROP CONSTRAINT IF EXISTS opollo_users_role_check;
+
+UPDATE opollo_users SET role = 'viewer' WHERE role = 'user';
+UPDATE opollo_users SET role = 'admin' WHERE role = 'super_admin';
+-- 'admin' rows that were originally 'operator' stay as 'admin' — no
+-- way to disambiguate post-rollback.
+
+ALTER TABLE opollo_users
+  ADD CONSTRAINT opollo_users_role_check
+    CHECK (role IN ('admin', 'operator', 'viewer'));
+
+ALTER TABLE opollo_users
+  ALTER COLUMN role SET DEFAULT 'viewer';


### PR DESCRIPTION
## Summary

Foundational sub-PR of AUTH-FOUNDATION phase 3. Migrates the legacy three-role enum (admin, operator, viewer) to the brief's three-role enum (super_admin, admin, user) and lays the schema for the custom invite + audit-log flows that supersede the existing Supabase magic-link invite path.

## What ships

### Migration 0057
1. \`opollo_users.role\` — drop old CHECK, map viewer→user + operator→admin, add new CHECK (super_admin | admin | user), default 'user'.
2. \`handle_new_auth_user\` trigger updated: first_admin_email → super_admin, everyone else → user.
3. \`opollo_config.first_admin_email\` upserted to \`hi@opollo.com\`.
4. \`opollo_users\` row for hi@opollo.com promoted to super_admin (handles existing 'admin' bootstrap).
5. New \`guard_super_admin\` trigger: blocks DELETE / role-change / email-change on the hi@opollo.com row. DB-level enforcement.
6. New \`invites\` table — token_hash sha256, 24h expiry, status enum, partial unique index on pending email.
7. New \`user_audit_log\` table — append-only, action enum, JSONB metadata.

### App-code updates (lockstep so main stays green)

- \`lib/auth.ts\` Role type → \`(super_admin | admin | user)\`.
- \`lib/admin-gate.ts\` ADMIN_ROLES → \`[super_admin, admin]\`.
- 75 call-sites bulk-renamed \`requiredRoles: [\"admin\", \"operator\"]\` → \`[\"super_admin\", \"admin\"]\`. Same trusted-operator semantics.
- \`/api/admin/users/[id]/role\`: RoleSchema → \`[admin, user]\` (super_admin not assignable). New 409 SUPER_ADMIN_LOCKED for clarity.
- \`AdminUserRow\` type updated.
- \`UserRoleActionCell\`: dropdown options → admin / user; super_admin rows render as a static badge.
- \`/optimiser/clients/[id]/settings\` gate broadened to all three new roles (page renders read-only for non-admins).
- 9 test files + \`_auth-helpers.ts\` updated.

## Risks identified and mitigated

- **Bulk role-string rename (75 files)** — typecheck on the new Role union catches any literal string that doesn't match. Lint + typecheck + build green is the safety net.
- **\`guard_super_admin\` trigger** uses BEFORE DELETE/UPDATE — exception bubbles up cleanly as a Postgres error so route handlers surface it normally.
- **\`invites_pending_email_uniq\` partial index** lets accepted/expired/revoked rows pile up without blocking re-invite. P3.2 surfaces 409 with clear copy.
- **Existing magic-link \`/api/admin/users/invite\` route** still works under the new enum. P3.2 replaces its implementation; URL stays the same.

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅

## Test plan

- [ ] Migration applies cleanly in staging
- [ ] hi@opollo.com shows as super_admin in /admin/users
- [ ] Existing admin/operator users land as admin; viewer users land as user
- [ ] Try to demote hi@opollo.com via the UI — get 409 SUPER_ADMIN_LOCKED
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)