### PR TITLE
fix(audit): strip SQL comments + strings before migration-ordering regex

### DIFF
--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -424,6 +424,104 @@ function check3_dbColumnReferences(): Issue[] {
 // Check 4 — Migration ordering (HIGH)
 // ============================================================================
 
+/**
+ * Strip Postgres comments + single-quoted string literals from SQL source so
+ * the structural regexes don't match the word "references" inside `--` line
+ * comments, `/​* ... *​/` block comments, or `COMMENT ON ... IS '...'`
+ * strings. Preserves line breaks and total length so byte offsets used by
+ * `src.slice(0, m.index).split("\n").length` keep reporting the correct
+ * line number.
+ *
+ *   '...' — handles the doubled-quote escape (`''`) inside strings.
+ *   $$...$$ — Postgres dollar-quoted strings (with optional tag).
+ *
+ * Whitespace replacement is a single space per stripped char so column
+ * positions only matter for line counting; not pretty but accurate.
+ */
+function stripSqlCommentsAndStrings(src: string): string {
+  let i = 0;
+  const out: string[] = [];
+  const len = src.length;
+
+  while (i < len) {
+    const ch = src[i];
+    const next = src[i + 1];
+
+    // Line comment: `--` to end of line.
+    if (ch === "-" && next === "-") {
+      while (i < len && src[i] !== "\n") {
+        out.push(src[i] === "\n" ? "\n" : " ");
+        i++;
+      }
+      continue;
+    }
+
+    // Block comment: `/​* ... *​/` (no nesting handled — Postgres allows
+    // nesting but the migrations don't use it).
+    if (ch === "/" && next === "*") {
+      out.push("  ");
+      i += 2;
+      while (i < len) {
+        if (src[i] === "*" && src[i + 1] === "/") {
+          out.push("  ");
+          i += 2;
+          break;
+        }
+        out.push(src[i] === "\n" ? "\n" : " ");
+        i++;
+      }
+      continue;
+    }
+
+    // Single-quoted string: handle `''` doubled-quote escape.
+    if (ch === "'") {
+      out.push(" ");
+      i++;
+      while (i < len) {
+        if (src[i] === "'" && src[i + 1] === "'") {
+          out.push("  ");
+          i += 2;
+          continue;
+        }
+        if (src[i] === "'") {
+          out.push(" ");
+          i++;
+          break;
+        }
+        out.push(src[i] === "\n" ? "\n" : " ");
+        i++;
+      }
+      continue;
+    }
+
+    // Dollar-quoted string: `$tag$ ... $tag$` or `$$ ... $$`.
+    if (ch === "$") {
+      const tagMatch = src.slice(i).match(/^\$([A-Za-z_][A-Za-z0-9_]*)?\$/);
+      if (tagMatch) {
+        const tag = tagMatch[0];
+        const tagLen = tag.length;
+        out.push(" ".repeat(tagLen));
+        i += tagLen;
+        while (i < len) {
+          if (src.startsWith(tag, i)) {
+            out.push(" ".repeat(tagLen));
+            i += tagLen;
+            break;
+          }
+          out.push(src[i] === "\n" ? "\n" : " ");
+          i++;
+        }
+        continue;
+      }
+    }
+
+    out.push(ch);
+    i++;
+  }
+
+  return out.join("");
+}
+
 function check4_migrationOrdering(): Issue[] {
   const issues: Issue[] = [];
   const migDir = join(REPO_ROOT, "supabase", "migrations");
@@ -461,7 +559,13 @@ function check4_migrationOrdering(): Issue[] {
     /REFERENCES\s+(?:public\.)?["']?([a-zA-Z_][a-zA-Z0-9_]*)["']?/gi;
 
   for (const f of files) {
-    const src = readSafe(join(migDir, f));
+    const rawSrc = readSafe(join(migDir, f));
+    // Strip comments + string literals before structural matching. The
+    // word "references" appears in plenty of `-- ... references ...`
+    // doc comments and inside `COMMENT ON COLUMN ... IS '... references
+    // the opt_proposals row ...'`-style strings; without the strip the
+    // regex below false-positives on every one of those.
+    const src = stripSqlCommentsAndStrings(rawSrc);
 
     // Local creates first (a migration can self-reference within its own body).
     const localCreated = new Set<string>();


### PR DESCRIPTION
## Summary

Closes the four false-positive HIGH issues that have been failing CI's `static-audit` job since PR #386 wired the script in. All four are matches against the English word "references" inside SQL comments / column-comment strings — not real FK ordering issues.

| File | Match site |
|---|---|
| `0004_m2a_auth_link.sql:66` | `-- ...unqualified references resolve predictably` |
| `0010_m4_1_image_library_schema.sql:45` | `-- ...image_usage row references it` |
| `0014_drop_dead_schema.sql:2` | `-- Audit confirmed no application code references these tables:` |
| `0053_optimiser_brief_submission.sql:57` | `COMMENT ON COLUMN ... IS '...this references the opt_proposals row...'` |

The structural regex in `check4_migrationOrdering` was running against the raw source — picking up `references resolve` / `references it` / `references these` / `references the` as `REFERENCES <ident>`. None of those tables (`resolve`, `it`, `these`, `the`) exist; all four false-positived as HIGH FK ordering breaks.

## What this PR adds

- **`stripSqlCommentsAndStrings(src)`** — small pre-pass that replaces the contents of `--` line comments, `/​*…*​/` block comments, `'…'` single-quoted strings (with `''` escape), and `$tag$…$tag$` dollar-quoted blocks with whitespace. Preserves `\n` and total length so the existing `src.slice(0, m.index).split("\n").length` line-number reporting keeps working.
- **Wired into Check 4 only.** Other checks operate on TypeScript source where the comment style is different and the false-positive risk is low; out of scope for this PR.

## Net result

- Before: `Total: 4 HIGH, 42 MEDIUM, 1 LOW / Exit 1 — at least one HIGH severity issue. CI gate fails.`
- After: `Total: 0 HIGH, 42 MEDIUM, 1 LOW / Exit 0 — no HIGH severity issues.`

The 33 unauthenticated-api HIGHs I saw on first run last session were from a local checkout that pre-dated the PLATFORM-AUDIT PR3 sites/list + `checkAdminAccess` landings on main; current main is clean in that category.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Stripping strings hides a real FK reference inside a quoted identifier | Postgres FK syntax never wraps the table name in single quotes; case-sensitive identifiers use double quotes, which the existing `["']?` group already handles. |
| Dollar-quoted plpgsql function bodies contain `REFERENCES` mentions in docstrings | FK constraints live at table-definition level outside function bodies; stripping `$$…$$` blocks is the right call. |
| Line-number accuracy regressed | Stripper writes one whitespace char per stripped char and preserves `\n`; the line-counting `src.slice(0, m.index).split("\n").length` still resolves correctly. Manually re-verified the four migration:line citations remain stable for any future real positive. |
| Real ordering issue silently hidden | The script's primary value is duplicate-version-prefix detection (which already runs against filename only, no comment-stripping needed). The FK ordering pass remains active; only the comment / string regions are bypassed. |

## Test plan

- [x] `npx tsx scripts/audit.ts` → `Total: 0 HIGH, 42 MEDIUM, 1 LOW (43 issues) / Exit 0`
- [x] `npm run lint --max-warnings=0` clean
- [x] `npm run typecheck` clean
- [ ] CI green; auto-merge per routine-merge rule

## What's NOT in this PR

- The 32 `db-column-references` MEDIUMs (`version_lock` / `last_edited_by` on `posts` etc.) are real-looking and worth a separate triage slice; not addressed here.
- The 9 `error-handling` MEDIUMs in the optimiser + regeneration paths are pre-existing and triage-worthy but out of scope (M15-7 / M15-4 #7 BACKLOG territory).
- The 1 LOW for `PLATFORM_ADMIN_ALERT_EMAILS` not being in `.env.example` — surfaced new but trivial; will fold into the next env-doc polish slice if not opportunistically picked up first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)