### PR TITLE
feat(sites): site mode onboarding screen (PR 6/15)

### DIFF
--- a/app/admin/sites/[id]/onboarding/page.tsx
+++ b/app/admin/sites/[id]/onboarding/page.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { SiteOnboardingForm } from "@/components/SiteOnboardingForm";
+import { Alert } from "@/components/ui/alert";
+import { H1, H3, Lead } from "@/components/ui/typography";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// /admin/sites/[id]/onboarding — DESIGN-SYSTEM-OVERHAUL PR 6.
+//
+// Mode-selection screen for the unified setup flow. Renders before
+// either the existing DESIGN-DISCOVERY wizard or the new copy-existing
+// extraction (PR 7). On submit, sets sites.site_mode and redirects to
+// the appropriate downstream surface.
+//
+// Already-onboarded sites land here via deep link or banner click;
+// they're redirected straight to the right downstream surface so the
+// operator doesn't have to pick the same mode twice.
+
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export default async function SiteOnboardingPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const access = await checkAdminAccess({
+    requiredRoles: ["super_admin", "admin"],
+    insufficientRoleRedirectTo: "/",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  if (!UUID_RE.test(params.id)) notFound();
+
+  const supabase = getServiceRoleClient();
+  const res = await supabase
+    .from("sites")
+    .select("id, name, site_mode")
+    .eq("id", params.id)
+    .maybeSingle();
+
+  if (res.error) {
+    return (
+      <Alert variant="destructive" title="Failed to load site">
+        {res.error.message}
+      </Alert>
+    );
+  }
+  if (!res.data) notFound();
+
+  const site = res.data as { id: string; name: string; site_mode: string | null };
+
+  if (site.site_mode === "copy_existing") {
+    redirect(`/admin/sites/${site.id}/setup/extract`);
+  }
+  if (site.site_mode === "new_design") {
+    redirect(`/admin/sites/${site.id}/setup?step=1`);
+  }
+
+  return (
+    <>
+      <Breadcrumbs
+        crumbs={[
+          { label: "Admin", href: "/admin/sites" },
+          { label: "Sites", href: "/admin/sites" },
+          { label: site.name, href: `/admin/sites/${site.id}` },
+          { label: "Onboarding" },
+        ]}
+      />
+
+      <div className="mt-4 max-w-3xl">
+        <H1>How would you like to use this site?</H1>
+        <Lead className="mt-2">
+          Pick one. We&apos;ll tailor the rest of the setup — and how
+          generated content is styled — based on your choice. You can
+          re-onboard later if you change your mind.
+        </Lead>
+
+        <SiteOnboardingForm siteId={site.id} />
+
+        <section className="mt-10 border-t pt-6">
+          <H3>Not sure which to pick?</H3>
+          <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
+            <li>
+              <strong className="text-foreground">Upload to existing</strong>{" "}
+              suits a client whose WordPress site already looks the way they
+              want it. We extract the colours, fonts, and class names so new
+              content matches the existing chrome.
+            </li>
+            <li>
+              <strong className="text-foreground">Build a new website</strong>{" "}
+              suits a fresh site (or a heavy redesign). The setup wizard
+              walks through design direction, concepts, tone of voice, and
+              the design tokens generation will use.
+            </li>
+          </ul>
+          <Link
+            href={`/admin/sites/${site.id}`}
+            className="mt-4 inline-block text-xs text-muted-foreground hover:text-foreground"
+          >
+            ← Back to site
+          </Link>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/app/admin/sites/[id]/page.tsx
+++ b/app/admin/sites/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { EditTenantBudgetButton } from "@/components/EditTenantBudgetButton";
+import { OnboardingReminderBanner } from "@/components/OnboardingReminderBanner";
 import { SetupReminderBanner } from "@/components/SetupReminderBanner";
 import { SiteDetailActions } from "@/components/SiteDetailActions";
 import { TenantBudgetBadge } from "@/components/TenantBudgetBadge";
@@ -141,13 +142,28 @@ export default async function SiteDetailPage({
   // the setup wizard. Renders only when BOTH discovery statuses are
   // 'pending'; the banner itself manages dismissal via localStorage.
   const setupStatusResult = await getSetupStatus(site.id);
+
+  // DESIGN-SYSTEM-OVERHAUL PR 6 — site_mode gate. NULL = operator
+  // hasn't picked between copy_existing / new_design yet. Render the
+  // onboarding banner and suppress the design-discovery one (which
+  // only applies to the new_design path).
+  const { data: siteModeRow } = await svc
+    .from("sites")
+    .select("site_mode")
+    .eq("id", site.id)
+    .maybeSingle();
+  const siteMode = (siteModeRow?.site_mode as string | null) ?? null;
+  const needsOnboarding = siteMode === null;
   const needsSetupReminder =
+    !needsOnboarding &&
+    siteMode === "new_design" &&
     setupStatusResult.ok &&
     setupStatusResult.data.design_direction_status === "pending" &&
     setupStatusResult.data.tone_of_voice_status === "pending";
 
   return (
     <>
+      {needsOnboarding && <OnboardingReminderBanner siteId={site.id} />}
       {needsSetupReminder && <SetupReminderBanner siteId={site.id} />}
       <div className="flex items-start justify-between gap-4">
         <div>

--- a/app/api/admin/sites/[id]/onboarding/route.ts
+++ b/app/api/admin/sites/[id]/onboarding/route.ts
@@ -1,0 +1,137 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// POST /api/admin/sites/[id]/onboarding
+//
+// Persists the operator's mode choice from /admin/sites/[id]/onboarding
+// and returns the URL to redirect to next. Re-onboarding (mode change)
+// is allowed — the wizard / extraction surfaces are forward-only with
+// their own state machines, but the operator can flip the mode if they
+// realise mid-stream that the wrong path was taken.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const BodySchema = z.object({
+  site_mode: z.enum(["copy_existing", "new_design"]),
+});
+
+function nextRedirect(siteId: string, mode: "copy_existing" | "new_design"): string {
+  if (mode === "copy_existing") return `/admin/sites/${siteId}/setup/extract`;
+  return `/admin/sites/${siteId}/setup?step=1`;
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({
+    roles: ["super_admin", "admin"] as const,
+  });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Site id must be a UUID.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body must be { site_mode: 'copy_existing' | 'new_design' }.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getServiceRoleClient();
+  const upd = await supabase
+    .from("sites")
+    .update({
+      site_mode: parsed.data.site_mode,
+      updated_at: new Date().toISOString(),
+      updated_by: gate.user?.id ?? null,
+    })
+    .eq("id", params.id)
+    .select("id, site_mode")
+    .maybeSingle();
+
+  if (upd.error) {
+    logger.error("site.onboarding.update_failed", {
+      site_id: params.id,
+      error: upd.error.message,
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to save site mode.",
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+  if (!upd.data) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: "Site not found.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 404 },
+    );
+  }
+
+  revalidatePath(`/admin/sites/${params.id}`);
+  revalidatePath(`/admin/sites/${params.id}/onboarding`);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        site_mode: parsed.data.site_mode,
+        redirect_to: nextRedirect(params.id, parsed.data.site_mode),
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200, headers: { "cache-control": "no-store" } },
+  );
+}

--- a/components/OnboardingReminderBanner.tsx
+++ b/components/OnboardingReminderBanner.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { Sparkles } from "lucide-react";
+
+// OnboardingReminderBanner — DESIGN-SYSTEM-OVERHAUL PR 6.
+//
+// Renders on the site detail page when sites.site_mode IS NULL, i.e.
+// the operator hasn't chosen between "copy existing" and "new design"
+// yet. Non-dismissible — the choice is the entry-point gate for both
+// the design-discovery wizard and the new copy-existing extraction
+// flow, so suppressing it locally would just mean the next visit shows
+// a partial setup with no clear path forward.
+
+export function OnboardingReminderBanner({ siteId }: { siteId: string }) {
+  return (
+    <div
+      className="mb-4 flex flex-wrap items-start gap-3 rounded-lg border border-primary/30 bg-primary/5 p-3 text-sm"
+      role="status"
+      data-testid="onboarding-reminder-banner"
+    >
+      <Sparkles aria-hidden className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+      <div className="min-w-0 flex-1">
+        <p className="font-medium">Finish setting up this site.</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          Pick whether we&apos;re uploading content to an existing WordPress
+          theme or building a fresh design. Generation styling and the
+          rest of setup follow from this choice.
+        </p>
+        <Link
+          href={`/admin/sites/${siteId}/onboarding`}
+          className="mt-2 inline-block text-xs font-medium underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          data-testid="onboarding-reminder-banner-cta"
+        >
+          Set up now →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/SiteCreateForm.tsx
+++ b/components/SiteCreateForm.tsx
@@ -159,14 +159,13 @@ export function SiteCreateForm() {
         | null;
       if (payload?.ok) {
         toast.success("Site connected", {
-          description: `${form.name} — let's set up the design and tone next.`,
+          description: `${form.name} — choose how you want to use this site next.`,
         });
-        // DESIGN-DISCOVERY (PR 11) — fresh sites land on the setup
-        // wizard at Step 1 instead of the bare detail page so the
-        // operator captures design + tone before generating any
-        // pages. The wizard is skippable; resume logic returns to
-        // the right step on subsequent visits.
-        router.push(`/admin/sites/${payload.data.id}/setup?step=1`);
+        // DESIGN-SYSTEM-OVERHAUL (PR 6) — fresh sites land on the
+        // mode-selection screen first; the existing copy / new-design
+        // branches diverge from there. The post-onboarding redirect
+        // sends the operator to the right wizard or extraction flow.
+        router.push(`/admin/sites/${payload.data.id}/onboarding`);
         return;
       }
       const message =

--- a/components/SiteOnboardingForm.tsx
+++ b/components/SiteOnboardingForm.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { Sparkles, UploadCloud } from "lucide-react";
+
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+type Mode = "copy_existing" | "new_design";
+
+const OPTIONS: Array<{
+  mode: Mode;
+  title: string;
+  blurb: string;
+  Icon: typeof UploadCloud;
+}> = [
+  {
+    mode: "copy_existing",
+    title: "Upload content to an existing site",
+    blurb:
+      "This site already has a WordPress theme. We'll extract its design so new content matches it seamlessly.",
+    Icon: UploadCloud,
+  },
+  {
+    mode: "new_design",
+    title: "Build a new website",
+    blurb:
+      "We'll help you design the site from scratch — concepts, colours, tone of voice, and a complete CSS system.",
+    Icon: Sparkles,
+  },
+];
+
+export function SiteOnboardingForm({ siteId }: { siteId: string }) {
+  const [selected, setSelected] = useState<Mode | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit() {
+    if (!selected) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/sites/${siteId}/onboarding`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ site_mode: selected }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: { redirect_to: string } }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (!res.ok || !payload?.ok) {
+        setError(
+          payload && payload.ok === false
+            ? payload.error.message
+            : `Failed to save (HTTP ${res.status}).`,
+        );
+        setSubmitting(false);
+        return;
+      }
+      window.location.assign(payload.data.redirect_to);
+    } catch (err) {
+      setError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mt-6 space-y-4" data-testid="site-onboarding-form">
+      <div className="grid gap-4 md:grid-cols-2">
+        {OPTIONS.map(({ mode, title, blurb, Icon }) => {
+          const isSelected = selected === mode;
+          return (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => setSelected(mode)}
+              className={`flex h-full flex-col gap-3 rounded-lg border-2 p-5 text-left transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                isSelected
+                  ? "border-primary bg-primary/5"
+                  : "border-muted hover:border-foreground/40"
+              }`}
+              data-testid={`site-onboarding-option-${mode}`}
+              aria-pressed={isSelected}
+            >
+              <Icon
+                aria-hidden
+                className={`h-6 w-6 ${
+                  isSelected ? "text-primary" : "text-muted-foreground"
+                }`}
+              />
+              <div>
+                <p className="text-base font-medium">{title}</p>
+                <p className="mt-1 text-sm text-muted-foreground">{blurb}</p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {error && (
+        <Alert variant="destructive" title="Couldn't save your choice">
+          {error}
+        </Alert>
+      )}
+
+      <div className="flex items-center justify-end gap-3 pt-2">
+        <Button
+          type="button"
+          onClick={() => void onSubmit()}
+          disabled={!selected || submitting}
+          data-testid="site-onboarding-submit"
+        >
+          {submitting ? "Saving…" : "Continue"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/e2e/design-discovery.spec.ts
+++ b/e2e/design-discovery.spec.ts
@@ -222,9 +222,15 @@ async function createSiteAndOpenSetup(
     /Connected as/i,
   );
   await page.getByTestId("site-create-save").click();
-  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/setup\?step=1/);
+  // DESIGN-SYSTEM-OVERHAUL (PR 6) — fresh sites first land on the
+  // /onboarding mode-selection screen. Pick "Build a new website" to
+  // reach the design-discovery wizard.
+  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/onboarding/);
   const id = page.url().match(/\/admin\/sites\/([0-9a-f-]{36})/)?.[1];
   if (!id) throw new Error(`Failed to extract site id from ${page.url()}`);
+  await page.getByTestId("site-onboarding-option-new_design").click();
+  await page.getByTestId("site-onboarding-submit").click();
+  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/setup\?step=1/);
   return id;
 }
 

--- a/e2e/site-setup.spec.ts
+++ b/e2e/site-setup.spec.ts
@@ -46,12 +46,17 @@ async function createSiteAndOpenSetup(
     /Connected as/i,
   );
   await page.getByTestId("site-create-save").click();
-  // PR 11 — fresh sites land on /setup?step=1 directly. Extract id
-  // from there; no need for a separate goto.
-  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/setup\?step=1/);
+  // DESIGN-SYSTEM-OVERHAUL (PR 6) — fresh sites land on the
+  // /onboarding mode-selection screen first. Pick "Build a new
+  // website" to continue into the existing design-discovery wizard
+  // at step 1.
+  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/onboarding/);
   const url = page.url();
   const id = url.match(/\/admin\/sites\/([0-9a-f-]{36})/)?.[1];
   if (!id) throw new Error(`Failed to extract site id from ${url}`);
+  await page.getByTestId("site-onboarding-option-new_design").click();
+  await page.getByTestId("site-onboarding-submit").click();
+  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/setup\?step=1/);
   return id;
 }
 

--- a/e2e/sites.spec.ts
+++ b/e2e/sites.spec.ts
@@ -46,10 +46,10 @@ async function createSiteViaForm(
 
   await expect(page.getByTestId("site-create-save")).toBeEnabled();
   await page.getByTestId("site-create-save").click();
-  // DESIGN-DISCOVERY (PR 11) — fresh sites now land on the setup
-  // wizard at Step 1 instead of the bare detail page. Tests that
-  // need the detail page navigate there explicitly afterwards.
-  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/setup\?step=1/);
+  // DESIGN-SYSTEM-OVERHAUL (PR 6) — fresh sites now land on the
+  // /onboarding mode-selection screen first; the design-discovery
+  // wizard sits behind the new_design branch.
+  await page.waitForURL(/\/admin\/sites\/[0-9a-f-]{36}\/onboarding/);
 }
 
 test.describe("sites CRUD", () => {
@@ -88,11 +88,12 @@ test.describe("sites CRUD", () => {
       password: "abcd efgh ijkl mnop qrst uvwx",
     });
 
-    // DESIGN-DISCOVERY (PR 11) — fresh sites land on the setup
-    // wizard at Step 1 instead of the bare detail page. The wizard
-    // heading reads "Set up <name>".
+    // DESIGN-SYSTEM-OVERHAUL (PR 6) — fresh sites land on the
+    // mode-selection screen first.
     await expect(
-      page.getByRole("heading", { name: new RegExp(`Set up ${uniqueName}`) }),
+      page.getByRole("heading", {
+        name: /How would you like to use this site\?/i,
+      }),
     ).toBeVisible();
 
     // Going back to the list shows the new row.


### PR DESCRIPTION
## Workstream: DESIGN-SYSTEM-OVERHAUL — PR 6 of 15 (onboarding screen)

Adds the mode-selection screen that gates the rest of the setup flow.

## New surfaces

- \`/admin/sites/[id]/onboarding\` — server-rendered full-page picker
  between **\"Upload content to an existing site\"** (\`copy_existing\`)
  and **\"Build a new website\"** (\`new_design\`). Already-onboarded
  sites short-circuit straight to their downstream surface so a
  re-visit doesn't ask twice.
- \`POST /api/admin/sites/[id]/onboarding\` — persists \`sites.site_mode\`
  and returns the redirect target. Re-onboarding allowed (operator can
  flip mid-stream if they realised the wrong mode was picked).

## Site detail integration

- \`SiteCreateForm\` post-create redirect now goes to \`/onboarding\`
  instead of \`/setup?step=1\`. Fresh sites pick their mode first.
- New \`OnboardingReminderBanner\` renders on the site detail when
  \`site_mode IS NULL\`. **Non-dismissible** — the choice gates both
  downstream paths so suppressing it locally would just hide the
  next step.
- The existing \`SetupReminderBanner\` (design-discovery wizard
  reminder) now only renders for \`site_mode = 'new_design'\`. The
  wizard doesn't apply to copy_existing sites.

## E2E

- \`e2e/sites.spec.ts\` — the post-create test now expects the
  \"How would you like to use this site?\" heading instead of the
  wizard heading. The \`/edit\` follow-up test extracts the site id
  from the URL and works unchanged.
- \`e2e/design-discovery.spec.ts\` and \`e2e/site-setup.spec.ts\` — their
  shared \`createSiteAndOpenSetup\` helpers now click through the new
  onboarding screen (selecting the \`new_design\` option) before
  reaching \`/setup?step=1\`.

## Risks identified and mitigated

- **/setup/extract is the redirect target for copy_existing — it
  doesn't exist yet.** Lands in PR 7 next. In the merge window
  between this PR and PR 7, an operator picking \"Upload to
  existing\" would hit a 404. Acceptable: the workstream lands them
  in sequence, and the existing site detail page still works.
- **Re-onboarding mid-stream.** \`POST /onboarding\` overwrites
  \`site_mode\` unconditionally. The downstream wizards / extraction
  flows are forward-only with their own state machines (the
  design-discovery columns aren't reset on a mode flip). An operator
  who picks new_design, runs the wizard halfway, then re-onboards to
  copy_existing leaves their wizard rows orphaned in the DB. Cheap
  to surface as a confirmation step in a follow-up; not a data
  corruption risk because both column sets remain valid for their
  own paths.
- **Onboarding banner shadowing.** The new banner suppresses the
  design-discovery one for site_mode IS NULL. Once the operator
  picks new_design and lands on the wizard, the design-discovery
  banner returns on detail visits while the wizard is incomplete.
  Mitigated explicitly in the page.tsx logic
  (\`needsSetupReminder\` now requires \`site_mode === \"new_design\"\`).

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx next lint\` clean on changed files.
- E2E note: existing site / design-discovery / site-setup specs
  updated to thread the new step. Per-spec walkthrough above.
- Pre-existing CI note (carried forward from PR 5): main's \"Start
  Supabase local stack\" CI step fails on the 0031 migration
  collision. Hotfix branch \`hotfix/migration-0031-collision\` (#348)
  is open but stale. Unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)