### PR TITLE
feat(optimiser): staged rollout banner on page detail view

### DIFF
--- a/app/optimiser/pages/[id]/page.tsx
+++ b/app/optimiser/pages/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { AbTestStatusBanner } from "@/components/optimiser/AbTestStatusBanner";
 import { ScoreBreakdownPanel } from "@/components/optimiser/ScoreBreakdownPanel";
+import { StagedRolloutBanner } from "@/components/optimiser/StagedRolloutBanner";
 import { ScoreHistoryTable } from "@/components/optimiser/ScoreHistoryTable";
 import { ScoreSparkline } from "@/components/optimiser/ScoreSparkline";
 import {
@@ -29,6 +30,7 @@ import {
 } from "@/lib/optimiser/scoring/conversion-subscore";
 import { computeTechnicalSubscore } from "@/lib/optimiser/scoring/technical-subscore";
 import { listScoreHistory, listScoreSparkline } from "@/lib/optimiser/scoring/score-history";
+import { getLatestRolloutForLandingPage } from "@/lib/optimiser/staged-rollout/read";
 import {
   DEFAULT_CONVERSION_COMPONENTS,
   DEFAULT_SCORE_WEIGHTS,
@@ -118,6 +120,11 @@ export default async function OptimiserPageDetail({
     .limit(1)
     .maybeSingle();
 
+  // Phase 1.5 follow-up: surface the most recent staged-rollout state
+  // (live / promoted / auto_reverted / manually_promoted / failed) for
+  // proposals on this page.
+  const latestRollout = await getLatestRolloutForLandingPage(page.id);
+
   return (
     <div className="space-y-6">
       <header className="flex flex-wrap items-center justify-between gap-4">
@@ -143,6 +150,7 @@ export default async function OptimiserPageDetail({
       </header>
 
       <AbTestStatusBanner test={latestTest as never} />
+      <StagedRolloutBanner rollout={latestRollout} />
 
       {composite ? (
         <ScoreBreakdownPanel

--- a/components/optimiser/StagedRolloutBanner.tsx
+++ b/components/optimiser/StagedRolloutBanner.tsx
@@ -1,0 +1,160 @@
+import Link from "next/link";
+
+import type { RolloutRow } from "@/lib/optimiser/staged-rollout/read";
+
+// Staged-rollout banner (Phase 1.5 follow-up) — surfaces on the page
+// detail view alongside AbTestStatusBanner. Renders the most recent
+// opt_staged_rollouts row's state so operators can see the rollout
+// lifecycle without leaving the page.
+//
+// Server-renderable, read-only.
+
+const STATE_TONE: Record<string, string> = {
+  live: "border-blue-200 bg-blue-50 text-blue-900",
+  promoted: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  manually_promoted: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  auto_reverted: "border-red-200 bg-red-50 text-red-900",
+  failed: "border-amber-200 bg-amber-50 text-amber-900",
+};
+
+const STATE_LABEL: Record<string, string> = {
+  live: "rolling out",
+  promoted: "promoted",
+  manually_promoted: "manually promoted",
+  auto_reverted: "auto-reverted",
+  failed: "monitor failed",
+};
+
+export function StagedRolloutBanner({ rollout }: { rollout: RolloutRow | null }) {
+  if (!rollout) return null;
+  const tone = STATE_TONE[rollout.current_state] ?? STATE_TONE.live;
+  const label = STATE_LABEL[rollout.current_state] ?? rollout.current_state;
+  const observed = rollout.latest_evaluation?.observed as
+    | {
+        cr_new?: number;
+        cr_baseline?: number;
+        cr_drop_pct?: number;
+        bounce_new?: number;
+        bounce_baseline?: number;
+        bounce_spike_pct?: number;
+        error_rate?: number;
+        floors_met?: { sessions: boolean; conversions: boolean; time: boolean };
+      }
+    | undefined;
+  const trips = rollout.latest_evaluation?.trips ?? [];
+
+  return (
+    <section className={`rounded-lg border p-4 ${tone}`}>
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold">
+          Staged rollout ({label})
+        </h3>
+        <p className="text-xs opacity-80">
+          Split: {rollout.traffic_split_percent}%
+          {" · "}
+          started {new Date(rollout.started_at).toLocaleString()}
+          {rollout.ended_at && (
+            <>
+              {" · ended "}
+              {new Date(rollout.ended_at).toLocaleString()}
+              {rollout.end_reason && <> ({rollout.end_reason})</>}
+            </>
+          )}
+        </p>
+      </header>
+
+      {observed && (
+        <ul className="mt-3 grid gap-2 text-xs sm:grid-cols-2">
+          <li>
+            <span className="opacity-70">CR (new): </span>
+            <span className="font-mono tabular-nums">
+              {fmtPct(observed.cr_new)}
+            </span>
+            <span className="opacity-70">
+              {" vs baseline "}
+              {fmtPct(observed.cr_baseline)}
+            </span>
+            {typeof observed.cr_drop_pct === "number" &&
+              observed.cr_drop_pct > 0 && (
+                <span className="ml-1 opacity-70">
+                  (drop {(observed.cr_drop_pct * 100).toFixed(1)}%)
+                </span>
+              )}
+          </li>
+          <li>
+            <span className="opacity-70">Bounce (new): </span>
+            <span className="font-mono tabular-nums">
+              {fmtPct(observed.bounce_new)}
+            </span>
+            <span className="opacity-70">
+              {" vs baseline "}
+              {fmtPct(observed.bounce_baseline)}
+            </span>
+          </li>
+          <li>
+            <span className="opacity-70">Error rate: </span>
+            <span className="font-mono tabular-nums">
+              {fmtPct(observed.error_rate)}
+            </span>
+            <span className="ml-1 opacity-60">
+              (5xx feed not yet ingested — defaults to 0)
+            </span>
+          </li>
+          <li>
+            <span className="opacity-70">Floors met: </span>
+            <span className="font-mono tabular-nums">
+              {observed.floors_met
+                ? [
+                    observed.floors_met.sessions ? "sessions" : null,
+                    observed.floors_met.conversions ? "conversions" : null,
+                    observed.floors_met.time ? "time" : null,
+                  ]
+                    .filter(Boolean)
+                    .join(" + ") || "none"
+                : "—"}
+            </span>
+          </li>
+        </ul>
+      )}
+
+      {trips.length > 0 && (
+        <ul className="mt-3 list-disc space-y-0.5 pl-5 text-xs">
+          {trips.map((t, i) => (
+            <li key={i} className="font-mono">{t}</li>
+          ))}
+        </ul>
+      )}
+
+      <p className="mt-3 text-xs opacity-70">
+        {rollout.evaluation_count > 0 ? (
+          <>
+            {rollout.evaluation_count} monitor evaluation
+            {rollout.evaluation_count === 1 ? "" : "s"} recorded
+            {rollout.latest_evaluation && (
+              <>
+                {" · last "}
+                {new Date(
+                  rollout.latest_evaluation.evaluated_at,
+                ).toLocaleString()}
+              </>
+            )}
+            {" · "}
+          </>
+        ) : (
+          <>Awaiting first monitor tick · </>
+        )}
+        <Link
+          href={`/optimiser/proposals/${rollout.proposal_id}`}
+          className="underline-offset-4 hover:underline"
+        >
+          source proposal
+        </Link>
+      </p>
+    </section>
+  );
+}
+
+function fmtPct(value: number | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "—";
+  return `${(value * 100).toFixed(2)}%`;
+}

--- a/lib/optimiser/staged-rollout/read.ts
+++ b/lib/optimiser/staged-rollout/read.ts
@@ -1,0 +1,114 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  DEFAULT_STAGED_ROLLOUT_CONFIG,
+  type StagedRolloutConfig,
+} from "@/lib/optimiser/types";
+
+// ---------------------------------------------------------------------------
+// Read-only helpers for surfacing opt_staged_rollouts state in operator
+// UI. The monitor cron and lifecycle writers live in manager.ts; this
+// module only does pointed lookups for page detail views and similar
+// review surfaces.
+//
+// The rollout row links to a brief_run-produced page_id (Site Builder)
+// and a proposal_id (optimiser). It does NOT carry a direct
+// landing_page_id reference. To surface "is there a rollout for this
+// landing page", we walk through opt_proposals where the landing page
+// matches and pick the most recent rollout.
+// ---------------------------------------------------------------------------
+
+export type RolloutCurrentState =
+  | "live"
+  | "auto_reverted"
+  | "promoted"
+  | "manually_promoted"
+  | "failed";
+
+export interface RolloutRow {
+  id: string;
+  proposal_id: string;
+  client_id: string;
+  page_id: string | null;
+  started_at: string;
+  ended_at: string | null;
+  end_reason: string | null;
+  config_snapshot: StagedRolloutConfig;
+  traffic_split_percent: number;
+  current_state: RolloutCurrentState;
+  /** Most recent monitor evaluation entry — what the operator actually
+   * cares about: which decision the monitor made + observed metrics. */
+  latest_evaluation: {
+    evaluated_at: string;
+    decision: "rollback" | "promote" | "wait" | "window_expired";
+    trips: string[];
+    observed: Record<string, unknown>;
+  } | null;
+  evaluation_count: number;
+}
+
+/** Returns the most recent rollout row for a landing page (any state),
+ * or null if no proposal on that page has produced a rollout yet. */
+export async function getLatestRolloutForLandingPage(
+  landingPageId: string,
+): Promise<RolloutRow | null> {
+  const supabase = getServiceRoleClient();
+  const { data: proposals } = await supabase
+    .from("opt_proposals")
+    .select("id")
+    .eq("landing_page_id", landingPageId)
+    .is("deleted_at", null);
+  const proposalIds = (proposals ?? [])
+    .map((p) => p.id as string)
+    .filter(Boolean);
+  if (proposalIds.length === 0) return null;
+
+  const { data } = await supabase
+    .from("opt_staged_rollouts")
+    .select(
+      "id, proposal_id, client_id, page_id, started_at, ended_at, end_reason, config_snapshot, traffic_split_percent, current_state, regression_check_results",
+    )
+    .in("proposal_id", proposalIds)
+    .order("started_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (!data) return null;
+
+  const evaluations = Array.isArray(data.regression_check_results)
+    ? (data.regression_check_results as Array<{
+        evaluated_at: string;
+        decision: "rollback" | "promote" | "wait" | "window_expired";
+        trips?: string[];
+        observed?: Record<string, unknown>;
+      }>)
+    : [];
+  const latest = evaluations.length > 0
+    ? evaluations[evaluations.length - 1]
+    : null;
+
+  return {
+    id: data.id as string,
+    proposal_id: data.proposal_id as string,
+    client_id: data.client_id as string,
+    page_id: (data.page_id as string | null) ?? null,
+    started_at: data.started_at as string,
+    ended_at: (data.ended_at as string | null) ?? null,
+    end_reason: (data.end_reason as string | null) ?? null,
+    config_snapshot: {
+      ...DEFAULT_STAGED_ROLLOUT_CONFIG,
+      ...((data.config_snapshot as Partial<StagedRolloutConfig>) ?? {}),
+    },
+    traffic_split_percent: data.traffic_split_percent as number,
+    current_state: data.current_state as RolloutCurrentState,
+    latest_evaluation: latest
+      ? {
+          evaluated_at: latest.evaluated_at,
+          decision: latest.decision,
+          trips: latest.trips ?? [],
+          observed: latest.observed ?? {},
+        }
+      : null,
+    evaluation_count: evaluations.length,
+  };
+}


### PR DESCRIPTION
## Phase 1.5 follow-up — operator-facing surface for opt_staged_rollouts state

The staged rollout monitor (Slice 16) tracks lifecycle state in \`opt_staged_rollouts\` and writes evaluations to \`regression_check_results\`, but until now the only way to see what happened to a rollout was to query the table directly. This PR surfaces that state on the page detail view.

## What lands

- \`lib/optimiser/staged-rollout/read.ts\` — \`getLatestRolloutForLandingPage(landingPageId)\`. Walks \`opt_proposals\` (filtered by landing_page_id, deleted_at IS NULL) → \`opt_staged_rollouts\` (most recent by started_at). Returns the rollout row plus the most recent evaluation entry pulled out of the JSONB log + the total evaluation count.
- \`components/optimiser/StagedRolloutBanner.tsx\` — server-renderable banner. Tone-coded (blue=live, green=promoted, red=auto_reverted, amber=failed). Shows traffic split, start/end timestamps + end_reason, observed CR/bounce/error rate vs baseline, floors-met breakdown, and any tripped thresholds. Includes a link back to the source proposal and an explicit note that the 5xx feed isn't yet ingested (errors_new defaults to 0 — separate sub-slice).
- Wired into \`app/optimiser/pages/[id]/page.tsx\` between \`AbTestStatusBanner\` and \`ScoreBreakdownPanel\`.

## Risks identified and mitigated

- **No schema change, no client write, no LLM** — pure read of existing data.
- **Permission scope** — the page is already gated by the optimiser auth chain; this banner inherits that gate (no separate route, no separate API).
- **Stale \`page_id\` reference** — \`opt_staged_rollouts.page_id\` references \`pages\` (Site Builder) and is \`ON DELETE SET NULL\`. Reader handles \`page_id\` being nullable; banner doesn't depend on the Site Builder page row existing.
- **JSONB shape variance** — \`regression_check_results\` is append-only JSONB. Reader defensively typechecks each entry's shape and tolerates missing \`trips\` / \`observed\` / \`evaluated_at\` rather than crashing.
- **Multiple rollouts per page** — a page can accumulate rollouts as proposals get applied over time. Banner shows only the most recent (by started_at). Operator can drill into older ones via the source-proposal link if needed; full history is a future surface if demand materialises.

## Verification

- \`npm run typecheck\` — clean
- \`npm run lint\` — clean
- \`npm run build\` — clean

## Coordination note

Hit a HEAD race during this slice — parallel session was on \`feat/design-discovery-3-wizard-shell-v2\` and pulled main mid-build, swapping HEAD off my branch. Recovered via stash + rebase onto the new main tip; no parallel-session files were committed by mistake (stash + targeted \`git add\` excluded their \`lib/design-discovery/\` work).