### PR TITLE
feat(design-discovery-2): schema for design discovery + tone of voice

### DIFF
--- a/lib/__tests__/design-discovery-schema.test.ts
+++ b/lib/__tests__/design-discovery-schema.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// Migration 0060 — design discovery columns on sites.
+//
+// Pins the eight columns the DESIGN-DISCOVERY workstream relies on:
+//   - design_brief (jsonb, nullable)
+//   - homepage_concept_html (text, nullable)
+//   - inner_page_concept_html (text, nullable)
+//   - tone_applied_homepage_html (text, nullable)
+//   - design_tokens (jsonb, nullable)
+//   - design_direction_status (text NOT NULL DEFAULT 'pending', CHECK enum)
+//   - tone_of_voice (jsonb, nullable)
+//   - tone_of_voice_status (text NOT NULL DEFAULT 'pending', CHECK enum)
+//
+// _setup.ts truncates between tests so seedSite is fresh each time.
+// ---------------------------------------------------------------------------
+
+const VALID_STATUSES = ["pending", "in_progress", "approved", "skipped"];
+
+describe("0060: fresh site defaults", () => {
+  it("has 'pending' for both status columns and NULL for the rest", async () => {
+    const site = await seedSite();
+    const svc = getServiceRoleClient();
+    const { data, error } = await svc
+      .from("sites")
+      .select(
+        "design_brief, homepage_concept_html, inner_page_concept_html, tone_applied_homepage_html, design_tokens, design_direction_status, tone_of_voice, tone_of_voice_status",
+      )
+      .eq("id", site.id)
+      .single();
+    expect(error).toBeNull();
+    expect(data?.design_brief).toBeNull();
+    expect(data?.homepage_concept_html).toBeNull();
+    expect(data?.inner_page_concept_html).toBeNull();
+    expect(data?.tone_applied_homepage_html).toBeNull();
+    expect(data?.design_tokens).toBeNull();
+    expect(data?.tone_of_voice).toBeNull();
+    expect(data?.design_direction_status).toBe("pending");
+    expect(data?.tone_of_voice_status).toBe("pending");
+  });
+});
+
+describe("0060: status CHECK constraints", () => {
+  it.each(VALID_STATUSES)(
+    "accepts design_direction_status='%s'",
+    async (status) => {
+      const site = await seedSite();
+      const svc = getServiceRoleClient();
+      const upd = await svc
+        .from("sites")
+        .update({ design_direction_status: status })
+        .eq("id", site.id)
+        .select("design_direction_status")
+        .single();
+      expect(upd.error).toBeNull();
+      expect(upd.data?.design_direction_status).toBe(status);
+    },
+  );
+
+  it.each(VALID_STATUSES)(
+    "accepts tone_of_voice_status='%s'",
+    async (status) => {
+      const site = await seedSite();
+      const svc = getServiceRoleClient();
+      const upd = await svc
+        .from("sites")
+        .update({ tone_of_voice_status: status })
+        .eq("id", site.id)
+        .select("tone_of_voice_status")
+        .single();
+      expect(upd.error).toBeNull();
+      expect(upd.data?.tone_of_voice_status).toBe(status);
+    },
+  );
+
+  it("rejects unknown design_direction_status via CHECK (23514)", async () => {
+    const site = await seedSite();
+    const svc = getServiceRoleClient();
+    const upd = await svc
+      .from("sites")
+      .update({ design_direction_status: "wat" })
+      .eq("id", site.id);
+    expect(upd.error).not.toBeNull();
+    expect((upd.error as { code?: string }).code).toBe("23514");
+  });
+
+  it("rejects unknown tone_of_voice_status via CHECK (23514)", async () => {
+    const site = await seedSite();
+    const svc = getServiceRoleClient();
+    const upd = await svc
+      .from("sites")
+      .update({ tone_of_voice_status: "wat" })
+      .eq("id", site.id);
+    expect(upd.error).not.toBeNull();
+    expect((upd.error as { code?: string }).code).toBe("23514");
+  });
+});
+
+describe("0060: jsonb columns round-trip", () => {
+  it("design_brief stores arbitrary JSON", async () => {
+    const site = await seedSite();
+    const svc = getServiceRoleClient();
+    const brief = {
+      industry: "msp",
+      reference_url: "https://example.com",
+      description: "Premium technical, friendly tone",
+      refinement_notes: ["lighten the hero", "increase white space"],
+    };
+    const upd = await svc
+      .from("sites")
+      .update({ design_brief: brief })
+      .eq("id", site.id)
+      .select("design_brief")
+      .single();
+    expect(upd.error).toBeNull();
+    expect(upd.data?.design_brief).toEqual(brief);
+  });
+
+  it("design_tokens stores the token JSON shape", async () => {
+    const site = await seedSite();
+    const svc = getServiceRoleClient();
+    const tokens = {
+      primary: "#0F172A",
+      secondary: "#475569",
+      accent: "#3B82F6",
+      background: "#FFFFFF",
+      text: "#0F172A",
+      font_heading: "Inter",
+      font_body: "Inter",
+      border_radius: "8px",
+      spacing_unit: "8px",
+    };
+    const upd = await svc
+      .from("sites")
+      .update({ design_tokens: tokens })
+      .eq("id", site.id)
+      .select("design_tokens")
+      .single();
+    expect(upd.error).toBeNull();
+    expect(upd.data?.design_tokens).toEqual(tokens);
+  });
+
+  it("tone_of_voice stores the tone JSON shape including arrays", async () => {
+    const site = await seedSite();
+    const svc = getServiceRoleClient();
+    const tone = {
+      formality_level: 3,
+      sentence_length: "short",
+      jargon_usage: "neutral",
+      personality_markers: ["professional", "straight-talking"],
+      avoid_markers: ["salesy", "jargon-heavy"],
+      target_audience: "MSP business owners 25-200 staff",
+      style_guide: "Sentences under 20 words. No filler.",
+      approved_samples: [{ kind: "hero", text: "..." }],
+    };
+    const upd = await svc
+      .from("sites")
+      .update({ tone_of_voice: tone })
+      .eq("id", site.id)
+      .select("tone_of_voice")
+      .single();
+    expect(upd.error).toBeNull();
+    expect(upd.data?.tone_of_voice).toEqual(tone);
+  });
+});
+
+describe("0060: html columns round-trip", () => {
+  it("homepage_concept_html / inner_page_concept_html / tone_applied_homepage_html accept long text", async () => {
+    const site = await seedSite();
+    const svc = getServiceRoleClient();
+    const long = "<section>" + "a".repeat(50_000) + "</section>";
+    const upd = await svc
+      .from("sites")
+      .update({
+        homepage_concept_html: long,
+        inner_page_concept_html: long,
+        tone_applied_homepage_html: long,
+      })
+      .eq("id", site.id)
+      .select(
+        "homepage_concept_html, inner_page_concept_html, tone_applied_homepage_html",
+      )
+      .single();
+    expect(upd.error).toBeNull();
+    expect(upd.data?.homepage_concept_html).toBe(long);
+    expect(upd.data?.inner_page_concept_html).toBe(long);
+    expect(upd.data?.tone_applied_homepage_html).toBe(long);
+  });
+});

--- a/supabase/migrations/0060_design_discovery_columns.sql
+++ b/supabase/migrations/0060_design_discovery_columns.sql
@@ -1,0 +1,84 @@
+-- 0060 — Design discovery columns on sites.
+-- Reference: DESIGN-DISCOVERY workstream, PR 2/12. Setup wizard
+-- /admin/sites/[id]/setup captures a design direction (Step 1) and a
+-- tone of voice (Step 2), both feeding into existing generation
+-- prompts (brief runner / M12 / M13 / BlogPostComposer) when the
+-- DESIGN_CONTEXT_ENABLED feature flag is on.
+--
+-- This migration only adds the storage columns. The wizard itself,
+-- the generation injection, and the feature flag are wired in later
+-- PRs (3..12). All columns are nullable / default to a sentinel so
+-- existing rows continue to work and the wizard's "skip for now"
+-- and "in_progress" states can be represented without a backfill.
+--
+-- Design decisions encoded here:
+--
+-- 1. CHECK constraints over Postgres ENUM types for the two status
+--    columns. Pattern: docs/patterns/new-migration.md "key shape
+--    rules". An enum'd status would require a multi-step ALTER for
+--    every future value; CHECK rewrites in one ALTER.
+-- 2. JSONB for design_brief, design_tokens, tone_of_voice. The shapes
+--    are still v1 — the spec calls out that tone/personality mapping
+--    will need refinement with real usage data — and JSONB lets us
+--    iterate the shape in app code without a schema change. Each
+--    column is nullable because a "skipped" or "pending" site
+--    legitimately has no captured value yet.
+-- 3. Three separate text columns for the rendered HTML
+--    (homepage_concept_html, inner_page_concept_html,
+--    tone_applied_homepage_html) rather than collapsing them into
+--    design_brief.json. The HTML can be megabytes per site once a
+--    full concept lands; storing it inline in a JSONB blob makes
+--    the row hot for every read of design_direction_status. Keeping
+--    them as their own columns means a status-only SELECT doesn't
+--    drag the HTML into memory.
+-- 4. Status columns NOT NULL DEFAULT 'pending'. Existing sites
+--    pre-discovery get 'pending' atomically as part of the ALTER —
+--    no backfill needed. The wizard treats 'pending' as "show Step 1
+--    fresh" and 'skipped' as "complete with defaults", so any older
+--    site automatically lands at the start of the flow when an
+--    operator first opens /admin/sites/[id]/setup.
+-- 5. No new UNIQUE constraints. design_brief / tone_of_voice are
+--    per-site and the existing sites.id PK already enforces that.
+--
+-- Write-safety notes:
+--   - Pure ALTER TABLE ADD COLUMN. No locks beyond the brief metadata
+--     update; no rewrite. Safe to run online.
+--   - CHECK constraints applied at column creation (no ADD CONSTRAINT
+--     pass) so there's no validation step over existing rows; default
+--     values satisfy the constraint by construction.
+
+ALTER TABLE sites
+  ADD COLUMN design_brief jsonb NULL,
+  ADD COLUMN homepage_concept_html text NULL,
+  ADD COLUMN inner_page_concept_html text NULL,
+  ADD COLUMN tone_applied_homepage_html text NULL,
+  ADD COLUMN design_tokens jsonb NULL,
+  ADD COLUMN design_direction_status text NOT NULL DEFAULT 'pending'
+    CHECK (design_direction_status IN ('pending','in_progress','approved','skipped')),
+  ADD COLUMN tone_of_voice jsonb NULL,
+  ADD COLUMN tone_of_voice_status text NOT NULL DEFAULT 'pending'
+    CHECK (tone_of_voice_status IN ('pending','in_progress','approved','skipped'));
+
+COMMENT ON COLUMN sites.design_brief IS
+  'JSONB capture of the operator''s design discovery inputs (reference URLs, screenshots metadata, text description, industry, refinement_notes[]). Nullable — set when the operator first runs the design direction step. Added 2026-04-30 (DESIGN-DISCOVERY).';
+
+COMMENT ON COLUMN sites.homepage_concept_html IS
+  'Rendered HTML for the approved homepage concept. Inline CSS only, no external deps. Used as reference context in downstream generation when DESIGN_CONTEXT_ENABLED. Added 2026-04-30 (DESIGN-DISCOVERY).';
+
+COMMENT ON COLUMN sites.inner_page_concept_html IS
+  'Rendered HTML for the approved inner-page concept (companion to homepage_concept_html). Added 2026-04-30 (DESIGN-DISCOVERY).';
+
+COMMENT ON COLUMN sites.tone_applied_homepage_html IS
+  'Homepage concept HTML with the approved tone of voice rewritten into the hero / CTA / first service card. Generated post tone-approval; falls back to homepage_concept_html on failure. Added 2026-04-30 (DESIGN-DISCOVERY).';
+
+COMMENT ON COLUMN sites.design_tokens IS
+  'JSONB design tokens extracted from the approved concept: { primary, secondary, accent, background, text, font_heading, font_body, border_radius, spacing_unit }. Added 2026-04-30 (DESIGN-DISCOVERY).';
+
+COMMENT ON COLUMN sites.design_direction_status IS
+  'Wizard Step 1 status. ''pending'' (default) = not started, ''in_progress'' = inputs captured but no concept approved, ''approved'' = stored homepage_concept_html / inner_page_concept_html / design_tokens, ''skipped'' = operator skipped, generic MSP defaults applied. Added 2026-04-30 (DESIGN-DISCOVERY).';
+
+COMMENT ON COLUMN sites.tone_of_voice IS
+  'JSONB tone capture: { formality_level, sentence_length, jargon_usage, personality_markers[], avoid_markers[], target_audience, style_guide, approved_samples }. Injected as few-shot context into generation prompts when DESIGN_CONTEXT_ENABLED. Added 2026-04-30 (DESIGN-DISCOVERY).';
+
+COMMENT ON COLUMN sites.tone_of_voice_status IS
+  'Wizard Step 2 status. Same semantics as design_direction_status. Added 2026-04-30 (DESIGN-DISCOVERY).';

--- a/supabase/rollbacks/0060_design_discovery_columns.down.sql
+++ b/supabase/rollbacks/0060_design_discovery_columns.down.sql
@@ -1,0 +1,14 @@
+-- Rollback for 0060_design_discovery_columns.sql
+-- Drops the eight columns the forward migration added on sites.
+-- Does NOT preserve any captured data. Intended for local dev / CI
+-- reset, not production recovery.
+
+ALTER TABLE sites
+  DROP COLUMN IF EXISTS tone_of_voice_status,
+  DROP COLUMN IF EXISTS tone_of_voice,
+  DROP COLUMN IF EXISTS design_direction_status,
+  DROP COLUMN IF EXISTS design_tokens,
+  DROP COLUMN IF EXISTS tone_applied_homepage_html,
+  DROP COLUMN IF EXISTS inner_page_concept_html,
+  DROP COLUMN IF EXISTS homepage_concept_html,
+  DROP COLUMN IF EXISTS design_brief;


### PR DESCRIPTION
Schema migration for the DESIGN-DISCOVERY workstream. Adds eight columns on `sites` that back the setup wizard's two-step capture (Step 1 design direction, Step 2 tone of voice) plus the rendered concept HTML, design tokens, and per-step status. Nothing else uses these columns yet — that's PRs 3..12.

## What lands
- `supabase/migrations/0060_design_discovery_columns.sql` — adds eight columns on `sites`. Six are nullable JSONB / text. Two are `text NOT NULL DEFAULT 'pending'` with a CHECK enum (`pending` / `in_progress` / `approved` / `skipped`).
- `supabase/rollbacks/0060_design_discovery_columns.down.sql` — hand-runnable reverse script. `IF EXISTS` everywhere.
- `lib/__tests__/design-discovery-schema.test.ts` — pins defaults, both CHECK constraints (accept all four enum values, reject unknowns with 23514), and JSON / HTML round-trips against the real local Supabase.

## Risks identified and mitigated
- **Status enum vs CHECK constraint.** Used CHECK over Postgres ENUM per the migration pattern doc — ENUM types are hard to alter; CHECK rewrites in one ALTER. New states added later need only a `DROP CONSTRAINT` + re-add, not the multi-step ENUM dance.
- **Existing-rows safety.** `NOT NULL DEFAULT 'pending'` on the two status columns means existing rows get `'pending'` atomically as part of the ALTER; no backfill, no downtime. The other six columns are nullable so they don't need a value.
- **HTML in JSONB.** Considered collapsing the three rendered-HTML columns into `design_brief` jsonb, rejected: HTML can be megabytes, JSONB row reads pull the whole blob, and a status-only SELECT shouldn't drag concept HTML into memory. Kept them as separate text columns.
- **No new UNIQUE constraints needed.** All values are per-site; the existing `sites.id` PK already enforces uniqueness.
- **Coexistence with `sites.design_direction text`.** The existing `design_direction text` column from migration 0028 is the brief-review free-text default. Different concept; coexists fine. The new wizard reads/writes `design_brief` jsonb + `design_direction_status` text, never the legacy text column.
- **Online-safe ALTER.** Pure ADD COLUMN; CHECK on column creation (no validation pass over existing rows since the default is allowed by construction). No table rewrite, no long lock.

## Deliberately deferred
- **Lib helpers** (`updateDesignBrief`, `approveDesignDirection`, `recordToneOfVoice`, etc.) — those land in PRs 4–8 alongside the UI that calls them. Adding scaffolding now would be dead code.
- **Zod schema for `design_brief` / `tone_of_voice` shapes** — same reason; the shapes are still v1 per the spec. PRs 4 and 8 introduce the typed shapes when the call sites exist.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm run test` — `design-discovery-schema.test.ts` runs in CI (Docker not available locally to apply migration).
- [ ] `npm run test:e2e` — N/A (pure schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)