### PR TITLE
feat(sites): copy-existing extraction wizard (PR 7/15)

### DIFF
--- a/app/admin/sites/[id]/setup/extract/page.tsx
+++ b/app/admin/sites/[id]/setup/extract/page.tsx
@@ -1,0 +1,99 @@
+import { notFound, redirect } from "next/navigation";
+
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { CopyExistingExtractionWizard } from "@/components/CopyExistingExtractionWizard";
+import { Alert } from "@/components/ui/alert";
+import { H1, Lead } from "@/components/ui/typography";
+import { checkAdminAccess } from "@/lib/admin-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// /admin/sites/[id]/setup/extract — DESIGN-SYSTEM-OVERHAUL PR 7.
+//
+// Copy-existing extraction wizard. Server component loads the site +
+// any existing extraction snapshot; the client wizard handles the
+// "Run extraction → Review → Confirm" flow.
+//
+// Gating:
+//   - site_mode === 'copy_existing' (operator must have completed
+//     onboarding with the right choice)
+//   - Other modes redirect back to /onboarding so the operator picks
+//     the right path
+
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export default async function CopyExistingExtractPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const access = await checkAdminAccess({
+    requiredRoles: ["super_admin", "admin"],
+    insufficientRoleRedirectTo: "/",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  if (!UUID_RE.test(params.id)) notFound();
+
+  const supabase = getServiceRoleClient();
+  const res = await supabase
+    .from("sites")
+    .select("id, name, wp_url, site_mode, extracted_design, extracted_css_classes")
+    .eq("id", params.id)
+    .maybeSingle();
+
+  if (res.error) {
+    return (
+      <Alert variant="destructive" title="Failed to load site">
+        {res.error.message}
+      </Alert>
+    );
+  }
+  if (!res.data) notFound();
+
+  const site = res.data as {
+    id: string;
+    name: string;
+    wp_url: string;
+    site_mode: string | null;
+    extracted_design: unknown;
+    extracted_css_classes: unknown;
+  };
+
+  if (site.site_mode === null) {
+    redirect(`/admin/sites/${site.id}/onboarding`);
+  }
+  if (site.site_mode !== "copy_existing") {
+    redirect(`/admin/sites/${site.id}/onboarding`);
+  }
+
+  return (
+    <>
+      <Breadcrumbs
+        crumbs={[
+          { label: "Admin", href: "/admin/sites" },
+          { label: "Sites", href: "/admin/sites" },
+          { label: site.name, href: `/admin/sites/${site.id}` },
+          { label: "Extract design" },
+        ]}
+      />
+
+      <div className="mt-4 max-w-3xl">
+        <H1>Extract design from {site.wp_url}</H1>
+        <Lead className="mt-2">
+          We&apos;ll fetch your live site and pull out the colours, fonts, and
+          common CSS class names so generated content matches the existing
+          theme. Review and tweak before saving.
+        </Lead>
+
+        <CopyExistingExtractionWizard
+          siteId={site.id}
+          siteUrl={site.wp_url}
+          existingDesign={site.extracted_design}
+          existingClasses={site.extracted_css_classes}
+        />
+      </div>
+    </>
+  );
+}

--- a/app/api/admin/sites/[id]/setup/extract/route.ts
+++ b/app/api/admin/sites/[id]/setup/extract/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { extractDesignFromUrl } from "@/lib/copy-existing-extract";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// POST /api/admin/sites/[id]/setup/extract
+//
+// Runs the copy-existing extraction (CSS + HTML scrape + Microlink
+// screenshot) and returns the snapshot. Does NOT persist — the
+// operator reviews + edits in the wizard before /save commits the
+// row.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const BodySchema = z
+  .object({
+    extra_pages: z.array(z.string().url()).max(5).optional(),
+  })
+  .optional();
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({
+    roles: ["super_admin", "admin"] as const,
+  });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Site id must be a UUID.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body validation failed.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getServiceRoleClient();
+  const siteRow = await supabase
+    .from("sites")
+    .select("id, wp_url, site_mode")
+    .eq("id", params.id)
+    .maybeSingle();
+
+  if (siteRow.error || !siteRow.data) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: "Site not found.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 404 },
+    );
+  }
+
+  const site = siteRow.data as { id: string; wp_url: string; site_mode: string | null };
+  if (site.site_mode !== "copy_existing") {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INVALID_STATE",
+          message:
+            "Extraction is only available for sites in copy_existing mode. Set the site mode via /onboarding first.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 409 },
+    );
+  }
+
+  const result = await extractDesignFromUrl(site.wp_url, {
+    existingPages: parsed.data?.extra_pages,
+  });
+
+  return NextResponse.json(
+    { ok: true, data: result, timestamp: new Date().toISOString() },
+    { status: 200, headers: { "cache-control": "no-store" } },
+  );
+}

--- a/app/api/admin/sites/[id]/setup/extract/save/route.ts
+++ b/app/api/admin/sites/[id]/setup/extract/save/route.ts
@@ -1,0 +1,166 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// POST /api/admin/sites/[id]/setup/extract/save
+//
+// Persists the operator-reviewed extraction snapshot. Sets
+// design_direction_status='approved' so the existing
+// design-discovery downstream code that checks that flag treats the
+// site as fully set up.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const ColorSchema = z.string().trim().min(3).max(40).nullable();
+const FontSchema = z.string().trim().min(1).max(120).nullable();
+const ClassNameSchema = z.string().trim().min(1).max(120).nullable();
+
+const ExtractedDesignSchema = z.object({
+  colors: z.object({
+    primary: ColorSchema,
+    secondary: ColorSchema,
+    accent: ColorSchema,
+    background: ColorSchema,
+    text: ColorSchema,
+  }),
+  fonts: z.object({
+    heading: FontSchema,
+    body: FontSchema,
+  }),
+  layout_density: z.enum(["compact", "medium", "spacious"]),
+  visual_tone: z.string().trim().min(1).max(80),
+  screenshot_url: z.string().url().nullable(),
+  source_pages: z.array(z.string().url()).max(10),
+});
+
+const ExtractedCssClassesSchema = z.object({
+  container: ClassNameSchema,
+  headings: z.object({
+    h1: ClassNameSchema,
+    h2: ClassNameSchema,
+    h3: ClassNameSchema,
+  }),
+  button: ClassNameSchema,
+  card: ClassNameSchema,
+});
+
+const BodySchema = z.object({
+  extracted_design: ExtractedDesignSchema,
+  extracted_css_classes: ExtractedCssClassesSchema,
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({
+    roles: ["super_admin", "admin"] as const,
+  });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Site id must be a UUID.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body validation failed.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getServiceRoleClient();
+  const upd = await supabase
+    .from("sites")
+    .update({
+      extracted_design: parsed.data.extracted_design,
+      extracted_css_classes: parsed.data.extracted_css_classes,
+      design_direction_status: "approved",
+      updated_at: new Date().toISOString(),
+      updated_by: gate.user?.id ?? null,
+    })
+    .eq("id", params.id)
+    .eq("site_mode", "copy_existing")
+    .select("id")
+    .maybeSingle();
+
+  if (upd.error) {
+    logger.error("site.extract.save_failed", {
+      site_id: params.id,
+      error: upd.error.message,
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to save extraction.",
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+  if (!upd.data) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INVALID_STATE",
+          message:
+            "Site not found or not in copy_existing mode. Re-run onboarding to set the mode.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 409 },
+    );
+  }
+
+  revalidatePath(`/admin/sites/${params.id}`);
+  revalidatePath(`/admin/sites/${params.id}/setup/extract`);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { site_id: params.id },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200, headers: { "cache-control": "no-store" } },
+  );
+}

--- a/components/CopyExistingExtractionWizard.tsx
+++ b/components/CopyExistingExtractionWizard.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+type LayoutDensity = "compact" | "medium" | "spacious";
+
+type ExtractedDesign = {
+  colors: {
+    primary: string | null;
+    secondary: string | null;
+    accent: string | null;
+    background: string | null;
+    text: string | null;
+  };
+  fonts: { heading: string | null; body: string | null };
+  layout_density: LayoutDensity;
+  visual_tone: string;
+  screenshot_url: string | null;
+  source_pages: string[];
+};
+
+type ExtractedCssClasses = {
+  container: string | null;
+  headings: { h1: string | null; h2: string | null; h3: string | null };
+  button: string | null;
+  card: string | null;
+};
+
+type ExtractionResponse = {
+  ok: boolean;
+  design: ExtractedDesign;
+  css_classes: ExtractedCssClasses;
+  notes: string[];
+};
+
+const EMPTY_DESIGN: ExtractedDesign = {
+  colors: { primary: null, secondary: null, accent: null, background: null, text: null },
+  fonts: { heading: null, body: null },
+  layout_density: "medium",
+  visual_tone: "Neutral",
+  screenshot_url: null,
+  source_pages: [],
+};
+
+const EMPTY_CLASSES: ExtractedCssClasses = {
+  container: null,
+  headings: { h1: null, h2: null, h3: null },
+  button: null,
+  card: null,
+};
+
+function isExtractedDesign(value: unknown): value is ExtractedDesign {
+  if (!value || typeof value !== "object") return false;
+  return "colors" in value && "fonts" in value;
+}
+
+function isExtractedCssClasses(value: unknown): value is ExtractedCssClasses {
+  if (!value || typeof value !== "object") return false;
+  return "headings" in value;
+}
+
+export function CopyExistingExtractionWizard({
+  siteId,
+  siteUrl,
+  existingDesign,
+  existingClasses,
+}: {
+  siteId: string;
+  siteUrl: string;
+  existingDesign: unknown;
+  existingClasses: unknown;
+}) {
+  const router = useRouter();
+  const seededDesign = isExtractedDesign(existingDesign) ? existingDesign : null;
+  const seededClasses = isExtractedCssClasses(existingClasses) ? existingClasses : null;
+  const [design, setDesign] = useState<ExtractedDesign>(seededDesign ?? EMPTY_DESIGN);
+  const [cssClasses, setCssClasses] = useState<ExtractedCssClasses>(
+    seededClasses ?? EMPTY_CLASSES,
+  );
+  const [hasResults, setHasResults] = useState(seededDesign !== null);
+  const [notes, setNotes] = useState<string[]>([]);
+  const [extraPagesText, setExtraPagesText] = useState("");
+  const [extracting, setExtracting] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  function parseExtraPages(text: string): string[] {
+    return text
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .slice(0, 5);
+  }
+
+  async function runExtraction() {
+    setExtracting(true);
+    setError(null);
+    setNotes([]);
+    try {
+      const res = await fetch(`/api/admin/sites/${siteId}/setup/extract`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          extra_pages: parseExtraPages(extraPagesText),
+        }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: ExtractionResponse }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (!res.ok || !payload?.ok) {
+        setError(
+          payload && payload.ok === false
+            ? payload.error.message
+            : `Extraction failed (HTTP ${res.status}).`,
+        );
+        return;
+      }
+      const result = payload.data;
+      setDesign(result.design);
+      setCssClasses(result.css_classes);
+      setHasResults(true);
+      setNotes(result.notes);
+    } catch (err) {
+      setError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setExtracting(false);
+    }
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/sites/${siteId}/setup/extract/save`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          extracted_design: design,
+          extracted_css_classes: cssClasses,
+        }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: { site_id: string } }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (!res.ok || !payload?.ok) {
+        setError(
+          payload && payload.ok === false
+            ? payload.error.message
+            : `Save failed (HTTP ${res.status}).`,
+        );
+        return;
+      }
+      setSavedAt(new Date().toLocaleTimeString());
+      router.replace(`/admin/sites/${siteId}`);
+    } catch (err) {
+      setError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function setColor(key: keyof ExtractedDesign["colors"], value: string) {
+    setDesign((prev) => ({ ...prev, colors: { ...prev.colors, [key]: value || null } }));
+  }
+  function setFont(key: "heading" | "body", value: string) {
+    setDesign((prev) => ({ ...prev, fonts: { ...prev.fonts, [key]: value || null } }));
+  }
+  function setHeadingClass(level: "h1" | "h2" | "h3", value: string) {
+    setCssClasses((prev) => ({
+      ...prev,
+      headings: { ...prev.headings, [level]: value || null },
+    }));
+  }
+
+  return (
+    <div className="mt-6 space-y-6" data-testid="copy-existing-wizard">
+      <section className="rounded-md border bg-muted/20 p-4">
+        <h2 className="text-sm font-semibold">1 · Run extraction</h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Source URL: <code>{siteUrl}</code>
+        </p>
+        <div className="mt-3 flex flex-col gap-2">
+          <label className="text-xs text-muted-foreground">
+            Extra pages (optional, one URL per line)
+            <textarea
+              value={extraPagesText}
+              onChange={(e) => setExtraPagesText(e.target.value)}
+              placeholder={`https://example.com/about\nhttps://example.com/services`}
+              rows={2}
+              className="mt-1 w-full rounded border bg-background px-2 py-1 text-sm"
+              disabled={extracting}
+            />
+          </label>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              onClick={() => void runExtraction()}
+              disabled={extracting}
+              data-testid="copy-existing-extract-run"
+            >
+              {extracting ? "Extracting…" : hasResults ? "Re-extract" : "Run extraction"}
+            </Button>
+            {notes.length > 0 && (
+              <p className="text-xs text-muted-foreground">
+                {notes.join(" ")}
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {hasResults && (
+        <section
+          className="rounded-md border bg-background p-4"
+          data-testid="copy-existing-design-profile"
+        >
+          <h2 className="text-sm font-semibold">2 · Review the design profile</h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Tweak any extracted value that looks wrong. Empty fields land as
+            null and the generation prompt falls back to the site theme.
+          </p>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Colours
+              </h3>
+              {(["primary", "secondary", "accent", "background", "text"] as const).map(
+                (key) => (
+                  <label key={key} className="flex items-center gap-2 text-sm">
+                    <span className="w-24 capitalize text-muted-foreground">{key}</span>
+                    <span
+                      className="h-5 w-5 shrink-0 rounded border"
+                      style={{
+                        backgroundColor: design.colors[key] ?? "transparent",
+                      }}
+                      aria-hidden
+                    />
+                    <input
+                      type="text"
+                      value={design.colors[key] ?? ""}
+                      onChange={(e) => setColor(key, e.target.value)}
+                      placeholder="#000000"
+                      className="flex-1 rounded border bg-background px-2 py-1 text-sm"
+                      data-testid={`copy-existing-color-${key}`}
+                    />
+                  </label>
+                ),
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Fonts
+              </h3>
+              {(["heading", "body"] as const).map((key) => (
+                <label key={key} className="flex items-center gap-2 text-sm">
+                  <span className="w-24 capitalize text-muted-foreground">{key}</span>
+                  <input
+                    type="text"
+                    value={design.fonts[key] ?? ""}
+                    onChange={(e) => setFont(key, e.target.value)}
+                    placeholder="Inter"
+                    className="flex-1 rounded border bg-background px-2 py-1 text-sm"
+                    style={{ fontFamily: design.fonts[key] ?? undefined }}
+                  />
+                </label>
+              ))}
+
+              <h3 className="mt-4 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Tone
+              </h3>
+              <label className="flex items-center gap-2 text-sm">
+                <span className="w-24 text-muted-foreground">Density</span>
+                <select
+                  value={design.layout_density}
+                  onChange={(e) =>
+                    setDesign((prev) => ({
+                      ...prev,
+                      layout_density: e.target.value as LayoutDensity,
+                    }))
+                  }
+                  className="flex-1 rounded border bg-background px-2 py-1 text-sm"
+                >
+                  <option value="compact">Compact</option>
+                  <option value="medium">Medium</option>
+                  <option value="spacious">Spacious</option>
+                </select>
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <span className="w-24 text-muted-foreground">Visual tone</span>
+                <input
+                  type="text"
+                  value={design.visual_tone}
+                  onChange={(e) =>
+                    setDesign((prev) => ({ ...prev, visual_tone: e.target.value }))
+                  }
+                  className="flex-1 rounded border bg-background px-2 py-1 text-sm"
+                />
+              </label>
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Detected CSS classes
+            </h3>
+            <div className="mt-2 grid gap-2 md:grid-cols-2">
+              <ClassInput
+                label="Container"
+                value={cssClasses.container}
+                onChange={(v) =>
+                  setCssClasses((prev) => ({ ...prev, container: v || null }))
+                }
+              />
+              <ClassInput
+                label="Button"
+                value={cssClasses.button}
+                onChange={(v) =>
+                  setCssClasses((prev) => ({ ...prev, button: v || null }))
+                }
+              />
+              <ClassInput
+                label="Card"
+                value={cssClasses.card}
+                onChange={(v) =>
+                  setCssClasses((prev) => ({ ...prev, card: v || null }))
+                }
+              />
+              {(["h1", "h2", "h3"] as const).map((lvl) => (
+                <ClassInput
+                  key={lvl}
+                  label={`${lvl.toUpperCase()}`}
+                  value={cssClasses.headings[lvl]}
+                  onChange={(v) => setHeadingClass(lvl, v)}
+                />
+              ))}
+            </div>
+          </div>
+
+          {design.screenshot_url && (
+            <div className="mt-6">
+              <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Site snapshot
+              </h3>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={design.screenshot_url}
+                alt="Site screenshot"
+                className="mt-2 max-h-64 rounded border"
+              />
+            </div>
+          )}
+        </section>
+      )}
+
+      {error && (
+        <Alert variant="destructive" title="Couldn't complete that step">
+          {error}
+        </Alert>
+      )}
+
+      {hasResults && (
+        <div className="flex items-center justify-end gap-3">
+          {savedAt && (
+            <span className="text-xs text-muted-foreground">Saved at {savedAt}</span>
+          )}
+          <Button
+            type="button"
+            onClick={() => void save()}
+            disabled={saving}
+            data-testid="copy-existing-save"
+          >
+            {saving ? "Saving…" : "Save design profile"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ClassInput({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string | null;
+  onChange: (next: string) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-sm">
+      <span className="w-24 text-muted-foreground">{label}</span>
+      <input
+        type="text"
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="(none detected)"
+        className="flex-1 rounded border bg-background px-2 py-1 font-mono text-xs"
+        data-testid={`copy-existing-class-${label.toLowerCase()}`}
+      />
+    </label>
+  );
+}

--- a/lib/copy-existing-extract.ts
+++ b/lib/copy-existing-extract.ts
@@ -1,0 +1,260 @@
+import "server-only";
+
+import { extractCssFromUrl } from "@/lib/design-discovery/extract-css";
+import { fetchMicrolinkScreenshot } from "@/lib/design-discovery/microlink";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// DESIGN-SYSTEM-OVERHAUL PR 7 — copy-existing extraction orchestrator.
+//
+// Produces the design-profile snapshot used to populate
+// sites.extracted_design + sites.extracted_css_classes when an
+// operator picks "Upload to existing site" during onboarding.
+//
+// This is an HTML/CSS-first extraction. Microlink supplies a
+// screenshot URL when reachable; the vision call is intentionally
+// deferred — extract-css.ts already produces strong colour / font /
+// tone signals from the response HTML alone, and the Sonnet vision
+// pass that the new_design wizard uses on operator-uploaded
+// screenshots is overkill for an automated rip of a public site.
+// A future slice can add a vision pass behind a flag if the v1
+// signals turn out to under-sample on JS-heavy sites.
+//
+// CSS class detection is a regex pass over `class="..."` attributes
+// in the response HTML, grouped into the four buckets the generation
+// prompt cares about: container, heading levels, button, card.
+// Cheap, deterministic, no external dep.
+// ---------------------------------------------------------------------------
+
+export interface ExtractedDesign {
+  colors: {
+    primary: string | null;
+    secondary: string | null;
+    accent: string | null;
+    background: string | null;
+    text: string | null;
+  };
+  fonts: {
+    heading: string | null;
+    body: string | null;
+  };
+  layout_density: "compact" | "medium" | "spacious";
+  visual_tone: string;
+  screenshot_url: string | null;
+  source_pages: string[];
+}
+
+export interface ExtractedCssClasses {
+  container: string | null;
+  headings: {
+    h1: string | null;
+    h2: string | null;
+    h3: string | null;
+  };
+  button: string | null;
+  card: string | null;
+}
+
+export interface ExtractionResult {
+  ok: boolean;
+  design: ExtractedDesign;
+  css_classes: ExtractedCssClasses;
+  notes: string[];
+}
+
+const CLASS_ATTR_RE = /class\s*=\s*"([^"]+)"/gi;
+const HEADING_TAG_RE = /<h([1-3])\b[^>]*class\s*=\s*"([^"]+)"/gi;
+
+function tally<T>(list: T[]): Map<T, number> {
+  const m = new Map<T, number>();
+  for (const v of list) m.set(v, (m.get(v) ?? 0) + 1);
+  return m;
+}
+
+function topByPattern(
+  classCounts: Map<string, number>,
+  patterns: RegExp[],
+): string | null {
+  const matches: Array<[string, number]> = [];
+  for (const [cls, count] of classCounts.entries()) {
+    if (patterns.some((p) => p.test(cls))) matches.push([cls, count]);
+  }
+  matches.sort((a, b) => b[1] - a[1]);
+  return matches[0]?.[0] ?? null;
+}
+
+function extractCssClasses(html: string): ExtractedCssClasses {
+  const allClasses: string[] = [];
+  let m: RegExpExecArray | null;
+  CLASS_ATTR_RE.lastIndex = 0;
+  while ((m = CLASS_ATTR_RE.exec(html))) {
+    for (const cls of m[1].split(/\s+/)) {
+      if (cls) allClasses.push(cls);
+    }
+  }
+  const counts = tally(allClasses);
+
+  const headingByLevel: Record<"h1" | "h2" | "h3", string | null> = {
+    h1: null,
+    h2: null,
+    h3: null,
+  };
+  HEADING_TAG_RE.lastIndex = 0;
+  const headingTally = {
+    h1: new Map<string, number>(),
+    h2: new Map<string, number>(),
+    h3: new Map<string, number>(),
+  };
+  while ((m = HEADING_TAG_RE.exec(html))) {
+    const level = `h${m[1]}` as "h1" | "h2" | "h3";
+    for (const cls of m[2].split(/\s+/)) {
+      if (!cls) continue;
+      headingTally[level].set(cls, (headingTally[level].get(cls) ?? 0) + 1);
+    }
+  }
+  for (const lvl of ["h1", "h2", "h3"] as const) {
+    const sorted = [...headingTally[lvl].entries()].sort((a, b) => b[1] - a[1]);
+    headingByLevel[lvl] = sorted[0]?.[0] ?? null;
+  }
+
+  return {
+    container: topByPattern(counts, [/container/i, /wrapper/i, /\bwrap\b/i, /content-area/i]),
+    headings: headingByLevel,
+    button: topByPattern(counts, [/\bbtn\b/i, /button/i, /\bcta\b/i]),
+    card: topByPattern(counts, [/\bcard\b/i, /tile/i, /feature(?!d)/i]),
+  };
+}
+
+function pickColor(swatches: string[], position: number): string | null {
+  return swatches[position] ?? null;
+}
+
+function deriveLayoutDensity(html: string): "compact" | "medium" | "spacious" {
+  const lower = html.toLowerCase();
+  // Heuristic: count top-level <section> markers + line-heights /
+  // padding hints. Not authoritative; the operator review step lets
+  // the operator override.
+  const sectionCount = (lower.match(/<section\b/g) ?? []).length;
+  const generousPadding = /padding[^;]*1[2-9][0-9]px|padding[^;]*[2-9][0-9][0-9]px/.test(
+    lower,
+  );
+  const tightPadding = /padding[^;]*[1-9]px|padding[^;]*1[0-5]px/.test(lower);
+  if (generousPadding || sectionCount >= 6) return "spacious";
+  if (tightPadding && sectionCount <= 3) return "compact";
+  return "medium";
+}
+
+function deriveVisualTone(toneTags: string[]): string {
+  if (toneTags.length === 0) return "Neutral";
+  return toneTags[0];
+}
+
+export async function extractDesignFromUrl(
+  url: string,
+  options: { existingPages?: string[] } = {},
+): Promise<ExtractionResult> {
+  const notes: string[] = [];
+  const sourcePages = [url, ...(options.existingPages ?? [])];
+
+  let cssResult;
+  try {
+    cssResult = await extractCssFromUrl(url);
+  } catch (err) {
+    logger.error("copy-existing-extract.css_failed", {
+      url,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      ok: false,
+      design: emptyDesign(url),
+      css_classes: emptyCssClasses(),
+      notes: [
+        `CSS extraction failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      ],
+    };
+  }
+
+  if (!cssResult.fetch_ok) {
+    notes.push(`Site fetch failed: ${cssResult.fetch_error ?? "unknown"}.`);
+    return {
+      ok: false,
+      design: emptyDesign(url),
+      css_classes: emptyCssClasses(),
+      notes,
+    };
+  }
+
+  // Microlink screenshot — best-effort. If it fails the rest of the
+  // extraction still lands.
+  const screenshot = await fetchMicrolinkScreenshot(url);
+  if (!screenshot.ok) {
+    notes.push(`Microlink unavailable: ${screenshot.error ?? "no detail"}.`);
+  }
+
+  // Re-fetch HTML for class scan — extract-css.ts doesn't expose its
+  // raw HTML buffer. Cheap (browsers cache, our outbound is unrelated)
+  // and lets the class detection run against the same surface as the
+  // colour extraction.
+  let html = "";
+  try {
+    const res = await fetch(url, {
+      headers: {
+        "user-agent":
+          "Opollo-Site-Builder/1.0 (+https://opollo.com) Design-Discovery",
+      },
+    });
+    if (res.ok) html = await res.text();
+  } catch {
+    // Soft-fail; class extraction will return null buckets which the
+    // generation pipeline treats as "use plain tags".
+  }
+
+  const cssClasses = extractCssClasses(html);
+
+  const design: ExtractedDesign = {
+    colors: {
+      primary: pickColor(cssResult.swatches, 0),
+      secondary: pickColor(cssResult.swatches, 1),
+      accent: pickColor(cssResult.swatches, 2),
+      background: pickColor(cssResult.swatches, 3) ?? "#ffffff",
+      text: pickColor(cssResult.swatches, 4) ?? "#111111",
+    },
+    fonts: {
+      heading: cssResult.fonts[0] ?? null,
+      body: cssResult.fonts[1] ?? cssResult.fonts[0] ?? null,
+    },
+    layout_density: deriveLayoutDensity(html),
+    visual_tone: deriveVisualTone(cssResult.visual_tone_tags),
+    screenshot_url: screenshot.screenshot_url,
+    source_pages: sourcePages,
+  };
+
+  return {
+    ok: true,
+    design,
+    css_classes: cssClasses,
+    notes,
+  };
+}
+
+function emptyDesign(url: string): ExtractedDesign {
+  return {
+    colors: { primary: null, secondary: null, accent: null, background: null, text: null },
+    fonts: { heading: null, body: null },
+    layout_density: "medium",
+    visual_tone: "Neutral",
+    screenshot_url: null,
+    source_pages: [url],
+  };
+}
+
+function emptyCssClasses(): ExtractedCssClasses {
+  return {
+    container: null,
+    headings: { h1: null, h2: null, h3: null },
+    button: null,
+    card: null,
+  };
+}


### PR DESCRIPTION
## Workstream: DESIGN-SYSTEM-OVERHAUL — PR 7 of 15 (extraction wizard)

Lands the operator-facing extraction flow that fills
\`sites.extracted_design\` + \`sites.extracted_css_classes\` for sites
whose \`site_mode\` is \`copy_existing\` (set during PR 6's onboarding).

## New surface

- \`/admin/sites/[id]/setup/extract\` — three-state wizard:
  Run extraction → Review the design profile → Save. Re-runnable;
  every visit can re-extract.
- \`POST /api/admin/sites/[id]/setup/extract\` — runs the orchestrator,
  returns the snapshot. No DB write — operator reviews + edits first.
- \`POST /api/admin/sites/[id]/setup/extract/save\` — persists the
  reviewed snapshot, sets \`design_direction_status='approved'\`,
  returns the site detail redirect.

## What the orchestrator does

\`lib/copy-existing-extract.ts\` composes existing pieces:

1. \`extractCssFromUrl\` (existing, \`lib/design-discovery/extract-css.ts\`)
   — colours, fonts, layout / tone tags from response HTML.
2. \`fetchMicrolinkScreenshot\` (existing) — screenshot URL when
   reachable; soft-fails to null.
3. New \`extractCssClasses\` scan — regex pass over \`class=\"...\"\`
   attributes, bucketed into container / heading levels / button / card
   by pattern (e.g. \`/btn|button|cta/i\` for the button bucket). Most
   common matching class per bucket is the v1 detection.

Vision pass intentionally deferred — \`extract-css.ts\` already
produces strong colour / font / tone signals from response HTML
alone, and adding a Sonnet vision call doubles the per-extraction
cost without obvious payback for an automated public-site rip.
A future slice can flag-gate it on if v1 under-samples on
JS-heavy targets.

## UI

\`CopyExistingExtractionWizard.tsx\` renders editable inputs for every
extracted field — 5 colours, 2 fonts, layout density, visual tone,
6 CSS classes — plus the screenshot if Microlink returned one. Empty
fields land as null and the generation prompt (PR 10) treats null
buckets as \"use plain tags / theme defaults\".

## Risks identified and mitigated

- **Heuristic class detection is fragile.** Mitigated by the editable
  review step — operator can correct any wrong bucket before Save
  commits. Null buckets are explicitly handled downstream.
- **Re-fetching HTML for class scan.** Cheap (browsers cache, our
  outbound is unrelated) and beats threading raw HTML through
  \`extract-css.ts\`'s public surface.
- **Microlink rate-limiting / failure.** Soft-fail path; rest of the
  snapshot still lands and the operator sees a notes line.
- **Cost: zero LLM spend.** Pure HTTP / regex. Adding a vision pass
  later is a one-route change behind a flag.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx next lint\` clean on changed files.
- [ ] Manually verify on staging: \`/admin/sites/<copy_existing site>/setup/extract\`,
  click Run extraction, verify the design profile renders + the screenshot,
  tweak a colour, click Save, verify redirect to site detail.
- E2E note: no new Playwright spec. The most useful coverage mocks
  Microlink + a live HTML fetch; deferred until the pre-existing CI
  Supabase-stack failure (0031 migration collision in
  \`hotfix/migration-0031-collision\` #348) is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)