### PR TITLE
feat(design-discovery-3): setup wizard shell + step 3 done screen

### DIFF
--- a/app/admin/sites/[id]/setup/page.tsx
+++ b/app/admin/sites/[id]/setup/page.tsx
@@ -1,0 +1,116 @@
+import { notFound, redirect } from "next/navigation";
+
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { SetupWizard } from "@/components/SetupWizard";
+import { H1, Lead } from "@/components/ui/typography";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import {
+  computeResumeStep,
+  getSetupStatus,
+  type SetupStep,
+} from "@/lib/site-setup";
+import { getSite } from "@/lib/sites";
+
+// ---------------------------------------------------------------------------
+// /admin/sites/[id]/setup — DESIGN-DISCOVERY wizard.
+//
+// Three-step setup that runs once per site after registration:
+//   1. Design direction — operator-supplied references / description /
+//      industry → 3 generated concepts → approve one (PRs 4–7).
+//   2. Tone of voice — sample copy + guided questions → tone JSON +
+//      approved samples (PR 8) → live tone application (PR 9).
+//   3. Done — summary + "Start generating content" CTA.
+//
+// Step is persisted in the URL (?step=1|2|3). When a step query param
+// is missing, we redirect to the resume step computed from the two
+// status columns. If both statuses are 'pending' the wizard opens
+// fresh at Step 1; once a step is 'approved' or 'skipped' it counts
+// as complete for navigation.
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+function parseStep(input: string | string[] | undefined): SetupStep | null {
+  const raw = Array.isArray(input) ? input[0] : input;
+  if (raw === "1") return 1;
+  if (raw === "2") return 2;
+  if (raw === "3") return 3;
+  return null;
+}
+
+export default async function SiteSetupPage({
+  params,
+  searchParams,
+}: {
+  params: { id: string };
+  searchParams: { step?: string | string[] };
+}) {
+  const access = await checkAdminAccess({
+    requiredRoles: ["super_admin", "admin"],
+    insufficientRoleRedirectTo: "/",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  const siteResult = await getSite(params.id);
+  if (!siteResult.ok) {
+    if (siteResult.error.code === "NOT_FOUND") notFound();
+    return (
+      <div
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        role="alert"
+      >
+        {siteResult.error.message}
+      </div>
+    );
+  }
+  const site = siteResult.data.site;
+
+  const statusResult = await getSetupStatus(params.id);
+  if (!statusResult.ok) {
+    if (statusResult.error.code === "NOT_FOUND") notFound();
+    return (
+      <div
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        role="alert"
+      >
+        {statusResult.error.message}
+      </div>
+    );
+  }
+  const status = statusResult.data;
+
+  // No explicit step → resume from status. Already-set step out of
+  // range falls back to the resume step too.
+  const requested = parseStep(searchParams.step);
+  if (requested === null) {
+    const resume = computeResumeStep(status);
+    redirect(`/admin/sites/${params.id}/setup?step=${resume}`);
+  }
+  const step: SetupStep = requested;
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <Breadcrumbs
+        crumbs={[
+          { label: "Sites", href: "/admin/sites" },
+          { label: site.name, href: `/admin/sites/${site.id}` },
+          { label: "Setup" },
+        ]}
+      />
+      <H1 className="mt-2">Set up {site.name}</H1>
+      <Lead className="mt-1">
+        A two-step setup that gives every generated page a consistent
+        look and voice. Skip any step to fall back to the default
+        styles — you can return any time.
+      </Lead>
+
+      <div className="mt-6">
+        <SetupWizard
+          siteId={site.id}
+          step={step}
+          status={status}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/sites/[id]/setup/skip/route.ts
+++ b/app/api/admin/sites/[id]/setup/skip/route.ts
@@ -1,0 +1,95 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { setStepStatus } from "@/lib/site-setup";
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/sites/[id]/setup/skip
+//
+// DESIGN-DISCOVERY wizard. Skips Step 1 (design direction) or Step 2
+// (tone of voice) by writing 'skipped' to the matching status column.
+// Step 3 ('done') has no skip — it's just the summary screen.
+//
+// Body: { step: 1 | 2 }
+//
+// Admin-only. Operators don't manage sites at the configuration layer;
+// they consume the configured site via briefs / batches.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const BodySchema = z.object({
+  step: z.union([z.literal(1), z.literal(2)]),
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Site id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body must be { step: 1 | 2 }.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await setStepStatus(params.id, parsed.data.step, "skipped");
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      result.error.code === "NOT_FOUND" ? 404 : 500,
+    );
+  }
+
+  revalidatePath(`/admin/sites/${params.id}/setup`);
+  revalidatePath(`/admin/sites/${params.id}`);
+
+  return NextResponse.json(
+    { ok: true, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/components/SetupWizard.tsx
+++ b/components/SetupWizard.tsx
@@ -1,0 +1,533 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Check, ChevronRight, Loader2, Palette, Volume2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import type { SetupStatus, SetupStep, SetupStepStatus } from "@/lib/site-setup";
+
+// ---------------------------------------------------------------------------
+// SetupWizard — DESIGN-DISCOVERY shell.
+//
+// Renders the active step (1, 2, or 3) and the progress strip at the top.
+// Steps 1 and 2 are placeholders for now — PRs 4–9 swap the inner
+// content for the real input surface, concept review, refinement and
+// approval flow. Step 3 is fully wired here: it summarises whatever
+// state the two status columns + design_tokens / tone_of_voice JSON
+// are in.
+//
+// All step writes for the placeholders go through one API endpoint
+// (POST /api/admin/sites/:id/setup/skip with { step }). The Approve
+// path lands with each step's real content.
+// ---------------------------------------------------------------------------
+
+interface Props {
+  siteId: string;
+  step: SetupStep;
+  status: SetupStatus;
+}
+
+const STEPS: Array<{ n: SetupStep; label: string; icon: typeof Palette }> = [
+  { n: 1, label: "Design direction", icon: Palette },
+  { n: 2, label: "Tone of voice", icon: Volume2 },
+  { n: 3, label: "Done", icon: Check },
+];
+
+function statusLabel(s: SetupStepStatus): string {
+  switch (s) {
+    case "approved":
+      return "Complete";
+    case "skipped":
+      return "Skipped — using defaults";
+    case "in_progress":
+      return "In progress";
+    case "pending":
+      return "Not started";
+  }
+}
+
+export function SetupWizard({ siteId, step, status }: Props) {
+  return (
+    <div className="space-y-6" data-testid="setup-wizard">
+      <ProgressStrip step={step} status={status} siteId={siteId} />
+      {step === 1 && <Step1 siteId={siteId} status={status} />}
+      {step === 2 && <Step2 siteId={siteId} status={status} />}
+      {step === 3 && <Step3 siteId={siteId} status={status} />}
+    </div>
+  );
+}
+
+function ProgressStrip({
+  step,
+  status,
+  siteId,
+}: {
+  step: SetupStep;
+  status: SetupStatus;
+  siteId: string;
+}) {
+  // A step is "complete" if its status column is approved or skipped.
+  // Step 3 is "complete" when both prior steps are complete.
+  const stepComplete = (n: SetupStep): boolean => {
+    if (n === 1) {
+      return (
+        status.design_direction_status === "approved" ||
+        status.design_direction_status === "skipped"
+      );
+    }
+    if (n === 2) {
+      return (
+        status.tone_of_voice_status === "approved" ||
+        status.tone_of_voice_status === "skipped"
+      );
+    }
+    return stepComplete(1) && stepComplete(2);
+  };
+
+  return (
+    <ol className="flex items-center gap-1 text-sm" aria-label="Setup progress">
+      {STEPS.map((s, i) => {
+        const active = s.n === step;
+        const done = stepComplete(s.n);
+        const Icon = done ? Check : s.icon;
+        return (
+          <li
+            key={s.n}
+            className="flex items-center gap-1"
+            data-testid={`setup-progress-step-${s.n}`}
+            data-active={active ? "true" : "false"}
+            data-complete={done ? "true" : "false"}
+          >
+            <Link
+              href={`/admin/sites/${siteId}/setup?step=${s.n}`}
+              className={[
+                "flex items-center gap-1.5 rounded-md border px-2.5 py-1 transition-smooth",
+                active
+                  ? "border-foreground bg-foreground text-background"
+                  : done
+                    ? "border-success/40 bg-success/10 text-success"
+                    : "border-muted bg-muted/30 text-muted-foreground",
+                "hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+              ].join(" ")}
+            >
+              <Icon aria-hidden className="h-3.5 w-3.5" />
+              <span className="font-medium">{s.label}</span>
+            </Link>
+            {i < STEPS.length - 1 && (
+              <ChevronRight
+                aria-hidden
+                className="h-4 w-4 shrink-0 text-muted-foreground"
+              />
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function StepFrame({
+  title,
+  intro,
+  body,
+  footer,
+  testid,
+}: {
+  title: string;
+  intro: React.ReactNode;
+  body: React.ReactNode;
+  footer: React.ReactNode;
+  testid: string;
+}) {
+  return (
+    <section className="rounded-lg border bg-card p-6" data-testid={testid}>
+      <h2 className="text-lg font-semibold">{title}</h2>
+      <p className="mt-1 text-sm text-muted-foreground">{intro}</p>
+      <div className="mt-4">{body}</div>
+      <div className="mt-6 flex flex-wrap items-center justify-between gap-3 border-t pt-4">
+        {footer}
+      </div>
+    </section>
+  );
+}
+
+function SkipButton({
+  siteId,
+  step,
+  label,
+  testid,
+}: {
+  siteId: string;
+  step: 1 | 2;
+  label: string;
+  testid: string;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  async function onSkip() {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/admin/sites/${siteId}/setup/skip`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ step }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error: { message: string } }
+        | null;
+      if (!payload?.ok) {
+        toast.error(
+          payload?.ok === false ? payload.error.message : "Skip failed.",
+        );
+        setBusy(false);
+        return;
+      }
+      const nextStep = step === 1 ? 2 : 3;
+      router.push(`/admin/sites/${siteId}/setup?step=${nextStep}`);
+      router.refresh();
+    } catch (err) {
+      toast.error(`Skip failed: ${err instanceof Error ? err.message : "unknown"}`);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={() => void onSkip()}
+      disabled={busy}
+      data-testid={testid}
+    >
+      {busy ? (
+        <>
+          <Loader2 aria-hidden className="h-3.5 w-3.5 animate-spin" />
+          Skipping…
+        </>
+      ) : (
+        label
+      )}
+    </Button>
+  );
+}
+
+function Step1({ siteId, status }: { siteId: string; status: SetupStatus }) {
+  return (
+    <StepFrame
+      testid="setup-step-1"
+      title="Design direction"
+      intro={
+        <>
+          What should this site look like? Provide a reference URL, an
+          existing site, screenshots, or a written description and we&apos;ll
+          generate three creative directions to choose from.
+        </>
+      }
+      body={
+        <div className="rounded-md border border-dashed bg-muted/20 p-6 text-sm text-muted-foreground">
+          <p>
+            Status:{" "}
+            <span className="font-medium text-foreground">
+              {statusLabel(status.design_direction_status)}
+            </span>
+          </p>
+          <p className="mt-2">
+            The design direction input surface and concept review land in
+            the next batch of changes. Skip for now to land at Step 2 with
+            the generic MSP defaults applied — you can return here any
+            time from Site Settings.
+          </p>
+        </div>
+      }
+      footer={
+        <>
+          <Link
+            href={`/admin/sites/${siteId}`}
+            className="text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          >
+            ← Back to site
+          </Link>
+          <div className="flex items-center gap-2">
+            <SkipButton
+              siteId={siteId}
+              step={1}
+              label="Skip for now"
+              testid="setup-step-1-skip"
+            />
+          </div>
+        </>
+      }
+    />
+  );
+}
+
+function Step2({ siteId, status }: { siteId: string; status: SetupStatus }) {
+  return (
+    <StepFrame
+      testid="setup-step-2"
+      title="Tone of voice"
+      intro={
+        <>
+          How should the site talk to clients? Paste sample copy, share a
+          reference URL, or answer the guided questions and we&apos;ll
+          extract a tone profile that feeds every page and post we
+          generate.
+        </>
+      }
+      body={
+        <div className="rounded-md border border-dashed bg-muted/20 p-6 text-sm text-muted-foreground">
+          <p>
+            Status:{" "}
+            <span className="font-medium text-foreground">
+              {statusLabel(status.tone_of_voice_status)}
+            </span>
+          </p>
+          <p className="mt-2">
+            The tone capture and sample preview land in a follow-up
+            change. Skip for now to land at Done with generic MSP defaults
+            applied to your generation prompts.
+          </p>
+        </div>
+      }
+      footer={
+        <>
+          <Link
+            href={`/admin/sites/${siteId}/setup?step=1`}
+            className="text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          >
+            ← Back
+          </Link>
+          <div className="flex items-center gap-2">
+            <SkipButton
+              siteId={siteId}
+              step={2}
+              label="Skip for now"
+              testid="setup-step-2-skip"
+            />
+          </div>
+        </>
+      }
+    />
+  );
+}
+
+function Step3({ siteId, status }: { siteId: string; status: SetupStatus }) {
+  const designApproved = status.design_direction_status === "approved";
+  const designSkipped = status.design_direction_status === "skipped";
+  const toneApproved = status.tone_of_voice_status === "approved";
+  const toneSkipped = status.tone_of_voice_status === "skipped";
+  const bothSkipped = designSkipped && toneSkipped;
+
+  return (
+    <StepFrame
+      testid="setup-step-3"
+      title="Setup complete"
+      intro={
+        bothSkipped ? (
+          <>
+            You&apos;re using default styles. Set these up any time from
+            Site Settings.
+          </>
+        ) : (
+          <>Here&apos;s what we&apos;ll use for every page we generate.</>
+        )
+      }
+      body={
+        <div className="grid gap-4 md:grid-cols-2">
+          <SummaryCard
+            heading="Design direction"
+            href={`/admin/sites/${siteId}/setup?step=1`}
+            state={status.design_direction_status}
+            details={
+              designApproved ? (
+                <DesignDirectionDetails tokens={status.design_tokens} />
+              ) : designSkipped ? (
+                <p className="text-xs text-muted-foreground">
+                  Using defaults.
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground">Not yet set.</p>
+              )
+            }
+          />
+          <SummaryCard
+            heading="Tone of voice"
+            href={`/admin/sites/${siteId}/setup?step=2`}
+            state={status.tone_of_voice_status}
+            details={
+              toneApproved ? (
+                <ToneOfVoiceDetails tone={status.tone_of_voice} />
+              ) : toneSkipped ? (
+                <p className="text-xs text-muted-foreground">
+                  Using defaults.
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground">Not yet set.</p>
+              )
+            }
+          />
+        </div>
+      }
+      footer={
+        <>
+          <Link
+            href={`/admin/sites/${siteId}/setup?step=2`}
+            className="text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          >
+            ← Back
+          </Link>
+          <div className="flex items-center gap-2">
+            <Button asChild data-testid="setup-step-3-finish">
+              <Link href={`/admin/sites/${siteId}`}>
+                Start generating content
+              </Link>
+            </Button>
+          </div>
+        </>
+      }
+    />
+  );
+}
+
+function SummaryCard({
+  heading,
+  href,
+  state,
+  details,
+}: {
+  heading: string;
+  href: string;
+  state: SetupStepStatus;
+  details: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-md border bg-muted/20 p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">{heading}</h3>
+        <span className="text-xs text-muted-foreground">
+          {statusLabel(state)}
+        </span>
+      </div>
+      <div className="mt-3">{details}</div>
+      <Link
+        href={href}
+        className="mt-4 inline-block text-xs text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+      >
+        Go back and edit →
+      </Link>
+    </div>
+  );
+}
+
+function DesignDirectionDetails({
+  tokens,
+}: {
+  tokens: Record<string, unknown> | null;
+}) {
+  if (!tokens) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Approved direction has no captured tokens yet.
+      </p>
+    );
+  }
+  const swatchOrder = ["primary", "secondary", "accent", "background", "text"];
+  const swatches = swatchOrder
+    .map((k) => ({ k, v: tokens[k] }))
+    .filter(
+      (s): s is { k: string; v: string } =>
+        typeof s.v === "string" && s.v.length > 0,
+    );
+  const fontHeading =
+    typeof tokens.font_heading === "string" ? tokens.font_heading : null;
+  const fontBody =
+    typeof tokens.font_body === "string" ? tokens.font_body : null;
+  return (
+    <div className="space-y-2 text-xs">
+      {swatches.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          {swatches.map((s) => (
+            <span
+              key={s.k}
+              className="inline-flex items-center gap-1 rounded-md border bg-background px-1.5 py-0.5"
+              title={`${s.k}: ${s.v}`}
+            >
+              <span
+                className="inline-block h-3 w-3 rounded-sm border"
+                style={{ background: s.v }}
+                aria-hidden
+              />
+              <span className="font-mono text-[10px] uppercase">{s.k}</span>
+            </span>
+          ))}
+        </div>
+      )}
+      {(fontHeading || fontBody) && (
+        <p className="text-muted-foreground">
+          {fontHeading && (
+            <>
+              Heading: <span className="text-foreground">{fontHeading}</span>
+            </>
+          )}
+          {fontHeading && fontBody && " · "}
+          {fontBody && (
+            <>
+              Body: <span className="text-foreground">{fontBody}</span>
+            </>
+          )}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ToneOfVoiceDetails({
+  tone,
+}: {
+  tone: Record<string, unknown> | null;
+}) {
+  if (!tone) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Approved tone has no captured profile yet.
+      </p>
+    );
+  }
+  const styleGuide =
+    typeof tone.style_guide === "string" ? tone.style_guide : null;
+  const samples = Array.isArray(tone.approved_samples)
+    ? tone.approved_samples
+    : [];
+  const firstSample = samples.find(
+    (s): s is { kind?: string; text: string } =>
+      typeof s === "object" &&
+      s !== null &&
+      "text" in s &&
+      typeof (s as { text: unknown }).text === "string",
+  );
+  return (
+    <div className="space-y-2 text-xs">
+      {styleGuide && (
+        <p className="text-muted-foreground">
+          <span className="font-medium text-foreground">Style: </span>
+          {styleGuide.length > 160 ? `${styleGuide.slice(0, 160)}…` : styleGuide}
+        </p>
+      )}
+      {firstSample && (
+        <blockquote className="rounded-md border-l-2 border-foreground/30 bg-background px-3 py-2 italic">
+          &ldquo;
+          {firstSample.text.length > 200
+            ? `${firstSample.text.slice(0, 200)}…`
+            : firstSample.text}
+          &rdquo;
+        </blockquote>
+      )}
+    </div>
+  );
+}

--- a/e2e/site-setup.spec.ts
+++ b/e2e/site-setup.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { auditA11y, signInAsAdmin } from "./helpers";
+
+// DESIGN-DISCOVERY PR 3 — wizard shell happy path.
+//
+// Drives /admin/sites/[id]/setup end-to-end:
+//   1. Land on Step 1 (resume logic; fresh site = step 1 since both
+//      status columns default to 'pending').
+//   2. Skip Step 1 → Step 2.
+//   3. Skip Step 2 → Step 3 (Done).
+//   4. Step 3 reflects "Using defaults" copy and the "Start generating
+//      content" CTA returns to /admin/sites/[id].
+//
+// Subsequent PRs add the real input surface inside each step; this
+// spec only covers the shell + skip + resume.
+
+async function stubTestConnection(page: Page): Promise<void> {
+  await page.route("**/api/sites/test-connection", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        user: {
+          display_name: "E2E WP Admin",
+          username: "wpadmin",
+          roles: ["administrator"],
+        },
+      }),
+    });
+  });
+}
+
+async function createSiteAndOpenSetup(
+  page: Page,
+  name: string,
+): Promise<string> {
+  await page.goto("/admin/sites/new");
+  await page.getByTestId("site-name").fill(name);
+  await page.getByTestId("site-wp-url").fill("https://setup-wizard.test");
+  await page.getByTestId("site-wp-user").fill("wp");
+  await page.getByTestId("site-wp-password").fill("password-1234");
+  await page.getByTestId("site-test-connection").click();
+  await expect(page.getByTestId("site-test-result")).toContainText(
+    /Connected as/i,
+  );
+  await page.getByTestId("site-create-save").click();
+  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}$/);
+  const detailUrl = page.url();
+  const id = detailUrl.match(/\/admin\/sites\/([0-9a-f-]{36})/)?.[1];
+  if (!id) throw new Error(`Failed to extract site id from ${detailUrl}`);
+  await page.goto(`/admin/sites/${id}/setup`);
+  return id;
+}
+
+test.describe("setup wizard shell", () => {
+  test.beforeEach(async ({ page }) => {
+    await signInAsAdmin(page);
+    await stubTestConnection(page);
+  });
+
+  test("fresh site lands on step 1; skip → step 2 → step 3 done with defaults", async ({
+    page,
+  }, testInfo) => {
+    const name = `Setup Wizard ${Date.now()}`;
+    const id = await createSiteAndOpenSetup(page, name);
+
+    // Resume redirect on no ?step → step 1.
+    await page.waitForURL(
+      new RegExp(`/admin/sites/${id}/setup\\?step=1`),
+    );
+    await expect(page.getByTestId("setup-step-1")).toBeVisible();
+    await auditA11y(page, testInfo);
+
+    // Skip Step 1 → land on Step 2.
+    await page.getByTestId("setup-step-1-skip").click();
+    await page.waitForURL(
+      new RegExp(`/admin/sites/${id}/setup\\?step=2`),
+    );
+    await expect(page.getByTestId("setup-step-2")).toBeVisible();
+    await auditA11y(page, testInfo);
+
+    // Skip Step 2 → Step 3 done screen.
+    await page.getByTestId("setup-step-2-skip").click();
+    await page.waitForURL(
+      new RegExp(`/admin/sites/${id}/setup\\?step=3`),
+    );
+    await expect(page.getByTestId("setup-step-3")).toBeVisible();
+    await expect(
+      page.getByText(
+        /You're using default styles\. Set these up any time from Site Settings\./i,
+      ),
+    ).toBeVisible();
+    await auditA11y(page, testInfo);
+
+    // Finish CTA returns to the site detail page.
+    await page.getByTestId("setup-step-3-finish").click();
+    await page.waitForURL(new RegExp(`/admin/sites/${id}$`));
+    await expect(page.getByRole("heading", { name })).toBeVisible();
+  });
+
+  test("returning to setup with both steps skipped resumes at step 3", async ({
+    page,
+  }) => {
+    const name = `Setup Resume ${Date.now()}`;
+    const id = await createSiteAndOpenSetup(page, name);
+    await page.waitForURL(
+      new RegExp(`/admin/sites/${id}/setup\\?step=1`),
+    );
+    await page.getByTestId("setup-step-1-skip").click();
+    await page.waitForURL(
+      new RegExp(`/admin/sites/${id}/setup\\?step=2`),
+    );
+    await page.getByTestId("setup-step-2-skip").click();
+    await page.waitForURL(
+      new RegExp(`/admin/sites/${id}/setup\\?step=3`),
+    );
+
+    // Re-enter the wizard without ?step — resume should land on 3.
+    await page.goto(`/admin/sites/${id}/setup`);
+    await page.waitForURL(
+      new RegExp(`/admin/sites/${id}/setup\\?step=3`),
+    );
+    await expect(page.getByTestId("setup-step-3")).toBeVisible();
+  });
+});

--- a/lib/site-setup.ts
+++ b/lib/site-setup.ts
@@ -1,0 +1,139 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// DESIGN-DISCOVERY — site setup wizard helpers.
+//
+// Backs the /admin/sites/[id]/setup wizard. The wizard captures a design
+// direction (Step 1) and a tone of voice (Step 2); progress lives in
+// sites.design_direction_status / sites.tone_of_voice_status (CHECK enum).
+// This module is the read + status-write entry point for the wizard
+// shell. Concept HTML / design tokens / tone JSON writes live with their
+// own helpers (PR 7 + PR 8).
+// ---------------------------------------------------------------------------
+
+export type SetupStepStatus =
+  | "pending"
+  | "in_progress"
+  | "approved"
+  | "skipped";
+
+export type SetupStep = 1 | 2 | 3;
+
+export interface SetupStatus {
+  design_direction_status: SetupStepStatus;
+  tone_of_voice_status: SetupStepStatus;
+  // Snapshot of the artefacts the Step 3 done screen renders. Loaded
+  // here so the server page renders in one round trip.
+  design_tokens: Record<string, unknown> | null;
+  tone_of_voice: Record<string, unknown> | null;
+}
+
+export type GetSetupStatusResult =
+  | { ok: true; data: SetupStatus }
+  | { ok: false; error: { code: "NOT_FOUND" | "INTERNAL_ERROR"; message: string } };
+
+export async function getSetupStatus(
+  siteId: string,
+): Promise<GetSetupStatusResult> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("sites")
+    .select(
+      "design_direction_status, tone_of_voice_status, design_tokens, tone_of_voice",
+    )
+    .eq("id", siteId)
+    .neq("status", "removed")
+    .maybeSingle();
+  if (error) {
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: error.message,
+      },
+    };
+  }
+  if (!data) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `No active site found with id ${siteId}.`,
+      },
+    };
+  }
+  return {
+    ok: true,
+    data: {
+      design_direction_status: data.design_direction_status as SetupStepStatus,
+      tone_of_voice_status: data.tone_of_voice_status as SetupStepStatus,
+      design_tokens: (data.design_tokens as Record<string, unknown> | null) ?? null,
+      tone_of_voice: (data.tone_of_voice as Record<string, unknown> | null) ?? null,
+    },
+  };
+}
+
+// Resume logic. Step 3 == done. Step 1 first, then 2, then done.
+// 'approved' and 'skipped' both count as "complete" for navigation.
+export function computeResumeStep(s: {
+  design_direction_status: SetupStepStatus;
+  tone_of_voice_status: SetupStepStatus;
+}): SetupStep {
+  const designDone =
+    s.design_direction_status === "approved" ||
+    s.design_direction_status === "skipped";
+  const toneDone =
+    s.tone_of_voice_status === "approved" ||
+    s.tone_of_voice_status === "skipped";
+  if (designDone && toneDone) return 3;
+  if (designDone) return 2;
+  return 1;
+}
+
+export type StepUpdateResult =
+  | { ok: true }
+  | {
+      ok: false;
+      error: {
+        code: "NOT_FOUND" | "INVALID_STEP" | "INTERNAL_ERROR";
+        message: string;
+      };
+    };
+
+export async function setStepStatus(
+  siteId: string,
+  step: 1 | 2,
+  status: SetupStepStatus,
+): Promise<StepUpdateResult> {
+  const supabase = getServiceRoleClient();
+  const column =
+    step === 1 ? "design_direction_status" : "tone_of_voice_status";
+  const { data, error } = await supabase
+    .from("sites")
+    .update({ [column]: status, updated_at: new Date().toISOString() })
+    .eq("id", siteId)
+    .neq("status", "removed")
+    .select("id")
+    .maybeSingle();
+  if (error) {
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: error.message,
+      },
+    };
+  }
+  if (!data) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `No active site found with id ${siteId}.`,
+      },
+    };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
PR 3 of the DESIGN-DISCOVERY workstream. Adds `/admin/sites/[id]/setup` — a three-step wizard that captures the site's design direction (Step 1) and tone of voice (Step 2), plus a Done screen (Step 3). Step is persisted in the URL via `?step=1|2|3`; without the param the wizard redirects to a resume step computed from the two status columns added in PR 2.

Step 1 and Step 2 ship as placeholder frames with a Skip button — the real input surface, concept generation, refinement, and approval land in PRs 4–9. Step 3 is fully wired in this PR.

## What lands
- `app/admin/sites/[id]/setup/page.tsx` — Server component. Admin gate, reads site + setup status, redirects to the resume step when no `?step` is provided.
- `components/SetupWizard.tsx` — Client wizard frame. Renders the progress strip + the active step (1 / 2 / 3). Step 3 summarises approved palette swatches + heading/body fonts (when `'approved'`), or "Using defaults" (when `'skipped'`); same shape for tone of voice. Both-skipped path shows the spec's "You're using default styles" copy.
- `lib/site-setup.ts` — `getSetupStatus`, `computeResumeStep`, `setStepStatus` helpers. Service-role-only.
- `app/api/admin/sites/[id]/setup/skip/route.ts` — POST `{ step: 1 | 2 }` to mark a step skipped. Admin role gate, Zod validation, UUID guard, `revalidatePath` on success.
- `e2e/site-setup.spec.ts` — Playwright happy path (skip → skip → done with "Using defaults" copy + Start CTA returns to detail) plus a resume-from-step-3 case after both skipped. `auditA11y` at every step.

## Risks identified and mitigated
- **No write-safety hotspots.** No external API calls, no money spent, no concurrency-sensitive multi-row writes. The skip endpoint flips one CHECK-bounded enum value on the site row.
- **CHECK-bounded status writes.** `setStepStatus` writes only the literal `'skipped'`. Schema CHECK in 0060 rejects any other invented value (23514).
- **Resume race.** If two tabs flip the status concurrently, last write wins (no `version_lock` CAS) — chosen deliberately. The status field is monotonic-by-intention (skip and approve are both terminal) and concurrent operator skip+approve is implausible. Adding CAS would force a 409 reload on every step transition for no real safety gain.
- **Auth gate.** `requireAdminForApi({ roles: ["super_admin", "admin"] })` on the skip endpoint, matching `/api/admin/sites/[id]/voice`. Operators don't manage site configuration.
- **Working tree race recovery.** This branch (`-v2`) replaces the original `feat/design-discovery-3-wizard-shell` after a parallel-session HEAD race bundled my files into Session B's slice-22 commit. Files were recovered via `git checkout bd896e1 -- <paths>` from the polluted commit and re-committed clean against current main.

## Deliberately deferred
- **Step 1 and Step 2 inner content.** Placeholder frames only; PRs 4–9 swap them for the real input surface, concept review, refinement, and approval.
- **Approve endpoint.** The skip endpoint ships now because the placeholders need it. The approve endpoint lands with PR 7 (design) + PR 8 (tone) when there's a real artefact to approve.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm run test:e2e` — runs in CI (Docker not available locally for `supabase start`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)