### PR TITLE
feat(p1): platform foundation schema + RLS (migration 0070)

### DIFF
--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -6,7 +6,23 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 
 <!-- CLAIM BLOCKS BELOW THIS LINE — append on slice start, remove on slice merge -->
 
-## ~~Session A~~ (stale claim from 2026-04-24, M12-6 shipped — left in place; A's owner removes when they next push)
+---
+## Session A
+- Started: 2026-05-02
+- Branch: feat/platform-p1-schema
+- Slice: P1 — Platform Foundation: schema + RLS for companies, users, roles, invitations, notifications. Migration also lands the full N-Series social schema in one shot per Steven's instruction (BUILD.md scope is platform; social schema rides along, social feature code lands in S1+).
+- Files claimed:
+  - supabase/migrations/0070_platform_foundation.sql (new)
+  - supabase/rollbacks/0070_platform_foundation.down.sql (new)
+  - lib/__tests__/p1-platform-schema.test.ts (new)
+  - lib/__tests__/_setup.ts (extend TRUNCATE list with platform_*/social_* tables)
+  - docs/WORK_IN_FLIGHT.md (this claim block; removed in next PR's first commit)
+- Migration number reserved: 0070
+- Expected completion: same session; auto-merge on green CI
+- Notes: Replaces an untracked supabase/migrations/20260502000000_platform_and_social_v1.sql draft Steven had sitting in the working tree. Renumbered to 0070 to fit the sequential pattern. Recovery preamble in 0070 handles environments where the 20260502 draft was applied locally.
+---
+
+## ~~Session A (stale)~~ (stale claim from 2026-04-24, M12-6 shipped — left in place; previous owner removes when they next push)
 - Started: 2026-04-24
 - Branch: feat/m12-6-save-draft-persistence
 - Slice: M12-6 — Save-Draft persistence for briefs review; PATCH endpoint + button + re-enable fixme'd E2E test
@@ -53,6 +69,7 @@ When a session starts a migration, reserve the number here before writing the fi
 - 0017 — M12-2 brand_voice + design_direction columns on briefs. Executing on `feat/m12-2-brand-voice-site-conventions`.
 - ~~0019 — M13-1 posts schema.~~ Shipped in #142.
 - ~~0021 — M13-3 briefs.content_type column.~~ Shipped in #145.
+- 0070 — P1 Platform Foundation (platform_* + social_* schema + RLS). Executing on `feat/platform-p1-schema`.
 
 ## Claim block template
 

--- a/lib/__tests__/_setup.ts
+++ b/lib/__tests__/_setup.ts
@@ -69,6 +69,46 @@ export async function truncateAll(): Promise<void> {
   // Order matters when referential actions other than CASCADE apply. We
   // use CASCADE to sidestep FK ordering between sites / design_systems.
   // Scoped to public-schema tables only.
+  // Platform / social tables (P1, migration 0070) are TRUNCATEd here too so
+  // any test that touches them resets cleanly. They use IF EXISTS-shaped
+  // logic via DO block — `TRUNCATE` itself raises if the table is absent
+  // (e.g. on a workspace running an older migration set).
+  await pg.query(`
+    DO $$
+    DECLARE
+      tbl text;
+      tbls text[] := ARRAY[
+        'social_webhook_events',
+        'social_publish_attempts',
+        'social_publish_jobs',
+        'social_schedule_entries',
+        'social_viewer_links',
+        'social_approval_events',
+        'social_approval_recipients',
+        'social_approval_requests',
+        'social_media_assets',
+        'social_post_variant',
+        'social_post_master',
+        'social_connection_alerts',
+        'social_connections',
+        'platform_notifications',
+        'platform_invitations',
+        'platform_company_users',
+        'platform_users',
+        'platform_companies'
+      ];
+    BEGIN
+      FOREACH tbl IN ARRAY tbls LOOP
+        IF EXISTS (
+          SELECT 1 FROM pg_tables
+          WHERE schemaname = 'public' AND tablename = tbl
+        ) THEN
+          EXECUTE format('TRUNCATE TABLE %I RESTART IDENTITY CASCADE', tbl);
+        END IF;
+      END LOOP;
+    END $$;
+  `);
+
   await pg.query(`
     TRUNCATE TABLE
       tenant_cost_budgets,

--- a/lib/__tests__/p1-platform-schema.test.ts
+++ b/lib/__tests__/p1-platform-schema.test.ts
@@ -1,0 +1,635 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import { seedAuthUser, signInAs, type SeededAuthUser } from "./_auth-helpers";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// 0070 — Platform Foundation: schema + RLS + helpers + seed.
+//
+// What this file proves:
+//   1. The migration's seed inserts the Opollo internal company at the fixed
+//      UUID 00000000-0000-0000-0000-000000000001.
+//   2. Schema-layer invariants the app cannot bypass:
+//        - UNIQUE (user_id) on platform_company_users (one user, one company).
+//        - is_opollo_internal singleton index (one Opollo internal company).
+//        - Pending-invitation uniqueness per (company_id, email).
+//   3. Auth helper functions return correct values per signed-in role:
+//        is_opollo_staff(), is_company_member(uuid),
+//        has_company_role(uuid, role), current_user_company().
+//   4. RLS isolates company A's data from company B's reader/writer, and
+//      Opollo staff override sees both.
+//
+// Social-table RLS gets a smoke isolation case here; the full role × table
+// matrix lands with the social feature code in S1+.
+// ---------------------------------------------------------------------------
+
+const OPOLLO_INTERNAL_ID = "00000000-0000-0000-0000-000000000001";
+const COMPANY_A_ID = "11111111-1111-1111-1111-111111111111";
+const COMPANY_B_ID = "22222222-2222-2222-2222-222222222222";
+
+function buildClient(accessToken: string): SupabaseClient {
+  const url = process.env.SUPABASE_URL!;
+  const anonKey = process.env.SUPABASE_ANON_KEY!;
+  return createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+}
+
+describe("0070 — platform foundation: schema, RLS, helpers, seed", () => {
+  let opolloStaff: SeededAuthUser;
+  let aAdmin: SeededAuthUser;
+  let aApprover: SeededAuthUser;
+  let aEditor: SeededAuthUser;
+  let aViewer: SeededAuthUser;
+  let bAdmin: SeededAuthUser;
+
+  let opolloClient: SupabaseClient;
+  let aAdminClient: SupabaseClient;
+  let aApproverClient: SupabaseClient;
+  let aEditorClient: SupabaseClient;
+  let aViewerClient: SupabaseClient;
+  let bAdminClient: SupabaseClient;
+
+  beforeAll(async () => {
+    // Persistent auth users — survive _setup.ts cleanupTrackedAuthUsers()
+    // calls so the JWTs minted here stay valid across the file. afterAll
+    // sweeps them.
+    opolloStaff = await seedAuthUser({
+      email: "p1-opollo@opollo.test",
+      persistent: true,
+    });
+    aAdmin = await seedAuthUser({
+      email: "p1-a-admin@opollo.test",
+      persistent: true,
+    });
+    aApprover = await seedAuthUser({
+      email: "p1-a-approver@opollo.test",
+      persistent: true,
+    });
+    aEditor = await seedAuthUser({
+      email: "p1-a-editor@opollo.test",
+      persistent: true,
+    });
+    aViewer = await seedAuthUser({
+      email: "p1-a-viewer@opollo.test",
+      persistent: true,
+    });
+    bAdmin = await seedAuthUser({
+      email: "p1-b-admin@opollo.test",
+      persistent: true,
+    });
+
+    opolloClient = buildClient(await signInAs(opolloStaff));
+    aAdminClient = buildClient(await signInAs(aAdmin));
+    aApproverClient = buildClient(await signInAs(aApprover));
+    aEditorClient = buildClient(await signInAs(aEditor));
+    aViewerClient = buildClient(await signInAs(aViewer));
+    bAdminClient = buildClient(await signInAs(bAdmin));
+  });
+
+  beforeEach(async () => {
+    // _setup.ts TRUNCATEd platform_* / social_* tables. Re-seed the world.
+    const svc = getServiceRoleClient();
+
+    await svc.from("platform_companies").insert([
+      {
+        id: OPOLLO_INTERNAL_ID,
+        name: "Opollo",
+        slug: "opollo",
+        is_opollo_internal: true,
+        timezone: "Australia/Melbourne",
+      },
+      {
+        id: COMPANY_A_ID,
+        name: "Acme Co",
+        slug: "acme",
+        domain: "acme.test",
+        timezone: "Australia/Melbourne",
+      },
+      {
+        id: COMPANY_B_ID,
+        name: "Beta Inc",
+        slug: "beta",
+        domain: "beta.test",
+        timezone: "Australia/Melbourne",
+      },
+    ]);
+
+    await svc.from("platform_users").insert([
+      {
+        id: opolloStaff.id,
+        email: opolloStaff.email,
+        full_name: "Opollo Staff",
+        is_opollo_staff: true,
+      },
+      { id: aAdmin.id, email: aAdmin.email, full_name: "A Admin" },
+      { id: aApprover.id, email: aApprover.email, full_name: "A Approver" },
+      { id: aEditor.id, email: aEditor.email, full_name: "A Editor" },
+      { id: aViewer.id, email: aViewer.email, full_name: "A Viewer" },
+      { id: bAdmin.id, email: bAdmin.email, full_name: "B Admin" },
+    ]);
+
+    await svc.from("platform_company_users").insert([
+      {
+        company_id: OPOLLO_INTERNAL_ID,
+        user_id: opolloStaff.id,
+        role: "admin",
+      },
+      { company_id: COMPANY_A_ID, user_id: aAdmin.id, role: "admin" },
+      { company_id: COMPANY_A_ID, user_id: aApprover.id, role: "approver" },
+      { company_id: COMPANY_A_ID, user_id: aEditor.id, role: "editor" },
+      { company_id: COMPANY_A_ID, user_id: aViewer.id, role: "viewer" },
+      { company_id: COMPANY_B_ID, user_id: bAdmin.id, role: "admin" },
+    ]);
+  });
+
+  afterAll(async () => {
+    // Persistent auth users were skipped by _setup.ts cleanup; sweep them
+    // here so they don't leak into auth.users across test runs.
+    const supabase = getServiceRoleClient();
+    for (const u of [opolloStaff, aAdmin, aApprover, aEditor, aViewer, bAdmin]) {
+      if (!u) continue;
+      await supabase.auth.admin.deleteUser(u.id);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Seed assertions
+  // -------------------------------------------------------------------------
+
+  describe("seed", () => {
+    it("migration file inserts the Opollo internal company at the fixed UUID", () => {
+      const sqlPath = path.resolve(
+        process.cwd(),
+        "supabase/migrations/0070_platform_foundation.sql",
+      );
+      const sql = readFileSync(sqlPath, "utf8");
+      expect(sql).toContain("00000000-0000-0000-0000-000000000001");
+      expect(sql).toMatch(
+        /INSERT INTO platform_companies[\s\S]+?'00000000-0000-0000-0000-000000000001'/,
+      );
+      expect(sql).toMatch(/ON CONFLICT \(id\) DO NOTHING/);
+    });
+
+    it("seeded internal company is readable with the documented attributes", async () => {
+      const svc = getServiceRoleClient();
+      const { data, error } = await svc
+        .from("platform_companies")
+        .select("id, name, slug, is_opollo_internal, timezone")
+        .eq("id", OPOLLO_INTERNAL_ID)
+        .single();
+      expect(error).toBeNull();
+      expect(data).toEqual({
+        id: OPOLLO_INTERNAL_ID,
+        name: "Opollo",
+        slug: "opollo",
+        is_opollo_internal: true,
+        timezone: "Australia/Melbourne",
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Schema-layer constraints
+  // -------------------------------------------------------------------------
+
+  describe("constraints", () => {
+    it("UNIQUE (user_id) blocks one user belonging to two companies", async () => {
+      const svc = getServiceRoleClient();
+      const { error } = await svc.from("platform_company_users").insert({
+        company_id: COMPANY_B_ID,
+        user_id: aAdmin.id,
+        role: "admin",
+      });
+      expect(error?.code).toBe("23505");
+    });
+
+    it("singleton index blocks a second is_opollo_internal=true row", async () => {
+      const svc = getServiceRoleClient();
+      const { error } = await svc.from("platform_companies").insert({
+        name: "Fake Internal",
+        slug: "fake-internal",
+        is_opollo_internal: true,
+      });
+      expect(error?.code).toBe("23505");
+    });
+
+    it("pending-invite uniqueness blocks duplicate sends to same email/company", async () => {
+      const svc = getServiceRoleClient();
+      const expires = new Date(Date.now() + 14 * 86_400_000).toISOString();
+      const first = await svc.from("platform_invitations").insert({
+        company_id: COMPANY_A_ID,
+        email: "newhire@acme.test",
+        role: "editor",
+        token_hash: `hash-first-${Date.now()}`,
+        expires_at: expires,
+      });
+      expect(first.error).toBeNull();
+
+      const second = await svc.from("platform_invitations").insert({
+        company_id: COMPANY_A_ID,
+        email: "newhire@acme.test",
+        role: "editor",
+        token_hash: `hash-second-${Date.now()}`,
+        expires_at: expires,
+      });
+      expect(second.error?.code).toBe("23505");
+    });
+
+    it("expired/accepted/revoked invites do NOT block re-invitation", async () => {
+      const svc = getServiceRoleClient();
+      const expires = new Date(Date.now() + 14 * 86_400_000).toISOString();
+      const first = await svc.from("platform_invitations").insert({
+        company_id: COMPANY_A_ID,
+        email: "rehire@acme.test",
+        role: "editor",
+        token_hash: `hash-rehire-1-${Date.now()}`,
+        expires_at: expires,
+        status: "expired",
+      });
+      expect(first.error).toBeNull();
+
+      const second = await svc.from("platform_invitations").insert({
+        company_id: COMPANY_A_ID,
+        email: "rehire@acme.test",
+        role: "editor",
+        token_hash: `hash-rehire-2-${Date.now()}`,
+        expires_at: expires,
+      });
+      expect(second.error).toBeNull();
+    });
+
+    it("auth.users delete cascades to platform_users", async () => {
+      const supabase = getServiceRoleClient();
+      const throwaway = await seedAuthUser({
+        email: `p1-cascade-${Date.now()}@opollo.test`,
+      });
+      await supabase
+        .from("platform_users")
+        .insert({ id: throwaway.id, email: throwaway.email });
+
+      await supabase.auth.admin.deleteUser(throwaway.id);
+
+      const { data } = await supabase
+        .from("platform_users")
+        .select("id")
+        .eq("id", throwaway.id);
+      expect(data).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SQL helper functions
+  // -------------------------------------------------------------------------
+
+  describe("SQL helpers", () => {
+    it("is_opollo_staff() = true for staff", async () => {
+      const { data, error } = await opolloClient.rpc("is_opollo_staff");
+      expect(error).toBeNull();
+      expect(data).toBe(true);
+    });
+
+    it("is_opollo_staff() = false for customer admin", async () => {
+      const { data, error } = await aAdminClient.rpc("is_opollo_staff");
+      expect(error).toBeNull();
+      expect(data).toBe(false);
+    });
+
+    it("is_company_member() = true for own company, false for other", async () => {
+      const own = await aAdminClient.rpc("is_company_member", {
+        company: COMPANY_A_ID,
+      });
+      expect(own.error).toBeNull();
+      expect(own.data).toBe(true);
+
+      const other = await aAdminClient.rpc("is_company_member", {
+        company: COMPANY_B_ID,
+      });
+      expect(other.error).toBeNull();
+      expect(other.data).toBe(false);
+    });
+
+    it("has_company_role: admin satisfies every minimum", async () => {
+      for (const role of ["admin", "approver", "editor", "viewer"] as const) {
+        const { data, error } = await aAdminClient.rpc("has_company_role", {
+          company: COMPANY_A_ID,
+          min_role: role,
+        });
+        expect(error).toBeNull();
+        expect(data).toBe(true);
+      }
+    });
+
+    it("has_company_role: editor satisfies editor+viewer, not admin/approver", async () => {
+      const cases: Array<[string, boolean]> = [
+        ["admin", false],
+        ["approver", false],
+        ["editor", true],
+        ["viewer", true],
+      ];
+      for (const [role, expected] of cases) {
+        const { data } = await aEditorClient.rpc("has_company_role", {
+          company: COMPANY_A_ID,
+          min_role: role,
+        });
+        expect(data).toBe(expected);
+      }
+    });
+
+    it("has_company_role: returns false when user is not a company member", async () => {
+      const { data } = await bAdminClient.rpc("has_company_role", {
+        company: COMPANY_A_ID,
+        min_role: "viewer",
+      });
+      expect(data).toBe(false);
+    });
+
+    it("current_user_company() returns the user's company", async () => {
+      const { data, error } = await aAdminClient.rpc("current_user_company");
+      expect(error).toBeNull();
+      expect(data).toBe(COMPANY_A_ID);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // RLS — platform_companies
+  // -------------------------------------------------------------------------
+
+  describe("RLS — platform_companies", () => {
+    it("company A admin reads own company", async () => {
+      const { data } = await aAdminClient
+        .from("platform_companies")
+        .select("id")
+        .eq("id", COMPANY_A_ID);
+      expect(data).toEqual([{ id: COMPANY_A_ID }]);
+    });
+
+    it("company A admin filtered when reading company B", async () => {
+      const { data, error } = await aAdminClient
+        .from("platform_companies")
+        .select("id")
+        .eq("id", COMPANY_B_ID);
+      expect(error).toBeNull();
+      expect(data).toEqual([]);
+    });
+
+    it("Opollo staff reads every company", async () => {
+      const { data } = await opolloClient
+        .from("platform_companies")
+        .select("id")
+        .in("id", [OPOLLO_INTERNAL_ID, COMPANY_A_ID, COMPANY_B_ID]);
+      expect(data).toHaveLength(3);
+    });
+
+    it("company A admin denied INSERT (write reserved for Opollo staff)", async () => {
+      const { error } = await aAdminClient
+        .from("platform_companies")
+        .insert({ name: "Hostile", slug: "hostile" })
+        .select();
+      expect(error?.code).toBe("42501");
+    });
+
+    it("Opollo staff allowed INSERT", async () => {
+      const { data, error } = await opolloClient
+        .from("platform_companies")
+        .insert({ name: "Charlie Co", slug: "charlie" })
+        .select("id, name");
+      expect(error).toBeNull();
+      expect(data).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // RLS — platform_company_users
+  // -------------------------------------------------------------------------
+
+  describe("RLS — platform_company_users", () => {
+    it("company A members can read own company's memberships", async () => {
+      const { data } = await aEditorClient
+        .from("platform_company_users")
+        .select("user_id")
+        .eq("company_id", COMPANY_A_ID);
+      expect(data?.length).toBe(4);
+    });
+
+    it("company A admin filtered when reading company B's memberships", async () => {
+      const { data } = await aAdminClient
+        .from("platform_company_users")
+        .select("user_id")
+        .eq("company_id", COMPANY_B_ID);
+      expect(data).toEqual([]);
+    });
+
+    it("company A editor denied UPDATE (admin-only write)", async () => {
+      const { data, error } = await aEditorClient
+        .from("platform_company_users")
+        .update({ role: "approver" })
+        .eq("user_id", aViewer.id)
+        .select();
+      // RLS USING fails → zero rows match → empty data, no error.
+      expect(error).toBeNull();
+      expect(data).toEqual([]);
+    });
+
+    it("company A admin can UPDATE a member's role within own company", async () => {
+      const { data, error } = await aAdminClient
+        .from("platform_company_users")
+        .update({ role: "approver" })
+        .eq("user_id", aEditor.id)
+        .select("user_id, role");
+      expect(error).toBeNull();
+      expect(data).toEqual([{ user_id: aEditor.id, role: "approver" }]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // RLS — platform_invitations
+  // -------------------------------------------------------------------------
+
+  describe("RLS — platform_invitations", () => {
+    it("company A admin can INSERT invitation for own company", async () => {
+      const { data, error } = await aAdminClient
+        .from("platform_invitations")
+        .insert({
+          company_id: COMPANY_A_ID,
+          email: "newperson@acme.test",
+          role: "editor",
+          token_hash: `hash-rls-${Date.now()}`,
+          expires_at: new Date(Date.now() + 14 * 86_400_000).toISOString(),
+          invited_by: aAdmin.id,
+        })
+        .select("id");
+      expect(error).toBeNull();
+      expect(data).toHaveLength(1);
+    });
+
+    it("company A editor denied INSERT (admin-only)", async () => {
+      const { error } = await aEditorClient
+        .from("platform_invitations")
+        .insert({
+          company_id: COMPANY_A_ID,
+          email: "denied@acme.test",
+          role: "editor",
+          token_hash: `hash-deny-${Date.now()}`,
+          expires_at: new Date(Date.now() + 14 * 86_400_000).toISOString(),
+        })
+        .select();
+      expect(error?.code).toBe("42501");
+    });
+
+    it("company A admin filtered when listing company B's invitations", async () => {
+      const svc = getServiceRoleClient();
+      await svc.from("platform_invitations").insert({
+        company_id: COMPANY_B_ID,
+        email: "secret@beta.test",
+        role: "viewer",
+        token_hash: `hash-secret-${Date.now()}`,
+        expires_at: new Date(Date.now() + 14 * 86_400_000).toISOString(),
+      });
+
+      const { data } = await aAdminClient
+        .from("platform_invitations")
+        .select("email")
+        .eq("company_id", COMPANY_B_ID);
+      expect(data).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // RLS — platform_notifications
+  // -------------------------------------------------------------------------
+
+  describe("RLS — platform_notifications", () => {
+    it("user reads own notifications, filtered from peers", async () => {
+      const svc = getServiceRoleClient();
+      await svc.from("platform_notifications").insert([
+        {
+          user_id: aEditor.id,
+          company_id: COMPANY_A_ID,
+          type: "approval_requested",
+          title: "Editor's notification",
+        },
+        {
+          user_id: aAdmin.id,
+          company_id: COMPANY_A_ID,
+          type: "approval_requested",
+          title: "Admin's notification",
+        },
+      ]);
+
+      const { data: ownData } = await aEditorClient
+        .from("platform_notifications")
+        .select("title");
+      expect(ownData?.map((r) => r.title)).toEqual(["Editor's notification"]);
+    });
+
+    it("user can mark own notification read", async () => {
+      const svc = getServiceRoleClient();
+      const { data: inserted } = await svc
+        .from("platform_notifications")
+        .insert({
+          user_id: aEditor.id,
+          company_id: COMPANY_A_ID,
+          type: "post_published",
+          title: "Mark me read",
+        })
+        .select("id")
+        .single();
+
+      const { data, error } = await aEditorClient
+        .from("platform_notifications")
+        .update({ read_at: new Date().toISOString() })
+        .eq("id", inserted!.id)
+        .select("id, read_at");
+      expect(error).toBeNull();
+      expect(data).toHaveLength(1);
+      expect(data![0]?.read_at).not.toBeNull();
+    });
+
+    it("user filtered when updating someone else's notification", async () => {
+      const svc = getServiceRoleClient();
+      const { data: inserted } = await svc
+        .from("platform_notifications")
+        .insert({
+          user_id: aAdmin.id,
+          company_id: COMPANY_A_ID,
+          type: "post_failed",
+          title: "Not for editor",
+        })
+        .select("id")
+        .single();
+
+      const { data, error } = await aEditorClient
+        .from("platform_notifications")
+        .update({ read_at: new Date().toISOString() })
+        .eq("id", inserted!.id)
+        .select();
+      expect(error).toBeNull();
+      expect(data).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // RLS — social table smoke (full matrix lives with feature code in S1+)
+  // -------------------------------------------------------------------------
+
+  describe("social tables — RLS smoke (full matrix lands with feature code in S1+)", () => {
+    it("company A admin filtered from company B's posts", async () => {
+      const svc = getServiceRoleClient();
+      const { data: bPost } = await svc
+        .from("social_post_master")
+        .insert({
+          company_id: COMPANY_B_ID,
+          state: "draft",
+          source_type: "manual",
+          master_text: "Beta secret post",
+        })
+        .select("id")
+        .single();
+
+      const { data, error } = await aAdminClient
+        .from("social_post_master")
+        .select("id")
+        .eq("id", bPost!.id);
+      expect(error).toBeNull();
+      expect(data).toEqual([]);
+    });
+
+    it("Opollo staff sees posts from every company", async () => {
+      const svc = getServiceRoleClient();
+      await svc.from("social_post_master").insert([
+        {
+          company_id: COMPANY_A_ID,
+          state: "draft",
+          source_type: "manual",
+          master_text: "A post",
+        },
+        {
+          company_id: COMPANY_B_ID,
+          state: "draft",
+          source_type: "manual",
+          master_text: "B post",
+        },
+      ]);
+
+      const { data } = await opolloClient
+        .from("social_post_master")
+        .select("company_id")
+        .in("company_id", [COMPANY_A_ID, COMPANY_B_ID]);
+      const companies = new Set((data ?? []).map((r) => r.company_id));
+      expect(companies).toEqual(new Set([COMPANY_A_ID, COMPANY_B_ID]));
+    });
+  });
+});

--- a/supabase/migrations/0070_platform_foundation.sql
+++ b/supabase/migrations/0070_platform_foundation.sql
@@ -1,0 +1,794 @@
+-- =============================================================================
+-- 0070 — Opollo Site Builder Platform Layer + N-Series Social Module schema.
+-- Reference: P1 Platform Foundation (BUILD.md). Parent plan in PR description.
+-- =============================================================================
+-- Creates:
+--   1. Platform layer (companies, users, roles, invitations, notifications)
+--   2. N-Series social module schema (full table set; feature code lands in S1+)
+--
+-- Layer ownership (see .claude/skills/n-series-layer-rules):
+--   P  Platform:    platform_companies, platform_users, platform_company_users,
+--                   platform_invitations, platform_notifications
+--   L1 Editorial:   social_post_master, social_post_variant, social_media_assets
+--   L2 Approval:    social_approval_requests, social_approval_recipients,
+--                   social_approval_events, social_viewer_links
+--   L3 Scheduling:  social_schedule_entries, social_publish_jobs
+--   L4 Publishing:  social_publish_attempts
+--   L5 Connections: social_connections, social_connection_alerts
+--   L6 Reliability: social_webhook_events
+--
+-- Write-safety hotspots addressed:
+--   - Singleton index `idx_companies_one_internal` enforces exactly one
+--     is_opollo_internal=true row at the schema layer (app can't accidentally
+--     create a second "Opollo Internal" company on a race).
+--   - UNIQUE (user_id) on platform_company_users encodes the V1 "one user
+--     belongs to exactly one company" rule at the schema layer.
+--   - UNIQUE partial index `idx_invitations_unique_pending` prevents two
+--     concurrent invitations to the same email for the same company.
+--   - UNIQUE (post_master_id, platform) on social_post_variant prevents
+--     duplicate variant rows per platform per post.
+--   - UNIQUE (event_id) on social_webhook_events is the bundle.social
+--     idempotency anchor — ON CONFLICT becomes the dedup mechanism.
+--   - UNIQUE (bundle_social_account_id) on social_connections prevents
+--     reconnect flows from inserting a second row for the same identity.
+--
+-- Recovery preamble: an earlier draft of this file lived at
+--   supabase/migrations/20260502000000_platform_and_social_v1.sql
+-- That file was never committed. If a local environment ran `supabase db push`
+-- while the draft was in the migrations folder, the objects below already
+-- exist without a schema_migrations row matching this 0070 version. Drop them
+-- up front so the CREATEs run cleanly. No production environment is affected.
+-- Drops are ordered child-first; CASCADE handles dependents.
+DROP TABLE IF EXISTS social_webhook_events CASCADE;
+DROP TABLE IF EXISTS social_publish_attempts CASCADE;
+DROP TABLE IF EXISTS social_publish_jobs CASCADE;
+DROP TABLE IF EXISTS social_schedule_entries CASCADE;
+DROP TABLE IF EXISTS social_viewer_links CASCADE;
+DROP TABLE IF EXISTS social_approval_events CASCADE;
+DROP TABLE IF EXISTS social_approval_recipients CASCADE;
+DROP TABLE IF EXISTS social_approval_requests CASCADE;
+DROP TABLE IF EXISTS social_media_assets CASCADE;
+DROP TABLE IF EXISTS social_post_variant CASCADE;
+DROP TABLE IF EXISTS social_post_master CASCADE;
+DROP TABLE IF EXISTS social_connection_alerts CASCADE;
+DROP TABLE IF EXISTS social_connections CASCADE;
+DROP TABLE IF EXISTS platform_notifications CASCADE;
+DROP TABLE IF EXISTS platform_invitations CASCADE;
+DROP TABLE IF EXISTS platform_company_users CASCADE;
+DROP TABLE IF EXISTS platform_users CASCADE;
+DROP TABLE IF EXISTS platform_companies CASCADE;
+DROP FUNCTION IF EXISTS is_opollo_staff() CASCADE;
+DROP FUNCTION IF EXISTS is_company_member(UUID) CASCADE;
+DROP FUNCTION IF EXISTS current_user_company() CASCADE;
+DROP FUNCTION IF EXISTS track_post_state_change() CASCADE;
+-- has_company_role / type-dependent functions drop with their type via CASCADE.
+DROP TYPE IF EXISTS platform_company_role CASCADE;
+DROP TYPE IF EXISTS platform_invitation_status CASCADE;
+DROP TYPE IF EXISTS platform_notification_type CASCADE;
+DROP TYPE IF EXISTS social_platform CASCADE;
+DROP TYPE IF EXISTS social_post_state CASCADE;
+DROP TYPE IF EXISTS social_post_source CASCADE;
+DROP TYPE IF EXISTS social_connection_status CASCADE;
+DROP TYPE IF EXISTS social_approval_rule CASCADE;
+DROP TYPE IF EXISTS social_approval_event_type CASCADE;
+DROP TYPE IF EXISTS social_attempt_status CASCADE;
+DROP TYPE IF EXISTS social_error_class CASCADE;
+DROP TYPE IF EXISTS social_alert_severity CASCADE;
+-- set_updated_at() trigger function: not dropped here. CREATE OR REPLACE
+-- below handles both fresh apply and re-apply paths cleanly.
+-- =============================================================================
+
+-- =============================================================================
+-- ENUMS
+-- =============================================================================
+
+-- Platform role enum
+CREATE TYPE platform_company_role AS ENUM (
+  'admin',     -- manages company + users + connections
+  'approver',  -- approves content
+  'editor',    -- drafts content
+  'viewer'     -- read-only
+);
+
+CREATE TYPE platform_invitation_status AS ENUM (
+  'pending',
+  'accepted',
+  'expired',
+  'revoked'
+);
+
+CREATE TYPE platform_notification_type AS ENUM (
+  'invitation_sent',
+  'invitation_reminder',
+  'invitation_expired',
+  'invitation_accepted',
+  'approval_requested',
+  'approval_decided',
+  'connection_lost',
+  'connection_restored',
+  'post_published',
+  'post_failed',
+  'changes_requested'
+);
+
+-- Social enums
+CREATE TYPE social_platform AS ENUM (
+  'linkedin_personal',
+  'linkedin_company',
+  'facebook_page',
+  'x',
+  'gbp'
+);
+
+CREATE TYPE social_post_state AS ENUM (
+  'draft',
+  'pending_client_approval',
+  'approved',
+  'rejected',
+  'changes_requested',
+  'pending_msp_release',
+  'scheduled',
+  'publishing',
+  'published',
+  'failed'
+);
+
+CREATE TYPE social_post_source AS ENUM (
+  'manual',
+  'csv',
+  'cap',
+  'api'
+);
+
+CREATE TYPE social_connection_status AS ENUM (
+  'healthy',
+  'degraded',
+  'auth_required',
+  'disconnected'
+);
+
+CREATE TYPE social_approval_rule AS ENUM (
+  'any_one',
+  'all_must'
+);
+
+CREATE TYPE social_approval_event_type AS ENUM (
+  'submitted',
+  'viewed',
+  'identity_bound',
+  'comment_added',
+  'approved',
+  'rejected',
+  'changes_requested',
+  'expired',
+  'revoked'
+);
+
+CREATE TYPE social_attempt_status AS ENUM (
+  'pending',
+  'in_flight',
+  'unknown',
+  'succeeded',
+  'failed',
+  'reconciling'
+);
+
+CREATE TYPE social_error_class AS ENUM (
+  'network',
+  'rate_limit',
+  'platform_error',
+  'auth',
+  'content_rejected',
+  'media_invalid',
+  'unknown'
+);
+
+CREATE TYPE social_alert_severity AS ENUM (
+  'info',
+  'warning',
+  'critical'
+);
+
+-- =============================================================================
+-- P — PLATFORM LAYER
+-- =============================================================================
+
+CREATE TABLE platform_companies (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  domain TEXT, -- customer's brand domain, e.g. 'skyview.com'
+  timezone TEXT NOT NULL DEFAULT 'Australia/Melbourne',
+  is_opollo_internal BOOLEAN NOT NULL DEFAULT false, -- true for the Opollo internal company
+  approval_default_required BOOLEAN NOT NULL DEFAULT true,
+  approval_default_rule social_approval_rule NOT NULL DEFAULT 'any_one',
+  concurrent_publish_limit INTEGER NOT NULL DEFAULT 5,
+  settings JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_companies_domain ON platform_companies(domain) WHERE domain IS NOT NULL;
+CREATE UNIQUE INDEX idx_companies_one_internal ON platform_companies((1)) WHERE is_opollo_internal = true;
+
+CREATE TABLE platform_users (
+  -- Profile data extending auth.users. Created on invitation acceptance.
+  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email TEXT NOT NULL UNIQUE,
+  full_name TEXT,
+  avatar_url TEXT,
+  is_opollo_staff BOOLEAN NOT NULL DEFAULT false,
+  last_active_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_users_opollo_staff ON platform_users(is_opollo_staff) WHERE is_opollo_staff = true;
+
+CREATE TABLE platform_company_users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES platform_users(id) ON DELETE CASCADE,
+  role platform_company_role NOT NULL,
+  added_by UUID REFERENCES platform_users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- V1 constraint: one user belongs to exactly one company
+  UNIQUE (user_id),
+  UNIQUE (company_id, user_id)
+);
+CREATE INDEX idx_company_users_company ON platform_company_users(company_id);
+CREATE INDEX idx_company_users_user ON platform_company_users(user_id);
+CREATE INDEX idx_company_users_role ON platform_company_users(company_id, role);
+
+CREATE TABLE platform_invitations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  role platform_company_role NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  status platform_invitation_status NOT NULL DEFAULT 'pending',
+  expires_at TIMESTAMPTZ NOT NULL,
+  invited_by UUID REFERENCES platform_users(id) ON DELETE SET NULL,
+  accepted_at TIMESTAMPTZ,
+  accepted_user_id UUID REFERENCES platform_users(id) ON DELETE SET NULL,
+  revoked_at TIMESTAMPTZ,
+  reminder_sent_at TIMESTAMPTZ,
+  expired_notified_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_invitations_company ON platform_invitations(company_id);
+CREATE INDEX idx_invitations_email ON platform_invitations(email);
+CREATE INDEX idx_invitations_pending ON platform_invitations(status) WHERE status = 'pending';
+-- Prevent duplicate active invitations to the same email for the same company
+CREATE UNIQUE INDEX idx_invitations_unique_pending
+  ON platform_invitations(company_id, email)
+  WHERE status = 'pending';
+
+CREATE TABLE platform_notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES platform_users(id) ON DELETE CASCADE,
+  company_id UUID REFERENCES platform_companies(id) ON DELETE CASCADE,
+  type platform_notification_type NOT NULL,
+  title TEXT NOT NULL,
+  body TEXT,
+  action_url TEXT,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  read_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_notifications_user_unread ON platform_notifications(user_id, created_at DESC)
+  WHERE read_at IS NULL;
+CREATE INDEX idx_notifications_user_all ON platform_notifications(user_id, created_at DESC);
+
+-- =============================================================================
+-- PLATFORM AUTH HELPERS
+-- =============================================================================
+
+-- Is the current user Opollo staff?
+CREATE OR REPLACE FUNCTION is_opollo_staff()
+RETURNS BOOLEAN AS $$
+  SELECT COALESCE(
+    (SELECT is_opollo_staff FROM platform_users WHERE id = auth.uid()),
+    false
+  );
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+-- Is the current user a member of this company?
+CREATE OR REPLACE FUNCTION is_company_member(company UUID)
+RETURNS BOOLEAN AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM platform_company_users
+    WHERE company_id = company
+      AND user_id = auth.uid()
+  );
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+-- Does the current user have at least this role in this company?
+CREATE OR REPLACE FUNCTION has_company_role(company UUID, min_role platform_company_role)
+RETURNS BOOLEAN AS $$
+DECLARE
+  user_role platform_company_role;
+  role_rank INT;
+  min_rank INT;
+BEGIN
+  SELECT role INTO user_role
+  FROM platform_company_users
+  WHERE company_id = company AND user_id = auth.uid();
+
+  IF user_role IS NULL THEN
+    RETURN false;
+  END IF;
+
+  -- Role hierarchy: admin > approver > editor > viewer
+  role_rank := CASE user_role
+    WHEN 'admin' THEN 4
+    WHEN 'approver' THEN 3
+    WHEN 'editor' THEN 2
+    WHEN 'viewer' THEN 1
+  END;
+
+  min_rank := CASE min_role
+    WHEN 'admin' THEN 4
+    WHEN 'approver' THEN 3
+    WHEN 'editor' THEN 2
+    WHEN 'viewer' THEN 1
+  END;
+
+  RETURN role_rank >= min_rank;
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;
+
+-- Get the current user's company (V1: one company per user)
+CREATE OR REPLACE FUNCTION current_user_company()
+RETURNS UUID AS $$
+  SELECT company_id FROM platform_company_users WHERE user_id = auth.uid() LIMIT 1;
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+-- =============================================================================
+-- L5 — CONNECTIONS (defined before L1 social tables for FK reference)
+-- =============================================================================
+
+CREATE TABLE social_connections (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  platform social_platform NOT NULL,
+  bundle_social_account_id TEXT NOT NULL UNIQUE,
+  display_name TEXT,
+  avatar_url TEXT,
+  status social_connection_status NOT NULL DEFAULT 'healthy',
+  last_error TEXT,
+  connected_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  disconnected_at TIMESTAMPTZ,
+  last_health_check_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_connections_company ON social_connections(company_id);
+CREATE INDEX idx_connections_status ON social_connections(status);
+
+CREATE TABLE social_connection_alerts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  connection_id UUID NOT NULL REFERENCES social_connections(id) ON DELETE CASCADE,
+  company_id UUID NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  severity social_alert_severity NOT NULL,
+  message TEXT NOT NULL,
+  detected_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  acknowledged_at TIMESTAMPTZ,
+  acknowledged_by UUID REFERENCES platform_users(id) ON DELETE SET NULL,
+  resolved_at TIMESTAMPTZ
+);
+CREATE INDEX idx_connection_alerts_unresolved ON social_connection_alerts(company_id) WHERE resolved_at IS NULL;
+
+-- =============================================================================
+-- L1 — EDITORIAL
+-- =============================================================================
+
+CREATE TABLE social_post_master (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  state social_post_state NOT NULL DEFAULT 'draft',
+  source_type social_post_source NOT NULL DEFAULT 'manual',
+  master_text TEXT,
+  link_url TEXT,
+  created_by UUID REFERENCES platform_users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  state_changed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_post_master_company_state ON social_post_master(company_id, state);
+CREATE INDEX idx_post_master_state_changed ON social_post_master(state_changed_at);
+
+CREATE TABLE social_post_variant (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_master_id UUID NOT NULL REFERENCES social_post_master(id) ON DELETE CASCADE,
+  platform social_platform NOT NULL,
+  connection_id UUID REFERENCES social_connections(id) ON DELETE SET NULL,
+  variant_text TEXT,
+  is_custom BOOLEAN NOT NULL DEFAULT false,
+  scheduled_at TIMESTAMPTZ,
+  media_asset_ids UUID[] DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (post_master_id, platform)
+);
+CREATE INDEX idx_post_variant_master ON social_post_variant(post_master_id);
+CREATE INDEX idx_post_variant_scheduled ON social_post_variant(scheduled_at) WHERE scheduled_at IS NOT NULL;
+
+CREATE TABLE social_media_assets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  storage_path TEXT NOT NULL,
+  mime_type TEXT NOT NULL,
+  bytes BIGINT NOT NULL,
+  width INTEGER,
+  height INTEGER,
+  duration_seconds NUMERIC,
+  derived_versions JSONB DEFAULT '{}'::jsonb,
+  uploaded_by UUID REFERENCES platform_users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_media_company ON social_media_assets(company_id);
+
+-- =============================================================================
+-- L2 — APPROVAL
+-- =============================================================================
+
+CREATE TABLE social_approval_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_master_id UUID NOT NULL REFERENCES social_post_master(id) ON DELETE CASCADE,
+  company_id UUID NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  approval_rule social_approval_rule NOT NULL,
+  snapshot_payload JSONB NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  revoked_at TIMESTAMPTZ,
+  -- Denormalised audit fields
+  final_approved_by_user_id UUID REFERENCES platform_users(id) ON DELETE SET NULL, -- if reviewer is platform user
+  final_approved_by_email TEXT, -- always populated (works for platform users + magic-link external)
+  final_approved_by_name TEXT,
+  final_approved_at TIMESTAMPTZ,
+  final_rejected_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_approval_requests_post ON social_approval_requests(post_master_id);
+CREATE INDEX idx_approval_requests_company ON social_approval_requests(company_id);
+
+CREATE TABLE social_approval_recipients (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  approval_request_id UUID NOT NULL REFERENCES social_approval_requests(id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  name TEXT,
+  -- If recipient is a platform user, link them. Otherwise null (one-off external).
+  platform_user_id UUID REFERENCES platform_users(id) ON DELETE SET NULL,
+  token_hash TEXT NOT NULL,
+  requires_otp BOOLEAN NOT NULL DEFAULT false,
+  otp_code_hash TEXT,
+  otp_expires_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_approval_recipients_request ON social_approval_recipients(approval_request_id);
+CREATE INDEX idx_approval_recipients_token_hash ON social_approval_recipients(token_hash);
+CREATE INDEX idx_approval_recipients_user ON social_approval_recipients(platform_user_id) WHERE platform_user_id IS NOT NULL;
+
+CREATE TABLE social_approval_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  approval_request_id UUID NOT NULL REFERENCES social_approval_requests(id) ON DELETE CASCADE,
+  recipient_id UUID REFERENCES social_approval_recipients(id) ON DELETE SET NULL,
+  event_type social_approval_event_type NOT NULL,
+  platform social_platform,
+  comment_text TEXT,
+  -- Identity captured at event time (auth session for users, soft-bound for non-users)
+  actor_user_id UUID REFERENCES platform_users(id) ON DELETE SET NULL,
+  bound_identity_name TEXT,
+  bound_identity_email TEXT,
+  ip_address INET,
+  user_agent TEXT,
+  occurred_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_approval_events_request ON social_approval_events(approval_request_id, occurred_at);
+
+CREATE TABLE social_viewer_links (
+  -- 90-day magic links for customer-facing read-only calendar
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  token_hash TEXT NOT NULL UNIQUE,
+  recipient_email TEXT,
+  recipient_name TEXT,
+  expires_at TIMESTAMPTZ NOT NULL,
+  revoked_at TIMESTAMPTZ,
+  last_viewed_at TIMESTAMPTZ,
+  created_by UUID REFERENCES platform_users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_viewer_links_company ON social_viewer_links(company_id);
+
+-- =============================================================================
+-- L3 — SCHEDULING
+-- =============================================================================
+
+CREATE TABLE social_schedule_entries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_variant_id UUID NOT NULL REFERENCES social_post_variant(id) ON DELETE CASCADE,
+  scheduled_at TIMESTAMPTZ NOT NULL,
+  qstash_message_id TEXT,
+  scheduled_by UUID REFERENCES platform_users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  cancelled_at TIMESTAMPTZ
+);
+CREATE INDEX idx_schedule_entries_variant ON social_schedule_entries(post_variant_id);
+CREATE INDEX idx_schedule_entries_pending ON social_schedule_entries(scheduled_at) WHERE cancelled_at IS NULL;
+
+CREATE TABLE social_publish_jobs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  schedule_entry_id UUID REFERENCES social_schedule_entries(id) ON DELETE SET NULL,
+  post_variant_id UUID NOT NULL REFERENCES social_post_variant(id) ON DELETE CASCADE,
+  company_id UUID NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  fire_at TIMESTAMPTZ NOT NULL,
+  fired_at TIMESTAMPTZ,
+  cancelled_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_publish_jobs_pending ON social_publish_jobs(fire_at) WHERE fired_at IS NULL AND cancelled_at IS NULL;
+
+-- =============================================================================
+-- L4 — PUBLISHING
+-- =============================================================================
+
+CREATE TABLE social_publish_attempts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  publish_job_id UUID NOT NULL REFERENCES social_publish_jobs(id) ON DELETE CASCADE,
+  post_variant_id UUID NOT NULL REFERENCES social_post_variant(id) ON DELETE CASCADE,
+  connection_id UUID NOT NULL REFERENCES social_connections(id),
+  status social_attempt_status NOT NULL DEFAULT 'pending',
+  bundle_post_id TEXT,
+  platform_post_url TEXT,
+  error_class social_error_class,
+  error_payload JSONB,
+  request_payload JSONB,
+  response_payload JSONB,
+  original_attempt_id UUID REFERENCES social_publish_attempts(id),
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ
+);
+CREATE INDEX idx_attempts_job ON social_publish_attempts(publish_job_id);
+CREATE INDEX idx_attempts_in_flight ON social_publish_attempts(started_at)
+  WHERE status IN ('pending', 'in_flight', 'unknown');
+CREATE INDEX idx_attempts_bundle_post ON social_publish_attempts(bundle_post_id) WHERE bundle_post_id IS NOT NULL;
+
+-- =============================================================================
+-- L6 — RELIABILITY
+-- =============================================================================
+
+CREATE TABLE social_webhook_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id TEXT NOT NULL UNIQUE,
+  event_type TEXT NOT NULL,
+  raw_payload JSONB NOT NULL,
+  signature_valid BOOLEAN NOT NULL,
+  processed_at TIMESTAMPTZ,
+  received_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_webhook_events_received ON social_webhook_events(received_at);
+
+-- =============================================================================
+-- TRIGGERS
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_companies_updated BEFORE UPDATE ON platform_companies
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER trg_users_updated BEFORE UPDATE ON platform_users
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER trg_post_master_updated BEFORE UPDATE ON social_post_master
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER trg_post_variant_updated BEFORE UPDATE ON social_post_variant
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER trg_connections_updated BEFORE UPDATE ON social_connections
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE OR REPLACE FUNCTION track_post_state_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.state IS DISTINCT FROM OLD.state THEN
+    NEW.state_changed_at = now();
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_post_master_state_change BEFORE UPDATE ON social_post_master
+  FOR EACH ROW EXECUTE FUNCTION track_post_state_change();
+
+-- =============================================================================
+-- ROW LEVEL SECURITY
+-- =============================================================================
+-- Three access patterns:
+--   1. Opollo staff → see everything (is_opollo_staff() = true)
+--   2. Company members → see only their company's data (is_company_member())
+--   3. External (approval/viewer tokens) → handled via RPC, not RLS
+
+ALTER TABLE platform_companies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE platform_users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE platform_company_users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE platform_invitations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE platform_notifications ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE social_connections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE social_connection_alerts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE social_post_master ENABLE ROW LEVEL SECURITY;
+ALTER TABLE social_post_variant ENABLE ROW LEVEL SECURITY;
+ALTER TABLE social_media_assets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE social_approval_requests ENABLE ROW LEVEL SECURITY;
+ALTER TABLE social_approval_recipients ENABLE ROW LEVEL SECURITY;
+ALTER TABLE social_approval_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE social_viewer_links ENABLE ROW LEVEL SECURITY;
+ALTER TABLE social_schedule_entries ENABLE ROW LEVEL SECURITY;
+ALTER TABLE social_publish_jobs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE social_publish_attempts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE social_webhook_events ENABLE ROW LEVEL SECURITY;
+
+-- Platform layer policies
+CREATE POLICY companies_read ON platform_companies FOR SELECT
+  USING (is_opollo_staff() OR is_company_member(id));
+CREATE POLICY companies_write ON platform_companies FOR ALL
+  USING (is_opollo_staff()) WITH CHECK (is_opollo_staff());
+
+CREATE POLICY users_read ON platform_users FOR SELECT
+  USING (
+    is_opollo_staff()
+    OR id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM platform_company_users a
+      JOIN platform_company_users b ON a.company_id = b.company_id
+      WHERE a.user_id = auth.uid() AND b.user_id = platform_users.id
+    )
+  );
+CREATE POLICY users_self_update ON platform_users FOR UPDATE
+  USING (id = auth.uid() OR is_opollo_staff())
+  WITH CHECK (id = auth.uid() OR is_opollo_staff());
+
+CREATE POLICY company_users_read ON platform_company_users FOR SELECT
+  USING (is_opollo_staff() OR is_company_member(company_id));
+CREATE POLICY company_users_admin_write ON platform_company_users FOR ALL
+  USING (is_opollo_staff() OR has_company_role(company_id, 'admin'))
+  WITH CHECK (is_opollo_staff() OR has_company_role(company_id, 'admin'));
+
+CREATE POLICY invitations_admin_access ON platform_invitations FOR ALL
+  USING (is_opollo_staff() OR has_company_role(company_id, 'admin'))
+  WITH CHECK (is_opollo_staff() OR has_company_role(company_id, 'admin'));
+
+CREATE POLICY notifications_self_read ON platform_notifications FOR SELECT
+  USING (user_id = auth.uid() OR is_opollo_staff());
+CREATE POLICY notifications_self_update ON platform_notifications FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- Social layer policies — most are "any company member can read/write"
+-- Application layer enforces role-based action permissions on top
+CREATE POLICY connections_access ON social_connections FOR ALL
+  USING (is_opollo_staff() OR is_company_member(company_id))
+  WITH CHECK (is_opollo_staff() OR is_company_member(company_id));
+
+CREATE POLICY connection_alerts_access ON social_connection_alerts FOR ALL
+  USING (is_opollo_staff() OR is_company_member(company_id))
+  WITH CHECK (is_opollo_staff() OR is_company_member(company_id));
+
+CREATE POLICY post_master_access ON social_post_master FOR ALL
+  USING (is_opollo_staff() OR is_company_member(company_id))
+  WITH CHECK (is_opollo_staff() OR is_company_member(company_id));
+
+CREATE POLICY post_variant_access ON social_post_variant FOR ALL
+  USING (
+    is_opollo_staff() OR EXISTS (
+      SELECT 1 FROM social_post_master m
+      WHERE m.id = post_master_id AND is_company_member(m.company_id)
+    )
+  )
+  WITH CHECK (
+    is_opollo_staff() OR EXISTS (
+      SELECT 1 FROM social_post_master m
+      WHERE m.id = post_master_id AND is_company_member(m.company_id)
+    )
+  );
+
+CREATE POLICY media_access ON social_media_assets FOR ALL
+  USING (is_opollo_staff() OR is_company_member(company_id))
+  WITH CHECK (is_opollo_staff() OR is_company_member(company_id));
+
+CREATE POLICY approval_requests_access ON social_approval_requests FOR ALL
+  USING (is_opollo_staff() OR is_company_member(company_id))
+  WITH CHECK (is_opollo_staff() OR is_company_member(company_id));
+
+CREATE POLICY approval_recipients_access ON social_approval_recipients FOR ALL
+  USING (
+    is_opollo_staff() OR EXISTS (
+      SELECT 1 FROM social_approval_requests r
+      WHERE r.id = approval_request_id AND is_company_member(r.company_id)
+    )
+  );
+
+CREATE POLICY approval_events_access ON social_approval_events FOR ALL
+  USING (
+    is_opollo_staff() OR EXISTS (
+      SELECT 1 FROM social_approval_requests r
+      WHERE r.id = approval_request_id AND is_company_member(r.company_id)
+    )
+  );
+
+CREATE POLICY viewer_links_access ON social_viewer_links FOR ALL
+  USING (is_opollo_staff() OR is_company_member(company_id));
+
+CREATE POLICY schedule_entries_access ON social_schedule_entries FOR ALL
+  USING (
+    is_opollo_staff() OR EXISTS (
+      SELECT 1 FROM social_post_variant v
+      JOIN social_post_master m ON m.id = v.post_master_id
+      WHERE v.id = post_variant_id AND is_company_member(m.company_id)
+    )
+  );
+
+CREATE POLICY publish_jobs_access ON social_publish_jobs FOR ALL
+  USING (is_opollo_staff() OR is_company_member(company_id));
+
+CREATE POLICY publish_attempts_access ON social_publish_attempts FOR ALL
+  USING (
+    is_opollo_staff() OR EXISTS (
+      SELECT 1 FROM social_publish_jobs j
+      WHERE j.id = publish_job_id AND is_company_member(j.company_id)
+    )
+  );
+
+-- Webhook events: staff only
+CREATE POLICY webhook_events_staff_only ON social_webhook_events FOR ALL
+  USING (is_opollo_staff());
+
+-- =============================================================================
+-- COMMENTS
+-- =============================================================================
+COMMENT ON TABLE platform_companies IS 'P — customer companies. is_opollo_internal=true for the Opollo internal company.';
+COMMENT ON TABLE platform_users IS 'P — profile data extending auth.users. Created on invitation acceptance.';
+COMMENT ON TABLE platform_company_users IS 'P — membership + role. UNIQUE(user_id) enforces "one company per user" V1 constraint.';
+COMMENT ON TABLE platform_invitations IS 'P — invitation lifecycle with day-3 reminder and day-14 expiry tracking.';
+COMMENT ON TABLE platform_notifications IS 'P — in-app notifications. Email-only notifications do not require a row.';
+COMMENT ON TABLE social_post_master IS 'L1 — editorial object, owns the state machine.';
+COMMENT ON TABLE social_approval_requests IS 'L2 — snapshot-bound approval. snapshot_payload is immutable after creation.';
+COMMENT ON COLUMN social_approval_requests.final_approved_by_user_id IS 'Set if reviewer was a platform user. NULL for one-off external reviewers.';
+COMMENT ON COLUMN social_approval_recipients.platform_user_id IS 'Linked if recipient is a platform user. NULL for one-off external reviewers.';
+COMMENT ON TABLE social_publish_jobs IS 'L3-owned — only L3 may insert rows. L4 reads and executes.';
+COMMENT ON TABLE social_publish_attempts IS 'L4 — one row per actual call to bundle.social. Immutable audit log.';
+COMMENT ON TABLE social_webhook_events IS 'L6 — idempotency log. event_id unique constraint prevents double-processing.';
+
+-- =============================================================================
+-- SEED: Opollo Internal Company
+-- =============================================================================
+-- Fixed UUID 00000000-0000-0000-0000-000000000001 — easy to recognise in
+-- dev/debug, idempotent on re-apply. The is_opollo_internal singleton index
+-- prevents a second internal company even if this INSERT ever ran twice;
+-- ON CONFLICT (id) makes the re-apply path a no-op rather than an error.
+--
+-- After migration, create the first Opollo staff user via Supabase Auth and
+-- link them:
+--   INSERT INTO platform_users (id, email, full_name, is_opollo_staff)
+--   VALUES (<auth.users.id>, 'hi@opollo.com', 'Steven', true);
+--   INSERT INTO platform_company_users (company_id, user_id, role)
+--   VALUES ('00000000-0000-0000-0000-000000000001', <user_id>, 'admin');
+
+INSERT INTO platform_companies (id, name, slug, is_opollo_internal, timezone)
+VALUES (
+  '00000000-0000-0000-0000-000000000001',
+  'Opollo',
+  'opollo',
+  true,
+  'Australia/Melbourne'
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- =============================================================================
+-- END OF MIGRATION
+-- =============================================================================

--- a/supabase/rollbacks/0070_platform_foundation.down.sql
+++ b/supabase/rollbacks/0070_platform_foundation.down.sql
@@ -1,0 +1,57 @@
+-- Rollback for 0070_platform_foundation.sql
+-- Drops every platform_* and social_* object the forward migration created.
+-- Does NOT restore row data. Intended for local dev / CI reset, not
+-- production recovery. set_updated_at() is left in place since it is shared
+-- with future migrations (0070 was its first introduction; once a later
+-- migration also references it, this drop becomes a hazard — leave it).
+
+-- ----------------------------------------------------------------------------
+-- Tables — dropped child-first; CASCADE handles policies, indexes, triggers.
+-- ----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS social_webhook_events CASCADE;
+DROP TABLE IF EXISTS social_publish_attempts CASCADE;
+DROP TABLE IF EXISTS social_publish_jobs CASCADE;
+DROP TABLE IF EXISTS social_schedule_entries CASCADE;
+DROP TABLE IF EXISTS social_viewer_links CASCADE;
+DROP TABLE IF EXISTS social_approval_events CASCADE;
+DROP TABLE IF EXISTS social_approval_recipients CASCADE;
+DROP TABLE IF EXISTS social_approval_requests CASCADE;
+DROP TABLE IF EXISTS social_media_assets CASCADE;
+DROP TABLE IF EXISTS social_post_variant CASCADE;
+DROP TABLE IF EXISTS social_post_master CASCADE;
+DROP TABLE IF EXISTS social_connection_alerts CASCADE;
+DROP TABLE IF EXISTS social_connections CASCADE;
+DROP TABLE IF EXISTS platform_notifications CASCADE;
+DROP TABLE IF EXISTS platform_invitations CASCADE;
+DROP TABLE IF EXISTS platform_company_users CASCADE;
+DROP TABLE IF EXISTS platform_users CASCADE;
+DROP TABLE IF EXISTS platform_companies CASCADE;
+
+-- ----------------------------------------------------------------------------
+-- Functions — drop standalone helpers. Functions whose signature uses an
+-- enum type drop with the type via the CASCADE below.
+-- ----------------------------------------------------------------------------
+
+DROP FUNCTION IF EXISTS is_opollo_staff() CASCADE;
+DROP FUNCTION IF EXISTS is_company_member(UUID) CASCADE;
+DROP FUNCTION IF EXISTS current_user_company() CASCADE;
+DROP FUNCTION IF EXISTS track_post_state_change() CASCADE;
+
+-- ----------------------------------------------------------------------------
+-- Types — drop after the tables and functions that reference them. CASCADE
+-- removes any dependent has_company_role(uuid, platform_company_role) etc.
+-- ----------------------------------------------------------------------------
+
+DROP TYPE IF EXISTS platform_company_role CASCADE;
+DROP TYPE IF EXISTS platform_invitation_status CASCADE;
+DROP TYPE IF EXISTS platform_notification_type CASCADE;
+DROP TYPE IF EXISTS social_platform CASCADE;
+DROP TYPE IF EXISTS social_post_state CASCADE;
+DROP TYPE IF EXISTS social_post_source CASCADE;
+DROP TYPE IF EXISTS social_connection_status CASCADE;
+DROP TYPE IF EXISTS social_approval_rule CASCADE;
+DROP TYPE IF EXISTS social_approval_event_type CASCADE;
+DROP TYPE IF EXISTS social_attempt_status CASCADE;
+DROP TYPE IF EXISTS social_error_class CASCADE;
+DROP TYPE IF EXISTS social_alert_severity CASCADE;


### PR DESCRIPTION
## Summary

P1 — first slice of **Phase A: Platform Layer**, per `BUILD.md`. Lands migration `0070_platform_foundation.sql` (platform layer + full N-Series social schema, in one shot per Steven's instruction), the matching rollback, an extension to the test harness, and a focused test file proving helpers, constraints, RLS isolation, and the seed.

Plain-English: every customer company, customer user, role, invitation, in-app notification, and social-module table now exists in the database with RLS on. Application code that uses any of these will land in P2+ (platform UI / API) and S1+ (social feature code).

## Phase A — Parent plan (covers P1–P5)

The platform layer is shared infrastructure used by social V1 today and by future LeadSource client views, generated-site reviews, and CAP. Phase A gets it built before social so social doesn't grow its own user/company logic. Five sub-slices:

| Slice | Scope | Output |
|---|---|---|
| **P1** *(this PR)* | Schema + RLS for companies, users, roles, invitations, notifications. Plus the full social schema in one migration so future S* slices add code only. | Migration 0070 + RLS + helpers + seed + tests. |
| P2 | Invitation flow: send, accept (set password), revoke, day-3 reminder, day-14 expiry. | API routes under `app/api/platform/invitations/*` + email templates + QStash callbacks. |
| P3 | Opollo admin UI: `/admin/companies` — list, create, drill down. | App routes under `app/(platform)/admin/*`. |
| P4 | Customer admin UI: `/company/users` for company admins. | App routes under `app/(platform)/company/*`. |
| P5 | Notification dispatcher: `lib/platform/notifications/dispatch.ts` writes in-app rows + emails for the V1 trigger list. | Library + templates + integration tests. |

After P5 ships, Phase B (S1–S8 social slices) starts. The social schema lands in this PR, so S1 is "schema already there, add the editorial code" rather than another migration.

## P1 — Sub-slice plan

### What this PR adds

1. **`supabase/migrations/0070_platform_foundation.sql`** — schema + RLS + helpers + seed.
   - Tables: `platform_companies`, `platform_users`, `platform_company_users`, `platform_invitations`, `platform_notifications`, plus `social_*` (connections, post_master, post_variant, media_assets, approval_requests, approval_recipients, approval_events, viewer_links, schedule_entries, publish_jobs, publish_attempts, connection_alerts, webhook_events).
   - Helpers: `is_opollo_staff()`, `is_company_member(uuid)`, `has_company_role(uuid, role)`, `current_user_company()`. All `STABLE SECURITY DEFINER`.
   - RLS: every new table has `ENABLE ROW LEVEL SECURITY` + policies. Platform pattern: `is_opollo_staff() OR is_company_member(company_id)`. Admin-only writes go via `has_company_role(company_id, 'admin')`. `platform_notifications` is self-only.
   - Seed: `platform_companies` row with `id = 00000000-0000-0000-0000-000000000001`, `name = 'Opollo'`, `slug = 'opollo'`, `is_opollo_internal = true`, `timezone = 'Australia/Melbourne'`. Idempotent via `ON CONFLICT (id) DO NOTHING`.
2. **`supabase/rollbacks/0070_platform_foundation.down.sql`** — drops every object in dependency order. Leaves `set_updated_at()` in place (it'll be shared once a future migration also references it).
3. **`lib/__tests__/p1-platform-schema.test.ts`** — covers helpers, constraints, platform-table RLS matrix, and social-table RLS smoke.
4. **`lib/__tests__/_setup.ts`** — extended TRUNCATE block now sweeps `platform_*` and `social_*` tables too. Wrapped in a `DO` block with `pg_tables` existence checks so older branches without 0070 still run.
5. **`docs/WORK_IN_FLIGHT.md`** — claim block + 0070 reservation.

### UNIQUE / CHECK / FK invariants the migration adds

- `UNIQUE (user_id)` on `platform_company_users` — V1 "one user, one company".
- `UNIQUE INDEX idx_companies_one_internal ON platform_companies((1)) WHERE is_opollo_internal = true` — singleton.
- `UNIQUE INDEX idx_invitations_unique_pending ON platform_invitations(company_id, email) WHERE status = 'pending'` — no concurrent dup invites.
- `UNIQUE (post_master_id, platform)` on `social_post_variant`, `UNIQUE (event_id)` on `social_webhook_events` (bundle.social idempotency anchor), `UNIQUE (bundle_social_account_id)` on `social_connections`, `UNIQUE (token_hash)` on `platform_invitations` and `social_viewer_links`.
- FK cascades: `platform_users.id → auth.users.id ON DELETE CASCADE`. `platform_company_users → platform_companies / platform_users ON DELETE CASCADE`. Notifications + invitations cascade off their parent company.

### Safety on populated tables

These tables don't exist before this migration, so there are no pre-existing rows to violate constraints. Safe.

### RLS / access changes that could break working code paths

None — no existing code references `platform_*` or `social_*` tables. P2+ slices add the code that uses them.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Two concurrent INSERTs racing to create a second "Opollo Internal" company | Singleton UNIQUE index `idx_companies_one_internal`. App can't bypass at write time. |
| Same email invited twice to same company before the first is accepted | Partial UNIQUE index `idx_invitations_unique_pending`. The second insert fails with 23505; app surfaces a friendly error. |
| User added to a second company on retry / race | `UNIQUE (user_id)` on `platform_company_users`. Schema-level enforcement of the V1 "one user, one company" rule. |
| Duplicate bundle.social webhook deliveries | `UNIQUE (event_id)` on `social_webhook_events` is the documented idempotency anchor (per bundle-social-integration skill). Insert-first, ON CONFLICT → 200 OK without reprocessing. |
| Reconnect race creates two `social_connections` rows for same identity | `UNIQUE (bundle_social_account_id)`. |
| Cross-company data leak via a buggy query | RLS `USING (is_opollo_staff() OR is_company_member(company_id))` on every customer-scoped table; defense-in-depth on top of app-level checks. Tested in `p1-platform-schema.test.ts`. |
| Deleted auth user leaving orphan `platform_users` row | `platform_users.id REFERENCES auth.users(id) ON DELETE CASCADE`. Tested. |
| Stale local 20260502 migration drafted before this rename | Recovery preamble in 0070 drops every object before recreating, so a local that ran the draft applies 0070 cleanly. No prod impact (the draft was never committed). |

### Deliberately deferred (with reason and follow-up)

- **Full social-table RLS test matrix.** This PR ships smoke RLS tests for social tables (cross-company isolation + Opollo-staff override on `social_post_master`). The full role × table × op matrix lands with the feature code in S1+ where the policies are exercised by real queries. The platform-table matrix is comprehensive in this PR.
- **`SET search_path` on SECURITY DEFINER helpers.** Standard hardening for SECURITY DEFINER functions; missing here. Customer users don't have CREATE-on-schema, so attack surface is narrow. Follow-up slice can pin `search_path` on all four helpers in one small migration.
- **Postgres ENUMs vs CHECK constraints.** The `new-migration.md` pattern prefers `CHECK (status IN (...))` over ENUM types. This migration uses ENUMs throughout (per the original schema draft). Future evolutions of the post-state machine and platform-role list will pay an `ALTER TYPE ... ADD VALUE` cost; manageable but worth knowing.
- **`deleted_at` / audit-column convention.** Per `docs/DATA_CONVENTIONS.md`, new tables ship soft-delete + audit columns. The platform/social tables omit `deleted_at` for now (deletes are real). `created_by` / `updated_by` exist via `invited_by`, `uploaded_by`, etc. on a per-table basis. Re-evaluate per-table when the feature code lands.

## Test plan

Tests live in `lib/__tests__/p1-platform-schema.test.ts` and require `supabase start` locally; CI runs them automatically.

- [x] `npm run lint` clean (`--max-warnings=0`)
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` succeeds
- [ ] `npm run test -- p1-platform-schema` — **not run locally** (Docker not running on this machine); CI Vitest workflow will validate.
- [ ] CI green end-to-end before auto-merge.

## Notes for review

- `BUILD.md`, `docs/social-module-decisions.md`, and the four `.claude/skills/*` folders that drove this PR are currently untracked locally. They aren't included here to keep this PR scoped to schema + RLS; happy to land them in a follow-up doc PR if you want them in the repo.
- The migration carries the full social schema (per your "keep all the schema content the same" instruction). The slice is still labelled P1 because the deliverable is *schema + RLS validation*; social feature code (which uses these tables) lives in S1+.
- `lib/__tests__/_setup.ts` is not on the hot-shared list but is a shared helper; my edit is purely additive (new TRUNCATE for new tables, wrapped in an existence check so older branches still run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
