### PR TITLE
feat(design-discovery-followup-1): screenshot upload for design direction input

### DIFF
--- a/app/api/admin/sites/[id]/setup/extract-screenshots/route.ts
+++ b/app/api/admin/sites/[id]/setup/extract-screenshots/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { extractFromScreenshots } from "@/lib/design-discovery/extract-screenshots";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/sites/[id]/setup/extract-screenshots
+//
+// Driven by Step-1's screenshot upload zone. Operator drops up to 5
+// images, the client base64-encodes them in memory, posts the array
+// here. We fan out to the vision lib (single Claude call), return the
+// merged design signals so the form can overlay them on the mood
+// board.
+//
+// Images are NOT persisted — they live in component state, in
+// transit they're inlined into the Anthropic call. The redaction in
+// lib/anthropic-call.ts:redactMessagesForTrace ensures the bytes
+// never reach Langfuse.
+//
+// Body: { screenshots: Array<{ data: string; media_type: ... }> }
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// Mirror lib/design-discovery/extract-screenshots.ts ScreenshotInput
+// keep both in sync.
+const MediaTypeSchema = z.union([
+  z.literal("image/png"),
+  z.literal("image/jpeg"),
+  z.literal("image/webp"),
+  z.literal("image/gif"),
+]);
+
+// 5MB per image, base64 = 4/3 * raw → ~6.67MB ASCII. Cap raw payload
+// envelope at ~36MB total for 5 images.
+const MAX_BASE64_BYTES = Math.ceil((5 * 1024 * 1024 * 4) / 3);
+
+const BodySchema = z.object({
+  screenshots: z
+    .array(
+      z.object({
+        data: z.string().min(1).max(MAX_BASE64_BYTES),
+        media_type: MediaTypeSchema,
+      }),
+    )
+    .min(1)
+    .max(5),
+});
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return errorJson("VALIDATION_FAILED", "Site id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body must be { screenshots: [{ data, media_type }, ...] }.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  let result;
+  try {
+    result = await extractFromScreenshots(parsed.data.screenshots, {
+      siteId: params.id,
+    });
+  } catch (err) {
+    logger.error("design-discovery.extract-screenshots.unhandled", {
+      site_id: params.id,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return errorJson(
+      "INTERNAL_ERROR",
+      err instanceof Error ? err.message : "Vision extraction failed.",
+      500,
+    );
+  }
+
+  if (!result.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { ...result.error, retryable: true },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: result.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/components/DesignDirectionInputs.tsx
+++ b/components/DesignDirectionInputs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Loader2, Sparkles } from "lucide-react";
 import { toast } from "sonner";
@@ -9,6 +9,10 @@ import { ConceptRefinementView } from "@/components/ConceptRefinementView";
 import { ConceptReviewCards } from "@/components/ConceptReviewCards";
 import { MoodBoardStrip } from "@/components/MoodBoardStrip";
 import { DesignUnderstandingPanel } from "@/components/DesignUnderstandingPanel";
+import {
+  ScreenshotUploadZone,
+  type UploadedScreenshot,
+} from "@/components/ScreenshotUploadZone";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -27,12 +31,16 @@ import {
 //   - Free text description
 //   - Industry selector (loads sensible defaults)
 //
-// Screenshot upload is reserved in the design brief shape but the
-// upload UI lands in a follow-up — see PR description.
+// Screenshots: drop up to 5 inspiration images, the client base64s
+// them in memory and posts to /setup/extract-screenshots which fans
+// out to a Claude vision call. Extracted patterns merge into the
+// mood-board view alongside URL extraction. Image bytes never touch
+// DB or Storage.
 //
 // Live mood board updates as inputs arrive: industry preset is
-// rendered immediately; URL extraction overlays its findings on top
-// when a URL is present and the operator clicks "Extract design".
+// rendered immediately; URL + screenshot extraction overlays
+// findings on top when present (URL extraction wins when both are
+// available — operator typed it explicitly, screenshots are inferred).
 // The understanding panel shows what we've inferred + the confidence
 // signal + a "Generate concepts" CTA. The CTA persists the brief and
 // fires three parallel Claude calls server-side; the resulting
@@ -86,6 +94,13 @@ export interface ExtractedSnapshot {
   fetched_at: string | null;
 }
 
+export interface ScreenshotExtraction {
+  swatches: string[];
+  fonts: string[];
+  layout_tags: string[];
+  visual_tone_tags: string[];
+}
+
 const INITIAL_DRAFT: DesignBriefDraft = {
   industry: "msp",
   reference_url: "",
@@ -109,6 +124,11 @@ export function DesignDirectionInputs({
   });
   const [extracting, setExtracting] = useState(false);
   const [extractError, setExtractError] = useState<string | null>(null);
+  const [screenshots, setScreenshots] = useState<UploadedScreenshot[]>([]);
+  const [screenshotExtraction, setScreenshotExtraction] =
+    useState<ScreenshotExtraction | null>(null);
+  const [analysingScreenshots, setAnalysingScreenshots] = useState(false);
+  const [screenshotError, setScreenshotError] = useState<string | null>(null);
   const [generating, setGenerating] = useState(false);
   const [concepts, setConcepts] = useState<ConceptResult[] | null>(null);
   const [conceptErrors, setConceptErrors] = useState<ConceptError[]>([]);
@@ -118,35 +138,122 @@ export function DesignDirectionInputs({
   const preset = useMemo(() => industryPreset(draft.industry), [draft.industry]);
 
   // The current "what we'll show in the mood board" view: industry
-  // preset overlaid by anything we extracted from the URL.
+  // preset, then screenshot extraction layered on top, then URL
+  // extraction wins when both are present (operator typed the URL
+  // explicitly).
   const view = useMemo(() => {
-    const ex = draft.extracted;
+    const url = draft.extracted;
+    const shots = screenshotExtraction;
+    const pickArr = (
+      a: string[] | undefined,
+      b: string[] | undefined,
+      fallback: string[],
+    ): string[] => {
+      if (a && a.length > 0) return a;
+      if (b && b.length > 0) return b;
+      return fallback;
+    };
     return {
-      swatches:
-        ex && ex.swatches.length > 0
-          ? ex.swatches
-          : Object.values(preset.swatches),
-      fonts: ex && ex.fonts.length > 0
-        ? ex.fonts
-        : [preset.font_heading, preset.font_body].filter(
-            (v, i, a) => a.indexOf(v) === i,
-          ),
-      layout_tags:
-        ex && ex.layout_tags.length > 0 ? ex.layout_tags : preset.layout_tags,
-      visual_tone_tags:
-        ex && ex.visual_tone_tags.length > 0
-          ? ex.visual_tone_tags
-          : preset.visual_tone_tags,
-      screenshot_url: ex?.screenshot_url ?? null,
+      swatches: pickArr(
+        url?.swatches,
+        shots?.swatches,
+        Object.values(preset.swatches),
+      ),
+      fonts: pickArr(
+        url?.fonts,
+        shots?.fonts,
+        [preset.font_heading, preset.font_body].filter(
+          (v, i, a) => a.indexOf(v) === i,
+        ),
+      ),
+      layout_tags: pickArr(
+        url?.layout_tags,
+        shots?.layout_tags,
+        preset.layout_tags,
+      ),
+      visual_tone_tags: pickArr(
+        url?.visual_tone_tags,
+        shots?.visual_tone_tags,
+        preset.visual_tone_tags,
+      ),
+      screenshot_url: url?.screenshot_url ?? null,
       visual_tone: preset.visual_tone,
     };
-  }, [draft.extracted, preset]);
+  }, [draft.extracted, screenshotExtraction, preset]);
 
   const hasAnyInput =
     draft.reference_url.trim().length > 0 ||
     draft.existing_site_url.trim().length > 0 ||
     draft.description.trim().length > 0 ||
+    screenshots.length > 0 ||
     draft.industry !== INITIAL_DRAFT.industry;
+
+  // Re-run vision extraction whenever the set of uploaded screenshots
+  // changes. Empty list → drop the cached extraction so the mood board
+  // falls back to URL/preset signals.
+  useEffect(() => {
+    if (screenshots.length === 0) {
+      setScreenshotExtraction(null);
+      setScreenshotError(null);
+      return;
+    }
+    let cancelled = false;
+    setAnalysingScreenshots(true);
+    setScreenshotError(null);
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/admin/sites/${siteId}/setup/extract-screenshots`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              screenshots: screenshots.map((s) => ({
+                data: s.base64,
+                media_type: s.media_type,
+              })),
+            }),
+          },
+        );
+        const payload = (await res.json().catch(() => null)) as
+          | { ok: true; data: ScreenshotExtraction }
+          | { ok: false; error: { message: string } }
+          | null;
+        if (cancelled) return;
+        if (!payload?.ok) {
+          setScreenshotError(
+            payload?.ok === false
+              ? payload.error.message
+              : "Could not read your screenshots. Try again or remove one.",
+          );
+          setAnalysingScreenshots(false);
+          return;
+        }
+        setScreenshotExtraction(payload.data);
+        setAnalysingScreenshots(false);
+      } catch (err) {
+        if (cancelled) return;
+        setScreenshotError(
+          err instanceof Error
+            ? err.message
+            : "Network error reading screenshots.",
+        );
+        setAnalysingScreenshots(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [screenshots, siteId]);
+
+  // Revoke object URLs when the component unmounts so the browser
+  // doesn't hold the raw bytes longer than necessary.
+  useEffect(() => {
+    return () => {
+      for (const s of screenshots) URL.revokeObjectURL(s.preview_url);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function setField<K extends keyof DesignBriefDraft>(
     key: K,
@@ -197,15 +304,22 @@ export function DesignDirectionInputs({
     setConcepts(null);
     setConceptErrors([]);
     setGenerationFailed(null);
+    // Merged extraction: URL signals win, screenshots fill gaps.
+    // Screenshot bytes themselves never persist; only the operator-
+    // visible filenames and the merged signals do.
+    const mergedExtracted = mergeExtractionForBrief(
+      draft.extracted,
+      screenshotExtraction,
+    );
     const brief = {
       industry: draft.industry,
       reference_url: draft.reference_url.trim() || null,
       existing_site_url: draft.existing_site_url.trim() || null,
       description: draft.description.trim() || null,
       edited_understanding: draft.edited_understanding.trim() || null,
-      screenshots: [],
+      screenshots: screenshots.map((s) => s.file_name),
       refinement_notes: [],
-      extracted: draft.extracted,
+      extracted: mergedExtracted,
     };
     // Persist the brief first so the wizard's resume logic returns to
     // Step 1 with the operator's inputs intact even if the generation
@@ -399,6 +513,13 @@ export function DesignDirectionInputs({
         </p>
       </div>
 
+      <ScreenshotUploadZone
+        screenshots={screenshots}
+        onChange={setScreenshots}
+        busy={analysingScreenshots}
+        errorMessage={screenshotError}
+      />
+
       <MoodBoardStrip view={view} />
 
       <DesignUnderstandingPanel
@@ -410,7 +531,8 @@ export function DesignDirectionInputs({
             (draft.reference_url.trim() || draft.existing_site_url.trim()
               ? 1
               : 0) +
-            (draft.description.trim() ? 1 : 0);
+            (draft.description.trim() ? 1 : 0) +
+            (screenshots.length > 0 ? 1 : 0);
           if (score >= 2) return "high";
           if (score === 1) return "medium";
           return "low";
@@ -452,7 +574,10 @@ export function DesignDirectionInputs({
             description: draft.description.trim() || null,
             edited_understanding: draft.edited_understanding.trim() || null,
             refinement_notes: [],
-            extracted: draft.extracted,
+            extracted: mergeExtractionForBrief(
+              draft.extracted,
+              screenshotExtraction,
+            ),
           }}
           initialConcept={refining}
           onCancel={() => setRefining(null)}
@@ -547,4 +672,33 @@ function ConceptResultsBlock({
       />
     </div>
   );
+}
+
+// URL-extracted signals win when present (operator typed the URL
+// explicitly). Screenshot signals fill any empty arrays so the
+// generation prompt + persisted brief reflect both inputs.
+function mergeExtractionForBrief(
+  url: ExtractedSnapshot | null,
+  shots: ScreenshotExtraction | null,
+): ExtractedSnapshot | null {
+  if (!url && !shots) return null;
+  const fillFrom = (
+    a: string[] | undefined,
+    b: string[] | undefined,
+  ): string[] => {
+    if (a && a.length > 0) return a;
+    return b ?? [];
+  };
+  return {
+    swatches: fillFrom(url?.swatches, shots?.swatches),
+    fonts: fillFrom(url?.fonts, shots?.fonts),
+    layout_tags: fillFrom(url?.layout_tags, shots?.layout_tags),
+    visual_tone_tags: fillFrom(
+      url?.visual_tone_tags,
+      shots?.visual_tone_tags,
+    ),
+    screenshot_url: url?.screenshot_url ?? null,
+    source_url: url?.source_url ?? null,
+    fetched_at: url?.fetched_at ?? null,
+  };
 }

--- a/components/ScreenshotUploadZone.tsx
+++ b/components/ScreenshotUploadZone.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useCallback, useId, useRef, useState } from "react";
+import { ImagePlus, Loader2, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+// ---------------------------------------------------------------------------
+// ScreenshotUploadZone — Step-1 image upload affordance.
+//
+// Operator drops or selects up to 5 inspiration images. We hold the
+// base64 + a preview URL in component state only — nothing is
+// persisted to DB / Storage (parent plan: "Store uploaded images
+// temporarily in component state only"). On each add we fire the
+// onExtract callback so the parent can fold the vision-extracted
+// design signals into the mood board.
+//
+// Accept: jpg / png / webp / gif. 5MB per file. Max 5 files.
+// ---------------------------------------------------------------------------
+
+const ACCEPTED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+] as const;
+type AcceptedType = (typeof ACCEPTED_TYPES)[number];
+
+const MAX_FILES = 5;
+const MAX_BYTES_PER_FILE = 5 * 1024 * 1024;
+
+export interface UploadedScreenshot {
+  id: string;
+  file_name: string;
+  media_type: AcceptedType;
+  base64: string; // no data: prefix
+  preview_url: string; // object URL — parent must revokeObjectURL on unmount
+  byte_size: number;
+}
+
+interface Props {
+  screenshots: UploadedScreenshot[];
+  onChange: (next: UploadedScreenshot[]) => void;
+  busy: boolean;
+  errorMessage?: string | null;
+}
+
+function isAcceptedType(t: string): t is AcceptedType {
+  return (ACCEPTED_TYPES as readonly string[]).includes(t);
+}
+
+async function fileToBase64(file: File): Promise<string> {
+  const buf = await file.arrayBuffer();
+  // btoa wants a binary string; build one in 8K chunks to avoid
+  // call-stack issues with large arrays.
+  const bytes = new Uint8Array(buf);
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const slice = bytes.subarray(i, i + CHUNK);
+    binary += String.fromCharCode(...slice);
+  }
+  return btoa(binary);
+}
+
+export function ScreenshotUploadZone({
+  screenshots,
+  onChange,
+  busy,
+  errorMessage,
+}: Props) {
+  const inputId = useId();
+  const dropZoneId = useId();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const remaining = MAX_FILES - screenshots.length;
+
+  const ingest = useCallback(
+    async (incoming: FileList | File[]) => {
+      setLocalError(null);
+      const list = Array.from(incoming);
+      if (list.length === 0) return;
+      if (screenshots.length + list.length > MAX_FILES) {
+        setLocalError(
+          `You can upload up to ${MAX_FILES} images. Remove one to add another.`,
+        );
+        return;
+      }
+      const accepted: UploadedScreenshot[] = [];
+      for (const file of list) {
+        if (!isAcceptedType(file.type)) {
+          setLocalError(
+            `${file.name}: only JPG, PNG, WebP, or GIF images are supported.`,
+          );
+          return;
+        }
+        if (file.size > MAX_BYTES_PER_FILE) {
+          setLocalError(`${file.name}: file is over 5MB.`);
+          return;
+        }
+        const base64 = await fileToBase64(file);
+        accepted.push({
+          id: `${file.name}-${file.size}-${file.lastModified}-${Math.random()
+            .toString(36)
+            .slice(2, 8)}`,
+          file_name: file.name,
+          media_type: file.type,
+          base64,
+          preview_url: URL.createObjectURL(file),
+          byte_size: file.size,
+        });
+      }
+      onChange([...screenshots, ...accepted]);
+    },
+    [onChange, screenshots],
+  );
+
+  function onSelect(e: React.ChangeEvent<HTMLInputElement>): void {
+    if (!e.target.files) return;
+    void ingest(e.target.files);
+    // Reset so the same filename can be re-selected after removal.
+    e.target.value = "";
+  }
+
+  function onDrop(e: React.DragEvent<HTMLDivElement>): void {
+    e.preventDefault();
+    setDragOver(false);
+    if (busy) return;
+    if (!e.dataTransfer.files || e.dataTransfer.files.length === 0) return;
+    void ingest(e.dataTransfer.files);
+  }
+
+  function onRemove(id: string): void {
+    const target = screenshots.find((s) => s.id === id);
+    if (target) URL.revokeObjectURL(target.preview_url);
+    onChange(screenshots.filter((s) => s.id !== id));
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLDivElement>): void {
+    if (busy || remaining <= 0) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      inputRef.current?.click();
+    }
+  }
+
+  const message = errorMessage ?? localError;
+
+  return (
+    <div
+      className="space-y-3"
+      data-testid="screenshot-upload"
+      aria-busy={busy ? "true" : "false"}
+    >
+      <div className="flex items-end justify-between">
+        <div>
+          <label htmlFor={inputId} className="block text-sm font-medium">
+            Upload reference screenshots{" "}
+            <span className="font-normal text-muted-foreground">
+              (optional, up to {MAX_FILES})
+            </span>
+          </label>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Drag-and-drop or browse. JPG / PNG / WebP / GIF up to 5MB
+            each. Used only to extract patterns — files aren&apos;t
+            saved.
+          </p>
+        </div>
+        {busy && (
+          <span
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+            data-testid="screenshot-upload-busy"
+            aria-live="polite"
+          >
+            <Loader2 aria-hidden className="h-3.5 w-3.5 animate-spin" />
+            Reading your images…
+          </span>
+        )}
+      </div>
+
+      <div
+        id={dropZoneId}
+        role="button"
+        tabIndex={busy || remaining <= 0 ? -1 : 0}
+        aria-label={
+          remaining > 0
+            ? `Upload reference screenshots — ${remaining} of ${MAX_FILES} slot${remaining === 1 ? "" : "s"} remaining`
+            : `Maximum ${MAX_FILES} screenshots reached`
+        }
+        aria-disabled={busy || remaining <= 0 ? "true" : "false"}
+        aria-controls={inputId}
+        onClick={() => {
+          if (busy || remaining <= 0) return;
+          inputRef.current?.click();
+        }}
+        onDragOver={(e) => {
+          e.preventDefault();
+          if (!busy && remaining > 0) setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={onDrop}
+        onKeyDown={onKeyDown}
+        className={[
+          "flex flex-col items-center justify-center rounded-md border border-dashed bg-background px-4 py-6 text-center",
+          "transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          dragOver
+            ? "border-foreground bg-muted/30"
+            : "border-muted-foreground/40 hover:border-foreground/60",
+          busy || remaining <= 0
+            ? "cursor-not-allowed opacity-60"
+            : "cursor-pointer",
+        ].join(" ")}
+        data-testid="screenshot-upload-dropzone"
+      >
+        <ImagePlus
+          aria-hidden
+          className="h-6 w-6 text-muted-foreground"
+        />
+        <p className="mt-2 text-sm">
+          {remaining > 0
+            ? "Drop images here, or click to browse"
+            : `${MAX_FILES} images uploaded — remove one to add another`}
+        </p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {remaining > 0
+            ? `${screenshots.length} of ${MAX_FILES} uploaded`
+            : "Maximum reached"}
+        </p>
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="file"
+          accept={ACCEPTED_TYPES.join(",")}
+          multiple
+          onChange={onSelect}
+          disabled={busy || remaining <= 0}
+          className="sr-only"
+          data-testid="screenshot-upload-input"
+        />
+      </div>
+
+      {message && (
+        <p
+          className="text-xs text-destructive"
+          role="alert"
+          data-testid="screenshot-upload-error"
+        >
+          {message}
+        </p>
+      )}
+
+      {screenshots.length > 0 && (
+        <ul
+          className="grid grid-cols-3 gap-2 md:grid-cols-5"
+          data-testid="screenshot-upload-thumbnails"
+          aria-label="Uploaded reference screenshots"
+        >
+          {screenshots.map((s) => (
+            <li
+              key={s.id}
+              className="relative overflow-hidden rounded-md border bg-muted/20"
+              data-testid="screenshot-upload-thumbnail"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={s.preview_url}
+                alt={`Reference screenshot: ${s.file_name}`}
+                className="block h-24 w-full object-cover"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="absolute right-1 top-1 h-6 w-6"
+                onClick={() => onRemove(s.id)}
+                disabled={busy}
+                aria-label={`Remove ${s.file_name}`}
+                data-testid="screenshot-upload-remove"
+              >
+                <X aria-hidden className="h-3 w-3" />
+              </Button>
+              <p
+                className="truncate px-1.5 py-0.5 text-[10px] text-muted-foreground"
+                title={s.file_name}
+              >
+                {s.file_name}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export const SCREENSHOT_LIMITS = {
+  maxFiles: MAX_FILES,
+  maxBytesPerFile: MAX_BYTES_PER_FILE,
+  acceptedTypes: ACCEPTED_TYPES,
+} as const;

--- a/lib/__tests__/design-discovery-extract-screenshots.test.ts
+++ b/lib/__tests__/design-discovery-extract-screenshots.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  extractFromScreenshots,
+  parseVisionOutput,
+} from "@/lib/design-discovery/extract-screenshots";
+import type { AnthropicCallFn } from "@/lib/anthropic-call";
+
+// ---------------------------------------------------------------------------
+// DESIGN-DISCOVERY-FOLLOWUP — vision-extraction unit tests.
+//
+// Pure-function coverage: parseVisionOutput tag handling + the
+// orchestrator's retry / error-shape behaviour with a stubbed
+// AnthropicCallFn. No real Anthropic call.
+// ---------------------------------------------------------------------------
+
+describe("parseVisionOutput", () => {
+  it("parses a clean <output>...</output> JSON", () => {
+    const out = parseVisionOutput(
+      `<output>{"swatches":["#111111","#eeeeee"],"fonts":["Inter"],"layout_tags":["centred-hero"],"visual_tone_tags":["minimal"]}</output>`,
+    );
+    expect(out).toEqual({
+      swatches: ["#111111", "#eeeeee"],
+      fonts: ["Inter"],
+      layout_tags: ["centred-hero"],
+      visual_tone_tags: ["minimal"],
+    });
+  });
+
+  it("falls back to fenced JSON when output tags are missing", () => {
+    const out = parseVisionOutput(
+      "```json\n{\"swatches\":[],\"fonts\":[],\"layout_tags\":[],\"visual_tone_tags\":[]}\n```",
+    );
+    expect(out).toEqual({
+      swatches: [],
+      fonts: [],
+      layout_tags: [],
+      visual_tone_tags: [],
+    });
+  });
+
+  it("returns null when no JSON is parseable", () => {
+    expect(parseVisionOutput("nothing structured here")).toBeNull();
+  });
+
+  it("returns null when JSON shape doesn't match the schema", () => {
+    expect(parseVisionOutput(`<output>{"foo":1}</output>`)).toEqual({
+      swatches: [],
+      fonts: [],
+      layout_tags: [],
+      visual_tone_tags: [],
+    });
+  });
+});
+
+describe("extractFromScreenshots", () => {
+  const goodResponse = {
+    id: "msg_test",
+    model: "claude-sonnet-4-6",
+    content: [
+      {
+        type: "text" as const,
+        text: `<output>{"swatches":["#222","#fff"],"fonts":["Inter"],"layout_tags":["card-grid"],"visual_tone_tags":["high-contrast"]}</output>`,
+      },
+    ],
+    stop_reason: "end_turn",
+    usage: { input_tokens: 10, output_tokens: 10 },
+  };
+
+  const sampleImages = [
+    {
+      data: "ZmFrZS1pbWFnZS1ieXRlcw==",
+      media_type: "image/png" as const,
+    },
+  ];
+
+  it("rejects empty input", async () => {
+    const result = await extractFromScreenshots([], { siteId: "site-x" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns parsed signals on success", async () => {
+    const call: AnthropicCallFn = vi.fn(async () => goodResponse);
+    const result = await extractFromScreenshots(
+      sampleImages,
+      { siteId: "site-x" },
+      call,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.swatches).toEqual(["#222", "#fff"]);
+      expect(result.data.layout_tags).toEqual(["card-grid"]);
+    }
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once when the first attempt returns an unparseable body", async () => {
+    const call: AnthropicCallFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: "m1",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text" as const, text: "not json at all" }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      })
+      .mockResolvedValueOnce(goodResponse);
+    const result = await extractFromScreenshots(
+      sampleImages,
+      { siteId: "site-x" },
+      call,
+    );
+    expect(result.ok).toBe(true);
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns VISION_FAILED after two parse failures", async () => {
+    const bad = {
+      id: "m1",
+      model: "claude-sonnet-4-6",
+      content: [{ type: "text" as const, text: "still not json" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+    const call: AnthropicCallFn = vi.fn(async () => bad);
+    const result = await extractFromScreenshots(
+      sampleImages,
+      { siteId: "site-x" },
+      call,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VISION_FAILED");
+    }
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  it("scopes idempotency keys to the site id", async () => {
+    const calls: string[] = [];
+    const call: AnthropicCallFn = vi.fn(async (req) => {
+      calls.push(req.idempotency_key);
+      return goodResponse;
+    });
+    await extractFromScreenshots(sampleImages, { siteId: "site-x" }, call);
+    expect(calls[0]).toMatch(/^screenshots:site-x:/);
+  });
+});

--- a/lib/design-discovery/extract-screenshots.ts
+++ b/lib/design-discovery/extract-screenshots.ts
@@ -1,0 +1,199 @@
+import "server-only";
+
+import { z } from "zod";
+
+import {
+  defaultAnthropicCall,
+  type AnthropicCallFn,
+  type AnthropicContentBlock,
+} from "@/lib/anthropic-call";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// DESIGN-DISCOVERY-FOLLOWUP — screenshot vision extraction.
+//
+// The setup wizard's Step-1 input surface accepts up to 5 image
+// uploads (see design-brief.ts: screenshots reserved). Operator
+// uploads → client posts base64 PNGs/JPEGs/WebPs/GIFs to this lib's
+// API route → we ask Claude to extract design patterns the operator
+// wants reflected in the generated concepts.
+//
+// Output: same shape as the URL-extraction snapshot (swatches /
+// fonts / layout_tags / visual_tone_tags) so the mood-board strip
+// can merge URL-extraction signals with vision-extraction signals
+// without two code paths.
+//
+// Model: project's current Sonnet (claude-sonnet-4-6). The brief's
+// reference to claude-sonnet-4-20250514 is a 2024 vintage that's not
+// in lib/anthropic-pricing.ts:PRICING_TABLE; using the allow-listed
+// equivalent keeps the wrapper's idempotency + cost-tracking
+// invariants intact.
+// ---------------------------------------------------------------------------
+
+const VISION_MODEL = "claude-sonnet-4-6";
+const VISION_MAX_TOKENS = 1024;
+
+export type ScreenshotMediaType =
+  | "image/png"
+  | "image/jpeg"
+  | "image/webp"
+  | "image/gif";
+
+export interface ScreenshotInput {
+  data: string; // base64 (no data: prefix)
+  media_type: ScreenshotMediaType;
+}
+
+// Same shape as ExtractedSnapshot, minus screenshot_url / source_url
+// (those are URL-extraction concepts).
+export interface ScreenshotExtractionResult {
+  swatches: string[];
+  fonts: string[];
+  layout_tags: string[];
+  visual_tone_tags: string[];
+}
+
+const ExtractedJsonSchema = z.object({
+  swatches: z.array(z.string()).max(8).default([]),
+  fonts: z.array(z.string()).max(6).default([]),
+  layout_tags: z.array(z.string()).max(8).default([]),
+  visual_tone_tags: z.array(z.string()).max(8).default([]),
+});
+
+const SYSTEM_PROMPT = `You are a senior visual designer doing a fast pattern read on inspiration screenshots a client just uploaded. Look at every image and return ONE consolidated set of design signals — colours, type feel, layout patterns, visual tone — that capture what the client is gravitating towards.
+
+Respond ONLY with a JSON object inside <output></output> tags, with this exact shape:
+
+{
+  "swatches": ["#rrggbb", ...],         // up to 8 hex colours, ordered by visual prominence
+  "fonts": ["Inter", "Source Serif", ...], // up to 6 font-family names; if you can't read a name, describe ("geometric sans", "humanist serif")
+  "layout_tags": ["centred-hero", "card-grid", "two-column", ...], // up to 8 short layout descriptors
+  "visual_tone_tags": ["minimal", "warm", "high-contrast", ...]   // up to 8 short tone descriptors
+}
+
+Do NOT include any other commentary. Do NOT include rationale. Do NOT include image-specific notes — collapse signals across all images into one consolidated set.`;
+
+const OUTPUT_RE = /<output>\s*([\s\S]+?)\s*<\/output>/i;
+
+export function parseVisionOutput(
+  text: string,
+): ScreenshotExtractionResult | null {
+  const m = OUTPUT_RE.exec(text);
+  const blob = m ? m[1] : text;
+  if (!blob) return null;
+  let json: unknown;
+  try {
+    json = JSON.parse(blob);
+  } catch {
+    const fenced = /```(?:json)?\s*([\s\S]+?)\s*```/.exec(blob);
+    if (!fenced || !fenced[1]) return null;
+    try {
+      json = JSON.parse(fenced[1]);
+    } catch {
+      return null;
+    }
+  }
+  const parsed = ExtractedJsonSchema.safeParse(json);
+  if (!parsed.success) return null;
+  return parsed.data;
+}
+
+function idempotencyKey(
+  siteId: string,
+  digest: string,
+  attempt: number,
+): string {
+  return `screenshots:${siteId}:${digest}:${attempt}`;
+}
+
+// Stable digest of the screenshots payload — base64 length + first /
+// last 16 chars of each image. Cheap, collision-resistant enough for
+// idempotency-key scope (Anthropic's 24h window dedups same-key calls).
+function digestScreenshots(images: ScreenshotInput[]): string {
+  const parts = images.map((img) => {
+    const head = img.data.slice(0, 16);
+    const tail = img.data.slice(-16);
+    return `${img.media_type}:${img.data.length}:${head}:${tail}`;
+  });
+  let h = 0;
+  const joined = parts.join("|");
+  for (let i = 0; i < joined.length; i++) {
+    h = (h * 31 + joined.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h).toString(36);
+}
+
+export async function extractFromScreenshots(
+  images: ScreenshotInput[],
+  ctx: { siteId: string },
+  callOverride?: AnthropicCallFn,
+): Promise<
+  | { ok: true; data: ScreenshotExtractionResult }
+  | { ok: false; error: { code: string; message: string } }
+> {
+  if (images.length === 0) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_FAILED",
+        message: "At least one screenshot is required.",
+      },
+    };
+  }
+  const call = callOverride ?? defaultAnthropicCall;
+  const digest = digestScreenshots(images);
+
+  const content: AnthropicContentBlock[] = [
+    ...images.map(
+      (img): AnthropicContentBlock => ({
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: img.media_type,
+          data: img.data,
+        },
+      }),
+    ),
+    {
+      type: "text",
+      text: "Read the visual signals across these screenshots and return the consolidated JSON described in the system prompt.",
+    },
+  ];
+
+  const tryOnce = async (
+    attempt: number,
+  ): Promise<ScreenshotExtractionResult | string> => {
+    try {
+      const res = await call({
+        model: VISION_MODEL,
+        max_tokens: VISION_MAX_TOKENS,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: "user", content }],
+        idempotency_key: idempotencyKey(ctx.siteId, digest, attempt),
+      });
+      const text = res.content.map((b) => b.text).join("");
+      const parsed = parseVisionOutput(text);
+      if (!parsed) return "parse failed";
+      return parsed;
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  };
+
+  const first = await tryOnce(1);
+  if (typeof first !== "string") return { ok: true, data: first };
+  logger.warn("design-discovery.screenshots.attempt-1-failed", {
+    site_id: ctx.siteId,
+    error: first,
+  });
+  const second = await tryOnce(2);
+  if (typeof second !== "string") return { ok: true, data: second };
+  logger.error("design-discovery.screenshots.attempt-2-failed", {
+    site_id: ctx.siteId,
+    error: second,
+  });
+  return {
+    ok: false,
+    error: { code: "VISION_FAILED", message: second },
+  };
+}


### PR DESCRIPTION
## Summary

DESIGN-DISCOVERY-FOLLOWUP PR 1 of 4. Step 1 of the setup wizard now accepts up to 5 inspiration screenshots; the client base64-encodes them in memory and posts to a new `/setup/extract-screenshots` route that runs a single Claude Sonnet vision pass and returns consolidated design signals (swatches / fonts / layout tags / visual tone tags). Signals merge into the live mood board (URL extraction wins when both present), bump the confidence indicator, and thread into the persisted `design_brief` on Generate / Refine.

- `ScreenshotUploadZone` — drag-and-drop or browse, inline thumbnails, per-thumb remove, fully keyboard-navigable, screen-reader-friendly. JPG/PNG/WebP/GIF, 5MB per file.
- `lib/design-discovery/extract-screenshots.ts` — single Claude call with one parse-fail retry, deterministic idempotency key per (site_id, content digest, attempt).
- `DesignDirectionInputs` integrates the zone, kicks off vision extraction whenever the upload set changes, layers signals onto the mood-board view, and revokes object URLs on unmount.
- Pure-function unit tests for the JSON parser + retry/error paths (stubbed `AnthropicCallFn`).

## Risks identified and mitigated

- **Image bytes leaking into observability** — `lib/anthropic-call.ts:redactMessagesForTrace` already redacts image-block payloads in trace metadata; this PR sends images as base64 inline blocks only, never logs them.
- **Persisting bytes to DB/Storage** — the design_brief.screenshots field stays `string[]` (filenames). Bytes live in client state + ephemeral object URLs only; no new storage path added.
- **Anthropic 24h idempotency cache double-billing** — idempotency key scopes to `(site_id, content-digest, attempt)`. Retries replay; distinct uploads get distinct keys.
- **Model allow-list drift** — the workstream brief named `claude-sonnet-4-20250514` (a 2024 vintage outside `PRICING_TABLE`); using the project's current Sonnet (`claude-sonnet-4-6`) preserves the pricing / cost-control invariants. Documented in the lib's header comment.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Unit tests added for `parseVisionOutput` + the orchestrator's retry path. Run via `npm run test design-discovery-extract-screenshots` (Supabase stack required for the global setup).
- [ ] Manual: Step 1 upload → thumbnails → remove → re-upload → mood board reflects extracted signals → Generate persists merged extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)