### PR TITLE
feat(s1-11): social posts dashboard quick-stats

### DIFF
--- a/app/company/page.tsx
+++ b/app/company/page.tsx
@@ -1,11 +1,130 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
-// /company — landing redirect to /company/users (the only V1 customer
-// surface). Future: /company/settings, /company/social, etc. Each will
-// have its own gate.
+import { SocialPostsDashboardCard } from "@/components/SocialPostsDashboardCard";
+import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
+import { getSocialPostsStats } from "@/lib/platform/social/posts";
+
+// ---------------------------------------------------------------------------
+// /company — customer landing dashboard (S1-11).
+//
+// Surfaces the social-posts quick-stats card + shortcuts to the rest
+// of the customer surface. Same gating as the rest of /company:
+//   1. No session → /login.
+//   2. No company membership → "Not provisioned" envelope.
+//
+// Stats query is gated by canDo("view_calendar") — same threshold as
+// the list page. Members of the company can see their own stats;
+// Opollo staff see whichever company they're scoped to.
+// ---------------------------------------------------------------------------
 
 export const dynamic = "force-dynamic";
 
-export default function CompanyLandingPage(): never {
-  redirect("/company/users");
+export default async function CompanyLandingPage() {
+  const session = await getCurrentPlatformSession();
+  if (!session) {
+    redirect(`/login?next=${encodeURIComponent("/company")}`);
+  }
+
+  if (!session.company) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-sm">
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-4">
+          <p className="font-medium">Account not provisioned to a company.</p>
+          <p className="mt-1 text-muted-foreground">
+            Your account isn&apos;t a member of any company on the
+            platform yet. Ask an admin to invite you, or contact
+            Opollo support.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const companyId = session.company.companyId;
+  const canViewCalendar = await canDo(companyId, "view_calendar");
+
+  // Without view_calendar permission we can't surface the stats; fall
+  // back to a minimal landing with the management surfaces the user
+  // does have access to. (Viewer is the lowest role and has
+  // view_calendar, so this branch is purely defensive against future
+  // role-table changes.)
+  if (!canViewCalendar) {
+    return <MinimalLanding role={session.company.role} />;
+  }
+
+  const statsResult = await getSocialPostsStats({ companyId });
+
+  return (
+    <main className="mx-auto max-w-5xl p-6 space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Welcome back</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Here&apos;s where your social content sits today.
+        </p>
+      </header>
+
+      {statsResult.ok ? (
+        <SocialPostsDashboardCard stats={statsResult.data} />
+      ) : (
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+          role="alert"
+          data-testid="dashboard-stats-error"
+        >
+          Failed to load stats: {statsResult.error.message}
+        </div>
+      )}
+
+      <nav
+        className="grid gap-3 sm:grid-cols-2"
+        aria-label="Customer surfaces"
+      >
+        <Link
+          href="/company/social/posts"
+          className="block rounded-md border bg-card p-4 hover:border-primary/40"
+          data-testid="dashboard-link-posts"
+        >
+          <div className="font-medium">Social posts</div>
+          <div className="mt-1 text-sm text-muted-foreground">
+            Drafts, approvals, scheduling, audit trail.
+          </div>
+        </Link>
+        <Link
+          href="/company/users"
+          className="block rounded-md border bg-card p-4 hover:border-primary/40"
+          data-testid="dashboard-link-users"
+        >
+          <div className="font-medium">Users</div>
+          <div className="mt-1 text-sm text-muted-foreground">
+            Manage team members and pending invitations.
+          </div>
+        </Link>
+      </nav>
+    </main>
+  );
+}
+
+function MinimalLanding({ role }: { role: string }) {
+  return (
+    <main className="mx-auto max-w-3xl p-6 text-sm">
+      <h1 className="text-2xl font-semibold">Welcome back</h1>
+      <p className="mt-2 text-muted-foreground">
+        Your role ({role}) doesn&apos;t have access to the calendar.
+        Ask an admin to elevate your permissions if you need to see
+        post stats.
+      </p>
+      <nav className="mt-6 grid gap-3 sm:grid-cols-2">
+        <Link
+          href="/company/users"
+          className="block rounded-md border bg-card p-4 hover:border-primary/40"
+        >
+          <div className="font-medium">Users</div>
+          <div className="mt-1 text-muted-foreground">
+            See teammates and (if admin) manage invitations.
+          </div>
+        </Link>
+      </nav>
+    </main>
+  );
 }

--- a/components/SocialPostsDashboardCard.tsx
+++ b/components/SocialPostsDashboardCard.tsx
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------
+// S1-11 — quick-stats panel for /company. Server-component-friendly.
+//
+// Six tiles linking through to the filtered list. The "Approved this
+// week" tile shares its filter with "Approved" but adds the emphasis;
+// since the list view doesn't yet have a date filter, the link still
+// goes to the approved tab.
+// ---------------------------------------------------------------------------
+
+import Link from "next/link";
+
+import type { SocialPostsStats } from "@/lib/platform/social/posts";
+
+type Props = {
+  stats: SocialPostsStats;
+};
+
+type Tile = {
+  label: string;
+  value: number;
+  href: string;
+  emphasis?: "primary" | "amber" | "emerald" | "sky";
+  testId: string;
+};
+
+const EMPHASIS_BG: Record<NonNullable<Tile["emphasis"]>, string> = {
+  primary: "bg-primary/10 text-primary",
+  amber: "bg-amber-100 text-amber-900",
+  emerald: "bg-emerald-100 text-emerald-900",
+  sky: "bg-sky-100 text-sky-900",
+};
+
+export function SocialPostsDashboardCard({ stats }: Props) {
+  const tiles: Tile[] = [
+    {
+      label: "Drafts",
+      value: stats.drafts,
+      href: "/company/social/posts?state=draft",
+      testId: "stats-drafts",
+    },
+    {
+      label: "Awaiting approval",
+      value: stats.awaitingApproval,
+      href: "/company/social/posts?state=pending_client_approval",
+      emphasis: "amber",
+      testId: "stats-awaiting",
+    },
+    {
+      label: "Approved",
+      value: stats.approved,
+      href: "/company/social/posts?state=approved",
+      emphasis: "emerald",
+      testId: "stats-approved",
+    },
+    {
+      label: "Scheduled",
+      value: stats.scheduled,
+      href: "/company/social/posts?state=scheduled",
+      emphasis: "sky",
+      testId: "stats-scheduled",
+    },
+    {
+      label: "Published",
+      value: stats.published,
+      href: "/company/social/posts?state=published",
+      emphasis: "primary",
+      testId: "stats-published",
+    },
+    {
+      label: "Approved this week",
+      value: stats.approvedThisWeek,
+      href: "/company/social/posts?state=approved",
+      emphasis: "emerald",
+      testId: "stats-approved-this-week",
+    },
+  ];
+
+  return (
+    <section
+      className="rounded-lg border bg-card p-6"
+      data-testid="social-posts-dashboard-card"
+      aria-label="Social posts at a glance"
+    >
+      <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Social posts at a glance</h2>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            Quick view of where your team&apos;s content sits in the
+            approval pipeline.
+          </p>
+        </div>
+        <Link
+          href="/company/social/posts"
+          className="text-sm text-primary hover:underline"
+          data-testid="stats-view-all"
+        >
+          View all posts →
+        </Link>
+      </header>
+
+      <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {tiles.map((t) => (
+          <li key={t.testId}>
+            <Link
+              href={t.href}
+              className="block rounded-md border bg-background p-4 transition hover:border-primary/40 hover:bg-muted/40"
+              data-testid={t.testId}
+            >
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="text-sm font-medium text-muted-foreground">
+                  {t.label}
+                </span>
+                {t.emphasis ? (
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-sm font-medium ${EMPHASIS_BG[t.emphasis]}`}
+                  >
+                    {t.value === 1 ? "1 post" : `${t.value} posts`}
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-2 text-2xl font-semibold tabular-nums">
+                {t.value}
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -9,18 +9,16 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session A
 - Started: 2026-05-03
-- Branch: feat/s1-10-cancel-approval
-- Slice: S1-10 — admin cancel-approval flow (write-safety hotspot). Migration 0073 adds a transactional cancel_post_approval Postgres function: revoke open request + bounce post pending_client_approval → draft + write a 'revoked' event row, all atomic. Route POST /api/platform/social/posts/[id]/cancel-approval gated by canDo(edit_post). Detail page button visible when post in pending_client_approval + permission.
+- Branch: feat/s1-11-dashboard-stats
+- Slice: S1-11 — social posts dashboard quick-stats. lib/platform/social/posts/dashboard.ts with getSocialPostsStats() (six HEAD counts via parallel index-friendly queries). SocialPostsDashboardCard.tsx renders six clickable tiles linking to the filtered list. /company landing converted from a redirect to a real dashboard.
 - Files claimed:
-  - supabase/migrations/0073_cancel_post_approval_fn.sql (new)
-  - supabase/rollbacks/0073_cancel_post_approval_fn.down.sql (new)
-  - lib/platform/social/posts/transitions.ts (extend with cancelApprovalRequest)
-  - lib/platform/social/posts/index.ts (re-export)
-  - app/api/platform/social/posts/[id]/cancel-approval/route.ts (new)
-  - components/SocialPostDetailClient.tsx (Cancel approval button + reason prompt)
-  - lib/__tests__/social-post-transitions.test.ts (extend with cancel coverage)
+  - lib/platform/social/posts/dashboard.ts (new)
+  - lib/platform/social/posts/index.ts (re-export getSocialPostsStats)
+  - components/SocialPostsDashboardCard.tsx (new)
+  - app/company/page.tsx (real dashboard; replaces redirect)
+  - lib/__tests__/social-posts-dashboard.test.ts (new)
   - docs/WORK_IN_FLIGHT.md
-- Migration number reserved: 0073.
+- Migration number reserved: none.
 - Expected completion: same session.
 ---
 

--- a/lib/__tests__/social-posts-dashboard.test.ts
+++ b/lib/__tests__/social-posts-dashboard.test.ts
@@ -1,0 +1,244 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import {
+  createPostMaster,
+  getSocialPostsStats,
+} from "@/lib/platform/social/posts";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser, type SeededAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// S1-11: dashboard stats.
+//
+// Verifies counts per state + cross-company isolation + the "approved
+// this week" 7-day window.
+// ---------------------------------------------------------------------------
+
+const COMPANY_A_ID = "abcdef00-0000-0000-0000-aaaaaaaa1111";
+const COMPANY_B_ID = "abcdef00-0000-0000-0000-bbbbbbbb1111";
+
+describe("lib/platform/social/posts/dashboard", () => {
+  let creator: SeededAuthUser;
+
+  beforeAll(async () => {
+    creator = await seedAuthUser({
+      email: "s1-11-creator@opollo.test",
+      persistent: true,
+    });
+  });
+
+  beforeEach(async () => {
+    const svc = getServiceRoleClient();
+
+    const companies = await svc
+      .from("platform_companies")
+      .insert([
+        {
+          id: COMPANY_A_ID,
+          name: "Acme Co",
+          slug: "s1-11-acme",
+          domain: "s1-11-acme.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+          approval_default_rule: "any_one",
+        },
+        {
+          id: COMPANY_B_ID,
+          name: "Beta Inc",
+          slug: "s1-11-beta",
+          domain: "s1-11-beta.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+          approval_default_rule: "any_one",
+        },
+      ])
+      .select("id");
+    if (companies.error) {
+      throw new Error(
+        `seed companies: ${companies.error.code ?? "?"} ${companies.error.message}`,
+      );
+    }
+
+    const user = await svc
+      .from("platform_users")
+      .insert({
+        id: creator.id,
+        email: creator.email,
+        full_name: "Creator",
+        is_opollo_staff: false,
+      })
+      .select("id");
+    if (user.error) {
+      throw new Error(
+        `seed creator: ${user.error.code ?? "?"} ${user.error.message}`,
+      );
+    }
+
+    const membership = await svc
+      .from("platform_company_users")
+      .insert({
+        company_id: COMPANY_A_ID,
+        user_id: creator.id,
+        role: "editor",
+      })
+      .select("id");
+    if (membership.error) {
+      throw new Error(
+        `seed membership: ${membership.error.code ?? "?"} ${membership.error.message}`,
+      );
+    }
+  });
+
+  afterAll(async () => {
+    const svc = getServiceRoleClient();
+    if (creator) await svc.auth.admin.deleteUser(creator.id);
+  });
+
+  it("returns zeroes for an empty company", async () => {
+    const result = await getSocialPostsStats({ companyId: COMPANY_A_ID });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toEqual({
+      drafts: 0,
+      awaitingApproval: 0,
+      approved: 0,
+      scheduled: 0,
+      published: 0,
+      approvedThisWeek: 0,
+    });
+  });
+
+  it("counts posts per state correctly", async () => {
+    // Two drafts via the lib (created_by + state defaults work).
+    await createPostMaster({
+      companyId: COMPANY_A_ID,
+      masterText: "draft 1",
+      createdBy: creator.id,
+    });
+    await createPostMaster({
+      companyId: COMPANY_A_ID,
+      masterText: "draft 2",
+      createdBy: creator.id,
+    });
+
+    // Force three more posts into different states directly.
+    const svc = getServiceRoleClient();
+    await svc.from("social_post_master").insert([
+      {
+        company_id: COMPANY_A_ID,
+        master_text: "p1",
+        state: "pending_client_approval",
+        source_type: "manual",
+      },
+      {
+        company_id: COMPANY_A_ID,
+        master_text: "p2",
+        state: "approved",
+        source_type: "manual",
+      },
+      {
+        company_id: COMPANY_A_ID,
+        master_text: "p3",
+        state: "scheduled",
+        source_type: "manual",
+      },
+      {
+        company_id: COMPANY_A_ID,
+        master_text: "p4",
+        state: "published",
+        source_type: "manual",
+      },
+    ]);
+
+    const result = await getSocialPostsStats({ companyId: COMPANY_A_ID });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.drafts).toBe(2);
+    expect(result.data.awaitingApproval).toBe(1);
+    expect(result.data.approved).toBe(1);
+    expect(result.data.scheduled).toBe(1);
+    expect(result.data.published).toBe(1);
+  });
+
+  it("isolates company A from company B's posts", async () => {
+    await createPostMaster({
+      companyId: COMPANY_A_ID,
+      masterText: "A draft",
+      createdBy: creator.id,
+    });
+
+    // Insert posts into company B directly (creator isn't a member).
+    const svc = getServiceRoleClient();
+    await svc.from("social_post_master").insert([
+      {
+        company_id: COMPANY_B_ID,
+        master_text: "B p1",
+        state: "draft",
+        source_type: "manual",
+      },
+      {
+        company_id: COMPANY_B_ID,
+        master_text: "B p2",
+        state: "approved",
+        source_type: "manual",
+      },
+    ]);
+
+    const aStats = await getSocialPostsStats({ companyId: COMPANY_A_ID });
+    expect(aStats.ok).toBe(true);
+    if (!aStats.ok) return;
+    expect(aStats.data.drafts).toBe(1);
+    expect(aStats.data.approved).toBe(0); // B's approved doesn't count
+
+    const bStats = await getSocialPostsStats({ companyId: COMPANY_B_ID });
+    expect(bStats.ok).toBe(true);
+    if (!bStats.ok) return;
+    expect(bStats.data.drafts).toBe(1);
+    expect(bStats.data.approved).toBe(1);
+  });
+
+  it("approvedThisWeek counts only approvals within the 7-day window", async () => {
+    const svc = getServiceRoleClient();
+    const now = new Date();
+    const eightDaysAgo = new Date(
+      now.getTime() - 8 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const yesterday = new Date(
+      now.getTime() - 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    // Two approved posts: one stamped 8 days ago, one stamped yesterday.
+    // The trigger track_post_state_change auto-updates state_changed_at
+    // on UPDATE, so we INSERT with both fields set, no later UPDATE.
+    await svc.from("social_post_master").insert([
+      {
+        company_id: COMPANY_A_ID,
+        master_text: "old approved",
+        state: "approved",
+        source_type: "manual",
+        state_changed_at: eightDaysAgo,
+      },
+      {
+        company_id: COMPANY_A_ID,
+        master_text: "recent approved",
+        state: "approved",
+        source_type: "manual",
+        state_changed_at: yesterday,
+      },
+    ]);
+
+    const result = await getSocialPostsStats({ companyId: COMPANY_A_ID });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.approved).toBe(2); // both count toward total
+    expect(result.data.approvedThisWeek).toBe(1); // only the recent one
+  });
+});

--- a/lib/platform/social/posts/dashboard.ts
+++ b/lib/platform/social/posts/dashboard.ts
@@ -1,0 +1,143 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// S1-11 — quick-stats for the company landing dashboard.
+//
+// Six lightweight counts keyed off social_post_master.state. Each is a
+// HEAD count (no body fetched) so the query is a constant ~1KB
+// regardless of post volume.
+//
+// Why not a single SQL group-by? supabase-js lacks a clean GROUP BY
+// surface; using a custom RPC for one dashboard read is overkill. Five
+// HEAD counts in parallel is cheap and the SQL planner reuses the
+// idx_post_master_company_state index for each.
+//
+// Caller is responsible for canDo("view_calendar", company_id). The
+// landing-page server component already gates the whole surface;
+// this lib trusts it.
+// ---------------------------------------------------------------------------
+
+export type SocialPostsStats = {
+  drafts: number;
+  awaitingApproval: number;
+  approved: number;
+  scheduled: number;
+  published: number;
+  // Subset of `approved`: state-flipped to approved within the last
+  // 7 days (state_changed_at). Useful for the "approved this week"
+  // tile.
+  approvedThisWeek: number;
+};
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+export async function getSocialPostsStats(args: {
+  companyId: string;
+}): Promise<ApiResponse<SocialPostsStats>> {
+  if (!args.companyId) {
+    return validation("Company id is required.");
+  }
+
+  const svc = getServiceRoleClient();
+  const sevenDaysAgo = new Date(Date.now() - SEVEN_DAYS_MS).toISOString();
+
+  // Issue six HEAD counts in parallel. Each query is index-friendly
+  // (idx_post_master_company_state) and bounded by the company's
+  // post volume.
+  const counters = await Promise.all([
+    countByState(svc, args.companyId, "draft"),
+    countByState(svc, args.companyId, "pending_client_approval"),
+    countByState(svc, args.companyId, "approved"),
+    countByState(svc, args.companyId, "scheduled"),
+    countByState(svc, args.companyId, "published"),
+    countApprovedSince(svc, args.companyId, sevenDaysAgo),
+  ]);
+
+  const errs = counters.filter((c) => c.error);
+  if (errs.length > 0) {
+    logger.error("social.posts.dashboard.stats_failed", {
+      err: errs.map((e) => e.error).join("; "),
+      company_id: args.companyId,
+    });
+    return internal(
+      `Failed to read stats: ${errs.map((e) => e.error).join("; ")}`,
+    );
+  }
+
+  const [drafts, awaiting, approved, scheduled, published, approvedRecent] =
+    counters;
+
+  return {
+    ok: true,
+    data: {
+      drafts: drafts.count,
+      awaitingApproval: awaiting.count,
+      approved: approved.count,
+      scheduled: scheduled.count,
+      published: published.count,
+      approvedThisWeek: approvedRecent.count,
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+type CountResult = { count: number; error: string | null };
+
+async function countByState(
+  svc: ReturnType<typeof getServiceRoleClient>,
+  companyId: string,
+  state: string,
+): Promise<CountResult> {
+  const r = await svc
+    .from("social_post_master")
+    .select("id", { count: "exact", head: true })
+    .eq("company_id", companyId)
+    .eq("state", state);
+  if (r.error) return { count: 0, error: r.error.message };
+  return { count: r.count ?? 0, error: null };
+}
+
+async function countApprovedSince(
+  svc: ReturnType<typeof getServiceRoleClient>,
+  companyId: string,
+  isoTimestamp: string,
+): Promise<CountResult> {
+  const r = await svc
+    .from("social_post_master")
+    .select("id", { count: "exact", head: true })
+    .eq("company_id", companyId)
+    .eq("state", "approved")
+    .gte("state_changed_at", isoTimestamp);
+  if (r.error) return { count: 0, error: r.error.message };
+  return { count: r.count ?? 0, error: null };
+}
+
+function validation(message: string): ApiResponse<SocialPostsStats> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<SocialPostsStats> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/posts/index.ts
+++ b/lib/platform/social/posts/index.ts
@@ -1,4 +1,5 @@
 export { createPostMaster } from "./create";
+export { getSocialPostsStats, type SocialPostsStats } from "./dashboard";
 export { deletePostMaster } from "./delete";
 export { getPostMaster } from "./get";
 export { listPostMasters } from "./list";


### PR DESCRIPTION
## Summary
Replaces `/company`'s redirect-to-/users with a real customer landing page. Surfaces six tiles — drafts / awaiting approval / approved / scheduled / published / approved this week — each linking through to the filtered list.

## Changes
- `lib/platform/social/posts/dashboard.ts` — `getSocialPostsStats()` fires six HEAD counts in parallel against `social_post_master`, scoped by `company_id`. Each query is index-friendly (`idx_post_master_company_state`). HEAD = no body fetched, so total transfer is constant regardless of post volume.
- `components/SocialPostsDashboardCard.tsx` — server-component-friendly grid of clickable tiles. Empty/zero counts still render so first-time customers see the surface.
- `app/company/page.tsx` — replaces the redirect with a proper dashboard. Same gating as the rest of `/company` (no session → /login; no membership → "not provisioned"). Falls back to a minimal landing for roles without `view_calendar` (defensive — viewer is the lowest role and already has it).
- `lib/__tests__/social-posts-dashboard.test.ts` — covers empty-company zeroes, per-state accuracy, cross-company isolation, "approved this week" 7-day window (post stamped 8 days ago doesn't count; yesterday does).

## Risks identified and mitigated
- **Cross-company stats leak**: every count is filtered by `company_id` at the lib layer in addition to RLS. Test asserts company A's stats don't include company B's posts.
- **Stat staleness**: server-rendered on every request (`dynamic='force-dynamic'`), so counts are always fresh.
- **Six round-trips per dashboard load**: each is a HEAD count, so ~1KB total. Cheaper than a single full-table read; can be collapsed into a single grouped RPC if a future profiler shows it matters.
- **Permission gating**: `canDo("view_calendar")` gate before the stats query. Routes through the existing permission table; no new action introduced.
- **Auto-merge eligible**: read-only L1 lib + read-only RSC, no writes, no migrations.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` clean — `/company` registered as the dashboard
- [ ] CI Vitest run — Docker not available locally; deferring to CI. Pre-existing m12-1-rls / m4-schema / etc. redness expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)