### PR TITLE
feat(p3-3): company detail page with members + pending invitations

### DIFF
--- a/app/admin/companies/[id]/page.tsx
+++ b/app/admin/companies/[id]/page.tsx
@@ -1,0 +1,31 @@
+import { notFound } from "next/navigation";
+
+import { PlatformCompanyDetail } from "@/components/PlatformCompanyDetail";
+import { getPlatformCompany } from "@/lib/platform/companies";
+
+// P3-3 — Opollo admin company detail. Server-rendered. Loads company +
+// members + pending invitations via a single lib helper that fans out
+// three parallel queries. Read-only this slice; invite-from-detail
+// (P3-4) wires actions onto this page.
+
+export const dynamic = "force-dynamic";
+
+export default async function CompanyDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const result = await getPlatformCompany(params.id);
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") notFound();
+    return (
+      <div
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        role="alert"
+      >
+        Failed to load company: {result.error.message}
+      </div>
+    );
+  }
+  return <PlatformCompanyDetail detail={result.data} />;
+}

--- a/components/PlatformCompaniesListClient.tsx
+++ b/components/PlatformCompaniesListClient.tsx
@@ -58,10 +58,18 @@ export function PlatformCompaniesListClient({
               {companies.map((c) => (
                 <tr
                   key={c.id}
-                  className="border-b last:border-b-0"
+                  className="border-b last:border-b-0 hover:bg-muted/20"
                   data-testid={`platform-company-row-${c.slug}`}
                 >
-                  <td className="px-4 py-3 font-medium">{c.name}</td>
+                  <td className="px-4 py-3 font-medium">
+                    <Link
+                      href={`/admin/companies/${c.id}`}
+                      className="hover:underline"
+                      data-testid={`platform-company-link-${c.slug}`}
+                    >
+                      {c.name}
+                    </Link>
+                  </td>
                   <td className="px-4 py-3 font-mono text-sm text-muted-foreground">
                     {c.slug}
                   </td>

--- a/components/PlatformCompanyDetail.tsx
+++ b/components/PlatformCompanyDetail.tsx
@@ -1,0 +1,190 @@
+import Link from "next/link";
+
+import { H1, Lead } from "@/components/ui/typography";
+import type { CompanyDetail } from "@/lib/platform/companies";
+
+// P3-3 — read-only company detail. Renders company metadata, the list
+// of members with their role, and any pending invitations. Action
+// buttons (invite, revoke) land in P3-4.
+
+export function PlatformCompanyDetail({ detail }: { detail: CompanyDetail }) {
+  const { company, members, pending_invitations } = detail;
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <Link
+          href="/admin/companies"
+          className="text-sm text-muted-foreground hover:underline"
+          data-testid="company-detail-back"
+        >
+          ← Back to companies
+        </Link>
+        <div className="mt-2 flex items-center gap-3">
+          <H1>{company.name}</H1>
+          {company.is_opollo_internal ? (
+            <span
+              className="rounded-full bg-primary/10 px-2 py-0.5 text-sm font-medium text-primary"
+              data-testid="company-internal-badge"
+            >
+              Opollo internal
+            </span>
+          ) : null}
+        </div>
+        <Lead className="mt-1">
+          {company.domain ? (
+            <span className="font-mono text-sm">{company.domain}</span>
+          ) : (
+            <span className="text-muted-foreground">No domain set</span>
+          )}
+        </Lead>
+      </header>
+
+      <section
+        className="rounded-lg border bg-card"
+        aria-labelledby="company-meta"
+      >
+        <h2
+          id="company-meta"
+          className="border-b px-4 py-3 text-base font-semibold"
+        >
+          Company settings
+        </h2>
+        <dl className="grid grid-cols-1 gap-3 p-4 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-muted-foreground">Slug</dt>
+            <dd
+              className="font-mono"
+              data-testid="company-detail-slug"
+            >
+              {company.slug}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Timezone</dt>
+            <dd>{company.timezone}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Approval required</dt>
+            <dd>{company.approval_default_required ? "Yes" : "No"}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Approval rule</dt>
+            <dd>{company.approval_default_rule}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Concurrent publish limit</dt>
+            <dd className="tabular-nums">
+              {company.concurrent_publish_limit}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Created</dt>
+            <dd>{formatDate(company.created_at)}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section
+        className="rounded-lg border bg-card"
+        aria-labelledby="company-members"
+        data-testid="company-members-section"
+      >
+        <header className="flex items-center justify-between border-b px-4 py-3">
+          <h2 id="company-members" className="text-base font-semibold">
+            Members ({members.length})
+          </h2>
+        </header>
+        {members.length === 0 ? (
+          <div className="p-6 text-center text-sm text-muted-foreground">
+            No members yet — send an invitation to get started (P3-4).
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/30 text-left text-sm uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2 font-medium">Name</th>
+                <th className="px-4 py-2 font-medium">Email</th>
+                <th className="px-4 py-2 font-medium">Role</th>
+                <th className="px-4 py-2 font-medium">Joined</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((m) => (
+                <tr
+                  key={m.user_id}
+                  className="border-b last:border-b-0"
+                  data-testid={`company-member-row-${m.user_id}`}
+                >
+                  <td className="px-4 py-3">{m.full_name ?? "—"}</td>
+                  <td className="px-4 py-3 font-mono text-sm text-muted-foreground">
+                    {m.email}
+                  </td>
+                  <td className="px-4 py-3 capitalize">{m.role}</td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">
+                    {formatDate(m.joined_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <section
+        className="rounded-lg border bg-card"
+        aria-labelledby="company-pending"
+        data-testid="company-pending-section"
+      >
+        <header className="flex items-center justify-between border-b px-4 py-3">
+          <h2 id="company-pending" className="text-base font-semibold">
+            Pending invitations ({pending_invitations.length})
+          </h2>
+        </header>
+        {pending_invitations.length === 0 ? (
+          <div className="p-6 text-center text-sm text-muted-foreground">
+            No pending invitations.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/30 text-left text-sm uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2 font-medium">Email</th>
+                <th className="px-4 py-2 font-medium">Role</th>
+                <th className="px-4 py-2 font-medium">Sent</th>
+                <th className="px-4 py-2 font-medium">Expires</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pending_invitations.map((inv) => (
+                <tr
+                  key={inv.id}
+                  className="border-b last:border-b-0"
+                  data-testid={`company-invitation-row-${inv.id}`}
+                >
+                  <td className="px-4 py-3 font-mono text-sm">{inv.email}</td>
+                  <td className="px-4 py-3 capitalize">{inv.role}</td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">
+                    {formatDate(inv.created_at)}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">
+                    {formatDate(inv.expires_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -9,16 +9,16 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session A
 - Started: 2026-05-02
-- Branch: feat/p3-2-create-company
-- Slice: P3-2 — Create company form. Second sub-slice of P3. Form at /admin/companies/new + POST /api/admin/companies + lib/platform/companies/create.ts.
+- Branch: feat/p3-3-company-detail
+- Slice: P3-3 — Company detail page (members + pending invitations). Server-rendered detail at /admin/companies/[id], lib helper loading company + members + invitations in parallel, read-only display.
 - Files claimed:
-  - lib/platform/companies/create.ts (new)
+  - lib/platform/companies/get.ts (new)
   - lib/platform/companies/index.ts (extend)
-  - app/admin/companies/new/page.tsx (new — server-rendered form shell)
-  - components/PlatformCompanyCreateForm.tsx (new — client form)
-  - app/api/admin/companies/route.ts (new — POST)
-  - components/PlatformCompaniesListClient.tsx (wire "New company" button to route)
-  - lib/__tests__/platform-companies-create.test.ts (new)
+  - app/admin/companies/[id]/page.tsx (new)
+  - components/PlatformCompanyDetail.tsx (new — read-only display)
+  - lib/__tests__/platform-companies-get.test.ts (new)
+  - e2e/platform-companies.spec.ts (extend with detail navigation)
+  - components/PlatformCompaniesListClient.tsx (wire row click to detail)
   - docs/WORK_IN_FLIGHT.md
 - Migration number reserved: none
 - Expected completion: same session.

--- a/e2e/platform-companies.spec.ts
+++ b/e2e/platform-companies.spec.ts
@@ -25,7 +25,7 @@ test.describe("platform admin / companies", () => {
     await auditA11y(page, testInfo);
   });
 
-  test("create form opens, submits, new row appears in list", async ({
+  test("create → row appears → click into detail page", async ({
     page,
   }, testInfo) => {
     await page.goto("/admin/companies");
@@ -47,5 +47,16 @@ test.describe("platform admin / companies", () => {
     await expect(
       page.getByTestId(`platform-company-row-${slug}`),
     ).toBeVisible();
+
+    // P3-3 — click the row name to land on the detail page.
+    await page.getByTestId(`platform-company-link-${slug}`).click();
+    await page.waitForURL(/\/admin\/companies\/[0-9a-f-]{36}/);
+    await expect(
+      page.getByRole("heading", { name: `E2E Test Co ${slug}` }),
+    ).toBeVisible();
+    await expect(page.getByTestId("company-detail-slug")).toHaveText(slug);
+    await expect(page.getByTestId("company-members-section")).toBeVisible();
+    await expect(page.getByTestId("company-pending-section")).toBeVisible();
+    await auditA11y(page, testInfo);
   });
 });

--- a/lib/__tests__/platform-companies-get.test.ts
+++ b/lib/__tests__/platform-companies-get.test.ts
@@ -1,0 +1,202 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import { getPlatformCompany } from "@/lib/platform/companies";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser, type SeededAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// P3-3 — getPlatformCompany lib helper.
+//
+// Loads company + members (with email + name from platform_users) +
+// pending invitations. Asserts the three-fan-out shape, NOT_FOUND, and
+// VALIDATION_FAILED on bad UUIDs.
+// ---------------------------------------------------------------------------
+
+const COMPANY_A_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const COMPANY_B_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+describe("lib/platform/companies/get — getPlatformCompany", () => {
+  let admin: SeededAuthUser;
+  let editor: SeededAuthUser;
+
+  beforeAll(async () => {
+    admin = await seedAuthUser({
+      email: "p3-3-admin@opollo.test",
+      persistent: true,
+    });
+    editor = await seedAuthUser({
+      email: "p3-3-editor@opollo.test",
+      persistent: true,
+    });
+  });
+
+  beforeEach(async () => {
+    const svc = getServiceRoleClient();
+
+    const companies = await svc
+      .from("platform_companies")
+      .insert([
+        {
+          id: COMPANY_A_ID,
+          name: "Acme Co",
+          slug: "p3-3-acme",
+          domain: "p3-3-acme.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+        },
+        {
+          id: COMPANY_B_ID,
+          name: "Beta Inc",
+          slug: "p3-3-beta",
+          domain: "p3-3-beta.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+        },
+      ])
+      .select("id");
+    if (companies.error) {
+      throw new Error(
+        `seed companies: ${companies.error.code ?? "?"} ${companies.error.message}`,
+      );
+    }
+
+    const users = await svc
+      .from("platform_users")
+      .insert([
+        {
+          id: admin.id,
+          email: admin.email,
+          full_name: "Acme Admin",
+          is_opollo_staff: false,
+        },
+        {
+          id: editor.id,
+          email: editor.email,
+          full_name: "Acme Editor",
+          is_opollo_staff: false,
+        },
+      ])
+      .select("id");
+    if (users.error) {
+      throw new Error(
+        `seed users: ${users.error.code ?? "?"} ${users.error.message}`,
+      );
+    }
+
+    const memberships = await svc
+      .from("platform_company_users")
+      .insert([
+        { company_id: COMPANY_A_ID, user_id: admin.id, role: "admin" },
+        { company_id: COMPANY_A_ID, user_id: editor.id, role: "editor" },
+      ])
+      .select("id");
+    if (memberships.error) {
+      throw new Error(
+        `seed memberships: ${memberships.error.code ?? "?"} ${memberships.error.message}`,
+      );
+    }
+
+    // Seed two pending invites + one accepted (which should NOT appear).
+    const expires = new Date(Date.now() + 14 * 86_400_000).toISOString();
+    const inviteSeed = await svc
+      .from("platform_invitations")
+      .insert([
+        {
+          company_id: COMPANY_A_ID,
+          email: "pending1@acme.test",
+          role: "viewer",
+          token_hash: `hash-p3-3-1-${Date.now()}`,
+          status: "pending",
+          expires_at: expires,
+          invited_by: admin.id,
+        },
+        {
+          company_id: COMPANY_A_ID,
+          email: "pending2@acme.test",
+          role: "approver",
+          token_hash: `hash-p3-3-2-${Date.now()}`,
+          status: "pending",
+          expires_at: expires,
+          invited_by: admin.id,
+        },
+        {
+          company_id: COMPANY_A_ID,
+          email: "accepted@acme.test",
+          role: "viewer",
+          token_hash: `hash-p3-3-3-${Date.now()}`,
+          status: "accepted",
+          expires_at: expires,
+          invited_by: admin.id,
+          accepted_at: new Date().toISOString(),
+        },
+      ])
+      .select("id");
+    if (inviteSeed.error) {
+      throw new Error(
+        `seed invitations: ${inviteSeed.error.code ?? "?"} ${inviteSeed.error.message}`,
+      );
+    }
+  });
+
+  afterAll(async () => {
+    const svc = getServiceRoleClient();
+    for (const u of [admin, editor]) {
+      if (!u) continue;
+      await svc.auth.admin.deleteUser(u.id);
+    }
+  });
+
+  it("happy path — returns company + members + pending-only invitations", async () => {
+    const result = await getPlatformCompany(COMPANY_A_ID);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.data.company.id).toBe(COMPANY_A_ID);
+    expect(result.data.company.name).toBe("Acme Co");
+
+    expect(result.data.members).toHaveLength(2);
+    const memberByRole = new Map(
+      result.data.members.map((m) => [m.role, m]),
+    );
+    expect(memberByRole.get("admin")?.email).toBe(admin.email);
+    expect(memberByRole.get("admin")?.full_name).toBe("Acme Admin");
+    expect(memberByRole.get("editor")?.email).toBe(editor.email);
+
+    // Only the two pending invitations; the accepted one is filtered.
+    expect(result.data.pending_invitations).toHaveLength(2);
+    const emails = result.data.pending_invitations.map((i) => i.email).sort();
+    expect(emails).toEqual(["pending1@acme.test", "pending2@acme.test"]);
+  });
+
+  it("returns NOT_FOUND for a non-existent UUID", async () => {
+    const result = await getPlatformCompany(
+      "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns VALIDATION_FAILED for a malformed id", async () => {
+    const result = await getPlatformCompany("not-a-uuid");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("empty company has zero members + zero invitations", async () => {
+    const result = await getPlatformCompany(COMPANY_B_ID);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.members).toHaveLength(0);
+    expect(result.data.pending_invitations).toHaveLength(0);
+  });
+});

--- a/lib/platform/companies/get.ts
+++ b/lib/platform/companies/get.ts
@@ -1,0 +1,195 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { PlatformCompany } from "./types";
+
+// P3-3 — load a company + its members + its pending invitations.
+//
+// Two FKs from platform_company_users to platform_users (user_id +
+// added_by) prevent embedded joins (PGRST ambiguity); same constraint
+// applies in send.ts. Three parallel queries are simpler and resilient
+// to future audit-FK additions.
+//
+// Returns NOT_FOUND when the id doesn't exist. The caller (route handler)
+// already gated on operator role, so service-role read here is fine.
+
+export type CompanyMember = {
+  user_id: string;
+  email: string;
+  full_name: string | null;
+  role: "admin" | "approver" | "editor" | "viewer";
+  joined_at: string;
+};
+
+export type CompanyPendingInvitation = {
+  id: string;
+  email: string;
+  role: "admin" | "approver" | "editor" | "viewer";
+  expires_at: string;
+  invited_by: string | null;
+  reminder_sent_at: string | null;
+  created_at: string;
+};
+
+export type CompanyDetail = {
+  company: PlatformCompany;
+  members: CompanyMember[];
+  pending_invitations: CompanyPendingInvitation[];
+};
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function getPlatformCompany(
+  id: string,
+): Promise<ApiResponse<CompanyDetail>> {
+  if (!UUID_RE.test(id)) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_FAILED",
+        message: "Company id must be a UUID.",
+        retryable: false,
+        suggested_action: "Check the URL and retry.",
+      },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  const svc = getServiceRoleClient();
+
+  // Three queries in parallel: company, members (joined to platform_users
+  // for email + name), pending invitations.
+  const [companyResult, membersResult, invitationsResult] = await Promise.all([
+    svc
+      .from("platform_companies")
+      .select(
+        "id, name, slug, domain, timezone, is_opollo_internal, approval_default_required, approval_default_rule, concurrent_publish_limit, created_at, updated_at",
+      )
+      .eq("id", id)
+      .maybeSingle(),
+    svc
+      .from("platform_company_users")
+      .select("user_id, role, created_at")
+      .eq("company_id", id)
+      .order("created_at", { ascending: true }),
+    svc
+      .from("platform_invitations")
+      .select(
+        "id, email, role, expires_at, invited_by, reminder_sent_at, created_at",
+      )
+      .eq("company_id", id)
+      .eq("status", "pending")
+      .order("created_at", { ascending: false }),
+  ]);
+
+  if (companyResult.error) {
+    logger.error("platform.companies.get.company_failed", {
+      err: companyResult.error.message,
+    });
+    return internal(`Failed to load company: ${companyResult.error.message}`);
+  }
+  if (!companyResult.data) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: "No company with that id.",
+        retryable: false,
+        suggested_action: "Check the URL.",
+      },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  if (membersResult.error) {
+    logger.error("platform.companies.get.members_failed", {
+      err: membersResult.error.message,
+    });
+    return internal(
+      `Failed to load members: ${membersResult.error.message}`,
+    );
+  }
+  if (invitationsResult.error) {
+    logger.error("platform.companies.get.invitations_failed", {
+      err: invitationsResult.error.message,
+    });
+    return internal(
+      `Failed to load invitations: ${invitationsResult.error.message}`,
+    );
+  }
+
+  // Resolve member emails + names via a single follow-up query keyed by
+  // user_id (no embed → no PGRST ambiguity).
+  const userIds = (membersResult.data ?? []).map((m) => m.user_id as string);
+  const userById = new Map<string, { email: string; full_name: string | null }>();
+  if (userIds.length > 0) {
+    const usersResult = await svc
+      .from("platform_users")
+      .select("id, email, full_name")
+      .in("id", userIds);
+    if (usersResult.error) {
+      logger.error("platform.companies.get.users_failed", {
+        err: usersResult.error.message,
+      });
+      return internal(
+        `Failed to load member profiles: ${usersResult.error.message}`,
+      );
+    }
+    for (const u of usersResult.data ?? []) {
+      userById.set(u.id as string, {
+        email: u.email as string,
+        full_name: (u.full_name as string | null) ?? null,
+      });
+    }
+  }
+
+  const members: CompanyMember[] = (membersResult.data ?? []).map((m) => {
+    const profile = userById.get(m.user_id as string);
+    return {
+      user_id: m.user_id as string,
+      email: profile?.email ?? "",
+      full_name: profile?.full_name ?? null,
+      role: m.role as CompanyMember["role"],
+      joined_at: m.created_at as string,
+    };
+  });
+
+  const pending: CompanyPendingInvitation[] = (
+    invitationsResult.data ?? []
+  ).map((inv) => ({
+    id: inv.id as string,
+    email: inv.email as string,
+    role: inv.role as CompanyPendingInvitation["role"],
+    expires_at: inv.expires_at as string,
+    invited_by: (inv.invited_by as string | null) ?? null,
+    reminder_sent_at: (inv.reminder_sent_at as string | null) ?? null,
+    created_at: inv.created_at as string,
+  }));
+
+  return {
+    ok: true,
+    data: {
+      company: companyResult.data as PlatformCompany,
+      members,
+      pending_invitations: pending,
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<CompanyDetail> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/companies/index.ts
+++ b/lib/platform/companies/index.ts
@@ -1,4 +1,10 @@
 export { listPlatformCompanies } from "./list";
 export { createPlatformCompany } from "./create";
+export { getPlatformCompany } from "./get";
 export type { CreateCompanyInput } from "./create";
+export type {
+  CompanyDetail,
+  CompanyMember,
+  CompanyPendingInvitation,
+} from "./get";
 export type { PlatformCompany, PlatformCompanyListItem } from "./types";


### PR DESCRIPTION
## Summary

P3-3 — third sub-slice of **P3 (Opollo admin companies UI)**. Adds the company detail page at `/admin/companies/[id]` with members + pending invitations. Read-only this slice; invite-from-detail (P3-4) wires the action buttons next.

## What this PR adds

- **`lib/platform/companies/get.ts`** — `getPlatformCompany(id)`. Returns `{ company, members, pending_invitations }`. Fans out three parallel queries (`Promise.all`), then resolves member emails + full names via a follow-up `platform_users` lookup keyed by `user_id`. Embed avoided because of the multi-FK ambiguity (`user_id` + `added_by`).
- **`app/admin/companies/[id]/page.tsx`** — server-rendered detail page. `notFound()` on `NOT_FOUND` from the lib; renders an alert on other lib errors.
- **`components/PlatformCompanyDetail.tsx`** — read-only display. Three sections: company settings (slug, timezone, approval defaults, concurrent publish limit, created date), members table, pending invitations table. All `text-sm` minimum per RULES.md typography rule.
- **`components/PlatformCompaniesListClient.tsx`** — wires the company name on each row to `Link href="/admin/companies/[id]"`.
- **`lib/__tests__/platform-companies-get.test.ts`** — happy path (company + 2 members + 2 pending; accepted invite filtered out), `NOT_FOUND` for unknown UUID, `VALIDATION_FAILED` for malformed id, empty company → empty arrays.
- **`e2e/platform-companies.spec.ts`** — extends the existing create-round-trip spec: after the new row appears, click the company-name link, assert detail page renders with the right slug + members + pending sections + a11y.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| PGRST embed ambiguity on `platform_company_users → platform_users` | Three separate queries + a fourth lookup for member profiles. Documented in the lib comment. |
| Detail page leaks accepted/revoked invitations as "pending" | `getPlatformCompany` filters `status = 'pending'` at the SQL layer. Tested. |
| 404 leaks vs deny | `NOT_FOUND` returned from the lib triggers Next's `notFound()` so the operator sees a standard 404 page rather than a generic error envelope. |
| Operator with unrelated `users.id` colliding with member `user_id` join | The follow-up query uses `.in("id", userIds)` with the exact ids from the membership rows; no risk of bleeding rows. |
| Static-audit LOW typography | All new text in the detail component uses `text-sm` minimum. |

### Deliberately deferred

- **Invite-from-detail action button.** Lands in P3-4 — needs a modal or `/admin/companies/[id]/invitations/new` page wiring `lib/platform/invitations.sendInvitation`.
- **Revoke-pending-invitation button.** Same slice as the invite action (P3-4); both surfaces wire to the existing P2-2 routes.
- **Edit company settings.** Out of P3 scope. Future slice.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npx next lint --max-warnings=0` clean.
- [x] `npx next build` succeeds.
- [ ] CI test job — `lib/__tests__/platform-companies-get.test.ts` cells all pass; pre-existing reds out of scope.
- [ ] CI e2e — extended `platform-companies.spec.ts` covers list → create → detail.
- [ ] On CI green: auto-merge per the routine-merge rule.

## Notes for review

- WORK_IN_FLIGHT updated: P3-2 claim block removed, P3-3 added.
- `member_count` on the list page is computed via a separate count query; the detail page's members table comes from a different code path. Both use the same multi-FK-safe pattern, so a future refactor can share a `lib/platform/companies/queries.ts` module if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
