### PR TITLE
fix(infra): renumber 0031_optimiser_clients to 0069 + repair input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,11 @@ jobs:
           # the file would make supabase db push try to re-apply it).
           # Each entry here needs a tracked follow-up to renumber + run
           # supabase migration repair across staging + prod.
-          #   - 0031: 0031_email_log.sql (#286) collides with
-          #           0031_optimiser_clients.sql (#293). One of the two
-          #           is silently missing from prod. Follow-up TBD.
-          allowlist="0031"
+          # Empty: the historical 0031 collision was resolved by
+          # renumbering 0031_optimiser_clients.sql → 0069. Production
+          # recovery for environments mid-collision is handled by
+          # deploy-migrations.yml's `repair_versions_applied` input.
+          allowlist=""
           fail=0
           for dir in supabase/migrations supabase/rollbacks; do
             [ -d "$dir" ] || continue

--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -27,6 +27,20 @@ on:
       - "supabase/migrations/**"
       - ".github/workflows/deploy-migrations.yml"
   workflow_dispatch:
+    inputs:
+      repair_versions_applied:
+        description: |
+          Space-separated list of migration versions to mark as APPLIED
+          (without re-running their SQL) before db push. Use when a
+          migration's SQL was applied out-of-band but the
+          schema_migrations row never landed (e.g. after a
+          version-prefix collision left the table created without the
+          tracking row). Each entry maps to:
+              supabase migration repair --status applied <version> --linked
+          To recover an environment mid 0031 collision, dispatch with
+          `repair_versions_applied=0069`. Leave blank for normal pushes.
+        required: false
+        default: ""
 
 concurrency:
   # Serialise runs against the same project — two concurrent
@@ -75,6 +89,17 @@ jobs:
 
       - name: Show pending migrations (diagnostic)
         run: supabase migration list --linked || true
+
+      - name: Repair flagged versions (mark applied without re-running SQL)
+        if: github.event_name == 'workflow_dispatch' && inputs.repair_versions_applied != ''
+        env:
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for v in ${{ inputs.repair_versions_applied }}; do
+            echo "Marking version $v as applied..."
+            supabase migration repair --status applied "$v" --linked
+          done
 
       - name: Push pending migrations
         env:

--- a/supabase/migrations/0069_optimiser_clients.sql
+++ b/supabase/migrations/0069_optimiser_clients.sql
@@ -1,5 +1,17 @@
--- 0031 — Optimiser: opt_clients (Slice 1 of feat/optimiser).
+-- 0069 — Optimiser: opt_clients (Slice 1 of feat/optimiser).
 -- Reference: docs/Optimisation_Engine_Spec_v1.5.docx §5.1 + §3.6 + §4.6 + §11.2.
+--
+-- Renumbered from 0031 → 0069 to resolve a version-prefix collision with
+-- 0031_email_log.sql (PR #286). supabase_migrations.schema_migrations
+-- enforces UNIQUE on the version column, so two files sharing prefix 0031
+-- meant `supabase db push` succeeded for whichever file ran first and
+-- silently failed (or partially applied) the other. On environments where
+-- the original 0031_optimiser_clients.sql had already created opt_clients
+-- without a tracking row, recover by triggering deploy-migrations.yml with
+-- `repair_versions_applied=0069` — the workflow runs
+-- `supabase migration repair --status applied 0069 --linked` before
+-- db push, marking 0069 applied without re-running the CREATE TABLE.
+-- Fresh environments apply this file normally as version 0069.
 --
 -- Design decisions encoded here:
 --

--- a/supabase/rollbacks/0069_optimiser_clients.down.sql
+++ b/supabase/rollbacks/0069_optimiser_clients.down.sql
@@ -1,4 +1,5 @@
--- Rollback for 0031_optimiser_clients.sql
+-- Rollback for 0069_optimiser_clients.sql (renumbered from 0031 to resolve
+-- version-prefix collision with 0031_email_log.sql).
 DROP POLICY IF EXISTS opt_clients_write ON opt_clients;
 DROP POLICY IF EXISTS opt_clients_read ON opt_clients;
 DROP POLICY IF EXISTS service_role_all ON opt_clients;


### PR DESCRIPTION
## Summary

`supabase_migrations.schema_migrations` enforces UNIQUE on the version column. `0031_email_log.sql` (#286) and `0031_optimiser_clients.sql` (#293) share prefix `0031`, so `supabase db push` succeeded for whichever ran first and silently failed (or partially applied) the other. The CI Supabase-stack job (E2E + Vitest workflows) has been wedged on this since both files merged — every PR's CI fails at "Start Supabase local stack". The DESIGN-SYSTEM-OVERHAUL workstream PRs all merged with passing lint + typecheck + build but couldn't be E2E-validated.

## Changes

- **Renumber** `0031_optimiser_clients.sql` → `0069_optimiser_clients.sql` (and matching rollback). `0069` is the next free slot after origin/main's `0068`. Migration header documents the renumber + the recovery path.
- **CI guard tightened**: drop `0031` from the migration-versions allow-list (now empty), so any future collision fails CI rather than being silently allow-listed.
- **Production recovery hook**: add a `repair_versions_applied` `workflow_dispatch` input to `deploy-migrations.yml`. When supplied, the workflow runs `supabase migration repair --status applied <version> --linked` for each listed version before `db push`. This recovers environments where the SQL was applied out-of-band but the `schema_migrations` row never landed.

## Recovery procedure for production

After this PR merges, trigger `deploy-migrations.yml` from `main` with `repair_versions_applied=0069`. The repair step marks `0069` as applied (matching the existing `opt_clients` table), then `db push` applies `0032` → `0068` cleanly. Fresh / not-yet-deployed environments apply `0069` normally — no repair needed.

## Risks identified and mitigated

- **Duplicate-prefix CI guard** going forward: the `migration-versions` job in `ci.yml` fails on any future prefix collision. Allow-list is now empty, so silent allow-listing isn't a path back.
- **Re-running CREATE TABLE on environments where opt_clients already exists**: mitigated by the repair-then-push flow. Operators run repair before push to mark `0069` applied without re-executing SQL.
- **Fresh environments** (CI Supabase stack, new staging projects) apply `0069` from scratch — no manual step needed. The CI Supabase stack should now start cleanly.
- **Rollback file** renamed in lockstep with the migration file so the down-script lookup by version still resolves.
- **No code references** to the old filename outside the file itself; verified via grep.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] No duplicate prefixes in `supabase/migrations/` or `supabase/rollbacks/`
- [ ] CI `migration-versions` job passes (was previously warning on `0031`, should now report no collisions)
- [ ] CI `test` job's "Start Supabase local stack" step succeeds for the first time since both 0031 files landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)