### PR TITLE
feat(p3-2): create company form + POST route + lib helper

### DIFF
--- a/app/admin/companies/new/page.tsx
+++ b/app/admin/companies/new/page.tsx
@@ -1,0 +1,11 @@
+import { PlatformCompanyCreateForm } from "@/components/PlatformCompanyCreateForm";
+
+// P3-2 — Opollo admin "create company" page. Server-rendered shell;
+// the form posts to POST /api/admin/companies. Gated by
+// app/admin/layout.tsx's checkAdminAccess (operator-side).
+
+export const dynamic = "force-dynamic";
+
+export default function NewCompanyPage() {
+  return <PlatformCompanyCreateForm />;
+}

--- a/app/api/admin/companies/route.ts
+++ b/app/api/admin/companies/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { logger } from "@/lib/logger";
+import { createPlatformCompany } from "@/lib/platform/companies";
+
+// POST /api/admin/companies — P3-2.
+//
+// Operator-only (requireAdminForApi). Customer companies are invite-only
+// per BUILD.md; only Opollo staff create them. The route translates
+// browser form input into createPlatformCompany() and revalidates the
+// list page so the new row appears on next render.
+//
+// Errors:
+//   400 VALIDATION_FAILED — body shape, name/slug constraints.
+//   401 UNAUTHORIZED      — no session.
+//   403 FORBIDDEN         — non-admin caller.
+//   409 ALREADY_EXISTS    — slug collision (UNIQUE platform_companies.slug).
+//   500 INTERNAL_ERROR    — DB failure.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const CreateCompanySchema = z.object({
+  name: z.string().min(1).max(200),
+  slug: z.string().min(1).max(60).optional(),
+  domain: z.string().max(253).optional().nullable(),
+  timezone: z.string().min(1).max(64).optional(),
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const gate = await requireAdminForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = CreateCompanySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message:
+            "Body must be { name: string, slug?: string, domain?: string|null, timezone?: string }.",
+          details: { issues: parsed.error.issues },
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await createPlatformCompany({
+    name: parsed.data.name,
+    slug: parsed.data.slug,
+    domain: parsed.data.domain ?? null,
+    timezone: parsed.data.timezone,
+    createdBy: gate.user?.id ?? null,
+  });
+
+  if (!result.ok) {
+    const code = result.error.code;
+    const status =
+      code === "VALIDATION_FAILED"
+        ? 400
+        : code === "ALREADY_EXISTS"
+          ? 409
+          : 500;
+    if (status >= 500) {
+      logger.error("admin.companies.create.failed", {
+        code,
+        message: result.error.message,
+      });
+    }
+    return errorJson(code, result.error.message, status);
+  }
+
+  // Revalidate the list page so the new company appears on next render.
+  revalidatePath("/admin/companies");
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { company: result.data },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 201 },
+  );
+}

--- a/components/PlatformCompaniesListClient.tsx
+++ b/components/PlatformCompaniesListClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -26,9 +27,11 @@ export function PlatformCompaniesListClient({
               : `${companies.length} ${companies.length === 1 ? "company" : "companies"} on the platform.`}
           </Lead>
         </div>
-        <Button data-testid="add-company-button" disabled>
-          <Plus aria-hidden className="h-4 w-4" />
-          New company (P3-2)
+        <Button asChild data-testid="add-company-button">
+          <Link href="/admin/companies/new">
+            <Plus aria-hidden className="h-4 w-4" />
+            New company
+          </Link>
         </Button>
       </div>
 

--- a/components/PlatformCompanyCreateForm.tsx
+++ b/components/PlatformCompanyCreateForm.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { H1, Lead } from "@/components/ui/typography";
+
+function Label({
+  htmlFor,
+  children,
+}: {
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label htmlFor={htmlFor} className="block text-sm font-medium">
+      {children}
+    </label>
+  );
+}
+
+// P3-2 — Form for creating a customer company. Operator-only — the API
+// route gates on requireAdminForApi.
+//
+// Slug is optional in the form: leaving it blank lets the lib helper
+// auto-generate a URL-safe slug from the name. Domain + timezone are
+// also optional.
+
+type FormState = {
+  name: string;
+  slug: string;
+  domain: string;
+  submitting: boolean;
+  error: string | null;
+};
+
+const INITIAL: FormState = {
+  name: "",
+  slug: "",
+  domain: "",
+  submitting: false,
+  error: null,
+};
+
+export function PlatformCompanyCreateForm() {
+  const router = useRouter();
+  const [form, setForm] = useState<FormState>(INITIAL);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setForm((s) => ({ ...s, submitting: true, error: null }));
+
+    const body: Record<string, string | null> = { name: form.name.trim() };
+    if (form.slug.trim()) body.slug = form.slug.trim();
+    if (form.domain.trim()) body.domain = form.domain.trim();
+
+    const response = await fetch("/api/admin/companies", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const json = (await response.json().catch(() => null)) as {
+      ok: boolean;
+      error?: { code: string; message: string };
+    } | null;
+
+    if (!response.ok || !json?.ok) {
+      setForm((s) => ({
+        ...s,
+        submitting: false,
+        error: json?.error?.message ?? `Request failed (${response.status}).`,
+      }));
+      return;
+    }
+
+    router.push("/admin/companies");
+    router.refresh();
+  }
+
+  return (
+    <div className="max-w-xl">
+      <div className="mb-6">
+        <H1>New company</H1>
+        <Lead className="mt-0.5">
+          Create a customer company. The first admin will be invited
+          separately from the company detail page (P3-4).
+        </Lead>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+        <div className="space-y-1.5">
+          <Label htmlFor="company-name">Name</Label>
+          <Input
+            id="company-name"
+            data-testid="company-name"
+            type="text"
+            required
+            maxLength={200}
+            value={form.name}
+            onChange={(e) =>
+              setForm((s) => ({ ...s, name: e.target.value, error: null }))
+            }
+            disabled={form.submitting}
+            placeholder="Skyview Technology"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="company-slug">Slug (optional)</Label>
+          <Input
+            id="company-slug"
+            data-testid="company-slug"
+            type="text"
+            maxLength={60}
+            value={form.slug}
+            onChange={(e) =>
+              setForm((s) => ({ ...s, slug: e.target.value, error: null }))
+            }
+            disabled={form.submitting}
+            placeholder="auto-generated from name"
+          />
+          <p className="text-sm text-muted-foreground">
+            URL-safe identifier. Leave blank to auto-generate from the
+            name. Lowercase letters, digits, and hyphens only.
+          </p>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="company-domain">Domain (optional)</Label>
+          <Input
+            id="company-domain"
+            data-testid="company-domain"
+            type="text"
+            maxLength={253}
+            value={form.domain}
+            onChange={(e) =>
+              setForm((s) => ({ ...s, domain: e.target.value, error: null }))
+            }
+            disabled={form.submitting}
+            placeholder="skyview.com"
+          />
+          <p className="text-sm text-muted-foreground">
+            The customer&apos;s brand domain.
+          </p>
+        </div>
+
+        {form.error ? (
+          <div
+            role="alert"
+            data-testid="company-create-error"
+            className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+          >
+            {form.error}
+          </div>
+        ) : null}
+
+        <div className="flex gap-2">
+          <Button
+            type="submit"
+            data-testid="company-create-submit"
+            disabled={form.submitting || !form.name.trim()}
+          >
+            {form.submitting ? "Creating…" : "Create company"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.push("/admin/companies")}
+            disabled={form.submitting}
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -9,14 +9,16 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session A
 - Started: 2026-05-02
-- Branch: feat/p3-opollo-admin-companies
-- Slice: P3-1 — Opollo admin companies list page. First sub-slice of P3 (companies management UI). Splitting the parent slice into P3-1 (list — this PR), P3-2 (create), P3-3 (detail + members), P3-4 (invite modal/page) so each ships small and reviewable. P2-4 QStash still blocked on env.
+- Branch: feat/p3-2-create-company
+- Slice: P3-2 — Create company form. Second sub-slice of P3. Form at /admin/companies/new + POST /api/admin/companies + lib/platform/companies/create.ts.
 - Files claimed:
-  - lib/platform/companies/{list,types,index}.ts (new)
-  - app/admin/companies/page.tsx (new — list)
-  - components/PlatformCompaniesListClient.tsx (new — client shell)
-  - lib/__tests__/platform-companies.test.ts (new)
-  - e2e/platform-companies.spec.ts (new — happy path)
+  - lib/platform/companies/create.ts (new)
+  - lib/platform/companies/index.ts (extend)
+  - app/admin/companies/new/page.tsx (new — server-rendered form shell)
+  - components/PlatformCompanyCreateForm.tsx (new — client form)
+  - app/api/admin/companies/route.ts (new — POST)
+  - components/PlatformCompaniesListClient.tsx (wire "New company" button to route)
+  - lib/__tests__/platform-companies-create.test.ts (new)
   - docs/WORK_IN_FLIGHT.md
 - Migration number reserved: none
 - Expected completion: same session.

--- a/e2e/platform-companies.spec.ts
+++ b/e2e/platform-companies.spec.ts
@@ -2,9 +2,10 @@ import { expect, test } from "@playwright/test";
 
 import { auditA11y, signInAsAdmin } from "./helpers";
 
-// P3-1 — Opollo admin companies list page.
-// Logged-in admin can navigate to /admin/companies and see the list.
-// Create-flow (P3-2), detail (P3-3), and invite (P3-4) are deferred.
+// P3-1 + P3-2 — Opollo admin companies list + create flow.
+// Logged-in admin can navigate to /admin/companies, see the list,
+// click "New company" to land on the form, and submit a new row that
+// appears in the list after refresh.
 
 test.describe("platform admin / companies", () => {
   test.beforeEach(async ({ page }) => {
@@ -17,13 +18,34 @@ test.describe("platform admin / companies", () => {
       page.getByRole("heading", { name: /Companies/i }),
     ).toBeVisible();
 
-    // The "New company (P3-2)" button is a placeholder until the create
-    // flow lands; assert it's present and disabled so a regression in
-    // either direction (misnamed test-id, accidentally enabled) is loud.
     const addButton = page.getByTestId("add-company-button");
     await expect(addButton).toBeVisible();
-    await expect(addButton).toBeDisabled();
+    await expect(addButton).not.toBeDisabled();
 
     await auditA11y(page, testInfo);
+  });
+
+  test("create form opens, submits, new row appears in list", async ({
+    page,
+  }, testInfo) => {
+    await page.goto("/admin/companies");
+
+    await page.getByTestId("add-company-button").click();
+    await page.waitForURL("**/admin/companies/new");
+    await expect(
+      page.getByRole("heading", { name: /New company/i }),
+    ).toBeVisible();
+    await auditA11y(page, testInfo);
+
+    const slug = `e2e-${Date.now()}`;
+    await page.getByTestId("company-name").fill(`E2E Test Co ${slug}`);
+    await page.getByTestId("company-slug").fill(slug);
+    await page.getByTestId("company-domain").fill(`${slug}.test`);
+    await page.getByTestId("company-create-submit").click();
+
+    await page.waitForURL("**/admin/companies");
+    await expect(
+      page.getByTestId(`platform-company-row-${slug}`),
+    ).toBeVisible();
   });
 });

--- a/lib/__tests__/platform-companies-create.test.ts
+++ b/lib/__tests__/platform-companies-create.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createPlatformCompany } from "@/lib/platform/companies";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// P3-2 — createPlatformCompany lib helper.
+//
+// Validation, slug auto-generation, and slug-collision (23505 → ALREADY_EXISTS).
+// Service-role bypasses RLS so the helper is exercised in isolation.
+// ---------------------------------------------------------------------------
+
+describe("lib/platform/companies/create — createPlatformCompany", () => {
+  const tracked: string[] = [];
+
+  beforeAll(() => {
+    // Each test inserts a row; collect ids for afterAll cleanup since
+    // _setup.ts TRUNCATEs platform_companies between tests anyway, but
+    // some tests don't trigger beforeEach (no SeededAuthUser).
+  });
+
+  afterAll(async () => {
+    if (tracked.length === 0) return;
+    const svc = getServiceRoleClient();
+    await svc.from("platform_companies").delete().in("id", tracked);
+  });
+
+  it("happy path — creates company, returns full row", async () => {
+    const result = await createPlatformCompany({
+      name: "Acme Co",
+      slug: "p3-2-acme-happy",
+      domain: "p3-2-acme-happy.test",
+      createdBy: null,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    tracked.push(result.data.id);
+
+    expect(result.data.name).toBe("Acme Co");
+    expect(result.data.slug).toBe("p3-2-acme-happy");
+    expect(result.data.domain).toBe("p3-2-acme-happy.test");
+    expect(result.data.is_opollo_internal).toBe(false);
+    expect(result.data.timezone).toBe("Australia/Melbourne");
+  });
+
+  it("auto-generates slug from name when slug omitted", async () => {
+    const result = await createPlatformCompany({
+      name: "Auto Slug Co",
+      createdBy: null,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    tracked.push(result.data.id);
+
+    expect(result.data.slug).toBe("auto-slug-co");
+  });
+
+  it("trims whitespace from name", async () => {
+    const result = await createPlatformCompany({
+      name: "  Trim Co  ",
+      createdBy: null,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    tracked.push(result.data.id);
+    expect(result.data.name).toBe("Trim Co");
+    expect(result.data.slug).toBe("trim-co");
+  });
+
+  it("normalises domain — null when blank string supplied", async () => {
+    const result = await createPlatformCompany({
+      name: "No Domain Co",
+      slug: "p3-2-no-domain",
+      domain: "",
+      createdBy: null,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    tracked.push(result.data.id);
+    expect(result.data.domain).toBeNull();
+  });
+
+  it("rejects empty name with VALIDATION_FAILED", async () => {
+    const result = await createPlatformCompany({
+      name: "   ",
+      createdBy: null,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("rejects slug with disallowed characters", async () => {
+    const result = await createPlatformCompany({
+      name: "X",
+      slug: "Bad Slug!",
+      createdBy: null,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("rejects oversize slug", async () => {
+    const result = await createPlatformCompany({
+      name: "X",
+      slug: "a".repeat(61),
+      createdBy: null,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns ALREADY_EXISTS on duplicate slug", async () => {
+    const slug = `p3-2-dupe-${Date.now()}`;
+    const first = await createPlatformCompany({
+      name: "Dupe One",
+      slug,
+      createdBy: null,
+    });
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    tracked.push(first.data.id);
+
+    const second = await createPlatformCompany({
+      name: "Dupe Two",
+      slug,
+      createdBy: null,
+    });
+    expect(second.ok).toBe(false);
+    if (second.ok) return;
+    expect(second.error.code).toBe("ALREADY_EXISTS");
+  });
+
+  it("auto-generated slug strips diacritics + non-alphanumerics", async () => {
+    const result = await createPlatformCompany({
+      name: "Café & Crème: Wow!",
+      createdBy: null,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    tracked.push(result.data.id);
+    // Combining diacritics stripped, & and : and ! become hyphens that
+    // collapse to single dashes, leading/trailing dashes trimmed.
+    expect(result.data.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    expect(result.data.slug).toContain("cafe");
+  });
+});

--- a/lib/platform/companies/create.ts
+++ b/lib/platform/companies/create.ts
@@ -1,0 +1,142 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { PlatformCompany } from "./types";
+
+// P3-2 — create a customer company. Caller (route handler) is responsible
+// for permission checks; this lib only validates input + writes the row.
+//
+// Auto-generates a URL-safe slug from `name` if the caller doesn't supply
+// one. Slug uniqueness is enforced at the schema layer (UNIQUE on
+// platform_companies.slug); a 23505 collision is surfaced as
+// SLUG_TAKEN so the caller can prompt for an alternate.
+
+export type CreateCompanyInput = {
+  name: string;
+  // Optional — auto-generated from name when omitted.
+  slug?: string;
+  // Optional — customer's brand domain (e.g. "skyview.com"). Nullable in
+  // the schema; pass null/undefined to leave unset.
+  domain?: string | null;
+  timezone?: string;
+  createdBy: string | null;
+};
+
+const DEFAULT_TIMEZONE = "Australia/Melbourne";
+const SLUG_RE = /^[a-z0-9-]+$/;
+
+export async function createPlatformCompany(
+  input: CreateCompanyInput,
+): Promise<ApiResponse<PlatformCompany>> {
+  const trimmedName = input.name.trim();
+  if (!trimmedName) {
+    return validation("Name is required.");
+  }
+  if (trimmedName.length > 200) {
+    return validation("Name must be 200 characters or fewer.");
+  }
+
+  const slug = (input.slug?.trim() || slugify(trimmedName)).toLowerCase();
+  if (!slug || !SLUG_RE.test(slug)) {
+    return validation(
+      "Slug must contain only lowercase letters, digits, and hyphens.",
+    );
+  }
+  if (slug.length > 60) {
+    return validation("Slug must be 60 characters or fewer.");
+  }
+
+  const domain = input.domain?.trim() || null;
+  if (domain !== null && domain.length > 253) {
+    return validation("Domain must be 253 characters or fewer.");
+  }
+
+  const timezone = (input.timezone ?? DEFAULT_TIMEZONE).trim();
+
+  const svc = getServiceRoleClient();
+  const result = await svc
+    .from("platform_companies")
+    .insert({
+      name: trimmedName,
+      slug,
+      domain,
+      timezone,
+      is_opollo_internal: false,
+    })
+    .select(
+      "id, name, slug, domain, timezone, is_opollo_internal, approval_default_required, approval_default_rule, concurrent_publish_limit, created_at, updated_at",
+    )
+    .single();
+
+  if (result.error) {
+    if (result.error.code === "23505") {
+      // Two unique constraints can fire here: idx_companies_one_internal
+      // (singleton) and the slug UNIQUE. We don't write is_opollo_internal=true
+      // from this path, so 23505 is always a slug collision.
+      return {
+        ok: false,
+        error: {
+          code: "ALREADY_EXISTS",
+          message: `Slug "${slug}" is already taken. Try a different name or supply a custom slug.`,
+          retryable: false,
+          suggested_action: "Pick a different slug and resubmit.",
+        },
+        timestamp: new Date().toISOString(),
+      };
+    }
+    logger.error("platform.companies.create.failed", {
+      err: result.error.message,
+      code: result.error.code,
+    });
+    return internal(`Failed to create company: ${result.error.message}`);
+  }
+
+  // createdBy is captured for future audit-log expansion; the V1
+  // platform_companies schema doesn't carry created_by/updated_by today.
+  void input.createdBy;
+
+  return {
+    ok: true,
+    data: result.data as PlatformCompany,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "") // strip combining diacritics
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+}
+
+function validation(message: string): ApiResponse<PlatformCompany> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<PlatformCompany> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/companies/index.ts
+++ b/lib/platform/companies/index.ts
@@ -1,2 +1,4 @@
 export { listPlatformCompanies } from "./list";
+export { createPlatformCompany } from "./create";
+export type { CreateCompanyInput } from "./create";
 export type { PlatformCompany, PlatformCompanyListItem } from "./types";


### PR DESCRIPTION
## Summary

P3-2 — second sub-slice of **P3 (Opollo admin companies UI)**. Adds the create-company form at `/admin/companies/new`, the `POST /api/admin/companies` route, and `lib/platform/companies/create.ts`. Wires up the placeholder "New company" button from P3-1.

## What this PR adds

- **`lib/platform/companies/create.ts`** — `createPlatformCompany({name, slug?, domain?, timezone?, createdBy})`. Validates input, auto-generates slug from name when omitted (URL-safe, max 60 chars), translates 23505 (UNIQUE collision on slug) to `ALREADY_EXISTS`. Service-role insert.
- **`app/api/admin/companies/route.ts`** — `POST` handler. Gated by `requireAdminForApi()` (operator-side, opollo_users super_admin/admin). Zod-parsed body, calls lib helper, calls `revalidatePath('/admin/companies')` so the list updates on next render.
- **`app/admin/companies/new/page.tsx`** — server-rendered shell hosting the client form.
- **`components/PlatformCompanyCreateForm.tsx`** — client form. Posts to the API route, shows server errors inline, redirects to `/admin/companies` on success then `router.refresh()` to surface the new row.
- **`components/PlatformCompaniesListClient.tsx`** — wires the previously-disabled "New company" button to a `Link` pointing at `/admin/companies/new`.
- **`lib/__tests__/platform-companies-create.test.ts`** — happy path, slug auto-generation, whitespace trim, blank-domain → null, validation errors (empty name, bad slug chars, oversize slug), slug-collision → ALREADY_EXISTS, diacritic stripping in auto-generated slugs.
- **`e2e/platform-companies.spec.ts`** — extends the P3-1 spec with the create round trip (button → form → submit → row appears).

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Two operators racing to create a company with the same slug | UNIQUE on `platform_companies.slug` at the schema layer; 23505 mapped to `ALREADY_EXISTS` with a clear "pick a different slug" message. |
| Operator creates `is_opollo_internal=true` from this path | Lib hardcodes `is_opollo_internal: false` on insert. The singleton index (`idx_companies_one_internal`) enforces at DB level too. |
| Auto-generated slug containing characters that break URLs | Regex strip + diacritic strip + lowercase + collapse-hyphens. Tested. |
| Stale list page after create | `revalidatePath("/admin/companies")` from the POST handler + `router.refresh()` from the form's success branch. Same pattern as `lib/sites.ts`. |
| Non-operator hits the route | `requireAdminForApi()` first line of the handler. Same gate as every other `/api/admin/*` route. |
| Static-audit LOW typography violations introduced | None in the new form (uses `text-sm` throughout). The P3-1 follow-up commit already fixed the three earlier violations in the list client. |

### Deliberately deferred

- **Audit columns on `platform_companies`.** The schema doesn't carry `created_by` / `updated_by` today; `createdBy` is captured in the lib signature for future expansion (referenced via `void input.createdBy` to avoid TS unused-arg warnings). Adding the columns is its own migration slice.
- **Inline domain validation.** Currently only length-checks. Format validation (RFC 1035) is over-engineering for an internal admin form; an invalid domain just won't resolve and operators retry.
- **Edit / archive flows.** Not in scope for this slice.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npx next lint --max-warnings=0` clean.
- [x] `npx next build` succeeds.
- [ ] CI test job — `lib/__tests__/platform-companies-create.test.ts` cells all pass; pre-existing m12-1-rls / m4-schema reds remain out of scope.
- [ ] CI e2e — extended `platform-companies.spec.ts` covers the create round trip.
- [ ] On CI green: auto-merge per the routine-merge rule.

## Notes for review

- WORK_IN_FLIGHT updated: P3-1 claim block removed, P3-2 added.
- The existing codebase doesn't have a shared `Label` primitive; I inlined the same private `Label` shape used in `AddSiteModal.tsx`. Worth promoting to `components/ui/label.tsx` in a future cleanup.
- After this PR: P3-3 (detail page with members + pending invitations), P3-4 (invite-from-detail flow). P2-4 (QStash callbacks) still blocked on env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
