### PR TITLE
feat(design-discovery-6): three-up concept review with iframe + micro UI + before/after

### DIFF
--- a/components/ConceptReviewCards.tsx
+++ b/components/ConceptReviewCards.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useState } from "react";
+import { Monitor, Smartphone } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { ConceptError, ConceptResult } from "@/components/DesignDirectionInputs";
+
+// ---------------------------------------------------------------------------
+// ConceptReviewCards — PR 6 of DESIGN-DISCOVERY.
+//
+// Renders the three generated concepts side-by-side (stacked on
+// mobile). Each card has:
+//   - Label "Direction A — Minimal" etc.
+//   - 1–2 line rationale
+//   - Five-swatch palette + heading/body fonts
+//   - Inline micro UI preview (button, card, input — NOT in an
+//     iframe, so the host card's typography styles bleed through)
+//   - Homepage iframe (sandboxed, srcdoc) with a desktop/mobile
+//     toggle and a homepage/inner-page toggle.
+//   - "Select this direction" CTA — PR 7 wires the refinement +
+//     approve flow to the onSelect callback.
+//
+// A separate before/after panel appears below the cards when the
+// operator provided a reference / existing-site URL: side-by-side
+// the Microlink screenshot + the *currently selected* concept's
+// homepage iframe.
+// ---------------------------------------------------------------------------
+
+const DIRECTION_TITLES: Record<ConceptResult["direction"], string> = {
+  minimal: "Direction A — Minimal",
+  dense: "Direction B — Conversion",
+  editorial: "Direction C — Editorial",
+};
+
+const SWATCH_KEYS: Array<keyof ConceptResult["design_tokens"]> = [
+  "primary",
+  "secondary",
+  "accent",
+  "background",
+  "text",
+];
+
+interface Props {
+  concepts: ConceptResult[];
+  errors: ConceptError[];
+  referenceScreenshotUrl: string | null;
+  onSelect?: (direction: ConceptResult["direction"]) => void;
+}
+
+export function ConceptReviewCards({
+  concepts,
+  errors,
+  referenceScreenshotUrl,
+  onSelect,
+}: Props) {
+  const [selected, setSelected] = useState<ConceptResult["direction"] | null>(
+    null,
+  );
+
+  const selectedConcept =
+    selected != null
+      ? concepts.find((c) => c.direction === selected) ?? null
+      : null;
+
+  return (
+    <div className="space-y-4" data-testid="concept-review-cards">
+      <div className="grid gap-4 md:grid-cols-3">
+        {concepts.map((c) => (
+          <ConceptCard
+            key={c.direction}
+            concept={c}
+            isSelected={selected === c.direction}
+            onSelect={() => {
+              setSelected(c.direction);
+              onSelect?.(c.direction);
+            }}
+          />
+        ))}
+      </div>
+
+      {errors.length > 0 && (
+        <div
+          className="rounded-md border border-warning/40 bg-warning/5 p-3 text-xs text-warning"
+          role="alert"
+          data-testid="concept-review-errors"
+        >
+          <p className="font-medium">
+            {errors.length} of {errors.length + concepts.length} directions
+            failed to generate.
+          </p>
+          <p className="mt-0.5">
+            {errors.map((e) => e.label).join(", ")} — click &quot;Generate
+            concepts&quot; again to retry.
+          </p>
+        </div>
+      )}
+
+      {referenceScreenshotUrl && selectedConcept && (
+        <BeforeAfterPanel
+          referenceUrl={referenceScreenshotUrl}
+          concept={selectedConcept}
+        />
+      )}
+    </div>
+  );
+}
+
+function ConceptCard({
+  concept,
+  isSelected,
+  onSelect,
+}: {
+  concept: ConceptResult;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  const [view, setView] = useState<"desktop" | "mobile">("desktop");
+  const [page, setPage] = useState<"homepage" | "inner">("homepage");
+
+  const html = page === "homepage" ? concept.homepage_html : concept.inner_page_html;
+  const iframeWidth = view === "mobile" ? "390px" : "100%";
+  const iframeHeightClass =
+    view === "mobile" ? "h-[640px]" : "h-[420px]";
+
+  return (
+    <article
+      className={[
+        "rounded-lg border bg-card p-4 transition-smooth",
+        isSelected
+          ? "border-foreground ring-2 ring-foreground/30"
+          : "hover:border-foreground/40",
+      ].join(" ")}
+      data-testid={`concept-card-${concept.direction}`}
+      data-selected={isSelected ? "true" : "false"}
+    >
+      <header className="flex items-start justify-between gap-2">
+        <h3 className="text-sm font-semibold">
+          {DIRECTION_TITLES[concept.direction]}
+        </h3>
+      </header>
+      <p
+        className="mt-1 text-xs text-muted-foreground"
+        data-testid={`concept-rationale-${concept.direction}`}
+      >
+        {concept.rationale}
+      </p>
+
+      <div className="mt-3 flex flex-wrap items-center gap-1.5">
+        {SWATCH_KEYS.map((k) => (
+          <span
+            key={k}
+            className="inline-flex items-center gap-1 rounded-md border bg-background px-1 py-0.5 text-[9px]"
+            title={`${k}: ${concept.design_tokens[k]}`}
+          >
+            <span
+              className="inline-block h-3 w-3 rounded-sm border"
+              style={{ background: concept.design_tokens[k] }}
+              aria-hidden
+            />
+            <span className="font-mono uppercase">{k}</span>
+          </span>
+        ))}
+      </div>
+
+      <p className="mt-2 text-[10px] text-muted-foreground">
+        Heading:{" "}
+        <span
+          className="text-foreground"
+          style={{ fontFamily: `${concept.design_tokens.font_heading}, system-ui, sans-serif` }}
+        >
+          {concept.design_tokens.font_heading}
+        </span>{" "}
+        · Body:{" "}
+        <span
+          className="text-foreground"
+          style={{ fontFamily: `${concept.design_tokens.font_body}, system-ui, sans-serif` }}
+        >
+          {concept.design_tokens.font_body}
+        </span>
+      </p>
+
+      <MicroUiPreview micro={concept.micro_ui} />
+
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2 border-t pt-3">
+        <div className="inline-flex rounded-md border bg-background p-0.5">
+          <button
+            type="button"
+            onClick={() => setView("desktop")}
+            className={[
+              "inline-flex items-center gap-1 rounded-sm px-2 py-0.5 text-[10px]",
+              view === "desktop"
+                ? "bg-foreground text-background"
+                : "text-muted-foreground hover:text-foreground",
+            ].join(" ")}
+            aria-pressed={view === "desktop"}
+            data-testid={`concept-view-desktop-${concept.direction}`}
+          >
+            <Monitor aria-hidden className="h-3 w-3" />
+            Desktop
+          </button>
+          <button
+            type="button"
+            onClick={() => setView("mobile")}
+            className={[
+              "inline-flex items-center gap-1 rounded-sm px-2 py-0.5 text-[10px]",
+              view === "mobile"
+                ? "bg-foreground text-background"
+                : "text-muted-foreground hover:text-foreground",
+            ].join(" ")}
+            aria-pressed={view === "mobile"}
+            data-testid={`concept-view-mobile-${concept.direction}`}
+          >
+            <Smartphone aria-hidden className="h-3 w-3" />
+            Mobile
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={() => setPage(page === "homepage" ? "inner" : "homepage")}
+          className="text-[10px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm"
+          data-testid={`concept-toggle-page-${concept.direction}`}
+        >
+          {page === "homepage" ? "View inner page →" : "← View homepage"}
+        </button>
+      </div>
+
+      <div
+        className={`mt-2 overflow-hidden rounded-md border bg-muted/20 ${iframeHeightClass}`}
+        data-testid={`concept-iframe-frame-${concept.direction}`}
+      >
+        <iframe
+          title={`${DIRECTION_TITLES[concept.direction]} — ${page}`}
+          srcDoc={html}
+          sandbox=""
+          className="block h-full"
+          style={{ width: iframeWidth, margin: view === "mobile" ? "0 auto" : undefined }}
+          data-testid={`concept-iframe-${concept.direction}`}
+        />
+      </div>
+
+      <div className="mt-3 flex items-center justify-end">
+        <Button
+          type="button"
+          size="sm"
+          onClick={onSelect}
+          variant={isSelected ? "default" : "outline"}
+          data-testid={`concept-select-${concept.direction}`}
+        >
+          {isSelected ? "Selected" : "Select this direction"}
+        </Button>
+      </div>
+    </article>
+  );
+}
+
+function MicroUiPreview({ micro }: { micro: ConceptResult["micro_ui"] }) {
+  return (
+    <div className="mt-3 rounded-md border bg-muted/10 p-2">
+      <p className="mb-1 text-[10px] font-medium text-muted-foreground">
+        Micro UI
+      </p>
+      <div
+        className="grid gap-1.5 text-[10px] text-foreground [&_*]:!max-w-full [&_*]:!box-border"
+        data-testid="concept-micro-ui"
+      >
+        <div
+          dangerouslySetInnerHTML={{ __html: micro.button }}
+          className="overflow-hidden"
+        />
+        <div
+          dangerouslySetInnerHTML={{ __html: micro.card }}
+          className="overflow-hidden"
+        />
+        <div
+          dangerouslySetInnerHTML={{ __html: micro.input }}
+          className="overflow-hidden"
+        />
+      </div>
+    </div>
+  );
+}
+
+function BeforeAfterPanel({
+  referenceUrl,
+  concept,
+}: {
+  referenceUrl: string;
+  concept: ConceptResult;
+}) {
+  return (
+    <section
+      className="rounded-lg border bg-card p-4"
+      data-testid="concept-before-after"
+    >
+      <h3 className="text-sm font-semibold">Before vs after</h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Your reference next to {DIRECTION_TITLES[concept.direction]}.
+      </p>
+      <div className="mt-3 grid gap-4 md:grid-cols-2">
+        <div>
+          <p className="text-[10px] font-medium text-muted-foreground">
+            Your reference
+          </p>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={referenceUrl}
+            alt="Reference site screenshot"
+            className="mt-1 w-full rounded-md border object-cover"
+            loading="lazy"
+            data-testid="concept-before-image"
+          />
+        </div>
+        <div>
+          <p className="text-[10px] font-medium text-muted-foreground">
+            Our interpretation
+          </p>
+          <div
+            className="mt-1 h-72 overflow-hidden rounded-md border bg-muted/20"
+            data-testid="concept-after-frame"
+          >
+            <iframe
+              title={`${DIRECTION_TITLES[concept.direction]} — homepage`}
+              srcDoc={concept.homepage_html}
+              sandbox=""
+              className="block h-full w-full"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/DesignDirectionInputs.tsx
+++ b/components/DesignDirectionInputs.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Loader2, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 
+import { ConceptReviewCards } from "@/components/ConceptReviewCards";
 import { MoodBoardStrip } from "@/components/MoodBoardStrip";
 import { DesignUnderstandingPanel } from "@/components/DesignUnderstandingPanel";
 import { Button } from "@/components/ui/button";
@@ -445,6 +446,7 @@ export function DesignDirectionInputs({
           concepts={concepts}
           conceptErrors={conceptErrors}
           generationFailed={generationFailed}
+          referenceScreenshotUrl={view.screenshot_url}
         />
       )}
     </div>
@@ -456,11 +458,13 @@ function ConceptResultsBlock({
   concepts,
   conceptErrors,
   generationFailed,
+  referenceScreenshotUrl,
 }: {
   generating: boolean;
   concepts: ConceptResult[] | null;
   conceptErrors: ConceptError[];
   generationFailed: string | null;
+  referenceScreenshotUrl: string | null;
 }) {
   if (generationFailed) {
     return (
@@ -503,61 +507,15 @@ function ConceptResultsBlock({
   if (!concepts) return null;
   return (
     <div className="space-y-3" data-testid="dd-concepts-ready">
-      <div className="rounded-md border bg-success/5 p-3 text-sm">
-        <p className="font-medium text-success">
-          {concepts.length} concept{concepts.length === 1 ? "" : "s"} generated.
-        </p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
-          The rich three-up review (iframes, micro-UI previews, before/after,
-          desktop-mobile toggle) lands in the next change. Until then, the
-          concepts are stored in this component&apos;s state and can be
-          inspected via the directions list below.
-        </p>
-      </div>
-      <ul className="grid gap-2 md:grid-cols-3">
-        {concepts.map((c) => (
-          <li
-            key={c.direction}
-            className="rounded-md border bg-card p-3 text-xs"
-            data-testid={`dd-concept-${c.direction}`}
-          >
-            <p className="font-semibold">{c.label}</p>
-            <p className="mt-1 text-muted-foreground">{c.rationale}</p>
-            <div className="mt-2 flex flex-wrap gap-1">
-              {Object.entries(c.design_tokens)
-                .filter(([k]) =>
-                  ["primary", "secondary", "accent", "background", "text"].includes(k),
-                )
-                .map(([k, v]) => (
-                  <span
-                    key={k}
-                    className="inline-flex items-center gap-1 rounded-md border bg-background px-1 py-0.5 text-[9px]"
-                    title={`${k}: ${v}`}
-                  >
-                    <span
-                      className="inline-block h-3 w-3 rounded-sm border"
-                      style={{ background: v as string }}
-                      aria-hidden
-                    />
-                    <span className="font-mono uppercase">{k}</span>
-                  </span>
-                ))}
-            </div>
-          </li>
-        ))}
-      </ul>
-      {conceptErrors.length > 0 && (
-        <p
-          className="text-xs text-warning"
-          data-testid="dd-concept-errors"
-          role="alert"
-        >
-          {conceptErrors.length} concept
-          {conceptErrors.length === 1 ? "" : "s"} failed to generate:{" "}
-          {conceptErrors.map((e) => e.label).join(", ")}. The full review will
-          show the others alongside a retry button.
-        </p>
-      )}
+      <ConceptReviewCards
+        concepts={concepts}
+        errors={conceptErrors}
+        referenceScreenshotUrl={referenceScreenshotUrl}
+        onSelect={() => {
+          // Refinement + approve flow lands in PR 7. For now we only
+          // highlight the selected card client-side.
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
PR 6 of DESIGN-DISCOVERY. Replaces PR 5's lightweight palette-only preview with the rich three-up review UI from the spec.

## What lands
- `components/ConceptReviewCards.tsx` — three concept cards side-by-side (stacked on mobile). Per card: title, rationale, swatch row, font names (rendered in their own family), inline micro-UI block (button / card / input via `dangerouslySetInnerHTML`, NOT in an iframe per the spec), sandboxed homepage iframe (`srcdoc` + `sandbox=""` — empty permissions allowlist), desktop/mobile toggle (390px constrained on mobile), homepage/inner-page toggle, "Select this direction" CTA.
- Before/after panel — only renders when the operator gave us a reference URL (so we have a Microlink screenshot) AND has selected a concept. Side-by-side: reference image vs the selected concept's homepage iframe; updates as selection changes.
- Per-direction failure list — when one of three failed, renders a warning banner naming the failed direction.
- `components/DesignDirectionInputs.tsx` — passes `view.screenshot_url` down to the result block so the before/after panel has a reference.

## Risks identified and mitigated
- **Iframe XSS.** `sandbox=""` (empty allowlist) on every concept iframe + the before/after panel iframe. No `allow-scripts`, no `allow-forms`, no `allow-top-navigation`. The model is also told not to emit `<script>` and PR 5's normalize pass strips them defensively.
- **Micro UI snippets rendered with `dangerouslySetInnerHTML`.** These render OUTSIDE an iframe (per spec), so the host page's CSS bleeds through. Risk: malicious HTML in a generated micro-UI string could place a clickjacking element. Mitigations: (1) `[&_*]:!max-w-full [&_*]:!box-border` Tailwind constraints clamp absurd sizing; (2) the Zod schema in PR 5 caps the lengths and validates the shape; (3) the snippets are produced by Claude under our system prompt, not from operator input. Acceptable for v1; flagged for a stricter sanitizer pass when the workstream lands a follow-up.
- **Selection state ephemeral.** PR 7 wires the actual approve flow (DB write of homepage_concept_html / inner_page_concept_html / design_tokens). For now selecting a card just highlights it — no DB side effect.
- **No DB migration.** Reuses existing schema.
- **Auth gate unchanged.** No new endpoints in this PR.

## Deliberately deferred
- **Refinement loop + approval.** PR 7 — `Select this direction` becomes the entry to a refinement textarea, regen call, and the Approve / Reset CTAs.
- **E2E spec.** The current PR-3 wizard happy path doesn't drive Generate, and Generate requires a real Anthropic key. PR 7's spec drives an approve path with a stubbed concept payload.
- **Stricter sanitizer for micro-UI snippets.** See Risks; v1 accepts the model output with shape validation only.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm run test` — unit tests run in CI.
- [ ] `npm run test:e2e` — N/A in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)