### PR TITLE
fix(infra): add repair_versions_reverted input to deploy-migrations

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -37,8 +37,21 @@ on:
           version-prefix collision left the table created without the
           tracking row). Each entry maps to:
               supabase migration repair --status applied <version> --linked
-          To recover an environment mid 0031 collision, dispatch with
-          `repair_versions_applied=0069`. Leave blank for normal pushes.
+          Leave blank for normal pushes.
+        required: false
+        default: ""
+      repair_versions_reverted:
+        description: |
+          Space-separated list of migration versions to mark as REVERTED
+          (clear the schema_migrations row without dropping any objects)
+          before db push. Use to undo a stale or wrongly-applied tracking
+          row — e.g. when `repair_versions_applied` was used on a fresh
+          environment that didn't actually have the underlying schema,
+          leaving a row that points at nothing. Each entry maps to:
+              supabase migration repair --status reverted <version> --linked
+          Leave blank for normal pushes. Reverted runs before applied
+          when both are supplied, so a row can be cleared and re-marked
+          in a single dispatch if needed.
         required: false
         default: ""
 
@@ -89,6 +102,17 @@ jobs:
 
       - name: Show pending migrations (diagnostic)
         run: supabase migration list --linked || true
+
+      - name: Repair flagged versions (mark reverted — clear tracking row)
+        if: github.event_name == 'workflow_dispatch' && inputs.repair_versions_reverted != ''
+        env:
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for v in ${{ inputs.repair_versions_reverted }}; do
+            echo "Marking version $v as reverted..."
+            supabase migration repair --status reverted "$v" --linked
+          done
 
       - name: Repair flagged versions (mark applied without re-running SQL)
         if: github.event_name == 'workflow_dispatch' && inputs.repair_versions_applied != ''


### PR DESCRIPTION
## Summary

Symmetric undo for the `repair_versions_applied` flow added in #371. When that hook is invoked against an environment that didn't actually have the underlying schema (e.g. a fresh project where the original collision never partially-applied), the result is a `schema_migrations` row pointing at nothing and `db push` immediately fails on the next dependent migration with `relation X does not exist`.

This is the actual state of production after run [25243244919](https://github.com/opollo5/opollo-site-builder/actions/runs/25243244919): `0069` is marked applied but `opt_clients` doesn't exist, so `0032_optimiser_client_credentials.sql` fails on the FK reference.

## Changes

- New `repair_versions_reverted` `workflow_dispatch` input. Runs `supabase migration repair --status reverted <version> --linked` for each entry. Clears the tracking row without dropping any objects.
- Reverted step runs before the existing applied step in the same job, so an operator can clear-and-re-mark in one dispatch if needed.

## Recovery procedure (post-merge)

1. Dispatch `deploy-migrations.yml` with `repair_versions_reverted=0069` — clears the bogus tracking row.
2. Dispatch `deploy-migrations.yml` with no inputs — `db push` runs `0069`'s `CREATE TABLE` normally, then `0032` → `0068` follow.

## Risks identified and mitigated

- **`reverted` does not drop objects** — only the tracking row is cleared. If a caller wrongly reverts a row whose schema *does* exist, the next `db push` will try to re-apply the migration's SQL and fail on `relation already exists`. Acceptable: that failure is loud and recoverable (revert it back to applied).
- **Order of operations** — reverted runs before applied so a clear-and-remark in the same dispatch resolves to the marked state. Documented in the input description.
- **No impact on push-on-main flow** — both inputs default to empty and the `if:` guard requires `workflow_dispatch`. Push-triggered runs are unchanged.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [ ] After merge: dispatch with `repair_versions_reverted=0069` → clears row.
- [ ] After merge: dispatch with no inputs → `db push` applies 0069 onward cleanly. Verify with `supabase migration list --linked` in the run summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)