### PR TITLE
feat(optimiser): applied-proposal → rollout link on review screen

### DIFF
--- a/app/optimiser/proposals/[id]/page.tsx
+++ b/app/optimiser/proposals/[id]/page.tsx
@@ -6,11 +6,13 @@ import { CreateVariantButton } from "@/components/optimiser/CreateVariantButton"
 import { PastCausalDeltasPanel } from "@/components/optimiser/PastCausalDeltasPanel";
 import { PatternPriorsPanel } from "@/components/optimiser/PatternPriorsPanel";
 import { ProposalReview } from "@/components/optimiser/ProposalReview";
+import { ProposalRolloutLink } from "@/components/optimiser/ProposalRolloutLink";
 import { getClient } from "@/lib/optimiser/clients";
 import { listRecentCausalDeltasForPlaybook } from "@/lib/optimiser/causal/read-deltas";
 import { listRelevantPatterns } from "@/lib/optimiser/pattern-library/priors";
 import { getProposalWithEvidence } from "@/lib/optimiser/proposals";
 import { getLandingPage } from "@/lib/optimiser/landing-pages";
+import { getRolloutForProposal } from "@/lib/optimiser/staged-rollout/read";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 export const metadata = { title: "Optimiser · Proposal review" };
@@ -58,6 +60,12 @@ export default async function OptimiserProposalReviewPage({
     playbookId: proposal.triggering_playbook_id,
   });
 
+  // Phase 1.5 follow-up — surface the staged-rollout state for this
+  // proposal once it's been applied. Returns null until a rollout has
+  // been created (i.e. while the proposal is still pending/approved
+  // pre-apply).
+  const rollout = await getRolloutForProposal(proposal.id);
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
@@ -68,6 +76,10 @@ export default async function OptimiserProposalReviewPage({
           Status: <code>{proposal.status}</code>
         </span>
       </div>
+      <ProposalRolloutLink
+        rollout={rollout}
+        landingPageId={proposal.landing_page_id}
+      />
       <PastCausalDeltasPanel
         deltas={pastDeltas}
         playbookId={proposal.triggering_playbook_id}

--- a/components/optimiser/ProposalRolloutLink.tsx
+++ b/components/optimiser/ProposalRolloutLink.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+
+import type { RolloutRow } from "@/lib/optimiser/staged-rollout/read";
+
+// Phase 1.5 follow-up — applied-proposal → rollout link on the
+// proposal review screen. Renders a one-line state badge linking to
+// the page detail view (where StagedRolloutBanner has the full
+// breakdown). Only shows when a rollout exists for the proposal.
+
+const STATE_TONE: Record<string, string> = {
+  live: "border-blue-200 bg-blue-50 text-blue-900",
+  promoted: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  manually_promoted: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  auto_reverted: "border-red-200 bg-red-50 text-red-900",
+  failed: "border-amber-200 bg-amber-50 text-amber-900",
+};
+
+const STATE_LABEL: Record<string, string> = {
+  live: "rolling out",
+  promoted: "promoted",
+  manually_promoted: "manually promoted",
+  auto_reverted: "auto-reverted",
+  failed: "monitor failed",
+};
+
+export function ProposalRolloutLink({
+  rollout,
+  landingPageId,
+}: {
+  rollout: RolloutRow | null;
+  landingPageId: string | null;
+}) {
+  if (!rollout || !landingPageId) return null;
+  const tone = STATE_TONE[rollout.current_state] ?? STATE_TONE.live;
+  const label = STATE_LABEL[rollout.current_state] ?? rollout.current_state;
+
+  return (
+    <section
+      className={`flex flex-wrap items-center justify-between gap-3 rounded-md border px-4 py-3 text-sm ${tone}`}
+    >
+      <div>
+        <p className="font-medium">Staged rollout: {label}</p>
+        <p className="text-xs opacity-80">
+          {rollout.traffic_split_percent}% traffic · started{" "}
+          {new Date(rollout.started_at).toLocaleString()}
+          {rollout.end_reason && (
+            <>
+              {" · "}
+              {rollout.end_reason}
+            </>
+          )}
+        </p>
+      </div>
+      <Link
+        href={`/optimiser/pages/${landingPageId}`}
+        className="text-xs font-medium underline-offset-4 hover:underline"
+      >
+        View on page →
+      </Link>
+    </section>
+  );
+}

--- a/lib/optimiser/staged-rollout/read.ts
+++ b/lib/optimiser/staged-rollout/read.ts
@@ -75,6 +75,29 @@ export async function getLatestRolloutForLandingPage(
     .maybeSingle();
   if (!data) return null;
 
+  return shapeRolloutRow(data);
+}
+
+/** Returns the most recent rollout row for a specific proposal (any
+ * state), or null if no rollout was created for it. */
+export async function getRolloutForProposal(
+  proposalId: string,
+): Promise<RolloutRow | null> {
+  const supabase = getServiceRoleClient();
+  const { data } = await supabase
+    .from("opt_staged_rollouts")
+    .select(
+      "id, proposal_id, client_id, page_id, started_at, ended_at, end_reason, config_snapshot, traffic_split_percent, current_state, regression_check_results",
+    )
+    .eq("proposal_id", proposalId)
+    .order("started_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (!data) return null;
+  return shapeRolloutRow(data);
+}
+
+function shapeRolloutRow(data: Record<string, unknown>): RolloutRow {
   const evaluations = Array.isArray(data.regression_check_results)
     ? (data.regression_check_results as Array<{
         evaluated_at: string;


### PR DESCRIPTION
## Phase 1.5 follow-up — close the loop from proposal review to rollout state

Item 2 of 3 from issue #298's bounded UI follow-ups. After a proposal is approved + applied, a staged rollout is created — but the proposal review screen had no signal that this had happened or where to look. This adds a one-line linked banner.

## What lands

- \`lib/optimiser/staged-rollout/read.ts\`:
  - New \`getRolloutForProposal(proposalId)\` — sibling of \`getLatestRolloutForLandingPage\`, pulls the rollout row directly off the \`proposal_id\` foreign key.
  - \`shapeRolloutRow\` factored out so both readers share the JSON/observed parsing logic.
- \`components/optimiser/ProposalRolloutLink.tsx\` — tone-coded one-liner (blue=live, green=promoted, red=auto_reverted, amber=failed). Shows state label + traffic split + start timestamp + end_reason (when terminal) + "View on page →" link to \`/optimiser/pages/[landing_page_id]\` where \`StagedRolloutBanner\` has the full breakdown.
- Wired into \`app/optimiser/proposals/[id]/page.tsx\` between the back-link header and \`PastCausalDeltasPanel\`. Renders null when no rollout exists for the proposal, so pre-apply proposals look unchanged.

## Risks identified and mitigated

- **No schema, no LLM, no client write** — pure read of existing data.
- **Auth / RLS** — proposal review page is already gated by the optimiser auth chain; this banner inherits.
- **Null safety** — \`landingPageId\` and \`rollout\` can both be null; component returns null in either case.
- **No double-banner** — the page detail view's \`StagedRolloutBanner\` shows full metrics; this surface intentionally only shows status + link to keep the proposal review focused on review, not monitoring. Operator drills into the page if they want the full breakdown.
- **Refactor scope** — \`shapeRolloutRow\` extraction is a behaviour-preserving refactor. Existing \`getLatestRolloutForLandingPage\` callers (only the page detail view) are unaffected.

## Verification

- \`npm run typecheck\` — clean
- \`npm run lint\` — clean
- \`npm run build\` — clean