### PR TITLE
fix(audit): sql comment strip + zero high baseline + docs (PLATFORM-AUDIT PR8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,11 @@ SENDGRID_API_KEY=
 SENDGRID_FROM_EMAIL=
 SENDGRID_FROM_NAME=
 
+# Comma-separated email-only recipients always copied on platform-admin
+# alerts. Use for inboxes that aren't backed by a platform user account
+# (e.g. ops@opollo.com, on-call rotations). Empty = staff users only.
+PLATFORM_ADMIN_ALERT_EMAILS=
+
 
 # -----------------------------------------------------------------------------
 # Feature flags (OPTIONAL — defaults documented per flag)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ A plan without a populated "Risks identified and mitigated" section is not ready
 - `npm run test` — Vitest
 - `npm run test:coverage` — Vitest with V8 coverage (60% line / 55% branch baseline)
 - `npm run test:e2e` — Playwright (requires `supabase start`)
+- `npm run audit:static` — static-analysis script (`scripts/audit.ts`) catching middleware/auth/db/migration/typography/env-var/error-handling/dead-route class errors before runtime. **HIGH severity gates CI.** Per `docs/RULES.md` rule #8 — see also the PLATFORM-AUDIT workstream PRs (#386, #389, #392, #394, #396, #398, #400, #402).
 - `npm run analyze` — production build with @next/bundle-analyzer reports
 
 ## DX hygiene

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -62,6 +62,14 @@ Sort: strongest "if you skip this, production breaks" signal at the top.
 
 ---
 
+## 8. Pre-merge checklist — `npm run audit:static` HIGH must be zero
+
+**Rule.** Every PR MUST pass the `static-audit` CI job — i.e. `npm run audit:static` exits with code 0 (no HIGH severity issues). The script lives at `scripts/audit.ts` and runs nine checks (HIGH severity: middleware-public-paths, migration-ordering, unauthenticated-api; MEDIUM: admin-api-gate, db-column-references, error-handling; LOW: typography-minimums, env-vars, dead-routes). HIGH severity gates the build; MEDIUM/LOW are advisory. If a HIGH hit is a genuine false positive, the fix is to refine the heuristic in the audit script itself — never bypass with `// audit:ignore` or similar (no such mechanism exists by design). If the audit reports a new MEDIUM or LOW class on a PR, address it in the same PR or open a follow-up; don't let the warning count drift up.
+
+**Incident (PLATFORM-AUDIT 2026-05-02).** UAT surfaced three logic-error classes that cost a half-day each to debug at runtime — middleware-public-path miss (invite acceptance link bounced to /login), admin API gate excluding super_admin (invite submit returned `Role 'super_admin' is not permitted`), and missing-column writes to `sites.updated_by` (mode save returned masked 500). All three would have been caught by static analysis. The PLATFORM-AUDIT workstream (PRs #386, #389, #392, #394, #396, #398, #400) shipped the audit script + CI integration + fixes for every HIGH finding the first run produced (38 → 0). Going forward, CI catches these classes at PR time, not at UAT time.
+
+---
+
 ## Adding a new rule
 
 - If a recurring shape with scaffolding emerges, that's a pattern — put it in `docs/patterns/`, not here.

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -463,8 +463,24 @@ function check4_migrationOrdering(): Issue[] {
   const refRe =
     /REFERENCES\s+(?:public\.)?["']?([a-zA-Z_][a-zA-Z0-9_]*)["']?/gi;
 
+  // Reserved SQL keywords / common prose words that follow "REFERENCES"
+  // in comment text. Filtering by lowercase to catch any case mix.
+  const PROSE_TOKENS = new Set([
+    "the", "this", "that", "these", "those", "it", "its",
+    "resolve", "resolves", "table", "row", "column", "user",
+    "users", "to", "above", "below", "earlier", "later",
+  ]);
+
   for (const f of files) {
-    const src = readSafe(join(migDir, f));
+    let src = readSafe(join(migDir, f));
+
+    // Strip SQL comments before regex matching. Two flavours:
+    //   - line comments  `-- ...` to end of line
+    //   - block comments `/* ... */` (multi-line)
+    // Without this, prose references inside comments produce false
+    // positives (e.g. "REFERENCES the parent table" → "the" flagged).
+    src = src.replace(/\/\*[\s\S]*?\*\//g, "");
+    src = src.replace(/--[^\n]*/g, "");
 
     // Local creates first (a migration can self-reference within its own body).
     const localCreated = new Set<string>();
@@ -483,6 +499,10 @@ function check4_migrationOrdering(): Issue[] {
       // Self-references to auth.* or pg_catalog.* are out of scope.
       if (target === "auth" || target.startsWith("pg_")) continue;
       if (created.has(target) || localCreated.has(target)) continue;
+      // Filter out comment-prose false positives — even with comment
+      // stripping, "REFERENCES" can appear inline in DO-block strings or
+      // string literals where the next word is prose.
+      if (PROSE_TOKENS.has(target.toLowerCase())) continue;
       const lineIdx = src.slice(0, rm.index).split("\n").length;
       issues.push({
         category: "migration-ordering",


### PR DESCRIPTION
## Summary

PLATFORM-AUDIT workstream **PR 8 of 8** — final run + docs. Closes out the workstream by reaching the brief's *"all HIGH severity issues must be zero"* criterion and documenting the audit script as a load-bearing pre-merge check.

## Changes

### 1. SQL comment stripping in \`check4_migrationOrdering\`

The 4 remaining HIGH issues at PR 7's close-out were all false positives:

\`\`\`
supabase/migrations/0004_m2a_auth_link.sql:66 — FK REFERENCES 'resolve'
supabase/migrations/0010_m4_1_image_library_schema.sql:45 — FK REFERENCES 'it'
supabase/migrations/0014_drop_dead_schema.sql:2 — FK REFERENCES 'these'
supabase/migrations/0053_optimiser_brief_submission.sql:57 — FK REFERENCES 'the'
\`\`\`

The regex matched the literal word "REFERENCES" inside SQL line comments / block comments, where the next token was prose like *"REFERENCES the parent table"* or *"REFERENCES it"* in commit-style migration headers.

Fix: strip \`--\` line comments and \`/* ... */\` block comments before regex matching. Plus a small \`PROSE_TOKENS\` allowlist (\`the / this / that / these / those / it / its / resolve / table / row / column / user / users\`) to filter inline prose-after-REFERENCES patterns inside DO-block string literals where the comment-strip can't reach.

### 2. \`.env.example\` — add \`PLATFORM_ADMIN_ALERT_EMAILS\`

New env var added during the workstream by P3 platform work in \`lib/platform/notifications/recipients.ts:67\`. Comma-separated email-only recipients always copied on platform-admin alerts.

### 3. Documentation

- **\`docs/RULES.md\`** — new rule #8 *"Pre-merge checklist — \`npm run audit:static\` HIGH must be zero"*. Cites all 8 workstream PRs and the three logic-error classes UAT surfaced (middleware-public-path miss, admin-gate excluding super_admin, missing-column writes to \`sites.updated_by\`).
- **\`CLAUDE.md\`** — add \`npm run audit:static\` to the Commands list with a note that HIGH severity gates CI.

## Final audit summary

\`\`\`
                  HIGH   MEDIUM   LOW    Total
PR1 first run:    38     110      3      152
PR8 final:         0      42     13       55
\`\`\`

The 42 MEDIUM and 13 LOW are heuristic-tolerant or operator-decision work — none gate CI:

| Category | Count | Why deferred |
|---|---|---|
| db-column-references | 32 MEDIUM | Regex parser noise on multi-line CREATE TABLE bodies; tightening the SQL parser is its own slice |
| error-handling | 9 MEDIUM | Fire-and-forget patterns inside terminal-failure handlers and audit-event helpers; per-callsite \`// audit:fire-and-forget\` markers are a follow-up |
| dead-routes | 13 LOW | Candidates surfaced for review; Anthropic tool-use schemas + ops curl callers can't be statically detected |
| admin-api-gate | 1 MEDIUM | New emerged hit on a recent platform PR; minor follow-up |
| env-vars | 0 LOW | All references match \`.env.example\` |
| typography | 0 LOW | Phase 1 sweep complete; Phase 2 in BACKLOG |
| migration-ordering | 0 HIGH | Comment stripping eliminates the 4 false positives |
| middleware-public-paths | 0 HIGH | Fix #384 closed the only one |
| unauthenticated-api | 0 HIGH | PR3 fixed 2 real bugs + audit recognises more auth patterns |

## Workstream summary

| PR | Title | Sha |
|---|---|---|
| #386 | feat(audit): static analysis script + CI integration | 1f77a6c |
| #389 | fix(audit): typography check skips comment context | 6677f82 |
| #392 | fix(auth): explicit gates + close 2 unauthed routes | bda9d24 |
| #394 | fix(audit): refine error-handling heuristic | af65d45 |
| #396 | feat(env): create .env.example template | 391c611 |
| #398 | feat(audit): dead-route detector + pageRouteFromFile bugfix | 2ce1c7b |
| #400 | feat(nav): role-aware sidebar fixes | 04dc623 |
| #402 | (this PR) sql comment strip + zero high baseline + docs | tbd |

## Test plan

- [x] Lint clean
- [x] Typecheck clean
- [x] Build clean
- [x] Audit re-run on origin/main: \`Total: 0 HIGH, 42 MEDIUM, 13 LOW (55 issues) — Exit 0\`
- [ ] CI \`static-audit\` job passes (Exit 0) — first time since the workstream started

🤖 Generated with [Claude Code](https://claude.com/claude-code)