### PR TITLE
feat(optimiser): onboarding Try auto-import button (§7.5)

### DIFF
--- a/components/optimiser/OnboardingWizard.tsx
+++ b/components/optimiser/OnboardingWizard.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { TryAutoImportPanel } from "@/components/optimiser/TryAutoImportPanel";
 import type { ConnectorStatus } from "@/lib/optimiser/connector-status";
 import type { OptClient } from "@/lib/optimiser/clients";
 
@@ -739,6 +740,7 @@ function PagesStep({ client, stepStatus, setStatus, onComplete }: PagesStepProps
       <Button onClick={saveSelections} disabled={saving} variant="outline">
         {saving ? "Saving…" : "Save selections"}
       </Button>
+      <TryAutoImportPanel clientId={client.id} />
     </div>
   );
 }

--- a/components/optimiser/TryAutoImportPanel.tsx
+++ b/components/optimiser/TryAutoImportPanel.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+// Phase 1.5 follow-up — onboarding §7.5 "Try auto-import" button.
+//
+// Pastes a URL + picks a destination Site Builder site → POST
+// /api/optimiser/pages/import → file a brief + brief_run, link to the
+// brief run progress page so the operator can watch the import.
+//
+// Lives in PagesStep alongside "Add page manually" — same UI shape but
+// runs the import pipeline instead of just registering a landing page.
+
+type SiteOption = {
+  id: string;
+  name: string;
+  wp_url: string;
+  status: string;
+};
+
+export function TryAutoImportPanel({
+  clientId,
+}: {
+  clientId: string;
+}) {
+  const [sites, setSites] = useState<SiteOption[]>([]);
+  const [loadingSites, setLoadingSites] = useState(true);
+  const [siteId, setSiteId] = useState<string>("");
+  const [url, setUrl] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<
+    | { tone: "ok"; brief_id: string; brief_run_id: string; site_id: string }
+    | { tone: "err"; message: string }
+    | null
+  >(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/sites/list", { cache: "no-store" });
+        const json = await res.json();
+        if (cancelled) return;
+        if (json.ok) {
+          const list: SiteOption[] = (json.data?.sites ?? []).map(
+            (s: SiteOption) => ({
+              id: s.id,
+              name: s.name,
+              wp_url: s.wp_url,
+              status: s.status,
+            }),
+          );
+          setSites(list);
+          if (list.length > 0) setSiteId(list[0].id);
+        }
+      } finally {
+        if (!cancelled) setLoadingSites(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function submit() {
+    if (!url || !siteId) return;
+    setSubmitting(true);
+    setResult(null);
+    try {
+      const res = await fetch("/api/optimiser/pages/import", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url, client_id: clientId, site_id: siteId }),
+      });
+      const json = await res.json();
+      if (json.ok) {
+        setResult({
+          tone: "ok",
+          brief_id: json.data.brief_id as string,
+          brief_run_id: json.data.brief_run_id as string,
+          site_id: siteId,
+        });
+        setUrl("");
+      } else {
+        setResult({
+          tone: "err",
+          message: json.error?.message ?? "Import failed.",
+        });
+      }
+    } catch (err) {
+      setResult({
+        tone: "err",
+        message: err instanceof Error ? err.message : "Import failed.",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border border-dashed border-border bg-muted/40 p-4">
+      <div className="space-y-1">
+        <p className="text-sm font-medium">
+          Try auto-import (§7.5)
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Fetch the live URL, file an import-mode brief, and reverse-engineer
+          the page into the Site Builder. The brief run runs through
+          M12/M13 in full_page mode using the destination site&apos;s
+          conventions. Use the brief-run progress link to watch + approve
+          the result.
+        </p>
+      </div>
+      <div className="grid gap-2 md:grid-cols-[1fr_240px_auto]">
+        <Input
+          placeholder="https://www.example.com/landing-page"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          disabled={submitting}
+        />
+        <select
+          className="h-9 rounded-md border border-input bg-background px-2 text-sm"
+          value={siteId}
+          onChange={(e) => setSiteId(e.target.value)}
+          disabled={submitting || loadingSites || sites.length === 0}
+        >
+          {loadingSites && <option>Loading sites…</option>}
+          {!loadingSites && sites.length === 0 && (
+            <option value="">No Site Builder sites available</option>
+          )}
+          {sites.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name} ({s.status})
+            </option>
+          ))}
+        </select>
+        <Button
+          onClick={submit}
+          disabled={submitting || !url || !siteId}
+        >
+          {submitting ? "Importing…" : "Try auto-import"}
+        </Button>
+      </div>
+      {result?.tone === "ok" && (
+        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-900">
+          Import filed.{" "}
+          <a
+            href={`/admin/sites/${result.site_id}/briefs/${result.brief_id}/run`}
+            className="underline-offset-4 hover:underline"
+          >
+            Watch brief run →
+          </a>
+        </div>
+      )}
+      {result?.tone === "err" && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-900">
+          {result.message}
+        </div>
+      )}
+      {sites.length === 0 && !loadingSites && (
+        <p className="text-xs text-muted-foreground">
+          No Site Builder sites are registered yet — register one under{" "}
+          <a
+            href="/admin/sites"
+            className="underline-offset-4 hover:underline"
+          >
+            /admin/sites
+          </a>{" "}
+          before running an import.
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Phase 1.5 follow-up — wires §7.5 page-import flow into the onboarding wizard

Item 1 of 3 from issue #298's bounded UI follow-ups. The import API (\`POST /api/optimiser/pages/import\`, Slice 17) has been live since Phase 1.5 but had no UI surface during onboarding.

## What lands

- \`components/optimiser/TryAutoImportPanel.tsx\` — client component. Fetches \`/api/sites/list\` on mount to populate a destination Site Builder site dropdown. URL input + dropdown + submit. POSTs \`/api/optimiser/pages/import\` with \`{url, client_id, site_id}\` and surfaces a link to \`/admin/sites/{id}/briefs/{brief_id}/run\` on success. Empty / no-sites state directs the operator to \`/admin/sites\` to register one first.
- Wired into the \`PagesStep\` of \`OnboardingWizard\`, below the existing "Save selections" button.

## Risks identified and mitigated

- **No new API, no schema, no LLM cost** — the import endpoint already exists; this is pure UI consumption.
- **Cross-module read** — calls \`/api/sites/list\` (Site Builder, not optimiser-namespaced). Per CLAUDE.md the optimiser inherits from Site Builder; reading the site list at the API layer is consistent with how the bridge resolves \`site_id\` server-side. Not adding a parallel endpoint.
- **Auth** — \`/api/optimiser/pages/import\` already gates on \`super_admin\`/\`admin\` and rate-limits via the \`test_connection\` bucket. The button just submits to it; no client-side auth bypass.
- **Empty-sites state** — handled explicitly with a hint. Submit button disabled when no site is selected.
- **Failure surfaces** — the existing endpoint returns \`INVALID_URL\` (400), \`HTTP_ERROR\` (502), \`BODY_TOO_LARGE\` (413), \`BRIEF_INSERT_FAILED\` (500). Component surfaces \`error.message\` directly so the operator sees the real reason.

## Verification

- \`npm run typecheck\` — clean
- \`npm run lint\` — clean
- \`npm run build\` — clean

E2E for the onboarding wizard already exists (auth-foundation specs); this slice doesn't change any existing happy paths it covers. The auto-import flow itself has API-level coverage in lib/optimiser/page-import; the UI is a thin shell over that.