### PR TITLE
feat(s1-9): reopen-for-editing from changes_requested

### DIFF
--- a/app/api/platform/social/posts/[id]/reopen/route.ts
+++ b/app/api/platform/social/posts/[id]/reopen/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { reopenForEditing } from "@/lib/platform/social/posts";
+
+// ---------------------------------------------------------------------------
+// S1-9 — POST /api/platform/social/posts/[id]/reopen
+//
+// Flips a `changes_requested` post back to `draft` so the editor can
+// revise it and re-submit. The originating approval_request stays in
+// its finalised state (audit preserved); the next submitForApproval
+// mints a fresh approval_request.
+//
+// Gate: canDo("edit_post", company_id) — same threshold as edit/delete.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+const Schema = z.object({
+  company_id: z.string().uuid(),
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+function statusForCode(code: string): number {
+  switch (code) {
+    case "VALIDATION_FAILED":
+      return 400;
+    case "NOT_FOUND":
+      return 404;
+    case "INVALID_STATE":
+      return 409;
+    default:
+      return 500;
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return errorJson("VALIDATION_FAILED", "id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = Schema.safeParse(body);
+  if (!parsed.success) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "Body must be { company_id: uuid }.",
+      400,
+    );
+  }
+
+  const gate = await requireCanDoForApi(parsed.data.company_id, "edit_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await reopenForEditing({
+    postId: id,
+    companyId: parsed.data.company_id,
+  });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      statusForCode(result.error.code),
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: result.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/components/SocialPostDetailClient.tsx
+++ b/components/SocialPostDetailClient.tsx
@@ -48,11 +48,13 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit }: Props) {
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [reopening, setReopening] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const isDraft = post.state === "draft";
   const editable = canEdit && isDraft;
   const submittable = canSubmit && isDraft;
+  const reopenable = canEdit && post.state === "changes_requested";
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
@@ -146,6 +148,43 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit }: Props) {
     }
   }
 
+  async function handleReopen() {
+    if (
+      !confirm(
+        "Reopen this post for editing? The reviewer's response will stay in the audit trail; you'll need to re-submit for approval after editing.",
+      )
+    ) {
+      return;
+    }
+    setReopening(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/platform/social/posts/${post.id}/reopen`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ company_id: post.company_id }),
+        },
+      );
+      const json = (await res.json()) as
+        | { ok: true; data: { postState: "draft" } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        const msg = !json.ok
+          ? json.error.message
+          : "Failed to reopen post.";
+        setError(msg);
+        setReopening(false);
+        return;
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setReopening(false);
+    }
+  }
+
   return (
     <>
       <div className="flex items-start justify-between gap-3">
@@ -183,6 +222,15 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit }: Props) {
                 data-testid="submit-post-button"
               >
                 {submitting ? "Submitting…" : "Submit for approval"}
+              </Button>
+            ) : null}
+            {reopenable ? (
+              <Button
+                onClick={handleReopen}
+                disabled={reopening}
+                data-testid="reopen-post-button"
+              >
+                {reopening ? "Reopening…" : "Reopen for editing"}
               </Button>
             ) : null}
             {editable ? (

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -9,15 +9,14 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session A
 - Started: 2026-05-03
-- Branch: feat/s1-8-decision-notifications
-- Slice: S1-8 — close the loop on the approval flow. Dispatch approval_decided notification (email + in_app to submitter + admins) when a decision finalises the request. Sender-side audit trail of decisions on the post detail page when the post is in approved/rejected/changes_requested.
+- Branch: feat/s1-9-reopen-for-editing
+- Slice: S1-9 — reopen-for-editing flow. lib reopenForEditing flips changes_requested → draft via atomic predicate-guarded UPDATE. Route POST /api/platform/social/posts/[id]/reopen gated by canDo(edit_post). Detail page Reopen button visible only when state=changes_requested + permission.
 - Files claimed:
-  - lib/platform/social/approvals/events/{list,index}.ts (new)
-  - lib/platform/social/approvals/index.ts (re-export listApprovalEvents)
-  - app/api/approve/[token]/decision/route.ts (best-effort dispatch on finalised=true)
-  - components/PostDecisionsAudit.tsx (new)
-  - app/company/social/posts/[id]/page.tsx (wire audit section)
-  - lib/__tests__/social-approval-events.test.ts (new)
+  - lib/platform/social/posts/transitions.ts (extend with reopenForEditing)
+  - lib/platform/social/posts/index.ts (re-export reopenForEditing)
+  - app/api/platform/social/posts/[id]/reopen/route.ts (new)
+  - components/SocialPostDetailClient.tsx (Reopen button)
+  - lib/__tests__/social-post-transitions.test.ts (extend with reopen coverage)
   - docs/WORK_IN_FLIGHT.md
 - Migration number reserved: none.
 - Expected completion: same session.

--- a/lib/__tests__/social-post-transitions.test.ts
+++ b/lib/__tests__/social-post-transitions.test.ts
@@ -9,6 +9,7 @@ import {
 
 import {
   createPostMaster,
+  reopenForEditing,
   submitForApproval,
 } from "@/lib/platform/social/posts";
 import { upsertVariant } from "@/lib/platform/social/variants";
@@ -312,5 +313,117 @@ describe("lib/platform/social/posts/submitForApproval", () => {
       .single();
     expect(reqRow.error).toBeNull();
     expect(reqRow.data?.approval_rule).toBe("all_must");
+  });
+
+  describe("reopenForEditing", () => {
+    async function makeChangesRequestedPost() {
+      const post = await createDraft("changes_requested target");
+      const svc = getServiceRoleClient();
+      // Force the post into changes_requested directly. The realistic
+      // path is submit + decision('changes_requested') but we don't
+      // need to exercise the full chain just to test reopenForEditing.
+      const update = await svc
+        .from("social_post_master")
+        .update({ state: "changes_requested" })
+        .eq("id", post.id)
+        .select("id, state")
+        .single();
+      expect(update.error).toBeNull();
+      expect(update.data?.state).toBe("changes_requested");
+      return post;
+    }
+
+    it("happy path — flips changes_requested → draft", async () => {
+      const post = await makeChangesRequestedPost();
+      const result = await reopenForEditing({
+        postId: post.id,
+        companyId: COMPANY_A_ID,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.postState).toBe("draft");
+
+      const svc = getServiceRoleClient();
+      const after = await svc
+        .from("social_post_master")
+        .select("state")
+        .eq("id", post.id)
+        .single();
+      expect(after.data?.state).toBe("draft");
+    });
+
+    it("rejects reopen on a draft post with INVALID_STATE", async () => {
+      const post = await createDraft("already draft");
+      const result = await reopenForEditing({
+        postId: post.id,
+        companyId: COMPANY_A_ID,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("INVALID_STATE");
+    });
+
+    it("rejects reopen on an approved post with INVALID_STATE", async () => {
+      const post = await createDraft("approved one");
+      const svc = getServiceRoleClient();
+      await svc
+        .from("social_post_master")
+        .update({ state: "approved" })
+        .eq("id", post.id);
+
+      const result = await reopenForEditing({
+        postId: post.id,
+        companyId: COMPANY_A_ID,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("INVALID_STATE");
+    });
+
+    it("returns NOT_FOUND for cross-company access", async () => {
+      const post = await makeChangesRequestedPost();
+      const result = await reopenForEditing({
+        postId: post.id,
+        companyId: COMPANY_B_ID,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns NOT_FOUND for missing post id", async () => {
+      const result = await reopenForEditing({
+        postId: "00000000-0000-0000-0000-000000000fff",
+        companyId: COMPANY_A_ID,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+
+    it("two parallel reopens converge — only one transitions, the other sees INVALID_STATE", async () => {
+      const post = await makeChangesRequestedPost();
+
+      const [a, b] = await Promise.all([
+        reopenForEditing({ postId: post.id, companyId: COMPANY_A_ID }),
+        reopenForEditing({ postId: post.id, companyId: COMPANY_A_ID }),
+      ]);
+
+      const successes = [a, b].filter((r) => r.ok);
+      const failures = [a, b].filter((r) => !r.ok);
+      expect(successes.length).toBe(1);
+      expect(failures.length).toBe(1);
+      if (failures[0]?.ok === false) {
+        expect(failures[0].error.code).toBe("INVALID_STATE");
+      }
+
+      const svc = getServiceRoleClient();
+      const post_after = await svc
+        .from("social_post_master")
+        .select("state")
+        .eq("id", post.id)
+        .single();
+      expect(post_after.data?.state).toBe("draft");
+    });
   });
 });

--- a/lib/platform/social/posts/index.ts
+++ b/lib/platform/social/posts/index.ts
@@ -3,8 +3,10 @@ export { deletePostMaster } from "./delete";
 export { getPostMaster } from "./get";
 export { listPostMasters } from "./list";
 export {
+  reopenForEditing,
   submitForApproval,
   type ApprovalSnapshot,
+  type ReopenForEditingResult,
   type SubmitForApprovalResult,
 } from "./transitions";
 export { updatePostMaster, type UpdatePostMasterInput } from "./update";

--- a/lib/platform/social/posts/transitions.ts
+++ b/lib/platform/social/posts/transitions.ts
@@ -225,3 +225,148 @@ function internal(message: string): ApiResponse<SubmitForApprovalResult> {
     timestamp: new Date().toISOString(),
   };
 }
+
+// ---------------------------------------------------------------------------
+// S1-9 — reopen a `changes_requested` post for editing.
+//
+// Flips state changes_requested → draft so the editor can revise and
+// re-submit. The originating approval_request stays in its finalised
+// state — its snapshot + events are preserved as the audit trail. The
+// editor's next submitForApproval will mint a fresh approval_request.
+//
+// Atomic single-row UPDATE with predicate (`state = 'changes_requested'`)
+// — concurrent reopens converge: one transitions, the others see 0
+// rows updated and return INVALID_STATE.
+//
+// Caller is responsible for canDo("edit_post", company_id).
+// ---------------------------------------------------------------------------
+
+export type ReopenForEditingResult = {
+  postId: string;
+  postState: "draft";
+};
+
+export async function reopenForEditing(args: {
+  postId: string;
+  companyId: string;
+}): Promise<ApiResponse<ReopenForEditingResult>> {
+  if (!args.postId) {
+    return reopenValidation("Post id is required.");
+  }
+  if (!args.companyId) {
+    return reopenValidation("Company id is required.");
+  }
+
+  const svc = getServiceRoleClient();
+
+  // Atomic predicate-guarded UPDATE. If the post moved out of
+  // changes_requested between client-side click and our UPDATE, we
+  // return 0 rows and surface INVALID_STATE rather than clobbering
+  // the now-current state.
+  const update = await svc
+    .from("social_post_master")
+    .update({ state: "draft" })
+    .eq("id", args.postId)
+    .eq("company_id", args.companyId)
+    .eq("state", "changes_requested")
+    .select("id, state")
+    .maybeSingle();
+
+  if (update.error) {
+    logger.error("social.posts.reopen.failed", {
+      err: update.error.message,
+      code: update.error.code,
+      post_id: args.postId,
+    });
+    return reopenInternal(`Failed to reopen post: ${update.error.message}`);
+  }
+
+  if (!update.data) {
+    // Either the post doesn't exist in this company OR it's not in
+    // changes_requested. Disambiguate via a follow-up read so the
+    // caller gets a useful envelope.
+    const lookup = await svc
+      .from("social_post_master")
+      .select("state")
+      .eq("id", args.postId)
+      .eq("company_id", args.companyId)
+      .maybeSingle();
+    if (lookup.error) {
+      return reopenInternal(`Lookup failed: ${lookup.error.message}`);
+    }
+    if (!lookup.data) {
+      return reopenNotFound();
+    }
+    return reopenInvalidState(
+      `Post is in '${lookup.data.state}', not 'changes_requested'. Only changes_requested posts can be reopened for editing.`,
+    );
+  }
+
+  return {
+    ok: true,
+    data: {
+      postId: update.data.id as string,
+      postState: "draft",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function reopenValidation(
+  message: string,
+): ApiResponse<ReopenForEditingResult> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function reopenNotFound(): ApiResponse<ReopenForEditingResult> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message: "No post with that id in this company.",
+      retryable: false,
+      suggested_action: "Check the post id.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function reopenInvalidState(
+  message: string,
+): ApiResponse<ReopenForEditingResult> {
+  return {
+    ok: false,
+    error: {
+      code: "INVALID_STATE",
+      message,
+      retryable: false,
+      suggested_action:
+        "Reload the page; another user may have already moved this post.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function reopenInternal(
+  message: string,
+): ApiResponse<ReopenForEditingResult> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary
When a reviewer responds with `changes_requested`, the post lands in that state with the audit trail attached. S1-9 gives the editor a way back to `draft` so they can revise and re-submit without losing the prior `approval_request`'s snapshot or events.

## Changes
- `lib/platform/social/posts/transitions.ts` — `reopenForEditing()` flips state `changes_requested` → `draft` via atomic predicate-guarded UPDATE (`WHERE state='changes_requested'`). The originating `approval_request` stays in its finalised state — its `snapshot_payload` and `social_approval_events` rows are preserved as the historical audit trail.
- `POST /api/platform/social/posts/[id]/reopen` — gated by `canDo("edit_post", company_id)` (editor+). Body: `{ company_id }`.
- `components/SocialPostDetailClient.tsx` — Reopen button visible only when `post.state === 'changes_requested'` AND user has `edit_post`. Confirm dialog warns the audit trail stays put and a fresh approval_request will be needed on re-submit.
- `lib/__tests__/social-post-transitions.test.ts` — extended with 6 cases: happy path, INVALID_STATE for non-changes_requested states (draft, approved), cross-company NOT_FOUND, missing post NOT_FOUND, two parallel reopens converging.

## Risks identified and mitigated
- **Race against another editor reopening or revoking**: predicate UPDATE `WHERE state='changes_requested'` ensures one transition wins; the second sees 0 rows and returns `INVALID_STATE`. Tested.
- **Audit history loss**: function does NOT touch `social_approval_requests` or `social_approval_events`. The historical approval_request stays `final_rejected_at`-stamped; its events stay attached. The next submit creates a brand-new approval_request.
- **Duplicate active request after reopen**: existing `submitForApproval` RPC's `state='draft'` predicate prevents that. Once we reopen, the post is in `draft`; one submit creates the new request; concurrent submits race on the predicate same as before.
- **Cross-company write**: lib UPDATE filters by `company_id`; route gate authorises against body's `company_id`; RLS as third layer.
- **Auto-merge eligible**: L1 editorial state-machine, no money / external service / WP mutation.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` clean — `/api/platform/social/posts/[id]/reopen` registered
- [ ] CI Vitest run — Docker not available locally; deferring to CI. Pre-existing m12-1-rls / m4-schema / etc. redness expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)