### PR TITLE
fix(auth): repair 2FA login flow end-to-end

### DIFF
--- a/app/api/auth/complete-login/route.ts
+++ b/app/api/auth/complete-login/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/2fa/cookies";
 import { registerTrustedDevice } from "@/lib/2fa/devices";
 import { createRouteAuthClient } from "@/lib/auth";
+import { logger } from "@/lib/logger";
 import { getClientIp } from "@/lib/rate-limit";
 
 // AUTH-FOUNDATION P4.2 — POST /api/auth/complete-login.
@@ -31,11 +32,18 @@ import { getClientIp } from "@/lib/rate-limit";
 //   - return { ok: true, data: { redirect_to } } (the next destination
 //     was preserved on the cookie set by the login server action)
 //
-// Concurrency: two tabs racing the complete-login (e.g. operator
-// approves on phone while desktop is open) — the consumeChallenge
-// CAS guarantees only one wins. The loser sees ALREADY_CONSUMED and
-// the polling page falls into the "consumed" branch (refresh →
-// admin).
+// Idempotency / concurrency: two tabs racing the complete-login (e.g.
+// operator approves on phone while desktop is open) — the
+// consumeChallenge CAS guarantees only one wins. Previously the loser
+// got 409 ALREADY_CONSUMED and the polling page rendered a static
+// "continue to admin" link whose click was bounced by middleware
+// (because THIS browser's opollo_2fa_pending cookie had not been
+// cleared on the loser's tab). That looked like a "stuck after sign-
+// in" bug. Now the loser is treated as success-after-the-fact:
+// provided the challenge belongs to the same authenticated user, we
+// clear THIS browser's 2FA cookies and return ok with the redirect
+// target. The trust-device write is skipped on the loser path because
+// the winning tab already wrote it (or chose not to).
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -47,10 +55,25 @@ const Body = z
   })
   .strict();
 
+function clearPendingCookies(cookieJar: ReturnType<typeof cookies>): void {
+  for (const name of [PENDING_2FA_COOKIE, "opollo_pending_device_id"]) {
+    cookieJar.set(name, "", {
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+      maxAge: 0,
+    });
+  }
+}
+
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const supabase = createRouteAuthClient();
   const userRes = await supabase.auth.getUser();
   if (userRes.error || !userRes.data.user) {
+    logger.warn("auth.2fa.complete_login.no_session", {
+      err: userRes.error?.message,
+    });
     return NextResponse.json(
       { ok: false, error: { code: "UNAUTHORIZED", message: "No session." } },
       { status: 401 },
@@ -66,6 +89,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
   const parsed = Body.safeParse(body);
   if (!parsed.success) {
+    logger.warn("auth.2fa.complete_login.validation_failed", {
+      user_id: userId,
+      issues: parsed.error.issues,
+    });
     return NextResponse.json(
       {
         ok: false,
@@ -82,21 +109,71 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // Re-check the challenge belongs to this user.
   const challenge = await lookupChallengeById(parsed.data.challenge_id);
   if (!challenge) {
+    logger.warn("auth.2fa.complete_login.challenge_not_found", {
+      user_id: userId,
+      challenge_id: parsed.data.challenge_id,
+    });
     return NextResponse.json(
       { ok: false, error: { code: "NOT_FOUND", message: "Challenge not found." } },
       { status: 404 },
     );
   }
   if (challenge.user_id !== userId) {
+    logger.warn("auth.2fa.complete_login.user_mismatch", {
+      user_id: userId,
+      challenge_id: parsed.data.challenge_id,
+      challenge_user_id: challenge.user_id,
+    });
     return NextResponse.json(
       { ok: false, error: { code: "FORBIDDEN", message: "Not your challenge." } },
       { status: 403 },
     );
   }
 
+  const cookieJar = cookies();
+  const headersList = headers();
+
+  // Already-consumed branch: another tab/device finished the flow
+  // already. THIS browser still has the opollo_2fa_pending cookie set,
+  // and middleware will keep bouncing /admin navigation back to
+  // /login/check-email until we clear it. Clearing the cookie + 200ing
+  // is the right move — the user is the same, the challenge already
+  // approved an authenticated session, we're just tidying the cookies
+  // on this specific tab. Trust-device write is skipped (the winning
+  // tab made that decision).
+  if (challenge.status === "consumed") {
+    logger.info("auth.2fa.complete_login.already_consumed", {
+      user_id: userId,
+      challenge_id: parsed.data.challenge_id,
+    });
+    clearPendingCookies(cookieJar);
+    return NextResponse.json({
+      ok: true,
+      data: { redirect_to: "/admin/sites", already_consumed: true },
+    });
+  }
+
   const consumed = await consumeChallenge(parsed.data.challenge_id);
   if (!consumed.ok) {
+    // expired / not_approved / a CAS race that flipped to consumed
+    // between the lookup above and this call.
+    if (consumed.reason === "already_consumed") {
+      logger.info("auth.2fa.complete_login.race_already_consumed", {
+        user_id: userId,
+        challenge_id: parsed.data.challenge_id,
+      });
+      clearPendingCookies(cookieJar);
+      return NextResponse.json({
+        ok: true,
+        data: { redirect_to: "/admin/sites", already_consumed: true },
+      });
+    }
     const status = consumed.reason === "expired" ? 410 : 409;
+    logger.warn("auth.2fa.complete_login.consume_failed", {
+      user_id: userId,
+      challenge_id: parsed.data.challenge_id,
+      reason: consumed.reason,
+    });
     return NextResponse.json(
       {
         ok: false,
@@ -105,17 +182,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           message:
             consumed.reason === "expired"
               ? "Challenge expired before completion."
-              : consumed.reason === "not_approved"
-                ? "Challenge has not been approved yet."
-                : "Challenge was already consumed.",
+              : "Challenge has not been approved yet.",
         },
       },
       { status },
     );
   }
-
-  const cookieJar = cookies();
-  const headersList = headers();
 
   // Trust-device path: upsert a trusted_devices row + set the signed
   // device_id cookie. The device_id was captured into a separate
@@ -139,20 +211,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     });
   }
 
-  // Clear the pending cookies regardless of trust-device choice.
-  cookieJar.set(PENDING_2FA_COOKIE, "", {
-    httpOnly: true,
-    secure: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: 0,
-  });
-  cookieJar.set("opollo_pending_device_id", "", {
-    httpOnly: true,
-    secure: true,
-    sameSite: "lax",
-    path: "/",
-    maxAge: 0,
+  clearPendingCookies(cookieJar);
+
+  logger.info("auth.2fa.complete_login.success", {
+    user_id: userId,
+    challenge_id: parsed.data.challenge_id,
+    trust_device: parsed.data.trust_device,
   });
 
   return NextResponse.json({

--- a/app/auth/approve/page.tsx
+++ b/app/auth/approve/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { ApproveCompleteHere } from "@/components/ApproveCompleteHere";
 import { Alert } from "@/components/ui/alert";
 import { H1, Lead } from "@/components/ui/typography";
@@ -9,22 +11,29 @@ import {
 // AUTH-FOUNDATION P4.3 — /auth/approve.
 //
 // The URL the "Approve sign-in" button in the email points at. Public
-// (no auth gate) — the token IS the auth. Server-component validates
-// the token + flips the challenge to approved, then renders one of:
+// (in middleware.ts PUBLIC_PATHS) — the token IS the auth. Server-
+// component validates the random 32-byte token via SHA-256 against
+// login_challenges.token_hash, flips the challenge from pending →
+// approved, and renders one of:
 //
-//   - "Sign-in approved. Return to your original tab to continue,
-//     or click below to complete sign-in here."
-//     With a "Complete sign-in here" button (the lost-tab fallback)
-//     that POSTs to /api/auth/approve-here, which signs the user in
-//     ON THIS DEVICE via a Supabase magic link.
+//   - "Sign-in approved." with a clear "Return to your original tab"
+//     instruction. The original tab's polling shell does the actual
+//     session work — this page intentionally does not try to set a
+//     session on the device that clicked the email link, because that
+//     device may be a phone or a different browser entirely.
 //
-//   - "This approval link has been used." (consumed already by the
-//     original tab's complete-login)
+//   - "Already used." (consumed already by the original tab's
+//     complete-login).
 //
-//   - "This link expired / is invalid" (typed reasons)
+//   - "Expired" / "Invalid" — typed reasons.
+//
+// Lost-tab fallback: a "Complete sign-in here" button is offered on
+// the approved/already-approved branches. POSTs to /api/auth/approve-
+// here, which mints a Supabase magic link the browser follows. This
+// is the path used when the original tab is closed.
 //
 // Single-use: the second visit to the same approval link sees the
-// 'consumed' state.
+// 'consumed' branch.
 
 export const dynamic = "force-dynamic";
 
@@ -77,53 +86,102 @@ async function resolveState(rawToken: string | undefined): Promise<RenderState> 
   };
 }
 
+function PageShell({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center">
+          <H1>{title}</H1>
+          {subtitle && <Lead className="mt-1">{subtitle}</Lead>}
+        </div>
+        <div className="rounded-lg border bg-background p-6 shadow-sm space-y-4">
+          {children}
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function StartOverLink() {
+  return (
+    <Link
+      href="/login"
+      className="inline-block text-sm font-medium underline underline-offset-4"
+    >
+      Back to sign in
+    </Link>
+  );
+}
+
 export default async function ApprovePage({ searchParams }: PageProps) {
   const state = await resolveState(searchParams.token);
 
   if (state.kind === "invalid") {
     return (
-      <div className="mx-auto max-w-md space-y-4">
-        <H1>Approval link</H1>
+      <PageShell title="Approval link">
         <Alert variant="destructive">
-          This approval link is invalid. Sign in again from your original
-          device or ask for a fresh attempt.
+          This approval link is invalid. Sign in again from your
+          original device to receive a fresh email.
         </Alert>
-      </div>
+        <StartOverLink />
+      </PageShell>
     );
   }
   if (state.kind === "expired") {
     return (
-      <div className="mx-auto max-w-md space-y-4">
-        <H1>Approval link expired</H1>
+      <PageShell title="Approval link expired">
         <Alert variant="destructive">
-          This approval link expired (15-minute window). Sign in again
-          from your original device to receive a fresh email.
+          This link expired (15-minute window). Sign in again to
+          receive a fresh email.
         </Alert>
-      </div>
+        <StartOverLink />
+      </PageShell>
     );
   }
   if (state.kind === "consumed") {
     return (
-      <div className="mx-auto max-w-md space-y-4">
-        <H1>Approval link used</H1>
+      <PageShell title="Approval link used">
         <Alert>
-          This approval link has been used. If you&apos;re already
-          signed in on the original device you can close this tab.
+          This sign-in has already been completed. If your original
+          tab is still open it should have advanced to the admin — you
+          can close this tab.
         </Alert>
-      </div>
+        <StartOverLink />
+      </PageShell>
     );
   }
 
   return (
-    <div className="mx-auto max-w-md space-y-4">
-      <H1>Sign-in approved</H1>
-      <Lead className="mt-1">
-        {state.tokenWasJustApproved
-          ? "Return to your original tab — it'll finish signing you in automatically."
-          : "Already approved. If your original tab is gone, complete sign-in here."}
-      </Lead>
+    <PageShell
+      title="Sign-in approved"
+      subtitle={
+        state.tokenWasJustApproved
+          ? "Return to your original tab — it will sign you in automatically within a few seconds."
+          : "Sign-in already approved. Return to your original tab, or complete here if that tab is gone."
+      }
+    >
+      <Alert>
+        <strong>Done.</strong> You can close this tab now. The browser
+        you signed in from will pick up the approval and finish the
+        sign-in.
+      </Alert>
 
-      <ApproveCompleteHere challengeId={state.challengeId} />
-    </div>
+      <div className="border-t pt-4">
+        <p className="text-sm font-medium">Lost your original tab?</p>
+        <p className="text-xs text-muted-foreground mt-1 mb-3">
+          Use the button below to finish signing in on this device
+          instead.
+        </p>
+        <ApproveCompleteHere challengeId={state.challengeId} />
+      </div>
+    </PageShell>
   );
 }

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -99,13 +99,34 @@ export async function loginAction(
     return { error: "Sign-in failed. Please try again." };
   }
 
-  // Flag off → existing behaviour.
+  // Flag off → existing behaviour. No 2FA cookies are ever set when the
+  // flag is off, so there's nothing stale to clear on this path.
   if (!is2faEnabled()) {
     redirect(next);
   }
 
   // Flag on — check for a matching trusted device.
   const cookieJar = cookies();
+
+  // Any stale 2FA cookies from a prior aborted attempt must be cleared
+  // on every successful path that does NOT issue a new challenge —
+  // otherwise middleware sees the leftover opollo_2fa_pending cookie
+  // and bounces every admin navigation back to /login/check-email,
+  // looking like a "stuck after sign-in" bug. The challenge-issuing
+  // path below overwrites these cookies with fresh values, so the
+  // clears here only apply on the trusted-device shortcut.
+  function clearStale2faCookies() {
+    for (const name of [PENDING_2FA_COOKIE, "opollo_pending_device_id"]) {
+      cookieJar.set(name, "", {
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        path: "/",
+        maxAge: 0,
+      });
+    }
+  }
+
   const cookieValue = cookieJar.get(DEVICE_ID_COOKIE)?.value;
   const deviceIdFromCookie = decodeDeviceCookie(cookieValue);
   if (deviceIdFromCookie) {
@@ -116,6 +137,7 @@ export async function loginAction(
     if (trusted) {
       // Skip the challenge — bump last_used_at + go.
       await touchTrustedDevice({ userId, deviceId: deviceIdFromCookie });
+      clearStale2faCookies();
       redirect(next);
     }
   }

--- a/app/login/check-email/page.tsx
+++ b/app/login/check-email/page.tsx
@@ -69,29 +69,33 @@ export default async function CheckEmailPage({ searchParams }: PageProps) {
   const next = searchParams.next ?? "/admin/sites";
 
   return (
-    <div className="mx-auto max-w-md">
-      <H1>Check your email</H1>
-      <Lead className="mt-1">
-        We sent an approval link to{" "}
-        <strong className="text-foreground">{userEmail}</strong>. Click
-        the link in the email and this page will sign you in
-        automatically.
-      </Lead>
+    <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center">
+          <H1>Check your email</H1>
+          <Lead className="mt-1">
+            We sent an approval link to{" "}
+            <strong className="text-foreground">{userEmail}</strong>.
+            Click the link and this page will sign you in
+            automatically.
+          </Lead>
+        </div>
 
-      {emailSendFailed && (
-        <Alert variant="destructive" className="mt-4">
-          Email delivery failed. Use the Resend button below — it
-          skips the cooldown.
-        </Alert>
-      )}
+        <div className="rounded-lg border bg-background p-6 shadow-sm space-y-4">
+          {emailSendFailed && (
+            <Alert variant="destructive">
+              Email delivery failed. Use the Resend button below — it
+              skips the cooldown.
+            </Alert>
+          )}
 
-      <div className="mt-6">
-        <CheckEmailPolling
-          challengeId={challenge.id}
-          next={next}
-          initialEmailFailed={emailSendFailed}
-        />
+          <CheckEmailPolling
+            challengeId={challenge.id}
+            next={next}
+            initialEmailFailed={emailSendFailed}
+          />
+        </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,7 +1,9 @@
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { LoginForm } from "@/components/LoginForm";
 import { H1, Lead } from "@/components/ui/typography";
+import { PENDING_2FA_COOKIE } from "@/lib/2fa/cookies";
 import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
 import { isAuthKillSwitchOn } from "@/lib/auth-kill-switch";
 
@@ -37,6 +39,19 @@ export default async function LoginPage({
   searchParams: { next?: string };
 }) {
   const next = safeNext(searchParams.next);
+
+  // Recovery path: arriving at /login with a stale opollo_2fa_pending
+  // cookie means the user was mid-2FA, then either expired the
+  // challenge, navigated away, or had their /complete-login fail.
+  // Without an explicit reset they get stuck — the existing session is
+  // still valid, the page short-circuits to /admin/sites, middleware
+  // sees the pending cookie and bounces back to /login/check-email,
+  // and the loop never terminates. /logout clears both the Supabase
+  // session and the 2FA cookies and redirects back here, so a clean
+  // form is shown on the next request.
+  if (cookies().has(PENDING_2FA_COOKIE)) {
+    redirect("/logout");
+  }
 
   if (isSupabaseAuthOn()) {
     let killSwitch = false;

--- a/app/logout/route.ts
+++ b/app/logout/route.ts
@@ -37,7 +37,24 @@ async function signOutAndRedirect(req: NextRequest): Promise<NextResponse> {
   url.search = "";
   // 303 See Other is the right status for POST→GET redirect. Browsers
   // respect it consistently; 302 is technically spec-ambiguous.
-  return NextResponse.redirect(url, { status: 303 });
+  const response = NextResponse.redirect(url, { status: 303 });
+
+  // Clear the 2FA in-flight cookies. signOut() above clears the Supabase
+  // session cookies via the SSR adapter; the 2FA cookies live outside
+  // that adapter and have to be cleared here. Without this, a logout
+  // mid-flow leaves opollo_2fa_pending set and the next /login →
+  // signInWithPassword → /admin/sites navigation gets bounced back to
+  // /login/check-email by middleware, looking like a stuck-login bug.
+  for (const name of ["opollo_2fa_pending", "opollo_pending_device_id"]) {
+    response.cookies.set(name, "", {
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+      maxAge: 0,
+    });
+  }
+  return response;
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {

--- a/components/CheckEmailPolling.tsx
+++ b/components/CheckEmailPolling.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Alert } from "@/components/ui/alert";
@@ -10,14 +9,29 @@ import { Button } from "@/components/ui/button";
 //
 // Polls GET /api/auth/challenge-status?challenge_id=... every 3s.
 // Pauses when the tab goes hidden (visibilitychange API), resumes
-// on focus. When the server reports status='approved', POSTs to
-// /api/auth/complete-login with the trust-device checkbox state and
-// redirects to `next` on success.
+// on focus. When the server reports status='approved' OR 'consumed',
+// POSTs to /api/auth/complete-login (now idempotent for the consumed
+// case — see the route's docstring for why) and follows the redirect.
+//
+// Single-fire contract: completion runs at most once per page mount.
+// A ref-based latch (completionStartedRef) prevents the duplicate
+// invocations that earlier shipped — the useEffect deps included
+// `status`, so every status transition rescheduled the poll loop AND
+// re-evaluated completeLogin's closure, racing two concurrent
+// /complete-login POSTs and stranding the user when the second tab
+// won the CAS but the first tab's network response never resolved
+// the navigation.
 
 const POLL_INTERVAL_MS = 3000;
 const RESEND_COOLDOWN_MS = 60_000;
 
 type Status = "pending" | "approved" | "expired" | "consumed" | "error";
+
+type CompletionPhase =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "navigating"; to: string }
+  | { kind: "failed"; message: string };
 
 export function CheckEmailPolling({
   challengeId,
@@ -28,56 +42,71 @@ export function CheckEmailPolling({
   next: string;
   initialEmailFailed: boolean;
 }) {
-  const router = useRouter();
   const [status, setStatus] = useState<Status>("pending");
-  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [pollErrorMsg, setPollErrorMsg] = useState<string | null>(null);
   const [trustDevice, setTrustDevice] = useState(true);
-  const [completing, setCompleting] = useState(false);
+  const [completion, setCompletion] = useState<CompletionPhase>({ kind: "idle" });
   const [resendBlocked, setResendBlocked] = useState<number>(
     initialEmailFailed ? 0 : Date.now() + RESEND_COOLDOWN_MS,
   );
   const [resending, setResending] = useState(false);
   const [_now, setNowTick] = useState(Date.now()); // re-render ticker for the resend countdown
-  const visibilityRef = useRef(true);
 
-  // Trust-device checkbox value at the moment of completion.
+  const visibilityRef = useRef(true);
+  const completionStartedRef = useRef(false);
   const trustDeviceRef = useRef(trustDevice);
   trustDeviceRef.current = trustDevice;
 
-  const completeLogin = useCallback(async () => {
-    if (completing) return;
-    setCompleting(true);
-    try {
-      const res = await fetch("/api/auth/complete-login", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          challenge_id: challengeId,
-          trust_device: trustDeviceRef.current,
-        }),
-      });
-      const payload = (await res.json().catch(() => null)) as
-        | { ok: true; data: { redirect_to?: string } }
-        | { ok: false; error: { code: string; message: string } }
-        | null;
-      if (!res.ok || !payload?.ok) {
-        setErrorMsg(
-          payload?.ok === false
-            ? payload.error.message
-            : `Couldn't complete sign-in (HTTP ${res.status}).`,
-        );
-        setCompleting(false);
-        return;
+  const completeLogin = useCallback(
+    async (opts?: { force?: boolean }) => {
+      if (!opts?.force && completionStartedRef.current) return;
+      completionStartedRef.current = true;
+      setCompletion({ kind: "running" });
+      try {
+        const res = await fetch("/api/auth/complete-login", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            challenge_id: challengeId,
+            trust_device: trustDeviceRef.current,
+          }),
+        });
+        const payload = (await res.json().catch(() => null)) as
+          | { ok: true; data: { redirect_to?: string; already_consumed?: boolean } }
+          | { ok: false; error: { code: string; message: string } }
+          | null;
+        if (!res.ok || !payload?.ok) {
+          const message =
+            payload && payload.ok === false
+              ? payload.error.message
+              : `Couldn't complete sign-in (HTTP ${res.status}).`;
+          // Allow retry: failed attempts release the latch.
+          completionStartedRef.current = false;
+          setCompletion({ kind: "failed", message });
+          return;
+        }
+        const dest = payload.data.redirect_to ?? next;
+        setCompletion({ kind: "navigating", to: dest });
+        // window.location.assign forces a full document load. router.push
+        // keeps the SPA cache warm but the browser doesn't always re-read
+        // the Set-Cookie clears made by the server in the same response;
+        // a hard navigation guarantees middleware sees the cleared cookies
+        // before /admin/sites renders.
+        window.location.assign(dest);
+      } catch (err) {
+        const message = `Network error: ${err instanceof Error ? err.message : String(err)}`;
+        completionStartedRef.current = false;
+        setCompletion({ kind: "failed", message });
       }
-      const dest = payload.data.redirect_to ?? next;
-      router.push(dest);
-    } catch (err) {
-      setErrorMsg(`Network error: ${err instanceof Error ? err.message : String(err)}`);
-      setCompleting(false);
-    }
-  }, [challengeId, completing, next, router]);
+    },
+    [challengeId, next],
+  );
 
-  // Poll loop.
+  // Poll loop. Crucially, `status` is NOT in the deps — including it
+  // would cancel + restart the loop on every status change, which
+  // is what made the previous version race two concurrent
+  // /complete-login calls. The loop self-terminates when it observes
+  // a terminal status.
   useEffect(() => {
     let cancelled = false;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -88,10 +117,7 @@ export function CheckEmailPolling({
 
     async function poll() {
       if (cancelled) return;
-      if (!visibilityRef.current) {
-        // Tab hidden — back off; resume on visibility change.
-        return;
-      }
+      if (!visibilityRef.current) return; // resume on visibility change
       try {
         const res = await fetch(
           `/api/auth/challenge-status?challenge_id=${encodeURIComponent(challengeId)}`,
@@ -104,35 +130,36 @@ export function CheckEmailPolling({
         if (cancelled) return;
         if (!res.ok || !payload?.ok) {
           setStatus("error");
-          setErrorMsg(
-            payload?.ok === false
+          setPollErrorMsg(
+            payload && payload.ok === false
               ? payload.error.message
               : `Status check failed (HTTP ${res.status}).`,
           );
           return;
         }
-        const next = payload.data.status;
-        setStatus(next);
-        if (next === "approved") {
+        const observed = payload.data.status;
+        setStatus(observed);
+        if (observed === "approved" || observed === "consumed") {
+          // Both states require us to call complete-login from THIS
+          // browser to clear the local opollo_2fa_pending cookie.
+          // complete-login is idempotent for `consumed`.
           await completeLogin();
           return;
         }
-        if (next === "expired" || next === "consumed") {
-          // Terminal — let the user retry via /login.
+        if (observed === "expired") {
           return;
         }
         schedule(POLL_INTERVAL_MS);
       } catch (err) {
         if (cancelled) return;
         setStatus("error");
-        setErrorMsg(err instanceof Error ? err.message : String(err));
+        setPollErrorMsg(err instanceof Error ? err.message : String(err));
       }
     }
 
     function onVisibility() {
       visibilityRef.current = document.visibilityState === "visible";
-      if (visibilityRef.current && status === "pending" && !cancelled) {
-        // Resume immediately on focus.
+      if (visibilityRef.current && !cancelled) {
         schedule(0);
       }
     }
@@ -145,21 +172,24 @@ export function CheckEmailPolling({
       if (timeoutId !== null) clearTimeout(timeoutId);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [challengeId, completeLogin, status]);
+  }, [challengeId, completeLogin]);
 
-  // Re-render every 1s while resend is on cooldown so the button
-  // label updates.
+  // Re-render every 1s while resend is on cooldown so the button label
+  // updates.
   useEffect(() => {
     const id = setInterval(() => setNowTick(Date.now()), 1000);
     return () => clearInterval(id);
   }, []);
 
-  const cooldownRemaining = Math.max(0, Math.ceil((resendBlocked - Date.now()) / 1000));
+  const cooldownRemaining = Math.max(
+    0,
+    Math.ceil((resendBlocked - Date.now()) / 1000),
+  );
 
   async function onResend() {
     if (resending || cooldownRemaining > 0) return;
     setResending(true);
-    setErrorMsg(null);
+    setPollErrorMsg(null);
     try {
       const res = await fetch("/api/auth/resend-challenge", { method: "POST" });
       const payload = (await res.json().catch(() => null)) as
@@ -167,8 +197,8 @@ export function CheckEmailPolling({
         | { ok: false; error: { code: string; message: string } }
         | null;
       if (!res.ok || !payload?.ok) {
-        setErrorMsg(
-          payload?.ok === false
+        setPollErrorMsg(
+          payload && payload.ok === false
             ? payload.error.message
             : `Resend failed (HTTP ${res.status}).`,
         );
@@ -180,38 +210,74 @@ export function CheckEmailPolling({
     }
   }
 
+  // Terminal: expired challenge.
   if (status === "expired") {
     return (
-      <Alert variant="destructive">
-        This sign-in attempt expired. Return to{" "}
-        <a href="/login" className="font-medium underline">
-          /login
-        </a>{" "}
-        to start over.
-      </Alert>
-    );
-  }
-  if (status === "consumed") {
-    return (
-      <Alert>
-        This sign-in has been completed in another tab. Refresh, or{" "}
-        <a href="/admin/sites" className="font-medium underline">
-          continue to the admin
+      <div className="space-y-4">
+        <Alert variant="destructive">
+          This sign-in attempt expired (15-minute window). The approval
+          email is no longer valid.
+        </Alert>
+        <a
+          href="/login"
+          className="inline-block text-sm font-medium underline underline-offset-4"
+        >
+          Start over
         </a>
-        .
-      </Alert>
+      </div>
     );
   }
 
+  // Completion failed — show error + retry + start-over.
+  if (completion.kind === "failed") {
+    return (
+      <div className="space-y-4">
+        <Alert variant="destructive" data-testid="check-email-error">
+          {completion.message}
+        </Alert>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            onClick={() => void completeLogin({ force: true })}
+            data-testid="complete-login-retry"
+          >
+            Try again
+          </Button>
+          <a
+            href="/login"
+            className="text-sm font-medium underline underline-offset-4"
+          >
+            Start over
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  // In flight — completing or about to navigate.
+  if (completion.kind === "running" || completion.kind === "navigating") {
+    return (
+      <div className="space-y-4">
+        <div
+          className="rounded-md border bg-muted/30 px-3 py-2 text-sm"
+          data-testid="check-email-status"
+        >
+          {completion.kind === "running"
+            ? "Approved — completing sign-in…"
+            : "Signed in. Redirecting…"}
+        </div>
+      </div>
+    );
+  }
+
+  // Pending — waiting for the operator to click the email link.
   return (
     <div className="space-y-4">
       <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
         <span data-testid="check-email-status" className="text-muted-foreground">
-          {status === "pending"
-            ? "Waiting for you to click the approval link in the email…"
-            : status === "approved"
-              ? "Approved — completing sign-in…"
-              : "Connection issue — retrying."}
+          {status === "error"
+            ? "Connection issue — retrying."
+            : "Waiting for you to click the approval link in the email…"}
         </span>
       </div>
 
@@ -220,7 +286,6 @@ export function CheckEmailPolling({
           type="checkbox"
           checked={trustDevice}
           onChange={(e) => setTrustDevice(e.target.checked)}
-          disabled={completing}
           className="mt-1"
           data-testid="trust-device-checkbox"
         />
@@ -260,9 +325,9 @@ export function CheckEmailPolling({
         with a different account.
       </p>
 
-      {errorMsg && (
+      {pollErrorMsg && (
         <Alert variant="destructive" data-testid="check-email-error">
-          {errorMsg}
+          {pollErrorMsg}
         </Alert>
       )}
     </div>

--- a/lib/__tests__/complete-login-route.test.ts
+++ b/lib/__tests__/complete-login-route.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// AUTH-FOUNDATION P4 — POST /api/auth/complete-login route.
+//
+// The fix this file pins: the `consumed` branch must return 200 and
+// clear the local opollo_2fa_pending cookie even though the challenge
+// was already consumed by another tab/device. Before the fix, the
+// loser of a CAS race got 409 ALREADY_CONSUMED; the polling shell
+// rendered a static "continue to admin" link whose click was bounced
+// by middleware (this browser still had the pending cookie set), and
+// the user got stuck in a "page loads for 1 second then nothing" loop.
+//
+// Other paths exercised: no-session, validation, user-mismatch,
+// expired (410, no cookie clear), happy-path consume + cookie clear.
+// ---------------------------------------------------------------------------
+
+interface ChallengeRow {
+  id: string;
+  user_id: string;
+  device_id: string;
+  status: "pending" | "approved" | "expired" | "consumed";
+  ua_string: string | null;
+  ip_hash: string | null;
+  created_at: string;
+  expires_at: string;
+  approved_at: string | null;
+}
+
+const mockState = vi.hoisted(() => ({
+  sessionUserId: null as string | null,
+  challenge: null as ChallengeRow | null,
+  consumeOutcome: null as
+    | { ok: true }
+    | { ok: false; reason: "not_found" | "expired" | "not_approved" | "already_consumed" }
+    | null,
+  registerTrustedCalls: 0,
+  cookieStore: new Map<string, string>(),
+  cookieSets: [] as Array<{ name: string; value: string; maxAge?: number }>,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: () => ({
+    auth: {
+      getUser: async () => {
+        if (mockState.sessionUserId) {
+          return { data: { user: { id: mockState.sessionUserId } }, error: null };
+        }
+        return { data: { user: null }, error: { message: "no session" } };
+      },
+    },
+  }),
+}));
+
+vi.mock("@/lib/2fa/challenges", () => ({
+  lookupChallengeById: async (_id: string) => mockState.challenge,
+  consumeChallenge: async (_id: string) => mockState.consumeOutcome,
+}));
+
+vi.mock("@/lib/2fa/devices", () => ({
+  registerTrustedDevice: async () => {
+    mockState.registerTrustedCalls += 1;
+  },
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({
+    get: (name: string) => {
+      const value = mockState.cookieStore.get(name);
+      return value === undefined ? undefined : { value };
+    },
+    set: (...args: unknown[]) => {
+      if (typeof args[0] === "string") {
+        const [name, value, options] = args as [string, string, { maxAge?: number } | undefined];
+        mockState.cookieSets.push({ name, value, maxAge: options?.maxAge });
+      } else {
+        const opts = args[0] as { name: string; value: string; maxAge?: number };
+        mockState.cookieSets.push({
+          name: opts.name,
+          value: opts.value,
+          maxAge: opts.maxAge,
+        });
+      }
+    },
+  }),
+  headers: () => new Headers(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  getClientIp: () => "127.0.0.1",
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+}));
+
+const { POST } = await import("@/app/api/auth/complete-login/route");
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_USER = "22222222-2222-4222-8222-222222222222";
+const CHALLENGE_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const DEVICE_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+function makeChallenge(overrides: Partial<ChallengeRow> = {}): ChallengeRow {
+  return {
+    id: CHALLENGE_ID,
+    user_id: USER_ID,
+    device_id: DEVICE_ID,
+    status: "approved",
+    ua_string: null,
+    ip_hash: null,
+    created_at: new Date().toISOString(),
+    expires_at: new Date(Date.now() + 5 * 60_000).toISOString(),
+    approved_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/auth/complete-login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  mockState.sessionUserId = USER_ID;
+  mockState.challenge = makeChallenge();
+  mockState.consumeOutcome = { ok: true };
+  mockState.registerTrustedCalls = 0;
+  mockState.cookieStore = new Map();
+  mockState.cookieSets = [];
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/auth/complete-login — happy path", () => {
+  it("consumes an approved challenge, clears pending cookies, returns 200", async () => {
+    mockState.challenge = makeChallenge({ status: "approved" });
+    mockState.consumeOutcome = { ok: true };
+
+    const res = await POST(
+      makeRequest({ challenge_id: CHALLENGE_ID, trust_device: false }) as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { redirect_to: string };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data.redirect_to).toBe("/admin/sites");
+
+    // Both pending cookies cleared (maxAge=0).
+    const cleared = mockState.cookieSets.filter((c) => c.maxAge === 0);
+    const names = new Set(cleared.map((c) => c.name));
+    expect(names.has("opollo_2fa_pending")).toBe(true);
+    expect(names.has("opollo_pending_device_id")).toBe(true);
+    expect(mockState.registerTrustedCalls).toBe(0);
+  });
+});
+
+describe("POST /api/auth/complete-login — already-consumed idempotency", () => {
+  it("clears pending cookies + returns 200 with already_consumed=true when challenge.status='consumed'", async () => {
+    mockState.challenge = makeChallenge({ status: "consumed" });
+    // consumeChallenge should NOT be called on the already-consumed path,
+    // so leave consumeOutcome at its default (would fail the test if hit).
+
+    const res = await POST(
+      makeRequest({ challenge_id: CHALLENGE_ID, trust_device: false }) as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { redirect_to: string; already_consumed?: boolean };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data.redirect_to).toBe("/admin/sites");
+    expect(body.data.already_consumed).toBe(true);
+
+    // The whole point of the fix: this browser's pending cookie must
+    // be cleared so middleware stops bouncing /admin/sites navigation.
+    const cleared = mockState.cookieSets.filter((c) => c.maxAge === 0);
+    const names = new Set(cleared.map((c) => c.name));
+    expect(names.has("opollo_2fa_pending")).toBe(true);
+    expect(names.has("opollo_pending_device_id")).toBe(true);
+    expect(mockState.registerTrustedCalls).toBe(0);
+  });
+
+  it("treats a CAS-race already_consumed result as success too", async () => {
+    // Lookup sees status=approved, but by the time we run consumeChallenge
+    // a second tab has flipped it to consumed.
+    mockState.challenge = makeChallenge({ status: "approved" });
+    mockState.consumeOutcome = { ok: false, reason: "already_consumed" };
+
+    const res = await POST(
+      makeRequest({ challenge_id: CHALLENGE_ID, trust_device: false }) as never,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { already_consumed?: boolean };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data.already_consumed).toBe(true);
+
+    const cleared = mockState.cookieSets.filter((c) => c.maxAge === 0);
+    expect(cleared.some((c) => c.name === "opollo_2fa_pending")).toBe(true);
+  });
+});
+
+describe("POST /api/auth/complete-login — error paths", () => {
+  it("401 UNAUTHORIZED when no session", async () => {
+    mockState.sessionUserId = null;
+    const res = await POST(
+      makeRequest({ challenge_id: CHALLENGE_ID, trust_device: false }) as never,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("400 VALIDATION_FAILED on bad body", async () => {
+    const res = await POST(
+      makeRequest({ challenge_id: "not-a-uuid", trust_device: false }) as never,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when the challenge row doesn't exist", async () => {
+    mockState.challenge = null;
+    const res = await POST(
+      makeRequest({ challenge_id: CHALLENGE_ID, trust_device: false }) as never,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("403 FORBIDDEN when challenge belongs to another user", async () => {
+    mockState.challenge = makeChallenge({ user_id: OTHER_USER });
+    const res = await POST(
+      makeRequest({ challenge_id: CHALLENGE_ID, trust_device: false }) as never,
+    );
+    expect(res.status).toBe(403);
+    // No cookies should be cleared on the forbidden path — this might
+    // be a stale cookie from a prior account on a shared browser, but
+    // we don't trust the request body to drive cookie state for a user
+    // we haven't authenticated.
+    expect(mockState.cookieSets.filter((c) => c.maxAge === 0)).toHaveLength(0);
+  });
+
+  it("410 GONE when challenge expired before consume", async () => {
+    mockState.challenge = makeChallenge({ status: "approved" });
+    mockState.consumeOutcome = { ok: false, reason: "expired" };
+    const res = await POST(
+      makeRequest({ challenge_id: CHALLENGE_ID, trust_device: false }) as never,
+    );
+    expect(res.status).toBe(410);
+    // Expired path doesn't clear the pending cookie — the user needs
+    // to start over via /login (which clears via the logout redirect).
+    expect(mockState.cookieSets.filter((c) => c.maxAge === 0)).toHaveLength(0);
+  });
+
+  it("409 NOT_APPROVED when challenge is still pending", async () => {
+    mockState.challenge = makeChallenge({ status: "pending" });
+    mockState.consumeOutcome = { ok: false, reason: "not_approved" };
+    const res = await POST(
+      makeRequest({ challenge_id: CHALLENGE_ID, trust_device: false }) as never,
+    );
+    expect(res.status).toBe(409);
+  });
+});

--- a/lib/__tests__/middleware.test.ts
+++ b/lib/__tests__/middleware.test.ts
@@ -192,6 +192,11 @@ describe("middleware: FEATURE_SUPABASE_AUTH on, no session", () => {
       "/auth/callback",
       "/api/auth/forgot-password",
       "/api/auth/reset-password",
+      // AUTH-FOUNDATION P4 — /auth/approve is the email-link landing
+      // page. The token is the auth, so it must be reachable from a
+      // device with no Supabase session (the operator clicking the
+      // approve email on their phone).
+      "/auth/approve",
     ]) {
       const res = await middleware(makeRequest(p));
       expect(res.status).toBe(200);

--- a/middleware.ts
+++ b/middleware.ts
@@ -78,6 +78,15 @@ const PUBLIC_PATHS = new Set<string>([
   // fragment). Reachable without a session because the whole point is
   // to MINT the session from the fragment.
   "/auth/callback",
+  // /auth/approve — 2FA email-approval landing page. The token IS the
+  // auth (server-component validates the random 32-byte token via a
+  // SHA-256 lookup against login_challenges.token_hash). The page must
+  // be reachable from any device, including ones with no Supabase
+  // session — the whole point of email approval is that the operator
+  // can click from a phone, hardware key, etc. Without this entry the
+  // middleware bounced unauthenticated callers to /login, breaking
+  // cross-device approval.
+  "/auth/approve",
 ]);
 
 function isPublicPath(pathname: string): boolean {
@@ -252,10 +261,11 @@ async function supabaseAuthGate(req: NextRequest): Promise<NextResponse> {
     const path = req.nextUrl.pathname;
     const allowedDuringPending =
       path === "/login/check-email" ||
-      path === "/auth/approve" ||
       path === "/logout" ||
       path.startsWith("/api/auth/") ||
       path.startsWith("/_next/");
+    // /auth/approve is now in PUBLIC_PATHS and short-circuits before
+    // here; listing it again would be dead code.
     if (!allowedDuringPending) {
       const url = req.nextUrl.clone();
       url.pathname = "/login/check-email";


### PR DESCRIPTION
## Summary
Repairs the broken 2FA email-approval login flow. Six interlocking bugs were causing the "stuck after sign-in" behaviour — fixing one without the others left the user stuck in a different way.

## Root causes

1. **`/auth/approve` not in middleware `PUBLIC_PATHS`.** The page comment claimed "Public — the token IS the auth", but it was only listed in `allowedDuringPending`. Operators clicking the approval email from a device with no Supabase session (phone, secondary browser, hardware key) got bounced to `/login`, leaving the original tab polling forever.
2. **`/api/auth/complete-login` returned 409 on already-consumed.** When a CAS race resolved, the loser tab kept its `opollo_2fa_pending` cookie set; the polling shell's static `<a href="/admin/sites">` click was bounced by middleware → back to `/login/check-email` → "consumed in another tab" → loop. Now idempotent for already-consumed (clears cookies, returns 200) provided the session matches the challenge user.
3. **`/login` had no recovery path.** A stuck user navigating to `/login` was short-circuited to `/admin/sites` (page redirects signed-in users) and immediately bounced back by middleware. Now redirects to `/logout` when `opollo_2fa_pending` is set.
4. **`/logout` did not clear the 2FA cookies.** `signOut()` handles only Supabase session cookies via the SSR adapter; the 2FA cookies live outside that. Now cleared explicitly.
5. **`loginAction` trusted-device shortcut didn't clear stale 2FA cookies.** Same stuck-loop pattern when re-signing-in on a trusted device with leftover cookies.
6. **`CheckEmailPolling` re-fired `completeLogin` under status transitions** because `status` was in the `useEffect` deps. Replaced with a ref-based latch + clean state machine (`idle → running → navigating | failed`). On failure: explicit "Try again" + "Start over". On `consumed`: still calls complete-login (now idempotent) so this browser's cookies get cleared regardless of who won the race.

## Styling
`/auth/approve` and `/login/check-email` now match the `/login` card pattern (centered max-w-md, rounded card, bg-canvas). The approve page uses clearer "return to your original tab" copy with a divider-separated lost-tab fallback section.

## Risks identified and mitigated

- **Idempotent complete-login is a security-relevant change.** If we 200 on an already-consumed challenge for a user who happens to share a session (impossible in normal flow), we'd leak admin access. Mitigated: the route validates `challenge.user_id === session.user.id` BEFORE the consumed branch — a different user's challenge still 403s. The trust-device write is skipped on the loser path so we never double-register a device.
- **`/login → /logout` recovery on stale cookie.** A user with a still-valid Supabase session AND a stale `opollo_2fa_pending` cookie gets signed out. That's a UX cost (re-enter password) for a stuck case; better than the current loop. Operators who hit this in normal use will be rare — most enter via the polling shell which now self-resolves.
- **Single-fire latch could strand a user if the network blip happens during the only completeLogin attempt.** Mitigated: the latch releases on failure (`completionStartedRef.current = false` in the catch + non-ok branches), so the "Try again" button calls it again with `force: true`.

## Test plan

Automated:
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `lib/__tests__/middleware.test.ts` — `/auth/approve` added to public-path matrix
- [x] `lib/__tests__/complete-login-route.test.ts` (new) — pins the idempotent already-consumed branch, CAS-race already_consumed return-from-consume branch, plus the existing 401/400/404/403/410/409 guarantees
- [ ] CI vitest green (Docker not available locally; CI runs Supabase stack)

Manual (operator E2E — I cannot drive a real browser + email inbox from this environment):
- [ ] Fresh incognito → `/login` → enter credentials → `/login/check-email`
- [ ] Email arrives → click approve link in same browser → approve page shows "Sign-in approved. Return to your original tab." (NOT "Authentication error")
- [ ] Original tab auto-advances to `/admin/sites` within ~3s
- [ ] User can navigate `/admin/sites` without being bounced
- [ ] Cross-device: open email on phone, click approve → approve page renders (does NOT redirect to /login). Original tab on desktop completes.
- [ ] Stuck-state recovery: sign in, close all tabs, reopen `/login` → form shown (not bounced)
- [ ] Lost-tab recovery: sign in, close original tab, click approve email → "Complete sign-in here" → lands on /admin/sites with valid session

## Files

| File | Change |
|---|---|
| `middleware.ts` | `/auth/approve` added to `PUBLIC_PATHS`; removed from `allowedDuringPending` (dead code now) |
| `app/api/auth/complete-login/route.ts` | Idempotent already-consumed; structured logging on every error path |
| `app/auth/approve/page.tsx` | `/login` card layout; clearer messaging; lost-tab section under divider |
| `app/login/check-email/page.tsx` | `/login` card layout |
| `app/login/page.tsx` | Recovery: redirect to `/logout` on stale `opollo_2fa_pending` cookie |
| `app/login/actions.ts` | Trusted-device path clears stale 2FA cookies before redirect |
| `app/logout/route.ts` | Clears `opollo_2fa_pending` + `opollo_pending_device_id` |
| `components/CheckEmailPolling.tsx` | Ref-based completion latch; recovery UI; auto-call complete-login on `consumed` |
| `lib/__tests__/middleware.test.ts` | `/auth/approve` public-path test row |
| `lib/__tests__/complete-login-route.test.ts` | New — pins the idempotency fix |

🤖 Generated with [Claude Code](https://claude.com/claude-code)