### PR TITLE
fix(platform): add /invite/[token] accept page (P2-3 follow-up)

### DIFF
--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+
+import { PlatformAcceptInviteForm } from "@/components/PlatformAcceptInviteForm";
+import { Alert } from "@/components/ui/alert";
+import { H1, Lead } from "@/components/ui/typography";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// Platform-layer invitation accept page (P2-3 follow-up).
+//
+// The send flow (POST /api/platform/invitations) emails recipients a link
+// to /invite/<raw-token>. This page hashes the path-param token, looks up
+// the matching platform_invitations row, validates state (pending +
+// unexpired + not revoked), and renders a form that posts the password +
+// full name to POST /api/platform/invitations/accept. The accept route
+// re-validates server-side; this page is the operator-facing surface.
+//
+// Distinct from /auth/accept-invite (operator-side P3.2 invites for the
+// existing Site Builder admin role band). Different table, different
+// minimum password length, different lib.
+
+export const dynamic = "force-dynamic";
+
+interface PageProps {
+  params: { token: string };
+}
+
+interface ValidatedInvite {
+  email: string;
+  role: "admin" | "approver" | "editor" | "viewer";
+  companyName: string;
+}
+
+async function validateToken(
+  rawToken: string,
+): Promise<
+  | { kind: "ok"; invite: ValidatedInvite }
+  | { kind: "err"; reason: "missing" | "invalid" | "expired" | "consumed" | "revoked" }
+> {
+  if (!rawToken || rawToken.length < 32) {
+    return { kind: "err", reason: "missing" };
+  }
+  const tokenHash = createHash("sha256").update(rawToken).digest("hex");
+  const supabase = getServiceRoleClient();
+  const inviteResult = await supabase
+    .from("platform_invitations")
+    .select("email, role, status, expires_at, company_id, revoked_at, accepted_at")
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+  if (inviteResult.error || !inviteResult.data) {
+    return { kind: "err", reason: "invalid" };
+  }
+  const row = inviteResult.data as {
+    email: string;
+    role: ValidatedInvite["role"];
+    status: string;
+    expires_at: string;
+    company_id: string;
+    revoked_at: string | null;
+    accepted_at: string | null;
+  };
+  if (row.status === "revoked" || row.revoked_at) {
+    return { kind: "err", reason: "revoked" };
+  }
+  if (row.status === "accepted" || row.accepted_at) {
+    return { kind: "err", reason: "consumed" };
+  }
+  if (new Date(row.expires_at).getTime() <= Date.now()) {
+    return { kind: "err", reason: "expired" };
+  }
+
+  // Separate query for the company name. Using an embed here would have
+  // to disambiguate which platform_companies FK is being followed, and
+  // a follow-up name fetch keeps the lib resilient to FK additions.
+  const companyResult = await supabase
+    .from("platform_companies")
+    .select("name")
+    .eq("id", row.company_id)
+    .maybeSingle();
+  const companyName =
+    (companyResult.data as { name: string } | null)?.name ?? "your company";
+
+  return {
+    kind: "ok",
+    invite: {
+      email: row.email,
+      role: row.role,
+      companyName,
+    },
+  };
+}
+
+export default async function PlatformInviteAcceptPage({ params }: PageProps) {
+  const result = await validateToken(params.token);
+
+  if (result.kind === "err") {
+    return (
+      <div className="mx-auto max-w-md space-y-4">
+        <H1>Invitation</H1>
+        <Alert variant="destructive">
+          {result.reason === "missing" && "No invitation token provided."}
+          {result.reason === "invalid" &&
+            "This invitation link is invalid. Ask the inviter for a fresh one."}
+          {result.reason === "expired" &&
+            "This invitation has expired. Ask the inviter for a new one."}
+          {result.reason === "consumed" &&
+            "This invitation has already been accepted. Sign in instead."}
+          {result.reason === "revoked" &&
+            "This invitation was revoked. Ask the inviter for a new one."}
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-md">
+      <H1>Join {result.invite.companyName}</H1>
+      <Lead className="mt-1">
+        Setting up your Opollo account for{" "}
+        <strong className="text-foreground">{result.invite.email}</strong> as{" "}
+        <strong className="text-foreground">
+          {capitaliseRole(result.invite.role)}
+        </strong>
+        .
+      </Lead>
+      <div className="mt-6">
+        <PlatformAcceptInviteForm
+          token={params.token}
+          email={result.invite.email}
+        />
+      </div>
+    </div>
+  );
+}
+
+function capitaliseRole(role: ValidatedInvite["role"]): string {
+  return role.charAt(0).toUpperCase() + role.slice(1);
+}

--- a/components/PlatformAcceptInviteForm.tsx
+++ b/components/PlatformAcceptInviteForm.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useMemo, useState, type FormEvent } from "react";
+
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+// Platform-layer accept-invite form.
+//
+// Posts to POST /api/platform/invitations/accept with the token, the
+// invitation email (re-validated server-side), the chosen password, and
+// the recipient's full name. Per BUILD.md the platform-layer minimum is
+// 8 characters (Supabase Auth's default). Distinct from the operator-side
+// AcceptInviteForm which uses a 12-char floor for Opollo internal users.
+
+const MIN_LENGTH = 8;
+
+export function PlatformAcceptInviteForm({
+  token,
+  email,
+}: {
+  token: string;
+  email: string;
+}) {
+  const router = useRouter();
+  const [fullName, setFullName] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const tooShort = password.length > 0 && password.length < MIN_LENGTH;
+  const mismatch = confirm.length > 0 && confirm !== password;
+  const fullNameOk = fullName.trim().length > 0;
+  const canSubmit =
+    !submitting &&
+    fullNameOk &&
+    password.length >= MIN_LENGTH &&
+    password === confirm;
+
+  const strength = useMemo(() => scoreStrength(password), [password]);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/platform/invitations/accept", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          token,
+          email,
+          password,
+          full_name: fullName.trim(),
+        }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: { user_id: string; company_id: string; role: string } }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (payload?.ok) {
+        // The platform layer doesn't auto-sign-in. The recipient now has
+        // an auth.users row + a platform_users + platform_company_users
+        // membership, but they prove credentials by signing in fresh.
+        const target = `/login?invite=accepted&email=${encodeURIComponent(email)}`;
+        router.push(target);
+        return;
+      }
+      setError(
+        payload?.ok === false
+          ? payload.error.message
+          : `Couldn't accept invitation (HTTP ${res.status}).`,
+      );
+    } catch (err) {
+      setError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="invite-email" className="block text-sm font-medium">
+          Email
+        </label>
+        <Input
+          id="invite-email"
+          value={email}
+          readOnly
+          disabled
+          className="mt-1 bg-muted/40"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="invite-full-name" className="block text-sm font-medium">
+          Full name
+        </label>
+        <Input
+          id="invite-full-name"
+          required
+          maxLength={254}
+          autoComplete="name"
+          value={fullName}
+          onChange={(e) => setFullName(e.target.value)}
+          disabled={submitting}
+          className="mt-1"
+          data-testid="platform-accept-invite-full-name"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="invite-password" className="block text-sm font-medium">
+          Password
+        </label>
+        <Input
+          id="invite-password"
+          type="password"
+          required
+          minLength={MIN_LENGTH}
+          maxLength={200}
+          autoComplete="new-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          disabled={submitting}
+          className="mt-1 font-mono text-sm"
+          aria-invalid={tooShort}
+          data-testid="platform-accept-invite-password"
+        />
+        <StrengthMeter score={strength} length={password.length} />
+        {tooShort && (
+          <p className="mt-1 text-sm text-destructive">
+            At least {MIN_LENGTH} characters.
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="invite-confirm" className="block text-sm font-medium">
+          Confirm password
+        </label>
+        <Input
+          id="invite-confirm"
+          type="password"
+          required
+          minLength={MIN_LENGTH}
+          maxLength={200}
+          autoComplete="new-password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          disabled={submitting}
+          className="mt-1 font-mono text-sm"
+          aria-invalid={mismatch}
+          data-testid="platform-accept-invite-confirm"
+        />
+        {mismatch && (
+          <p className="mt-1 text-sm text-destructive">
+            Passwords don&apos;t match.
+          </p>
+        )}
+      </div>
+
+      {error && (
+        <Alert variant="destructive" data-testid="platform-accept-invite-error">
+          {error}
+        </Alert>
+      )}
+
+      <Button
+        type="submit"
+        disabled={!canSubmit}
+        className="w-full"
+        data-testid="platform-accept-invite-submit"
+      >
+        {submitting ? "Setting password…" : "Set password and continue"}
+      </Button>
+    </form>
+  );
+}
+
+function scoreStrength(password: string): number {
+  if (password.length < MIN_LENGTH) return 0;
+  let bonus = 0;
+  if (/[A-Z]/.test(password) && /[a-z]/.test(password)) bonus += 1;
+  if (/[0-9]/.test(password)) bonus += 1;
+  if (/[^A-Za-z0-9]/.test(password)) bonus += 1;
+  if (password.length >= 16) return Math.min(4, 1 + bonus + 1);
+  return Math.min(4, 1 + bonus);
+}
+
+function StrengthMeter({ score, length }: { score: number; length: number }) {
+  if (length === 0) return null;
+  const labels = ["", "weak", "fair", "good", "strong"];
+  const tone =
+    score === 0
+      ? "text-destructive"
+      : score === 1
+        ? "text-destructive"
+        : score === 2
+          ? "text-warning"
+          : score === 3
+            ? "text-success"
+            : "text-success";
+  return (
+    <div
+      className="mt-1 flex items-center gap-2"
+      data-testid="platform-accept-invite-strength"
+    >
+      <div className="flex h-1.5 flex-1 gap-0.5" aria-hidden>
+        {[1, 2, 3, 4].map((step) => (
+          <div
+            key={step}
+            className={cn(
+              "h-full flex-1 rounded-full transition-smooth",
+              step <= score
+                ? score >= 3
+                  ? "bg-success"
+                  : score === 2
+                    ? "bg-warning"
+                    : "bg-destructive"
+                : "bg-muted",
+            )}
+          />
+        ))}
+      </div>
+      <span className={cn("text-sm", tone)}>
+        {score === 0 ? `${length}/${MIN_LENGTH}` : labels[score]}
+      </span>
+    </div>
+  );
+}

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -7,19 +7,17 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 <!-- CLAIM BLOCKS BELOW THIS LINE — append on slice start, remove on slice merge -->
 
 ---
-## Session A
+## Session A — fix/platform-invite-accept-page (BUILD-AUDIT P0)
 - Started: 2026-05-02
-- Branch: feat/p2-3-invitation-accept
-- Slice: P2-3 — Accept invitation flow. Public POST endpoint validates the raw token, creates auth.users + platform_users + platform_company_users, marks the invitation accepted. P2-4 QStash callbacks still blocked on env.
+- Branch: fix/platform-invite-accept-page
+- Slice: BUILD-AUDIT P0 — `/invite/[token]` page that renders the platform invitation accept form. P2-2 send emails point recipients here; without the page they 404. P2-3 (#385) explicitly deferred this page and merged the API route only.
 - Files claimed:
-  - lib/platform/invitations/accept.ts (new)
-  - lib/platform/invitations/index.ts (extend exports)
-  - lib/platform/invitations/types.ts (extend with AcceptResult)
-  - app/api/platform/invitations/accept/route.ts (new — public POST)
-  - lib/__tests__/platform-invitations-accept.test.ts (new)
-  - docs/WORK_IN_FLIGHT.md (claim block; removed in next PR's first commit)
+  - app/invite/[token]/page.tsx (new — server-component validates token via service-role, looks up platform_invitations row + company name)
+  - components/PlatformAcceptInviteForm.tsx (new — client form posting to POST /api/platform/invitations/accept)
+  - middleware.ts (add `/invite/` prefix to public-paths list — same pattern as `/auth/accept-invite`)
+  - docs/WORK_IN_FLIGHT.md (this claim; removed in next PR's first commit)
 - Migration number reserved: none
-- Expected completion: same session.
+- Expected completion: same session; auto-merge on green CI.
 ---
 
 ## ~~Session A (stale)~~ (stale claim from 2026-04-24, M12-6 shipped — left in place; previous owner removes when they next push)

--- a/middleware.ts
+++ b/middleware.ts
@@ -102,6 +102,12 @@ const PUBLIC_PATHS = new Set<string>([
 
 function isPublicPath(pathname: string): boolean {
   if (PUBLIC_PATHS.has(pathname)) return true;
+  // /invite/<token> — platform-layer invitation accept page. Token IS
+  // the auth (server-component validates SHA-256 against
+  // platform_invitations.token_hash). Recipients have no Supabase
+  // session yet — the whole point is to MINT one by setting their
+  // password. Without this, the email link bounces to /login.
+  if (pathname.startsWith("/invite/")) return true;
   // All /api/auth/* endpoints (login, logout-not-applicable-here,
   // callback, future invite/reset routes) are by definition pre-session.
   if (pathname.startsWith("/api/auth/")) return true;


### PR DESCRIPTION
## Summary

Closes the BUILD-AUDIT P0 surfaced this run: every platform invitation recipient currently 404s because the email link target was never built.

P2-2 (#380) ships POST `/api/platform/invitations` which sends emails with links to `${origin}/invite/${rawToken}`. P2-3 (#385) shipped the backend accept route but explicitly deferred the page in its description ("Lands with P3 (Opollo admin UI) or as a small dedicated slice. The route works without it… but humans need a page."). Until this lands, every recipient gets a 404.

## What this PR adds

- **`app/invite/[token]/page.tsx`** — server-component validates the path-param token via SHA-256 lookup against `platform_invitations.token_hash`, walks the state checks (revoked / accepted / expired), fetches the company name in a follow-up query (no embed — keeps the lib resilient to FK additions), and renders the form. Mirrors the legacy `/auth/accept-invite` shape; distinct module (different tables, different password floor).
- **`components/PlatformAcceptInviteForm.tsx`** — client form posting to `POST /api/platform/invitations/accept` with `{token, email, password, full_name}`. 8-char password minimum per BUILD.md (vs 12 for the operator-side `AcceptInviteForm`). Mismatch + length validation client-side; lib re-validates server-side. Strength meter mirrors the legacy form.
- **`middleware.ts`** — adds `/invite/` prefix to the public-paths allowlist. Recipients arrive without a Supabase session (the whole point is to mint one). Same pattern as the existing `/api/auth/`, `/api/cron/`, `/api/ops/` prefix entries.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Service-role page exposing sensitive invitation data | Page selects only `email`, `role`, `status`, `expires_at`, `company_id`, `revoked_at`, `accepted_at`. Token is never returned to the client. Same shape `/auth/accept-invite` already uses. |
| Token enumeration / brute force | Generic "invalid" message for unknown tokens. POST endpoint has the per-IP `invite_accept` rate-limit bucket from P2-3. |
| Race vs concurrent acceptance | Server re-validates state on POST; the lib returns `ALREADY_ACCEPTED` without provisioning a second user. |
| Middleware allow-list drift | `/invite/` is a prefix check; the path still requires a server-validated token. No escape hatch beyond what P2-3 already accepts. |
| Email mismatch on submit | Lib normalises both invite.email and submitted email to lowercase; surfaces `EMAIL_MISMATCH`. |

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint --max-warnings=0` clean
- [x] `npm run build` succeeds
- [ ] CI green; auto-merge per routine-merge rule
- Manual smoke (post-merge against staging): `/invite/<unknown>` → "invalid"; `/invite/<expired>` → "expired"; happy-path → form renders → submit → `/login?invite=accepted`.

## What's NOT in this PR

- No tests for the page itself — it's a thin wrapper around the already-tested lib (`platform-invitations-accept.test.ts`). Same coverage shape as the legacy `/auth/accept-invite` page.
- No E2E spec — public route, not admin (CLAUDE.md hard-requires E2E for *admin* UI changes). Opportunistic add when the platform-customer-management slice next touches `e2e/platform-*.spec.ts`.
- P2-4 reminder/expiry callbacks — still blocked on `QSTASH_*` env provisioning (per BUILD.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)