### PR TITLE
feat(p3-1): opollo admin companies list page

### DIFF
--- a/app/admin/companies/page.tsx
+++ b/app/admin/companies/page.tsx
@@ -1,0 +1,30 @@
+import { PlatformCompaniesListClient } from "@/components/PlatformCompaniesListClient";
+import { listPlatformCompanies } from "@/lib/platform/companies";
+
+// P3-1 — Opollo admin companies list. Gated by app/admin/layout.tsx's
+// checkAdminAccess (operator opollo_users.role IN super_admin/admin).
+// Reads via service-role at request time; the platform_companies RLS
+// would also allow opollo staff to read, but we go through service-role
+// for consistency with the rest of /admin/* (no embed surprises).
+//
+// Future sub-slices in this directory:
+//   - new/page.tsx       (P3-2: create company form)
+//   - [id]/page.tsx      (P3-3: detail with members + invitations)
+//   - [id]/invitations/  (P3-4: invite-from-detail flow)
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminCompaniesPage() {
+  const result = await listPlatformCompanies();
+  if (!result.ok) {
+    return (
+      <div
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        role="alert"
+      >
+        Failed to load companies: {result.error.message}
+      </div>
+    );
+  }
+  return <PlatformCompaniesListClient companies={result.data.companies} />;
+}

--- a/components/PlatformCompaniesListClient.tsx
+++ b/components/PlatformCompaniesListClient.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { H1, Lead } from "@/components/ui/typography";
+import type { PlatformCompanyListItem } from "@/lib/platform/companies";
+
+// P3-1 — client shell for /admin/companies. Renders the table; the
+// "New company" button is a placeholder until P3-2 lands the create
+// flow. Server component supplies the initial list.
+
+export function PlatformCompaniesListClient({
+  companies,
+}: {
+  companies: PlatformCompanyListItem[];
+}) {
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <H1>Companies</H1>
+          <Lead className="mt-0.5">
+            {companies.length === 0
+              ? "No customer companies yet."
+              : `${companies.length} ${companies.length === 1 ? "company" : "companies"} on the platform.`}
+          </Lead>
+        </div>
+        <Button data-testid="add-company-button" disabled>
+          <Plus aria-hidden className="h-4 w-4" />
+          New company (P3-2)
+        </Button>
+      </div>
+
+      <div
+        className="mt-4 overflow-hidden rounded-lg border bg-card"
+        data-testid="platform-companies-table"
+      >
+        {companies.length === 0 ? (
+          <div className="p-8 text-center text-sm text-muted-foreground">
+            No companies yet — click <strong>New company</strong> to add one.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/30 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2 font-medium">Name</th>
+                <th className="px-4 py-2 font-medium">Slug</th>
+                <th className="px-4 py-2 font-medium">Domain</th>
+                <th className="px-4 py-2 font-medium">Members</th>
+                <th className="px-4 py-2 font-medium">Type</th>
+              </tr>
+            </thead>
+            <tbody>
+              {companies.map((c) => (
+                <tr
+                  key={c.id}
+                  className="border-b last:border-b-0"
+                  data-testid={`platform-company-row-${c.slug}`}
+                >
+                  <td className="px-4 py-3 font-medium">{c.name}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                    {c.slug}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {c.domain ?? "—"}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {c.member_count}
+                  </td>
+                  <td className="px-4 py-3 text-xs">
+                    {c.is_opollo_internal ? (
+                      <span className="rounded-full bg-primary/10 px-2 py-0.5 font-medium text-primary">
+                        Opollo internal
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">Customer</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </>
+  );
+}

--- a/components/PlatformCompaniesListClient.tsx
+++ b/components/PlatformCompaniesListClient.tsx
@@ -42,7 +42,7 @@ export function PlatformCompaniesListClient({
           </div>
         ) : (
           <table className="w-full text-sm">
-            <thead className="border-b bg-muted/30 text-left text-xs uppercase tracking-wide text-muted-foreground">
+            <thead className="border-b bg-muted/30 text-left text-sm uppercase tracking-wide text-muted-foreground">
               <tr>
                 <th className="px-4 py-2 font-medium">Name</th>
                 <th className="px-4 py-2 font-medium">Slug</th>
@@ -59,7 +59,7 @@ export function PlatformCompaniesListClient({
                   data-testid={`platform-company-row-${c.slug}`}
                 >
                   <td className="px-4 py-3 font-medium">{c.name}</td>
-                  <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                  <td className="px-4 py-3 font-mono text-sm text-muted-foreground">
                     {c.slug}
                   </td>
                   <td className="px-4 py-3 text-muted-foreground">
@@ -68,7 +68,7 @@ export function PlatformCompaniesListClient({
                   <td className="px-4 py-3 text-right tabular-nums">
                     {c.member_count}
                   </td>
-                  <td className="px-4 py-3 text-xs">
+                  <td className="px-4 py-3 text-sm">
                     {c.is_opollo_internal ? (
                       <span className="rounded-full bg-primary/10 px-2 py-0.5 font-medium text-primary">
                         Opollo internal

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -9,15 +9,15 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session A
 - Started: 2026-05-02
-- Branch: feat/p2-3-invitation-accept
-- Slice: P2-3 — Accept invitation flow. Public POST endpoint validates the raw token, creates auth.users + platform_users + platform_company_users, marks the invitation accepted. P2-4 QStash callbacks still blocked on env.
+- Branch: feat/p3-opollo-admin-companies
+- Slice: P3-1 — Opollo admin companies list page. First sub-slice of P3 (companies management UI). Splitting the parent slice into P3-1 (list — this PR), P3-2 (create), P3-3 (detail + members), P3-4 (invite modal/page) so each ships small and reviewable. P2-4 QStash still blocked on env.
 - Files claimed:
-  - lib/platform/invitations/accept.ts (new)
-  - lib/platform/invitations/index.ts (extend exports)
-  - lib/platform/invitations/types.ts (extend with AcceptResult)
-  - app/api/platform/invitations/accept/route.ts (new — public POST)
-  - lib/__tests__/platform-invitations-accept.test.ts (new)
-  - docs/WORK_IN_FLIGHT.md (claim block; removed in next PR's first commit)
+  - lib/platform/companies/{list,types,index}.ts (new)
+  - app/(platform)/admin/companies/page.tsx (new — list)
+  - components/PlatformCompaniesListClient.tsx (new — client shell)
+  - lib/__tests__/platform-companies.test.ts (new)
+  - e2e/platform-companies.spec.ts (new — happy path)
+  - docs/WORK_IN_FLIGHT.md
 - Migration number reserved: none
 - Expected completion: same session.
 ---

--- a/e2e/platform-companies.spec.ts
+++ b/e2e/platform-companies.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+import { auditA11y, signInAsAdmin } from "./helpers";
+
+// P3-1 — Opollo admin companies list page.
+// Logged-in admin can navigate to /admin/companies and see the list.
+// Create-flow (P3-2), detail (P3-3), and invite (P3-4) are deferred.
+
+test.describe("platform admin / companies", () => {
+  test.beforeEach(async ({ page }) => {
+    await signInAsAdmin(page);
+  });
+
+  test("list page renders + heading + a11y", async ({ page }, testInfo) => {
+    await page.goto("/admin/companies");
+    await expect(
+      page.getByRole("heading", { name: /Companies/i }),
+    ).toBeVisible();
+
+    // The "New company (P3-2)" button is a placeholder until the create
+    // flow lands; assert it's present and disabled so a regression in
+    // either direction (misnamed test-id, accidentally enabled) is loud.
+    const addButton = page.getByTestId("add-company-button");
+    await expect(addButton).toBeVisible();
+    await expect(addButton).toBeDisabled();
+
+    await auditA11y(page, testInfo);
+  });
+});

--- a/lib/__tests__/platform-companies.test.ts
+++ b/lib/__tests__/platform-companies.test.ts
@@ -1,0 +1,213 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import { listPlatformCompanies } from "@/lib/platform/companies";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser, type SeededAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// P3-1: lib/platform/companies/list.ts
+//
+// Asserts the list helper returns ordered companies with member counts
+// computed correctly. Service-role bypasses RLS so this exercises the
+// pure data-layer behaviour; the server-component / page integration is
+// covered by the e2e spec (e2e/platform-companies.spec.ts).
+// ---------------------------------------------------------------------------
+
+const COMPANY_A_ID = "88888888-8888-8888-8888-888888888888";
+const COMPANY_B_ID = "99999999-9999-9999-9999-999999999999";
+
+describe("lib/platform/companies/list — listPlatformCompanies", () => {
+  let userA1: SeededAuthUser;
+  let userA2: SeededAuthUser;
+  let userB1: SeededAuthUser;
+
+  beforeAll(async () => {
+    userA1 = await seedAuthUser({
+      email: "p3-a1@opollo.test",
+      persistent: true,
+    });
+    userA2 = await seedAuthUser({
+      email: "p3-a2@opollo.test",
+      persistent: true,
+    });
+    userB1 = await seedAuthUser({
+      email: "p3-b1@opollo.test",
+      persistent: true,
+    });
+  });
+
+  beforeEach(async () => {
+    const svc = getServiceRoleClient();
+
+    // Two companies, A created later so it appears first in desc order.
+    const baselineCreatedAt = new Date(Date.now() - 60_000).toISOString();
+    const recentCreatedAt = new Date().toISOString();
+
+    const companies = await svc
+      .from("platform_companies")
+      .insert([
+        {
+          id: COMPANY_B_ID,
+          name: "Beta Inc",
+          slug: "p3-beta",
+          domain: "p3-beta.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+          created_at: baselineCreatedAt,
+        },
+        {
+          id: COMPANY_A_ID,
+          name: "Acme Co",
+          slug: "p3-acme",
+          domain: "p3-acme.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+          created_at: recentCreatedAt,
+        },
+      ])
+      .select("id");
+    if (companies.error) {
+      throw new Error(
+        `seed companies: ${companies.error.code ?? "?"} ${companies.error.message}`,
+      );
+    }
+
+    const users = await svc
+      .from("platform_users")
+      .insert([
+        {
+          id: userA1.id,
+          email: userA1.email,
+          full_name: "A One",
+          is_opollo_staff: false,
+        },
+        {
+          id: userA2.id,
+          email: userA2.email,
+          full_name: "A Two",
+          is_opollo_staff: false,
+        },
+        {
+          id: userB1.id,
+          email: userB1.email,
+          full_name: "B One",
+          is_opollo_staff: false,
+        },
+      ])
+      .select("id");
+    if (users.error) {
+      throw new Error(
+        `seed users: ${users.error.code ?? "?"} ${users.error.message}`,
+      );
+    }
+
+    // A has 2 members, B has 1 — exercises the count-grouping logic.
+    const memberships = await svc
+      .from("platform_company_users")
+      .insert([
+        { company_id: COMPANY_A_ID, user_id: userA1.id, role: "admin" },
+        { company_id: COMPANY_A_ID, user_id: userA2.id, role: "editor" },
+        { company_id: COMPANY_B_ID, user_id: userB1.id, role: "admin" },
+      ])
+      .select("id");
+    if (memberships.error) {
+      throw new Error(
+        `seed memberships: ${memberships.error.code ?? "?"} ${memberships.error.message}`,
+      );
+    }
+  });
+
+  afterAll(async () => {
+    const svc = getServiceRoleClient();
+    for (const u of [userA1, userA2, userB1]) {
+      if (!u) continue;
+      await svc.auth.admin.deleteUser(u.id);
+    }
+  });
+
+  it("returns companies ordered by created_at desc with member counts", async () => {
+    const result = await listPlatformCompanies();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const onlyMine = result.data.companies.filter(
+      (c) => c.id === COMPANY_A_ID || c.id === COMPANY_B_ID,
+    );
+    expect(onlyMine).toHaveLength(2);
+
+    // A was inserted with the more-recent created_at, so it should come
+    // first in the filtered slice. (Other companies seeded by the
+    // migration may be present too; assertion is on relative order.)
+    const idxA = onlyMine.findIndex((c) => c.id === COMPANY_A_ID);
+    const idxB = onlyMine.findIndex((c) => c.id === COMPANY_B_ID);
+    expect(idxA).toBeLessThan(idxB);
+
+    const a = onlyMine[idxA]!;
+    expect(a.name).toBe("Acme Co");
+    expect(a.slug).toBe("p3-acme");
+    expect(a.domain).toBe("p3-acme.test");
+    expect(a.member_count).toBe(2);
+    expect(a.is_opollo_internal).toBe(false);
+
+    const b = onlyMine[idxB]!;
+    expect(b.member_count).toBe(1);
+  });
+
+  it("returns member_count=0 for a company with no members", async () => {
+    const svc = getServiceRoleClient();
+    const emptyId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const insert = await svc
+      .from("platform_companies")
+      .insert({
+        id: emptyId,
+        name: "Empty Co",
+        slug: "p3-empty",
+        domain: null,
+        is_opollo_internal: false,
+        timezone: "Australia/Melbourne",
+      })
+      .select("id");
+    expect(insert.error).toBeNull();
+
+    const result = await listPlatformCompanies();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const empty = result.data.companies.find((c) => c.id === emptyId);
+    expect(empty).toBeDefined();
+    expect(empty?.member_count).toBe(0);
+  });
+
+  it("includes the Opollo internal company when seeded", async () => {
+    const svc = getServiceRoleClient();
+    const opolloInternalId = "00000000-0000-0000-0000-000000000001";
+    await svc
+      .from("platform_companies")
+      .insert({
+        id: opolloInternalId,
+        name: "Opollo",
+        slug: "opollo",
+        domain: null,
+        is_opollo_internal: true,
+        timezone: "Australia/Melbourne",
+      });
+
+    const result = await listPlatformCompanies();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const internal = result.data.companies.find(
+      (c) => c.id === opolloInternalId,
+    );
+    expect(internal).toBeDefined();
+    expect(internal?.is_opollo_internal).toBe(true);
+  });
+});

--- a/lib/platform/companies/index.ts
+++ b/lib/platform/companies/index.ts
@@ -1,0 +1,2 @@
+export { listPlatformCompanies } from "./list";
+export type { PlatformCompany, PlatformCompanyListItem } from "./types";

--- a/lib/platform/companies/list.ts
+++ b/lib/platform/companies/list.ts
@@ -1,0 +1,96 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { PlatformCompanyListItem } from "./types";
+
+// Returns every customer company (and the Opollo internal company) ordered
+// by created_at desc. Caller is expected to be Opollo staff — the route /
+// page handler enforces is_opollo_staff before invoking this. The lib does
+// NOT re-check; it trusts the caller.
+//
+// Member count is computed via a separate query rather than an embedded
+// join because platform_company_users has multiple FKs back to
+// platform_users (user_id + added_by) and PostgREST embed errors out on
+// the ambiguity. See feedback memory "PostgREST embed fails on multi-FK
+// tables" (2026-05-02). Two queries keep the lib resilient and readable.
+
+export async function listPlatformCompanies(): Promise<
+  ApiResponse<{ companies: PlatformCompanyListItem[] }>
+> {
+  const svc = getServiceRoleClient();
+  const now = () => new Date().toISOString();
+
+  const companiesResult = await svc
+    .from("platform_companies")
+    .select("id, name, slug, domain, timezone, is_opollo_internal, created_at")
+    .order("created_at", { ascending: false });
+
+  if (companiesResult.error) {
+    logger.error("platform.companies.list.failed", {
+      err: companiesResult.error.message,
+    });
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: `Failed to list companies: ${companiesResult.error.message}`,
+        retryable: false,
+        suggested_action: "Retry. If the error persists, contact support.",
+      },
+      timestamp: now(),
+    };
+  }
+
+  const companies = companiesResult.data ?? [];
+  if (companies.length === 0) {
+    return { ok: true, data: { companies: [] }, timestamp: now() };
+  }
+
+  // Single membership query covering every company in the result set.
+  // Postgres returns one row per (company_id, user_id) — group locally.
+  const membershipResult = await svc
+    .from("platform_company_users")
+    .select("company_id")
+    .in(
+      "company_id",
+      companies.map((c) => c.id),
+    );
+
+  if (membershipResult.error) {
+    logger.error("platform.companies.list.membership_count_failed", {
+      err: membershipResult.error.message,
+    });
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: `Failed to count members: ${membershipResult.error.message}`,
+        retryable: false,
+        suggested_action: "Retry. If the error persists, contact support.",
+      },
+      timestamp: now(),
+    };
+  }
+
+  const counts = new Map<string, number>();
+  for (const row of membershipResult.data ?? []) {
+    const companyId = row.company_id as string;
+    counts.set(companyId, (counts.get(companyId) ?? 0) + 1);
+  }
+
+  const items: PlatformCompanyListItem[] = companies.map((c) => ({
+    id: c.id as string,
+    name: c.name as string,
+    slug: c.slug as string,
+    domain: (c.domain as string | null) ?? null,
+    timezone: c.timezone as string,
+    is_opollo_internal: c.is_opollo_internal as boolean,
+    member_count: counts.get(c.id as string) ?? 0,
+    created_at: c.created_at as string,
+  }));
+
+  return { ok: true, data: { companies: items }, timestamp: now() };
+}

--- a/lib/platform/companies/types.ts
+++ b/lib/platform/companies/types.ts
@@ -1,0 +1,25 @@
+export type PlatformCompany = {
+  id: string;
+  name: string;
+  slug: string;
+  domain: string | null;
+  timezone: string;
+  is_opollo_internal: boolean;
+  approval_default_required: boolean;
+  approval_default_rule: "any_one" | "all_must";
+  concurrent_publish_limit: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type PlatformCompanyListItem = {
+  id: string;
+  name: string;
+  slug: string;
+  domain: string | null;
+  timezone: string;
+  is_opollo_internal: boolean;
+  // Member count is denormalised on read for the list view; cheap join.
+  member_count: number;
+  created_at: string;
+};


### PR DESCRIPTION
## Summary

P3-1 — first sub-slice of **P3 (Opollo admin companies UI)**. Server-rendered list page at `/admin/companies` reading via the new `lib/platform/companies/list.ts` helper. Pure read-only this PR; create / detail / invite-from-detail land in subsequent sub-slices.

## P3 sub-slice plan

P3 is the operator-side companies UI. Splitting into four sub-slices keeps each PR ≤ ~600 lines and reviewable.

| Sub-slice | Scope | Status |
|---|---|---|
| **P3-1** *(this PR)* | List page at `/admin/companies` + lib helper + lib tests + e2e happy path. | This PR. |
| P3-2 | `New company` form at `/admin/companies/new` + `POST /api/admin/companies` + `lib/platform/companies/create.ts` + tests. | Next. |
| P3-3 | Detail page at `/admin/companies/[id]` showing members + pending invitations. | After P3-2. |
| P3-4 | Invite-from-detail flow (modal or `/admin/companies/[id]/invitations/new` page) wiring `lib/platform/invitations.sendInvitation`. | After P3-3. |

After P3 ships, P4 (customer admin UI for users), then P5 (notifications dispatcher). P2-4 (QStash callbacks) still blocked on env.

## What this PR adds

- **`lib/platform/companies/types.ts`** — `PlatformCompany`, `PlatformCompanyListItem` (the latter denormalises `member_count` for the list view).
- **`lib/platform/companies/list.ts`** — `listPlatformCompanies()`. Two-query pattern: companies, then memberships, group counts locally. Embed avoided because `platform_company_users` has two FKs back to `platform_users` (`user_id` + `added_by`) and PostgREST embed errors out on the ambiguity. (See feedback memory `feedback_postgrest_embed_ambiguous_fk.md`.)
- **`lib/platform/companies/index.ts`** — barrel export.
- **`app/admin/companies/page.tsx`** — server component. Calls `listPlatformCompanies` at request time, hands off to the client shell. Inherits `app/admin/layout.tsx` (operator sidebar + `checkAdminAccess` gate).
- **`components/PlatformCompaniesListClient.tsx`** — client shell. Renders the table, surfaces a placeholder `New company (P3-2)` button (disabled, with the next-slice marker so a regression in either direction is loud).
- **`lib/__tests__/platform-companies.test.ts`** — covers ordering by `created_at desc`, member-count grouping (2/1/0), Opollo internal company seed.
- **`e2e/platform-companies.spec.ts`** — Playwright happy path: signed-in admin navigates to `/admin/companies`, asserts heading + the disabled placeholder button + a11y.

## Why `app/admin/companies/` not `app/(platform)/admin/companies/`

BUILD.md's source-tree sketch reserves `app/(platform)/admin/*` for platform-layer admin pages. In practice, route groups don't inherit a sibling segment's layout — putting the page inside `(platform)` would lose `app/admin/layout.tsx`'s sidebar + operator gate, forcing me to duplicate both. Operators should see consistent nav across `/admin/sites`, `/admin/users`, `/admin/companies`. The "platform" naming is captured in the lib helpers and component prefixes (`Platform*`) instead of the URL structure. This is a design trade-off worth flagging for review — happy to refactor to `(platform)/` with a dedicated layout in a follow-up if you'd rather keep the source-tree scoping strict.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Cross-FK PostgREST embed quietly returning an error | Avoided embed; two queries instead. Lib comment explicitly references the project memory. |
| Stale list across navigation (Next caching) | `export const dynamic = "force-dynamic"`; server component reads per-request, no client-side cache layer. Same pattern as `app/admin/sites/page.tsx`. |
| Operator with `user` role accessing the page | `app/admin/layout.tsx`'s `checkAdminAccess()` runs first; redirects non-admin to `/`. |
| Customer accidentally landing on the page | Operator gate blocks them — they have no `opollo_users` row at all (only `platform_users`). |
| Member-count drift if `is_opollo_internal` company has staff | Counted normally; the list flags Opollo-internal with a badge so the operator knows the row is special. |

### Deliberately deferred

- **Detail page (P3-3).** Requires its own member-list + pending-invitation surfaces and is meaningfully different from the list.
- **Create flow (P3-2).** Server action + Zod schema + `revalidatePath` after insert; standalone slice.
- **Invite-from-detail (P3-4).** Wires the existing `lib/platform/invitations.sendInvitation` from a UI surface; needs the detail page first.
- **Soft-delete / archive.** Deferred until V1 has a real reason to support it (per the platform-customer-management skill, customer companies are invite-only and managed by Opollo staff — accidental creation is the failure mode that matters, not deletion).

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npx next lint --max-warnings=0` clean.
- [x] `npx next build` succeeds.
- [ ] CI test job — `lib/__tests__/platform-companies.test.ts` cells all pass; pre-existing m12-1-rls / m4-schema failures still red, out of scope.
- [ ] CI e2e job — `e2e/platform-companies.spec.ts` happy path + a11y.
- [ ] On CI green: auto-merge per the routine-merge rule (no merge nod ping).

## Notes for review

- WORK_IN_FLIGHT updated: P2-3 claim block removed, P3-1 added.
- The `New company (P3-2)` placeholder button is intentionally disabled with the next-slice marker — keeps the surface honest about what's shipped.
- Member count is computed per-request rather than denormalised on the table. At V1 scale (single-digit companies, dozens of users) the second query is cheap. Revisit if list pagination ever becomes necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
