### PR TITLE
feat(sites): mode-aware appearance panel (PR 8/15)

### DIFF
--- a/app/admin/sites/[id]/appearance/page.tsx
+++ b/app/admin/sites/[id]/appearance/page.tsx
@@ -1,34 +1,35 @@
+import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
 import { AppearancePanelClient } from "@/components/AppearancePanelClient";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { ExtractedProfilePanel } from "@/components/ExtractedProfilePanel";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { H1, Lead } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { listAppearanceEventsForSite } from "@/lib/appearance-events";
 import { getSite } from "@/lib/sites";
 import { getServiceRoleClient } from "@/lib/supabase";
 
-// ---------------------------------------------------------------------------
-// /admin/sites/[id]/appearance — M13-5d.
+// /admin/sites/[id]/appearance — DESIGN-SYSTEM-OVERHAUL PR 8.
 //
-// Server Component. Loads only Opollo-side state — no WP calls here,
-// because:
-//   1. WP calls hit the operator's WordPress; if it's down, every
-//      panel render would block.
-//   2. Calling /preflight server-side would write a preflight_run
-//      audit event on every page load (refresh, navigation, etc.) —
-//      the audit log would be dominated by render noise.
+// Mode-aware Appearance panel. Three states:
 //
-// The client component fires POST /preflight on mount instead. That:
-//   - Writes one preflight_run event per session (operator-visible
-//     activity, useful for incident reconstruction)
-//   - Stamps sites.kadence_installed_at on first confirmed detection
-//   - Returns the full context (install / palette / proposal / diff)
-//     for the panel to render
+//   site_mode IS NULL    → empty state with link to /onboarding.
+//                          The Kadence/preflight stack is gated behind
+//                          a confirmed mode choice; rendering it for
+//                          unonboarded sites is what produced the
+//                          "context_build_failed" leak under M13-5d.
 //
-// The server side carries the operator-trustable state: site row +
-// kadence_* timestamps from sites + last 20 appearance_events for
-// the audit-log section.
-// ---------------------------------------------------------------------------
+//   copy_existing        → ExtractedProfilePanel: read-only summary of
+//                          the PR 7 extraction + Re-extract link. No
+//                          Kadence sync — copy_existing sites use the
+//                          host theme's styling.
+//
+//   new_design           → existing AppearancePanelClient. Owns the
+//                          /preflight + /sync-palette + /rollback
+//                          state machine for Kadence-backed sites.
 
 export const dynamic = "force-dynamic";
 
@@ -61,42 +62,84 @@ export default async function SiteAppearancePage({
   }
   const site = siteRes.data.site;
 
-  // Read kadence timestamps + version_lock directly — SiteRecord
-  // doesn't carry these.
   const svc = getServiceRoleClient();
-  const kadenceRes = await svc
+  const modeRes = await svc
     .from("sites")
     .select(
-      "kadence_installed_at, kadence_globals_synced_at, version_lock",
+      "site_mode, extracted_design, extracted_css_classes, kadence_installed_at, kadence_globals_synced_at, version_lock",
     )
     .eq("id", params.id)
     .single();
 
-  const kadence = kadenceRes.data as {
+  const modeRow = modeRes.data as {
+    site_mode: string | null;
+    extracted_design: unknown;
+    extracted_css_classes: unknown;
     kadence_installed_at: string | null;
     kadence_globals_synced_at: string | null;
     version_lock: number;
   };
 
-  // Last 20 appearance_events for the panel's event-log section.
+  const breadcrumbs = (
+    <Breadcrumbs
+      crumbs={[
+        { label: "Sites", href: "/admin/sites" },
+        { label: site.name, href: `/admin/sites/${site.id}` },
+        { label: "Appearance" },
+      ]}
+    />
+  );
+
+  if (modeRow.site_mode === null) {
+    return (
+      <main className="mx-auto max-w-5xl p-6">
+        {breadcrumbs}
+        <div className="mt-6 max-w-2xl">
+          <H1>{site.name}</H1>
+          <Lead className="mt-1">Appearance</Lead>
+          <Alert className="mt-6" title="Finish setting up this site first">
+            Pick whether we&apos;re uploading content to an existing WordPress
+            theme or building a fresh design before opening Appearance.
+            Generation styling and the rest of setup follow from this choice.
+          </Alert>
+          <Button asChild className="mt-4">
+            <Link href={`/admin/sites/${site.id}/onboarding`}>
+              Go to onboarding →
+            </Link>
+          </Button>
+        </div>
+      </main>
+    );
+  }
+
+  if (modeRow.site_mode === "copy_existing") {
+    return (
+      <main className="mx-auto max-w-5xl p-6">
+        {breadcrumbs}
+        <ExtractedProfilePanel
+          siteId={site.id}
+          siteName={site.name}
+          siteUrl={site.wp_url}
+          extractedDesign={modeRow.extracted_design}
+          extractedClasses={modeRow.extracted_css_classes}
+        />
+      </main>
+    );
+  }
+
+  // new_design — preserve the existing Kadence-aware panel verbatim.
   const events = await listAppearanceEventsForSite(params.id, 20);
 
   return (
     <main className="mx-auto max-w-5xl p-6">
-      <Breadcrumbs
-        crumbs={[
-          { label: "Sites", href: "/admin/sites" },
-          { label: site.name, href: `/admin/sites/${site.id}` },
-          { label: "Appearance" },
-        ]}
-      />
+      {breadcrumbs}
       <AppearancePanelClient
         siteId={site.id}
         siteName={site.name}
         siteWpUrl={site.wp_url}
-        initialKadenceInstalledAt={kadence.kadence_installed_at}
-        initialKadenceGlobalsSyncedAt={kadence.kadence_globals_synced_at}
-        initialSiteVersionLock={kadence.version_lock}
+        initialKadenceInstalledAt={modeRow.kadence_installed_at}
+        initialKadenceGlobalsSyncedAt={modeRow.kadence_globals_synced_at}
+        initialSiteVersionLock={modeRow.version_lock}
         initialEvents={events}
       />
     </main>

--- a/components/ExtractedProfilePanel.tsx
+++ b/components/ExtractedProfilePanel.tsx
@@ -1,0 +1,228 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { H1, H3, Lead } from "@/components/ui/typography";
+
+// DESIGN-SYSTEM-OVERHAUL PR 8 — Appearance panel for copy_existing
+// sites. Pure read-only summary of sites.extracted_design +
+// sites.extracted_css_classes from the PR 7 wizard. Kadence sync is
+// intentionally absent — copy_existing sites use the host theme's
+// styling and we don't push our palette over it.
+
+type ExtractedDesign = {
+  colors?: {
+    primary?: string | null;
+    secondary?: string | null;
+    accent?: string | null;
+    background?: string | null;
+    text?: string | null;
+  };
+  fonts?: { heading?: string | null; body?: string | null };
+  layout_density?: string | null;
+  visual_tone?: string | null;
+  screenshot_url?: string | null;
+  source_pages?: string[];
+};
+
+type ExtractedCssClasses = {
+  container?: string | null;
+  headings?: { h1?: string | null; h2?: string | null; h3?: string | null };
+  button?: string | null;
+  card?: string | null;
+};
+
+function isExtractedDesign(value: unknown): value is ExtractedDesign {
+  return !!value && typeof value === "object";
+}
+
+function isExtractedClasses(value: unknown): value is ExtractedCssClasses {
+  return !!value && typeof value === "object";
+}
+
+export function ExtractedProfilePanel({
+  siteId,
+  siteName,
+  siteUrl,
+  extractedDesign,
+  extractedClasses,
+}: {
+  siteId: string;
+  siteName: string;
+  siteUrl: string;
+  extractedDesign: unknown;
+  extractedClasses: unknown;
+}) {
+  const design = isExtractedDesign(extractedDesign) ? extractedDesign : null;
+  const classes = isExtractedClasses(extractedClasses) ? extractedClasses : null;
+  const hasProfile = design !== null;
+
+  return (
+    <div data-testid="extracted-profile-panel" className="mt-6 space-y-6">
+      <header>
+        <H1>{siteName}</H1>
+        <Lead className="mt-1">
+          Appearance — design extracted from{" "}
+          <a
+            href={siteUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="underline-offset-2 hover:underline"
+          >
+            {siteUrl}
+          </a>
+        </Lead>
+      </header>
+
+      {!hasProfile ? (
+        <section
+          className="rounded-md border border-dashed bg-muted/20 p-6 text-sm"
+          data-testid="extracted-profile-empty"
+        >
+          <p className="font-medium">
+            We haven&apos;t extracted a design profile for this site yet.
+          </p>
+          <p className="mt-1 text-muted-foreground">
+            Run the extraction so generated content can match the existing
+            theme.
+          </p>
+          <Button asChild className="mt-4">
+            <Link href={`/admin/sites/${siteId}/setup/extract`}>
+              Set up your design profile →
+            </Link>
+          </Button>
+        </section>
+      ) : (
+        <>
+          <section className="rounded-md border bg-background p-5">
+            <H3>Design profile</H3>
+            <div className="mt-3 grid gap-6 md:grid-cols-2">
+              <div>
+                <h4 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Colours
+                </h4>
+                <ul className="mt-2 space-y-1 text-sm">
+                  {(["primary", "secondary", "accent", "background", "text"] as const).map(
+                    (key) => {
+                      const value = design.colors?.[key] ?? null;
+                      return (
+                        <li
+                          key={key}
+                          className="flex items-center gap-3 capitalize"
+                        >
+                          <span
+                            className="h-5 w-5 shrink-0 rounded border"
+                            style={{ backgroundColor: value ?? "transparent" }}
+                            aria-hidden
+                          />
+                          <span className="w-24 text-muted-foreground">{key}</span>
+                          <code className="font-mono text-xs">
+                            {value ?? "—"}
+                          </code>
+                        </li>
+                      );
+                    },
+                  )}
+                </ul>
+
+                <h4 className="mt-4 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Fonts
+                </h4>
+                <ul className="mt-2 space-y-1 text-sm">
+                  {(["heading", "body"] as const).map((key) => {
+                    const value = design.fonts?.[key] ?? null;
+                    return (
+                      <li key={key} className="flex items-center gap-3 capitalize">
+                        <span className="w-24 text-muted-foreground">{key}</span>
+                        <span style={{ fontFamily: value ?? undefined }}>
+                          {value ?? "(theme default)"}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+
+                <h4 className="mt-4 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Tone
+                </h4>
+                <p className="mt-1 text-sm">
+                  {design.layout_density ?? "medium"} ·{" "}
+                  {design.visual_tone ?? "Neutral"}
+                </p>
+              </div>
+
+              <div>
+                {design.screenshot_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={design.screenshot_url}
+                    alt={`${siteName} homepage screenshot`}
+                    className="max-h-72 w-full rounded border object-contain"
+                  />
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    No screenshot captured.
+                  </p>
+                )}
+                {design.source_pages && design.source_pages.length > 0 && (
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    Source pages:{" "}
+                    {design.source_pages.map((p, i) => (
+                      <span key={p}>
+                        {i > 0 && ", "}
+                        <a
+                          href={p}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="underline-offset-2 hover:underline"
+                        >
+                          {p}
+                        </a>
+                      </span>
+                    ))}
+                  </p>
+                )}
+              </div>
+            </div>
+          </section>
+
+          {classes && (
+            <section className="rounded-md border bg-background p-5">
+              <H3>Detected CSS classes</H3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Generated content reuses these class names so it picks up the
+                existing theme&apos;s styling without injecting new CSS.
+              </p>
+              <dl className="mt-3 grid gap-2 text-sm md:grid-cols-2">
+                <ClassRow label="Container" value={classes.container ?? null} />
+                <ClassRow label="H1" value={classes.headings?.h1 ?? null} />
+                <ClassRow label="H2" value={classes.headings?.h2 ?? null} />
+                <ClassRow label="H3" value={classes.headings?.h3 ?? null} />
+                <ClassRow label="Button" value={classes.button ?? null} />
+                <ClassRow label="Card" value={classes.card ?? null} />
+              </dl>
+            </section>
+          )}
+
+          <div className="flex justify-end">
+            <Button asChild variant="outline">
+              <Link href={`/admin/sites/${siteId}/setup/extract`}>
+                Re-extract design profile
+              </Link>
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function ClassRow({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="flex items-center justify-between rounded border bg-muted/20 px-3 py-1.5">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <code className="font-mono text-xs">{value ?? "(none detected)"}</code>
+    </div>
+  );
+}


### PR DESCRIPTION
## Workstream: DESIGN-SYSTEM-OVERHAUL — PR 8 of 15 (appearance overhaul)

Wraps the existing Appearance surface in a \`site_mode\` router so each
mode renders the right view, and the unonboarded state (which
produced the \"context_build_failed\" leak the audit flagged) is
replaced with an actionable empty state.

## Three branches off \`site_mode\`

- **NULL** → empty state + \"Go to onboarding\" CTA. The
  Kadence / preflight stack is gated behind a confirmed mode choice
  so we never render it for sites that haven't been onboarded.
- **copy_existing** → new \`ExtractedProfilePanel\`. Read-only summary
  of \`sites.extracted_design\` + \`sites.extracted_css_classes\` from
  PR 7's wizard, plus a Re-extract link. **Kadence sync intentionally
  absent** — copy_existing sites use the host theme's styling.
- **new_design** → existing \`AppearancePanelClient\` verbatim.
  Preserves the /preflight + /sync-palette + /rollback state machine
  for Kadence-backed sites.

The existing \`AppearancePanelClient\` (863 lines, owns the Kadence
state machine) is untouched. The only change is **which sites reach
it**: only new_design now.

## Risks identified and mitigated

- **Existing E2E coverage assumed an unguarded render.** Still works
  for sites whose \`site_mode = 'new_design'\`; sites that haven't
  onboarded (NULL) now render the empty state. Existing seed sites
  default to NULL until explicitly upgraded — verified by reading
  migration 0067; no automatic onboarding side-effect added.
- **Server contract preserved.** The page still passes the same
  props it did before; only the gate around when to render the
  panel changed.
- **Audit-log filtering deferred to PR 14.** The brief mentions
  filtering raw error codes from the activity log; that's
  scoped into PR 14 (error-state cleanup) so PR 8 stays focused on
  the routing change.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx next lint\` clean on changed files.
- [ ] On staging, verify: NULL site renders empty state; copy_existing
  site renders the extracted profile + Re-extract link; new_design
  site renders the existing Kadence panel unchanged.
- E2E note: existing \`e2e/appearance.spec.ts\` coverage is for the
  new_design path (preserved verbatim). The new NULL and
  copy_existing branches are read-only routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)