### PR TITLE
fix(auth): admin API gate default permits super_admin

### DIFF
--- a/lib/__tests__/admin-api-gate.test.ts
+++ b/lib/__tests__/admin-api-gate.test.ts
@@ -187,4 +187,40 @@ describe("requireAdminForApi: FEATURE_SUPABASE_AUTH on, kill switch off", () => 
     if (gate.kind !== "allow") throw new Error("unreachable");
     expect(gate.user?.role).toBe("admin");
   });
+
+  // Regression — UAT §1.1.3 surfaced that the no-arg gate defaulted to
+  // ["admin"] only, which 403'd super_admin on every admin route called
+  // with no args. Default now permits both super_admin and admin.
+  it("allows a super_admin via the no-arg default gate", async () => {
+    const superAdmin = await seedAuthUser({ role: "super_admin" });
+    mockState.client = await signedInClient(superAdmin.email);
+
+    const gate = await requireAdminForApi();
+    expect(gate.kind).toBe("allow");
+    if (gate.kind !== "allow") throw new Error("unreachable");
+    expect(gate.user?.role).toBe("super_admin");
+    expect(gate.user?.email).toBe(superAdmin.email);
+  });
+
+  it("allows a super_admin via an explicit super_admin-only roles list", async () => {
+    const superAdmin = await seedAuthUser({ role: "super_admin" });
+    mockState.client = await signedInClient(superAdmin.email);
+
+    const gate = await requireAdminForApi({ roles: ["super_admin"] });
+    expect(gate.kind).toBe("allow");
+    if (gate.kind !== "allow") throw new Error("unreachable");
+    expect(gate.user?.role).toBe("super_admin");
+  });
+
+  it("denies an admin when only super_admin is required", async () => {
+    const admin = await seedAuthUser({ role: "admin" });
+    mockState.client = await signedInClient(admin.email);
+
+    const gate = await requireAdminForApi({ roles: ["super_admin"] });
+    expect(gate.kind).toBe("deny");
+    if (gate.kind !== "deny") throw new Error("unreachable");
+    expect(gate.response.status).toBe(403);
+    const body = await gate.response.json();
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
 });

--- a/lib/admin-api-gate.ts
+++ b/lib/admin-api-gate.ts
@@ -72,7 +72,7 @@ function denyResponse(
 export async function requireAdminForApi(
   opts: { roles?: readonly Role[] } = {},
 ): Promise<ApiGateResult> {
-  const roles = opts.roles ?? (["admin"] as const);
+  const roles = opts.roles ?? (["super_admin", "admin"] as const);
 
   if (!isSupabaseAuthOn()) return { kind: "allow", user: null };
 


### PR DESCRIPTION
## Summary

`requireAdminForApi()` defaulted `roles` to `['admin']` only, which 403'd super_admin on every admin route called without explicit args. Discovered during UAT §1.1.3 — invite submission as super_admin returned the gate's `Role 'super_admin' is not permitted for this resource.` denial.

## Fix

One-line change to `lib/admin-api-gate.ts:75` — default `roles` is now `["super_admin", "admin"]`, matching the pattern ~50 other admin routes use explicitly. Role hierarchy is `super_admin > admin > user`; super_admin should pass any gate admin passes.

## Affected routes (9 — all currently broken for super_admin)

- \`app/api/admin/invites/route.ts\` (POST + DELETE)
- \`app/api/admin/invites/[id]/route.ts\`
- \`app/api/admin/users/invite/route.ts\` (legacy M2d-3 path)
- \`app/api/admin/users/list/route.ts\`
- \`app/api/admin/users/[id]/role/route.ts\`
- \`app/api/admin/users/[id]/revoke/route.ts\`
- \`app/api/admin/users/[id]/reinstate/route.ts\`
- \`app/api/admin/sites/[id]/budget/route.ts\`
- \`app/api/ops/self-probe/route.ts\`

The one explicit super_admin-only gate at \`app/api/admin/email-test/route.ts\` is unaffected (passes \`roles: ["super_admin"]\` explicitly).

## Test plan

- [x] Lint clean
- [x] Typecheck clean
- [x] Build clean
- [x] Three new tests in \`lib/__tests__/admin-api-gate.test.ts\`: super_admin allowed by default; super_admin allowed by explicit super_admin-only; admin denied when super_admin-only required
- [ ] CI green on full integration suite (Supabase-backed)
- [ ] Verify on staging by re-running UAT §1.1.3 (invite submission as super_admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)