### PR TITLE
feat(env): create .env.example template (PLATFORM-AUDIT PR5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,196 @@
+# =============================================================================
+# Opollo Site Builder — environment variable template
+# =============================================================================
+#
+# Copy this file to .env.local for local development. Production + preview
+# values are set in the Vercel dashboard, not here.
+#
+# Each var is grouped by component, with a one-line note on what depends
+# on it. Vars marked HARD will throw on cold start if missing; vars marked
+# OPTIONAL degrade gracefully (the relevant feature no-ops).
+#
+# Generated 2026-05-02 by PLATFORM-AUDIT PR5. Audit script
+# (scripts/audit.ts) catches drift — every process.env.X / requireEnv("X")
+# reference must appear here, and every entry here must have a code
+# reference.
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# Supabase (HARD)
+# -----------------------------------------------------------------------------
+# Project URL + keys. Service-role key is the privileged DB key — every
+# server-side write goes through it; never ship it to the client. Anon key
+# is what the browser uses (RLS enforces).
+
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+# Direct Postgres URL for SKIP LOCKED / advisory locks (workers use this).
+SUPABASE_DB_URL=
+
+
+# -----------------------------------------------------------------------------
+# Site origin + auth (HARD in prod)
+# -----------------------------------------------------------------------------
+# NEXT_PUBLIC_SITE_URL pins the canonical origin for Supabase auth
+# redirectTo URLs and protects against Host-header spoofing. Must match
+# the deployed domain exactly. Falls back to request origin in dev.
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# Supabase Auth flag. "true" enables session-based auth; unset/false
+# falls back to legacy Basic Auth path.
+FEATURE_SUPABASE_AUTH=true
+
+# Email-2FA approval flow gate. "true" intercepts fresh sign-ins on
+# unrecognised devices and emails an approval link. Unset = skip 2FA.
+AUTH_2FA_ENABLED=
+
+# HMAC secret for signed cookies (opollo_2fa_pending, device_id). Min
+# 32 random bytes, base64-encoded. Rotate via key rotation playbook.
+COOKIE_SIGNING_SECRET=
+
+# Per-IP rate-limit hashing pepper. Random 32+ chars; never logged.
+IP_HASH_PEPPER=
+
+
+# -----------------------------------------------------------------------------
+# Anthropic API (HARD)
+# -----------------------------------------------------------------------------
+# Used by chat route, brief runner, caption pipeline, optimiser
+# proposals. Hard-throws at cold start if missing.
+ANTHROPIC_API_KEY=
+
+
+# -----------------------------------------------------------------------------
+# Cron + ops (HARD)
+# -----------------------------------------------------------------------------
+# Bearer token for /api/cron/* routes. Vercel cron must send this. Min
+# 16 chars; rotate together with cron-deploy if compromised.
+CRON_SECRET=
+
+# Break-glass auth for /api/emergency, /api/ops/self-probe,
+# /api/ops/reset-admin-password. Min 32 chars. Used only when
+# Supabase Auth itself is the thing being debugged.
+OPOLLO_EMERGENCY_KEY=
+
+
+# -----------------------------------------------------------------------------
+# Site-credential encryption (HARD)
+# -----------------------------------------------------------------------------
+# AES-256-GCM key for encrypting site_credentials.ciphertext and
+# opt_client_credentials. Generate via `openssl rand -base64 32`.
+# Rotation requires re-encrypting every encrypted row.
+OPOLLO_MASTER_KEY=
+
+
+# -----------------------------------------------------------------------------
+# Cloudflare Images (HARD)
+# -----------------------------------------------------------------------------
+# Account ID and API token from the Cloudflare dashboard. Hash is the
+# delivery-URL prefix (per-account); without it every image URL becomes
+# a double-slashed 404. Per UAT.md §1.1 row 14 this is HIGH-priority.
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_IMAGES_API_TOKEN=
+CLOUDFLARE_IMAGES_HASH=
+
+
+# -----------------------------------------------------------------------------
+# WordPress source (HARD)
+# -----------------------------------------------------------------------------
+# Source WP for parse + preview (LeadSource). The NEXT_PUBLIC_ value
+# must match LEADSOURCE_WP_URL — CSP frame-src + iframe loaders both
+# read it.
+LEADSOURCE_WP_URL=
+LEADSOURCE_WP_USER=
+LEADSOURCE_WP_APP_PASSWORD=
+NEXT_PUBLIC_LEADSOURCE_WP_URL=
+
+
+# -----------------------------------------------------------------------------
+# Transactional email — SendGrid (HARD when AUTH_2FA_ENABLED or invites used)
+# -----------------------------------------------------------------------------
+# All email goes through lib/email/sendgrid.ts. Direct @sendgrid/mail
+# imports outside that file are a code-review block. Every send writes
+# to the email_log table.
+SENDGRID_API_KEY=
+SENDGRID_FROM_EMAIL=
+SENDGRID_FROM_NAME=
+
+
+# -----------------------------------------------------------------------------
+# Feature flags (OPTIONAL — defaults documented per flag)
+# -----------------------------------------------------------------------------
+# Gates the v2 design_systems registry path (legacy v1 path runs if
+# unset). Different flag from DESIGN_CONTEXT_ENABLED.
+FEATURE_DESIGN_SYSTEM_V2=
+
+# Gates DESIGN-DISCOVERY context injection in brief-runner. true =
+# inject design_tokens + concept HTML into prompts; unset = legacy
+# generation path.
+DESIGN_CONTEXT_ENABLED=
+
+
+# -----------------------------------------------------------------------------
+# Logging + observability (OPTIONAL — degrades gracefully when unset)
+# -----------------------------------------------------------------------------
+# Logger level: "debug" | "info" | "warn" | "error". Default "info".
+LOG_LEVEL=
+
+# Sentry — leave unset to no-op. Set both DSN env vars together.
+SENTRY_DSN=
+
+# Axiom log shipper — leave both unset to fall back to in-memory transport.
+AXIOM_TOKEN=
+AXIOM_DATASET=
+
+# Langfuse — observability for Anthropic calls. Leave unset to skip
+# tracing (the SDK gracefully no-ops).
+LANGFUSE_HOST=
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+
+# Upstash Redis (rate limiting). Both must be set or the rate limiter
+# fails open (no limiting). Setting only one is invalid.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+
+# -----------------------------------------------------------------------------
+# Vercel API access (OPTIONAL — only used by optimiser sync of Vercel logs)
+# -----------------------------------------------------------------------------
+# Required when /api/cron/optimiser-sync-vercel-logs is enabled. Pulls
+# request logs into the optimiser scoring pipeline.
+VERCEL_API_TOKEN=
+VERCEL_PROJECT_ID=
+VERCEL_TEAM_ID=
+
+
+# -----------------------------------------------------------------------------
+# Optimiser module (OPTIONAL — module is dormant unless these are set)
+# -----------------------------------------------------------------------------
+# Feature flags for optimiser sub-features.
+OPT_AUTO_IMPORT_ENABLED=
+OPT_PATTERN_LIBRARY_ENABLED=
+
+# Email backend for optimiser notifications. Currently "sendgrid".
+OPTIMISER_EMAIL_PROVIDER=
+
+# Per-client daily caps for the regen pipeline.
+REGEN_DAILY_BUDGET_CENTS=
+
+# Google Ads integration credentials (OAuth dance + dev token).
+GOOGLE_ADS_CLIENT_ID=
+GOOGLE_ADS_CLIENT_SECRET=
+GOOGLE_ADS_DEVELOPER_TOKEN=
+
+# PageSpeed Insights API key (Lighthouse-style scoring).
+PSI_API_KEY=
+
+# Opollo hosting bridge (LeadSource customer slice deploys).
+OPOLLO_HOSTING_HOST=
+OPOLLO_HOSTING_USER=
+OPOLLO_HOSTING_KEY=
+
+# Spend cap on the iStock seed image library.
+ISTOCK_SEED_CAP_CENTS=

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -615,32 +615,44 @@ function check6_envVars(): Issue[] {
     if (m) declared.add(m[1]);
   }
 
-  // Extract referenced env vars in app + lib.
+  // Extract referenced env vars in app + lib. Two access patterns:
+  //   - Direct: `process.env.X`
+  //   - Via helper: `requireEnv("X")` / `getEnv("X")` / `readEnv("X")`
+  // The helper-based path is what hard-throws on cold start when a
+  // critical env var is missing; both patterns count.
   const referenced = new Map<string, string>(); // name → first file:line
-  const envRe = /process\.env\.([A-Z][A-Z0-9_]*)/g;
+  const envPatterns = [
+    /process\.env\.([A-Z][A-Z0-9_]*)/g,
+    /(?:requireEnv|getEnv|readEnv)\(\s*["']([A-Z][A-Z0-9_]*)["']/g,
+  ];
   for (const root of ["app", "lib"]) {
     const dir = join(REPO_ROOT, root);
     if (!existsSync(dir)) continue;
     for (const file of walkFiles(dir, [".ts", ".tsx"])) {
       if (file.includes("__tests__")) continue;
       const src = readSafe(file);
-      let m;
-      while ((m = envRe.exec(src)) !== null) {
-        const name = m[1];
-        if (!referenced.has(name)) {
-          const lineIdx = src.slice(0, m.index).split("\n").length;
-          referenced.set(name, `${relPath(file)}:${lineIdx}`);
+      for (const re of envPatterns) {
+        re.lastIndex = 0;
+        let m;
+        while ((m = re.exec(src)) !== null) {
+          const name = m[1];
+          if (!referenced.has(name)) {
+            const lineIdx = src.slice(0, m.index).split("\n").length;
+            referenced.set(name, `${relPath(file)}:${lineIdx}`);
+          }
         }
       }
     }
   }
 
-  // Allow-list — these are framework / Vercel / Node built-ins that don't
-  // need declaring in .env.example.
+  // Allow-list — framework / Vercel / Node built-ins that don't need
+  // declaring in .env.example. Vercel injects these automatically.
   const ALLOWLIST = new Set([
     "NODE_ENV",
     "VERCEL_ENV",
     "VERCEL_URL",
+    "VERCEL_GIT_COMMIT_SHA",
+    "VERCEL_DEPLOYMENT_ID",
     "CI",
     "PORT",
     "NEXT_RUNTIME",


### PR DESCRIPTION
## Summary

PLATFORM-AUDIT workstream **PR 5 of 8** — Env-var coverage.

The PR1 first run flagged \`.env.example missing\` as the only LOW finding. This PR creates the template enumerating every env var the codebase references, organised by component, and refines the audit to recognise both access patterns.

## Changes

### 1. Audit script — recognise \`requireEnv()\` helper

\`scripts/audit.ts\` \`check6_envVars\` now matches both patterns:
- Direct: \`process.env.X\`
- Via helper: \`requireEnv("X")\` / \`getEnv("X")\` / \`readEnv("X")\`

Without this, vars like \`SUPABASE_SERVICE_ROLE_KEY\` (accessed via \`requireEnv()\` only — see \`lib/supabase.ts:22\`) would falsely show as "declared but no reference" once the \`.env.example\` landed.

Also added \`VERCEL_GIT_COMMIT_SHA\` and \`VERCEL_DEPLOYMENT_ID\` to the framework allowlist (Vercel injects these automatically; no need to declare).

### 2. \`.env.example\` template

47 env vars enumerated and grouped:

| Section | Vars | Notes |
|---|---|---|
| Supabase | URL, ANON_KEY, SERVICE_ROLE_KEY, DB_URL | All HARD |
| Site origin + auth | NEXT_PUBLIC_SITE_URL, FEATURE_SUPABASE_AUTH, AUTH_2FA_ENABLED, COOKIE_SIGNING_SECRET, IP_HASH_PEPPER | Site origin HARD in prod; flags optional |
| Anthropic | ANTHROPIC_API_KEY | HARD |
| Cron + ops | CRON_SECRET, OPOLLO_EMERGENCY_KEY | Both HARD |
| Encryption | OPOLLO_MASTER_KEY | HARD |
| Cloudflare Images | ACCOUNT_ID, IMAGES_API_TOKEN, IMAGES_HASH | HARD; HASH is the one UAT.md flags as HIGH-priority |
| WordPress source | LEADSOURCE_WP_* (3) + NEXT_PUBLIC_LEADSOURCE_WP_URL | HARD; PUBLIC must match private |
| SendGrid | API_KEY, FROM_EMAIL, FROM_NAME | HARD when invites/2FA used |
| Feature flags | FEATURE_DESIGN_SYSTEM_V2, DESIGN_CONTEXT_ENABLED | Optional |
| Observability | LOG_LEVEL, SENTRY_DSN, AXIOM_*, LANGFUSE_*, UPSTASH_REDIS_* | All optional, degrade gracefully |
| Vercel API | VERCEL_API_TOKEN, PROJECT_ID, TEAM_ID | Optional, only for log sync |
| Optimiser | 11 vars (feature flags, Google Ads, PSI, hosting, iStock cap) | Optional, module dormant unless set |

Each section has a one-line note on what depends on the var and whether it's HARD (throws on cold start) or OPTIONAL (degrades gracefully).

## Audit summary

Before PR5 (post-PR4):
\`\`\`
Total: 4 HIGH, 42 MEDIUM, 1 LOW (47 issues)
\`\`\`

After PR5:
\`\`\`
Total: 4 HIGH, 42 MEDIUM, 0 LOW (46 issues)
\`\`\`

\`env-vars\` LOW: **1 → 0**. The remaining 4 HIGH (migration-ordering) and 42 MEDIUM are PR 6+ territory or already-deferred ambiguous cases (per PR4 rationale).

## Test plan

- [x] Lint clean
- [x] Typecheck clean
- [x] Build clean
- [x] Audit re-run shows env-vars 1 → 0
- [ ] CI \`static-audit\` job — still fails on the 4 migration-ordering HIGH (pre-existing); no regression.

## Risks identified and mitigated

- **Empty placeholder values:** \`.env.example\` ships with empty values (\`KEY=\`). Operators copying to \`.env.local\` must fill in real values; the audit script doesn't gate on emptiness because that would block valid "intentionally unset" cases (e.g. SENTRY_DSN being unset to disable Sentry locally).
- **NEXT_PUBLIC_SITE_URL pre-filled with localhost:** harmless dev default. Production sets the real domain via Vercel; that's documented in CLAUDE.md.
- **Some optimiser-only vars listed even though optimiser is dormant:** declared explicitly so cold-start failures surface during onboarding rather than at first invocation. The audit's "dead var" warning would otherwise prompt removing them, which would mask the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)