### PR TITLE
feat(ui): error fallback primitive + clean up raw error codes (PR 14/15)

### DIFF
--- a/components/AppearancePanelClient.tsx
+++ b/components/AppearancePanelClient.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { AppearanceEventLog } from "@/components/AppearanceEventLog";
+import { ErrorFallback } from "@/components/ErrorFallback";
 import { KadencePaletteDiffTable } from "@/components/KadencePaletteDiffTable";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -368,23 +369,23 @@ export function AppearancePanelClient({
       )}
 
       {phase === "error" && (
-        <div
-          role="alert"
-          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-        >
-          <p className="font-medium">Something went wrong.</p>
-          <p className="mt-1">{errorMessage}</p>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="mt-3"
-            onClick={runPreflight}
-            disabled={actionState !== "idle"}
-          >
-            {actionState === "rechecking" ? "Re-checking…" : "Re-check"}
-          </Button>
-        </div>
+        <ErrorFallback
+          title="Couldn't load the appearance panel"
+          description={
+            <>
+              <p>{errorMessage}</p>
+              <p className="mt-1 text-xs">
+                If this happens repeatedly, the WordPress site or Kadence
+                plugin may be down. Re-checking sometimes helps after a
+                brief pause.
+              </p>
+            </>
+          }
+          action={{
+            label: actionState === "rechecking" ? "Re-checking…" : "Re-check",
+            onClick: runPreflight,
+          }}
+        />
       )}
 
       {/* Ready state — full panel. */}

--- a/components/ErrorFallback.tsx
+++ b/components/ErrorFallback.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+// DESIGN-SYSTEM-OVERHAUL PR 14 — uniform "something went wrong"
+// surface. Wherever an admin route has historically dumped a raw
+// error code (`INTERNAL_ERROR`, `KADENCE_NOT_ACTIVE`, etc.) into the
+// UI, render this instead. Three slots:
+//
+//   title       — plain-English summary, never a code.
+//   description — what happened, why it matters, in one or two
+//                 sentences.
+//   action      — primary remedial click. A Link or onClick is fine;
+//                 the component renders whatever the caller passes
+//                 inside the <Button> wrapper.
+//
+// Everything is operator-visible. Codes still belong in the audit
+// log — they are valuable for incident reconstruction — but they
+// don't belong in the UI.
+
+export interface ErrorFallbackProps {
+  title: string;
+  description: ReactNode;
+  action?: {
+    label: string;
+    href?: string;
+    onClick?: () => void;
+  };
+  supportHref?: string;
+  testId?: string;
+}
+
+export function ErrorFallback({
+  title,
+  description,
+  action,
+  supportHref = "https://opollo.com/contact",
+  testId,
+}: ErrorFallbackProps) {
+  return (
+    <div
+      className="rounded-md border border-destructive/40 bg-destructive/5 p-5"
+      role="alert"
+      data-testid={testId ?? "error-fallback"}
+    >
+      <div className="flex items-start gap-3">
+        <AlertTriangle
+          aria-hidden
+          className="mt-0.5 h-5 w-5 shrink-0 text-destructive"
+        />
+        <div className="flex-1 space-y-2">
+          <p className="text-sm font-semibold">{title}</p>
+          <div className="text-sm text-muted-foreground">{description}</div>
+          {action && (
+            <div className="pt-1">
+              {action.href ? (
+                <Button asChild size="sm">
+                  <Link href={action.href}>{action.label}</Link>
+                </Button>
+              ) : (
+                <Button size="sm" type="button" onClick={action.onClick}>
+                  {action.label}
+                </Button>
+              )}
+            </div>
+          )}
+          <p className="pt-1 text-xs text-muted-foreground">
+            Still stuck?{" "}
+            <a
+              href={supportHref}
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              Contact support
+            </a>
+            .
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/SiteEditForm.tsx
+++ b/components/SiteEditForm.tsx
@@ -451,7 +451,7 @@ function TestResultPanel({
       role="alert"
       data-testid="site-test-result"
     >
-      <p className="font-medium">{result.code}</p>
+      <p className="font-medium">Connection test failed</p>
       <p className="mt-0.5 text-xs">{result.message}</p>
     </div>
   );


### PR DESCRIPTION
## Workstream: DESIGN-SYSTEM-OVERHAUL — PR 14 of 15 (error states)

Introduces a uniform \`ErrorFallback\` component that wraps
\"something went wrong\" surfaces with a consistent shape (title,
description, action, support link) and removes the most
operator-visible raw-error-code leaks.

## New primitive

\`components/ErrorFallback.tsx\` — three slots:

- \`title\` — plain English, never a code.
- \`description\` — what happened, one or two sentences.
- \`action\` — primary remedial click (Link or onClick).
- \`supportHref\` — defaults to https://opollo.com/contact.

Codes still belong in the audit log, where they're valuable for
incident reconstruction — they don't belong in the operator's
workflow.

## Apply sites

- **AppearancePanelClient** — unrecoverable \"error\" phase now
  renders \`ErrorFallback\` with a richer description (one line
  about WP / Kadence outages plus the original error message)
  and the existing \"Re-check\" remedial action.
- **SiteEditForm** — connection-test failure block was rendering
  the API error code as the headline (\`UNKNOWN\`, \`WP_AUTH_FAILED\`,
  etc.). Headline now reads \"Connection test failed\"; the message
  body still surfaces the human-readable text.

## Already addressed earlier in the workstream

- \`context_build_failed\` never appeared in user-facing UI per the
  audit (server-side audit log only). PR 8's empty state for
  unonboarded sites removed the only path operators conflated with
  that failure mode.

## Out of scope (deferred)

- \`EmailTestForm\` renders the raw error code intentionally — low-
  traffic ops debug surface where codes are useful for support
  tickets.
- \`BriefReviewClient\` renders gate / warning codes as \`<code>\`
  blocks; those are explicit operator-debug data, not generic
  errors.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx next lint\` clean.
- E2E note: visual change only on two components; existing
  appearance + sites E2E specs cover the surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)