### PR TITLE
feat(p3-2): custom invite/accept-invite flow + email + atomic audit

### DIFF
--- a/app/api/admin/invites/[id]/route.ts
+++ b/app/api/admin/invites/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { revokeInvite } from "@/lib/invites";
+
+// AUTH-FOUNDATION P3.2 — DELETE /api/admin/invites/[id].
+//
+// Marks a pending invite revoked + writes the matching audit row in
+// one transaction (via the revoke_invite Postgres function).
+//
+// Both super_admin and admin can revoke (the row's existence in
+// pending state is the operative signal; preventing role escalation
+// happens at create-time, not revoke-time).
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "VALIDATION_FAILED", message: "Invite id must be a UUID." },
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await revokeInvite({
+    inviteId: params.id,
+    actorId: gate.user?.id ?? null,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { ok: false, error: result.error },
+      { status: 500 },
+    );
+  }
+  if (!result.revoked) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "STATUS_CONFLICT",
+          message: "Invite is no longer pending — already accepted, revoked, or expired.",
+        },
+      },
+      { status: 409 },
+    );
+  }
+  return NextResponse.json({ ok: true, data: { revoked: true } });
+}

--- a/app/api/admin/invites/route.ts
+++ b/app/api/admin/invites/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { buildAuthRedirectUrl } from "@/lib/auth-redirect";
+import { sendEmail } from "@/lib/email/sendgrid";
+import { renderInviteEmail } from "@/lib/email/templates/invite";
+import { createInvite } from "@/lib/invites";
+import { logger } from "@/lib/logger";
+import {
+  checkRateLimit,
+  getClientIp,
+  rateLimitExceeded,
+} from "@/lib/rate-limit";
+
+// AUTH-FOUNDATION P3.2 — POST /api/admin/invites.
+//
+// Per-actor role gating per the brief's role matrix:
+//   - super_admin: can invite admin OR user
+//   - admin:       can invite user only (not admin)
+//   - user:        403 (gate denies)
+//
+// Body: { email, role: 'admin' | 'user' }
+// Returns: { ok: true, data: { invite_id, email, role, expires_at, accept_url } }
+//        | { ok: false, error: { code, message } }
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z
+  .object({
+    email: z.string().email().max(254),
+    role: z.enum(["admin", "user"]),
+  })
+  .strict();
+
+function errJson(code: string, message: string, status: number): NextResponse {
+  return NextResponse.json(
+    { ok: false, error: { code, message } },
+    { status },
+  );
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const gate = await requireAdminForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  // Rate limit: per-actor when authenticated, per-IP otherwise. Reuses
+  // the existing 'invite' bucket (20/hour).
+  const rlId = gate.user ? `user:${gate.user.id}` : `ip:${getClientIp(req)}`;
+  const rl = await checkRateLimit("invite", rlId);
+  if (!rl.ok) return rateLimitExceeded(rl);
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = null;
+  }
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body must be { email, role: 'admin' | 'user' }.",
+          details: { issues: parsed.error.issues },
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  // Per-actor role guard — admin can only invite role=user.
+  // (super_admin can invite any. The /admin/users UI hides the
+  // role dropdown options accordingly; this gate is defence in depth.)
+  if (
+    gate.user &&
+    gate.user.role === "admin" &&
+    parsed.data.role !== "user"
+  ) {
+    return errJson(
+      "FORBIDDEN",
+      "Admins can only invite role=user. Promote the user later requires a super_admin.",
+      403,
+    );
+  }
+
+  const result = await createInvite({
+    email: parsed.data.email,
+    role: parsed.data.role,
+    invitedBy: gate.user?.id ?? null,
+  });
+
+  if (!result.ok) {
+    const status =
+      result.error.code === "PENDING_EXISTS" ||
+      result.error.code === "ACTIVE_USER_EXISTS"
+        ? 409
+        : result.error.code === "INVALID_ROLE"
+          ? 400
+          : 500;
+    return errJson(result.error.code, result.error.message, status);
+  }
+
+  // Build the accept URL. The auth-redirect helper already resolves
+  // NEXT_PUBLIC_SITE_URL → request origin → localhost in that order
+  // so dev / preview / prod all just work.
+  const acceptUrl = buildAuthRedirectUrl(
+    `/auth/accept-invite?token=${encodeURIComponent(result.raw_token)}`,
+    req,
+  );
+
+  // Render + send. Email failure is logged but does NOT roll back the
+  // invite — the action_link can be copy-pasted to the invitee out of
+  // band if delivery is broken (matches the brief's spec).
+  const email = renderInviteEmail({
+    invitee_email: parsed.data.email,
+    invited_by_email: gate.user?.email ?? "an Opollo admin",
+    role: parsed.data.role,
+    accept_url: acceptUrl,
+    expires_at: result.expires_at,
+  });
+  const sendResult = await sendEmail({
+    to: parsed.data.email,
+    subject: email.subject,
+    html: email.html,
+    text: email.text,
+  });
+  if (!sendResult.ok) {
+    logger.warn("admin.invites.email_send_failed", {
+      invite_id: result.invite_id,
+      email: parsed.data.email,
+      err_code: sendResult.error.code,
+    });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    data: {
+      invite_id: result.invite_id,
+      email: parsed.data.email,
+      role: parsed.data.role,
+      expires_at: result.expires_at,
+      // Surface the accept URL so an operator can copy-paste if email
+      // delivery failed (mirrors the legacy magic-link route's pattern).
+      accept_url: sendResult.ok ? null : acceptUrl,
+      email_sent: sendResult.ok,
+    },
+  });
+}

--- a/app/api/auth/accept-invite/route.ts
+++ b/app/api/auth/accept-invite/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { acceptInvite } from "@/lib/invites";
+import {
+  checkRateLimit,
+  getClientIp,
+  rateLimitExceeded,
+} from "@/lib/rate-limit";
+
+// AUTH-FOUNDATION P3.2 — POST /api/auth/accept-invite.
+//
+// Public route — the token IS the auth. Validates the token,
+// creates auth.users via Supabase admin API, marks the invite
+// accepted + writes audit row atomically. Returns enough info for
+// the page to redirect to /login (no auto-sign-in: brief is explicit
+// that the new user lands on /login after acceptance).
+//
+// Rate limit: per-IP via the existing 'login' bucket (10/min).
+// The token is high-entropy + 24h-expiring; brute force is
+// impractical, but the rate limit caps enumeration noise.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z
+  .object({
+    token: z.string().min(32).max(128),
+    password: z.string().min(12).max(200),
+  })
+  .strict();
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const rl = await checkRateLimit("login", `ip:${getClientIp(req)}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = null;
+  }
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message:
+            "Body must be { token: string (≥32 chars), password: string (≥12 chars) }.",
+          details: { issues: parsed.error.issues },
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await acceptInvite({
+    rawToken: parsed.data.token,
+    password: parsed.data.password,
+  });
+
+  if (!result.ok) {
+    const status =
+      result.error.code === "INVALID_TOKEN" ||
+      result.error.code === "EXPIRED" ||
+      result.error.code === "ALREADY_ACCEPTED" ||
+      result.error.code === "AUTH_CREATE_FAILED"
+        ? 409
+        : result.error.code === "PASSWORD_TOO_SHORT"
+          ? 400
+          : 500;
+    return NextResponse.json(
+      { ok: false, error: result.error },
+      { status },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    data: {
+      email: result.email,
+      role: result.role,
+    },
+  });
+}

--- a/app/auth/accept-invite/page.tsx
+++ b/app/auth/accept-invite/page.tsx
@@ -1,0 +1,98 @@
+import { createHash } from "node:crypto";
+
+import { AcceptInviteForm } from "@/components/AcceptInviteForm";
+import { Alert } from "@/components/ui/alert";
+import { H1, Lead } from "@/components/ui/typography";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// AUTH-FOUNDATION P3.2 — /auth/accept-invite.
+//
+// Public route (no auth gate — the token IS the auth). Server-component
+// validates the token by hashing it and checking invites for a
+// matching pending+unexpired row. The shape returned to the client
+// form is intentionally narrow: we send the invite's email (so the
+// page can show "Setting password for foo@example.com" — a reassurance
+// that the right person is on the link) but NOT the role or invite_id.
+// The POST /api/auth/accept-invite endpoint re-validates server-side
+// before creating the user.
+
+export const dynamic = "force-dynamic";
+
+interface PageProps {
+  searchParams: { token?: string };
+}
+
+interface ValidatedInvite {
+  email: string;
+  expires_at: string;
+}
+
+async function validateToken(
+  rawToken: string,
+): Promise<
+  | { kind: "ok"; invite: ValidatedInvite }
+  | { kind: "err"; reason: "missing" | "invalid" | "expired" | "consumed" }
+> {
+  if (!rawToken || rawToken.length < 32) {
+    return { kind: "err", reason: "missing" };
+  }
+  const tokenHash = createHash("sha256").update(rawToken).digest("hex");
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("invites")
+    .select("email, status, expires_at")
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+  if (error || !data) {
+    return { kind: "err", reason: "invalid" };
+  }
+  const row = data as { email: string; status: string; expires_at: string };
+  if (row.status === "accepted") {
+    return { kind: "err", reason: "consumed" };
+  }
+  if (row.status === "revoked") {
+    return { kind: "err", reason: "invalid" };
+  }
+  if (new Date(row.expires_at).getTime() <= Date.now()) {
+    return { kind: "err", reason: "expired" };
+  }
+  return {
+    kind: "ok",
+    invite: { email: row.email, expires_at: row.expires_at },
+  };
+}
+
+export default async function AcceptInvitePage({ searchParams }: PageProps) {
+  const rawToken = searchParams.token ?? "";
+  const result = await validateToken(rawToken);
+
+  if (result.kind === "err") {
+    return (
+      <div className="mx-auto max-w-md space-y-4">
+        <H1>Invite link</H1>
+        <Alert variant="destructive">
+          {result.reason === "missing" && "No invite token provided."}
+          {result.reason === "invalid" &&
+            "This invite link is invalid. Ask your admin for a fresh invite."}
+          {result.reason === "expired" &&
+            "This invite has expired. Ask your admin for a fresh invite."}
+          {result.reason === "consumed" &&
+            "This invite has already been accepted. Sign in normally."}
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-md">
+      <H1>Set your password</H1>
+      <Lead className="mt-1">
+        Setting up Opollo Site Builder for{" "}
+        <strong className="text-foreground">{result.invite.email}</strong>.
+      </Lead>
+      <div className="mt-6">
+        <AcceptInviteForm token={rawToken} email={result.invite.email} />
+      </div>
+    </div>
+  );
+}

--- a/components/AcceptInviteForm.tsx
+++ b/components/AcceptInviteForm.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useMemo, useState, type FormEvent } from "react";
+
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+// AUTH-FOUNDATION P3.2 — Accept-invite client form.
+//
+// Brief requirements:
+//   - Email shown read-only (server-component prop, displayed above)
+//   - Password + confirm-password fields
+//   - Password requirements: min 12 chars, no other rules
+//   - Inline strength meter
+//
+// On submit: POST /api/auth/accept-invite { token, password }.
+// On success: sonner toast + redirect to /login.
+
+const MIN_LENGTH = 12;
+
+export function AcceptInviteForm({
+  token,
+  email,
+}: {
+  token: string;
+  email: string;
+}) {
+  const router = useRouter();
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const tooShort = password.length > 0 && password.length < MIN_LENGTH;
+  const mismatch = confirm.length > 0 && confirm !== password;
+  const canSubmit =
+    !submitting &&
+    password.length >= MIN_LENGTH &&
+    password === confirm;
+
+  const strength = useMemo(() => scoreStrength(password), [password]);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/auth/accept-invite", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token, password }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: { email: string; role: string } }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (payload?.ok) {
+        // Redirect to /login. Brief is explicit on no auto-sign-in:
+        // the new user proves credentials by signing in fresh.
+        const target = `/login?invite=accepted&email=${encodeURIComponent(email)}`;
+        router.push(target);
+        return;
+      }
+      setError(
+        payload?.ok === false
+          ? payload.error.message
+          : `Couldn't accept invite (HTTP ${res.status}).`,
+      );
+    } catch (err) {
+      setError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="invite-email" className="block text-sm font-medium">
+          Email
+        </label>
+        <Input
+          id="invite-email"
+          value={email}
+          readOnly
+          disabled
+          className="mt-1 bg-muted/40"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="invite-password" className="block text-sm font-medium">
+          Password
+        </label>
+        <Input
+          id="invite-password"
+          type="password"
+          required
+          minLength={MIN_LENGTH}
+          maxLength={200}
+          autoComplete="new-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          disabled={submitting}
+          className="mt-1 font-mono text-sm"
+          aria-invalid={tooShort}
+          data-testid="accept-invite-password"
+        />
+        <StrengthMeter score={strength} length={password.length} />
+        {tooShort && (
+          <p className="mt-1 text-xs text-destructive">
+            At least {MIN_LENGTH} characters.
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="invite-confirm" className="block text-sm font-medium">
+          Confirm password
+        </label>
+        <Input
+          id="invite-confirm"
+          type="password"
+          required
+          minLength={MIN_LENGTH}
+          maxLength={200}
+          autoComplete="new-password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          disabled={submitting}
+          className="mt-1 font-mono text-sm"
+          aria-invalid={mismatch}
+          data-testid="accept-invite-confirm"
+        />
+        {mismatch && (
+          <p className="mt-1 text-xs text-destructive">
+            Passwords don&apos;t match.
+          </p>
+        )}
+      </div>
+
+      {error && (
+        <Alert variant="destructive" data-testid="accept-invite-error">
+          {error}
+        </Alert>
+      )}
+
+      <Button
+        type="submit"
+        disabled={!canSubmit}
+        className="w-full"
+        data-testid="accept-invite-submit"
+      >
+        {submitting ? "Setting password…" : "Set password and continue"}
+      </Button>
+    </form>
+  );
+}
+
+// 0..4 strength score. Pure heuristic; no third-party lib.
+//   0: too short for the meter to bother
+//   1: meets length, no diversity
+//   2: meets length + 1 of {upper, digit, symbol}
+//   3: meets length + 2 of {upper, digit, symbol}
+//   4: meets length + all 3 OR ≥ 16 chars
+function scoreStrength(password: string): number {
+  if (password.length < MIN_LENGTH) return 0;
+  let bonus = 0;
+  if (/[A-Z]/.test(password) && /[a-z]/.test(password)) bonus += 1;
+  if (/[0-9]/.test(password)) bonus += 1;
+  if (/[^A-Za-z0-9]/.test(password)) bonus += 1;
+  if (password.length >= 16) return Math.min(4, 1 + bonus + 1);
+  return Math.min(4, 1 + bonus);
+}
+
+function StrengthMeter({ score, length }: { score: number; length: number }) {
+  if (length === 0) return null;
+  const labels = ["", "weak", "fair", "good", "strong"];
+  const tone =
+    score === 0
+      ? "text-destructive"
+      : score === 1
+        ? "text-destructive"
+        : score === 2
+          ? "text-warning"
+          : score === 3
+            ? "text-success"
+            : "text-success";
+  return (
+    <div
+      className="mt-1 flex items-center gap-2"
+      data-testid="accept-invite-strength"
+    >
+      <div className="flex h-1.5 flex-1 gap-0.5" aria-hidden>
+        {[1, 2, 3, 4].map((step) => (
+          <div
+            key={step}
+            className={cn(
+              "h-full flex-1 rounded-full transition-smooth",
+              step <= score
+                ? score >= 3
+                  ? "bg-success"
+                  : score === 2
+                    ? "bg-warning"
+                    : "bg-destructive"
+                : "bg-muted",
+            )}
+          />
+        ))}
+      </div>
+      <span className={cn("text-xs", tone)}>
+        {score === 0 ? `${length}/${MIN_LENGTH}` : labels[score]}
+      </span>
+    </div>
+  );
+}

--- a/lib/email/templates/invite.ts
+++ b/lib/email/templates/invite.ts
@@ -1,0 +1,111 @@
+import "server-only";
+
+import { renderBaseEmail, escapeHtml } from "./base";
+
+// AUTH-FOUNDATION P3.2 — Invite email template.
+//
+// Sent by POST /api/admin/invites after a successful createInvite().
+// Wraps the brand-base shell with the invite-specific copy:
+//   - "You've been invited to Opollo Site Builder"
+//   - Who invited them (actor's email)
+//   - What role they'll have
+//   - Big "Accept invite" button → /auth/accept-invite?token=<raw>
+//   - 24-hour expiry note
+//   - Footer warning to ignore if they didn't expect this
+
+export interface InviteEmailInput {
+  /** Recipient (the invitee). Used only in the email body, not in headers. */
+  invitee_email: string;
+  /** Email of the actor who created the invite. */
+  invited_by_email: string;
+  /** Role the invitee will receive on acceptance. */
+  role: "admin" | "user";
+  /** Absolute URL to /auth/accept-invite?token=<raw_token>. */
+  accept_url: string;
+  /** ISO timestamp of when the invite expires (24h after creation). */
+  expires_at: string;
+}
+
+export function renderInviteEmail(input: InviteEmailInput): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const subject = "You've been invited to Opollo Site Builder";
+
+  const expiresLocal = formatExpiry(input.expires_at);
+
+  const bodyHtml = `
+    <p style="margin:0 0 12px 0;font-size:14px;line-height:1.5;color:#0f172a;">
+      <strong>${escapeHtml(input.invited_by_email)}</strong> invited you to
+      Opollo Site Builder as <strong>${escapeHtml(input.role)}</strong>.
+    </p>
+    <p style="margin:0 0 16px 0;font-size:14px;line-height:1.5;color:#0f172a;">
+      Opollo is a builder for managing WordPress sites with AI assistance.
+      Click the button below to set your password and complete sign-up.
+    </p>
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin:16px 0;">
+      <tr>
+        <td style="border-radius:6px;background-color:#0f172a;">
+          <a href="${escapeHtml(input.accept_url)}" style="display:inline-block;padding:12px 24px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">
+            Accept invite
+          </a>
+        </td>
+      </tr>
+    </table>
+    <p style="margin:0 0 8px 0;font-size:12px;line-height:1.5;color:#64748b;">
+      This invite expires on <strong>${escapeHtml(expiresLocal)}</strong>.
+      After that, ask ${escapeHtml(input.invited_by_email)} for a new one.
+    </p>
+    <p style="margin:0;font-size:12px;line-height:1.5;color:#64748b;">
+      If you weren't expecting this invite, ignore this email — no account
+      will be created until you set a password.
+    </p>
+  `;
+
+  const bodyText = [
+    `${input.invited_by_email} invited you to Opollo Site Builder as ${input.role}.`,
+    "",
+    "Opollo is a builder for managing WordPress sites with AI assistance.",
+    "Click the link below to set your password and complete sign-up.",
+    "",
+    input.accept_url,
+    "",
+    `This invite expires on ${expiresLocal}.`,
+    `After that, ask ${input.invited_by_email} for a new one.`,
+    "",
+    "If you weren't expecting this invite, ignore this email — no account",
+    "will be created until you set a password.",
+  ].join("\n");
+
+  const { html, text } = renderBaseEmail({
+    heading: subject,
+    bodyHtml,
+    bodyText,
+    footerNote:
+      "You received this email because someone invited you to an Opollo Site Builder account.",
+  });
+
+  return { subject, html, text };
+}
+
+function formatExpiry(iso: string): string {
+  // Format as "Wed 1 May 2026, 17:30 UTC" — readable, unambiguous,
+  // no timezone-magic. Email clients across timezones see the same
+  // string.
+  const d = new Date(iso);
+  const day = d.toLocaleString("en-AU", {
+    weekday: "short",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+  const time = d.toLocaleString("en-AU", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "UTC",
+    hour12: false,
+  });
+  return `${day}, ${time} UTC`;
+}

--- a/lib/invites.ts
+++ b/lib/invites.ts
@@ -1,0 +1,346 @@
+import "server-only";
+
+import { createHash, randomBytes } from "node:crypto";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// AUTH-FOUNDATION P3.2 — Invite lifecycle helpers.
+//
+// Three operations:
+//   - createInvite()  — generates a 32-byte raw token, hashes it for
+//                       storage (sha256), inserts the invites row +
+//                       user_audit_log row in a single transaction
+//                       via the create_invite Postgres function. The
+//                       raw token is RETURNED to the caller (for the
+//                       email body) and never stored anywhere.
+//   - revokeInvite()  — flips status to 'revoked' + writes audit row
+//                       atomically via revoke_invite RPC.
+//   - acceptInvite()  — validates the token, creates auth.users via
+//                       Supabase admin API, then accepts the invite +
+//                       writes audit row + promotes role via the
+//                       accept_invite RPC. The Supabase admin API
+//                       call is unavoidably outside the Postgres
+//                       transaction; on partial failure (auth.users
+//                       created, accept_invite failed), the orphaned
+//                       auth.users row can complete signup via password
+//                       reset.
+// ---------------------------------------------------------------------------
+
+const TOKEN_BYTES = 32;
+const INVITE_TTL_MS = 24 * 60 * 60 * 1000;
+
+export type InviteRole = "admin" | "user";
+
+export interface CreateInviteInput {
+  email: string;
+  role: InviteRole;
+  invitedBy: string | null;
+}
+
+export type CreateInviteResult =
+  | {
+      ok: true;
+      invite_id: string;
+      raw_token: string;
+      expires_at: string;
+    }
+  | {
+      ok: false;
+      error: {
+        code:
+          | "PENDING_EXISTS"
+          | "ACTIVE_USER_EXISTS"
+          | "INVALID_ROLE"
+          | "INTERNAL_ERROR";
+        message: string;
+      };
+    };
+
+export async function createInvite(
+  input: CreateInviteInput,
+): Promise<CreateInviteResult> {
+  if (input.role !== "admin" && input.role !== "user") {
+    return {
+      ok: false,
+      error: { code: "INVALID_ROLE", message: "Role must be 'admin' or 'user'." },
+    };
+  }
+
+  const email = input.email.trim().toLowerCase();
+  const supabase = getServiceRoleClient();
+
+  // Pre-check: does an active (non-revoked) opollo_users row already
+  // exist for this email? The brief: "Inviting an email that already
+  // has an active user: API returns 409 ALREADY_ACTIVE."
+  const userCheck = await supabase
+    .from("opollo_users")
+    .select("id, revoked_at")
+    .eq("email", email)
+    .maybeSingle();
+  if (userCheck.error) {
+    logger.error("invites.createInvite.user_lookup_failed", {
+      err: userCheck.error.message,
+    });
+    return internalError(`User lookup failed: ${userCheck.error.message}`);
+  }
+  if (userCheck.data && userCheck.data.revoked_at === null) {
+    return {
+      ok: false,
+      error: {
+        code: "ACTIVE_USER_EXISTS",
+        message:
+          "This user is already active. To change their role, use the row action in /admin/users.",
+      },
+    };
+  }
+
+  const rawToken = randomBytes(TOKEN_BYTES).toString("hex");
+  const tokenHash = createHash("sha256").update(rawToken).digest("hex");
+  const expiresAt = new Date(Date.now() + INVITE_TTL_MS).toISOString();
+
+  const { data, error } = await supabase.rpc("create_invite", {
+    p_email: email,
+    p_role: input.role,
+    p_invited_by: input.invitedBy,
+    p_token_hash: tokenHash,
+    p_expires_at: expiresAt,
+  });
+
+  if (error) {
+    if (/INVITE_PENDING_EXISTS/.test(error.message)) {
+      return {
+        ok: false,
+        error: {
+          code: "PENDING_EXISTS",
+          message:
+            "An invite is already pending for this email. Revoke it first or wait for it to expire.",
+        },
+      };
+    }
+    logger.error("invites.createInvite.rpc_failed", { err: error.message });
+    return internalError(error.message);
+  }
+
+  return {
+    ok: true,
+    invite_id: data as string,
+    raw_token: rawToken,
+    expires_at: expiresAt,
+  };
+}
+
+export interface RevokeInviteInput {
+  inviteId: string;
+  actorId: string | null;
+}
+
+export type RevokeInviteResult =
+  | { ok: true; revoked: boolean }
+  | { ok: false; error: { code: string; message: string } };
+
+export async function revokeInvite(
+  input: RevokeInviteInput,
+): Promise<RevokeInviteResult> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase.rpc("revoke_invite", {
+    p_invite_id: input.inviteId,
+    p_actor_id: input.actorId,
+  });
+  if (error) {
+    logger.error("invites.revokeInvite.rpc_failed", { err: error.message });
+    return internalError(error.message);
+  }
+  return { ok: true, revoked: data === true };
+}
+
+export interface AcceptInviteInput {
+  rawToken: string;
+  password: string;
+}
+
+export type AcceptInviteResult =
+  | {
+      ok: true;
+      user_id: string;
+      email: string;
+      role: InviteRole;
+    }
+  | {
+      ok: false;
+      error: {
+        code:
+          | "INVALID_TOKEN"
+          | "EXPIRED"
+          | "ALREADY_ACCEPTED"
+          | "PASSWORD_TOO_SHORT"
+          | "AUTH_CREATE_FAILED"
+          | "INTERNAL_ERROR";
+        message: string;
+      };
+    };
+
+export async function acceptInvite(
+  input: AcceptInviteInput,
+): Promise<AcceptInviteResult> {
+  if (input.password.length < 12) {
+    return {
+      ok: false,
+      error: {
+        code: "PASSWORD_TOO_SHORT",
+        message: "Password must be at least 12 characters.",
+      },
+    };
+  }
+  const tokenHash = createHash("sha256").update(input.rawToken).digest("hex");
+  const supabase = getServiceRoleClient();
+
+  // 1. Look up the invite by token_hash. We accept any status here so
+  //    the failure messages are precise (expired vs already accepted vs
+  //    bad token); the accept_invite RPC re-validates atomically.
+  const inviteRes = await supabase
+    .from("invites")
+    .select("id, email, role, status, expires_at")
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+  if (inviteRes.error) {
+    logger.error("invites.acceptInvite.lookup_failed", {
+      err: inviteRes.error.message,
+    });
+    return internalError(inviteRes.error.message);
+  }
+  if (!inviteRes.data) {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_TOKEN",
+        message:
+          "This invite link is invalid. Request a new invite from your admin.",
+      },
+    };
+  }
+
+  const invite = inviteRes.data as {
+    id: string;
+    email: string;
+    role: string;
+    status: string;
+    expires_at: string;
+  };
+  if (invite.status === "accepted") {
+    return {
+      ok: false,
+      error: {
+        code: "ALREADY_ACCEPTED",
+        message: "This invite has already been accepted. Sign in normally.",
+      },
+    };
+  }
+  if (invite.status === "revoked" || invite.status === "expired") {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_TOKEN",
+        message:
+          "This invite is no longer valid. Request a new invite from your admin.",
+      },
+    };
+  }
+  if (new Date(invite.expires_at).getTime() <= Date.now()) {
+    return {
+      ok: false,
+      error: {
+        code: "EXPIRED",
+        message:
+          "This invite has expired. Request a new invite from your admin.",
+      },
+    };
+  }
+
+  // 2. Create the auth.users row via Supabase admin API. The
+  //    handle_new_auth_user trigger inserts opollo_users with
+  //    role='user' (or 'super_admin' if this email is the
+  //    first_admin_email). The accept_invite RPC will promote the role
+  //    if the invite was for 'admin'.
+  const createRes = await supabase.auth.admin.createUser({
+    email: invite.email,
+    password: input.password,
+    email_confirm: true,
+  });
+  if (createRes.error || !createRes.data?.user) {
+    // Email already registered? Rare — the createInvite ACTIVE_USER_EXISTS
+    // check should have caught it. Still surface a clean error.
+    const status = (createRes.error as { status?: number } | undefined)?.status;
+    if (
+      status === 422 ||
+      /already (registered|exists)/i.test(createRes.error?.message ?? "")
+    ) {
+      return {
+        ok: false,
+        error: {
+          code: "AUTH_CREATE_FAILED",
+          message:
+            "An account already exists for this email. Sign in instead.",
+        },
+      };
+    }
+    logger.error("invites.acceptInvite.auth_create_failed", {
+      err: createRes.error?.message,
+    });
+    return {
+      ok: false,
+      error: {
+        code: "AUTH_CREATE_FAILED",
+        message:
+          "Could not create your account. Try again or ask your admin for a fresh invite.",
+      },
+    };
+  }
+  const userId = createRes.data.user.id;
+
+  // 3. Atomically: accept invite + promote role + write audit row.
+  const acceptRes = await supabase.rpc("accept_invite", {
+    p_invite_id: invite.id,
+    p_user_id: userId,
+    p_email: invite.email,
+  });
+  if (acceptRes.error) {
+    logger.error("invites.acceptInvite.rpc_failed", {
+      err: acceptRes.error.message,
+      user_id: userId,
+    });
+    return internalError(acceptRes.error.message);
+  }
+  if (acceptRes.data !== true) {
+    // Race: invite was accepted/revoked between lookup + RPC. The
+    // user.users row exists but the audit didn't land. Recovery: the
+    // user can sign in (auth works); the orphan invite row is what
+    // it is.
+    return {
+      ok: false,
+      error: {
+        code: "ALREADY_ACCEPTED",
+        message:
+          "This invite was just accepted by another tab. Sign in normally.",
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    user_id: userId,
+    email: invite.email,
+    role: invite.role as InviteRole,
+  };
+}
+
+function internalError(message: string): {
+  ok: false;
+  error: { code: "INTERNAL_ERROR"; message: string };
+} {
+  return {
+    ok: false,
+    error: { code: "INTERNAL_ERROR", message },
+  };
+}

--- a/supabase/migrations/0058_invite_audit_functions.sql
+++ b/supabase/migrations/0058_invite_audit_functions.sql
@@ -1,0 +1,194 @@
+-- 0058 — AUTH-FOUNDATION P3.2: transactional invite + audit Postgres functions.
+--
+-- The brief requires that every user-management action and its
+-- corresponding user_audit_log row land in a SINGLE TRANSACTION — so
+-- a successful invite_sent / invite_revoked / invite_accepted /
+-- user_removed / role_changed action always has an audit row, and an
+-- audit row never appears for an action that didn't land.
+--
+-- supabase-js doesn't expose connection-level BEGIN/COMMIT, so the
+-- transactional surface goes through Postgres functions invoked via
+-- supabase.rpc(). Each function does the action + audit insert
+-- atomically.
+--
+-- Functions:
+--   - create_invite(p_email, p_role, p_invited_by, p_token_hash,
+--                   p_expires_at)
+--       Inserts an invites row + invite_sent audit row.
+--       Raises 'INVITE_PENDING_EXISTS' if a pending invite for the
+--       email already exists (the partial unique index would also
+--       block, but the function surfaces the error explicitly so
+--       the API can return a clean 409).
+--       Returns the invite id.
+--
+--   - revoke_invite(p_invite_id, p_actor_id)
+--       Marks an invite revoked + writes invite_revoked audit row.
+--       No-ops on already-terminal invites (returns false instead
+--       of raising — the API surfaces this as a clean 409).
+--
+--   - accept_invite(p_invite_id, p_user_id, p_email)
+--       Marks an invite accepted + writes invite_accepted audit row.
+--       Used post-auth.users creation by the accept-invite route;
+--       the auth.users creation is unavoidably outside this
+--       transaction (Supabase admin API), but the invite-status flip
+--       + audit row are atomic.
+--       Returns true on success, false if the invite is no longer
+--       pending (raced or already accepted).
+--
+-- All three functions are SECURITY DEFINER so the API doesn't need
+-- to grant the anon/authenticated role direct INSERT on the
+-- invites/audit tables. RLS policies on those tables stay
+-- service-role-only.
+
+-- ----------------------------------------------------------------------------
+-- create_invite
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.create_invite(
+  p_email       text,
+  p_role        text,
+  p_invited_by  uuid,
+  p_token_hash  text,
+  p_expires_at  timestamptz
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_invite_id uuid;
+  v_actor_email text;
+BEGIN
+  -- Pre-check: surface a clean named exception when a pending
+  -- invite already exists. The partial unique index catches the
+  -- race; this just gives the API a typed failure string to match.
+  IF EXISTS (
+    SELECT 1 FROM invites
+    WHERE email = p_email AND status = 'pending'
+  ) THEN
+    RAISE EXCEPTION 'INVITE_PENDING_EXISTS' USING
+      DETAIL = format('A pending invite for %s already exists.', p_email);
+  END IF;
+
+  INSERT INTO invites (email, role, token_hash, invited_by, expires_at)
+    VALUES (p_email, p_role, p_token_hash, p_invited_by, p_expires_at)
+    RETURNING id INTO v_invite_id;
+
+  -- Resolve actor email for the audit row's metadata column.
+  SELECT email INTO v_actor_email
+    FROM opollo_users WHERE id = p_invited_by;
+
+  INSERT INTO user_audit_log (actor_id, action, target_email, metadata)
+    VALUES (
+      p_invited_by,
+      'invite_sent',
+      p_email,
+      jsonb_build_object(
+        'invite_id', v_invite_id,
+        'role',      p_role,
+        'expires_at', p_expires_at,
+        'actor_email', v_actor_email
+      )
+    );
+
+  RETURN v_invite_id;
+END;
+$$;
+
+-- ----------------------------------------------------------------------------
+-- revoke_invite
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.revoke_invite(
+  p_invite_id uuid,
+  p_actor_id  uuid
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_email text;
+  v_role  text;
+BEGIN
+  UPDATE invites
+     SET status = 'revoked'
+   WHERE id = p_invite_id
+     AND status = 'pending'
+   RETURNING email, role INTO v_email, v_role;
+
+  IF NOT FOUND THEN
+    RETURN false;
+  END IF;
+
+  INSERT INTO user_audit_log (actor_id, action, target_email, metadata)
+    VALUES (
+      p_actor_id,
+      'invite_revoked',
+      v_email,
+      jsonb_build_object('invite_id', p_invite_id, 'role', v_role)
+    );
+
+  RETURN true;
+END;
+$$;
+
+-- ----------------------------------------------------------------------------
+-- accept_invite
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.accept_invite(
+  p_invite_id uuid,
+  p_user_id   uuid,
+  p_email     text
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role text;
+BEGIN
+  UPDATE invites
+     SET status = 'accepted',
+         accepted_at = now()
+   WHERE id = p_invite_id
+     AND status = 'pending'
+     AND expires_at > now()
+   RETURNING role INTO v_role;
+
+  IF NOT FOUND THEN
+    RETURN false;
+  END IF;
+
+  -- Promote the auto-created opollo_users row (handle_new_auth_user
+  -- inserted it with role='user' by default) to the invite's role.
+  -- Skipped when the invite was for role='user' since the trigger
+  -- already left them as user.
+  IF v_role <> 'user' THEN
+    UPDATE opollo_users
+       SET role = v_role
+     WHERE id = p_user_id;
+  END IF;
+
+  INSERT INTO user_audit_log (actor_id, action, target_email, metadata)
+    VALUES (
+      p_user_id,
+      'invite_accepted',
+      p_email,
+      jsonb_build_object('invite_id', p_invite_id, 'role', v_role)
+    );
+
+  RETURN true;
+END;
+$$;
+
+COMMENT ON FUNCTION public.create_invite(text, text, uuid, text, timestamptz) IS
+  'AUTH-FOUNDATION P3.2: transactional INSERT into invites + user_audit_log. Raises INVITE_PENDING_EXISTS on collision. SECURITY DEFINER. Added 2026-04-30.';
+COMMENT ON FUNCTION public.revoke_invite(uuid, uuid) IS
+  'AUTH-FOUNDATION P3.2: transactional UPDATE invites SET status=revoked + INSERT into user_audit_log. Returns false when the invite is no longer pending. SECURITY DEFINER. Added 2026-04-30.';
+COMMENT ON FUNCTION public.accept_invite(uuid, uuid, text) IS
+  'AUTH-FOUNDATION P3.2: transactional UPDATE invites SET status=accepted + role promotion + INSERT into user_audit_log. Returns false when the invite is no longer pending or has expired. SECURITY DEFINER. Added 2026-04-30.';

--- a/supabase/rollbacks/0058_invite_audit_functions.down.sql
+++ b/supabase/rollbacks/0058_invite_audit_functions.down.sql
@@ -1,0 +1,5 @@
+-- Rollback for 0058_invite_audit_functions.sql.
+
+DROP FUNCTION IF EXISTS public.accept_invite(uuid, uuid, text);
+DROP FUNCTION IF EXISTS public.revoke_invite(uuid, uuid);
+DROP FUNCTION IF EXISTS public.create_invite(text, text, uuid, text, timestamptz);


### PR DESCRIPTION
## Summary

Replaces the legacy Supabase magic-link invite path with the brief's custom invites-table flow. The raw token only ever appears in the invite email (sha-256 hashed for storage); the operator-facing API returns the accept URL when email delivery fails so out-of-band handoff still works.

## What ships

### Migration 0058 — three transactional Postgres functions

- \`create_invite\` — INSERT invites + INSERT user_audit_log atomically. Raises \`INVITE_PENDING_EXISTS\` for clean 409.
- \`revoke_invite\` — UPDATE invites + INSERT audit, atomic. Returns false on already-terminal invites.
- \`accept_invite\` — UPDATE invites + role promotion + INSERT audit, atomic.

### \`lib/invites.ts\` — application wrappers

- \`createInvite()\`: pre-checks active user, generates 32-byte raw token, hashes for storage, RPC, returns raw token + expiry.
- \`revokeInvite()\`, \`acceptInvite()\`: thin RPC wrappers with typed error envelopes.
- Note: \`acceptInvite\` calls Supabase admin API to create auth.users, which is unavoidably outside the Postgres transaction. Partial failure path documented (orphan auth user can complete signup via password reset).

### \`lib/email/templates/invite.ts\`

Wraps base template with: actor email + role + button to accept URL + 24h expiry note + ignore-if-not-expected footer. Plaintext mirror.

### Routes

- **\`POST /api/admin/invites\`** — admin/operator gated. Per-actor role guard (admin can only invite role=user; super_admin can invite any). Sends email; surfaces \`accept_url\` + \`email_sent\` in response for out-of-band handoff.
- **\`DELETE /api/admin/invites/[id]\`** — admin/operator gated; revoke RPC. 409 STATUS_CONFLICT on already-terminal.
- **\`POST /api/auth/accept-invite\`** — public (token IS the auth). Rate-limited via 'login' bucket. Body validation enforces password ≥12.
- **\`/auth/accept-invite\` page** — server component validates the token, renders the form (email read-only + password + confirm + 4-stage strength meter). Redirects to \`/login?invite=accepted&email=…\` on success (no auto-sign-in per the brief).

## Risks identified and mitigated

- **Audit row never lands without the action** — enforced by Postgres function transactionality.
- **Raw token never stored** — sha-256 hashed before insert; lookups re-hash incoming tokens.
- **Pending-invite collision** blocked by partial unique index (P3.1) AND the function's pre-check.
- **Active-user collision** blocked by lib's pre-check; clean 409 ACTIVE_USER_EXISTS.
- **Per-actor role gating** at the API level (defence in depth; UI hides options too in P3.3).
- **Email delivery failure logged but doesn't roll back the invite** per the brief — accept_url is in response for copy-paste handoff.
- **Legacy \`/api/admin/users/invite\` (magic-link) route untouched** — P3.3 swaps the UI to the new endpoint; legacy route deleted in a follow-up cleanup.

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅
- New routes built: \`/api/admin/invites\`, \`/api/admin/invites/[id]\`, \`/api/auth/accept-invite\`, \`/auth/accept-invite\` (4.94 kB / 173 kB First Load JS)

## Test plan

- [ ] Migration 0058 applies cleanly in staging
- [ ] \`POST /api/admin/invites\` from super_admin returns invite_id + accept_url
- [ ] Invite email arrives at SendGrid (or accept_url is surfaced in response on send failure)
- [ ] \`/auth/accept-invite?token=…\` validates + shows form
- [ ] Submit short password → 400 PASSWORD_TOO_SHORT
- [ ] Submit valid password → redirected to /login?invite=accepted, can sign in
- [ ] Try a revoked / expired / used token → matching error message
- [ ] Operator gate at end of P3 (after P3.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)