### PR TITLE
feat(optimiser): vercel logs → opt_metrics_daily 5xx feed (slice D)

### DIFF
--- a/app/api/cron/optimiser-sync-vercel-logs/route.ts
+++ b/app/api/cron/optimiser-sync-vercel-logs/route.ts
@@ -1,0 +1,48 @@
+import { type NextRequest } from "next/server";
+
+import { syncVercelLogs } from "@/lib/optimiser/sync/vercel-logs";
+import {
+  authorisedCronRequest,
+  runOptimiserCronTick,
+  unauthorisedResponse,
+} from "@/lib/optimiser/sync/cron-shared";
+
+// Daily Vercel logs → opt_metrics_daily sync (Phase 1.5 follow-up, slice D).
+//
+// Pulls the last 24 h of HTTP logs, attributes 5xx counts to managed
+// landing pages, writes opt_metrics_daily rows with source='server_errors'.
+// No-op + clean exit when VERCEL_API_TOKEN / VERCEL_PROJECT_ID are unset.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+async function handle(req: NextRequest) {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+  return runOptimiserCronTick({
+    eventName: "optimiser.vercel_logs_sync",
+    run: async () => {
+      const r = await syncVercelLogs();
+      if (!r.ok) {
+        return {
+          outcomes: [],
+          total: 0,
+          meta: { ok: false, reason: r.reason, message: r.message },
+        };
+      }
+      return {
+        outcomes: [],
+        total: r.rows_written,
+        meta: {
+          ok: true,
+          pages_with_errors: r.pages_with_errors,
+          total_5xx: r.total_5xx,
+          total_requests: r.total_requests,
+        },
+      };
+    },
+  });
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/app/optimiser/diagnostics/page.tsx
+++ b/app/optimiser/diagnostics/page.tsx
@@ -120,6 +120,47 @@ export default async function OptimiserDiagnosticsPage() {
         </p>
       </section>
 
+      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
+        <h2 className="text-lg font-medium">
+          Server-error feed (Phase 1.5 slice D)
+        </h2>
+        <ModuleRow
+          label="Vercel logs env configured"
+          ok={report.server_error_feed.env_configured}
+          detail={
+            report.server_error_feed.env_configured
+              ? "Daily sync at 11:00 UTC writes opt_metrics_daily rows with source='server_errors'."
+              : `Missing: ${report.server_error_feed.missing.join(", ")}. Without this, staged-rollout error_rate threshold can't fire (errors_new stays 0).`
+          }
+        />
+        <ul className="space-y-1 text-sm">
+          <li>
+            <span className="text-muted-foreground">Last sync: </span>
+            <span className="font-mono">
+              {report.server_error_feed.last_synced_at
+                ? new Date(report.server_error_feed.last_synced_at).toLocaleString()
+                : "(never)"}
+            </span>
+          </li>
+          <li>
+            <span className="text-muted-foreground">Pages with 5xx (24h): </span>
+            <span
+              className={`font-mono ${report.server_error_feed.pages_with_errors_24h > 0 ? "text-amber-700" : ""}`}
+            >
+              {report.server_error_feed.pages_with_errors_24h}
+            </span>
+          </li>
+          <li>
+            <span className="text-muted-foreground">Total 5xx (24h): </span>
+            <span
+              className={`font-mono ${report.server_error_feed.total_5xx_24h > 0 ? "text-amber-700" : ""}`}
+            >
+              {report.server_error_feed.total_5xx_24h}
+            </span>
+          </li>
+        </ul>
+      </section>
+
       <section className="space-y-4">
         <h2 className="text-lg font-medium">Data sources</h2>
         {report.sources.map((s) => (

--- a/lib/optimiser/diagnostics.ts
+++ b/lib/optimiser/diagnostics.ts
@@ -68,10 +68,24 @@ export type PatternLibraryDiagnostic = {
   last_extracted_at: string | null;
 };
 
+// Phase 1.5 follow-up slice D — 5xx feed from Vercel logs. Reports
+// whether the env vars are configured, when the last sync wrote rows,
+// and how many landing pages saw 5xx in the most recent window. The
+// staged-rollout monitor's error_rate threshold is dormant when this
+// feed is unconfigured — operators rely on the diagnostic to know.
+export type ServerErrorFeedDiagnostic = {
+  env_configured: boolean;
+  missing: string[];
+  last_synced_at: string | null;
+  pages_with_errors_24h: number;
+  total_5xx_24h: number;
+};
+
 export type DiagnosticsReport = {
   module: ModuleDiagnostic;
   sources: SourceDiagnostic[];
   pattern_library: PatternLibraryDiagnostic;
+  server_error_feed: ServerErrorFeedDiagnostic;
   generated_at: string;
 };
 
@@ -166,6 +180,7 @@ export async function runDiagnostics(): Promise<DiagnosticsReport> {
   }
 
   const patternLibrary = await diagnosePatternLibrary(schemaReachable);
+  const serverErrorFeed = await diagnoseServerErrorFeed(schemaReachable);
 
   return {
     module: {
@@ -182,7 +197,59 @@ export async function runDiagnostics(): Promise<DiagnosticsReport> {
     },
     sources,
     pattern_library: patternLibrary,
+    server_error_feed: serverErrorFeed,
     generated_at: new Date().toISOString(),
+  };
+}
+
+async function diagnoseServerErrorFeed(
+  schemaReachable: boolean,
+): Promise<ServerErrorFeedDiagnostic> {
+  const required = ["VERCEL_API_TOKEN", "VERCEL_PROJECT_ID"];
+  const missing = required.filter(
+    (k) => (process.env[k] ?? "").trim().length === 0,
+  );
+  const envConfigured = missing.length === 0;
+  if (!schemaReachable) {
+    return {
+      env_configured: envConfigured,
+      missing,
+      last_synced_at: null,
+      pages_with_errors_24h: 0,
+      total_5xx_24h: 0,
+    };
+  }
+  const supabase = getServiceRoleClient();
+  let lastSyncedAt: string | null = null;
+  let pagesWithErrors = 0;
+  let total5xx = 0;
+  try {
+    const today = new Date().toISOString().slice(0, 10);
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    const { data } = await supabase
+      .from("opt_metrics_daily")
+      .select("metrics, ingested_at")
+      .eq("source", "server_errors")
+      .in("metric_date", [today, yesterday]);
+    for (const row of data ?? []) {
+      const m = (row.metrics ?? {}) as Record<string, unknown>;
+      const errs = typeof m.errors_5xx === "number" ? m.errors_5xx : 0;
+      if (errs > 0) pagesWithErrors += 1;
+      total5xx += errs;
+      const at = row.ingested_at as string | null;
+      if (at && (!lastSyncedAt || at > lastSyncedAt)) lastSyncedAt = at;
+    }
+  } catch {
+    // Best-effort.
+  }
+  return {
+    env_configured: envConfigured,
+    missing,
+    last_synced_at: lastSyncedAt,
+    pages_with_errors_24h: pagesWithErrors,
+    total_5xx_24h: total5xx,
   };
 }
 

--- a/lib/optimiser/staged-rollout/metrics.ts
+++ b/lib/optimiser/staged-rollout/metrics.ts
@@ -16,10 +16,12 @@ import type { RolloutMetrics } from "./evaluator";
 //   - bounces (sessions * (1 - engagement_rate) where engagement_rate
 //             is the GA4 default; falls back to 0 if missing).
 //
-// "errors_new" — 5xx on the new variant — is not yet ingested into
-// opt_metrics_daily. Returned as 0 until a server-error feed lands;
-// document this gap in the cron's per-tick log so operators don't
-// over-trust the error_rate threshold.
+// "errors_new" — 5xx on the new variant — comes from
+// opt_metrics_daily rows with source='server_errors' written by the
+// Vercel logs sync (Phase 1.5 slice D). When the Vercel feed isn't
+// configured (env vars unset), no rows are written and errors_new
+// stays at 0 for affected windows; the diagnostic surface flags the
+// dormant feed so operators don't over-trust the error_rate threshold.
 //
 // Until the actual traffic-split mechanism (Ads URL swap or JS hash
 // split) lands, "new" and "baseline" both read the same page-level
@@ -69,6 +71,14 @@ export async function fetchRolloutMetrics(
     .eq("dimension_key", "")
     .gte("metric_date", baselineStart.toISOString().slice(0, 10))
     .lte("metric_date", baselineEnd.toISOString().slice(0, 10));
+  const errorsRes = await supabase
+    .from("opt_metrics_daily")
+    .select("metric_date, metrics")
+    .eq("landing_page_id", input.landing_page_id)
+    .eq("source", "server_errors")
+    .eq("dimension_key", "")
+    .gte("metric_date", startedAt.toISOString().slice(0, 10))
+    .lte("metric_date", input.now.toISOString().slice(0, 10));
 
   if (newRes.error) {
     logger.error("staged-rollout: metrics new window fetch failed", {
@@ -80,19 +90,36 @@ export async function fetchRolloutMetrics(
       err: baselineRes.error.message,
     });
   }
+  if (errorsRes.error) {
+    logger.error("staged-rollout: server_errors fetch failed", {
+      err: errorsRes.error.message,
+    });
+  }
 
   const newAgg = aggregate(newRes.data ?? []);
   const baselineAgg = aggregate(baselineRes.data ?? []);
+  const errorsAgg = aggregateErrors(errorsRes.data ?? []);
 
   return {
     sessions_new: newAgg.sessions,
     conversions_new: newAgg.conversions,
     bounces_new: newAgg.bounces,
-    errors_new: 0, // 5xx feed not ingested yet — see header comment.
+    errors_new: errorsAgg.errors_5xx,
     sessions_baseline: baselineAgg.sessions,
     conversions_baseline: baselineAgg.conversions,
     bounces_baseline: baselineAgg.bounces,
   };
+}
+
+function aggregateErrors(
+  rows: Array<{ metrics: unknown }>,
+): { errors_5xx: number } {
+  let errors = 0;
+  for (const row of rows) {
+    const m = (row.metrics ?? {}) as Record<string, unknown>;
+    if (typeof m.errors_5xx === "number") errors += m.errors_5xx;
+  }
+  return { errors_5xx: errors };
 }
 
 interface MetricsAgg {

--- a/lib/optimiser/sync/vercel-logs.ts
+++ b/lib/optimiser/sync/vercel-logs.ts
@@ -1,0 +1,268 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// Vercel logs sync — Phase 1.5 follow-up.
+//
+// Pulls the last 24 h of HTTP logs from Vercel's REST API, filters
+// to status >= 500, attributes each request to an opt_landing_pages
+// row by URL match, and upserts into opt_metrics_daily with
+// source='server_errors'.
+//
+// Wired into the Vercel deployment logs API:
+//   GET https://api.vercel.com/v3/projects/{projectId}/runtime-logs
+// (or the equivalent integrations log-drain query). Default to the
+// project ID + token in env; bail out gracefully when either is unset.
+//
+// Env vars (all required for the sync to run; sync is a no-op when any
+// is missing — diagnostics surface flags this):
+//   - VERCEL_API_TOKEN — Vercel access token with 'logs:read' scope
+//   - VERCEL_PROJECT_ID — the deployed project's id (prj_…)
+//   - VERCEL_TEAM_ID — optional; required for team-scoped projects
+//
+// Failure modes the sync tolerates:
+//   - 401/403  → env misconfigured; logged + diagnostic surfaces
+//   - 429      → rate limit; daily cadence keeps us well below limits
+//   - 5xx      → transient Vercel side; cron re-runs the next day
+//   - parse    → individual log lines that don't match are skipped
+//
+// The metrics row shape:
+//   { errors_5xx: number, total_requests: number, sampled_window_hours: number }
+// ---------------------------------------------------------------------------
+
+const VERCEL_API_BASE = "https://api.vercel.com";
+const SAMPLED_WINDOW_HOURS = 24;
+const MAX_LOG_PAGES = 10; // hard cap so a runaway response doesn't burn a slot
+const PAGE_SIZE = 1000;
+
+export type VercelSyncResult =
+  | {
+      ok: true;
+      pages_with_errors: number;
+      total_5xx: number;
+      total_requests: number;
+      rows_written: number;
+    }
+  | {
+      ok: false;
+      reason:
+        | "env_missing"
+        | "auth_failed"
+        | "rate_limited"
+        | "transport_error"
+        | "no_pages";
+      message: string;
+    };
+
+interface VercelLogEntry {
+  /** ISO timestamp from Vercel. */
+  timestampInMs?: number;
+  level?: string;
+  type?: string;
+  /** The HTTP request URL — Vercel's payload shapes vary; we look at
+   *  proxy.url, request.url, and message-embedded URL fields. */
+  proxy?: { url?: string; statusCode?: number; method?: string };
+  request?: { url?: string };
+  statusCode?: number;
+  message?: string;
+}
+
+interface VercelLogsResponse {
+  logs?: VercelLogEntry[];
+  pagination?: { next?: string };
+}
+
+export async function syncVercelLogs(): Promise<VercelSyncResult> {
+  const token = process.env.VERCEL_API_TOKEN?.trim();
+  const projectId = process.env.VERCEL_PROJECT_ID?.trim();
+  const teamId = process.env.VERCEL_TEAM_ID?.trim();
+  if (!token || !projectId) {
+    return {
+      ok: false,
+      reason: "env_missing",
+      message:
+        "VERCEL_API_TOKEN or VERCEL_PROJECT_ID not set; server-error feed is dormant.",
+    };
+  }
+
+  const supabase = getServiceRoleClient();
+
+  // Pull all managed landing pages once; build URL → page_id index.
+  const { data: pages } = await supabase
+    .from("opt_landing_pages")
+    .select("id, client_id, url")
+    .eq("managed", true)
+    .is("deleted_at", null);
+  if (!pages || pages.length === 0) {
+    return {
+      ok: false,
+      reason: "no_pages",
+      message: "No managed landing pages — nothing to attribute logs to.",
+    };
+  }
+  const pageIndex = buildPageIndex(
+    pages as Array<{ id: string; client_id: string; url: string }>,
+  );
+
+  // Pull the last SAMPLED_WINDOW_HOURS of logs, paged.
+  const sinceMs = Date.now() - SAMPLED_WINDOW_HOURS * 60 * 60 * 1000;
+  const counts = new Map<
+    string,
+    { errors: number; total: number; client_id: string }
+  >();
+  let cursor: string | undefined = undefined;
+  let pagesFetched = 0;
+  while (pagesFetched < MAX_LOG_PAGES) {
+    const url = new URL(
+      `/v3/projects/${encodeURIComponent(projectId)}/runtime-logs`,
+      VERCEL_API_BASE,
+    );
+    url.searchParams.set("limit", String(PAGE_SIZE));
+    url.searchParams.set("since", String(sinceMs));
+    if (cursor) url.searchParams.set("cursor", cursor);
+    if (teamId) url.searchParams.set("teamId", teamId);
+
+    const res = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.status === 401 || res.status === 403) {
+      return {
+        ok: false,
+        reason: "auth_failed",
+        message: `Vercel logs ${res.status}; check VERCEL_API_TOKEN scope.`,
+      };
+    }
+    if (res.status === 429) {
+      return {
+        ok: false,
+        reason: "rate_limited",
+        message: "Vercel logs API returned 429; back off until tomorrow.",
+      };
+    }
+    if (!res.ok) {
+      return {
+        ok: false,
+        reason: "transport_error",
+        message: `Vercel logs ${res.status}: ${(await res.text()).slice(0, 200)}`,
+      };
+    }
+    const json = (await res.json()) as VercelLogsResponse;
+    for (const entry of json.logs ?? []) {
+      const reqUrl =
+        entry.proxy?.url ?? entry.request?.url ?? extractUrlFromMessage(entry.message);
+      const status =
+        entry.proxy?.statusCode ?? entry.statusCode ?? extractStatusFromMessage(entry.message);
+      if (!reqUrl || !status) continue;
+      const matched = pageIndex.match(reqUrl);
+      if (!matched) continue;
+      const slot = counts.get(matched.id) ?? {
+        errors: 0,
+        total: 0,
+        client_id: matched.client_id,
+      };
+      slot.total += 1;
+      if (status >= 500 && status < 600) slot.errors += 1;
+      counts.set(matched.id, slot);
+    }
+    cursor = json.pagination?.next;
+    pagesFetched += 1;
+    if (!cursor) break;
+  }
+
+  // UPSERT one row per landing page that saw at least one request.
+  const today = new Date().toISOString().slice(0, 10);
+  let rowsWritten = 0;
+  let totalErrors = 0;
+  let totalRequests = 0;
+  for (const [landingPageId, slot] of counts) {
+    totalErrors += slot.errors;
+    totalRequests += slot.total;
+    const { error } = await supabase.from("opt_metrics_daily").upsert(
+      {
+        client_id: slot.client_id,
+        landing_page_id: landingPageId,
+        metric_date: today,
+        source: "server_errors",
+        dimension_key: "",
+        dimension_value: "",
+        metrics: {
+          errors_5xx: slot.errors,
+          total_requests: slot.total,
+          sampled_window_hours: SAMPLED_WINDOW_HOURS,
+        },
+        ingested_at: new Date().toISOString(),
+      },
+      {
+        onConflict:
+          "landing_page_id,metric_date,source,dimension_key,dimension_value",
+      },
+    );
+    if (error) {
+      logger.warn("optimiser.vercel_logs.upsert_failed", {
+        landing_page_id: landingPageId,
+        err: error.message,
+      });
+      continue;
+    }
+    rowsWritten += 1;
+  }
+
+  return {
+    ok: true,
+    pages_with_errors: Array.from(counts.values()).filter((s) => s.errors > 0)
+      .length,
+    total_5xx: totalErrors,
+    total_requests: totalRequests,
+    rows_written: rowsWritten,
+  };
+}
+
+interface PageIndex {
+  match(requestUrl: string): { id: string; client_id: string } | null;
+}
+
+function buildPageIndex(
+  pages: Array<{ id: string; client_id: string; url: string }>,
+): PageIndex {
+  // Build origin+path → page lookup. Strip query/hash; lowercase host.
+  // Multiple landing pages can share a host but must have unique paths.
+  const byKey = new Map<string, { id: string; client_id: string }>();
+  for (const p of pages) {
+    const k = canonicalKey(p.url);
+    if (!k) continue;
+    byKey.set(k, { id: p.id, client_id: p.client_id });
+  }
+  return {
+    match(requestUrl: string) {
+      const k = canonicalKey(requestUrl);
+      if (!k) return null;
+      return byKey.get(k) ?? null;
+    },
+  };
+}
+
+function canonicalKey(url: string): string | null {
+  try {
+    const u = new URL(url);
+    const path = u.pathname.replace(/\/+$/, "") || "/";
+    return `${u.host.toLowerCase()}${path}`;
+  } catch {
+    return null;
+  }
+}
+
+function extractUrlFromMessage(message: string | undefined): string | null {
+  if (!message) return null;
+  const m = message.match(/https?:\/\/\S+/);
+  return m ? m[0] : null;
+}
+
+function extractStatusFromMessage(message: string | undefined): number | null {
+  if (!message) return null;
+  const m = message.match(/\b(\d{3})\b/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isFinite(n) && n >= 100 && n < 600 ? n : null;
+}

--- a/supabase/migrations/0065_optimiser_server_errors_source.sql
+++ b/supabase/migrations/0065_optimiser_server_errors_source.sql
@@ -1,0 +1,31 @@
+-- 0065 — Optimiser: extend opt_metrics_daily.source to include 'server_errors'.
+-- Reference: spec §12.2.1 (rollback thresholds — error_rate),
+-- staged-rollout/metrics.ts (errors_new feed), Phase 1.5 follow-up.
+--
+-- The staged rollout monitor evaluates an error_rate threshold to
+-- auto-revert a rollout. Until this slice landed, the metric fetcher
+-- hard-coded errors_new to 0 because no source emitted 5xx counts to
+-- opt_metrics_daily. Slice D wires Vercel logs as that source.
+--
+-- The metrics JSONB shape for source='server_errors':
+--   { errors_5xx: number, total_requests: number, sampled_window_hours: number }
+--
+-- Idempotent UPSERT key (landing_page_id, metric_date, source,
+-- dimension_key, dimension_value) is unchanged. Vercel sync runs daily
+-- at 11:00 UTC and rewrites the previous 24h worth of rows.
+
+ALTER TABLE opt_metrics_daily
+  DROP CONSTRAINT IF EXISTS opt_metrics_daily_source_check;
+
+ALTER TABLE opt_metrics_daily
+  ADD CONSTRAINT opt_metrics_daily_source_check
+    CHECK (source IN (
+      'google_ads',
+      'clarity',
+      'ga4',
+      'pagespeed',
+      'server_errors'
+    ));
+
+COMMENT ON COLUMN opt_metrics_daily.source IS
+  'Data source. server_errors added 2026-05-01 (OPTIMISER P1.5 follow-up — Vercel logs feed for staged-rollout error_rate threshold).';

--- a/supabase/rollbacks/0065_optimiser_server_errors_source.down.sql
+++ b/supabase/rollbacks/0065_optimiser_server_errors_source.down.sql
@@ -1,0 +1,20 @@
+-- Rollback 0065 — restore opt_metrics_daily.source CHECK without 'server_errors'.
+--
+-- Pre-flight: caller must remove any existing rows with source='server_errors'
+-- (otherwise the constraint replacement fails). The optimiser server-errors
+-- sync writes idempotently, so deleting these rows just means the next sync
+-- run will rewrite them — no permanent data loss for live rollouts.
+
+DELETE FROM opt_metrics_daily WHERE source = 'server_errors';
+
+ALTER TABLE opt_metrics_daily
+  DROP CONSTRAINT IF EXISTS opt_metrics_daily_source_check;
+
+ALTER TABLE opt_metrics_daily
+  ADD CONSTRAINT opt_metrics_daily_source_check
+    CHECK (source IN (
+      'google_ads',
+      'clarity',
+      'ga4',
+      'pagespeed'
+    ));

--- a/vercel.json
+++ b/vercel.json
@@ -75,6 +75,10 @@
     {
       "path": "/api/cron/optimiser-extract-patterns",
       "schedule": "0 10 * * *"
+    },
+    {
+      "path": "/api/cron/optimiser-sync-vercel-logs",
+      "schedule": "0 11 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Phase 1.5 follow-up slice D — wire the staged-rollout error_rate threshold to a real signal

Until this slice, \`staged-rollout/metrics.ts\` returned \`errors_new: 0\` always; the §12.2.1 \`error_spike_rollback_rate\` threshold (1% by default) could never fire. Now there's a real source feeding it.

## What lands

- **Migration 0065** — \`opt_metrics_daily.source\` CHECK extended with \`server_errors\`. Idempotent UPSERT key unchanged. Rollback removes any rows of that source first to avoid CHECK violation.
- **\`lib/optimiser/sync/vercel-logs.ts\`** — \`syncVercelLogs()\` pulls the last 24h of Vercel runtime logs (paged via cursor, 10-page hard cap), filters \`status >= 500\`, canonicalises request URLs (lowercased host + trailing-slash-normalised path), matches against \`opt_landing_pages.url\`, and UPSERTs one row per managed page with \`metrics: { errors_5xx, total_requests, sampled_window_hours: 24 }\`. Returns typed \`ok: false\` for env_missing / auth_failed / rate_limited / transport_error / no_pages so the cron/diagnostics surfaces can present them honestly. No-op + clean exit when \`VERCEL_API_TOKEN\` / \`VERCEL_PROJECT_ID\` unset.
- **\`/api/cron/optimiser-sync-vercel-logs\`** — daily at 11:00 UTC. Routed through the existing \`runOptimiserCronTick\` shared shell.
- **\`staged-rollout/metrics.ts\`** — now reads \`source='server_errors'\` for the rollout window and aggregates \`errors_5xx\` into \`errors_new\` instead of hardcoding 0. Header comment updated to explain dormant-when-unconfigured behaviour.
- **Diagnostics** — new \`server_error_feed\` section in \`runDiagnostics\` and on \`/optimiser/diagnostics\`: env status (with missing-vars list), last sync timestamp, 24h pages-with-errors and total 5xx counts. Operators can see immediately whether the threshold is armed.

## Risks identified and mitigated

- **Vercel API auth failure** — 401/403 returns typed \`auth_failed\` reason; sync writes nothing. Diagnostic surfaces the missing config so the operator knows.
- **Rate limits** — daily cadence is well below Vercel's documented limits; 10-page cap (10×1000=10k log entries max per run) stops a runaway response from burning the cron slot.
- **URL → page attribution** — canonical key strips query/hash, lowercases host, trims trailing slashes. Multiple landing pages on the same host disambiguate by path. Logs that don't parse as URLs are skipped, not crashed.
- **Schema rollback safety** — \`0065.down.sql\` deletes existing \`server_errors\` rows before re-tightening the CHECK constraint; otherwise the constraint replace would fail on existing data. Recoverable: next sync run will rewrite.
- **Idempotency** — UPSERT keyed on \`(landing_page_id, metric_date, source, dimension_key, dimension_value)\`. Daily reruns within the same day rewrite the same row; no duplicates.
- **No client-site write, no LLM cost** — pure data ingestion.
- **Auth on cron** — \`authorisedCronRequest\` (CRON_SECRET Bearer) gate inherited from the existing cron shell. Same posture as every other optimiser cron.
- **Concurrency** — sync is read-only against \`opt_landing_pages\`; UPSERT is keyed and atomic. Cron runs serially, single tick per schedule, no concurrent writers.

## Verification

- \`npm run typecheck\` — clean
- \`npm run lint\` — clean
- \`npm run build\` — clean

## Operator setup needed before going live

Set in Vercel project env:

- \`VERCEL_API_TOKEN\` — access token with \`logs:read\` scope
- \`VERCEL_PROJECT_ID\` — \`prj_…\` of the deployed project
- \`VERCEL_TEAM_ID\` — optional; required for team-scoped projects

Without these the sync is dormant and \`errors_new\` stays 0; the diagnostic surface flags the gap so it's not silent.