### PR TITLE
feat(p4-1): email-2FA schema + lib helpers + signed-cookie utilities

### DIFF
--- a/lib/2fa/challenges.ts
+++ b/lib/2fa/challenges.ts
@@ -1,0 +1,259 @@
+import "server-only";
+
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { hashIp } from "./cookies";
+
+// ---------------------------------------------------------------------------
+// AUTH-FOUNDATION P4.1 — Login challenge lifecycle.
+//
+// Four operations:
+//
+//   - createLoginChallenge() — called from the login server action
+//     after password validation succeeds and the user has no matching
+//     trusted device. Generates a 32-byte raw token + a fresh
+//     device_id; INSERTs a login_challenges row; returns the
+//     challenge_id (the row id, used in the URL) + the raw token (for
+//     the email body) + the device_id (for the eventual cookie write).
+//
+//   - lookupChallengeByToken() — called from the /auth/approve page.
+//     Hashes the incoming raw token + matches against token_hash.
+//     Returns the row + its current state so the page can render the
+//     right error (invalid / expired / already-used).
+//
+//   - approveChallenge() — flips status pending → approved + records
+//     approved_at. Single-use: the second click on the same approval
+//     link returns CONSUMED.
+//
+//   - consumeChallenge() — flips status approved → consumed. Called
+//     by the complete-login API after the session cookie + (optional)
+//     trusted_devices row land. Idempotent: returns false on a
+//     second consume.
+//
+// All operations are Postgres-side; supabase-js doesn't expose
+// transactions, but each operation is a single UPDATE WHERE status=...
+// so concurrent attempts collapse to a single winner via row-level
+// CAS.
+// ---------------------------------------------------------------------------
+
+const TOKEN_BYTES = 32;
+const CHALLENGE_TTL_MS = 15 * 60 * 1000;
+
+export interface CreateChallengeInput {
+  userId: string;
+  ip: string | null;
+  userAgent: string | null;
+}
+
+export interface CreateChallengeResult {
+  ok: true;
+  challenge_id: string;
+  device_id: string;
+  raw_token: string;
+  expires_at: string;
+}
+
+export type CreateChallengeOutcome =
+  | CreateChallengeResult
+  | { ok: false; error: { code: "INTERNAL_ERROR"; message: string } };
+
+export async function createLoginChallenge(
+  input: CreateChallengeInput,
+): Promise<CreateChallengeOutcome> {
+  const supabase = getServiceRoleClient();
+  const rawToken = randomBytes(TOKEN_BYTES).toString("hex");
+  const tokenHash = createHash("sha256").update(rawToken).digest("hex");
+  const deviceId = randomUUID();
+  const expiresAt = new Date(Date.now() + CHALLENGE_TTL_MS).toISOString();
+
+  const { data, error } = await supabase
+    .from("login_challenges")
+    .insert({
+      user_id: input.userId,
+      device_id: deviceId,
+      token_hash: tokenHash,
+      ip_hash: hashIp(input.ip),
+      ua_string: input.userAgent,
+      expires_at: expiresAt,
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    logger.error("2fa.challenges.create_failed", {
+      err: error?.message,
+      user_id: input.userId,
+    });
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: error?.message ?? "Failed to create login challenge.",
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    challenge_id: data.id as string,
+    device_id: deviceId,
+    raw_token: rawToken,
+    expires_at: expiresAt,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
+
+export interface ChallengeRow {
+  id: string;
+  user_id: string;
+  device_id: string;
+  status: "pending" | "approved" | "expired" | "consumed";
+  ua_string: string | null;
+  ip_hash: string | null;
+  created_at: string;
+  expires_at: string;
+  approved_at: string | null;
+}
+
+export async function lookupChallengeById(
+  challengeId: string,
+): Promise<ChallengeRow | null> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("login_challenges")
+    .select(
+      "id, user_id, device_id, status, ua_string, ip_hash, created_at, expires_at, approved_at",
+    )
+    .eq("id", challengeId)
+    .maybeSingle();
+  if (error) {
+    logger.error("2fa.challenges.lookup_by_id_failed", { err: error.message });
+    return null;
+  }
+  return (data as ChallengeRow | null) ?? null;
+}
+
+export async function lookupChallengeByToken(
+  rawToken: string,
+): Promise<ChallengeRow | null> {
+  const tokenHash = createHash("sha256").update(rawToken).digest("hex");
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("login_challenges")
+    .select(
+      "id, user_id, device_id, status, ua_string, ip_hash, created_at, expires_at, approved_at",
+    )
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+  if (error) {
+    logger.error("2fa.challenges.lookup_by_token_failed", { err: error.message });
+    return null;
+  }
+  return (data as ChallengeRow | null) ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// State transitions (CAS-protected)
+// ---------------------------------------------------------------------------
+
+export type ApproveResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: "not_found" | "expired" | "already_consumed" | "already_approved";
+    };
+
+export async function approveChallenge(challengeId: string): Promise<ApproveResult> {
+  const supabase = getServiceRoleClient();
+  const row = await lookupChallengeById(challengeId);
+  if (!row) return { ok: false, reason: "not_found" };
+  if (row.status === "consumed") return { ok: false, reason: "already_consumed" };
+  if (row.status === "approved") return { ok: false, reason: "already_approved" };
+  if (row.status === "expired") return { ok: false, reason: "expired" };
+  if (new Date(row.expires_at).getTime() <= Date.now()) {
+    // Best-effort flip to expired so polling sees the right state.
+    await supabase
+      .from("login_challenges")
+      .update({ status: "expired" })
+      .eq("id", challengeId)
+      .eq("status", "pending");
+    return { ok: false, reason: "expired" };
+  }
+
+  const { error, data } = await supabase
+    .from("login_challenges")
+    .update({ status: "approved", approved_at: new Date().toISOString() })
+    .eq("id", challengeId)
+    .eq("status", "pending")
+    .select("id");
+
+  if (error) {
+    return {
+      ok: false,
+      reason: "not_found",
+    };
+  }
+  if (!data || data.length === 0) {
+    // Race: another tab consumed/expired between lookup + update.
+    return { ok: false, reason: "already_consumed" };
+  }
+  return { ok: true };
+}
+
+export type ConsumeResult =
+  | { ok: true; challenge: ChallengeRow }
+  | { ok: false; reason: "not_found" | "expired" | "not_approved" | "already_consumed" };
+
+export async function consumeChallenge(
+  challengeId: string,
+): Promise<ConsumeResult> {
+  const supabase = getServiceRoleClient();
+  const row = await lookupChallengeById(challengeId);
+  if (!row) return { ok: false, reason: "not_found" };
+  if (row.status === "consumed") return { ok: false, reason: "already_consumed" };
+  if (row.status !== "approved") return { ok: false, reason: "not_approved" };
+  if (new Date(row.expires_at).getTime() <= Date.now()) {
+    return { ok: false, reason: "expired" };
+  }
+
+  const { error, data } = await supabase
+    .from("login_challenges")
+    .update({ status: "consumed" })
+    .eq("id", challengeId)
+    .eq("status", "approved")
+    .select("id");
+
+  if (error) {
+    return { ok: false, reason: "not_found" };
+  }
+  if (!data || data.length === 0) {
+    return { ok: false, reason: "already_consumed" };
+  }
+  return { ok: true, challenge: { ...row, status: "consumed" } };
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit helper: count active challenges for an email in the last hour.
+// Used by the login server action before issuing a new challenge.
+// ---------------------------------------------------------------------------
+
+export async function recentChallengeCountForUser(userId: string): Promise<number> {
+  const supabase = getServiceRoleClient();
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const { count, error } = await supabase
+    .from("login_challenges")
+    .select("id", { head: true, count: "exact" })
+    .eq("user_id", userId)
+    .gte("created_at", oneHourAgo);
+  if (error) {
+    logger.error("2fa.challenges.rate_count_failed", { err: error.message });
+    return 0;
+  }
+  return count ?? 0;
+}

--- a/lib/2fa/cookies.ts
+++ b/lib/2fa/cookies.ts
@@ -1,0 +1,118 @@
+import "server-only";
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// AUTH-FOUNDATION P4.1 — signed device_id cookie helpers.
+//
+// device_id is the second half of the trust-matching tuple (the first
+// half is user_id from the Supabase session). It's persisted as a
+// signed cookie:
+//
+//   Name:     opollo_device_id
+//   Value:    <uuid>.<hmac-sha256-base64url>
+//   HttpOnly, Secure, SameSite=Lax, Path=/, Max-Age=30 days
+//
+// Signing key: COOKIE_SIGNING_SECRET env var (32-byte hex, set in P1).
+//
+// Why HMAC instead of just storing the uuid:
+//   - A bare uuid cookie is forgeable by anyone who can guess it.
+//     The HMAC binds the value to a server-side secret so an attacker
+//     can't fabricate device_id values, only replay a value they
+//     already control.
+//   - Even if device_id leaks, trust still requires the user_id to
+//     match the Supabase session — so the leak alone doesn't grant
+//     access without also stealing the session cookie.
+//
+// On sign-out: clear the session cookie but KEEP device_id (per the
+// brief — next sign-in matches the trusted device). On
+// "sign out this device": clear both AND mark trusted_devices row
+// revoked.
+// ---------------------------------------------------------------------------
+
+export const DEVICE_ID_COOKIE = "opollo_device_id";
+
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+export function getCookieMaxAgeSeconds(): number {
+  return COOKIE_MAX_AGE_SECONDS;
+}
+
+function loadSigningSecret(): Buffer {
+  const raw = process.env.COOKIE_SIGNING_SECRET;
+  if (!raw) {
+    throw new Error(
+      "COOKIE_SIGNING_SECRET is not set. Generate via `openssl rand -hex 32` and add to Vercel env vars.",
+    );
+  }
+  // Accept either hex (32 bytes = 64 chars) or any non-empty string.
+  // Hex is the canonical shape per the P1 brief; non-hex still works
+  // since HMAC takes any byte sequence as a key.
+  if (/^[0-9a-f]{64}$/i.test(raw)) {
+    return Buffer.from(raw, "hex");
+  }
+  return Buffer.from(raw, "utf8");
+}
+
+function sign(value: string): string {
+  const key = loadSigningSecret();
+  return createHmac("sha256", key).update(value).digest("base64url");
+}
+
+/** Build the cookie value for a given device_id (uuid). */
+export function encodeDeviceCookie(deviceId: string): string {
+  return `${deviceId}.${sign(deviceId)}`;
+}
+
+/** Validate the cookie value and return the device_id if valid, else null. */
+export function decodeDeviceCookie(cookieValue: string | undefined): string | null {
+  if (!cookieValue) return null;
+  const parts = cookieValue.split(".");
+  if (parts.length !== 2) return null;
+  const [deviceId, signature] = parts;
+  if (!deviceId || !signature) return null;
+  const expected = sign(deviceId);
+  // timingSafeEqual requires equal-length buffers; bail on mismatch
+  // BEFORE calling it to avoid the synchronous throw that would
+  // otherwise leak the comparison size.
+  const a = Buffer.from(signature, "utf8");
+  const b = Buffer.from(expected, "utf8");
+  if (a.length !== b.length) {
+    // Constant-time false: feed a same-length filler through the
+    // comparator so timing doesn't depend on value length.
+    timingSafeEqual(a, Buffer.alloc(a.length));
+    return null;
+  }
+  if (!timingSafeEqual(a, b)) return null;
+  // Sanity-check the deviceId shape — UUID-ish.
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(deviceId)) {
+    return null;
+  }
+  return deviceId;
+}
+
+export function isCookieSigningSecretSet(): boolean {
+  const raw = process.env.COOKIE_SIGNING_SECRET;
+  return Boolean(raw && raw.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// IP hashing for ip_hash columns. Uses IP_HASH_PEPPER (per P1) so the
+// raw IP isn't recoverable from the stored hash.
+// ---------------------------------------------------------------------------
+
+import { createHash } from "node:crypto";
+
+export function hashIp(ip: string | null): string | null {
+  if (!ip) return null;
+  const pepper = process.env.IP_HASH_PEPPER;
+  if (!pepper) {
+    // No pepper → return the unsalted hash. Less ideal but still
+    // doesn't store the raw IP. P1 requires the pepper, so this
+    // branch only fires in misconfigured environments.
+    return createHash("sha256").update(ip).digest("hex");
+  }
+  return createHash("sha256")
+    .update(`${pepper}:${ip}`)
+    .digest("hex");
+}

--- a/lib/2fa/devices.ts
+++ b/lib/2fa/devices.ts
@@ -1,0 +1,192 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { hashIp, getCookieMaxAgeSeconds } from "./cookies";
+
+// ---------------------------------------------------------------------------
+// AUTH-FOUNDATION P4.1 — Trusted-device registry.
+//
+// One row per (user_id, device_id) that has completed an email-
+// approval flow with trust_device=true. Trust matching uses
+// (user_id, device_id) ALONE — UA strings are stored as metadata
+// only because browser updates rotate UA and we don't want to break
+// already-trusted devices.
+//
+// Operations:
+//   - registerTrustedDevice() — UPSERT on (user_id, device_id). A
+//     second successful approval on the same trusted device extends
+//     trusted_until + bumps last_used_at instead of inserting a
+//     duplicate.
+//   - isDeviceTrusted() — single hot-path lookup. Filters revoked
+//     and not-yet-expired rows.
+//   - touchTrustedDevice() — bumps last_used_at on a successful
+//     trust-skip login (no challenge needed).
+//   - listTrustedDevicesForUser() — for /admin/account/devices.
+//   - revokeTrustedDevice() / revokeAllOtherDevices() — for the
+//     "Sign out this device" / "Sign out all other devices" buttons.
+// ---------------------------------------------------------------------------
+
+export interface RegisterTrustedDeviceInput {
+  userId: string;
+  deviceId: string;
+  ip: string | null;
+  userAgent: string | null;
+}
+
+export async function registerTrustedDevice(
+  input: RegisterTrustedDeviceInput,
+): Promise<boolean> {
+  const supabase = getServiceRoleClient();
+  const trustedUntil = new Date(
+    Date.now() + getCookieMaxAgeSeconds() * 1000,
+  ).toISOString();
+  const { error } = await supabase
+    .from("trusted_devices")
+    .upsert(
+      {
+        user_id: input.userId,
+        device_id: input.deviceId,
+        ua_string: input.userAgent,
+        ip_hash: hashIp(input.ip),
+        trusted_until: trustedUntil,
+        last_used_at: new Date().toISOString(),
+        revoked_at: null,
+      },
+      { onConflict: "user_id,device_id" },
+    );
+  if (error) {
+    logger.error("2fa.devices.register_failed", {
+      err: error.message,
+      user_id: input.userId,
+    });
+    return false;
+  }
+  return true;
+}
+
+export interface IsDeviceTrustedInput {
+  userId: string;
+  deviceId: string;
+}
+
+export async function isDeviceTrusted(
+  input: IsDeviceTrustedInput,
+): Promise<boolean> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("trusted_devices")
+    .select("id, trusted_until")
+    .eq("user_id", input.userId)
+    .eq("device_id", input.deviceId)
+    .is("revoked_at", null)
+    .maybeSingle();
+  if (error) {
+    logger.error("2fa.devices.check_failed", { err: error.message });
+    return false;
+  }
+  if (!data) return false;
+  return new Date(data.trusted_until as string).getTime() > Date.now();
+}
+
+export async function touchTrustedDevice(
+  input: IsDeviceTrustedInput,
+): Promise<void> {
+  const supabase = getServiceRoleClient();
+  const { error } = await supabase
+    .from("trusted_devices")
+    .update({ last_used_at: new Date().toISOString() })
+    .eq("user_id", input.userId)
+    .eq("device_id", input.deviceId)
+    .is("revoked_at", null);
+  if (error) {
+    logger.warn("2fa.devices.touch_failed", { err: error.message });
+  }
+}
+
+export interface TrustedDeviceListing {
+  id: string;
+  device_id: string;
+  ua_string: string | null;
+  trusted_until: string;
+  last_used_at: string;
+  created_at: string;
+  is_current_device: boolean;
+}
+
+export async function listTrustedDevicesForUser(
+  userId: string,
+  currentDeviceId: string | null,
+): Promise<TrustedDeviceListing[]> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("trusted_devices")
+    .select(
+      "id, device_id, ua_string, trusted_until, last_used_at, created_at",
+    )
+    .eq("user_id", userId)
+    .is("revoked_at", null)
+    .order("last_used_at", { ascending: false });
+  if (error) {
+    logger.error("2fa.devices.list_failed", {
+      err: error.message,
+      user_id: userId,
+    });
+    return [];
+  }
+  return (data ?? []).map((row) => ({
+    id: row.id as string,
+    device_id: row.device_id as string,
+    ua_string: (row.ua_string as string | null) ?? null,
+    trusted_until: row.trusted_until as string,
+    last_used_at: row.last_used_at as string,
+    created_at: row.created_at as string,
+    is_current_device:
+      currentDeviceId !== null && row.device_id === currentDeviceId,
+  }));
+}
+
+export async function revokeTrustedDevice(
+  deviceRowId: string,
+  actorUserId: string,
+): Promise<boolean> {
+  const supabase = getServiceRoleClient();
+  const { error, data } = await supabase
+    .from("trusted_devices")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", deviceRowId)
+    .eq("user_id", actorUserId)        // self-only revocation
+    .is("revoked_at", null)
+    .select("id");
+  if (error) {
+    logger.error("2fa.devices.revoke_failed", {
+      err: error.message,
+      device_id: deviceRowId,
+    });
+    return false;
+  }
+  return Array.isArray(data) && data.length > 0;
+}
+
+export async function revokeAllOtherDevices(
+  userId: string,
+  keepDeviceId: string,
+): Promise<number> {
+  const supabase = getServiceRoleClient();
+  const { error, data } = await supabase
+    .from("trusted_devices")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("user_id", userId)
+    .is("revoked_at", null)
+    .neq("device_id", keepDeviceId)
+    .select("id");
+  if (error) {
+    logger.error("2fa.devices.revoke_others_failed", {
+      err: error.message,
+      user_id: userId,
+    });
+    return 0;
+  }
+  return Array.isArray(data) ? data.length : 0;
+}

--- a/lib/2fa/flag.ts
+++ b/lib/2fa/flag.ts
@@ -1,0 +1,12 @@
+import "server-only";
+
+// AUTH-FOUNDATION P4.1 — feature flag for the email-2FA flow.
+//
+// Default false; flip AUTH_2FA_ENABLED=true in Vercel env when
+// staging is ready to test (per the P4 operator gate). When false,
+// the login server action behaves as today (P3 + earlier).
+
+export function is2faEnabled(): boolean {
+  const v = process.env.AUTH_2FA_ENABLED;
+  return v === "true" || v === "1";
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -36,7 +36,8 @@ export type LimiterName =
   | "invite"
   | "register"
   | "password_reset"
-  | "test_connection";
+  | "test_connection"
+  | "auth_2fa";
 
 type LimiterConfig = {
   requests: number;
@@ -65,6 +66,12 @@ const CONFIGS: Record<LimiterName, LimiterConfig> = {
   // or /admin/sites/[id]/edit; 60/hour comfortably covers that without
   // letting a logged-in admin scan arbitrary WP installs at scale.
   test_connection: { requests: 60, window: "1 h" },
+  // AUTH-FOUNDATION P4.1: email-2FA challenge issuance. Per the brief
+  // §4: max 5 challenges per email per rolling hour. The recently-
+  // active count is also enforced via a Postgres count (which sees
+  // every challenge regardless of which Redis bucket fired); this
+  // limiter is the IP-side belt-and-braces.
+  auth_2fa: { requests: 5, window: "1 h" },
 };
 
 export type RateLimitResult =

--- a/supabase/migrations/0062_auth_foundation_2fa_schema.sql
+++ b/supabase/migrations/0062_auth_foundation_2fa_schema.sql
@@ -1,0 +1,129 @@
+-- 0062 — AUTH-FOUNDATION P4.1: email-2FA schema (login_challenges + trusted_devices).
+--
+-- Two tables underpin the email-approval second factor that fronts
+-- every login from an untrusted device when AUTH_2FA_ENABLED is on:
+--
+--   1. login_challenges — one row per password-validated sign-in
+--      that needs an approval click. The id doubles as the
+--      challenge_id used in /login/check-email URLs and the polling
+--      endpoint. token_hash is sha-256 of a 32-byte random; the raw
+--      token only ever appears in the approval email. 15-minute
+--      expiry. ip_hash captures the originating client (peppered
+--      with IP_HASH_PEPPER) for audit + future anomaly detection.
+--      ua_string is metadata for the email body's "Device: …" line.
+--
+--   2. trusted_devices — one row per (user_id, device_id) that has
+--      successfully completed an approval flow. device_id is server-
+--      generated per challenge and persisted in a signed HttpOnly
+--      cookie. trust_until = created_at + 30 days unless revoked.
+--      ua_string is metadata only — trust matching uses
+--      (user_id, device_id) ALONE (UA strings change on browser
+--      updates and shouldn't break trust).
+--
+-- Forward-only. RLS service-role-only on both tables; the auth
+-- pipeline reads + writes via lib/2fa/* with the service-role
+-- client.
+
+-- ----------------------------------------------------------------------------
+-- login_challenges
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE login_challenges (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      uuid NOT NULL REFERENCES opollo_users(id) ON DELETE CASCADE,
+
+  -- Generated server-side per challenge. On approval, this id is
+  -- written into a signed cookie and (if trust_device=true) into
+  -- trusted_devices.
+  device_id    uuid NOT NULL,
+
+  -- sha-256 of a 32-byte random. Raw token only appears in the email.
+  token_hash   text NOT NULL UNIQUE,
+
+  status       text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'approved', 'expired', 'consumed')),
+
+  ip_hash      text,                 -- peppered with IP_HASH_PEPPER
+  ua_string    text,                 -- raw UA for the email body
+
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  expires_at   timestamptz NOT NULL DEFAULT (now() + interval '15 minutes'),
+  approved_at  timestamptz
+);
+
+-- Hot-path query: token_hash lookup from /auth/approve.
+-- The UNIQUE on token_hash gives this for free; no extra index needed.
+
+-- Polling lookup by (user_id, status). Polling endpoint hits this
+-- every 3 seconds while the user waits.
+CREATE INDEX login_challenges_user_status_idx
+  ON login_challenges (user_id, status, created_at DESC);
+
+-- Rate-limit query: count challenges per email per hour.
+-- Joined to opollo_users via user_id, so no email column needed here.
+CREATE INDEX login_challenges_user_created_idx
+  ON login_challenges (user_id, created_at DESC);
+
+ALTER TABLE login_challenges ENABLE ROW LEVEL SECURITY;
+CREATE POLICY service_role_all ON login_challenges
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE login_challenges IS
+  'AUTH-FOUNDATION P4 email-2FA challenges. One row per password-valid sign-in that needs an email approval click. id doubles as challenge_id in URLs. 15-min expiry; status flips pending → approved → consumed (or expired). Added 2026-04-30.';
+
+COMMENT ON COLUMN login_challenges.device_id IS
+  'Server-generated per challenge. Persisted in the signed device_id cookie on completion + into trusted_devices when trust_device=true. Trust matching uses (user_id, device_id) ALONE.';
+
+COMMENT ON COLUMN login_challenges.token_hash IS
+  'sha-256 of a 32-byte random. Raw token only appears in the approval email.';
+
+-- ----------------------------------------------------------------------------
+-- trusted_devices
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE trusted_devices (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid NOT NULL REFERENCES opollo_users(id) ON DELETE CASCADE,
+
+  -- Matches a login_challenges.device_id that completed approval.
+  device_id       uuid NOT NULL,
+
+  -- Metadata for /admin/account/devices display only — NOT used for
+  -- trust matching (UA strings change on browser updates).
+  ua_string       text,
+  ip_hash         text,                 -- peppered
+
+  trusted_until   timestamptz NOT NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  revoked_at      timestamptz,
+  last_used_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- Trust-matching lookup: hot path on every login when 2FA is on.
+-- Partial index so revoked/expired rows don't bloat the seek.
+CREATE INDEX trusted_devices_active_idx
+  ON trusted_devices (user_id, device_id)
+  WHERE revoked_at IS NULL;
+
+-- /admin/account/devices listing.
+CREATE INDEX trusted_devices_user_listing_idx
+  ON trusted_devices (user_id, created_at DESC);
+
+-- Idempotent UPSERT key. A second successful approval for the same
+-- (user_id, device_id) updates last_used_at + extends trusted_until
+-- rather than creating a duplicate row.
+CREATE UNIQUE INDEX trusted_devices_user_device_uniq
+  ON trusted_devices (user_id, device_id);
+
+ALTER TABLE trusted_devices ENABLE ROW LEVEL SECURITY;
+CREATE POLICY service_role_all ON trusted_devices
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE trusted_devices IS
+  'AUTH-FOUNDATION P4 trusted-device registry. One row per (user_id, device_id) that completed an email-approval flow with trust_device=true. Trust matching uses (user_id, device_id) only. ua_string + ip_hash are metadata for /admin/account/devices display. Added 2026-04-30.';
+
+COMMENT ON COLUMN trusted_devices.ua_string IS
+  'User-Agent header from the approval-completing request. METADATA ONLY — trust matching does NOT use UA (browser updates rotate UA strings; UA-coupled trust would break legitimately-trusted devices).';
+
+COMMENT ON COLUMN trusted_devices.ip_hash IS
+  'IP_HASH_PEPPER-peppered sha-256 of the originating IP. Stored to surface "this device" hints in the listing without retaining raw IPs.';

--- a/supabase/rollbacks/0062_auth_foundation_2fa_schema.down.sql
+++ b/supabase/rollbacks/0062_auth_foundation_2fa_schema.down.sql
@@ -1,0 +1,7 @@
+-- Rollback for 0062_auth_foundation_2fa_schema.sql.
+-- Drops both 2FA tables. Any in-flight challenges + trusted-device
+-- registrations are lost; users will be challenged again on next
+-- login (when AUTH_2FA_ENABLED is re-enabled).
+
+DROP TABLE IF EXISTS trusted_devices;
+DROP TABLE IF EXISTS login_challenges;


### PR DESCRIPTION
## Summary

Foundational sub-PR of AUTH-FOUNDATION phase 4. Lays the database + service helpers the next three slices (login interception, approval page, devices UI) consume. Nothing here is wired to live auth flows — \`AUTH_2FA_ENABLED\` stays default false until P4.2 ships.

## What ships

### Migration 0062
- **\`login_challenges\`** — 15-min expiry; status pending → approved → consumed | expired; \`token_hash\` sha256 (raw token only in email); ip_hash + ua_string for audit + email body.
- **\`trusted_devices\`** — UPSERT key on (user_id, device_id); 30-day trusted_until; UA stored as **METADATA only** — trust matching uses (user_id, device_id) **alone** so browser updates don't break trust.
- Both RLS service-role-only.

### Libraries
- **\`lib/2fa/cookies.ts\`** — signed device_id cookie helpers. HMAC-SHA256 with COOKIE_SIGNING_SECRET. Constant-time signature comparison + UUID shape sanity-check. \`hashIp()\` peppered with IP_HASH_PEPPER.
- **\`lib/2fa/challenges.ts\`** — login_challenges DAO. \`createLoginChallenge\`, \`lookupChallengeByToken\`, CAS-protected \`approveChallenge\` / \`consumeChallenge\` with precise failure reasons. \`recentChallengeCountForUser\` for the §4 rate limit.
- **\`lib/2fa/devices.ts\`** — trusted_devices DAO. UPSERT \`registerTrustedDevice\` (re-trust extends rather than duplicates), \`isDeviceTrusted\` (partial-index hot path), \`touchTrustedDevice\`, listing for /admin/account/devices, \`revokeTrustedDevice\` / \`revokeAllOtherDevices\` (self-only via .eq).
- **\`lib/2fa/flag.ts\`** — \`is2faEnabled()\` reads \`AUTH_2FA_ENABLED\`. Default false.
- **\`lib/rate-limit.ts\`** — new \`auth_2fa\` bucket (5/hour) — IP-side belt-and-braces alongside the canonical Postgres count.

## Risks identified and mitigated

- **\`COOKIE_SIGNING_SECRET\` unset** → \`loadSigningSecret\` throws with clear remediation. P4.2 only intercepts when flag is on, so missing secret in flag-off env doesn't crash login.
- **\`IP_HASH_PEPPER\` unset** → \`hashIp\` falls back to unsalted sha256 (still doesn't store raw IP).
- **Trust matching uses (user_id, device_id) only** per the brief — UA strings stored only as metadata.
- **Single-use approval** enforced via CAS UPDATE WHERE status=...; concurrent clicks collapse to one winner.
- **\`registerTrustedDevice\` resets revoked_at to null on UPSERT** — re-approving a previously-revoked device re-trusts it (operator can opt out via the trust checkbox if not desired).

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅
- No flag flip in this PR

## Test plan

- [ ] Migration 0062 applies cleanly in staging
- [ ] CI green
- [ ] P4.2 wires the login server action to these helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)