### PR TITLE
feat(design-discovery-9): live tone application to approved homepage

### DIFF
--- a/app/api/admin/sites/[id]/setup/apply-tone/route.ts
+++ b/app/api/admin/sites/[id]/setup/apply-tone/route.ts
@@ -1,0 +1,64 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { applyToneToHomepage } from "@/lib/design-discovery/apply-tone";
+
+// POST /api/admin/sites/[id]/setup/apply-tone
+//
+// Fired by the client immediately after tone approval. Reads the
+// approved homepage + tone JSONB from the site row; rewrites only
+// the hero / CTA / first service card text via Claude; persists to
+// sites.tone_applied_homepage_html. Failure is silent — the route
+// returns ok=false but the caller falls back to the original
+// approved homepage per the spec.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function errorJson(code: string, message: string, status: number): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Site id must be a UUID.", 400);
+  }
+
+  const result = await applyToneToHomepage(params.id);
+  if (!result.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: result.error.code, message: result.error.message, retryable: false },
+        timestamp: new Date().toISOString(),
+      },
+      // 200 even on failure so the client treats it as a soft skip
+      // — the spec says "If API call fails: silently skip, show
+      // original approved concept, do not block flow or show error."
+      { status: 200 },
+    );
+  }
+
+  revalidatePath(`/admin/sites/${params.id}/setup`);
+  return NextResponse.json(
+    { ok: true, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/components/ConceptRefinementView.tsx
+++ b/components/ConceptRefinementView.tsx
@@ -311,12 +311,14 @@ export function ApprovedDesignReadout({
   siteId,
   homepageHtml,
   innerPageHtml,
+  toneAppliedHomepageHtml,
   tokens,
   onReset,
 }: {
   siteId: string;
   homepageHtml: string | null;
   innerPageHtml: string | null;
+  toneAppliedHomepageHtml?: string | null;
   tokens: Record<string, unknown> | null;
   onReset?: () => void;
 }) {
@@ -420,12 +422,20 @@ export function ApprovedDesignReadout({
         <div className="grid gap-3 md:grid-cols-2">
           <div>
             <p className="text-[10px] font-medium text-muted-foreground">
-              Homepage
+              {toneAppliedHomepageHtml
+                ? "Your design with your voice applied"
+                : "Homepage"}
             </p>
-            <div className="mt-1 h-72 overflow-hidden rounded-md border bg-muted/20">
+            <div
+              className="mt-1 h-72 overflow-hidden rounded-md border bg-muted/20"
+              data-testid="approved-design-homepage-frame"
+              data-tone-applied={
+                toneAppliedHomepageHtml ? "true" : "false"
+              }
+            >
               <iframe
                 title="Approved homepage"
-                srcDoc={homepageHtml}
+                srcDoc={toneAppliedHomepageHtml ?? homepageHtml}
                 sandbox=""
                 className="block h-full w-full"
               />

--- a/components/SetupWizard.tsx
+++ b/components/SetupWizard.tsx
@@ -249,6 +249,7 @@ function Step1({ siteId, status }: { siteId: string; status: SetupStatus }) {
             siteId={siteId}
             homepageHtml={status.homepage_concept_html}
             innerPageHtml={status.inner_page_concept_html}
+            toneAppliedHomepageHtml={status.tone_applied_homepage_html}
             tokens={status.design_tokens}
           />
         ) : (
@@ -474,39 +475,61 @@ function Step3({ siteId, status }: { siteId: string; status: SetupStatus }) {
         )
       }
       body={
-        <div className="grid gap-4 md:grid-cols-2">
-          <SummaryCard
-            heading="Design direction"
-            href={`/admin/sites/${siteId}/setup?step=1`}
-            state={status.design_direction_status}
-            details={
-              designApproved ? (
-                <DesignDirectionDetails tokens={status.design_tokens} />
-              ) : designSkipped ? (
-                <p className="text-xs text-muted-foreground">
-                  Using defaults.
+        <div className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <SummaryCard
+              heading="Design direction"
+              href={`/admin/sites/${siteId}/setup?step=1`}
+              state={status.design_direction_status}
+              details={
+                designApproved ? (
+                  <DesignDirectionDetails tokens={status.design_tokens} />
+                ) : designSkipped ? (
+                  <p className="text-xs text-muted-foreground">
+                    Using defaults.
+                  </p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">Not yet set.</p>
+                )
+              }
+            />
+            <SummaryCard
+              heading="Tone of voice"
+              href={`/admin/sites/${siteId}/setup?step=2`}
+              state={status.tone_of_voice_status}
+              details={
+                toneApproved ? (
+                  <ToneOfVoiceDetails tone={status.tone_of_voice} />
+                ) : toneSkipped ? (
+                  <p className="text-xs text-muted-foreground">
+                    Using defaults.
+                  </p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">Not yet set.</p>
+                )
+              }
+            />
+          </div>
+          {designApproved &&
+            toneApproved &&
+            status.tone_applied_homepage_html && (
+              <div
+                className="rounded-md border bg-card p-3"
+                data-testid="setup-step-3-tone-applied"
+              >
+                <p className="text-xs font-medium">
+                  Your design with your voice applied
                 </p>
-              ) : (
-                <p className="text-xs text-muted-foreground">Not yet set.</p>
-              )
-            }
-          />
-          <SummaryCard
-            heading="Tone of voice"
-            href={`/admin/sites/${siteId}/setup?step=2`}
-            state={status.tone_of_voice_status}
-            details={
-              toneApproved ? (
-                <ToneOfVoiceDetails tone={status.tone_of_voice} />
-              ) : toneSkipped ? (
-                <p className="text-xs text-muted-foreground">
-                  Using defaults.
-                </p>
-              ) : (
-                <p className="text-xs text-muted-foreground">Not yet set.</p>
-              )
-            }
-          />
+                <div className="mt-2 h-72 overflow-hidden rounded-md border bg-muted/20">
+                  <iframe
+                    title="Design + voice preview"
+                    srcDoc={status.tone_applied_homepage_html}
+                    sandbox=""
+                    className="block h-full w-full"
+                  />
+                </div>
+              </div>
+            )}
         </div>
       }
       footer={

--- a/components/ToneOfVoiceInputs.tsx
+++ b/components/ToneOfVoiceInputs.tsx
@@ -225,6 +225,13 @@ export function ToneOfVoiceInputs({
         setApproving(false);
         return;
       }
+      // Fire the live tone application as a best-effort follow-up.
+      // Silent failure per the spec — if Claude can't produce
+      // tone_applied_homepage_html, we fall back to the original
+      // approved homepage on the Done screen.
+      void fetch(`/api/admin/sites/${siteId}/setup/apply-tone`, {
+        method: "POST",
+      }).catch(() => {});
       toast.success("Tone of voice approved.");
       router.push(`/admin/sites/${siteId}/setup?step=3`);
       router.refresh();

--- a/lib/design-discovery/apply-tone.ts
+++ b/lib/design-discovery/apply-tone.ts
@@ -1,0 +1,208 @@
+import "server-only";
+
+import {
+  defaultAnthropicCall,
+  type AnthropicCallFn,
+} from "@/lib/anthropic-call";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// DESIGN-DISCOVERY — apply approved tone of voice to approved homepage.
+//
+// Runs once after tone approval (PR 9 of the workstream). Single
+// Sonnet call: rewrite ONLY the text content of the hero, CTA
+// section, and first service card. Preserve all HTML structure, CSS,
+// class names, layout, non-text content. Store result as
+// tone_applied_homepage_html. Failure is silent — caller falls
+// back to the original approved homepage_concept_html per the
+// spec.
+// ---------------------------------------------------------------------------
+
+const APPLY_TONE_MODEL = "claude-sonnet-4-6";
+const APPLY_TONE_MAX_TOKENS = 4096;
+
+interface ApplyToneInputs {
+  homepage_html: string;
+  style_guide: string;
+  approved_samples: Array<{ kind: string; text: string }>;
+}
+
+const APPLY_TONE_SYSTEM_PROMPT = `You are a senior copywriter rewriting marketing site copy to match a given tone of voice. The HTML you receive is a complete homepage; you rewrite ONLY the text content of three regions, leaving everything else byte-for-byte identical:
+
+1. Hero section (.ls-hero) — headline, subheadline, primary CTA button text
+2. CTA section (.ls-cta) — heading and button text
+3. The FIRST service card under .ls-services — title + description ONLY
+
+Do NOT change:
+- Any HTML structure, tags, attributes, class names, IDs, data attributes
+- Any inline CSS or <style> blocks
+- Any layout, spacing, colors, or non-text content
+- Any other section's text (value-prop, social proof, footer)
+- The 2nd / 3rd service cards
+- The order or structure of sections
+
+Output strictly the updated full HTML, wrapped in <output>...</output>. No JSON, no commentary, no markdown.`;
+
+function buildUserMessage(inputs: ApplyToneInputs): string {
+  const lines: string[] = [];
+  lines.push("Style guide (apply this voice):");
+  lines.push(inputs.style_guide);
+  lines.push("");
+  if (inputs.approved_samples.length > 0) {
+    lines.push("Few-shot voice examples (these have been operator-approved as on-brand):");
+    for (const s of inputs.approved_samples) {
+      lines.push(`- ${s.kind}: ${s.text}`);
+    }
+    lines.push("");
+  }
+  lines.push("Original homepage HTML (rewrite ONLY hero, CTA, first service card text — leave everything else byte-for-byte identical):");
+  lines.push("");
+  lines.push(inputs.homepage_html);
+  return lines.join("\n");
+}
+
+const OUTPUT_RE = /<output>\s*([\s\S]+?)\s*<\/output>/i;
+
+export type ApplyToneResult =
+  | { ok: true; tone_applied_html: string }
+  | { ok: false; error: { code: "GENERATION_FAILED" | "NOT_FOUND" | "INTERNAL_ERROR"; message: string } };
+
+export async function applyToneToHomepage(
+  siteId: string,
+  callOverride?: AnthropicCallFn,
+): Promise<ApplyToneResult> {
+  const supabase = getServiceRoleClient();
+
+  // Read the approved homepage + tone JSONB. Both must be present.
+  const { data, error } = await supabase
+    .from("sites")
+    .select(
+      "homepage_concept_html, tone_of_voice, design_direction_status, tone_of_voice_status",
+    )
+    .eq("id", siteId)
+    .neq("status", "removed")
+    .maybeSingle();
+  if (error) {
+    return {
+      ok: false,
+      error: { code: "INTERNAL_ERROR", message: error.message },
+    };
+  }
+  if (!data) {
+    return {
+      ok: false,
+      error: { code: "NOT_FOUND", message: `Site ${siteId} not found.` },
+    };
+  }
+  const homepage = data.homepage_concept_html as string | null;
+  const tone = data.tone_of_voice as Record<string, unknown> | null;
+  if (!homepage || !tone) {
+    // Nothing to apply — design + tone must both be approved first.
+    // Caller should have checked; we fail soft here.
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message:
+          "Cannot apply tone: homepage_concept_html or tone_of_voice missing.",
+      },
+    };
+  }
+  const styleGuide =
+    typeof tone.style_guide === "string" ? tone.style_guide : "";
+  const samples = Array.isArray(tone.approved_samples)
+    ? (tone.approved_samples as Array<{ kind?: unknown; text?: unknown }>)
+        .filter(
+          (s): s is { kind: string; text: string } =>
+            typeof s === "object" &&
+            s !== null &&
+            typeof (s as { kind?: unknown }).kind === "string" &&
+            typeof (s as { text?: unknown }).text === "string",
+        )
+        .map((s) => ({ kind: s.kind, text: s.text }))
+    : [];
+  if (!styleGuide) {
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "tone_of_voice.style_guide is empty; nothing to apply.",
+      },
+    };
+  }
+
+  const call = callOverride ?? defaultAnthropicCall;
+  let text: string;
+  try {
+    const res = await call({
+      model: APPLY_TONE_MODEL,
+      max_tokens: APPLY_TONE_MAX_TOKENS,
+      system: APPLY_TONE_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: buildUserMessage({
+            homepage_html: homepage,
+            style_guide: styleGuide,
+            approved_samples: samples,
+          }),
+        },
+      ],
+      idempotency_key: `apply-tone:${siteId}:${homepage.length}:${styleGuide.length}`,
+    });
+    text = res.content.map((b) => b.text).join("");
+  } catch (err) {
+    logger.warn("design-discovery.apply-tone.call-failed", {
+      site_id: siteId,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      ok: false,
+      error: {
+        code: "GENERATION_FAILED",
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+
+  const m = OUTPUT_RE.exec(text);
+  const html = (m ? m[1] : text).trim();
+  if (!html || html.length < 100 || !/<section[^>]*class="[^"]*ls-hero/i.test(html)) {
+    logger.warn("design-discovery.apply-tone.unparsable", {
+      site_id: siteId,
+      output_bytes: html.length,
+    });
+    return {
+      ok: false,
+      error: {
+        code: "GENERATION_FAILED",
+        message: "Output failed sanity check (missing ls-hero section or too short).",
+      },
+    };
+  }
+
+  const upd = await supabase
+    .from("sites")
+    .update({
+      tone_applied_homepage_html: html,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", siteId)
+    .neq("status", "removed")
+    .select("id")
+    .maybeSingle();
+  if (upd.error) {
+    return {
+      ok: false,
+      error: { code: "INTERNAL_ERROR", message: upd.error.message },
+    };
+  }
+  if (!upd.data) {
+    return {
+      ok: false,
+      error: { code: "NOT_FOUND", message: `Site ${siteId} not found.` },
+    };
+  }
+  return { ok: true, tone_applied_html: html };
+}

--- a/lib/site-setup.ts
+++ b/lib/site-setup.ts
@@ -31,6 +31,7 @@ export interface SetupStatus {
   design_tokens: Record<string, unknown> | null;
   homepage_concept_html: string | null;
   inner_page_concept_html: string | null;
+  tone_applied_homepage_html: string | null;
   tone_of_voice: Record<string, unknown> | null;
 }
 
@@ -45,7 +46,7 @@ export async function getSetupStatus(
   const { data, error } = await supabase
     .from("sites")
     .select(
-      "design_direction_status, tone_of_voice_status, design_brief, design_tokens, homepage_concept_html, inner_page_concept_html, tone_of_voice",
+      "design_direction_status, tone_of_voice_status, design_brief, design_tokens, homepage_concept_html, inner_page_concept_html, tone_applied_homepage_html, tone_of_voice",
     )
     .eq("id", siteId)
     .neq("status", "removed")
@@ -77,6 +78,8 @@ export async function getSetupStatus(
       design_tokens: (data.design_tokens as Record<string, unknown> | null) ?? null,
       homepage_concept_html: (data.homepage_concept_html as string | null) ?? null,
       inner_page_concept_html: (data.inner_page_concept_html as string | null) ?? null,
+      tone_applied_homepage_html:
+        (data.tone_applied_homepage_html as string | null) ?? null,
       tone_of_voice: (data.tone_of_voice as Record<string, unknown> | null) ?? null,
     },
   };


### PR DESCRIPTION
PR 9 of DESIGN-DISCOVERY. Runs immediately after tone approval (PR 8). Single Sonnet call rewrites ONLY the hero, CTA section, and first service card text in the approved `homepage_concept_html`, preserving all structure / class names / inline CSS / layout. Result persists as `sites.tone_applied_homepage_html`. Failure is silent per the spec.

## What lands
- `lib/design-discovery/apply-tone.ts` — `applyToneToHomepage()` reads the approved homepage + tone JSONB, builds a focused system prompt that explicitly forbids changing structure / classes / non-text content, fires one Sonnet call (`max_tokens=4096`), validates the output against a sanity check (must contain `ls-hero` section + > 100 chars), persists. Soft-fails on parse / API errors.
- `app/api/admin/sites/[id]/setup/apply-tone/route.ts` — admin-gated POST. Always returns HTTP 200 (success or soft fail) so the client treats apply-tone as best-effort per the spec ("If API call fails: silently skip").
- `components/ToneOfVoiceInputs.tsx` — `onApprove` fires apply-tone fire-and-forget after the approval write succeeds.
- `components/ConceptRefinementView.tsx` — `ApprovedDesignReadout` accepts `toneAppliedHomepageHtml`; when present, the homepage iframe renders that with the label "Your design with your voice applied".
- `components/SetupWizard.tsx` — Step 1 readout passes the tone-applied html through. Step 3 done screen renders an additional preview block when both steps are approved AND the tone-applied html exists.
- `lib/site-setup.ts` — `getSetupStatus` also loads `tone_applied_homepage_html` for one-round-trip render.

## Risks identified and mitigated
- **Model breaks structure / class names.** The system prompt is explicit ("Do NOT change … HTML structure, class names, IDs, attributes"). Output sanity check requires `ls-hero` to survive — if it doesn't, we soft-fail and keep the original. Diff-level structural validation (DOM parse + compare) is overkill for v1 and would require shipping a parser dependency.
- **Cost.** One Sonnet call per tone approval; ~$0.05 max. No retry — if it fails, we fall back to the original homepage.
- **Race with reset.** If an operator resets the design between approve-tone and the apply-tone follow-up, the read of `homepage_concept_html` returns null and the route returns soft-fail. No partial state.
- **Database write.** Single UPDATE; either lands or doesn't.
- **Idempotency-key.** `apply-tone:<siteId>:<homepage.length>:<styleGuide.length>` — stable across same approval, fresh after reset (which re-generates homepage with different length).
- **Auth gate.** Admin-only.
- **No DB migration.** Reuses `sites.tone_applied_homepage_html` from PR 2.

## Deliberately deferred
- **DOM-diff structural validation.** v1 trusts the prompt + a regex sanity check. A future sweep can add a real diff if we see structural drift in production.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm run test` — runs in CI.
- [ ] `npm run test:e2e` — N/A in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)