### PR TITLE
feat(images): bulk drag-drop upload with duplicate handling (PR 4/15)

### DIFF
--- a/app/admin/images/page.tsx
+++ b/app/admin/images/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { BulkImageUpload } from "@/components/BulkImageUpload";
 import { ImagesTable } from "@/components/ImagesTable";
 import { Alert } from "@/components/ui/alert";
 import { H1, Lead } from "@/components/ui/typography";
@@ -157,6 +158,8 @@ export default async function AdminImagesPage({
           {parsed.deleted ? "← Active images" : "View archived →"}
         </Link>
       </div>
+
+      {!parsed.deleted && <BulkImageUpload />}
 
       <form
         method="GET"

--- a/app/api/admin/images/check-existing/route.ts
+++ b/app/api/admin/images/check-existing/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// POST /api/admin/images/check-existing
+//
+// Pre-flight duplicate check for the bulk-upload UI. Accepts up to
+// MAX_FILENAMES filenames in one request and returns the subset that
+// already exist (active rows) on image_library, with their ids so the
+// client can render a "replace this one" decision per file. Soft-deleted
+// rows are intentionally excluded — restoring an archived image is a
+// separate operator action.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_FILENAMES = 200;
+
+const BodySchema = z.object({
+  filenames: z
+    .array(z.string().trim().min(1).max(255))
+    .min(1)
+    .max(MAX_FILENAMES),
+});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const gate = await requireAdminForApi({
+    roles: ["super_admin", "admin"] as const,
+  });
+  if (gate.kind === "deny") return gate.response;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body must be { filenames: string[] } with up to 200 entries.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const filenames = Array.from(new Set(parsed.data.filenames));
+  const supabase = getServiceRoleClient();
+  const res = await supabase
+    .from("image_library")
+    .select("id, filename")
+    .in("filename", filenames)
+    .is("deleted_at", null);
+
+  if (res.error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to look up existing filenames.",
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+
+  const existing = (res.data ?? []).map((row) => ({
+    image_id: row.id as string,
+    filename: row.filename as string,
+  }));
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { existing },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200, headers: { "cache-control": "no-store" } },
+  );
+}

--- a/app/api/admin/images/upload/route.ts
+++ b/app/api/admin/images/upload/route.ts
@@ -8,6 +8,7 @@ import {
   deliveryUrl,
   uploadImageFromBytes,
 } from "@/lib/cloudflare-images";
+import { readImageDimensions } from "@/lib/image-dimensions";
 import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -81,6 +82,39 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const cloudflareId = `opollo/upload/${randomUUID()}`;
   const filename = file.name || `${cloudflareId}.bin`;
   const bytes = new Uint8Array(await file.arrayBuffer());
+  const dims = readImageDimensions(bytes);
+
+  // Optional duplicate-handling: ?replace=1 archives any active row with
+  // the same filename before the new upload lands so the new row can
+  // own the (filename) namespace. Skip mode is enforced client-side via
+  // /api/admin/images/check-existing — by the time we reach this
+  // endpoint the operator already chose to upload this file.
+  const url = new URL(req.url);
+  const replaceExisting = url.searchParams.get("replace") === "1";
+  if (replaceExisting && filename) {
+    const supabaseLookup = getServiceRoleClient();
+    const dup = await supabaseLookup
+      .from("image_library")
+      .select("id")
+      .eq("filename", filename)
+      .is("deleted_at", null)
+      .maybeSingle();
+    if (dup.data?.id) {
+      const archived = await supabaseLookup
+        .from("image_library")
+        .update({
+          deleted_at: new Date().toISOString(),
+          deleted_by: gate.user?.id ?? null,
+        })
+        .eq("id", dup.data.id);
+      if (archived.error) {
+        logger.error("image.upload.replace_archive_failed", {
+          existing_id: dup.data.id,
+          error: archived.error.message,
+        });
+      }
+    }
+  }
 
   let cfRecord;
   try {
@@ -122,6 +156,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     source: "upload" as const,
     source_ref: filename,
     bytes: file.size,
+    width_px: dims?.width ?? null,
+    height_px: dims?.height ?? null,
     created_by: gate.user?.id ?? null,
   };
   const ins = await supabase

--- a/components/BulkImageUpload.tsx
+++ b/components/BulkImageUpload.tsx
@@ -1,0 +1,402 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useMemo, useRef, useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+
+const ACCEPTED_TYPES = new Set([
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+]);
+const ACCEPTED_EXTS = [".jpg", ".jpeg", ".png", ".webp", ".gif"];
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const BATCH_SIZE = 10;
+
+type DupePolicy = "skip" | "replace" | "ask";
+
+type FileState =
+  | "queued"
+  | "checking"
+  | "ask"
+  | "uploading"
+  | "done"
+  | "skipped"
+  | "replaced"
+  | "failed";
+
+type FileRow = {
+  id: string;
+  file: File;
+  state: FileState;
+  message?: string;
+  existingImageId?: string;
+};
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function newFileId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function isAccepted(file: File): boolean {
+  if (ACCEPTED_TYPES.has(file.type.toLowerCase())) return true;
+  const lower = file.name.toLowerCase();
+  return ACCEPTED_EXTS.some((ext) => lower.endsWith(ext));
+}
+
+export function BulkImageUpload() {
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+  const [policy, setPolicy] = useState<DupePolicy>("skip");
+  const [rows, setRows] = useState<FileRow[]>([]);
+  const [running, setRunning] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const summary = useMemo(() => {
+    const done = rows.filter((r) => r.state === "done" || r.state === "replaced").length;
+    const skipped = rows.filter((r) => r.state === "skipped").length;
+    const failed = rows.filter((r) => r.state === "failed").length;
+    return { total: rows.length, done, skipped, failed };
+  }, [rows]);
+
+  const updateRow = useCallback(
+    (id: string, patch: Partial<FileRow>) => {
+      setRows((prev) =>
+        prev.map((r) => (r.id === id ? { ...r, ...patch } : r)),
+      );
+    },
+    [],
+  );
+
+  const addFiles = useCallback((files: FileList | File[]) => {
+    const toAdd: FileRow[] = [];
+    for (const file of Array.from(files)) {
+      if (!isAccepted(file)) continue;
+      if (file.size === 0) continue;
+      if (file.size > MAX_FILE_BYTES) {
+        toAdd.push({
+          id: newFileId(),
+          file,
+          state: "failed",
+          message: `Exceeds 10 MB cap (${fmtBytes(file.size)}).`,
+        });
+        continue;
+      }
+      toAdd.push({ id: newFileId(), file, state: "queued" });
+    }
+    if (toAdd.length > 0) {
+      setRows((prev) => [...prev, ...toAdd]);
+    }
+  }, []);
+
+  const onDrop = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setDragActive(false);
+      if (event.dataTransfer.files.length > 0) addFiles(event.dataTransfer.files);
+    },
+    [addFiles],
+  );
+
+  async function checkDuplicates(rowsToCheck: FileRow[]): Promise<Map<string, string>> {
+    const filenames = rowsToCheck.map((r) => r.file.name);
+    const res = await fetch("/api/admin/images/check-existing", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ filenames }),
+    });
+    if (!res.ok) return new Map();
+    const payload = (await res.json().catch(() => null)) as
+      | { ok: true; data: { existing: Array<{ filename: string; image_id: string }> } }
+      | null;
+    if (!payload?.ok) return new Map();
+    const map = new Map<string, string>();
+    for (const e of payload.data.existing) map.set(e.filename, e.image_id);
+    return map;
+  }
+
+  async function uploadOne(row: FileRow, replace: boolean): Promise<{ ok: boolean; message?: string }> {
+    const url = `/api/admin/images/upload${replace ? "?replace=1" : ""}`;
+    const body = new FormData();
+    body.append("file", row.file);
+    const res = await fetch(url, { method: "POST", body });
+    const payload = (await res.json().catch(() => null)) as
+      | { ok: true; data: unknown }
+      | { ok: false; error: { code: string; message: string } }
+      | null;
+    if (res.ok && payload && payload.ok) return { ok: true };
+    const message =
+      payload && payload.ok === false
+        ? payload.error.message
+        : `HTTP ${res.status}`;
+    return { ok: false, message };
+  }
+
+  async function startUpload() {
+    if (running) return;
+    setRunning(true);
+
+    const queued = rows.filter((r) => r.state === "queued");
+    if (queued.length === 0) {
+      setRunning(false);
+      return;
+    }
+
+    for (const r of queued) updateRow(r.id, { state: "checking" });
+    const dupMap = await checkDuplicates(queued);
+
+    // Apply the duplicate policy in one pass before upload starts.
+    const decided = queued.map((r) => {
+      const existing = dupMap.get(r.file.name);
+      if (!existing) return { row: r, action: "upload" as const, replace: false };
+      if (policy === "skip") return { row: r, action: "skip" as const, replace: false, existing };
+      if (policy === "replace")
+        return { row: r, action: "upload" as const, replace: true, existing };
+      return { row: r, action: "ask" as const, replace: false, existing };
+    });
+
+    for (const d of decided) {
+      if (d.action === "skip") {
+        updateRow(d.row.id, {
+          state: "skipped",
+          message: "Already exists — skipped.",
+          existingImageId: d.existing,
+        });
+      } else if (d.action === "ask") {
+        updateRow(d.row.id, {
+          state: "ask",
+          message: "Already exists — choose Replace or Skip.",
+          existingImageId: d.existing,
+        });
+      } else {
+        updateRow(d.row.id, { state: "uploading", existingImageId: d.existing });
+      }
+    }
+
+    const toUpload = decided.filter((d) => d.action === "upload");
+    for (let i = 0; i < toUpload.length; i += BATCH_SIZE) {
+      const batch = toUpload.slice(i, i + BATCH_SIZE);
+      await Promise.all(
+        batch.map(async (d) => {
+          const result = await uploadOne(d.row, d.replace);
+          if (result.ok) {
+            updateRow(d.row.id, {
+              state: d.replace ? "replaced" : "done",
+              message: d.replace ? "Replaced existing." : undefined,
+            });
+          } else {
+            updateRow(d.row.id, {
+              state: "failed",
+              message: result.message ?? "Upload failed.",
+            });
+          }
+        }),
+      );
+    }
+
+    setRunning(false);
+    startTransition(() => router.refresh());
+  }
+
+  async function resolveAsk(rowId: string, decision: "skip" | "replace") {
+    const row = rows.find((r) => r.id === rowId);
+    if (!row || row.state !== "ask") return;
+    if (decision === "skip") {
+      updateRow(rowId, { state: "skipped", message: "Skipped by operator." });
+      return;
+    }
+    updateRow(rowId, { state: "uploading", message: "Replacing…" });
+    const result = await uploadOne(row, true);
+    updateRow(rowId, {
+      state: result.ok ? "replaced" : "failed",
+      message: result.ok ? "Replaced existing." : result.message ?? "Upload failed.",
+    });
+    startTransition(() => router.refresh());
+  }
+
+  function clearFinished() {
+    setRows((prev) =>
+      prev.filter(
+        (r) =>
+          r.state === "queued" ||
+          r.state === "uploading" ||
+          r.state === "checking" ||
+          r.state === "ask",
+      ),
+    );
+  }
+
+  return (
+    <section
+      className="mt-6 rounded-md border bg-muted/20 p-4"
+      data-testid="bulk-image-upload"
+    >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold">Bulk upload</h2>
+          <p className="text-xs text-muted-foreground">
+            Drag images here, or click to pick. Up to 10 MB each. JPEG / PNG / WebP / GIF.
+          </p>
+        </div>
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          On duplicate
+          <select
+            value={policy}
+            onChange={(e) => setPolicy(e.target.value as DupePolicy)}
+            disabled={running}
+            className="h-7 rounded border bg-background px-2 text-xs"
+            data-testid="bulk-upload-policy"
+          >
+            <option value="skip">Skip all</option>
+            <option value="replace">Replace all</option>
+            <option value="ask">Ask each time</option>
+          </select>
+        </label>
+      </div>
+
+      <div
+        onDragOver={(e) => {
+          e.preventDefault();
+          if (!dragActive) setDragActive(true);
+        }}
+        onDragLeave={() => setDragActive(false)}
+        onDrop={onDrop}
+        onClick={() => inputRef.current?.click()}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") inputRef.current?.click();
+        }}
+        className={`mt-3 flex h-28 cursor-pointer items-center justify-center rounded border-2 border-dashed text-sm transition-smooth ${
+          dragActive
+            ? "border-primary bg-primary/10"
+            : "border-muted-foreground/40 hover:border-muted-foreground"
+        }`}
+        data-testid="bulk-upload-dropzone"
+      >
+        {dragActive
+          ? "Drop to add to the queue"
+          : "Drop images here or click to pick"}
+        <input
+          ref={inputRef}
+          type="file"
+          accept={ACCEPTED_EXTS.join(",")}
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            if (e.target.files) addFiles(e.target.files);
+            e.target.value = "";
+          }}
+        />
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => void startUpload()}
+          disabled={running || rows.every((r) => r.state !== "queued")}
+          data-testid="bulk-upload-start"
+        >
+          {running
+            ? `Uploading ${summary.done + summary.skipped}/${summary.total}…`
+            : `Upload ${rows.filter((r) => r.state === "queued").length} queued`}
+        </Button>
+        {rows.length > 0 && (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={clearFinished}
+            disabled={running}
+          >
+            Clear finished
+          </Button>
+        )}
+        {rows.length > 0 && (
+          <span className="text-muted-foreground">
+            {summary.done} uploaded · {summary.skipped} skipped · {summary.failed} failed · of {summary.total}
+          </span>
+        )}
+      </div>
+
+      {rows.length > 0 && (
+        <ul
+          className="mt-3 space-y-1 text-xs"
+          data-testid="bulk-upload-list"
+        >
+          {rows.map((row) => (
+            <li
+              key={row.id}
+              className="flex flex-wrap items-center justify-between gap-2 rounded border bg-background px-3 py-1.5"
+              data-state={row.state}
+              data-testid={`bulk-upload-row-${row.state}`}
+            >
+              <span className="truncate">
+                <strong className="font-medium">{row.file.name}</strong>{" "}
+                <span className="text-muted-foreground">
+                  ({fmtBytes(row.file.size)})
+                </span>
+              </span>
+              <span className="flex items-center gap-2">
+                <StateBadge state={row.state} />
+                {row.message && (
+                  <span className="text-muted-foreground">{row.message}</span>
+                )}
+                {row.state === "ask" && (
+                  <>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void resolveAsk(row.id, "skip")}
+                    >
+                      Skip
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void resolveAsk(row.id, "replace")}
+                    >
+                      Replace
+                    </Button>
+                  </>
+                )}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function StateBadge({ state }: { state: FileState }) {
+  const palette: Record<FileState, string> = {
+    queued: "bg-muted text-muted-foreground",
+    checking: "bg-muted text-muted-foreground",
+    ask: "bg-amber-100 text-amber-900",
+    uploading: "bg-blue-100 text-blue-900",
+    done: "bg-emerald-100 text-emerald-900",
+    skipped: "bg-muted text-muted-foreground",
+    replaced: "bg-emerald-100 text-emerald-900",
+    failed: "bg-destructive/10 text-destructive",
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${palette[state]}`}
+    >
+      {state}
+    </span>
+  );
+}


### PR DESCRIPTION
## Workstream: DESIGN-SYSTEM-OVERHAUL — PR 4 of 15 (image library uploader)

Adds a bulk drag-drop upload zone to \`/admin/images\` so operators can
push dozens of images at once without the existing single-file picker
becoming a click-storm. Sequenced behind a duplicate-handling preference
so a re-upload doesn't silently shadow active rows.

## Behaviour

- Drag images on top of the new \"Bulk upload\" panel, or click to pick
  via the OS dialog. JPEG / PNG / WebP / GIF, ≤10 MB each.
- Per-file state machine rendered inline:
  \`queued → checking → uploading → done / skipped / replaced / failed\`.
- Top-level **On duplicate** preference: Skip all (default), Replace
  all, Ask each time. Ask renders Skip / Replace buttons next to every
  duplicate row when the queue starts.
- Pre-flight duplicate check via the new
  \`POST /api/admin/images/check-existing\` — one batched lookup against
  \`image_library.filename\` (active rows only). 200-filename cap per call.
- Sequential 10-at-a-time batches via \`Promise.all\` so a 100-file drop
  doesn't fan out into 100 concurrent fetches.

## Server changes

- \`POST /api/admin/images/upload\` now reads PNG / JPEG / GIF / WebP
  dimensions from the uploaded bytes (via \`lib/image-dimensions.ts\`
  shipped in PR 3) and persists \`width_px\` / \`height_px\` on insert.
  Bulk uploads land complete; PR 3's re-extract button is the
  retroactive escape hatch for older rows.
- The same endpoint accepts \`?replace=1\`. When set, any active row
  with the same filename is soft-deleted (\`deleted_at\` + \`deleted_by\`)
  before the new upload lands. Used by the UI's Replace path.

## Cloudflare optimised variant

Out of scope for this PR. Cloudflare Images variants are
**per-account dashboard configuration**, not provisionable per-upload
from the API. Operators who want a 1200px-wide optimised delivery URL
should add an \`optimised\` variant in the CF dashboard
(\`width=1200, fit=scale-down\`); the existing \`deliveryUrl()\` helper
already picks up named variants by string. Future slice can surface
a UI to choose the default variant per generation surface.

## Migration

\`0066_design_discovery_regen_counts.sql\` already exists in main from
the design-discovery follow-up. No new migration in this PR.

## Risks identified and mitigated

- **Soft-delete on Replace.** Replacing by filename archives the older
  row but keeps it. \`image_library_filename_unique\` (or the
  equivalent \`(source, source_ref)\` constraint) only counts active
  rows because of the \`WHERE deleted_at IS NULL\` partial index, so
  the new INSERT doesn't collide with the archived one. Verified by
  reading migration \`0010_m4_1_image_library_schema.sql\`.
- **Concurrent uploads racing on filename.** Two operators bulk-uploading
  the same filename simultaneously could both pass the pre-flight
  duplicate check, both hit \`?replace=1\`, and the second's archive +
  insert serialises after the first's. End state: one active, one
  archived — same as the manual case. No corruption.
- **Cloudflare quota.** No concurrency cap was added — at 10 parallel
  uploads per batch, Cloudflare's per-account rate limit could be hit
  on large drops. Mitigated by the upload endpoint's existing
  retry-on-429 logic in \`lib/cloudflare-images.ts\`. Adding a
  configurable batch size is a follow-up if drops in the 500+ range
  become routine.
- **No abuse cap on the queue.** A bored operator could queue 10k
  files and click Upload. Mitigated by the existing 10 MB per-file
  cap + per-batch sequencing; total wall time scales linearly. Queue
  state is client-only — refresh = reset.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx next lint\` clean on changed files.
- [ ] Manually verify on staging: drop 5 files, confirm Skip / Replace
  policy paths, confirm dimensions land on the new rows, confirm
  duplicate detection finds an existing iStock filename.
- E2E note: \`e2e/images.spec.ts\` covers the list page; the bulk
  upload UI is client-state heavy and the most useful E2E (full
  drag-drop + Cloudflare upload) needs live CF credentials, which the
  test environment doesn't have. Additions deferred until the
  Cloudflare-mocking pattern shipped in another slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)