### PR TITLE
feat(nav): role-aware sidebar fixes (PLATFORM-AUDIT PR7)

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -33,11 +33,19 @@ export default async function AdminLayout({
 
   const user = access.user;
 
-  // The Users link is admin-only when the flag is on. Under flag-off /
-  // kill-switch, `user` is null and the Basic Auth operator has root-
-  // level trust already — show the link rather than break the admin
-  // surface during a break-glass outage.
-  const showUsersLink = !user || user.role === "admin";
+  // PLATFORM-AUDIT PR7 — role-aware nav.
+  //
+  // Under flag-off / kill-switch, `user` is null and the Basic Auth
+  // operator has root-level trust already — surface every nav link.
+  //
+  // Under flag-on, gate by role. The previous code path used
+  // `user.role === "admin"` only, which silently excluded super_admin
+  // from the Users link (UAT-found bug). Now both super_admin AND admin
+  // see operator-management surfaces; super_admin alone sees the
+  // sub-tier admin tools (audit log, email test).
+  const isAdminTier =
+    !user || user.role === "admin" || user.role === "super_admin";
+  const isSuperAdmin = !user || user.role === "super_admin";
 
   // Cookie value drives initial collapse state. Default false (expanded)
   // when the cookie is absent — first-time operators get the full rail.
@@ -55,7 +63,8 @@ export default async function AdminLayout({
       </a>
       <AdminSidebar
         user={user}
-        showUsersLink={showUsersLink}
+        isAdminTier={isAdminTier}
+        isSuperAdmin={isSuperAdmin}
         initialCollapsed={initialCollapsed}
       />
       <main

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -4,16 +4,20 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
+  Building2,
   ChevronsLeft,
   ChevronsRight,
+  FileText,
   Globe,
   Image as ImageIcon,
   KeyRound,
   Laptop,
   LogOut,
+  Mail,
   Menu,
   PenSquare,
   Settings,
+  ShieldCheck,
   Users,
   Workflow,
   X,
@@ -57,7 +61,14 @@ type NavLink = {
 
 interface AdminSidebarProps {
   user: SessionUser | null;
-  showUsersLink: boolean;
+  /** Operator-tier roles (admin or super_admin) — sees the operator-
+   *  management surfaces (Users, Companies). PLATFORM-AUDIT PR7
+   *  replaced the old `showUsersLink` boolean with the richer
+   *  isAdminTier / isSuperAdmin pair. */
+  isAdminTier: boolean;
+  /** Top-tier role only — sees the super_admin-only surfaces
+   *  (Audit log, Email test). */
+  isSuperAdmin: boolean;
   /** R2 fix — cookie-driven initial state from the server layout so
    *  SSR matches the first client render and there's no flash. */
   initialCollapsed?: boolean;
@@ -65,7 +76,8 @@ interface AdminSidebarProps {
 
 export function AdminSidebar({
   user,
-  showUsersLink,
+  isAdminTier,
+  isSuperAdmin,
   initialCollapsed = false,
 }: AdminSidebarProps) {
   const pathname = usePathname();
@@ -132,7 +144,7 @@ export function AdminSidebar({
       icon: ImageIcon,
       testId: "nav-images",
     },
-    ...(showUsersLink
+    ...(isAdminTier
       ? [
           {
             label: "Users",
@@ -140,9 +152,36 @@ export function AdminSidebar({
             icon: Users,
             testId: "nav-users",
           },
+          {
+            label: "Companies",
+            href: "/admin/companies",
+            icon: Building2,
+            testId: "nav-companies",
+          },
         ]
       : []),
   ];
+
+  // PLATFORM-AUDIT PR7 — super_admin-only "Admin" sub-section. These
+  // pages exist but had no nav entry, so they were unreachable except by
+  // typing the URL. Surface them as a separate tier in the rail rather
+  // than mixing them with the operator-management top-level links.
+  const adminLinks: NavLink[] = isSuperAdmin
+    ? [
+        {
+          label: "Audit log",
+          href: "/admin/users/audit",
+          icon: ShieldCheck,
+          testId: "nav-audit-log",
+        },
+        {
+          label: "Email test",
+          href: "/admin/email-test",
+          icon: Mail,
+          testId: "nav-email-test",
+        },
+      ]
+    : [];
 
   function isActiveRoute(href: string): boolean {
     return pathname === href || pathname.startsWith(href + "/");
@@ -271,6 +310,54 @@ export function AdminSidebar({
                 );
               })}
             </ul>
+
+            {/* Super_admin-only Admin sub-section. Separator label
+                hidden when the rail is collapsed. */}
+            {adminLinks.length > 0 && (
+              <>
+                <div className="mt-4 mb-1 px-2.5">
+                  {!collapsed && (
+                    <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+                      Admin
+                    </p>
+                  )}
+                </div>
+                <ul className="space-y-0.5">
+                  {adminLinks.map(({ label, href, icon: Icon, testId }) => {
+                    const active = isActiveRoute(href);
+                    return (
+                      <li key={href}>
+                        <Link
+                          href={href}
+                          data-testid={testId}
+                          aria-current={active ? "page" : undefined}
+                          title={collapsed ? label : undefined}
+                          className={cn(
+                            "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                            active
+                              ? "bg-muted font-medium text-foreground"
+                              : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+                          )}
+                        >
+                          <Icon
+                            aria-hidden
+                            className={cn(
+                              "h-4 w-4 shrink-0",
+                              active
+                                ? "text-foreground"
+                                : "text-muted-foreground group-hover:text-foreground",
+                            )}
+                          />
+                          {!collapsed && (
+                            <span className="truncate">{label}</span>
+                          )}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            )}
           </nav>
 
           {/* Footer rail — ⌘K hint + user menu */}


### PR DESCRIPTION
## Summary

PLATFORM-AUDIT workstream **PR 7 of 8** — Navigation audit. Three changes to the admin sidebar and its role-gating logic.

## 1. Critical bug fix — super_admin sees Users link

\`app/admin/layout.tsx:40\` had:
\`\`\`ts
const showUsersLink = !user || user.role === "admin";
\`\`\`

This silently excluded super_admin from the Users nav link. UAT-found: Steven (super_admin) could not see Users in the sidebar because the gate required \`user.role === "admin"\` exactly.

Replaced the boolean with two role booleans:
\`\`\`ts
const isAdminTier  = !user || user.role === "admin" || user.role === "super_admin";
const isSuperAdmin = !user || user.role === "super_admin";
\`\`\`

## 2. Add Companies nav entry

\`/admin/companies\` (P3-1 platform companies list, gated by the same admin-tier check) had no nav entry — operators had to type the URL. Now appears in the primary rail next to Users for admin + super_admin.

## 3. Add super_admin "Admin" sub-section

Two super_admin-only pages were unreachable except by typing the URL:
- \`/admin/users/audit\` (P3-3 audit log viewer)
- \`/admin/email-test\` (P1 SendGrid debug surface)

Both now appear under a separated **"Admin"** label in the rail, visible only to super_admin. Matches the brief's Step 5 role spec:
- super_admin: Sites, Users, Images, **Admin**
- admin: Sites, Users, Images
- user: Sites, Images

The dead-route detector from PR 6 had flagged both \`/admin/email-test\` and \`/admin/users/audit\` as routes with 0 inbound references — this PR closes those gaps.

## Sidebar prop change

\`AdminSidebar\` now takes:
- \`isAdminTier: boolean\` (admin OR super_admin)
- \`isSuperAdmin: boolean\` (super_admin only)

Replacing the previous \`showUsersLink: boolean\`. Single callsite in \`app/admin/layout.tsx\`; verified via grep there are no other consumers.

## Final nav structure

**Primary rail (always visible):**
- Sites, Post a blog, Batches, Images

**Primary rail (admin tier — admin or super_admin):**
- Users, Companies

**Admin sub-section (super_admin only):**
- Audit log, Email test

**Footer rail (any signed-in user):**
- Account security, Trusted devices, Back to builder, Sign out

## Out of scope (deferred to follow-up)

The brief's Step 4 also called for *"each site detail page must have clear sub-navigation to: Briefs, Posts, Design System, Appearance, Settings, Images"*. The site detail page currently links to Design System / Appearance / Settings via inline cards but has no consolidated tab strip for Briefs list / Posts / per-site Images. That's a substantial UI redesign — separate PR.

## Test plan

- [x] Lint clean
- [x] Typecheck clean
- [x] Build clean
- [ ] Manual smoke on staging:
  - Sign in as super_admin → see Users, Companies in primary rail; see "Admin" subhead with Audit log + Email test
  - Sign in as admin → see Users, Companies in primary rail; no Admin subhead
  - Sign in as user → see only Sites/Post-a-blog/Batches/Images
- [ ] CI \`static-audit\` job — still fails on 4 migration-ordering HIGH (pre-existing); no regression. Audit dead-route hits drop by 2 (Audit log, Email test now reachable).

## Risks identified and mitigated

- **Sidebar visual hierarchy:** the new "Admin" subhead introduces a new tier of visual structure. Used the existing typography conventions (uppercase tracking-wide muted text) consistent with the rest of the rail. Mobile drawer keeps the same scroll layout.
- **Companies might surface to operators who shouldn't see it:** \`/admin/companies\` is gated at admin tier, which matches what the new nav entry surfaces. No ACL widening.
- **Layout prop signature change is a one-call-site refactor:** verified via grep that no other component takes \`showUsersLink\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)