### PR TITLE
feat(optimiser-24): cross-client consent toggle + diagnostics surface

### DIFF
--- a/app/api/optimiser/clients/[id]/cross-client-consent/route.ts
+++ b/app/api/optimiser/clients/[id]/cross-client-consent/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { recordChangeLog } from "@/lib/optimiser/change-log";
+
+// PATCH /api/optimiser/clients/[id]/cross-client-consent — Phase 3 Slice 24.
+// Toggle the per-client cross_client_learning_consent flag.
+//
+// Admin-only — flipping this opts the client into BOTH directions of
+// the cross-client pattern library (per spec §11.2.2): their causal
+// observations contribute to the anonymised pattern table, AND their
+// proposals receive cross-client priors. Spec §11.2.4 requires an
+// MSA-clause to be signed before the flag is flipped to true; the API
+// records the toggle but legal sign-off is enforced operationally,
+// not in code.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z.object({
+  enabled: z.boolean(),
+});
+
+export async function PATCH(
+  req: NextRequest,
+  ctx: { params: { id: string } },
+): Promise<NextResponse> {
+  const access = await checkAdminAccess({ requiredRoles: ["admin"] });
+  if (access.kind === "redirect") {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "UNAUTHORIZED", message: "Admin access required" },
+      },
+      { status: 401 },
+    );
+  }
+  let body;
+  try {
+    body = Body.parse(await req.json());
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INVALID_BODY",
+          message: err instanceof Error ? err.message : "Invalid body",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getServiceRoleClient();
+  const { data: existing } = await supabase
+    .from("opt_clients")
+    .select("id, cross_client_learning_consent")
+    .eq("id", ctx.params.id)
+    .is("deleted_at", null)
+    .maybeSingle();
+  if (!existing) {
+    return NextResponse.json(
+      { ok: false, error: { code: "NOT_FOUND", message: "Client not found" } },
+      { status: 404 },
+    );
+  }
+
+  const before = Boolean(existing.cross_client_learning_consent);
+  if (before === body.enabled) {
+    return NextResponse.json({
+      ok: true,
+      data: {
+        client_id: ctx.params.id,
+        cross_client_learning_consent: body.enabled,
+        changed: false,
+      },
+    });
+  }
+
+  const { error: updErr } = await supabase
+    .from("opt_clients")
+    .update({
+      cross_client_learning_consent: body.enabled,
+      updated_at: new Date().toISOString(),
+      updated_by: access.user?.id ?? null,
+    })
+    .eq("id", ctx.params.id);
+  if (updErr) {
+    return NextResponse.json(
+      { ok: false, error: { code: "UPDATE_FAILED", message: updErr.message } },
+      { status: 500 },
+    );
+  }
+
+  await recordChangeLog({
+    clientId: ctx.params.id,
+    event: "cross_client_learning_consent_toggled",
+    actorUserId: access.user?.id ?? null,
+    details: { before, after: body.enabled },
+  });
+
+  return NextResponse.json({
+    ok: true,
+    data: {
+      client_id: ctx.params.id,
+      cross_client_learning_consent: body.enabled,
+      changed: true,
+    },
+  });
+}

--- a/app/optimiser/clients/[id]/settings/page.tsx
+++ b/app/optimiser/clients/[id]/settings/page.tsx
@@ -3,8 +3,10 @@ import { notFound } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import { AssistedApprovalToggle } from "@/components/optimiser/AssistedApprovalToggle";
+import { CrossClientConsentToggle } from "@/components/optimiser/CrossClientConsentToggle";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getClient } from "@/lib/optimiser/clients";
+import { isPatternLibraryEnabled } from "@/lib/optimiser/pattern-library/feature-flag";
 import {
   DEFAULT_CONVERSION_COMPONENTS,
   DEFAULT_SCORE_WEIGHTS,
@@ -151,6 +153,18 @@ export default async function ClientSettingsPage({
           clientId={client.id}
           enabled={client.assisted_approval_enabled}
           isAdmin={isAdmin}
+        />
+      </section>
+
+      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
+        <h2 className="text-lg font-medium">
+          Cross-client learning (Phase 3)
+        </h2>
+        <CrossClientConsentToggle
+          clientId={client.id}
+          enabled={client.cross_client_learning_consent}
+          isAdmin={isAdmin}
+          patternLibraryEnabled={isPatternLibraryEnabled()}
         />
       </section>
     </div>

--- a/app/optimiser/diagnostics/page.tsx
+++ b/app/optimiser/diagnostics/page.tsx
@@ -63,6 +63,63 @@ export default async function OptimiserDiagnosticsPage() {
         </p>
       </section>
 
+      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
+        <h2 className="text-lg font-medium">
+          Cross-client pattern library (Phase 3)
+        </h2>
+        <ModuleRow
+          label="OPT_PATTERN_LIBRARY_ENABLED feature flag"
+          ok={report.pattern_library.feature_flag_enabled}
+          detail={
+            report.pattern_library.feature_flag_enabled
+              ? "Extraction cron and priors reader are active."
+              : "Flag is off — extraction cron is a no-op and priors reader returns []. Per spec §11.2.4, MSA-clause adoption gates the production flip."
+          }
+        />
+        <ul className="space-y-1 text-sm">
+          <li>
+            <span className="text-muted-foreground">Consenting clients: </span>
+            <span className="font-mono">
+              {report.pattern_library.consenting_client_count}
+            </span>
+            <span className="ml-2 text-xs text-muted-foreground">
+              (gates BOTH contribution and application — §11.2.2)
+            </span>
+          </li>
+          <li>
+            <span className="text-muted-foreground">Pattern rows: </span>
+            <span className="font-mono">
+              {report.pattern_library.pattern_count}
+            </span>
+            {report.pattern_library.pattern_count > 0 && (
+              <span className="ml-2 text-xs text-muted-foreground">
+                ({report.pattern_library.pattern_by_confidence.high} high
+                · {report.pattern_library.pattern_by_confidence.moderate}{" "}
+                moderate ·{" "}
+                {report.pattern_library.pattern_by_confidence.low} low)
+              </span>
+            )}
+          </li>
+          <li>
+            <span className="text-muted-foreground">
+              Last extraction:{" "}
+            </span>
+            <span className="font-mono">
+              {report.pattern_library.last_extracted_at
+                ? new Date(
+                    report.pattern_library.last_extracted_at,
+                  ).toLocaleString()
+                : "(never)"}
+            </span>
+          </li>
+        </ul>
+        <p className="text-xs text-muted-foreground">
+          Pattern rows are anonymised by schema — no foreign keys to
+          client/page/proposal. The extractor cron runs daily at 10:00
+          UTC; per-client consent toggles on the client settings page.
+        </p>
+      </section>
+
       <section className="space-y-4">
         <h2 className="text-lg font-medium">Data sources</h2>
         {report.sources.map((s) => (

--- a/components/optimiser/CrossClientConsentToggle.tsx
+++ b/components/optimiser/CrossClientConsentToggle.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+
+// Phase 3 Slice 24 — toggle for cross-client learning consent on the
+// client settings page. Admin-only; the API enforces the role gate too.
+//
+// Per spec §11.2.2 this flag gates both directions: contribution to
+// the anonymised pattern library AND application of cross-client priors
+// to this client's proposals. Per §11.2.4 an MSA-clause must be signed
+// before the flag is flipped to true — the warning copy reminds the
+// operator of that precondition. Legal sign-off is operational; we
+// don't gate it in code.
+
+export function CrossClientConsentToggle({
+  clientId,
+  enabled,
+  isAdmin,
+  patternLibraryEnabled,
+}: {
+  clientId: string;
+  enabled: boolean;
+  isAdmin: boolean;
+  patternLibraryEnabled: boolean;
+}) {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [status, setStatus] = useState<{
+    message: string;
+    tone: "ok" | "err";
+  } | null>(null);
+
+  async function toggle() {
+    setSubmitting(true);
+    setStatus(null);
+    try {
+      const res = await fetch(
+        `/api/optimiser/clients/${clientId}/cross-client-consent`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ enabled: !enabled }),
+        },
+      );
+      const json = await res.json();
+      if (!json.ok) {
+        setStatus({
+          message: json.error?.message ?? "Toggle failed.",
+          tone: "err",
+        });
+        return;
+      }
+      setStatus({
+        message: json.data.cross_client_learning_consent
+          ? "Cross-client learning enabled. Anonymised patterns will be contributed AND applied for this client."
+          : "Cross-client learning disabled. This client neither contributes patterns nor receives cross-client priors.",
+        tone: "ok",
+      });
+      setTimeout(() => router.refresh(), 800);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm">
+        Status:{" "}
+        <strong className={enabled ? "text-emerald-700" : "text-muted-foreground"}>
+          {enabled ? "consenting" : "not consenting"}
+        </strong>
+      </p>
+      <p className="text-sm text-muted-foreground">
+        When enabled, this client both <strong>contributes</strong>{" "}
+        anonymised structural patterns from their causal deltas to the
+        cross-client pattern library, AND <strong>receives</strong>{" "}
+        cross-client priors blended into the expected-impact range of new
+        proposals. Disabling later stops both directions immediately;
+        previously contributed patterns remain (anonymised, no client
+        identifier stored).
+      </p>
+      <p className="text-sm text-muted-foreground">
+        Anonymisation is structural-only — the schema has no foreign keys
+        to client, page, or proposal rows. Pattern observations describe
+        shapes (e.g. <em>cta_position above-fold vs below-fold</em>), not
+        copy, URLs, testimonials, or pricing.
+      </p>
+      <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+        <p className="font-medium">Legal precondition (spec §11.2.4)</p>
+        <p className="mt-1">
+          An MSA cross-client-learning clause must be signed before flipping
+          this on. The toggle does not enforce that — it is operational.
+        </p>
+      </div>
+      {!patternLibraryEnabled && (
+        <div className="rounded-md border border-muted bg-muted/40 p-3 text-xs text-muted-foreground">
+          The <code className="font-mono">OPT_PATTERN_LIBRARY_ENABLED</code>{" "}
+          feature flag is currently off. Even with consent on, no
+          contribution or application will happen until the flag is set.
+        </div>
+      )}
+      {isAdmin ? (
+        <Button
+          type="button"
+          onClick={toggle}
+          disabled={submitting}
+          variant={enabled ? "outline" : "default"}
+        >
+          {submitting
+            ? "Saving…"
+            : enabled
+              ? "Withdraw cross-client consent"
+              : "Enable cross-client learning"}
+        </Button>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Only admins can toggle this setting.
+        </p>
+      )}
+      {status && (
+        <div
+          className={`rounded-md border px-3 py-2 text-sm ${
+            status.tone === "err"
+              ? "border-red-200 bg-red-50 text-red-900"
+              : "border-emerald-200 bg-emerald-50 text-emerald-900"
+          }`}
+        >
+          {status.message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/optimiser/change-log.ts
+++ b/lib/optimiser/change-log.ts
@@ -23,7 +23,8 @@ export type ChangeLogEvent =
   | "staged_rollout_window_expired"
   | "ab_winner_promoted"
   | "ab_test_inconclusive"
-  | "assisted_approval_toggled";
+  | "assisted_approval_toggled"
+  | "cross_client_learning_consent_toggled";
 
 export type ChangeLogRow = {
   id: number;

--- a/lib/optimiser/diagnostics.ts
+++ b/lib/optimiser/diagnostics.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { getServiceRoleClient } from "@/lib/supabase";
+import { isPatternLibraryEnabled } from "./pattern-library/feature-flag";
 import type { OptCredentialSource } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -52,9 +53,25 @@ export type ModuleDiagnostic = {
   onboarded_count: number;
 };
 
+// Phase 3 Slice 24 — pattern library state for the diagnostics surface.
+// Reports whether the feature flag is on, how many clients consent
+// (contribution + application gate per §11.2.2), how many pattern rows
+// have been extracted, and when the most recent extraction ran. The
+// breakdown by confidence helps the operator see whether the cohort is
+// large enough to be useful — patterns at "low" confidence dominate
+// until the consenting-client pool grows past ~5.
+export type PatternLibraryDiagnostic = {
+  feature_flag_enabled: boolean;
+  consenting_client_count: number;
+  pattern_count: number;
+  pattern_by_confidence: { high: number; moderate: number; low: number };
+  last_extracted_at: string | null;
+};
+
 export type DiagnosticsReport = {
   module: ModuleDiagnostic;
   sources: SourceDiagnostic[];
+  pattern_library: PatternLibraryDiagnostic;
   generated_at: string;
 };
 
@@ -148,6 +165,8 @@ export async function runDiagnostics(): Promise<DiagnosticsReport> {
     sources.push(await diagnoseSource(source));
   }
 
+  const patternLibrary = await diagnosePatternLibrary(schemaReachable);
+
   return {
     module: {
       schema_reachable: schemaReachable,
@@ -162,7 +181,57 @@ export async function runDiagnostics(): Promise<DiagnosticsReport> {
       onboarded_count: onboardedCount,
     },
     sources,
+    pattern_library: patternLibrary,
     generated_at: new Date().toISOString(),
+  };
+}
+
+async function diagnosePatternLibrary(
+  schemaReachable: boolean,
+): Promise<PatternLibraryDiagnostic> {
+  const flagEnabled = isPatternLibraryEnabled();
+  if (!schemaReachable) {
+    return {
+      feature_flag_enabled: flagEnabled,
+      consenting_client_count: 0,
+      pattern_count: 0,
+      pattern_by_confidence: { high: 0, moderate: 0, low: 0 },
+      last_extracted_at: null,
+    };
+  }
+  const supabase = getServiceRoleClient();
+  let consenting = 0;
+  let total = 0;
+  const byConf = { high: 0, moderate: 0, low: 0 };
+  let lastExtractedAt: string | null = null;
+  try {
+    const { count: cConsent } = await supabase
+      .from("opt_clients")
+      .select("id", { count: "exact", head: true })
+      .eq("cross_client_learning_consent", true)
+      .is("deleted_at", null);
+    consenting = cConsent ?? 0;
+    const { data: patterns } = await supabase
+      .from("opt_pattern_library")
+      .select("id, confidence, last_extracted_at");
+    for (const row of patterns ?? []) {
+      total += 1;
+      const conf = row.confidence as keyof typeof byConf;
+      if (conf in byConf) byConf[conf] += 1;
+      const at = row.last_extracted_at as string | null;
+      if (at && (!lastExtractedAt || at > lastExtractedAt)) {
+        lastExtractedAt = at;
+      }
+    }
+  } catch {
+    // Best-effort; surface zeros if the read fails.
+  }
+  return {
+    feature_flag_enabled: flagEnabled,
+    consenting_client_count: consenting,
+    pattern_count: total,
+    pattern_by_confidence: byConf,
+    last_extracted_at: lastExtractedAt,
   };
 }
 


### PR DESCRIPTION
## Phase 3 Slice 24 — operator UI for consent + diagnostics

Final Phase 3 slice. Surfaces the existing `cross_client_learning_consent` flag (per-client) and `OPT_PATTERN_LIBRARY_ENABLED` (env) so operators can see and control them without going through the database.

## Plan

- PATCH `/api/optimiser/clients/[id]/cross-client-consent` admin-only (matches Slice 21 assisted-approval shape: zod body, audit-trail row, no version_lock since this is a single-flag toggle).
- `CrossClientConsentToggle` component — explicit copy that the consent gates BOTH contribution AND application per §11.2.2. MSA-clause warning per §11.2.4. Read-only badge for non-admin viewers.
- Wired into `/optimiser/clients/[id]/settings` next to the assisted-approval toggle.
- Diagnostics extension — `runDiagnostics` now reports pattern library state: feature flag, consenting client count, pattern row counts grouped by confidence (high/moderate/low), last extraction timestamp.
- `cross_client_learning_consent_toggled` added to `ChangeLogEvent`.

## Risks identified and mitigated

- **Admin gate** — the API uses `checkAdminAccess({ requiredRoles: ['admin'] })` and returns 401 on non-admin. Toggle component also checks `isAdmin` before rendering the button (defence in depth — UI hides, API enforces).
- **Audit trail** — every flag flip writes an `opt_change_log` row with before/after + actor_user_id. No silent toggles.
- **No-op when same value** — handler short-circuits without writing if before === after, so accidental double-clicks don't pollute the change log.
- **Anonymisation invariant** — toggle copy makes the structural-only contract explicit. The schema enforces it (no FKs to client/page/proposal); the UI explains it so the operator knows what consent actually authorises.
- **Legal precondition is operational, not coded** — §11.2.4 requires an MSA cross-client-learning clause before flipping. The toggle warns about this; we don't gate it in code because that's a Steven decision per client and the existing playbook is contract-side.
- **Diagnostics is best-effort** — read failures don't fail the diagnostics page; missing reads surface as zeros so the operator still sees env-flag state and the rest of the report.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — clean

## Notes for next session

After merge, this completes Phase 3:
- #312 — fixed Phase 1.5 defect #307
- #316 — Slice 22 pattern library schema + extractor cron
- #317 — Slice 23 priors blended into proposal generation
- THIS — Slice 24 consent UI + diagnostics

Tracking issue + WORK_IN_FLIGHT cleanup will follow this merge.