### PR TITLE
feat(design-discovery-11): redirect new sites to the setup wizard

### DIFF
--- a/components/SiteCreateForm.tsx
+++ b/components/SiteCreateForm.tsx
@@ -159,9 +159,14 @@ export function SiteCreateForm() {
         | null;
       if (payload?.ok) {
         toast.success("Site connected", {
-          description: `${form.name} is ready. Open it from the sites list.`,
+          description: `${form.name} — let's set up the design and tone next.`,
         });
-        router.push(`/admin/sites/${payload.data.id}`);
+        // DESIGN-DISCOVERY (PR 11) — fresh sites land on the setup
+        // wizard at Step 1 instead of the bare detail page so the
+        // operator captures design + tone before generating any
+        // pages. The wizard is skippable; resume logic returns to
+        // the right step on subsequent visits.
+        router.push(`/admin/sites/${payload.data.id}/setup?step=1`);
         return;
       }
       const message =

--- a/e2e/site-setup.spec.ts
+++ b/e2e/site-setup.spec.ts
@@ -46,11 +46,12 @@ async function createSiteAndOpenSetup(
     /Connected as/i,
   );
   await page.getByTestId("site-create-save").click();
-  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}$/);
-  const detailUrl = page.url();
-  const id = detailUrl.match(/\/admin\/sites\/([0-9a-f-]{36})/)?.[1];
-  if (!id) throw new Error(`Failed to extract site id from ${detailUrl}`);
-  await page.goto(`/admin/sites/${id}/setup`);
+  // PR 11 — fresh sites land on /setup?step=1 directly. Extract id
+  // from there; no need for a separate goto.
+  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/setup\?step=1/);
+  const url = page.url();
+  const id = url.match(/\/admin\/sites\/([0-9a-f-]{36})/)?.[1];
+  if (!id) throw new Error(`Failed to extract site id from ${url}`);
   return id;
 }
 

--- a/e2e/sites.spec.ts
+++ b/e2e/sites.spec.ts
@@ -46,7 +46,10 @@ async function createSiteViaForm(
 
   await expect(page.getByTestId("site-create-save")).toBeEnabled();
   await page.getByTestId("site-create-save").click();
-  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}$/);
+  // DESIGN-DISCOVERY (PR 11) — fresh sites now land on the setup
+  // wizard at Step 1 instead of the bare detail page. Tests that
+  // need the detail page navigate there explicitly afterwards.
+  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/setup\?step=1/);
 }
 
 test.describe("sites CRUD", () => {
@@ -85,8 +88,12 @@ test.describe("sites CRUD", () => {
       password: "abcd efgh ijkl mnop qrst uvwx",
     });
 
-    // Detail page renders the new site name.
-    await expect(page.getByRole("heading", { name: uniqueName })).toBeVisible();
+    // DESIGN-DISCOVERY (PR 11) — fresh sites land on the setup
+    // wizard at Step 1 instead of the bare detail page. The wizard
+    // heading reads "Set up <name>".
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Set up ${uniqueName}`) }),
+    ).toBeVisible();
 
     // Going back to the list shows the new row.
     await page.goto("/admin/sites");
@@ -123,9 +130,12 @@ test.describe("sites CRUD", () => {
     });
 
     // Navigate via the URL — the actions-menu Edit button on the
-    // sites list lands on the same route.
-    const detailUrl = page.url();
-    const editUrl = `${detailUrl}/edit`;
+    // sites list lands on the same route. PR 11 lands the create
+    // flow on /setup?step=1 so we extract the site id from there.
+    const wizardUrl = page.url();
+    const id = wizardUrl.match(/\/admin\/sites\/([0-9a-f-]{36})/)?.[1];
+    if (!id) throw new Error(`Failed to extract site id from ${wizardUrl}`);
+    const editUrl = `/admin/sites/${id}/edit`;
     await page.goto(editUrl);
 
     // Form pre-seeds with the existing values.


### PR DESCRIPTION
PR 11 of DESIGN-DISCOVERY. After `/admin/sites/new` saves successfully, the operator now lands on `/admin/sites/[id]/setup?step=1` instead of the bare detail page. The wizard is skippable in two clicks if the operator doesn't want the discovery flow; resume logic returns them to the right step on subsequent visits.

## What lands
- `components/SiteCreateForm.tsx` — `router.push` target swapped from `/admin/sites/[id]` to `/admin/sites/[id]/setup?step=1`. Toast description updated to match.
- `e2e/sites.spec.ts` — `createSiteViaForm` helper waits for the wizard URL. The "add site" happy path now asserts the wizard heading (`Set up <name>`); the edit-flow test extracts the site id from the wizard URL before navigating to `/edit`.
- `e2e/site-setup.spec.ts` — `createSiteAndOpenSetup` helper drops the redundant `goto` — save now lands on `/setup?step=1` directly.

## Risks identified and mitigated
- **Operator-confused-about-where-they-are.** The wizard's H1 reads "Set up <site name>" and the breadcrumbs include the site link, so operators know they can return to the detail page. Skip-for-now on each step is one click away.
- **Edit-form regression.** Edit-form behaviour is unchanged — only the create flow's `router.push` was touched. Confirmed in `EditSiteModal` / `app/admin/sites/[id]/edit/page.tsx`.
- **E2E spec breakage.** The two specs that drove the create flow were updated in this PR. Both `npm run lint` and `npm run typecheck` clean.
- **No DB migration / no API change.** Pure client-side redirect target.

## Deliberately deferred
- **Inline "skip both and continue" CTA on Step 1.** Would shave one click off the no-discovery path. Out of scope; the existing skip-skip-finish path is two clicks already.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm run test` — runs in CI.
- [ ] `npm run test:e2e` — runs in CI; both updated specs build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)