### PR TITLE
fix(optimiser): submit-brief reads client_slug, closes #307

### DIFF
--- a/lib/optimiser/site-builder-bridge/submit-brief.ts
+++ b/lib/optimiser/site-builder-bridge/submit-brief.ts
@@ -242,7 +242,7 @@ async function loadProposalContext(
 
   const clientRes = await supabase
     .from("opt_clients")
-    .select("id, slug, hosting_mode")
+    .select("id, client_slug, hosting_mode")
     .eq("id", proposalRes.data.client_id as string)
     .maybeSingle();
   if (clientRes.error) throw new Error(clientRes.error.message);
@@ -280,7 +280,7 @@ async function loadProposalContext(
       | "opollo_subdomain"
       | "opollo_cname"
       | "client_slice",
-    client_slug: clientRes.data.slug as string,
+    client_slug: clientRes.data.client_slug as string,
     site_id: siteId,
   };
 }


### PR DESCRIPTION
Two-line fix. Closes #307. Phase 2 Slice 18's variant generator already worked around this with a parallel submitter; this just brings submit-brief.ts into line.