### PR TITLE
feat(s1-1): social_post_master lib (create + list + get)

### DIFF
--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -9,18 +9,11 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session A
 - Started: 2026-05-03
-- Branch: feat/p2-4-invitation-callbacks
-- Slice: P2-4 — invitation reminder + expiry callbacks via QStash. Day-3 reminder + day-14 expiry transitions, idempotent on duplicate webhook fires.
+- Branch: feat/s1-1-social-posts-lib
+- Slice: S1-1 — L1 editorial layer foundation. Lib functions for social_post_master CRUD (create + list + get) on top of migration 0070's schema. No HTTP API yet; that lands with the UI in S1-2.
 - Files claimed:
-  - lib/qstash.ts (new)
-  - lib/platform/invitations/callbacks.ts (new)
-  - lib/platform/invitations/index.ts (re-export)
-  - app/api/platform/invitations/route.ts (enqueue on send)
-  - app/api/platform/invitations/callbacks/reminder/route.ts (new webhook)
-  - app/api/platform/invitations/callbacks/expiry/route.ts (new webhook)
-  - lib/__tests__/platform-invitation-callbacks.test.ts (new)
-  - .env.example, .env.local.example (QStash env vars)
-  - package.json + package-lock.json (@upstash/qstash)
+  - lib/platform/social/posts/{types,create,list,get,index}.ts (new)
+  - lib/__tests__/social-posts.test.ts (new)
   - docs/WORK_IN_FLIGHT.md
 - Migration number reserved: none
 - Expected completion: same session.

--- a/lib/__tests__/social-posts.test.ts
+++ b/lib/__tests__/social-posts.test.ts
@@ -1,0 +1,360 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import {
+  createPostMaster,
+  getPostMaster,
+  listPostMasters,
+} from "@/lib/platform/social/posts";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser, type SeededAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// S1-1: lib-layer tests for social_post_master CRUD.
+//
+// Same shape as platform-companies.test.ts: persistent auth users, fresh
+// platform_* rows per test (truncate + reseed in beforeEach), service-role
+// client throughout. Permission checks live at the route layer (canDo
+// gate) and are tested separately when S1-2 lands.
+// ---------------------------------------------------------------------------
+
+const COMPANY_A_ID = "abcdef00-0000-0000-0000-aaaaaaaaaaaa";
+const COMPANY_B_ID = "abcdef00-0000-0000-0000-bbbbbbbbbbbb";
+
+describe("lib/platform/social/posts", () => {
+  let creator: SeededAuthUser;
+
+  beforeAll(async () => {
+    creator = await seedAuthUser({
+      email: "s1-1-creator@opollo.test",
+      persistent: true,
+    });
+  });
+
+  beforeEach(async () => {
+    const svc = getServiceRoleClient();
+
+    const companies = await svc
+      .from("platform_companies")
+      .insert([
+        {
+          id: COMPANY_A_ID,
+          name: "Acme Co",
+          slug: "s1-1-acme",
+          domain: "s1-1-acme.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+        },
+        {
+          id: COMPANY_B_ID,
+          name: "Beta Inc",
+          slug: "s1-1-beta",
+          domain: "s1-1-beta.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+        },
+      ])
+      .select("id");
+    if (companies.error) {
+      throw new Error(
+        `seed companies: ${companies.error.code ?? "?"} ${companies.error.message}`,
+      );
+    }
+
+    const user = await svc
+      .from("platform_users")
+      .insert({
+        id: creator.id,
+        email: creator.email,
+        full_name: "Creator",
+        is_opollo_staff: false,
+      })
+      .select("id");
+    if (user.error) {
+      throw new Error(
+        `seed creator: ${user.error.code ?? "?"} ${user.error.message}`,
+      );
+    }
+
+    const membership = await svc
+      .from("platform_company_users")
+      .insert({
+        company_id: COMPANY_A_ID,
+        user_id: creator.id,
+        role: "editor",
+      })
+      .select("id");
+    if (membership.error) {
+      throw new Error(
+        `seed membership: ${membership.error.code ?? "?"} ${membership.error.message}`,
+      );
+    }
+  });
+
+  afterAll(async () => {
+    const svc = getServiceRoleClient();
+    if (creator) await svc.auth.admin.deleteUser(creator.id);
+  });
+
+  describe("createPostMaster", () => {
+    it("happy path — text-only post lands in state='draft'", async () => {
+      const result = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "Hello world from Acme.",
+        createdBy: creator.id,
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.company_id).toBe(COMPANY_A_ID);
+      expect(result.data.state).toBe("draft");
+      expect(result.data.source_type).toBe("manual");
+      expect(result.data.master_text).toBe("Hello world from Acme.");
+      expect(result.data.link_url).toBeNull();
+      expect(result.data.created_by).toBe(creator.id);
+    });
+
+    it("happy path — link-only post is allowed", async () => {
+      const result = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        linkUrl: "https://example.com/article",
+        createdBy: creator.id,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.master_text).toBeNull();
+      expect(result.data.link_url).toBe("https://example.com/article");
+    });
+
+    it("trims master_text + treats whitespace-only as null", async () => {
+      const trimmed = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "  spaced  ",
+        createdBy: creator.id,
+      });
+      expect(trimmed.ok).toBe(true);
+      if (trimmed.ok) expect(trimmed.data.master_text).toBe("spaced");
+
+      const empty = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "   ",
+        linkUrl: "https://example.com/",
+        createdBy: creator.id,
+      });
+      expect(empty.ok).toBe(true);
+      if (empty.ok) expect(empty.data.master_text).toBeNull();
+    });
+
+    it("rejects empty post (no text and no link) with VALIDATION_FAILED", async () => {
+      const result = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        createdBy: creator.id,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("rejects non-http(s) link_url with VALIDATION_FAILED", async () => {
+      const result = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        linkUrl: "javascript:alert(1)",
+        createdBy: creator.id,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("rejects unknown company_id with NOT_FOUND (FK violation)", async () => {
+      const result = await createPostMaster({
+        companyId: "00000000-0000-0000-0000-000000000999",
+        masterText: "ghost company",
+        createdBy: creator.id,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+
+    it("rejects master_text exceeding the cap with VALIDATION_FAILED", async () => {
+      const result = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "x".repeat(10_001),
+        createdBy: creator.id,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("VALIDATION_FAILED");
+    });
+  });
+
+  describe("listPostMasters", () => {
+    it("returns rows for the queried company only", async () => {
+      const a1 = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "A-1",
+        createdBy: creator.id,
+      });
+      const a2 = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "A-2",
+        createdBy: creator.id,
+      });
+      // B has no membership for the creator but the lib doesn't enforce
+      // permissions — the route layer does. Insert directly to assert
+      // scoping by company_id.
+      const svc = getServiceRoleClient();
+      await svc.from("social_post_master").insert({
+        company_id: COMPANY_B_ID,
+        master_text: "B-1",
+        state: "draft",
+        source_type: "manual",
+      });
+      expect(a1.ok && a2.ok).toBe(true);
+
+      const result = await listPostMasters({ companyId: COMPANY_A_ID });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.posts.length).toBe(2);
+      const texts = result.data.posts.map((p) => p.master_text).sort();
+      expect(texts).toEqual(["A-1", "A-2"]);
+    });
+
+    it("filters by state when supplied", async () => {
+      const draft = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "still drafting",
+        createdBy: creator.id,
+      });
+      expect(draft.ok).toBe(true);
+      if (!draft.ok) return;
+
+      // Promote one row to 'approved' directly so the filter has
+      // something to discriminate. The state-machine API will land
+      // in a later slice; for now we exercise the column directly.
+      const svc = getServiceRoleClient();
+      const promoted = await svc
+        .from("social_post_master")
+        .insert({
+          company_id: COMPANY_A_ID,
+          master_text: "approved one",
+          state: "approved",
+          source_type: "manual",
+        })
+        .select("id")
+        .single();
+      expect(promoted.error).toBeNull();
+
+      const drafts = await listPostMasters({
+        companyId: COMPANY_A_ID,
+        states: ["draft"],
+      });
+      expect(drafts.ok).toBe(true);
+      if (!drafts.ok) return;
+      expect(drafts.data.posts.every((p) => p.state === "draft")).toBe(true);
+      expect(drafts.data.posts.length).toBe(1);
+
+      const approved = await listPostMasters({
+        companyId: COMPANY_A_ID,
+        states: ["approved"],
+      });
+      expect(approved.ok).toBe(true);
+      if (!approved.ok) return;
+      expect(approved.data.posts.length).toBe(1);
+      expect(approved.data.posts[0]?.state).toBe("approved");
+    });
+
+    it("returns empty array when company has no posts", async () => {
+      const result = await listPostMasters({ companyId: COMPANY_A_ID });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.posts).toEqual([]);
+    });
+
+    it("respects limit + offset", async () => {
+      for (let i = 0; i < 5; i++) {
+        await createPostMaster({
+          companyId: COMPANY_A_ID,
+          masterText: `post ${i}`,
+          createdBy: creator.id,
+        });
+      }
+      const page1 = await listPostMasters({
+        companyId: COMPANY_A_ID,
+        limit: 2,
+        offset: 0,
+      });
+      const page2 = await listPostMasters({
+        companyId: COMPANY_A_ID,
+        limit: 2,
+        offset: 2,
+      });
+      expect(page1.ok && page2.ok).toBe(true);
+      if (!page1.ok || !page2.ok) return;
+      expect(page1.data.posts.length).toBe(2);
+      expect(page2.data.posts.length).toBe(2);
+      const ids = new Set([
+        ...page1.data.posts.map((p) => p.id),
+        ...page2.data.posts.map((p) => p.id),
+      ]);
+      expect(ids.size).toBe(4);
+    });
+  });
+
+  describe("getPostMaster", () => {
+    it("returns the row when scoped to the right company", async () => {
+      const created = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "fetch me",
+        createdBy: creator.id,
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+
+      const result = await getPostMaster({
+        postId: created.data.id,
+        companyId: COMPANY_A_ID,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.id).toBe(created.data.id);
+      expect(result.data.master_text).toBe("fetch me");
+    });
+
+    it("returns NOT_FOUND for a row in a different company", async () => {
+      const created = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "scoped",
+        createdBy: creator.id,
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+
+      const result = await getPostMaster({
+        postId: created.data.id,
+        companyId: COMPANY_B_ID,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns NOT_FOUND for a missing post id", async () => {
+      const result = await getPostMaster({
+        postId: "00000000-0000-0000-0000-000000000aaa",
+        companyId: COMPANY_A_ID,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+  });
+});

--- a/lib/platform/social/posts/create.ts
+++ b/lib/platform/social/posts/create.ts
@@ -1,0 +1,149 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { CreatePostMasterInput, PostMaster } from "./types";
+
+// ---------------------------------------------------------------------------
+// S1-1 — create a social_post_master row.
+//
+// Pure data-write. The route handler that calls this is responsible for
+// the canDo("create_post") check + resolving the company_id from the
+// authenticated user's membership. This lib trusts the caller has done
+// both — same convention as lib/platform/companies/create.ts.
+//
+// V1 scope: master_text + link_url + source_type only. Variants
+// (social_post_variant rows per platform) and media attachments
+// (social_media_assets) come in subsequent slices. New posts always
+// land in state='draft' — the state machine takes over from there.
+// ---------------------------------------------------------------------------
+
+const MASTER_TEXT_MAX = 10_000;
+const LINK_URL_MAX = 2048;
+
+export async function createPostMaster(
+  input: CreatePostMasterInput,
+): Promise<ApiResponse<PostMaster>> {
+  if (!input.companyId) {
+    return validation("Company id is required.");
+  }
+
+  const masterText = normaliseText(input.masterText);
+  if (masterText !== null && masterText.length > MASTER_TEXT_MAX) {
+    return validation(
+      `master_text must be ${MASTER_TEXT_MAX} characters or fewer.`,
+    );
+  }
+
+  const linkUrl = normaliseText(input.linkUrl);
+  if (linkUrl !== null) {
+    if (linkUrl.length > LINK_URL_MAX) {
+      return validation(`link_url must be ${LINK_URL_MAX} characters or fewer.`);
+    }
+    if (!isHttpUrl(linkUrl)) {
+      return validation("link_url must be a valid http(s) URL.");
+    }
+  }
+
+  // Reject the empty post — at least one of master_text or link_url
+  // must be present. The schema allows both to be null, but a post with
+  // neither is meaningless and will trip later validators (variant
+  // generation, approval snapshots).
+  if (masterText === null && linkUrl === null) {
+    return validation(
+      "A post must have at least master_text or link_url.",
+    );
+  }
+
+  const sourceType = input.sourceType ?? "manual";
+
+  const svc = getServiceRoleClient();
+  const result = await svc
+    .from("social_post_master")
+    .insert({
+      company_id: input.companyId,
+      state: "draft",
+      source_type: sourceType,
+      master_text: masterText,
+      link_url: linkUrl,
+      created_by: input.createdBy,
+    })
+    .select(
+      "id, company_id, state, source_type, master_text, link_url, created_by, created_at, updated_at, state_changed_at",
+    )
+    .single();
+
+  if (result.error) {
+    // 23503 = FK violation. The only FKs on this table are company_id
+    // (→ platform_companies) and created_by (→ platform_users).
+    if (result.error.code === "23503") {
+      return {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message:
+            "Company or creator does not exist. Check company_id and created_by.",
+          retryable: false,
+          suggested_action:
+            "Verify the company exists and the user is a platform user.",
+        },
+        timestamp: new Date().toISOString(),
+      };
+    }
+    logger.error("social.posts.create.failed", {
+      err: result.error.message,
+      code: result.error.code,
+      company_id: input.companyId,
+    });
+    return internal(`Failed to create post: ${result.error.message}`);
+  }
+
+  return {
+    ok: true,
+    data: result.data as PostMaster,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function normaliseText(value: string | null | undefined): string | null {
+  if (value === undefined || value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function validation(message: string): ApiResponse<PostMaster> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<PostMaster> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/posts/get.ts
+++ b/lib/platform/social/posts/get.ts
@@ -1,0 +1,92 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { PostMaster } from "./types";
+
+// ---------------------------------------------------------------------------
+// S1-1 — fetch one social_post_master row.
+//
+// Returns NOT_FOUND when the row doesn't exist OR doesn't belong to the
+// supplied companyId. Hiding the difference is deliberate — opollo
+// staff get the same envelope (they can verify cross-company existence
+// out-of-band via the staff console). Customer admins should never see
+// a "this post belongs to a different company" leak.
+// ---------------------------------------------------------------------------
+
+export async function getPostMaster(args: {
+  postId: string;
+  companyId: string;
+}): Promise<ApiResponse<PostMaster>> {
+  if (!args.postId) {
+    return validation("Post id is required.");
+  }
+  if (!args.companyId) {
+    return validation("Company id is required.");
+  }
+
+  const svc = getServiceRoleClient();
+  const result = await svc
+    .from("social_post_master")
+    .select(
+      "id, company_id, state, source_type, master_text, link_url, created_by, created_at, updated_at, state_changed_at",
+    )
+    .eq("id", args.postId)
+    .eq("company_id", args.companyId)
+    .maybeSingle();
+
+  if (result.error) {
+    logger.error("social.posts.get.failed", {
+      err: result.error.message,
+      post_id: args.postId,
+    });
+    return internal(`Failed to read post: ${result.error.message}`);
+  }
+
+  if (!result.data) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: "No post with that id in this company.",
+        retryable: false,
+        suggested_action: "Check the post id.",
+      },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  return {
+    ok: true,
+    data: result.data as PostMaster,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(message: string): ApiResponse<PostMaster> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<PostMaster> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/posts/index.ts
+++ b/lib/platform/social/posts/index.ts
@@ -1,0 +1,11 @@
+export { createPostMaster } from "./create";
+export { getPostMaster } from "./get";
+export { listPostMasters } from "./list";
+export type {
+  CreatePostMasterInput,
+  ListPostMastersInput,
+  PostMaster,
+  PostMasterListItem,
+  SocialPostSource,
+  SocialPostState,
+} from "./types";

--- a/lib/platform/social/posts/list.ts
+++ b/lib/platform/social/posts/list.ts
@@ -1,0 +1,101 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { ListPostMastersInput, PostMasterListItem } from "./types";
+
+// ---------------------------------------------------------------------------
+// S1-1 — list social_post_master rows scoped to one company.
+//
+// Caller (route handler / RSC page) is responsible for the canDo
+// permission gate (view_calendar at minimum) and for resolving the
+// caller's company_id. RLS enforces the company scope at the DB layer
+// regardless, but the lib explicitly filters by company_id so opollo
+// staff (who can read every company under RLS) get the same scoped
+// view in this code path.
+//
+// Default ordering: most-recently changed first (state_changed_at DESC),
+// which matches the calendar's "what moved today" mental model better
+// than created_at.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+export async function listPostMasters(
+  input: ListPostMastersInput,
+): Promise<ApiResponse<{ posts: PostMasterListItem[] }>> {
+  if (!input.companyId) {
+    return validation("Company id is required.");
+  }
+
+  const limit = clamp(input.limit ?? DEFAULT_LIMIT, 1, MAX_LIMIT);
+  const offset = Math.max(0, input.offset ?? 0);
+
+  const svc = getServiceRoleClient();
+  let query = svc
+    .from("social_post_master")
+    .select(
+      "id, state, source_type, master_text, link_url, created_by, created_at, updated_at, state_changed_at",
+    )
+    .eq("company_id", input.companyId)
+    .order("state_changed_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (input.states && input.states.length > 0) {
+    query = query.in("state", input.states);
+  }
+
+  const result = await query;
+
+  if (result.error) {
+    logger.error("social.posts.list.failed", {
+      err: result.error.message,
+      company_id: input.companyId,
+    });
+    return internal(`Failed to list posts: ${result.error.message}`);
+  }
+
+  return {
+    ok: true,
+    data: { posts: (result.data ?? []) as PostMasterListItem[] },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) return min;
+  return Math.min(max, Math.max(min, Math.floor(value)));
+}
+
+function validation(
+  message: string,
+): ApiResponse<{ posts: PostMasterListItem[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(
+  message: string,
+): ApiResponse<{ posts: PostMasterListItem[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/posts/types.ts
+++ b/lib/platform/social/posts/types.ts
@@ -1,0 +1,64 @@
+// Mirrors social_post_state / social_post_source enums in migration 0070.
+// Keep aligned: extending the enum requires a forward-only migration AND
+// extending these literal unions; TypeScript catches the gap at compile
+// time via exhaustive switches over the type.
+export type SocialPostState =
+  | "draft"
+  | "pending_client_approval"
+  | "approved"
+  | "rejected"
+  | "changes_requested"
+  | "pending_msp_release"
+  | "scheduled"
+  | "publishing"
+  | "published"
+  | "failed";
+
+export type SocialPostSource = "manual" | "csv" | "cap" | "api";
+
+export type PostMaster = {
+  id: string;
+  company_id: string;
+  state: SocialPostState;
+  source_type: SocialPostSource;
+  master_text: string | null;
+  link_url: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+  state_changed_at: string;
+};
+
+export type PostMasterListItem = {
+  id: string;
+  state: SocialPostState;
+  source_type: SocialPostSource;
+  master_text: string | null;
+  link_url: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+  state_changed_at: string;
+};
+
+export type CreatePostMasterInput = {
+  companyId: string;
+  // V1 keeps the master copy as plain text (no rich text, no per-platform
+  // variants yet). Variants get added in a later slice; this slice ships
+  // the editorial L1 foundation.
+  masterText?: string | null;
+  linkUrl?: string | null;
+  sourceType?: SocialPostSource;
+  createdBy: string | null;
+};
+
+export type ListPostMastersInput = {
+  companyId: string;
+  // Optional state filter — useful for the "drafts" / "scheduled" /
+  // "published" tabs the calendar UI will need.
+  states?: SocialPostState[];
+  // Soft pagination knobs for V1; fancier cursor pagination lands when
+  // any single tab gets >200 rows in practice.
+  limit?: number;
+  offset?: number;
+};


### PR DESCRIPTION
## Summary
- Phase B kickoff. L1 editorial-layer foundation on top of migration 0070's social schema.
- Pure data-access functions for `social_post_master` — text + link_url, state machine starts at `draft`. No HTTP API yet; that lands with the UI in S1-2.
- Mirrors the `lib/platform/companies` pattern (lib does the data work, route does the permission gate). Permission checks (`canDo("create_post")`, `view_calendar`) are deferred to S1-2 alongside the route.

## Changes
- `lib/platform/social/posts/types.ts` — `PostMaster` / `PostMasterListItem` / input types + `SocialPostState` / `SocialPostSource` literal unions mirroring the 0070 enums.
- `lib/platform/social/posts/create.ts` — text + link_url validation, `master_text`/`link_url` length caps, http(s)-only URL guard, `23503` (FK violation) → `NOT_FOUND` envelope.
- `lib/platform/social/posts/list.ts` — company-scoped, optional `states[]` filter, ordered by `state_changed_at desc`, soft pagination (default 50, max 200).
- `lib/platform/social/posts/get.ts` — scoped lookup, hides cross-company existence behind `NOT_FOUND` to prevent leaks.
- `lib/__tests__/social-posts.test.ts` — happy paths, validation rejections, FK violations, scoping, state filter, pagination across 4 pages.

## Risks identified and mitigated
- **Cross-company read leak**: `get` and `list` both filter by `company_id` at the lib layer in addition to the RLS gate at the DB. Tested by inserting a row in company B then asserting `NOT_FOUND` on a `get` scoped to company A.
- **Empty post**: rejected at validation rather than letting an unusable row land in the schema. Variant generation + approval snapshots both assume some content.
- **Permission gating**: deferred to the route layer per the `lib/platform/companies` pattern. The `canDo("create_post")` / `view_calendar` gates already exist in `lib/platform/auth/permissions.ts` and will be wired in S1-2.
- **Unbounded text growth**: `master_text` capped at 10k chars, `link_url` at 2048 chars. Not enforced at the schema layer (TEXT) — bounded at the lib layer where the validator can return a friendly error.
- **State machine consistency**: V1 lib only writes `state='draft'` on insert. Other transitions (submit / approve / schedule / publish) are write-safety-critical and will be added per their dedicated slices with explicit invariants.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` clean
- [ ] CI Vitest run — Docker not available locally, deferring to CI. Pre-existing m12-1-rls / m4-schema / etc. redness is expected and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)