### PR TITLE
fix(infra): swap 0031/0069 slot ownership — opt_clients back to 0031

### DIFF
--- a/supabase/migrations/0031_optimiser_clients.sql
+++ b/supabase/migrations/0031_optimiser_clients.sql
@@ -1,17 +1,30 @@
--- 0069 — Optimiser: opt_clients (Slice 1 of feat/optimiser).
+-- 0031 — Optimiser: opt_clients (Slice 1 of feat/optimiser).
 -- Reference: docs/Optimisation_Engine_Spec_v1.5.docx §5.1 + §3.6 + §4.6 + §11.2.
 --
--- Renumbered from 0031 → 0069 to resolve a version-prefix collision with
--- 0031_email_log.sql (PR #286). supabase_migrations.schema_migrations
--- enforces UNIQUE on the version column, so two files sharing prefix 0031
--- meant `supabase db push` succeeded for whichever file ran first and
--- silently failed (or partially applied) the other. On environments where
--- the original 0031_optimiser_clients.sql had already created opt_clients
--- without a tracking row, recover by triggering deploy-migrations.yml with
--- `repair_versions_applied=0069` — the workflow runs
--- `supabase migration repair --status applied 0069 --linked` before
--- db push, marking 0069 applied without re-running the CREATE TABLE.
--- Fresh environments apply this file normally as version 0069.
+-- Version-prefix collision history:
+--
+-- This file originally landed at 0031. A separate 0031_email_log.sql
+-- (PR #286) collided with it on the same prefix; supabase_migrations.
+-- schema_migrations enforces UNIQUE on version, so `supabase db push`
+-- recorded whichever file ran first and silently failed the other.
+--
+-- An earlier remediation renumbered this file 0031 → 0069 (PR #371) on
+-- the assumption production had opt_clients from the partial collision.
+-- That assumption was wrong on the actual prod state, AND putting
+-- opt_clients at 0069 broke FK ordering for fresh environments —
+-- 0032_optimiser_client_credentials.sql (and the rest of the optimiser
+-- chain through 0061) reference opt_clients via FK, so they apply
+-- before 0069 in version order and fail on `relation does not exist`.
+--
+-- The final fix swaps the slot ownership: opt_clients returns to 0031
+-- (which restores the correct FK-before-dependents order) and
+-- email_log moves to 0069 (it has no FK dependents, so trailing the
+-- chain is safe). Production recovery: dispatch deploy-migrations.yml
+-- with repair_versions_reverted=0031 repair_versions_applied=0069 —
+-- the revert clears the historical 0031 row (originally tracking
+-- email_log's apply); the apply marks 0069 as applied (matching the
+-- email_log table that already exists in prod). db push then runs
+-- this file's CREATE TABLE, then 0032 → 0068 in order.
 --
 -- Design decisions encoded here:
 --

--- a/supabase/migrations/0069_email_log.sql
+++ b/supabase/migrations/0069_email_log.sql
@@ -1,4 +1,15 @@
--- 0031 — AUTH-FOUNDATION P1: SendGrid email log.
+-- 0069 — AUTH-FOUNDATION P1: SendGrid email log.
+--
+-- Renumbered from 0031 → 0069 to resolve a version-prefix collision
+-- with 0031_optimiser_clients.sql. opt_clients (originally at 0031)
+-- has FK dependents at 0032+, so it must keep slot 0031. email_log
+-- has no FK dependents, so it tails the chain at 0069. Production
+-- recovery for environments where this file's content already
+-- applied as version 0031: dispatch deploy-migrations.yml with
+-- repair_versions_reverted=0031 (clears the historical row) and
+-- repair_versions_applied=0069 (marks this file applied without
+-- re-running the CREATE TABLE, since email_log already exists).
+-- Fresh environments apply this file normally as version 0069.
 --
 -- Every transactional email send (success and failure) writes a row
 -- here. Phases 2-4 attach to this for invite emails, login-challenge

--- a/supabase/rollbacks/0031_optimiser_clients.down.sql
+++ b/supabase/rollbacks/0031_optimiser_clients.down.sql
@@ -1,5 +1,4 @@
--- Rollback for 0069_optimiser_clients.sql (renumbered from 0031 to resolve
--- version-prefix collision with 0031_email_log.sql).
+-- Rollback for 0031_optimiser_clients.sql.
 DROP POLICY IF EXISTS opt_clients_write ON opt_clients;
 DROP POLICY IF EXISTS opt_clients_read ON opt_clients;
 DROP POLICY IF EXISTS service_role_all ON opt_clients;


### PR DESCRIPTION
## Summary

Follow-up to #371 + #372. The first remediation moved `0031_optimiser_clients.sql` → `0069` on the assumption production had `opt_clients` from the original collision's partial application. That assumption was wrong; deploy run [25243244919](https://github.com/opollo5/opollo-site-builder/actions/runs/25243244919) failed at `0032_optimiser_client_credentials.sql` with `relation "opt_clients" does not exist`. Putting `opt_clients` at 0069 also breaks fresh environments — every optimiser migration `0032` → `0061` FKs to `opt_clients`, so they apply before `0069` in version order.

## Changes

Swap which file owns which slot:
- `0069_optimiser_clients.sql` → `0031_optimiser_clients.sql` (back to its original slot — restores FK-before-dependents order).
- `0031_email_log.sql` → `0069_email_log.sql` (no FK dependents, safe to tail the chain).
- Headers updated on both files documenting the swap and the recovery procedure.

## Production recovery (single dispatch after merge)

```
gh workflow run deploy-migrations.yml --ref main \
  -f repair_versions_reverted=0031 \
  -f repair_versions_applied=0069
```

- `reverted=0031` clears the historical `schema_migrations` row that tracked email_log's original 0031 apply.
- `applied=0069` marks email_log applied at its new slot (the table already exists in prod, so no need to re-run `CREATE TABLE`).
- `db push` then runs `0031_optimiser_clients.sql` (creates `opt_clients`), `0032` → `0068` in order, and skips `0069` (already marked).

## Fresh environments (CI Supabase stack)

No repair needed. Migrations apply in version order: `0031` creates `opt_clients`, `0032+` FK to it, `0069` creates `email_log` last. The CI E2E + Vitest "Start Supabase local stack" step should now succeed.

## Risks identified and mitigated

- **Schema drift between 0069_email_log content and the existing prod table**: file content is unchanged from what created the prod table originally — no drift.
- **Wrong-order repair**: workflow runs `reverted` before `applied` in the same job (PR #372), so a single dispatch with both inputs resolves cleanly.
- **CI duplicate-prefix guard**: still empty allow-list. Verified no duplicate prefixes after swap.
- **Rollback file**: renamed in lockstep with the migration file. email_log has no rollback file (forward-only per its own header).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] No duplicate prefixes after swap
- [ ] After merge: dispatch with both repair inputs, run completes green.
- [ ] After merge: `supabase migration list --linked` shows 0031 → 0068 applied.
- [ ] After merge: future PR's CI Supabase stack starts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)