### PR TITLE
feat(p4-3): /auth/approve page + approve API + lost-tab fallback

### DIFF
--- a/app/api/auth/approve-here/route.ts
+++ b/app/api/auth/approve-here/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import {
+  consumeChallenge,
+  lookupChallengeById,
+} from "@/lib/2fa/challenges";
+import { buildAuthRedirectUrl } from "@/lib/auth-redirect";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// AUTH-FOUNDATION P4.3 — POST /api/auth/approve-here.
+//
+// Lost-tab fallback. Operator clicked "Complete sign-in here" on the
+// /auth/approve page (likely on a different device than the one they
+// signed in from). The challenge was approved when the page loaded;
+// here we:
+//
+//   1. Consume the challenge (CAS approved → consumed).
+//   2. Generate a Supabase magic link for the user via the admin API.
+//   3. Return the action_link as redirect_to. The browser follows
+//      it; the magic-link callback sets the session cookie + drops
+//      the operator on /admin/sites.
+//
+// trust_device is intentionally FALSE in this path — the device
+// completing the flow may be a phone, and we shouldn't auto-trust
+// a non-original device.
+//
+// Public route: the challenge id is the auth (random uuid; we
+// re-look-up to confirm it's in the right state).
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const Body = z
+  .object({
+    challenge_id: z.string().uuid(),
+  })
+  .strict();
+
+export async function POST(_req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await _req.json();
+  } catch {
+    body = null;
+  }
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body must be { challenge_id }.",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const challenge = await lookupChallengeById(parsed.data.challenge_id);
+  if (!challenge) {
+    return NextResponse.json(
+      { ok: false, error: { code: "NOT_FOUND", message: "Challenge not found." } },
+      { status: 404 },
+    );
+  }
+  if (challenge.status !== "approved") {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "NOT_APPROVED",
+          message:
+            challenge.status === "consumed"
+              ? "This sign-in was already completed elsewhere."
+              : "Approve the link first.",
+        },
+      },
+      { status: 409 },
+    );
+  }
+
+  const consumed = await consumeChallenge(parsed.data.challenge_id);
+  if (!consumed.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: consumed.reason.toUpperCase(),
+          message: "Could not consume the approval. It may have been used in another tab.",
+        },
+      },
+      { status: 409 },
+    );
+  }
+
+  // Resolve the user's email + generate a magic link.
+  const svc = getServiceRoleClient();
+  const userRow = await svc
+    .from("opollo_users")
+    .select("email")
+    .eq("id", challenge.user_id)
+    .maybeSingle();
+  const email = userRow.data?.email as string | undefined;
+  if (!email) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Could not resolve user email.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+
+  const redirectTo = buildAuthRedirectUrl(`/api/auth/callback?next=/admin/sites`);
+  const linkRes = await svc.auth.admin.generateLink({
+    type: "magiclink",
+    email,
+    options: { redirectTo },
+  });
+  if (linkRes.error || !linkRes.data?.properties?.action_link) {
+    logger.error("auth.2fa.approve-here.magiclink_failed", {
+      err: linkRes.error?.message,
+      challenge_id: parsed.data.challenge_id,
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "MAGIC_LINK_FAILED",
+          message: "Could not issue session token. Sign in again from your original device.",
+        },
+      },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    data: { redirect_to: linkRes.data.properties.action_link },
+  });
+}

--- a/app/auth/approve/page.tsx
+++ b/app/auth/approve/page.tsx
@@ -1,0 +1,129 @@
+import { ApproveCompleteHere } from "@/components/ApproveCompleteHere";
+import { Alert } from "@/components/ui/alert";
+import { H1, Lead } from "@/components/ui/typography";
+import {
+  approveChallenge,
+  lookupChallengeByToken,
+} from "@/lib/2fa/challenges";
+
+// AUTH-FOUNDATION P4.3 — /auth/approve.
+//
+// The URL the "Approve sign-in" button in the email points at. Public
+// (no auth gate) — the token IS the auth. Server-component validates
+// the token + flips the challenge to approved, then renders one of:
+//
+//   - "Sign-in approved. Return to your original tab to continue,
+//     or click below to complete sign-in here."
+//     With a "Complete sign-in here" button (the lost-tab fallback)
+//     that POSTs to /api/auth/approve-here, which signs the user in
+//     ON THIS DEVICE via a Supabase magic link.
+//
+//   - "This approval link has been used." (consumed already by the
+//     original tab's complete-login)
+//
+//   - "This link expired / is invalid" (typed reasons)
+//
+// Single-use: the second visit to the same approval link sees the
+// 'consumed' state.
+
+export const dynamic = "force-dynamic";
+
+interface PageProps {
+  searchParams: { token?: string };
+}
+
+type RenderState =
+  | { kind: "approved"; challengeId: string; tokenWasJustApproved: boolean }
+  | { kind: "consumed" }
+  | { kind: "expired" }
+  | { kind: "invalid" };
+
+async function resolveState(rawToken: string | undefined): Promise<RenderState> {
+  if (!rawToken || rawToken.length < 32) return { kind: "invalid" };
+  const challenge = await lookupChallengeByToken(rawToken);
+  if (!challenge) return { kind: "invalid" };
+
+  if (challenge.status === "consumed") return { kind: "consumed" };
+  if (challenge.status === "expired") return { kind: "expired" };
+  if (new Date(challenge.expires_at).getTime() <= Date.now()) {
+    return { kind: "expired" };
+  }
+  if (challenge.status === "approved") {
+    return {
+      kind: "approved",
+      challengeId: challenge.id,
+      tokenWasJustApproved: false,
+    };
+  }
+
+  // Pending → flip to approved.
+  const approveResult = await approveChallenge(challenge.id);
+  if (!approveResult.ok) {
+    if (approveResult.reason === "already_consumed") return { kind: "consumed" };
+    if (approveResult.reason === "expired") return { kind: "expired" };
+    if (approveResult.reason === "already_approved") {
+      return {
+        kind: "approved",
+        challengeId: challenge.id,
+        tokenWasJustApproved: false,
+      };
+    }
+    return { kind: "invalid" };
+  }
+  return {
+    kind: "approved",
+    challengeId: challenge.id,
+    tokenWasJustApproved: true,
+  };
+}
+
+export default async function ApprovePage({ searchParams }: PageProps) {
+  const state = await resolveState(searchParams.token);
+
+  if (state.kind === "invalid") {
+    return (
+      <div className="mx-auto max-w-md space-y-4">
+        <H1>Approval link</H1>
+        <Alert variant="destructive">
+          This approval link is invalid. Sign in again from your original
+          device or ask for a fresh attempt.
+        </Alert>
+      </div>
+    );
+  }
+  if (state.kind === "expired") {
+    return (
+      <div className="mx-auto max-w-md space-y-4">
+        <H1>Approval link expired</H1>
+        <Alert variant="destructive">
+          This approval link expired (15-minute window). Sign in again
+          from your original device to receive a fresh email.
+        </Alert>
+      </div>
+    );
+  }
+  if (state.kind === "consumed") {
+    return (
+      <div className="mx-auto max-w-md space-y-4">
+        <H1>Approval link used</H1>
+        <Alert>
+          This approval link has been used. If you&apos;re already
+          signed in on the original device you can close this tab.
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-md space-y-4">
+      <H1>Sign-in approved</H1>
+      <Lead className="mt-1">
+        {state.tokenWasJustApproved
+          ? "Return to your original tab — it'll finish signing you in automatically."
+          : "Already approved. If your original tab is gone, complete sign-in here."}
+      </Lead>
+
+      <ApproveCompleteHere challengeId={state.challengeId} />
+    </div>
+  );
+}

--- a/components/ApproveCompleteHere.tsx
+++ b/components/ApproveCompleteHere.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+// AUTH-FOUNDATION P4.3 — "Complete sign-in here" fallback button.
+//
+// Posts to /api/auth/approve-here. The server consumes the challenge,
+// generates a Supabase magic link for the user, and returns the
+// action_link as `redirect_to` for the browser to follow.
+//
+// trust_device defaults to FALSE here per the brief — the approving
+// device may be a different machine (phone) than the one that
+// originally signed in, so we don't auto-trust it.
+
+export function ApproveCompleteHere({ challengeId }: { challengeId: string }) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onClick() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/auth/approve-here", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ challenge_id: challengeId }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: { redirect_to: string } }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (!res.ok || !payload?.ok) {
+        setError(
+          payload?.ok === false
+            ? payload.error.message
+            : `Couldn't complete sign-in (HTTP ${res.status}).`,
+        );
+        setSubmitting(false);
+        return;
+      }
+      // Hand the browser to the magic link, which sets the session
+      // cookie + redirects to /admin/sites.
+      window.location.assign(payload.data.redirect_to);
+    } catch (err) {
+      setError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <Button
+        type="button"
+        onClick={() => void onClick()}
+        disabled={submitting}
+        className="w-full"
+        data-testid="approve-complete-here"
+      >
+        {submitting ? "Signing you in…" : "Complete sign-in here"}
+      </Button>
+      <p className="text-xs text-muted-foreground">
+        Use this if you can&apos;t get back to your original tab. This
+        device won&apos;t be trusted automatically — you&apos;ll be
+        challenged again next time.
+      </p>
+      {error && (
+        <Alert variant="destructive" data-testid="approve-here-error">
+          {error}
+        </Alert>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The URL the email button hits + the optional \"complete sign-in here\" escape hatch when the original tab is gone.

## What ships

### \`/auth/approve?token=…\` page (server component, public)
- Hashes incoming raw token, looks up challenge.
- Validates state: invalid / expired / consumed return clean copy. Pending → flips to approved (idempotent — second visit to already-approved link sees same state).
- Renders one of:
  - \"Sign-in approved. Return to your original tab to continue, or click below to complete sign-in here.\" (with the ApproveCompleteHere button)
  - \"This approval link has been used.\"
  - \"This link expired / is invalid.\"

### ApproveCompleteHere client
POSTs to \`/api/auth/approve-here\` on click, follows the returned magic link.

### \`POST /api/auth/approve-here\`
Public route; challenge_id is the auth (already approved per /auth/approve flow). Consumes via CAS, generates Supabase magic link via admin API, returns action_link as \`redirect_to\`. Browser follows the action_link; magic-link callback sets session cookie + drops operator on /admin/sites. \`trust_device\` intentionally **FALSE** on this path.

## How the two paths interleave

- **Original-tab path (P4.2)**: poll sees status=approved → posts complete-login → consumes + sets device_id cookie if trust=true.
- **Lost-tab path (P4.3)**: operator clicks \"Complete sign-in here\" → consumes + magic-links the user in on THIS device, no trust.
- **Race**: whichever path consumes first wins via CAS UPDATE in \`consumeChallenge()\`. Loser's button shows the CONSUMED branch.

## Risks identified and mitigated

- **Magic-link URL leaks** — Supabase's callback contains a single-use code invalidated on first exchange. Replay fails.
- **Public approve page rate-limiting** — challenge has 15-min expiry + 32-byte random token; brute force impractical. Upstream creation rate (5/email/hour) bounds search space.
- **Two visits to /auth/approve** — second sees 'approved' (idempotent). consumeChallenge in the API enforces single-use.
- **\`generateLink(magiclink)\`** returns the action_link regardless of SMTP delivery; we only use the link, no second email.

## Quality gates

- \`npm run lint\` ✅
- \`npm run typecheck\` ✅
- \`npm run build\` ✅

## Test plan

- [ ] AUTH_2FA_ENABLED still false in all envs
- [ ] P4.4 ships /admin/account/devices
- [ ] Operator gate flips AUTH_2FA_ENABLED=true in staging after P4.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)