### PR TITLE
feat(s1-13): bundle.social SDK + foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -169,6 +169,21 @@ QSTASH_TOKEN=
 QSTASH_CURRENT_SIGNING_KEY=
 QSTASH_NEXT_SIGNING_KEY=
 
+# bundle.social — publishing intermediary for the social workstream
+# (S1-13+). Three vars:
+#   BUNDLE_SOCIAL_API                   — API key from the bundle.social
+#                                         dashboard (server only).
+#   BUNDLE_SOCIAL_TEAM_ID               — team to publish through. Find via
+#                                         `npx tsx scripts/bundlesocial-list-teams.ts`.
+#   BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET — verifies inbound webhook HMAC
+#                                         (post.published / post.failed /
+#                                         social-account.* events). Required
+#                                         per their docs even in development.
+# Unset → connect + publish surfaces no-op (degraded UX, not crash).
+BUNDLE_SOCIAL_API=
+BUNDLE_SOCIAL_TEAM_ID=
+BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET=
+
 
 # -----------------------------------------------------------------------------
 # Vercel API access (OPTIONAL — only used by optimiser sync of Vercel logs)

--- a/.env.local.example
+++ b/.env.local.example
@@ -168,6 +168,30 @@ QSTASH_TOKEN=
 QSTASH_CURRENT_SIGNING_KEY=
 QSTASH_NEXT_SIGNING_KEY=
 
+# --- bundle.social: social publishing intermediary (S1-13+, optional) -----
+# Three vars. Unset → connect + publish surfaces no-op (degraded UX, not
+# crash); social_connections rows still readable, just no new ones.
+#
+#   BUNDLE_SOCIAL_API
+#     API key from https://app.bundle.social → Settings. Server only;
+#     never ship to client.
+#
+#   BUNDLE_SOCIAL_TEAM_ID
+#     Team to publish through. bundle.social's API is team-scoped even
+#     though the SDK constructor only takes the API key. Find the id by
+#     running:
+#       npx tsx scripts/bundlesocial-list-teams.ts
+#
+#   BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET
+#     HMAC-SHA256 secret used to verify the x-signature header on inbound
+#     webhooks (post.published / post.failed / social-account.* events).
+#     bundle.social's docs are emphatic: required even in development.
+#     Register the webhook endpoint in their dashboard pointing at
+#     https://<your-host>/api/webhooks/bundlesocial.
+BUNDLE_SOCIAL_API=
+BUNDLE_SOCIAL_TEAM_ID=
+BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET=
+
 # --- Log level (optional) --------------------------------------------------
 # debug | info | warn | error. Defaults to "info" in production, "debug"
 # in non-prod. Below-threshold calls are O(1) — no string building.

--- a/lib/bundlesocial.ts
+++ b/lib/bundlesocial.ts
@@ -1,0 +1,100 @@
+import "server-only";
+
+import { Bundlesocial } from "bundlesocial";
+
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// bundle.social SDK wrapper.
+//
+// Lazy singleton over the official `bundlesocial` SDK. Returns null
+// when env vars aren't set so tests + local dev stay no-op rather
+// than hard-failing at module load. Same pattern as lib/qstash.ts +
+// lib/redis.ts.
+//
+// Env contract:
+//   BUNDLE_SOCIAL_API                    — API key from the bundle.social
+//                                          dashboard (server only; never
+//                                          ship to the client).
+//   BUNDLE_SOCIAL_TEAM_ID                — required for create-portal-link
+//                                          and connect endpoints; bundle.
+//                                          social's API is team-scoped
+//                                          even though the SDK constructor
+//                                          only takes the API key.
+//   BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET  — verifies inbound webhook
+//                                          signatures (HMAC-SHA256 in
+//                                          x-signature header). Bundle's
+//                                          docs are emphatic: required
+//                                          even in development.
+//
+// Callers that need to publish or initiate connects MUST check the
+// returned client for null and fall back to a degraded path (route
+// returns 503 RECEIVER_NOT_CONFIGURED, or feature-flag the surface
+// off). Webhook routes do the same with the signing secret.
+// ---------------------------------------------------------------------------
+
+let cached: Bundlesocial | null | undefined = undefined;
+
+export function getBundlesocialClient(): Bundlesocial | null {
+  if (cached !== undefined) return cached;
+  const apiKey = process.env.BUNDLE_SOCIAL_API;
+  if (!apiKey) {
+    cached = null;
+    return null;
+  }
+  cached = new Bundlesocial(apiKey);
+  return cached;
+}
+
+export function getBundlesocialTeamId(): string | null {
+  return process.env.BUNDLE_SOCIAL_TEAM_ID ?? null;
+}
+
+export type WebhookVerifyResult =
+  | { ok: true }
+  | { ok: false; reason: "no_secret" | "missing_signature" | "invalid" };
+
+// Verifies the x-signature header against the raw body using
+// HMAC-SHA256 of the signing secret. Returns `no_secret` when env
+// is unset (tests + local dev). Webhook routes MUST treat
+// `no_secret` as a config error in production.
+//
+// We compute the HMAC ourselves rather than reaching into the SDK
+// internals so the verifier stays testable without instantiating
+// a client.
+export async function verifyBundlesocialSignature(args: {
+  signature: string | null;
+  rawBody: string;
+}): Promise<WebhookVerifyResult> {
+  const secret = process.env.BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET;
+  if (!secret) return { ok: false, reason: "no_secret" };
+  if (!args.signature) return { ok: false, reason: "missing_signature" };
+
+  try {
+    const { createHmac, timingSafeEqual } = await import("node:crypto");
+    const expected = createHmac("sha256", secret)
+      .update(args.rawBody)
+      .digest("hex");
+
+    // Constant-time compare. Bail early when length differs to avoid
+    // timing leaks.
+    const expectedBuf = Buffer.from(expected, "utf8");
+    const providedBuf = Buffer.from(args.signature, "utf8");
+    if (expectedBuf.length !== providedBuf.length) {
+      return { ok: false, reason: "invalid" };
+    }
+    if (!timingSafeEqual(expectedBuf, providedBuf)) {
+      return { ok: false, reason: "invalid" };
+    }
+    return { ok: true };
+  } catch (err) {
+    logger.warn("bundlesocial.verify_failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return { ok: false, reason: "invalid" };
+  }
+}
+
+export function __resetBundlesocialForTests(): void {
+  cached = undefined;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@upstash/qstash": "^2.10.1",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",
+        "bundlesocial": "^2.47.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -6554,6 +6555,15 @@
       "optional": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bundlesocial": {
+      "version": "2.47.0",
+      "resolved": "https://registry.npmjs.org/bundlesocial/-/bundlesocial-2.47.0.tgz",
+      "integrity": "sha512-DmyIiAOaS6Uc5fWYe0EReujj+9a9iyXUUKbYdnaGSeFj7DtwWJ6yXesK5eZJ5DkU8uuLfXbwSpxDhLg3HkzKdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/busboy": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@upstash/qstash": "^2.10.1",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",
+    "bundlesocial": "^2.47.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/scripts/bundlesocial-list-teams.ts
+++ b/scripts/bundlesocial-list-teams.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * scripts/bundlesocial-list-teams.ts
+ *
+ * One-shot helper: lists every team accessible to the current
+ * BUNDLE_SOCIAL_API key. The team_id you want for
+ * BUNDLE_SOCIAL_TEAM_ID is the `id` field of the team you intend
+ * Opollo to publish through.
+ *
+ * Usage:
+ *   BUNDLE_SOCIAL_API=sk_... npx tsx scripts/bundlesocial-list-teams.ts
+ *
+ * Or, if you've already added BUNDLE_SOCIAL_API to .env.local:
+ *   npx tsx scripts/bundlesocial-list-teams.ts
+ *
+ * Output: one JSON object per team, plus a summary line.
+ */
+
+import { config } from "dotenv";
+import { Bundlesocial } from "bundlesocial";
+
+// Load .env.local if it exists so the script Just Works.
+config({ path: ".env.local" });
+
+async function main(): Promise<void> {
+  const apiKey = process.env.BUNDLE_SOCIAL_API;
+  if (!apiKey) {
+    console.error(
+      "BUNDLE_SOCIAL_API is not set. Either pass it inline:\n  BUNDLE_SOCIAL_API=sk_... npx tsx scripts/bundlesocial-list-teams.ts\nor add it to .env.local.",
+    );
+    process.exit(1);
+  }
+
+  const client = new Bundlesocial(apiKey);
+
+  // Pull the org first so we can also surface the org id (sometimes
+  // useful for webhook configuration in the dashboard).
+  try {
+    const org = (await client.organization.organizationGetOrganization()) as {
+      id?: string;
+      name?: string;
+      teams?: Array<{ id: string; name: string }>;
+    };
+    if (org?.id) {
+      console.log(
+        JSON.stringify(
+          { kind: "organization", id: org.id, name: org.name ?? null },
+          null,
+          2,
+        ),
+      );
+    }
+  } catch (err) {
+    // Some accounts may not expose organization scope; fall through to
+    // the team listing.
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`organizationGetOrganization failed (continuing): ${message}`);
+  }
+
+  const teams = (await client.team.teamGetList()) as {
+    items?: Array<{
+      id: string;
+      name: string;
+      createdAt?: string;
+      bots?: Array<unknown>;
+    }>;
+    total?: number;
+  };
+
+  const items = teams.items ?? [];
+  if (items.length === 0) {
+    console.log(
+      "No teams found. Create one at https://app.bundle.social and re-run this script.",
+    );
+    return;
+  }
+
+  for (const t of items) {
+    console.log(
+      JSON.stringify(
+        {
+          kind: "team",
+          id: t.id,
+          name: t.name,
+          bots: t.bots?.length ?? 0,
+          createdAt: t.createdAt ?? null,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  console.log(`\n${items.length} team(s) found.`);
+  if (items.length === 1) {
+    console.log(
+      `\nSet BUNDLE_SOCIAL_TEAM_ID=${items[0]?.id} in Vercel + your local .env.local.`,
+    );
+  } else {
+    console.log(
+      "\nMultiple teams visible — pick the one you want Opollo to publish through and set BUNDLE_SOCIAL_TEAM_ID to its id.",
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(
+    "Failed to list teams:",
+    err instanceof Error ? err.message : err,
+  );
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Lands the `bundlesocial` npm SDK + a lazy-singleton wrapper + a team-discovery script + env-var docs. The connect-portal flow + publish pipeline land in S1-14+ (need `BUNDLE_SOCIAL_TEAM_ID` first — see below).

## Changes
- **npm**: `bundlesocial@^2.47.0`. Zero prod deps, MIT, Node 18+. Auto-generated from bundle.social's OpenAPI spec.
- `lib/bundlesocial.ts` — lazy singleton over `Bundlesocial`. Returns `null` when `BUNDLE_SOCIAL_API` is unset (same pattern as `lib/qstash.ts` + `lib/redis.ts`). Exposes `verifyBundleSocialSignature({ rawBody, signature })` — HMAC-SHA256 in constant time against `BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET`. No-secret returns a discriminated `reason` so webhook routes can distinguish "config missing" (503) from "bad signature" (401).
- `scripts/bundlesocial-list-teams.ts` — one-shot CLI that prints the org + every team accessible to `BUNDLE_SOCIAL_API`. Picks the team_id you want for `BUNDLE_SOCIAL_TEAM_ID`. Loads `.env.local` via dotenv so it Just Works locally.
- `.env.example` + `.env.local.example` — documented all three bundle.social env vars with discovery instructions.

## Provisioning status
Three env vars total:
- ✅ `BUNDLE_SOCIAL_API` — provisioned in Vercel
- ⚠️ `BUNDLE_SOCIAL_TEAM_ID` — **Steven runs `npx tsx scripts/bundlesocial-list-teams.ts` to find this** and adds to Vercel
- ✅ `BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET` — provisioned in Vercel

S1-14 (the actual portal-link connect flow) is blocked on `BUNDLE_SOCIAL_TEAM_ID`. The publish pipeline + webhook handler can also be built once S1-14 lands.

## Risks identified and mitigated
- **Hard-fail at module load when env unset**: lazy singleton returns `null`; callers MUST check. Same pattern as the other Upstash wrappers.
- **Webhook signature timing leaks**: `timingSafeEqual` on equal-length Buffers; early bail on length mismatch doesn't leak the secret.
- **Auto-generated SDK = wide attack surface**: zero prod deps means the surface is just typed HTTP wrappers around bundle.social's API. No `postinstall` script. Manually verified before install.
- **`BUNDLE_SOCIAL_API` exposure**: `import "server-only"` at top of the wrapper guarantees client bundles never see it.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` clean
- [ ] Steven runs `npx tsx scripts/bundlesocial-list-teams.ts` to surface team_id (manual step, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)