### PR TITLE
fix(audit): typography check skips comment context (PLATFORM-AUDIT PR2)

### DIFF
--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -500,6 +500,53 @@ function check4_migrationOrdering(): Issue[] {
 // Check 5 — Typography minimums (LOW)
 // ============================================================================
 
+/**
+ * Strip comments from a source line so checks don't false-positive on doc
+ * mentions of forbidden patterns. Tracks block-comment state across lines.
+ *
+ *   - Block comments `/* ... *​/` (multi-line) — stripped, state carried.
+ *   - Line comments `//` (TS/JS/JSX, not CSS) — everything after stripped.
+ *   - JSX comments are wrapped `{/* ... *​/}` but the inner block-comment
+ *     pattern is the same; the regex strip handles them naturally.
+ *
+ * Crude on string literals (`'//'` would be stripped) but acceptable for
+ * the typography check since the false-positive risk on string-literal
+ * `text-xs` is low (test fixtures already excluded via SKIP_DIRS).
+ */
+function stripComments(
+  line: string,
+  state: { inBlock: boolean },
+  isCss: boolean,
+): string {
+  let result = line;
+
+  if (state.inBlock) {
+    const endIdx = result.indexOf("*/");
+    if (endIdx === -1) return ""; // entire line is in a block comment
+    result = result.slice(endIdx + 2);
+    state.inBlock = false;
+  }
+
+  while (true) {
+    const startIdx = result.indexOf("/*");
+    if (startIdx === -1) break;
+    const endIdx = result.indexOf("*/", startIdx + 2);
+    if (endIdx === -1) {
+      result = result.slice(0, startIdx);
+      state.inBlock = true;
+      break;
+    }
+    result = result.slice(0, startIdx) + result.slice(endIdx + 2);
+  }
+
+  if (!isCss) {
+    const lineCommentIdx = result.indexOf("//");
+    if (lineCommentIdx !== -1) result = result.slice(0, lineCommentIdx);
+  }
+
+  return result;
+}
+
 function check5_typography(): Issue[] {
   const issues: Issue[] = [];
   const roots = ["app", "components", "lib"];
@@ -516,8 +563,11 @@ function check5_typography(): Issue[] {
     for (const file of walkFiles(dir, [".ts", ".tsx", ".css"])) {
       const lines = readSafe(file).split(/\r?\n/);
       const rel = relPath(file);
+      const isCss = file.endsWith(".css");
+      const state = { inBlock: false };
       lines.forEach((ln, i) => {
-        if (textXsRe.test(ln)) {
+        const stripped = stripComments(ln, state, isCss);
+        if (textXsRe.test(stripped)) {
           issues.push({
             category: "typography-minimums",
             severity: "LOW",
@@ -526,7 +576,7 @@ function check5_typography(): Issue[] {
             message: "text-xs (12px) is below the 0.875rem / 14px floor — uplift to text-sm (RULES.md #7)",
           });
         }
-        if (fsPxRe.test(ln)) {
+        if (fsPxRe.test(stripped)) {
           issues.push({
             category: "typography-minimums",
             severity: "LOW",


### PR DESCRIPTION
## Summary

PLATFORM-AUDIT workstream **PR 2 of 8** — Typography fixes.

Scope shrank to a single audit-script refinement because Fix #382 (DESIGN-SYSTEM-OVERHAUL typography-minimums sweep) already preempted PR 2's bulk-replace task — 530 \`text-xs\` occurrences across 122 files were uplifted to \`text-sm\` before this workstream started.

## What the audit found

The first run flagged 2 LOW typography hits, both in \`app/globals.css\` (lines 150 + 154). Both are inside the typography-rule documentation comment block — sentences like *"text-xs (0.75rem / 12px) is FORBIDDEN"* describing the rule itself, not actual classNames being used.

Per the workstream's HALT criterion (*"any fix where correct value is ambiguous"*), a literal find-and-replace would break the documentation (replacing "text-xs is FORBIDDEN" with "text-sm is FORBIDDEN" reverses the meaning — text-sm is the FLOOR, not forbidden). The correct auto-fix is to update the audit script to skip comment context.

## Change

Adds \`stripComments()\` helper to \`scripts/audit.ts\`. Tracks block-comment state across lines:

- \`/* ... */\` multi-line blocks (CSS + TS/JSX)
- \`//\` line comments (TS/JS/JSX, not CSS)
- JSX \`{/* ... */}\` patterns (handled naturally by the block-strip pass)

The check5_typography function now strips comments before running the \`text-xs\` and \`fontSize\` regex tests.

## Verification

Before:
\`\`\`
typography-minimums                  │     0 │       0 │    2 │
Total: 39 HIGH, 110 MEDIUM, 3 LOW
\`\`\`

After:
\`\`\`
typography-minimums                  │     0 │       0 │    0 │
Total: 39 HIGH, 110 MEDIUM, 1 LOW (150 issues)
\`\`\`

Typography category drops from 2 to 0. The remaining LOW (1) is the missing \`.env.example\` warning — that's PR 5's territory.

## Test plan

- [x] Lint clean
- [x] Typecheck clean
- [x] Build clean
- [x] Audit re-run on main shows 0 typography-minimums hits
- [ ] CI \`static-audit\` job passes the typography check (still fails on the 39 HIGH it inherited — unchanged from PR 1)

## Risks identified and mitigated

- **String-literal false negatives:** the comment-strip is crude and would also remove \`text-xs\` if it appeared inside a string literal that contains \`//\` or \`/*\`. Mitigation: \`__tests__\` directories already excluded via SKIP_DIRS — that's where 99% of \`text-xs\`-in-string-literal cases live (test fixtures asserting class names). Production code referencing \`text-xs\` as a string is rare and would still get flagged via the className context.
- **Block-comment state leakage across files:** the \`state.inBlock\` is fresh per file (created inside the file loop), so a file that doesn't close its block comment can't leak state to the next file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)