### PR TITLE
fix(infra): idempotent recovery preamble in 0062 + 0063 auth migrations

### DIFF
--- a/supabase/migrations/0062_auth_foundation_2fa_schema.sql
+++ b/supabase/migrations/0062_auth_foundation_2fa_schema.sql
@@ -23,6 +23,17 @@
 -- Forward-only. RLS service-role-only on both tables; the auth
 -- pipeline reads + writes via lib/2fa/* with the service-role
 -- client.
+--
+-- Recovery preamble: the 0031 version-prefix collision (resolved in
+-- #371/#372/#373) blocked this migration from being recorded. On
+-- environments where an earlier `supabase db push` got far enough to
+-- create these tables before failing on a later statement, the
+-- tables now exist with no schema_migrations row. Drop them up front
+-- so the CREATE statements below can run cleanly. Auth flows weren't
+-- functional pre-recovery, so these tables are empty in every
+-- affected environment — nothing to preserve.
+DROP TABLE IF EXISTS trusted_devices CASCADE;
+DROP TABLE IF EXISTS login_challenges CASCADE;
 
 -- ----------------------------------------------------------------------------
 -- login_challenges

--- a/supabase/migrations/0063_auth_foundation_roles_and_invites.sql
+++ b/supabase/migrations/0063_auth_foundation_roles_and_invites.sql
@@ -174,6 +174,17 @@ CREATE TRIGGER guard_super_admin_trigger
 -- ----------------------------------------------------------------------------
 -- 5. invites table
 -- ----------------------------------------------------------------------------
+--
+-- Recovery preamble: the 0031 version-prefix collision (resolved in
+-- #371/#372/#373) blocked this migration from being recorded. On
+-- environments where an earlier `supabase db push` got far enough to
+-- create these tables before failing on a later statement, the
+-- tables now exist with no schema_migrations row. Drop them up front
+-- so the CREATE statements below can run cleanly. Invite/audit flows
+-- weren't functional pre-recovery, so these tables are empty in
+-- every affected environment — nothing to preserve.
+DROP TABLE IF EXISTS user_audit_log CASCADE;
+DROP TABLE IF EXISTS invites CASCADE;
 
 CREATE TABLE invites (
   id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## Summary

After #373's swap + recovery dispatch ([run 25244994352](https://github.com/opollo5/opollo-site-builder/actions/runs/25244994352)), `db push` applied `0031` → `0061` cleanly but failed at `0062_auth_foundation_2fa_schema.sql` with `relation "login_challenges" already exists`. The 0031 collision blocked `0032`–`0068` from being recorded in `schema_migrations`, but somewhere along the way 0062's first `CREATE TABLE` got partially applied — the table exists in prod with no tracking row.

## Changes

Recovery preamble at the top of each affected migration that drops the orphan tables before re-creating them. No-op on fresh environments.

- `0062_auth_foundation_2fa_schema.sql`: `DROP TABLE IF EXISTS trusted_devices CASCADE; DROP TABLE IF EXISTS login_challenges CASCADE;`
- `0063_auth_foundation_roles_and_invites.sql`: `DROP TABLE IF EXISTS user_audit_log CASCADE; DROP TABLE IF EXISTS invites CASCADE;`

## Risks identified and mitigated

- **Data loss in dropped tables**: auth flows weren't functional in any pre-recovery environment (the `create_invite` incident in #348/#349 traces back to this exact collision). All affected tables are empty in every environment that needs the cleanup.
- **Fresh environments**: `DROP TABLE IF EXISTS` is a no-op when the table doesn't exist. CI Supabase stack and new projects apply both migrations identically to before the preamble was added.
- **0064 functions**: already idempotent (`CREATE OR REPLACE FUNCTION`). No fix needed.
- **0065-0068 ADD COLUMN migrations**: the collision blocked execution well before these would have been reached, so no orphan state. Leaving them untouched.

## Recovery procedure (post-merge)

Single dispatch with no inputs — db push picks up where it left off:

```
gh workflow run deploy-migrations.yml --ref main
```

Schema_migrations after merge run: `0001`–`0068` applied, `0069` already marked applied (matches existing `email_log` table). Run summary's `migration list --linked` should show all entries paired Local | Remote.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [ ] After merge: dispatch with no inputs, run completes green, full chain applied.
- [ ] After merge: future PR's CI Supabase stack starts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)