### PR TITLE
fix(db-direct): skip SSL for localhost (hotfix for #407 CI red)

### DIFF
--- a/lib/db-direct.ts
+++ b/lib/db-direct.ts
@@ -56,10 +56,17 @@ export function parseDbUrl(raw: string): ClientConfig {
     ? decodeURIComponent(url.pathname.slice(1))
     : undefined;
 
-  // Supabase pooler requires TLS. We don't pin a CA — Supabase rotates
-  // their cert chain freely. rejectUnauthorized:false matches the
-  // pre-fix behaviour with sslmode=require.
-  const ssl = { rejectUnauthorized: false };
+  // SSL: hosted Supabase pooler/direct requires TLS; the local
+  // `supabase start` Docker image uses unencrypted Postgres on
+  // 127.0.0.1 (vitest's globalSetup spins this up for the CI test
+  // job + local dev). Detect by host. rejectUnauthorized:false on
+  // remote matches the pre-fix behaviour with sslmode=require.
+  const isLocal =
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "host.docker.internal";
+  const ssl = isLocal ? false : { rejectUnauthorized: false };
 
   return { host, port, user, password, database, ssl };
 }


### PR DESCRIPTION
## Summary

Hotfix for PR #407. The new `requireDbConfig()` helper unconditionally set `ssl: { rejectUnauthorized: false }`, which broke vitest jobs on the `transfer-worker-caption` and `transfer-worker-upload` suites. They connect to the local `supabase start` Docker image at 127.0.0.1 — unencrypted Postgres — and pg throws `The server does not support SSL connections`.

Detect localhost / 127.0.0.1 / ::1 / host.docker.internal and disable SSL for those hosts. Hosted Supabase pooler still gets TLS (host = `aws-*.pooler.supabase.com`).

## Risks identified and mitigated

- Production / staging hosts unchanged (still TLS with rejectUnauthorized:false).
- Local dev + CI Supabase stack now connects without SSL, restoring the test job to green.
- Detection list covers the four hostnames the local Supabase image binds to in practice; if a future setup uses a different localhost alias we'll see the same SSL error and add it.

## Test plan

- [ ] CI green on this PR (the failing transfer-worker suites pass)
- [ ] Hosted cron still returns 200 once the new build deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)