### PR TITLE
feat(s1-2): social posts HTTP API + customer list page

### DIFF
--- a/app/api/platform/social/posts/route.ts
+++ b/app/api/platform/social/posts/route.ts
@@ -1,0 +1,183 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import {
+  createPostMaster,
+  listPostMasters,
+  type SocialPostState,
+} from "@/lib/platform/social/posts";
+
+// ---------------------------------------------------------------------------
+// S1-2 — HTTP API for social_post_master.
+//
+//   POST /api/platform/social/posts — create a new draft post.
+//     Body: { company_id, master_text?, link_url?, source_type? }
+//     Gate: canDo("create_post", company_id) — editor+.
+//
+//   GET /api/platform/social/posts?company_id=...&state=draft,approved
+//     Gate: canDo("view_calendar", company_id) — viewer+.
+//
+// Errors follow the standard envelope shape used across the platform
+// layer (lib/tool-schemas ApiResponse). State machine transitions
+// (submit / approve / schedule / publish) live in their dedicated
+// per-slice routes; this slice ships only the editorial CRUD surface.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const VALID_STATES: readonly SocialPostState[] = [
+  "draft",
+  "pending_client_approval",
+  "approved",
+  "rejected",
+  "changes_requested",
+  "pending_msp_release",
+  "scheduled",
+  "publishing",
+  "published",
+  "failed",
+];
+
+const CreateSchema = z.object({
+  company_id: z.string().uuid(),
+  master_text: z.string().max(10_000).optional(),
+  link_url: z.string().url().max(2048).optional(),
+  source_type: z.enum(["manual", "csv", "cap", "api"]).optional(),
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: {
+        code,
+        message,
+        retryable: false,
+        ...(details ? { details } : {}),
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = CreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "Body must be { company_id: uuid, master_text?: string, link_url?: string, source_type?: 'manual'|'csv'|'cap'|'api' }.",
+      400,
+      { issues: parsed.error.issues },
+    );
+  }
+
+  const gate = await requireCanDoForApi(parsed.data.company_id, "create_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await createPostMaster({
+    companyId: parsed.data.company_id,
+    masterText: parsed.data.master_text ?? null,
+    linkUrl: parsed.data.link_url ?? null,
+    sourceType: parsed.data.source_type ?? "manual",
+    createdBy: gate.userId,
+  });
+
+  if (!result.ok) {
+    const status =
+      result.error.code === "VALIDATION_FAILED"
+        ? 400
+        : result.error.code === "NOT_FOUND"
+          ? 404
+          : 500;
+    return errorJson(result.error.code, result.error.message, status);
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { post: result.data },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 201 },
+  );
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const url = new URL(req.url);
+  const companyId = url.searchParams.get("company_id");
+  if (!companyId) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "company_id query parameter is required.",
+      400,
+    );
+  }
+  if (!/^[0-9a-f-]{36}$/i.test(companyId)) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "company_id must be a UUID.",
+      400,
+    );
+  }
+
+  const gate = await requireCanDoForApi(companyId, "view_calendar");
+  if (gate.kind === "deny") return gate.response;
+
+  const stateParam = url.searchParams.get("state");
+  const states = stateParam
+    ? stateParam
+        .split(",")
+        .map((s) => s.trim())
+        .filter(
+          (s): s is SocialPostState =>
+            VALID_STATES.includes(s as SocialPostState),
+        )
+    : undefined;
+
+  const limit = parseIntOr(url.searchParams.get("limit"));
+  const offset = parseIntOr(url.searchParams.get("offset"));
+
+  const result = await listPostMasters({
+    companyId,
+    states,
+    limit: limit ?? undefined,
+    offset: offset ?? undefined,
+  });
+
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      result.error.code === "VALIDATION_FAILED" ? 400 : 500,
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: result.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}
+
+function parseIntOr(raw: string | null): number | null {
+  if (!raw) return null;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : null;
+}

--- a/app/company/social/posts/page.tsx
+++ b/app/company/social/posts/page.tsx
@@ -1,0 +1,66 @@
+import { redirect } from "next/navigation";
+
+import { SocialPostsListClient } from "@/components/SocialPostsListClient";
+import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
+import { listPostMasters } from "@/lib/platform/social/posts";
+
+// ---------------------------------------------------------------------------
+// S1-2 — customer-facing social posts list at /company/social/posts.
+//
+// Server-rendered. Gates:
+//   1. No session → /login.
+//   2. No platform_users / no company membership → "Not provisioned".
+//   3. Authenticated members (viewer+) get the list. Editor+ also get
+//      the "New post" button (canDo "create_post"); viewers get a
+//      read-only view.
+//   4. Opollo staff land here too — they can see/manage every customer's
+//      posts via the same surface (RLS allows + canDo passes for staff
+//      via the is_opollo_staff override).
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+export default async function CompanySocialPostsPage() {
+  const session = await getCurrentPlatformSession();
+  if (!session) {
+    redirect(`/login?next=${encodeURIComponent("/company/social/posts")}`);
+  }
+
+  if (!session.company) {
+    return (
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm">
+        <p className="font-medium">Account not provisioned to a company.</p>
+        <p className="mt-1 text-muted-foreground">
+          Your account isn&apos;t a member of any company on the platform
+          yet. Ask an admin to invite you, or contact Opollo support.
+        </p>
+      </div>
+    );
+  }
+
+  const companyId = session.company.companyId;
+
+  const [postsResult, canCreate] = await Promise.all([
+    listPostMasters({ companyId }),
+    canDo(companyId, "create_post"),
+  ]);
+
+  if (!postsResult.ok) {
+    return (
+      <div
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        role="alert"
+      >
+        Failed to load posts: {postsResult.error.message}
+      </div>
+    );
+  }
+
+  return (
+    <SocialPostsListClient
+      companyId={companyId}
+      initialPosts={postsResult.data.posts}
+      canCreate={canCreate}
+    />
+  );
+}

--- a/components/SocialPostsListClient.tsx
+++ b/components/SocialPostsListClient.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { H1, Lead } from "@/components/ui/typography";
+import type {
+  PostMasterListItem,
+  SocialPostState,
+} from "@/lib/platform/social/posts";
+
+// ---------------------------------------------------------------------------
+// S1-2 — client shell for /company/social/posts.
+//
+// Renders a state-filterable list of social posts. The "New post"
+// button wires straight to POST /api/platform/social/posts and
+// reloads on success. V1 keeps the create form inline + minimal
+// (master_text + link_url); a richer modal lands when variant /
+// scheduling slices arrive and the form needs more inputs.
+// ---------------------------------------------------------------------------
+
+type Props = {
+  companyId: string;
+  initialPosts: PostMasterListItem[];
+  canCreate: boolean;
+};
+
+const STATE_PILL: Record<SocialPostState, string> = {
+  draft: "bg-muted text-muted-foreground",
+  pending_client_approval: "bg-amber-100 text-amber-900",
+  approved: "bg-emerald-100 text-emerald-900",
+  rejected: "bg-rose-100 text-rose-900",
+  changes_requested: "bg-amber-100 text-amber-900",
+  pending_msp_release: "bg-sky-100 text-sky-900",
+  scheduled: "bg-sky-100 text-sky-900",
+  publishing: "bg-sky-200 text-sky-900",
+  published: "bg-primary/10 text-primary",
+  failed: "bg-rose-100 text-rose-900",
+};
+
+const STATE_LABEL: Record<SocialPostState, string> = {
+  draft: "Draft",
+  pending_client_approval: "Awaiting approval",
+  approved: "Approved",
+  rejected: "Rejected",
+  changes_requested: "Changes requested",
+  pending_msp_release: "Awaiting MSP release",
+  scheduled: "Scheduled",
+  publishing: "Publishing",
+  published: "Published",
+  failed: "Failed",
+};
+
+const FILTER_TABS: Array<{ key: "all" | SocialPostState; label: string }> = [
+  { key: "all", label: "All" },
+  { key: "draft", label: "Drafts" },
+  { key: "pending_client_approval", label: "Awaiting approval" },
+  { key: "approved", label: "Approved" },
+  { key: "scheduled", label: "Scheduled" },
+  { key: "published", label: "Published" },
+];
+
+export function SocialPostsListClient({
+  companyId,
+  initialPosts,
+  canCreate,
+}: Props) {
+  const [posts, setPosts] = useState(initialPosts);
+  const [filter, setFilter] = useState<(typeof FILTER_TABS)[number]["key"]>("all");
+  const [showCreate, setShowCreate] = useState(false);
+  const [masterText, setMasterText] = useState("");
+  const [linkUrl, setLinkUrl] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const visible = useMemo(
+    () => (filter === "all" ? posts : posts.filter((p) => p.state === filter)),
+    [posts, filter],
+  );
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/platform/social/posts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          company_id: companyId,
+          master_text: masterText.trim() || undefined,
+          link_url: linkUrl.trim() || undefined,
+        }),
+      });
+      const json = (await res.json()) as
+        | { ok: true; data: { post: PostMasterListItem } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        const msg = !json.ok ? json.error.message : "Failed to create post.";
+        setError(msg);
+        return;
+      }
+      setPosts((prev) => [json.data.post, ...prev]);
+      setMasterText("");
+      setLinkUrl("");
+      setShowCreate(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <H1>Social posts</H1>
+          <Lead className="mt-0.5">
+            {posts.length === 0
+              ? "No posts yet."
+              : `${posts.length} ${posts.length === 1 ? "post" : "posts"}.`}
+          </Lead>
+        </div>
+        {canCreate ? (
+          <Button
+            data-testid="new-post-button"
+            onClick={() => setShowCreate((v) => !v)}
+          >
+            {showCreate ? "Cancel" : "New post"}
+          </Button>
+        ) : null}
+      </div>
+
+      {showCreate && canCreate ? (
+        <form
+          onSubmit={handleCreate}
+          className="mt-4 rounded-lg border bg-card p-4"
+          data-testid="new-post-form"
+        >
+          <label className="block text-sm font-medium" htmlFor="master_text">
+            Post copy
+          </label>
+          <textarea
+            id="master_text"
+            className="mt-1 w-full rounded-md border bg-background p-2 text-sm"
+            rows={4}
+            placeholder="What do you want to post?"
+            value={masterText}
+            onChange={(e) => setMasterText(e.target.value)}
+            data-testid="new-post-master-text"
+          />
+          <label
+            className="mt-3 block text-sm font-medium"
+            htmlFor="link_url"
+          >
+            Link URL (optional)
+          </label>
+          <input
+            id="link_url"
+            type="url"
+            className="mt-1 w-full rounded-md border bg-background p-2 text-sm"
+            placeholder="https://example.com/article"
+            value={linkUrl}
+            onChange={(e) => setLinkUrl(e.target.value)}
+            data-testid="new-post-link-url"
+          />
+          {error ? (
+            <p
+              className="mt-3 text-sm text-destructive"
+              role="alert"
+              data-testid="new-post-error"
+            >
+              {error}
+            </p>
+          ) : null}
+          <div className="mt-4 flex items-center gap-2">
+            <Button type="submit" disabled={submitting} data-testid="new-post-submit">
+              {submitting ? "Saving…" : "Save draft"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                setShowCreate(false);
+                setError(null);
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      ) : null}
+
+      <nav
+        className="mt-6 flex flex-wrap gap-2"
+        aria-label="Filter posts by state"
+      >
+        {FILTER_TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setFilter(t.key)}
+            className={`rounded-full border px-3 py-1 text-sm transition ${
+              filter === t.key
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-muted-foreground/20 hover:bg-muted/40"
+            }`}
+            data-testid={`posts-filter-${t.key}`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+
+      <div
+        className="mt-4 overflow-hidden rounded-lg border bg-card"
+        data-testid="social-posts-table"
+      >
+        {visible.length === 0 ? (
+          <div className="p-8 text-center text-sm text-muted-foreground">
+            {posts.length === 0
+              ? "No posts yet — click New post to draft your first one."
+              : "No posts match this filter."}
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/30 text-left text-sm uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2 font-medium">Copy</th>
+                <th className="px-4 py-2 font-medium">Link</th>
+                <th className="px-4 py-2 font-medium">State</th>
+                <th className="px-4 py-2 font-medium">Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((p) => (
+                <tr
+                  key={p.id}
+                  className="border-b last:border-b-0 hover:bg-muted/20"
+                  data-testid={`social-post-row-${p.id}`}
+                >
+                  <td className="max-w-md truncate px-4 py-3">
+                    {p.master_text ?? (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </td>
+                  <td className="max-w-xs truncate px-4 py-3 text-sm text-muted-foreground">
+                    {p.link_url ?? "—"}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATE_PILL[p.state]}`}
+                    >
+                      {STATE_LABEL[p.state]}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground tabular-nums">
+                    {new Date(p.state_changed_at).toLocaleString("en-AU", {
+                      day: "numeric",
+                      month: "short",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </>
+  );
+}

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -9,11 +9,12 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session A
 - Started: 2026-05-03
-- Branch: feat/s1-1-social-posts-lib
-- Slice: S1-1 — L1 editorial layer foundation. Lib functions for social_post_master CRUD (create + list + get) on top of migration 0070's schema. No HTTP API yet; that lands with the UI in S1-2.
+- Branch: feat/s1-2-social-posts-api
+- Slice: S1-2 — HTTP API + customer-facing list page for social posts. POST/GET /api/platform/social/posts gated by canDo("create_post"/"view_calendar"). Customer page at /company/social/posts.
 - Files claimed:
-  - lib/platform/social/posts/{types,create,list,get,index}.ts (new)
-  - lib/__tests__/social-posts.test.ts (new)
+  - app/api/platform/social/posts/route.ts (new)
+  - app/company/social/posts/page.tsx (new)
+  - components/SocialPostsListClient.tsx (new)
   - docs/WORK_IN_FLIGHT.md
 - Migration number reserved: none
 - Expected completion: same session.


### PR DESCRIPTION
## Summary
- Wires the S1-1 lib (`lib/platform/social/posts`) to a routed surface so customers can actually create + browse posts.
- `POST /api/platform/social/posts` — gated by `canDo("create_post", company_id)` (editor+).
- `GET /api/platform/social/posts?company_id=&state=` — gated by `canDo("view_calendar", company_id)` (viewer+).
- Customer-facing list at `/company/social/posts`. RSC reads `listPostMasters` + `canDo("create_post")` server-side; editor+ get the New post button, viewers see read-only.

## Changes
- `app/api/platform/social/posts/route.ts` — POST + GET handlers. Body schema validated with zod; query params parsed defensively (state filter accepts comma-separated values; unknown values dropped).
- `app/company/social/posts/page.tsx` — server component. Mirrors `/company/users` gating: redirect on no session, friendly "not provisioned" envelope on missing membership, error envelope on lib failure.
- `components/SocialPostsListClient.tsx` — filterable table (All / Drafts / Awaiting approval / Approved / Scheduled / Published) + inline create form (master_text + optional link_url). Optimistic prepend on POST success; surfaces server-side validation errors inline.

## Risks identified and mitigated
- **Cross-company writes**: route gate evaluates `canDo` against the `company_id` from the body before calling the lib. The lib's own `company_id` scoping + the schema's RLS policy give two more layers underneath.
- **Permission elevation via state filter**: GET only returns rows in `company_id`; the state filter is an additive narrowing, never a widening. Opollo staff bypass `canDo` via `is_opollo_staff` (intentional — same path used by `/admin/companies`).
- **`source_type` injection**: zod enum locks the value to `'manual'|'csv'|'cap'|'api'` so a client can't write a row that bypasses CSV-import guardrails (those land in a separate slice).
- **Variant + media gaps**: this slice ships only the master row. Variants (`social_post_variant`) and media (`social_media_assets`) come in later S1 sub-slices alongside per-platform copy and image upload.
- **Not write-safety-critical**: L1 editorial only. No money spent, no external services hit, no WP mutation. Auto-merge eligible per CLAUDE.md.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run audit:static` — 0 HIGH (one new LOW dead-routes notice on the new page; expected for a top-level route reachable via direct URL/sidebar nav, which lands in a follow-up slice)
- [x] `npm run build` clean — both routes registered
- [ ] CI Vitest run — Docker not available locally; deferring to CI. Pre-existing m12-1-rls / m4-schema / etc. redness is expected and unrelated.
- [ ] E2E spec for the new page — deferred to a follow-up to keep this slice tight; lib + route layer is fully unit-covered (S1-1 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)