### PR TITLE
feat(generation): mode-aware design context injection (PR 10/15)

### DIFF
--- a/lib/__tests__/build-injection-modes.test.ts
+++ b/lib/__tests__/build-injection-modes.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { renderInjection } from "@/lib/design-discovery/build-injection";
+
+// Pure-function tests for renderInjection's mode dispatch. Doesn't
+// touch the DB loader; covers the two write-safety-critical
+// branches:
+//
+//   1. copy_existing emits <existing_theme_context> regardless of
+//      DESIGN_CONTEXT_ENABLED so onboarded copy_existing sites don't
+//      depend on the legacy flag.
+//   2. new_design with the flag off returns the empty string —
+//      preserves the pre-PR-10 behaviour for sites that haven't
+//      explicitly opted into the new context injection.
+
+const ORIGINAL_FLAG = process.env.DESIGN_CONTEXT_ENABLED;
+
+afterEach(() => {
+  if (ORIGINAL_FLAG === undefined) delete process.env.DESIGN_CONTEXT_ENABLED;
+  else process.env.DESIGN_CONTEXT_ENABLED = ORIGINAL_FLAG;
+});
+
+describe("renderInjection — copy_existing", () => {
+  it("emits theme context regardless of DESIGN_CONTEXT_ENABLED", () => {
+    delete process.env.DESIGN_CONTEXT_ENABLED;
+    const result = renderInjection({
+      site_mode: "copy_existing",
+      design_direction_status: null,
+      tone_of_voice_status: null,
+      design_tokens: null,
+      homepage_concept_html: null,
+      tone_applied_homepage_html: null,
+      tone_of_voice: null,
+      extracted_design: {
+        colors: {
+          primary: "#1f2937",
+          secondary: "#6b7280",
+          accent: null,
+          background: "#ffffff",
+          text: "#111111",
+        },
+        fonts: { heading: "Inter", body: "Inter" },
+        layout_density: "spacious",
+        visual_tone: "Premium",
+      },
+      extracted_css_classes: {
+        container: "wp-container",
+        headings: { h1: "page-title", h2: null, h3: null },
+        button: "btn-primary",
+        card: "feature-card",
+      },
+    });
+    expect(result).toContain("<existing_theme_context>");
+    expect(result).toContain("primary: #1f2937");
+    expect(result).toContain("container: .wp-container");
+    expect(result).toContain("button: .btn-primary");
+    expect(result).not.toContain("<design_context>");
+    expect(result).not.toContain("<voice_context>");
+  });
+
+  it("returns empty string when both extracted columns are null", () => {
+    process.env.DESIGN_CONTEXT_ENABLED = "true";
+    const result = renderInjection({
+      site_mode: "copy_existing",
+      design_direction_status: null,
+      tone_of_voice_status: null,
+      design_tokens: null,
+      homepage_concept_html: null,
+      tone_applied_homepage_html: null,
+      tone_of_voice: null,
+      extracted_design: null,
+      extracted_css_classes: null,
+    });
+    expect(result.trim()).toBe("");
+  });
+});
+
+describe("renderInjection — new_design", () => {
+  it("returns empty string when the flag is off", () => {
+    delete process.env.DESIGN_CONTEXT_ENABLED;
+    const result = renderInjection({
+      site_mode: "new_design",
+      design_direction_status: "approved",
+      tone_of_voice_status: "approved",
+      design_tokens: { primary: "#000000" },
+      homepage_concept_html: "<section>hi</section>",
+      tone_applied_homepage_html: null,
+      tone_of_voice: { style_guide: "Be brief.", approved_samples: [] },
+      extracted_design: null,
+      extracted_css_classes: null,
+    });
+    expect(result).toBe("");
+  });
+
+  it("emits design_context + voice_context when flag is on and statuses approved", () => {
+    process.env.DESIGN_CONTEXT_ENABLED = "true";
+    const result = renderInjection({
+      site_mode: "new_design",
+      design_direction_status: "approved",
+      tone_of_voice_status: "approved",
+      design_tokens: { primary: "#000000", font_heading: "Inter" },
+      homepage_concept_html: "<section>hi</section>",
+      tone_applied_homepage_html: null,
+      tone_of_voice: {
+        style_guide: "Be brief.",
+        approved_samples: [{ kind: "hero", text: "Welcome." }],
+      },
+      extracted_design: null,
+      extracted_css_classes: null,
+    });
+    expect(result).toContain("<design_context>");
+    expect(result).toContain("primary: #000000");
+    expect(result).toContain("<voice_context>");
+    expect(result).toContain("style_guide:");
+    expect(result).toContain("hero: Welcome.");
+  });
+});
+
+describe("renderInjection — null mode", () => {
+  it("returns empty string when site_mode IS NULL and flag is off", () => {
+    delete process.env.DESIGN_CONTEXT_ENABLED;
+    const result = renderInjection({
+      site_mode: null,
+      design_direction_status: null,
+      tone_of_voice_status: null,
+      design_tokens: null,
+      homepage_concept_html: null,
+      tone_applied_homepage_html: null,
+      tone_of_voice: null,
+      extracted_design: null,
+      extracted_css_classes: null,
+    });
+    expect(result).toBe("");
+  });
+});

--- a/lib/design-discovery/build-injection.ts
+++ b/lib/design-discovery/build-injection.ts
@@ -6,29 +6,30 @@ import { getServiceRoleClient } from "@/lib/supabase";
 // ---------------------------------------------------------------------------
 // DESIGN-DISCOVERY — generation-time context injection.
 //
-// PR 10. Reads sites.{design_*, tone_of_voice*} for a given site
-// and returns a string to prepend to a generation system prompt.
-// Wrapped in the DESIGN_CONTEXT_ENABLED feature flag — when off,
-// returns the empty string and the caller's existing behaviour is
-// preserved exactly.
+// PR 10 (DESIGN-DISCOVERY) — original new_design pathway.
+// PR 10 (DESIGN-SYSTEM-OVERHAUL) — added the copy_existing pathway.
 //
-// Injection shape:
+// Reads sites.* for a given site and returns a string to prepend to
+// a generation system prompt. Behaviour now depends on site_mode:
 //
-//   <design_context>
-//   tokens: { primary, secondary, ... }
-//   homepage_reference (truncated to 2000 chars):
-//   <html...>
-//   </design_context>
+//   site_mode = 'new_design'   → existing design-discovery injection
+//                                (design_tokens / homepage_concept_html /
+//                                tone_of_voice). Gated by
+//                                DESIGN_CONTEXT_ENABLED — the flag
+//                                preserves the previous opt-in posture.
 //
-//   <voice_context>
-//   style_guide: ...
-//   on_brand_examples:
-//   - hero: ...
-//   - service: ...
-//   - blog: ...
-//   </voice_context>
+//   site_mode = 'copy_existing'→ injects sites.extracted_design +
+//                                sites.extracted_css_classes (PR 7
+//                                output) and instructs the model to
+//                                use the extracted class names rather
+//                                than emit fresh CSS. NOT gated by
+//                                DESIGN_CONTEXT_ENABLED — copy_existing
+//                                only ships once a site has explicitly
+//                                onboarded into that mode, so the flag
+//                                isn't the right gate.
 //
-// Either block is omitted entirely when its status column != 'approved'.
+//   site_mode IS NULL          → empty string. Caller's previous
+//                                behaviour preserved.
 //
 // Cost: typically 500–2000 additional input tokens per generation
 // call. The brief runner's per-pass token budget already accounts
@@ -43,23 +44,25 @@ export function isDesignContextEnabled(): boolean {
 }
 
 interface SiteContextRow {
+  site_mode: string | null;
   design_direction_status: string | null;
   tone_of_voice_status: string | null;
   design_tokens: Record<string, unknown> | null;
   homepage_concept_html: string | null;
   tone_applied_homepage_html: string | null;
   tone_of_voice: Record<string, unknown> | null;
+  extracted_design: Record<string, unknown> | null;
+  extracted_css_classes: Record<string, unknown> | null;
 }
 
 export async function loadSiteDesignContext(
   siteId: string,
 ): Promise<SiteContextRow | null> {
-  if (!isDesignContextEnabled()) return null;
   const supabase = getServiceRoleClient();
   const { data, error } = await supabase
     .from("sites")
     .select(
-      "design_direction_status, tone_of_voice_status, design_tokens, homepage_concept_html, tone_applied_homepage_html, tone_of_voice",
+      "site_mode, design_direction_status, tone_of_voice_status, design_tokens, homepage_concept_html, tone_applied_homepage_html, tone_of_voice, extracted_design, extracted_css_classes",
     )
     .eq("id", siteId)
     .neq("status", "removed")
@@ -112,8 +115,102 @@ function samplesBlock(tone: Record<string, unknown>): string {
   return out.join("\n");
 }
 
+function renderCopyExistingInjection(row: SiteContextRow): string {
+  const design = (row.extracted_design ?? null) as
+    | {
+        colors?: Record<string, string | null>;
+        fonts?: Record<string, string | null>;
+        layout_density?: string | null;
+        visual_tone?: string | null;
+      }
+    | null;
+  const classes = (row.extracted_css_classes ?? null) as
+    | {
+        container?: string | null;
+        headings?: { h1?: string | null; h2?: string | null; h3?: string | null };
+        button?: string | null;
+        card?: string | null;
+      }
+    | null;
+
+  if (!design && !classes) return "";
+
+  const lines: string[] = ["<existing_theme_context>"];
+  lines.push(
+    "This site has a live WordPress theme. Generated content must blend in seamlessly — do NOT introduce new CSS classes or inline styles unless absolutely necessary; the host theme handles styling.",
+  );
+
+  if (design?.colors) {
+    const c = design.colors;
+    const colorLines = (
+      ["primary", "secondary", "accent", "background", "text"] as const
+    )
+      .map((key) => (c[key] ? `  ${key}: ${c[key]}` : null))
+      .filter((line): line is string => line !== null);
+    if (colorLines.length > 0) {
+      lines.push("colors:");
+      lines.push(...colorLines);
+    }
+  }
+
+  if (design?.fonts) {
+    const f = design.fonts;
+    const fontLines = (["heading", "body"] as const)
+      .map((key) => (f[key] ? `  ${key}: ${f[key]}` : null))
+      .filter((line): line is string => line !== null);
+    if (fontLines.length > 0) {
+      lines.push("fonts:");
+      lines.push(...fontLines);
+    }
+  }
+
+  if (design?.layout_density || design?.visual_tone) {
+    lines.push(
+      `layout: ${design.layout_density ?? "medium"} · tone: ${
+        design.visual_tone ?? "Neutral"
+      }`,
+    );
+  }
+
+  if (classes) {
+    const classLines: string[] = [];
+    if (classes.container) classLines.push(`  container: .${classes.container}`);
+    if (classes.headings?.h1) classLines.push(`  h1: .${classes.headings.h1}`);
+    if (classes.headings?.h2) classLines.push(`  h2: .${classes.headings.h2}`);
+    if (classes.headings?.h3) classLines.push(`  h3: .${classes.headings.h3}`);
+    if (classes.button) classLines.push(`  button: .${classes.button}`);
+    if (classes.card) classLines.push(`  card: .${classes.card}`);
+    if (classLines.length > 0) {
+      lines.push(
+        "Use these existing CSS classes (drop the .) on the matching elements:",
+      );
+      lines.push(...classLines);
+    }
+  }
+
+  lines.push(
+    "If a bucket above is missing, fall back to plain semantic tags without a class.",
+  );
+  lines.push("</existing_theme_context>");
+  return lines.join("\n");
+}
+
 export function renderInjection(row: SiteContextRow | null): string {
   if (!row) return "";
+
+  // copy_existing pathway runs regardless of DESIGN_CONTEXT_ENABLED —
+  // it's gated by site_mode itself, which is only set after the
+  // operator opts in via /onboarding.
+  if (row.site_mode === "copy_existing") {
+    return renderCopyExistingInjection(row) + "\n\n";
+  }
+
+  // new_design pathway — preserve the original DESIGN-DISCOVERY
+  // behaviour, including the flag gate.
+  if (row.site_mode !== "new_design" && !isDesignContextEnabled()) {
+    return "";
+  }
+
   const blocks: string[] = [];
 
   if (row.design_direction_status === "approved") {
@@ -164,10 +261,27 @@ export function renderInjection(row: SiteContextRow | null): string {
 }
 
 // Convenience: load + render in one call. Most callers want this.
+//
+// Dispatch:
+//   site_mode = 'copy_existing' → always runs (mode itself is the gate).
+//   site_mode = 'new_design'    → runs when DESIGN_CONTEXT_ENABLED is on.
+//   site_mode IS NULL           → empty string (no caller-visible change
+//                                  vs the pre-PR-10 behaviour).
+//
+// Returns "" on early exit so callers don't have to pre-check.
 export async function buildDesignContextPrefix(
   siteId: string,
 ): Promise<string> {
-  if (!isDesignContextEnabled()) return "";
   const row = await loadSiteDesignContext(siteId);
+  if (!row) return "";
+  if (row.site_mode === "copy_existing") return renderInjection(row);
+  if (row.site_mode === "new_design") {
+    if (!isDesignContextEnabled()) return "";
+    return renderInjection(row);
+  }
+  // site_mode IS NULL — preserve the pre-PR-10 fallback exactly so a
+  // half-onboarded site doesn't suddenly start pulling discovery
+  // context.
+  if (!isDesignContextEnabled()) return "";
   return renderInjection(row);
 }


### PR DESCRIPTION
## Workstream: DESIGN-SYSTEM-OVERHAUL — PR 10 of 15 (generation contract)

Makes \`buildDesignContextPrefix\` dispatch on \`sites.site_mode\` so
the brief runner / batch worker / blog pipeline emit the right shape
of context for each onboarding path. **The most consequential PR for
generation behaviour in this workstream.**

## Three branches

- **\`site_mode = 'copy_existing'\`** — always runs (the mode itself
  is the gate; \`DESIGN_CONTEXT_ENABLED\` is irrelevant). Emits a new
  \`<existing_theme_context>\` block built from
  \`sites.extracted_design\` + \`sites.extracted_css_classes\` (PR 7
  output). Tells the model to use the extracted CSS class names on
  container / h1 / h2 / h3 / button / card, and NOT to introduce new
  CSS or inline styles unless absolutely necessary. Falls back to
  plain semantic tags for any null bucket.
- **\`site_mode = 'new_design'\`** — existing DESIGN-DISCOVERY
  behaviour preserved: gated by \`DESIGN_CONTEXT_ENABLED\`, emits
  \`<design_context>\` + \`<voice_context>\` from \`design_tokens\` /
  \`homepage_concept_html\` / \`tone_of_voice\`.
- **\`site_mode IS NULL\`** — pre-PR-10 fallback exactly: empty string
  unless the flag is on, and the existing mode-agnostic injection
  if it is.

The downstream callers (\`lib/brief-runner.ts\`,
\`lib/system-prompt.ts\`) already consume \`buildDesignContextPrefix\`
via a single line each — no caller-side changes needed.

## Tests

\`lib/__tests__/build-injection-modes.test.ts\` covers all three
branches as a pure-function exercise (no DB):

- copy_existing emits theme context regardless of the flag.
- new_design with the flag off returns the empty string (preserves
  the legacy posture for half-flipped envs).
- copy_existing with both extracted columns null returns empty.
- new_design with the flag on emits the design + voice blocks.
- Null mode + flag off returns empty.

## Risks identified and mitigated

- **Cost regression.** copy_existing adds ~300–500 input tokens per
  generation. The brief runner already budgets system-prompt growth;
  the M3 batch worker tracks \`input_tokens\` in its cost calculator.
- **Wrong-mode injection.** A half-onboarded site (site_mode NULL
  with extracted_design somehow populated) would not emit the theme
  context. **By design** — the save endpoint (PR 7) guards on
  \`site_mode = 'copy_existing'\` so this state shouldn't exist;
  even if it did, the safest behaviour is to fall through to the
  legacy path.
- **Class-name injection contract.** Extracted classes appear in
  the prompt with a leading \".\", but the prompt explicitly tells the
  model to drop it when applying. The Path B contract
  (\`lib/brief-runner.ts:574–609\`) already constrains class
  prefixes; the new instruction is additive.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx next lint\` clean.
- [x] Unit tests added for the three dispatch branches.
- [ ] On staging, after PR 7 has populated an \`extracted_design\` for
  a copy_existing site, verify the brief runner emits the theme
  context block (visible via \`ANTHROPIC_LOG_PROMPT=true\` in the
  worker logs).
- E2E note: the canonical E2E for this is \`e2e/briefs-full-loop\`
  which is gated by the pre-existing CI Supabase-stack failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)