### PR TITLE
fix(auth): auto-close 2FA approval tab after success (PR 1/15)

### DIFF
--- a/app/auth/approve/page.tsx
+++ b/app/auth/approve/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { ApproveAutoClose } from "@/components/ApproveAutoClose";
 import { ApproveCompleteHere } from "@/components/ApproveCompleteHere";
 import { Alert } from "@/components/ui/alert";
 import { H1, Lead } from "@/components/ui/typography";
@@ -150,9 +151,7 @@ export default async function ApprovePage({ searchParams }: PageProps) {
     return (
       <PageShell title="Approval link used">
         <Alert>
-          This sign-in has already been completed. If your original
-          tab is still open it should have advanced to the admin — you
-          can close this tab.
+          This approval link has been used. You can close this tab.
         </Alert>
         <StartOverLink />
       </PageShell>
@@ -168,11 +167,7 @@ export default async function ApprovePage({ searchParams }: PageProps) {
           : "Sign-in already approved. Return to your original tab, or complete here if that tab is gone."
       }
     >
-      <Alert>
-        <strong>Done.</strong> You can close this tab now. The browser
-        you signed in from will pick up the approval and finish the
-        sign-in.
-      </Alert>
+      <ApproveAutoClose tokenWasJustApproved={state.tokenWasJustApproved} />
 
       <div className="border-t pt-4">
         <p className="text-sm font-medium">Lost your original tab?</p>

--- a/components/ApproveAutoClose.tsx
+++ b/components/ApproveAutoClose.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+const AUTO_CLOSE_DELAY_MS = 2000;
+const FALLBACK_DELAY_MS = 100;
+
+export function ApproveAutoClose({ tokenWasJustApproved }: { tokenWasJustApproved: boolean }) {
+  const [closeBlocked, setCloseBlocked] = useState(false);
+
+  useEffect(() => {
+    const closeTimer = setTimeout(() => {
+      try {
+        window.close();
+      } catch {
+        // Some browsers throw, treat as a no-op so we render the fallback.
+      }
+      const fallbackTimer = setTimeout(() => {
+        if (!window.closed) setCloseBlocked(true);
+      }, FALLBACK_DELAY_MS);
+      return () => clearTimeout(fallbackTimer);
+    }, AUTO_CLOSE_DELAY_MS);
+    return () => clearTimeout(closeTimer);
+  }, []);
+
+  function handleManualClose() {
+    try {
+      window.close();
+    } catch {
+      // Manual close also can fail; nothing more we can do.
+    }
+  }
+
+  return (
+    <Alert>
+      <strong>Sign-in approved.</strong>{" "}
+      {closeBlocked ? (
+        <span>You can close this tab.</span>
+      ) : (
+        <span>
+          {tokenWasJustApproved
+            ? "Closing this tab in a moment — your original tab will sign you in automatically."
+            : "Closing this tab in a moment."}
+        </span>
+      )}
+      {closeBlocked && (
+        <div className="mt-3">
+          <Button
+            type="button"
+            onClick={handleManualClose}
+            data-testid="approve-close-tab"
+            variant="outline"
+          >
+            Close tab
+          </Button>
+        </div>
+      )}
+    </Alert>
+  );
+}


### PR DESCRIPTION
## Workstream: DESIGN-SYSTEM-OVERHAUL — PR 1 of 15 (quick fix)

Fixes the 2FA approval tab UX. After clicking the approval link in the
email, the mail client opens a new tab pointed at \`/auth/approve\`. The
challenge is flipped to approved server-side, the original tab's polling
shell signs the user in — the approval tab has nothing left to do, but
was sitting on a generic \"Done — close this tab\" copy that operators
were mis-reading as an unresolved auth error.

## Change

- Replace the static \`<Alert>Done…\` block on the approved branch with a
  new client component \`components/ApproveAutoClose.tsx\` that:
  - Renders \"Sign-in approved.\" plus a short status hint.
  - Schedules \`window.close()\` after 2 seconds.
  - Falls back to \"Sign-in approved. You can close this tab.\" + a manual
    \"Close tab\" button when the browser refuses to close the tab (which
    is the common case for tabs not opened by JS).
- Tighten the \`consumed\` branch copy to the brief's wording:
  \"This approval link has been used. You can close this tab.\" — no
  auth-error framing on this page in any state.
- The \"Lost your original tab?\" \`ApproveCompleteHere\` block stays as a
  tertiary fallback for the genuinely-stranded case.

## Risks identified and mitigated

- **window.close() unreliability.** Most browsers refuse to close tabs
  not opened by \`window.open\`. Mitigated by detecting the no-op via
  \`window.closed\` after a short delay and rendering an explicit close
  button + plain-English instruction.
- **Hydration mismatch.** Component is \`\"use client\"\`, useEffect-based,
  no SSR-time DOM access — no hydration risk.
- **Regression on consumed branch.** The previous copy mentioned the
  original tab advancing to admin; the new copy is shorter. No
  functional change — the consumed state already short-circuits before
  the \`approveChallenge\` call.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx next lint\` clean on the two changed files.
- [x] \`npm run build\` — \`/auth/approve\` builds at 4.55 kB / 175 kB
  shared (within range).
- [ ] Manually verify the new render in staging by triggering a 2FA
  email → clicking the approval link.
- E2E note: \`/auth/approve\` has no Playwright spec today (auth flows
  need email infra to drive end-to-end). This change is a UX swap on
  the already-approved render, no server-side behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)