### PR TITLE
fix(infra): renumber colliding 0057/0058 migrations + add CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,65 @@ env:
   RUN_CI: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
 
 jobs:
+  # Fails when two files in supabase/migrations/ or supabase/rollbacks/ share
+  # the same numeric version prefix (everything before the first underscore).
+  # supabase_migrations.schema_migrations enforces UNIQUE on version, so two
+  # files with the same prefix mean `supabase db push` silently skips one of
+  # them — the missing-create_invite staging incident was a real instance.
+  migration-versions:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for duplicate migration version prefixes
+        run: |
+          set -euo pipefail
+          # Versions present on main today that collide but cannot be
+          # renumbered without an ops migration (each affected migration
+          # is already applied to at least one environment, so renaming
+          # the file would make supabase db push try to re-apply it).
+          # Each entry here needs a tracked follow-up to renumber + run
+          # supabase migration repair across staging + prod.
+          #   - 0031: 0031_email_log.sql (#286) collides with
+          #           0031_optimiser_clients.sql (#293). One of the two
+          #           is silently missing from prod. Follow-up TBD.
+          allowlist="0031"
+          fail=0
+          for dir in supabase/migrations supabase/rollbacks; do
+            [ -d "$dir" ] || continue
+            all_dupes=$(ls "$dir" | grep -E '\.sql$' | awk -F_ '{print $1}' | sort | uniq -d || true)
+            dupes=""
+            while read -r v; do
+              [ -z "$v" ] && continue
+              if grep -qFx "$v" <<< "$allowlist"; then
+                echo "::warning::$dir: version $v collides but is allow-listed (historical)."
+                continue
+              fi
+              dupes+="$v"$'\n'
+            done <<< "$all_dupes"
+            if [ -n "$dupes" ]; then
+              echo "::error::Duplicate version prefixes in $dir:"
+              while read -r v; do
+                [ -z "$v" ] && continue
+                echo "  $v collides between:"
+                ls "$dir" | grep "^${v}_" | sed 's/^/    /'
+              done <<< "$dupes"
+              fail=1
+            fi
+          done
+          if [ "$fail" = "1" ]; then
+            echo
+            echo "Each migration must have a unique numeric version prefix."
+            echo "supabase_migrations.schema_migrations enforces UNIQUE on the"
+            echo "version, so two files sharing a prefix mean supabase db push"
+            echo "silently skips one. Renumber the newer file to the next free"
+            echo "slot, and reserve the number in docs/WORK_IN_FLIGHT.md so a"
+            echo "parallel session can't grab it again."
+            exit 1
+          fi
+          echo "OK — no duplicate version prefixes (or only allow-listed ones)."
+
   typecheck:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -434,6 +434,7 @@ Log the provisioning date + vendor account IDs somewhere persistent; each rotati
    ```
    This lists `Applied` + `Local`. Any migration present in `Local` but not `Applied` is pending.
 3. **Check the deploy workflow.** `.github/workflows/deploy-migrations.yml` runs on merge to main. Look at the run for the merge commit that introduced the new migration. A failure there is the root cause (not the missing migration itself — the workflow is the gap).
+4. **Rule out a version-prefix collision.** If `supabase migration list` shows the missing migration's version as `Applied` even though the schema isn't present, two files in `supabase/migrations/` share the same numeric prefix (everything before the first `_`). `supabase_migrations.schema_migrations` enforces UNIQUE on version, so `supabase db push` records whichever ran first and silently skips the other. Run `ls supabase/migrations/ | awk -F_ '{print $1}' | sort | uniq -d` to find collisions. The CI `migration-versions` job (added in `.github/workflows/ci.yml`) blocks new collisions, but historical ones live as allow-list entries. Resolve by renumbering the unapplied file to the next free slot **and** running `supabase migration repair --status applied <new-version>` against each environment that still has the orphan recorded under the old version.
 
 **Mitigate:**
 

--- a/supabase/migrations/0063_auth_foundation_roles_and_invites.sql
+++ b/supabase/migrations/0063_auth_foundation_roles_and_invites.sql
@@ -1,4 +1,9 @@
--- 0057 — AUTH-FOUNDATION P3: super_admin tier + role rename + invites + audit log.
+-- 0063 — AUTH-FOUNDATION P3: super_admin tier + role rename + invites + audit log.
+--
+-- Renumbered from 0057 to resolve a version-prefix collision with
+-- 0057_optimiser_ab_variants_tests.sql. supabase_migrations.schema_migrations
+-- has a unique constraint on the version prefix, so two files sharing "0057"
+-- meant supabase db push silently skipped whichever one was applied second.
 --
 -- Replaces the legacy three-role enum (admin, operator, viewer) with the
 -- AUTH-FOUNDATION brief's three-role enum (super_admin, admin, user) and

--- a/supabase/migrations/0064_invite_audit_functions.sql
+++ b/supabase/migrations/0064_invite_audit_functions.sql
@@ -1,4 +1,10 @@
--- 0058 — AUTH-FOUNDATION P3.2: transactional invite + audit Postgres functions.
+-- 0064 — AUTH-FOUNDATION P3.2: transactional invite + audit Postgres functions.
+--
+-- Renumbered from 0058 to resolve a version-prefix collision with
+-- 0058_optimiser_phase_2_playbooks.sql. The collision caused supabase
+-- db push to silently skip this file on staging, leaving create_invite /
+-- revoke_invite / accept_invite missing from the DB and the invite flow
+-- failing with PGRST schema-cache errors.
 --
 -- The brief requires that every user-management action and its
 -- corresponding user_audit_log row land in a SINGLE TRANSACTION — so

--- a/supabase/rollbacks/0063_auth_foundation_roles_and_invites.down.sql
+++ b/supabase/rollbacks/0063_auth_foundation_roles_and_invites.down.sql
@@ -1,4 +1,4 @@
--- Rollback for 0057_auth_foundation_roles_and_invites.sql.
+-- Rollback for 0063_auth_foundation_roles_and_invites.sql.
 --
 -- Caveats:
 --   - The role rename viewer→user / operator→admin is data-lossy on

--- a/supabase/rollbacks/0064_invite_audit_functions.down.sql
+++ b/supabase/rollbacks/0064_invite_audit_functions.down.sql
@@ -1,4 +1,4 @@
--- Rollback for 0058_invite_audit_functions.sql.
+-- Rollback for 0064_invite_audit_functions.sql.
 
 DROP FUNCTION IF EXISTS public.accept_invite(uuid, uuid, text);
 DROP FUNCTION IF EXISTS public.revoke_invite(uuid, uuid);


### PR DESCRIPTION
## Why

Operator tried to invite a user on staging and got:
> Could not find the function public.create_invite(p_email, p_expires_at, p_invited_by, p_role, p_token_hash) in the schema cache

The function is defined in `supabase/migrations/0058_invite_audit_functions.sql` (PR #310). Function genuinely missing from the staging DB — not a stale PostgREST cache.

Root cause: two parallel work streams added migrations with colliding version prefixes:

| Version | File | PR |
|---|---|---|
| 0057 | `0057_optimiser_ab_variants_tests.sql` | #301 |
| 0057 | `0057_auth_foundation_roles_and_invites.sql` | #308 |
| 0058 | `0058_optimiser_phase_2_playbooks.sql` | #303 |
| 0058 | `0058_invite_audit_functions.sql` | #310 |

`supabase_migrations.schema_migrations` enforces UNIQUE on version. The optimiser PRs merged first, so each optimiser file was recorded as version 0057 / 0058 applied. When the auth PRs landed, `supabase db push` saw 0057 + 0058 already applied and silently skipped both auth files.

## What this PR does

1. Rename the two auth files to the next free slots (0063 / 0064) — origin/main already has 0062 (`0062_auth_foundation_2fa_schema.sql`). Headers + rollback file references updated in lockstep. Migrations use `CREATE OR REPLACE` / `CREATE TABLE` so re-applying against a DB that already has them (if any) is a no-op.
2. Add a `migration-versions` job in `.github/workflows/ci.yml` that fails any PR introducing two `.sql` files in `supabase/migrations/` or `supabase/rollbacks/` with the same numeric version prefix.
3. Add a step under the existing "Diagnose a missing-migration incident" runbook entry pointing investigators at the version-collision failure mode.

## Risks identified and mitigated

- **Auth migrations re-apply in environments that did get them.** Both files are idempotent (`CREATE OR REPLACE FUNCTION`, `CREATE INDEX IF NOT EXISTS`, etc.). Worst case is no-op + a fresh row in `schema_migrations` under the new version. Verified with the migration content; no destructive `DROP` on existing data.
- **CI gate breaks origin/main today.** Origin/main has a third historical collision: `0031_email_log.sql` (#286) vs `0031_optimiser_clients.sql` (#293). Same root cause, same pattern. The check allow-lists 0031 explicitly with a comment pointing at the follow-up needed. **Surfacing this separately:** one of those two files is silently missing from production — needs its own renumber + `supabase migration repair` across staging + prod, which I'm not bundling into this hotfix.
- **Renumbering this PR's files itself doesn't fix prod's `schema_migrations` table.** After merge, `deploy-migrations.yml` will run `supabase db push --linked --include-all` which will pick up 0063 + 0064 as new migrations and apply them. That's the intended outcome; no manual `supabase migration repair` needed for these two because the OLD versions (0057/0058 auth) were never recorded as applied — only the optimiser 0057/0058 were.

## Out of scope (follow-ups for Steven to decide)

- **0031 collision.** Separate PR needed. The renumber strategy depends on which file's migration has been silently skipped (would require querying production's `schema_migrations` to find out, plus deciding whether the missing schema can be applied via a fresh migration with a `DO $$ ... IF NOT EXISTS ... $$` guard, or via `supabase migration repair`).
- **`0031_email_log.sql` has no rollback file** in `supabase/rollbacks/`. Likely just an oversight at the time; not load-bearing for this incident, but worth catching the next time a rollback is needed.
- **Reservation discipline.** `docs/WORK_IN_FLIGHT.md` has a "Reserved migration numbers" list specifically to prevent this, but neither 0031, 0057, nor 0058 was reserved before either branch added the file. The CI gate now backstops this, but the WORK_IN_FLIGHT process itself is the first line of defence and clearly broke down across three incidents.

## Test plan

- [x] `migration-versions` CI job passes (only allow-listed 0031 collision present).
- [x] Synthetic dupe (e.g. add a second `0064_*.sql`) fails the job — verified locally.
- [ ] After merge, `deploy-migrations.yml` runs `supabase db push --linked --include-all` against the linked project and applies 0063 + 0064 cleanly.
- [ ] Operator retries the invite flow on staging and the call succeeds (no PGRST schema-cache error).