### PR TITLE
feat(generation): per-site image library context injection (PR 11/15)

### DIFF
--- a/app/admin/sites/[id]/settings/page.tsx
+++ b/app/admin/sites/[id]/settings/page.tsx
@@ -2,10 +2,12 @@ import { notFound, redirect } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { SiteVoiceSettingsForm } from "@/components/SiteVoiceSettingsForm";
+import { UseImageLibraryToggle } from "@/components/UseImageLibraryToggle";
 import { Alert } from "@/components/ui/alert";
 import { H1, H2, Lead } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getSite } from "@/lib/sites";
+import { getServiceRoleClient } from "@/lib/supabase";
 
 // /admin/sites/[id]/settings — RS-2.
 //
@@ -40,6 +42,15 @@ export default async function SiteSettingsPage({
   }
   const site = result.data.site;
 
+  const svc = getServiceRoleClient();
+  const useImageLibraryRow = await svc
+    .from("sites")
+    .select("use_image_library")
+    .eq("id", site.id)
+    .maybeSingle();
+  const useImageLibrary =
+    (useImageLibraryRow.data?.use_image_library as boolean | undefined) ?? false;
+
   return (
     <div className="mx-auto max-w-3xl">
       <Breadcrumbs
@@ -71,6 +82,23 @@ export default async function SiteSettingsPage({
             initialBrandVoice={site.brand_voice}
             initialDesignDirection={site.design_direction}
             initialVersionLock={site.version_lock}
+          />
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="image-library-heading"
+        className="mt-6 rounded-lg border p-4"
+      >
+        <H2 id="image-library-heading">Image library</H2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          When enabled, brief generation can suggest images from the shared
+          library where the page topic matches.
+        </p>
+        <div className="mt-4">
+          <UseImageLibraryToggle
+            siteId={site.id}
+            initialEnabled={useImageLibrary}
           />
         </div>
       </section>

--- a/app/api/admin/sites/[id]/use-image-library/route.ts
+++ b/app/api/admin/sites/[id]/use-image-library/route.ts
@@ -1,0 +1,117 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// POST /api/admin/sites/[id]/use-image-library
+// Body: { enabled: boolean }
+// Toggles sites.use_image_library. Admin-gated; per-site, no
+// version_lock (single boolean, idempotent re-write).
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const BodySchema = z.object({ enabled: z.boolean() });
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({
+    roles: ["super_admin", "admin"] as const,
+  });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Site id must be a UUID.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Body must be { enabled: boolean }.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getServiceRoleClient();
+  const upd = await supabase
+    .from("sites")
+    .update({
+      use_image_library: parsed.data.enabled,
+      updated_at: new Date().toISOString(),
+      updated_by: gate.user?.id ?? null,
+    })
+    .eq("id", params.id)
+    .select("id, use_image_library")
+    .maybeSingle();
+
+  if (upd.error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to update toggle.",
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+  if (!upd.data) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message: "Site not found.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 404 },
+    );
+  }
+
+  revalidatePath(`/admin/sites/${params.id}/settings`);
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { use_image_library: upd.data.use_image_library },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200, headers: { "cache-control": "no-store" } },
+  );
+}

--- a/components/UseImageLibraryToggle.tsx
+++ b/components/UseImageLibraryToggle.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+
+export function UseImageLibraryToggle({
+  siteId,
+  initialEnabled,
+}: {
+  siteId: string;
+  initialEnabled: boolean;
+}) {
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  async function commit(next: boolean) {
+    setError(null);
+    const previous = enabled;
+    setEnabled(next);
+    try {
+      const res = await fetch(`/api/admin/sites/${siteId}/use-image-library`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: next }),
+      });
+      if (!res.ok) {
+        const payload = (await res.json().catch(() => null)) as
+          | { ok: false; error: { message: string } }
+          | null;
+        setError(payload?.error.message ?? `Failed (HTTP ${res.status}).`);
+        setEnabled(previous);
+      }
+    } catch (err) {
+      setError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
+      setEnabled(previous);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-background p-3">
+      <div>
+        <p className="text-sm font-medium">Use images from the library</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Suggest up to 5 captioned images per page based on the page title.
+          Only images with caption + alt text are included; off by default
+          until you&apos;ve verified the metadata quality.
+        </p>
+      </div>
+      <Button
+        type="button"
+        variant={enabled ? "default" : "outline"}
+        onClick={() => startTransition(() => void commit(!enabled))}
+        disabled={pending}
+        data-testid="use-image-library-toggle"
+        aria-pressed={enabled}
+      >
+        {enabled ? "Enabled" : "Disabled"}
+      </Button>
+      {error && (
+        <p className="basis-full text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lib/brief-runner.ts
+++ b/lib/brief-runner.ts
@@ -12,6 +12,7 @@ import {
   isAllowedAnthropicModel,
 } from "@/lib/anthropic-pricing";
 import { buildDesignContextPrefix } from "@/lib/design-discovery/build-injection";
+import { buildImageLibraryContextPrefix } from "@/lib/image-library-context";
 import type {
   BriefPageCritiqueEntry,
   BriefPagePassKind,
@@ -1605,6 +1606,20 @@ async function processPagePassLoop(
   // or neither step is approved; existing behaviour preserved.
   const designContextPrefix = await buildDesignContextPrefix(brief.site_id);
 
+  // DESIGN-SYSTEM-OVERHAUL PR 11 — when sites.use_image_library is on,
+  // pull up to 5 captioned images keyed off the page title and append
+  // their URLs as suggestions. Off by default; the lib short-circuits
+  // when the toggle is off so the cost is one cheap row read per
+  // page-tick. Page title is the cheapest topic signal — search_tsv
+  // is GIN-indexed and websearch tolerant. Stitched onto the
+  // existing designContextPrefix so the prompt still receives a
+  // single string at this slot — no PageContext interface change.
+  const imageLibraryPrefix = await buildImageLibraryContextPrefix({
+    siteId: brief.site_id,
+    topic: page.title,
+  });
+  const combinedContextPrefix = designContextPrefix + imageLibraryPrefix;
+
   // Resume pointer.
   let kindToRun: TextSequencePassKind | null = null;
   let numberToRun = 0;
@@ -1663,7 +1678,7 @@ async function processPagePassLoop(
       previousVisualCritique: null,
       sitePrefix,
       designSystemVersion,
-      designContextPrefix,
+      designContextPrefix: combinedContextPrefix,
     };
 
     const isAnchorFinalPass =
@@ -1925,7 +1940,7 @@ async function processPagePassLoop(
     visualRender,
     sitePrefix,
     designSystemVersion,
-    designContextPrefix,
+    combinedContextPrefix,
   );
   if (visualOutcome.fatal) {
     return visualOutcome.fatal;

--- a/lib/image-library-context.ts
+++ b/lib/image-library-context.ts
@@ -1,0 +1,125 @@
+import "server-only";
+
+import { deliveryUrl } from "@/lib/cloudflare-images";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// DESIGN-SYSTEM-OVERHAUL PR 11 — image library context for generation.
+//
+// When sites.use_image_library is true, returns a prompt block listing
+// up to 5 captioned images from image_library whose search_tsv matches
+// the supplied topic keywords. The model can reference the URLs
+// directly in <img src="...">.
+//
+// Hard rules:
+//
+//   - Skip rows missing caption or alt_text — the brief is explicit
+//     that we should only suggest images with confirmed metadata.
+//   - Skip soft-deleted rows.
+//   - Skip rows whose Cloudflare delivery URL can't be built (hash
+//     unset). Without a URL the model has nothing to reference.
+//   - Empty topic + no matches → empty block, never a hard fail.
+//
+// Topic search uses Postgres' websearch_to_tsquery on
+// image_library.search_tsv (a GIN-indexed materialised column from
+// migration 0010). websearch parsing tolerates phrase quotes, AND/OR,
+// and bare words equally well — operators don't have to memorise the
+// to_tsquery syntax.
+// ---------------------------------------------------------------------------
+
+const MAX_IMAGES = 5;
+
+export interface ImageLibrarySuggestion {
+  id: string;
+  url: string;
+  caption: string;
+  alt_text: string;
+  tags: string[];
+}
+
+export async function fetchImageLibrarySuggestions(opts: {
+  siteId: string;
+  topic: string;
+}): Promise<ImageLibrarySuggestion[]> {
+  const { siteId, topic } = opts;
+  if (!topic.trim()) return [];
+
+  const supabase = getServiceRoleClient();
+  const enabledRow = await supabase
+    .from("sites")
+    .select("use_image_library")
+    .eq("id", siteId)
+    .maybeSingle();
+
+  if (enabledRow.error || !enabledRow.data?.use_image_library) {
+    return [];
+  }
+
+  const { data, error } = await supabase
+    .from("image_library")
+    .select("id, cloudflare_id, caption, alt_text, tags")
+    .is("deleted_at", null)
+    .not("caption", "is", null)
+    .not("alt_text", "is", null)
+    .neq("caption", "")
+    .neq("alt_text", "")
+    .textSearch("search_tsv", topic, { type: "websearch" })
+    .limit(MAX_IMAGES);
+
+  if (error) {
+    logger.warn("image-library-context.fetch_failed", {
+      site_id: siteId,
+      topic,
+      error: error.message,
+    });
+    return [];
+  }
+
+  const out: ImageLibrarySuggestion[] = [];
+  for (const row of data ?? []) {
+    const cloudflareId = row.cloudflare_id as string | null;
+    if (!cloudflareId) continue;
+    const url = deliveryUrl(cloudflareId, "public");
+    if (!url) continue;
+    out.push({
+      id: row.id as string,
+      url,
+      caption: row.caption as string,
+      alt_text: row.alt_text as string,
+      tags: (row.tags as string[]) ?? [],
+    });
+  }
+  return out;
+}
+
+export function renderImageLibraryBlock(
+  suggestions: ImageLibrarySuggestion[],
+): string {
+  if (suggestions.length === 0) return "";
+  const lines = ["<image_library_context>"];
+  lines.push(
+    "Use these pre-approved images from our library when an image fits the section. Reference URLs directly in <img src=\"...\"> with the supplied alt text. If none fit, generate without images — do NOT invent URLs.",
+  );
+  lines.push("");
+  for (const s of suggestions) {
+    lines.push(`- url: ${s.url}`);
+    lines.push(`  caption: ${s.caption}`);
+    lines.push(`  alt: ${s.alt_text}`);
+    if (s.tags.length > 0) {
+      lines.push(`  tags: ${s.tags.join(", ")}`);
+    }
+  }
+  lines.push("</image_library_context>");
+  return lines.join("\n");
+}
+
+export async function buildImageLibraryContextPrefix(opts: {
+  siteId: string;
+  topic: string;
+}): Promise<string> {
+  const suggestions = await fetchImageLibrarySuggestions(opts);
+  const block = renderImageLibraryBlock(suggestions);
+  if (!block) return "";
+  return block + "\n\n";
+}

--- a/supabase/migrations/0068_site_use_image_library.sql
+++ b/supabase/migrations/0068_site_use_image_library.sql
@@ -1,0 +1,17 @@
+-- 0068 — Per-site "Use images from library" toggle.
+-- Reference: DESIGN-SYSTEM-OVERHAUL workstream (PR 11/15).
+--
+-- When enabled, the brief runner pulls up to 5 captioned images from
+-- image_library that match the page topic and passes them to the
+-- generation prompt as suggestions. Default OFF — the operator opts
+-- in only after confirming that the captioning + alt-text quality is
+-- good enough for the site's content surfaces.
+--
+-- Pure ALTER TABLE ADD COLUMN with constant default. Existing rows
+-- pick up the column metadata-only (no table rewrite, no backfill).
+
+ALTER TABLE sites
+  ADD COLUMN use_image_library boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN sites.use_image_library IS
+  'Per-site opt-in for inlining image_library suggestions into the generation system prompt. Default false. Toggled from /admin/sites/[id]/settings. Added 2026-05-02 (DESIGN-SYSTEM-OVERHAUL PR 11).';

--- a/supabase/rollbacks/0068_site_use_image_library.down.sql
+++ b/supabase/rollbacks/0068_site_use_image_library.down.sql
@@ -1,0 +1,2 @@
+-- Rollback for 0068_site_use_image_library.sql
+ALTER TABLE sites DROP COLUMN IF EXISTS use_image_library;


### PR DESCRIPTION
## Workstream: DESIGN-SYSTEM-OVERHAUL — PR 11 of 15 (image library opt-in)

Adds an opt-in path so generation can pull captioned images from the
image library and pass them to the prompt as suggestions, scoped per
page topic.

## Schema

\`0068_site_use_image_library.sql\` — \`sites.use_image_library boolean
NOT NULL DEFAULT false\`. Pure ADD COLUMN with constant default; no
rewrite, no backfill.

## Library + integration

- \`lib/image-library-context.ts\` exposes
  \`buildImageLibraryContextPrefix({siteId, topic})\`. Short-circuits
  when the toggle is off. Otherwise queries \`image_library\` where:
  - \`deleted_at IS NULL\`
  - \`caption IS NOT NULL AND caption != ''\`
  - \`alt_text IS NOT NULL AND alt_text != ''\`
  - \`search_tsv @@ websearch_to_tsquery(topic)\`
  Limits to 5. Renders an \`<image_library_context>\` block telling
  the model to reference URLs directly and NOT to invent URLs.
- \`lib/brief-runner.ts\` stitches the image-library prefix onto the
  design-context prefix and passes the combined string into the
  existing \`PageContext.designContextPrefix\` slot — no interface
  change; the visual-review loop sees the combined value too.
- Topic source: \`page.title\` (the cheapest signal already available
  per page-tick; \`search_tsv\` is GIN-indexed and websearch-tolerant).

## UI

\`/admin/sites/[id]/settings\` gets a new \"Image library\" section with
a toggle component. \`POST /api/admin/sites/[id]/use-image-library\`
flips the column.

## Risks identified and mitigated

- **Cost.** Each enabled page-tick fires one PK lookup + one indexed
  FTS query. Negligible vs the LLM call itself.
- **Hallucinated URLs.** The prompt block explicitly says do NOT
  invent URLs; the fragment-validation gate would catch one anyway.
- **Stale captions / wrong alt text.** Operator opt-in (default OFF)
  is the gate. Flip on only after metadata audit clears.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx next lint\` clean.
- [ ] On staging: enable the toggle on one site that has captioned
  images, run a brief, verify \`<image_library_context>\` appears in
  the system prompt (worker debug log).
- E2E note: the canonical brief-loop E2E is gated by the pre-existing
  CI Supabase-stack failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)