### PR TITLE
feat(p3-3): /admin/users — invite-modal swap, pending invites, audit log viewer

### DIFF
--- a/app/admin/users/audit/page.tsx
+++ b/app/admin/users/audit/page.tsx
@@ -1,0 +1,158 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { Alert } from "@/components/ui/alert";
+import { H1, Lead } from "@/components/ui/typography";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { formatRelativeTime } from "@/lib/utils";
+
+// AUTH-FOUNDATION P3.3 — /admin/users/audit.
+//
+// super_admin-only viewer of the user_audit_log table. Read-only,
+// paginated (50/page). Joined with opollo_users to show actor email
+// (the table only stores actor_id; resolving here keeps the storage
+// row narrow).
+
+export const dynamic = "force-dynamic";
+
+const PAGE_SIZE = 50;
+
+interface PageProps {
+  searchParams: { page?: string };
+}
+
+export default async function UserAuditPage({ searchParams }: PageProps) {
+  const access = await checkAdminAccess({
+    requiredRoles: ["super_admin"],
+    insufficientRoleRedirectTo: "/admin/users",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  const pageNum = Math.max(1, Number(searchParams.page ?? "1"));
+  const offset = (pageNum - 1) * PAGE_SIZE;
+
+  const svc = getServiceRoleClient();
+  const { data, error, count } = await svc
+    .from("user_audit_log")
+    .select(
+      "id, action, target_email, metadata, created_at, actor:opollo_users!user_audit_log_actor_id_fkey(email)",
+      { count: "exact" },
+    )
+    .order("created_at", { ascending: false })
+    .range(offset, offset + PAGE_SIZE - 1);
+
+  const totalPages = count ? Math.max(1, Math.ceil(count / PAGE_SIZE)) : 1;
+
+  return (
+    <>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <H1>User audit log</H1>
+          <Lead className="mt-0.5">
+            Append-only record of every user-management action.
+            super_admin only.
+          </Lead>
+        </div>
+        <Link
+          href="/admin/users"
+          className="rounded-md border px-3 py-2 text-sm transition-smooth hover:bg-muted"
+        >
+          ← Back to users
+        </Link>
+      </div>
+
+      {error ? (
+        <Alert variant="destructive" className="mt-6" title="Failed to load audit log">
+          {error.message}
+        </Alert>
+      ) : (
+        <>
+          <div className="mt-6 rounded-md border">
+            <table className="w-full text-sm">
+              <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <tr>
+                  <th className="px-3 py-2 font-medium">When</th>
+                  <th className="px-3 py-2 font-medium">Actor</th>
+                  <th className="px-3 py-2 font-medium">Action</th>
+                  <th className="px-3 py-2 font-medium">Target</th>
+                  <th className="px-3 py-2 font-medium">Detail</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(data ?? []).map((row) => {
+                  const actor = (row as unknown as {
+                    actor?: { email?: string } | null;
+                  }).actor;
+                  return (
+                    <tr
+                      key={(row.id as number).toString()}
+                      className="border-b align-top last:border-b-0"
+                      data-testid="audit-row"
+                    >
+                      <td className="px-3 py-2 text-xs text-muted-foreground">
+                        <span data-screenshot-mask>
+                          {formatRelativeTime(row.created_at as string)}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-xs">
+                        {actor?.email ?? "(deleted user)"}
+                      </td>
+                      <td className="px-3 py-2 text-xs font-medium">
+                        {row.action as string}
+                      </td>
+                      <td className="px-3 py-2 text-xs">
+                        {row.target_email as string}
+                      </td>
+                      <td className="px-3 py-2 text-xs text-muted-foreground">
+                        <code className="font-mono text-[11px]">
+                          {JSON.stringify(row.metadata ?? {}, null, 0)}
+                        </code>
+                      </td>
+                    </tr>
+                  );
+                })}
+                {(data ?? []).length === 0 && (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      className="px-3 py-6 text-center text-sm text-muted-foreground"
+                    >
+                      No audit events yet.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          {totalPages > 1 && (
+            <div className="mt-4 flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">
+                Page {pageNum} of {totalPages} · {count} total events
+              </span>
+              <div className="flex gap-2">
+                {pageNum > 1 && (
+                  <Link
+                    href={`/admin/users/audit?page=${pageNum - 1}`}
+                    className="rounded border px-3 py-1 text-xs hover:bg-muted"
+                  >
+                    ← Previous
+                  </Link>
+                )}
+                {pageNum < totalPages && (
+                  <Link
+                    href={`/admin/users/audit?page=${pageNum + 1}`}
+                    className="rounded border px-3 py-1 text-xs hover:bg-muted"
+                  >
+                    Next →
+                  </Link>
+                )}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,6 +1,8 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { InviteUserButton } from "@/components/InviteUserButton";
+import { PendingInvitesTable } from "@/components/PendingInvitesTable";
 import { Alert } from "@/components/ui/alert";
 import { H1, Lead } from "@/components/ui/typography";
 import { UsersTable } from "@/components/UsersTable";
@@ -9,37 +11,69 @@ import { getServiceRoleClient } from "@/lib/supabase";
 import type { AdminUserRow } from "@/app/api/admin/users/list/route";
 
 // ---------------------------------------------------------------------------
-// /admin/users — M2d-1.
+// /admin/users — M2d-1 + AUTH-FOUNDATION P3.3.
 //
-// Admin-only page listing every opollo_users row. Operators who follow
-// a stale link are sent back to /admin/sites rather than all the way
-// out to the chat builder; viewers never reach /admin/* at all because
-// the layout gate filters them first.
-//
-// Reads via the service-role client — RLS is belt-and-braces here, the
-// admin gate above is the actual access control.
+// P3.3 layered onto the existing M2d page:
+//   - Pending invites section (read from `invites` table) with
+//     per-row revoke action.
+//   - Actor role threaded through to InviteUserButton so the modal
+//     filters role-dropdown options (super_admin → admin/user;
+//     admin → user only).
+//   - Audit-log link (super_admin only) to /admin/users/audit.
 // ---------------------------------------------------------------------------
 
 export const dynamic = "force-dynamic";
 
+interface PendingInviteRow {
+  id: string;
+  email: string;
+  role: "admin" | "user";
+  invited_by_email: string | null;
+  created_at: string;
+  expires_at: string;
+}
+
 export default async function AdminUsersPage() {
   const access = await checkAdminAccess({
-    requiredRoles: ["admin"],
+    requiredRoles: ["super_admin", "admin"],
     insufficientRoleRedirectTo: "/admin/sites",
   });
   if (access.kind === "redirect") redirect(access.to);
 
-  // Under flag-off / kill-switch, `access.user` is null — the role
-  // action cell treats null as "no self to compare against" and
-  // enables every row. The server route still enforces the
-  // last-admin guard.
   const currentUserId = access.user?.id ?? null;
+  const actorRole = access.user?.role ?? "admin";
+  const isSuperAdmin = actorRole === "super_admin";
 
   const svc = getServiceRoleClient();
-  const { data, error } = await svc
+
+  const usersRes = await svc
     .from("opollo_users")
     .select("id, email, display_name, role, created_at, revoked_at")
     .order("created_at", { ascending: false });
+
+  // Pending invites + their inviter email (joined via FK).
+  const invitesRes = await svc
+    .from("invites")
+    .select(
+      "id, email, role, created_at, expires_at, invited_by:opollo_users!invites_invited_by_fkey(email)",
+    )
+    .eq("status", "pending")
+    .order("created_at", { ascending: false });
+
+  const pendingInvites: PendingInviteRow[] = (invitesRes.data ?? []).map(
+    (row) => {
+      const inviter = (row as unknown as { invited_by?: { email?: string } | null })
+        .invited_by;
+      return {
+        id: row.id as string,
+        email: row.email as string,
+        role: row.role as "admin" | "user",
+        invited_by_email: inviter?.email ?? null,
+        created_at: row.created_at as string,
+        expires_at: row.expires_at as string,
+      };
+    },
+  );
 
   return (
     <>
@@ -47,24 +81,49 @@ export default async function AdminUsersPage() {
         <div>
           <H1>Users</H1>
           <Lead className="mt-0.5">
-            {(data ?? []).length === 0
+            {(usersRes.data ?? []).length === 0
               ? "No users yet."
-              : `${(data ?? []).length} ${(data ?? []).length === 1 ? "user" : "users"} with access to this builder. Change a role inline; the server blocks self-modification and last-admin demotions.`}
+              : `${(usersRes.data ?? []).length} ${(usersRes.data ?? []).length === 1 ? "user" : "users"} with access. Change a role inline; the server blocks self-modification, last-admin demotions, and any change to the super_admin row.`}
           </Lead>
         </div>
-        <InviteUserButton />
+        <div className="flex items-center gap-2">
+          {isSuperAdmin && (
+            <Link
+              href="/admin/users/audit"
+              className="rounded-md border px-3 py-2 text-sm transition-smooth hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              data-testid="users-audit-link"
+            >
+              Audit log
+            </Link>
+          )}
+          <InviteUserButton actorRole={actorRole} />
+        </div>
       </div>
 
-      <div className="mt-4">
-        {error ? (
+      {pendingInvites.length > 0 && (
+        <div className="mt-6">
+          <h2 className="mb-2 text-sm font-medium text-muted-foreground">
+            Pending invites · {pendingInvites.length}
+          </h2>
+          <PendingInvitesTable invites={pendingInvites} />
+        </div>
+      )}
+
+      <div className="mt-6">
+        {usersRes.error ? (
           <Alert variant="destructive" title="Failed to load users">
-            {error.message}
+            {usersRes.error.message}
           </Alert>
         ) : (
-          <UsersTable
-            users={(data ?? []) as AdminUserRow[]}
-            currentUserId={currentUserId}
-          />
+          <>
+            <h2 className="mb-2 text-sm font-medium text-muted-foreground">
+              Active and revoked users · {(usersRes.data ?? []).length}
+            </h2>
+            <UsersTable
+              users={(usersRes.data ?? []) as AdminUserRow[]}
+              currentUserId={currentUserId}
+            />
+          </>
         )}
       </div>
     </>

--- a/components/InviteUserButton.tsx
+++ b/components/InviteUserButton.tsx
@@ -7,13 +7,27 @@ import { InviteUserModal } from "@/components/InviteUserModal";
 
 // Lightweight client wrapper so the server-rendered /admin/users page
 // stays mostly server — only the button + modal need client state.
+//
+// AUTH-FOUNDATION P3.3: actorRole drives the role dropdown options
+// inside the modal (super_admin → admin/user; admin → user only).
+// Defence in depth — POST /api/admin/invites also gates per-actor.
 
-export function InviteUserButton() {
+export function InviteUserButton({
+  actorRole,
+}: {
+  actorRole: "super_admin" | "admin" | "user";
+}) {
   const [open, setOpen] = useState(false);
   return (
     <>
-      <Button onClick={() => setOpen(true)}>Invite user</Button>
-      <InviteUserModal open={open} onClose={() => setOpen(false)} />
+      <Button onClick={() => setOpen(true)} data-testid="invite-user-button">
+        Invite user
+      </Button>
+      <InviteUserModal
+        open={open}
+        onClose={() => setOpen(false)}
+        actorRole={actorRole}
+      />
     </>
   );
 }

--- a/components/InviteUserModal.tsx
+++ b/components/InviteUserModal.tsx
@@ -1,10 +1,22 @@
 "use client";
 
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+
+// AUTH-FOUNDATION P3.3 — Invite-user modal.
+//
+// POSTs to /api/admin/invites (the new custom-token flow) instead of
+// the legacy /api/admin/users/invite (Supabase magic-link).
+//
+// Role dropdown options vary by actor role per the brief's matrix:
+//   - super_admin: admin OR user
+//   - admin:       user only
+
+type ActorRole = "super_admin" | "admin" | "user";
+type InviteRole = "admin" | "user";
 
 type Status =
   | { kind: "idle" }
@@ -12,24 +24,35 @@ type Status =
   | {
       kind: "success";
       email: string;
-      actionLink: string | null;
+      role: InviteRole;
+      acceptUrl: string | null;
+      emailSent: boolean;
     }
   | { kind: "error"; message: string };
 
 export function InviteUserModal({
   open,
   onClose,
+  actorRole,
 }: {
   open: boolean;
   onClose: () => void;
+  actorRole: ActorRole;
 }) {
   const router = useRouter();
   const [email, setEmail] = useState("");
+  const [role, setRole] = useState<InviteRole>("user");
   const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  const allowedRoles: InviteRole[] = useMemo(
+    () => (actorRole === "super_admin" ? ["admin", "user"] : ["user"]),
+    [actorRole],
+  );
 
   useEffect(() => {
     if (open) {
       setEmail("");
+      setRole("user");
       setStatus({ kind: "idle" });
     }
   }, [open]);
@@ -50,17 +73,24 @@ export function InviteUserModal({
     setStatus({ kind: "submitting" });
 
     try {
-      const res = await fetch("/api/admin/users/invite", {
+      const res = await fetch("/api/admin/invites", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, role }),
       });
       const payload = (await res.json().catch(() => null)) as
         | {
             ok: true;
-            data: { email: string; action_link: string | null };
+            data: {
+              invite_id: string;
+              email: string;
+              role: InviteRole;
+              expires_at: string;
+              accept_url: string | null;
+              email_sent: boolean;
+            };
           }
-        | { ok: false; error: { message?: string } }
+        | { ok: false; error: { code?: string; message?: string } }
         | null;
 
       if (!res.ok || !payload || payload.ok !== true) {
@@ -75,9 +105,11 @@ export function InviteUserModal({
       setStatus({
         kind: "success",
         email: payload.data.email,
-        actionLink: payload.data.action_link,
+        role: payload.data.role,
+        acceptUrl: payload.data.accept_url,
+        emailSent: payload.data.email_sent,
       });
-      // Refresh the users table so the new pending user row appears.
+      // Refresh the users + invites tables so the new pending row appears.
       router.refresh();
     } catch (err) {
       setStatus({
@@ -104,31 +136,39 @@ export function InviteUserModal({
           Invite user
         </h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          New users start as <code>viewer</code>. Promote from the users list
-          after they accept.
+          Sends a 24-hour acceptance link via email. The invitee sets
+          their own password.
         </p>
 
         {status.kind === "success" ? (
           <div className="mt-4 space-y-3">
             <div
-              className="rounded-md border border-primary/40 bg-primary/10 px-3 py-2 text-sm"
+              className="rounded-md border border-success/40 bg-success/10 px-3 py-2 text-sm"
               role="status"
+              data-testid="invite-success"
             >
-              Invite generated for{" "}
-              <span className="font-medium">{status.email}</span>.
+              Invite sent to{" "}
+              <span className="font-medium">{status.email}</span> as{" "}
+              <span className="font-medium">{status.role}</span>.
+              {!status.emailSent && (
+                <p className="mt-1 text-xs">
+                  Email delivery failed — copy the link below to share
+                  out of band.
+                </p>
+              )}
             </div>
-            {status.actionLink && (
+            {status.acceptUrl && (
               <div className="flex flex-col gap-1">
                 <label
-                  htmlFor="invite-action-link"
+                  htmlFor="invite-accept-url"
                   className="text-xs font-medium text-muted-foreground"
                 >
-                  Invite URL (copy + share if email delivery is disabled)
+                  Acceptance URL (copy + share if email delivery is broken)
                 </label>
                 <Input
-                  id="invite-action-link"
+                  id="invite-accept-url"
                   readOnly
-                  value={status.actionLink}
+                  value={status.acceptUrl}
                   onFocus={(e) => e.currentTarget.select()}
                   className="font-mono text-xs"
                 />
@@ -156,12 +196,41 @@ export function InviteUserModal({
                 onChange={(e) => setEmail(e.target.value)}
                 disabled={submitting}
                 autoFocus
+                data-testid="invite-email"
               />
+            </div>
+            <div>
+              <label
+                htmlFor="invite-role"
+                className="block text-sm font-medium"
+              >
+                Role
+              </label>
+              <select
+                id="invite-role"
+                value={role}
+                onChange={(e) => setRole(e.target.value as InviteRole)}
+                disabled={submitting || allowedRoles.length === 1}
+                data-testid="invite-role"
+                className="mt-1 h-10 w-full rounded-md border bg-background px-3 text-sm"
+              >
+                {allowedRoles.map((r) => (
+                  <option key={r} value={r}>
+                    {r}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {allowedRoles.length === 1
+                  ? "Admins can only invite role=user. Ask a super_admin to invite admins."
+                  : "Choose admin to grant invite + remove powers; user otherwise."}
+              </p>
             </div>
             {status.kind === "error" && (
               <div
                 className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
                 role="alert"
+                data-testid="invite-error"
               >
                 {status.message}
               </div>
@@ -175,7 +244,11 @@ export function InviteUserModal({
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={submitting}>
+              <Button
+                type="submit"
+                disabled={submitting}
+                data-testid="invite-submit"
+              >
                 {submitting ? "Inviting…" : "Send invite"}
               </Button>
             </div>

--- a/components/PendingInvitesTable.tsx
+++ b/components/PendingInvitesTable.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { formatRelativeTime } from "@/lib/utils";
+
+// AUTH-FOUNDATION P3.3 — pending-invites table on /admin/users.
+
+interface PendingInvite {
+  id: string;
+  email: string;
+  role: "admin" | "user";
+  invited_by_email: string | null;
+  created_at: string;
+  expires_at: string;
+}
+
+export function PendingInvitesTable({
+  invites,
+}: {
+  invites: PendingInvite[];
+}) {
+  const router = useRouter();
+  const [revoking, setRevoking] = useState<string | null>(null);
+
+  async function revoke(id: string, email: string) {
+    if (!window.confirm(`Revoke pending invite for ${email}?`)) return;
+    setRevoking(id);
+    try {
+      const res = await fetch(
+        `/api/admin/invites/${encodeURIComponent(id)}`,
+        { method: "DELETE" },
+      );
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        toast.error("Couldn't revoke invite", {
+          description:
+            payload?.error?.message ?? `Revoke failed (HTTP ${res.status}).`,
+        });
+        return;
+      }
+      toast.success(`Invite for ${email} revoked.`);
+      router.refresh();
+    } catch (err) {
+      toast.error("Network error revoking invite", {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setRevoking(null);
+    }
+  }
+
+  return (
+    <div className="rounded-md border">
+      <table className="w-full text-sm">
+        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+          <tr>
+            <th className="px-3 py-2 font-medium">Email</th>
+            <th className="px-3 py-2 font-medium">Role</th>
+            <th className="px-3 py-2 font-medium">Invited by</th>
+            <th className="px-3 py-2 font-medium">Sent</th>
+            <th className="px-3 py-2 font-medium">Expires</th>
+            <th className="w-24 px-2 py-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {invites.map((inv) => {
+            const expiresIn = new Date(inv.expires_at).getTime() - Date.now();
+            const expiringSoon = expiresIn < 60 * 60 * 1000; // < 1h
+            return (
+              <tr
+                key={inv.id}
+                className="border-b transition-smooth last:border-b-0 hover:bg-muted/40"
+                data-testid="pending-invite-row"
+              >
+                <td className="px-3 py-2 font-medium">{inv.email}</td>
+                <td className="px-3 py-2">
+                  <span className="inline-flex items-center rounded border border-input px-2 py-0.5 text-xs">
+                    {inv.role}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-xs text-muted-foreground">
+                  {inv.invited_by_email ?? "(deleted user)"}
+                </td>
+                <td className="px-3 py-2 text-xs text-muted-foreground">
+                  <span data-screenshot-mask>
+                    {formatRelativeTime(inv.created_at)}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-xs">
+                  <span
+                    className={
+                      expiringSoon
+                        ? "text-warning"
+                        : "text-muted-foreground"
+                    }
+                    data-screenshot-mask
+                  >
+                    {formatRelativeTime(inv.expires_at)}
+                  </span>
+                </td>
+                <td className="px-2 py-2 text-right">
+                  <button
+                    type="button"
+                    onClick={() => void revoke(inv.id, inv.email)}
+                    disabled={revoking === inv.id}
+                    className="rounded border px-2 py-0.5 text-xs text-destructive transition-smooth hover:bg-destructive/10 disabled:opacity-60"
+                    data-testid="invite-revoke-button"
+                  >
+                    {revoking === inv.id ? "…" : "Revoke"}
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Wires the P3.2 backend into the existing /admin/users page and adds the brief's audit log viewer (super_admin only).

## What ships

- **InviteUserButton + InviteUserModal swapped** from legacy \`/api/admin/users/invite\` (Supabase magic-link) to \`/api/admin/invites\` (custom-token flow).
- **Role dropdown in the modal**:
  - super_admin → admin OR user
  - admin → user only (dropdown disabled, single option)
  - Defence in depth — POST also gates per-actor at the API layer.
- **Success copy** reads back the role + accept_url + email_sent flag from the new response shape so the operator can copy-paste the link if SendGrid delivery failed.
- **\`/admin/users\` adds a \"Pending invites · N\" section** above the users table when invites exist. Joined with opollo_users for inviter email; per-row Revoke action hits DELETE /api/admin/invites/[id]. Expiring-soon (< 1h) renders in warning tone.
- **\`/admin/users/audit\`** — new super_admin-only viewer of \`user_audit_log\`. Read-only, paginated 50/page, joined with opollo_users for actor email. Empty state when no events.
- **Audit log link** surfaced in the /admin/users header for super_admin only; admin role doesn't see it.

## Risks identified and mitigated

- **Legacy \`/api/admin/users/invite\` (magic-link) route** is no longer wired into any UI surface. Still exists unreferenced; follow-up cleanup deletes the file once existing tests are updated.
- **\`/admin/users/audit\` gated at \`requiredRoles: ['super_admin']\`**; insufficientRoleRedirectTo points back to /admin/users so an admin who follows a bookmark gets a graceful redirect.
- **Pending-invite revoke uses window.confirm()** — consistent with the existing site-archive flow's confirmation pattern. Future polish swap to ConfirmActionModal is optional.
- **PendingInvitesTable optimistically refreshes** via router.refresh() so the row disappears + count drops without full page reload.

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅
- /admin/users — 6.09 kB / 186 kB First Load JS
- /admin/users/audit — 1.03 kB / 164 kB First Load JS

## Test plan

- [ ] As super_admin: see admin + user role options in the invite modal
- [ ] As admin: see only user role option (dropdown disabled)
- [ ] After invite: pending row appears, revoke button works
- [ ] /admin/users/audit shows the invite_sent + invite_revoked rows
- [ ] As admin (not super_admin): /admin/users/audit redirects back to /admin/users
- [ ] Operator gate at end of P3 (after P3.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)