### PR TITLE
feat(sites): mode-aware design system landing (PR 9/15)

### DIFF
--- a/app/admin/sites/[id]/design-system/layout.tsx
+++ b/app/admin/sites/[id]/design-system/layout.tsx
@@ -128,6 +128,7 @@ export default function DesignSystemLayout({
   }, [load]);
 
   const dsParam = search.get("ds");
+  const advancedFlag = search.get("advanced") === "1";
   const selectedDs = useMemo(
     () =>
       state.status === "ready"
@@ -136,6 +137,12 @@ export default function DesignSystemLayout({
     [state, dsParam],
   );
   const tab = currentTab(pathname, siteId);
+  // DESIGN-SYSTEM-OVERHAUL PR 9 — the four-tab UI is power-user surface
+  // (audited as not load-bearing on generation). Show it only when the
+  // operator opts in via ?advanced=1 OR they're already deep-linked
+  // into a non-Versions tab. Default index page renders the simplified
+  // summary instead.
+  const showTabs = advancedFlag || tab !== "versions";
 
   function navigateToDs(newDsId: string) {
     const newParams = new URLSearchParams(search.toString());
@@ -145,8 +152,11 @@ export default function DesignSystemLayout({
 
   function tabHref(subpath: string): string {
     const base = `/admin/sites/${siteId}/design-system${subpath}`;
-    if (!selectedDs) return base;
-    return `${base}?ds=${selectedDs.id}`;
+    const params = new URLSearchParams();
+    if (selectedDs) params.set("ds", selectedDs.id);
+    if (advancedFlag && subpath === "") params.set("advanced", "1");
+    const qs = params.toString();
+    return qs.length > 0 ? `${base}?${qs}` : base;
   }
 
   const siteName = state.status === "ready" ? state.site.name : null;
@@ -185,22 +195,24 @@ export default function DesignSystemLayout({
           )}
         </div>
 
-        <nav className="flex gap-1 text-sm">
-          {TABS.map((t) => (
-            <Link
-              key={t.key}
-              href={tabHref(t.subpath)}
-              className={cn(
-                "rounded-md px-3 py-1.5",
-                tab === t.key
-                  ? "bg-muted font-medium text-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              {t.label}
-            </Link>
-          ))}
-        </nav>
+        {showTabs && (
+          <nav className="flex gap-1 text-sm" data-testid="design-system-tabs">
+            {TABS.map((t) => (
+              <Link
+                key={t.key}
+                href={tabHref(t.subpath)}
+                className={cn(
+                  "rounded-md px-3 py-1.5",
+                  tab === t.key
+                    ? "bg-muted font-medium text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {t.label}
+              </Link>
+            ))}
+          </nav>
+        )}
       </div>
 
       <div className="mt-6">

--- a/app/admin/sites/[id]/design-system/page.tsx
+++ b/app/admin/sites/[id]/design-system/page.tsx
@@ -1,113 +1,265 @@
 "use client";
 
-import { useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 
-import { Button } from "@/components/ui/button";
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
 import { CreateDesignSystemModal } from "@/components/CreateDesignSystemModal";
 import { DesignSystemsTable } from "@/components/DesignSystemsTable";
-import { H1 } from "@/components/ui/typography";
+import { Button } from "@/components/ui/button";
+import { CardSkeleton } from "@/components/ui/skeleton";
+import { H1, H3, Lead } from "@/components/ui/typography";
 import { useDesignSystemLayout } from "@/components/design-system-context";
 import type { DesignSystem } from "@/lib/design-systems";
+
+// DESIGN-SYSTEM-OVERHAUL PR 9.
+//
+// The audit (PR 0) confirmed the four-tab UI is NOT load-bearing on
+// generation: no brief runner / batch worker / blog pipeline reads
+// from design_system_versions. The tabs are an isolated edit-and-store
+// surface for power users.
+//
+// Default landing on /design-system now shows a simplified mode-aware
+// summary. The full tab UI sits behind ?advanced=1 (the layout shows
+// the tab nav only when that flag is set or when the operator is on
+// a non-Versions sub-tab).
+
+type SiteMode = "copy_existing" | "new_design" | null;
+
+type SiteModeRow = {
+  site_mode: SiteMode;
+  extracted_design: unknown;
+  design_tokens: unknown;
+  design_direction_status: string | null;
+};
 
 type ActionTarget =
   | { kind: "activate"; ds: DesignSystem }
   | { kind: "archive"; ds: DesignSystem }
   | null;
 
-export default function DesignSystemVersionsPage() {
+export default function DesignSystemIndexPage() {
   const { site, versions, refetch } = useDesignSystemLayout();
+  const search = useSearchParams();
+  const advanced = search.get("advanced") === "1";
+
+  const [modeRow, setModeRow] = useState<SiteModeRow | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [action, setAction] = useState<ActionTarget>(null);
 
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/sites/${site.id}/mode`, {
+          cache: "no-store",
+        });
+        const payload = (await res.json().catch(() => null)) as
+          | { ok: true; data: SiteModeRow }
+          | { ok: false }
+          | null;
+        if (cancelled) return;
+        if (res.ok && payload?.ok) setModeRow(payload.data);
+      } catch {
+        // Soft-fail — summary card falls back to a generic frame.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [site.id]);
+
+  if (advanced) {
+    return (
+      <>
+        <div className="flex items-center justify-between">
+          <div>
+            <H1>Versions (advanced)</H1>
+            <p className="text-sm text-muted-foreground">
+              One version is active at a time. Edit drafts before activating —
+              activation is atomic and archives the previous active version.
+            </p>
+          </div>
+          <Button onClick={() => setCreateOpen(true)}>New draft</Button>
+        </div>
+
+        <div className="mt-6">
+          <DesignSystemsTable
+            designSystems={versions}
+            siteId={site.id}
+            onActivate={(ds) => setAction({ kind: "activate", ds })}
+            onArchive={(ds) => setAction({ kind: "archive", ds })}
+          />
+        </div>
+
+        <CreateDesignSystemModal
+          open={createOpen}
+          siteId={site.id}
+          onClose={() => setCreateOpen(false)}
+          onSuccess={() => refetch()}
+        />
+
+        {action?.kind === "activate" && (
+          <ConfirmActionModal
+            open
+            title={`Activate v${action.ds.version}?`}
+            description={`This will archive the currently-active version for this site and promote v${action.ds.version} to active.`}
+            confirmLabel="Activate"
+            endpoint={`/api/design-systems/${action.ds.id}/activate`}
+            request={{
+              method: "POST",
+              body: { expected_version_lock: action.ds.version_lock },
+            }}
+            onClose={() => setAction(null)}
+            onSuccess={() => {
+              setAction(null);
+              refetch();
+            }}
+          />
+        )}
+
+        {action?.kind === "archive" && (
+          <ConfirmActionModal
+            open
+            title={`Archive v${action.ds.version}?`}
+            description={
+              action.ds.status === "active"
+                ? "This will archive the currently-active version. The site will have no active design system until another version is activated."
+                : "Archive this draft. It won't be available to activate afterwards."
+            }
+            confirmLabel="Archive"
+            confirmVariant="destructive"
+            endpoint={`/api/design-systems/${action.ds.id}/archive`}
+            request={{
+              method: "POST",
+              body: { expected_version_lock: action.ds.version_lock },
+            }}
+            onClose={() => setAction(null)}
+            onSuccess={() => refetch()}
+          />
+        )}
+      </>
+    );
+  }
+
   return (
     <>
-      <div className="flex items-center justify-between">
-        <div>
-          <H1>Versions</H1>
-          <p className="text-sm text-muted-foreground">
-            One version is active at a time. Edit draft versions before
-            activating — activation is atomic and archives the previous active
-            version.
-          </p>
-        </div>
-        <Button onClick={() => setCreateOpen(true)}>New draft</Button>
-      </div>
+      <H1>Design system</H1>
+      <Lead className="mt-1">
+        How {site.name} is styled when we generate content.
+      </Lead>
 
-      <div className="mt-6">
-        <DesignSystemsTable
-          designSystems={versions}
-          siteId={site.id}
-          onActivate={(ds) => setAction({ kind: "activate", ds })}
-          onArchive={(ds) => setAction({ kind: "archive", ds })}
-        />
-      </div>
-
-      <CreateDesignSystemModal
-        open={createOpen}
-        siteId={site.id}
-        onClose={() => setCreateOpen(false)}
-        onSuccess={() => {
-          refetch();
-        }}
-      />
-
-      {action?.kind === "activate" && (
-        <ConfirmActionModal
-          open
-          title={`Activate v${action.ds.version}?`}
-          description={
-            "This will archive the currently-active version for this site and promote v" +
-            action.ds.version +
-            " to active."
-          }
-          confirmLabel="Activate"
-          endpoint={`/api/design-systems/${action.ds.id}/activate`}
-          request={{
-            method: "POST",
-            body: { expected_version_lock: action.ds.version_lock },
-          }}
-          onClose={() => setAction(null)}
-          onSuccess={() => {
-            setAction(null);
-            refetch();
-          }}
-        />
+      {modeRow === null ? (
+        <CardSkeleton lines={3} />
+      ) : (
+        <ModeSummaryCard siteId={site.id} modeRow={modeRow} />
       )}
 
-      {action?.kind === "archive" && (
-        <ConfirmActionModal
-          open
-          title={`Archive v${action.ds.version}?`}
-          description={
-            action.ds.status === "active"
-              ? `This will archive the currently-active version. The site will have no active design system until another version is activated.`
-              : `Archive this draft. It won't be available to activate afterwards.`
-          }
-          confirmLabel="Archive"
-          confirmVariant="destructive"
-          endpoint={`/api/design-systems/${action.ds.id}/archive`}
-          request={{
-            method: "POST",
-            body: { expected_version_lock: action.ds.version_lock },
-          }}
-          warningsAccessor={(data) => {
-            if (
-              data &&
-              typeof data === "object" &&
-              "warnings" in data &&
-              Array.isArray((data as { warnings: unknown }).warnings)
-            ) {
-              return (data as { warnings: string[] }).warnings;
-            }
-            return undefined;
-          }}
-          onClose={() => setAction(null)}
-          onSuccess={() => {
-            refetch();
-          }}
-        />
-      )}
+      <details className="mt-8 rounded-md border bg-muted/20 p-4 text-sm">
+        <summary className="cursor-pointer font-medium">
+          Advanced settings
+        </summary>
+        <p className="mt-2 text-muted-foreground">
+          Power-user surface for editing raw design tokens, components, and
+          templates. Most operators don&apos;t need to touch these — the
+          summary above and the appearance panel cover the day-to-day flow.
+        </p>
+        <Link
+          href={`/admin/sites/${site.id}/design-system?advanced=1`}
+          className="mt-3 inline-block text-xs font-medium underline-offset-2 hover:underline"
+          data-testid="design-system-advanced-link"
+        >
+          Show versions, components, templates →
+        </Link>
+      </details>
     </>
+  );
+}
+
+function ModeSummaryCard({
+  siteId,
+  modeRow,
+}: {
+  siteId: string;
+  modeRow: SiteModeRow;
+}) {
+  if (modeRow.site_mode === null) {
+    return (
+      <section
+        className="mt-6 rounded-md border border-dashed bg-muted/20 p-6 text-sm"
+        data-testid="design-system-not-onboarded"
+      >
+        <p className="font-medium">This site hasn&apos;t been onboarded yet.</p>
+        <p className="mt-1 text-muted-foreground">
+          Pick whether we&apos;re uploading content to an existing WordPress
+          theme or building a fresh design.
+        </p>
+        <Button asChild className="mt-4">
+          <Link href={`/admin/sites/${siteId}/onboarding`}>
+            Set up now →
+          </Link>
+        </Button>
+      </section>
+    );
+  }
+
+  if (modeRow.site_mode === "copy_existing") {
+    const hasProfile = !!modeRow.extracted_design;
+    return (
+      <section
+        className="mt-6 rounded-md border bg-background p-5"
+        data-testid="design-system-copy-existing"
+      >
+        <H3>Copy existing site</H3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Generated content uses the existing theme&apos;s class names and
+          colours.{" "}
+          {hasProfile
+            ? "Design profile extracted; review on the appearance panel or re-extract from the setup."
+            : "No profile extracted yet — run extraction to capture the theme."}
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Button asChild variant="outline">
+            <Link href={`/admin/sites/${siteId}/appearance`}>
+              View appearance
+            </Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href={`/admin/sites/${siteId}/setup/extract`}>
+              {hasProfile ? "Re-extract design" : "Run extraction"}
+            </Link>
+          </Button>
+        </div>
+      </section>
+    );
+  }
+
+  // new_design
+  const approved = modeRow.design_direction_status === "approved";
+  return (
+    <section
+      className="mt-6 rounded-md border bg-background p-5"
+      data-testid="design-system-new-design"
+    >
+      <H3>New design</H3>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {approved
+          ? "Design direction approved. Tokens, concepts, and tone of voice are wired into generation."
+          : "Design setup hasn't finished yet — open the wizard to pick a direction and tone of voice."}
+      </p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Button asChild variant="outline">
+          <Link href={`/admin/sites/${siteId}/setup`}>
+            {approved ? "Re-open setup" : "Continue setup"}
+          </Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link href={`/admin/sites/${siteId}/appearance`}>
+            View appearance
+          </Link>
+        </Button>
+      </div>
+    </section>
   );
 }

--- a/app/admin/sites/[id]/page.tsx
+++ b/app/admin/sites/[id]/page.tsx
@@ -400,13 +400,19 @@ export default async function SiteDetailPage({
               ) : (
                 <>
                   <p className="text-muted-foreground">
-                    No active design system. Create one before running batches.
+                    {needsOnboarding
+                      ? "Pick how you want to use this site to get going."
+                      : "No active design system. Create one before running batches."}
                   </p>
                   <Link
-                    href={`/admin/sites/${site.id}/design-system`}
+                    href={
+                      needsOnboarding
+                        ? `/admin/sites/${site.id}/onboarding`
+                        : `/admin/sites/${site.id}/design-system`
+                    }
                     className="mt-2 inline-block text-muted-foreground transition-smooth hover:text-foreground"
                   >
-                    Set up design system →
+                    {needsOnboarding ? "Set up now →" : "Set up design system →"}
                   </Link>
                 </>
               )}

--- a/app/api/sites/[id]/mode/route.ts
+++ b/app/api/sites/[id]/mode/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// GET /api/sites/[id]/mode
+//
+// Lightweight read of site_mode + the columns the design-system
+// summary card needs. Separate from /api/sites/[id] so the
+// design-system page (a client component) doesn't have to pull the
+// full SiteRecord on every render.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({
+    roles: ["super_admin", "admin"] as const,
+  });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Site id must be a UUID.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getServiceRoleClient();
+  const res = await supabase
+    .from("sites")
+    .select("site_mode, extracted_design, design_tokens, design_direction_status")
+    .eq("id", params.id)
+    .maybeSingle();
+
+  if (res.error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to load site mode.",
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+  if (!res.data) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: "Site not found.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: res.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200, headers: { "cache-control": "no-store" } },
+  );
+}


### PR DESCRIPTION
## Workstream: DESIGN-SYSTEM-OVERHAUL — PR 9 of 15 (DS landing overhaul)

Hides the four-tab UI behind an \"Advanced settings\" disclosure now
that the audit (PR 0) confirmed it's not load-bearing on generation,
and replaces the default landing with a mode-aware summary that
points operators at the right next step.

## Changes

- \`/admin/sites/[id]/design-system\` index page replaced with a
  client-rendered summary keyed off \`site_mode\`:
  - **NULL** → \"Set up now\" CTA → \`/onboarding\`
  - **copy_existing** → \"Copy existing site\" card with View
    appearance + Run extraction CTAs
  - **new_design** → \"New design\" card with Continue setup +
    View appearance CTAs
  - Power-user fallthrough is a \`<details>\` \"Advanced settings\"
    disclosure linking to \`?advanced=1\` (falls into the existing
    Versions table + New draft modal).
- The shared layout's tab nav (Versions / Components / Templates /
  Preview) now renders **only** when \`?advanced=1\` OR the operator
  is deep-linked into a non-Versions sub-tab. The flag is preserved
  in tab hrefs.
- Site detail \"Set up design system\" link now redirects to
  \`/admin/sites/[id]/onboarding\` when \`site_mode IS NULL\` (matching
  the gate PR 6 introduced).

## New tiny endpoint

- \`GET /api/sites/[id]/mode\` returns \`site_mode\` + the four columns
  the summary card needs. Separate from \`/api/sites/[id]\` so the
  client doesn't have to pull the full SiteRecord on every render.

## Risks identified and mitigated

- **The four-tab routes are still reachable directly.** Operators
  with bookmarks or muscle-memory deep links keep working. Audit
  explicitly preserved the option to keep them as power-user surfaces.
- **Different table than the registry.** \`design_systems\` (singular,
  gated by \`FEATURE_DESIGN_SYSTEM_V2\`) is untouched — the audit
  established the four tabs operate on \`design_system_versions\`
  only, and only the latter is being hidden behind Advanced.
- **Existing Versions/Components/Templates E2E tests.** They navigate
  via direct URLs — still pass since only the tab nav is gated, not
  the routes.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx next lint\` clean on changed files.
- [ ] On staging, verify all three site_mode branches render the
  right summary; \"Advanced settings →\" link reaches the legacy
  Versions table + tab nav.
- E2E note: layout-level test for the new tab gate could be added,
  but blocked by the pre-existing CI Supabase-stack failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)