### PR TITLE
feat(images): detail page thumbnail, re-extract metadata, download (PR 3/15)

### DIFF
--- a/app/admin/images/[id]/page.tsx
+++ b/app/admin/images/[id]/page.tsx
@@ -3,6 +3,8 @@ import { notFound, redirect } from "next/navigation";
 import { Fragment } from "react";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { DownloadImageButton } from "@/components/DownloadImageButton";
+import { ReextractMetadataButton } from "@/components/ReextractMetadataButton";
 import { Alert } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { H1, H3 } from "@/components/ui/typography";
@@ -119,9 +121,13 @@ export default async function AdminImageDetailPage({
   const publicUrl = image.cloudflare_id
     ? deliveryUrl(image.cloudflare_id, "public")
     : null;
-  const thumbUrl = image.cloudflare_id
-    ? deliveryUrl(image.cloudflare_id, "thumbnail")
-    : null;
+  // Thumbnail intentionally reuses the `public` variant — Cloudflare
+  // accounts that haven't configured a named `thumbnail` variant 404 on
+  // its delivery URL, leaving the row blank for the operator. The
+  // browser scales the public bytes down for the 40px tile cheaply
+  // enough that a dedicated variant isn't worth the per-account setup
+  // burden.
+  const thumbUrl = publicUrl;
 
   return (
     <>
@@ -149,7 +155,7 @@ export default async function AdminImageDetailPage({
             )}
           </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           {!image.deleted_at && (
             <EditImageMetadataButton
               image={{
@@ -160,6 +166,15 @@ export default async function AdminImageDetailPage({
                 version_lock: image.version_lock,
               }}
             />
+          )}
+          {image.cloudflare_id && (
+            <DownloadImageButton
+              imageId={image.id}
+              filename={image.filename}
+            />
+          )}
+          {!image.deleted_at && (
+            <ReextractMetadataButton imageId={image.id} />
           )}
           <ImageArchiveButton
             image={{ id: image.id, deleted_at: image.deleted_at }}

--- a/app/api/admin/images/[id]/download/route.ts
+++ b/app/api/admin/images/[id]/download/route.ts
@@ -1,0 +1,132 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { deliveryUrl } from "@/lib/cloudflare-images";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// GET /api/admin/images/[id]/download
+//
+// Streams the full-resolution Cloudflare delivery bytes back to the
+// browser with `Content-Disposition: attachment` so the operator gets
+// a real download instead of a tab open. Proxies via the server because
+// the cross-origin `download` attribute on a plain <a> tag is ignored
+// without a same-origin response.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function quoteFilename(name: string): string {
+  return name.replace(/"/g, "").replace(/[\r\n]/g, "");
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<Response> {
+  const gate = await requireAdminForApi({
+    roles: ["super_admin", "admin"] as const,
+  });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Image id must be a UUID.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getServiceRoleClient();
+  const row = await supabase
+    .from("image_library")
+    .select("id, cloudflare_id, filename")
+    .eq("id", params.id)
+    .maybeSingle();
+
+  if (row.error || !row.data) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: "Image not found.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 404 },
+    );
+  }
+
+  const cloudflareId = row.data.cloudflare_id as string | null;
+  if (!cloudflareId) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "PRECONDITION_FAILED",
+          message: "Image has no Cloudflare id; nothing to download.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 412 },
+    );
+  }
+
+  const url = deliveryUrl(cloudflareId, "public");
+  if (!url) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "CLOUDFLARE_CONFIG_MISSING",
+          message: "CLOUDFLARE_IMAGES_HASH is not configured on the server.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 503 },
+    );
+  }
+
+  const upstream = await fetch(url);
+  if (!upstream.ok || !upstream.body) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "CLOUDFLARE_FETCH_FAILED",
+          message: `Cloudflare returned HTTP ${upstream.status}.`,
+          retryable: upstream.status >= 500,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 502 },
+    );
+  }
+
+  const filename = quoteFilename(
+    (row.data.filename as string | null) ?? `${cloudflareId}.bin`,
+  );
+  const contentType =
+    upstream.headers.get("content-type") ?? "application/octet-stream";
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      "content-type": contentType,
+      "content-disposition": `attachment; filename="${filename}"`,
+      "cache-control": "private, no-store",
+    },
+  });
+}

--- a/app/api/admin/images/[id]/reextract/route.ts
+++ b/app/api/admin/images/[id]/reextract/route.ts
@@ -1,0 +1,56 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { reextractImageMetadata } from "@/lib/image-reextract";
+import { errorCodeToStatus } from "@/lib/tool-schemas";
+
+// POST /api/admin/images/[id]/reextract
+//
+// Re-derives width / height / iStock id from the stored Cloudflare bytes
+// + filename. Idempotent. Returns the extraction summary so the UI can
+// show a meaningful toast.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({
+    roles: ["super_admin", "admin"] as const,
+  });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Image id must be a UUID.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await reextractImageMetadata(params.id, {
+    updatedBy: gate.user?.id ?? null,
+  });
+
+  if (!result.ok) {
+    const status = errorCodeToStatus(result.error.code);
+    return NextResponse.json(result, { status });
+  }
+
+  revalidatePath(`/admin/images/${params.id}`);
+  revalidatePath("/admin/images");
+
+  return NextResponse.json(result, { status: 200 });
+}

--- a/components/DownloadImageButton.tsx
+++ b/components/DownloadImageButton.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+export function DownloadImageButton({
+  imageId,
+  filename,
+}: {
+  imageId: string;
+  filename: string | null;
+}) {
+  const href = `/api/admin/images/${imageId}/download`;
+  return (
+    <Button asChild variant="outline" size="sm" data-testid="image-download-button">
+      <a href={href} download={filename ?? undefined} rel="noreferrer">
+        Download
+      </a>
+    </Button>
+  );
+}

--- a/components/ReextractMetadataButton.tsx
+++ b/components/ReextractMetadataButton.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+
+type ReextractResult = {
+  dimensions_updated: boolean;
+  width_px: number | null;
+  height_px: number | null;
+  istock_id: string | null;
+  istock_id_added: boolean;
+  notes: string[];
+};
+
+export function ReextractMetadataButton({ imageId }: { imageId: string }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onClick() {
+    setBusy(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const res = await fetch(`/api/admin/images/${imageId}/reextract`, {
+        method: "POST",
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: ReextractResult }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (!res.ok || !payload?.ok) {
+        setError(
+          payload && payload.ok === false
+            ? payload.error.message
+            : `Re-extract failed (HTTP ${res.status}).`,
+        );
+        setBusy(false);
+        return;
+      }
+      const data = payload.data;
+      const parts: string[] = [];
+      if (data.dimensions_updated && data.width_px && data.height_px) {
+        parts.push(`Dimensions ${data.width_px}×${data.height_px}px`);
+      }
+      if (data.istock_id_added && data.istock_id) {
+        parts.push(`iStock id ${data.istock_id}`);
+      }
+      setMessage(
+        parts.length === 0
+          ? "Nothing new to extract — the row was already complete."
+          : `Updated: ${parts.join(", ")}.`,
+      );
+      startTransition(() => router.refresh());
+    } catch (err) {
+      setError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => void onClick()}
+        disabled={busy}
+        data-testid="image-reextract-button"
+      >
+        {busy ? "Re-extracting…" : "Re-extract metadata"}
+      </Button>
+      {message && (
+        <p className="text-xs text-muted-foreground" role="status">
+          {message}
+        </p>
+      )}
+      {error && (
+        <p className="text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lib/__tests__/image-dimensions.test.ts
+++ b/lib/__tests__/image-dimensions.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseIstockIdFromFilename,
+  readImageDimensions,
+} from "@/lib/image-dimensions";
+
+function buildPng(width: number, height: number): Uint8Array {
+  const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  const ihdrLen = [0x00, 0x00, 0x00, 0x0d];
+  const ihdrType = [0x49, 0x48, 0x44, 0x52];
+  const w = [
+    (width >>> 24) & 0xff,
+    (width >>> 16) & 0xff,
+    (width >>> 8) & 0xff,
+    width & 0xff,
+  ];
+  const h = [
+    (height >>> 24) & 0xff,
+    (height >>> 16) & 0xff,
+    (height >>> 8) & 0xff,
+    height & 0xff,
+  ];
+  return new Uint8Array([
+    ...sig,
+    ...ihdrLen,
+    ...ihdrType,
+    ...w,
+    ...h,
+    0x08,
+    0x02,
+    0x00,
+    0x00,
+    0x00,
+  ]);
+}
+
+function buildJpegSof0(width: number, height: number): Uint8Array {
+  const soi = [0xff, 0xd8];
+  const app0 = [0xff, 0xe0, 0x00, 0x10];
+  const jfifPad = new Array(14).fill(0);
+  const sof0Marker = [0xff, 0xc0];
+  const sof0Len = [0x00, 0x11];
+  const precision = [0x08];
+  const heightBytes = [(height >> 8) & 0xff, height & 0xff];
+  const widthBytes = [(width >> 8) & 0xff, width & 0xff];
+  const components = new Array(11).fill(0);
+  return new Uint8Array([
+    ...soi,
+    ...app0,
+    ...jfifPad,
+    ...sof0Marker,
+    ...sof0Len,
+    ...precision,
+    ...heightBytes,
+    ...widthBytes,
+    ...components,
+  ]);
+}
+
+function buildGif(width: number, height: number): Uint8Array {
+  const header = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61];
+  const w = [width & 0xff, (width >> 8) & 0xff];
+  const h = [height & 0xff, (height >> 8) & 0xff];
+  return new Uint8Array([...header, ...w, ...h, 0x00, 0x00, 0x00]);
+}
+
+describe("readImageDimensions", () => {
+  it("parses PNG width and height from IHDR", () => {
+    expect(readImageDimensions(buildPng(640, 480))).toEqual({
+      width: 640,
+      height: 480,
+    });
+  });
+
+  it("parses JPEG width and height from SOF0", () => {
+    expect(readImageDimensions(buildJpegSof0(800, 600))).toEqual({
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it("parses GIF width and height from logical screen descriptor", () => {
+    expect(readImageDimensions(buildGif(120, 90))).toEqual({
+      width: 120,
+      height: 90,
+    });
+  });
+
+  it("returns null for an unrecognised header", () => {
+    const garbage = new Uint8Array(64).fill(0x00);
+    expect(readImageDimensions(garbage)).toBeNull();
+  });
+
+  it("returns null when the input is too short", () => {
+    expect(readImageDimensions(new Uint8Array([0x89, 0x50]))).toBeNull();
+  });
+});
+
+describe("parseIstockIdFromFilename", () => {
+  it("extracts the numeric id from the canonical iStock filename", () => {
+    expect(parseIstockIdFromFilename("iStock-2216481617.jpg")).toBe(
+      "2216481617",
+    );
+  });
+
+  it("matches the underscore variant case-insensitively", () => {
+    expect(parseIstockIdFromFilename("istock_1234567890_v1.jpeg")).toBe(
+      "1234567890",
+    );
+  });
+
+  it("returns null when the filename has no iStock prefix", () => {
+    expect(parseIstockIdFromFilename("hero-shot.jpg")).toBeNull();
+  });
+
+  it("returns null for a null filename", () => {
+    expect(parseIstockIdFromFilename(null)).toBeNull();
+  });
+});

--- a/lib/image-dimensions.ts
+++ b/lib/image-dimensions.ts
@@ -1,0 +1,148 @@
+// ---------------------------------------------------------------------------
+// Minimal image-dimensions reader. Handles PNG, JPEG, GIF, and WebP (VP8 /
+// VP8L / VP8X). Used by the image-library re-extract endpoint to populate
+// width_px / height_px after a bulk upload that didn't capture them.
+//
+// Pure header parser — no Sharp / image-size dep. Operates on the first
+// chunk of bytes (caller can stream the first ~64KB of a Cloudflare
+// delivery URL and pass them in). Returns null when the bytes don't look
+// like a recognised format or the format-specific marker is missing in
+// the supplied prefix.
+// ---------------------------------------------------------------------------
+
+export type ImageDimensions = { width: number; height: number };
+
+const PNG_SIG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+export function readImageDimensions(bytes: Uint8Array): ImageDimensions | null {
+  if (bytes.length < 24) return null;
+
+  if (matchesAt(bytes, 0, PNG_SIG)) return readPng(bytes);
+  if (bytes[0] === 0xff && bytes[1] === 0xd8) return readJpeg(bytes);
+  if (
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38
+  ) {
+    return readGif(bytes);
+  }
+  if (
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return readWebp(bytes);
+  }
+  return null;
+}
+
+function matchesAt(buf: Uint8Array, offset: number, sig: number[]): boolean {
+  if (buf.length < offset + sig.length) return false;
+  for (let i = 0; i < sig.length; i++) {
+    if (buf[offset + i] !== sig[i]) return false;
+  }
+  return true;
+}
+
+function readPng(b: Uint8Array): ImageDimensions | null {
+  if (b.length < 24) return null;
+  const width = readUint32BE(b, 16);
+  const height = readUint32BE(b, 20);
+  if (width <= 0 || height <= 0) return null;
+  return { width, height };
+}
+
+function readJpeg(b: Uint8Array): ImageDimensions | null {
+  // Walk JPEG segments: each marker is FF Mn followed (for non-SOI/EOI)
+  // by a 2-byte big-endian length that includes the length bytes
+  // themselves. SOF markers FF C0..FF CF (excluding C4 / C8 / CC) carry
+  // dimensions: 1 byte precision, 2 bytes height (BE), 2 bytes width (BE).
+  let i = 2;
+  while (i + 9 < b.length) {
+    if (b[i] !== 0xff) return null;
+    const marker = b[i + 1];
+    if (marker === 0xd8 || marker === 0xd9) {
+      i += 2;
+      continue;
+    }
+    if (marker === 0xda) return null;
+    const len = (b[i + 2] << 8) | b[i + 3];
+    if (len < 2) return null;
+    const isSof =
+      marker >= 0xc0 &&
+      marker <= 0xcf &&
+      marker !== 0xc4 &&
+      marker !== 0xc8 &&
+      marker !== 0xcc;
+    if (isSof) {
+      if (i + 9 >= b.length) return null;
+      const height = (b[i + 5] << 8) | b[i + 6];
+      const width = (b[i + 7] << 8) | b[i + 8];
+      if (width <= 0 || height <= 0) return null;
+      return { width, height };
+    }
+    i += 2 + len;
+  }
+  return null;
+}
+
+function readGif(b: Uint8Array): ImageDimensions | null {
+  if (b.length < 10) return null;
+  const width = b[6] | (b[7] << 8);
+  const height = b[8] | (b[9] << 8);
+  if (width <= 0 || height <= 0) return null;
+  return { width, height };
+}
+
+function readWebp(b: Uint8Array): ImageDimensions | null {
+  if (b.length < 30) return null;
+  const fourcc = String.fromCharCode(b[12], b[13], b[14], b[15]);
+  if (fourcc === "VP8 ") {
+    if (b.length < 30) return null;
+    const width = ((b[26] | (b[27] << 8)) & 0x3fff);
+    const height = ((b[28] | (b[29] << 8)) & 0x3fff);
+    if (width <= 0 || height <= 0) return null;
+    return { width, height };
+  }
+  if (fourcc === "VP8L") {
+    if (b.length < 25) return null;
+    const w = (b[21] | (b[22] << 8)) & 0x3fff;
+    const h = ((b[22] >> 6) | (b[23] << 2) | (b[24] << 10)) & 0x3fff;
+    return { width: w + 1, height: h + 1 };
+  }
+  if (fourcc === "VP8X") {
+    if (b.length < 30) return null;
+    const w = b[24] | (b[25] << 8) | (b[26] << 16);
+    const h = b[27] | (b[28] << 8) | (b[29] << 16);
+    return { width: w + 1, height: h + 1 };
+  }
+  return null;
+}
+
+function readUint32BE(b: Uint8Array, offset: number): number {
+  return (
+    (b[offset] * 0x1000000) +
+    (b[offset + 1] << 16) +
+    (b[offset + 2] << 8) +
+    b[offset + 3]
+  );
+}
+
+const ISTOCK_FILENAME_RE = /iStock[-_](\d{6,})/i;
+
+/**
+ * Extract a numeric iStock asset id from a filename like
+ * `iStock-2216481617.jpg` or `istock_1234567890_v1.jpeg`. Returns null
+ * when the filename doesn't carry an iStock prefix.
+ */
+export function parseIstockIdFromFilename(filename: string | null): string | null {
+  if (!filename) return null;
+  const m = ISTOCK_FILENAME_RE.exec(filename);
+  return m?.[1] ?? null;
+}

--- a/lib/image-reextract.ts
+++ b/lib/image-reextract.ts
@@ -1,0 +1,251 @@
+import { deliveryUrl } from "@/lib/cloudflare-images";
+import {
+  parseIstockIdFromFilename,
+  readImageDimensions,
+} from "@/lib/image-dimensions";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// Re-extract metadata for an image library row.
+//
+// Bulk-uploaded images (scripts/import-bulk-uploaded-images.ts) land with
+// width_px / height_px / iStock provenance unset. This helper reads the
+// public Cloudflare delivery URL header bytes, derives dimensions, parses
+// any iStock asset id from the original filename, and writes both back:
+//
+//   - image_library.{width_px, height_px, bytes} when dimensions land.
+//   - image_metadata (key='istock_id') when the filename matches.
+//
+// Idempotent: re-running on a row that already has dimensions and the
+// iStock id is a no-op. The endpoint that wraps this returns a summary of
+// what changed so the UI can render an actionable toast.
+// ---------------------------------------------------------------------------
+
+export const REEXTRACT_PREFIX_BYTES = 64 * 1024;
+
+export type ReextractResult = {
+  image_id: string;
+  dimensions_updated: boolean;
+  width_px: number | null;
+  height_px: number | null;
+  bytes: number | null;
+  istock_id: string | null;
+  istock_id_added: boolean;
+  notes: string[];
+};
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function notFound(msg = "Image not found."): ApiResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message: msg,
+      retryable: false,
+      suggested_action: "Reload the image library; the row may have been archived.",
+    },
+    timestamp: now(),
+  };
+}
+
+function internalError(message: string, details?: Record<string, unknown>): ApiResponse<never> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      details,
+      retryable: false,
+      suggested_action: "Check Supabase / Cloudflare connectivity and server logs.",
+    },
+    timestamp: now(),
+  };
+}
+
+async function fetchHeaderBytes(url: string): Promise<{ bytes: Uint8Array; total: number | null }> {
+  // Use a Range request so Cloudflare doesn't have to stream the whole
+  // file just for dimension extraction. Cloudflare delivery URLs honour
+  // Range; if a hash misconfig drops it, we fall back to a regular GET
+  // and slice the buffer.
+  const res = await fetch(url, {
+    headers: { Range: `bytes=0-${REEXTRACT_PREFIX_BYTES - 1}` },
+  });
+  if (!res.ok && res.status !== 206) {
+    throw new Error(`Cloudflare delivery URL returned HTTP ${res.status}.`);
+  }
+  const buf = new Uint8Array(await res.arrayBuffer());
+  const totalHeader = res.headers.get("content-range");
+  let total: number | null = null;
+  if (totalHeader) {
+    const m = /\/(\d+)$/.exec(totalHeader);
+    if (m) total = Number(m[1]);
+  } else {
+    const len = res.headers.get("content-length");
+    if (len) total = Number(len);
+  }
+  return { bytes: buf, total };
+}
+
+export async function reextractImageMetadata(
+  imageId: string,
+  opts: { updatedBy?: string | null } = {},
+): Promise<ApiResponse<ReextractResult>> {
+  const supabase = getServiceRoleClient();
+
+  const imageRes = await supabase
+    .from("image_library")
+    .select(
+      "id, cloudflare_id, filename, width_px, height_px, bytes, version_lock, deleted_at, source_ref, source",
+    )
+    .eq("id", imageId)
+    .maybeSingle();
+
+  if (imageRes.error) {
+    return internalError("Failed to load image_library row.", {
+      supabase_error: imageRes.error,
+    });
+  }
+  if (!imageRes.data) return notFound();
+
+  const row = imageRes.data as {
+    id: string;
+    cloudflare_id: string | null;
+    filename: string | null;
+    width_px: number | null;
+    height_px: number | null;
+    bytes: number | null;
+    version_lock: number;
+    deleted_at: string | null;
+    source_ref: string | null;
+    source: string;
+  };
+
+  if (row.deleted_at) {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_STATE",
+        message: "Cannot re-extract metadata on an archived image. Restore it first.",
+        retryable: false,
+        suggested_action: "Restore the image and retry.",
+      },
+      timestamp: now(),
+    };
+  }
+
+  const notes: string[] = [];
+  let nextWidth = row.width_px;
+  let nextHeight = row.height_px;
+  let nextBytes = row.bytes;
+  let dimensionsUpdated = false;
+
+  if (row.cloudflare_id) {
+    if (!row.width_px || !row.height_px || !row.bytes) {
+      const url = deliveryUrl(row.cloudflare_id, "public");
+      if (!url) {
+        notes.push("CLOUDFLARE_IMAGES_HASH unset; skipped dimension probe.");
+      } else {
+        try {
+          const { bytes, total } = await fetchHeaderBytes(url);
+          const dims = readImageDimensions(bytes);
+          if (dims) {
+            nextWidth = nextWidth ?? dims.width;
+            nextHeight = nextHeight ?? dims.height;
+            dimensionsUpdated = true;
+          } else {
+            notes.push("Could not parse dimensions from image header bytes.");
+          }
+          if (!nextBytes && typeof total === "number" && total > 0) {
+            nextBytes = total;
+          }
+        } catch (err) {
+          notes.push(
+            `Dimension probe failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    } else {
+      notes.push("Dimensions already populated — left as-is.");
+    }
+  } else {
+    notes.push("Image has no cloudflare_id; cannot probe.");
+  }
+
+  const istockId = parseIstockIdFromFilename(row.filename);
+  let istockIdAdded = false;
+  if (istockId) {
+    const existing = await supabase
+      .from("image_metadata")
+      .select("id, value_jsonb")
+      .eq("image_id", row.id)
+      .eq("key", "istock_id")
+      .maybeSingle();
+    if (existing.error) {
+      return internalError("Failed to read image_metadata.", {
+        supabase_error: existing.error,
+      });
+    }
+    if (!existing.data) {
+      const insertRes = await supabase
+        .from("image_metadata")
+        .insert({
+          image_id: row.id,
+          key: "istock_id",
+          value_jsonb: istockId,
+        });
+      if (insertRes.error) {
+        return internalError("Failed to insert image_metadata.", {
+          supabase_error: insertRes.error,
+        });
+      }
+      istockIdAdded = true;
+    } else {
+      notes.push("istock_id metadata already present — left as-is.");
+    }
+  }
+
+  if (
+    dimensionsUpdated ||
+    (nextBytes !== row.bytes && nextBytes !== null)
+  ) {
+    const updateRow: Record<string, unknown> = {
+      version_lock: row.version_lock + 1,
+      updated_at: now(),
+    };
+    if (nextWidth !== row.width_px) updateRow.width_px = nextWidth;
+    if (nextHeight !== row.height_px) updateRow.height_px = nextHeight;
+    if (nextBytes !== row.bytes) updateRow.bytes = nextBytes;
+    if (opts.updatedBy) updateRow.updated_by = opts.updatedBy;
+
+    const updRes = await supabase
+      .from("image_library")
+      .update(updateRow)
+      .eq("id", row.id)
+      .eq("version_lock", row.version_lock);
+
+    if (updRes.error) {
+      return internalError("Failed to update image_library.", {
+        supabase_error: updRes.error,
+      });
+    }
+  }
+
+  return {
+    ok: true,
+    data: {
+      image_id: row.id,
+      dimensions_updated: dimensionsUpdated,
+      width_px: nextWidth,
+      height_px: nextHeight,
+      bytes: nextBytes,
+      istock_id: istockId,
+      istock_id_added: istockIdAdded,
+      notes,
+    },
+    timestamp: now(),
+  };
+}


### PR DESCRIPTION
## Workstream: DESIGN-SYSTEM-OVERHAUL — PR 3 of 15 (image-library quick fixes)

Three fixes on \`/admin/images/[id]\`:

### 1. Thumbnail row renders again

The small tile at \`page.tsx:122–124\` was pointing at the \`thumbnail\`
Cloudflare delivery variant. Cloudflare Images variants are configured
per-account; on accounts where a named \`thumbnail\` variant doesn't
exist the URL 404s and the row shows blank. Switched the tile to the
\`public\` variant + CSS-scaled to 40px — costs nothing extra on the
browser side and avoids the per-account variant setup burden.

### 2. \"Re-extract metadata\" button

Bulk-uploaded images
(\`scripts/import-bulk-uploaded-images.ts\`) land with
\`width_px\` / \`height_px\` / \`bytes\` / iStock provenance unset. The new
endpoint \`POST /api/admin/images/[id]/reextract\`:

- Parses the iStock asset id from the filename
  (regex \`/iStock[-_](\d{6,})/i\`) and inserts an \`image_metadata\` row
  with \`key='istock_id'\`.
- Issues a \`Range: bytes=0-65535\` GET against the public Cloudflare
  delivery URL and parses width / height from PNG / JPEG / GIF /
  WebP headers via the new \`lib/image-dimensions.ts\` (no \`sharp\` /
  \`image-size\` dep).
- Updates \`image_library.{width_px,height_px,bytes}\` when any landed.
- Optimistic-locked on \`version_lock\`. Idempotent — re-running on a
  complete row is a no-op.

### 3. \"Download\" button

Cross-origin \`<a download>\` is ignored without a same-origin response,
so a small server proxy at \`GET /api/admin/images/[id]/download\` streams
the public Cloudflare bytes back with
\`Content-Disposition: attachment\` + the original filename.

## Files changed

- \`app/admin/images/[id]/page.tsx\` — thumbnail variant swap, action-row buttons.
- \`app/api/admin/images/[id]/reextract/route.ts\` — new POST endpoint.
- \`app/api/admin/images/[id]/download/route.ts\` — new GET proxy.
- \`components/ReextractMetadataButton.tsx\` — new client button + result toast.
- \`components/DownloadImageButton.tsx\` — new client button.
- \`lib/image-dimensions.ts\` — header-only PNG / JPEG / GIF / WebP parser.
- \`lib/image-reextract.ts\` — re-extract orchestration (DB + Cloudflare).
- \`lib/__tests__/image-dimensions.test.ts\` — pure-fn tests for the parser.

## Risks identified and mitigated

- **Dimension parser correctness.** Wrong width/height would corrupt
  layout decisions downstream. Mitigated by handcrafted PNG / JPEG SOF0
  / GIF fixtures in the test, plus a garbage-rejection assertion.
  WebP's three sub-formats (VP8, VP8L, VP8X) handled but not
  individually fixtured — acceptable given JPEG / PNG cover ~99% of the
  current corpus; falls back to \`null\` (safe) on any unrecognised
  shape.
- **Range request fallback.** Some upstreams reject \`Range\` and serve
  the whole file. The endpoint accepts both 206 and 200 and operates
  on whatever bytes come back. 64 KB is enough for every supported
  format's header.
- **Cross-origin download.** Plain \`<a download>\` is silently ignored
  by browsers when the response is cross-origin. Mitigated by proxying
  through a same-origin server route that sets \`Content-Disposition\`
  explicitly.
- **Source / source_ref reassignment.** Did NOT change \`source\` from
  \`upload\` → \`istock\` for bulk-uploaded iStock files: the schema has
  \`UNIQUE NULLS NOT DISTINCT (source, source_ref)\` and a flip could
  collide with an existing seed row. Stored the iStock id in
  \`image_metadata\` (k/v) instead, which is conflict-free.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx next lint\` clean on changed files.
- [x] Vitest unit test added for the parser.
- [ ] Manually verify on staging: thumbnail renders, Re-extract button
  populates dimensions on an iStock-named bulk-upload row, Download
  button streams the file with the original filename.
- E2E note: existing \`e2e/images.spec.ts\` covers the page render
  surface; the new buttons go through standard fetch + \`revalidatePath\`
  patterns. No new E2E added because the most useful coverage requires
  a live Cloudflare delivery URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)