### PR TITLE
feat(design-discovery-8): tone of voice input + extraction + samples + approval

### DIFF
--- a/app/api/admin/sites/[id]/setup/approve-tone/route.ts
+++ b/app/api/admin/sites/[id]/setup/approve-tone/route.ts
@@ -1,0 +1,123 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// POST /api/admin/sites/[id]/setup/approve-tone — admin-gated.
+//   Body: { tone_of_voice, approved_samples }
+//   Persists tone_of_voice JSON (with approved_samples folded in) and
+//   flips status to 'approved'.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const ToneSchema = z.object({
+  formality_level: z.number().min(1).max(5),
+  sentence_length: z.union([
+    z.literal("short"),
+    z.literal("medium"),
+    z.literal("long"),
+  ]),
+  jargon_usage: z.union([
+    z.literal("embraced"),
+    z.literal("neutral"),
+    z.literal("avoided"),
+  ]),
+  personality_markers: z.array(z.string()),
+  avoid_markers: z.array(z.string()),
+  target_audience: z.string(),
+  style_guide: z.string().min(1),
+});
+
+const SampleSchema = z.object({
+  kind: z.union([
+    z.literal("hero"),
+    z.literal("service"),
+    z.literal("blog"),
+  ]),
+  text: z.string().min(1).max(800),
+});
+
+const BodySchema = z.object({
+  tone_of_voice: ToneSchema,
+  approved_samples: z.array(SampleSchema).max(5),
+});
+
+function errorJson(code: string, message: string, status: number): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Site id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body failed validation.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("sites")
+    .update({
+      tone_of_voice: {
+        ...parsed.data.tone_of_voice,
+        approved_samples: parsed.data.approved_samples,
+      },
+      tone_of_voice_status: "approved",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", params.id)
+    .neq("status", "removed")
+    .select("id")
+    .maybeSingle();
+  if (error) {
+    return errorJson("INTERNAL_ERROR", error.message, 500);
+  }
+  if (!data) {
+    return errorJson("NOT_FOUND", `No active site found with id ${params.id}.`, 404);
+  }
+
+  revalidatePath(`/admin/sites/${params.id}/setup`);
+  revalidatePath(`/admin/sites/${params.id}`);
+  return NextResponse.json(
+    { ok: true, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/app/api/admin/sites/[id]/setup/extract-tone/route.ts
+++ b/app/api/admin/sites/[id]/setup/extract-tone/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { extractTone } from "@/lib/design-discovery/extract-tone";
+import {
+  AVOID_OPTIONS,
+  PERSONALITY_OPTIONS,
+} from "@/lib/design-discovery/tone-mapping";
+import { logger } from "@/lib/logger";
+
+// POST /api/admin/sites/[id]/setup/extract-tone — admin-gated.
+// Body matches ToneInputs in lib/design-discovery/extract-tone.ts.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const BodySchema = z.object({
+  industry: z.string().min(1).max(50),
+  existing_content_url: z.string().max(500).nullable(),
+  sample_copy: z.string().max(5000).nullable(),
+  target_audience: z.string().max(500).nullable(),
+  personality: z.array(z.enum(PERSONALITY_OPTIONS)).max(PERSONALITY_OPTIONS.length),
+  avoid: z.array(z.enum(AVOID_OPTIONS)).max(AVOID_OPTIONS.length),
+  admired_brand: z.string().max(200).nullable(),
+});
+
+function errorJson(code: string, message: string, status: number): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Site id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body failed validation.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  let result;
+  try {
+    result = await extractTone(parsed.data, { siteId: params.id });
+  } catch (err) {
+    logger.error("design-discovery.extract-tone.unhandled", {
+      site_id: params.id,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return errorJson(
+      "INTERNAL_ERROR",
+      err instanceof Error ? err.message : "Tone extraction failed.",
+      500,
+    );
+  }
+
+  if (!result.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: result.error.code, message: result.error.message, retryable: true },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }
+
+  return NextResponse.json(
+    { ok: true, data: result.data, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/app/api/admin/sites/[id]/setup/regenerate-tone-samples/route.ts
+++ b/app/api/admin/sites/[id]/setup/regenerate-tone-samples/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { regenerateSamples } from "@/lib/design-discovery/extract-tone";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const ToneSchema = z.object({
+  formality_level: z.number().min(1).max(5),
+  sentence_length: z.union([
+    z.literal("short"),
+    z.literal("medium"),
+    z.literal("long"),
+  ]),
+  jargon_usage: z.union([
+    z.literal("embraced"),
+    z.literal("neutral"),
+    z.literal("avoided"),
+  ]),
+  personality_markers: z.array(z.string()),
+  avoid_markers: z.array(z.string()),
+  target_audience: z.string(),
+  style_guide: z.string(),
+});
+
+const BodySchema = z.object({
+  tone_of_voice: ToneSchema,
+  feedback: z.string().max(1000).nullable().optional(),
+  attempt: z.number().int().min(1).max(11).default(1),
+});
+
+function errorJson(code: string, message: string, status: number): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Site id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body failed validation.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await regenerateSamples(
+    parsed.data.tone_of_voice,
+    parsed.data.feedback ?? null,
+    { siteId: params.id, attempt: parsed.data.attempt },
+  );
+  if (!result.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: result.error.code, message: result.error.message, retryable: true },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }
+  return NextResponse.json(
+    { ok: true, data: { samples: result.samples }, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/components/SetupWizard.tsx
+++ b/components/SetupWizard.tsx
@@ -12,6 +12,7 @@ import {
   type DesignBriefDraft,
   type ExtractedSnapshot,
 } from "@/components/DesignDirectionInputs";
+import { ToneOfVoiceInputs } from "@/components/ToneOfVoiceInputs";
 import { Button } from "@/components/ui/button";
 import type { Industry } from "@/lib/design-discovery/industry-defaults";
 import type { SetupStatus, SetupStep, SetupStepStatus } from "@/lib/site-setup";
@@ -331,32 +332,44 @@ function briefToInitialDraft(
 }
 
 function Step2({ siteId, status }: { siteId: string; status: SetupStatus }) {
+  // Industry from the design brief drives the default voice seed
+  // (industry-defaults.ts default_voice_seed). When the design step
+  // was skipped, fall back to MSP — the same default the design
+  // step ships with.
+  const industry =
+    typeof status.design_brief?.industry === "string"
+      ? (status.design_brief.industry as string)
+      : "msp";
+  const tone =
+    status.tone_of_voice && typeof status.tone_of_voice === "object"
+      ? (status.tone_of_voice as Record<string, unknown>)
+      : null;
+  const initialTone = toneFromStatus(tone);
+  const initialSamples = samplesFromStatus(tone);
+
   return (
     <StepFrame
       testid="setup-step-2"
       title="Tone of voice"
       intro={
         <>
-          How should the site talk to clients? Paste sample copy, share a
-          reference URL, or answer the guided questions and we&apos;ll
-          extract a tone profile that feeds every page and post we
-          generate.
+          How should the site talk to clients? Paste sample copy, share an
+          existing content URL, or answer the guided questions — we&apos;ll
+          extract a tone profile and three sample snippets you can edit.
+          Status:{" "}
+          <span className="font-medium text-foreground">
+            {statusLabel(status.tone_of_voice_status)}
+          </span>
+          .
         </>
       }
       body={
-        <div className="rounded-md border border-dashed bg-muted/20 p-6 text-sm text-muted-foreground">
-          <p>
-            Status:{" "}
-            <span className="font-medium text-foreground">
-              {statusLabel(status.tone_of_voice_status)}
-            </span>
-          </p>
-          <p className="mt-2">
-            The tone capture and sample preview land in a follow-up
-            change. Skip for now to land at Done with generic MSP defaults
-            applied to your generation prompts.
-          </p>
-        </div>
+        <ToneOfVoiceInputs
+          siteId={siteId}
+          industry={industry}
+          initialTone={initialTone}
+          initialSamples={initialSamples}
+        />
       }
       footer={
         <>
@@ -378,6 +391,65 @@ function Step2({ siteId, status }: { siteId: string; status: SetupStatus }) {
       }
     />
   );
+}
+
+function toneFromStatus(
+  raw: Record<string, unknown> | null,
+): Parameters<typeof ToneOfVoiceInputs>[0]["initialTone"] {
+  if (!raw) return null;
+  const isStr = (v: unknown): v is string => typeof v === "string";
+  const isNum = (v: unknown): v is number => typeof v === "number";
+  const formality = isNum(raw.formality_level) ? raw.formality_level : null;
+  const sentence = isStr(raw.sentence_length) ? raw.sentence_length : null;
+  const jargon = isStr(raw.jargon_usage) ? raw.jargon_usage : null;
+  const audience = isStr(raw.target_audience) ? raw.target_audience : null;
+  const style = isStr(raw.style_guide) ? raw.style_guide : null;
+  if (
+    formality === null ||
+    sentence === null ||
+    jargon === null ||
+    audience === null ||
+    style === null
+  ) {
+    return null;
+  }
+  if (sentence !== "short" && sentence !== "medium" && sentence !== "long") {
+    return null;
+  }
+  if (jargon !== "embraced" && jargon !== "neutral" && jargon !== "avoided") {
+    return null;
+  }
+  return {
+    formality_level: formality,
+    sentence_length: sentence,
+    jargon_usage: jargon,
+    personality_markers: Array.isArray(raw.personality_markers)
+      ? (raw.personality_markers.filter((s) => typeof s === "string") as string[])
+      : [],
+    avoid_markers: Array.isArray(raw.avoid_markers)
+      ? (raw.avoid_markers.filter((s) => typeof s === "string") as string[])
+      : [],
+    target_audience: audience,
+    style_guide: style,
+  };
+}
+
+function samplesFromStatus(
+  raw: Record<string, unknown> | null,
+): Parameters<typeof ToneOfVoiceInputs>[0]["initialSamples"] {
+  if (!raw) return [];
+  const arr = raw.approved_samples;
+  if (!Array.isArray(arr)) return [];
+  const out: Array<{ kind: "hero" | "service" | "blog"; text: string }> = [];
+  for (const item of arr) {
+    if (!item || typeof item !== "object") continue;
+    const k = (item as Record<string, unknown>).kind;
+    const t = (item as Record<string, unknown>).text;
+    if (typeof t !== "string") continue;
+    if (k !== "hero" && k !== "service" && k !== "blog") continue;
+    out.push({ kind: k, text: t });
+  }
+  return out;
 }
 
 function Step3({ siteId, status }: { siteId: string; status: SetupStatus }) {

--- a/components/ToneOfVoiceInputs.tsx
+++ b/components/ToneOfVoiceInputs.tsx
@@ -1,0 +1,618 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Loader2, Sparkles, Check } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  AVOID_OPTIONS,
+  PERSONALITY_OPTIONS,
+  type AvoidOption,
+  type PersonalityOption,
+} from "@/lib/design-discovery/tone-mapping";
+
+// ---------------------------------------------------------------------------
+// ToneOfVoiceInputs — Step 2 input surface (PR 8).
+//
+// Captures:
+//   - Existing content URL (we fetch homepage prose server-side)
+//   - Sample copy paste
+//   - Target audience (free text)
+//   - Personality multi-select (positive markers)
+//   - Never-sound-like multi-select (avoidance markers)
+//   - Admired brand free text
+//
+// On Generate: posts to /setup/extract-tone, gets tone_of_voice JSON +
+// 3 samples back. Operator edits each sample inline (plain textarea
+// per the spec — no rich text). Approve persists; Skip flips
+// tone_of_voice_status to 'skipped' via the existing skip endpoint.
+// ---------------------------------------------------------------------------
+
+interface ToneOfVoice {
+  formality_level: number;
+  sentence_length: "short" | "medium" | "long";
+  jargon_usage: "embraced" | "neutral" | "avoided";
+  personality_markers: string[];
+  avoid_markers: string[];
+  target_audience: string;
+  style_guide: string;
+}
+
+interface ToneSample {
+  kind: "hero" | "service" | "blog";
+  text: string;
+}
+
+const SAMPLE_LABELS: Record<ToneSample["kind"], string> = {
+  hero: "Homepage hero",
+  service: "Service description",
+  blog: "Blog post opening",
+};
+
+const REGEN_CAP = 10;
+
+interface DraftInputs {
+  existing_content_url: string;
+  sample_copy: string;
+  target_audience: string;
+  personality: PersonalityOption[];
+  avoid: AvoidOption[];
+  admired_brand: string;
+}
+
+const INITIAL_INPUTS: DraftInputs = {
+  existing_content_url: "",
+  sample_copy: "",
+  target_audience: "",
+  personality: [],
+  avoid: [],
+  admired_brand: "",
+};
+
+interface Props {
+  siteId: string;
+  industry: string;
+  initialTone: ToneOfVoice | null;
+  initialSamples: ToneSample[];
+}
+
+export function ToneOfVoiceInputs({
+  siteId,
+  industry,
+  initialTone,
+  initialSamples,
+}: Props) {
+  const router = useRouter();
+  const [inputs, setInputs] = useState<DraftInputs>(INITIAL_INPUTS);
+  const [extracting, setExtracting] = useState(false);
+  const [extractError, setExtractError] = useState<string | null>(null);
+  const [tone, setTone] = useState<ToneOfVoice | null>(initialTone);
+  const [samples, setSamples] = useState<ToneSample[]>(
+    initialSamples.length > 0 ? initialSamples : [],
+  );
+  const [regenAttempts, setRegenAttempts] = useState(0);
+  const [regenFeedback, setRegenFeedback] = useState("");
+  const [regenerating, setRegenerating] = useState(false);
+  const [approving, setApproving] = useState(false);
+  const [approveError, setApproveError] = useState<string | null>(null);
+  const [skipping, setSkipping] = useState(false);
+
+  function setField<K extends keyof DraftInputs>(key: K, value: DraftInputs[K]) {
+    setInputs((p) => ({ ...p, [key]: value }));
+  }
+
+  function toggleMulti<T>(list: T[], value: T): T[] {
+    if (list.includes(value)) return list.filter((v) => v !== value);
+    return [...list, value];
+  }
+
+  const hasInputs =
+    Boolean(inputs.existing_content_url.trim()) ||
+    Boolean(inputs.sample_copy.trim()) ||
+    Boolean(inputs.target_audience.trim()) ||
+    inputs.personality.length > 0 ||
+    inputs.avoid.length > 0 ||
+    Boolean(inputs.admired_brand.trim());
+
+  async function onExtract() {
+    if (!hasInputs) {
+      toast.error("Add at least one input — a URL, sample copy, or guided answer.");
+      return;
+    }
+    setExtracting(true);
+    setExtractError(null);
+    try {
+      const res = await fetch(`/api/admin/sites/${siteId}/setup/extract-tone`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          industry,
+          existing_content_url: inputs.existing_content_url.trim() || null,
+          sample_copy: inputs.sample_copy.trim() || null,
+          target_audience: inputs.target_audience.trim() || null,
+          personality: inputs.personality,
+          avoid: inputs.avoid,
+          admired_brand: inputs.admired_brand.trim() || null,
+        }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: { tone_of_voice: ToneOfVoice; samples: ToneSample[] } }
+        | { ok: false; error: { message: string } }
+        | null;
+      if (!payload?.ok) {
+        setExtractError(
+          payload?.ok === false ? payload.error.message : "Tone extraction failed.",
+        );
+        setExtracting(false);
+        return;
+      }
+      setTone(payload.data.tone_of_voice);
+      setSamples(payload.data.samples);
+      setRegenAttempts(0);
+      setExtracting(false);
+    } catch (err) {
+      setExtractError(err instanceof Error ? err.message : "Network error.");
+      setExtracting(false);
+    }
+  }
+
+  async function onRegenerate() {
+    if (!tone) return;
+    if (regenAttempts >= REGEN_CAP) {
+      toast.error("Regeneration cap reached.");
+      return;
+    }
+    setRegenerating(true);
+    try {
+      const res = await fetch(
+        `/api/admin/sites/${siteId}/setup/regenerate-tone-samples`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            tone_of_voice: tone,
+            feedback: regenFeedback.trim() || null,
+            attempt: regenAttempts + 1,
+          }),
+        },
+      );
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: { samples: ToneSample[] } }
+        | { ok: false; error: { message: string } }
+        | null;
+      if (!payload?.ok) {
+        toast.error(
+          payload?.ok === false ? payload.error.message : "Regeneration failed.",
+        );
+        setRegenerating(false);
+        return;
+      }
+      setSamples(payload.data.samples);
+      setRegenAttempts((p) => p + 1);
+      setRegenFeedback("");
+      setRegenerating(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Network error.");
+      setRegenerating(false);
+    }
+  }
+
+  async function onApprove() {
+    if (!tone) return;
+    setApproving(true);
+    setApproveError(null);
+    try {
+      const res = await fetch(`/api/admin/sites/${siteId}/setup/approve-tone`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          tone_of_voice: tone,
+          approved_samples: samples,
+        }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error: { message: string } }
+        | null;
+      if (!payload?.ok) {
+        setApproveError(
+          payload?.ok === false ? payload.error.message : "Approval failed.",
+        );
+        setApproving(false);
+        return;
+      }
+      toast.success("Tone of voice approved.");
+      router.push(`/admin/sites/${siteId}/setup?step=3`);
+      router.refresh();
+    } catch (err) {
+      setApproveError(err instanceof Error ? err.message : "Network error.");
+      setApproving(false);
+    }
+  }
+
+  async function onSkip() {
+    setSkipping(true);
+    try {
+      const res = await fetch(`/api/admin/sites/${siteId}/setup/skip`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ step: 2 }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true }
+        | { ok: false; error: { message: string } }
+        | null;
+      if (!payload?.ok) {
+        toast.error(
+          payload?.ok === false ? payload.error.message : "Skip failed.",
+        );
+        setSkipping(false);
+        return;
+      }
+      router.push(`/admin/sites/${siteId}/setup?step=3`);
+      router.refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Network error.");
+      setSkipping(false);
+    }
+  }
+
+  function setSampleText(idx: number, text: string) {
+    setSamples((prev) =>
+      prev.map((s, i) => (i === idx ? { ...s, text } : s)),
+    );
+  }
+
+  return (
+    <div className="space-y-5" data-testid="tone-of-voice-inputs">
+      {/* Inputs */}
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <label htmlFor="tov-url" className="block text-sm font-medium">
+            Existing content URL{" "}
+            <span className="font-normal text-muted-foreground">(optional)</span>
+          </label>
+          <Input
+            id="tov-url"
+            type="url"
+            placeholder="https://existing-site.com"
+            value={inputs.existing_content_url}
+            onChange={(e) => setField("existing_content_url", e.target.value)}
+            className="mt-1"
+            data-testid="tov-url"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            We fetch the homepage prose and infer tone from it.
+          </p>
+        </div>
+        <div>
+          <label htmlFor="tov-audience" className="block text-sm font-medium">
+            Who is your target client?{" "}
+            <span className="font-normal text-muted-foreground">(optional)</span>
+          </label>
+          <Input
+            id="tov-audience"
+            placeholder="MSP business owners running 25–200-staff IT operations"
+            value={inputs.target_audience}
+            onChange={(e) => setField("target_audience", e.target.value)}
+            className="mt-1"
+            data-testid="tov-audience"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="tov-sample" className="block text-sm font-medium">
+          Sample copy{" "}
+          <span className="font-normal text-muted-foreground">
+            (optional — paste 2–3 paragraphs that sound like you)
+          </span>
+        </label>
+        <Textarea
+          id="tov-sample"
+          rows={4}
+          maxLength={5000}
+          value={inputs.sample_copy}
+          onChange={(e) => setField("sample_copy", e.target.value)}
+          className="mt-1"
+          data-testid="tov-sample"
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <p className="block text-sm font-medium">Personality</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Pick everything that fits — these become positive voice rules.
+          </p>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {PERSONALITY_OPTIONS.map((opt) => {
+              const on = inputs.personality.includes(opt);
+              return (
+                <button
+                  key={opt}
+                  type="button"
+                  onClick={() =>
+                    setField("personality", toggleMulti(inputs.personality, opt))
+                  }
+                  className={[
+                    "rounded-full border px-2.5 py-0.5 text-xs transition-smooth",
+                    on
+                      ? "border-foreground bg-foreground text-background"
+                      : "border-muted bg-muted/30 text-muted-foreground hover:bg-muted/50",
+                  ].join(" ")}
+                  aria-pressed={on}
+                  data-testid={`tov-personality-${opt}`}
+                >
+                  {opt}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        <div>
+          <p className="block text-sm font-medium">Never sound like</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Pick anti-patterns — these become avoidance rules.
+          </p>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {AVOID_OPTIONS.map((opt) => {
+              const on = inputs.avoid.includes(opt);
+              return (
+                <button
+                  key={opt}
+                  type="button"
+                  onClick={() =>
+                    setField("avoid", toggleMulti(inputs.avoid, opt))
+                  }
+                  className={[
+                    "rounded-full border px-2.5 py-0.5 text-xs transition-smooth",
+                    on
+                      ? "border-destructive bg-destructive text-background"
+                      : "border-muted bg-muted/30 text-muted-foreground hover:bg-muted/50",
+                  ].join(" ")}
+                  aria-pressed={on}
+                  data-testid={`tov-avoid-${opt}`}
+                >
+                  {opt}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="tov-admired" className="block text-sm font-medium">
+          A brand whose communication style you admire{" "}
+          <span className="font-normal text-muted-foreground">(optional)</span>
+        </label>
+        <Input
+          id="tov-admired"
+          placeholder="e.g. Stripe, Linear, Basecamp"
+          value={inputs.admired_brand}
+          onChange={(e) => setField("admired_brand", e.target.value)}
+          className="mt-1"
+          data-testid="tov-admired"
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-4">
+        <p className="text-xs text-muted-foreground">
+          Estimated cost: ~$0.02 — extracts tone JSON + three preview
+          samples in a single call.
+        </p>
+        <Button
+          type="button"
+          onClick={() => void onExtract()}
+          disabled={extracting || !hasInputs}
+          data-testid="tov-extract"
+        >
+          {extracting ? (
+            <>
+              <Loader2 aria-hidden className="h-4 w-4 animate-spin" />
+              Extracting…
+            </>
+          ) : (
+            <>
+              <Sparkles aria-hidden className="h-4 w-4" />
+              {tone ? "Re-extract tone" : "Extract tone of voice"}
+            </>
+          )}
+        </Button>
+      </div>
+
+      {extractError && (
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive"
+          role="alert"
+          data-testid="tov-extract-error"
+        >
+          {extractError}
+        </div>
+      )}
+
+      {tone && (
+        <ToneSummary tone={tone} />
+      )}
+
+      {samples.length > 0 && (
+        <SamplesEditor
+          samples={samples}
+          onChange={setSampleText}
+          regenFeedback={regenFeedback}
+          onRegenFeedbackChange={setRegenFeedback}
+          regenAttempts={regenAttempts}
+          regenerating={regenerating}
+          onRegenerate={onRegenerate}
+        />
+      )}
+
+      {approveError && (
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive"
+          role="alert"
+        >
+          {approveError}
+        </div>
+      )}
+
+      {tone && samples.length > 0 && (
+        <div className="flex flex-wrap items-center justify-end gap-2 border-t pt-4">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => void onSkip()}
+            disabled={skipping || approving}
+            data-testid="tov-skip"
+          >
+            {skipping ? "Skipping…" : "Skip for now"}
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void onApprove()}
+            disabled={approving || regenerating}
+            data-testid="tov-approve"
+          >
+            {approving ? (
+              <>
+                <Loader2 aria-hidden className="h-4 w-4 animate-spin" />
+                Approving…
+              </>
+            ) : (
+              <>
+                <Check aria-hidden className="h-4 w-4" />
+                Approve tone of voice
+              </>
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ToneSummary({ tone }: { tone: ToneOfVoice }) {
+  return (
+    <div
+      className="rounded-md border bg-muted/20 p-3 text-xs"
+      data-testid="tov-summary"
+    >
+      <p className="font-medium">Tone profile</p>
+      <dl className="mt-2 grid gap-1 md:grid-cols-2">
+        <div>
+          <dt className="text-muted-foreground">Formality</dt>
+          <dd>
+            {tone.formality_level} / 5
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Sentence length</dt>
+          <dd>{tone.sentence_length}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Jargon</dt>
+          <dd>{tone.jargon_usage}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground">Audience</dt>
+          <dd>{tone.target_audience}</dd>
+        </div>
+      </dl>
+      <details className="mt-3">
+        <summary className="cursor-pointer text-muted-foreground">
+          Style guide ({tone.style_guide.length} chars)
+        </summary>
+        <pre className="mt-2 whitespace-pre-wrap rounded bg-background p-2 text-[11px] text-foreground">
+          {tone.style_guide}
+        </pre>
+      </details>
+    </div>
+  );
+}
+
+function SamplesEditor({
+  samples,
+  onChange,
+  regenFeedback,
+  onRegenFeedbackChange,
+  regenAttempts,
+  regenerating,
+  onRegenerate,
+}: {
+  samples: ToneSample[];
+  onChange: (idx: number, text: string) => void;
+  regenFeedback: string;
+  onRegenFeedbackChange: (v: string) => void;
+  regenAttempts: number;
+  regenerating: boolean;
+  onRegenerate: () => Promise<void>;
+}) {
+  const atCap = regenAttempts >= REGEN_CAP;
+  return (
+    <div className="space-y-3" data-testid="tov-samples">
+      <p className="text-sm font-medium">Sample text — edit if needed</p>
+      <div className="grid gap-3 md:grid-cols-3">
+        {samples.map((s, i) => (
+          <div
+            key={s.kind}
+            className="rounded-md border bg-card p-3"
+            data-testid={`tov-sample-${s.kind}`}
+          >
+            <p className="text-[10px] font-semibold uppercase text-muted-foreground">
+              {SAMPLE_LABELS[s.kind]}
+            </p>
+            <Textarea
+              rows={s.kind === "hero" ? 3 : 5}
+              value={s.text}
+              onChange={(e) => onChange(i, e.target.value)}
+              maxLength={800}
+              className="mt-1 text-xs"
+            />
+          </div>
+        ))}
+      </div>
+      <div className="rounded-md border bg-muted/20 p-3">
+        <label
+          htmlFor="tov-regen-feedback"
+          className="text-xs font-medium"
+        >
+          Regenerate samples
+        </label>
+        <Textarea
+          id="tov-regen-feedback"
+          rows={2}
+          maxLength={1000}
+          placeholder="Optional: e.g. punchier hero, drop the second sentence."
+          value={regenFeedback}
+          onChange={(e) => onRegenFeedbackChange(e.target.value)}
+          disabled={regenerating || atCap}
+          className="mt-1 text-xs"
+        />
+        <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+          <span data-testid="tov-regen-counter">
+            {regenAttempts}/{REGEN_CAP} regenerations used
+            {atCap && (
+              <span className="ml-2 text-destructive">— cap reached</span>
+            )}
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => void onRegenerate()}
+            disabled={regenerating || atCap}
+            data-testid="tov-regenerate"
+          >
+            {regenerating ? "Regenerating…" : "Regenerate samples"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/design-discovery/extract-tone.ts
+++ b/lib/design-discovery/extract-tone.ts
@@ -1,0 +1,366 @@
+import "server-only";
+
+import { z } from "zod";
+
+import {
+  defaultAnthropicCall,
+  type AnthropicCallFn,
+} from "@/lib/anthropic-call";
+import { extractCssFromUrl } from "@/lib/design-discovery/extract-css";
+import { extractJsonFromOutputTags } from "@/lib/design-discovery/generate-concepts";
+import {
+  buildStyleGuide,
+  type AvoidOption,
+  type PersonalityOption,
+} from "@/lib/design-discovery/tone-mapping";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// DESIGN-DISCOVERY — tone-of-voice extraction (PR 8).
+//
+// Single Claude call that takes the operator's inputs (existing
+// content URL, sample copy, personality / avoid markers, target
+// audience, admired brand) and returns:
+//   - The structured tone_of_voice JSON the spec mandates
+//   - Three sample text blocks (hero, service description, blog
+//     opening paragraph) the operator can edit before approving
+//
+// Fetching the existing content URL happens server-side via the
+// existing extractCssFromUrl helper which we re-use for raw HTML.
+// We strip HTML tags into plain prose and feed the first ~6000
+// characters to the model.
+// ---------------------------------------------------------------------------
+
+const TONE_MODEL = "claude-sonnet-4-6";
+const TONE_MAX_TOKENS = 4096;
+
+const ToneOfVoiceSchema = z.object({
+  formality_level: z.number().min(1).max(5),
+  sentence_length: z.union([
+    z.literal("short"),
+    z.literal("medium"),
+    z.literal("long"),
+  ]),
+  jargon_usage: z.union([
+    z.literal("embraced"),
+    z.literal("neutral"),
+    z.literal("avoided"),
+  ]),
+  personality_markers: z.array(z.string()).max(20),
+  avoid_markers: z.array(z.string()).max(20),
+  target_audience: z.string().max(500),
+  style_guide: z.string().min(1).max(4000),
+});
+
+const SampleSchema = z.object({
+  kind: z.union([
+    z.literal("hero"),
+    z.literal("service"),
+    z.literal("blog"),
+  ]),
+  text: z.string().min(1).max(800),
+});
+
+const ExtractionResponseSchema = z.object({
+  tone_of_voice: ToneOfVoiceSchema,
+  samples: z.array(SampleSchema).length(3),
+});
+
+export type ToneOfVoice = z.infer<typeof ToneOfVoiceSchema>;
+export type ToneSample = z.infer<typeof SampleSchema>;
+
+export interface ToneInputs {
+  industry: string;
+  existing_content_url: string | null;
+  sample_copy: string | null;
+  target_audience: string | null;
+  personality: PersonalityOption[];
+  avoid: AvoidOption[];
+  admired_brand: string | null;
+}
+
+export interface ToneExtractionResult {
+  tone_of_voice: ToneOfVoice;
+  samples: ToneSample[];
+  source: { fetched_url: string; bytes: number } | null;
+}
+
+const TONE_SYSTEM_PROMPT = `You are a senior brand strategist at a top agency. The operator captured inputs about how an MSP/IT-services site should sound; your job is to produce the structured tone-of-voice JSON the downstream generation pipeline reads, plus three sample text blocks the operator reviews and edits before approving.
+
+Output strictly the JSON below, wrapped in <output>...</output>. No prose outside the tags.
+
+{
+  "tone_of_voice": {
+    "formality_level": 3,                       // 1 (very casual) – 5 (very formal)
+    "sentence_length": "short" | "medium" | "long",
+    "jargon_usage": "embraced" | "neutral" | "avoided",
+    "personality_markers": ["professional", "friendly", ...],
+    "avoid_markers": ["salesy", "jargon-heavy", ...],
+    "target_audience": "Short description of who the site speaks to.",
+    "style_guide": "Multi-paragraph prose writing instructions. Concrete dos and don'ts. Includes the operator-supplied multi-select rules verbatim. Used as system context in every downstream generation."
+  },
+  "samples": [
+    { "kind": "hero", "text": "Headline + subheadline (max 2 sentences)." },
+    { "kind": "service", "text": "Service description paragraph (max 100 words)." },
+    { "kind": "blog", "text": "Blog opening paragraph (max 100 words)." }
+  ]
+}
+
+Style_guide rules:
+- Always include the operator's multi-select prose rules verbatim — never drop them.
+- Add 2–4 additional rules grounded in any pasted sample copy or fetched content.
+- Concrete: prefer "Sentences under 20 words." over "be concise".
+- Lead with what to do; finish with what to avoid.
+- 4–10 sentences total.`;
+
+function htmlToPlainText(html: string): string {
+  // Cheap HTML → text. Skip script/style content; collapse whitespace.
+  let text = html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, " ")
+    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'");
+  return text.replace(/\s+/g, " ").trim();
+}
+
+async function fetchSiteProse(url: string): Promise<string | null> {
+  const css = await extractCssFromUrl(url);
+  if (!css.fetch_ok) return null;
+  // We want the raw HTML to strip prose. extractCssFromUrl doesn't
+  // expose it; fetch once more (cached at the host's cache layer).
+  // Cheap: one extra request, both go through the same fetch wrapper.
+  try {
+    const res = await fetch(url, {
+      headers: {
+        "user-agent":
+          "Opollo-Site-Builder/1.0 (+https://opollo.com) Tone-Extraction",
+      },
+    });
+    if (!res.ok) return null;
+    const html = await res.text();
+    const prose = htmlToPlainText(html);
+    return prose.slice(0, 6000);
+  } catch {
+    return null;
+  }
+}
+
+function buildUserMessage(
+  inputs: ToneInputs,
+  fetchedProse: string | null,
+): string {
+  const styleSeed = buildStyleGuide(
+    inputs.personality,
+    inputs.avoid,
+    inputs.target_audience,
+    inputs.admired_brand,
+  );
+  const lines: string[] = [];
+  lines.push(`Industry: ${inputs.industry}`);
+  if (inputs.target_audience) {
+    lines.push(`Target audience (operator-supplied): ${inputs.target_audience}`);
+  }
+  if (inputs.admired_brand) {
+    lines.push(`Admired brand (style reference): ${inputs.admired_brand}`);
+  }
+  if (inputs.personality.length > 0) {
+    lines.push(`Personality multi-select: ${inputs.personality.join(", ")}`);
+  }
+  if (inputs.avoid.length > 0) {
+    lines.push(`Never-sound-like multi-select: ${inputs.avoid.join(", ")}`);
+  }
+  if (styleSeed) {
+    lines.push("");
+    lines.push("Multi-select prose seed (include verbatim in style_guide):");
+    lines.push(styleSeed);
+  }
+  if (inputs.sample_copy) {
+    lines.push("");
+    lines.push("Pasted sample copy:");
+    lines.push(inputs.sample_copy.slice(0, 4000));
+  }
+  if (fetchedProse) {
+    lines.push("");
+    lines.push("Fetched existing content (truncated):");
+    lines.push(fetchedProse);
+  }
+  lines.push("");
+  lines.push(
+    "Produce the JSON now. The samples MUST follow the resulting tone_of_voice consistently.",
+  );
+  return lines.join("\n");
+}
+
+function idempotencyKey(siteId: string, inputs: ToneInputs, attempt: number): string {
+  const json = JSON.stringify({
+    industry: inputs.industry,
+    url: inputs.existing_content_url ?? "",
+    sample: (inputs.sample_copy ?? "").slice(0, 200),
+    audience: inputs.target_audience ?? "",
+    p: inputs.personality,
+    a: inputs.avoid,
+    brand: inputs.admired_brand ?? "",
+  });
+  let h = 0;
+  for (let i = 0; i < json.length; i++) h = (h * 31 + json.charCodeAt(i)) | 0;
+  return `tone:${siteId}:${Math.abs(h).toString(36)}:${attempt}`;
+}
+
+export async function extractTone(
+  inputs: ToneInputs,
+  ctx: { siteId: string },
+  callOverride?: AnthropicCallFn,
+): Promise<
+  | { ok: true; data: ToneExtractionResult }
+  | { ok: false; error: { code: "GENERATION_FAILED" | "NO_INPUT"; message: string } }
+> {
+  const hasInputs =
+    Boolean(inputs.existing_content_url?.trim()) ||
+    Boolean(inputs.sample_copy?.trim()) ||
+    inputs.personality.length > 0 ||
+    inputs.avoid.length > 0 ||
+    Boolean(inputs.target_audience?.trim()) ||
+    Boolean(inputs.admired_brand?.trim());
+  if (!hasInputs) {
+    return {
+      ok: false,
+      error: {
+        code: "NO_INPUT",
+        message: "Add at least one input (URL, sample copy, or guided answers).",
+      },
+    };
+  }
+
+  let fetchedProse: string | null = null;
+  let source: ToneExtractionResult["source"] = null;
+  if (inputs.existing_content_url?.trim()) {
+    const url = inputs.existing_content_url.trim();
+    fetchedProse = await fetchSiteProse(url);
+    if (fetchedProse) {
+      source = { fetched_url: url, bytes: fetchedProse.length };
+    }
+  }
+
+  const call = callOverride ?? defaultAnthropicCall;
+  const system = TONE_SYSTEM_PROMPT;
+  const user = buildUserMessage(inputs, fetchedProse);
+
+  const tryOnce = async (attempt: number): Promise<ToneExtractionResult | string> => {
+    try {
+      const res = await call({
+        model: TONE_MODEL,
+        max_tokens: TONE_MAX_TOKENS,
+        system,
+        messages: [{ role: "user", content: user }],
+        idempotency_key: idempotencyKey(ctx.siteId, inputs, attempt),
+      });
+      const text = res.content.map((b) => b.text).join("");
+      const json = extractJsonFromOutputTags(text);
+      const parsed = ExtractionResponseSchema.safeParse(json);
+      if (!parsed.success) {
+        return `parse failed: ${parsed.error.issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join("; ")}`;
+      }
+      return {
+        tone_of_voice: parsed.data.tone_of_voice,
+        samples: parsed.data.samples,
+        source,
+      };
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  };
+
+  const first = await tryOnce(1);
+  if (typeof first !== "string") return { ok: true, data: first };
+
+  logger.warn("design-discovery.tone.attempt-1-failed", {
+    site_id: ctx.siteId,
+    error: first,
+  });
+  const second = await tryOnce(2);
+  if (typeof second !== "string") return { ok: true, data: second };
+
+  logger.error("design-discovery.tone.attempt-2-failed", {
+    site_id: ctx.siteId,
+    error: second,
+  });
+  return {
+    ok: false,
+    error: { code: "GENERATION_FAILED", message: second },
+  };
+}
+
+// Sample-only regeneration after tone is already extracted. Used by
+// the "Regenerate samples" button. Cheaper call (max_tokens 1024).
+const SAMPLE_SYSTEM_PROMPT = `You are a senior copywriter. Given a tone_of_voice JSON profile and an optional regeneration note, produce three fresh sample text blocks (hero, service, blog) consistent with the tone. Output strictly:
+
+<output>
+{
+  "samples": [
+    { "kind": "hero", "text": "..." },
+    { "kind": "service", "text": "..." },
+    { "kind": "blog", "text": "..." }
+  ]
+}
+</output>`;
+
+const SamplesOnlySchema = z.object({
+  samples: z.array(SampleSchema).length(3),
+});
+
+export async function regenerateSamples(
+  tone: ToneOfVoice,
+  feedback: string | null,
+  ctx: { siteId: string; attempt: number },
+  callOverride?: AnthropicCallFn,
+): Promise<
+  | { ok: true; samples: ToneSample[] }
+  | { ok: false; error: { code: "GENERATION_FAILED"; message: string } }
+> {
+  const call = callOverride ?? defaultAnthropicCall;
+  const lines = [
+    "tone_of_voice:",
+    JSON.stringify(tone, null, 2),
+    "",
+    feedback?.trim()
+      ? `Regeneration note (apply): ${feedback.trim()}`
+      : "Regenerate fresh samples; vary specifics from prior outputs.",
+  ];
+  try {
+    const res = await call({
+      model: TONE_MODEL,
+      max_tokens: 1024,
+      system: SAMPLE_SYSTEM_PROMPT,
+      messages: [{ role: "user", content: lines.join("\n") }],
+      idempotency_key: `tone-samples:${ctx.siteId}:${ctx.attempt}:${Date.now()}`,
+    });
+    const text = res.content.map((b) => b.text).join("");
+    const json = extractJsonFromOutputTags(text);
+    const parsed = SamplesOnlySchema.safeParse(json);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "GENERATION_FAILED",
+          message: "Parse failed.",
+        },
+      };
+    }
+    return { ok: true, samples: parsed.data.samples };
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        code: "GENERATION_FAILED",
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+}

--- a/lib/design-discovery/tone-mapping.ts
+++ b/lib/design-discovery/tone-mapping.ts
@@ -1,0 +1,82 @@
+// DESIGN-DISCOVERY — tone-of-voice multi-select → prose style guide.
+//
+// The Step-2 input surface offers two multi-selects: a "Personality"
+// list (positive markers) and a "Never sound like" list (avoidance
+// markers). The spec maps each option to a prose writing instruction;
+// we expand the operator's selections into a single style_guide
+// string before the Claude tone-extraction call so the model has the
+// hard "do this, never that" rules in front of it.
+
+export const PERSONALITY_OPTIONS = [
+  "Professional",
+  "Friendly",
+  "Technical",
+  "Straight-talking",
+  "Premium",
+  "Innovative",
+] as const;
+export type PersonalityOption = (typeof PERSONALITY_OPTIONS)[number];
+
+export const AVOID_OPTIONS = [
+  "Salesy",
+  "Jargon-heavy",
+  "Overly casual",
+  "Corporate robot",
+  "Overly technical",
+] as const;
+export type AvoidOption = (typeof AVOID_OPTIONS)[number];
+
+const PERSONALITY_MAP: Record<PersonalityOption, string> = {
+  Professional:
+    "Write in second person. Complete sentences. Avoid contractions.",
+  Friendly: "Conversational. Contractions fine. Warm but not casual.",
+  Technical:
+    "Use industry terminology. Assume reader understands IT concepts.",
+  "Straight-talking":
+    "Sentences under 20 words. No filler. Never write 'we are passionate about' or 'world-class solutions'.",
+  Premium:
+    "Elevated language. Avoid superlatives. Quality through specificity.",
+  Innovative:
+    "Forward-looking. Reference outcomes and transformation.",
+};
+
+const AVOID_MAP: Record<AvoidOption, string> = {
+  Salesy: "No urgency tactics. No 'limited time'. No exclamation marks.",
+  "Jargon-heavy":
+    "Minimise acronyms. Define technical terms on first use.",
+  "Overly casual": "No slang. No emoji. No sentence fragments for effect.",
+  "Corporate robot":
+    "No passive voice. No 'leverage', 'synergy', 'holistic'. Write like a human.",
+  "Overly technical":
+    "Lead with business outcomes, not technical specs.",
+};
+
+export function buildStyleGuide(
+  personality: PersonalityOption[],
+  avoid: AvoidOption[],
+  target_audience: string | null,
+  admired_brand: string | null,
+): string {
+  const lines: string[] = [];
+  if (target_audience && target_audience.trim()) {
+    lines.push(`Target audience: ${target_audience.trim()}.`);
+  }
+  if (personality.length > 0) {
+    lines.push("Voice rules:");
+    for (const p of personality) {
+      lines.push(`- ${p}: ${PERSONALITY_MAP[p]}`);
+    }
+  }
+  if (avoid.length > 0) {
+    lines.push("Avoid:");
+    for (const a of avoid) {
+      lines.push(`- ${a}: ${AVOID_MAP[a]}`);
+    }
+  }
+  if (admired_brand && admired_brand.trim()) {
+    lines.push(
+      `Reference style: emulate the communication style of ${admired_brand.trim()} where appropriate.`,
+    );
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
PR 8 of DESIGN-DISCOVERY. Replaces the Step-2 placeholder with the real tone-of-voice capture flow per the spec.

## What lands
- `lib/design-discovery/tone-mapping.ts` — multi-select lists + the spec's prose mapping. `buildStyleGuide()` combines target audience, personality picks, avoidance picks, and admired-brand seed into a single string the model receives verbatim.
- `lib/design-discovery/extract-tone.ts` — single Sonnet call (max_tokens 4096) returning `{ tone_of_voice, samples[] }`. Fetches the operator's existing-content URL server-side (HTML-strip to plain prose, first 6KB). Zod-validated; retry once on parse-fail; idempotency-key hashes inputs. `regenerateSamples()` is a separate cheap call (max_tokens 1024) for the regenerate button.
- `app/api/admin/sites/[id]/setup/extract-tone/route.ts` — admin-gated, Zod body matches `ToneInputs`.
- `app/api/admin/sites/[id]/setup/regenerate-tone-samples/route.ts` — POST `{ tone_of_voice, feedback, attempt }`.
- `app/api/admin/sites/[id]/setup/approve-tone/route.ts` — POST `{ tone_of_voice, approved_samples }`; persists with `approved_samples` folded into the `tone_of_voice` JSONB; flips status to `'approved'`.
- `components/ToneOfVoiceInputs.tsx` — Step-2 form: existing content URL, sample copy paste, target audience, personality multi-select, never-sound-like multi-select, admired brand. Cost line ($0.02). Tone summary panel after extraction (formality 1-5, sentence length, jargon usage, expandable style guide). Three sample cards with inline plain textarea editing (spec mandates plain). Regenerate samples textarea + 10-cap counter. Approve routes to Step 3; Skip flips `'skipped'`.
- `components/SetupWizard.tsx` — Step 2 now renders `ToneOfVoiceInputs` with industry pulled from the design brief (falls back to `'msp'` when Step 1 was skipped). Tone + samples rehydrate from `sites.tone_of_voice` so resume preserves operator state.

## Risks identified and mitigated
- **Cost vector.** Extraction is one Sonnet call (~$0.02). Regenerate samples is cheap (max_tokens 1024). Soft cap at 10 client-side. Server doesn't enforce cap — same gap as PR 7's design-refinement; flagged for follow-up.
- **External fetch.** `fetchSiteProse` runs through the same fetch wrapper as the design-extraction step (custom UA, 8s+ timeout). HTML stripping is regex-based — cheap, no DOM parser dependency.
- **Schema validation.** Both routes' inputs are Zod-validated; the model output runs through `ExtractionResponseSchema` / `SamplesOnlySchema` before return.
- **Retry idempotency.** `tone:<siteId>:<inputs-hash>:<attempt>` for tone extraction; `tone-samples:<siteId>:<attempt>:<Date.now()>` for regen — regen intentionally fresh per click since the operator wants different output each time.
- **Operator-edited samples.** The spec says edited values are saved as `tone_of_voice.approved_samples`. Approval folds the edited array into the JSONB blob exactly as edited.
- **Auth gate.** All three new routes use `requireAdminForApi({ roles: ["super_admin", "admin"] })`.
- **No DB migration.** Reuses `sites.tone_of_voice` JSONB + `tone_of_voice_status` from PR 2.
- **Prompt-injection in pasted sample copy.** The model receives operator-pasted copy in the user message. Risk: operator pastes "ignore the system prompt and …". Acceptable for v1 because the operator is admin-trusted; the model's output goes through Zod validation that constrains shape, so any injection would have to coincidentally produce valid JSON in the expected structure.

## Deliberately deferred
- **Skip → write generic MSP default `tone_of_voice` payload.** The spec calls for "uses generic MSP defaults" on skip; PR 10 implements the use-defaults-at-generation-time fallback when status is `skipped`. The DB write of a default payload on skip would just be a redundancy — same end-state for the brief runner.
- **Server-side regen cap.** Same gap as PR 7's design refinement.
- **E2E spec.** The flow needs a real Claude call or a stub; the existing PR-3 wizard spec still binds (it doesn't drive Extract).

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm run test` — runs in CI.
- [ ] `npm run test:e2e` — N/A in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)