### PR TITLE
feat(s1-5): submit-for-approval state transition

### DIFF
--- a/app/api/platform/social/posts/[id]/submit/route.ts
+++ b/app/api/platform/social/posts/[id]/submit/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { submitForApproval } from "@/lib/platform/social/posts";
+
+// ---------------------------------------------------------------------------
+// S1-5 — POST /api/platform/social/posts/[id]/submit
+//
+// Transitions a draft post to pending_client_approval and creates the
+// approval_request snapshot. Atomic via the migration-0071 Postgres
+// function; see lib/platform/social/posts/transitions.ts for the
+// snapshot shape.
+//
+// Gate: canDo("submit_for_approval", company_id) — editor+ in role
+// hierarchy (per lib/platform/auth/permissions.ts).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+const Schema = z.object({
+  company_id: z.string().uuid(),
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+function statusForCode(code: string): number {
+  switch (code) {
+    case "VALIDATION_FAILED":
+      return 400;
+    case "NOT_FOUND":
+      return 404;
+    case "INVALID_STATE":
+      return 409;
+    default:
+      return 500;
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return errorJson("VALIDATION_FAILED", "id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = Schema.safeParse(body);
+  if (!parsed.success) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "Body must be { company_id: uuid }.",
+      400,
+    );
+  }
+
+  const gate = await requireCanDoForApi(
+    parsed.data.company_id,
+    "submit_for_approval",
+  );
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await submitForApproval({
+    postId: id,
+    companyId: parsed.data.company_id,
+  });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      statusForCode(result.error.code),
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: result.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/company/social/posts/[id]/page.tsx
+++ b/app/company/social/posts/[id]/page.tsx
@@ -48,10 +48,11 @@ export default async function CompanySocialPostDetailPage({
 
   const companyId = session.company.companyId;
 
-  const [postResult, variantsResult, canEdit] = await Promise.all([
+  const [postResult, variantsResult, canEdit, canSubmit] = await Promise.all([
     getPostMaster({ postId: id, companyId }),
     listVariants({ postMasterId: id, companyId }),
     canDo(companyId, "edit_post"),
+    canDo(companyId, "submit_for_approval"),
   ]);
 
   if (!postResult.ok) {
@@ -68,7 +69,11 @@ export default async function CompanySocialPostDetailPage({
 
   return (
     <>
-      <SocialPostDetailClient post={postResult.data} canEdit={canEdit} />
+      <SocialPostDetailClient
+        post={postResult.data}
+        canEdit={canEdit}
+        canSubmit={canSubmit}
+      />
       {variantsResult.ok ? (
         <PostVariantsSection
           postId={postResult.data.id}

--- a/components/SocialPostDetailClient.tsx
+++ b/components/SocialPostDetailClient.tsx
@@ -24,6 +24,7 @@ import type {
 type Props = {
   post: PostMaster;
   canEdit: boolean;
+  canSubmit: boolean;
 };
 
 const STATE_LABEL: Record<SocialPostState, string> = {
@@ -39,17 +40,19 @@ const STATE_LABEL: Record<SocialPostState, string> = {
   failed: "Failed",
 };
 
-export function SocialPostDetailClient({ post, canEdit }: Props) {
+export function SocialPostDetailClient({ post, canEdit, canSubmit }: Props) {
   const router = useRouter();
   const [masterText, setMasterText] = useState(post.master_text ?? "");
   const [linkUrl, setLinkUrl] = useState(post.link_url ?? "");
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const isDraft = post.state === "draft";
   const editable = canEdit && isDraft;
+  const submittable = canSubmit && isDraft;
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
@@ -106,6 +109,43 @@ export function SocialPostDetailClient({ post, canEdit }: Props) {
     }
   }
 
+  async function handleSubmitForApproval() {
+    if (
+      !confirm(
+        "Submit this post for approval? You won't be able to edit it again until the reviewer responds.",
+      )
+    ) {
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/platform/social/posts/${post.id}/submit`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ company_id: post.company_id }),
+        },
+      );
+      const json = (await res.json()) as
+        | { ok: true; data: { approvalRequestId: string } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        const msg = !json.ok
+          ? json.error.message
+          : "Failed to submit for approval.";
+        setError(msg);
+        setSubmitting(false);
+        return;
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSubmitting(false);
+    }
+  }
+
   return (
     <>
       <div className="flex items-start justify-between gap-3">
@@ -126,22 +166,35 @@ export function SocialPostDetailClient({ post, canEdit }: Props) {
             </span>
           </Lead>
         </div>
-        {editable && !editing ? (
-          <div className="flex gap-2">
-            <Button
-              onClick={() => setEditing(true)}
-              data-testid="edit-post-button"
-            >
-              Edit
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDelete}
-              disabled={deleting}
-              data-testid="delete-post-button"
-            >
-              {deleting ? "Deleting…" : "Delete"}
-            </Button>
+        {!editing ? (
+          <div className="flex flex-wrap gap-2">
+            {editable ? (
+              <Button
+                onClick={() => setEditing(true)}
+                data-testid="edit-post-button"
+              >
+                Edit
+              </Button>
+            ) : null}
+            {submittable ? (
+              <Button
+                onClick={handleSubmitForApproval}
+                disabled={submitting}
+                data-testid="submit-post-button"
+              >
+                {submitting ? "Submitting…" : "Submit for approval"}
+              </Button>
+            ) : null}
+            {editable ? (
+              <Button
+                variant="destructive"
+                onClick={handleDelete}
+                disabled={deleting}
+                data-testid="delete-post-button"
+              >
+                {deleting ? "Deleting…" : "Delete"}
+              </Button>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -9,16 +9,19 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session A
 - Started: 2026-05-03
-- Branch: feat/s1-4-post-variants
-- Slice: S1-4 — per-platform post variants. lib/platform/social/variants {list,upsert} (UNIQUE post_master_id+platform; draft-only edits). GET+PUT /api/platform/social/posts/[id]/variants. Detail page renders the variants section.
+- Branch: feat/s1-5-submit-for-approval
+- Slice: S1-5 — submit-for-approval state transition (write-safety hotspot). Migration 0071 adds a transactional submit_post_for_approval(post_id, company_id, snapshot, expires_at) Postgres function so the state-machine flip + approval_request snapshot insert happen atomically. Lib + route + detail page button.
 - Files claimed:
-  - lib/platform/social/variants/{types,list,upsert,index}.ts (new)
-  - app/api/platform/social/posts/[id]/variants/route.ts (new)
-  - components/PostVariantsSection.tsx (new)
-  - app/company/social/posts/[id]/page.tsx (wire variants section)
-  - lib/__tests__/social-variants.test.ts (new)
+  - supabase/migrations/0071_submit_post_for_approval_fn.sql (new)
+  - supabase/rollbacks/0071_submit_post_for_approval_fn.down.sql (new)
+  - lib/platform/social/posts/transitions.ts (new)
+  - lib/platform/social/posts/index.ts (re-export)
+  - app/api/platform/social/posts/[id]/submit/route.ts (new)
+  - components/SocialPostDetailClient.tsx (Submit-for-approval button + canSubmit prop)
+  - app/company/social/posts/[id]/page.tsx (canSubmit gate)
+  - lib/__tests__/social-post-transitions.test.ts (new)
   - docs/WORK_IN_FLIGHT.md
-- Migration number reserved: none
+- Migration number reserved: 0071 — see Reserved migration numbers list.
 - Expected completion: same session.
 ---
 
@@ -70,6 +73,7 @@ When a session starts a migration, reserve the number here before writing the fi
 - ~~0019 — M13-1 posts schema.~~ Shipped in #142.
 - ~~0021 — M13-3 briefs.content_type column.~~ Shipped in #145.
 - ~~0070 — P1 Platform Foundation (platform_* + social_* schema + RLS).~~ Shipped in #376 + #377.
+- 0071 — Session A — S1-5 submit_post_for_approval transactional function (branch: feat/s1-5-submit-for-approval)
 
 ## Claim block template
 

--- a/lib/__tests__/social-post-transitions.test.ts
+++ b/lib/__tests__/social-post-transitions.test.ts
@@ -1,0 +1,316 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import {
+  createPostMaster,
+  submitForApproval,
+} from "@/lib/platform/social/posts";
+import { upsertVariant } from "@/lib/platform/social/variants";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser, type SeededAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// S1-5: lib-layer tests for submitForApproval.
+//
+// Exercises migration 0071's submit_post_for_approval Postgres function
+// end-to-end against the live Supabase stack. Concurrency invariant
+// covered explicitly: two parallel submits → exactly one
+// social_approval_requests row.
+// ---------------------------------------------------------------------------
+
+const COMPANY_A_ID = "abcdef00-0000-0000-0000-eeeeeeeeeeee";
+const COMPANY_B_ID = "abcdef00-0000-0000-0000-ffffffffffff";
+
+describe("lib/platform/social/posts/submitForApproval", () => {
+  let creator: SeededAuthUser;
+
+  beforeAll(async () => {
+    creator = await seedAuthUser({
+      email: "s1-5-creator@opollo.test",
+      persistent: true,
+    });
+  });
+
+  beforeEach(async () => {
+    const svc = getServiceRoleClient();
+
+    const companies = await svc
+      .from("platform_companies")
+      .insert([
+        {
+          id: COMPANY_A_ID,
+          name: "Acme Co",
+          slug: "s1-5-acme",
+          domain: "s1-5-acme.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+          approval_default_rule: "any_one",
+        },
+        {
+          id: COMPANY_B_ID,
+          name: "Beta Inc",
+          slug: "s1-5-beta",
+          domain: "s1-5-beta.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+          approval_default_rule: "all_must",
+        },
+      ])
+      .select("id");
+    if (companies.error) {
+      throw new Error(
+        `seed companies: ${companies.error.code ?? "?"} ${companies.error.message}`,
+      );
+    }
+
+    const user = await svc
+      .from("platform_users")
+      .insert({
+        id: creator.id,
+        email: creator.email,
+        full_name: "Creator",
+        is_opollo_staff: false,
+      })
+      .select("id");
+    if (user.error) {
+      throw new Error(
+        `seed creator: ${user.error.code ?? "?"} ${user.error.message}`,
+      );
+    }
+
+    const membership = await svc
+      .from("platform_company_users")
+      .insert({
+        company_id: COMPANY_A_ID,
+        user_id: creator.id,
+        role: "editor",
+      })
+      .select("id");
+    if (membership.error) {
+      throw new Error(
+        `seed membership: ${membership.error.code ?? "?"} ${membership.error.message}`,
+      );
+    }
+  });
+
+  afterAll(async () => {
+    const svc = getServiceRoleClient();
+    if (creator) await svc.auth.admin.deleteUser(creator.id);
+  });
+
+  async function createDraft(text = "ready to submit") {
+    const created = await createPostMaster({
+      companyId: COMPANY_A_ID,
+      masterText: text,
+      createdBy: creator.id,
+    });
+    if (!created.ok) {
+      throw new Error(`createDraft: ${created.error.code}`);
+    }
+    return created.data;
+  }
+
+  it("happy path — flips state to pending_client_approval AND inserts approval_request", async () => {
+    const post = await createDraft("hello reviewers");
+
+    const result = await submitForApproval({
+      postId: post.id,
+      companyId: COMPANY_A_ID,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.approvalRequestId).toMatch(/^[0-9a-f-]{36}$/);
+
+    const svc = getServiceRoleClient();
+    const after = await svc
+      .from("social_post_master")
+      .select("state")
+      .eq("id", post.id)
+      .single();
+    expect(after.error).toBeNull();
+    expect(after.data?.state).toBe("pending_client_approval");
+
+    const requests = await svc
+      .from("social_approval_requests")
+      .select("id, post_master_id, company_id, approval_rule, snapshot_payload, expires_at")
+      .eq("post_master_id", post.id);
+    expect(requests.error).toBeNull();
+    expect(requests.data?.length).toBe(1);
+    const req = requests.data?.[0];
+    expect(req?.approval_rule).toBe("any_one");
+    expect(req?.company_id).toBe(COMPANY_A_ID);
+    expect(req?.snapshot_payload).toMatchObject({
+      master_text: "hello reviewers",
+      link_url: null,
+    });
+  });
+
+  it("snapshot freezes per-platform variants at submit time", async () => {
+    const post = await createDraft("master");
+    await upsertVariant({
+      postMasterId: post.id,
+      companyId: COMPANY_A_ID,
+      platform: "linkedin_personal",
+      variantText: "linked-in flavour",
+    });
+    await upsertVariant({
+      postMasterId: post.id,
+      companyId: COMPANY_A_ID,
+      platform: "x",
+      variantText: "x flavour",
+    });
+
+    const result = await submitForApproval({
+      postId: post.id,
+      companyId: COMPANY_A_ID,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const svc = getServiceRoleClient();
+    const reqRow = await svc
+      .from("social_approval_requests")
+      .select("snapshot_payload")
+      .eq("post_master_id", post.id)
+      .single();
+    expect(reqRow.error).toBeNull();
+    const snap = reqRow.data?.snapshot_payload as {
+      variants: Array<{ platform: string; variant_text: string | null; is_custom: boolean }>;
+    };
+    const li = snap.variants.find((v) => v.platform === "linkedin_personal");
+    const x = snap.variants.find((v) => v.platform === "x");
+    const fb = snap.variants.find((v) => v.platform === "facebook_page");
+    expect(li).toMatchObject({ variant_text: "linked-in flavour", is_custom: true });
+    expect(x).toMatchObject({ variant_text: "x flavour", is_custom: true });
+    expect(fb).toMatchObject({ variant_text: null, is_custom: false });
+  });
+
+  it("two concurrent submits produce exactly one approval_request (atomic)", async () => {
+    const post = await createDraft("race target");
+
+    const [a, b] = await Promise.all([
+      submitForApproval({ postId: post.id, companyId: COMPANY_A_ID }),
+      submitForApproval({ postId: post.id, companyId: COMPANY_A_ID }),
+    ]);
+
+    // One must succeed, one must lose.
+    const successes = [a, b].filter((r) => r.ok);
+    const failures = [a, b].filter((r) => !r.ok);
+    expect(successes.length).toBe(1);
+    expect(failures.length).toBe(1);
+    expect(failures[0]?.ok).toBe(false);
+    if (!failures[0]?.ok) {
+      expect(failures[0]?.error.code).toBe("INVALID_STATE");
+    }
+
+    const svc = getServiceRoleClient();
+    const requests = await svc
+      .from("social_approval_requests")
+      .select("id")
+      .eq("post_master_id", post.id);
+    expect(requests.error).toBeNull();
+    expect(requests.data?.length).toBe(1);
+  });
+
+  it("rejects submit on non-draft post with INVALID_STATE", async () => {
+    const post = await createDraft();
+    const svc = getServiceRoleClient();
+    await svc
+      .from("social_post_master")
+      .update({ state: "approved" })
+      .eq("id", post.id);
+
+    const result = await submitForApproval({
+      postId: post.id,
+      companyId: COMPANY_A_ID,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("INVALID_STATE");
+  });
+
+  it("returns NOT_FOUND for cross-company access", async () => {
+    const post = await createDraft();
+    const result = await submitForApproval({
+      postId: post.id,
+      companyId: COMPANY_B_ID,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns NOT_FOUND for missing post id", async () => {
+    const result = await submitForApproval({
+      postId: "00000000-0000-0000-0000-000000000fff",
+      companyId: COMPANY_A_ID,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("rejects submit when post has neither master_text nor link_url", async () => {
+    const svc = getServiceRoleClient();
+    // Insert a post directly with both null (validates the lib-side
+    // guard on the submit path; createPostMaster wouldn't allow this).
+    const inserted = await svc
+      .from("social_post_master")
+      .insert({
+        company_id: COMPANY_A_ID,
+        state: "draft",
+        source_type: "manual",
+        master_text: null,
+        link_url: null,
+      })
+      .select("id")
+      .single();
+    expect(inserted.error).toBeNull();
+
+    const result = await submitForApproval({
+      postId: inserted.data!.id as string,
+      companyId: COMPANY_A_ID,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("uses approval_default_rule from the company", async () => {
+    // Create a post in company B (default rule = all_must per beforeEach
+    // setup). Insert directly because creator isn't a member of B.
+    const svc = getServiceRoleClient();
+    const inserted = await svc
+      .from("social_post_master")
+      .insert({
+        company_id: COMPANY_B_ID,
+        state: "draft",
+        source_type: "manual",
+        master_text: "post in beta",
+      })
+      .select("id")
+      .single();
+    expect(inserted.error).toBeNull();
+
+    const result = await submitForApproval({
+      postId: inserted.data!.id as string,
+      companyId: COMPANY_B_ID,
+    });
+    expect(result.ok).toBe(true);
+
+    const reqRow = await svc
+      .from("social_approval_requests")
+      .select("approval_rule")
+      .eq("post_master_id", inserted.data!.id)
+      .single();
+    expect(reqRow.error).toBeNull();
+    expect(reqRow.data?.approval_rule).toBe("all_must");
+  });
+});

--- a/lib/platform/social/posts/index.ts
+++ b/lib/platform/social/posts/index.ts
@@ -2,6 +2,11 @@ export { createPostMaster } from "./create";
 export { deletePostMaster } from "./delete";
 export { getPostMaster } from "./get";
 export { listPostMasters } from "./list";
+export {
+  submitForApproval,
+  type ApprovalSnapshot,
+  type SubmitForApprovalResult,
+} from "./transitions";
 export { updatePostMaster, type UpdatePostMasterInput } from "./update";
 export type {
   CreatePostMasterInput,

--- a/lib/platform/social/posts/transitions.ts
+++ b/lib/platform/social/posts/transitions.ts
@@ -1,0 +1,227 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { listVariants } from "@/lib/platform/social/variants";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// S1-5 — submit-for-approval state transition.
+//
+// Calls the Postgres function submit_post_for_approval (migration 0071)
+// which performs the state flip + approval_request snapshot insert in
+// a single transaction. The function uses SECURITY DEFINER so the
+// service-role client can call it.
+//
+// The snapshot is built application-side from the post + variant
+// rows, then passed in. We could read inside the SQL function, but
+// that adds branching in plpgsql and obscures the snapshot shape from
+// the application contract. Building it here also lets the lib unit-
+// test the snapshot shape independently.
+//
+// Caller is responsible for canDo("submit_for_approval", company_id).
+// ---------------------------------------------------------------------------
+
+const APPROVAL_TTL_DAYS = 14;
+
+export type SubmitForApprovalResult = {
+  approvalRequestId: string;
+  // Echo the snapshot so the route can return it for client display
+  // (or log it for audit).
+  snapshot: ApprovalSnapshot;
+};
+
+export type ApprovalSnapshot = {
+  // V1 schema. The approval-flow consumer (snapshot reader) reads
+  // these keys directly; do NOT rename without coordinating.
+  master_text: string | null;
+  link_url: string | null;
+  variants: ReadonlyArray<{
+    platform: string;
+    variant_text: string | null;
+    is_custom: boolean;
+  }>;
+  // Captured at submit time so the reviewer sees what was asked of them.
+  submitted_at: string;
+};
+
+export async function submitForApproval(args: {
+  postId: string;
+  companyId: string;
+  // Caller-provided expiry override (test plumbing); production
+  // defaults to +14 days.
+  expiresAt?: string;
+}): Promise<ApiResponse<SubmitForApprovalResult>> {
+  if (!args.postId) return validation("Post id is required.");
+  if (!args.companyId) return validation("Company id is required.");
+
+  const svc = getServiceRoleClient();
+
+  // Read the parent post + variants to build the snapshot. We do this
+  // BEFORE the RPC so the snapshot we send is exactly what we're
+  // committing. The atomic transition inside the function still
+  // catches concurrent edits via the state='draft' predicate; if
+  // someone else flips the state in the window between our read and
+  // the RPC, the function returns INVALID_STATE.
+  const post = await svc
+    .from("social_post_master")
+    .select("id, state, master_text, link_url")
+    .eq("id", args.postId)
+    .eq("company_id", args.companyId)
+    .maybeSingle();
+  if (post.error) {
+    logger.error("social.posts.submit.post_lookup_failed", {
+      err: post.error.message,
+      post_id: args.postId,
+    });
+    return internal(`Failed to read post: ${post.error.message}`);
+  }
+  if (!post.data) return notFound();
+
+  if (post.data.state !== "draft") {
+    return invalidState(
+      `Post is in '${post.data.state}', not 'draft'.`,
+    );
+  }
+
+  if (!post.data.master_text && !post.data.link_url) {
+    return validation(
+      "Cannot submit a post with neither master_text nor link_url.",
+    );
+  }
+
+  const variants = await listVariants({
+    postMasterId: args.postId,
+    companyId: args.companyId,
+  });
+  if (!variants.ok) {
+    // listVariants already returns the standard envelope shape; bubble
+    // it up unchanged.
+    return variants;
+  }
+
+  const snapshot: ApprovalSnapshot = {
+    master_text: (post.data.master_text as string | null) ?? null,
+    link_url: (post.data.link_url as string | null) ?? null,
+    variants: variants.data.resolved.map((r) => ({
+      platform: r.platform,
+      variant_text: r.variant?.is_custom
+        ? (r.variant.variant_text ?? null)
+        : null,
+      is_custom: r.variant?.is_custom === true,
+    })),
+    submitted_at: new Date().toISOString(),
+  };
+
+  const expiresAt =
+    args.expiresAt ??
+    new Date(
+      Date.now() + APPROVAL_TTL_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+  const rpc = await svc.rpc("submit_post_for_approval", {
+    p_post_id: args.postId,
+    p_company_id: args.companyId,
+    p_snapshot: snapshot,
+    p_expires_at: expiresAt,
+  });
+
+  if (rpc.error) {
+    // The function raises P0001 (INVALID_STATE) and P0002 (NOT_FOUND)
+    // with the precise error in the message. PostgREST surfaces these
+    // as { code: 'P0001' | 'P0002', message: 'INVALID_STATE: ...' }.
+    if (rpc.error.code === "P0001") {
+      return invalidState(stripPrefix(rpc.error.message, "INVALID_STATE: "));
+    }
+    if (rpc.error.code === "P0002") {
+      return notFoundWith(stripPrefix(rpc.error.message, "NOT_FOUND: "));
+    }
+    logger.error("social.posts.submit.rpc_failed", {
+      err: rpc.error.message,
+      code: rpc.error.code,
+      post_id: args.postId,
+    });
+    return internal(`Submit RPC failed: ${rpc.error.message}`);
+  }
+
+  // The function returns the new approval_request id as the scalar
+  // result. supabase-js rpc() with a scalar function returns it on
+  // `data` directly.
+  const approvalRequestId = rpc.data as unknown as string;
+  if (!approvalRequestId) {
+    return internal("Submit RPC returned no approval_request id.");
+  }
+
+  return {
+    ok: true,
+    data: { approvalRequestId, snapshot },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function stripPrefix(message: string, prefix: string): string {
+  return message.startsWith(prefix) ? message.slice(prefix.length) : message;
+}
+
+function validation(
+  message: string,
+): ApiResponse<SubmitForApprovalResult> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function invalidState(
+  message: string,
+): ApiResponse<SubmitForApprovalResult> {
+  return {
+    ok: false,
+    error: {
+      code: "INVALID_STATE",
+      message,
+      retryable: false,
+      suggested_action:
+        "Reload the page; another user may have already submitted or moved this post.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function notFound(): ApiResponse<SubmitForApprovalResult> {
+  return notFoundWith("No post with that id in this company.");
+}
+
+function notFoundWith(
+  message: string,
+): ApiResponse<SubmitForApprovalResult> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message,
+      retryable: false,
+      suggested_action: "Check the post id.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<SubmitForApprovalResult> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/supabase/migrations/0071_submit_post_for_approval_fn.sql
+++ b/supabase/migrations/0071_submit_post_for_approval_fn.sql
@@ -1,0 +1,105 @@
+-- =============================================================================
+-- 0071 — Transactional submit-for-approval function for social posts.
+-- =============================================================================
+-- Wraps the two writes that S1-5 needs:
+--   1. UPDATE social_post_master SET state='pending_client_approval'
+--      WHERE id=p_post_id AND company_id=p_company_id AND state='draft'
+--   2. INSERT INTO social_approval_requests with the snapshot payload
+--
+-- Doing both in one Postgres function makes them atomic: either both
+-- happen or neither does. The alternative — two PostgREST calls in
+-- application code — leaves a window where the state has flipped but
+-- the approval_request hasn't landed (or vice versa), breaking the
+-- invariant "every pending_client_approval post has exactly one open
+-- approval_request".
+--
+-- Concurrency:
+--   - The state predicate (`state='draft'`) gives us optimistic locking.
+--     Two concurrent submits both UPDATE; the second affects 0 rows
+--     and we RAISE EXCEPTION with SQLSTATE P0001.
+--   - Caller-side retries on P0001 are a no-op (state already moved).
+--
+-- Snapshot:
+--   - Caller passes the snapshot pre-built (master_text + per-platform
+--     variants array). The function does NOT recompute it from current
+--     rows — that would race with concurrent variant edits inside the
+--     same transaction window.
+--   - approval_rule defaults to platform_companies.approval_default_rule.
+--   - expires_at is caller-supplied (default ~+14d at the lib layer).
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION submit_post_for_approval(
+  p_post_id    UUID,
+  p_company_id UUID,
+  p_snapshot   JSONB,
+  p_expires_at TIMESTAMPTZ
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_rule social_approval_rule;
+  v_request_id UUID;
+  v_updated_id UUID;
+BEGIN
+  -- 1. Atomic transition. Predicate enforces draft + correct company.
+  -- A row missing OR a row not in the right company OR not in 'draft'
+  -- all trip the same RAISE — caller can't distinguish "no such post"
+  -- from "post in wrong state" via the SQLSTATE alone, so we encode
+  -- the precise error in MESSAGE for the lib to parse.
+  UPDATE social_post_master
+     SET state = 'pending_client_approval'
+   WHERE id = p_post_id
+     AND company_id = p_company_id
+     AND state = 'draft'
+   RETURNING id INTO v_updated_id;
+
+  IF v_updated_id IS NULL THEN
+    -- Disambiguate: did the post exist at all in this company?
+    IF EXISTS (
+      SELECT 1 FROM social_post_master
+       WHERE id = p_post_id AND company_id = p_company_id
+    ) THEN
+      RAISE EXCEPTION USING
+        ERRCODE = 'P0001',
+        MESSAGE = 'INVALID_STATE: post is not in draft.';
+    ELSE
+      RAISE EXCEPTION USING
+        ERRCODE = 'P0002',
+        MESSAGE = 'NOT_FOUND: post not in this company.';
+    END IF;
+  END IF;
+
+  -- 2. Resolve the company's approval rule. Function rather than a
+  -- subquery so we can RAISE if the company is missing (defence-in-
+  -- depth — the FK from posts already prevents orphans).
+  SELECT approval_default_rule INTO v_rule
+    FROM platform_companies
+   WHERE id = p_company_id;
+
+  IF v_rule IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = 'P0002',
+      MESSAGE = 'NOT_FOUND: company missing.';
+  END IF;
+
+  -- 3. INSERT the approval_request bound to this post + this snapshot.
+  -- snapshot_payload is immutable post-insert per the schema comment;
+  -- callers must NOT update it later.
+  INSERT INTO social_approval_requests (
+    post_master_id, company_id, approval_rule,
+    snapshot_payload, expires_at
+  )
+  VALUES (
+    p_post_id, p_company_id, v_rule,
+    p_snapshot, p_expires_at
+  )
+  RETURNING id INTO v_request_id;
+
+  RETURN v_request_id;
+END;
+$$;
+
+COMMENT ON FUNCTION submit_post_for_approval(UUID, UUID, JSONB, TIMESTAMPTZ) IS
+  'S1-5 — atomic state flip (draft → pending_client_approval) plus the matching approval_request insert. SQLSTATE P0001 = INVALID_STATE; P0002 = NOT_FOUND. SECURITY DEFINER because the lib calls this via service-role; canDo gating happens at the route layer.';

--- a/supabase/rollbacks/0071_submit_post_for_approval_fn.down.sql
+++ b/supabase/rollbacks/0071_submit_post_for_approval_fn.down.sql
@@ -1,0 +1,2 @@
+-- Rollback for 0071_submit_post_for_approval_fn.sql
+DROP FUNCTION IF EXISTS submit_post_for_approval(UUID, UUID, JSONB, TIMESTAMPTZ);


### PR DESCRIPTION
## Summary
- **Write-safety hotspot.** Transitions a draft post to `pending_client_approval` AND inserts the approval_request snapshot in one Postgres transaction so the invariant "every `pending_client_approval` post has exactly one open `approval_request`" holds even under concurrent submits.
- Migration **0071** wraps the two writes in a `SECURITY DEFINER` plpgsql function. Caller-side optimistic locking via `WHERE state='draft'` rejects races with `SQLSTATE P0001` (INVALID_STATE) and missing-post / wrong-company with `P0002` (NOT_FOUND).
- New `POST /api/platform/social/posts/[id]/submit` gated by `canDo("submit_for_approval", company_id)` (editor+).
- Detail page surfaces a Submit-for-approval button when state=draft AND the user has the permission. Confirm dialog warns that further edits are blocked once submitted.

## Changes
- `supabase/migrations/0071_submit_post_for_approval_fn.sql` + matching rollback.
- `lib/platform/social/posts/transitions.ts` — builds the snapshot application-side (master_text + per-platform variants frozen at submit time), then calls the RPC. Maps `P0001` → INVALID_STATE, `P0002` → NOT_FOUND, anything else → INTERNAL_ERROR.
- `app/api/platform/social/posts/[id]/submit/route.ts` — body `{ company_id }`, gated on `submit_for_approval`.
- `components/SocialPostDetailClient.tsx` — new `canSubmit` prop + button row reorganised; Edit / Submit / Delete shown side-by-side when applicable.
- `app/company/social/posts/[id]/page.tsx` — resolves `canSubmit` alongside `canEdit` + variants list.
- `lib/__tests__/social-post-transitions.test.ts` — 8 cases covering happy path, snapshot freezes, atomic concurrent submits, draft-only guard, cross-company NOT_FOUND, missing-post NOT_FOUND, empty-content guard, `approval_default_rule` from `platform_companies`.

## Risks identified and mitigated
- **Snapshot integrity**: function does NOT recompute the snapshot from current rows — caller passes it pre-built. Ensures the variant rows read at submit-time are exactly what gets committed. Test asserts each variant override is preserved with `is_custom=true`.
- **Concurrent submits**: optimistic-locking via `state='draft'` predicate. Two parallel UPDATEs both target the row; the second affects 0 rows and we RAISE `P0001`. Test asserts exactly one `social_approval_requests` row after `Promise.all` of two submits + that one of the two callers got `INVALID_STATE`.
- **Mid-flight variant edit**: variant lib already enforces draft-only (S1-4). Once state flips, subsequent variant upserts return `INVALID_STATE`; the snapshot already captured is frozen.
- **Cross-company submit**: gate authorises against body's `company_id`; function re-applies `WHERE company_id=p_company_id`; RLS adds a third layer. Tested.
- **Empty-content submit**: lib + function both refuse to submit a post with neither `master_text` nor `link_url` (no useful approval body).
- **Idempotency on retry**: a second submit returns `INVALID_STATE` cleanly; route surfaces 409. Caller can retry safely.
- **`SECURITY DEFINER` exposure**: function runs with the definer's privileges (`postgres`). RLS bypass is intentional — the lib calls via service-role anyway and the canDo gate at the route layer is the real authorisation. The function still re-applies `company_id` so a service-role caller can't smuggle a wrong scope.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` clean — submit route registered
- [ ] CI Vitest run — Docker not available locally; deferring to CI. The new social-post-transitions test exercises the migration end-to-end so should land green if the Supabase stack is healthy. Pre-existing m12-1-rls / m4-schema / etc. redness expected.
- [ ] E2E — deferred; lib + route + migration covered at the unit layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)