### PR TITLE
fix(middleware): permit /auth/accept-invite without a session

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -87,6 +87,17 @@ const PUBLIC_PATHS = new Set<string>([
   // middleware bounced unauthenticated callers to /login, breaking
   // cross-device approval.
   "/auth/approve",
+  // /auth/accept-invite — invite redemption landing page (P3.2). Same
+  // rationale as /auth/approve: the token IS the auth (server-component
+  // validates a SHA-256 hash against invites.token_hash). The whole
+  // point is that an invitee — who has no Supabase session yet because
+  // they don't have an account — clicks the link from their email and
+  // sets a password. Without this entry the middleware bounced them to
+  // /login, where they had no credentials, so invites were unredeemable
+  // (UAT §1.1.4 surfaced this 2026-05-02). The /api/auth/accept-invite
+  // POST counterpart that the form submits to is already covered by
+  // the /api/auth/* prefix check below.
+  "/auth/accept-invite",
 ]);
 
 function isPublicPath(pathname: string): boolean {


### PR DESCRIPTION
## Summary

Middleware's \`PUBLIC_PATHS\` set was missing \`/auth/accept-invite\`. Unauthenticated requests to the invite-redemption page were bounced to \`/login\` before the route could render the token, making invites unredeemable end-to-end.

## Discovery

UAT §1.1.4, 2026-05-02 — the test invitee clicked the invite email's "Accept invite" button and landed on the standard login form instead of the password-set form at \`/auth/accept-invite?token=…\`. The route (\`app/auth/accept-invite/page.tsx\`) and the email template (\`lib/email/templates/invite.ts\`) are both correct; the AUTH-FOUNDATION P3.2 work shipped them but didn't add the corresponding middleware exception. So invites have been silently broken since P3.2 landed.

## Fix

Add \`"/auth/accept-invite"\` to \`PUBLIC_PATHS\` in \`middleware.ts\`. Same rationale as the existing \`/auth/approve\` entry — the token IS the auth (SHA-256 hash lookup against \`invites.token_hash\` server-side; see \`app/auth/accept-invite/page.tsx:30–63\`). Comment block matches the \`/auth/approve\` precedent.

The \`/api/auth/accept-invite\` POST counterpart that the form submits to is already covered by the \`/api/auth/*\` prefix check at \`middleware.ts:96\`. No additional changes needed.

## Test plan

- [x] Lint clean
- [x] Typecheck clean
- [x] Build clean
- [ ] Resume UAT §1.1.4 once deployed: invite link should land on the password-set form with the invitee's email pre-filled (read-only).

## Risks identified and mitigated

- **Could the public-path entry expose anything sensitive?** No. The route is a server component that hashes the incoming token with SHA-256 and looks up \`invites\` by \`token_hash\`. Random/garbage tokens hit the "missing" or "invalid" error branch (lines 36–38, 46–48) and render an Alert with no information leak. Already-consumed or expired invites get specific user-facing reasons (lines 50–58). The rendered success state shows the invitee's own email from the matched row — public knowledge to the holder of a valid token.
- **Could an attacker enumerate valid tokens?** Not via this route. Tokens are 32+ random bytes per the \`length < 32\` guard at line 36 and the SHA-256 hash space precludes brute force. No timing oracle (the \`maybeSingle()\` Supabase query is constant-time relative to its index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)