### PR TITLE
fix(commit): drop double-confirm modal + extend race retry to 4s

### DIFF
--- a/app/admin/sites/[id]/briefs/[brief_id]/run/page.tsx
+++ b/app/admin/sites/[id]/briefs/[brief_id]/run/page.tsx
@@ -66,10 +66,12 @@ export default async function BriefRunPage({
   // to /run, but the read here can hit a connection pool that hasn't
   // yet seen the COMMIT. Retry briefly when the brief looks "almost
   // committed" so the operator sees the run surface, not a misleading
-  // "isn't committed yet" panel. Capped at ~1.5s total — beyond that,
-  // it's a real not-committed brief and we fall through to the panel.
+  // "isn't committed yet" panel. UAT (2026-05-03 round-3): bumped from
+  // 3 × 500ms (1.5s) to 8 × 500ms (4s) because PostgREST pool
+  // propagation occasionally takes >2s under load and operators were
+  // still hitting the panel.
   if (brief.status === "parsed") {
-    for (let attempt = 0; attempt < 3; attempt++) {
+    for (let attempt = 0; attempt < 8; attempt++) {
       await new Promise((resolve) => setTimeout(resolve, 500));
       const retry = await getBriefWithPages(params.brief_id);
       if (!retry.ok) break;

--- a/components/BriefReviewClient.tsx
+++ b/components/BriefReviewClient.tsx
@@ -653,10 +653,13 @@ export function BriefReviewClient({
           <Button
             type="button"
             variant="default"
-            onClick={() => setCommitState("confirming")}
-            disabled={sortedPages.length === 0}
+            onClick={() => void handleCommit()}
+            disabled={
+              sortedPages.length === 0 || commitState === "committing"
+            }
+            data-testid="brief-review-commit-button"
           >
-            Commit page list
+            {commitState === "committing" ? "Committing…" : "Commit page list"}
           </Button>
         </div>
       )}
@@ -667,14 +670,16 @@ export function BriefReviewClient({
           === "committed". The committed state still exists in the DB —
           just no UI surface for it on this page. */}
 
-      {commitState === "confirming" && (
-        <CommitConfirmModal
-          pageCount={sortedPages.length}
-          firstPageTitle={sortedPages[0]?.title ?? ""}
-          onCancel={() => setCommitState("idle")}
-          onConfirm={handleCommit}
-        />
-      )}
+      {/* UAT (2026-05-03 round-3): the CommitConfirmModal was removed
+          because it was a low-value double-confirm — operators clicked
+          "Commit page list" twice (button → modal → inner button) for
+          every routine commit. The modal component is kept defined
+          below for future use behind a high-cost gate, but never
+          rendered today. The handleCommit POST → /api/.../commit fires
+          directly from the Commit button. M12-4 risk-15 confirmation
+          (CONFIRMATION_REQUIRED on cost > 50% remaining) is still
+          enforced server-side and surfaced on the run page when it
+          fires. */}
     </div>
   );
 }


### PR DESCRIPTION
Two UAT round-3 fixes. Removed the CommitConfirmModal (low-value double-confirm; modal kept defined for future high-cost gating but not rendered). Bumped /run race retry from 3×500ms to 8×500ms because PostgREST occasionally takes >2s to propagate.