### PR TITLE
feat(design-discovery-followup-3): server-side regeneration caps

### DIFF
--- a/app/api/admin/sites/[id]/setup/approve-design/route.ts
+++ b/app/api/admin/sites/[id]/setup/approve-design/route.ts
@@ -8,6 +8,7 @@ import {
   resetDesignDirection,
 } from "@/lib/design-discovery/approve-design";
 import { DesignBriefSchema } from "@/lib/design-discovery/design-brief";
+import { resetRegenCount } from "@/lib/design-discovery/regen-caps";
 
 // ---------------------------------------------------------------------------
 // POST   /api/admin/sites/[id]/setup/approve-design
@@ -125,6 +126,12 @@ export async function DELETE(
       result.error.code === "NOT_FOUND" ? 404 : 500,
     );
   }
+
+  // "Reset and start over" zeros the concept_refinements bucket so
+  // the operator gets a fresh 10-call budget on the next pass.
+  // Tolerate a NOT_FOUND-after-reset by ignoring it; the design reset
+  // already succeeded and the site clearly exists.
+  await resetRegenCount(params.id, "concept_refinements");
 
   revalidatePath(`/admin/sites/${params.id}/setup`);
   return NextResponse.json(

--- a/app/api/admin/sites/[id]/setup/extract-tone/route.ts
+++ b/app/api/admin/sites/[id]/setup/extract-tone/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { extractTone } from "@/lib/design-discovery/extract-tone";
+import { resetRegenCount } from "@/lib/design-discovery/regen-caps";
 import {
   AVOID_OPTIONS,
   PERSONALITY_OPTIONS,
@@ -98,6 +99,12 @@ export async function POST(
       { status: 200 },
     );
   }
+
+  // Re-extracting tone replaces the existing profile + samples on
+  // the client (ToneOfVoiceInputs.onExtract sets regenAttempts to 0
+  // locally). Mirror that on the server so the cap budget refreshes
+  // for the new tone run too.
+  await resetRegenCount(params.id, "tone_samples");
 
   return NextResponse.json(
     { ok: true, data: result.data, timestamp: new Date().toISOString() },

--- a/app/api/admin/sites/[id]/setup/refine-concept/route.ts
+++ b/app/api/admin/sites/[id]/setup/refine-concept/route.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { DesignBriefSchema } from "@/lib/design-discovery/design-brief";
 import { regenerateConcept } from "@/lib/design-discovery/generate-concepts";
+import { incrementRegenCount } from "@/lib/design-discovery/regen-caps";
 import { logger } from "@/lib/logger";
 import { getSite } from "@/lib/sites";
 
@@ -89,6 +90,37 @@ export async function POST(
       siteResult.error.code,
       siteResult.error.message,
       siteResult.error.code === "NOT_FOUND" ? 404 : 500,
+    );
+  }
+
+  // Server-side cap enforcement. Increment FIRST so the count is
+  // burned the moment the call lands; if Anthropic later fails the
+  // operator still owes that attempt against the cap (matches the
+  // intended product behaviour: 10 paid calls per site, not 10
+  // successful refinements).
+  const cap = await incrementRegenCount(
+    siteResult.data.site.id,
+    "concept_refinements",
+  );
+  if (!cap.ok) {
+    if (cap.error.code === "LIMIT_REACHED") {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: "LIMIT_REACHED",
+            message: cap.error.message,
+            retryable: false,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 429 },
+      );
+    }
+    return errorJson(
+      cap.error.code,
+      cap.error.message,
+      cap.error.code === "NOT_FOUND" ? 404 : 500,
     );
   }
 

--- a/app/api/admin/sites/[id]/setup/regenerate-tone-samples/route.ts
+++ b/app/api/admin/sites/[id]/setup/regenerate-tone-samples/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { regenerateSamples } from "@/lib/design-discovery/extract-tone";
+import { incrementRegenCount } from "@/lib/design-discovery/regen-caps";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -76,6 +77,32 @@ export async function POST(
         timestamp: new Date().toISOString(),
       },
       { status: 400 },
+    );
+  }
+
+  // Server-side cap (DESIGN-DISCOVERY-FOLLOWUP PR 3). Increment first
+  // so the bucket is debited the moment the call lands, regardless of
+  // whether the Anthropic call later succeeds.
+  const cap = await incrementRegenCount(params.id, "tone_samples");
+  if (!cap.ok) {
+    if (cap.error.code === "LIMIT_REACHED") {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: "LIMIT_REACHED",
+            message: cap.error.message,
+            retryable: false,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 429 },
+      );
+    }
+    return errorJson(
+      cap.error.code,
+      cap.error.message,
+      cap.error.code === "NOT_FOUND" ? 404 : 500,
     );
   }
 

--- a/components/ConceptRefinementView.tsx
+++ b/components/ConceptRefinementView.tsx
@@ -94,12 +94,26 @@ export function ConceptRefinementView({
       );
       const payload = (await res.json().catch(() => null)) as
         | { ok: true; data: ConceptResult }
-        | { ok: false; error: { message: string } }
+        | { ok: false; error: { code?: string; message: string } }
         | null;
       if (!payload?.ok) {
         setError(
           payload?.ok === false ? payload.error.message : "Refinement failed.",
         );
+        // Server-side cap (DESIGN-DISCOVERY-FOLLOWUP PR 3): a 429
+        // means the operator has burned their 10-call budget on the
+        // server, even if local state thinks they have remaining.
+        // Snap the local counter forward so the Refine button locks.
+        if (
+          res.status === 429 ||
+          (payload?.ok === false && payload.error.code === "LIMIT_REACHED")
+        ) {
+          setRefinementNotes(
+            new Array(REFINE_CAP).fill("").map((_, i) =>
+              refinementNotes[i] ?? "(server-side cap)",
+            ),
+          );
+        }
         setRefining(false);
         return;
       }

--- a/components/ToneOfVoiceInputs.tsx
+++ b/components/ToneOfVoiceInputs.tsx
@@ -182,12 +182,21 @@ export function ToneOfVoiceInputs({
       );
       const payload = (await res.json().catch(() => null)) as
         | { ok: true; data: { samples: ToneSample[] } }
-        | { ok: false; error: { message: string } }
+        | { ok: false; error: { code?: string; message: string } }
         | null;
       if (!payload?.ok) {
         toast.error(
           payload?.ok === false ? payload.error.message : "Regeneration failed.",
         );
+        // Server-side cap (DESIGN-DISCOVERY-FOLLOWUP PR 3): a 429
+        // means the cap is exhausted on the server even if local
+        // state hasn't caught up. Lock the button.
+        if (
+          res.status === 429 ||
+          (payload?.ok === false && payload.error.code === "LIMIT_REACHED")
+        ) {
+          setRegenAttempts(REGEN_CAP);
+        }
         setRegenerating(false);
         return;
       }

--- a/lib/__tests__/design-discovery-regen-caps.test.ts
+++ b/lib/__tests__/design-discovery-regen-caps.test.ts
@@ -1,0 +1,152 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  getRegenCounts,
+  incrementRegenCount,
+  REGEN_CAP,
+  resetRegenCount,
+} from "@/lib/design-discovery/regen-caps";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// DESIGN-DISCOVERY-FOLLOWUP PR 3 — server-side cap state machine.
+// Runs against a live local Supabase (vitest globalSetup TRUNCATEs
+// between tests). No mocks.
+// ---------------------------------------------------------------------------
+
+const TEST_SITE_NAME = "regen-caps-test-site";
+const TEST_SITE_PREFIX = "regen-caps-test";
+
+let TEST_SITE_ID: string;
+
+async function createSite(): Promise<string> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("sites")
+    .insert({
+      name: TEST_SITE_NAME,
+      wp_url: "https://regen-caps.test",
+      prefix: TEST_SITE_PREFIX,
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error || !data) {
+    throw new Error(`createSite failed: ${error?.message ?? "no data"}`);
+  }
+  return data.id;
+}
+
+beforeEach(async () => {
+  TEST_SITE_ID = await createSite();
+});
+
+afterAll(async () => {
+  // _setup.ts truncates between tests; nothing to do here.
+});
+
+describe("incrementRegenCount", () => {
+  it("starts at 0 and increments to 1 on first call", async () => {
+    const result = await incrementRegenCount(
+      TEST_SITE_ID,
+      "concept_refinements",
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.current).toBe(1);
+  });
+
+  it("increments independently across the two buckets", async () => {
+    await incrementRegenCount(TEST_SITE_ID, "concept_refinements");
+    await incrementRegenCount(TEST_SITE_ID, "concept_refinements");
+    await incrementRegenCount(TEST_SITE_ID, "tone_samples");
+
+    const counts = await getRegenCounts(TEST_SITE_ID);
+    expect(counts.ok).toBe(true);
+    if (counts.ok) {
+      expect(counts.counts.concept_refinements).toBe(2);
+      expect(counts.counts.tone_samples).toBe(1);
+    }
+  });
+
+  it("returns LIMIT_REACHED at the cap", async () => {
+    for (let i = 0; i < REGEN_CAP; i++) {
+      const r = await incrementRegenCount(TEST_SITE_ID, "concept_refinements");
+      expect(r.ok).toBe(true);
+    }
+    const beyond = await incrementRegenCount(
+      TEST_SITE_ID,
+      "concept_refinements",
+    );
+    expect(beyond.ok).toBe(false);
+    if (!beyond.ok) {
+      expect(beyond.error.code).toBe("LIMIT_REACHED");
+      expect(beyond.error.message).toMatch(/Refinement limit reached/);
+      expect(beyond.error.message).toMatch(/10\/10/);
+    }
+  });
+
+  it("does NOT increment when the cap is hit", async () => {
+    for (let i = 0; i < REGEN_CAP; i++) {
+      await incrementRegenCount(TEST_SITE_ID, "tone_samples");
+    }
+    await incrementRegenCount(TEST_SITE_ID, "tone_samples");
+    await incrementRegenCount(TEST_SITE_ID, "tone_samples");
+    const counts = await getRegenCounts(TEST_SITE_ID);
+    expect(counts.ok).toBe(true);
+    if (counts.ok) expect(counts.counts.tone_samples).toBe(REGEN_CAP);
+  });
+
+  it("returns NOT_FOUND for an unknown site", async () => {
+    const r = await incrementRegenCount(
+      "00000000-0000-0000-0000-000000000000",
+      "concept_refinements",
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe("NOT_FOUND");
+  });
+});
+
+describe("resetRegenCount", () => {
+  it("zeros the targeted bucket without touching the other", async () => {
+    await incrementRegenCount(TEST_SITE_ID, "concept_refinements");
+    await incrementRegenCount(TEST_SITE_ID, "concept_refinements");
+    await incrementRegenCount(TEST_SITE_ID, "tone_samples");
+    await resetRegenCount(TEST_SITE_ID, "concept_refinements");
+    const counts = await getRegenCounts(TEST_SITE_ID);
+    expect(counts.ok).toBe(true);
+    if (counts.ok) {
+      expect(counts.counts.concept_refinements).toBe(0);
+      expect(counts.counts.tone_samples).toBe(1);
+    }
+  });
+
+  it("re-enables increments after a reset", async () => {
+    for (let i = 0; i < REGEN_CAP; i++) {
+      await incrementRegenCount(TEST_SITE_ID, "concept_refinements");
+    }
+    const overCap = await incrementRegenCount(
+      TEST_SITE_ID,
+      "concept_refinements",
+    );
+    expect(overCap.ok).toBe(false);
+
+    await resetRegenCount(TEST_SITE_ID, "concept_refinements");
+    const afterReset = await incrementRegenCount(
+      TEST_SITE_ID,
+      "concept_refinements",
+    );
+    expect(afterReset.ok).toBe(true);
+    if (afterReset.ok) expect(afterReset.current).toBe(1);
+  });
+});
+
+describe("getRegenCounts", () => {
+  it("returns the default row for a freshly-created site", async () => {
+    const counts = await getRegenCounts(TEST_SITE_ID);
+    expect(counts.ok).toBe(true);
+    if (counts.ok) {
+      expect(counts.counts.concept_refinements).toBe(0);
+      expect(counts.counts.tone_samples).toBe(0);
+    }
+  });
+});

--- a/lib/design-discovery/regen-caps.ts
+++ b/lib/design-discovery/regen-caps.ts
@@ -1,0 +1,246 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// DESIGN-DISCOVERY-FOLLOWUP — server-side regeneration caps.
+//
+// Each setup-wizard regeneration loop (concept refinement / tone
+// sample regeneration) is capped at 10 calls per site. Pre-this-PR
+// the cap lived in client state only; this module moves enforcement
+// to the server and lets the routes return 429 the moment the cap
+// is hit.
+//
+// Storage: sites.regeneration_counts JSONB
+//   { concept_refinements: number, tone_samples: number }
+// Schema: migration 0066.
+// ---------------------------------------------------------------------------
+
+export type RegenCounter = "concept_refinements" | "tone_samples";
+
+export const REGEN_CAP = 10;
+
+export type IncrementResult =
+  | { ok: true; current: number }
+  | {
+      ok: false;
+      error: {
+        code: "NOT_FOUND" | "LIMIT_REACHED" | "INTERNAL_ERROR";
+        message: string;
+        current?: number;
+      };
+    };
+
+const COUNTER_LABEL: Record<RegenCounter, string> = {
+  concept_refinements: "Refinement",
+  tone_samples: "Sample regeneration",
+};
+
+interface CountsRow {
+  regeneration_counts: Record<string, number> | null;
+}
+
+function readCount(
+  raw: Record<string, unknown> | null,
+  key: RegenCounter,
+): number {
+  if (!raw) return 0;
+  const v = raw[key];
+  return typeof v === "number" && v >= 0 ? Math.floor(v) : 0;
+}
+
+/**
+ * Atomic-enough increment: read the current value, refuse if at cap,
+ * write the new bucket back. The race window is bounded — a single
+ * operator drives one site through the wizard — and the worst case is
+ * one extra call slipping through during a same-millisecond double
+ * post, which is fine as long as the schema-level CHECK keeps the
+ * value non-negative.
+ */
+export async function incrementRegenCount(
+  siteId: string,
+  counter: RegenCounter,
+): Promise<IncrementResult> {
+  const supabase = getServiceRoleClient();
+  const { data: row, error: readErr } = await supabase
+    .from("sites")
+    .select("regeneration_counts")
+    .eq("id", siteId)
+    .neq("status", "removed")
+    .maybeSingle<CountsRow>();
+  if (readErr) {
+    return {
+      ok: false,
+      error: { code: "INTERNAL_ERROR", message: readErr.message },
+    };
+  }
+  if (!row) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `No active site found with id ${siteId}.`,
+      },
+    };
+  }
+  const counts = (row.regeneration_counts ?? {}) as Record<string, unknown>;
+  const current = readCount(counts, counter);
+  if (current >= REGEN_CAP) {
+    const label = COUNTER_LABEL[counter];
+    const reset =
+      counter === "concept_refinements"
+        ? "Reset your design direction to start over."
+        : "Reset your tone of voice to start over.";
+    return {
+      ok: false,
+      error: {
+        code: "LIMIT_REACHED",
+        message: `${label} limit reached (${current}/${REGEN_CAP}). ${reset}`,
+        current,
+      },
+    };
+  }
+  const nextCounts: Record<string, number> = {};
+  for (const k of Object.keys(counts)) {
+    nextCounts[k] = readCount(counts, k as RegenCounter);
+  }
+  nextCounts[counter] = current + 1;
+  const { data: updated, error: writeErr } = await supabase
+    .from("sites")
+    .update({
+      regeneration_counts: nextCounts,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", siteId)
+    .neq("status", "removed")
+    .select("id")
+    .maybeSingle();
+  if (writeErr) {
+    return {
+      ok: false,
+      error: { code: "INTERNAL_ERROR", message: writeErr.message },
+    };
+  }
+  if (!updated) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Site ${siteId} disappeared during increment.`,
+      },
+    };
+  }
+  return { ok: true, current: current + 1 };
+}
+
+export type ResetResult =
+  | { ok: true }
+  | {
+      ok: false;
+      error: { code: "NOT_FOUND" | "INTERNAL_ERROR"; message: string };
+    };
+
+/**
+ * Zero one of the two buckets. Used by:
+ *   - DELETE /setup/approve-design ("Reset and start over" on Step 1) →
+ *     resets concept_refinements
+ *   - POST /setup/extract-tone (re-extraction wipes the existing tone +
+ *     samples) → resets tone_samples
+ */
+export async function resetRegenCount(
+  siteId: string,
+  counter: RegenCounter,
+): Promise<ResetResult> {
+  const supabase = getServiceRoleClient();
+  const { data: row, error: readErr } = await supabase
+    .from("sites")
+    .select("regeneration_counts")
+    .eq("id", siteId)
+    .neq("status", "removed")
+    .maybeSingle<CountsRow>();
+  if (readErr) {
+    return {
+      ok: false,
+      error: { code: "INTERNAL_ERROR", message: readErr.message },
+    };
+  }
+  if (!row) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `No active site found with id ${siteId}.`,
+      },
+    };
+  }
+  const counts = (row.regeneration_counts ?? {}) as Record<string, unknown>;
+  const next: Record<string, number> = {};
+  for (const k of Object.keys(counts)) {
+    next[k] = readCount(counts, k as RegenCounter);
+  }
+  next[counter] = 0;
+  const { data: updated, error: writeErr } = await supabase
+    .from("sites")
+    .update({
+      regeneration_counts: next,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", siteId)
+    .neq("status", "removed")
+    .select("id")
+    .maybeSingle();
+  if (writeErr) {
+    return {
+      ok: false,
+      error: { code: "INTERNAL_ERROR", message: writeErr.message },
+    };
+  }
+  if (!updated) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Site ${siteId} disappeared during reset.`,
+      },
+    };
+  }
+  return { ok: true };
+}
+
+export async function getRegenCounts(
+  siteId: string,
+): Promise<
+  | { ok: true; counts: Record<RegenCounter, number> }
+  | { ok: false; error: { code: string; message: string } }
+> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase
+    .from("sites")
+    .select("regeneration_counts")
+    .eq("id", siteId)
+    .neq("status", "removed")
+    .maybeSingle<CountsRow>();
+  if (error) {
+    return {
+      ok: false,
+      error: { code: "INTERNAL_ERROR", message: error.message },
+    };
+  }
+  if (!data) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `No active site found with id ${siteId}.`,
+      },
+    };
+  }
+  const counts = (data.regeneration_counts ?? {}) as Record<string, unknown>;
+  return {
+    ok: true,
+    counts: {
+      concept_refinements: readCount(counts, "concept_refinements"),
+      tone_samples: readCount(counts, "tone_samples"),
+    },
+  };
+}

--- a/supabase/migrations/0066_design_discovery_regen_counts.sql
+++ b/supabase/migrations/0066_design_discovery_regen_counts.sql
@@ -1,0 +1,50 @@
+-- 0066 — Design discovery server-side regeneration caps.
+-- Reference: DESIGN-DISCOVERY-FOLLOWUP PR 3.
+--
+-- Today the 10-call cap on concept refinements + tone-sample
+-- regenerations lives client-side only. Refresh the page or hit the
+-- API directly and the cap is silently bypassed; that drives both
+-- cost (every refinement is a paid Anthropic call) and quality
+-- (operators rotate through prompts indefinitely instead of accepting
+-- a result).
+--
+-- Move enforcement to the server. Add a regeneration_counts JSONB
+-- column to sites with two named buckets, increment from the API
+-- handlers, return 429 when a bucket >= 10. The "Reset and start over"
+-- CTAs zero the relevant bucket.
+--
+-- Design decisions encoded here:
+--
+-- 1. Single JSONB column over two int columns. The shape is likely to
+--    grow (Phase 2 spec mentions style-token regenerations + per-page
+--    re-runs); JSONB lets the schema iterate without column churn.
+-- 2. NOT NULL DEFAULT '{"concept_refinements":0,"tone_samples":0}'. No
+--    backfill needed — every existing row gets the default atomically
+--    as part of the ALTER. The application reads the bucket via
+--    COALESCE so unknown buckets default to 0 (forward-compatible).
+-- 3. CHECK ((regeneration_counts->>'concept_refinements')::int >= 0
+--    AND (regeneration_counts->>'tone_samples')::int >= 0). Schema-level
+--    guard against an app bug writing a negative count and silently
+--    re-enabling refinements; the cap is enforced in app code at
+--    < 10, so the schema only needs the floor.
+-- 4. No UNIQUE / FK changes. Counts are per-site and the existing
+--    sites.id PK already enforces that.
+--
+-- Write-safety notes:
+--   - Pure ALTER TABLE ADD COLUMN with a constant DEFAULT. No table
+--     rewrite (Postgres 11+); existing rows pick up the default
+--     metadata-only.
+--   - CHECK constraint applied at column creation; the default value
+--     satisfies it by construction so there's no validation pass over
+--     existing rows.
+
+ALTER TABLE sites
+  ADD COLUMN regeneration_counts jsonb NOT NULL
+    DEFAULT '{"concept_refinements":0,"tone_samples":0}'::jsonb
+    CHECK (
+      COALESCE((regeneration_counts->>'concept_refinements')::int, 0) >= 0
+      AND COALESCE((regeneration_counts->>'tone_samples')::int, 0) >= 0
+    );
+
+COMMENT ON COLUMN sites.regeneration_counts IS
+  'Server-enforced cap state for the setup wizard. Buckets: concept_refinements (Step 1 refinement loop, capped at 10) and tone_samples (Step 2 sample regeneration loop, capped at 10). Reset to 0 on the relevant Reset CTA. Added 2026-05-01 (DESIGN-DISCOVERY-FOLLOWUP).';

--- a/supabase/rollbacks/0066_design_discovery_regen_counts.down.sql
+++ b/supabase/rollbacks/0066_design_discovery_regen_counts.down.sql
@@ -1,0 +1,6 @@
+-- Rollback for 0066_design_discovery_regen_counts.sql
+-- Drops the regeneration_counts column added on sites. Does NOT
+-- preserve any captured count data. Intended for local dev / CI
+-- reset, not production recovery.
+
+ALTER TABLE sites DROP COLUMN IF EXISTS regeneration_counts;


### PR DESCRIPTION
## Summary

DESIGN-DISCOVERY-FOLLOWUP PR 3 of 4. The 10-call cap on Step-1 concept refinements + Step-2 tone-sample regenerations was client-side only; refresh the page or hit the API directly and the cap silently bypassed. Move enforcement to the server.

- **Schema (migration 0066):** `sites.regeneration_counts JSONB NOT NULL DEFAULT '{"concept_refinements":0,"tone_samples":0}'` plus a CHECK on non-negative buckets. JSONB over two int columns so the shape can iterate.
- **Lib (`lib/design-discovery/regen-caps.ts`):** `incrementRegenCount` returns `LIMIT_REACHED` at >= 10, otherwise atomic-enough increment; `resetRegenCount`; `getRegenCounts`.
- **Routes:**
  - `POST /setup/refine-concept` — debits `concept_refinements` before the Anthropic call (failed call still owes the attempt). 429 on cap.
  - `POST /setup/regenerate-tone-samples` — same on `tone_samples`.
  - `DELETE /setup/approve-design` — zeros `concept_refinements` ("Reset and start over").
  - `POST /setup/extract-tone` — zeros `tone_samples` (re-extraction is the de-facto reset here).
- **Client (`ConceptRefinementView`, `ToneOfVoiceInputs`):** on 429 / `LIMIT_REACHED`, snaps the local counter to the cap so the Refine / Regenerate button locks and the spec's "Refinement limit reached (10/10). Reset your design direction to start over." message lands as the toast/banner.
- **Tests:** `lib/__tests__/design-discovery-regen-caps.test.ts` exercises the live local Supabase — fresh-row default, independent buckets, cap enforcement, no-increment-when-capped, reset re-enables, NOT_FOUND on unknown site.

## Risks identified and mitigated

- **Concurrent same-operator increments racing past the cap** — bounded race window (one operator, one site). Schema CHECK keeps the floor non-negative; app-level cap keeps the ceiling at <10. Worst case: one extra paid call slips through.
- **Race vs. reset** — a refinement call landing during a "Reset and start over" click could increment after the reset completes. The next call returns 429; the operator's UX message stays correct.
- **Failed Anthropic call still debits the cap** — deliberate. Matches the intended product behaviour: "10 paid calls per site," not "10 successful refinements." Otherwise an operator could hammer the API while every call hits a transient 5xx and burn budget without progressing.
- **Forward-compat for new buckets** — `getRegenCounts` COALESCEs unknown buckets to 0; adding a third bucket later doesn't require a schema migration.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Vitest unit tests for the cap helper (live Supabase)
- [ ] Manual: refine 10 times → 11th lands 429 → message shown → "Reset and start over" → refine works again

🤖 Generated with [Claude Code](https://claude.com/claude-code)