### PR TITLE
fix: parser warning noise + briefs-list bfcache refresh

### DIFF
--- a/components/UploadBriefButton.tsx
+++ b/components/UploadBriefButton.tsx
@@ -1,14 +1,36 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import { UploadBriefModal } from "@/components/UploadBriefModal";
 
 // Client shell that wraps the UploadBriefModal and exposes the button
 // that opens it. Used by the site detail server component.
+//
+// UAT (2026-05-03) — bfcache busts the briefs-list staleness fix in
+// UploadBriefModal (router.refresh() before push) when the operator
+// browser-Backs from the review page. The browser restores the cached
+// DOM from before the upload, so the new brief row is invisible until
+// a hard reload. Listening for `pageshow.persisted === true` fires a
+// client-side router.refresh() in that exact path. Adding the listener
+// at the site-detail surface (not inside the modal) means it fires for
+// any back-nav into the site page, not just back-from-review.
 export function UploadBriefButton({ siteId }: { siteId: string }) {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    function onPageShow(event: PageTransitionEvent) {
+      if (event.persisted) {
+        router.refresh();
+      }
+    }
+    window.addEventListener("pageshow", onPageShow);
+    return () => window.removeEventListener("pageshow", onPageShow);
+  }, [router]);
+
   return (
     <>
       <Button

--- a/lib/brief-parser.ts
+++ b/lib/brief-parser.ts
@@ -522,16 +522,33 @@ export async function parseBriefDocument(opts: {
   // first non-empty line trimmed to 60 chars, else "Untitled page".
   // Mode is short_brief vs full_text per the same word-count threshold
   // as the structural path.
+  //
+  // UAT round-3 polish (2026-05-03): when the single-page fallback fires,
+  // strip the noisy tier-2 (Claude inference) warnings. Those warnings
+  // describe partial failures of an earlier tier whose output we just
+  // discarded; surfacing them on the review page makes the review look
+  // alarmist when the final result is fine. Keep only structural-parser
+  // warnings (tier 1) and append the single-page fallback note.
   const trimmed = source.trim();
   if (trimmed.length > 0) {
     const inferredTitle = inferTitleFromBlob(trimmed);
     const wordCount = countWords(trimmed);
     const mode: BriefPageMode =
       wordCount >= FULL_TEXT_WORD_THRESHOLD ? "full_text" : "short_brief";
+    // Strip tier-2 inference warnings — the inference output didn't land,
+    // its warnings are noise on the operator-visible review page.
+    const inferenceWarningCodes: ReadonlyArray<ParserWarning["code"]> = [
+      "INFERENCE_ENTRY_DROPPED",
+    ];
+    for (let i = warnings.length - 1; i >= 0; i--) {
+      if (inferenceWarningCodes.includes(warnings[i].code)) {
+        warnings.splice(i, 1);
+      }
+    }
     warnings.push({
       code: "HEADING_HIERARCHY_SKIPPED",
       detail:
-        "Structural parser + Claude inference both failed to find page boundaries. Treated the whole document as a single page.",
+        "No page boundaries were detected, so the whole document was treated as a single page. You can rename this page on the review form before committing.",
     });
     logger.info("brief-parser.single_page_fallback", {
       brief_id: briefId,


### PR DESCRIPTION
## Summary

UAT round-3 polish from Steven's run-through:

**Test 5 / parser noise** (`lib/brief-parser.ts`)
- When the third-tier single-page fallback fires, strip the tier-2 `INFERENCE_ENTRY_DROPPED` warnings — those describe a partial failure of an output tier we just discarded; surfacing them on the review screen makes a successful fallback look alarmist.
- Reword the `HEADING_HIERARCHY_SKIPPED` copy to land as informational rather than alarmist: "No page boundaries were detected, so the whole document was treated as a single page. You can rename this page on the review form before committing."

**Test 7 / briefs list staleness** (`components/UploadBriefButton.tsx`)
- The `router.refresh()` in `UploadBriefModal` covers the soft-nav case but not the bfcache restore that happens on `browser back`. Add a `pageshow` listener that fires `router.refresh()` when `event.persisted === true`. That's the canonical bfcache hook.
- Listener mounted at the `UploadBriefButton` (which is on every site detail page) so back-nav into the site page from anywhere fires a fresh server render.

## Risks
- The pageshow listener fires on every bfcache-restore, not just after-upload. That means it'll occasionally cause an unnecessary refresh. Trade-off: the UX cost of a second-long refresh once per back-nav is dwarfed by the data-staleness frustration of showing a missing brief.
- Stripping warnings is final-tier-only; tier-1 structural warnings still flow through, so genuine markdown problems aren't silenced.

## Test plan
- [ ] Lint + typecheck (green locally)
- [ ] CI passes (pre-existing reds remain)
- [ ] Manual: upload free-form brief → review page shows the friendly fallback note, no INFERENCE_ENTRY_DROPPED noise
- [ ] Manual: upload → press Back → site detail shows the new brief immediately (no manual reload)