### PR TITLE
feat(design-discovery-10): generation context injection (DESIGN_CONTEXT_ENABLED flag)

### DIFF
--- a/lib/brief-runner.ts
+++ b/lib/brief-runner.ts
@@ -11,6 +11,7 @@ import {
   computeCostCents,
   isAllowedAnthropicModel,
 } from "@/lib/anthropic-pricing";
+import { buildDesignContextPrefix } from "@/lib/design-discovery/build-injection";
 import type {
   BriefPageCritiqueEntry,
   BriefPagePassKind,
@@ -551,6 +552,10 @@ type PageContext = {
   // before insert, or hard-fail if ds version is required).
   sitePrefix: string;
   designSystemVersion: string;
+  // DESIGN-DISCOVERY (PR 10) — when DESIGN_CONTEXT_ENABLED and the
+  // site has approved design + tone, this is the prefix to prepend
+  // to the system prompt. Empty string when off or unapproved.
+  designContextPrefix: string;
 };
 
 function systemPromptFor(ctx: PageContext): string {
@@ -563,6 +568,11 @@ function systemPromptFor(ctx: PageContext): string {
   // docs/INTEGRATION_MODEL_DECISION.md and
   // docs/plans/path-b-migration-parent.md.
   const parts = [
+    // DESIGN-DISCOVERY (PR 10) — design + voice context, when present.
+    // Empty string when DESIGN_CONTEXT_ENABLED is off or neither step
+    // approved. Goes BEFORE the structural rules so the model has the
+    // brand frame in mind while the rules say what to emit.
+    ctx.designContextPrefix,
     "You are a website page generator. You produce one CONTENT FRAGMENT at a time. The fragment slots into a WordPress page's content area; the host theme provides the surrounding chrome (DOCTYPE, html, head, body, nav, header, footer) and base visual tokens (palette, fonts, spacing).",
     "",
     "OUTPUT FORMAT — STRICT REQUIREMENTS:",
@@ -1459,6 +1469,11 @@ async function processPagePassLoop(
       ? String(dsRowRes.rows[0].version)
       : "";
 
+  // DESIGN-DISCOVERY (PR 10) — load the design + voice context once
+  // per page-tick. Empty string when DESIGN_CONTEXT_ENABLED is off
+  // or neither step is approved; existing behaviour preserved.
+  const designContextPrefix = await buildDesignContextPrefix(brief.site_id);
+
   // Resume pointer.
   let kindToRun: TextSequencePassKind | null = null;
   let numberToRun = 0;
@@ -1517,6 +1532,7 @@ async function processPagePassLoop(
       previousVisualCritique: null,
       sitePrefix,
       designSystemVersion,
+      designContextPrefix,
     };
 
     const isAnchorFinalPass =
@@ -1778,6 +1794,7 @@ async function processPagePassLoop(
     visualRender,
     sitePrefix,
     designSystemVersion,
+    designContextPrefix,
   );
   if (visualOutcome.fatal) {
     return visualOutcome.fatal;
@@ -1905,6 +1922,7 @@ async function runVisualReviewLoop(
   visualRender: VisualRenderFn,
   sitePrefix: string,
   designSystemVersion: string,
+  designContextPrefix: string,
 ): Promise<VisualReviewOutcome> {
   // Resolve the per-page cost ceiling. Tenant override wins; else the
   // lib default from lib/visual-review.
@@ -2087,6 +2105,7 @@ async function runVisualReviewLoop(
           previousVisualCritique: critiqueText,
           sitePrefix,
           designSystemVersion,
+          designContextPrefix,
         },
         passKind: "visual_revise",
         passNumber: i,

--- a/lib/design-discovery/build-injection.ts
+++ b/lib/design-discovery/build-injection.ts
@@ -1,0 +1,173 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// DESIGN-DISCOVERY — generation-time context injection.
+//
+// PR 10. Reads sites.{design_*, tone_of_voice*} for a given site
+// and returns a string to prepend to a generation system prompt.
+// Wrapped in the DESIGN_CONTEXT_ENABLED feature flag — when off,
+// returns the empty string and the caller's existing behaviour is
+// preserved exactly.
+//
+// Injection shape:
+//
+//   <design_context>
+//   tokens: { primary, secondary, ... }
+//   homepage_reference (truncated to 2000 chars):
+//   <html...>
+//   </design_context>
+//
+//   <voice_context>
+//   style_guide: ...
+//   on_brand_examples:
+//   - hero: ...
+//   - service: ...
+//   - blog: ...
+//   </voice_context>
+//
+// Either block is omitted entirely when its status column != 'approved'.
+//
+// Cost: typically 500–2000 additional input tokens per generation
+// call. The brief runner's per-pass token budget already accounts
+// for system-prompt growth; the M3 batch worker tracks input_tokens
+// in its cost calculator and rolls them up as you'd expect.
+// ---------------------------------------------------------------------------
+
+const HTML_TRUNCATE_BYTES = 2000;
+
+export function isDesignContextEnabled(): boolean {
+  return process.env.DESIGN_CONTEXT_ENABLED === "true";
+}
+
+interface SiteContextRow {
+  design_direction_status: string | null;
+  tone_of_voice_status: string | null;
+  design_tokens: Record<string, unknown> | null;
+  homepage_concept_html: string | null;
+  tone_applied_homepage_html: string | null;
+  tone_of_voice: Record<string, unknown> | null;
+}
+
+export async function loadSiteDesignContext(
+  siteId: string,
+): Promise<SiteContextRow | null> {
+  if (!isDesignContextEnabled()) return null;
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("sites")
+    .select(
+      "design_direction_status, tone_of_voice_status, design_tokens, homepage_concept_html, tone_applied_homepage_html, tone_of_voice",
+    )
+    .eq("id", siteId)
+    .neq("status", "removed")
+    .maybeSingle();
+  if (error) {
+    logger.warn("design-discovery.injection.load-failed", {
+      site_id: siteId,
+      message: error.message,
+    });
+    return null;
+  }
+  if (!data) return null;
+  return data as SiteContextRow;
+}
+
+function tokensSummary(tokens: Record<string, unknown> | null): string {
+  if (!tokens) return "";
+  const keep = [
+    "primary",
+    "secondary",
+    "accent",
+    "background",
+    "text",
+    "font_heading",
+    "font_body",
+    "border_radius",
+    "spacing_unit",
+  ];
+  const lines: string[] = [];
+  for (const k of keep) {
+    const v = tokens[k];
+    if (typeof v === "string") {
+      lines.push(`  ${k}: ${v}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function samplesBlock(tone: Record<string, unknown>): string {
+  const arr = tone.approved_samples;
+  if (!Array.isArray(arr)) return "";
+  const out: string[] = [];
+  for (const item of arr) {
+    if (!item || typeof item !== "object") continue;
+    const k = (item as Record<string, unknown>).kind;
+    const t = (item as Record<string, unknown>).text;
+    if (typeof t !== "string" || typeof k !== "string") continue;
+    out.push(`- ${k}: ${t}`);
+  }
+  return out.join("\n");
+}
+
+export function renderInjection(row: SiteContextRow | null): string {
+  if (!row) return "";
+  const blocks: string[] = [];
+
+  if (row.design_direction_status === "approved") {
+    const tokens = tokensSummary(row.design_tokens);
+    const refHtml =
+      row.tone_applied_homepage_html ?? row.homepage_concept_html ?? "";
+    const truncated = refHtml.slice(0, HTML_TRUNCATE_BYTES);
+    const designLines = ["<design_context>"];
+    if (tokens) {
+      designLines.push("tokens:");
+      designLines.push(tokens);
+    }
+    if (truncated) {
+      designLines.push("homepage_reference (truncated):");
+      designLines.push(truncated);
+    }
+    designLines.push("</design_context>");
+    if (designLines.length > 2) {
+      blocks.push(designLines.join("\n"));
+    }
+  }
+
+  if (
+    row.tone_of_voice_status === "approved" &&
+    row.tone_of_voice &&
+    typeof row.tone_of_voice === "object"
+  ) {
+    const tone = row.tone_of_voice;
+    const styleGuide =
+      typeof tone.style_guide === "string" ? tone.style_guide : "";
+    const samples = samplesBlock(tone);
+    const voiceLines = ["<voice_context>"];
+    if (styleGuide) {
+      voiceLines.push("style_guide:");
+      voiceLines.push(styleGuide);
+    }
+    if (samples) {
+      voiceLines.push("on_brand_examples:");
+      voiceLines.push(samples);
+    }
+    voiceLines.push("</voice_context>");
+    if (voiceLines.length > 2) {
+      blocks.push(voiceLines.join("\n"));
+    }
+  }
+
+  return blocks.length > 0 ? blocks.join("\n\n") + "\n\n" : "";
+}
+
+// Convenience: load + render in one call. Most callers want this.
+export async function buildDesignContextPrefix(
+  siteId: string,
+): Promise<string> {
+  if (!isDesignContextEnabled()) return "";
+  const row = await loadSiteDesignContext(siteId);
+  return renderInjection(row);
+}

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/design-systems";
 import { listComponents, type DesignComponent } from "@/lib/components";
 import { listTemplates, type DesignTemplate } from "@/lib/templates";
+import { buildDesignContextPrefix } from "@/lib/design-discovery/build-injection";
 import { renderRegistryBlock } from "@/lib/design-system-prompt";
 import { logger } from "@/lib/logger";
 
@@ -178,7 +179,7 @@ export async function buildSystemPromptForSite(
     design_system_updated,
   } = await resolveDesignSystemSlot(site);
 
-  return buildSystemPrompt({
+  const base = buildSystemPrompt({
     site_name: site.site_name,
     prefix: site.prefix,
     design_system_version,
@@ -191,6 +192,13 @@ export async function buildSystemPromptForSite(
     templates_list: "[]",
     session_recent_pages: "[]",
   });
+
+  // DESIGN-DISCOVERY (PR 10) — prepend the design + voice context
+  // when DESIGN_CONTEXT_ENABLED and the site has approved either
+  // step. Empty string when off or unapproved; existing behaviour
+  // preserved. Loads from the `sites` row directly.
+  const ddPrefix = site.id ? await buildDesignContextPrefix(site.id) : "";
+  return ddPrefix ? `${ddPrefix}${base}` : base;
 }
 
 // Picks which content fills {{design_system_html_full_file}} and how the


### PR DESCRIPTION
PR 10 of DESIGN-DISCOVERY. When `DESIGN_CONTEXT_ENABLED=true` AND the site has approved either Step 1 (design direction) or Step 2 (tone of voice), the generation system prompt is prepended with a `<design_context>` and/or `<voice_context>` block. Default-off so the flag flip is the operator-controlled rollout switch.

## What lands
- `lib/design-discovery/build-injection.ts` — single source of truth. `isDesignContextEnabled()`, `loadSiteDesignContext()`, `renderInjection()`, `buildDesignContextPrefix()`. Reads `sites.{design_*, tone_*}` once per generation call. Either block omitted when its status ≠ `'approved'` or when the flag is off. HTML reference truncated to 2000 chars.
- `lib/system-prompt.ts` — `buildSystemPromptForSite()` now prepends the prefix. **One change point covers** the M3 batch worker (`lib/batch-worker.ts`), the M13 regeneration worker (`lib/regeneration-worker.ts`), AND the chat route (`app/api/chat/route.ts`).
- `lib/brief-runner.ts` (M12 brief runner) — uses its own `systemPromptFor()` instead of the shared helper. Extended `PageContext` with `designContextPrefix`; loaded once per page tick at the top of `processPagePassLoop` and threaded through the pass loop + the visual review loop.

## Generation call sites covered
Searched the repo (excluding worktree backups + the optimiser module which is intentionally isolated per CLAUDE.md):

| Caller | Prompt path | Covered by |
|---|---|---|
| `lib/batch-worker.ts` (M3) | `buildSystemPromptForSite()` | system-prompt.ts change |
| `lib/regeneration-worker.ts` (M13 blog regen) | `buildSystemPromptForSite()` | system-prompt.ts change |
| `app/api/chat/route.ts` (chat) | `buildSystemPromptForSite()` | system-prompt.ts change |
| `lib/brief-runner.ts` (M12 brief runner) | `systemPromptFor(ctx)` (file-local) | brief-runner.ts change |
| `lib/brief-parser.ts` (parses uploaded briefs into pages) | N/A — operator-input parser, doesn't generate content | — |
| `lib/anthropic-caption.ts` (image alt text) | N/A — alt-text only, not content generation | — |
| `lib/design-discovery/{generate-concepts,extract-tone,apply-tone}.ts` | N/A — these PRODUCE the context, they don't consume it | — |
| Optimiser code | Out of scope per CLAUDE.md isolation rules | — |

## Risks identified and mitigated
- **Default-off.** `process.env.DESIGN_CONTEXT_ENABLED === 'true'` is the only path that loads + injects. Empty string returned otherwise; existing behaviour preserved bit-for-bit.
- **Per-call DB read.** One `SELECT` per generation call; small (eight columns of one row). Anthropic prompt caching cushions repeat runs on the same site within the day.
- **Token budget.** Estimated 500–2000 input tokens added per call when injection is active. Existing per-page cost ceilings (M3 + M12) and tenant budgets absorb the increase; if a site over-runs its ceiling because of injection, the existing failure paths fire (job/page goes to `'failed'` with `BUDGET_CEILING_HIT`).
- **Pending/skipped statuses.** Both blocks are gated on `status === 'approved'`. A site with one approved + one skipped gets only the approved block; a site with both pending gets neither, identical to flag-off behaviour.
- **HTML reference safety.** The 2000-char homepage HTML is included as plain text inside `<design_context>` tags — the model treats it as reference, not as something to copy. The system prompt remains the structural authority.
- **No DB migration.** Reuses the columns from PR 2.
- **No new external calls.** Pure server-side prompt augmentation.

## Deliberately deferred
- **Cost calculator update.** The existing `computeCostCents` reads Anthropic's `usage.input_tokens` directly from the response — the additional context tokens are already counted in `input_tokens` per the SDK contract. No code change required for accounting; the bookkeeping is already correct.
- **Per-call Langfuse metadata for the injection.** Future observability sweep — useful to see "did this run inject context, and how many tokens did it add?" — for now the system prompt size landing in the existing trace is enough signal.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm run test` — runs in CI.
- [ ] `npm run test:e2e` — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)