### PR TITLE
feat(optimiser-23): pattern application as priors (phase 3)

### DIFF
--- a/app/optimiser/proposals/[id]/page.tsx
+++ b/app/optimiser/proposals/[id]/page.tsx
@@ -4,9 +4,11 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { CreateVariantButton } from "@/components/optimiser/CreateVariantButton";
 import { PastCausalDeltasPanel } from "@/components/optimiser/PastCausalDeltasPanel";
+import { PatternPriorsPanel } from "@/components/optimiser/PatternPriorsPanel";
 import { ProposalReview } from "@/components/optimiser/ProposalReview";
 import { getClient } from "@/lib/optimiser/clients";
 import { listRecentCausalDeltasForPlaybook } from "@/lib/optimiser/causal/read-deltas";
+import { listRelevantPatterns } from "@/lib/optimiser/pattern-library/priors";
 import { getProposalWithEvidence } from "@/lib/optimiser/proposals";
 import { getLandingPage } from "@/lib/optimiser/landing-pages";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -48,6 +50,14 @@ export default async function OptimiserProposalReviewPage({
     !existingTest &&
     (proposal.status === "approved" || proposal.status === "applied");
 
+  // Phase 3 Slice 23: cross-client pattern priors. Reader gates on
+  // OPT_PATTERN_LIBRARY_ENABLED flag + receiving client's
+  // cross_client_learning_consent — returns [] when either is off.
+  const relevantPatterns = await listRelevantPatterns({
+    clientId: proposal.client_id,
+    playbookId: proposal.triggering_playbook_id,
+  });
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
@@ -60,6 +70,10 @@ export default async function OptimiserProposalReviewPage({
       </div>
       <PastCausalDeltasPanel
         deltas={pastDeltas}
+        playbookId={proposal.triggering_playbook_id}
+      />
+      <PatternPriorsPanel
+        patterns={relevantPatterns}
         playbookId={proposal.triggering_playbook_id}
       />
       {canCreateVariant && client && (

--- a/components/optimiser/PatternPriorsPanel.tsx
+++ b/components/optimiser/PatternPriorsPanel.tsx
@@ -1,0 +1,93 @@
+import type { PatternRow } from "@/lib/optimiser/pattern-library/types";
+
+// "Cross-client priors" panel — Phase 3 Slice 23 (§11.2).
+//
+// Surfaces on the proposal review screen alongside the past-causal-
+// deltas panel. Reads from opt_pattern_library through
+// listRelevantPatterns(). Renders only when:
+//   - The feature flag is on (caller's responsibility — server fetches
+//     listRelevantPatterns which short-circuits to [] when off)
+//   - The receiving client has cross_client_learning_consent=true
+//   - At least one pattern matches the proposal's playbook
+//
+// Anonymisation: every field shown here is structural — no client
+// names, no URLs, no copy.
+
+const CONFIDENCE_LABEL: Record<string, string> = {
+  high: "high confidence",
+  moderate: "moderate confidence",
+  low: "low confidence",
+};
+
+const CONFIDENCE_COLOUR: Record<string, string> = {
+  high: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  moderate: "border-blue-200 bg-blue-50 text-blue-900",
+  low: "border-muted-foreground/20 bg-muted text-muted-foreground",
+};
+
+export function PatternPriorsPanel({
+  patterns,
+  playbookId,
+}: {
+  patterns: PatternRow[];
+  playbookId: string | null;
+}) {
+  if (!playbookId) return null;
+  if (patterns.length === 0) return null;
+
+  // Pick the highest-confidence pattern for the headline summary; show
+  // the others as supporting rows.
+  const top = patterns[0];
+  const colour = CONFIDENCE_COLOUR[top.confidence] ?? CONFIDENCE_COLOUR.low;
+  const label = CONFIDENCE_LABEL[top.confidence] ?? "low confidence";
+  const meanPp = Number(top.effect_pp_mean);
+  const ciLow = Number(top.effect_pp_ci_low);
+  const ciHigh = Number(top.effect_pp_ci_high);
+  const sign = meanPp >= 0 ? "+" : "";
+
+  return (
+    <section className={`rounded-md border p-4 text-sm ${colour}`}>
+      <header className="space-y-1">
+        <p className="font-medium">
+          Cross-client priors
+          <span className="ml-2 text-xs uppercase tracking-wide opacity-80">
+            anonymised, {label}
+          </span>
+        </p>
+        <p>
+          Past <strong>{top.sample_size_observations}</strong> proposals across{" "}
+          <strong>{top.sample_size_clients}</strong> consenting clients
+          using <strong>{playbookId.replace(/_/g, " ")}</strong> averaged{" "}
+          <strong>
+            {sign}
+            {meanPp.toFixed(1)}pp CR
+          </strong>{" "}
+          (95% CI: {ciLow.toFixed(1)} to {ciHigh.toFixed(1)}).
+        </p>
+        <p className="text-xs opacity-80">
+          Pattern: <em>{top.observation}</em>
+        </p>
+      </header>
+      {patterns.length > 1 && (
+        <ul className="mt-3 space-y-1 text-xs opacity-90">
+          {patterns.slice(1, 4).map((p) => {
+            const m = Number(p.effect_pp_mean);
+            const s = m >= 0 ? "+" : "";
+            return (
+              <li key={p.id}>
+                · {p.observation}: {s}
+                {m.toFixed(1)}pp ({p.sample_size_clients} clients,{" "}
+                {p.confidence})
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      <p className="mt-3 text-xs opacity-70">
+        Cross-client patterns are anonymised structural observations
+        only — no client names, URLs, copy, testimonials, or pricing
+        leave the contributing accounts. Per spec §11.2.
+      </p>
+    </section>
+  );
+}

--- a/lib/optimiser/pattern-library/priors.ts
+++ b/lib/optimiser/pattern-library/priors.ts
@@ -1,0 +1,186 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { isPatternLibraryEnabled } from "./feature-flag";
+import type { PatternConfidence, PatternRow } from "./types";
+
+// ---------------------------------------------------------------------------
+// Pattern-library priors reader for the Phase 3 Slice 23 proposal
+// generator integration. Spec §11.2.1 says "patterns may be applied as
+// proposals to clients with consent = true". §11.2 says cross-client
+// patterns inform the expected_impact range — "past five CTA-move
+// proposals for this client averaged +1.4% CR with high confidence."
+//
+// Slice 23 widens that to the cross-client surface: when a pattern row
+// applies to the same playbook as the proposal being generated AND the
+// receiving client has cross_client_learning_consent=true, the priors
+// reader returns a blend recommendation:
+//
+//   - blended_min_pp / blended_max_pp = weighted blend of
+//     playbook.seed_impact_min/max_pp (50%) and the pattern's
+//     effect_pp_ci_low/high (50%) when confidence is high
+//     (37.5/62.5 for moderate, 25/75 for low — the seed dominates
+//     when the cross-client signal is weak).
+//
+// The blend keeps proposals grounded in the playbook's calibrated seed
+// while pulling toward observed cross-client outcomes. When no
+// matching pattern exists, the seed flows through unchanged.
+//
+// Hard gates:
+//   1. isPatternLibraryEnabled()  — env flag
+//   2. receiving client's cross_client_learning_consent must be true
+//      (consent gates BOTH contribution AND application per §11.2.2)
+// ---------------------------------------------------------------------------
+
+const BLEND_WEIGHT_BY_CONFIDENCE: Record<PatternConfidence, number> = {
+  high: 0.5,
+  moderate: 0.375,
+  low: 0.25,
+};
+
+export interface PriorsResult {
+  /** TRUE when a relevant pattern was found and the blend was applied. */
+  applied: boolean;
+  /** Reason the priors were not applied — propagated to the
+   * proposal's pattern_priors_applied JSON for transparency. */
+  reason?:
+    | "feature_flag_off"
+    | "client_not_consenting"
+    | "no_matching_pattern"
+    | "client_lookup_failed";
+  /** The pattern row used for the blend, when applied. */
+  pattern: PatternRow | null;
+  /** Blend weight applied to the pattern (0..1). 0 = seed only. */
+  blend_weight: number;
+  /** Output expected-impact range. When applied=false, equals the
+   * input seed range so callers can write through unchanged. */
+  expected_min_pp: number;
+  expected_max_pp: number;
+}
+
+export async function applyPriorsToImpactRange(args: {
+  clientId: string;
+  playbookId: string | null;
+  seedMinPp: number;
+  seedMaxPp: number;
+}): Promise<PriorsResult> {
+  if (!isPatternLibraryEnabled()) {
+    return {
+      applied: false,
+      reason: "feature_flag_off",
+      pattern: null,
+      blend_weight: 0,
+      expected_min_pp: args.seedMinPp,
+      expected_max_pp: args.seedMaxPp,
+    };
+  }
+
+  const supabase = getServiceRoleClient();
+  const { data: client, error: cErr } = await supabase
+    .from("opt_clients")
+    .select("id, cross_client_learning_consent")
+    .eq("id", args.clientId)
+    .is("deleted_at", null)
+    .maybeSingle();
+  if (cErr) {
+    return {
+      applied: false,
+      reason: "client_lookup_failed",
+      pattern: null,
+      blend_weight: 0,
+      expected_min_pp: args.seedMinPp,
+      expected_max_pp: args.seedMaxPp,
+    };
+  }
+  if (!client?.cross_client_learning_consent) {
+    return {
+      applied: false,
+      reason: "client_not_consenting",
+      pattern: null,
+      blend_weight: 0,
+      expected_min_pp: args.seedMinPp,
+      expected_max_pp: args.seedMaxPp,
+    };
+  }
+
+  if (!args.playbookId) {
+    return {
+      applied: false,
+      reason: "no_matching_pattern",
+      pattern: null,
+      blend_weight: 0,
+      expected_min_pp: args.seedMinPp,
+      expected_max_pp: args.seedMaxPp,
+    };
+  }
+
+  // Pick the most-trusted pattern row for the playbook. Order:
+  // confidence (high > moderate > low) then sample_size_clients desc.
+  const { data: pattern } = await supabase
+    .from("opt_pattern_library")
+    .select(
+      "id, pattern_type, observation, variant_label, baseline_label, sample_size_pages, sample_size_ad_groups, sample_size_clients, sample_size_observations, effect_pp_mean, effect_pp_ci_low, effect_pp_ci_high, confidence, applies_to, triggering_playbook_id, last_extracted_at, created_at",
+    )
+    .eq("triggering_playbook_id", args.playbookId)
+    .order("confidence", { ascending: false })
+    .order("sample_size_clients", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (!pattern) {
+    return {
+      applied: false,
+      reason: "no_matching_pattern",
+      pattern: null,
+      blend_weight: 0,
+      expected_min_pp: args.seedMinPp,
+      expected_max_pp: args.seedMaxPp,
+    };
+  }
+
+  const row = pattern as PatternRow;
+  const w = BLEND_WEIGHT_BY_CONFIDENCE[row.confidence];
+  const blendedMin =
+    args.seedMinPp * (1 - w) + Number(row.effect_pp_ci_low) * w;
+  const blendedMax =
+    args.seedMaxPp * (1 - w) + Number(row.effect_pp_ci_high) * w;
+  return {
+    applied: true,
+    pattern: row,
+    blend_weight: w,
+    expected_min_pp: round3(Math.min(blendedMin, blendedMax)),
+    expected_max_pp: round3(Math.max(blendedMin, blendedMax)),
+  };
+}
+
+/** Read all patterns relevant to a (client, playbook) pair so the
+ * proposal review surface can show "past N proposals across X
+ * consenting clients averaged +Y% CR". Returns [] when feature flag
+ * off or client doesn't consent. */
+export async function listRelevantPatterns(args: {
+  clientId: string;
+  playbookId: string | null;
+}): Promise<PatternRow[]> {
+  if (!isPatternLibraryEnabled() || !args.playbookId) return [];
+  const supabase = getServiceRoleClient();
+  const { data: client } = await supabase
+    .from("opt_clients")
+    .select("id, cross_client_learning_consent")
+    .eq("id", args.clientId)
+    .is("deleted_at", null)
+    .maybeSingle();
+  if (!client?.cross_client_learning_consent) return [];
+  const { data } = await supabase
+    .from("opt_pattern_library")
+    .select(
+      "id, pattern_type, observation, variant_label, baseline_label, sample_size_pages, sample_size_ad_groups, sample_size_clients, sample_size_observations, effect_pp_mean, effect_pp_ci_low, effect_pp_ci_high, confidence, applies_to, triggering_playbook_id, last_extracted_at, created_at",
+    )
+    .eq("triggering_playbook_id", args.playbookId)
+    .order("confidence", { ascending: false })
+    .order("sample_size_clients", { ascending: false });
+  return (data ?? []) as PatternRow[];
+}
+
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}

--- a/lib/optimiser/proposal-generation.ts
+++ b/lib/optimiser/proposal-generation.ts
@@ -5,6 +5,7 @@ import { logger } from "@/lib/logger";
 
 import { computeConfidence } from "./confidence";
 import type { PageMetricsRollup } from "./metrics-aggregation";
+import { applyPriorsToImpactRange } from "./pattern-library/priors";
 import type { PlaybookRow } from "./playbook-execution";
 
 // ---------------------------------------------------------------------------
@@ -96,9 +97,25 @@ export async function generateProposal(
     trigger_magnitude: inputs.triggerMagnitude,
   });
 
-  const seedMidpoint =
-    (inputs.playbook.seed_impact_min_pp + inputs.playbook.seed_impact_max_pp) /
-    2;
+  // Phase 3 Slice 23 — pull cross-client priors when the feature flag
+  // is on AND the receiving client has cross_client_learning_consent.
+  // Priors blend the playbook seed range with the matching pattern's
+  // 95% CI, weighted by pattern confidence. Falls through to
+  // seed-only when priors aren't applied.
+  const priors = await applyPriorsToImpactRange({
+    clientId: inputs.clientId,
+    playbookId: inputs.playbook.id,
+    seedMinPp: inputs.playbook.seed_impact_min_pp,
+    seedMaxPp: inputs.playbook.seed_impact_max_pp,
+  });
+
+  const effectiveMinPp = priors.applied
+    ? priors.expected_min_pp
+    : inputs.playbook.seed_impact_min_pp;
+  const effectiveMaxPp = priors.applied
+    ? priors.expected_max_pp
+    : inputs.playbook.seed_impact_max_pp;
+  const seedMidpoint = (effectiveMinPp + effectiveMaxPp) / 2;
   // Impact (0–100): a relative score in the client's pool. Phase 1
   // approximation: seed midpoint × log(sessions+1) / 8, clamped.
   // Slice 6 will normalise across the client's pending pool, but the
@@ -147,8 +164,8 @@ export async function generateProposal(
     confidence_freshness: confidence.freshness,
     confidence_stability: confidence.stability,
     confidence_signal: confidence.signal,
-    expected_impact_min_pp: inputs.playbook.seed_impact_min_pp,
-    expected_impact_max_pp: inputs.playbook.seed_impact_max_pp,
+    expected_impact_min_pp: effectiveMinPp,
+    expected_impact_max_pp: effectiveMaxPp,
     change_set: changeSet,
     before_snapshot: beforeSnapshot,
     after_snapshot: afterSnapshot,

--- a/skills/optimiser/pattern-application/SKILL.md
+++ b/skills/optimiser/pattern-application/SKILL.md
@@ -1,0 +1,48 @@
+# Skill — pattern-application (Phase 3)
+
+Apply cross-client patterns from `opt_pattern_library` as priors when generating new proposals (§11.2.1, Phase 3 Slice 23).
+
+## When this fires
+Inside `generateProposal` (`lib/optimiser/proposal-generation.ts`). Before writing the new `opt_proposals` row, the generator calls `applyPriorsToImpactRange` to maybe blend the playbook's seed impact range with cross-client observed effects.
+
+## Hard gates
+1. **Feature flag** — `OPT_PATTERN_LIBRARY_ENABLED` must be `true`. Spec §11.2.4 requires MSA-clause adoption before flipping in production.
+2. **Receiving-client consent** — `opt_clients.cross_client_learning_consent` must be `true` for the proposal's client. Per §11.2.2, consent gates BOTH contribution AND application: a non-consenting client doesn't contribute observations, and doesn't receive cross-client priors either.
+3. **Matching pattern** — at least one row in `opt_pattern_library` with `triggering_playbook_id = proposal.triggering_playbook_id`.
+
+When any gate fails, the generator falls through to seed-only impact range. The proposal is still generated normally.
+
+## Blend formula
+The pattern's 95% credible interval is blended with the playbook's seed range. The blend weight depends on the pattern's confidence:
+
+| Confidence | Pattern weight | Seed weight |
+|---|---|---|
+| `high` | 0.50 | 0.50 |
+| `moderate` | 0.375 | 0.625 |
+| `low` | 0.25 | 0.75 |
+
+`expected_min_pp = seed_min × (1 − w) + pattern.ci_low × w`
+`expected_max_pp = seed_max × (1 − w) + pattern.ci_high × w`
+
+Output range is clamped to `[min(min,max), max(min,max)]` so a wide negative blend doesn't invert.
+
+## Pattern selection
+When multiple patterns match the same playbook, the generator picks the row with highest confidence (`high > moderate > low`) then highest `sample_size_clients`. Other rows surface in the proposal review UI's `PatternPriorsPanel` as supporting evidence.
+
+## UI surface
+`PatternPriorsPanel` on the proposal review page. Renders only when:
+- The feature flag is on
+- The receiving client consents
+- ≥ 1 pattern matches the proposal's playbook
+
+Shows: total observations across consenting clients, mean effect with 95% CI, pattern's structural description, supporting rows for other matches. **Anonymisation guarantee**: only structural fields render — no client names, URLs, copy, testimonials, or pricing.
+
+## Spec
+§11.2.1 (what is shared — patterns, not content), §11.2.2 (consent gating, both directions), §11.2.3 (anonymisation), §11.2.4 (legal action required), §6 feature 10.
+
+## Pointers
+- `lib/optimiser/pattern-library/priors.ts:applyPriorsToImpactRange` — generator integration
+- `lib/optimiser/pattern-library/priors.ts:listRelevantPatterns` — UI reader
+- `lib/optimiser/proposal-generation.ts` — caller (Slice 23 wiring)
+- `components/optimiser/PatternPriorsPanel.tsx` — review UI
+- `app/optimiser/proposals/[id]/page.tsx` — page that mounts the panel


### PR DESCRIPTION
## Summary
Phase 3 second slice. §11.2.1 cross-client priors fed into proposal generation. Adds the priors reader, integrates into \`generateProposal\`, surfaces the cross-client evidence panel on the review page, and ships the pattern-application skill.

## Plan (sub-slice)
**Stack base.** \`main\` (Slice 22 just merged at \`228d187\`).

**Approach.** Two functions in \`lib/optimiser/pattern-library/priors.ts\` — \`applyPriorsToImpactRange\` (used by the generator) and \`listRelevantPatterns\` (used by the UI). Both enforce the same consent + feature-flag gates. The blend formula widens the seed range toward the pattern's 95% CI, weighted by confidence — high (50%), moderate (37.5%), low (25%). Seed-only fallthrough on any gate miss.

## Risks identified and mitigated
- **Consent symmetry** (§11.2.2) — receiving client's \`cross_client_learning_consent\` is checked at apply-time too, not just at extraction. Non-consenting clients see seed-only impact and an empty UI panel.
- **Blend monotonicity** — clamped so a CI crossing zero doesn't invert the range.
- **Confidence weighting** — low confidence only nudges 25%; high never exceeds 50%. A single noisy pattern can't dominate.
- **Anonymisation in UI** — \`PatternPriorsPanel\` renders structural fields only.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)