### PR TITLE
feat(design-discovery-12): setup reminder banner on site detail

### DIFF
--- a/app/admin/sites/[id]/page.tsx
+++ b/app/admin/sites/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { EditTenantBudgetButton } from "@/components/EditTenantBudgetButton";
+import { SetupReminderBanner } from "@/components/SetupReminderBanner";
 import { SiteDetailActions } from "@/components/SiteDetailActions";
 import { TenantBudgetBadge } from "@/components/TenantBudgetBadge";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -18,6 +19,7 @@ import { FileText, Layers, Sparkles, Workflow } from "lucide-react";
 import { UploadBriefButton } from "@/components/UploadBriefButton";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { listSiteBriefs } from "@/lib/briefs";
+import { getSetupStatus } from "@/lib/site-setup";
 import { getSite } from "@/lib/sites";
 import { getServiceRoleClient } from "@/lib/supabase";
 import { getTenantBudget } from "@/lib/tenant-budgets";
@@ -135,8 +137,18 @@ export default async function SiteDetailPage({
   const briefsResult = await listSiteBriefs(site.id);
   const briefs = briefsResult.ok ? briefsResult.data.briefs : [];
 
+  // DESIGN-DISCOVERY PR 12 — banner reminding the operator to run
+  // the setup wizard. Renders only when BOTH discovery statuses are
+  // 'pending'; the banner itself manages dismissal via localStorage.
+  const setupStatusResult = await getSetupStatus(site.id);
+  const needsSetupReminder =
+    setupStatusResult.ok &&
+    setupStatusResult.data.design_direction_status === "pending" &&
+    setupStatusResult.data.tone_of_voice_status === "pending";
+
   return (
     <>
+      {needsSetupReminder && <SetupReminderBanner siteId={site.id} />}
       <div className="flex items-start justify-between gap-4">
         <div>
           <Breadcrumbs

--- a/components/SetupReminderBanner.tsx
+++ b/components/SetupReminderBanner.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { Sparkles, X } from "lucide-react";
+
+// SetupReminderBanner — DESIGN-DISCOVERY PR 12.
+//
+// Renders on the site detail page when both
+// sites.design_direction_status and sites.tone_of_voice_status are
+// 'pending'. Dismissible — dismissed state lives in localStorage
+// keyed by site id (not a DB column per the spec). Returning to the
+// detail page after running through the wizard means the parent
+// server component drops needsSetup=false and the banner doesn't
+// render at all.
+
+const STORAGE_PREFIX = "opollo:design-discovery:banner-dismissed:";
+
+export function SetupReminderBanner({ siteId }: { siteId: string }) {
+  const [hidden, setHidden] = useState(true);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const dismissed = window.localStorage.getItem(`${STORAGE_PREFIX}${siteId}`);
+      setHidden(dismissed === "1");
+    } catch {
+      setHidden(false);
+    }
+  }, [siteId]);
+
+  if (hidden) return null;
+
+  function dismiss() {
+    try {
+      window.localStorage.setItem(`${STORAGE_PREFIX}${siteId}`, "1");
+    } catch {
+      // Storage quota / private mode — the dismissal won't persist
+      // across reloads but the banner closes for this session.
+    }
+    setHidden(true);
+  }
+
+  return (
+    <div
+      className="mb-4 flex flex-wrap items-start gap-3 rounded-lg border border-foreground/15 bg-foreground/5 p-3 text-sm"
+      role="status"
+      data-testid="setup-reminder-banner"
+    >
+      <Sparkles aria-hidden className="mt-0.5 h-4 w-4 shrink-0 text-foreground" />
+      <div className="min-w-0 flex-1">
+        <p className="font-medium">
+          Set up your design direction and tone of voice to improve
+          generated content quality.
+        </p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          Two skippable steps. Sets the look and voice every page we
+          generate is styled around.
+        </p>
+        <Link
+          href={`/admin/sites/${siteId}/setup`}
+          className="mt-2 inline-block text-xs font-medium underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          data-testid="setup-reminder-banner-cta"
+        >
+          Set up now →
+        </Link>
+      </div>
+      <button
+        type="button"
+        onClick={dismiss}
+        className="rounded-md p-1 text-muted-foreground transition-smooth hover:bg-foreground/10 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        aria-label="Dismiss"
+        data-testid="setup-reminder-banner-dismiss"
+      >
+        <X aria-hidden className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
PR 12 of DESIGN-DISCOVERY — final PR. Sites that haven't run the setup wizard yet (both `design_direction_status` and `tone_of_voice_status` = `'pending'`) show a dismissible banner at the top of `/admin/sites/[id]`. Existing sites pre-dating the workstream default to `'pending'` (PR 2's migration), so they're the target audience.

## What lands
- `components/SetupReminderBanner.tsx` — client component. Reads `localStorage` on mount, renders the spec's exact copy ("Set up your design direction and tone of voice to improve generated content quality.") plus a "Set up now" link and a dismiss X. Dismissed state keyed by site id (`opollo:design-discovery:banner-dismissed:<siteId>`); not a DB column per the spec.
- `app/admin/sites/[id]/page.tsx` — server component reads `getSetupStatus()` and renders the banner only when both statuses are `'pending'`. Once the operator runs even one step (status flips to `'in_progress'` / `'approved'` / `'skipped'`), the server stops rendering the banner regardless of localStorage state — so a returning operator who started setup elsewhere never sees a stale reminder.

## Risks identified and mitigated
- **localStorage quota / private mode.** Wrapped in try/catch; falls back to in-session dismissal (banner closes for the page but reappears on reload). Acceptable.
- **Banner persists after wizard completion.** Server-side guard means once any step is non-pending, the banner is gone — localStorage state is irrelevant.
- **Banner placement.** Top of the detail page, above the H1; doesn't shift the breadcrumbs, doesn't overlap the actions. Renders without the H1's surrounding flex container so the banner stretches full width.
- **No DB / API changes.** Pure UI.
- **Auth gate unchanged.** Inherits the existing `checkAdminAccess` on the detail page.

## Deliberately deferred
- **E2E spec for the banner.** Manual verification: existing site with both `'pending'` columns sees the banner; click Set up now → wizard; X click dismisses + persists across reload. Adding an E2E for a UX-only widget adds spec churn without much signal.
- **A "snooze for 7 days" option.** Spec says dismissible, not time-boxed. Out of scope.

## Self-test
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [ ] `npm run test` — runs in CI.
- [ ] `npm run test:e2e` — runs in CI; existing specs unchanged.

## Workstream summary

This is the final PR (12/12) of the DESIGN-DISCOVERY workstream. Everything ships to `main`.

| PR | Subject |
|---|---|
| 1 | Application Password help on site-add form |
| 2 | Schema migration (design_brief, tone_of_voice, statuses, …) |
| 3 | Setup wizard shell + Step 3 done screen |
| 4 | Step 1 input surface + mood board + understanding panel |
| 5 | Three-parallel concept generation + HTML normalization |
| 6 | Three-up concept review (iframe, micro UI, before/after) |
| 7 | Refinement loop + approval + reset |
| 8 | Tone of voice input + extraction + samples + approval |
| 9 | Live tone application to approved homepage |
| 10 | Generation context injection (`DESIGN_CONTEXT_ENABLED`) |
| 11 | Redirect new sites to the setup wizard |
| 12 | Setup reminder banner on site detail (this PR) |

Operator validation: spin up a fresh site → wizard opens at Step 1 → run through design + tone → finish. Set `DESIGN_CONTEXT_ENABLED=true` and run a brief / batch / blog regen → verify the system prompt includes `<design_context>` + `<voice_context>` blocks (visible in Langfuse if configured). Returning to an existing site with both statuses pending → banner shows; Set up now lands on the wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)