### PR TITLE
fix(build): externalise ssh2/ssh2-sftp-client native addon for Vercel

### DIFF
--- a/lib/static-hosting.ts
+++ b/lib/static-hosting.ts
@@ -2,9 +2,40 @@ import "server-only";
 
 import { createHash } from "node:crypto";
 
-import Client from "ssh2-sftp-client";
+import type ClientType from "ssh2-sftp-client";
 
 import { logger } from "@/lib/logger";
+
+// ssh2-sftp-client depends on ssh2's native C++ addon (sshcrypto.node).
+// Vercel's serverless build will not bundle the native binary, and at
+// runtime the addon may also fail to load on platforms that don't ship
+// the OpenSSL headers it needs. The module is loaded lazily inside
+// writeStaticPage and any failure (build-time externalisation gap or
+// runtime loader error) is converted into a dry-run result. Production
+// SiteGround writes will only succeed in environments that resolve the
+// require — the dry-run fallback is the existing safe path.
+type SftpClientCtor = new () => ClientType;
+
+async function loadSftpClient(): Promise<
+  | { ok: true; ctor: SftpClientCtor }
+  | { ok: false; error: string }
+> {
+  try {
+    const mod = (await import("ssh2-sftp-client")) as
+      | { default: SftpClientCtor }
+      | SftpClientCtor;
+    const ctor =
+      typeof mod === "function"
+        ? (mod as SftpClientCtor)
+        : (mod.default as SftpClientCtor);
+    return { ok: true, ctor };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
 
 // ---------------------------------------------------------------------------
 // OPTIMISER PHASE 1.5 SLICE 14 — Static-file write to SiteGround.
@@ -70,7 +101,10 @@ export type StaticWriteResult =
     };
 
 export interface DryRunPayload {
-  reason: "credentials_not_configured" | "credentials_invalid";
+  reason:
+    | "credentials_not_configured"
+    | "credentials_invalid"
+    | "module_unavailable";
   missing_env_vars: string[];
   target_path: string;
   body_size: number;
@@ -149,7 +183,22 @@ export async function writeStaticPage(
 
   const target = targetPath(input);
   const archive = historyPath(input);
-  const sftp = new Client();
+
+  const loaded = await loadSftpClient();
+  if (!loaded.ok) {
+    logger.warn("static-hosting: ssh2-sftp-client unavailable, dry-running", {
+      err: loaded.error,
+      target,
+    });
+    return {
+      ok: true,
+      dry_run: true,
+      payload: buildDryRunPayload(input, "module_unavailable", [
+        "ssh2-sftp-client (native module unavailable)",
+      ]),
+    };
+  }
+  const sftp = new loaded.ctor();
 
   try {
     await sftp.connect({
@@ -231,7 +280,7 @@ function dirname(path: string): string {
   return idx > 0 ? path.slice(0, idx) : "/";
 }
 
-async function ensureDir(sftp: Client, dir: string): Promise<void> {
+async function ensureDir(sftp: ClientType, dir: string): Promise<void> {
   try {
     await sftp.mkdir(dir, true);
   } catch (err) {
@@ -244,7 +293,7 @@ async function ensureDir(sftp: Client, dir: string): Promise<void> {
   }
 }
 
-async function fileExists(sftp: Client, path: string): Promise<boolean> {
+async function fileExists(sftp: ClientType, path: string): Promise<boolean> {
   try {
     const stat = await sftp.stat(path);
     return Boolean(stat);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -68,7 +68,32 @@ const nextConfig = {
     // reaches playwright-core through `await import("playwright-core")`
     // inside defaultVisualRender; tests inject a stub render fn so the
     // import is never evaluated at test time.
-    serverComponentsExternalPackages: ["playwright-core"],
+    //
+    // ssh2 / ssh2-sftp-client: ssh2 ships a native C++ addon
+    // (sshcrypto.node) that webpack cannot bundle. Without externalising
+    // these, the Vercel build fails on `./node_modules/ssh2/lib/protocol/
+    // crypto/build/Release/sshcrypto.node`. lib/static-hosting.ts
+    // additionally guards the require with a try/catch + dry-run fallback
+    // so a runtime load failure on serverless does not break the brief
+    // runner.
+    serverComponentsExternalPackages: [
+      "playwright-core",
+      "ssh2",
+      "ssh2-sftp-client",
+    ],
+  },
+  webpack: (config, { isServer }) => {
+    // Belt-and-braces with the experimental list above: native-addon
+    // packages must not be parsed by the webpack loader graph at all.
+    if (isServer) {
+      const externals = Array.isArray(config.externals)
+        ? config.externals
+        : config.externals
+          ? [config.externals]
+          : [];
+      config.externals = [...externals, "ssh2", "ssh2-sftp-client"];
+    }
+    return config;
   },
 };
 


### PR DESCRIPTION
## Summary
- Vercel build was failing on `./node_modules/ssh2/lib/protocol/crypto/build/Release/sshcrypto.node` because webpack tried to bundle ssh2's native C++ addon. The chain is `app/api/cron/process-brief-runner/route.ts` → `lib/brief-runner.ts` → `lib/optimiser/site-builder-bridge/publish-full-page.ts` → `lib/static-hosting.ts` → `ssh2-sftp-client` → `ssh2` (.node).
- `next.config.mjs`: add `ssh2` + `ssh2-sftp-client` to `experimental.serverComponentsExternalPackages` and to the server webpack externals. webpack stops parsing the package; Node resolves the require at runtime.
- `lib/static-hosting.ts`: convert the eager `import Client from "ssh2-sftp-client"` into a dynamic import wrapped in try/catch. If the require fails (build-time externalisation gap or runtime addon load error on serverless), `writeStaticPage` returns a dry-run result with `reason='module_unavailable'` and the brief-runner pipeline continues. Same safe fallback path the existing `OPOLLO_HOSTING_HOST/USER/KEY` missing branch already takes; staging has those env vars unset so production behaviour is unchanged.

## Risks identified and mitigated
- **Real SFTP writes silently fail in environments where the addon doesn't load.** Mitigated: the dry-run payload's `reason='module_unavailable'` is distinct from `credentials_*`, so `opt_change_log.dry_run_payload.reason` makes the diagnosis visible in the change-log timeline. Operator gate sees the failure mode; this is the same gate the credentials path already relies on.
- **Webpack externalisation could be insufficient on Vercel.** Mitigated by the dynamic-import + try/catch as belt-and-braces. If the require fails at runtime, the brief-runner doesn't 500 — it dry-runs.
- **Existing test surface.** `lib/__tests__/static-hosting.test.ts` exercises the credentials-missing dry-run path. The new `module_unavailable` path is a strictly wider-aperture variant of the same fallback (returns the same `StaticWriteResult` shape with one new reason literal); call sites in `publish-full-page.ts` already discriminate on `result.dry_run` only.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (Vercel-equivalent webpack pass)
- [ ] CI green on this PR (vitest + e2e + lighthouse)
- [ ] Vercel deployment succeeds on this branch (the actual reason this PR exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)