### PR TITLE
feat(p3-4): invite-from-detail modal + per-row revoke action

### DIFF
--- a/components/PlatformCompanyDetail.tsx
+++ b/components/PlatformCompanyDetail.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { PlatformInviteUserModal } from "@/components/PlatformInviteUserModal";
+import { PlatformRevokeInvitationButton } from "@/components/PlatformRevokeInvitationButton";
 import { H1, Lead } from "@/components/ui/typography";
 import type { CompanyDetail } from "@/lib/platform/companies";
 
@@ -94,10 +96,12 @@ export function PlatformCompanyDetail({ detail }: { detail: CompanyDetail }) {
           <h2 id="company-members" className="text-base font-semibold">
             Members ({members.length})
           </h2>
+          <PlatformInviteUserModal companyId={company.id} />
         </header>
         {members.length === 0 ? (
           <div className="p-6 text-center text-sm text-muted-foreground">
-            No members yet — send an invitation to get started (P3-4).
+            No members yet — click <strong>Invite user</strong> to send the
+            first invitation.
           </div>
         ) : (
           <table className="w-full text-sm">
@@ -153,6 +157,7 @@ export function PlatformCompanyDetail({ detail }: { detail: CompanyDetail }) {
                 <th className="px-4 py-2 font-medium">Role</th>
                 <th className="px-4 py-2 font-medium">Sent</th>
                 <th className="px-4 py-2 font-medium">Expires</th>
+                <th className="px-4 py-2 text-right font-medium">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -169,6 +174,12 @@ export function PlatformCompanyDetail({ detail }: { detail: CompanyDetail }) {
                   </td>
                   <td className="px-4 py-3 text-sm text-muted-foreground">
                     {formatDate(inv.expires_at)}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <PlatformRevokeInvitationButton
+                      invitationId={inv.id}
+                      email={inv.email}
+                    />
                   </td>
                 </tr>
               ))}

--- a/components/PlatformInviteUserModal.tsx
+++ b/components/PlatformInviteUserModal.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+// P3-4 — invite-user button + modal. Self-contained client component.
+// Drops into the company detail header. Posts to POST /api/platform/invitations
+// (which gates on requireCanDoForApi(companyId, "manage_invitations") via
+// session cookie — operator opollo_users staff and customer admins both
+// satisfy this on /admin/companies/[id]).
+//
+// On success: close the modal + router.refresh() so the new pending row
+// appears in the detail page's pending-invitations table.
+
+type Role = "admin" | "approver" | "editor" | "viewer";
+
+const ROLE_OPTIONS: Array<{ value: Role; label: string; help: string }> = [
+  {
+    value: "admin",
+    label: "Admin",
+    help: "Manages users, settings, and connections.",
+  },
+  {
+    value: "approver",
+    label: "Approver",
+    help: "Approves content for publishing.",
+  },
+  {
+    value: "editor",
+    label: "Editor",
+    help: "Drafts and submits content.",
+  },
+  {
+    value: "viewer",
+    label: "Viewer",
+    help: "Read-only calendar access.",
+  },
+];
+
+function Label({
+  htmlFor,
+  children,
+}: {
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label htmlFor={htmlFor} className="block text-sm font-medium">
+      {children}
+    </label>
+  );
+}
+
+export function PlatformInviteUserModal({
+  companyId,
+}: {
+  companyId: string;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<Role>("editor");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function reset() {
+    setEmail("");
+    setRole("editor");
+    setSubmitting(false);
+    setError(null);
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const response = await fetch("/api/platform/invitations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        company_id: companyId,
+        email: email.trim(),
+        role,
+      }),
+    });
+    const json = (await response.json().catch(() => null)) as {
+      ok: boolean;
+      error?: { code: string; message: string };
+    } | null;
+
+    if (!response.ok || !json?.ok) {
+      setError(
+        json?.error?.message ?? `Request failed (${response.status}).`,
+      );
+      setSubmitting(false);
+      return;
+    }
+
+    setOpen(false);
+    reset();
+    router.refresh();
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        data-testid="invite-user-button"
+        onClick={() => {
+          reset();
+          setOpen(true);
+        }}
+      >
+        <Plus aria-hidden className="h-4 w-4" />
+        Invite user
+      </Button>
+
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!submitting) setOpen(next);
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Invite a user</DialogTitle>
+            <DialogDescription>
+              They&apos;ll receive an email with a magic link to set their
+              password. The invitation expires in 14 days.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+            <div className="space-y-1.5">
+              <Label htmlFor="invite-email">Email</Label>
+              <Input
+                id="invite-email"
+                data-testid="invite-email"
+                type="email"
+                required
+                maxLength={254}
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  setError(null);
+                }}
+                disabled={submitting}
+                placeholder="newhire@example.com"
+              />
+            </div>
+
+            <fieldset className="space-y-2" disabled={submitting}>
+              <legend className="text-sm font-medium">Role</legend>
+              {ROLE_OPTIONS.map((opt) => (
+                <label
+                  key={opt.value}
+                  className="flex cursor-pointer items-start gap-2 rounded border p-2 text-sm hover:bg-muted/30"
+                >
+                  <input
+                    type="radio"
+                    name="invite-role"
+                    value={opt.value}
+                    checked={role === opt.value}
+                    onChange={() => setRole(opt.value)}
+                    data-testid={`invite-role-${opt.value}`}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <strong>{opt.label}</strong>
+                    <span className="block text-sm text-muted-foreground">
+                      {opt.help}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </fieldset>
+
+            {error ? (
+              <div
+                role="alert"
+                data-testid="invite-error"
+                className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+              >
+                {error}
+              </div>
+            ) : null}
+
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpen(false)}
+                disabled={submitting}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                data-testid="invite-submit"
+                disabled={submitting || !email.trim()}
+              >
+                {submitting ? "Sending…" : "Send invitation"}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/PlatformRevokeInvitationButton.tsx
+++ b/components/PlatformRevokeInvitationButton.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+// P3-4 — per-row revoke action on the company detail's pending invitations
+// table. Calls DELETE /api/platform/invitations/[id]; the route gates on
+// requireCanDoForApi(companyId, "manage_invitations") so opollo staff +
+// customer admins both reach it. On success: router.refresh() so the row
+// disappears from the table.
+
+export function PlatformRevokeInvitationButton({
+  invitationId,
+  email,
+}: {
+  invitationId: string;
+  email: string;
+}) {
+  const router = useRouter();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleClick() {
+    if (submitting) return;
+    if (
+      !globalThis.confirm(
+        `Revoke the pending invitation to ${email}? This cannot be undone — they would need a fresh invite to join.`,
+      )
+    ) {
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+
+    const response = await fetch(
+      `/api/platform/invitations/${invitationId}`,
+      { method: "DELETE" },
+    );
+    const json = (await response.json().catch(() => null)) as {
+      ok: boolean;
+      error?: { code: string; message: string };
+    } | null;
+
+    if (!response.ok || !json?.ok) {
+      setError(
+        json?.error?.message ?? `Request failed (${response.status}).`,
+      );
+      setSubmitting(false);
+      return;
+    }
+
+    router.refresh();
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleClick}
+        disabled={submitting}
+        data-testid={`revoke-invitation-${invitationId}`}
+      >
+        {submitting ? "Revoking…" : "Revoke"}
+      </Button>
+      {error ? (
+        <span
+          role="alert"
+          className="text-sm text-destructive"
+          data-testid={`revoke-invitation-error-${invitationId}`}
+        >
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -8,17 +8,15 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 
 ---
 ## Session A
-- Started: 2026-05-02
-- Branch: feat/p3-3-company-detail
-- Slice: P3-3 — Company detail page (members + pending invitations). Server-rendered detail at /admin/companies/[id], lib helper loading company + members + invitations in parallel, read-only display.
+- Started: 2026-05-03
+- Branch: feat/p3-4-invite-from-detail
+- Slice: P3-4 — Invite-from-detail flow. Adds an "Invite user" button on the company detail page (modal wiring sendInvitation) and a "Revoke" action on each pending invitation row (DELETE /api/platform/invitations/[id]). Closes P3.
 - Files claimed:
-  - lib/platform/companies/get.ts (new)
-  - lib/platform/companies/index.ts (extend)
-  - app/admin/companies/[id]/page.tsx (new)
-  - components/PlatformCompanyDetail.tsx (new — read-only display)
-  - lib/__tests__/platform-companies-get.test.ts (new)
-  - e2e/platform-companies.spec.ts (extend with detail navigation)
-  - components/PlatformCompaniesListClient.tsx (wire row click to detail)
+  - components/PlatformCompanyDetail.tsx (modify — add invite button + revoke per-row)
+  - components/PlatformInviteUserModal.tsx (new)
+  - components/PlatformCompanyDetailClient.tsx (new — client wrapper holding modal + revoke state)
+  - app/admin/companies/[id]/page.tsx (modify — render new client wrapper)
+  - e2e/platform-companies.spec.ts (extend with invite + revoke)
   - docs/WORK_IN_FLIGHT.md
 - Migration number reserved: none
 - Expected completion: same session.

--- a/e2e/platform-companies.spec.ts
+++ b/e2e/platform-companies.spec.ts
@@ -58,5 +58,38 @@ test.describe("platform admin / companies", () => {
     await expect(page.getByTestId("company-members-section")).toBeVisible();
     await expect(page.getByTestId("company-pending-section")).toBeVisible();
     await auditA11y(page, testInfo);
+
+    // P3-4 — Invite-user modal opens, accepts input, submits via stubbed
+    // POST. SendGrid isn't reachable from CI; stub returns the same shape
+    // the route would return on success so the modal-close path runs.
+    await page.route("**/api/platform/invitations", async (route) => {
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          data: {
+            invitation: {
+              id: "00000000-0000-0000-0000-00000000e2e1",
+              email: "stubbed@e2e.test",
+              role: "editor",
+              status: "pending",
+            },
+          },
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await page.getByTestId("invite-user-button").click();
+    await expect(
+      page.getByRole("heading", { name: /Invite a user/i }),
+    ).toBeVisible();
+    await page.getByTestId("invite-email").fill("stubbed@e2e.test");
+    await page.getByTestId("invite-role-editor").check();
+    await page.getByTestId("invite-submit").click();
+    await expect(
+      page.getByRole("heading", { name: /Invite a user/i }),
+    ).not.toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

P3-4 — final sub-slice of **P3 (Opollo admin companies UI)**. Adds invite + revoke actions to the company detail page. Closes P3.

## What this PR adds

- **`components/PlatformInviteUserModal.tsx`** — self-contained "Invite user" button + dialog. Form posts to `POST /api/platform/invitations`. Role picker is a fieldset of radio cards with role + description. On success: closes + `router.refresh()`. On failure: surfaces the server error inline.
- **`components/PlatformRevokeInvitationButton.tsx`** — per-row revoke action. Confirmation prompt before firing `DELETE /api/platform/invitations/[id]`. On success: `router.refresh()` so the row drops from the pending table.
- **`components/PlatformCompanyDetail.tsx`** — wires the invite button into the Members section header and adds a "Revoke" cell to the pending-invitations table.
- **`e2e/platform-companies.spec.ts`** — extends the existing create-round-trip spec with the invite flow (POST stubbed because SendGrid isn't reachable from CI; the actual route + lib are covered by P2-2's unit tests).

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Invite POST hangs the modal if SendGrid is degraded | The route returns `502 EMAIL_DELIVERY_FAILED` with the invitation_id so the operator can resend later. Modal surfaces the message in `data-testid="invite-error"`. |
| Operator double-clicks Revoke and fires two requests | Button is `disabled` while the request is in flight; second click is a no-op. |
| Browser confirm dialog blocking E2E | E2E doesn't exercise the revoke button (would need a seeded pending row); the lib + route logic is fully covered by P2-2's unit tests. The confirm prompt is plain `globalThis.confirm` per the existing codebase pattern in `e2e/sites.spec.ts`. |
| Route gate bypass for non-admins | `requireCanDoForApi(companyId, "manage_invitations")` runs first. Same gate as the operator-side; admin role or Opollo staff only. |
| Static-audit LOW typography | All new UI uses `text-sm` minimum. |

### Deliberately deferred / scoped out

- **In-app notification badge updates after invite/revoke.** Notifications dispatcher lands in P5; this PR only writes the invitation row. Recipients receive email via P2-2's send path.
- **Bulk invite / CSV upload.** That's a social S7 concern (per BUILD.md), not P3.
- **Audit-log entry for revoke action.** `platform_audit_log` table doesn't exist yet — captured as `void revokedBy` in the lib for future expansion.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npx next lint --max-warnings=0` clean.
- [x] `npx next build` succeeds.
- [ ] CI test job — no new lib tests in this slice (UI-only); P2-2 covers send/revoke at the lib layer. Pre-existing reds out of scope.
- [ ] CI e2e — extended `platform-companies.spec.ts` covers the invite-modal flow (stubbed POST).
- [ ] On CI green: auto-merge per the routine-merge rule.

## What's next

- **P3 closes with this PR.** Full Opollo-admin companies surface live: list / create / detail / invite / revoke.
- **P4 — customer admin UI for users.** Mirrors P3 but scoped to a single company (the customer admin's). Files: `app/(platform)/company/users/*`.
- **P5 — notifications dispatcher.** `lib/platform/notifications/dispatch.ts` writing both `platform_notifications` rows and SendGrid email per the trigger table in BUILD.md.
- **P2-4 — QStash callbacks** for invitation reminders + expiry. Still blocked on `QSTASH_*` env.

## Notes for review

- WORK_IN_FLIGHT updated: P3-3 claim block removed, P3-4 added.
- The invite modal's role picker is radio buttons with help text rather than a `<select>` — gives operators visibility into what each role can do before they pick. Same shape as the customer-onboarding flow in BUILD.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
