### PR TITLE
fix(p1): consistent insert columns + error checks in test seed

### DIFF
--- a/lib/__tests__/p1-platform-schema.test.ts
+++ b/lib/__tests__/p1-platform-schema.test.ts
@@ -101,58 +101,131 @@ describe("0070 — platform foundation: schema, RLS, helpers, seed", () => {
 
   beforeEach(async () => {
     // _setup.ts TRUNCATEd platform_* / social_* tables. Re-seed the world.
+    // Each insert is error-checked + thrown — silent failures here cascade
+    // into FK and PGRST116 errors deep in the assertions, masking the root
+    // cause. PR #376's CI uncovered this; do not regress to silent inserts.
     const svc = getServiceRoleClient();
 
-    await svc.from("platform_companies").insert([
-      {
-        id: OPOLLO_INTERNAL_ID,
-        name: "Opollo",
-        slug: "opollo",
-        is_opollo_internal: true,
-        timezone: "Australia/Melbourne",
-      },
-      {
-        id: COMPANY_A_ID,
-        name: "Acme Co",
-        slug: "acme",
-        domain: "acme.test",
-        timezone: "Australia/Melbourne",
-      },
-      {
-        id: COMPANY_B_ID,
-        name: "Beta Inc",
-        slug: "beta",
-        domain: "beta.test",
-        timezone: "Australia/Melbourne",
-      },
-    ]);
+    // PostgREST batch insert takes the UNION of keys across rows — any row
+    // omitting a key the union mentions sends explicit NULL, violating
+    // NOT NULL columns. Spell every column on every row.
+    const companies = await svc
+      .from("platform_companies")
+      .insert([
+        {
+          id: OPOLLO_INTERNAL_ID,
+          name: "Opollo",
+          slug: "opollo",
+          domain: null,
+          is_opollo_internal: true,
+          timezone: "Australia/Melbourne",
+        },
+        {
+          id: COMPANY_A_ID,
+          name: "Acme Co",
+          slug: "acme",
+          domain: "acme.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+        },
+        {
+          id: COMPANY_B_ID,
+          name: "Beta Inc",
+          slug: "beta",
+          domain: "beta.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+        },
+      ])
+      .select("id");
+    if (companies.error) {
+      throw new Error(
+        `seed platform_companies: ${companies.error.code ?? "?"} ${companies.error.message}`,
+      );
+    }
+    if ((companies.data?.length ?? 0) !== 3) {
+      throw new Error(
+        `seed platform_companies: inserted ${companies.data?.length ?? 0}/3 rows`,
+      );
+    }
 
-    await svc.from("platform_users").insert([
-      {
-        id: opolloStaff.id,
-        email: opolloStaff.email,
-        full_name: "Opollo Staff",
-        is_opollo_staff: true,
-      },
-      { id: aAdmin.id, email: aAdmin.email, full_name: "A Admin" },
-      { id: aApprover.id, email: aApprover.email, full_name: "A Approver" },
-      { id: aEditor.id, email: aEditor.email, full_name: "A Editor" },
-      { id: aViewer.id, email: aViewer.email, full_name: "A Viewer" },
-      { id: bAdmin.id, email: bAdmin.email, full_name: "B Admin" },
-    ]);
+    const users = await svc
+      .from("platform_users")
+      .insert([
+        {
+          id: opolloStaff.id,
+          email: opolloStaff.email,
+          full_name: "Opollo Staff",
+          is_opollo_staff: true,
+        },
+        {
+          id: aAdmin.id,
+          email: aAdmin.email,
+          full_name: "A Admin",
+          is_opollo_staff: false,
+        },
+        {
+          id: aApprover.id,
+          email: aApprover.email,
+          full_name: "A Approver",
+          is_opollo_staff: false,
+        },
+        {
+          id: aEditor.id,
+          email: aEditor.email,
+          full_name: "A Editor",
+          is_opollo_staff: false,
+        },
+        {
+          id: aViewer.id,
+          email: aViewer.email,
+          full_name: "A Viewer",
+          is_opollo_staff: false,
+        },
+        {
+          id: bAdmin.id,
+          email: bAdmin.email,
+          full_name: "B Admin",
+          is_opollo_staff: false,
+        },
+      ])
+      .select("id");
+    if (users.error) {
+      throw new Error(
+        `seed platform_users: ${users.error.code ?? "?"} ${users.error.message}`,
+      );
+    }
+    if ((users.data?.length ?? 0) !== 6) {
+      throw new Error(
+        `seed platform_users: inserted ${users.data?.length ?? 0}/6 rows`,
+      );
+    }
 
-    await svc.from("platform_company_users").insert([
-      {
-        company_id: OPOLLO_INTERNAL_ID,
-        user_id: opolloStaff.id,
-        role: "admin",
-      },
-      { company_id: COMPANY_A_ID, user_id: aAdmin.id, role: "admin" },
-      { company_id: COMPANY_A_ID, user_id: aApprover.id, role: "approver" },
-      { company_id: COMPANY_A_ID, user_id: aEditor.id, role: "editor" },
-      { company_id: COMPANY_A_ID, user_id: aViewer.id, role: "viewer" },
-      { company_id: COMPANY_B_ID, user_id: bAdmin.id, role: "admin" },
-    ]);
+    const memberships = await svc
+      .from("platform_company_users")
+      .insert([
+        {
+          company_id: OPOLLO_INTERNAL_ID,
+          user_id: opolloStaff.id,
+          role: "admin",
+        },
+        { company_id: COMPANY_A_ID, user_id: aAdmin.id, role: "admin" },
+        { company_id: COMPANY_A_ID, user_id: aApprover.id, role: "approver" },
+        { company_id: COMPANY_A_ID, user_id: aEditor.id, role: "editor" },
+        { company_id: COMPANY_A_ID, user_id: aViewer.id, role: "viewer" },
+        { company_id: COMPANY_B_ID, user_id: bAdmin.id, role: "admin" },
+      ])
+      .select("id");
+    if (memberships.error) {
+      throw new Error(
+        `seed platform_company_users: ${memberships.error.code ?? "?"} ${memberships.error.message}`,
+      );
+    }
+    if ((memberships.data?.length ?? 0) !== 6) {
+      throw new Error(
+        `seed platform_company_users: inserted ${memberships.data?.length ?? 0}/6 rows`,
+      );
+    }
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary

Fix-forward for PR #376 (P1 platform foundation). 17 of my new tests in `lib/__tests__/p1-platform-schema.test.ts` failed on the merge-commit CI run. Root cause traced; both root cause and a debug guard fixed in this PR.

**This PR will not be merged via auto-merge.** I'll wait for explicit CI green on the test job and check with you before squashing.

## What broke

The new test file's `beforeEach` re-seeds three batch INSERTs against `platform_companies`, `platform_users`, and `platform_company_users`. The batch INSERTs silently failed and `beforeEach` did not check `result.error` — so every test that depended on the seed saw an empty database and reported nonsense errors:

- `seeded internal company is readable` → `PGRST116` (zero rows from `.single()`).
- `UNIQUE (user_id) blocks…` → got `23503` (FK violation, no row in `platform_users`) instead of `23505`.
- `singleton index blocks a second is_opollo_internal=true row` → got `undefined` (insert succeeded; no existing row to conflict with).
- `pending-invite uniqueness…` → got `23503` (no `platform_companies` row for `COMPANY_A_ID`).
- `is_opollo_staff() = true for staff` → got `false` (no `platform_users` row for `opolloStaff`).
- The one test that passed in this group (`auth.users delete cascades to platform_users`) creates its own row inline and doesn't depend on the seed.

Every failure traces to the same root.

## Root cause

PostgREST's batch-INSERT semantics: the request body's column set is the **union of keys across all rows**. Any row that omits a key from that union receives an explicit `NULL` for that column, not the column default.

My seed batches were heterogeneous:

```ts
// platform_companies — row 1 has is_opollo_internal but no domain;
// rows 2/3 have domain but not is_opollo_internal.
[
  { id: …, name: "Opollo", slug: "opollo", is_opollo_internal: true,  timezone: … },
  { id: …, name: "Acme",   slug: "acme",   domain: "acme.test",       timezone: … },
  { id: …, name: "Beta",   slug: "beta",   domain: "beta.test",       timezone: … },
]
```

Union = `{id, name, slug, domain, is_opollo_internal, timezone}`. Rows 2 and 3 sent `is_opollo_internal = NULL` explicitly. The schema declares `is_opollo_internal BOOLEAN NOT NULL DEFAULT false`. NOT NULL violation → batch rolled back → all three rows missing from the table.

Same shape for `platform_users` (only the staff row had `is_opollo_staff: true`; the other five omitted the key, became NULL, violated NOT NULL).

The downstream FK errors and PGRST116s are symptoms of this single root.

## Fix

Two changes, both in `lib/__tests__/p1-platform-schema.test.ts`:

1. **Consistent column sets across every row in every batch insert.** Every row spells `is_opollo_internal`, `domain` (where applicable), and `is_opollo_staff` explicitly. PostgREST's union now matches what the schema expects.
2. **Error-checking guards on every seed insert.** Each `await svc.from(…).insert(…).select("id")` is followed by an `if (error) throw` and a row-count check that throws if the batch inserted fewer rows than expected. Future silent-failure regressions surface as a single descriptive `beforeEach` exception, not as a cascade of FK / PGRST116 errors deep in assertions.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Same silent-insert failure recurring in future tests | Error-check guards throw on `error` and on partial-row count. |
| PostgREST union behaviour subtly bites another seed | Comment in `beforeEach` explains the union semantics so the next person spelling a heterogeneous batch knows why. |
| Pre-existing `m12-1-rls` and `m4-schema` test failures masking my fix | Acknowledged — those red on every recent CI run on main, predate this PR. They are not in scope here. CI's `test` job will still report failure overall, but the **p1-platform-schema** subset should now go green. I'll show you the exact pass/fail split when CI lands. |

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npx next lint --max-warnings=0` clean.
- [ ] CI test job — verify `p1-platform-schema.test.ts` cells now all pass; pre-existing `m12-1` / `m4` failures remain.
- [ ] **No `gh pr merge --auto`.** Once CI runs, I'll show you the pass/fail diff and wait for your nod before `gh pr merge --squash`.

## Notes for review

- This is a test-only change. No production code, no schema, no migration touched.
- The pre-existing `m12-1` / `m4` test reds on `main` are out of scope for this PR but worth a separate triage slice — CI's `test` job has been red on every recent run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
