### PR TITLE
fix(infra): renumber 0031_optimiser_clients to 0066 + deploy-migrations repair input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,11 @@ jobs:
       - name: Check for duplicate migration version prefixes
         run: |
           set -euo pipefail
-          # Versions present on main today that collide but cannot be
-          # renumbered without an ops migration (each affected migration
-          # is already applied to at least one environment, so renaming
-          # the file would make supabase db push try to re-apply it).
-          # Each entry here needs a tracked follow-up to renumber + run
-          # supabase migration repair across staging + prod.
-          #   - 0031: 0031_email_log.sql (#286) collides with
-          #           0031_optimiser_clients.sql (#293). One of the two
-          #           is silently missing from prod. Follow-up TBD.
-          allowlist="0031"
+          # Allow-list of historical version-prefix collisions that
+          # cannot be cleaned up via a simple renumber. Empty today —
+          # 0031 was renumbered to 0066 in this PR alongside the
+          # corresponding `supabase migration repair` step.
+          allowlist=""
           fail=0
           for dir in supabase/migrations supabase/rollbacks; do
             [ -d "$dir" ] || continue

--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -27,6 +27,19 @@ on:
       - "supabase/migrations/**"
       - ".github/workflows/deploy-migrations.yml"
   workflow_dispatch:
+    inputs:
+      repair_versions_applied:
+        description: |
+          Space-separated list of migration versions to mark as APPLIED
+          (without re-running their SQL) before db push. Use when a
+          migration's SQL was applied out-of-band but the
+          schema_migrations row never landed (e.g. after a
+          version-prefix collision left the table created without the
+          tracking row). Each entry maps to:
+              supabase migration repair --status applied <version> --linked
+          Leave blank for normal pushes.
+        required: false
+        default: ""
 
 concurrency:
   # Serialise runs against the same project — two concurrent
@@ -75,6 +88,17 @@ jobs:
 
       - name: Show pending migrations (diagnostic)
         run: supabase migration list --linked || true
+
+      - name: Repair flagged versions (mark applied without re-running SQL)
+        if: github.event_name == 'workflow_dispatch' && inputs.repair_versions_applied != ''
+        env:
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for v in ${{ inputs.repair_versions_applied }}; do
+            echo "Marking version $v as applied..."
+            supabase migration repair --status applied "$v" --linked
+          done
 
       - name: Push pending migrations
         env:

--- a/supabase/migrations/0066_optimiser_clients.sql
+++ b/supabase/migrations/0066_optimiser_clients.sql
@@ -1,4 +1,14 @@
--- 0031 — Optimiser: opt_clients (Slice 1 of feat/optimiser).
+-- 0066 — Optimiser: opt_clients (Slice 1 of feat/optimiser).
+--
+-- Renumbered from 0031 to resolve a version-prefix collision with
+-- 0031_email_log.sql (#286). On the first deploy-migrations run after
+-- the SUPABASE_DB_PASSWORD rotation (2026-04-30), 0031_email_log.sql
+-- successfully applied + recorded as version 0031, then this file's
+-- CREATE TABLE ran but the INSERT into schema_migrations hit the
+-- unique-version constraint. Production now has the opt_clients table
+-- created without a corresponding schema_migrations row, so this file
+-- is being marked applied via `supabase migration repair --status
+-- applied 0066` rather than re-applied.
 -- Reference: docs/Optimisation_Engine_Spec_v1.5.docx §5.1 + §3.6 + §4.6 + §11.2.
 --
 -- Design decisions encoded here:

--- a/supabase/rollbacks/0066_optimiser_clients.down.sql
+++ b/supabase/rollbacks/0066_optimiser_clients.down.sql
@@ -1,4 +1,4 @@
--- Rollback for 0031_optimiser_clients.sql
+-- Rollback for 0066_optimiser_clients.sql
 DROP POLICY IF EXISTS opt_clients_write ON opt_clients;
 DROP POLICY IF EXISTS opt_clients_read ON opt_clients;
 DROP POLICY IF EXISTS service_role_all ON opt_clients;


### PR DESCRIPTION
## Why

Follow-up to #337. After `SUPABASE_DB_PASSWORD` rotated and deploy-migrations re-ran, the run got past auth and hit the 0031 collision flagged in #337's allow-list:

```
Applying migration 0031_email_log.sql...           → success (recorded as version 0031)
Applying migration 0031_optimiser_clients.sql...   → ERROR: duplicate key value
                                                     violates unique constraint
                                                     "schema_migrations_pkey"
                                                     Key (version)=(0031) already exists.
```

`0031_optimiser_clients.sql` has `CREATE TABLE opt_clients` with no `IF NOT EXISTS`, but the SQL ran successfully — the failure was on the *next* statement (the `INSERT INTO supabase_migrations.schema_migrations`). So production now has:
- `opt_clients` table created, **not** recorded in `schema_migrations` (orphan)
- `email_log` table created, recorded as version 0031
- 0032 → 0064 (including #337's auth migrations) never applied
- `create_invite` still missing → original staging fire still active

Verified `opt_clients` exists via service-role read.

## What this PR does

1. Rename `supabase/migrations/0031_optimiser_clients.sql` → `0066_optimiser_clients.sql` (next free slot — origin/main now has up to 0065). Rollback file renumbered to match. Header updated.
2. Remove `0031` from the `migration-versions` CI allow-list — empty now.
3. Add a `repair_versions_applied` `workflow_dispatch` input to `deploy-migrations.yml`. When supplied (space-separated list of versions), the workflow runs `supabase migration repair --status applied <v> --linked` for each one before `supabase db push`. Makes "SQL applied, tracking row missing" recoverable without operator CLI work.

## Recovery procedure

Before merging, trigger deploy-migrations on this branch:

```
gh workflow run deploy-migrations.yml \
  --ref hotfix/migration-0031-collision \
  -f repair_versions_applied=0066
```

The repair step marks version 0066 as applied (matching the already-existing `opt_clients` table), then `supabase db push --include-all` applies 0032 → 0064 cleanly. After that completes successfully, merge the PR. The push-to-main trigger fires deploy-migrations again, sees everything applied, and is a no-op.

## Risks identified and mitigated

- **`migration repair` writes directly to `supabase_migrations.schema_migrations`.** The migration the repair targets (0066_optimiser_clients) has SQL that we've confirmed *already applied to prod* — table exists and was created by the failed deploy-migrations run. So marking it applied isn't a fiction; it's reconciling a partial state.
- **Re-applying 0032 → 0064 against half-applied prod.** Skimmed each: most are `CREATE TABLE` against new optimiser tables (no conflict — those tables don't exist yet), `ALTER TABLE ADD COLUMN`, or `CREATE OR REPLACE FUNCTION`. The auth migrations (0063, 0064) are pure function definitions plus role/index changes; idempotent shape. If any fails, the run aborts and we triage.
- **Workflow input is a space-separated string parsed by shell.** Risk: shell injection via `gh workflow run -f`. Mitigation: input is a string of digits + spaces; the only invocation path (`gh workflow run`) is operator-controlled, not user-controlled. Workflow is `environment: production`-gated, so a future required-reviewer rule on that environment is the second layer.
- **0066 free at branch time.** Verified — origin/main's latest is 0065 (`0065_optimiser_server_errors_source.sql`).

## Test plan

- [x] CI `migration-versions` check passes (no collisions, allow-list empty).
- [ ] `gh workflow run deploy-migrations.yml --ref hotfix/migration-0031-collision -f repair_versions_applied=0066` succeeds.
- [ ] After repair + push, `create_invite` function exists on production (verifiable with the service-role check).
- [ ] After merge, the auto-fired deploy-migrations run on main is a no-op.