### PR TITLE
fix(typography): enforce minimum sizes — body ≥ 1rem, no text-xs

### DIFF
--- a/app/account/devices/page.tsx
+++ b/app/account/devices/page.tsx
@@ -60,7 +60,7 @@ export default async function AccountDevicesPage() {
         <Alert className="mt-6">
           Email-2FA is not currently enabled on this environment.
           Trusted-device tracking starts when{" "}
-          <code className="font-mono text-xs">AUTH_2FA_ENABLED</code>{" "}
+          <code className="font-mono text-sm">AUTH_2FA_ENABLED</code>{" "}
           is flipped to <code>true</code> in env.
         </Alert>
       )}

--- a/app/account/security/page.tsx
+++ b/app/account/security/page.tsx
@@ -37,7 +37,7 @@ export default async function AccountSecurityPage() {
         </p>
       </div>
       <AccountSecurityForm userEmail={user.email} />
-      <div className="text-xs text-muted-foreground">
+      <div className="text-sm text-muted-foreground">
         <a href="/admin/sites" className="underline hover:no-underline">
           ← Back to admin
         </a>

--- a/app/admin/batches/[id]/page.tsx
+++ b/app/admin/batches/[id]/page.tsx
@@ -126,7 +126,7 @@ export default async function BatchDetailPage({
           <div className="flex items-center gap-2">
             <Link
               href="/admin/batches"
-              className="text-xs text-muted-foreground hover:text-foreground"
+              className="text-sm text-muted-foreground hover:text-foreground"
             >
               ← Batches
             </Link>
@@ -134,7 +134,7 @@ export default async function BatchDetailPage({
           <H1 className="mt-1">
             {site.name} · {tmpl.name}
           </H1>
-          <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
+          <div className="mt-1 flex items-center gap-3 text-sm text-muted-foreground">
             <StatusPill kind={jobStatusKind(job.status as Parameters<typeof jobStatusKind>[0])} />
             <span>
               {job.succeeded_count} ok · {job.failed_count} fail ·{" "}
@@ -159,7 +159,7 @@ export default async function BatchDetailPage({
         <div>
           <H3>Slots</H3>
           <div className="mt-2 overflow-x-auto rounded-md border">
-            <table className="w-full text-xs">
+            <table className="w-full text-sm">
               <thead>
                 <tr className="border-b bg-muted/40 text-left text-muted-foreground">
                   <th className="px-3 py-2 font-medium">#</th>
@@ -224,7 +224,7 @@ export default async function BatchDetailPage({
             {(recentEvents ?? []).map((e) => (
               <div
                 key={String(e.id)}
-                className="rounded-md border p-2 text-xs"
+                className="rounded-md border p-2 text-sm"
               >
                 <div className="flex items-center justify-between">
                   <span className="font-medium">{e.event as string}</span>
@@ -238,7 +238,7 @@ export default async function BatchDetailPage({
               </div>
             ))}
             {(recentEvents ?? []).length === 0 && (
-              <p className="text-xs text-muted-foreground">No events yet.</p>
+              <p className="text-sm text-muted-foreground">No events yet.</p>
             )}
           </div>
         </div>

--- a/app/admin/batches/page.tsx
+++ b/app/admin/batches/page.tsx
@@ -192,7 +192,7 @@ export default async function AdminBatchesPage({
           {siteForButton && (
             <Link
               href="/admin/batches"
-              className="mt-1 inline-block text-xs text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+              className="mt-1 inline-block text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
             >
               ← All batches
             </Link>
@@ -222,7 +222,7 @@ export default async function AdminBatchesPage({
           <div className="overflow-x-auto rounded-md border">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b bg-muted/40 text-left text-xs text-muted-foreground">
+                <tr className="border-b bg-muted/40 text-left text-sm text-muted-foreground">
                   <th className="px-3 py-2 font-medium">Site / Template</th>
                   <th className="px-3 py-2 font-medium">Status</th>
                   <th className="px-3 py-2 font-medium">Progress</th>
@@ -241,24 +241,24 @@ export default async function AdminBatchesPage({
                       >
                         {r.site_name}
                       </Link>
-                      <div className="text-xs text-muted-foreground">
+                      <div className="text-sm text-muted-foreground">
                         {r.template_name}
                       </div>
                     </td>
                     <td className="px-3 py-2">
                       <StatusPill kind={jobStatusKind(r.status as Parameters<typeof jobStatusKind>[0])} />
                     </td>
-                    <td className="px-3 py-2 text-xs text-muted-foreground">
+                    <td className="px-3 py-2 text-sm text-muted-foreground">
                       {r.succeeded_count} ok · {r.failed_count} fail ·{" "}
                       {r.requested_count} total
                     </td>
-                    <td className="px-3 py-2 text-xs text-muted-foreground">
+                    <td className="px-3 py-2 text-sm text-muted-foreground">
                       {formatCostCents(r.total_cost_usd_cents)}
                     </td>
-                    <td className="px-3 py-2 text-xs text-muted-foreground">
+                    <td className="px-3 py-2 text-sm text-muted-foreground">
                       {formatDate(r.created_at)}
                     </td>
-                    <td className="px-3 py-2 text-xs text-muted-foreground">
+                    <td className="px-3 py-2 text-sm text-muted-foreground">
                       {r.created_by_email ?? "—"}
                     </td>
                   </tr>

--- a/app/admin/email-test/page.tsx
+++ b/app/admin/email-test/page.tsx
@@ -33,7 +33,7 @@ export default async function EmailTestPage() {
 
       <Alert className="mt-6">
         Restricted to <strong>super_admin</strong>. Every send is
-        captured in <code className="font-mono text-xs">email_log</code>{" "}
+        captured in <code className="font-mono text-sm">email_log</code>{" "}
         for audit.
       </Alert>
 

--- a/app/admin/images/[id]/page.tsx
+++ b/app/admin/images/[id]/page.tsx
@@ -181,7 +181,7 @@ export default async function AdminImageDetailPage({
           />
           <Link
             href={backHref}
-            className="text-xs text-muted-foreground hover:text-foreground"
+            className="text-sm text-muted-foreground hover:text-foreground"
           >
             ← Back to library
           </Link>
@@ -206,7 +206,7 @@ export default async function AdminImageDetailPage({
             )}
           </div>
           {thumbUrl && (
-            <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            <div className="flex items-center gap-3 text-sm text-muted-foreground">
               <span>Thumbnail:</span>
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
@@ -251,7 +251,7 @@ export default async function AdminImageDetailPage({
                 {image.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="rounded bg-muted px-2 py-0.5 text-xs"
+                    className="rounded bg-muted px-2 py-0.5 text-sm"
                   >
                     {tag}
                   </span>
@@ -263,7 +263,7 @@ export default async function AdminImageDetailPage({
           <dd className="capitalize">
             {image.source}
             {image.source_ref && (
-              <span className="ml-2 text-xs text-muted-foreground">
+              <span className="ml-2 text-sm text-muted-foreground">
                 ({image.source_ref})
               </span>
             )}
@@ -282,11 +282,11 @@ export default async function AdminImageDetailPage({
       <section className="mt-8">
         <H3>
           Used on sites{" "}
-          <span className="text-xs font-normal text-muted-foreground">
+          <span className="text-sm font-normal text-muted-foreground">
             ({usage.length})
           </span>
         </H3>
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Every WP site this image has been mirrored to via the publish pipeline.
         </p>
         <div className="mt-3" data-testid="image-usage-list">
@@ -297,7 +297,7 @@ export default async function AdminImageDetailPage({
           ) : (
             <div className="overflow-hidden rounded-md border">
               <table className="w-full text-sm">
-                <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
                   <tr>
                     <th className="px-4 py-2 font-medium">Site</th>
                     <th className="px-4 py-2 font-medium">State</th>
@@ -320,13 +320,13 @@ export default async function AdminImageDetailPage({
                           {u.site_name}
                         </Link>
                         {u.wp_url && (
-                          <div className="text-xs text-muted-foreground">
+                          <div className="text-sm text-muted-foreground">
                             {u.wp_url}
                           </div>
                         )}
                       </td>
                       <td className="px-4 py-3">{usageStateBadge(u.state)}</td>
-                      <td className="px-4 py-3 text-xs text-muted-foreground">
+                      <td className="px-4 py-3 text-sm text-muted-foreground">
                         {u.wp_media_id !== null ? (
                           u.wp_source_url ? (
                             <a
@@ -344,7 +344,7 @@ export default async function AdminImageDetailPage({
                           "—"
                         )}
                       </td>
-                      <td className="px-4 py-3 text-xs text-muted-foreground">
+                      <td className="px-4 py-3 text-sm text-muted-foreground">
                         {u.transferred_at
                           ? formatRelativeTime(u.transferred_at)
                           : "—"}
@@ -361,11 +361,11 @@ export default async function AdminImageDetailPage({
       <section className="mt-8">
         <H3>
           Additional metadata{" "}
-          <span className="text-xs font-normal text-muted-foreground">
+          <span className="text-sm font-normal text-muted-foreground">
             ({metadata.length})
           </span>
         </H3>
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           EXIF, licensing notes, model info, and any other per-image attributes
           tracked outside the main row.
         </p>
@@ -378,10 +378,10 @@ export default async function AdminImageDetailPage({
             <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 rounded-md border p-4 text-sm">
               {metadata.map((m) => (
                 <Fragment key={m.key}>
-                  <dt className="font-mono text-xs text-muted-foreground">
+                  <dt className="font-mono text-sm text-muted-foreground">
                     {m.key}
                   </dt>
-                  <dd className="break-all font-mono text-xs">
+                  <dd className="break-all font-mono text-sm">
                     {formatJsonValue(m.value_jsonb)}
                   </dd>
                 </Fragment>

--- a/app/admin/images/page.tsx
+++ b/app/admin/images/page.tsx
@@ -153,7 +153,7 @@ export default async function AdminImagesPage({
         </div>
         <Link
           href={buildHref(parsed, { deleted: !parsed.deleted, page: 1 })}
-          className="text-xs text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          className="text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
         >
           {parsed.deleted ? "← Active images" : "View archived →"}
         </Link>
@@ -169,7 +169,7 @@ export default async function AdminImagesPage({
         <div className="flex flex-col gap-1">
           <label
             htmlFor="images-q"
-            className="text-xs font-medium text-muted-foreground"
+            className="text-sm font-medium text-muted-foreground"
           >
             Search
           </label>
@@ -185,7 +185,7 @@ export default async function AdminImagesPage({
         <div className="flex flex-col gap-1">
           <label
             htmlFor="images-tag"
-            className="text-xs font-medium text-muted-foreground"
+            className="text-sm font-medium text-muted-foreground"
           >
             Tags (comma-separated, all must match)
           </label>
@@ -202,7 +202,7 @@ export default async function AdminImagesPage({
         <div className="flex flex-col gap-1">
           <label
             htmlFor="images-source"
-            className="text-xs font-medium text-muted-foreground"
+            className="text-sm font-medium text-muted-foreground"
           >
             Source
           </label>
@@ -233,14 +233,14 @@ export default async function AdminImagesPage({
               { ...parsed, query: null, tags: [], source: null },
               { page: 1 },
             )}
-            className="text-xs text-muted-foreground hover:text-foreground"
+            className="text-sm text-muted-foreground hover:text-foreground"
           >
             Clear
           </Link>
         )}
       </form>
 
-      <div className="mt-4 flex items-center justify-between text-xs text-muted-foreground">
+      <div className="mt-4 flex items-center justify-between text-sm text-muted-foreground">
         <div data-testid="images-range">
           {total === 0
             ? "0 images"

--- a/app/admin/sites/[id]/design-system/layout.tsx
+++ b/app/admin/sites/[id]/design-system/layout.tsx
@@ -165,7 +165,7 @@ export default function DesignSystemLayout({
     <>
       <div className="flex flex-col gap-2 border-b pb-4">
         <div className="flex items-center justify-between gap-4">
-          <div className="text-xs text-muted-foreground">
+          <div className="text-sm text-muted-foreground">
             <Link href="/admin/sites" className="hover:underline">
               Sites
             </Link>
@@ -175,12 +175,12 @@ export default function DesignSystemLayout({
             <span>Design system</span>
           </div>
           {state.status === "ready" && state.versions.length > 0 && (
-            <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <label className="flex items-center gap-2 text-sm text-muted-foreground">
               Version
               <select
                 value={selectedDs?.id ?? ""}
                 onChange={(e) => navigateToDs(e.target.value)}
-                className="rounded-md border bg-background px-2 py-1 text-xs"
+                className="rounded-md border bg-background px-2 py-1 text-sm"
               >
                 {state.versions
                   .slice()

--- a/app/admin/sites/[id]/design-system/page.tsx
+++ b/app/admin/sites/[id]/design-system/page.tsx
@@ -167,7 +167,7 @@ export default function DesignSystemIndexPage() {
         </p>
         <Link
           href={`/admin/sites/${site.id}/design-system?advanced=1`}
-          className="mt-3 inline-block text-xs font-medium underline-offset-2 hover:underline"
+          className="mt-3 inline-block text-sm font-medium underline-offset-2 hover:underline"
           data-testid="design-system-advanced-link"
         >
           Show versions, components, templates →

--- a/app/admin/sites/[id]/onboarding/page.tsx
+++ b/app/admin/sites/[id]/onboarding/page.tsx
@@ -100,7 +100,7 @@ export default async function SiteOnboardingPage({
           </ul>
           <Link
             href={`/admin/sites/${site.id}`}
-            className="mt-4 inline-block text-xs text-muted-foreground hover:text-foreground"
+            className="mt-4 inline-block text-sm text-muted-foreground hover:text-foreground"
           >
             ← Back to site
           </Link>

--- a/app/admin/sites/[id]/page.tsx
+++ b/app/admin/sites/[id]/page.tsx
@@ -191,7 +191,7 @@ export default async function SiteDetailPage({
             ]}
           />
           <H1 className="mt-2">{site.name}</H1>
-          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
+          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-sm text-muted-foreground">
             <StatusPill kind={siteStatusKind(site.status as Parameters<typeof siteStatusKind>[0])} />
             <a
               href={site.wp_url}
@@ -224,7 +224,7 @@ export default async function SiteDetailPage({
             <H3>Recent batches</H3>
             <Link
               href={`/admin/batches?site_id=${encodeURIComponent(site.id)}`}
-              className="text-xs text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+              className="text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
             >
               View all →
             </Link>
@@ -246,7 +246,7 @@ export default async function SiteDetailPage({
                 />
               </div>
             ) : (
-              <table className="w-full text-xs">
+              <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b bg-muted/40 text-left text-muted-foreground">
                     <th className="px-3 py-2 font-medium">Template</th>
@@ -321,7 +321,7 @@ export default async function SiteDetailPage({
                 />
               </div>
             ) : (
-              <table className="w-full text-xs">
+              <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b bg-muted/40 text-left text-muted-foreground">
                     <th className="px-3 py-2 font-medium">Title</th>
@@ -382,7 +382,7 @@ export default async function SiteDetailPage({
 
           <div className="rounded-lg border p-3">
             <H3>Design system</H3>
-            <div className="mt-2 text-xs" data-testid="site-design-system-card">
+            <div className="mt-2 text-sm" data-testid="site-design-system-card">
               {needsOnboarding ? (
                 <>
                   <p className="text-muted-foreground">
@@ -518,13 +518,13 @@ export default async function SiteDetailPage({
               <Layers aria-hidden className="mt-0.5 h-4 w-4 text-muted-foreground" />
               <div className="min-w-0 flex-1">
                 <H3>Appearance</H3>
-                <p className="mt-1 text-xs text-muted-foreground">
+                <p className="mt-1 text-sm text-muted-foreground">
                   Sync the active DS palette to Kadence on this site&apos;s
                   WordPress install.
                 </p>
                 <Link
                   href={`/admin/sites/${site.id}/appearance`}
-                  className="mt-2 inline-block text-xs text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+                  className="mt-2 inline-block text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
                 >
                   Open Appearance panel →
                 </Link>
@@ -545,13 +545,13 @@ export default async function SiteDetailPage({
                     <StatusPill kind="brief_parsing" label="Not set" />
                   )}
                 </div>
-                <p className="mt-1 text-xs text-muted-foreground">
+                <p className="mt-1 text-sm text-muted-foreground">
                   Brand voice &amp; design direction defaults that every new
                   brief inherits.
                 </p>
                 <Link
                   href={`/admin/sites/${site.id}/settings`}
-                  className="mt-2 inline-block text-xs text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+                  className="mt-2 inline-block text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
                 >
                   Open Settings →
                 </Link>

--- a/app/admin/sites/[id]/pages/[pageId]/page.tsx
+++ b/app/admin/sites/[id]/pages/[pageId]/page.tsx
@@ -125,7 +125,7 @@ export default async function PageDetail({
       <div className="mt-4 flex items-start justify-between gap-4">
         <div className="min-w-0">
           <H1 className="truncate">{page.title}</H1>
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
             {statusBadge(page.status)}
             <span className="rounded bg-muted px-2 py-0.5">
               {page.page_type.replace(/_/g, " ")}
@@ -159,7 +159,7 @@ export default async function PageDetail({
                 href={wpAdminEditUrl(page.site_wp_url, page.wp_page_id)}
                 target="_blank"
                 rel="noreferrer"
-                className="text-xs underline hover:text-foreground"
+                className="text-sm underline hover:text-foreground"
                 data-testid="wp-admin-link"
               >
                 Open in WP admin ↗
@@ -169,7 +169,7 @@ export default async function PageDetail({
                   href={wpPublicUrl(page.site_wp_url, page.slug)}
                   target="_blank"
                   rel="noreferrer"
-                  className="text-xs underline hover:text-foreground"
+                  className="text-sm underline hover:text-foreground"
                   data-testid="wp-public-link"
                 >
                   View live ↗
@@ -179,7 +179,7 @@ export default async function PageDetail({
           )}
           <Link
             href={backHref}
-            className="text-xs text-muted-foreground hover:text-foreground"
+            className="text-sm text-muted-foreground hover:text-foreground"
             data-testid="page-back-to-list"
           >
             ← Back to pages
@@ -197,7 +197,7 @@ export default async function PageDetail({
           <dt className="text-muted-foreground">Title</dt>
           <dd>{page.title}</dd>
           <dt className="text-muted-foreground">Slug</dt>
-          <dd className="font-mono text-xs">{page.slug}</dd>
+          <dd className="font-mono text-sm">{page.slug}</dd>
           <dt className="text-muted-foreground">Type</dt>
           <dd className="capitalize">
             {page.page_type.replace(/_/g, " ")}
@@ -213,22 +213,22 @@ export default async function PageDetail({
           <dt className="text-muted-foreground">DS version</dt>
           <dd>v{page.design_system_version}</dd>
           <dt className="text-muted-foreground">WP page id</dt>
-          <dd className="font-mono text-xs">#{page.wp_page_id}</dd>
+          <dd className="font-mono text-sm">#{page.wp_page_id}</dd>
           <dt className="text-muted-foreground">Created</dt>
-          <dd className="text-xs">{formatRelativeTime(page.created_at)}</dd>
+          <dd className="text-sm">{formatRelativeTime(page.created_at)}</dd>
           <dt className="text-muted-foreground">Updated</dt>
-          <dd className="text-xs">{formatRelativeTime(page.updated_at)}</dd>
+          <dd className="text-sm">{formatRelativeTime(page.updated_at)}</dd>
         </dl>
       </section>
 
       <section className="mt-8">
         <H3>
           Re-generation history{" "}
-          <span className="text-xs font-normal text-muted-foreground">
+          <span className="text-sm font-normal text-muted-foreground">
             ({regenJobs.length})
           </span>
         </H3>
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Each row is one operator-triggered re-run against the current design
           system. Cost + tokens come from Anthropic; failures carry their
           terminal code. In-flight jobs auto-refresh while the Re-generate

--- a/app/admin/sites/[id]/pages/page.tsx
+++ b/app/admin/sites/[id]/pages/page.tsx
@@ -150,7 +150,7 @@ export default async function SitePagesList({
         </div>
         <Link
           href={`/admin/sites/${params.id}`}
-          className="text-xs text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          className="text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
         >
           ← Site detail
         </Link>
@@ -164,7 +164,7 @@ export default async function SitePagesList({
         <div className="flex flex-col gap-1">
           <label
             htmlFor="pages-q"
-            className="text-xs font-medium text-muted-foreground"
+            className="text-sm font-medium text-muted-foreground"
           >
             Search
           </label>
@@ -180,7 +180,7 @@ export default async function SitePagesList({
         <div className="flex flex-col gap-1">
           <label
             htmlFor="pages-status"
-            className="text-xs font-medium text-muted-foreground"
+            className="text-sm font-medium text-muted-foreground"
           >
             Status
           </label>
@@ -198,7 +198,7 @@ export default async function SitePagesList({
         <div className="flex flex-col gap-1">
           <label
             htmlFor="pages-type"
-            className="text-xs font-medium text-muted-foreground"
+            className="text-sm font-medium text-muted-foreground"
           >
             Type
           </label>
@@ -230,14 +230,14 @@ export default async function SitePagesList({
               page_type: null,
               page: 1,
             })}
-            className="text-xs text-muted-foreground hover:text-foreground"
+            className="text-sm text-muted-foreground hover:text-foreground"
           >
             Clear
           </Link>
         )}
       </form>
 
-      <div className="mt-4 flex items-center justify-between text-xs text-muted-foreground">
+      <div className="mt-4 flex items-center justify-between text-sm text-muted-foreground">
         <div data-testid="pages-range">
           {total === 0 ? "0 pages" : `Showing ${rangeStart}–${rangeEnd} of ${total}`}
         </div>

--- a/app/admin/sites/[id]/posts/page.tsx
+++ b/app/admin/sites/[id]/posts/page.tsx
@@ -167,7 +167,7 @@ export default async function SitePostsList({
         <div>
           <label
             htmlFor="status-filter"
-            className="block text-xs font-medium text-muted-foreground"
+            className="block text-sm font-medium text-muted-foreground"
           >
             Status
           </label>
@@ -186,7 +186,7 @@ export default async function SitePostsList({
         <div className="flex-1">
           <label
             htmlFor="q-filter"
-            className="block text-xs font-medium text-muted-foreground"
+            className="block text-sm font-medium text-muted-foreground"
           >
             Search title / slug
           </label>
@@ -208,7 +208,7 @@ export default async function SitePostsList({
         {(parsed.status || parsed.query) && (
           <Link
             href={`/admin/sites/${site.id}/posts`}
-            className="text-xs text-muted-foreground underline hover:text-foreground"
+            className="text-sm text-muted-foreground underline hover:text-foreground"
           >
             Clear filters
           </Link>
@@ -277,7 +277,7 @@ export default async function SitePostsList({
                         {post.title}
                       </Link>
                     </h2>
-                    <p className="mt-0.5 text-xs text-muted-foreground">
+                    <p className="mt-0.5 text-sm text-muted-foreground">
                       <code className="text-[11px]">/{post.slug}</code>
                       {post.wp_post_id
                         ? ` · WP id ${post.wp_post_id}`

--- a/app/admin/sites/[id]/settings/page.tsx
+++ b/app/admin/sites/[id]/settings/page.tsx
@@ -72,7 +72,7 @@ export default async function SiteSettingsPage({
         className="mt-6 rounded-lg border p-4"
       >
         <H2 id="voice-heading">Brand voice &amp; design direction</H2>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           Set once for the site; the brief commit form inherits these as
           defaults.
         </p>
@@ -91,7 +91,7 @@ export default async function SiteSettingsPage({
         className="mt-6 rounded-lg border p-4"
       >
         <H2 id="image-library-heading">Image library</H2>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           When enabled, brief generation can suggest images from the shared
           library where the page topic matches.
         </p>

--- a/app/admin/users/audit/page.tsx
+++ b/app/admin/users/audit/page.tsx
@@ -70,7 +70,7 @@ export default async function UserAuditPage({ searchParams }: PageProps) {
         <>
           <div className="mt-6 rounded-md border">
             <table className="w-full text-sm">
-              <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
                 <tr>
                   <th className="px-3 py-2 font-medium">When</th>
                   <th className="px-3 py-2 font-medium">Actor</th>
@@ -90,21 +90,21 @@ export default async function UserAuditPage({ searchParams }: PageProps) {
                       className="border-b align-top last:border-b-0"
                       data-testid="audit-row"
                     >
-                      <td className="px-3 py-2 text-xs text-muted-foreground">
+                      <td className="px-3 py-2 text-sm text-muted-foreground">
                         <span data-screenshot-mask>
                           {formatRelativeTime(row.created_at as string)}
                         </span>
                       </td>
-                      <td className="px-3 py-2 text-xs">
+                      <td className="px-3 py-2 text-sm">
                         {actor?.email ?? "(deleted user)"}
                       </td>
-                      <td className="px-3 py-2 text-xs font-medium">
+                      <td className="px-3 py-2 text-sm font-medium">
                         {row.action as string}
                       </td>
-                      <td className="px-3 py-2 text-xs">
+                      <td className="px-3 py-2 text-sm">
                         {row.target_email as string}
                       </td>
-                      <td className="px-3 py-2 text-xs text-muted-foreground">
+                      <td className="px-3 py-2 text-sm text-muted-foreground">
                         <code className="font-mono text-[11px]">
                           {JSON.stringify(row.metadata ?? {}, null, 0)}
                         </code>
@@ -135,7 +135,7 @@ export default async function UserAuditPage({ searchParams }: PageProps) {
                 {pageNum > 1 && (
                   <Link
                     href={`/admin/users/audit?page=${pageNum - 1}`}
-                    className="rounded border px-3 py-1 text-xs hover:bg-muted"
+                    className="rounded border px-3 py-1 text-sm hover:bg-muted"
                   >
                     ← Previous
                   </Link>
@@ -143,7 +143,7 @@ export default async function UserAuditPage({ searchParams }: PageProps) {
                 {pageNum < totalPages && (
                   <Link
                     href={`/admin/users/audit?page=${pageNum + 1}`}
-                    className="rounded border px-3 py-1 text-xs hover:bg-muted"
+                    className="rounded border px-3 py-1 text-sm hover:bg-muted"
                   >
                     Next →
                   </Link>

--- a/app/auth/approve/page.tsx
+++ b/app/auth/approve/page.tsx
@@ -171,7 +171,7 @@ export default async function ApprovePage({ searchParams }: PageProps) {
 
       <div className="border-t pt-4">
         <p className="text-sm font-medium">Lost your original tab?</p>
-        <p className="text-xs text-muted-foreground mt-1 mb-3">
+        <p className="text-sm text-muted-foreground mt-1 mb-3">
           Use the button below to finish signing in on this device
           instead.
         </p>

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -29,7 +29,7 @@ export default function ForgotPasswordPage() {
         <div className="rounded-lg border bg-background p-6 shadow-sm">
           <ForgotPasswordForm />
         </div>
-        <p className="text-center text-xs text-muted-foreground">
+        <p className="text-center text-sm text-muted-foreground">
           <a
             href="/login"
             className="underline transition-smooth hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -41,7 +41,7 @@ export default async function ResetPasswordPage() {
               <a href="/auth/forgot-password">Request a new link</a>
             </Button>
           </div>
-          <p className="text-center text-xs text-muted-foreground">
+          <p className="text-center text-sm text-muted-foreground">
             <a
               href="/login"
               className="underline transition-smooth hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"

--- a/app/globals.css
+++ b/app/globals.css
@@ -134,16 +134,28 @@
  * admin surface — those are marketing-page energy and pushed every list
  * below the operator's fold.
  *
- *   <H1>      page heading             text-xl   font-semibold tracking-tight
- *   <H2>      section heading          text-base font-semibold tracking-tight
- *   <H3>      sub-section / card       text-sm   font-semibold
- *   <Eyebrow> small uppercase label    text-xs   font-medium uppercase tracking-wide
+ *   <H1>      page heading             text-xl   font-semibold tracking-tight  ~20px
+ *   <H2>      section heading          text-base font-semibold tracking-tight  ~16px
+ *   <H3>      sub-section / card       text-sm   font-semibold                 ~14px
+ *   <Eyebrow> small uppercase label    text-sm   font-medium uppercase tracking-wide  ~14px
  *                                                 text-muted-foreground
- *   <Lead>    intro / context line     text-sm   text-muted-foreground
+ *   <Lead>    intro / context line     text-base text-muted-foreground         ~16px
  *
- * Body text defaults to text-sm. Metadata + table cells + pills sit at
- * text-xs. font-mono is reserved for literal data (cloudflare ids,
- * cost values, code tokens) — not for stylistic accent.
+ * Type-size minimums (UAT 2026-05-02):
+ *   • Body text: text-base (1rem / 16px) is the floor. Paragraph copy,
+ *     form input values, page descriptions, modal body all sit at this
+ *     size or larger.
+ *   • Small text: text-sm (0.875rem / 14px) is the floor for helper
+ *     copy, captions, badges, eyebrows, breadcrumbs, status microcopy.
+ *   • text-xs (0.75rem / 12px) is FORBIDDEN on every operator surface.
+ *
+ * Per-callsite uses of text-sm for primary reading copy (paragraphs,
+ * descriptions) are a known follow-up sweep — see docs/BACKLOG.md
+ * "Typography minimums Phase 2" — but no new text-xs is permitted in the
+ * meantime.
+ *
+ * font-mono is reserved for literal data (cloudflare ids, cost values,
+ * code tokens) — not for stylistic accent.
  *
  * Reference quality bar: matches Linear's issue view + Vercel's
  * deployment header. Do not introduce a 6th tier without revisiting.

--- a/app/optimiser/change-log/page.tsx
+++ b/app/optimiser/change-log/page.tsx
@@ -73,11 +73,11 @@ export default async function OptimiserChangeLogPage({
             )}
             {rows.map((r) => (
               <tr key={r.id} className="border-t border-border align-top">
-                <td className="px-3 py-2 text-xs text-muted-foreground whitespace-nowrap">
+                <td className="px-3 py-2 text-sm text-muted-foreground whitespace-nowrap">
                   {new Date(r.created_at).toLocaleString()}
                 </td>
-                <td className="px-3 py-2 font-mono text-xs">{r.event}</td>
-                <td className="px-3 py-2 font-mono text-xs">
+                <td className="px-3 py-2 font-mono text-sm">{r.event}</td>
+                <td className="px-3 py-2 font-mono text-sm">
                   {r.proposal_id ? (
                     <Link
                       href={`/optimiser/proposals/${r.proposal_id}`}
@@ -89,11 +89,11 @@ export default async function OptimiserChangeLogPage({
                     "—"
                   )}
                 </td>
-                <td className="px-3 py-2 font-mono text-xs">
+                <td className="px-3 py-2 font-mono text-sm">
                   {r.landing_page_id ? `${r.landing_page_id.slice(0, 8)}…` : "—"}
                 </td>
                 <td className="px-3 py-2">
-                  <pre className="max-h-32 max-w-md overflow-auto rounded bg-muted p-2 text-xs">
+                  <pre className="max-h-32 max-w-md overflow-auto rounded bg-muted p-2 text-sm">
 {JSON.stringify(r.details, null, 2)}
                   </pre>
                 </td>

--- a/app/optimiser/clients/[id]/settings/page.tsx
+++ b/app/optimiser/clients/[id]/settings/page.tsx
@@ -65,7 +65,7 @@ export default async function ClientSettingsPage({
     <div className="space-y-6">
       <header className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <p className="text-xs text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             <Link href="/optimiser" className="text-primary underline-offset-4 hover:underline">
               ← Page browser
             </Link>
@@ -89,11 +89,11 @@ export default async function ClientSettingsPage({
         <h2 className="text-lg font-medium">Composite score weights</h2>
         <p className="text-sm text-muted-foreground">
           The composite is{" "}
-          <code className="font-mono text-xs">
+          <code className="font-mono text-sm">
             (alignment × {weights.alignment.toFixed(2)}) + (behaviour × {weights.behaviour.toFixed(2)}) + (conversion × {weights.conversion.toFixed(2)}) + (technical × {weights.technical.toFixed(2)})
           </code>
           . Defaults are{" "}
-          <code className="font-mono text-xs">0.25 / 0.30 / 0.30 / 0.15</code>.
+          <code className="font-mono text-sm">0.25 / 0.30 / 0.30 / 0.15</code>.
         </p>
         <ul className="space-y-3">
           {(Object.keys(weights) as Array<keyof ScoreWeights>).map((key) => (

--- a/app/optimiser/diagnostics/page.tsx
+++ b/app/optimiser/diagnostics/page.tsx
@@ -82,7 +82,7 @@ export default async function OptimiserDiagnosticsPage() {
             <span className="font-mono">
               {report.pattern_library.consenting_client_count}
             </span>
-            <span className="ml-2 text-xs text-muted-foreground">
+            <span className="ml-2 text-sm text-muted-foreground">
               (gates BOTH contribution and application — §11.2.2)
             </span>
           </li>
@@ -92,7 +92,7 @@ export default async function OptimiserDiagnosticsPage() {
               {report.pattern_library.pattern_count}
             </span>
             {report.pattern_library.pattern_count > 0 && (
-              <span className="ml-2 text-xs text-muted-foreground">
+              <span className="ml-2 text-sm text-muted-foreground">
                 ({report.pattern_library.pattern_by_confidence.high} high
                 · {report.pattern_library.pattern_by_confidence.moderate}{" "}
                 moderate ·{" "}
@@ -113,7 +113,7 @@ export default async function OptimiserDiagnosticsPage() {
             </span>
           </li>
         </ul>
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Pattern rows are anonymised by schema — no foreign keys to
           client/page/proposal. The extractor cron runs daily at 10:00
           UTC; per-client consent toggles on the client settings page.
@@ -173,7 +173,7 @@ export default async function OptimiserDiagnosticsPage() {
                 {s.source.replace("_", " ")}
               </h3>
               <span
-                className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${
+                className={`inline-flex items-center rounded-full border px-2 py-0.5 text-sm font-medium ${
                   s.env.configured
                     ? "border-emerald-200 bg-emerald-50 text-emerald-900"
                     : "border-red-200 bg-red-50 text-red-900"

--- a/app/optimiser/imports/[brief_id]/page.tsx
+++ b/app/optimiser/imports/[brief_id]/page.tsx
@@ -30,7 +30,7 @@ export default async function OptimiserImportReviewPage({
     <div className="space-y-6">
       <header className="flex flex-wrap items-center justify-between gap-4">
         <div className="space-y-1">
-          <p className="text-xs text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             <Link
               href="/optimiser"
               className="text-primary underline-offset-4 hover:underline"
@@ -43,13 +43,13 @@ export default async function OptimiserImportReviewPage({
           </h1>
           <p className="text-sm text-muted-foreground">
             Brief status:{" "}
-            <code className="font-mono text-xs">{details.brief.status}</code>
+            <code className="font-mono text-sm">{details.brief.status}</code>
             {" · "}
             {details.brief_page.word_count.toLocaleString()} words captured
             {details.brief_page.import_source_url && (
               <>
                 {" · "}
-                <span className="font-mono text-xs">
+                <span className="font-mono text-sm">
                   {details.brief_page.import_source_url}
                 </span>
               </>

--- a/app/optimiser/onboarding/page.tsx
+++ b/app/optimiser/onboarding/page.tsx
@@ -44,7 +44,7 @@ export default async function OptimiserOnboardingHome() {
               >
                 <div>
                   <p className="font-medium">{c.name}</p>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-sm text-muted-foreground">
                     {c.client_slug} · created {new Date(c.created_at).toLocaleDateString()}
                   </p>
                 </div>
@@ -70,7 +70,7 @@ export default async function OptimiserOnboardingHome() {
               >
                 <div>
                   <p className="font-medium">{c.name}</p>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-sm text-muted-foreground">
                     {c.client_slug} ·{" "}
                     {c.onboarded_at
                       ? `onboarded ${new Date(c.onboarded_at).toLocaleDateString()}`

--- a/app/optimiser/pages/[id]/page.tsx
+++ b/app/optimiser/pages/[id]/page.tsx
@@ -129,7 +129,7 @@ export default async function OptimiserPageDetail({
     <div className="space-y-6">
       <header className="flex flex-wrap items-center justify-between gap-4">
         <div className="space-y-1">
-          <p className="text-xs text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             <Link href="/optimiser" className="text-primary underline-offset-4 hover:underline">
               ← Page browser
             </Link>{" "}
@@ -138,7 +138,7 @@ export default async function OptimiserPageDetail({
           <h1 className="text-2xl font-semibold tracking-tight">
             {page.display_name ?? page.url}
           </h1>
-          <p className="font-mono text-xs text-muted-foreground">{page.url}</p>
+          <p className="font-mono text-sm text-muted-foreground">{page.url}</p>
         </div>
         <Button asChild variant="outline">
           <Link

--- a/app/optimiser/proposals/[id]/page.tsx
+++ b/app/optimiser/proposals/[id]/page.tsx
@@ -72,7 +72,7 @@ export default async function OptimiserProposalReviewPage({
         <Button asChild variant="outline" size="sm">
           <Link href="/optimiser/proposals">← All proposals</Link>
         </Button>
-        <span className="text-xs text-muted-foreground">
+        <span className="text-sm text-muted-foreground">
           Status: <code>{proposal.status}</code>
         </span>
       </div>

--- a/app/optimiser/proposals/page.tsx
+++ b/app/optimiser/proposals/page.tsx
@@ -86,13 +86,13 @@ export default async function OptimiserProposalsList({
               <tr key={p.id} className="border-t border-border align-top">
                 <td className="px-3 py-2">
                   <div className="font-medium">{p.headline}</div>
-                  <div className="text-xs text-muted-foreground">
+                  <div className="text-sm text-muted-foreground">
                     {p.problem_summary ?? "—"}
                   </div>
                 </td>
                 <td className="px-3 py-2">
                   <span
-                    className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${RISK_PILL[p.risk_level]}`}
+                    className={`inline-flex items-center rounded-full border px-2 py-0.5 text-sm font-medium ${RISK_PILL[p.risk_level]}`}
                   >
                     {p.risk_level}
                   </span>
@@ -109,7 +109,7 @@ export default async function OptimiserProposalsList({
                     ? `+${p.expected_impact_min_pp.toFixed(1)}–${p.expected_impact_max_pp.toFixed(1)}pp`
                     : "—"}
                 </td>
-                <td className="px-3 py-2 text-xs text-muted-foreground">
+                <td className="px-3 py-2 text-sm text-muted-foreground">
                   {p.expires_at ? new Date(p.expires_at).toLocaleDateString() : "—"}
                 </td>
                 <td className="px-3 py-2">

--- a/components/AcceptInviteForm.tsx
+++ b/components/AcceptInviteForm.tsx
@@ -112,7 +112,7 @@ export function AcceptInviteForm({
         />
         <StrengthMeter score={strength} length={password.length} />
         {tooShort && (
-          <p className="mt-1 text-xs text-destructive">
+          <p className="mt-1 text-sm text-destructive">
             At least {MIN_LENGTH} characters.
           </p>
         )}
@@ -137,7 +137,7 @@ export function AcceptInviteForm({
           data-testid="accept-invite-confirm"
         />
         {mismatch && (
-          <p className="mt-1 text-xs text-destructive">
+          <p className="mt-1 text-sm text-destructive">
             Passwords don&apos;t match.
           </p>
         )}
@@ -212,7 +212,7 @@ function StrengthMeter({ score, length }: { score: number; length: number }) {
           />
         ))}
       </div>
-      <span className={cn("text-xs", tone)}>
+      <span className={cn("text-sm", tone)}>
         {score === 0 ? `${length}/${MIN_LENGTH}` : labels[score]}
       </span>
     </div>

--- a/components/AccountSecurityForm.tsx
+++ b/components/AccountSecurityForm.tsx
@@ -120,7 +120,7 @@ export function AccountSecurityForm({ userEmail }: { userEmail: string }) {
 
   return (
     <form onSubmit={handleSubmit} className="flex w-full flex-col gap-5">
-      <p className="text-xs text-muted-foreground">
+      <p className="text-sm text-muted-foreground">
         Signed in as <span className="font-mono">{userEmail}</span>
       </p>
 
@@ -154,9 +154,9 @@ export function AccountSecurityForm({ userEmail }: { userEmail: string }) {
           onChange={(e) => setNext(e.target.value)}
           suppressHydrationWarning
         />
-        {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+        {hint && <p className="text-sm text-muted-foreground">{hint}</p>}
         {sameAsCurrent && (
-          <p className="text-xs text-destructive">
+          <p className="text-sm text-destructive">
             New password must differ from the current one.
           </p>
         )}
@@ -177,7 +177,7 @@ export function AccountSecurityForm({ userEmail }: { userEmail: string }) {
           suppressHydrationWarning
         />
         {mismatch && (
-          <p className="text-xs text-destructive">Passwords don&apos;t match.</p>
+          <p className="text-sm text-destructive">Passwords don&apos;t match.</p>
         )}
       </div>
 

--- a/components/AddSiteModal.tsx
+++ b/components/AddSiteModal.tsx
@@ -36,7 +36,7 @@ function Label({
 
 function FieldError({ message }: { message?: string | null }) {
   if (!message) return null;
-  return <p className="mt-1 text-xs text-destructive">{message}</p>;
+  return <p className="mt-1 text-sm text-destructive">{message}</p>;
 }
 
 export function AddSiteModal({
@@ -233,7 +233,7 @@ export function AddSiteModal({
               <button
                 type="button"
                 onClick={() => setShowPassword((v) => !v)}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground hover:text-foreground"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-sm text-muted-foreground hover:text-foreground"
                 tabIndex={-1}
               >
                 {showPassword ? "hide" : "show"}

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -277,11 +277,11 @@ export function AdminSidebar({
           <div className="border-t p-2">
             {!collapsed && (
               <div className="mb-2 flex items-center justify-between rounded-md bg-muted/40 px-2 py-1.5">
-                <span className="text-xs text-muted-foreground">
+                <span className="text-sm text-muted-foreground">
                   Command palette
                 </span>
                 <span
-                  className="flex items-center gap-0.5 text-xs text-muted-foreground"
+                  className="flex items-center gap-0.5 text-sm text-muted-foreground"
                   aria-hidden
                 >
                   <kbd className="rounded border bg-background px-1 font-mono text-[10px]">

--- a/components/AppearanceEventLog.tsx
+++ b/components/AppearanceEventLog.tsx
@@ -152,7 +152,7 @@ function EventRow({ event }: { event: AppearanceEventRow }) {
           <Badge tone={present.tone}>{present.label}</Badge>
           <span className="flex-1 text-foreground">{summary}</span>
           <time
-            className="text-xs text-muted-foreground"
+            className="text-sm text-muted-foreground"
             dateTime={event.created_at}
           >
             {formatTimestamp(event.created_at)}

--- a/components/AppearancePanelClient.tsx
+++ b/components/AppearancePanelClient.tsx
@@ -323,7 +323,7 @@ export function AppearancePanelClient({
       {/* Scope clarifier — what Opollo owns vs what the operator owns. */}
       <div
         role="note"
-        className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground"
+        className="rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground"
       >
         <p>
           <strong className="text-foreground">Opollo owns palette only.</strong>{" "}
@@ -374,7 +374,7 @@ export function AppearancePanelClient({
           description={
             <>
               <p>{errorMessage}</p>
-              <p className="mt-1 text-xs">
+              <p className="mt-1 text-sm">
                 If this happens repeatedly, the WordPress site or Kadence
                 plugin may be down. Re-checking sometimes helps after a
                 brief pause.
@@ -482,7 +482,7 @@ function PreflightBlockedBanner({
     >
       <p className="font-medium">{blocker.title}</p>
       <p className="mt-1">{blocker.detail}</p>
-      <p className="mt-2 text-xs">
+      <p className="mt-2 text-sm">
         <strong>What to do:</strong> {blocker.nextAction}
       </p>
       <Button
@@ -520,20 +520,20 @@ function KadenceInactiveBanner({
       <p className="font-medium">Kadence isn&apos;t the active theme.</p>
       <p className="mt-1">
         The currently-active theme on{" "}
-        <span className="font-mono text-xs">{siteWpUrl}</span> is{" "}
-        <span className="font-mono text-xs">{activeSlug}</span>.{" "}
+        <span className="font-mono text-sm">{siteWpUrl}</span> is{" "}
+        <span className="font-mono text-sm">{activeSlug}</span>.{" "}
         {installed
           ? "Kadence is installed but not active."
           : "Kadence isn't installed yet."}
       </p>
-      <p className="mt-2 text-xs">
+      <p className="mt-2 text-sm">
         <strong>What to do:</strong>{" "}
         {installed
           ? "In WP Admin → Appearance → Themes, hover over Kadence and click Activate."
           : "In WP Admin → Appearance → Themes → Add New, search 'kadence', click Install + Activate."}{" "}
         Then come back here and click Re-check.
       </p>
-      <p className="mt-2 text-xs">
+      <p className="mt-2 text-sm">
         <a
           href={`${siteWpUrl}/wp-admin/themes.php`}
           target="_blank"
@@ -587,16 +587,16 @@ function ReadyState({
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p className="text-sm">
-              <span className="inline-flex rounded bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-700">
+              <span className="inline-flex rounded bg-emerald-500/10 px-2 py-0.5 text-sm font-medium text-emerald-700">
                 Kadence active
               </span>
               {ctx.install.kadence_version && (
-                <span className="ml-2 text-xs text-muted-foreground">
+                <span className="ml-2 text-sm text-muted-foreground">
                   v{ctx.install.kadence_version}
                 </span>
               )}
             </p>
-            <dl className="mt-2 grid grid-cols-1 gap-x-6 gap-y-1 text-xs text-muted-foreground sm:grid-cols-2">
+            <dl className="mt-2 grid grid-cols-1 gap-x-6 gap-y-1 text-sm text-muted-foreground sm:grid-cols-2">
               <div>
                 <dt className="inline">Detected:</dt>{" "}
                 <dd className="inline">
@@ -656,18 +656,18 @@ function ReadyState({
               Proposed palette
             </h2>
             {ctx.already_synced ? (
-              <span className="inline-flex rounded bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-700">
+              <span className="inline-flex rounded bg-emerald-500/10 px-2 py-0.5 text-sm font-medium text-emerald-700">
                 Already synced
               </span>
             ) : (
-              <span className="inline-flex rounded bg-yellow-500/10 px-2 py-0.5 text-xs font-medium text-yellow-900 dark:text-yellow-200">
+              <span className="inline-flex rounded bg-yellow-500/10 px-2 py-0.5 text-sm font-medium text-yellow-900 dark:text-yellow-200">
                 {ctx.diff.entries.filter((e) => e.changed).length} slot
                 {ctx.diff.entries.filter((e) => e.changed).length === 1 ? "" : "s"} pending
               </span>
             )}
           </div>
           <KadencePaletteDiffTable diff={ctx.diff} />
-          <p className="mt-2 text-xs text-muted-foreground">
+          <p className="mt-2 text-sm text-muted-foreground">
             Source:{" "}
             <span className="font-mono">{ctx.proposal.source}</span>
             {ctx.proposal.source === "explicit" &&
@@ -762,7 +762,7 @@ function SyncConfirmModal({
         </div>
 
         <div className="mt-5">
-          <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <h3 className="mb-2 text-sm font-medium uppercase tracking-wide text-muted-foreground">
             Slot-by-slot changes
           </h3>
           <KadencePaletteDiffTable diff={diff} />

--- a/components/ApproveCompleteHere.tsx
+++ b/components/ApproveCompleteHere.tsx
@@ -61,7 +61,7 @@ export function ApproveCompleteHere({ challengeId }: { challengeId: string }) {
       >
         {submitting ? "Signing you in…" : "Complete sign-in here"}
       </Button>
-      <p className="text-xs text-muted-foreground">
+      <p className="text-sm text-muted-foreground">
         Use this if you can&apos;t get back to your original tab. This
         device won&apos;t be trusted automatically — you&apos;ll be
         challenged again next time.

--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -100,7 +100,7 @@ const ERROR_TRANSLATIONS: Record<string, string> = {
 function SourceHint({ source }: { source: ParseSource }) {
   if (source === "none") return null;
   return (
-    <span className="text-xs text-muted-foreground">{SOURCE_HINTS[source]}</span>
+    <span className="text-sm text-muted-foreground">{SOURCE_HINTS[source]}</span>
   );
 }
 
@@ -553,7 +553,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
           <div className="mt-1 flex items-center justify-between gap-2">
             <SourceHint source={slug.source} />
             {!slugIsValid && slug.value.length > 0 && (
-              <span className="text-xs text-destructive">
+              <span className="text-sm text-destructive">
                 Lowercase letters, numbers, dashes only.
               </span>
             )}
@@ -614,7 +614,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
               disabled={submitting}
               triggerId="post-parent-page"
             />
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className="mt-1 text-sm text-muted-foreground">
               Where this post will live in the WP site tree (queries
               <code className="ml-1 font-mono">/wp/v2/pages</code>).
             </p>
@@ -646,7 +646,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
                 metaDescription.value.length > 0 && !metaDescriptionIsValid
               }
             />
-            <div className="mt-1 flex items-center justify-between gap-2 text-xs">
+            <div className="mt-1 flex items-center justify-between gap-2 text-sm">
               <SourceHint source={metaDescription.source} />
               <MetaDescriptionLengthHint
                 length={metaDescription.value.length}
@@ -659,7 +659,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
           <div className="flex items-start justify-between gap-3">
             <div>
               <p className="font-medium">Featured image</p>
-              <p className="mt-1 text-xs text-muted-foreground">
+              <p className="mt-1 text-sm text-muted-foreground">
                 Required at publish (enforced by BP-7&apos;s server-side
                 guard). Selecting here previews; persistence + WP attachment
                 ship in BP-7.
@@ -696,7 +696,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
                 <button
                   type="button"
                   onClick={() => setFeaturedImage(null)}
-                  className="text-xs text-muted-foreground underline hover:text-foreground"
+                  className="text-sm text-muted-foreground underline hover:text-foreground"
                 >
                   Remove
                 </button>
@@ -711,7 +711,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
       {/* BL-2 — saved indicator + restored draft notice + discard button.
           Sits flush above the action row so the operator catches the
           state change in their primary scan path. */}
-      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
         <SaveStatus
           autosave={autosave}
           restoredAt={draftRestoredAt}
@@ -722,7 +722,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
       <div className="flex flex-wrap items-center justify-end gap-2">
         <span
           aria-hidden
-          className="hidden items-center gap-0.5 text-xs text-muted-foreground sm:inline-flex"
+          className="hidden items-center gap-0.5 text-sm text-muted-foreground sm:inline-flex"
         >
           <kbd className="rounded border bg-muted px-1 font-mono text-[10px]">
             ⌘
@@ -747,7 +747,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
         </Button>
       </div>
       {!canStartRun && canSaveDraft && (
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Start run needs the SEO meta fields, parent page, and featured
           image — open <button
             type="button"
@@ -792,7 +792,7 @@ function ReadingChip({ text }: { text: string }) {
       // BL-9 — fade-in the first time the chip surfaces. Re-runs on
       // remount only (text changes don't re-trigger because React
       // doesn't add the class on re-render of an already-mounted node).
-      className="opollo-fade-in text-xs text-muted-foreground"
+      className="opollo-fade-in text-sm text-muted-foreground"
     >
       {words.toLocaleString()} {words === 1 ? "word" : "words"} ·{" "}
       {minutes} min read
@@ -809,7 +809,7 @@ function TitleLengthHint({
 }) {
   if (!valid) {
     return (
-      <span className="text-xs text-destructive">Title required.</span>
+      <span className="text-sm text-destructive">Title required.</span>
     );
   }
   if (length === 0) return null;
@@ -818,7 +818,7 @@ function TitleLengthHint({
     <span
       data-testid="post-title-length-hint"
       className={cn(
-        "text-xs",
+        "text-sm",
         overSeoCap ? "text-warning" : "text-muted-foreground",
       )}
     >
@@ -835,7 +835,7 @@ function MetaTitleLengthHint({ length }: { length: number }) {
     <span
       data-testid="post-meta-title-length-hint"
       className={cn(
-        "text-xs",
+        "text-sm",
         overSeoCap ? "text-warning" : "text-muted-foreground",
       )}
     >
@@ -927,7 +927,7 @@ function AdvancedDisclosure({
           <ChevronRight aria-hidden className="h-4 w-4 text-muted-foreground" />
         )}
         <span className="font-medium">More options</span>
-        <span className="truncate text-xs text-muted-foreground">{summary}</span>
+        <span className="truncate text-sm text-muted-foreground">{summary}</span>
       </button>
       {open && (
         <div
@@ -1207,7 +1207,7 @@ function WpPageCombobox({
             {error && (
               <div
                 role="alert"
-                className="px-3 py-2 text-xs text-destructive"
+                className="px-3 py-2 text-sm text-destructive"
               >
                 {error}
               </div>
@@ -1225,7 +1225,7 @@ function WpPageCombobox({
                 }}
               >
                 <span className="flex-1 truncate">{p.title}</span>
-                <span className="ml-2 shrink-0 text-xs text-muted-foreground">
+                <span className="ml-2 shrink-0 text-sm text-muted-foreground">
                   /{p.slug}
                 </span>
               </CommandItem>

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -13,7 +13,7 @@ export function Breadcrumbs({ crumbs }: { crumbs: Crumb[] }) {
   return (
     <nav
       aria-label="Breadcrumb"
-      className="flex flex-wrap items-center gap-1.5 text-xs"
+      className="flex flex-wrap items-center gap-1.5 text-sm"
     >
       {crumbs.map((c, i) => {
         const isLast = i === crumbs.length - 1;

--- a/components/BriefReviewClient.tsx
+++ b/components/BriefReviewClient.tsx
@@ -330,7 +330,7 @@ export function BriefReviewClient({
           <ul className="mt-1 list-disc space-y-1 pl-5">
             {warnings.map((w: { code: string; detail?: string }, i: number) => (
               <li key={i}>
-                <code className="text-xs">{w.code}</code>
+                <code className="text-sm">{w.code}</code>
                 {w.detail ? <>: {w.detail}</> : null}
               </li>
             ))}
@@ -347,7 +347,7 @@ export function BriefReviewClient({
               <h2 id="voice-direction-heading" className="text-base font-semibold">
                 Brand voice &amp; design direction
               </h2>
-              <p className="mt-1 text-xs text-muted-foreground">
+              <p className="mt-1 text-sm text-muted-foreground">
                 {hasSiteDefault && !voiceOverrideOpen
                   ? "Inheriting from site defaults. Expand to customize for this brief."
                   : hasSiteDefault
@@ -372,7 +372,7 @@ export function BriefReviewClient({
             <div className="space-y-2 rounded-md bg-muted/40 p-3 text-sm">
               {siteBrandVoiceDefault && (
                 <div>
-                  <p className="text-xs font-medium text-muted-foreground">
+                  <p className="text-sm font-medium text-muted-foreground">
                     Brand voice (site default)
                   </p>
                   <p className="mt-1 whitespace-pre-wrap">
@@ -382,7 +382,7 @@ export function BriefReviewClient({
               )}
               {siteDesignDirectionDefault && (
                 <div>
-                  <p className="text-xs font-medium text-muted-foreground">
+                  <p className="text-sm font-medium text-muted-foreground">
                     Design direction (site default)
                   </p>
                   <p className="mt-1 whitespace-pre-wrap">
@@ -400,7 +400,7 @@ export function BriefReviewClient({
             <div>
               <label
                 htmlFor="brand-voice-input"
-                className="block text-xs font-medium text-muted-foreground"
+                className="block text-sm font-medium text-muted-foreground"
               >
                 Brand voice
               </label>
@@ -416,7 +416,7 @@ export function BriefReviewClient({
               />
               <p
                 id="brand-voice-hint"
-                className="mt-1 text-xs text-muted-foreground"
+                className="mt-1 text-sm text-muted-foreground"
               >
                 How every page should sound. 4 KB max.
               </p>
@@ -424,7 +424,7 @@ export function BriefReviewClient({
             <div>
               <label
                 htmlFor="design-direction-input"
-                className="block text-xs font-medium text-muted-foreground"
+                className="block text-sm font-medium text-muted-foreground"
               >
                 Design direction
               </label>
@@ -440,7 +440,7 @@ export function BriefReviewClient({
               />
               <p
                 id="design-direction-hint"
-                className="mt-1 text-xs text-muted-foreground"
+                className="mt-1 text-sm text-muted-foreground"
               >
                 Constrains the anchor cycle on page 1, then re-used verbatim
                 for pages 2..N. 4 KB max.
@@ -456,7 +456,7 @@ export function BriefReviewClient({
             <h2 id="model-tier-heading" className="text-base font-semibold">
               Model tier
             </h2>
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className="mt-1 text-sm text-muted-foreground">
               Pick the Claude model for text generation and for the visual
               review critique. Sonnet is the default for both — Opus is
               reserved for complex-judgment briefs. See the cost estimate on
@@ -467,7 +467,7 @@ export function BriefReviewClient({
             <div>
               <label
                 htmlFor="text-model-select"
-                className="block text-xs font-medium text-muted-foreground"
+                className="block text-sm font-medium text-muted-foreground"
               >
                 Text model (draft / critique / revise passes)
               </label>
@@ -484,14 +484,14 @@ export function BriefReviewClient({
                   </option>
                 ))}
               </select>
-              <p className="mt-1 text-xs text-muted-foreground">
+              <p className="mt-1 text-sm text-muted-foreground">
                 {MODEL_OPTIONS.find((o) => o.value === textModel)?.hint ?? ""}
               </p>
             </div>
             <div>
               <label
                 htmlFor="visual-model-select"
-                className="block text-xs font-medium text-muted-foreground"
+                className="block text-sm font-medium text-muted-foreground"
               >
                 Visual critique model
               </label>
@@ -508,7 +508,7 @@ export function BriefReviewClient({
                   </option>
                 ))}
               </select>
-              <p className="mt-1 text-xs text-muted-foreground">
+              <p className="mt-1 text-sm text-muted-foreground">
                 {MODEL_OPTIONS.find((o) => o.value === visualModel)?.hint ?? ""}
               </p>
             </div>
@@ -520,7 +520,7 @@ export function BriefReviewClient({
         <section aria-label="Page list">
           <div className="mb-3 flex items-center justify-between">
             <h2 className="text-base font-semibold">Page list</h2>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               {sortedPages.length} page{sortedPages.length === 1 ? "" : "s"}
             </p>
           </div>
@@ -529,13 +529,13 @@ export function BriefReviewClient({
             {sortedPages.map((p) => (
               <li key={p.localKey} className="rounded-lg border p-4">
                 <div className="flex items-start gap-4">
-                  <div className="w-8 shrink-0 text-center text-xs text-muted-foreground pt-2">
+                  <div className="w-8 shrink-0 text-center text-sm text-muted-foreground pt-2">
                     {p.ordinal + 1}
                   </div>
 
                   <div className="flex-1 space-y-3">
                     <div>
-                      <label className="block text-xs font-medium text-muted-foreground">
+                      <label className="block text-sm font-medium text-muted-foreground">
                         Page title
                       </label>
                       <Input
@@ -549,7 +549,7 @@ export function BriefReviewClient({
 
                     <div className="flex items-center gap-4">
                       {p.mode === "import" ? (
-                        <span className="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-900">
+                        <span className="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-2.5 py-0.5 text-sm font-medium text-blue-900">
                           Import (mode locked)
                         </span>
                       ) : (
@@ -563,17 +563,17 @@ export function BriefReviewClient({
                           }
                         />
                       )}
-                      <span className="text-xs text-muted-foreground">
+                      <span className="text-sm text-muted-foreground">
                         {p.word_count} word{p.word_count === 1 ? "" : "s"}
                       </span>
                     </div>
 
                     <details className="group">
-                      <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+                      <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
                         Show source excerpt
                       </summary>
                       <Textarea
-                        className="mt-2 text-xs"
+                        className="mt-2 text-sm"
                         value={p.source_text}
                         readOnly
                         rows={Math.min(12, Math.max(3, p.source_text.split("\n").length))}
@@ -683,7 +683,7 @@ function ModePill({
   return (
     <button
       type="button"
-      className="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs font-medium hover:bg-muted disabled:opacity-50"
+      className="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-sm font-medium hover:bg-muted disabled:opacity-50"
       onClick={onToggle}
       disabled={disabled}
       title={description}

--- a/components/BriefRunClient.tsx
+++ b/components/BriefRunClient.tsx
@@ -374,7 +374,7 @@ export function BriefRunClient({
             {polled.isStale && (
               <span
                 role="status"
-                className="ml-2 inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+                className="ml-2 inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-sm text-muted-foreground"
                 title="Live updates paused — retrying"
               >
                 <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-amber-500" />
@@ -420,7 +420,7 @@ export function BriefRunClient({
           title={
             <>
               Run failed:{" "}
-              <code className="text-xs">{activeRun.failure_code}</code>
+              <code className="text-sm">{activeRun.failure_code}</code>
             </>
           }
         >
@@ -460,7 +460,7 @@ export function BriefRunClient({
                     >
                       {page.ordinal + 1}. {page.title}
                     </h3>
-                    <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+                    <div className="mt-1 flex flex-wrap items-center gap-2 text-sm">
                       <PageStatusPill status={page.page_status} />
                       {page.quality_flag && (
                         <QualityFlagBadge flag={page.quality_flag} />
@@ -609,7 +609,7 @@ function PagePreview({
     <div className="mt-4 space-y-3">
       {html ? (
         <details className="group">
-          <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+          <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
             Show rendered preview
           </summary>
           {looksTruncated && (
@@ -645,7 +645,7 @@ function PagePreview({
           />
         </details>
       ) : (
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           No draft HTML yet.
         </p>
       )}
@@ -656,10 +656,10 @@ function PagePreview({
 
       {page.operator_notes && page.operator_notes.trim() !== "" && (
         <details className="group">
-          <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">
+          <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
             Your past notes
           </summary>
-          <pre className="mt-2 whitespace-pre-wrap rounded border bg-muted p-2 text-xs">
+          <pre className="mt-2 whitespace-pre-wrap rounded border bg-muted p-2 text-sm">
             {page.operator_notes}
           </pre>
         </details>
@@ -701,9 +701,9 @@ function VisualCritiqueBlock({ entry }: { entry: BriefPageCritiqueEntry }) {
     <div className="rounded border bg-muted/50 p-3 text-sm">
       <p className="font-medium">Visual critique</p>
       {critique.issues.length === 0 ? (
-        <p className="mt-1 text-xs text-muted-foreground">No issues flagged.</p>
+        <p className="mt-1 text-sm text-muted-foreground">No issues flagged.</p>
       ) : (
-        <ul className="mt-2 space-y-1 text-xs">
+        <ul className="mt-2 space-y-1 text-sm">
           {critique.issues.map((issue, i) => (
             <li key={i} className="flex gap-2">
               <span
@@ -724,7 +724,7 @@ function VisualCritiqueBlock({ entry }: { entry: BriefPageCritiqueEntry }) {
         </ul>
       )}
       {critique.overall_notes && (
-        <p className="mt-2 text-xs text-muted-foreground">
+        <p className="mt-2 text-sm text-muted-foreground">
           {critique.overall_notes}
         </p>
       )}
@@ -828,7 +828,7 @@ function ReviseModal({
         <div className="mt-4">
           <label
             htmlFor="revise-note-input"
-            className="block text-xs font-medium text-muted-foreground"
+            className="block text-sm font-medium text-muted-foreground"
           >
             Note for the generator
           </label>
@@ -841,7 +841,7 @@ function ReviseModal({
             placeholder="e.g. The hero section is too dense. Break into a headline + single CTA with generous whitespace underneath."
             maxLength={2000}
           />
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-sm text-muted-foreground">
             {note.length} / 2000 characters
           </p>
         </div>

--- a/components/BulkImageUpload.tsx
+++ b/components/BulkImageUpload.tsx
@@ -243,17 +243,17 @@ export function BulkImageUpload() {
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <h2 className="text-sm font-semibold">Bulk upload</h2>
-          <p className="text-xs text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             Drag images here, or click to pick. Up to 10 MB each. JPEG / PNG / WebP / GIF.
           </p>
         </div>
-        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+        <label className="flex items-center gap-2 text-sm text-muted-foreground">
           On duplicate
           <select
             value={policy}
             onChange={(e) => setPolicy(e.target.value as DupePolicy)}
             disabled={running}
-            className="h-7 rounded border bg-background px-2 text-xs"
+            className="h-7 rounded border bg-background px-2 text-sm"
             data-testid="bulk-upload-policy"
           >
             <option value="skip">Skip all</option>
@@ -299,7 +299,7 @@ export function BulkImageUpload() {
         />
       </div>
 
-      <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+      <div className="mt-3 flex flex-wrap items-center gap-2 text-sm">
         <Button
           type="button"
           size="sm"
@@ -331,7 +331,7 @@ export function BulkImageUpload() {
 
       {rows.length > 0 && (
         <ul
-          className="mt-3 space-y-1 text-xs"
+          className="mt-3 space-y-1 text-sm"
           data-testid="bulk-upload-list"
         >
           {rows.map((row) => (

--- a/components/BulkUploadPanel.tsx
+++ b/components/BulkUploadPanel.tsx
@@ -278,7 +278,7 @@ export function BulkUploadPanel({ siteId }: { siteId: string }) {
       >
         <Upload aria-hidden className="mx-auto mb-2 h-6 w-6 text-muted-foreground" />
         <p className="font-medium">Drop markdown, HTML, or text files here</p>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           Each file becomes one post. Max 10 MB per file. Or
           <button
             type="button"
@@ -313,14 +313,14 @@ export function BulkUploadPanel({ siteId }: { siteId: string }) {
         >
           Or paste multiple posts
         </label>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           Separate documents with a <code className="font-mono">---</code>
           {" "}line on its own (between blank lines), or stack YAML front-
           matter blocks back-to-back.
         </p>
         <Textarea
           id="bulk-paste"
-          className="mt-2 font-mono text-xs"
+          className="mt-2 font-mono text-sm"
           rows={10}
           value={pasted}
           onChange={(e) => setPasted(e.target.value)}
@@ -342,7 +342,7 @@ Body of second post.`}
       {error && (
         <div
           role="alert"
-          className="whitespace-pre-line rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive"
+          className="whitespace-pre-line rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
         >
           {error}
         </div>
@@ -358,7 +358,7 @@ Body of second post.`}
               type="button"
               onClick={clearAll}
               disabled={running}
-              className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground disabled:opacity-50"
+              className="text-sm text-muted-foreground underline underline-offset-2 hover:text-foreground disabled:opacity-50"
             >
               Clear all
             </button>
@@ -385,7 +385,7 @@ Body of second post.`}
       <div className="flex flex-wrap items-center justify-end gap-2">
         {summary.detail && (
           <p
-            className="text-xs text-muted-foreground"
+            className="text-sm text-muted-foreground"
             data-testid="bulk-run-detail"
           >
             {summary.detail}
@@ -393,7 +393,7 @@ Body of second post.`}
         )}
         <span
           aria-hidden
-          className="hidden items-center gap-0.5 text-xs text-muted-foreground sm:inline-flex"
+          className="hidden items-center gap-0.5 text-sm text-muted-foreground sm:inline-flex"
         >
           <kbd className="rounded border bg-muted px-1 font-mono text-[10px]">
             ⌘
@@ -591,10 +591,10 @@ function BulkCandidateCard({
               }}
               aria-invalid={!slugIsValid}
               data-testid="bulk-candidate-slug"
-              className="h-8 font-mono text-xs"
+              className="h-8 font-mono text-sm"
             />
           </div>
-          <p className="text-xs text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             {candidate.origin} · {candidate.wordCount.toLocaleString()} words
             {!slugIsValid && (
               <span className="ml-2 text-destructive">
@@ -605,7 +605,7 @@ function BulkCandidateCard({
           {candidate.status === "failed" && candidate.error && (
             <p
               role="alert"
-              className="rounded-md border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive"
+              className="rounded-md border border-destructive/40 bg-destructive/10 p-2 text-sm text-destructive"
               data-testid="bulk-candidate-error"
             >
               {candidate.error}
@@ -615,7 +615,7 @@ function BulkCandidateCard({
             type="button"
             onClick={() => setPreviewOpen((v) => !v)}
             aria-expanded={previewOpen}
-            className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
             data-testid="bulk-candidate-preview-toggle"
           >
             {previewOpen ? (
@@ -627,7 +627,7 @@ function BulkCandidateCard({
           </button>
           {previewOpen && (
             <div
-              className="rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground whitespace-pre-wrap"
+              className="rounded-md border bg-muted/30 p-3 text-sm text-muted-foreground whitespace-pre-wrap"
               data-testid="bulk-candidate-preview"
             >
               {bodyPreview.slice(0, BODY_PREVIEW_CHARS)}
@@ -652,7 +652,7 @@ function BulkCandidateCard({
               disabled={runDisabled || candidate.status === "saving"}
               data-testid="bulk-candidate-reject"
               className={cn(
-                "rounded border px-2 py-0.5 text-xs transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50",
+                "rounded border px-2 py-0.5 text-sm transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50",
                 candidate.rejected
                   ? "border-success/40 bg-success/10 text-success hover:bg-success/20"
                   : "border-input text-muted-foreground hover:bg-muted hover:text-foreground",

--- a/components/CheckEmailPolling.tsx
+++ b/components/CheckEmailPolling.tsx
@@ -291,7 +291,7 @@ export function CheckEmailPolling({
         />
         <span>
           <strong>Trust this device for 30 days.</strong>{" "}
-          <span className="text-xs text-muted-foreground">
+          <span className="text-sm text-muted-foreground">
             Future sign-ins from this browser skip the email-approval
             step. Uncheck on a shared computer.
           </span>
@@ -299,7 +299,7 @@ export function CheckEmailPolling({
       </label>
 
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="text-xs text-muted-foreground">
+        <div className="text-sm text-muted-foreground">
           Lost the email? You can retry below.
         </div>
         <Button
@@ -317,7 +317,7 @@ export function CheckEmailPolling({
         </Button>
       </div>
 
-      <p className="text-xs text-muted-foreground">
+      <p className="text-sm text-muted-foreground">
         Wrong email?{" "}
         <a href="/logout" className="underline">
           Sign in again

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -273,7 +273,7 @@ export function CommandPalette() {
                     <Icon aria-hidden className="h-4 w-4 text-muted-foreground" />
                     <span className="flex-1 truncate">{item.label}</span>
                     {item.description && (
-                      <span className="ml-2 shrink-0 text-xs text-muted-foreground">
+                      <span className="ml-2 shrink-0 text-sm text-muted-foreground">
                         {item.description}
                       </span>
                     )}
@@ -294,7 +294,7 @@ export function CommandPalette() {
                     >
                       <Globe aria-hidden className="h-4 w-4 text-muted-foreground" />
                       <span className="flex-1 truncate">{site.name}</span>
-                      <span className="ml-2 shrink-0 text-xs text-muted-foreground">
+                      <span className="ml-2 shrink-0 text-sm text-muted-foreground">
                         /{site.prefix}
                       </span>
                     </CommandItem>
@@ -354,13 +354,13 @@ export function CommandPalette() {
                   className="h-4 w-4 text-muted-foreground"
                 />
                 <span className="flex-1">Open docs (GitHub)</span>
-                <span className="ml-2 shrink-0 text-xs text-muted-foreground">
+                <span className="ml-2 shrink-0 text-sm text-muted-foreground">
                   ↗
                 </span>
               </CommandItem>
             </CommandGroup>
           </CommandList>
-          <div className="flex items-center justify-between border-t px-3 py-2 text-xs text-muted-foreground">
+          <div className="flex items-center justify-between border-t px-3 py-2 text-sm text-muted-foreground">
             <span className="flex items-center gap-1">
               <kbd className="rounded border bg-muted px-1 font-mono text-[10px]">
                 ↑↓

--- a/components/ComponentFormModal.tsx
+++ b/components/ComponentFormModal.tsx
@@ -49,7 +49,7 @@ function Label({
 
 function FieldError({ message }: { message?: string | null }) {
   if (!message) return null;
-  return <p className="mt-1 text-xs text-destructive">{message}</p>;
+  return <p className="mt-1 text-sm text-destructive">{message}</p>;
 }
 
 function initialFromComponent(c: DesignComponent): FormState {
@@ -307,7 +307,7 @@ export function ComponentFormModal({
               />
               <FieldError message={fieldErrors.name} />
               {mode.kind === "edit" && (
-                <p className="mt-1 text-xs text-muted-foreground">
+                <p className="mt-1 text-sm text-muted-foreground">
                   Name is immutable after create — it&apos;s part of the uniqueness
                   key with variant.
                 </p>
@@ -342,7 +342,7 @@ export function ComponentFormModal({
             <Label htmlFor="cf-html">HTML template</Label>
             <textarea
               id="cf-html"
-              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
               value={form.html_template}
               onChange={(e) => setField("html_template", e.target.value)}
               spellCheck={false}
@@ -355,14 +355,14 @@ export function ComponentFormModal({
             <Label htmlFor="cf-css">CSS</Label>
             <textarea
               id="cf-css"
-              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
               value={form.css}
               onChange={(e) => setField("css", e.target.value)}
               spellCheck={false}
               disabled={submitting}
             />
             <FieldError message={fieldErrors.css} />
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className="mt-1 text-sm text-muted-foreground">
               Every class selector must use the site&apos;s scope prefix (e.g.
               .ls-*). The server rejects unscoped CSS at submit time.
             </p>
@@ -372,7 +372,7 @@ export function ComponentFormModal({
             <Label htmlFor="cf-schema">Content shape (JSON Schema)</Label>
             <textarea
               id="cf-schema"
-              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
               value={form.content_schema}
               onChange={(e) => setField("content_schema", e.target.value)}
               spellCheck={false}
@@ -385,7 +385,7 @@ export function ComponentFormModal({
             <Label htmlFor="cf-image-slots">Image slots (optional)</Label>
             <textarea
               id="cf-image-slots"
-              className="mt-1 h-20 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              className="mt-1 h-20 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
               value={form.image_slots}
               onChange={(e) => setField("image_slots", e.target.value)}
               spellCheck={false}

--- a/components/ComponentsGrid.tsx
+++ b/components/ComponentsGrid.tsx
@@ -45,7 +45,7 @@ export function ComponentsGrid({
     <div className="space-y-8">
       {categories.map((cat) => (
         <section key={cat}>
-          <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-muted-foreground">
             {cat}
           </h2>
           <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -60,15 +60,15 @@ export function ComponentsGrid({
                   <div className="flex items-start justify-between gap-2">
                     <div>
                       <div className="text-sm font-medium">{c.name}</div>
-                      <div className="text-xs text-muted-foreground">
+                      <div className="text-sm text-muted-foreground">
                         {variantLabel(c)}
                       </div>
                     </div>
-                    <div className="shrink-0 text-xs text-muted-foreground">
+                    <div className="shrink-0 text-sm text-muted-foreground">
                       v<span className="font-mono">{c.version_lock}</span>
                     </div>
                   </div>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-sm text-muted-foreground">
                     {countRequiredFields(c.content_schema)} required field
                     {countRequiredFields(c.content_schema) === 1 ? "" : "s"}
                   </p>

--- a/components/Composer.tsx
+++ b/components/Composer.tsx
@@ -201,7 +201,7 @@ export function Composer({
           >
             <span aria-hidden className="text-base leading-none">📎</span>
             <span className="truncate font-medium">{value.file.name}</span>
-            <span className="shrink-0 text-xs text-muted-foreground">
+            <span className="shrink-0 text-sm text-muted-foreground">
               {Math.round(value.file.size / 1024).toLocaleString()} KB
             </span>
             <button
@@ -271,7 +271,7 @@ export function Composer({
       </div>
 
       {acceptHint && (
-        <p className="px-3 pb-2 text-xs text-muted-foreground">{acceptHint}</p>
+        <p className="px-3 pb-2 text-sm text-muted-foreground">{acceptHint}</p>
       )}
     </div>
   );

--- a/components/ConceptRefinementView.tsx
+++ b/components/ConceptRefinementView.tsx
@@ -177,14 +177,14 @@ export function ConceptRefinementView({
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h3 className="text-sm font-semibold">{current.label} direction</h3>
-          <p className="mt-0.5 text-xs text-muted-foreground">
+          <p className="mt-0.5 text-sm text-muted-foreground">
             {current.rationale}
           </p>
         </div>
         <button
           type="button"
           onClick={onCancel}
-          className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm"
+          className="text-sm text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm"
           data-testid="concept-refinement-back"
         >
           ← Back to all directions
@@ -210,7 +210,7 @@ export function ConceptRefinementView({
             </div>
           </div>
         ) : (
-          <div className="text-xs text-muted-foreground">
+          <div className="text-sm text-muted-foreground">
             <p className="text-[10px] font-medium">Previous version</p>
             <div className="mt-1 flex h-72 items-center justify-center rounded-md border bg-muted/10">
               No prior version yet — first refinement will land here.
@@ -238,7 +238,7 @@ export function ConceptRefinementView({
       <div className="rounded-md border bg-muted/20 p-3">
         <label
           htmlFor="concept-refinement-feedback"
-          className="block text-xs font-medium"
+          className="block text-sm font-medium"
         >
           Refine this direction
         </label>
@@ -253,7 +253,7 @@ export function ConceptRefinementView({
           className="mt-1"
           data-testid="concept-refinement-feedback"
         />
-        <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+        <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
           <span data-testid="concept-refinement-counter">
             {refinementsUsed}/{REFINE_CAP} refinements used.
             {showWarning && (
@@ -289,7 +289,7 @@ export function ConceptRefinementView({
 
       {error && (
         <div
-          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
           role="alert"
           data-testid="concept-refinement-error"
         >
@@ -383,7 +383,7 @@ export function ApprovedDesignReadout({
           <p className="text-sm font-semibold text-success">
             Design direction approved
           </p>
-          <p className="mt-0.5 text-xs text-muted-foreground">
+          <p className="mt-0.5 text-sm text-muted-foreground">
             This is what every page we generate will be styled around.
           </p>
         </div>
@@ -475,7 +475,7 @@ export function ApprovedDesignReadout({
 
       {error && (
         <div
-          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
           role="alert"
         >
           {error}

--- a/components/ConceptReviewCards.tsx
+++ b/components/ConceptReviewCards.tsx
@@ -81,7 +81,7 @@ export function ConceptReviewCards({
 
       {errors.length > 0 && (
         <div
-          className="rounded-md border border-warning/40 bg-warning/5 p-3 text-xs text-warning"
+          className="rounded-md border border-warning/40 bg-warning/5 p-3 text-sm text-warning"
           role="alert"
           data-testid="concept-review-errors"
         >
@@ -140,7 +140,7 @@ function ConceptCard({
         </h3>
       </header>
       <p
-        className="mt-1 text-xs text-muted-foreground"
+        className="mt-1 text-sm text-muted-foreground"
         data-testid={`concept-rationale-${concept.direction}`}
       >
         {concept.rationale}
@@ -294,7 +294,7 @@ function BeforeAfterPanel({
       data-testid="concept-before-after"
     >
       <h3 className="text-sm font-semibold">Before vs after</h3>
-      <p className="mt-1 text-xs text-muted-foreground">
+      <p className="mt-1 text-sm text-muted-foreground">
         Your reference next to {DIRECTION_TITLES[concept.direction]}.
       </p>
       <div className="mt-3 grid gap-4 md:grid-cols-2">

--- a/components/CopyExistingExtractionWizard.tsx
+++ b/components/CopyExistingExtractionWizard.tsx
@@ -183,11 +183,11 @@ export function CopyExistingExtractionWizard({
     <div className="mt-6 space-y-6" data-testid="copy-existing-wizard">
       <section className="rounded-md border bg-muted/20 p-4">
         <h2 className="text-sm font-semibold">1 · Run extraction</h2>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           Source URL: <code>{siteUrl}</code>
         </p>
         <div className="mt-3 flex flex-col gap-2">
-          <label className="text-xs text-muted-foreground">
+          <label className="text-sm text-muted-foreground">
             Extra pages (optional, one URL per line)
             <textarea
               value={extraPagesText}
@@ -208,7 +208,7 @@ export function CopyExistingExtractionWizard({
               {extracting ? "Extracting…" : hasResults ? "Re-extract" : "Run extraction"}
             </Button>
             {notes.length > 0 && (
-              <p className="text-xs text-muted-foreground">
+              <p className="text-sm text-muted-foreground">
                 {notes.join(" ")}
               </p>
             )}
@@ -222,14 +222,14 @@ export function CopyExistingExtractionWizard({
           data-testid="copy-existing-design-profile"
         >
           <h2 className="text-sm font-semibold">2 · Review the design profile</h2>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-sm text-muted-foreground">
             Tweak any extracted value that looks wrong. Empty fields land as
             null and the generation prompt falls back to the site theme.
           </p>
 
           <div className="mt-4 grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <h3 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
                 Colours
               </h3>
               {(["primary", "secondary", "accent", "background", "text"] as const).map(
@@ -257,7 +257,7 @@ export function CopyExistingExtractionWizard({
             </div>
 
             <div className="space-y-2">
-              <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <h3 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
                 Fonts
               </h3>
               {(["heading", "body"] as const).map((key) => (
@@ -274,7 +274,7 @@ export function CopyExistingExtractionWizard({
                 </label>
               ))}
 
-              <h3 className="mt-4 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <h3 className="mt-4 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                 Tone
               </h3>
               <label className="flex items-center gap-2 text-sm">
@@ -309,7 +309,7 @@ export function CopyExistingExtractionWizard({
           </div>
 
           <div className="mt-6">
-            <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <h3 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
               Detected CSS classes
             </h3>
             <div className="mt-2 grid gap-2 md:grid-cols-2">
@@ -347,7 +347,7 @@ export function CopyExistingExtractionWizard({
 
           {design.screenshot_url && (
             <div className="mt-6">
-              <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <h3 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
                 Site snapshot
               </h3>
               {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -370,7 +370,7 @@ export function CopyExistingExtractionWizard({
       {hasResults && (
         <div className="flex items-center justify-end gap-3">
           {savedAt && (
-            <span className="text-xs text-muted-foreground">Saved at {savedAt}</span>
+            <span className="text-sm text-muted-foreground">Saved at {savedAt}</span>
           )}
           <Button
             type="button"
@@ -403,7 +403,7 @@ function ClassInput({
         value={value ?? ""}
         onChange={(e) => onChange(e.target.value)}
         placeholder="(none detected)"
-        className="flex-1 rounded border bg-background px-2 py-1 font-mono text-xs"
+        className="flex-1 rounded border bg-background px-2 py-1 font-mono text-sm"
         data-testid={`copy-existing-class-${label.toLowerCase()}`}
       />
     </label>

--- a/components/CreateDesignSystemModal.tsx
+++ b/components/CreateDesignSystemModal.tsx
@@ -32,7 +32,7 @@ function Label({
 
 function FieldError({ message }: { message?: string | null }) {
   if (!message) return null;
-  return <p className="mt-1 text-xs text-destructive">{message}</p>;
+  return <p className="mt-1 text-sm text-destructive">{message}</p>;
 }
 
 export function CreateDesignSystemModal({
@@ -168,13 +168,13 @@ export function CreateDesignSystemModal({
         <form onSubmit={handleSubmit} className="mt-4 space-y-3">
           <div>
             <Label htmlFor="ds-tokens">tokens.css</Label>
-            <p className="mt-0.5 text-xs text-muted-foreground">
+            <p className="mt-0.5 text-sm text-muted-foreground">
               Design tokens (colours, spacing, typography) as CSS custom
               properties on the scope wrapper.
             </p>
             <textarea
               id="ds-tokens"
-              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
               value={form.tokens_css}
               onChange={(e) => setField("tokens_css", e.target.value)}
               placeholder=".ls-scope {\n  --ls-blue: #185FA5;\n  /* ... */\n}"
@@ -187,13 +187,13 @@ export function CreateDesignSystemModal({
 
           <div>
             <Label htmlFor="ds-base-styles">base-styles.css</Label>
-            <p className="mt-0.5 text-xs text-muted-foreground">
+            <p className="mt-0.5 text-sm text-muted-foreground">
               Baseline component styles (containers, typography reset,
               primitives) that every page inherits.
             </p>
             <textarea
               id="ds-base-styles"
-              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              className="mt-1 h-40 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
               value={form.base_styles}
               onChange={(e) => setField("base_styles", e.target.value)}
               placeholder=".ls-container { max-width: 1160px; }"

--- a/components/DesignDirectionInputs.tsx
+++ b/components/DesignDirectionInputs.tsx
@@ -415,7 +415,7 @@ export function DesignDirectionInputs({
               </option>
             ))}
           </select>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-sm text-muted-foreground">
             Pre-loads sensible defaults. Stronger signals (URL,
             description) override.
           </p>
@@ -437,7 +437,7 @@ export function DesignDirectionInputs({
             data-testid="dd-existing-url"
             className="mt-1"
           />
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-sm text-muted-foreground">
             Establishes the brand baseline.
           </p>
         </div>
@@ -483,7 +483,7 @@ export function DesignDirectionInputs({
         </div>
         {extractError && (
           <p
-            className="mt-2 text-xs text-destructive"
+            className="mt-2 text-sm text-destructive"
             data-testid="dd-extract-error"
             role="alert"
           >
@@ -507,7 +507,7 @@ export function DesignDirectionInputs({
           data-testid="dd-description"
           className="mt-1"
         />
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           Free text — describe the feeling, layout, density, anything that
           helps us understand what you want.
         </p>
@@ -540,7 +540,7 @@ export function DesignDirectionInputs({
       />
 
       <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-4">
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Estimated cost: ~$0.24 — includes homepage + inner page for each of
           3 concept directions. This is a full design pass.
         </p>
@@ -631,8 +631,8 @@ function ConceptResultsBlock({
         data-testid="dd-generation-failed"
       >
         <p className="font-medium">Generation failed.</p>
-        <p className="mt-1 text-xs">{generationFailed}</p>
-        <p className="mt-2 text-xs">
+        <p className="mt-1 text-sm">{generationFailed}</p>
+        <p className="mt-2 text-sm">
           Click &quot;Generate concepts&quot; to try again.
         </p>
       </div>

--- a/components/DesignSystemsTable.tsx
+++ b/components/DesignSystemsTable.tsx
@@ -56,7 +56,7 @@ export function DesignSystemsTable({
   return (
     <div className="overflow-hidden rounded-md border">
       <table className="w-full text-sm">
-        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+        <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
           <tr>
             <th className="px-4 py-2 font-medium">Version</th>
             <th className="px-4 py-2 font-medium">Status</th>
@@ -89,19 +89,19 @@ export function DesignSystemsTable({
                 <div className="flex flex-wrap items-center justify-end gap-2">
                   <Link
                     href={`/admin/sites/${siteId}/design-system/components?ds=${ds.id}`}
-                    className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+                    className="text-sm text-muted-foreground hover:text-foreground hover:underline"
                   >
                     Components →
                   </Link>
                   <Link
                     href={`/admin/sites/${siteId}/design-system/templates?ds=${ds.id}`}
-                    className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+                    className="text-sm text-muted-foreground hover:text-foreground hover:underline"
                   >
                     Templates →
                   </Link>
                   <Link
                     href={`/admin/sites/${siteId}/design-system/preview?ds=${ds.id}`}
-                    className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+                    className="text-sm text-muted-foreground hover:text-foreground hover:underline"
                   >
                     Preview →
                   </Link>

--- a/components/DesignUnderstandingPanel.tsx
+++ b/components/DesignUnderstandingPanel.tsx
@@ -64,7 +64,7 @@ export function DesignUnderstandingPanel({
       <div className="flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-sm font-semibold">Here&apos;s what we understood</h3>
         <span
-          className="inline-flex items-center gap-1.5 text-xs"
+          className="inline-flex items-center gap-1.5 text-sm"
           data-testid="dd-confidence"
           data-confidence={confidence}
         >
@@ -76,7 +76,7 @@ export function DesignUnderstandingPanel({
         </span>
       </div>
 
-      <dl className="mt-3 grid gap-2 text-xs md:grid-cols-2">
+      <dl className="mt-3 grid gap-2 text-sm md:grid-cols-2">
         <div>
           <dt className="font-medium text-muted-foreground">Tone</dt>
           <dd>{tone}</dd>
@@ -118,7 +118,7 @@ export function DesignUnderstandingPanel({
       <button
         type="button"
         onClick={() => setShowEditor((v) => !v)}
-        className="mt-3 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+        className="mt-3 text-sm text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
         aria-expanded={showEditor}
         data-testid="dd-edit-understanding-toggle"
       >

--- a/components/EditImageMetadataModal.tsx
+++ b/components/EditImageMetadataModal.tsx
@@ -196,7 +196,7 @@ export function EditImageMetadataModal({
               placeholder="comma, separated, tags"
               disabled={submitting}
             />
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className="mt-1 text-sm text-muted-foreground">
               Up to 12 tags, max 40 characters each.
             </p>
           </div>

--- a/components/EditPageMetadataModal.tsx
+++ b/components/EditPageMetadataModal.tsx
@@ -152,12 +152,12 @@ export function EditPageMetadataModal({
               maxLength={100}
               disabled={submitting}
             />
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className="mt-1 text-sm text-muted-foreground">
               Lowercase letters, digits, and hyphens only.
             </p>
             {slugChanged && (
               <p
-                className="mt-1 text-xs text-yellow-700"
+                className="mt-1 text-sm text-yellow-700"
                 data-testid="slug-change-warning"
               >
                 Changing the slug updates our record only — WordPress keeps

--- a/components/EmailTestForm.tsx
+++ b/components/EmailTestForm.tsx
@@ -118,7 +118,7 @@ export function EmailTestForm() {
       {result.kind === "ok" && (
         <Alert data-testid="email-test-success">
           Sent. SendGrid message id:{" "}
-          <code className="font-mono text-xs">{result.messageId}</code>
+          <code className="font-mono text-sm">{result.messageId}</code>
         </Alert>
       )}
       {result.kind === "err" && (

--- a/components/ErrorFallback.tsx
+++ b/components/ErrorFallback.tsx
@@ -66,7 +66,7 @@ export function ErrorFallback({
               )}
             </div>
           )}
-          <p className="pt-1 text-xs text-muted-foreground">
+          <p className="pt-1 text-sm text-muted-foreground">
             Still stuck?{" "}
             <a
               href={supportHref}

--- a/components/ExtractedProfilePanel.tsx
+++ b/components/ExtractedProfilePanel.tsx
@@ -97,7 +97,7 @@ export function ExtractedProfilePanel({
             <H3>Design profile</H3>
             <div className="mt-3 grid gap-6 md:grid-cols-2">
               <div>
-                <h4 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <h4 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
                   Colours
                 </h4>
                 <ul className="mt-2 space-y-1 text-sm">
@@ -115,7 +115,7 @@ export function ExtractedProfilePanel({
                             aria-hidden
                           />
                           <span className="w-24 text-muted-foreground">{key}</span>
-                          <code className="font-mono text-xs">
+                          <code className="font-mono text-sm">
                             {value ?? "—"}
                           </code>
                         </li>
@@ -124,7 +124,7 @@ export function ExtractedProfilePanel({
                   )}
                 </ul>
 
-                <h4 className="mt-4 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <h4 className="mt-4 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                   Fonts
                 </h4>
                 <ul className="mt-2 space-y-1 text-sm">
@@ -141,7 +141,7 @@ export function ExtractedProfilePanel({
                   })}
                 </ul>
 
-                <h4 className="mt-4 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <h4 className="mt-4 text-sm font-medium uppercase tracking-wide text-muted-foreground">
                   Tone
                 </h4>
                 <p className="mt-1 text-sm">
@@ -164,7 +164,7 @@ export function ExtractedProfilePanel({
                   </p>
                 )}
                 {design.source_pages && design.source_pages.length > 0 && (
-                  <p className="mt-3 text-xs text-muted-foreground">
+                  <p className="mt-3 text-sm text-muted-foreground">
                     Source pages:{" "}
                     {design.source_pages.map((p, i) => (
                       <span key={p}>
@@ -188,7 +188,7 @@ export function ExtractedProfilePanel({
           {classes && (
             <section className="rounded-md border bg-background p-5">
               <H3>Detected CSS classes</H3>
-              <p className="mt-1 text-xs text-muted-foreground">
+              <p className="mt-1 text-sm text-muted-foreground">
                 Generated content reuses these class names so it picks up the
                 existing theme&apos;s styling without injecting new CSS.
               </p>
@@ -219,10 +219,10 @@ export function ExtractedProfilePanel({
 function ClassRow({ label, value }: { label: string; value: string | null }) {
   return (
     <div className="flex items-center justify-between rounded border bg-muted/20 px-3 py-1.5">
-      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      <span className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
         {label}
       </span>
-      <code className="font-mono text-xs">{value ?? "(none detected)"}</code>
+      <code className="font-mono text-sm">{value ?? "(none detected)"}</code>
     </div>
   );
 }

--- a/components/ImageArchiveButton.tsx
+++ b/components/ImageArchiveButton.tsx
@@ -72,7 +72,7 @@ export function ImageArchiveButton({
       {error && (
         <p
           role="alert"
-          className="max-w-xs text-right text-xs text-destructive"
+          className="max-w-xs text-right text-sm text-destructive"
           data-testid="image-action-error"
         >
           {error}

--- a/components/ImagePickerModal.tsx
+++ b/components/ImagePickerModal.tsx
@@ -304,7 +304,7 @@ export function ImagePickerModal({
               </div>
             )}
             <ImageGrid items={browseItems} onSelect={handleSelect} />
-            <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <div className="flex items-center justify-between text-sm text-muted-foreground">
               <span>
                 {browseTotal > 0
                   ? `Showing ${browseItems.length} of ${browseTotal}`
@@ -354,7 +354,7 @@ function SuggestedPanel({
 }) {
   return (
     <div className="mt-4 space-y-3">
-      <div className="rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+      <div className="rounded-md border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
         {fallbackToRecent ? (
           <>No post content yet — showing your recent uploads.</>
         ) : basedOn ? (
@@ -486,7 +486,7 @@ function UploadTab({
         }}
       >
         <p className="font-medium text-foreground">Upload an image</p>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           Drag-drop a file here, or click the button below. JPEG / PNG /
           GIF / WebP. Max 10 MB. Captioning runs in the background.
         </p>
@@ -510,7 +510,7 @@ function UploadTab({
             {uploading ? "Uploading…" : "Pick file"}
           </Button>
           {uploading && (
-            <span className="text-xs text-muted-foreground">
+            <span className="text-sm text-muted-foreground">
               Pushing to Cloudflare…
             </span>
           )}
@@ -518,7 +518,7 @@ function UploadTab({
         {error && (
           <div
             role="alert"
-            className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive"
+            className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 p-2 text-sm text-destructive"
           >
             {error}
           </div>
@@ -585,7 +585,7 @@ function UrlSubMode({
         type="button"
         onClick={() => setOpen(true)}
         data-testid="picker-url-disclosure"
-        className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
       >
         <Link2 aria-hidden className="h-3 w-3" />
         Or paste a URL instead
@@ -598,7 +598,7 @@ function UrlSubMode({
       {/* R2-fix — header row with a cancel affordance so the operator
           can collapse the disclosure if they opened it accidentally. */}
       <div className="flex items-start justify-between gap-2">
-        <p className="text-xs font-medium">Fetch image from URL</p>
+        <p className="text-sm font-medium">Fetch image from URL</p>
         <button
           type="button"
           onClick={() => {
@@ -607,12 +607,12 @@ function UrlSubMode({
             setError(null);
           }}
           aria-label="Cancel URL fetch"
-          className="text-xs text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          className="text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
         >
           Cancel
         </button>
       </div>
-      <p className="mt-1 text-xs text-muted-foreground">
+      <p className="mt-1 text-sm text-muted-foreground">
         Server fetches, validates type + size, and uploads to the library.
         30s timeout; 10 MB cap. Internal IPs blocked.
       </p>
@@ -640,7 +640,7 @@ function UrlSubMode({
       {error && (
         <div
           role="alert"
-          className="mt-2 rounded-md border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive"
+          className="mt-2 rounded-md border border-destructive/40 bg-destructive/10 p-2 text-sm text-destructive"
         >
           {error}
         </div>
@@ -728,14 +728,14 @@ function ImageGrid({
                   className="h-full w-full object-cover transition-smooth group-hover:scale-105"
                 />
               ) : (
-                <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
+                <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
                   No preview
                 </div>
               )}
             </div>
             {img.caption && (
               <p
-                className="truncate px-2 py-1 text-xs text-muted-foreground"
+                className="truncate px-2 py-1 text-sm text-muted-foreground"
                 title={img.caption}
               >
                 {img.caption}

--- a/components/ImagesTable.tsx
+++ b/components/ImagesTable.tsx
@@ -34,7 +34,7 @@ function Thumbnail({ item }: { item: ImageListItem }) {
     return (
       <div
         aria-hidden="true"
-        className="flex h-12 w-12 items-center justify-center rounded bg-muted text-xs text-muted-foreground"
+        className="flex h-12 w-12 items-center justify-center rounded bg-muted text-sm text-muted-foreground"
       >
         —
       </div>
@@ -83,7 +83,7 @@ export function ImagesTable({ items, backHref }: ImagesTableProps) {
   return (
     <div className="overflow-hidden rounded-md border">
       <table className="w-full text-sm">
-        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+        <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
           <tr>
             <th className="w-16 px-4 py-2 font-medium">Preview</th>
             <th className="px-4 py-2 font-medium">Caption</th>
@@ -117,7 +117,7 @@ export function ImagesTable({ items, backHref }: ImagesTableProps) {
                   )}
                 </Link>
                 {item.filename && (
-                  <div className="mt-1 text-xs text-muted-foreground">
+                  <div className="mt-1 text-sm text-muted-foreground">
                     {item.filename}
                   </div>
                 )}
@@ -125,19 +125,19 @@ export function ImagesTable({ items, backHref }: ImagesTableProps) {
               <td className="px-4 py-3 align-top">
                 <div className="flex flex-wrap gap-1">
                   {item.tags.length === 0 ? (
-                    <span className="text-xs text-muted-foreground">—</span>
+                    <span className="text-sm text-muted-foreground">—</span>
                   ) : (
                     item.tags.slice(0, 6).map((tag) => (
                       <span
                         key={tag}
-                        className="rounded bg-muted px-2 py-0.5 text-xs"
+                        className="rounded bg-muted px-2 py-0.5 text-sm"
                       >
                         {tag}
                       </span>
                     ))
                   )}
                   {item.tags.length > 6 && (
-                    <span className="text-xs text-muted-foreground">
+                    <span className="text-sm text-muted-foreground">
                       +{item.tags.length - 6}
                     </span>
                   )}
@@ -146,10 +146,10 @@ export function ImagesTable({ items, backHref }: ImagesTableProps) {
               <td className="px-4 py-3 align-top">
                 <StatusPill kind={imageSourceKind(item.source)} />
               </td>
-              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
                 {formatDimensions(item.width_px, item.height_px)}
               </td>
-              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
                 {formatRelativeTime(item.created_at)}
               </td>
             </tr>

--- a/components/InviteUserModal.tsx
+++ b/components/InviteUserModal.tsx
@@ -151,7 +151,7 @@ export function InviteUserModal({
               <span className="font-medium">{status.email}</span> as{" "}
               <span className="font-medium">{status.role}</span>.
               {!status.emailSent && (
-                <p className="mt-1 text-xs">
+                <p className="mt-1 text-sm">
                   Email delivery failed — copy the link below to share
                   out of band.
                 </p>
@@ -161,7 +161,7 @@ export function InviteUserModal({
               <div className="flex flex-col gap-1">
                 <label
                   htmlFor="invite-accept-url"
-                  className="text-xs font-medium text-muted-foreground"
+                  className="text-sm font-medium text-muted-foreground"
                 >
                   Acceptance URL (copy + share if email delivery is broken)
                 </label>
@@ -170,7 +170,7 @@ export function InviteUserModal({
                   readOnly
                   value={status.acceptUrl}
                   onFocus={(e) => e.currentTarget.select()}
-                  className="font-mono text-xs"
+                  className="font-mono text-sm"
                 />
               </div>
             )}
@@ -220,7 +220,7 @@ export function InviteUserModal({
                   </option>
                 ))}
               </select>
-              <p className="mt-1 text-xs text-muted-foreground">
+              <p className="mt-1 text-sm text-muted-foreground">
                 {allowedRoles.length === 1
                   ? "Admins can only invite role=user. Ask a super_admin to invite admins."
                   : "Choose admin to grant invite + remove powers; user otherwise."}

--- a/components/KadencePaletteDiffTable.tsx
+++ b/components/KadencePaletteDiffTable.tsx
@@ -34,7 +34,7 @@ export function KadencePaletteDiffTable({
   return (
     <div className="overflow-x-auto rounded-lg border">
       <table className="w-full text-sm">
-        <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+        <thead className="bg-muted/40 text-sm uppercase tracking-wide text-muted-foreground">
           <tr>
             <th className="px-3 py-2 text-left">Slot</th>
             <th className="px-3 py-2 text-left">Current</th>
@@ -55,7 +55,7 @@ export function KadencePaletteDiffTable({
 function DiffRow({ entry }: { entry: PaletteDiffEntry }) {
   return (
     <tr className={entry.changed ? "bg-yellow-500/5" : ""}>
-      <td className="px-3 py-2 font-mono text-xs">{entry.slot}</td>
+      <td className="px-3 py-2 font-mono text-sm">{entry.slot}</td>
       <td className="px-3 py-2">
         <ColorCell name={entry.current.name} color={entry.current.color} />
       </td>
@@ -64,11 +64,11 @@ function DiffRow({ entry }: { entry: PaletteDiffEntry }) {
       </td>
       <td className="px-3 py-2 text-right">
         {entry.changed ? (
-          <span className="inline-flex rounded bg-yellow-500/10 px-2 py-0.5 text-xs font-medium text-yellow-900 dark:text-yellow-200">
+          <span className="inline-flex rounded bg-yellow-500/10 px-2 py-0.5 text-sm font-medium text-yellow-900 dark:text-yellow-200">
             Changed
           </span>
         ) : (
-          <span className="text-xs text-muted-foreground">No change</span>
+          <span className="text-sm text-muted-foreground">No change</span>
         )}
       </td>
     </tr>
@@ -83,7 +83,7 @@ function ColorCell({
   color: string | null;
 }) {
   if (!color) {
-    return <span className="text-xs text-muted-foreground">—</span>;
+    return <span className="text-sm text-muted-foreground">—</span>;
   }
   return (
     <div className="flex items-center gap-2">
@@ -93,9 +93,9 @@ function ColorCell({
         style={{ backgroundColor: color }}
       />
       <div className="min-w-0">
-        <div className="font-mono text-xs">{color}</div>
+        <div className="font-mono text-sm">{color}</div>
         {name && (
-          <div className="truncate text-xs text-muted-foreground">{name}</div>
+          <div className="truncate text-sm text-muted-foreground">{name}</div>
         )}
       </div>
     </div>

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -74,7 +74,7 @@ export function LoginForm({ next }: { next: string }) {
 
       <SubmitButton />
 
-      <p className="text-center text-xs text-muted-foreground">
+      <p className="text-center text-sm text-muted-foreground">
         <a
           href="/auth/forgot-password"
           className="underline hover:no-underline"

--- a/components/MoodBoardStrip.tsx
+++ b/components/MoodBoardStrip.tsx
@@ -18,14 +18,14 @@ export function MoodBoardStrip({ view }: { view: View }) {
       data-testid="mood-board-strip"
     >
       <h3 className="text-sm font-semibold">Mood board</h3>
-      <p className="mt-1 text-xs text-muted-foreground">
+      <p className="mt-1 text-sm text-muted-foreground">
         What we&apos;re hearing so far. Updates as you add inputs.
       </p>
 
       <div className="mt-4 grid gap-4 md:grid-cols-[1fr_auto]">
         <div className="space-y-3">
           <div>
-            <p className="text-xs font-medium text-muted-foreground">
+            <p className="text-sm font-medium text-muted-foreground">
               Colour swatches
             </p>
             <div className="mt-1.5 flex flex-wrap items-center gap-2">
@@ -47,13 +47,13 @@ export function MoodBoardStrip({ view }: { view: View }) {
                   </span>
                 ))
               ) : (
-                <span className="text-xs text-muted-foreground">—</span>
+                <span className="text-sm text-muted-foreground">—</span>
               )}
             </div>
           </div>
 
           <div>
-            <p className="text-xs font-medium text-muted-foreground">
+            <p className="text-sm font-medium text-muted-foreground">
               Typography
             </p>
             <div className="mt-1.5 flex flex-wrap items-center gap-3">
@@ -65,18 +65,18 @@ export function MoodBoardStrip({ view }: { view: View }) {
                     style={{ fontFamily: `${f}, system-ui, sans-serif` }}
                   >
                     <span className="text-base">Aa Bb Cc 123</span>
-                    <span className="text-xs text-muted-foreground">{f}</span>
+                    <span className="text-sm text-muted-foreground">{f}</span>
                   </span>
                 ))
               ) : (
-                <span className="text-xs text-muted-foreground">—</span>
+                <span className="text-sm text-muted-foreground">—</span>
               )}
             </div>
           </div>
 
           <div className="grid gap-3 md:grid-cols-2">
             <div>
-              <p className="text-xs font-medium text-muted-foreground">
+              <p className="text-sm font-medium text-muted-foreground">
                 Layout
               </p>
               <div className="mt-1.5 flex flex-wrap gap-1.5">
@@ -90,12 +90,12 @@ export function MoodBoardStrip({ view }: { view: View }) {
                     </span>
                   ))
                 ) : (
-                  <span className="text-xs text-muted-foreground">—</span>
+                  <span className="text-sm text-muted-foreground">—</span>
                 )}
               </div>
             </div>
             <div>
-              <p className="text-xs font-medium text-muted-foreground">
+              <p className="text-sm font-medium text-muted-foreground">
                 Visual tone
               </p>
               <div className="mt-1.5 flex flex-wrap gap-1.5">
@@ -109,7 +109,7 @@ export function MoodBoardStrip({ view }: { view: View }) {
                     </span>
                   ))
                 ) : (
-                  <span className="text-xs text-muted-foreground">—</span>
+                  <span className="text-sm text-muted-foreground">—</span>
                 )}
               </div>
             </div>
@@ -118,7 +118,7 @@ export function MoodBoardStrip({ view }: { view: View }) {
 
         {view.screenshot_url && (
           <div className="hidden md:block">
-            <p className="text-xs font-medium text-muted-foreground">
+            <p className="text-sm font-medium text-muted-foreground">
               Reference
             </p>
             {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/components/NewBatchModal.tsx
+++ b/components/NewBatchModal.tsx
@@ -172,7 +172,7 @@ export function NewBatchModal({
               disabled={submitting}
               className="font-mono min-h-[140px]"
             />
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className="mt-1 text-sm text-muted-foreground">
               One slug per line. Up to 100 per batch.
             </p>
           </div>

--- a/components/OnboardingReminderBanner.tsx
+++ b/components/OnboardingReminderBanner.tsx
@@ -20,14 +20,14 @@ export function OnboardingReminderBanner({ siteId }: { siteId: string }) {
       <Sparkles aria-hidden className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
       <div className="min-w-0 flex-1">
         <p className="font-medium">Finish setting up this site.</p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
+        <p className="mt-0.5 text-sm text-muted-foreground">
           Pick whether we&apos;re uploading content to an existing WordPress
           theme or building a fresh design. Generation styling and the
           rest of setup follow from this choice.
         </p>
         <Link
           href={`/admin/sites/${siteId}/onboarding`}
-          className="mt-2 inline-block text-xs font-medium underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          className="mt-2 inline-block text-sm font-medium underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
           data-testid="onboarding-reminder-banner-cta"
         >
           Set up now →

--- a/components/PageHtmlPreview.tsx
+++ b/components/PageHtmlPreview.tsx
@@ -40,7 +40,7 @@ export function PageHtmlPreview({ html }: { html: string | null }) {
           Generated HTML is larger than {HTML_SIZE_MAX_BYTES / 1024}KB — inline
           preview skipped to keep the admin page responsive.
         </p>
-        <p className="text-xs">
+        <p className="text-sm">
           Open the page in WordPress admin to view it rendered.
         </p>
       </div>
@@ -49,7 +49,7 @@ export function PageHtmlPreview({ html }: { html: string | null }) {
 
   return (
     <div className="rounded-md border bg-white">
-      <div className="flex items-center justify-between border-b px-3 py-2 text-xs text-muted-foreground">
+      <div className="flex items-center justify-between border-b px-3 py-2 text-sm text-muted-foreground">
         <span>Preview (static, design-system CSS only)</span>
         <span className="font-mono">
           {(estimateHtmlBytes(html) / 1024).toFixed(1)} KB

--- a/components/PagesTable.tsx
+++ b/components/PagesTable.tsx
@@ -44,7 +44,7 @@ export function PagesTable({ items, siteId, backHref }: PagesTableProps) {
   return (
     <div className="overflow-hidden rounded-md border">
       <table className="w-full text-sm">
-        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+        <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
           <tr>
             <th className="px-4 py-2 font-medium">Title</th>
             <th className="px-4 py-2 font-medium">Type</th>
@@ -69,21 +69,21 @@ export function PagesTable({ items, siteId, backHref }: PagesTableProps) {
                 >
                   {p.title}
                 </Link>
-                <div className="mt-1 text-xs text-muted-foreground">
+                <div className="mt-1 text-sm text-muted-foreground">
                   /{p.slug}
                 </div>
               </td>
-              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
                 {p.page_type.replace(/_/g, " ")}
               </td>
               <td className="px-4 py-3 align-top">
                 {/* page status taxonomy is identical to post (draft / published) */}
                 <StatusPill kind={postStatusKind(p.status as Parameters<typeof postStatusKind>[0])} className="capitalize" />
               </td>
-              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
                 v{p.design_system_version}
               </td>
-              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
                 {formatRelativeTime(p.updated_at)}
               </td>
             </tr>

--- a/components/PendingInvitesTable.tsx
+++ b/components/PendingInvitesTable.tsx
@@ -55,7 +55,7 @@ export function PendingInvitesTable({
   return (
     <div className="rounded-md border">
       <table className="w-full text-sm">
-        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+        <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
           <tr>
             <th className="px-3 py-2 font-medium">Email</th>
             <th className="px-3 py-2 font-medium">Role</th>
@@ -77,19 +77,19 @@ export function PendingInvitesTable({
               >
                 <td className="px-3 py-2 font-medium">{inv.email}</td>
                 <td className="px-3 py-2">
-                  <span className="inline-flex items-center rounded border border-input px-2 py-0.5 text-xs">
+                  <span className="inline-flex items-center rounded border border-input px-2 py-0.5 text-sm">
                     {inv.role}
                   </span>
                 </td>
-                <td className="px-3 py-2 text-xs text-muted-foreground">
+                <td className="px-3 py-2 text-sm text-muted-foreground">
                   {inv.invited_by_email ?? "(deleted user)"}
                 </td>
-                <td className="px-3 py-2 text-xs text-muted-foreground">
+                <td className="px-3 py-2 text-sm text-muted-foreground">
                   <span data-screenshot-mask>
                     {formatRelativeTime(inv.created_at)}
                   </span>
                 </td>
-                <td className="px-3 py-2 text-xs">
+                <td className="px-3 py-2 text-sm">
                   <span
                     className={
                       expiringSoon
@@ -106,7 +106,7 @@ export function PendingInvitesTable({
                     type="button"
                     onClick={() => void revoke(inv.id, inv.email)}
                     disabled={revoking === inv.id}
-                    className="rounded border px-2 py-0.5 text-xs text-destructive transition-smooth hover:bg-destructive/10 disabled:opacity-60"
+                    className="rounded border px-2 py-0.5 text-sm text-destructive transition-smooth hover:bg-destructive/10 disabled:opacity-60"
                     data-testid="invite-revoke-button"
                   >
                     {revoking === inv.id ? "…" : "Revoke"}

--- a/components/PostDetailClient.tsx
+++ b/components/PostDetailClient.tsx
@@ -143,13 +143,13 @@ export function PostDetailClient({
         <div>
           <H1>{post.title}</H1>
           <p className="mt-1 text-sm text-muted-foreground">
-            <code className="text-xs">/{post.slug}</code>
+            <code className="text-sm">/{post.slug}</code>
             {" · "}
             <StatusPill kind={postStatusKind(post.status)} className="capitalize" />
             {post.wp_post_id && (
               <>
                 {" · "}
-                <span className="text-xs">WP id {post.wp_post_id}</span>
+                <span className="text-sm">WP id {post.wp_post_id}</span>
               </>
             )}
           </p>
@@ -189,7 +189,7 @@ export function PostDetailClient({
           {"blocker" in preflight && (
             <>
               <p>{preflight.blocker.detail}</p>
-              <p className="mt-2 text-xs">
+              <p className="mt-2 text-sm">
                 <strong>What to do:</strong> {preflight.blocker.nextAction}
               </p>
             </>
@@ -231,7 +231,7 @@ export function PostDetailClient({
       )}
 
       {wpFrontendUrl && post.status === "published" && (
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Live on WordPress:{" "}
           <a
             href={wpFrontendUrl}

--- a/components/PostsNewClient.tsx
+++ b/components/PostsNewClient.tsx
@@ -153,7 +153,7 @@ function SitePicker({
         className="rounded-md border bg-muted/40 px-4 py-3 text-sm text-muted-foreground"
       >
         No sites available. Pair a WordPress install in
-        <code className="mx-1 font-mono text-xs">/admin/sites</code>
+        <code className="mx-1 font-mono text-sm">/admin/sites</code>
         before posting.
       </div>
     );
@@ -206,7 +206,7 @@ function SitePicker({
                   data-testid={`posts-new-site-option-${s.id}`}
                 >
                   <span className="flex-1 truncate">{s.name}</span>
-                  <span className="ml-2 shrink-0 truncate text-xs text-muted-foreground">
+                  <span className="ml-2 shrink-0 truncate text-sm text-muted-foreground">
                     {hostnameOf(s.wp_url)}
                   </span>
                 </CommandItem>
@@ -216,7 +216,7 @@ function SitePicker({
         </PopoverContent>
       </Popover>
       {value && (
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Posting to <span className="font-medium text-foreground">{value.name}</span>{" "}
           ({hostnameOf(value.wp_url)}).
         </p>
@@ -236,7 +236,7 @@ function EmptyShell({
     <div className="rounded-md border border-dashed bg-muted/20 px-6 py-12 text-center text-sm">
       <p className="font-medium">{label}</p>
       {description && (
-        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
       )}
     </div>
   );

--- a/components/PreviewGallery.tsx
+++ b/components/PreviewGallery.tsx
@@ -53,7 +53,7 @@ function compositionChain(t: DesignTemplate): string[] {
 function Block({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div>
-      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      <div className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
         {label}
       </div>
       <div className="mt-1">{children}</div>
@@ -63,7 +63,7 @@ function Block({ label, children }: { label: string; children: React.ReactNode }
 
 function CodeBlock({ text }: { text: string }) {
   return (
-    <pre className="max-h-80 overflow-auto rounded-md border bg-muted/40 p-3 font-mono text-xs leading-relaxed">
+    <pre className="max-h-80 overflow-auto rounded-md border bg-muted/40 p-3 font-mono text-sm leading-relaxed">
       {text.length > 0 ? text : <em className="text-muted-foreground">(empty)</em>}
     </pre>
   );
@@ -104,11 +104,11 @@ export function PreviewGallery({
                   <header className="flex items-center justify-between border-b pb-3">
                     <div>
                       <div className="text-sm font-medium">{c.name}</div>
-                      <div className="text-xs text-muted-foreground">
+                      <div className="text-sm text-muted-foreground">
                         {c.variant ? `${c.category} · ${c.variant}` : c.category}
                       </div>
                     </div>
-                    <div className="text-xs text-muted-foreground">
+                    <div className="text-sm text-muted-foreground">
                       v<span className="font-mono">{c.version_lock}</span>
                     </div>
                   </header>
@@ -125,7 +125,7 @@ export function PreviewGallery({
                   <div className="mt-4">
                     <Block label={`Fields (${fields.length})`}>
                       {fields.length === 0 ? (
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-sm text-muted-foreground">
                           content_schema has no properties.
                         </p>
                       ) : (
@@ -135,13 +135,13 @@ export function PreviewGallery({
                               key={f.name}
                               className="flex items-center justify-between px-3 py-2"
                             >
-                              <span className="font-mono text-xs">
+                              <span className="font-mono text-sm">
                                 {f.name}
                                 {f.required && (
                                   <span className="ml-1 text-destructive">*</span>
                                 )}
                               </span>
-                              <span className="text-xs text-muted-foreground">
+                              <span className="text-sm text-muted-foreground">
                                 {f.type}
                                 {f.constraint ? ` · ${f.constraint}` : ""}
                               </span>
@@ -185,23 +185,23 @@ export function PreviewGallery({
                   <header className="flex items-center justify-between border-b pb-3">
                     <div>
                       <div className="text-sm font-medium">{t.name}</div>
-                      <div className="text-xs text-muted-foreground">
+                      <div className="text-sm text-muted-foreground">
                         {t.page_type}
                         {t.is_default ? " · default" : ""}
                       </div>
                     </div>
-                    <div className="text-xs text-muted-foreground">
+                    <div className="text-sm text-muted-foreground">
                       v<span className="font-mono">{t.version_lock}</span>
                     </div>
                   </header>
                   <div className="pt-3">
                     <Block label={`Composition (${chain.length})`}>
                       {chain.length === 0 ? (
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-sm text-muted-foreground">
                           (empty composition)
                         </p>
                       ) : (
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-sm text-muted-foreground">
                           <span className="font-mono">{chain.join(" → ")}</span>
                         </p>
                       )}

--- a/components/PreviewPane.tsx
+++ b/components/PreviewPane.tsx
@@ -40,7 +40,7 @@ export function PreviewPane({ pageId }: { pageId: number | null }) {
         <p className="text-sm text-muted-foreground">
           NEXT_PUBLIC_LEADSOURCE_WP_URL is not configured.
         </p>
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Set it in your deployment environment to enable the preview iframe.
         </p>
       </div>
@@ -78,7 +78,7 @@ export function PreviewPane({ pageId }: { pageId: number | null }) {
             Open in new tab
           </a>
         </Button>
-        <span className="ml-auto text-xs text-muted-foreground">
+        <span className="ml-auto text-sm text-muted-foreground">
           page_id: {pageId}
         </span>
       </div>

--- a/components/ReextractMetadataButton.tsx
+++ b/components/ReextractMetadataButton.tsx
@@ -76,12 +76,12 @@ export function ReextractMetadataButton({ imageId }: { imageId: string }) {
         {busy ? "Re-extracting…" : "Re-extract metadata"}
       </Button>
       {message && (
-        <p className="text-xs text-muted-foreground" role="status">
+        <p className="text-sm text-muted-foreground" role="status">
           {message}
         </p>
       )}
       {error && (
-        <p className="text-xs text-destructive" role="alert">
+        <p className="text-sm text-destructive" role="alert">
           {error}
         </p>
       )}

--- a/components/RegenHistoryPanel.tsx
+++ b/components/RegenHistoryPanel.tsx
@@ -35,7 +35,7 @@ export function RegenHistoryPanel({ jobs }: { jobs: RegenJobRow[] }) {
   if (jobs.length === 0) {
     return (
       <div
-        className="rounded-md border border-dashed p-6 text-center text-xs text-muted-foreground"
+        className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground"
         data-testid="regen-history-empty"
       >
         No regenerations yet. Click &ldquo;Re-generate&rdquo; to refresh this
@@ -50,7 +50,7 @@ export function RegenHistoryPanel({ jobs }: { jobs: RegenJobRow[] }) {
       data-testid="regen-history-panel"
     >
       <table className="w-full text-sm">
-        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+        <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
           <tr>
             <th className="px-4 py-2 font-medium">Status</th>
             <th className="px-4 py-2 font-medium">Attempts</th>
@@ -74,21 +74,21 @@ export function RegenHistoryPanel({ jobs }: { jobs: RegenJobRow[] }) {
                   {job.status.replace(/_/g, " ")}
                 </Badge>
               </td>
-              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
                 {job.attempts}
               </td>
-              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
                 {formatCostCents(job.cost_usd_cents)}
               </td>
-              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
                 {job.input_tokens} / {job.output_tokens}
               </td>
-              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
                 {job.started_at
                   ? formatRelativeTime(job.started_at)
                   : formatRelativeTime(job.created_at)}
               </td>
-              <td className="px-4 py-3 align-top text-xs text-muted-foreground">
+              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
                 {job.failure_code ? (
                   <span
                     className="text-destructive"

--- a/components/RegenerateButton.tsx
+++ b/components/RegenerateButton.tsx
@@ -98,7 +98,7 @@ export function RegenerateButton({
       {error && (
         <p
           role="alert"
-          className="max-w-xs text-right text-xs text-destructive"
+          className="max-w-xs text-right text-sm text-destructive"
           data-testid="regenerate-error"
         >
           {error}

--- a/components/ResetPasswordForm.tsx
+++ b/components/ResetPasswordForm.tsx
@@ -106,7 +106,7 @@ export function ResetPasswordForm({ userEmail }: { userEmail: string | null }) {
   return (
     <form onSubmit={handleSubmit} className="flex w-full flex-col gap-4">
       {userEmail && (
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Signed in as <span className="font-mono">{userEmail}</span>
         </p>
       )}
@@ -127,7 +127,7 @@ export function ResetPasswordForm({ userEmail }: { userEmail: string | null }) {
           suppressHydrationWarning
         />
         {hint && (
-          <p className="text-xs text-muted-foreground">{hint}</p>
+          <p className="text-sm text-muted-foreground">{hint}</p>
         )}
       </div>
 
@@ -146,7 +146,7 @@ export function ResetPasswordForm({ userEmail }: { userEmail: string | null }) {
           suppressHydrationWarning
         />
         {mismatch && (
-          <p className="text-xs text-destructive">Passwords don&apos;t match.</p>
+          <p className="text-sm text-destructive">Passwords don&apos;t match.</p>
         )}
       </div>
 

--- a/components/RunCostTicker.tsx
+++ b/components/RunCostTicker.tsx
@@ -111,7 +111,7 @@ export function RunCostTicker({
       >
         <div className="flex items-center justify-between gap-3 p-3 sm:min-w-[280px]">
           <div className="flex items-baseline gap-2">
-            <span className="text-xs uppercase tracking-wide text-muted-foreground">
+            <span className="text-sm uppercase tracking-wide text-muted-foreground">
               Run cost
             </span>
             <span
@@ -120,7 +120,7 @@ export function RunCostTicker({
             >
               {centsToUsd(animatedSpent)}
             </span>
-            <span className="text-xs text-muted-foreground">
+            <span className="text-sm text-muted-foreground">
               of {centsToUsd(estimateCents)} est
             </span>
           </div>
@@ -151,7 +151,7 @@ export function RunCostTicker({
         {expanded && (
           <div
             id="run-cost-details"
-            className="border-t px-3 pb-3 pt-2 text-xs"
+            className="border-t px-3 pb-3 pt-2 text-sm"
           >
             <dl className="grid grid-cols-2 gap-x-3 gap-y-1">
               <dt className="text-muted-foreground">Remaining this month</dt>

--- a/components/ScreenshotUploadZone.tsx
+++ b/components/ScreenshotUploadZone.tsx
@@ -162,7 +162,7 @@ export function ScreenshotUploadZone({
               (optional, up to {MAX_FILES})
             </span>
           </label>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-sm text-muted-foreground">
             Drag-and-drop or browse. JPG / PNG / WebP / GIF up to 5MB
             each. Used only to extract patterns — files aren&apos;t
             saved.
@@ -170,7 +170,7 @@ export function ScreenshotUploadZone({
         </div>
         {busy && (
           <span
-            className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground"
             data-testid="screenshot-upload-busy"
             aria-live="polite"
           >
@@ -223,7 +223,7 @@ export function ScreenshotUploadZone({
             ? "Drop images here, or click to browse"
             : `${MAX_FILES} images uploaded — remove one to add another`}
         </p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
+        <p className="mt-0.5 text-sm text-muted-foreground">
           {remaining > 0
             ? `${screenshots.length} of ${MAX_FILES} uploaded`
             : "Maximum reached"}
@@ -243,7 +243,7 @@ export function ScreenshotUploadZone({
 
       {message && (
         <p
-          className="text-xs text-destructive"
+          className="text-sm text-destructive"
           role="alert"
           data-testid="screenshot-upload-error"
         >

--- a/components/SetupReminderBanner.tsx
+++ b/components/SetupReminderBanner.tsx
@@ -53,13 +53,13 @@ export function SetupReminderBanner({ siteId }: { siteId: string }) {
           Set up your design direction and tone of voice to improve
           generated content quality.
         </p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
+        <p className="mt-0.5 text-sm text-muted-foreground">
           Two skippable steps. Sets the look and voice every page we
           generate is styled around.
         </p>
         <Link
           href={`/admin/sites/${siteId}/setup`}
-          className="mt-2 inline-block text-xs font-medium underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          className="mt-2 inline-block text-sm font-medium underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
           data-testid="setup-reminder-banner-cta"
         >
           Set up now →

--- a/components/SetupWizard.tsx
+++ b/components/SetupWizard.tsx
@@ -485,11 +485,11 @@ function Step3({ siteId, status }: { siteId: string; status: SetupStatus }) {
                 designApproved ? (
                   <DesignDirectionDetails tokens={status.design_tokens} />
                 ) : designSkipped ? (
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-sm text-muted-foreground">
                     Using defaults.
                   </p>
                 ) : (
-                  <p className="text-xs text-muted-foreground">Not yet set.</p>
+                  <p className="text-sm text-muted-foreground">Not yet set.</p>
                 )
               }
             />
@@ -501,11 +501,11 @@ function Step3({ siteId, status }: { siteId: string; status: SetupStatus }) {
                 toneApproved ? (
                   <ToneOfVoiceDetails tone={status.tone_of_voice} />
                 ) : toneSkipped ? (
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-sm text-muted-foreground">
                     Using defaults.
                   </p>
                 ) : (
-                  <p className="text-xs text-muted-foreground">Not yet set.</p>
+                  <p className="text-sm text-muted-foreground">Not yet set.</p>
                 )
               }
             />
@@ -517,7 +517,7 @@ function Step3({ siteId, status }: { siteId: string; status: SetupStatus }) {
                 className="rounded-md border bg-card p-3"
                 data-testid="setup-step-3-tone-applied"
               >
-                <p className="text-xs font-medium">
+                <p className="text-sm font-medium">
                   Your design with your voice applied
                 </p>
                 <div className="mt-2 h-72 overflow-hidden rounded-md border bg-muted/20">
@@ -568,14 +568,14 @@ function SummaryCard({
     <div className="rounded-md border bg-muted/20 p-4">
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold">{heading}</h3>
-        <span className="text-xs text-muted-foreground">
+        <span className="text-sm text-muted-foreground">
           {statusLabel(state)}
         </span>
       </div>
       <div className="mt-3">{details}</div>
       <Link
         href={href}
-        className="mt-4 inline-block text-xs text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+        className="mt-4 inline-block text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
       >
         Go back and edit →
       </Link>
@@ -590,7 +590,7 @@ function DesignDirectionDetails({
 }) {
   if (!tokens) {
     return (
-      <p className="text-xs text-muted-foreground">
+      <p className="text-sm text-muted-foreground">
         Approved direction has no captured tokens yet.
       </p>
     );
@@ -607,7 +607,7 @@ function DesignDirectionDetails({
   const fontBody =
     typeof tokens.font_body === "string" ? tokens.font_body : null;
   return (
-    <div className="space-y-2 text-xs">
+    <div className="space-y-2 text-sm">
       {swatches.length > 0 && (
         <div className="flex flex-wrap items-center gap-2">
           {swatches.map((s) => (
@@ -652,7 +652,7 @@ function ToneOfVoiceDetails({
 }) {
   if (!tone) {
     return (
-      <p className="text-xs text-muted-foreground">
+      <p className="text-sm text-muted-foreground">
         Approved tone has no captured profile yet.
       </p>
     );
@@ -670,7 +670,7 @@ function ToneOfVoiceDetails({
       typeof (s as { text: unknown }).text === "string",
   );
   return (
-    <div className="space-y-2 text-xs">
+    <div className="space-y-2 text-sm">
       {styleGuide && (
         <p className="text-muted-foreground">
           <span className="font-medium text-foreground">Style: </span>

--- a/components/SiteActionsMenu.tsx
+++ b/components/SiteActionsMenu.tsx
@@ -92,7 +92,7 @@ export function SiteActionsMenu({
           <div className="absolute right-0 z-10 mt-1 w-44 rounded-md border bg-background shadow-md">
             <button
               type="button"
-              className="w-full px-3 py-1.5 text-left text-xs hover:bg-muted"
+              className="w-full px-3 py-1.5 text-left text-sm hover:bg-muted"
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
@@ -105,7 +105,7 @@ export function SiteActionsMenu({
             </button>
             <button
               type="button"
-              className="w-full px-3 py-1.5 text-left text-xs text-destructive hover:bg-destructive/10"
+              className="w-full px-3 py-1.5 text-left text-sm text-destructive hover:bg-destructive/10"
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
@@ -119,7 +119,7 @@ export function SiteActionsMenu({
             <button
               type="button"
               disabled
-              className="w-full cursor-not-allowed px-3 py-1.5 text-left text-xs text-muted-foreground"
+              className="w-full cursor-not-allowed px-3 py-1.5 text-left text-sm text-muted-foreground"
               title="Coming in a follow-up slice"
             >
               Clone DS (soon)

--- a/components/SiteCreateForm.tsx
+++ b/components/SiteCreateForm.tsx
@@ -217,7 +217,7 @@ export function SiteCreateForm() {
           className="mt-1"
           data-testid="site-wp-url"
         />
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           Full origin including <code className="font-mono">https://</code>.
           Trailing slash is stripped automatically.
         </p>
@@ -259,17 +259,17 @@ export function SiteCreateForm() {
           <button
             type="button"
             onClick={() => setShowPassword((v) => !v)}
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm px-1"
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-sm text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm px-1"
             tabIndex={-1}
           >
             {showPassword ? "hide" : "show"}
           </button>
         </div>
-        <p className="mt-1 text-xs font-semibold text-foreground">
+        <p className="mt-1 text-sm font-semibold text-foreground">
           This is NOT your WordPress login password.
         </p>
         <ApplicationPasswordHelp />
-        <p className="mt-2 text-xs text-muted-foreground">
+        <p className="mt-2 text-sm text-muted-foreground">
           You need an Administrator or Editor account. Subscriber or
           Contributor accounts will fail the connection test.
         </p>
@@ -279,7 +279,7 @@ export function SiteCreateForm() {
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <p className="text-sm font-medium">Connection test</p>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               Required before saving. Re-runs after any URL / username /
               password edit.
             </p>
@@ -364,7 +364,7 @@ function TestResultPanel({
                 ? `Connected as ${result.user.display_name}`
                 : "Credentials changed since last successful test"}
             </p>
-            <p className="mt-0.5 text-xs">
+            <p className="mt-0.5 text-sm">
               {matchesCurrent
                 ? `WordPress username: ${result.user.username}. Roles: ${
                     result.user.roles.join(", ") || "(none)"
@@ -384,7 +384,7 @@ function TestResultPanel({
       data-testid="site-test-result"
     >
       <p className="font-medium">{result.code}</p>
-      <p className="mt-0.5 text-xs">{result.message}</p>
+      <p className="mt-0.5 text-sm">{result.message}</p>
     </div>
   );
 }
@@ -396,7 +396,7 @@ function ApplicationPasswordHelp() {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm"
         aria-expanded={open}
         aria-controls="app-password-help-body"
         data-testid="site-wp-password-help-toggle"
@@ -412,7 +412,7 @@ function ApplicationPasswordHelp() {
       {open && (
         <ol
           id="app-password-help-body"
-          className="mt-2 list-decimal space-y-1 rounded-md border bg-muted/30 p-3 pl-6 text-xs text-muted-foreground"
+          className="mt-2 list-decimal space-y-1 rounded-md border bg-muted/30 p-3 pl-6 text-sm text-muted-foreground"
           data-testid="site-wp-password-help-body"
         >
           <li>Log in to WordPress Admin</li>

--- a/components/SiteEditForm.tsx
+++ b/components/SiteEditForm.tsx
@@ -324,13 +324,13 @@ export function SiteEditForm({
           <button
             type="button"
             onClick={() => setShowPassword((v) => !v)}
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm px-1"
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-sm text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm px-1"
             tabIndex={-1}
           >
             {showPassword ? "hide" : "show"}
           </button>
         </div>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           {form.passwordTouched
             ? "Submitting saves this new Application Password."
             : "Leave empty to keep the stored Application Password."}
@@ -341,7 +341,7 @@ export function SiteEditForm({
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <p className="text-sm font-medium">Connection test</p>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
               {isExplicit
                 ? "Tests the credentials in the form."
                 : hasStoredCredentials
@@ -432,7 +432,7 @@ function TestResultPanel({
                 ? `Connected as ${result.user.display_name}`
                 : "Credentials changed since last successful test"}
             </p>
-            <p className="mt-0.5 text-xs">
+            <p className="mt-0.5 text-sm">
               {matchesCurrent
                 ? `WordPress username: ${result.user.username}. Roles: ${
                     result.user.roles.join(", ") || "(none)"
@@ -452,7 +452,7 @@ function TestResultPanel({
       data-testid="site-test-result"
     >
       <p className="font-medium">Connection test failed</p>
-      <p className="mt-0.5 text-xs">{result.message}</p>
+      <p className="mt-0.5 text-sm">{result.message}</p>
     </div>
   );
 }
@@ -470,7 +470,7 @@ function ApplicationPasswordTooltip() {
       />
       <span
         role="tooltip"
-        className="pointer-events-none absolute left-1/2 top-5 z-10 w-72 -translate-x-1/2 rounded-md border bg-popover p-3 text-xs text-popover-foreground opacity-0 shadow-lg transition-smooth group-hover:opacity-100 group-focus:opacity-100"
+        className="pointer-events-none absolute left-1/2 top-5 z-10 w-72 -translate-x-1/2 rounded-md border bg-popover p-3 text-sm text-popover-foreground opacity-0 shadow-lg transition-smooth group-hover:opacity-100 group-focus:opacity-100"
       >
         Generate at{" "}
         <strong>wp-admin → Users → Profile → Application Passwords</strong>.

--- a/components/SiteSwitcher.tsx
+++ b/components/SiteSwitcher.tsx
@@ -239,7 +239,7 @@ export function SiteSwitcher() {
                   />
                   <span className="flex-1 truncate">{s.name}</span>
                   {selected && (
-                    <span className="text-xs text-muted-foreground">✓</span>
+                    <span className="text-sm text-muted-foreground">✓</span>
                   )}
                 </button>
               );

--- a/components/SiteVoiceSettingsForm.tsx
+++ b/components/SiteVoiceSettingsForm.tsx
@@ -104,7 +104,7 @@ export function SiteVoiceSettingsForm({
           maxLength={FIELD_MAX_BYTES}
           placeholder="e.g. Warm, confident, plain language. Avoid jargon. Second-person (you / your) by default."
         />
-        <p className="mt-1.5 text-xs text-muted-foreground">
+        <p className="mt-1.5 text-sm text-muted-foreground">
           How every page on this site should sound. New briefs inherit
           this as a default.{" "}
           <span className="font-mono">
@@ -131,7 +131,7 @@ export function SiteVoiceSettingsForm({
           maxLength={FIELD_MAX_BYTES}
           placeholder="e.g. Generous white space. Hero with photo background. Single CTA per section, accent color for emphasis."
         />
-        <p className="mt-1.5 text-xs text-muted-foreground">
+        <p className="mt-1.5 text-sm text-muted-foreground">
           Visual constraints for the anchor cycle on every brief.{" "}
           <span className="font-mono">
             {designDirection.length.toLocaleString()}/

--- a/components/SitesTable.tsx
+++ b/components/SitesTable.tsx
@@ -89,7 +89,7 @@ export function SitesTable({ sites, onCreateClick }: SitesTableProps) {
   return (
     <div className="rounded-md border">
       <table className="w-full text-sm">
-        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+        <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
           <tr>
             <th className="px-3 py-2 font-medium">Name</th>
             <th className="px-3 py-2 font-medium">WP URL</th>
@@ -127,7 +127,7 @@ export function SitesTable({ sites, onCreateClick }: SitesTableProps) {
               <td className="px-3 py-2">
                 <StatusCell status={s.status} />
               </td>
-              <td className="px-3 py-2 text-xs text-muted-foreground">
+              <td className="px-3 py-2 text-sm text-muted-foreground">
                 <span data-screenshot-mask>
                   {formatRelativeTime(s.updated_at)}
                 </span>

--- a/components/TemplateFormModal.tsx
+++ b/components/TemplateFormModal.tsx
@@ -41,12 +41,12 @@ function Label({
 
 function FieldError({ message }: { message?: string | null }) {
   if (!message) return null;
-  return <p className="mt-1 text-xs text-destructive">{message}</p>;
+  return <p className="mt-1 text-sm text-destructive">{message}</p>;
 }
 
 function FieldWarning({ message }: { message?: string | null }) {
   if (!message) return null;
-  return <p className="mt-1 text-xs text-yellow-700 dark:text-yellow-400">{message}</p>;
+  return <p className="mt-1 text-sm text-yellow-700 dark:text-yellow-400">{message}</p>;
 }
 
 function initialFromTemplate(t: DesignTemplate): FormState {
@@ -360,7 +360,7 @@ export function TemplateFormModal({
               />
               <FieldError message={fieldErrors.page_type} />
               {mode.kind === "edit" && (
-                <p className="mt-1 text-xs text-muted-foreground">
+                <p className="mt-1 text-sm text-muted-foreground">
                   Page type is immutable after create.
                 </p>
               )}
@@ -395,7 +395,7 @@ export function TemplateFormModal({
             <Label htmlFor="tf-composition">Template composition</Label>
             <textarea
               id="tf-composition"
-              className="mt-1 h-48 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              className="mt-1 h-48 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
               value={form.composition}
               onChange={(e) => setField("composition", e.target.value)}
               spellCheck={false}
@@ -403,7 +403,7 @@ export function TemplateFormModal({
             />
             <FieldError message={fieldErrors.composition} />
             <FieldWarning message={fieldWarnings.composition} />
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className="mt-1 text-sm text-muted-foreground">
               Ordered array of {"{"} component, content_source {"}"} entries.
               Every <code>component</code> must resolve to a component in this
               design system — a warning shows above if one doesn&apos;t.
@@ -414,7 +414,7 @@ export function TemplateFormModal({
             <Label htmlFor="tf-required">Required fields per component</Label>
             <textarea
               id="tf-required"
-              className="mt-1 h-24 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              className="mt-1 h-24 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
               value={form.required_fields}
               onChange={(e) => setField("required_fields", e.target.value)}
               spellCheck={false}
@@ -427,7 +427,7 @@ export function TemplateFormModal({
             <Label htmlFor="tf-seo">SEO defaults (optional)</Label>
             <textarea
               id="tf-seo"
-              className="mt-1 h-20 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs"
+              className="mt-1 h-20 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
               value={form.seo_defaults}
               onChange={(e) => setField("seo_defaults", e.target.value)}
               spellCheck={false}

--- a/components/TemplatesTable.tsx
+++ b/components/TemplatesTable.tsx
@@ -41,7 +41,7 @@ export function TemplatesTable({
   return (
     <div className="overflow-hidden rounded-md border">
       <table className="w-full text-sm">
-        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+        <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
           <tr>
             <th className="px-4 py-2 font-medium">Page type</th>
             <th className="px-4 py-2 font-medium">Name</th>
@@ -53,12 +53,12 @@ export function TemplatesTable({
         <tbody>
           {sorted.map((t) => (
             <tr key={t.id} className="border-b last:border-b-0">
-              <td className="px-4 py-3 font-mono text-xs">{t.page_type}</td>
+              <td className="px-4 py-3 font-mono text-sm">{t.page_type}</td>
               <td className="px-4 py-3 font-medium">{t.name}</td>
-              <td className="px-4 py-3 text-xs text-muted-foreground">
+              <td className="px-4 py-3 text-sm text-muted-foreground">
                 {compositionPreview(t)}
               </td>
-              <td className="px-4 py-3 text-xs text-muted-foreground">
+              <td className="px-4 py-3 text-sm text-muted-foreground">
                 {t.is_default ? "Yes" : "—"}
               </td>
               <td className="px-4 py-3">

--- a/components/TenantBudgetBadge.tsx
+++ b/components/TenantBudgetBadge.tsx
@@ -54,7 +54,7 @@ function Row({
   const paused = cap === 0;
   return (
     <div className="space-y-1">
-      <div className="flex items-center justify-between text-xs">
+      <div className="flex items-center justify-between text-sm">
         <span className="font-medium">{label}</span>
         <span className="text-muted-foreground">
           {paused ? (
@@ -84,7 +84,7 @@ export function TenantBudgetBadge({ budget }: { budget: TenantBudget | null }) {
   if (!budget) {
     return (
       <div
-        className="rounded-md border border-dashed p-3 text-xs text-muted-foreground"
+        className="rounded-md border border-dashed p-3 text-sm text-muted-foreground"
         data-testid="tenant-budget-missing"
       >
         No budget row. Every enqueue will self-heal via the tenant-budget

--- a/components/ToneOfVoiceInputs.tsx
+++ b/components/ToneOfVoiceInputs.tsx
@@ -301,7 +301,7 @@ export function ToneOfVoiceInputs({
             className="mt-1"
             data-testid="tov-url"
           />
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-sm text-muted-foreground">
             We fetch the homepage prose and infer tone from it.
           </p>
         </div>
@@ -342,7 +342,7 @@ export function ToneOfVoiceInputs({
       <div className="grid gap-4 md:grid-cols-2">
         <div>
           <p className="block text-sm font-medium">Personality</p>
-          <p className="mt-0.5 text-xs text-muted-foreground">
+          <p className="mt-0.5 text-sm text-muted-foreground">
             Pick everything that fits — these become positive voice rules.
           </p>
           <div className="mt-2 flex flex-wrap gap-1.5">
@@ -356,7 +356,7 @@ export function ToneOfVoiceInputs({
                     setField("personality", toggleMulti(inputs.personality, opt))
                   }
                   className={[
-                    "rounded-full border px-2.5 py-0.5 text-xs transition-smooth",
+                    "rounded-full border px-2.5 py-0.5 text-sm transition-smooth",
                     on
                       ? "border-foreground bg-foreground text-background"
                       : "border-muted bg-muted/30 text-muted-foreground hover:bg-muted/50",
@@ -372,7 +372,7 @@ export function ToneOfVoiceInputs({
         </div>
         <div>
           <p className="block text-sm font-medium">Never sound like</p>
-          <p className="mt-0.5 text-xs text-muted-foreground">
+          <p className="mt-0.5 text-sm text-muted-foreground">
             Pick anti-patterns — these become avoidance rules.
           </p>
           <div className="mt-2 flex flex-wrap gap-1.5">
@@ -386,7 +386,7 @@ export function ToneOfVoiceInputs({
                     setField("avoid", toggleMulti(inputs.avoid, opt))
                   }
                   className={[
-                    "rounded-full border px-2.5 py-0.5 text-xs transition-smooth",
+                    "rounded-full border px-2.5 py-0.5 text-sm transition-smooth",
                     on
                       ? "border-destructive bg-destructive text-background"
                       : "border-muted bg-muted/30 text-muted-foreground hover:bg-muted/50",
@@ -418,7 +418,7 @@ export function ToneOfVoiceInputs({
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-4">
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Estimated cost: ~$0.02 — extracts tone JSON + three preview
           samples in a single call.
         </p>
@@ -444,7 +444,7 @@ export function ToneOfVoiceInputs({
 
       {extractError && (
         <div
-          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
           role="alert"
           data-testid="tov-extract-error"
         >
@@ -470,7 +470,7 @@ export function ToneOfVoiceInputs({
 
       {approveError && (
         <div
-          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
           role="alert"
         >
           {approveError}
@@ -516,7 +516,7 @@ export function ToneOfVoiceInputs({
 function ToneSummary({ tone }: { tone: ToneOfVoice }) {
   return (
     <div
-      className="rounded-md border bg-muted/20 p-3 text-xs"
+      className="rounded-md border bg-muted/20 p-3 text-sm"
       data-testid="tov-summary"
     >
       <p className="font-medium">Tone profile</p>
@@ -588,7 +588,7 @@ function SamplesEditor({
               value={s.text}
               onChange={(e) => onChange(i, e.target.value)}
               maxLength={800}
-              className="mt-1 text-xs"
+              className="mt-1 text-sm"
             />
           </div>
         ))}
@@ -596,7 +596,7 @@ function SamplesEditor({
       <div className="rounded-md border bg-muted/20 p-3">
         <label
           htmlFor="tov-regen-feedback"
-          className="text-xs font-medium"
+          className="text-sm font-medium"
         >
           Regenerate samples
         </label>
@@ -608,9 +608,9 @@ function SamplesEditor({
           value={regenFeedback}
           onChange={(e) => onRegenFeedbackChange(e.target.value)}
           disabled={regenerating || atCap}
-          className="mt-1 text-xs"
+          className="mt-1 text-sm"
         />
-        <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+        <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
           <span data-testid="tov-regen-counter">
             {regenAttempts}/{REGEN_CAP} regenerations used
             {atCap && (

--- a/components/TrustedDevicesList.tsx
+++ b/components/TrustedDevicesList.tsx
@@ -106,7 +106,7 @@ export function TrustedDevicesList({
 
       <div className="rounded-md border">
         <table className="w-full text-sm">
-          <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+          <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
             <tr>
               <th className="px-3 py-2 font-medium">Device</th>
               <th className="px-3 py-2 font-medium">Last used</th>
@@ -132,12 +132,12 @@ export function TrustedDevicesList({
                       </span>
                     )}
                   </td>
-                  <td className="px-3 py-2 text-xs text-muted-foreground">
+                  <td className="px-3 py-2 text-sm text-muted-foreground">
                     <span data-screenshot-mask>
                       {formatRelativeTime(d.last_used_at)}
                     </span>
                   </td>
-                  <td className="px-3 py-2 text-xs text-muted-foreground">
+                  <td className="px-3 py-2 text-sm text-muted-foreground">
                     <span data-screenshot-mask>
                       {formatRelativeTime(d.trusted_until)}
                     </span>
@@ -147,7 +147,7 @@ export function TrustedDevicesList({
                       type="button"
                       onClick={() => void revokeOne(d.id, label)}
                       disabled={revokingId === d.id}
-                      className="rounded border px-2 py-0.5 text-xs text-destructive transition-smooth hover:bg-destructive/10 disabled:opacity-60"
+                      className="rounded border px-2 py-0.5 text-sm text-destructive transition-smooth hover:bg-destructive/10 disabled:opacity-60"
                       data-testid="revoke-device"
                     >
                       {revokingId === d.id ? "…" : "Sign out"}

--- a/components/UploadBriefModal.tsx
+++ b/components/UploadBriefModal.tsx
@@ -207,7 +207,7 @@ export function UploadBriefModal({
                   Post brief
                 </label>
               </div>
-              <p className="mt-1 text-xs text-muted-foreground">
+              <p className="mt-1 text-sm text-muted-foreground">
                 Page briefs build site pages with anchor + revise cycles. Post
                 briefs build blog posts (no anchor cycle).
               </p>

--- a/components/UseImageLibraryToggle.tsx
+++ b/components/UseImageLibraryToggle.tsx
@@ -42,7 +42,7 @@ export function UseImageLibraryToggle({
     <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-background p-3">
       <div>
         <p className="text-sm font-medium">Use images from the library</p>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           Suggest up to 5 captioned images per page based on the page title.
           Only images with caption + alt text are included; off by default
           until you&apos;ve verified the metadata quality.
@@ -59,7 +59,7 @@ export function UseImageLibraryToggle({
         {enabled ? "Enabled" : "Disabled"}
       </Button>
       {error && (
-        <p className="basis-full text-xs text-destructive" role="alert">
+        <p className="basis-full text-sm text-destructive" role="alert">
           {error}
         </p>
       )}

--- a/components/UserRoleActionCell.tsx
+++ b/components/UserRoleActionCell.tsx
@@ -94,7 +94,7 @@ export function UserRoleActionCell({
   if (isSuperAdmin) {
     return (
       <span
-        className="inline-flex items-center rounded border border-input bg-muted/50 px-2 py-0.5 text-xs text-muted-foreground"
+        className="inline-flex items-center rounded border border-input bg-muted/50 px-2 py-0.5 text-sm text-muted-foreground"
         title="Super admin cannot be modified."
       >
         super_admin
@@ -109,7 +109,7 @@ export function UserRoleActionCell({
       disabled={isSelf || submitting}
       aria-label={`Change role for user ${userId}`}
       title={isSelf ? "You cannot change your own role." : undefined}
-      className="rounded border bg-background px-2 py-1 text-xs transition-smooth disabled:opacity-60"
+      className="rounded border bg-background px-2 py-1 text-sm transition-smooth disabled:opacity-60"
     >
       <option value="admin">admin</option>
       <option value="user">user</option>

--- a/components/UserStatusActionCell.tsx
+++ b/components/UserStatusActionCell.tsx
@@ -65,12 +65,12 @@ export function UserStatusActionCell({
   if (optimisticRevoked) {
     return (
       <div className="flex items-center gap-2">
-        <span className="text-xs text-destructive">revoked</span>
+        <span className="text-sm text-destructive">revoked</span>
         <button
           type="button"
           onClick={() => void reinstate()}
           disabled={submitting}
-          className="rounded border px-2 py-0.5 text-xs transition-smooth hover:bg-muted disabled:opacity-60"
+          className="rounded border px-2 py-0.5 text-sm transition-smooth hover:bg-muted disabled:opacity-60"
         >
           {submitting ? "…" : "Reinstate"}
         </button>
@@ -80,13 +80,13 @@ export function UserStatusActionCell({
 
   return (
     <div className="flex items-center gap-2">
-      <span className="text-xs text-muted-foreground">active</span>
+      <span className="text-sm text-muted-foreground">active</span>
       <button
         type="button"
         onClick={() => setRevokeOpen(true)}
         disabled={isSelf || submitting}
         title={isSelf ? "You cannot revoke your own access." : undefined}
-        className="rounded border px-2 py-0.5 text-xs text-destructive transition-smooth hover:bg-destructive/10 disabled:opacity-60"
+        className="rounded border px-2 py-0.5 text-sm text-destructive transition-smooth hover:bg-destructive/10 disabled:opacity-60"
       >
         {submitting ? "…" : "Revoke"}
       </button>

--- a/components/UsersTable.tsx
+++ b/components/UsersTable.tsx
@@ -42,7 +42,7 @@ export function UsersTable({
         title="No users yet"
         body={
           <>
-            The <code className="font-mono text-xs">first_admin_email</code>{" "}
+            The <code className="font-mono text-sm">first_admin_email</code>{" "}
             bootstrap promotes the first Supabase signup to admin; everyone
             else starts as viewer.
           </>
@@ -55,7 +55,7 @@ export function UsersTable({
     <div className="overflow-x-auto rounded-md border">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b bg-muted/40 text-left text-xs text-muted-foreground">
+          <tr className="border-b bg-muted/40 text-left text-sm text-muted-foreground">
             <th className="px-3 py-2 font-medium">Email</th>
             <th className="px-3 py-2 font-medium">Role</th>
             <th className="px-3 py-2 font-medium">Created</th>
@@ -69,7 +69,7 @@ export function UsersTable({
                 <div className="flex flex-col">
                   <span>{u.email}</span>
                   {u.display_name && (
-                    <span className="text-xs text-muted-foreground">
+                    <span className="text-sm text-muted-foreground">
                       {u.display_name}
                     </span>
                   )}

--- a/components/optimiser/AbTestStatusBanner.tsx
+++ b/components/optimiser/AbTestStatusBanner.tsx
@@ -36,7 +36,7 @@ export function AbTestStatusBanner({ test }: { test: TestRow | null }) {
         <h3 className="text-sm font-semibold">
           A/B test ({test.status.replace("_", " ")})
         </h3>
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Split: B {test.traffic_split_percent}% / A {100 - test.traffic_split_percent}%
           {test.started_at && (
             <>
@@ -72,7 +72,7 @@ export function AbTestStatusBanner({ test }: { test: TestRow | null }) {
         />
       </div>
       {snapshot.evaluated_at && (
-        <p className="mt-2 text-xs text-muted-foreground">
+        <p className="mt-2 text-sm text-muted-foreground">
           Last evaluated: {new Date(snapshot.evaluated_at).toLocaleString()}
         </p>
       )}
@@ -105,7 +105,7 @@ function VariantPanel({
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium">{label}</span>
         {isWinner && (
-          <span className="text-xs font-semibold uppercase tracking-wide text-emerald-700">
+          <span className="text-sm font-semibold uppercase tracking-wide text-emerald-700">
             winner
           </span>
         )}

--- a/components/optimiser/AssistedApprovalToggle.tsx
+++ b/components/optimiser/AssistedApprovalToggle.tsx
@@ -66,8 +66,8 @@ export function AssistedApprovalToggle({
       </p>
       <p className="text-sm text-muted-foreground">
         When enabled, proposals with{" "}
-        <code className="font-mono text-xs">risk_level=low</code> AND{" "}
-        <code className="font-mono text-xs">effort_bucket=1</code> auto-approve after 48 hours of being unreviewed. Staff get an email notification when auto-approval fires.
+        <code className="font-mono text-sm">risk_level=low</code> AND{" "}
+        <code className="font-mono text-sm">effort_bucket=1</code> auto-approve after 48 hours of being unreviewed. Staff get an email notification when auto-approval fires.
       </p>
       <p className="text-sm text-muted-foreground">
         High-risk proposals always require manual approval, regardless of this setting. Enforced at the API level, not just UI.
@@ -82,7 +82,7 @@ export function AssistedApprovalToggle({
           {submitting ? "Saving…" : enabled ? "Disable assisted approval" : "Enable assisted approval"}
         </Button>
       ) : (
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Only admins can toggle this setting.
         </p>
       )}

--- a/components/optimiser/CreateVariantButton.tsx
+++ b/components/optimiser/CreateVariantButton.tsx
@@ -66,7 +66,7 @@ export function CreateVariantButton({
     <div className="rounded-lg border border-border bg-card p-4 space-y-3">
       <header>
         <h3 className="text-sm font-semibold">A/B test (Phase 2)</h3>
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Generate a structurally distinct alternative and route a slice of traffic to it.
           Winner detection runs hourly via the §6 feature 8 Bayesian monitor.
         </p>

--- a/components/optimiser/CrossClientConsentToggle.tsx
+++ b/components/optimiser/CrossClientConsentToggle.tsx
@@ -88,7 +88,7 @@ export function CrossClientConsentToggle({
         shapes (e.g. <em>cta_position above-fold vs below-fold</em>), not
         copy, URLs, testimonials, or pricing.
       </p>
-      <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+      <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
         <p className="font-medium">Legal precondition (spec §11.2.4)</p>
         <p className="mt-1">
           An MSA cross-client-learning clause must be signed before flipping
@@ -96,7 +96,7 @@ export function CrossClientConsentToggle({
         </p>
       </div>
       {!patternLibraryEnabled && (
-        <div className="rounded-md border border-muted bg-muted/40 p-3 text-xs text-muted-foreground">
+        <div className="rounded-md border border-muted bg-muted/40 p-3 text-sm text-muted-foreground">
           The <code className="font-mono">OPT_PATTERN_LIBRARY_ENABLED</code>{" "}
           feature flag is currently off. Even with consent on, no
           contribution or application will happen until the flag is set.
@@ -116,7 +116,7 @@ export function CrossClientConsentToggle({
               : "Enable cross-client learning"}
         </Button>
       ) : (
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Only admins can toggle this setting.
         </p>
       )}

--- a/components/optimiser/ImportSideBySide.tsx
+++ b/components/optimiser/ImportSideBySide.tsx
@@ -36,7 +36,7 @@ export function ImportSideBySide({
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Cached snapshot (left) is what the runner will reproduce. Live
           URL (right) is the current state of the source — drift between
           the two is operator-visible signal that the page has changed
@@ -45,7 +45,7 @@ export function ImportSideBySide({
         <button
           type="button"
           onClick={() => setShowLive((v) => !v)}
-          className="rounded-md border border-border px-3 py-1 text-xs hover:bg-muted"
+          className="rounded-md border border-border px-3 py-1 text-sm hover:bg-muted"
         >
           {showLive ? "Hide live preview" : "Show live preview"}
         </button>
@@ -55,7 +55,7 @@ export function ImportSideBySide({
         <section className="space-y-2 rounded-lg border border-border bg-card p-3">
           <header className="flex items-center justify-between text-sm">
             <span className="font-medium">Cached snapshot</span>
-            <span className="text-xs text-muted-foreground">
+            <span className="text-sm text-muted-foreground">
               capture-time HTML, sandboxed
             </span>
           </header>
@@ -76,7 +76,7 @@ export function ImportSideBySide({
                   href={liveUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="font-mono text-xs underline-offset-4 hover:underline"
+                  className="font-mono text-sm underline-offset-4 hover:underline"
                 >
                   open ↗
                 </a>
@@ -90,7 +90,7 @@ export function ImportSideBySide({
                   sandbox="allow-same-origin"
                   className="h-[640px] w-full rounded-md border border-border bg-white"
                 />
-                <p className="text-xs text-muted-foreground">
+                <p className="text-sm text-muted-foreground">
                   Many sites set X-Frame-Options to DENY/SAMEORIGIN — if
                   the iframe is blank, open the URL in a new tab using
                   the link above.
@@ -110,7 +110,7 @@ export function ImportSideBySide({
         {briefRunStatus ? (
           <p className="mt-1 text-muted-foreground">
             Brief run is{" "}
-            <code className="font-mono text-xs">{briefRunStatus}</code>
+            <code className="font-mono text-sm">{briefRunStatus}</code>
             {briefRunCreatedAt && (
               <>
                 {" "}· created {new Date(briefRunCreatedAt).toLocaleString()}
@@ -129,7 +129,7 @@ export function ImportSideBySide({
         ) : (
           <p className="mt-1 text-muted-foreground">No brief run yet.</p>
         )}
-        <p className="mt-2 text-xs text-muted-foreground">
+        <p className="mt-2 text-sm text-muted-foreground">
           The brief-runner consumer of mode=&apos;import&apos; lands in a
           follow-up sub-slice. Once shipped, this panel will render the
           Site-Builder-native output alongside the source.

--- a/components/optimiser/OnboardingWizard.tsx
+++ b/components/optimiser/OnboardingWizard.tsx
@@ -77,7 +77,7 @@ export function OnboardingWizard({
                     </span>
                     <StatusDot state={state} />
                   </div>
-                  <p className="mt-1 text-xs text-muted-foreground">
+                  <p className="mt-1 text-sm text-muted-foreground">
                     {step.description}
                   </p>
                 </button>
@@ -242,7 +242,7 @@ function ClientDetailsStep({
           value={budget}
           onChange={(e) => setBudget(Number(e.target.value))}
         />
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Soft warning at 75%, hard cutoff at 100%. Default: $50.
         </p>
       </div>
@@ -453,7 +453,7 @@ function ClarityStep({
       </div>
       <div>
         <p className="text-sm font-medium">JS snippet</p>
-        <pre className="mt-2 max-h-64 overflow-auto rounded-md bg-muted p-3 text-xs">
+        <pre className="mt-2 max-h-64 overflow-auto rounded-md bg-muted p-3 text-sm">
 {snippet}
         </pre>
       </div>
@@ -717,7 +717,7 @@ function PagesStep({ client, stepStatus, setStatus, onComplete }: PagesStepProps
                     }
                   />
                 </td>
-                <td className="px-3 py-2 font-mono text-xs">{p.url}</td>
+                <td className="px-3 py-2 font-mono text-sm">{p.url}</td>
                 <td className="px-3 py-2 text-right">
                   ${(p.spend_30d_usd_cents / 100).toFixed(0)}
                 </td>

--- a/components/optimiser/PageBrowser.tsx
+++ b/components/optimiser/PageBrowser.tsx
@@ -211,7 +211,7 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
                   <td className="px-3 py-2">
                     <Link
                       href={`/optimiser/pages/${p.id}`}
-                      className="font-mono text-xs text-primary underline-offset-4 hover:underline"
+                      className="font-mono text-sm text-primary underline-offset-4 hover:underline"
                     >
                       {p.url}
                     </Link>
@@ -220,7 +220,7 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
                         {(p.active_technical_alerts as string[]).map((alert) => (
                           <span
                             key={alert}
-                            className="inline-flex items-center rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-xs text-red-900"
+                            className="inline-flex items-center rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-sm text-red-900"
                           >
                             ⚠ {alert.replace(/_/g, " ")}
                           </span>
@@ -232,12 +232,12 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
                     {score != null && cls ? (
                       <ScoreBadge score={score} classification={cls} />
                     ) : (
-                      <span className="text-xs text-muted-foreground">—</span>
+                      <span className="text-sm text-muted-foreground">—</span>
                     )}
                   </td>
                   <td className="px-3 py-2">
                     <span
-                      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${STATE_PILL[p.state]}`}
+                      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-sm font-medium ${STATE_PILL[p.state]}`}
                     >
                       {STATE_LABEL[p.state]}
                     </span>
@@ -272,7 +272,7 @@ export function PageBrowser({ client, pages }: PageBrowserProps) {
           </tbody>
         </table>
       </div>
-      <p className="text-xs text-muted-foreground">
+      <p className="text-sm text-muted-foreground">
         Client: <span className="font-medium">{client.name}</span> ·{" "}
         <Link
           href={`/optimiser/onboarding/${client.id}`}

--- a/components/optimiser/PastCausalDeltasPanel.tsx
+++ b/components/optimiser/PastCausalDeltasPanel.tsx
@@ -48,7 +48,7 @@ export function PastCausalDeltasPanel({
         {[crSummary, scoreSummary].filter(Boolean).join(" / ")}
         {confidenceLabel ? ` with ${confidenceLabel}` : ""}.
       </p>
-      <ul className="mt-2 space-y-1 text-xs text-emerald-800/80">
+      <ul className="mt-2 space-y-1 text-sm text-emerald-800/80">
         {deltas.slice(0, 3).map((d) => (
           <li key={d.id}>
             ·{" "}

--- a/components/optimiser/PatternPriorsPanel.tsx
+++ b/components/optimiser/PatternPriorsPanel.tsx
@@ -50,7 +50,7 @@ export function PatternPriorsPanel({
       <header className="space-y-1">
         <p className="font-medium">
           Cross-client priors
-          <span className="ml-2 text-xs uppercase tracking-wide opacity-80">
+          <span className="ml-2 text-sm uppercase tracking-wide opacity-80">
             anonymised, {label}
           </span>
         </p>
@@ -64,12 +64,12 @@ export function PatternPriorsPanel({
           </strong>{" "}
           (95% CI: {ciLow.toFixed(1)} to {ciHigh.toFixed(1)}).
         </p>
-        <p className="text-xs opacity-80">
+        <p className="text-sm opacity-80">
           Pattern: <em>{top.observation}</em>
         </p>
       </header>
       {patterns.length > 1 && (
-        <ul className="mt-3 space-y-1 text-xs opacity-90">
+        <ul className="mt-3 space-y-1 text-sm opacity-90">
           {patterns.slice(1, 4).map((p) => {
             const m = Number(p.effect_pp_mean);
             const s = m >= 0 ? "+" : "";
@@ -83,7 +83,7 @@ export function PatternPriorsPanel({
           })}
         </ul>
       )}
-      <p className="mt-3 text-xs opacity-70">
+      <p className="mt-3 text-sm opacity-70">
         Cross-client patterns are anonymised structural observations
         only — no client names, URLs, copy, testimonials, or pricing
         leave the contributing accounts. Per spec §11.2.

--- a/components/optimiser/ProposalReview.tsx
+++ b/components/optimiser/ProposalReview.tsx
@@ -139,7 +139,7 @@ export function ProposalReview({
             <div>
               <h1 className="text-2xl font-semibold">{proposal.headline}</h1>
               {pageUrl && (
-                <p className="font-mono text-xs text-muted-foreground">{pageUrl}</p>
+                <p className="font-mono text-sm text-muted-foreground">{pageUrl}</p>
               )}
             </div>
             <RiskPill risk={proposal.risk_level} />
@@ -163,7 +163,7 @@ export function ProposalReview({
                 <div className="font-medium">
                   {e.label ?? e.evidence_type}
                 </div>
-                <pre className="mt-1 max-h-40 overflow-auto rounded bg-muted p-2 text-xs">
+                <pre className="mt-1 max-h-40 overflow-auto rounded bg-muted p-2 text-sm">
 {JSON.stringify(e.payload, null, 2)}
                 </pre>
               </li>
@@ -175,14 +175,14 @@ export function ProposalReview({
         </Section>
 
         <Section title="Current performance">
-          <pre className="max-h-60 overflow-auto rounded-md border border-border bg-card p-4 text-xs">
+          <pre className="max-h-60 overflow-auto rounded-md border border-border bg-card p-4 text-sm">
 {JSON.stringify(proposal.current_performance, null, 2)}
           </pre>
         </Section>
 
         <Section title="Pre-build reprompt (optional)">
           <RepromptForm value={reprompt} onChange={setReprompt} />
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-sm text-muted-foreground">
             Appended to the change set on approve. Phase 1.5 forwards this into the Site Builder brief.
           </p>
         </Section>
@@ -245,7 +245,7 @@ export function ProposalReview({
           >
             {submitting ? "Submitting…" : "Approve all"}
           </Button>
-          <p className="text-xs text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             Phase 1: approval marks the proposal as <code>approved</code>. Brief submission to the Site Builder generation engine lands in Phase 1.5.
           </p>
         </div>
@@ -282,7 +282,7 @@ export function ProposalReview({
           >
             {submitting ? "Submitting…" : "Reject"}
           </Button>
-          <p className="text-xs text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             Per §11.1: 3× the same reason (excluding &quot;Bad timing&quot;) suppresses the playbook for this client.
           </p>
         </div>
@@ -311,7 +311,7 @@ function Row({ label, value }: { label: string; value: string }) {
 
 function SubRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex items-center justify-between pl-4 text-xs">
+    <div className="flex items-center justify-between pl-4 text-sm">
       <span className="text-muted-foreground">· {label}</span>
       <span className="font-mono">{value}</span>
     </div>
@@ -327,7 +327,7 @@ function RiskPill({ risk }: { risk: string }) {
         : "bg-emerald-100 text-emerald-900 border-emerald-200";
   return (
     <span
-      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${cls}`}
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-sm font-medium ${cls}`}
     >
       {risk} risk
     </span>

--- a/components/optimiser/ProposalRolloutLink.tsx
+++ b/components/optimiser/ProposalRolloutLink.tsx
@@ -40,7 +40,7 @@ export function ProposalRolloutLink({
     >
       <div>
         <p className="font-medium">Staged rollout: {label}</p>
-        <p className="text-xs opacity-80">
+        <p className="text-sm opacity-80">
           {rollout.traffic_split_percent}% traffic · started{" "}
           {new Date(rollout.started_at).toLocaleString()}
           {rollout.end_reason && (
@@ -53,7 +53,7 @@ export function ProposalRolloutLink({
       </div>
       <Link
         href={`/optimiser/pages/${landingPageId}`}
-        className="text-xs font-medium underline-offset-4 hover:underline"
+        className="text-sm font-medium underline-offset-4 hover:underline"
       >
         View on page →
       </Link>

--- a/components/optimiser/RepromptForm.tsx
+++ b/components/optimiser/RepromptForm.tsx
@@ -83,7 +83,7 @@ export function RepromptForm({
         >
           Free reprompt
         </button>
-        <span className="ml-2 text-xs text-muted-foreground">
+        <span className="ml-2 text-sm text-muted-foreground">
           {mode === "controlled"
             ? "Pick what to preserve and what to change. Recommended."
             : "Freeform — lower precision, useful when the structured form doesn't fit."}
@@ -126,7 +126,7 @@ export function RepromptForm({
               className="mt-1"
             />
           </div>
-          <p className="text-xs text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             Generated brief:{" "}
             <code className="font-mono">
               {controlledSerialised || "(nothing yet)"}
@@ -144,7 +144,7 @@ export function RepromptForm({
             rows={3}
             placeholder="Augment the brief: 'keep the existing testimonial component' / 'use the centred hero variant' / etc."
           />
-          <p className="text-xs text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             Both modes route through the Site Builder generation engine —
             never direct edits.
           </p>

--- a/components/optimiser/RollbackButton.tsx
+++ b/components/optimiser/RollbackButton.tsx
@@ -64,7 +64,7 @@ export function RollbackButton({
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="rounded-md border border-border bg-background px-2 py-1 text-xs hover:bg-muted"
+        className="rounded-md border border-border bg-background px-2 py-1 text-sm hover:bg-muted"
       >
         Roll back
       </button>
@@ -85,7 +85,7 @@ export function RollbackButton({
               </h2>
               <p className="text-sm text-muted-foreground">
                 Restoring this version will mark the latest applied proposal
-                as <code className="font-mono text-xs">applied_then_reverted</code>{" "}
+                as <code className="font-mono text-sm">applied_then_reverted</code>{" "}
                 and re-evaluate the score against the restored content. The
                 full audit trail goes into opt_change_log.
               </p>
@@ -94,13 +94,13 @@ export function RollbackButton({
               <li>
                 <span className="text-muted-foreground">Target composite: </span>
                 <span className="font-mono font-semibold">{composite}</span>{" "}
-                <span className="text-xs text-muted-foreground">
+                <span className="text-sm text-muted-foreground">
                   ({classification.replace("_", " ")})
                 </span>
               </li>
               <li>
                 <span className="text-muted-foreground">When: </span>
-                <span className="font-mono text-xs">{versionLabel}</span>
+                <span className="font-mono text-sm">{versionLabel}</span>
               </li>
             </ul>
             <div className="space-y-2">

--- a/components/optimiser/ScoreBreakdownPanel.tsx
+++ b/components/optimiser/ScoreBreakdownPanel.tsx
@@ -58,7 +58,7 @@ export function ScoreBreakdownPanel({
     <section className="space-y-5 rounded-lg border border-border bg-card p-6">
       <header className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          <p className="text-sm uppercase tracking-wide text-muted-foreground">
             Composite score
           </p>
           <p className="mt-1 flex items-center gap-3">
@@ -127,7 +127,7 @@ export function ScoreBreakdownPanel({
       )}
 
       {result.redistribution_applied && (
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Note: weights redistributed because some sub-scores didn&apos;t
           have enough data or the page is flagged conversion_n_a.
         </p>

--- a/components/optimiser/ScoreHistoryTable.tsx
+++ b/components/optimiser/ScoreHistoryTable.tsx
@@ -63,7 +63,7 @@ export function ScoreHistoryTable({
                   isCurrent ? "bg-emerald-50/40" : ""
                 }`}
               >
-                <td className="px-3 py-2 whitespace-nowrap text-xs text-muted-foreground">
+                <td className="px-3 py-2 whitespace-nowrap text-sm text-muted-foreground">
                   {new Date(row.evaluated_at).toLocaleString()}
                   {isCurrent && (
                     <span className="ml-2 text-emerald-700">current</span>
@@ -74,30 +74,30 @@ export function ScoreHistoryTable({
                 </td>
                 <td className="px-3 py-2">
                   <span
-                    className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs ${colours.bg} ${colours.border} ${colours.text}`}
+                    className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-sm ${colours.bg} ${colours.border} ${colours.text}`}
                   >
                     <span aria-hidden className={`size-1.5 rounded-full ${colours.dot}`} />
                     {classificationLabel(row.classification)}
                   </span>
                 </td>
-                <td className="px-3 py-2 text-right font-mono text-xs">
+                <td className="px-3 py-2 text-right font-mono text-sm">
                   {row.alignment_subscore ?? "—"}
                 </td>
-                <td className="px-3 py-2 text-right font-mono text-xs">
+                <td className="px-3 py-2 text-right font-mono text-sm">
                   {row.behaviour_subscore ?? "—"}
                 </td>
-                <td className="px-3 py-2 text-right font-mono text-xs">
+                <td className="px-3 py-2 text-right font-mono text-sm">
                   {row.conversion_subscore ?? "—"}
                 </td>
-                <td className="px-3 py-2 text-right font-mono text-xs">
+                <td className="px-3 py-2 text-right font-mono text-sm">
                   {row.technical_subscore ?? "—"}
                 </td>
-                <td className="px-3 py-2 text-xs">
+                <td className="px-3 py-2 text-sm">
                   {row.triggering_proposal_id
                     ? row.change_set_summary ?? row.triggering_proposal_id.slice(0, 8) + "…"
                     : "—"}
                 </td>
-                <td className="px-3 py-2 text-xs">
+                <td className="px-3 py-2 text-sm">
                   {delta?.actual_impact_cr != null
                     ? `${delta.actual_impact_cr > 0 ? "+" : ""}${(delta.actual_impact_cr * 100).toFixed(1)}% CR`
                     : delta?.actual_impact_score != null

--- a/components/optimiser/ScoreSparkline.tsx
+++ b/components/optimiser/ScoreSparkline.tsx
@@ -29,7 +29,7 @@ export function ScoreSparkline({
     return (
       <div
         style={{ width, height }}
-        className="flex items-center justify-center rounded-md border border-dashed border-border text-xs text-muted-foreground"
+        className="flex items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground"
       >
         no history
       </div>

--- a/components/optimiser/StagedRolloutBanner.tsx
+++ b/components/optimiser/StagedRolloutBanner.tsx
@@ -49,7 +49,7 @@ export function StagedRolloutBanner({ rollout }: { rollout: RolloutRow | null })
         <h3 className="text-sm font-semibold">
           Staged rollout ({label})
         </h3>
-        <p className="text-xs opacity-80">
+        <p className="text-sm opacity-80">
           Split: {rollout.traffic_split_percent}%
           {" · "}
           started {new Date(rollout.started_at).toLocaleString()}
@@ -64,7 +64,7 @@ export function StagedRolloutBanner({ rollout }: { rollout: RolloutRow | null })
       </header>
 
       {observed && (
-        <ul className="mt-3 grid gap-2 text-xs sm:grid-cols-2">
+        <ul className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
           <li>
             <span className="opacity-70">CR (new): </span>
             <span className="font-mono tabular-nums">
@@ -118,14 +118,14 @@ export function StagedRolloutBanner({ rollout }: { rollout: RolloutRow | null })
       )}
 
       {trips.length > 0 && (
-        <ul className="mt-3 list-disc space-y-0.5 pl-5 text-xs">
+        <ul className="mt-3 list-disc space-y-0.5 pl-5 text-sm">
           {trips.map((t, i) => (
             <li key={i} className="font-mono">{t}</li>
           ))}
         </ul>
       )}
 
-      <p className="mt-3 text-xs opacity-70">
+      <p className="mt-3 text-sm opacity-70">
         {rollout.evaluation_count > 0 ? (
           <>
             {rollout.evaluation_count} monitor evaluation

--- a/components/optimiser/TryAutoImportPanel.tsx
+++ b/components/optimiser/TryAutoImportPanel.tsx
@@ -106,7 +106,7 @@ export function TryAutoImportPanel({
         <p className="text-sm font-medium">
           Try auto-import (§7.5)
         </p>
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Fetch the live URL, file an import-mode brief, and reverse-engineer
           the page into the Site Builder. The brief run runs through
           M12/M13 in full_page mode using the destination site&apos;s
@@ -161,7 +161,7 @@ export function TryAutoImportPanel({
         </div>
       )}
       {sites.length === 0 && !loadingSites && (
-        <p className="text-xs text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           No Site Builder sites are registered yet — register one under{" "}
           <a
             href="/admin/sites"

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -13,7 +13,7 @@ import { cn } from "@/lib/utils";
 // 95% of the time and Badge directly only for one-off labels (image
 // source category, design-system version, etc.).
 //
-// Density target: text-xs / py-0.5 / px-2 = ~22px tall. Linear-density.
+// Density target: text-sm / py-0.5 / px-2 = ~22px tall. Linear-density.
 // `density="default"` (22px) for inline rows; `density="loose"` (24px)
 // for badges that sit alongside an H1 and need slightly more weight.
 // ---------------------------------------------------------------------------
@@ -41,9 +41,9 @@ const badgeVariants = cva(
       },
       density: {
         // ~22px tall — the default for inline badge usage in tables / lists.
-        default: "px-2 py-0.5 text-xs",
+        default: "px-2 py-0.5 text-sm",
         // ~24px tall — for badges adjacent to H1 / H2 headings.
-        loose: "px-2.5 py-1 text-xs",
+        loose: "px-2.5 py-1 text-sm",
       },
     },
     defaultVariants: {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -40,7 +40,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
+        sm: "h-8 rounded-md px-3 text-sm",
         lg: "h-11 rounded-md px-6",
         icon: "h-10 w-10",
       },

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -79,7 +79,7 @@ const CommandGroup = React.forwardRef<
     className={cn(
       "overflow-hidden p-1 text-foreground",
       "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5",
-      "[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      "[&_[cmdk-group-heading]]:text-sm [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
       className,
     )}
     {...props}

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -38,7 +38,7 @@ export function Toaster() {
           toast:
             "rounded-md border bg-background text-foreground shadow-lg",
           title: "text-sm font-medium",
-          description: "text-xs text-muted-foreground",
+          description: "text-sm text-muted-foreground",
         },
       }}
     />

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -24,7 +24,7 @@ const TooltipContent = React.forwardRef<
     sideOffset={sideOffset}
     className={cn(
       "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5",
-      "text-xs text-popover-foreground shadow-md",
+      "text-sm text-popover-foreground shadow-md",
       "data-[state=delayed-open]:opollo-fade-in data-[state=closed]:opollo-fade-out",
       className,
     )}

--- a/components/ui/typography.tsx
+++ b/components/ui/typography.tsx
@@ -10,9 +10,9 @@ import { cn } from "@/lib/utils";
 //   <H1>      page heading             text-xl font-semibold     ~20px
 //   <H2>      section heading          text-base font-semibold   ~16px
 //   <H3>      sub-section / card title text-sm font-semibold     ~14px
-//   <Eyebrow> small uppercase label    text-xs font-medium       ~12px
+//   <Eyebrow> small uppercase label    text-sm font-medium       ~14px
 //                                      uppercase tracking-wide
-//   <Lead>    intro / context line     text-sm                   ~14px
+//   <Lead>    intro / context line     text-base                 ~16px
 //                                      text-muted-foreground
 //
 // Why these tiers (Linear / Vercel / Stripe alignment):
@@ -40,7 +40,7 @@ import { cn } from "@/lib/utils";
 //   • <h2 className="text-base font-medium">  → <H2>
 //   • <p className="text-sm text-muted-foreground"> beneath a heading
 //     → <Lead>
-//   • <span className="text-xs font-medium uppercase tracking-wide
+//   • <span className="text-sm font-medium uppercase tracking-wide
 //     text-muted-foreground"> → <Eyebrow>
 //
 // A-1 sweeps the page-heading <h1> pattern. Per-screen <h2> + Lead +
@@ -101,7 +101,7 @@ export const Eyebrow = React.forwardRef<HTMLSpanElement, SpanProps>(
       <span
         ref={ref}
         className={cn(
-          "text-xs font-medium uppercase tracking-wide text-muted-foreground",
+          "text-sm font-medium uppercase tracking-wide text-muted-foreground",
           className,
         )}
         {...props}
@@ -117,7 +117,7 @@ export const Lead = React.forwardRef<HTMLParagraphElement, ParagraphProps>(
     return (
       <p
         ref={ref}
-        className={cn("text-sm text-muted-foreground", className)}
+        className={cn("text-base text-muted-foreground", className)}
         {...props}
       />
     );

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,24 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
+## Typography minimums Phase 2 — `text-sm`-as-body callsite sweep (opened 2026-05-02 during UAT)
+
+**Tags:** `ux`, `typography`, `tech-debt`
+
+**What:** Phase 1 (this PR) eliminated `text-xs` site-wide (530 occurrences across 122 files → uplifted to `text-sm`) and bumped the `Lead` typography primitive from `text-sm` to `text-base`. Phase 2 walks every remaining `text-sm` usage and re-classifies: if the role is body copy (paragraph, description, form input value, modal body), bump to `text-base`; if it's small text (helper, caption, badge, eyebrow, breadcrumb, status microcopy), keep at `text-sm`. Per `docs/RULES.md` rule #7, body text floor is 1rem and small text floor is 0.875rem.
+
+**Why deferred:** Phase 1 was a mechanical bulk replace — safe, scoped, reviewable. Phase 2 needs per-callsite judgment ("is this paragraph or a caption?") which scales worse and risks visual hierarchy drift if done in one shot. Doing it as its own slice lets the review focus on the role-classification calls instead of mixing them with the bulk uplift.
+
+**Also deferred from Phase 2:**
+- The `H3` primitive sits at `text-sm` (14px) as a sub-section heading. Bumping it to `text-base` collides with `H2` (also 16px) and collapses the H1/H2/H3 visual hierarchy. A redesign that introduces `text-lg` for `H2` (or similar tier shift) is a separate design call. Steven's intent for "body ≥ 1rem" is about reading copy, not heading hierarchy — leaving `H3` at `text-sm` is consistent with that interpretation.
+- ESLint rule blocking `text-xs` in JSX className attributes. Would catch regressions automatically. Needs `eslint-plugin-tailwindcss` or a custom rule and a config plumbing step.
+
+**Trigger:** the next per-screen polish PR (e.g. when a slice naturally touches the affected component), OR proactively when Phase 1 stabilises and operators report any remaining "text too small" feedback.
+
+**Rough scope:** Medium (~half a day). Visual diff review across the admin surfaces, per-component classname audit, layout adjustments where the bump causes overflow / truncation. Manual visual pass on `/admin/sites/[id]`, brief review surface, post detail surface, image library, audit log, settings.
+
+---
+
 ## DATA_CONVENTIONS rollout — add audit columns to `sites` (opened 2026-05-02 during UAT §3.1.2)
 
 **Tags:** `schema`, `data-conventions`, `tech-debt`

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -54,6 +54,14 @@ Sort: strongest "if you skip this, production breaks" signal at the top.
 
 ---
 
+## 7. Typography minimums — body ≥ 1rem, small ≥ 0.875rem, no text-xs
+
+**Rule.** Operator-facing UI text has two floors. Body text (paragraph copy, form input values, page descriptions, modal body, table cells used as primary reading content) sits at `text-base` (1rem / 16px) minimum. Small text (helper copy, captions, badges, eyebrows, breadcrumbs, status microcopy) sits at `text-sm` (0.875rem / 14px) minimum. `text-xs` (0.75rem / 12px) is forbidden on every operator surface; do not introduce it in new code, and uplift any encountered to `text-sm`. The two floors map directly to Tailwind's existing utilities — no custom font-size values, no inline `style={{ fontSize: ... }}` below 14px. Reference: A-1 typography-scale doc block in `app/globals.css`.
+
+**Incident (UAT 2026-05-02).** Steven flagged during UAT that the admin UI had "a lot of text that is too small to read" — 530+ `text-xs` (12px) usages across 122 files lived in the operator surfaces, plus the A-1 typography primitives' `Lead` ("intro / context line") sat at `text-sm` despite being the body-copy companion to `H1`. Phase 1 sweep eliminated `text-xs` site-wide and bumped `Lead` to `text-base`. Phase 2 — auditing each `text-sm` callsite where the role is body copy rather than helper / caption — is captured in `docs/BACKLOG.md`.
+
+---
+
 ## Adding a new rule
 
 - If a recurring shape with scaffolding emerges, that's a pattern — put it in `docs/patterns/`, not here.


### PR DESCRIPTION
## Summary

Phase 1 of typography minimums enforcement, flagged during UAT 2026-05-02 ("the UI has a lot of text that is too small to read"). Operator-facing UI had 530+ \`text-xs\` (0.75rem / 12px) occurrences across 122 files. New floors per Steven's spec: body text ≥ 1rem (16px); small text ≥ 0.875rem (14px); \`text-xs\` forbidden.

## Changes (Phase 1 — mechanical sweep)

- **Bulk replaced** \`\\btext-xs\\b\` → \`text-sm\` across \`app/\`, \`components/\`, \`lib/\` (.tsx + .ts + .css). 122 files updated via PowerShell with explicit UTF-8-no-BOM encoding (avoiding PS5.1's BOM trap). Verified zero remaining \`text-xs\` in operator surfaces.
- **Bumped \`Lead\` primitive** in \`components/ui/typography.tsx\` from \`text-sm\` (14px) → \`text-base\` (16px). Lead is the "intro / context line" companion to H1; it's body copy and belongs above the 1rem floor.
- **Updated the A-1 typography doc block** in \`app/globals.css\` to state the minimums explicitly: body ≥ 1rem (text-base); small ≥ 0.875rem (text-sm); text-xs forbidden.
- **Added rule #7** in \`docs/RULES.md\` codifying the minimums and citing the UAT incident.
- **Added BACKLOG entry** for Phase 2 (per-callsite \`text-sm\`-as-body sweep, \`H3\` hierarchy reconsider, ESLint rule for \`text-xs\` blocking).

## Why Phase 1 only

Phase 1 is a mechanical bulk replace — safe, scoped, reviewable. Phase 2 walks every remaining \`text-sm\` callsite and re-classifies "is this body or small text?" — that needs per-callsite design judgment and risks visual hierarchy drift if done in one shot. Doing it as its own slice lets the review focus on the role-classification calls instead of mixing them with the bulk uplift.

The \`H3\` primitive sits at \`text-sm\` (14px) as a sub-section heading — bumping it to \`text-base\` collides with \`H2\` (also 16px) and collapses the H1/H2/H3 visual hierarchy. That's a separate design call (introduce \`text-lg\` for H2? new tier?) and lands in Phase 2.

## Test plan

- [x] Lint clean (next lint, --max-warnings=0 enforced via Husky)
- [x] Typecheck clean (tsc --noEmit)
- [x] Build clean (next build)
- [ ] Manual visual pass on staging once deployed: \`/admin/users\`, \`/admin/sites\`, \`/admin/sites/[id]\`, brief review surface, post detail surface, image library, audit log, settings — confirm no copy that was previously 12px now overflows / breaks layout.
- [ ] Resume UAT typography spot-check on the surfaces that previously triggered the complaint.

## Risks identified and mitigated

- **Layout overflow from 12→14px bump:** some dense surfaces (table cells, badges) may overflow with the 16% size increase. Mitigation: visible in the manual visual pass; any breakage is captured as a layout fix in Phase 2 rather than bulk-revert. Worst case is a slightly cropped badge — no data loss.
- **Inline \`style={{ fontSize: ... }}\` below 14px:** grep returned zero matches for explicit sub-14px inline styles in app/ + components/ + lib/. No callsites missed.
- **Shadcn primitive defaults:** the bulk replace covered \`components/ui/*\` so any \`text-xs\` defaults in shadcn primitives (Badge, Tooltip, Toast, Command, Button) are uplifted at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)