### PR TITLE
feat(optimiser): side-by-side import review (§7.5)

### DIFF
--- a/app/optimiser/imports/[brief_id]/page.tsx
+++ b/app/optimiser/imports/[brief_id]/page.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { ImportSideBySide } from "@/components/optimiser/ImportSideBySide";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { getImportDetails } from "@/lib/optimiser/page-import/read-import";
+
+export const metadata = { title: "Optimiser · Import review" };
+export const dynamic = "force-dynamic";
+
+export default async function OptimiserImportReviewPage({
+  params,
+}: {
+  params: { brief_id: string };
+}) {
+  const access = await checkAdminAccess({
+    requiredRoles: ["super_admin", "admin"],
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  const details = await getImportDetails(params.brief_id);
+  if (!details) notFound();
+
+  const briefRunHref = details.brief_run
+    ? `/admin/sites/${details.brief.site_id}/briefs/${details.brief.id}/run`
+    : null;
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-1">
+          <p className="text-xs text-muted-foreground">
+            <Link
+              href="/optimiser"
+              className="text-primary underline-offset-4 hover:underline"
+            >
+              ← Page browser
+            </Link>
+          </p>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Import review — {details.brief_page.title}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Brief status:{" "}
+            <code className="font-mono text-xs">{details.brief.status}</code>
+            {" · "}
+            {details.brief_page.word_count.toLocaleString()} words captured
+            {details.brief_page.import_source_url && (
+              <>
+                {" · "}
+                <span className="font-mono text-xs">
+                  {details.brief_page.import_source_url}
+                </span>
+              </>
+            )}
+          </p>
+        </div>
+        {briefRunHref && (
+          <Button asChild variant="outline">
+            <Link href={briefRunHref}>Brief run progress</Link>
+          </Button>
+        )}
+      </header>
+
+      <ImportSideBySide
+        cachedHtml={details.brief_page.source_text}
+        liveUrl={details.brief_page.import_source_url}
+        briefRunStatus={details.brief_run?.status ?? null}
+        briefRunHref={briefRunHref}
+        briefRunCreatedAt={details.brief_run?.created_at ?? null}
+      />
+    </div>
+  );
+}

--- a/components/optimiser/ImportSideBySide.tsx
+++ b/components/optimiser/ImportSideBySide.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+
+// Phase 1.5 follow-up — side-by-side import review (§7.5.2 step 5).
+//
+// LEFT: cached snapshot — the HTML we captured at import time, rendered
+//       via iframe srcDoc. This is what the runner will see.
+// RIGHT: live URL — what's currently at the source URL. Lets the
+//        operator detect drift between capture time and now.
+//
+// Iframe sandboxing: srcDoc rendering is sandboxed (allow-same-origin
+// off, no scripts) so the cached HTML can't reach back into our app.
+// The live URL uses a regular src; many sites set X-Frame-Options to
+// DENY/SAMEORIGIN, so a fallback link is always shown beneath.
+//
+// Rendered-import preview is a placeholder until the brief-runner
+// consumer of mode='import' lands; the brief-run status + link gets
+// the operator to the existing run progress page.
+
+export function ImportSideBySide({
+  cachedHtml,
+  liveUrl,
+  briefRunStatus,
+  briefRunHref,
+  briefRunCreatedAt,
+}: {
+  cachedHtml: string;
+  liveUrl: string | null;
+  briefRunStatus: string | null;
+  briefRunHref: string | null;
+  briefRunCreatedAt: string | null;
+}) {
+  const [showLive, setShowLive] = useState(true);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-xs text-muted-foreground">
+          Cached snapshot (left) is what the runner will reproduce. Live
+          URL (right) is the current state of the source — drift between
+          the two is operator-visible signal that the page has changed
+          since capture.
+        </p>
+        <button
+          type="button"
+          onClick={() => setShowLive((v) => !v)}
+          className="rounded-md border border-border px-3 py-1 text-xs hover:bg-muted"
+        >
+          {showLive ? "Hide live preview" : "Show live preview"}
+        </button>
+      </div>
+
+      <div className={`grid gap-4 ${showLive ? "lg:grid-cols-2" : "lg:grid-cols-1"}`}>
+        <section className="space-y-2 rounded-lg border border-border bg-card p-3">
+          <header className="flex items-center justify-between text-sm">
+            <span className="font-medium">Cached snapshot</span>
+            <span className="text-xs text-muted-foreground">
+              capture-time HTML, sandboxed
+            </span>
+          </header>
+          <iframe
+            title="Cached snapshot"
+            srcDoc={cachedHtml}
+            sandbox=""
+            className="h-[640px] w-full rounded-md border border-border bg-white"
+          />
+        </section>
+
+        {showLive && (
+          <section className="space-y-2 rounded-lg border border-border bg-card p-3">
+            <header className="flex items-center justify-between text-sm">
+              <span className="font-medium">Live URL</span>
+              {liveUrl && (
+                <a
+                  href={liveUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-xs underline-offset-4 hover:underline"
+                >
+                  open ↗
+                </a>
+              )}
+            </header>
+            {liveUrl ? (
+              <>
+                <iframe
+                  title="Live source URL"
+                  src={liveUrl}
+                  sandbox="allow-same-origin"
+                  className="h-[640px] w-full rounded-md border border-border bg-white"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Many sites set X-Frame-Options to DENY/SAMEORIGIN — if
+                  the iframe is blank, open the URL in a new tab using
+                  the link above.
+                </p>
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No source URL recorded for this import.
+              </p>
+            )}
+          </section>
+        )}
+      </div>
+
+      <section className="rounded-lg border border-dashed border-border bg-muted/40 p-4 text-sm">
+        <p className="font-medium">Rendered import</p>
+        {briefRunStatus ? (
+          <p className="mt-1 text-muted-foreground">
+            Brief run is{" "}
+            <code className="font-mono text-xs">{briefRunStatus}</code>
+            {briefRunCreatedAt && (
+              <>
+                {" "}· created {new Date(briefRunCreatedAt).toLocaleString()}
+              </>
+            )}
+            .{" "}
+            {briefRunHref && (
+              <a
+                href={briefRunHref}
+                className="underline-offset-4 hover:underline"
+              >
+                Watch run →
+              </a>
+            )}
+          </p>
+        ) : (
+          <p className="mt-1 text-muted-foreground">No brief run yet.</p>
+        )}
+        <p className="mt-2 text-xs text-muted-foreground">
+          The brief-runner consumer of mode=&apos;import&apos; lands in a
+          follow-up sub-slice. Once shipped, this panel will render the
+          Site-Builder-native output alongside the source.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/components/optimiser/TryAutoImportPanel.tsx
+++ b/components/optimiser/TryAutoImportPanel.tsx
@@ -148,10 +148,10 @@ export function TryAutoImportPanel({
         <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-900">
           Import filed.{" "}
           <a
-            href={`/admin/sites/${result.site_id}/briefs/${result.brief_id}/run`}
+            href={`/optimiser/imports/${result.brief_id}`}
             className="underline-offset-4 hover:underline"
           >
-            Watch brief run →
+            Open side-by-side review →
           </a>
         </div>
       )}

--- a/lib/optimiser/page-import/read-import.ts
+++ b/lib/optimiser/page-import/read-import.ts
@@ -1,0 +1,92 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// Read-only helper for the side-by-side import review surface.
+//
+// Given a brief_id, returns the import-mode brief_page (source HTML +
+// import_source_url) plus the brief metadata + the most recent
+// brief_run state. Side-by-side review uses this to render the cached
+// snapshot, the live URL, and the brief-run progress link.
+// ---------------------------------------------------------------------------
+
+export interface ImportReviewData {
+  brief: {
+    id: string;
+    site_id: string;
+    title: string;
+    status: string;
+    created_at: string;
+  };
+  brief_page: {
+    id: string;
+    title: string;
+    source_text: string;
+    word_count: number;
+    import_source_url: string | null;
+  };
+  brief_run: {
+    id: string;
+    status: string;
+    created_at: string;
+    started_at: string | null;
+    completed_at: string | null;
+  } | null;
+}
+
+export async function getImportDetails(
+  briefId: string,
+): Promise<ImportReviewData | null> {
+  const supabase = getServiceRoleClient();
+  const { data: brief } = await supabase
+    .from("briefs")
+    .select("id, site_id, title, status, created_at")
+    .eq("id", briefId)
+    .maybeSingle();
+  if (!brief) return null;
+
+  const { data: page } = await supabase
+    .from("brief_pages")
+    .select("id, title, source_text, word_count, import_source_url, mode")
+    .eq("brief_id", briefId)
+    .eq("mode", "import")
+    .order("ordinal", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (!page) return null;
+
+  const { data: run } = await supabase
+    .from("brief_runs")
+    .select("id, status, created_at, started_at, completed_at")
+    .eq("brief_id", briefId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  return {
+    brief: {
+      id: brief.id as string,
+      site_id: brief.site_id as string,
+      title: brief.title as string,
+      status: brief.status as string,
+      created_at: brief.created_at as string,
+    },
+    brief_page: {
+      id: page.id as string,
+      title: page.title as string,
+      source_text: page.source_text as string,
+      word_count: page.word_count as number,
+      import_source_url: (page.import_source_url as string | null) ?? null,
+    },
+    brief_run: run
+      ? {
+          id: run.id as string,
+          status: run.status as string,
+          created_at: run.created_at as string,
+          started_at: (run.started_at as string | null) ?? null,
+          completed_at: (run.completed_at as string | null) ?? null,
+        }
+      : null,
+  };
+}


### PR DESCRIPTION
## Phase 1.5 follow-up — operator review surface for imported pages

Item 3 of 3 from issue #298's bounded UI follow-ups. The import API and side-by-side button were both already wired (Slice 17 + the auto-import button merged in #338); this PR adds the actual review surface they were pointing at.

## What lands

- \`lib/optimiser/page-import/read-import.ts\` — \`getImportDetails(briefId)\` reads brief + import-mode brief_page + most recent brief_run.
- \`components/optimiser/ImportSideBySide.tsx\` — client component:
  - **Left:** cached snapshot (\`source_text\`) rendered via iframe \`srcDoc\` with strict sandbox (no \`allow-scripts\`, no \`allow-same-origin\`) so untrusted captured HTML can't reach back.
  - **Right:** live source URL (\`import_source_url\`) in a regular iframe, with an \`open ↗\` fallback link beneath because most production sites set X-Frame-Options.
  - **Bottom:** rendered-import placeholder + brief-run status + link to the existing brief-run progress page.
  - "Hide live preview" toggle for narrow screens / when X-Frame-Options blocks the right pane.
- \`app/optimiser/imports/[brief_id]/page.tsx\` — admin-gated server component (\`super_admin\`/\`admin\`). Header shows brief status, captured word count, source URL, and a button to the brief-run progress page when one exists.
- \`TryAutoImportPanel\` success message now links to \`/optimiser/imports/[brief_id]\` instead of straight to the brief-run page.

## Risks identified and mitigated

- **Untrusted captured HTML in iframe** — the cached snapshot may contain arbitrary HTML/JS from the source page. Mitigated with \`sandbox=""\` (no flags = maximal restriction: no scripts, no same-origin, no forms, no popups). Renders the page visually but can't run scripts or read parent state.
- **Iframe X-Frame-Options for live preview** — many production sites block framing. The component always shows an "open ↗" link to the source URL so the operator can fall back to a new tab. The "Hide live preview" toggle handles the case where the blank iframe is annoying.
- **Auth gate** — admin-only, matches the import API's gate. Non-admin viewers redirect.
- **No rendered-import yet** — the brief-runner consumer of \`mode='import'\` is a separate write-safety-critical sub-slice (per Slice 17 docs). This surface ships the side-by-side now and will gain the rendered preview when the runner integration lands; copy makes the placeholder explicit.
- **No schema, no LLM, no client write** — pure read of existing data.
- **Cross-module link** — the run-progress button points to \`/admin/sites/.../briefs/.../run\` (Site Builder route). That route is part of the inherited Site Builder surface per CLAUDE.md; this PR just deep-links into it, doesn't add new admin-namespace logic.

## Verification

- \`npm run typecheck\` — clean
- \`npm run lint\` — clean
- \`npm run build\` — clean