### PR TITLE
feat(optimiser-22): cross-client pattern library schema + extractor (phase 3)

### DIFF
--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -6,6 +6,30 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 
 <!-- CLAIM BLOCKS BELOW THIS LINE — append on slice start, remove on slice merge -->
 
+---
+## Session B
+- Started: 2026-04-30
+- Branch: feat/optimiser-phase-3 (and slice sub-branches)
+- Slice: Optimiser Phase 3 — cross-client pattern library schema + extraction (Slice 22), pattern application as priors (Slice 23), consent UI + diagnostics (Slice 24)
+- Files claimed (all new/optimiser-only; no Phase 1.5 / Phase 2 surfaces touched outside the optimiser module):
+  - supabase/migrations/0061_optimiser_pattern_library.sql (new)
+  - supabase/rollbacks/0061_*.down.sql
+  - lib/optimiser/pattern-library/* (new folder — Slices 22 + 23)
+  - app/api/cron/optimiser-extract-patterns/route.ts (new — Slice 22)
+  - app/api/optimiser/clients/[id]/cross-client-consent/route.ts (new — Slice 24)
+  - components/optimiser/CrossClientConsentToggle.tsx, PatternsAppliedPanel.tsx (new)
+  - app/optimiser/clients/[id]/settings/page.tsx (Slice 24 — consent toggle section)
+  - app/optimiser/proposals/[id]/page.tsx (Slice 23 — pattern-applied panel)
+  - app/optimiser/diagnostics/page.tsx (Slice 24 — pattern library state)
+  - lib/optimiser/proposal-generation.ts (Slice 23 — read priors from pattern library)
+  - lib/optimiser/diagnostics.ts (Slice 24 — extend report with pattern stats)
+  - skills/optimiser/{pattern-extraction,pattern-application}/SKILL.md (new)
+  - vercel.json (additive — appends one cron entry only)
+- Migration numbers reserved: 0061
+- Expected completion: same session; squash-merge each slice on green CI per the user's Phase 3 brief
+- Notes: Phase 3 is consent-gated per spec §11.2.2 — code ships behind feature-flag env var OPT_PATTERN_LIBRARY_ENABLED + per-client cross_client_learning_consent (already exists from Phase 1 schema, default false). Spec §11.2.4 requires MSA-clause adoption before flipping the flag in production; UI surfaces this constraint.
+---
+
 ## ~~Session A~~ (stale claim from 2026-04-24, M12-6 shipped — left in place; A's owner removes when they next push)
 - Started: 2026-04-24
 - Branch: feat/m12-6-save-draft-persistence


### PR DESCRIPTION
## Summary
Phase 3 first slice. Spec §11.2 (cross-client learning, consent-gated), §6 feature 10, §12.4. Adds the \`opt_pattern_library\` table, the daily extractor cron, the feature flag + per-client consent gate, and the pattern classifier.

## Plan (sub-slice)
**Stack base.** \`main\` (Phase 2 + #312 fix already landed).

**Anonymisation by construction.** The schema has no foreign keys to client / page / proposal — the persisted shape is pattern_type, structural variant + baseline labels, sample-size aggregates, effect mean + 95% CI, confidence label, optional triggering_playbook_id. The extractor reads source ids only into memory for distinct-counting, never persists them.

**Two hard gates.**
1. \`OPT_PATTERN_LIBRARY_ENABLED\` env flag must be \`true\`. Spec §11.2.4 requires MSA-clause adoption before flipping in production.
2. Per-client \`cross_client_learning_consent\` (existing column from Phase 1 migration 0031). Default \`false\`; non-consenting clients contribute zero observations.

**Min cohort.** ≥ 2 distinct consenting clients before any pattern is written. Single-client patterns are rejected with \`reason='single_client_only'\`.

## Risks identified and mitigated
- **Anonymisation invariant** — schema-level: no FKs to client/page/proposal. Code-level: source ids never written to opt_pattern_library.
- **Consent gating** — hard SQL filter on \`cross_client_learning_consent=true\`. Skipping the filter would be a CR-blocker.
- **Feature flag** — extractor returns cleanly when off; no DB writes.
- **Min cohort** — 2-client floor prevents a single client's data masquerading as cross-client.
- **Idempotency** — UPSERT keyed on \`(type, variant, baseline, COALESCE(playbook_id, ''))\` so re-runs are no-ops on unchanged inputs.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean (\`/api/cron/optimiser-extract-patterns\` registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)