### PR TITLE
fix(sites): drop updated_by writes pending audit-columns rollout

### DIFF
--- a/app/api/admin/sites/[id]/onboarding/route.ts
+++ b/app/api/admin/sites/[id]/onboarding/route.ts
@@ -76,12 +76,12 @@ export async function POST(
   }
 
   const supabase = getServiceRoleClient();
+  // audit columns not yet on sites — DATA_CONVENTIONS rollout pending
   const upd = await supabase
     .from("sites")
     .update({
       site_mode: parsed.data.site_mode,
       updated_at: new Date().toISOString(),
-      updated_by: gate.user?.id ?? null,
     })
     .eq("id", params.id)
     .select("id, site_mode")

--- a/app/api/admin/sites/[id]/setup/extract/save/route.ts
+++ b/app/api/admin/sites/[id]/setup/extract/save/route.ts
@@ -104,6 +104,7 @@ export async function POST(
   }
 
   const supabase = getServiceRoleClient();
+  // audit columns not yet on sites — DATA_CONVENTIONS rollout pending
   const upd = await supabase
     .from("sites")
     .update({
@@ -111,7 +112,6 @@ export async function POST(
       extracted_css_classes: parsed.data.extracted_css_classes,
       design_direction_status: "approved",
       updated_at: new Date().toISOString(),
-      updated_by: gate.user?.id ?? null,
     })
     .eq("id", params.id)
     .eq("site_mode", "copy_existing")

--- a/app/api/admin/sites/[id]/use-image-library/route.ts
+++ b/app/api/admin/sites/[id]/use-image-library/route.ts
@@ -64,12 +64,12 @@ export async function POST(
   }
 
   const supabase = getServiceRoleClient();
+  // audit columns not yet on sites — DATA_CONVENTIONS rollout pending
   const upd = await supabase
     .from("sites")
     .update({
       use_image_library: parsed.data.enabled,
       updated_at: new Date().toISOString(),
-      updated_by: gate.user?.id ?? null,
     })
     .eq("id", params.id)
     .select("id, use_image_library")

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,28 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## DATA_CONVENTIONS rollout — add audit columns to `sites` (opened 2026-05-02 during UAT §3.1.2)
+
+**Tags:** `schema`, `data-conventions`, `tech-debt`
+
+**What:** Migration adds `created_by uuid` and `updated_by uuid` columns to the `sites` table (both nullable, FK to `opollo_users(id)` with `ON DELETE SET NULL`). After the migration lands, restore the `updated_by: gate.user?.id ?? null` writes in three routes that drop them today:
+- `app/api/admin/sites/[id]/onboarding/route.ts`
+- `app/api/admin/sites/[id]/use-image-library/route.ts`
+- `app/api/admin/sites/[id]/setup/extract/save/route.ts`
+
+**Why deferred:** UAT was blocked when those three routes returned 500 (`column "updated_by" of relation "sites" does not exist`). The surgical fix dropped the column writes to unblock. Per `docs/DATA_CONVENTIONS.md`, audit columns are forward-facing — existing tables fold in on the next natural migration. The fold-in for `sites` deserves its own slice with a backfill plan, not a UAT-blocker drive-by.
+
+**Trigger:** any future slice that wants per-row authorship on `sites` (e.g. an admin audit-log surface that filters site changes by actor). Or proactive cleanup once the schema migration backlog is light.
+
+**Rough scope:**
+- Migration: `ALTER TABLE sites ADD COLUMN created_by uuid REFERENCES opollo_users(id) ON DELETE SET NULL, ADD COLUMN updated_by uuid REFERENCES opollo_users(id) ON DELETE SET NULL;`. Existing rows: NULL (no historical attribution available — that's fine).
+- Restore the three writes (revert the surgical drop). Cite this PR's commit when restoring.
+- Optional: backfill `created_by` for newly-onboarded sites going forward via the `OnboardingReminderBanner` flow's saving step (out of scope unless authorship is a hard product requirement).
+
+**Size:** Small (~30 min for the migration + 10 min to restore the three writes + tests).
+
+---
+
 ## Component test infra — jsdom + @testing-library/react (opened 2026-04-27 by RS-1 / RS-4)
 
 **What:** Add `jsdom` (or `happy-dom`), `@testing-library/react`, and a vitest project split (or `environmentMatchGlobs`) so we can run hook + component tests under `lib/__tests__/` (or a new `components/__tests__/`).


### PR DESCRIPTION
## Summary

Three routes write \`updated_by: gate.user?.id ?? null\` to the \`sites\` table, but \`sites\` doesn't have audit columns yet — Postgres rejects the UPDATE and routes return 500 with masked envelopes. Per \`docs/DATA_CONVENTIONS.md\`, audit columns are forward-facing on existing tables; \`sites\` hadn't been folded in.

Discovered during UAT §3.1.2 — picking a site mode returned masked "Failed to save site mode." The underlying error (in server logs as \`site.onboarding.update_failed\`) is \`column "updated_by" of relation "sites" does not exist\`.

## Fix

Surgical — drop the \`updated_by\` field from three UPDATE statements; keep \`updated_at\`. Each gets a one-line comment noting the rollout is pending.

## Affected routes

- \`app/api/admin/sites/[id]/onboarding/route.ts\` (mode save — UAT §3.1.2)
- \`app/api/admin/sites/[id]/use-image-library/route.ts\` (image-library toggle — UAT §3.6)
- \`app/api/admin/sites/[id]/setup/extract/save/route.ts\` (extraction confirm — UAT §3.2.3)

## Follow-up

Added \`docs/BACKLOG.md\` entry "DATA_CONVENTIONS rollout — add audit columns to \`sites\`" — captures the migration (add \`created_by\` + \`updated_by\` uuid columns, FK to \`opollo_users(id)\`) and the write restoration as a separate slice.

## Test plan

- [x] Lint clean
- [x] Typecheck clean
- [x] Build clean
- [ ] CI green on integration suite (Supabase-backed)
- [ ] Verify on staging by re-running UAT §3.1.2 (mode save lands \`new_design\` + redirects to \`/setup?step=1\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)