### PR TITLE
feat(p2-4): invitation reminder + expiry callbacks via QStash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,6 +160,15 @@ LANGFUSE_SECRET_KEY=
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
+# Upstash QStash — delayed-message queue. Drives platform invitation
+# day-3 reminder + day-14 expiry callbacks (P2-4). Unset = callbacks
+# don't fire; invitation rows still get created and the immediate
+# invite email is still sent. CURRENT + NEXT signing keys verify
+# inbound webhooks; NEXT only matters during a key-rotation window.
+QSTASH_TOKEN=
+QSTASH_CURRENT_SIGNING_KEY=
+QSTASH_NEXT_SIGNING_KEY=
+
 
 # -----------------------------------------------------------------------------
 # Vercel API access (OPTIONAL — only used by optimiser sync of Vercel logs)

--- a/.env.local.example
+++ b/.env.local.example
@@ -157,6 +157,17 @@ LANGFUSE_HOST=
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
+# --- Upstash QStash: invitation callbacks (P2-4, optional) ----------------
+# Drives the platform invitation day-3 reminder + day-14 expiry callbacks.
+# When QSTASH_TOKEN is unset, the enqueue step no-ops (invitation row +
+# initial email still succeed); reminders + auto-expiry simply don't
+# fire. CURRENT + NEXT signing keys verify the inbound webhooks under
+# /api/platform/invitations/callbacks/{reminder,expiry}. Provision via
+# the Upstash console; rotate by populating NEXT before swapping CURRENT.
+QSTASH_TOKEN=
+QSTASH_CURRENT_SIGNING_KEY=
+QSTASH_NEXT_SIGNING_KEY=
+
 # --- Log level (optional) --------------------------------------------------
 # debug | info | warn | error. Defaults to "info" in production, "debug"
 # in non-prod. Below-threshold calls are O(1) — no string building.

--- a/app/api/platform/invitations/callbacks/expiry/route.ts
+++ b/app/api/platform/invitations/callbacks/expiry/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { logger } from "@/lib/logger";
+import { handleExpiryCallback } from "@/lib/platform/invitations";
+import { verifyQstashSignature } from "@/lib/qstash";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/invitations/callbacks/expiry — P2-4.
+//
+// QStash invokes this at the invitation's expires_at (~14 days post-
+// creation by default). Verifies the Upstash-Signature header, then:
+//   - Atomically transitions status pending → expired and stamps
+//     expired_notified_at (handleExpiryCallback enforces the
+//     idempotent UPDATE ... WHERE status='pending' clause).
+//   - Dispatches an invitation_expired notification (email-only).
+//
+// Already-accepted or already-revoked invitations are no-ops. The
+// dispatch is gated on the atomic UPDATE returning a row, so duplicate
+// webhook fires never produce duplicate emails.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+const BodySchema = z.object({
+  invitationId: z.string().uuid(),
+});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const rawBody = await req.text();
+
+  const verify = await verifyQstashSignature({
+    signature: req.headers.get("upstash-signature"),
+    rawBody,
+  });
+  if (!verify.ok) {
+    logger.warn("invitations.callback.expiry.unauthorized", {
+      reason: verify.reason,
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code:
+            verify.reason === "no_receiver"
+              ? "RECEIVER_NOT_CONFIGURED"
+              : "INVALID_SIGNATURE",
+          message: "Invalid or missing Upstash-Signature.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: verify.reason === "no_receiver" ? 503 : 401 },
+    );
+  }
+
+  let parsed: z.infer<typeof BodySchema>;
+  try {
+    parsed = BodySchema.parse(JSON.parse(rawBody));
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: `Invalid body: ${err instanceof Error ? err.message : String(err)}`,
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await handleExpiryCallback({
+    invitationId: parsed.invitationId,
+  });
+
+  if (result.outcome === "internal_error") {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: result.message ?? "callback handler failed",
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { outcome: result.outcome, invitationId: result.invitationId },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/platform/invitations/callbacks/reminder/route.ts
+++ b/app/api/platform/invitations/callbacks/reminder/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { logger } from "@/lib/logger";
+import { handleReminderCallback } from "@/lib/platform/invitations";
+import { verifyQstashSignature } from "@/lib/qstash";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/invitations/callbacks/reminder — P2-4.
+//
+// QStash invokes this 3 days after invitation creation with body
+// { invitationId, rawToken }. Verifies the Upstash-Signature header,
+// then dispatches an invitation_reminder notification (email-only,
+// per EVENT_CHANNELS in lib/platform/notifications/types.ts).
+//
+// Idempotency lives in handleReminderCallback: the atomic UPDATE ...
+// WHERE reminder_sent_at IS NULL ensures duplicate webhook fires (a
+// QStash retry, or a network blip causing QStash to re-send) only
+// dispatch one email. Always returns 200 once the signature is
+// verified — QStash retries on 5xx, so a transient DB blip + a 5xx
+// would re-fire and the idempotency layer would handle it cleanly.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+const BodySchema = z.object({
+  invitationId: z.string().uuid(),
+  rawToken: z.string().min(1).optional(),
+});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  // Read raw body for signature verification — must be the exact bytes
+  // QStash signed. Do not consume req.json() before verifying.
+  const rawBody = await req.text();
+
+  const verify = await verifyQstashSignature({
+    signature: req.headers.get("upstash-signature"),
+    rawBody,
+  });
+  if (!verify.ok) {
+    logger.warn("invitations.callback.reminder.unauthorized", {
+      reason: verify.reason,
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code:
+            verify.reason === "no_receiver"
+              ? "RECEIVER_NOT_CONFIGURED"
+              : "INVALID_SIGNATURE",
+          message: "Invalid or missing Upstash-Signature.",
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: verify.reason === "no_receiver" ? 503 : 401 },
+    );
+  }
+
+  let parsed: z.infer<typeof BodySchema>;
+  try {
+    parsed = BodySchema.parse(JSON.parse(rawBody));
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: `Invalid body: ${err instanceof Error ? err.message : String(err)}`,
+          retryable: false,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await handleReminderCallback({
+    invitationId: parsed.invitationId,
+    rawToken: parsed.rawToken,
+  });
+
+  // 200 across the board (including no-ops) so QStash treats the
+  // webhook as delivered and stops retrying. Internal errors return
+  // 500 so QStash retries — the idempotency layer ensures retries
+  // are safe.
+  if (result.outcome === "internal_error") {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: result.message ?? "callback handler failed",
+          retryable: true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { outcome: result.outcome, invitationId: result.invitationId },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/platform/invitations/route.ts
+++ b/app/api/platform/invitations/route.ts
@@ -4,7 +4,10 @@ import { z } from "zod";
 import { sendEmail } from "@/lib/email/sendgrid";
 import { renderPlatformInviteEmail } from "@/lib/email/templates/platform-invite";
 import { logger } from "@/lib/logger";
-import { sendInvitation } from "@/lib/platform/invitations";
+import {
+  enqueueInvitationCallbacks,
+  sendInvitation,
+} from "@/lib/platform/invitations";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -192,6 +195,17 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       { status: 502 },
     );
   }
+
+  // Schedule the day-3 reminder + day-14 expiry callbacks via QStash.
+  // No-op when QSTASH_TOKEN is unset (local dev / unprovisioned envs).
+  // Failures are logged but never fail the parent request — the
+  // invitation row + initial email already succeeded.
+  await enqueueInvitationCallbacks({
+    invitationId: result.invitation.id,
+    rawToken: result.rawToken,
+    expiresAt: result.invitation.expires_at,
+    origin,
+  });
 
   // Strip token-related fields from the response — token_hash isn't
   // included in the select but stay defensive on the shape.

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -9,11 +9,18 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session A
 - Started: 2026-05-03
-- Branch: feat/p5-notifications-dispatcher
-- Slice: P5 — Notifications dispatcher. Single entry point lib/platform/notifications/dispatch.ts that writes platform_notifications + sends email per the trigger table in BUILD.md. Per-event recipient resolution (company admins, opollo admins, submitter, invitee). V1 ships dispatch + recipients + inline templates; the templates/ subfolder + queries.ts (unread/list/mark-read) land with the bell-icon UI in a later slice.
+- Branch: feat/p2-4-invitation-callbacks
+- Slice: P2-4 — invitation reminder + expiry callbacks via QStash. Day-3 reminder + day-14 expiry transitions, idempotent on duplicate webhook fires.
 - Files claimed:
-  - lib/platform/notifications/{types,recipients,dispatch,index}.ts (new)
-  - lib/__tests__/platform-notifications.test.ts (new)
+  - lib/qstash.ts (new)
+  - lib/platform/invitations/callbacks.ts (new)
+  - lib/platform/invitations/index.ts (re-export)
+  - app/api/platform/invitations/route.ts (enqueue on send)
+  - app/api/platform/invitations/callbacks/reminder/route.ts (new webhook)
+  - app/api/platform/invitations/callbacks/expiry/route.ts (new webhook)
+  - lib/__tests__/platform-invitation-callbacks.test.ts (new)
+  - .env.example, .env.local.example (QStash env vars)
+  - package.json + package-lock.json (@upstash/qstash)
   - docs/WORK_IN_FLIGHT.md
 - Migration number reserved: none
 - Expected completion: same session.

--- a/lib/__tests__/platform-invitation-callbacks.test.ts
+++ b/lib/__tests__/platform-invitation-callbacks.test.ts
@@ -1,0 +1,359 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// Mock SendGrid so the dispatcher's email side-effect is observable in
+// the test without firing real network requests. Each test inspects
+// the mock to verify the right number of emails went out.
+vi.mock("@/lib/email/sendgrid", () => ({
+  sendEmail: vi.fn(async (_input: { to: string }) => ({
+    ok: true as const,
+    messageId: `mock-${_input.to}`,
+  })),
+}));
+
+import { sendEmail } from "@/lib/email/sendgrid";
+import {
+  enqueueInvitationCallbacks,
+  generateRawToken,
+  handleExpiryCallback,
+  handleReminderCallback,
+  hashToken,
+} from "@/lib/platform/invitations";
+import { __resetQstashForTests } from "@/lib/qstash";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser, type SeededAuthUser } from "./_auth-helpers";
+
+const mockSendEmail = sendEmail as unknown as ReturnType<typeof vi.fn>;
+
+const COMPANY_A_ID = "abababab-abab-abab-abab-abababababab";
+
+async function insertInvitation(args: {
+  companyId: string;
+  email: string;
+  invitedBy: string | null;
+  status?: "pending" | "accepted" | "revoked" | "expired";
+  expiresAt?: string;
+  reminderSentAt?: string | null;
+  expiredNotifiedAt?: string | null;
+  acceptedAt?: string | null;
+  acceptedUserId?: string | null;
+  revokedAt?: string | null;
+}): Promise<{ id: string; rawToken: string }> {
+  const svc = getServiceRoleClient();
+  const rawToken = generateRawToken();
+  const tokenHash = hashToken(rawToken);
+  const expiresAt =
+    args.expiresAt ??
+    new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString();
+
+  const insert = await svc
+    .from("platform_invitations")
+    .insert({
+      company_id: args.companyId,
+      email: args.email,
+      role: "editor",
+      token_hash: tokenHash,
+      status: args.status ?? "pending",
+      expires_at: expiresAt,
+      invited_by: args.invitedBy,
+      reminder_sent_at: args.reminderSentAt ?? null,
+      expired_notified_at: args.expiredNotifiedAt ?? null,
+      accepted_at: args.acceptedAt ?? null,
+      accepted_user_id: args.acceptedUserId ?? null,
+      revoked_at: args.revokedAt ?? null,
+    })
+    .select("id")
+    .single();
+  if (insert.error) {
+    throw new Error(
+      `insertInvitation: ${insert.error.code ?? "?"} ${insert.error.message}`,
+    );
+  }
+  return { id: insert.data.id as string, rawToken };
+}
+
+async function readInvitation(id: string) {
+  const svc = getServiceRoleClient();
+  const r = await svc
+    .from("platform_invitations")
+    .select(
+      "id, status, reminder_sent_at, expired_notified_at, accepted_at, revoked_at",
+    )
+    .eq("id", id)
+    .single();
+  if (r.error) throw new Error(`readInvitation: ${r.error.message}`);
+  return r.data;
+}
+
+describe("lib/platform/invitations/callbacks", () => {
+  let inviter: SeededAuthUser;
+
+  beforeAll(async () => {
+    inviter = await seedAuthUser({
+      email: "p2-4-inviter@opollo.test",
+      persistent: true,
+    });
+  });
+
+  beforeEach(async () => {
+    mockSendEmail.mockClear();
+    __resetQstashForTests();
+
+    const svc = getServiceRoleClient();
+    const company = await svc
+      .from("platform_companies")
+      .insert({
+        id: COMPANY_A_ID,
+        name: "Acme Co",
+        slug: "p2-4-acme",
+        domain: "p2-4-acme.test",
+        is_opollo_internal: false,
+        timezone: "Australia/Melbourne",
+      })
+      .select("id");
+    if (company.error) {
+      throw new Error(
+        `seed company: ${company.error.code ?? "?"} ${company.error.message}`,
+      );
+    }
+
+    const user = await svc
+      .from("platform_users")
+      .insert({
+        id: inviter.id,
+        email: inviter.email,
+        full_name: "Inviter",
+        is_opollo_staff: false,
+      })
+      .select("id");
+    if (user.error) {
+      throw new Error(
+        `seed inviter: ${user.error.code ?? "?"} ${user.error.message}`,
+      );
+    }
+
+    const membership = await svc
+      .from("platform_company_users")
+      .insert({
+        company_id: COMPANY_A_ID,
+        user_id: inviter.id,
+        role: "admin",
+      })
+      .select("id");
+    if (membership.error) {
+      throw new Error(
+        `seed membership: ${membership.error.code ?? "?"} ${membership.error.message}`,
+      );
+    }
+  });
+
+  afterAll(async () => {
+    const svc = getServiceRoleClient();
+    if (inviter) await svc.auth.admin.deleteUser(inviter.id);
+  });
+
+  describe("handleReminderCallback", () => {
+    it("happy path — dispatches reminder + stamps reminder_sent_at", async () => {
+      const { id, rawToken } = await insertInvitation({
+        companyId: COMPANY_A_ID,
+        email: "newhire@acme.test",
+        invitedBy: inviter.id,
+      });
+
+      const result = await handleReminderCallback({
+        invitationId: id,
+        rawToken,
+      });
+
+      expect(result.outcome).toBe("dispatched");
+      // invitation_reminder is email-only with one recipient (the invitee).
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
+      expect(mockSendEmail.mock.calls[0]?.[0]).toMatchObject({
+        to: "newhire@acme.test",
+      });
+
+      const row = await readInvitation(id);
+      expect(row.reminder_sent_at).not.toBeNull();
+      expect(row.status).toBe("pending");
+    });
+
+    it("idempotent — second fire is noop_already_handled, no second email", async () => {
+      const { id, rawToken } = await insertInvitation({
+        companyId: COMPANY_A_ID,
+        email: "dup-fire@acme.test",
+        invitedBy: inviter.id,
+      });
+
+      const first = await handleReminderCallback({
+        invitationId: id,
+        rawToken,
+      });
+      expect(first.outcome).toBe("dispatched");
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
+
+      const second = await handleReminderCallback({
+        invitationId: id,
+        rawToken,
+      });
+      expect(second.outcome).toBe("noop_already_handled");
+      // Mock was not called a second time — total stays 1.
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it("noop when invitation already accepted — does not email", async () => {
+      const { id, rawToken } = await insertInvitation({
+        companyId: COMPANY_A_ID,
+        email: "already-in@acme.test",
+        invitedBy: inviter.id,
+        status: "accepted",
+        acceptedAt: new Date().toISOString(),
+        acceptedUserId: inviter.id,
+      });
+
+      const result = await handleReminderCallback({
+        invitationId: id,
+        rawToken,
+      });
+      expect(result.outcome).toBe("noop_not_pending");
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it("noop when invitation revoked — does not email", async () => {
+      const { id, rawToken } = await insertInvitation({
+        companyId: COMPANY_A_ID,
+        email: "revoked@acme.test",
+        invitedBy: inviter.id,
+        status: "revoked",
+        revokedAt: new Date().toISOString(),
+      });
+
+      const result = await handleReminderCallback({
+        invitationId: id,
+        rawToken,
+      });
+      expect(result.outcome).toBe("noop_not_pending");
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it("noop when invitation does not exist", async () => {
+      const result = await handleReminderCallback({
+        invitationId: "00000000-0000-0000-0000-000000000999",
+      });
+      expect(result.outcome).toBe("noop_not_found");
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleExpiryCallback", () => {
+    it("happy path — flips status to expired + dispatches notification", async () => {
+      const { id } = await insertInvitation({
+        companyId: COMPANY_A_ID,
+        email: "expired@acme.test",
+        invitedBy: inviter.id,
+      });
+
+      const result = await handleExpiryCallback({ invitationId: id });
+      expect(result.outcome).toBe("dispatched");
+
+      // invitation_expired is email-only; recipients = invitee + inviter.
+      // Inviter exists in this test, so 2 sends.
+      expect(mockSendEmail).toHaveBeenCalledTimes(2);
+      const recipients = mockSendEmail.mock.calls
+        .map((c) => (c[0] as { to: string }).to)
+        .sort();
+      expect(recipients).toEqual(
+        ["expired@acme.test", inviter.email].sort(),
+      );
+
+      const row = await readInvitation(id);
+      expect(row.status).toBe("expired");
+      expect(row.expired_notified_at).not.toBeNull();
+    });
+
+    it("idempotent — second fire is noop_already_handled, no second email batch", async () => {
+      const { id } = await insertInvitation({
+        companyId: COMPANY_A_ID,
+        email: "dup-expiry@acme.test",
+        invitedBy: inviter.id,
+      });
+
+      const first = await handleExpiryCallback({ invitationId: id });
+      expect(first.outcome).toBe("dispatched");
+      const callsAfterFirst = mockSendEmail.mock.calls.length;
+
+      const second = await handleExpiryCallback({ invitationId: id });
+      expect(second.outcome).toBe("noop_already_handled");
+      expect(mockSendEmail).toHaveBeenCalledTimes(callsAfterFirst);
+    });
+
+    it("noop when invitation already accepted — status stays accepted, no email", async () => {
+      const { id } = await insertInvitation({
+        companyId: COMPANY_A_ID,
+        email: "early-accept@acme.test",
+        invitedBy: inviter.id,
+        status: "accepted",
+        acceptedAt: new Date().toISOString(),
+        acceptedUserId: inviter.id,
+      });
+
+      const result = await handleExpiryCallback({ invitationId: id });
+      expect(result.outcome).toBe("noop_not_pending");
+      expect(mockSendEmail).not.toHaveBeenCalled();
+
+      const row = await readInvitation(id);
+      expect(row.status).toBe("accepted");
+      expect(row.expired_notified_at).toBeNull();
+    });
+
+    it("noop when invitation already revoked", async () => {
+      const { id } = await insertInvitation({
+        companyId: COMPANY_A_ID,
+        email: "early-revoke@acme.test",
+        invitedBy: inviter.id,
+        status: "revoked",
+        revokedAt: new Date().toISOString(),
+      });
+
+      const result = await handleExpiryCallback({ invitationId: id });
+      expect(result.outcome).toBe("noop_not_pending");
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it("noop when invitation does not exist", async () => {
+      const result = await handleExpiryCallback({
+        invitationId: "00000000-0000-0000-0000-000000000aaa",
+      });
+      expect(result.outcome).toBe("noop_not_found");
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("enqueueInvitationCallbacks", () => {
+    it("no-ops when QSTASH_TOKEN is unset — returns null ids, does not throw", async () => {
+      const original = process.env.QSTASH_TOKEN;
+      delete process.env.QSTASH_TOKEN;
+      __resetQstashForTests();
+      try {
+        const result = await enqueueInvitationCallbacks({
+          invitationId: "00000000-0000-0000-0000-000000000bbb",
+          rawToken: "irrelevant",
+          expiresAt: new Date(Date.now() + 14 * 24 * 3600 * 1000).toISOString(),
+          origin: "https://example.test",
+        });
+        expect(result.reminderMessageId).toBeNull();
+        expect(result.expiryMessageId).toBeNull();
+      } finally {
+        if (original !== undefined) process.env.QSTASH_TOKEN = original;
+        __resetQstashForTests();
+      }
+    });
+  });
+});

--- a/lib/platform/invitations/callbacks.ts
+++ b/lib/platform/invitations/callbacks.ts
@@ -203,18 +203,23 @@ export async function handleExpiryCallback(args: {
 
   const invitation = lookup.data as Invitation;
 
+  // Idempotency anchor first: expired_notified_at is only set by a
+  // previous successful expiry fire (which also flips status to
+  // 'expired'). Checking it before the status gate gives a precise
+  // "duplicate fire" signal rather than the looser noop_not_pending
+  // we'd return otherwise.
+  if (invitation.expired_notified_at) {
+    return {
+      outcome: "noop_already_handled",
+      invitationId: args.invitationId,
+    };
+  }
+
   if (invitation.status !== "pending") {
     return {
       outcome: "noop_not_pending",
       invitationId: args.invitationId,
       message: `status=${invitation.status}`,
-    };
-  }
-
-  if (invitation.expired_notified_at) {
-    return {
-      outcome: "noop_already_handled",
-      invitationId: args.invitationId,
     };
   }
 

--- a/lib/platform/invitations/callbacks.ts
+++ b/lib/platform/invitations/callbacks.ts
@@ -1,0 +1,373 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { dispatch } from "@/lib/platform/notifications";
+import { getQstashClient } from "@/lib/qstash";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import type { Invitation } from "./types";
+
+// ---------------------------------------------------------------------------
+// P2-4 — invitation reminder + expiry callbacks.
+//
+// QStash publishes a delayed POST to our webhook routes 3 days and 14
+// days after invitation creation. Each handler:
+//   1. Looks up the invitation by id.
+//   2. Returns "no-op" if the invitation is not pending OR the
+//      side-effect column (reminder_sent_at / expired_notified_at) is
+//      already populated. Both rules together make duplicate webhook
+//      fires idempotent — QStash retries on non-2xx, so handlers MUST
+//      be safe to call repeatedly.
+//   3. For expiry: atomically transitions status pending → expired
+//      using `UPDATE ... WHERE status='pending'`. Two concurrent
+//      callback fires both UPDATE; the second affects 0 rows, so only
+//      one notification is dispatched.
+//   4. For reminder: atomically sets reminder_sent_at using
+//      `UPDATE ... WHERE reminder_sent_at IS NULL`. Same race-safe
+//      pattern.
+//   5. Calls dispatch() AFTER the atomic update returned a row, so the
+//      "I won the race" branch is the only one that emails.
+//
+// Why store the side-effect timestamps on the invitation row rather
+// than dedup via a separate webhook-event table? platform_invitations
+// already has reminder_sent_at + expired_notified_at columns, and the
+// rate of fires is low enough that no separate table is justified.
+// social_webhook_events (for bundle.social) is the right pattern when
+// many webhook types share an idempotency anchor — invitation
+// callbacks are 2 events per invitation max.
+// ---------------------------------------------------------------------------
+
+export type CallbackResult = {
+  // What the handler did. Lets the route handler log + the test
+  // assert without inspecting DB state.
+  outcome:
+    | "noop_already_handled"
+    | "noop_not_pending"
+    | "noop_not_found"
+    | "dispatched"
+    | "internal_error";
+  invitationId: string;
+  message?: string;
+};
+
+const ACCEPT_PATH = "/invite";
+
+function buildAcceptUrl(rawTokenPlaceholder: string | null): string {
+  // Reminder path: we don't have the raw token at callback time (only
+  // the hash is stored). The reminder email links to the magic-link
+  // page with the same hash-bound flow — the recipient gets the
+  // accept URL that the original invitation_sent email already
+  // delivered, just nudged again with a "expires soon" lead.
+  //
+  // Implementation: we pass the original raw token through QStash's
+  // body so the reminder email can re-link to /invite/<token>.
+  // This callback handler accepts the token via parameter; if the
+  // caller doesn't pass one, we fall back to the platform's pending-
+  // invitations admin page so the user can request a fresh link.
+  const origin = (process.env.NEXT_PUBLIC_SITE_URL ?? "").replace(/\/+$/, "");
+  if (rawTokenPlaceholder) {
+    return `${origin}${ACCEPT_PATH}/${rawTokenPlaceholder}`;
+  }
+  return `${origin}/invite-help`;
+}
+
+export async function handleReminderCallback(args: {
+  invitationId: string;
+  // QStash's delayed publish carries the raw token in the body so the
+  // reminder email can re-link to the same accept URL. Optional —
+  // an absent token degrades to a fallback URL.
+  rawToken?: string;
+}): Promise<CallbackResult> {
+  const svc = getServiceRoleClient();
+
+  const lookup = await svc
+    .from("platform_invitations")
+    .select(
+      "id, company_id, email, role, status, expires_at, invited_by, accepted_at, accepted_user_id, revoked_at, reminder_sent_at, expired_notified_at, created_at",
+    )
+    .eq("id", args.invitationId)
+    .maybeSingle();
+
+  if (lookup.error) {
+    logger.error("invitations.callback.reminder.lookup_failed", {
+      invitation_id: args.invitationId,
+      err: lookup.error.message,
+    });
+    return {
+      outcome: "internal_error",
+      invitationId: args.invitationId,
+      message: lookup.error.message,
+    };
+  }
+
+  if (!lookup.data) {
+    return { outcome: "noop_not_found", invitationId: args.invitationId };
+  }
+
+  const invitation = lookup.data as Invitation;
+
+  if (invitation.status !== "pending") {
+    return {
+      outcome: "noop_not_pending",
+      invitationId: args.invitationId,
+      message: `status=${invitation.status}`,
+    };
+  }
+
+  if (invitation.reminder_sent_at) {
+    return {
+      outcome: "noop_already_handled",
+      invitationId: args.invitationId,
+    };
+  }
+
+  // Atomic mark-as-sent. WHERE clause makes concurrent fires safe:
+  // only one UPDATE returns a row.
+  const claim = await svc
+    .from("platform_invitations")
+    .update({ reminder_sent_at: new Date().toISOString() })
+    .eq("id", args.invitationId)
+    .is("reminder_sent_at", null)
+    .eq("status", "pending")
+    .select("id")
+    .maybeSingle();
+
+  if (claim.error) {
+    logger.error("invitations.callback.reminder.claim_failed", {
+      invitation_id: args.invitationId,
+      err: claim.error.message,
+    });
+    return {
+      outcome: "internal_error",
+      invitationId: args.invitationId,
+      message: claim.error.message,
+    };
+  }
+
+  if (!claim.data) {
+    // Another fire claimed it first.
+    return {
+      outcome: "noop_already_handled",
+      invitationId: args.invitationId,
+    };
+  }
+
+  const acceptUrl = buildAcceptUrl(args.rawToken ?? null);
+
+  const dispatchResult = await dispatch({
+    event: "invitation_reminder",
+    companyId: invitation.company_id,
+    inviteeEmail: invitation.email,
+    acceptUrl,
+    expiresAt: invitation.expires_at,
+  });
+
+  if (dispatchResult.errors.length > 0) {
+    logger.warn("invitations.callback.reminder.dispatch_partial_failure", {
+      invitation_id: args.invitationId,
+      errors: dispatchResult.errors,
+    });
+  }
+
+  return { outcome: "dispatched", invitationId: args.invitationId };
+}
+
+export async function handleExpiryCallback(args: {
+  invitationId: string;
+}): Promise<CallbackResult> {
+  const svc = getServiceRoleClient();
+
+  const lookup = await svc
+    .from("platform_invitations")
+    .select(
+      "id, company_id, email, role, status, expires_at, invited_by, accepted_at, accepted_user_id, revoked_at, reminder_sent_at, expired_notified_at, created_at",
+    )
+    .eq("id", args.invitationId)
+    .maybeSingle();
+
+  if (lookup.error) {
+    logger.error("invitations.callback.expiry.lookup_failed", {
+      invitation_id: args.invitationId,
+      err: lookup.error.message,
+    });
+    return {
+      outcome: "internal_error",
+      invitationId: args.invitationId,
+      message: lookup.error.message,
+    };
+  }
+
+  if (!lookup.data) {
+    return { outcome: "noop_not_found", invitationId: args.invitationId };
+  }
+
+  const invitation = lookup.data as Invitation;
+
+  if (invitation.status !== "pending") {
+    return {
+      outcome: "noop_not_pending",
+      invitationId: args.invitationId,
+      message: `status=${invitation.status}`,
+    };
+  }
+
+  if (invitation.expired_notified_at) {
+    return {
+      outcome: "noop_already_handled",
+      invitationId: args.invitationId,
+    };
+  }
+
+  // Atomic transition: pending → expired + stamp expired_notified_at.
+  // Concurrent fires: only one UPDATE affects a row.
+  const claim = await svc
+    .from("platform_invitations")
+    .update({
+      status: "expired",
+      expired_notified_at: new Date().toISOString(),
+    })
+    .eq("id", args.invitationId)
+    .eq("status", "pending")
+    .is("expired_notified_at", null)
+    .select("id, company_id, email, invited_by")
+    .maybeSingle();
+
+  if (claim.error) {
+    logger.error("invitations.callback.expiry.claim_failed", {
+      invitation_id: args.invitationId,
+      err: claim.error.message,
+    });
+    return {
+      outcome: "internal_error",
+      invitationId: args.invitationId,
+      message: claim.error.message,
+    };
+  }
+
+  if (!claim.data) {
+    return {
+      outcome: "noop_already_handled",
+      invitationId: args.invitationId,
+    };
+  }
+
+  const dispatchResult = await dispatch({
+    event: "invitation_expired",
+    companyId: invitation.company_id,
+    inviteeEmail: invitation.email,
+    inviterUserId: invitation.invited_by,
+  });
+
+  if (dispatchResult.errors.length > 0) {
+    logger.warn("invitations.callback.expiry.dispatch_partial_failure", {
+      invitation_id: args.invitationId,
+      errors: dispatchResult.errors,
+    });
+  }
+
+  return { outcome: "dispatched", invitationId: args.invitationId };
+}
+
+// ---------------------------------------------------------------------------
+// Enqueueing — called from the invitation send route after a successful
+// insert. Enqueues two delayed messages on QStash:
+//   1. Reminder at +3 days, body { invitationId, rawToken }
+//   2. Expiry at expires_at - now() (default ~14 days),
+//      body { invitationId }
+//
+// QStash failures are logged but do NOT fail the parent request — the
+// invitation row is already created and the immediate invitation_sent
+// email has already been delivered. Missing callbacks degrade UX
+// (no reminder + no auto-expiry mark) but don't break correctness.
+//
+// When QSTASH_TOKEN is unset (local dev / staging without provisioning),
+// this function logs and returns { reminder: null, expiry: null } so
+// the caller's happy path stays the same.
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const REMINDER_DELAY_DAYS = 3;
+
+export type EnqueueResult = {
+  reminderMessageId: string | null;
+  expiryMessageId: string | null;
+};
+
+export async function enqueueInvitationCallbacks(args: {
+  invitationId: string;
+  rawToken: string;
+  expiresAt: string;
+  origin: string;
+}): Promise<EnqueueResult> {
+  const client = getQstashClient();
+  if (!client) {
+    logger.info("invitations.enqueue.skipped_no_qstash", {
+      invitation_id: args.invitationId,
+    });
+    return { reminderMessageId: null, expiryMessageId: null };
+  }
+
+  const baseUrl = args.origin.replace(/\/+$/, "");
+  const reminderUrl = `${baseUrl}/api/platform/invitations/callbacks/reminder`;
+  const expiryUrl = `${baseUrl}/api/platform/invitations/callbacks/expiry`;
+
+  const now = Date.now();
+  const reminderDelaySeconds = Math.max(
+    1,
+    Math.floor((REMINDER_DELAY_DAYS * DAY_MS) / 1000),
+  );
+  const expiryDelaySeconds = Math.max(
+    1,
+    Math.floor((new Date(args.expiresAt).getTime() - now) / 1000),
+  );
+
+  // Run both publishes in parallel; an error on one shouldn't block
+  // the other from being scheduled.
+  const [reminder, expiry] = await Promise.allSettled([
+    client.publishJSON({
+      url: reminderUrl,
+      body: { invitationId: args.invitationId, rawToken: args.rawToken },
+      delay: reminderDelaySeconds,
+      // deduplicationId scopes against re-fires of the same logical
+      // event — protects against a duplicate enqueue if the route
+      // handler retries.
+      deduplicationId: `invitation-reminder-${args.invitationId}`,
+    }),
+    client.publishJSON({
+      url: expiryUrl,
+      body: { invitationId: args.invitationId },
+      delay: expiryDelaySeconds,
+      deduplicationId: `invitation-expiry-${args.invitationId}`,
+    }),
+  ]);
+
+  let reminderId: string | null = null;
+  let expiryId: string | null = null;
+
+  if (reminder.status === "fulfilled") {
+    reminderId =
+      (reminder.value as { messageId?: string }).messageId ?? null;
+  } else {
+    logger.error("invitations.enqueue.reminder_failed", {
+      invitation_id: args.invitationId,
+      err:
+        reminder.reason instanceof Error
+          ? reminder.reason.message
+          : String(reminder.reason),
+    });
+  }
+
+  if (expiry.status === "fulfilled") {
+    expiryId = (expiry.value as { messageId?: string }).messageId ?? null;
+  } else {
+    logger.error("invitations.enqueue.expiry_failed", {
+      invitation_id: args.invitationId,
+      err:
+        expiry.reason instanceof Error
+          ? expiry.reason.message
+          : String(expiry.reason),
+    });
+  }
+
+  return { reminderMessageId: reminderId, expiryMessageId: expiryId };
+}

--- a/lib/platform/invitations/index.ts
+++ b/lib/platform/invitations/index.ts
@@ -2,6 +2,13 @@ export { sendInvitation } from "./send";
 export { revokeInvitation } from "./revoke";
 export { acceptInvitation } from "./accept";
 export {
+  enqueueInvitationCallbacks,
+  handleExpiryCallback,
+  handleReminderCallback,
+  type CallbackResult,
+  type EnqueueResult,
+} from "./callbacks";
+export {
   generateRawToken,
   hashToken,
   defaultExpiry,

--- a/lib/qstash.ts
+++ b/lib/qstash.ts
@@ -1,0 +1,89 @@
+import "server-only";
+
+import { Client, Receiver } from "@upstash/qstash";
+
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// QStash client + receiver — Upstash's HTTP-native delayed-message queue.
+//
+// Lazy singletons. Returns null when env vars aren't set so tests + local
+// dev stay no-op rather than hard-failing at module load. Same pattern as
+// lib/redis.ts.
+//
+// Env contract:
+//   QSTASH_TOKEN                — publish credential (server → Upstash)
+//   QSTASH_CURRENT_SIGNING_KEY  — verifies inbound webhook signatures
+//   QSTASH_NEXT_SIGNING_KEY     — verifies inbound webhook signatures
+//                                 during a key rotation. Optional but
+//                                 strongly recommended in prod.
+//
+// Callers (invitation enqueue + webhook handlers) check for null before
+// using and degrade gracefully — the platform_invitations row exists with
+// status='pending' regardless; missing callbacks just mean no day-3
+// reminder and no auto-expiry mark. Acceptable for V1 — operators can
+// revoke manually.
+// ---------------------------------------------------------------------------
+
+let cachedClient: Client | null | undefined = undefined;
+let cachedReceiver: Receiver | null | undefined = undefined;
+
+export function getQstashClient(): Client | null {
+  if (cachedClient !== undefined) return cachedClient;
+  const token = process.env.QSTASH_TOKEN;
+  if (!token) {
+    cachedClient = null;
+    return null;
+  }
+  cachedClient = new Client({ token });
+  return cachedClient;
+}
+
+export function getQstashReceiver(): Receiver | null {
+  if (cachedReceiver !== undefined) return cachedReceiver;
+  const currentSigningKey = process.env.QSTASH_CURRENT_SIGNING_KEY;
+  if (!currentSigningKey) {
+    cachedReceiver = null;
+    return null;
+  }
+  cachedReceiver = new Receiver({
+    currentSigningKey,
+    nextSigningKey: process.env.QSTASH_NEXT_SIGNING_KEY ?? "",
+  });
+  return cachedReceiver;
+}
+
+export type VerifyResult =
+  | { ok: true }
+  | { ok: false; reason: "no_receiver" | "missing_signature" | "invalid" };
+
+// Verifies the Upstash-Signature header against the raw body. Returns
+// `no_receiver` when env is unset (tests + local dev). Webhook routes
+// MUST treat `no_receiver` as a config error in production — they
+// should refuse to run if the signing key is missing — but in test
+// environments we mock this entire function.
+export async function verifyQstashSignature(args: {
+  signature: string | null;
+  rawBody: string;
+}): Promise<VerifyResult> {
+  const receiver = getQstashReceiver();
+  if (!receiver) return { ok: false, reason: "no_receiver" };
+  if (!args.signature) return { ok: false, reason: "missing_signature" };
+  try {
+    await receiver.verify({
+      signature: args.signature,
+      body: args.rawBody,
+    });
+    return { ok: true };
+  } catch (err) {
+    logger.warn("qstash.verify_failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return { ok: false, reason: "invalid" };
+  }
+}
+
+export function __resetQstashForTests(): void {
+  cachedClient = undefined;
+  cachedReceiver = undefined;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@sendgrid/mail": "^8.1.6",
         "@sentry/nextjs": "^10.49.0",
         "@supabase/supabase-js": "^2.104.0",
+        "@upstash/qstash": "^2.10.1",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",
         "class-variance-authority": "^0.7.0",
@@ -5499,6 +5500,17 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@upstash/qstash": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@upstash/qstash/-/qstash-2.10.1.tgz",
+      "integrity": "sha512-LsTAPxPk0dFvhlEnRqwObRS94b8mmDHYaBlF3IaONUL+Scq6i9cZraA6936KSUVe+Vq3eNQle3CjOZkStPUFTw==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": ">=4.2.0",
+        "jose": "^5.2.3",
+        "neverthrow": "^7.0.1"
+      }
+    },
     "node_modules/@upstash/ratelimit": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
@@ -7249,6 +7261,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-functions-list": {
       "version": "3.3.3",
@@ -10069,6 +10087,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11276,6 +11303,15 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/neverthrow": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-7.2.0.tgz",
+      "integrity": "sha512-iGBUfFB7yPczHHtA8dksKTJ9E8TESNTAx1UQWW6TzMF280vo9jdPYpLUXrMN1BCkPdHFdNG3fxOt2CUad8KhAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/next": {
       "version": "14.2.35",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@sendgrid/mail": "^8.1.6",
     "@sentry/nextjs": "^10.49.0",
     "@supabase/supabase-js": "^2.104.0",
+    "@upstash/qstash": "^2.10.1",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",
     "class-variance-authority": "^0.7.0",

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -746,6 +746,7 @@ function check7_unauthenticatedApi(): Issue[] {
     /verifyToken/,
     /verifyMagicLink/,
     /requireCanDoForApi/, // Platform layer canDo gate
+    /verifyQstashSignature/, // QStash webhook signature verification (HMAC)
     /createHash/,
     /\bauth\.getUser\b/,
   ];


### PR DESCRIPTION
## Summary
- Day-3 reminder + day-14 expiry callbacks for platform invitations via Upstash QStash. Both events flow through the existing notification dispatcher (`invitation_reminder` / `invitation_expired`).
- Webhooks are idempotent on duplicate fires via atomic `UPDATE ... WHERE reminder_sent_at IS NULL` / `WHERE status='pending'` predicates — the first fire wins, the second is a no-op, the dispatcher only runs when the atomic update returned a row.
- Routes degrade gracefully when QSTASH env vars are unset: invitation row + initial email still succeed, only the reminders + auto-expiry don't fire (operator can revoke manually). Signature verification is mandatory at the webhook layer (401 on missing/invalid, 503 when receiver isn't configured).

## Changes
- `lib/qstash.ts` — lazy singleton client + receiver, mirrors the lib/redis.ts pattern (null when env unset).
- `lib/platform/invitations/callbacks.ts` — pure handlers (`handleReminderCallback`, `handleExpiryCallback`) + `enqueueInvitationCallbacks` for the send route.
- `app/api/platform/invitations/route.ts` — enqueues both delayed messages after a successful invitation insert.
- `app/api/platform/invitations/callbacks/{reminder,expiry}/route.ts` — webhook routes, signature-verified.
- `lib/__tests__/platform-invitation-callbacks.test.ts` — covers happy path, idempotent second fire, accepted/revoked early-out, missing invitation, and the QSTASH-unset no-op.
- `scripts/audit.ts` — `verifyQstashSignature` added to `AUTH_PATTERNS` so HMAC-gated webhook routes don't trip the unauthenticated-api check.
- `.env.example` + `.env.local.example` — documented `QSTASH_TOKEN`, `QSTASH_CURRENT_SIGNING_KEY`, `QSTASH_NEXT_SIGNING_KEY`.
- `docs/WORK_IN_FLIGHT.md` — swapped the stale P5 claim block (#399 merged) for the active P2-4 block.
- `package.json` + `package-lock.json` — `@upstash/qstash@^2.10.1`.

## Risks identified and mitigated
- **Duplicate webhook fire** (QStash retries on non-2xx, network blips): atomic UPDATE-with-predicate ensures only one fire dispatches. Test asserts `noop_already_handled` on second fire and that the SendGrid mock isn't called twice.
- **Concurrent fires on the same invitation**: race-safe via the same UPDATE-with-predicate — second UPDATE affects 0 rows.
- **Inviter deleted between send + expiry**: the dispatcher's `resolveUserById` tolerates a missing inviter and falls back to invitee-only recipients.
- **QStash enqueue failure**: logged but never fails the parent send. The invitation row + initial email already succeeded; missing reminder/expiry is degraded UX, not a correctness problem.
- **Stale 'pending' invitations** when enqueue silently fails: known follow-up. Mitigation is a daily cron sweep of `expires_at < now() AND status='pending'`. Out of scope for P2-4; documented for a follow-up slice.
- **Signature verification**: 401 on missing/invalid `Upstash-Signature`; 503 when the receiver isn't configured (prod must provision `QSTASH_CURRENT_SIGNING_KEY`).

## Provisioning
- Set `QSTASH_TOKEN`, `QSTASH_CURRENT_SIGNING_KEY`, `QSTASH_NEXT_SIGNING_KEY` in Vercel (preview + prod). Until set, callbacks no-op silently.
- Webhook URLs registered automatically via `client.publishJSON({ url })` — no console-side configuration needed.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean — both callback routes registered (`/api/platform/invitations/callbacks/{reminder,expiry}`)
- [x] `npm run audit:static` — 0 HIGH (was 2 before adding `verifyQstashSignature` to AUTH_PATTERNS)
- [ ] CI Vitest run — Docker not available locally, deferring to CI. Pre-existing m12-1-rls / m4-schema redness is expected and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)