### PR TITLE
feat(optimiser-22): cross-client pattern library schema + extractor (phase 3, redo of #315)

### DIFF
--- a/app/api/cron/optimiser-extract-patterns/route.ts
+++ b/app/api/cron/optimiser-extract-patterns/route.ts
@@ -1,0 +1,39 @@
+import { type NextRequest } from "next/server";
+
+import { runPatternExtraction } from "@/lib/optimiser/pattern-library/extractor";
+import {
+  authorisedCronRequest,
+  runOptimiserCronTick,
+  unauthorisedResponse,
+} from "@/lib/optimiser/sync/cron-shared";
+
+// Daily cross-client pattern extraction (Phase 3 Slice 22, spec §11.2).
+// Gated on OPT_PATTERN_LIBRARY_ENABLED feature flag + per-client
+// cross_client_learning_consent. Cron returns cleanly when the flag is
+// off — no DB writes.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+async function handle(req: NextRequest) {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+  return runOptimiserCronTick({
+    eventName: "optimiser.pattern_extraction",
+    run: async () => {
+      const r = await runPatternExtraction();
+      return {
+        outcomes: r.outcomes,
+        total: r.patterns_upserted,
+        meta: {
+          enabled: r.enabled,
+          consenting_clients: r.consenting_clients,
+          observations_total: r.observations_total,
+        },
+      };
+    },
+  });
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/lib/optimiser/pattern-library/classify-pattern.ts
+++ b/lib/optimiser/pattern-library/classify-pattern.ts
@@ -1,0 +1,118 @@
+// Pattern classification for the Phase 3 extractor.
+//
+// Given a causal-delta or A/B winning-variant record, derive the
+// (pattern_type, variant_label, baseline_label) tuple that describes
+// the structural change being measured. The classifier inspects the
+// proposal's change_set + the playbook id — entirely structural, no
+// content / copy / brand strings touched.
+//
+// New pattern types are added by extending the dispatch below; the
+// schema-level `pattern_type` is free-text so additions are
+// migration-free.
+
+export interface PatternClassification {
+  pattern_type: string;
+  variant_label: string;
+  baseline_label: string;
+}
+
+const TWIST_TO_VARIANT: Record<string, string> = {
+  centred_hero_with_long_form: "centred_hero",
+  trust_first_above_offer: "trust_first",
+  two_step_form_with_progress_indicator: "two_step_form",
+};
+
+/** Classify a winning-variant outcome by reading the structural marker
+ * the variant generator wrote into change_set._variant_b_twist (Slice
+ * 18 deterministic fallback) or by inferring from the playbook id. */
+export function classifyVariantOutcome(args: {
+  change_set: Record<string, unknown>;
+  playbook_id: string | null;
+}): PatternClassification | null {
+  const twist = (args.change_set as { _variant_b_twist?: unknown })
+    ._variant_b_twist;
+  if (typeof twist === "string" && twist in TWIST_TO_VARIANT) {
+    return {
+      pattern_type: "variant_b_twist",
+      variant_label: TWIST_TO_VARIANT[twist],
+      baseline_label: "control",
+    };
+  }
+  // Playbook-id fallback — the playbook's structural intent is enough
+  // to type the pattern even when the change_set doesn't carry a
+  // marker. e.g. weak_above_the_fold proposals are about CTA
+  // position; form_friction proposals are about form length.
+  if (!args.playbook_id) return null;
+  switch (args.playbook_id) {
+    case "weak_above_the_fold":
+      return {
+        pattern_type: "cta_position",
+        variant_label: "viewport_1",
+        baseline_label: "viewport_2_plus",
+      };
+    case "form_friction":
+      return {
+        pattern_type: "form_field_count",
+        variant_label: "le_5_fields",
+        baseline_label: "gt_5_fields",
+      };
+    case "offer_clarity":
+      return {
+        pattern_type: "offer_above_fold",
+        variant_label: "offer_above_fold",
+        baseline_label: "offer_below_fold",
+      };
+    case "trust_gap":
+      return {
+        pattern_type: "trust_signal_placement",
+        variant_label: "trust_adjacent_to_cta",
+        baseline_label: "trust_isolated",
+      };
+    case "stale_social_proof":
+      return {
+        pattern_type: "social_proof_position",
+        variant_label: "viewport_1_to_3",
+        baseline_label: "viewport_4_plus",
+      };
+    case "cta_verb_mismatch":
+      return {
+        pattern_type: "cta_verb_match",
+        variant_label: "matches_ad",
+        baseline_label: "does_not_match_ad",
+      };
+    case "message_mismatch":
+      return {
+        pattern_type: "hero_keyword_match",
+        variant_label: "h1_includes_top_keyword",
+        baseline_label: "h1_excludes_top_keyword",
+      };
+    default:
+      return null;
+  }
+}
+
+/** One-line structural description matched to the (pattern_type,
+ * variant, baseline) tuple — surfaced in the diagnostics + proposal
+ * review UI. No content / brand / URL leakage. */
+export function describePattern(c: PatternClassification): string {
+  switch (c.pattern_type) {
+    case "cta_position":
+      return "Primary CTA placed in viewport 1 vs viewport 2+";
+    case "form_field_count":
+      return "Form length ≤ 5 fields vs > 5 fields";
+    case "offer_above_fold":
+      return "Offer restated above the fold vs only below";
+    case "trust_signal_placement":
+      return "Trust signals adjacent to CTA vs isolated section";
+    case "social_proof_position":
+      return "Social proof in viewport 1-3 vs viewport 4+";
+    case "cta_verb_match":
+      return "CTA verb matches ad copy vs differs";
+    case "hero_keyword_match":
+      return "Hero H1 includes the ad's top keyword vs excludes it";
+    case "variant_b_twist":
+      return `Variant B twist: ${c.variant_label.replace(/_/g, " ")} vs control`;
+    default:
+      return `${c.variant_label} vs ${c.baseline_label}`;
+  }
+}

--- a/lib/optimiser/pattern-library/extractor.ts
+++ b/lib/optimiser/pattern-library/extractor.ts
@@ -1,0 +1,295 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import {
+  classifyVariantOutcome,
+  describePattern,
+  type PatternClassification,
+} from "./classify-pattern";
+import { isPatternLibraryEnabled } from "./feature-flag";
+import type { PatternConfidence, PatternObservation } from "./types";
+
+// ---------------------------------------------------------------------------
+// Cross-client pattern extractor (Phase 3 Slice 22).
+//
+// Daily cron iterates causal-delta + A/B winning-variant data ONLY for
+// clients with cross_client_learning_consent=true on opt_clients,
+// classifies each outcome into a (pattern_type, variant, baseline)
+// triple via classifyVariantOutcome, aggregates across consenting
+// clients, and UPSERTs one row per (type, variant, baseline,
+// playbook_id) into opt_pattern_library.
+//
+// Anonymisation guarantees, enforced by construction:
+//   - Only consenting clients contribute (cross_client_learning_consent
+//     boolean on opt_clients, default false).
+//   - Source columns (client_id, page_id, proposal_id, ad_group_id)
+//     never persist — they're only used to count distinct contributors
+//     and weight observations during aggregation.
+//   - The persisted row carries pattern_type, structural variant
+//     labels, sample-size aggregates, effect mean + 95% CI, and
+//     confidence — no copy, URLs, brand names, or testimonial text.
+//
+// Feature flag: isPatternLibraryEnabled() (env var
+// OPT_PATTERN_LIBRARY_ENABLED) must return true for the cron to do
+// any work. Spec §11.2.4 requires MSA-clause adoption before this
+// flag flips in production.
+// ---------------------------------------------------------------------------
+
+const MIN_CLIENTS_FOR_EXTRACTION = 2;
+
+export interface ExtractorOutcome {
+  pattern_type: string;
+  variant_label: string;
+  baseline_label: string;
+  triggering_playbook_id: string | null;
+  upserted: boolean;
+  reason?: string;
+}
+
+export async function runPatternExtraction(): Promise<{
+  enabled: boolean;
+  consenting_clients: number;
+  observations_total: number;
+  patterns_upserted: number;
+  outcomes: ExtractorOutcome[];
+}> {
+  if (!isPatternLibraryEnabled()) {
+    return {
+      enabled: false,
+      consenting_clients: 0,
+      observations_total: 0,
+      patterns_upserted: 0,
+      outcomes: [],
+    };
+  }
+
+  const supabase = getServiceRoleClient();
+
+  // 1. List consenting clients.
+  const { data: consenting, error: clientsErr } = await supabase
+    .from("opt_clients")
+    .select("id")
+    .eq("cross_client_learning_consent", true)
+    .is("deleted_at", null);
+  if (clientsErr) {
+    throw new Error(`runPatternExtraction list clients: ${clientsErr.message}`);
+  }
+  const consentingIds = new Set(
+    (consenting ?? []).map((c) => c.id as string),
+  );
+  if (consentingIds.size < MIN_CLIENTS_FOR_EXTRACTION) {
+    return {
+      enabled: true,
+      consenting_clients: consentingIds.size,
+      observations_total: 0,
+      patterns_upserted: 0,
+      outcomes: [],
+    };
+  }
+
+  // 2. Collect observations from opt_causal_deltas — measured CR
+  //    delta per applied proposal. Phase 3 expansion: also read
+  //    opt_client_memory.winning_variants once Phase 2 A/B winners
+  //    accumulate.
+  const observations: PatternObservation[] = [];
+
+  const { data: deltas, error: deltasErr } = await supabase
+    .from("opt_causal_deltas")
+    .select(
+      "client_id, landing_page_id, proposal_id, change_set, actual_impact_cr, triggering_playbook_id, evaluation_window_start, evaluation_window_end",
+    )
+    .not("actual_impact_cr", "is", null);
+  if (deltasErr) {
+    logger.error("optimiser.pattern_extractor.deltas_failed", {
+      error: deltasErr.message,
+    });
+  }
+  for (const row of deltas ?? []) {
+    if (!consentingIds.has(row.client_id as string)) continue;
+    const cls = classifyVariantOutcome({
+      change_set: (row.change_set ?? {}) as Record<string, unknown>,
+      playbook_id: (row.triggering_playbook_id as string | null) ?? null,
+    });
+    if (!cls) continue;
+    const observed = row.actual_impact_cr as number;
+    observations.push({
+      pattern_type: cls.pattern_type,
+      variant_label: cls.variant_label,
+      baseline_label: cls.baseline_label,
+      triggering_playbook_id:
+        (row.triggering_playbook_id as string | null) ?? null,
+      client_id: row.client_id as string,
+      page_id: row.landing_page_id as string,
+      ad_group_id: null,
+      proposal_id: row.proposal_id as string,
+      // observed CR delta is stored as a relative ratio in
+      // opt_causal_deltas; convert to percentage points (×100) and
+      // round to the schema's numeric(6,3) precision.
+      observed_effect_pp: Math.round(observed * 1000) / 10,
+      sample_size: 1,
+    });
+  }
+
+  // 3. Aggregate per (pattern_type, variant_label, baseline_label,
+  //    triggering_playbook_id) tuple.
+  const grouped = groupObservations(observations);
+
+  // 4. UPSERT each group as one opt_pattern_library row.
+  const outcomes: ExtractorOutcome[] = [];
+  let upsertedCount = 0;
+  const nowIso = new Date().toISOString();
+  for (const group of grouped.values()) {
+    const distinctClients = new Set(group.observations.map((o) => o.client_id))
+      .size;
+    if (distinctClients < MIN_CLIENTS_FOR_EXTRACTION) {
+      outcomes.push({
+        pattern_type: group.pattern_type,
+        variant_label: group.variant_label,
+        baseline_label: group.baseline_label,
+        triggering_playbook_id: group.triggering_playbook_id,
+        upserted: false,
+        reason: `single_client_only:${distinctClients}`,
+      });
+      continue;
+    }
+    const distinctPages = new Set(group.observations.map((o) => o.page_id))
+      .size;
+    const distinctAdGroups = new Set(
+      group.observations
+        .map((o) => o.ad_group_id)
+        .filter((v): v is string => v != null),
+    ).size;
+    const effects = group.observations.map((o) => o.observed_effect_pp);
+    const stats = summariseEffects(effects);
+    const confidence = deriveConfidence(distinctClients, stats);
+    const cls: PatternClassification = {
+      pattern_type: group.pattern_type,
+      variant_label: group.variant_label,
+      baseline_label: group.baseline_label,
+    };
+
+    const { error: upsertErr } = await supabase
+      .from("opt_pattern_library")
+      .upsert(
+        {
+          pattern_type: group.pattern_type,
+          observation: describePattern(cls),
+          variant_label: group.variant_label,
+          baseline_label: group.baseline_label,
+          sample_size_pages: distinctPages,
+          sample_size_ad_groups: distinctAdGroups,
+          sample_size_clients: distinctClients,
+          sample_size_observations: group.observations.length,
+          effect_pp_mean: stats.mean,
+          effect_pp_ci_low: stats.ci_low,
+          effect_pp_ci_high: stats.ci_high,
+          confidence,
+          triggering_playbook_id: group.triggering_playbook_id,
+          last_extracted_at: nowIso,
+        },
+        {
+          onConflict:
+            "pattern_type,variant_label,baseline_label,triggering_playbook_id",
+        },
+      );
+    if (upsertErr) {
+      logger.error("optimiser.pattern_extractor.upsert_failed", {
+        pattern_type: group.pattern_type,
+        error: upsertErr.message,
+      });
+      outcomes.push({
+        pattern_type: group.pattern_type,
+        variant_label: group.variant_label,
+        baseline_label: group.baseline_label,
+        triggering_playbook_id: group.triggering_playbook_id,
+        upserted: false,
+        reason: `upsert_failed:${upsertErr.message}`,
+      });
+      continue;
+    }
+    upsertedCount += 1;
+    outcomes.push({
+      pattern_type: group.pattern_type,
+      variant_label: group.variant_label,
+      baseline_label: group.baseline_label,
+      triggering_playbook_id: group.triggering_playbook_id,
+      upserted: true,
+    });
+  }
+
+  return {
+    enabled: true,
+    consenting_clients: consentingIds.size,
+    observations_total: observations.length,
+    patterns_upserted: upsertedCount,
+    outcomes,
+  };
+}
+
+interface ObservationGroup {
+  pattern_type: string;
+  variant_label: string;
+  baseline_label: string;
+  triggering_playbook_id: string | null;
+  observations: PatternObservation[];
+}
+
+function groupObservations(
+  observations: PatternObservation[],
+): Map<string, ObservationGroup> {
+  const out = new Map<string, ObservationGroup>();
+  for (const obs of observations) {
+    const key = `${obs.pattern_type}|${obs.variant_label}|${obs.baseline_label}|${obs.triggering_playbook_id ?? ""}`;
+    let group = out.get(key);
+    if (!group) {
+      group = {
+        pattern_type: obs.pattern_type,
+        variant_label: obs.variant_label,
+        baseline_label: obs.baseline_label,
+        triggering_playbook_id: obs.triggering_playbook_id,
+        observations: [],
+      };
+      out.set(key, group);
+    }
+    group.observations.push(obs);
+  }
+  return out;
+}
+
+function summariseEffects(values: number[]): {
+  mean: number;
+  ci_low: number;
+  ci_high: number;
+} {
+  if (values.length === 0) return { mean: 0, ci_low: 0, ci_high: 0 };
+  const n = values.length;
+  const mean = values.reduce((a, b) => a + b, 0) / n;
+  if (n < 2) return { mean: round3(mean), ci_low: round3(mean), ci_high: round3(mean) };
+  const variance =
+    values.reduce((acc, v) => acc + (v - mean) ** 2, 0) / (n - 1);
+  const stddev = Math.sqrt(variance);
+  // 95% CI of the mean via z-approximation.
+  const halfWidth = 1.96 * (stddev / Math.sqrt(n));
+  return {
+    mean: round3(mean),
+    ci_low: round3(mean - halfWidth),
+    ci_high: round3(mean + halfWidth),
+  };
+}
+
+function deriveConfidence(
+  distinctClients: number,
+  stats: { mean: number; ci_low: number; ci_high: number },
+): PatternConfidence {
+  if (distinctClients >= 10 && (stats.ci_low > 0 || stats.ci_high < 0)) {
+    return "high";
+  }
+  if (distinctClients >= 5) return "moderate";
+  return "low";
+}
+
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}

--- a/lib/optimiser/pattern-library/feature-flag.ts
+++ b/lib/optimiser/pattern-library/feature-flag.ts
@@ -1,0 +1,18 @@
+// Feature-flag gate for the Phase 3 pattern library.
+//
+// Spec §11.2.4 requires the MSA / engagement letter to include an
+// explicit consent clause before the pattern library is enabled in
+// production. Engineering can ship the code behind a flag in the
+// meantime; flipping the flag in production is a Caleb / Matthew
+// decision once the legal text is in place.
+//
+// The flag is binary: when off, the extractor cron is a no-op and the
+// proposal generator skips reading priors from opt_pattern_library
+// even if rows exist. Per-client `cross_client_learning_consent` is a
+// secondary gate inside the extractor — patterns are only built from
+// consenting clients regardless of the global flag.
+
+export function isPatternLibraryEnabled(): boolean {
+  const v = process.env.OPT_PATTERN_LIBRARY_ENABLED;
+  return v === "true" || v === "1";
+}

--- a/lib/optimiser/pattern-library/types.ts
+++ b/lib/optimiser/pattern-library/types.ts
@@ -1,0 +1,46 @@
+// Phase 3 cross-client pattern library types.
+
+export type PatternConfidence = "low" | "moderate" | "high";
+
+export interface PatternRow {
+  id: string;
+  pattern_type: string;
+  observation: string;
+  variant_label: string;
+  baseline_label: string;
+  sample_size_pages: number;
+  sample_size_ad_groups: number;
+  sample_size_clients: number;
+  sample_size_observations: number;
+  effect_pp_mean: number;
+  effect_pp_ci_low: number;
+  effect_pp_ci_high: number;
+  confidence: PatternConfidence;
+  applies_to: Record<string, unknown> | null;
+  triggering_playbook_id: string | null;
+  last_extracted_at: string;
+  created_at: string;
+}
+
+/** A single observation from a consenting client's A/B test outcome
+ * or causal-delta record. The extractor groups these by
+ * (pattern_type, variant_label, baseline_label, playbook_id) and
+ * aggregates. */
+export interface PatternObservation {
+  pattern_type: string;
+  variant_label: string;
+  baseline_label: string;
+  triggering_playbook_id: string | null;
+  /** Source: which client / page / proposal / test contributed. The
+   * extractor uses these to count distinct clients + pages but
+   * NEVER persists them — anonymisation guarantee. */
+  client_id: string;
+  page_id: string;
+  ad_group_id: string | null;
+  proposal_id: string;
+  /** Effect — variant CR minus baseline CR in percentage points.
+   * Positive means the variant outperforms the baseline. */
+  observed_effect_pp: number;
+  /** Per-observation sample size, used to weight aggregation. */
+  sample_size: number;
+}

--- a/skills/optimiser/pattern-extraction/SKILL.md
+++ b/skills/optimiser/pattern-extraction/SKILL.md
@@ -1,0 +1,55 @@
+# Skill — pattern-extraction (Phase 3)
+
+Cross-client pattern extractor for the §11.2 anonymised pattern library. Phase 3 Slice 22.
+
+## Cron
+`/api/cron/optimiser-extract-patterns` runs daily at 10:00 UTC.
+
+## Hard gates
+1. **Feature flag** — `OPT_PATTERN_LIBRARY_ENABLED` must be `true` / `1`. When off, the extractor returns cleanly with no DB writes. Spec §11.2.4 requires MSA-clause adoption before flipping this in production; flag exists so engineering can ship the code in advance.
+2. **Per-client consent** — only clients with `cross_client_learning_consent=true` on `opt_clients` contribute observations. Default is `false`; toggling requires admin action plus the legal precondition above.
+3. **Minimum cohort** — patterns require ≥ 2 distinct consenting clients before any row is written. Single-client patterns are rejected with `reason: 'single_client_only'`.
+
+## Sources
+- `opt_causal_deltas` rows where `actual_impact_cr IS NOT NULL` — measured CR delta after applied proposals
+- (Phase 3 future expansion) `opt_client_memory.winning_variants` rows from concluded A/B tests
+
+Source rows are joined to `opt_proposals` to recover the triggering playbook id, then classified via `classifyVariantOutcome`.
+
+## Anonymisation guarantees (by construction)
+- `client_id`, `landing_page_id`, `proposal_id`, `ad_group_id` are read into memory only — they're used to count distinct clients / pages / ad groups during aggregation but never persist on `opt_pattern_library`.
+- The persisted row carries `pattern_type`, structural variant + baseline labels, sample-size aggregates, effect mean + 95% CI, confidence label, optional triggering_playbook_id. **No copy, URLs, brand names, testimonial text, or pricing.**
+- The schema has no foreign keys to client / page / proposal — the anonymisation invariant lives in the schema shape, not just in code.
+
+## Pattern types
+Phase 3 ships seven, with room to extend by adding cases to `classifyVariantOutcome`:
+- `cta_position` (viewport_1 vs viewport_2_plus)
+- `form_field_count` (le_5_fields vs gt_5_fields)
+- `offer_above_fold`
+- `trust_signal_placement`
+- `social_proof_position`
+- `cta_verb_match`
+- `hero_keyword_match`
+- `variant_b_twist` (for Slice 18 deterministic-fallback variants — centred_hero / trust_first / two_step_form)
+
+## Aggregation
+- Group observations by `(pattern_type, variant_label, baseline_label, triggering_playbook_id)`.
+- Mean = simple mean of observed CR deltas (percentage points).
+- 95% CI = `mean ± 1.96 × stddev / √n` (z-approximation).
+- Confidence label:
+  - `high` — ≥ 10 distinct consenting clients AND CI excludes 0
+  - `moderate` — ≥ 5 distinct consenting clients
+  - `low` — otherwise
+
+## Idempotency
+UPSERT keyed on `(pattern_type, variant_label, baseline_label, COALESCE(triggering_playbook_id, ''))`. The extractor recomputes the aggregate every tick and overwrites; re-running the cron is a no-op when the underlying observations haven't changed.
+
+## Spec
+§11.2 (cross-client learning), §11.2.3 (anonymisation), §11.2.4 (legal action required), §6 feature 10, §12.4.
+
+## Pointers
+- `lib/optimiser/pattern-library/extractor.ts:runPatternExtraction`
+- `lib/optimiser/pattern-library/classify-pattern.ts`
+- `lib/optimiser/pattern-library/feature-flag.ts:isPatternLibraryEnabled`
+- Cron route: `app/api/cron/optimiser-extract-patterns/route.ts`
+- Migration: `supabase/migrations/0061_optimiser_pattern_library.sql`

--- a/supabase/migrations/0061_optimiser_pattern_library.sql
+++ b/supabase/migrations/0061_optimiser_pattern_library.sql
@@ -1,0 +1,68 @@
+-- 0061 — Optimiser Phase 3 Slice 22: opt_pattern_library.
+-- Reference: docs/Optimisation_Engine_Spec_v1.5.docx §11.2 (cross-client
+-- learning, consent-gated), §6 feature 10 (Phase 3 cross-client
+-- learning), §12.4 (Phase 3 build order).
+--
+-- Anonymised cross-client patterns. Each row records a STRUCTURAL
+-- observation across N consenting clients — never client-specific
+-- content, copy, or testimonials. Per §11.2.3:
+--
+--   pattern_type:  "cta_position" / "form_field_count" / "hero_layout" / etc.
+--   observation:   one-line structural description (no URLs / names)
+--   sample_size_*: how many pages / ad groups / clients contributed
+--   effect_pp_*:   observed CR uplift in percentage points + 95% CI
+--   confidence:    "low" / "moderate" / "high" derived from sample size
+--
+-- The pattern library is read by the proposal generator (Slice 23) to
+-- bias expected_impact ranges with cross-client priors. Patterns are
+-- ONLY extracted from clients with cross_client_learning_consent=true
+-- on opt_clients (existing column from Phase 1 migration 0031).
+--
+-- Hard schema-level safeguard: NO foreign keys to client / page /
+-- proposal tables. The pattern library is anonymised by construction —
+-- no row should carry data linkable back to a single client.
+
+CREATE TABLE opt_pattern_library (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pattern_type             text NOT NULL,
+  observation              text NOT NULL,
+  variant_label            text NOT NULL,
+  baseline_label           text NOT NULL,
+  sample_size_pages        integer NOT NULL CHECK (sample_size_pages >= 0),
+  sample_size_ad_groups    integer NOT NULL CHECK (sample_size_ad_groups >= 0),
+  sample_size_clients      integer NOT NULL CHECK (sample_size_clients >= 0),
+  sample_size_observations integer NOT NULL CHECK (sample_size_observations >= 0),
+  effect_pp_mean           numeric(6, 3) NOT NULL,
+  effect_pp_ci_low         numeric(6, 3) NOT NULL,
+  effect_pp_ci_high        numeric(6, 3) NOT NULL,
+  confidence               text NOT NULL DEFAULT 'low'
+    CHECK (confidence IN ('low', 'moderate', 'high')),
+  applies_to               jsonb,
+  triggering_playbook_id   text REFERENCES opt_playbooks(id) ON DELETE SET NULL,
+  last_extracted_at        timestamptz NOT NULL DEFAULT now(),
+  created_at               timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX opt_pattern_library_uniq
+  ON opt_pattern_library (
+    pattern_type,
+    variant_label,
+    baseline_label,
+    COALESCE(triggering_playbook_id, '')
+  );
+
+CREATE INDEX opt_pattern_library_playbook_idx
+  ON opt_pattern_library (triggering_playbook_id, confidence DESC, sample_size_clients DESC)
+  WHERE triggering_playbook_id IS NOT NULL;
+
+CREATE INDEX opt_pattern_library_type_confidence_idx
+  ON opt_pattern_library (pattern_type, confidence DESC);
+
+ALTER TABLE opt_pattern_library ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON opt_pattern_library
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY opt_pattern_library_read ON opt_pattern_library
+  FOR SELECT TO authenticated
+  USING (public.auth_role() IN ('admin', 'operator', 'viewer'));

--- a/supabase/rollbacks/0061_optimiser_pattern_library.down.sql
+++ b/supabase/rollbacks/0061_optimiser_pattern_library.down.sql
@@ -1,0 +1,8 @@
+-- Rollback for 0061_optimiser_pattern_library.sql
+DROP POLICY IF EXISTS opt_pattern_library_read ON opt_pattern_library;
+DROP POLICY IF EXISTS service_role_all ON opt_pattern_library;
+ALTER TABLE IF EXISTS opt_pattern_library DISABLE ROW LEVEL SECURITY;
+DROP INDEX IF EXISTS opt_pattern_library_type_confidence_idx;
+DROP INDEX IF EXISTS opt_pattern_library_playbook_idx;
+DROP INDEX IF EXISTS opt_pattern_library_uniq;
+DROP TABLE IF EXISTS opt_pattern_library;

--- a/vercel.json
+++ b/vercel.json
@@ -71,6 +71,10 @@
     {
       "path": "/api/cron/optimiser-assisted-approval",
       "schedule": "30 * * * *"
+    },
+    {
+      "path": "/api/cron/optimiser-extract-patterns",
+      "schedule": "0 10 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Why redo
PR #315 was supposed to ship Slice 22 but a parallel-session HEAD race meant my actual \`git commit\` landed on a sibling branch (\`feat/design-discovery-3-wizard-shell\`) — #315 only carried the WORK_IN_FLIGHT claim. This PR brings the real Slice 22 build to main.

## Summary
Phase 3 first slice. Spec §11.2 (cross-client learning, consent-gated), §6 feature 10, §12.4. Adds \`opt_pattern_library\`, the daily extractor cron, the feature flag + per-client consent gate, the pattern classifier, and the SKILL.md.

## Anonymisation by construction
- Schema has **no foreign keys** to client / page / proposal.
- Extractor reads source ids only into memory for distinct-counting; never persists.
- Persisted shape: \`pattern_type\`, structural variant + baseline labels, sample-size aggregates, effect mean + 95% CI, confidence label, optional triggering_playbook_id. **No copy / URLs / brand names / testimonial text.**

## Hard gates
1. \`OPT_PATTERN_LIBRARY_ENABLED\` env flag must be \`true\` (default off). Spec §11.2.4 requires MSA-clause adoption before flipping in production.
2. Per-client \`cross_client_learning_consent=true\` (existing column from Phase 1; default \`false\`).
3. Min cohort: ≥ 2 distinct consenting clients before any pattern is written.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean (post \`rm -rf .next\` to clear parallel-session stale artefacts)
- [x] \`npm run build\` clean (\`/api/cron/optimiser-extract-patterns\` registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)