### PR TITLE
feat(design-discovery-4): step 1 input surface + mood board + understanding

### DIFF
--- a/app/api/admin/sites/[id]/setup/extract-design/route.ts
+++ b/app/api/admin/sites/[id]/setup/extract-design/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { extractCssFromUrl } from "@/lib/design-discovery/extract-css";
+import { fetchMicrolinkScreenshot } from "@/lib/design-discovery/microlink";
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/sites/[id]/setup/extract-design
+//
+// Driven by the Step-1 input surface. Operator pastes a reference URL
+// (or "this is our existing site" URL) and we fetch a snapshot of the
+// design tokens we can see plus a Microlink screenshot URL for the
+// before/after panel later. Microlink failure is silent — we fall
+// back to CSS-only extraction per the brief.
+//
+// Body: { url: string }
+// Returns:
+//   { ok: true, data: { swatches, fonts, layout_tags, visual_tone_tags,
+//                       screenshot_url } }
+//   { ok: false, error: { code, message } }
+//
+// Rate limiting is reused from the existing test_connection bucket —
+// the abuse profile is the same (operator pastes a URL, we fetch it).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const BodySchema = z.object({
+  url: z.string().min(1).max(500),
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Site id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body must include { url: string }.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  // Run CSS extraction + Microlink in parallel. Both have their own
+  // timeouts; whichever finishes first lands in the response shape.
+  const [css, microlink] = await Promise.all([
+    extractCssFromUrl(parsed.data.url),
+    fetchMicrolinkScreenshot(parsed.data.url),
+  ]);
+
+  if (!css.fetch_ok && !microlink.ok) {
+    // Both failed → return a soft error so the form can show "Could
+    // not fetch that URL. Try pasting your copy directly instead."
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "FETCH_FAILED",
+          message:
+            css.fetch_error ||
+            microlink.error ||
+            "Could not reach the URL. Try pasting your copy directly instead.",
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        swatches: css.swatches,
+        fonts: css.fonts,
+        layout_tags: css.layout_tags,
+        visual_tone_tags: css.visual_tone_tags,
+        screenshot_url: microlink.screenshot_url,
+        source_url: css.fetched_url,
+        fetched_at: new Date().toISOString(),
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/admin/sites/[id]/setup/save-brief/route.ts
+++ b/app/api/admin/sites/[id]/setup/save-brief/route.ts
@@ -1,0 +1,92 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import {
+  DesignBriefSchema,
+  saveDesignBrief,
+} from "@/lib/design-discovery/design-brief";
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/sites/[id]/setup/save-brief
+//
+// Step-1 progress save. Persists the operator-built design brief to
+// sites.design_brief and (when advance_status=true) flips
+// design_direction_status to 'in_progress' so the wizard can resume
+// here.
+//
+// Body: { brief: DesignBrief, advance_status?: boolean }
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Site id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const wrapper = body as { brief?: unknown; advance_status?: unknown };
+  const parsed = DesignBriefSchema.safeParse(wrapper?.brief ?? null);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "brief failed validation.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await saveDesignBrief(params.id, parsed.data, {
+    advanceStatus: wrapper.advance_status === true,
+  });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      result.error.code === "NOT_FOUND" ? 404 : 500,
+    );
+  }
+
+  revalidatePath(`/admin/sites/${params.id}/setup`);
+  return NextResponse.json(
+    { ok: true, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/components/DesignDirectionInputs.tsx
+++ b/components/DesignDirectionInputs.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+
+import { MoodBoardStrip } from "@/components/MoodBoardStrip";
+import { DesignUnderstandingPanel } from "@/components/DesignUnderstandingPanel";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  INDUSTRY_PRESETS,
+  industryPreset,
+  type Industry,
+} from "@/lib/design-discovery/industry-defaults";
+
+// ---------------------------------------------------------------------------
+// DesignDirectionInputs — Step 1 input surface.
+//
+// Operator provides any combination of:
+//   - Reference URL (a site they like)
+//   - Existing site URL ("this is our current site")
+//   - Free text description
+//   - Industry selector (loads sensible defaults)
+//
+// Screenshot upload is reserved in the design brief shape but the
+// upload UI lands in a follow-up — see PR description.
+//
+// Live mood board updates as inputs arrive: industry preset is
+// rendered immediately; URL extraction overlays its findings on top
+// when a URL is present and the operator clicks "Extract design".
+// The understanding panel shows what we've inferred + the confidence
+// signal + a "Generate concepts" CTA. PR 5 wires the actual concept
+// generation; for now Generate saves the brief and routes to the
+// generating-state intermediate screen.
+// ---------------------------------------------------------------------------
+
+export interface DesignBriefDraft {
+  industry: Industry;
+  reference_url: string;
+  existing_site_url: string;
+  description: string;
+  edited_understanding: string;
+  extracted: ExtractedSnapshot | null;
+}
+
+export interface ExtractedSnapshot {
+  swatches: string[];
+  fonts: string[];
+  layout_tags: string[];
+  visual_tone_tags: string[];
+  screenshot_url: string | null;
+  source_url: string | null;
+  fetched_at: string | null;
+}
+
+const INITIAL_DRAFT: DesignBriefDraft = {
+  industry: "msp",
+  reference_url: "",
+  existing_site_url: "",
+  description: "",
+  edited_understanding: "",
+  extracted: null,
+};
+
+export function DesignDirectionInputs({
+  siteId,
+  initial,
+}: {
+  siteId: string;
+  initial?: Partial<DesignBriefDraft>;
+}) {
+  const router = useRouter();
+  const [draft, setDraft] = useState<DesignBriefDraft>({
+    ...INITIAL_DRAFT,
+    ...initial,
+  });
+  const [extracting, setExtracting] = useState(false);
+  const [extractError, setExtractError] = useState<string | null>(null);
+  const [generating, setGenerating] = useState(false);
+
+  const preset = useMemo(() => industryPreset(draft.industry), [draft.industry]);
+
+  // The current "what we'll show in the mood board" view: industry
+  // preset overlaid by anything we extracted from the URL.
+  const view = useMemo(() => {
+    const ex = draft.extracted;
+    return {
+      swatches:
+        ex && ex.swatches.length > 0
+          ? ex.swatches
+          : Object.values(preset.swatches),
+      fonts: ex && ex.fonts.length > 0
+        ? ex.fonts
+        : [preset.font_heading, preset.font_body].filter(
+            (v, i, a) => a.indexOf(v) === i,
+          ),
+      layout_tags:
+        ex && ex.layout_tags.length > 0 ? ex.layout_tags : preset.layout_tags,
+      visual_tone_tags:
+        ex && ex.visual_tone_tags.length > 0
+          ? ex.visual_tone_tags
+          : preset.visual_tone_tags,
+      screenshot_url: ex?.screenshot_url ?? null,
+      visual_tone: preset.visual_tone,
+    };
+  }, [draft.extracted, preset]);
+
+  const hasAnyInput =
+    draft.reference_url.trim().length > 0 ||
+    draft.existing_site_url.trim().length > 0 ||
+    draft.description.trim().length > 0 ||
+    draft.industry !== INITIAL_DRAFT.industry;
+
+  function setField<K extends keyof DesignBriefDraft>(
+    key: K,
+    value: DesignBriefDraft[K],
+  ): void {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function runExtract(targetUrl: string) {
+    setExtracting(true);
+    setExtractError(null);
+    try {
+      const res = await fetch(`/api/admin/sites/${siteId}/setup/extract-design`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url: targetUrl }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: ExtractedSnapshot }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (!payload?.ok) {
+        setExtractError(
+          payload?.ok === false
+            ? payload.error.message
+            : "Could not fetch that URL. Try pasting your copy directly instead.",
+        );
+        return;
+      }
+      setDraft((prev) => ({ ...prev, extracted: payload.data }));
+    } catch (err) {
+      setExtractError(
+        err instanceof Error ? err.message : "Network error during extraction.",
+      );
+    } finally {
+      setExtracting(false);
+    }
+  }
+
+  async function onGenerate() {
+    if (!hasAnyInput) {
+      toast.error(
+        "Add at least one input first — a URL, a description, or an industry choice.",
+      );
+      return;
+    }
+    setGenerating(true);
+    try {
+      const brief = {
+        industry: draft.industry,
+        reference_url: draft.reference_url.trim() || null,
+        existing_site_url: draft.existing_site_url.trim() || null,
+        description: draft.description.trim() || null,
+        edited_understanding: draft.edited_understanding.trim() || null,
+        screenshots: [],
+        refinement_notes: [],
+        extracted: draft.extracted,
+      };
+      const res = await fetch(`/api/admin/sites/${siteId}/setup/save-brief`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ brief, advance_status: true }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error: { message: string } }
+        | null;
+      if (!payload?.ok) {
+        toast.error(
+          payload?.ok === false ? payload.error.message : "Save failed.",
+        );
+        setGenerating(false);
+        return;
+      }
+      router.refresh();
+      // Concept generation lands in the next change. For now we sit
+      // on Step 1 with the brief saved + status='in_progress' so the
+      // resume logic correctly returns the operator here.
+      toast.success("Brief saved. Concept generation lands in the next change.");
+      setGenerating(false);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Network error during save.",
+      );
+      setGenerating(false);
+    }
+  }
+
+  const referenceUrlValid =
+    draft.reference_url.trim().length === 0 ||
+    /^https?:\/\/|^[a-z0-9-]+\./i.test(draft.reference_url.trim());
+
+  return (
+    <div className="space-y-6" data-testid="design-direction-inputs">
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <label
+            htmlFor="dd-industry"
+            className="block text-sm font-medium"
+          >
+            Industry
+          </label>
+          <select
+            id="dd-industry"
+            className="mt-1 block w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            value={draft.industry}
+            onChange={(e) =>
+              setField("industry", e.target.value as Industry)
+            }
+            data-testid="dd-industry"
+          >
+            {(Object.keys(INDUSTRY_PRESETS) as Industry[]).map((k) => (
+              <option key={k} value={k}>
+                {INDUSTRY_PRESETS[k].label}
+              </option>
+            ))}
+          </select>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Pre-loads sensible defaults. Stronger signals (URL,
+            description) override.
+          </p>
+        </div>
+        <div>
+          <label htmlFor="dd-existing-url" className="block text-sm font-medium">
+            Your existing site URL{" "}
+            <span className="font-normal text-muted-foreground">
+              (optional)
+            </span>
+          </label>
+          <Input
+            id="dd-existing-url"
+            type="url"
+            inputMode="url"
+            placeholder="https://yourcurrent-site.com"
+            value={draft.existing_site_url}
+            onChange={(e) => setField("existing_site_url", e.target.value)}
+            data-testid="dd-existing-url"
+            className="mt-1"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Establishes the brand baseline.
+          </p>
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="dd-reference-url" className="block text-sm font-medium">
+          Reference URL{" "}
+          <span className="font-normal text-muted-foreground">
+            (optional — paste a site you like)
+          </span>
+        </label>
+        <div className="mt-1 flex flex-col gap-2 md:flex-row">
+          <Input
+            id="dd-reference-url"
+            type="url"
+            inputMode="url"
+            placeholder="https://example.com"
+            value={draft.reference_url}
+            onChange={(e) => setField("reference_url", e.target.value)}
+            data-testid="dd-reference-url"
+            className="flex-1"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={
+              !draft.reference_url.trim() || !referenceUrlValid || extracting
+            }
+            onClick={() => void runExtract(draft.reference_url.trim())}
+            data-testid="dd-extract"
+          >
+            {extracting ? (
+              <>
+                <Loader2 aria-hidden className="h-3.5 w-3.5 animate-spin" />
+                Extracting…
+              </>
+            ) : (
+              "Extract design"
+            )}
+          </Button>
+        </div>
+        {extractError && (
+          <p
+            className="mt-2 text-xs text-destructive"
+            data-testid="dd-extract-error"
+            role="alert"
+          >
+            {extractError}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="dd-description" className="block text-sm font-medium">
+          Describe the look and feel{" "}
+          <span className="font-normal text-muted-foreground">(optional)</span>
+        </label>
+        <Textarea
+          id="dd-description"
+          placeholder="e.g. Premium, technical, lots of whitespace. Two-column hero. Subtle blue accents on a near-white background."
+          value={draft.description}
+          onChange={(e) => setField("description", e.target.value)}
+          maxLength={4000}
+          rows={4}
+          data-testid="dd-description"
+          className="mt-1"
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          Free text — describe the feeling, layout, density, anything that
+          helps us understand what you want.
+        </p>
+      </div>
+
+      <MoodBoardStrip view={view} />
+
+      <DesignUnderstandingPanel
+        view={view}
+        editedUnderstanding={draft.edited_understanding}
+        onEditUnderstanding={(v) => setField("edited_understanding", v)}
+        confidence={(() => {
+          const score =
+            (draft.reference_url.trim() || draft.existing_site_url.trim()
+              ? 1
+              : 0) +
+            (draft.description.trim() ? 1 : 0);
+          if (score >= 2) return "high";
+          if (score === 1) return "medium";
+          return "low";
+        })()}
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-4">
+        <p className="text-xs text-muted-foreground">
+          Estimated cost: ~$0.24 — includes homepage + inner page for each of
+          3 concept directions. This is a full design pass.
+        </p>
+        <Button
+          type="button"
+          onClick={() => void onGenerate()}
+          disabled={generating || !hasAnyInput}
+          data-testid="dd-generate"
+        >
+          {generating ? (
+            <>
+              <Loader2 aria-hidden className="h-4 w-4 animate-spin" />
+              Saving brief…
+            </>
+          ) : (
+            <>
+              <Sparkles aria-hidden className="h-4 w-4" />
+              Generate concepts
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/DesignUnderstandingPanel.tsx
+++ b/components/DesignUnderstandingPanel.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+
+import { Textarea } from "@/components/ui/textarea";
+
+interface View {
+  swatches: string[];
+  fonts: string[];
+  layout_tags: string[];
+  visual_tone_tags: string[];
+  visual_tone: string;
+}
+
+interface Props {
+  view: View;
+  editedUnderstanding: string;
+  onEditUnderstanding: (v: string) => void;
+  confidence: "high" | "medium" | "low";
+}
+
+const CONFIDENCE_META: Record<
+  Props["confidence"],
+  { dotClass: string; label: string }
+> = {
+  high: {
+    dotClass: "bg-success",
+    label: "High confidence — multiple inputs aligned",
+  },
+  medium: {
+    dotClass: "bg-warning",
+    label: "Medium confidence — one strong input or mixed signals",
+  },
+  low: {
+    dotClass: "bg-muted-foreground",
+    label: "Low confidence — text only or no inputs yet",
+  },
+};
+
+export function DesignUnderstandingPanel({
+  view,
+  editedUnderstanding,
+  onEditUnderstanding,
+  confidence,
+}: Props) {
+  const [showEditor, setShowEditor] = useState(false);
+  const meta = CONFIDENCE_META[confidence];
+
+  const tone = view.visual_tone_tags.join(", ") || view.visual_tone;
+  const layout = view.layout_tags.join(", ") || "—";
+  const typography =
+    view.fonts.slice(0, 2).join(" + ") || "Default sans-serif";
+  const density =
+    view.layout_tags.includes("Dense data") ||
+    view.layout_tags.includes("Card grid")
+      ? "Medium-high information density"
+      : "Comfortable whitespace";
+
+  return (
+    <div
+      className="rounded-lg border bg-card p-4"
+      data-testid="design-understanding-panel"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold">Here&apos;s what we understood</h3>
+        <span
+          className="inline-flex items-center gap-1.5 text-xs"
+          data-testid="dd-confidence"
+          data-confidence={confidence}
+        >
+          <span
+            aria-hidden
+            className={`inline-block h-2 w-2 rounded-full ${meta.dotClass}`}
+          />
+          <span className="text-muted-foreground">{meta.label}</span>
+        </span>
+      </div>
+
+      <dl className="mt-3 grid gap-2 text-xs md:grid-cols-2">
+        <div>
+          <dt className="font-medium text-muted-foreground">Tone</dt>
+          <dd>{tone}</dd>
+        </div>
+        <div>
+          <dt className="font-medium text-muted-foreground">Layout</dt>
+          <dd>{layout}</dd>
+        </div>
+        <div>
+          <dt className="font-medium text-muted-foreground">Typography</dt>
+          <dd>{typography}</dd>
+        </div>
+        <div>
+          <dt className="font-medium text-muted-foreground">Density</dt>
+          <dd>{density}</dd>
+        </div>
+        <div className="md:col-span-2">
+          <dt className="font-medium text-muted-foreground">Colour direction</dt>
+          <dd className="mt-1 flex flex-wrap gap-1.5">
+            {view.swatches.slice(0, 5).map((c, i) => (
+              <span
+                key={`${c}-${i}`}
+                className="inline-flex items-center gap-1 rounded-md border bg-background px-1.5 py-0.5 text-[10px]"
+                title={c}
+              >
+                <span
+                  className="inline-block h-3 w-3 rounded-sm border"
+                  style={{ background: c }}
+                  aria-hidden
+                />
+                <span className="font-mono">{c}</span>
+              </span>
+            ))}
+            {view.swatches.length === 0 && <span className="text-muted-foreground">—</span>}
+          </dd>
+        </div>
+      </dl>
+
+      <button
+        type="button"
+        onClick={() => setShowEditor((v) => !v)}
+        className="mt-3 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+        aria-expanded={showEditor}
+        data-testid="dd-edit-understanding-toggle"
+      >
+        {showEditor ? "Hide override" : "Edit understanding →"}
+      </button>
+      {showEditor && (
+        <div className="mt-2">
+          <Textarea
+            placeholder="If we got it wrong, describe the design direction in your own words. We use this verbatim instead of the auto-extracted summary."
+            value={editedUnderstanding}
+            onChange={(e) => onEditUnderstanding(e.target.value)}
+            maxLength={2000}
+            rows={3}
+            data-testid="dd-edit-understanding"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/MoodBoardStrip.tsx
+++ b/components/MoodBoardStrip.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+interface View {
+  swatches: string[];
+  fonts: string[];
+  layout_tags: string[];
+  visual_tone_tags: string[];
+  visual_tone: string;
+  screenshot_url: string | null;
+}
+
+const SWATCH_LABELS = ["Primary", "Secondary", "Accent", "Background", "Text"];
+
+export function MoodBoardStrip({ view }: { view: View }) {
+  return (
+    <div
+      className="rounded-lg border bg-muted/20 p-4"
+      data-testid="mood-board-strip"
+    >
+      <h3 className="text-sm font-semibold">Mood board</h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        What we&apos;re hearing so far. Updates as you add inputs.
+      </p>
+
+      <div className="mt-4 grid gap-4 md:grid-cols-[1fr_auto]">
+        <div className="space-y-3">
+          <div>
+            <p className="text-xs font-medium text-muted-foreground">
+              Colour swatches
+            </p>
+            <div className="mt-1.5 flex flex-wrap items-center gap-2">
+              {view.swatches.length > 0 ? (
+                view.swatches.slice(0, 8).map((c, i) => (
+                  <span
+                    key={`${c}-${i}`}
+                    className="inline-flex items-center gap-1 rounded-md border bg-background px-1.5 py-0.5 text-[10px]"
+                    title={c}
+                  >
+                    <span
+                      className="inline-block h-4 w-4 rounded-sm border"
+                      style={{ background: c }}
+                      aria-hidden
+                    />
+                    <span className="font-mono uppercase">
+                      {SWATCH_LABELS[i] ?? `c${i + 1}`}
+                    </span>
+                  </span>
+                ))
+              ) : (
+                <span className="text-xs text-muted-foreground">—</span>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-xs font-medium text-muted-foreground">
+              Typography
+            </p>
+            <div className="mt-1.5 flex flex-wrap items-center gap-3">
+              {view.fonts.length > 0 ? (
+                view.fonts.slice(0, 3).map((f) => (
+                  <span
+                    key={f}
+                    className="inline-flex items-baseline gap-2 rounded-md border bg-background px-2 py-1"
+                    style={{ fontFamily: `${f}, system-ui, sans-serif` }}
+                  >
+                    <span className="text-base">Aa Bb Cc 123</span>
+                    <span className="text-xs text-muted-foreground">{f}</span>
+                  </span>
+                ))
+              ) : (
+                <span className="text-xs text-muted-foreground">—</span>
+              )}
+            </div>
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            <div>
+              <p className="text-xs font-medium text-muted-foreground">
+                Layout
+              </p>
+              <div className="mt-1.5 flex flex-wrap gap-1.5">
+                {view.layout_tags.length > 0 ? (
+                  view.layout_tags.slice(0, 5).map((t) => (
+                    <span
+                      key={t}
+                      className="rounded-full border bg-background px-2 py-0.5 text-[10px]"
+                    >
+                      {t}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-xs text-muted-foreground">—</span>
+                )}
+              </div>
+            </div>
+            <div>
+              <p className="text-xs font-medium text-muted-foreground">
+                Visual tone
+              </p>
+              <div className="mt-1.5 flex flex-wrap gap-1.5">
+                {view.visual_tone_tags.length > 0 ? (
+                  view.visual_tone_tags.slice(0, 5).map((t) => (
+                    <span
+                      key={t}
+                      className="rounded-full border bg-foreground/10 px-2 py-0.5 text-[10px]"
+                    >
+                      {t}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-xs text-muted-foreground">—</span>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {view.screenshot_url && (
+          <div className="hidden md:block">
+            <p className="text-xs font-medium text-muted-foreground">
+              Reference
+            </p>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={view.screenshot_url}
+              alt="Reference site screenshot"
+              className="mt-1.5 h-32 w-48 rounded-md border object-cover"
+              data-testid="mood-board-screenshot"
+              loading="lazy"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/SetupWizard.tsx
+++ b/components/SetupWizard.tsx
@@ -6,7 +6,13 @@ import { useState } from "react";
 import { Check, ChevronRight, Loader2, Palette, Volume2 } from "lucide-react";
 import { toast } from "sonner";
 
+import {
+  DesignDirectionInputs,
+  type DesignBriefDraft,
+  type ExtractedSnapshot,
+} from "@/components/DesignDirectionInputs";
 import { Button } from "@/components/ui/button";
+import type { Industry } from "@/lib/design-discovery/industry-defaults";
 import type { SetupStatus, SetupStep, SetupStepStatus } from "@/lib/site-setup";
 
 // ---------------------------------------------------------------------------
@@ -218,6 +224,7 @@ function SkipButton({
 }
 
 function Step1({ siteId, status }: { siteId: string; status: SetupStatus }) {
+  const initial = briefToInitialDraft(status.design_brief);
   return (
     <StepFrame
       testid="setup-step-1"
@@ -225,26 +232,15 @@ function Step1({ siteId, status }: { siteId: string; status: SetupStatus }) {
       intro={
         <>
           What should this site look like? Provide a reference URL, an
-          existing site, screenshots, or a written description and we&apos;ll
-          generate three creative directions to choose from.
+          existing site, or a written description and we&apos;ll work from
+          there. Status:{" "}
+          <span className="font-medium text-foreground">
+            {statusLabel(status.design_direction_status)}
+          </span>
+          .
         </>
       }
-      body={
-        <div className="rounded-md border border-dashed bg-muted/20 p-6 text-sm text-muted-foreground">
-          <p>
-            Status:{" "}
-            <span className="font-medium text-foreground">
-              {statusLabel(status.design_direction_status)}
-            </span>
-          </p>
-          <p className="mt-2">
-            The design direction input surface and concept review land in
-            the next batch of changes. Skip for now to land at Step 2 with
-            the generic MSP defaults applied — you can return here any
-            time from Site Settings.
-          </p>
-        </div>
-      }
+      body={<DesignDirectionInputs siteId={siteId} initial={initial} />}
       footer={
         <>
           <Link
@@ -265,6 +261,44 @@ function Step1({ siteId, status }: { siteId: string; status: SetupStatus }) {
       }
     />
   );
+}
+
+function briefToInitialDraft(
+  brief: Record<string, unknown> | null,
+): Partial<DesignBriefDraft> | undefined {
+  if (!brief) return undefined;
+  const get = <T,>(k: string, validate: (v: unknown) => v is T): T | undefined => {
+    const v = brief[k];
+    return validate(v) ? v : undefined;
+  };
+  const isString = (v: unknown): v is string => typeof v === "string";
+  const isIndustry = (v: unknown): v is Industry =>
+    typeof v === "string" &&
+    ["msp", "it_services", "cybersecurity", "general_b2b", "other"].includes(v);
+  const extractedRaw = brief.extracted;
+  let extracted: ExtractedSnapshot | null = null;
+  if (extractedRaw && typeof extractedRaw === "object") {
+    const e = extractedRaw as Record<string, unknown>;
+    extracted = {
+      swatches: Array.isArray(e.swatches) ? (e.swatches as string[]) : [],
+      fonts: Array.isArray(e.fonts) ? (e.fonts as string[]) : [],
+      layout_tags: Array.isArray(e.layout_tags) ? (e.layout_tags as string[]) : [],
+      visual_tone_tags: Array.isArray(e.visual_tone_tags)
+        ? (e.visual_tone_tags as string[])
+        : [],
+      screenshot_url: typeof e.screenshot_url === "string" ? e.screenshot_url : null,
+      source_url: typeof e.source_url === "string" ? e.source_url : null,
+      fetched_at: typeof e.fetched_at === "string" ? e.fetched_at : null,
+    };
+  }
+  return {
+    industry: get("industry", isIndustry) ?? "msp",
+    reference_url: get("reference_url", isString) ?? "",
+    existing_site_url: get("existing_site_url", isString) ?? "",
+    description: get("description", isString) ?? "",
+    edited_understanding: get("edited_understanding", isString) ?? "",
+    extracted,
+  };
 }
 
 function Step2({ siteId, status }: { siteId: string; status: SetupStatus }) {

--- a/lib/design-discovery/design-brief.ts
+++ b/lib/design-discovery/design-brief.ts
@@ -1,0 +1,157 @@
+import "server-only";
+
+import { z } from "zod";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// DESIGN-DISCOVERY — design brief schema + persistence.
+//
+// design_brief is a JSONB column on sites; this module owns its v1
+// shape and the read / write helpers used by the wizard.
+
+export const DesignBriefSchema = z.object({
+  industry: z.enum([
+    "msp",
+    "it_services",
+    "cybersecurity",
+    "general_b2b",
+    "other",
+  ]),
+  reference_url: z.string().max(500).nullable(),
+  existing_site_url: z.string().max(500).nullable(),
+  description: z.string().max(4000).nullable(),
+  // PR 4 ships without screenshot upload; the array is reserved.
+  // PR 5 wires the Claude vision pass on uploaded screenshots.
+  screenshots: z.array(z.string()).max(5).optional().default([]),
+  // Operator-edited interpretation of what we extracted; overrides the
+  // auto-extracted understanding when set. Free text.
+  edited_understanding: z.string().max(2000).nullable().optional(),
+  // Refinement notes accumulate across the iterate loop in PR 7.
+  refinement_notes: z.array(z.string()).optional().default([]),
+  // Cached extraction snapshot from the last URL fetch — drives the
+  // mood board / understanding panel without re-fetching on every
+  // render.
+  extracted: z
+    .object({
+      swatches: z.array(z.string()).default([]),
+      fonts: z.array(z.string()).default([]),
+      layout_tags: z.array(z.string()).default([]),
+      visual_tone_tags: z.array(z.string()).default([]),
+      screenshot_url: z.string().nullable().default(null),
+      source_url: z.string().nullable().default(null),
+      fetched_at: z.string().nullable().default(null),
+    })
+    .nullable()
+    .optional(),
+});
+
+export type DesignBrief = z.infer<typeof DesignBriefSchema>;
+
+export type SaveDesignBriefResult =
+  | { ok: true }
+  | {
+      ok: false;
+      error: {
+        code: "NOT_FOUND" | "VALIDATION_FAILED" | "INTERNAL_ERROR";
+        message: string;
+      };
+    };
+
+export async function saveDesignBrief(
+  siteId: string,
+  brief: DesignBrief,
+  opts: { advanceStatus?: boolean } = {},
+): Promise<SaveDesignBriefResult> {
+  const parsed = DesignBriefSchema.safeParse(brief);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_FAILED",
+        message: parsed.error.issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join("; "),
+      },
+    };
+  }
+  const supabase = getServiceRoleClient();
+  const patch: Record<string, unknown> = {
+    design_brief: parsed.data,
+    updated_at: new Date().toISOString(),
+  };
+  if (opts.advanceStatus) {
+    patch.design_direction_status = "in_progress";
+  }
+  const { data, error } = await supabase
+    .from("sites")
+    .update(patch)
+    .eq("id", siteId)
+    .neq("status", "removed")
+    .select("id")
+    .maybeSingle();
+  if (error) {
+    return {
+      ok: false,
+      error: { code: "INTERNAL_ERROR", message: error.message },
+    };
+  }
+  if (!data) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `No active site found with id ${siteId}.`,
+      },
+    };
+  }
+  return { ok: true };
+}
+
+export async function getDesignBrief(
+  siteId: string,
+): Promise<{ ok: true; data: DesignBrief | null } | { ok: false; error: { code: string; message: string } }> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("sites")
+    .select("design_brief")
+    .eq("id", siteId)
+    .neq("status", "removed")
+    .maybeSingle();
+  if (error) {
+    return {
+      ok: false,
+      error: { code: "INTERNAL_ERROR", message: error.message },
+    };
+  }
+  if (!data) {
+    return {
+      ok: false,
+      error: { code: "NOT_FOUND", message: `Site ${siteId} not found.` },
+    };
+  }
+  if (!data.design_brief) return { ok: true, data: null };
+  const parsed = DesignBriefSchema.safeParse(data.design_brief);
+  if (!parsed.success) {
+    // Tolerate legacy / partial briefs by returning the raw shape;
+    // call sites that need typed fields can fall back to defaults.
+    return { ok: true, data: data.design_brief as unknown as DesignBrief };
+  }
+  return { ok: true, data: parsed.data };
+}
+
+// Confidence signal for the understanding panel. Green = multiple
+// inputs with aligned signals; Amber = mixed signals or partial
+// inputs; Grey = text description only.
+export type Confidence = "high" | "medium" | "low";
+
+export function computeConfidence(brief: DesignBrief): Confidence {
+  const hasUrl = Boolean(
+    brief.reference_url?.trim() || brief.existing_site_url?.trim(),
+  );
+  const hasScreens = (brief.screenshots ?? []).length > 0;
+  const hasText = Boolean(brief.description?.trim());
+  const score = (hasUrl ? 1 : 0) + (hasScreens ? 1 : 0) + (hasText ? 1 : 0);
+  if (score >= 2) return "high";
+  if (score === 1 && (hasUrl || hasScreens)) return "medium";
+  return "low";
+}

--- a/lib/design-discovery/extract-css.ts
+++ b/lib/design-discovery/extract-css.ts
@@ -1,0 +1,219 @@
+import "server-only";
+
+// DESIGN-DISCOVERY — CSS / HTML scraping.
+//
+// Fetches an HTML document and pulls a small amount of design signal
+// out: hex / rgb colors, font-family declarations, and a quick layout
+// heuristic ("dark theme" / "card grid" / "full-width hero"). This is
+// the cheap fallback when Microlink is unavailable, and the primary
+// signal when the operator pastes a reference URL. The Claude vision
+// pass on uploaded screenshots produces stronger signals (PR 5).
+//
+// We do NOT execute CSS or fetch linked stylesheets — that would mean
+// running a browser. We scan the inline <style> blocks + the response
+// HTML for color / font literals and do a layout-keyword heuristic on
+// the markup itself. Cheap and good enough for v1.
+
+const HEX_COLOR_RE = /#(?:[0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})\b/gi;
+const RGB_COLOR_RE = /rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+(?:\s*,\s*[\d.]+)?\s*\)/gi;
+const FONT_FAMILY_RE = /font-family\s*:\s*([^;}\n]+)/gi;
+const LINK_HREF_RE = /<link[^>]+rel\s*=\s*["']?stylesheet["']?[^>]*href\s*=\s*["']([^"']+)["']/gi;
+
+export interface CssExtractionResult {
+  swatches: string[];
+  fonts: string[];
+  layout_tags: string[];
+  visual_tone_tags: string[];
+  fetched_url: string;
+  fetch_ok: boolean;
+  fetch_error: string | null;
+}
+
+const FETCH_TIMEOUT_MS = 8000;
+
+async function fetchWithTimeout(
+  url: string,
+  ms: number,
+): Promise<Response | { error: string }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ms);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        // Some hosts (Cloudflare, AWS WAF) reject default fetch UA.
+        "user-agent":
+          "Opollo-Site-Builder/1.0 (+https://opollo.com) Design-Discovery",
+      },
+    });
+    return res;
+  } catch (err) {
+    return {
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function parseFontFamilies(css: string): string[] {
+  const out = new Set<string>();
+  let m: RegExpExecArray | null;
+  while ((m = FONT_FAMILY_RE.exec(css))) {
+    const list = m[1] ?? "";
+    for (const raw of list.split(",")) {
+      const cleaned = raw
+        .trim()
+        .replace(/^["']|["']$/g, "")
+        .replace(/!important$/, "")
+        .trim();
+      if (
+        cleaned &&
+        !/^var\(/.test(cleaned) &&
+        !/^(serif|sans-serif|monospace|cursive|fantasy|system-ui|inherit|initial|unset)$/i.test(
+          cleaned,
+        )
+      ) {
+        out.add(cleaned);
+      }
+    }
+    if (out.size >= 6) break;
+  }
+  return [...out].slice(0, 4);
+}
+
+function parseColors(text: string): string[] {
+  const tally = new Map<string, number>();
+  const consider = (raw: string) => {
+    const k = raw.toLowerCase();
+    tally.set(k, (tally.get(k) ?? 0) + 1);
+  };
+  let m: RegExpExecArray | null;
+  while ((m = HEX_COLOR_RE.exec(text))) consider(m[0]);
+  while ((m = RGB_COLOR_RE.exec(text))) consider(m[0]);
+  // Reset state — RegExp.exec is stateful with the /g flag.
+  HEX_COLOR_RE.lastIndex = 0;
+  RGB_COLOR_RE.lastIndex = 0;
+  const sorted = [...tally.entries()].sort((a, b) => b[1] - a[1]);
+  // Drop pure white + pure black + transparent — they're noise.
+  const filtered = sorted.filter(
+    ([k]) =>
+      k !== "#fff" &&
+      k !== "#ffffff" &&
+      k !== "#000" &&
+      k !== "#000000" &&
+      !/rgba?\(\s*0\s*,\s*0\s*,\s*0\s*(,\s*0\b)/.test(k),
+  );
+  return filtered.slice(0, 8).map(([k]) => k);
+}
+
+function detectLayoutTags(html: string): string[] {
+  const out: string[] = [];
+  const lower = html.toLowerCase();
+  if (/<section[^>]*class="[^"]*hero/i.test(html) || /class="[^"]*hero/i.test(html)) {
+    out.push("Full-width hero");
+  }
+  if (
+    /<div[^>]*class="[^"]*(card|grid)/i.test(html) ||
+    /grid-template/.test(html)
+  ) {
+    out.push("Card grid");
+  }
+  if (/<form/i.test(html) && /(subscribe|newsletter|cta)/i.test(html)) {
+    out.push("Inline CTA form");
+  }
+  if (/<footer/i.test(html)) {
+    out.push("Footer");
+  }
+  if (
+    lower.includes("dark") ||
+    /background[^;]*#0|background[^;]*#1[0-9a-f]/.test(lower)
+  ) {
+    // Not authoritative but a useful prior; the visual_tone_tags step
+    // can override.
+    out.push("Dark theme");
+  }
+  return out.slice(0, 4);
+}
+
+function detectVisualToneTags(html: string): string[] {
+  const out: string[] = [];
+  const lower = html.toLowerCase();
+  // Heuristics — fragile but cheap. The Claude vision step on
+  // uploaded screenshots produces stronger signals.
+  if (/whitespace|minimal|less is more/.test(lower)) out.push("Minimal");
+  if (/premium|enterprise|world-class/.test(lower)) out.push("Premium");
+  if (/(secure|cyber|threat|breach)/.test(lower)) out.push("Authoritative");
+  if (/playful|friendly|delightful/.test(lower)) out.push("Friendly");
+  if (/(technical|api|sdk|developer)/.test(lower)) out.push("Technical");
+  return [...new Set(out)].slice(0, 4);
+}
+
+function normaliseUrl(input: string): string {
+  let url = input.trim();
+  if (!/^https?:\/\//i.test(url)) {
+    url = `https://${url}`;
+  }
+  return url.replace(/\/+$/, "");
+}
+
+export async function extractCssFromUrl(
+  inputUrl: string,
+): Promise<CssExtractionResult> {
+  const url = normaliseUrl(inputUrl);
+  const empty = (err: string | null): CssExtractionResult => ({
+    swatches: [],
+    fonts: [],
+    layout_tags: [],
+    visual_tone_tags: [],
+    fetched_url: url,
+    fetch_ok: false,
+    fetch_error: err,
+  });
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return empty("Invalid URL.");
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return empty("URL must use http:// or https://.");
+  }
+
+  const res = await fetchWithTimeout(url, FETCH_TIMEOUT_MS);
+  if ("error" in res) {
+    return empty(res.error);
+  }
+  if (!res.ok) {
+    return empty(`HTTP ${res.status}`);
+  }
+  const ct = res.headers.get("content-type") ?? "";
+  if (!ct.includes("text/html") && !ct.includes("application/xhtml")) {
+    return empty(`Unexpected content-type: ${ct}`);
+  }
+  let html: string;
+  try {
+    html = await res.text();
+  } catch (err) {
+    return empty(err instanceof Error ? err.message : String(err));
+  }
+
+  // Reset regex state before extraction passes.
+  LINK_HREF_RE.lastIndex = 0;
+
+  const swatches = parseColors(html);
+  const fonts = parseFontFamilies(html);
+  const layout_tags = detectLayoutTags(html);
+  const visual_tone_tags = detectVisualToneTags(html);
+
+  return {
+    swatches,
+    fonts,
+    layout_tags,
+    visual_tone_tags,
+    fetched_url: url,
+    fetch_ok: true,
+    fetch_error: null,
+  };
+}

--- a/lib/design-discovery/industry-defaults.ts
+++ b/lib/design-discovery/industry-defaults.ts
@@ -1,0 +1,130 @@
+// DESIGN-DISCOVERY — industry presets.
+//
+// Pre-loaded defaults keyed by industry. Applied client-side when the
+// operator picks an industry from the input surface so the mood board
+// has something to render before they paste a URL or upload a sample.
+// Each preset gets overridden by stronger signals (URL extraction,
+// screenshot vision pass) when those land.
+
+export type Industry =
+  | "msp"
+  | "it_services"
+  | "cybersecurity"
+  | "general_b2b"
+  | "other";
+
+export interface IndustryPreset {
+  label: string;
+  visual_tone: string;
+  layout_tags: string[];
+  visual_tone_tags: string[];
+  // Five-swatch palette: primary / secondary / accent / background / text.
+  swatches: {
+    primary: string;
+    secondary: string;
+    accent: string;
+    background: string;
+    text: string;
+  };
+  font_heading: string;
+  font_body: string;
+  // Default tone-of-voice nudge — used in the next step when the
+  // operator pastes no URL and writes nothing.
+  default_voice_seed: string;
+}
+
+export const INDUSTRY_PRESETS: Record<Industry, IndustryPreset> = {
+  msp: {
+    label: "MSP",
+    visual_tone: "Premium, technical, trustworthy",
+    layout_tags: ["Full-width hero", "Card grid", "Clean whitespace"],
+    visual_tone_tags: ["Premium", "Technical", "Trustworthy"],
+    swatches: {
+      primary: "#0F172A",
+      secondary: "#475569",
+      accent: "#3B82F6",
+      background: "#FFFFFF",
+      text: "#0F172A",
+    },
+    font_heading: "Inter",
+    font_body: "Inter",
+    default_voice_seed:
+      "Professional, straight-talking, technical when needed but never jargon-heavy. Speaks to business owners running their own IT operation.",
+  },
+  it_services: {
+    label: "IT Services",
+    visual_tone: "Approachable, professional, modern",
+    layout_tags: ["Hero with CTA", "Service tiles", "Testimonial band"],
+    visual_tone_tags: ["Approachable", "Professional", "Modern"],
+    swatches: {
+      primary: "#111827",
+      secondary: "#4B5563",
+      accent: "#2563EB",
+      background: "#F9FAFB",
+      text: "#111827",
+    },
+    font_heading: "Inter",
+    font_body: "Inter",
+    default_voice_seed:
+      "Friendly, professional, outcome-focused. Lead with business outcomes; keep technical detail in service descriptions.",
+  },
+  cybersecurity: {
+    label: "Cybersecurity",
+    visual_tone: "Authoritative, modern, dark accents",
+    layout_tags: ["Dark theme", "Dense data", "Hero with stats"],
+    visual_tone_tags: ["Authoritative", "Premium", "Technical"],
+    swatches: {
+      primary: "#0B1220",
+      secondary: "#1F2937",
+      accent: "#22D3EE",
+      background: "#0B1220",
+      text: "#E5E7EB",
+    },
+    font_heading: "IBM Plex Sans",
+    font_body: "Inter",
+    default_voice_seed:
+      "Authoritative, calm, evidence-based. Avoid fear-based copy; lead with concrete capabilities and outcomes.",
+  },
+  general_b2b: {
+    label: "General B2B",
+    visual_tone: "Clean, modern, conversion-focused",
+    layout_tags: ["Hero with CTA", "Feature grid", "Logo bar"],
+    visual_tone_tags: ["Modern", "Clear", "Conversion-focused"],
+    swatches: {
+      primary: "#1E293B",
+      secondary: "#64748B",
+      accent: "#6366F1",
+      background: "#FFFFFF",
+      text: "#0F172A",
+    },
+    font_heading: "Inter",
+    font_body: "Inter",
+    default_voice_seed:
+      "Professional, clear, action-oriented. Sentences under 20 words; lead each section with a benefit.",
+  },
+  other: {
+    label: "Other",
+    visual_tone: "Modern, flexible, neutral",
+    layout_tags: ["Hero", "Content sections", "CTA band"],
+    visual_tone_tags: ["Modern", "Neutral"],
+    swatches: {
+      primary: "#1E293B",
+      secondary: "#64748B",
+      accent: "#3B82F6",
+      background: "#FFFFFF",
+      text: "#0F172A",
+    },
+    font_heading: "Inter",
+    font_body: "Inter",
+    default_voice_seed:
+      "Professional, clear, friendly. Avoid jargon; lead with outcomes.",
+  },
+};
+
+export function industryPreset(input: string | null | undefined): IndustryPreset {
+  if (!input) return INDUSTRY_PRESETS.other;
+  if ((INDUSTRY_PRESETS as Record<string, IndustryPreset>)[input]) {
+    return INDUSTRY_PRESETS[input as Industry];
+  }
+  return INDUSTRY_PRESETS.other;
+}

--- a/lib/design-discovery/microlink.ts
+++ b/lib/design-discovery/microlink.ts
@@ -1,0 +1,73 @@
+import "server-only";
+
+// DESIGN-DISCOVERY — Microlink screenshot fetch.
+//
+// Per the workstream brief: "use Microlink (microlink.io) — free tier,
+// no API key required, works on Vercel serverless." We just need the
+// PNG screenshot URL; if Microlink is down, the caller falls back to
+// CSS-only extraction silently.
+
+const MICROLINK_TIMEOUT_MS = 12_000;
+
+export interface MicrolinkResult {
+  screenshot_url: string | null;
+  ok: boolean;
+  error: string | null;
+}
+
+export async function fetchMicrolinkScreenshot(
+  targetUrl: string,
+): Promise<MicrolinkResult> {
+  const apiUrl = `https://api.microlink.io/?url=${encodeURIComponent(
+    targetUrl,
+  )}&screenshot=true&meta=false&embed=screenshot.url&waitForTimeout=2000`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), MICROLINK_TIMEOUT_MS);
+  try {
+    const res = await fetch(apiUrl, {
+      signal: controller.signal,
+      headers: {
+        accept: "application/json",
+        "user-agent":
+          "Opollo-Site-Builder/1.0 (+https://opollo.com) Design-Discovery",
+      },
+    });
+    if (!res.ok) {
+      return {
+        screenshot_url: null,
+        ok: false,
+        error: `Microlink HTTP ${res.status}`,
+      };
+    }
+    // With embed=screenshot.url Microlink returns the raw URL as text
+    // in the body. Without embed it returns JSON; we handle both for
+    // resilience to API changes.
+    const ct = res.headers.get("content-type") ?? "";
+    if (ct.includes("application/json")) {
+      const json = (await res.json().catch(() => null)) as
+        | { data?: { screenshot?: { url?: string } } }
+        | null;
+      const url = json?.data?.screenshot?.url ?? null;
+      return {
+        screenshot_url: typeof url === "string" ? url : null,
+        ok: true,
+        error: null,
+      };
+    }
+    const body = (await res.text().catch(() => "")).trim();
+    return {
+      screenshot_url: body.startsWith("http") ? body : null,
+      ok: true,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      screenshot_url: null,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/lib/site-setup.ts
+++ b/lib/site-setup.ts
@@ -24,8 +24,10 @@ export type SetupStep = 1 | 2 | 3;
 export interface SetupStatus {
   design_direction_status: SetupStepStatus;
   tone_of_voice_status: SetupStepStatus;
-  // Snapshot of the artefacts the Step 3 done screen renders. Loaded
-  // here so the server page renders in one round trip.
+  // Snapshot of the artefacts the Step 3 done screen renders, plus
+  // the in-flight design_brief used to resume Step 1. Loaded here so
+  // the server page renders in one round trip.
+  design_brief: Record<string, unknown> | null;
   design_tokens: Record<string, unknown> | null;
   tone_of_voice: Record<string, unknown> | null;
 }
@@ -41,7 +43,7 @@ export async function getSetupStatus(
   const { data, error } = await supabase
     .from("sites")
     .select(
-      "design_direction_status, tone_of_voice_status, design_tokens, tone_of_voice",
+      "design_direction_status, tone_of_voice_status, design_brief, design_tokens, tone_of_voice",
     )
     .eq("id", siteId)
     .neq("status", "removed")
@@ -69,6 +71,7 @@ export async function getSetupStatus(
     data: {
       design_direction_status: data.design_direction_status as SetupStepStatus,
       tone_of_voice_status: data.tone_of_voice_status as SetupStepStatus,
+      design_brief: (data.design_brief as Record<string, unknown> | null) ?? null,
       design_tokens: (data.design_tokens as Record<string, unknown> | null) ?? null,
       tone_of_voice: (data.tone_of_voice as Record<string, unknown> | null) ?? null,
     },


### PR DESCRIPTION
PR 4 of the DESIGN-DISCOVERY workstream. Replaces the placeholder body in Step 1 of the setup wizard with the real input surface — industry preset, reference URL with extraction, existing site URL, free-text description, live mood board, design understanding panel with confidence signal, and a Generate-concepts CTA that persists the design brief to the DB and flips status to `'in_progress'`. The actual concept generation lands in PR 5.

## What lands

**UI**
- `components/DesignDirectionInputs.tsx` — the form: industry selector (MSP / IT Services / Cybersecurity / General B2B / Other), reference URL with "Extract design" button, existing site URL, 4000-char description, mood board, understanding panel, cost estimate, Generate concepts CTA.
- `components/MoodBoardStrip.tsx` — five-swatch palette, Aa Bb Cc font preview, layout + visual-tone tag pills, optional reference screenshot thumbnail. Renders from industry preset and overlays URL extraction signals when present.
- `components/DesignUnderstandingPanel.tsx` — Tone / Layout / Typography / Density / Colour direction, plus the spec's confidence dot (green / amber / grey) and "Edit understanding" override textarea.
- `components/SetupWizard.tsx` — Step 1 body is now `<DesignDirectionInputs initial={...} />`. Resume logic feeds the prior brief back into the form via the `initial` prop.

**Backend**
- `lib/design-discovery/industry-defaults.ts` — five industry presets with palette + fonts + layout / visual-tone tags + voice seed (the seed feeds Tone of Voice in PR 8).
- `lib/design-discovery/extract-css.ts` — server-only HTML / CSS scraper. Pulls hex/rgb colour literals + font-family declarations + a small set of layout-keyword heuristics from the response body. 8s fetch timeout, custom UA, content-type guard.
- `lib/design-discovery/microlink.ts` — server-only wrapper for `api.microlink.io/?url=...&screenshot=true`. No API key, free tier; 12s timeout. Failure is silent — the route falls back to CSS-only signals.
- `lib/design-discovery/design-brief.ts` — Zod-validated `DesignBrief` v1 shape + `saveDesignBrief` / `getDesignBrief` / `computeConfidence` helpers.
- `app/api/admin/sites/[id]/setup/extract-design/route.ts` — POST `{ url }`. Runs CSS extraction + Microlink in parallel; returns the snapshot. Both-fail surfaces as a soft FETCH_FAILED so the form prompts "Try pasting your copy directly instead."
- `app/api/admin/sites/[id]/setup/save-brief/route.ts` — POST `{ brief, advance_status? }`. Zod-validates against `DesignBriefSchema`, persists, optionally flips `design_direction_status` to `'in_progress'`.
- `lib/site-setup.ts` — `getSetupStatus` now also loads `design_brief` so resume rehydrates the form.

## Risks identified and mitigated
- **External fetch from server.** Both `extractCssFromUrl` and `fetchMicrolinkScreenshot` use `AbortController` timeouts (8s / 12s) and a custom UA so we don't hang the request handler on a slow target site. Both are wrapped in try/catch returning `ok=false` rather than throwing.
- **Content-type guard.** The CSS extractor refuses to parse responses that aren't `text/html` / `application/xhtml+xml`. Prevents accidentally regex-scanning a 50MB binary.
- **Self-fetch / SSRF.** No mitigation in this PR; flagged for follow-up. The endpoint is admin-only (operator role can't reach `requireAdminForApi({ roles: super_admin / admin })`) so the abuse profile is "an admin pastes localhost / RFC1918 / cloud-metadata as a reference URL." For Phase 2 we should reject private CIDR ranges before the fetch fires. **Deliberately deferred** to keep PR 4 focused on the UI.
- **Cost / rate.** No external paid service in this PR. Microlink free tier; CSS extraction is one fetch from our server. Estimated cost line in the UI is for PR 5's Claude API call, not this endpoint.
- **JSONB shape drift.** `DesignBriefSchema` validates on save; tolerant on read (returns the raw shape if validation fails) so a future schema bump doesn't lock operators out of saved drafts.
- **Auth gate.** Both new routes call `requireAdminForApi({ roles: ["super_admin", "admin"] })`, matching `/api/admin/sites/[id]/voice` and the skip endpoint shipped in PR 3.
- **No DB migration.** Reuses `sites.design_brief` JSONB added in PR 2.

## Deliberately deferred
- **Screenshot upload (1–5 images).** The brief lists this as one of five input types. The `design_brief.screenshots[]` field is reserved in the Zod schema; the upload UI + Claude vision pass land in a follow-up PR. The other four input types satisfy the at-least-one-required validation today.
- **SSRF guard.** Flagged in Risks above; reject private CIDR ranges in a Phase 2 hardening pass.
- **Real concept generation on Generate click.** PR 5's job. For now Generate persists the brief and toasts "Brief saved. Concept generation lands in the next change."
- **E2E spec for the input surface.** The Step-1 placeholder spec from PR 3 still passes; the new input surface is exercised manually for now. A real spec lands when concept generation is wired (PR 5) so the test can drive the full flow end-to-end rather than asserting on intermediate state.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm run test` — runs in CI.
- [ ] `npm run test:e2e` — existing PR-3 spec still binds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)