### PR TITLE
feat(branding): opollo favicon + page title metadata (PR 2/15)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,25 @@ import "./globals.css";
 export const metadata: Metadata = {
   title: "Opollo Site Builder",
   description: "Claude-powered WordPress page generation for Opollo sites.",
+  icons: {
+    icon: [
+      {
+        url: "https://opollo.com/wp-content/uploads/2025/04/cropped-Icon-black_inverse-rounded-corners-150x150.gif",
+        sizes: "32x32",
+        type: "image/gif",
+      },
+      {
+        url: "https://opollo.com/wp-content/uploads/2025/04/cropped-Icon-black_inverse-rounded-corners-300x300.gif",
+        sizes: "192x192",
+        type: "image/gif",
+      },
+    ],
+    apple: {
+      url: "https://opollo.com/wp-content/uploads/2025/04/cropped-Icon-black_inverse-rounded-corners-300x300.gif",
+      sizes: "180x180",
+      type: "image/gif",
+    },
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Workstream: DESIGN-SYSTEM-OVERHAUL — PR 2 of 15 (quick fix)

Wires the Opollo favicon into the Next.js root metadata so browsers
pick up the brand icon for tabs and bookmarks. The page title already
reads \"Opollo Site Builder\" — no change there.

## Change

\`app/layout.tsx\` — extend the \`metadata\` export with an \`icons\` block:

- \`icon\` 32x32 → \`...cropped-Icon-black_inverse-rounded-corners-150x150.gif\`
- \`icon\` 192x192 → \`...cropped-Icon-black_inverse-rounded-corners-300x300.gif\`
- \`apple\` 180x180 → \`...cropped-Icon-black_inverse-rounded-corners-300x300.gif\`

External URLs are already permitted by the existing CSP
(\`lib/security-headers.ts:97\` — \`img-src 'self' data: blob: https:\`).

## Risks identified and mitigated

- **External asset dependency.** Favicon is hosted on opollo.com, not
  bundled. If opollo.com goes down the favicon falls back to the
  browser default; no functional impact on the app. Acceptable
  tradeoff vs hosting a duplicate copy in /public.
- **CSP.** Verified \`img-src\` already permits \`https:\` so the icons
  load without a header change.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx next lint app/layout.tsx\` clean.
- [ ] After deploy, verify favicon renders in Chrome / Safari / Firefox
  tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)