### PR TITLE
feat(run-ux): brief run page feels alive + debug footer

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -8,6 +8,7 @@ import {
   SIDEBAR_COLLAPSED_COOKIE,
 } from "@/components/AdminSidebar";
 import { CommandPalette } from "@/components/CommandPalette";
+import { DebugFooter } from "@/components/DebugFooter";
 import { Toaster } from "@/components/ui/toaster";
 
 // Shared shell for every page under /admin.
@@ -79,6 +80,14 @@ export default async function AdminLayout({
       </main>
       <Toaster />
       <CommandPalette />
+      {isSuperAdmin && (
+        <DebugFooter
+          buildSha={process.env.VERCEL_GIT_COMMIT_SHA ?? null}
+          vercelEnv={process.env.VERCEL_ENV ?? null}
+          userEmail={user?.email ?? null}
+          userRole={user?.role ?? null}
+        />
+      )}
     </div>
   );
 }

--- a/app/admin/sites/[id]/briefs/[brief_id]/run/page.tsx
+++ b/app/admin/sites/[id]/briefs/[brief_id]/run/page.tsx
@@ -60,7 +60,26 @@ export default async function BriefRunPage({
   if (briefResult.data.brief.site_id !== params.id) notFound();
 
   const site = siteResult.data.site;
-  const { brief, pages } = briefResult.data;
+  let { brief, pages } = briefResult.data;
+
+  // Read-after-write race: the commit POST returns 200, client pushes
+  // to /run, but the read here can hit a connection pool that hasn't
+  // yet seen the COMMIT. Retry briefly when the brief looks "almost
+  // committed" so the operator sees the run surface, not a misleading
+  // "isn't committed yet" panel. Capped at ~1.5s total — beyond that,
+  // it's a real not-committed brief and we fall through to the panel.
+  if (brief.status === "parsed") {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const retry = await getBriefWithPages(params.brief_id);
+      if (!retry.ok) break;
+      if (retry.data.brief.status === "committed") {
+        brief = retry.data.brief;
+        pages = retry.data.pages;
+        break;
+      }
+    }
+  }
 
   if (brief.status !== "committed") {
     // The run surface is only meaningful once the brief is committed.

--- a/app/api/cron/process-brief-runner/route.ts
+++ b/app/api/cron/process-brief-runner/route.ts
@@ -164,25 +164,9 @@ async function handle(req: NextRequest): Promise<NextResponse> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     const stack = err instanceof Error ? err.stack : null;
-    const rawDbUrl = process.env.SUPABASE_DB_URL ?? "";
-    const dbUrlHost = (() => {
-      try {
-        return new URL(rawDbUrl.replace(/^postgres(ql)?:/, "http:")).host;
-      } catch (e) {
-        return `parse_failed:${e instanceof Error ? e.message : String(e)}`;
-      }
-    })();
-    const masked = rawDbUrl.replace(/:[^:@]+@/, ":***@");
     logger.error("cron.brief_runner.tick_failed", {
       error: message,
       stack,
-      db_url_length: rawDbUrl.length,
-      db_url_first_30: rawDbUrl.slice(0, 30),
-      db_url_last_30: rawDbUrl.slice(-30),
-      db_url_parsed_host: dbUrlHost,
-      db_url_masked: masked,
-      pghost_env: process.env.PGHOST ?? null,
-      pgport_env: process.env.PGPORT ?? null,
     });
     return NextResponse.json(
       {

--- a/components/BriefReviewClient.tsx
+++ b/components/BriefReviewClient.tsx
@@ -137,15 +137,22 @@ export function BriefReviewClient({
   const [voiceOverrideOpen, setVoiceOverrideOpen] = useState<boolean>(
     !hasSiteDefault || hasPerBriefOverride,
   );
-  // M12-5 — operator picks model tiers at commit time. Default to the
-  // value the server committed the brief with; fall back to the cheap
-  // default (Haiku) when a row has no value, so dev/UAT runs don't
-  // accidentally spend Sonnet/Opus money. Operator opts up explicitly.
+  // M12-5 — operator picks model tiers at commit time. Once committed,
+  // the brief carries the operator's choice and we display that. Pre-
+  // commit, default to DEFAULT_MODEL_ID (Sonnet 4.6) regardless of the
+  // DB column default — UAT (2026-05-02) showed Haiku's first-pass
+  // output reads thin on real briefs, and operators were slipping past
+  // the picker on the assumption that "default" meant "right". Cheap
+  // dev/test runs opt DOWN to Haiku explicitly.
   const [textModel, setTextModel] = useState<string>(
-    brief.text_model ?? DEFAULT_MODEL_ID,
+    brief.status === "committed" && brief.text_model
+      ? brief.text_model
+      : DEFAULT_MODEL_ID,
   );
   const [visualModel, setVisualModel] = useState<string>(
-    brief.visual_model ?? DEFAULT_MODEL_ID,
+    brief.status === "committed" && brief.visual_model
+      ? brief.visual_model
+      : DEFAULT_MODEL_ID,
   );
 
   const isReadOnly = brief.status === "committed";

--- a/components/BriefRunClient.tsx
+++ b/components/BriefRunClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { TriangleAlert } from "lucide-react";
 
 import { Alert } from "@/components/ui/alert";
@@ -162,6 +162,27 @@ export function BriefRunClient({
     const detailsEl = el.querySelector<HTMLDetailsElement>("details");
     if (detailsEl) detailsEl.open = true;
   }
+
+  // Auto-scroll to the first awaiting-review page when the surface
+  // first lands on one. Tracks the page id so re-renders during the
+  // same review session don't yank scroll position around. Cleared
+  // when the operator approves / revises (page id changes or no page
+  // is awaiting). Honours prefers-reduced-motion via behavior:auto.
+  const lastScrolledToRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!firstAwaitingReview) {
+      lastScrolledToRef.current = null;
+      return;
+    }
+    if (lastScrolledToRef.current === firstAwaitingReview.id) return;
+    lastScrolledToRef.current = firstAwaitingReview.id;
+    // Defer one tick so the page card has rendered before we scroll.
+    const id = window.requestAnimationFrame(() => {
+      scrollToPageCard(firstAwaitingReview.id);
+    });
+    return () => window.cancelAnimationFrame(id);
+  }, [firstAwaitingReview]);
 
   const isRunTerminal =
     activeRun?.status === "succeeded" ||

--- a/components/BriefRunClient.tsx
+++ b/components/BriefRunClient.tsx
@@ -157,6 +157,10 @@ export function BriefRunClient({
     // After the smooth scroll begins, focus the card so screen-readers
     // jump along with the visual focus.
     el.focus({ preventScroll: true });
+    // Open the rendered-preview <details> so the operator sees the
+    // generated page immediately, not a collapsed panel.
+    const detailsEl = el.querySelector<HTMLDetailsElement>("details");
+    if (detailsEl) detailsEl.open = true;
   }
 
   const isRunTerminal =
@@ -368,10 +372,11 @@ export function BriefRunClient({
                 )}
               </>
             )}
-            {/* RS-4 — discreet stale indicator. Only renders when the
-                last successful poll is more than 8s old (intervalMs * 2),
-                so a single late tick doesn't flicker the badge. */}
-            {polled.isStale && (
+            {/* RS-4 — live-update indicator. Stale (>8s without a fresh
+                fetch) shows amber; healthy shows a faint pulsing green
+                so the operator sees the surface is wired up and doesn't
+                feel the urge to refresh. */}
+            {polled.isStale ? (
               <span
                 role="status"
                 className="ml-2 inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-sm text-muted-foreground"
@@ -379,6 +384,18 @@ export function BriefRunClient({
               >
                 <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-amber-500" />
                 Reconnecting…
+              </span>
+            ) : (
+              <span
+                role="status"
+                className="ml-2 inline-flex items-center gap-1 rounded-md bg-emerald-50 px-2 py-0.5 text-xs text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300"
+                title="This page auto-updates as the runner makes progress"
+              >
+                <span
+                  aria-hidden
+                  className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500"
+                />
+                Live
               </span>
             )}
           </p>
@@ -608,9 +625,9 @@ function PagePreview({
   return (
     <div className="mt-4 space-y-3">
       {html ? (
-        <details className="group">
+        <details className="group" open={isCurrentAwaitingReview}>
           <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground">
-            Show rendered preview
+            {isCurrentAwaitingReview ? "Hide rendered preview" : "Show rendered preview"}
           </summary>
           {looksTruncated && (
             <Alert

--- a/components/DebugFooter.tsx
+++ b/components/DebugFooter.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+
+// ---------------------------------------------------------------------------
+// DebugFooter — super_admin-only ops widget.
+//
+// Fixed bottom-right pill that expands to a copy-pasteable diagnostic
+// blob covering: route, build SHA, deploy env, recent x-request-ids
+// observed on this tab, recent 4xx/5xx responses, browser/UA. Copying
+// it into an issue or chat dramatically shortens the round-trip when
+// debugging UI bugs.
+//
+// Wired into the shared admin layout below the Toaster. Gated on
+// `isSuperAdmin` so operators don't see it.
+//
+// Capture mechanism: a tiny fetch interceptor records the last 20
+// requests to /api/* (request-id from `x-request-id` header, status,
+// path, ts). Window-scoped so it survives soft-nav. Cleared on full
+// page reload.
+// ---------------------------------------------------------------------------
+
+interface ApiEvent {
+  ts: number;
+  method: string;
+  path: string;
+  status: number;
+  request_id: string | null;
+  duration_ms: number;
+}
+
+interface DebugWindow extends Window {
+  __opolloDebug?: {
+    events: ApiEvent[];
+    push: (e: ApiEvent) => void;
+  };
+}
+
+declare const window: DebugWindow;
+
+function ensureCapture() {
+  if (typeof window === "undefined") return;
+  if (window.__opolloDebug) return;
+  const events: ApiEvent[] = [];
+  window.__opolloDebug = {
+    events,
+    push(e) {
+      events.push(e);
+      if (events.length > 20) events.shift();
+    },
+  };
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = async (input, init) => {
+    const t0 = performance.now();
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+    const method = (init?.method ?? "GET").toUpperCase();
+    try {
+      const res = await originalFetch(input, init);
+      if (url.includes("/api/")) {
+        try {
+          const u = new URL(url, window.location.origin);
+          window.__opolloDebug!.push({
+            ts: Date.now(),
+            method,
+            path: u.pathname + u.search,
+            status: res.status,
+            request_id: res.headers.get("x-request-id"),
+            duration_ms: Math.round(performance.now() - t0),
+          });
+        } catch {
+          // best-effort logging — never break a real request
+        }
+      }
+      return res;
+    } catch (err) {
+      if (url.includes("/api/")) {
+        try {
+          const u = new URL(url, window.location.origin);
+          window.__opolloDebug!.push({
+            ts: Date.now(),
+            method,
+            path: u.pathname + u.search,
+            status: 0,
+            request_id: null,
+            duration_ms: Math.round(performance.now() - t0),
+          });
+        } catch {
+          // ignore
+        }
+      }
+      throw err;
+    }
+  };
+}
+
+interface DebugFooterProps {
+  buildSha: string | null;
+  vercelEnv: string | null;
+  userEmail: string | null;
+  userRole: string | null;
+}
+
+export function DebugFooter({
+  buildSha,
+  vercelEnv,
+  userEmail,
+  userRole,
+}: DebugFooterProps) {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [eventsTick, setEventsTick] = useState(0);
+
+  useEffect(() => {
+    ensureCapture();
+    const id = setInterval(() => setEventsTick((n) => n + 1), 2000);
+    return () => clearInterval(id);
+  }, []);
+
+  const events =
+    typeof window !== "undefined" ? window.__opolloDebug?.events ?? [] : [];
+
+  function buildBlob(): string {
+    const lines: string[] = [];
+    lines.push("opollo debug snapshot");
+    lines.push(`captured-at: ${new Date().toISOString()}`);
+    lines.push(`route: ${pathname ?? "(unknown)"}`);
+    lines.push(`build-sha: ${buildSha ?? "(unset)"}`);
+    lines.push(`vercel-env: ${vercelEnv ?? "(unset)"}`);
+    lines.push(`user: ${userEmail ?? "(none)"} (${userRole ?? "no role"})`);
+    if (typeof navigator !== "undefined") {
+      lines.push(`ua: ${navigator.userAgent}`);
+      lines.push(
+        `viewport: ${window.innerWidth}x${window.innerHeight} dpr=${window.devicePixelRatio}`,
+      );
+    }
+    lines.push("");
+    lines.push(`recent api events (${events.length}):`);
+    for (const e of events.slice(-20)) {
+      const age = Math.round((Date.now() - e.ts) / 1000);
+      lines.push(
+        `  ${e.method.padEnd(6)} ${String(e.status).padStart(3)} ${
+          e.duration_ms
+        }ms x-request-id=${e.request_id ?? "-"} ${e.path} (${age}s ago)`,
+      );
+    }
+    return lines.join("\n");
+  }
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(buildBlob());
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  const errorCount = events.filter((e) => e.status === 0 || e.status >= 400).length;
+
+  return (
+    <div
+      className="pointer-events-none fixed bottom-2 right-2 z-50 flex flex-col items-end gap-2"
+      data-testid="debug-footer"
+      // Suppress hydration mismatch warning — pathname/window read
+      // after first paint deliberately differs from server render.
+      suppressHydrationWarning
+    >
+      {open && (
+        <div className="pointer-events-auto max-w-[480px] rounded-lg border border-border bg-popover p-3 text-xs shadow-lg">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <span className="font-semibold">Debug</span>
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="rounded border bg-background px-2 py-0.5 hover:bg-muted"
+              >
+                {copied ? "Copied" : "Copy"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded border bg-background px-2 py-0.5 hover:bg-muted"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+          <pre className="max-h-[40vh] overflow-auto whitespace-pre-wrap break-all rounded border bg-muted/40 p-2 font-mono text-[11px]">
+            {buildBlob()}
+          </pre>
+          <p className="mt-2 text-[10px] text-muted-foreground">
+            Click <strong>Copy</strong>, paste into a chat with engineering, and
+            include what you were trying to do.
+          </p>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="pointer-events-auto inline-flex items-center gap-1.5 rounded-full border border-border bg-popover px-2.5 py-1 text-[11px] font-medium text-muted-foreground shadow-md hover:bg-muted hover:text-foreground"
+        title={open ? "Hide debug panel" : "Open debug panel — click to copy diagnostic info"}
+        aria-label={open ? "Hide debug panel" : "Show debug panel"}
+      >
+        <span
+          aria-hidden
+          className={
+            errorCount > 0
+              ? "h-1.5 w-1.5 rounded-full bg-red-500"
+              : "h-1.5 w-1.5 rounded-full bg-emerald-500"
+          }
+        />
+        Debug{errorCount > 0 ? ` (${errorCount} err)` : ""}{" "}
+        <span className="hidden sm:inline">
+          · {(buildSha ?? "—").slice(0, 7)}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/components/UploadBriefModal.tsx
+++ b/components/UploadBriefModal.tsx
@@ -136,6 +136,12 @@ export function UploadBriefModal({
       if (payload?.ok) {
         // Whether or not the parser succeeded, we land on the review
         // page — it surfaces the failure details and the re-upload CTA.
+        // refresh() before push() invalidates the site-detail RSC tree
+        // so a subsequent back-nav shows the new brief without a manual
+        // page reload (the upload route's revalidatePath flushes the
+        // server cache, but the client-side router cache also needs a
+        // poke for bfcache / soft-nav consistency).
+        router.refresh();
         router.push(payload.data.review_url);
         onClose();
         return;

--- a/components/ui/status-pill.tsx
+++ b/components/ui/status-pill.tsx
@@ -100,7 +100,7 @@ const STATUS_MAP: Record<StatusKind, StatusEntry> = {
   brief_failed_parse: { label: "Parse failed", tone: "error" },
 
   // Run
-  run_queued: { label: "Queued", tone: "primary" },
+  run_queued: { label: "Queued — waiting for runner", tone: "primary", pulse: true },
   run_running: { label: "Running", tone: "primary", pulse: true },
   run_paused: { label: "Awaiting your review", tone: "warning" },
   run_succeeded: { label: "Complete", tone: "success" },

--- a/lib/anthropic-models.ts
+++ b/lib/anthropic-models.ts
@@ -35,14 +35,14 @@ export type ModelOption = {
 export const MODEL_OPTIONS: ReadonlyArray<ModelOption> = Object.freeze([
   {
     value: "claude-haiku-4-5-20251001",
-    label: "Haiku (fastest, cheapest — default)",
-    hint: "Default for dev / UAT / simple briefs. ~5× cheaper than Sonnet, ~25× cheaper than Opus.",
+    label: "Haiku (fastest, cheapest)",
+    hint: "Use for dev / UAT smoke-test runs. ~5× cheaper than Sonnet but produces noticeably thinner copy and flatter layouts on real briefs.",
     tier: "haiku",
   },
   {
     value: "claude-sonnet-4-6",
-    label: "Sonnet (balanced)",
-    hint: "Mid-tier. Use for production briefs where Haiku output reads thin.",
+    label: "Sonnet (balanced — default)",
+    hint: "Default for production briefs. Best ratio of quality to cost; substantially richer first-pass output than Haiku.",
     tier: "sonnet",
   },
   {
@@ -54,11 +54,12 @@ export const MODEL_OPTIONS: ReadonlyArray<ModelOption> = Object.freeze([
 ]);
 
 /**
- * Default model id for fresh brief runs. UAT-smoke-1: Haiku for
- * cost-control. Operators can opt up to Sonnet/Opus per-brief on the
- * review surface.
+ * Default model id for fresh brief runs. Sonnet 4.6 — UAT (2026-05-02)
+ * surfaced that Haiku output reads as generic / flat in real-use briefs.
+ * Operators opt DOWN to Haiku per-brief for cheap dev/test runs via the
+ * review-screen picker.
  */
-export const DEFAULT_MODEL_ID = "claude-haiku-4-5-20251001";
+export const DEFAULT_MODEL_ID = "claude-sonnet-4-6";
 
 // Defense-in-depth: every option in this UI list must be in the
 // allowlist exported by lib/anthropic-pricing.ts. A drift between the


### PR DESCRIPTION
## Summary

UAT (2026-05-02) generated a long list of gripes on the brief run/review surface — the most operator-visible flow in the platform. Bundled fix targeting the highest-impact items.

### Changes

**Run page UX**
- `Review now →` button now opens the rendered-preview `<details>` in addition to scrolling. Click does something visible even when the card is in view.
- Rendered preview auto-opens for pages in `awaiting_review`. Operators no longer have to also click "Show rendered preview".
- New "Live" pulse indicator next to run status. Polling was already wired (`usePoll` every 4s); the perception bug was that nothing on screen hinted at it. Now operators see a faint emerald dot + "Live" text next to the run status, plus the existing "Reconnecting…" stale fallback.

**Status pill**
- `run_queued` now pulses + reads "Queued — waiting for runner". Was a static neutral dot — operators couldn't tell if anything was happening.

**Default model** (the real cause of "boring output")
- `DEFAULT_MODEL_ID` flipped from Haiku to Sonnet 4.6. UAT showed Haiku produces flat generic copy on real briefs; operators were slipping past the picker assuming "default" meant "appropriate". Operators now opt DOWN to Haiku for cheap dev runs.
- Review form ignores the DB column default pre-commit (still Haiku per migration 0027) and surfaces `DEFAULT_MODEL_ID` instead. Post-commit, the operator's choice is shown as before.

**Briefs list staleness**
- `UploadBriefModal` now fires `router.refresh()` before `router.push()` so a back-nav to the site detail page surfaces the new brief without a manual reload.

**Commit-redirect race**
- `/run` retries the brief read up to 3× × 500ms when status is still `parsed`, before falling through to "isn't committed yet". Fixes the misleading error operators saw on a successful commit when PostgREST's pool hadn't yet picked up the COMMIT.

**Debug footer (new)**
- `components/DebugFooter.tsx` — super_admin-only pill, fixed bottom-right. Captures the last 20 `/api/*` requests via a fetch interceptor (status, `x-request-id`, duration). One-click copy bundles route + build SHA + viewport + UA + recent events. Designed for operator → engineering chat: paste the blob, no follow-up "what URL were you on?" round-trip.
- Wired into `app/admin/layout.tsx` behind `isSuperAdmin`.

**Cleanup**
- Removed the temporary diagnostic logging in `app/api/cron/process-brief-runner/route.ts` (added during the ENOTFOUND base hunt). The fix shipped in #407 + #409; the diag block did its job.

### Risks identified and mitigated

- **Default model cost change** — Sonnet is ~5× Haiku. Mitigated by: per-tenant cost ceiling already enforced (M12-4 risk 14), pre-commit cost-estimate modal fires when the run exceeds 50% of remaining budget (M12-4 risk 15). Cheap dev/UAT runs opt down explicitly via the picker.
- **Commit-race retry** — adds up to 1.5s to the /run server render in the worst case. Acceptable trade vs the misleading "not committed yet" panel users hit during UAT. Capped — won't loop forever.
- **Debug footer event capture** — wraps `window.fetch` globally on the client, but only mutates a window-scoped buffer (≤ 20 entries) and only logs `/api/*` paths. No PII. No network egress beyond what was already happening.
- **Auto-opening preview** — could surprise operators who deliberately collapsed it. Mitigation: the `<details>` `open` is per-render, not persisted — operator can re-collapse and it stays collapsed until the next status change (or page nav).

### Test plan
- [ ] Lint + typecheck (already green locally)
- [ ] CI passes (pre-existing m12-1-rls / m4-schema reds remain, not caused by this PR)
- [ ] Manual: upload a brief → land on /review → Sonnet pre-selected → commit → /run shows new "Live" pill + queued state pulses → cron tick → page auto-advances to awaiting_review with preview already open
- [ ] Manual: super_admin sees Debug pill bottom-right; copy produces a paste-friendly blob

🤖 Generated with [Claude Code](https://claude.com/claude-code)