### PR TITLE
feat(sites): site_mode + extracted design columns (PR 5/15)

### DIFF
--- a/supabase/migrations/0067_site_mode_columns.sql
+++ b/supabase/migrations/0067_site_mode_columns.sql
@@ -1,0 +1,63 @@
+-- 0067 — Site mode + extracted-design columns.
+-- Reference: DESIGN-SYSTEM-OVERHAUL workstream (PR 5/15).
+--
+-- Foundation schema for the unified setup flow. Each site gets one of
+-- two modes:
+--
+--   copy_existing — site already has a live WordPress theme. The setup
+--                   flow extracts the design profile (colours, fonts,
+--                   common CSS class names) so generated content
+--                   matches without injecting new CSS.
+--
+--   new_design    — site is being built fresh. The existing
+--                   DESIGN-DISCOVERY wizard runs (concepts → tokens →
+--                   tone). Generated content includes inline CSS
+--                   accumulated into the design system.
+--
+-- Site mode is captured BEFORE either path runs (see PR 6's
+-- /admin/sites/[id]/onboarding screen). NULL = site hasn't been
+-- onboarded yet; the existing site detail page will show a banner
+-- prompting the operator to pick.
+--
+-- Design decisions encoded here:
+--
+-- 1. site_mode as text + CHECK constraint rather than ENUM. Same
+--    rationale as opt_clients.hosting_mode (migration 0031): future
+--    additions (e.g. 'hybrid') don't require a type ALTER.
+--
+-- 2. extracted_design + extracted_css_classes as JSONB. Both shapes
+--    are iterating during PR 7's extraction work and committing to a
+--    columnar shape now would lock us into the v1 cut.
+--
+-- 3. NULLable site_mode + extracted_* default to NULL. No backfill —
+--    existing rows are mid-DESIGN-DISCOVERY and the onboarding banner
+--    catches them on the next site detail visit.
+--
+-- 4. No FK to a separate site_modes lookup table. Two values today
+--    (three with the noted future). Lookup table would be ceremony
+--    without payback.
+--
+-- 5. No site_modes UNIQUE / index — site_mode is queried by the
+--    site row's PK lookup; no need for a secondary index.
+--
+-- Write-safety notes:
+--   - Pure ALTER TABLE ADD COLUMN with constant defaults / NULLs. No
+--     table rewrite; existing rows pick up the new columns lazily.
+--   - The CHECK constraint applies only when site_mode is NOT NULL
+--     (Postgres CHECK semantics on NULL = pass), so existing rows
+--     with NULL pass without re-validation.
+
+ALTER TABLE sites
+  ADD COLUMN site_mode text
+    CHECK (site_mode IS NULL OR site_mode IN ('copy_existing', 'new_design')),
+  ADD COLUMN extracted_design jsonb,
+  ADD COLUMN extracted_css_classes jsonb;
+
+COMMENT ON COLUMN sites.site_mode IS
+  'Site onboarding mode. NULL = onboarding not yet complete. ''copy_existing'' = site has a live WP theme; setup flow extracts design profile (PR 7). ''new_design'' = built fresh; existing DESIGN-DISCOVERY wizard runs. Added 2026-05-02 (DESIGN-SYSTEM-OVERHAUL PR 5).';
+
+COMMENT ON COLUMN sites.extracted_design IS
+  'Extracted design profile for copy_existing sites. Shape (v1): {colors: {primary, secondary, accent, background, text}, fonts: {heading, body}, layout_density, visual_tone, screenshot_url, source_pages}. NULL until extraction runs in PR 7.';
+
+COMMENT ON COLUMN sites.extracted_css_classes IS
+  'Common CSS class patterns scraped from the live site. Shape (v1): {container, headings: {h1, h2, h3}, button, card}. Used by mode-aware content generation (PR 10) so produced HTML carries the existing theme''s class names instead of inventing new ones. NULL until extraction runs in PR 7.';

--- a/supabase/rollbacks/0067_site_mode_columns.down.sql
+++ b/supabase/rollbacks/0067_site_mode_columns.down.sql
@@ -1,0 +1,8 @@
+-- Rollback for 0067_site_mode_columns.sql
+-- Drops the three columns added on sites. Does NOT preserve any
+-- captured mode / extracted design data. Intended for local dev / CI
+-- reset, not production recovery.
+
+ALTER TABLE sites DROP COLUMN IF EXISTS extracted_css_classes;
+ALTER TABLE sites DROP COLUMN IF EXISTS extracted_design;
+ALTER TABLE sites DROP COLUMN IF EXISTS site_mode;


### PR DESCRIPTION
## Workstream: DESIGN-SYSTEM-OVERHAUL — PR 5 of 15 (schema)

Foundation schema for the unified setup flow. Migration-only.

## Change

Migration \`0067_site_mode_columns.sql\` adds three nullable columns to
\`sites\`:

| column | type | nullable | purpose |
|---|---|---|---|
| \`site_mode\` | text + CHECK | yes | One of \`copy_existing\` / \`new_design\`. NULL = onboarding not yet complete; site detail will show a banner prompting the choice (PR 6). |
| \`extracted_design\` | jsonb | yes | Output of the copy-existing extraction (PR 7). v1 shape: colours / fonts / layout_density / visual_tone / screenshot_url / source_pages. |
| \`extracted_css_classes\` | jsonb | yes | Common CSS class patterns scraped from the live site. Consumed by mode-aware content gen (PR 10). |

Existing DESIGN-DISCOVERY columns (\`design_brief\`, \`design_tokens\`,
\`homepage_concept_html\`, \`tone_of_voice\`, etc) stay untouched as the
\`new_design\` path's storage.

## Risks identified and mitigated

- **Online migration safety.** Pure \`ALTER TABLE ADD COLUMN\` with
  NULL defaults — no table rewrite (Postgres handles NULL-default
  adds metadata-only since 11.x), no backfill, no lock window concern.
- **CHECK on existing rows.** \`site_mode IS NULL OR site_mode IN
  (...)\` — existing rows with NULL pass without re-validation per
  Postgres CHECK semantics on NULL.
- **Choice of text+CHECK over ENUM.** Same rationale as
  \`opt_clients.hosting_mode\` (migration 0031): future additions
  (\`hybrid\`, etc) don't require a type ALTER.
- **JSONB for extracted_*.** The shape iterates during PR 7. Locking
  to a columnar layout now would force a follow-up migration when
  the extraction prompt's output settles.
- **No FK / UNIQUE / index.** site_mode is read on site PK lookup;
  secondary index wouldn't pay back at two-value cardinality.

## Pre-existing CI note

Main currently fails its \"Start Supabase local stack\" CI step on every
push due to a duplicate-key collision between
\`0031_email_log.sql\` and \`0031_optimiser_clients.sql\`. The hotfix
branch \`hotfix/migration-0031-collision\` (#348) is open but stale
relative to current main and hasn't been merged. This PR's migration
is numbered 0067 and doesn't interact with the collision; the CI
failure is unrelated.

## Test plan

- [x] \`npx tsc --noEmit\` clean (no callers touching the new columns
  yet, migration-only).
- [ ] On staging, after \`supabase db push\`, verify the columns land
  as expected (\`SELECT column_name FROM information_schema.columns
  WHERE table_name = 'sites' AND column_name IN ('site_mode',
  'extracted_design', 'extracted_css_classes')\`).
- N/A — no admin UI surface in this PR (per the E2E rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)