### PR TITLE
feat(s1-6): approval recipients + magic-link email delivery

### DIFF
--- a/app/api/platform/social/posts/[id]/recipients/[recipient_id]/route.ts
+++ b/app/api/platform/social/posts/[id]/recipients/[recipient_id]/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { revokeRecipient } from "@/lib/platform/social/approvals";
+
+// ---------------------------------------------------------------------------
+// S1-6 — DELETE /api/platform/social/posts/[id]/recipients/[recipient_id]
+//
+// Soft-revoke a single recipient. The recipient row stays on disk
+// (audit), only revoked_at flips. The magic-link viewer slice will
+// reject revoked tokens.
+//
+// Gate: canDo("submit_for_approval") — same as add.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+function statusForCode(code: string): number {
+  switch (code) {
+    case "VALIDATION_FAILED":
+      return 400;
+    case "NOT_FOUND":
+      return 404;
+    case "INVALID_STATE":
+      return 409;
+    default:
+      return 500;
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  {
+    params,
+  }: { params: Promise<{ id: string; recipient_id: string }> },
+): Promise<NextResponse> {
+  const { id, recipient_id } = await params;
+  if (!UUID_RE.test(id)) {
+    return errorJson("VALIDATION_FAILED", "post id must be a UUID.", 400);
+  }
+  if (!UUID_RE.test(recipient_id)) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "recipient_id must be a UUID.",
+      400,
+    );
+  }
+  const companyId = new URL(req.url).searchParams.get("company_id");
+  if (!companyId || !UUID_RE.test(companyId)) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "company_id query parameter (uuid) is required.",
+      400,
+    );
+  }
+
+  const gate = await requireCanDoForApi(companyId, "submit_for_approval");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await revokeRecipient({
+    recipientId: recipient_id,
+    companyId,
+  });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      statusForCode(result.error.code),
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { recipient: result.data },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/platform/social/posts/[id]/recipients/route.ts
+++ b/app/api/platform/social/posts/[id]/recipients/route.ts
@@ -1,0 +1,286 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { sendEmail } from "@/lib/email/sendgrid";
+import { renderSocialApprovalRequestEmail } from "@/lib/email/templates/social-approval-request";
+import { logger } from "@/lib/logger";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import {
+  addRecipient,
+  listRecipients,
+} from "@/lib/platform/social/approvals";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// S1-6 — GET / POST recipients for a post's open approval_request.
+//
+// We resolve the active approval_request from the post id rather than
+// asking the caller to know the request id directly. V1 only allows
+// one open request per post (the lib + DB don't enforce this — the
+// state machine does: a draft submit creates one, a finalised request
+// can't accept new recipients). When a post is in
+// pending_client_approval there's exactly one open row.
+//
+// POST gate: canDo("submit_for_approval") — same role threshold as
+// submitting (editor+). The reviewer-add affordance lives next to
+// the Submit button on the detail page.
+// GET gate: canDo("view_calendar") — viewer+ can see the audit list.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+const PostBodySchema = z.object({
+  company_id: z.string().uuid(),
+  email: z.string().email().max(254),
+  name: z.string().max(200).nullable().optional(),
+  requires_otp: z.boolean().optional(),
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: {
+        code,
+        message,
+        retryable: false,
+        ...(details ? { details } : {}),
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+function statusForCode(code: string): number {
+  switch (code) {
+    case "VALIDATION_FAILED":
+      return 400;
+    case "NOT_FOUND":
+      return 404;
+    case "INVALID_STATE":
+      return 409;
+    default:
+      return 500;
+  }
+}
+
+// Resolve the open approval_request for a post. "Open" =
+// !revoked_at AND no final_*_at. Returns the request id or null.
+async function resolveOpenRequestId(
+  postId: string,
+  companyId: string,
+): Promise<{ id: string } | null> {
+  const svc = getServiceRoleClient();
+  const r = await svc
+    .from("social_approval_requests")
+    .select("id, revoked_at, final_approved_at, final_rejected_at")
+    .eq("post_master_id", postId)
+    .eq("company_id", companyId)
+    .is("revoked_at", null)
+    .is("final_approved_at", null)
+    .is("final_rejected_at", null)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (r.error) return null;
+  if (!r.data) return null;
+  return { id: r.data.id as string };
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return errorJson("VALIDATION_FAILED", "id must be a UUID.", 400);
+  }
+  const companyId = new URL(req.url).searchParams.get("company_id");
+  if (!companyId || !UUID_RE.test(companyId)) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "company_id query parameter (uuid) is required.",
+      400,
+    );
+  }
+
+  const gate = await requireCanDoForApi(companyId, "view_calendar");
+  if (gate.kind === "deny") return gate.response;
+
+  const reqRow = await resolveOpenRequestId(id, companyId);
+  if (!reqRow) {
+    return NextResponse.json(
+      {
+        ok: true,
+        data: { recipients: [], approvalRequestId: null },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }
+
+  const result = await listRecipients({
+    approvalRequestId: reqRow.id,
+    companyId,
+  });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      statusForCode(result.error.code),
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        recipients: result.data.recipients,
+        approvalRequestId: reqRow.id,
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return errorJson("VALIDATION_FAILED", "id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = PostBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "Body must be { company_id: uuid, email: string, name?: string, requires_otp?: boolean }.",
+      400,
+      { issues: parsed.error.issues },
+    );
+  }
+
+  const gate = await requireCanDoForApi(
+    parsed.data.company_id,
+    "submit_for_approval",
+  );
+  if (gate.kind === "deny") return gate.response;
+
+  const reqRow = await resolveOpenRequestId(id, parsed.data.company_id);
+  if (!reqRow) {
+    return errorJson(
+      "INVALID_STATE",
+      "Post has no open approval request. Submit the post for approval first.",
+      409,
+    );
+  }
+
+  const result = await addRecipient({
+    approvalRequestId: reqRow.id,
+    companyId: parsed.data.company_id,
+    email: parsed.data.email,
+    name: parsed.data.name ?? null,
+    requiresOtp: parsed.data.requires_otp,
+  });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      statusForCode(result.error.code),
+    );
+  }
+
+  // Look up the company name for the email. Best-effort; if the read
+  // fails we still want the recipient row to exist (operator can
+  // resend manually). The route already authorised access to this
+  // company so service-role read is fine.
+  const svc = getServiceRoleClient();
+  let companyName = "your team";
+  const companyRead = await svc
+    .from("platform_companies")
+    .select("name")
+    .eq("id", parsed.data.company_id)
+    .maybeSingle();
+  if (!companyRead.error && companyRead.data?.name) {
+    companyName = companyRead.data.name as string;
+  }
+
+  // Look up expires_at on the request for the email body.
+  let expiresAt = result.data.recipient.created_at;
+  const reqRead = await svc
+    .from("social_approval_requests")
+    .select("expires_at")
+    .eq("id", reqRow.id)
+    .maybeSingle();
+  if (!reqRead.error && reqRead.data?.expires_at) {
+    expiresAt = reqRead.data.expires_at as string;
+  }
+
+  const origin =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ??
+    new URL(req.url).origin;
+  const reviewUrl = `${origin}/approve/${result.data.rawToken}`;
+
+  const emailContent = renderSocialApprovalRequestEmail({
+    recipient_email: parsed.data.email,
+    recipient_name: parsed.data.name?.trim() || null,
+    company_name: companyName,
+    review_url: reviewUrl,
+    expires_at: expiresAt,
+  });
+
+  const sendResult = await sendEmail({
+    to: parsed.data.email,
+    subject: emailContent.subject,
+    html: emailContent.html,
+    text: emailContent.text,
+  });
+
+  if (!sendResult.ok) {
+    logger.warn("social.approvals.recipients.add.email_failed", {
+      recipient_id: result.data.recipient.id,
+      err: sendResult.error?.message,
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "EMAIL_DELIVERY_FAILED",
+          message:
+            "Recipient was added but email delivery failed. Revoke and re-add, or resend manually.",
+          retryable: false,
+          details: { recipient_id: result.data.recipient.id },
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { recipient: result.data.recipient },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 201 },
+  );
+}

--- a/app/approve/[token]/page.tsx
+++ b/app/approve/[token]/page.tsx
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------
+// S1-6 — magic-link landing page (stub).
+//
+// V1 of the recipient-add flow puts a real token on the email but the
+// reviewer-side viewer + approve/reject UI lands in a follow-up slice.
+// For now this page just acknowledges the link arrived; the next slice
+// will swap in the snapshot reader + decision form.
+//
+// Public route: NO auth gate, the token IS the auth (validated server-
+// side once the viewer slice lands; this stub doesn't touch the DB).
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+export default async function ApproveLandingPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  await params; // Reserved for the viewer slice.
+  return (
+    <main className="mx-auto max-w-xl p-6 text-sm">
+      <h1 className="text-xl font-semibold">Approval link received</h1>
+      <p className="mt-3 text-muted-foreground">
+        Thanks for clicking through. The review experience is coming
+        online soon — we&apos;ll email you again when the post is ready
+        for your decision. If you weren&apos;t expecting this email,
+        you can safely ignore it.
+      </p>
+    </main>
+  );
+}

--- a/app/company/social/posts/[id]/page.tsx
+++ b/app/company/social/posts/[id]/page.tsx
@@ -1,10 +1,13 @@
 import { notFound, redirect } from "next/navigation";
 
+import { PostApprovalSection } from "@/components/PostApprovalSection";
 import { PostVariantsSection } from "@/components/PostVariantsSection";
 import { SocialPostDetailClient } from "@/components/SocialPostDetailClient";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
+import { listRecipients } from "@/lib/platform/social/approvals";
 import { getPostMaster } from "@/lib/platform/social/posts";
 import { listVariants } from "@/lib/platform/social/variants";
+import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
 // S1-3 — customer post detail at /company/social/posts/[id].
@@ -67,6 +70,38 @@ export default async function CompanySocialPostDetailPage({
     );
   }
 
+  // Resolve the open approval_request (if any) so the recipients
+  // section can render. Inlined here rather than wrapped in a lib
+  // helper because it's the only consumer in V1; can lift to
+  // lib/platform/social/approvals/get-open.ts when a second caller
+  // appears.
+  let approvalRequestId: string | null = null;
+  let initialRecipients: Awaited<
+    ReturnType<typeof listRecipients>
+  > | null = null;
+  const isPendingApproval = postResult.data.state === "pending_client_approval";
+  if (isPendingApproval) {
+    const svc = getServiceRoleClient();
+    const open = await svc
+      .from("social_approval_requests")
+      .select("id")
+      .eq("post_master_id", postResult.data.id)
+      .eq("company_id", companyId)
+      .is("revoked_at", null)
+      .is("final_approved_at", null)
+      .is("final_rejected_at", null)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (!open.error && open.data) {
+      approvalRequestId = open.data.id as string;
+      initialRecipients = await listRecipients({
+        approvalRequestId,
+        companyId,
+      });
+    }
+  }
+
   return (
     <>
       <SocialPostDetailClient
@@ -81,6 +116,15 @@ export default async function CompanySocialPostDetailPage({
           initialResolved={variantsResult.data.resolved}
           masterText={variantsResult.data.masterText}
           canEdit={canEdit && postResult.data.state === "draft"}
+        />
+      ) : null}
+      {isPendingApproval && initialRecipients?.ok ? (
+        <PostApprovalSection
+          postId={postResult.data.id}
+          companyId={companyId}
+          initialRecipients={initialRecipients.data.recipients}
+          initialApprovalRequestId={approvalRequestId}
+          canManage={canSubmit && isPendingApproval}
         />
       ) : null}
     </>

--- a/components/PostApprovalSection.tsx
+++ b/components/PostApprovalSection.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+// ---------------------------------------------------------------------------
+// S1-6 — recipients section on the post detail page.
+//
+// Renders the list of reviewers attached to the post's open
+// approval_request (or an empty state when none yet) and an inline
+// add form for editor+ on a pending_client_approval post. Revoke
+// soft-deletes a single recipient.
+// ---------------------------------------------------------------------------
+
+type RecipientRow = {
+  id: string;
+  email: string;
+  name: string | null;
+  requires_otp: boolean;
+  revoked_at: string | null;
+  created_at: string;
+};
+
+type Props = {
+  postId: string;
+  companyId: string;
+  initialRecipients: RecipientRow[];
+  initialApprovalRequestId: string | null;
+  // Editor+ on a pending_client_approval post can add or revoke.
+  canManage: boolean;
+};
+
+export function PostApprovalSection({
+  postId,
+  companyId,
+  initialRecipients,
+  initialApprovalRequestId,
+  canManage,
+}: Props) {
+  const [recipients, setRecipients] = useState(initialRecipients);
+  const [approvalRequestId] = useState(initialApprovalRequestId);
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    setAdding(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/platform/social/posts/${postId}/recipients`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            company_id: companyId,
+            email: email.trim().toLowerCase(),
+            name: name.trim() || null,
+          }),
+        },
+      );
+      const json = (await res.json()) as
+        | { ok: true; data: { recipient: RecipientRow } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        const msg = !json.ok ? json.error.message : "Failed to add recipient.";
+        setError(msg);
+        return;
+      }
+      setRecipients((prev) => [...prev, json.data.recipient]);
+      setEmail("");
+      setName("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function handleRevoke(recipientId: string) {
+    if (!confirm("Revoke this reviewer's magic link?")) return;
+    setRevokingId(recipientId);
+    setError(null);
+    try {
+      const url = `/api/platform/social/posts/${postId}/recipients/${recipientId}?company_id=${encodeURIComponent(companyId)}`;
+      const res = await fetch(url, { method: "DELETE" });
+      const json = (await res.json()) as
+        | { ok: true; data: { recipient: RecipientRow } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        const msg = !json.ok ? json.error.message : "Failed to revoke.";
+        setError(msg);
+        return;
+      }
+      setRecipients((prev) =>
+        prev.map((r) =>
+          r.id === recipientId
+            ? { ...r, revoked_at: json.data.recipient.revoked_at }
+            : r,
+        ),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRevokingId(null);
+    }
+  }
+
+  if (!approvalRequestId && recipients.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mt-8" data-testid="post-approval-section">
+      <h2 className="text-lg font-semibold">Approval reviewers</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Reviewers receive a magic link to view + respond to this post.
+      </p>
+
+      {error ? (
+        <p
+          className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          role="alert"
+          data-testid="recipients-error"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {recipients.length > 0 ? (
+        <ul
+          className="mt-4 divide-y rounded-lg border bg-card"
+          data-testid="recipients-list"
+        >
+          {recipients.map((r) => (
+            <li
+              key={r.id}
+              className="flex flex-wrap items-center justify-between gap-3 p-3"
+              data-testid={`recipient-row-${r.id}`}
+            >
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium">
+                  {r.name?.trim() ? `${r.name} <${r.email}>` : r.email}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  Added {new Date(r.created_at).toLocaleString("en-AU", {
+                    day: "numeric",
+                    month: "short",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                  {r.revoked_at ? " • Revoked" : null}
+                  {r.requires_otp ? " • OTP required" : null}
+                </div>
+              </div>
+              {canManage && !r.revoked_at ? (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleRevoke(r.id)}
+                  disabled={revokingId === r.id}
+                  data-testid={`recipient-revoke-${r.id}`}
+                >
+                  {revokingId === r.id ? "Revoking…" : "Revoke"}
+                </Button>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {canManage && approvalRequestId ? (
+        <form
+          onSubmit={handleAdd}
+          className="mt-4 rounded-lg border bg-card p-4"
+          data-testid="add-recipient-form"
+        >
+          <h3 className="text-sm font-semibold">Add a reviewer</h3>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <div>
+              <label
+                className="block text-sm font-medium"
+                htmlFor="recipient_email"
+              >
+                Email
+              </label>
+              <input
+                id="recipient_email"
+                type="email"
+                required
+                className="mt-1 w-full rounded-md border bg-background p-2 text-sm"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                data-testid="add-recipient-email"
+              />
+            </div>
+            <div>
+              <label
+                className="block text-sm font-medium"
+                htmlFor="recipient_name"
+              >
+                Name (optional)
+              </label>
+              <input
+                id="recipient_name"
+                type="text"
+                className="mt-1 w-full rounded-md border bg-background p-2 text-sm"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                data-testid="add-recipient-name"
+              />
+            </div>
+          </div>
+          <div className="mt-3 flex gap-2">
+            <Button
+              type="submit"
+              disabled={adding}
+              data-testid="add-recipient-submit"
+            >
+              {adding ? "Sending…" : "Send invite"}
+            </Button>
+          </div>
+        </form>
+      ) : null}
+    </section>
+  );
+}

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -9,19 +9,21 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session A
 - Started: 2026-05-03
-- Branch: feat/s1-5-submit-for-approval
-- Slice: S1-5 — submit-for-approval state transition (write-safety hotspot). Migration 0071 adds a transactional submit_post_for_approval(post_id, company_id, snapshot, expires_at) Postgres function so the state-machine flip + approval_request snapshot insert happen atomically. Lib + route + detail page button.
+- Branch: feat/s1-6-approval-recipients
+- Slice: S1-6 — approval recipients (magic-link delivery to reviewers). Lib add/list/revoke against social_approval_recipients with SHA-256 token storage. POST/GET /api/platform/social/posts/[id]/recipients + DELETE /[recipient_id]. Detail page renders the recipient list + add form when state=pending_client_approval. /approve/[token] stub landing page (viewer + decision flow lands in S1-7).
 - Files claimed:
-  - supabase/migrations/0071_submit_post_for_approval_fn.sql (new)
-  - supabase/rollbacks/0071_submit_post_for_approval_fn.down.sql (new)
-  - lib/platform/social/posts/transitions.ts (new)
-  - lib/platform/social/posts/index.ts (re-export)
-  - app/api/platform/social/posts/[id]/submit/route.ts (new)
-  - components/SocialPostDetailClient.tsx (Submit-for-approval button + canSubmit prop)
-  - app/company/social/posts/[id]/page.tsx (canSubmit gate)
-  - lib/__tests__/social-post-transitions.test.ts (new)
+  - lib/platform/social/approvals/{types,index}.ts (new)
+  - lib/platform/social/approvals/recipients/{add,list,revoke,index}.ts (new)
+  - lib/email/templates/social-approval-request.ts (new)
+  - app/api/platform/social/posts/[id]/recipients/route.ts (new)
+  - app/api/platform/social/posts/[id]/recipients/[recipient_id]/route.ts (new)
+  - components/PostApprovalSection.tsx (new)
+  - app/company/social/posts/[id]/page.tsx (wire approval section)
+  - app/approve/[token]/page.tsx (new — stub)
+  - middleware.ts (add /approve/ to public paths)
+  - lib/__tests__/social-approval-recipients.test.ts (new)
   - docs/WORK_IN_FLIGHT.md
-- Migration number reserved: 0071 — see Reserved migration numbers list.
+- Migration number reserved: none (existing 0070 schema covers it).
 - Expected completion: same session.
 ---
 

--- a/lib/__tests__/social-approval-recipients.test.ts
+++ b/lib/__tests__/social-approval-recipients.test.ts
@@ -1,0 +1,357 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import { hashToken } from "@/lib/platform/invitations";
+import {
+  addRecipient,
+  listRecipients,
+  revokeRecipient,
+} from "@/lib/platform/social/approvals";
+import {
+  createPostMaster,
+  submitForApproval,
+} from "@/lib/platform/social/posts";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser, type SeededAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// S1-6: lib-layer tests for approval recipients (add / list / revoke).
+// ---------------------------------------------------------------------------
+
+const COMPANY_A_ID = "abcdef00-0000-0000-0000-111111111111";
+const COMPANY_B_ID = "abcdef00-0000-0000-0000-222222222222";
+
+describe("lib/platform/social/approvals/recipients", () => {
+  let creator: SeededAuthUser;
+
+  beforeAll(async () => {
+    creator = await seedAuthUser({
+      email: "s1-6-creator@opollo.test",
+      persistent: true,
+    });
+  });
+
+  beforeEach(async () => {
+    const svc = getServiceRoleClient();
+
+    const companies = await svc
+      .from("platform_companies")
+      .insert([
+        {
+          id: COMPANY_A_ID,
+          name: "Acme Co",
+          slug: "s1-6-acme",
+          domain: "s1-6-acme.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+          approval_default_rule: "any_one",
+        },
+        {
+          id: COMPANY_B_ID,
+          name: "Beta Inc",
+          slug: "s1-6-beta",
+          domain: "s1-6-beta.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+        },
+      ])
+      .select("id");
+    if (companies.error) {
+      throw new Error(
+        `seed companies: ${companies.error.code ?? "?"} ${companies.error.message}`,
+      );
+    }
+
+    const user = await svc
+      .from("platform_users")
+      .insert({
+        id: creator.id,
+        email: creator.email,
+        full_name: "Creator",
+        is_opollo_staff: false,
+      })
+      .select("id");
+    if (user.error) {
+      throw new Error(
+        `seed creator: ${user.error.code ?? "?"} ${user.error.message}`,
+      );
+    }
+
+    const membership = await svc
+      .from("platform_company_users")
+      .insert({
+        company_id: COMPANY_A_ID,
+        user_id: creator.id,
+        role: "editor",
+      })
+      .select("id");
+    if (membership.error) {
+      throw new Error(
+        `seed membership: ${membership.error.code ?? "?"} ${membership.error.message}`,
+      );
+    }
+  });
+
+  afterAll(async () => {
+    const svc = getServiceRoleClient();
+    if (creator) await svc.auth.admin.deleteUser(creator.id);
+  });
+
+  // Set up an open approval_request for company A to operate against.
+  async function createOpenRequest(): Promise<string> {
+    const post = await createPostMaster({
+      companyId: COMPANY_A_ID,
+      masterText: "ready for review",
+      createdBy: creator.id,
+    });
+    if (!post.ok) throw new Error(`createOpenRequest: post ${post.error.code}`);
+    const submitted = await submitForApproval({
+      postId: post.data.id,
+      companyId: COMPANY_A_ID,
+    });
+    if (!submitted.ok) {
+      throw new Error(`createOpenRequest: submit ${submitted.error.code}`);
+    }
+    return submitted.data.approvalRequestId;
+  }
+
+  describe("addRecipient", () => {
+    it("happy path — inserts a recipient and returns a raw token + hashed token in DB", async () => {
+      const requestId = await createOpenRequest();
+      const result = await addRecipient({
+        approvalRequestId: requestId,
+        companyId: COMPANY_A_ID,
+        email: "Reviewer@External.Test",
+        name: "Rita Reviewer",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // Email normalised to lowercase + trimmed.
+      expect(result.data.recipient.email).toBe("reviewer@external.test");
+      expect(result.data.recipient.name).toBe("Rita Reviewer");
+      expect(result.data.recipient.requires_otp).toBe(false);
+      expect(result.data.rawToken).toMatch(/^[0-9a-f]{64}$/);
+
+      // Confirm the hash on disk matches the raw token.
+      const svc = getServiceRoleClient();
+      const row = await svc
+        .from("social_approval_recipients")
+        .select("token_hash")
+        .eq("id", result.data.recipient.id)
+        .single();
+      expect(row.error).toBeNull();
+      expect(row.data?.token_hash).toBe(hashToken(result.data.rawToken));
+      expect(row.data?.token_hash).not.toBe(result.data.rawToken);
+    });
+
+    it("normalises email — trims + lowercases", async () => {
+      const requestId = await createOpenRequest();
+      const result = await addRecipient({
+        approvalRequestId: requestId,
+        companyId: COMPANY_A_ID,
+        email: "  Mixed@Acme.Test  ",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.recipient.email).toBe("mixed@acme.test");
+    });
+
+    it("rejects bad email with VALIDATION_FAILED", async () => {
+      const requestId = await createOpenRequest();
+      const result = await addRecipient({
+        approvalRequestId: requestId,
+        companyId: COMPANY_A_ID,
+        email: "not-an-email",
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("returns NOT_FOUND for cross-company access", async () => {
+      const requestId = await createOpenRequest();
+      const result = await addRecipient({
+        approvalRequestId: requestId,
+        companyId: COMPANY_B_ID,
+        email: "intruder@b.test",
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+
+    it("rejects when the approval_request is revoked (INVALID_STATE)", async () => {
+      const requestId = await createOpenRequest();
+      const svc = getServiceRoleClient();
+      await svc
+        .from("social_approval_requests")
+        .update({ revoked_at: new Date().toISOString() })
+        .eq("id", requestId);
+
+      const result = await addRecipient({
+        approvalRequestId: requestId,
+        companyId: COMPANY_A_ID,
+        email: "late@external.test",
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("INVALID_STATE");
+    });
+
+    it("rejects when the approval_request is finalised (INVALID_STATE)", async () => {
+      const requestId = await createOpenRequest();
+      const svc = getServiceRoleClient();
+      await svc
+        .from("social_approval_requests")
+        .update({ final_approved_at: new Date().toISOString() })
+        .eq("id", requestId);
+
+      const result = await addRecipient({
+        approvalRequestId: requestId,
+        companyId: COMPANY_A_ID,
+        email: "post-final@external.test",
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("INVALID_STATE");
+    });
+
+    it("denormalises platform_user_id when recipient email matches a platform user", async () => {
+      // Seed a platform user with a known email.
+      const svc = getServiceRoleClient();
+      const otherUser = await seedAuthUser({
+        email: "linked-recipient@opollo.test",
+      });
+      const insertUser = await svc
+        .from("platform_users")
+        .insert({
+          id: otherUser.id,
+          email: otherUser.email,
+          full_name: "Linked",
+          is_opollo_staff: false,
+        })
+        .select("id");
+      expect(insertUser.error).toBeNull();
+
+      const requestId = await createOpenRequest();
+      const result = await addRecipient({
+        approvalRequestId: requestId,
+        companyId: COMPANY_A_ID,
+        email: otherUser.email,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.recipient.platform_user_id).toBe(otherUser.id);
+    });
+  });
+
+  describe("listRecipients", () => {
+    it("returns recipients for the open request, ordered by created_at asc", async () => {
+      const requestId = await createOpenRequest();
+      await addRecipient({
+        approvalRequestId: requestId,
+        companyId: COMPANY_A_ID,
+        email: "first@external.test",
+      });
+      await addRecipient({
+        approvalRequestId: requestId,
+        companyId: COMPANY_A_ID,
+        email: "second@external.test",
+      });
+
+      const result = await listRecipients({
+        approvalRequestId: requestId,
+        companyId: COMPANY_A_ID,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const emails = result.data.recipients.map((r) => r.email);
+      expect(emails).toEqual([
+        "first@external.test",
+        "second@external.test",
+      ]);
+    });
+
+    it("returns NOT_FOUND for cross-company access", async () => {
+      const requestId = await createOpenRequest();
+      const result = await listRecipients({
+        approvalRequestId: requestId,
+        companyId: COMPANY_B_ID,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("revokeRecipient", () => {
+    it("happy path — sets revoked_at and returns the row", async () => {
+      const requestId = await createOpenRequest();
+      const added = await addRecipient({
+        approvalRequestId: requestId,
+        companyId: COMPANY_A_ID,
+        email: "revoke-target@external.test",
+      });
+      expect(added.ok).toBe(true);
+      if (!added.ok) return;
+
+      const result = await revokeRecipient({
+        recipientId: added.data.recipient.id,
+        companyId: COMPANY_A_ID,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.revoked_at).not.toBeNull();
+    });
+
+    it("returns ALREADY_REVOKED on the second call", async () => {
+      const requestId = await createOpenRequest();
+      const added = await addRecipient({
+        approvalRequestId: requestId,
+        companyId: COMPANY_A_ID,
+        email: "double-revoke@external.test",
+      });
+      expect(added.ok).toBe(true);
+      if (!added.ok) return;
+
+      const first = await revokeRecipient({
+        recipientId: added.data.recipient.id,
+        companyId: COMPANY_A_ID,
+      });
+      expect(first.ok).toBe(true);
+      const second = await revokeRecipient({
+        recipientId: added.data.recipient.id,
+        companyId: COMPANY_A_ID,
+      });
+      expect(second.ok).toBe(false);
+      if (second.ok) return;
+      expect(second.error.code).toBe("INVALID_STATE");
+    });
+
+    it("returns NOT_FOUND for cross-company access", async () => {
+      const requestId = await createOpenRequest();
+      const added = await addRecipient({
+        approvalRequestId: requestId,
+        companyId: COMPANY_A_ID,
+        email: "scoped@external.test",
+      });
+      expect(added.ok).toBe(true);
+      if (!added.ok) return;
+
+      const result = await revokeRecipient({
+        recipientId: added.data.recipient.id,
+        companyId: COMPANY_B_ID,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+  });
+});

--- a/lib/__tests__/social-approval-recipients.test.ts
+++ b/lib/__tests__/social-approval-recipients.test.ts
@@ -60,6 +60,7 @@ describe("lib/platform/social/approvals/recipients", () => {
           domain: "s1-6-beta.test",
           is_opollo_internal: false,
           timezone: "Australia/Melbourne",
+          approval_default_rule: "any_one",
         },
       ])
       .select("id");

--- a/lib/email/templates/social-approval-request.ts
+++ b/lib/email/templates/social-approval-request.ts
@@ -1,0 +1,92 @@
+import "server-only";
+
+import { renderBaseEmail, escapeHtml } from "./base";
+
+// S1-6 — magic-link email to a reviewer asking them to approve a
+// social post. Sent by POST /api/platform/social/posts/[id]/recipients
+// after addRecipient() returns ok with the raw token.
+//
+// V1 keeps the body minimal — the snapshot lives behind the magic link
+// rather than being inlined in the email, so reviewers always see the
+// most up-to-date snapshot at the time of review (and can't be tricked
+// by a stale email forward into approving a different draft).
+
+export interface SocialApprovalRequestEmailInput {
+  recipient_email: string;
+  recipient_name: string | null;
+  company_name: string;
+  // Absolute URL to /approve/<raw_token>.
+  review_url: string;
+  // ISO timestamp string; rendered in the recipient's locale.
+  expires_at: string;
+}
+
+export function renderSocialApprovalRequestEmail(
+  input: SocialApprovalRequestEmailInput,
+): { subject: string; html: string; text: string } {
+  const subject = `Approval requested — ${input.company_name} on Opollo`;
+  const greeting = input.recipient_name?.trim()
+    ? escapeHtml(input.recipient_name.trim())
+    : "Hi";
+  const expiresLocal = formatExpiry(input.expires_at);
+
+  const bodyHtml = `
+    <p style="margin:0 0 12px 0;font-size:14px;line-height:1.5;color:#0f172a;">
+      ${greeting},
+    </p>
+    <p style="margin:0 0 12px 0;font-size:14px;line-height:1.5;color:#0f172a;">
+      <strong>${escapeHtml(input.company_name)}</strong> has prepared a
+      social post and would like your approval before it's scheduled.
+    </p>
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin:16px 0;">
+      <tr>
+        <td style="border-radius:6px;background-color:#0f172a;">
+          <a href="${escapeHtml(input.review_url)}" style="display:inline-block;padding:12px 24px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:6px;">
+            Review and respond
+          </a>
+        </td>
+      </tr>
+    </table>
+    <p style="margin:0 0 8px 0;font-size:12px;line-height:1.5;color:#64748b;">
+      The link expires on <strong>${escapeHtml(expiresLocal)}</strong>.
+    </p>
+    <p style="margin:0;font-size:12px;line-height:1.5;color:#64748b;">
+      If you didn't expect this request, you can safely ignore the
+      email.
+    </p>
+  `;
+
+  const textBody = [
+    `${input.recipient_name?.trim() ?? "Hi"},`,
+    ``,
+    `${input.company_name} has prepared a social post and would like your approval.`,
+    ``,
+    `Review and respond: ${input.review_url}`,
+    ``,
+    `The link expires on ${expiresLocal}.`,
+    ``,
+    `If you didn't expect this request, you can safely ignore the email.`,
+  ].join("\n");
+
+  const { html, text } = renderBaseEmail({
+    heading: subject,
+    bodyHtml,
+    bodyText: textBody,
+    footerNote: "Sent automatically by Opollo.",
+  });
+
+  return { subject, html, text };
+}
+
+function formatExpiry(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString("en-AU", {
+    weekday: "short",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+  });
+}

--- a/lib/platform/social/approvals/index.ts
+++ b/lib/platform/social/approvals/index.ts
@@ -1,0 +1,14 @@
+export {
+  addRecipient,
+  listRecipients,
+  revokeRecipient,
+} from "./recipients";
+export type {
+  AddRecipientInput,
+  AddRecipientResult,
+  ApprovalEventType,
+  ApprovalRecipient,
+  ApprovalRequest,
+  ApprovalRule,
+  ListRecipientsInput,
+} from "./types";

--- a/lib/platform/social/approvals/recipients/add.ts
+++ b/lib/platform/social/approvals/recipients/add.ts
@@ -1,0 +1,189 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { generateRawToken, hashToken } from "@/lib/platform/invitations";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { AddRecipientInput, AddRecipientResult } from "../types";
+
+// ---------------------------------------------------------------------------
+// S1-6 — add a recipient (reviewer) to an open approval_request.
+//
+// The caller passes an approval_request_id; we verify the parent
+// request belongs to companyId and is still open (not revoked + not
+// already finalised) before inserting the recipient row.
+//
+// Token contract:
+//   - Generate a 64-char hex random token.
+//   - Store SHA-256 hex hash in social_approval_recipients.token_hash.
+//   - Return the raw token ONCE to the caller for the email body.
+//   - Caller must build the magic-link URL and send the email; the
+//     lib does not know the deployment origin and stays decoupled
+//     from SendGrid for testability (mirror of sendInvitation in
+//     lib/platform/invitations).
+//
+// Caller is responsible for canDo("submit_for_approval", companyId).
+// Approval recipients can be added by anyone who could submit the
+// post — typically the editor who drafted it.
+// ---------------------------------------------------------------------------
+
+export async function addRecipient(
+  input: AddRecipientInput,
+): Promise<ApiResponse<AddRecipientResult>> {
+  const email = input.email.trim().toLowerCase();
+  if (!email || !email.includes("@")) {
+    return validation("A valid email is required.");
+  }
+  if (!input.approvalRequestId) {
+    return validation("Approval request id is required.");
+  }
+  if (!input.companyId) {
+    return validation("Company id is required.");
+  }
+
+  const svc = getServiceRoleClient();
+
+  // 1. Look up the parent request, scope by company_id, verify it's
+  // still open. Open = !revoked_at AND no final_*_at timestamps.
+  // Scoping at the lib (in addition to RLS) so a service-role caller
+  // can't add recipients to another company's request via stale id.
+  const reqLookup = await svc
+    .from("social_approval_requests")
+    .select(
+      "id, company_id, revoked_at, final_approved_at, final_rejected_at, expires_at",
+    )
+    .eq("id", input.approvalRequestId)
+    .eq("company_id", input.companyId)
+    .maybeSingle();
+
+  if (reqLookup.error) {
+    logger.error("social.approvals.recipients.add.req_lookup_failed", {
+      err: reqLookup.error.message,
+      approval_request_id: input.approvalRequestId,
+    });
+    return internal(`Failed to read approval request: ${reqLookup.error.message}`);
+  }
+  if (!reqLookup.data) {
+    return notFound("No approval request with that id in this company.");
+  }
+  if (reqLookup.data.revoked_at) {
+    return invalidState("Approval request was revoked.");
+  }
+  if (reqLookup.data.final_approved_at || reqLookup.data.final_rejected_at) {
+    return invalidState("Approval request is already finalised.");
+  }
+  // expires_at is informational here — the recipient list works
+  // until revoke/finalise; the magic-link viewer slice will reject
+  // expired tokens server-side at click time.
+
+  // 2. Look up whether this email already corresponds to a platform
+  // user, to denormalise the link in social_approval_recipients
+  // (audit makes "approved by" attribution easier downstream).
+  const userLookup = await svc
+    .from("platform_users")
+    .select("id")
+    .eq("email", email)
+    .maybeSingle();
+  if (userLookup.error) {
+    logger.error("social.approvals.recipients.add.user_lookup_failed", {
+      err: userLookup.error.message,
+    });
+    return internal(`Failed to read user: ${userLookup.error.message}`);
+  }
+  const platformUserId = userLookup.data?.id ?? null;
+
+  // 3. Generate the token.
+  const rawToken = generateRawToken();
+  const tokenHash = hashToken(rawToken);
+
+  // 4. Insert. The schema has no UNIQUE on (approval_request_id, email)
+  // — operators can deliberately add the same email twice (e.g. send
+  // two reminder rounds with different tokens). That matches the spec:
+  // each recipient row is one magic link.
+  const insertResult = await svc
+    .from("social_approval_recipients")
+    .insert({
+      approval_request_id: input.approvalRequestId,
+      email,
+      name: input.name?.trim() || null,
+      platform_user_id: platformUserId,
+      token_hash: tokenHash,
+      requires_otp: input.requiresOtp === true,
+    })
+    .select(
+      "id, approval_request_id, email, name, platform_user_id, requires_otp, otp_expires_at, revoked_at, created_at",
+    )
+    .single();
+
+  if (insertResult.error) {
+    logger.error("social.approvals.recipients.add.insert_failed", {
+      err: insertResult.error.message,
+      code: insertResult.error.code,
+      approval_request_id: input.approvalRequestId,
+    });
+    return internal(`Failed to add recipient: ${insertResult.error.message}`);
+  }
+
+  return {
+    ok: true,
+    data: {
+      recipient: insertResult.data as AddRecipientResult["recipient"],
+      rawToken,
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(message: string): ApiResponse<AddRecipientResult> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function notFound(message: string): ApiResponse<AddRecipientResult> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message,
+      retryable: false,
+      suggested_action: "Check the approval request id.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function invalidState(message: string): ApiResponse<AddRecipientResult> {
+  return {
+    ok: false,
+    error: {
+      code: "INVALID_STATE",
+      message,
+      retryable: false,
+      suggested_action:
+        "The approval request is no longer accepting new recipients.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<AddRecipientResult> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/approvals/recipients/index.ts
+++ b/lib/platform/social/approvals/recipients/index.ts
@@ -1,0 +1,3 @@
+export { addRecipient } from "./add";
+export { listRecipients } from "./list";
+export { revokeRecipient } from "./revoke";

--- a/lib/platform/social/approvals/recipients/list.ts
+++ b/lib/platform/social/approvals/recipients/list.ts
@@ -1,0 +1,111 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { ApprovalRecipient, ListRecipientsInput } from "../types";
+
+// ---------------------------------------------------------------------------
+// S1-6 — list recipients of an approval_request.
+//
+// Returns every recipient (including revoked) so the operator UI can
+// render the full audit trail. The route layer's view_calendar gate
+// is enough — every member of the company can see who was asked.
+// ---------------------------------------------------------------------------
+
+export async function listRecipients(
+  input: ListRecipientsInput,
+): Promise<ApiResponse<{ recipients: ApprovalRecipient[] }>> {
+  if (!input.approvalRequestId) {
+    return validation("Approval request id is required.");
+  }
+  if (!input.companyId) {
+    return validation("Company id is required.");
+  }
+
+  const svc = getServiceRoleClient();
+
+  // Verify the parent request belongs to this company before listing.
+  // Saves the caller from a "this request doesn't exist" 404 leaking
+  // cross-company existence.
+  const reqLookup = await svc
+    .from("social_approval_requests")
+    .select("id")
+    .eq("id", input.approvalRequestId)
+    .eq("company_id", input.companyId)
+    .maybeSingle();
+  if (reqLookup.error) {
+    logger.error("social.approvals.recipients.list.req_lookup_failed", {
+      err: reqLookup.error.message,
+    });
+    return internal(`Failed to read approval request: ${reqLookup.error.message}`);
+  }
+  if (!reqLookup.data) {
+    return notFound();
+  }
+
+  const rows = await svc
+    .from("social_approval_recipients")
+    .select(
+      "id, approval_request_id, email, name, platform_user_id, requires_otp, otp_expires_at, revoked_at, created_at",
+    )
+    .eq("approval_request_id", input.approvalRequestId)
+    .order("created_at", { ascending: true });
+
+  if (rows.error) {
+    logger.error("social.approvals.recipients.list.failed", {
+      err: rows.error.message,
+    });
+    return internal(`Failed to list recipients: ${rows.error.message}`);
+  }
+
+  return {
+    ok: true,
+    data: { recipients: (rows.data ?? []) as ApprovalRecipient[] },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(
+  message: string,
+): ApiResponse<{ recipients: ApprovalRecipient[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function notFound(): ApiResponse<{ recipients: ApprovalRecipient[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message: "No approval request with that id in this company.",
+      retryable: false,
+      suggested_action: "Check the approval request id.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(
+  message: string,
+): ApiResponse<{ recipients: ApprovalRecipient[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/approvals/recipients/revoke.ts
+++ b/lib/platform/social/approvals/recipients/revoke.ts
@@ -1,0 +1,150 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { ApprovalRecipient } from "../types";
+
+// ---------------------------------------------------------------------------
+// S1-6 — revoke a recipient. Idempotent on revoked_at: re-revoking
+// returns ALREADY_REVOKED rather than re-stamping. Once revoked, the
+// magic-link viewer rejects the token even though token_hash is
+// still on disk (the lookup will see revoked_at != null).
+// ---------------------------------------------------------------------------
+
+export async function revokeRecipient(args: {
+  recipientId: string;
+  // Same scoping discipline as add/list: the parent approval_request
+  // must belong to this company.
+  companyId: string;
+}): Promise<ApiResponse<ApprovalRecipient>> {
+  if (!args.recipientId) return validation("Recipient id is required.");
+  if (!args.companyId) return validation("Company id is required.");
+
+  const svc = getServiceRoleClient();
+
+  // Two-FK lookup avoided: we read the recipient first, then the
+  // parent request scoped by company, mirroring the
+  // platform_company_users embed-failure pattern documented in
+  // memory/feedback_postgrest_embed_ambiguous_fk.md.
+  const recipientLookup = await svc
+    .from("social_approval_recipients")
+    .select(
+      "id, approval_request_id, email, name, platform_user_id, requires_otp, otp_expires_at, revoked_at, created_at",
+    )
+    .eq("id", args.recipientId)
+    .maybeSingle();
+  if (recipientLookup.error) {
+    logger.error("social.approvals.recipients.revoke.lookup_failed", {
+      err: recipientLookup.error.message,
+    });
+    return internal(`Failed to read recipient: ${recipientLookup.error.message}`);
+  }
+  if (!recipientLookup.data) return notFound();
+
+  const recipient = recipientLookup.data as ApprovalRecipient;
+
+  if (recipient.revoked_at) {
+    return alreadyRevoked();
+  }
+
+  const reqLookup = await svc
+    .from("social_approval_requests")
+    .select("id")
+    .eq("id", recipient.approval_request_id)
+    .eq("company_id", args.companyId)
+    .maybeSingle();
+  if (reqLookup.error) {
+    logger.error("social.approvals.recipients.revoke.req_lookup_failed", {
+      err: reqLookup.error.message,
+    });
+    return internal(`Failed to scope check: ${reqLookup.error.message}`);
+  }
+  if (!reqLookup.data) {
+    // Recipient exists but in another company. Keep the leak surface
+    // narrow — return NOT_FOUND, not FORBIDDEN.
+    return notFound();
+  }
+
+  // Atomic flip; concurrent revokes converge.
+  const update = await svc
+    .from("social_approval_recipients")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", args.recipientId)
+    .is("revoked_at", null)
+    .select(
+      "id, approval_request_id, email, name, platform_user_id, requires_otp, otp_expires_at, revoked_at, created_at",
+    )
+    .maybeSingle();
+
+  if (update.error) {
+    logger.error("social.approvals.recipients.revoke.update_failed", {
+      err: update.error.message,
+    });
+    return internal(`Failed to revoke: ${update.error.message}`);
+  }
+  if (!update.data) {
+    // Race: another request revoked it between our lookup and update.
+    return alreadyRevoked();
+  }
+
+  return {
+    ok: true,
+    data: update.data as ApprovalRecipient,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(message: string): ApiResponse<ApprovalRecipient> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function notFound(): ApiResponse<ApprovalRecipient> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message: "No recipient with that id in this company.",
+      retryable: false,
+      suggested_action: "Check the recipient id.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function alreadyRevoked(): ApiResponse<ApprovalRecipient> {
+  return {
+    ok: false,
+    error: {
+      code: "INVALID_STATE",
+      message: "Recipient is already revoked.",
+      retryable: false,
+      suggested_action:
+        "Add a new recipient if you need a fresh magic link.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<ApprovalRecipient> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/approvals/types.ts
+++ b/lib/platform/social/approvals/types.ts
@@ -1,0 +1,73 @@
+// Mirrors social_approval_rule + event_type enums in migration 0070.
+export type ApprovalRule = "any_one" | "all_must";
+
+export type ApprovalEventType =
+  | "submitted"
+  | "viewed"
+  | "identity_bound"
+  | "comment_added"
+  | "approved"
+  | "rejected"
+  | "changes_requested"
+  | "expired"
+  | "revoked";
+
+export type ApprovalRequest = {
+  id: string;
+  post_master_id: string;
+  company_id: string;
+  approval_rule: ApprovalRule;
+  expires_at: string;
+  revoked_at: string | null;
+  final_approved_by_user_id: string | null;
+  final_approved_by_email: string | null;
+  final_approved_by_name: string | null;
+  final_approved_at: string | null;
+  final_rejected_at: string | null;
+  created_at: string;
+};
+
+// Recipient view returned to the operator UI. token_hash and
+// otp_code_hash are NEVER returned to the client — only stored
+// server-side for verification. The raw token is returned ONCE on
+// addRecipient() so the route can build the magic-link URL for the
+// email body, then immediately discarded.
+export type ApprovalRecipient = {
+  id: string;
+  approval_request_id: string;
+  email: string;
+  name: string | null;
+  platform_user_id: string | null;
+  requires_otp: boolean;
+  // ISO timestamps
+  revoked_at: string | null;
+  created_at: string;
+  // The OTP code is hashed; we only expose its expiry so the UI can
+  // surface "OTP expired" without seeing the secret.
+  otp_expires_at: string | null;
+};
+
+export type AddRecipientInput = {
+  approvalRequestId: string;
+  // Caller's company_id — used for scoping the parent request lookup
+  // (defence-in-depth on top of RLS).
+  companyId: string;
+  email: string;
+  name?: string | null;
+  // If true, the magic-link viewer will challenge the recipient with
+  // an OTP before showing the snapshot. V1 stores requires_otp but
+  // the OTP issuance flow lands in the viewer slice.
+  requiresOtp?: boolean;
+};
+
+export type AddRecipientResult = {
+  recipient: ApprovalRecipient;
+  // Raw token returned ONCE to the caller for the email body. Caller
+  // MUST send the email immediately and discard the value from memory.
+  rawToken: string;
+};
+
+export type ListRecipientsInput = {
+  approvalRequestId: string;
+  companyId: string;
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -108,6 +108,12 @@ function isPublicPath(pathname: string): boolean {
   // session yet — the whole point is to MINT one by setting their
   // password. Without this, the email link bounces to /login.
   if (pathname.startsWith("/invite/")) return true;
+  // /approve/<token> — social-approval magic link (S1-6). External
+  // reviewers may not be platform users at all; the token is the
+  // auth (server-component validates SHA-256 against
+  // social_approval_recipients.token_hash). Same rationale as
+  // /invite/<token> — the link must work pre-session.
+  if (pathname.startsWith("/approve/")) return true;
   // All /api/auth/* endpoints (login, logout-not-applicable-here,
   // callback, future invite/reset routes) are by definition pre-session.
   if (pathname.startsWith("/api/auth/")) return true;


### PR DESCRIPTION
## Summary
- Editors can attach reviewers (email + optional name) to a post's open `approval_request`. Each recipient gets a single-use magic-link emailed to them.
- The viewer + decision flow lands in S1-7; this slice ships the recipient roster + email delivery + soft revoke.
- `/approve/<token>` is a stub landing page for the magic link; real viewer/decision UI in the next slice. Middleware allows the route as a public path (token-as-auth, recipient may not be a platform user).

## Changes
- `lib/platform/social/approvals/recipients/{add,list,revoke}.ts`: reuses `lib/platform/invitations/tokens` for SHA-256 token storage. `add()` returns the raw token ONCE; only the hash hits disk. `revoke()` is idempotent on `revoked_at` (race-safe via `WHERE revoked_at IS NULL`).
- `POST/GET /api/platform/social/posts/[id]/recipients` (canDo `submit_for_approval` / `view_calendar`) and `DELETE /[recipient_id]` (canDo `submit_for_approval`). The route resolves the open approval_request from post id + scoping company.
- `lib/email/templates/social-approval-request.ts`: minimal magic-link email. The snapshot lives behind the link, not inlined, so reviewers always see the most up-to-date state on click.
- `components/PostApprovalSection.tsx`: list + add form + soft-revoke buttons on the post detail page when state is `pending_client_approval`.
- `app/approve/[token]/page.tsx`: stub landing for the magic link.
- `middleware.ts`: `/approve/` added to public paths.
- `lib/__tests__/social-approval-recipients.test.ts`: 12 cases — happy path with hash verification, email normalisation, validation, cross-company NOT_FOUND, revoked/finalised guards (INVALID_STATE), platform_user_id de-norm, list ordering, double-revoke idempotency.

## Risks identified and mitigated
- **Token leakage**: SHA-256 hash on disk; raw token returned ONCE in the route response (POST 201) and embedded in the email body. Caller discards the raw value.
- **Cross-company recipient adds**: every lib op reads the parent request scoped by `company_id` BEFORE writing. RLS on `social_approval_recipients` embeds via `approval_request → company_id` (already in 0070). Tests assert NOT_FOUND across the boundary.
- **Adding recipients to a finalised request**: lib refuses with `INVALID_STATE`; tested directly by stamping `final_approved_at` / `revoked_at` and re-asserting.
- **Concurrent revokes**: predicate UPDATE `WHERE revoked_at IS NULL`; the second caller sees `INVALID_STATE`.
- **Email delivery failure**: route returns 502 `EMAIL_DELIVERY_FAILED` but the recipient row still exists (operator can resend manually or revoke + re-add).
- **`platform_users` de-norm**: when a recipient email matches an existing platform user, `platform_user_id` is captured for audit attribution downstream. Tested.
- **Public route exposure**: `/approve/<token>` is intentionally pre-auth (token IS the auth). Stub page does not touch the DB; the validation happens in S1-7's viewer slice. Middleware comment documents the rationale alongside `/invite/<token>`.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` clean — recipients route + /approve/[token] registered
- [ ] CI Vitest run — Docker not available locally; deferring to CI. Pre-existing m12-1-rls / m4-schema / etc. redness expected.
- [ ] E2E — deferred; lib + route covered at the unit layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)