### PR TITLE
chore(optimiser): consolidate sync credentials onto allow-listed env vars

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -181,24 +181,21 @@ ISTOCK_SEED_CAP_CENTS=
 # Provisioning runbook: docs/runbook/optimiser-credentials.md
 # Verify: GET /api/optimiser/diagnostics or /optimiser/diagnostics (admin)
 
-# Google Ads OAuth client + Opollo MCC developer token. All three required
-# together; missing any one → daily Ads sync skips with `skipped: true`.
-# Provision steps in the runbook above.
+# Google OAuth client + Opollo MCC developer token. The OAuth client
+# above is shared across BOTH Ads and GA4 sync — the same Cloud OAuth
+# client must have `adwords` + `analytics.readonly` scopes authorised,
+# and both `/api/optimiser/oauth/ads/callback` and
+# `/api/optimiser/oauth/ga4/callback` listed under "Authorised redirect
+# URIs". Missing client/secret → Ads + GA4 sync skip; missing developer
+# token → Ads sync skips.
 GOOGLE_ADS_CLIENT_ID=
 GOOGLE_ADS_CLIENT_SECRET=
 GOOGLE_ADS_DEVELOPER_TOKEN=
 
-# GA4 OAuth client. Either GA4_* or the GOOGLE_OAUTH_* fallback pair must
-# be set for GA4 sync. Empty → GA4 sync skips.
-GA4_CLIENT_ID=
-GA4_CLIENT_SECRET=
-GOOGLE_OAUTH_CLIENT_ID=
-GOOGLE_OAUTH_CLIENT_SECRET=
-
 # PageSpeed Insights API key (free tier, 25k queries/day). Single
 # Opollo-wide key — Clarity is the only Phase 1 source that uses
 # per-client tokens. Empty → PSI sync skips silently.
-PAGESPEED_API_KEY=
+PSI_API_KEY=
 
 # Optimiser email transport. Phase 1 ships a no-op + log_only fallback;
 # `noop` (or unset) means digests are dropped with a structured log line.

--- a/app/api/cron/optimiser-sync-pagespeed/route.ts
+++ b/app/api/cron/optimiser-sync-pagespeed/route.ts
@@ -10,8 +10,8 @@ import { syncPagespeedForClient } from "@/lib/optimiser/sync/pagespeed";
 import { logger } from "@/lib/logger";
 
 // PSI sync: weekly per landing page. PSI uses a single Opollo-wide API
-// key (PAGESPEED_API_KEY) rather than per-client credentials, so this
-// route iterates opt_clients directly rather than going through the
+// key (PSI_API_KEY) rather than per-client credentials, so this route
+// iterates opt_clients directly rather than going through the
 // credential-aware sync runner.
 
 export const runtime = "nodejs";

--- a/components/optimiser/OnboardingWizard.tsx
+++ b/components/optimiser/OnboardingWizard.tsx
@@ -753,7 +753,7 @@ function oauthErrorCopy(error: string): string {
     case "ads_oauth_not_configured":
       return "Ads OAuth env not provisioned. Contact ops to set GOOGLE_ADS_CLIENT_ID / _SECRET / _DEVELOPER_TOKEN.";
     case "ga4_oauth_not_configured":
-      return "GA4 OAuth env not provisioned. Contact ops to set GA4_CLIENT_ID / _SECRET.";
+      return "GA4 OAuth env not provisioned. Contact ops to set GOOGLE_ADS_CLIENT_ID / _SECRET (GA4 reuses the shared Google OAuth client).";
     case "ads_oauth_exchange_failed":
     case "ga4_oauth_exchange_failed":
       return "Token exchange failed. Try again; if it persists check the OAuth client config.";

--- a/docs/runbook/optimiser-credentials.md
+++ b/docs/runbook/optimiser-credentials.md
@@ -38,19 +38,15 @@ GOOGLE_ADS_DEVELOPER_TOKEN=<from MCC>
 ## 2. GA4 (refresh-token OAuth)
 
 ### What you need
-1. **OAuth client.** Same Google Cloud project as the Ads OAuth client (or a separate one — both work). The optimiser accepts either `GA4_CLIENT_ID`/`_SECRET` or `GOOGLE_OAUTH_CLIENT_ID`/`_SECRET` as a fallback so a single shared client can drive both flows.
+1. **OAuth client — same one as Ads.** Phase 1 mandates a single shared Google OAuth client across both Ads and GA4. The same Cloud OAuth client must have both `adwords` and `analytics.readonly` scopes authorised. (`GA4_CLIENT_ID`/`GOOGLE_OAUTH_CLIENT_ID` env-var fallbacks were removed — only `GOOGLE_ADS_CLIENT_ID` / `GOOGLE_ADS_CLIENT_SECRET` are read.)
 2. Enable **Google Analytics Data API v1beta** for the Cloud project (Console → Library → search "analyticsdata").
-3. Add `https://<deploy-host>/api/optimiser/oauth/ga4/callback` to the OAuth client's "Authorised redirect URIs".
+3. Add `https://<deploy-host>/api/optimiser/oauth/ga4/callback` to the OAuth client's "Authorised redirect URIs" (alongside the existing `/api/optimiser/oauth/ads/callback`).
 
-### Set the env vars
+### Env vars
+GA4 reads the same env vars Ads uses — no GA4-specific entries:
 ```
-GA4_CLIENT_ID=<from oauth client>
-GA4_CLIENT_SECRET=<from oauth client>
-```
-Or, if reusing the Ads OAuth client:
-```
-GOOGLE_OAUTH_CLIENT_ID=<shared>
-GOOGLE_OAUTH_CLIENT_SECRET=<shared>
+GOOGLE_ADS_CLIENT_ID=<shared with Ads>
+GOOGLE_ADS_CLIENT_SECRET=<shared with Ads>
 ```
 
 ### Verify
@@ -80,7 +76,7 @@ Click "Verify install" — the verifier calls Clarity's `project-live-insights` 
 
 ### Set the env var
 ```
-PAGESPEED_API_KEY=<from credentials>
+PSI_API_KEY=<from credentials>
 ```
 
 ### Verify

--- a/lib/optimiser/connector-status.ts
+++ b/lib/optimiser/connector-status.ts
@@ -177,8 +177,8 @@ export function bannerForConnector(
       return null;
     case "pagespeed":
       // PSI uses an Opollo-wide API key; per-client banner only fires
-      // if PAGESPEED_API_KEY is genuinely missing — that's a system
-      // banner, not a client banner.
+      // if PSI_API_KEY is genuinely missing — that's a system banner,
+      // not a client banner.
       return null;
   }
 }

--- a/lib/optimiser/diagnostics.ts
+++ b/lib/optimiser/diagnostics.ts
@@ -101,15 +101,17 @@ const SOURCE_ENV: Record<
     ],
   },
   ga4: {
-    required: ["GA4_CLIENT_ID", "GA4_CLIENT_SECRET"],
-    optional: ["GOOGLE_OAUTH_CLIENT_ID", "GOOGLE_OAUTH_CLIENT_SECRET"],
+    // GA4 reuses the Google Ads OAuth client (single shared client across
+    // both flows). Listed here so the diagnostic surface still reports
+    // GA4-readiness independently — they happen to share names with Ads.
+    required: ["GOOGLE_ADS_CLIENT_ID", "GOOGLE_ADS_CLIENT_SECRET"],
   },
   clarity: {
     // Clarity uses per-client tokens; no Opollo-wide env needed.
     required: [],
   },
   pagespeed: {
-    required: ["PAGESPEED_API_KEY"],
+    required: ["PSI_API_KEY"],
   },
   anthropic: {
     required: ["ANTHROPIC_API_KEY"],
@@ -122,21 +124,6 @@ function checkEnv(source: OptCredentialSource | "anthropic"): EnvCheck {
   for (const key of cfg.required) {
     const v = process.env[key];
     if (!v || v.trim().length === 0) missing.push(key);
-  }
-  // For GA4, accept the GOOGLE_OAUTH_* fallback pair as a substitute.
-  if (source === "ga4" && missing.length === cfg.required.length) {
-    const fallback = (cfg.optional ?? []).every(
-      (k) => (process.env[k] ?? "").trim().length > 0,
-    );
-    if (fallback) {
-      return {
-        name: source,
-        required: cfg.required,
-        optional: cfg.optional,
-        configured: true,
-        missing: [],
-      };
-    }
   }
   return {
     name: source,

--- a/lib/optimiser/oauth.ts
+++ b/lib/optimiser/oauth.ts
@@ -108,8 +108,8 @@ export function ga4ConsentUrl(args: {
   redirectUri: string;
   state: string;
 }): string | null {
-  const clientId =
-    process.env.GA4_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID;
+  // GA4 reuses the Google Ads OAuth client.
+  const clientId = process.env.GOOGLE_ADS_CLIENT_ID;
   if (!clientId) return null;
   const params = new URLSearchParams({
     client_id: clientId,
@@ -128,14 +128,9 @@ export async function exchangeCodeForRefreshToken(args: {
   redirectUri: string;
   source: OAuthSource;
 }): Promise<{ refresh_token: string; access_token: string } | null> {
-  const clientId =
-    args.source === "google_ads"
-      ? process.env.GOOGLE_ADS_CLIENT_ID
-      : process.env.GA4_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID;
-  const clientSecret =
-    args.source === "google_ads"
-      ? process.env.GOOGLE_ADS_CLIENT_SECRET
-      : process.env.GA4_CLIENT_SECRET ?? process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  // Both Ads and GA4 use the same Google OAuth client.
+  const clientId = process.env.GOOGLE_ADS_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_ADS_CLIENT_SECRET;
   if (!clientId || !clientSecret) return null;
   const body = new URLSearchParams({
     client_id: clientId,

--- a/lib/optimiser/sync/ga4.ts
+++ b/lib/optimiser/sync/ga4.ts
@@ -34,9 +34,12 @@ type Ga4CredentialPayload = {
 };
 
 function getOAuthEnv(): { client_id: string; client_secret: string } | null {
-  const clientId = process.env.GA4_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID;
-  const clientSecret =
-    process.env.GA4_CLIENT_SECRET ?? process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  // GA4 reuses the Google Ads OAuth client (single shared OAuth client across
+  // both flows). The Cloud OAuth client must have both `adwords` and
+  // `analytics.readonly` scopes authorised, with the GA4 callback URL added
+  // under "Authorised redirect URIs".
+  const clientId = process.env.GOOGLE_ADS_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_ADS_CLIENT_SECRET;
   if (!clientId || !clientSecret) return null;
   return { client_id: clientId, client_secret: clientSecret };
 }

--- a/lib/optimiser/sync/pagespeed.ts
+++ b/lib/optimiser/sync/pagespeed.ts
@@ -33,7 +33,7 @@ type PsiResult = {
 export async function syncPagespeedForClient(
   clientId: string,
 ): Promise<{ rows_written: number; skipped?: boolean }> {
-  const apiKey = process.env.PAGESPEED_API_KEY;
+  const apiKey = process.env.PSI_API_KEY;
   if (!apiKey) {
     return { rows_written: 0, skipped: true };
   }

--- a/lib/optimiser/verify-connector.ts
+++ b/lib/optimiser/verify-connector.ts
@@ -209,10 +209,9 @@ export async function verifyClarity(clientId: string): Promise<VerifyResult> {
 }
 
 export async function verifyGa4(clientId: string): Promise<VerifyResult> {
-  const oauthClient =
-    process.env.GA4_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID;
-  const oauthSecret =
-    process.env.GA4_CLIENT_SECRET ?? process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  // GA4 reuses the shared Google Ads OAuth client.
+  const oauthClient = process.env.GOOGLE_ADS_CLIENT_ID;
+  const oauthSecret = process.env.GOOGLE_ADS_CLIENT_SECRET;
   if (!oauthClient || !oauthSecret) {
     return {
       ok: false,

--- a/skills/optimiser/pagespeed-reading/SKILL.md
+++ b/skills/optimiser/pagespeed-reading/SKILL.md
@@ -4,7 +4,7 @@ Read Google PageSpeed Insights Core Web Vitals into `opt_metrics_daily`.
 
 ## Inputs
 - `client_id`
-- `process.env.PAGESPEED_API_KEY` — single Opollo-wide free-tier key.
+- `process.env.PSI_API_KEY` — single Opollo-wide free-tier key.
 
 PSI is the only Phase 1 source that does not use per-client credentials. The credential-aware sync runner is bypassed; the cron iterates `opt_clients` directly.
 


### PR DESCRIPTION
## Why

Lock the optimiser sync subsystem to the org-level env-var allow-list. Per-client credentials (Ads refresh token, GA4 refresh token, Clarity api_token) live exclusively in `opt_client_credentials` — that part already worked, this PR closes the gap on the org-level OAuth/API key surface.

The allowed env-vars are fixed at:

| Env var | Used by | Per-client? |
|---|---|---|
| `GOOGLE_ADS_DEVELOPER_TOKEN` | Ads sync | no |
| `GOOGLE_ADS_CLIENT_ID` | **Both** Ads and GA4 OAuth (shared client) | no |
| `GOOGLE_ADS_CLIENT_SECRET` | **Both** Ads and GA4 OAuth (shared client) | no |
| `PSI_API_KEY` | PageSpeed Insights | no |
| `VERCEL_API_TOKEN`, `VERCEL_PROJECT_ID` | server-error feed | no |
| `ANTHROPIC_API_KEY` | LLM scoring | no |
| `OPOLLO_HOSTING_HOST`, `_USER`, `_KEY` | static hosting | no |

Removed: `GA4_CLIENT_ID`, `GA4_CLIENT_SECRET`, `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`. Renamed: `PAGESPEED_API_KEY` → `PSI_API_KEY`.

## Audit findings (current state of each sync)

| Sync | Per-client cred source | Org env-vars before | After |
|---|---|---|---|
| ads.ts | `opt_client_credentials` ✓ | `GOOGLE_ADS_*` (correct) | unchanged |
| ga4.ts | `opt_client_credentials` ✓ | `GA4_*` / `GOOGLE_OAUTH_*` (wrong) | `GOOGLE_ADS_CLIENT_ID/_SECRET` |
| clarity.ts | `opt_client_credentials` ✓ | none | unchanged |
| pagespeed.ts | n/a (org-level) | `PAGESPEED_API_KEY` (wrong name) | `PSI_API_KEY` |

## Onboarding wizard

Already collects all per-client credentials correctly (Ads OAuth, Clarity api_token, GA4 OAuth + property_id). Only a single error-copy line referenced the removed env-var names; updated to point at the shared OAuth client. No new collection step needed.

## Diagnostics endpoint

`SOURCE_ENV` map updated: ga4 now lists the same `GOOGLE_ADS_*` env vars Ads requires (with a comment explaining the shared OAuth client); pagespeed now lists `PSI_API_KEY`. The dead GA4 fallback branch in `checkEnv` is removed.

## Operator actions required after deploy

1. **Rename in Vercel:** `PAGESPEED_API_KEY` → `PSI_API_KEY`. Failure mode if missed: PSI sync silently skips with no error, no metrics ingest.
2. **Google Cloud Console:** if GA4 currently uses a separate OAuth client (`GA4_CLIENT_ID`/`GA4_CLIENT_SECRET` set in Vercel), add the `analytics.readonly` scope and the `/api/optimiser/oauth/ga4/callback` redirect URI to the existing Ads OAuth client. Then remove `GA4_CLIENT_ID`, `GA4_CLIENT_SECRET`, `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET` from Vercel env vars.
3. Verify: `/optimiser/diagnostics` — `ga4` and `pagespeed` sections must both show `env configured: true`.

## Risks identified and mitigated

- **Existing GA4 connections survive the OAuth-client switch** if the GA4 OAuth was already pointed at the same Cloud project as Ads — the refresh tokens stored in `opt_client_credentials` are tied to the OAuth client they were issued by. If GA4 is currently using a *different* Cloud OAuth client, every existing GA4 connection will need re-OAuth after deploy. Mitigation: the verify-connector flow already flips the credential row to `expired` on refresh failure, so the wizard surfaces "Re-connect" automatically.
- **PSI sync is best-effort weekly**, so the env-var rename causing a brief skip is non-blocking. The diagnostic surface flags the missing key.
- **No DB writes, no migrations** — pure refactor of read paths + naming.

## Test plan

- [x] CI typecheck/lint/build/test pass.
- [x] No straggler refs to removed env-var names outside the runbook (which intentionally documents the removal).
- [ ] After deploy: `/optimiser/diagnostics` reports both ga4 and pagespeed `env configured: true`.
- [ ] After deploy: trigger a GA4 sync via the Verify button; confirm refresh-token exchange still works.