### PR TITLE
feat(s1-14): schedule entries (L3 layer)

### DIFF
--- a/app/api/platform/social/posts/[id]/schedule/[entry_id]/route.ts
+++ b/app/api/platform/social/posts/[id]/schedule/[entry_id]/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { cancelScheduleEntry } from "@/lib/platform/social/scheduling";
+
+// ---------------------------------------------------------------------------
+// S1-14 — DELETE /api/platform/social/posts/[id]/schedule/[entry_id]
+//
+// Soft-cancel a schedule entry. Atomic UPDATE WHERE cancelled_at IS NULL
+// ensures concurrent cancels converge.
+//
+// Gate: canDo("schedule_post", company_id) — same threshold as create.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+function statusForCode(code: string): number {
+  switch (code) {
+    case "VALIDATION_FAILED":
+      return 400;
+    case "NOT_FOUND":
+      return 404;
+    case "INVALID_STATE":
+      return 409;
+    default:
+      return 500;
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; entry_id: string }> },
+): Promise<NextResponse> {
+  const { id, entry_id } = await params;
+  if (!UUID_RE.test(id)) {
+    return errorJson("VALIDATION_FAILED", "post id must be a UUID.", 400);
+  }
+  if (!UUID_RE.test(entry_id)) {
+    return errorJson("VALIDATION_FAILED", "entry_id must be a UUID.", 400);
+  }
+  const companyId = new URL(req.url).searchParams.get("company_id");
+  if (!companyId || !UUID_RE.test(companyId)) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "company_id query parameter (uuid) is required.",
+      400,
+    );
+  }
+
+  const gate = await requireCanDoForApi(companyId, "schedule_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await cancelScheduleEntry({
+    entryId: entry_id,
+    companyId,
+  });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      statusForCode(result.error.code),
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { entry: result.data },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/platform/social/posts/[id]/schedule/route.ts
+++ b/app/api/platform/social/posts/[id]/schedule/route.ts
@@ -1,0 +1,169 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import {
+  createScheduleEntry,
+  listScheduleEntries,
+} from "@/lib/platform/social/scheduling";
+
+// ---------------------------------------------------------------------------
+// S1-14 — schedule endpoints scoped to a single post.
+//
+//   GET /api/platform/social/posts/[id]/schedule?company_id=&include_cancelled=
+//     canDo("view_calendar", company_id) (viewer+).
+//
+//   POST /api/platform/social/posts/[id]/schedule
+//     Body { company_id, platform, scheduled_at }
+//     canDo("schedule_post", company_id) (approver+). Lib enforces
+//     post.state='approved' + future scheduled_at + no double-booking.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+const PostBodySchema = z.object({
+  company_id: z.string().uuid(),
+  platform: z.enum([
+    "linkedin_personal",
+    "linkedin_company",
+    "facebook_page",
+    "x",
+    "gbp",
+  ]),
+  scheduled_at: z.string().datetime(),
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: {
+        code,
+        message,
+        retryable: false,
+        ...(details ? { details } : {}),
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+function statusForCode(code: string): number {
+  switch (code) {
+    case "VALIDATION_FAILED":
+      return 400;
+    case "NOT_FOUND":
+      return 404;
+    case "INVALID_STATE":
+      return 409;
+    default:
+      return 500;
+  }
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return errorJson("VALIDATION_FAILED", "id must be a UUID.", 400);
+  }
+  const url = new URL(req.url);
+  const companyId = url.searchParams.get("company_id");
+  if (!companyId || !UUID_RE.test(companyId)) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "company_id query parameter (uuid) is required.",
+      400,
+    );
+  }
+  const includeCancelled = url.searchParams.get("include_cancelled") === "true";
+
+  const gate = await requireCanDoForApi(companyId, "view_calendar");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await listScheduleEntries({
+    postMasterId: id,
+    companyId,
+    includeCancelled,
+  });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      statusForCode(result.error.code),
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: result.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return errorJson("VALIDATION_FAILED", "id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = PostBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "Body must be { company_id: uuid, platform: SocialPlatform, scheduled_at: ISO timestamp }.",
+      400,
+      { issues: parsed.error.issues },
+    );
+  }
+
+  const gate = await requireCanDoForApi(parsed.data.company_id, "schedule_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await createScheduleEntry({
+    postMasterId: id,
+    companyId: parsed.data.company_id,
+    platform: parsed.data.platform,
+    scheduledAt: parsed.data.scheduled_at,
+    scheduledBy: gate.userId,
+  });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      statusForCode(result.error.code),
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { entry: result.data },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 201 },
+  );
+}

--- a/app/company/social/posts/[id]/page.tsx
+++ b/app/company/social/posts/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { PostApprovalSection } from "@/components/PostApprovalSection";
 import { PostDecisionsAudit } from "@/components/PostDecisionsAudit";
+import { PostScheduleSection } from "@/components/PostScheduleSection";
 import { PostVariantsSection } from "@/components/PostVariantsSection";
 import { SocialPostDetailClient } from "@/components/SocialPostDetailClient";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
@@ -10,6 +11,7 @@ import {
   listRecipients,
 } from "@/lib/platform/social/approvals";
 import { getPostMaster } from "@/lib/platform/social/posts";
+import { listScheduleEntries } from "@/lib/platform/social/scheduling";
 import { listVariants } from "@/lib/platform/social/variants";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -61,12 +63,14 @@ export default async function CompanySocialPostDetailPage({
 
   const companyId = session.company.companyId;
 
-  const [postResult, variantsResult, canEdit, canSubmit] = await Promise.all([
-    getPostMaster({ postId: id, companyId }),
-    listVariants({ postMasterId: id, companyId }),
-    canDo(companyId, "edit_post"),
-    canDo(companyId, "submit_for_approval"),
-  ]);
+  const [postResult, variantsResult, canEdit, canSubmit, canSchedule] =
+    await Promise.all([
+      getPostMaster({ postId: id, companyId }),
+      listVariants({ postMasterId: id, companyId }),
+      canDo(companyId, "edit_post"),
+      canDo(companyId, "submit_for_approval"),
+      canDo(companyId, "schedule_post"),
+    ]);
 
   if (!postResult.ok) {
     if (postResult.error.code === "NOT_FOUND") notFound();
@@ -164,6 +168,33 @@ export default async function CompanySocialPostDetailPage({
       {isPostDecision && auditEvents?.ok ? (
         <PostDecisionsAudit events={auditEvents.data.events} />
       ) : null}
+      {postResult.data.state === "approved"
+        ? await renderScheduleSection({
+            postId: postResult.data.id,
+            companyId,
+            canSchedule,
+          })
+        : null}
     </>
+  );
+}
+
+async function renderScheduleSection(args: {
+  postId: string;
+  companyId: string;
+  canSchedule: boolean;
+}) {
+  const entries = await listScheduleEntries({
+    postMasterId: args.postId,
+    companyId: args.companyId,
+  });
+  if (!entries.ok) return null;
+  return (
+    <PostScheduleSection
+      postId={args.postId}
+      companyId={args.companyId}
+      initialEntries={entries.data.entries}
+      canSchedule={args.canSchedule}
+    />
   );
 }

--- a/components/PostScheduleSection.tsx
+++ b/components/PostScheduleSection.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  PLATFORM_LABEL,
+  SUPPORTED_PLATFORMS,
+  type SocialPlatform,
+} from "@/lib/platform/social/variants/types";
+
+// ---------------------------------------------------------------------------
+// S1-14 — schedule entries section on the post detail page.
+//
+// Visible when post.state='approved'. Approver+ (canSchedule) can
+// add new entries + cancel existing ones. Viewers see the list
+// read-only.
+//
+// V1 shows non-cancelled entries only. A future slice can add a
+// "show cancelled" toggle that re-fetches with include_cancelled=true.
+// ---------------------------------------------------------------------------
+
+type Entry = {
+  id: string;
+  post_variant_id: string;
+  platform: SocialPlatform;
+  scheduled_at: string;
+  cancelled_at: string | null;
+  qstash_message_id: string | null;
+  scheduled_by: string | null;
+  created_at: string;
+};
+
+type Props = {
+  postId: string;
+  companyId: string;
+  initialEntries: Entry[];
+  canSchedule: boolean;
+};
+
+export function PostScheduleSection({
+  postId,
+  companyId,
+  initialEntries,
+  canSchedule,
+}: Props) {
+  const [entries, setEntries] = useState(initialEntries);
+  const [adding, setAdding] = useState(false);
+  const [platform, setPlatform] = useState<SocialPlatform>("linkedin_personal");
+  const [scheduledAt, setScheduledAt] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+  const [cancellingId, setCancellingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      // The form gives us a local datetime ('2026-05-12T09:00').
+      // Convert to ISO with the browser's timezone.
+      const isoFromLocal = new Date(scheduledAt).toISOString();
+      const res = await fetch(
+        `/api/platform/social/posts/${postId}/schedule`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            company_id: companyId,
+            platform,
+            scheduled_at: isoFromLocal,
+          }),
+        },
+      );
+      const json = (await res.json()) as
+        | { ok: true; data: { entry: Entry } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        const msg = !json.ok ? json.error.message : "Failed to schedule.";
+        setError(msg);
+        return;
+      }
+      setEntries((prev) => {
+        const next = [...prev, json.data.entry];
+        next.sort(
+          (a, b) =>
+            Date.parse(a.scheduled_at) - Date.parse(b.scheduled_at),
+        );
+        return next;
+      });
+      setAdding(false);
+      setScheduledAt("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleCancel(entryId: string) {
+    if (!confirm("Cancel this schedule entry?")) return;
+    setCancellingId(entryId);
+    setError(null);
+    try {
+      const url = `/api/platform/social/posts/${postId}/schedule/${entryId}?company_id=${encodeURIComponent(companyId)}`;
+      const res = await fetch(url, { method: "DELETE" });
+      const json = (await res.json()) as
+        | { ok: true; data: { entry: Entry } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        const msg = !json.ok ? json.error.message : "Failed to cancel.";
+        setError(msg);
+        return;
+      }
+      // Drop from the visible list (we don't show cancelled in V1).
+      setEntries((prev) => prev.filter((e) => e.id !== entryId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCancellingId(null);
+    }
+  }
+
+  // Default datetime: tomorrow 09:00 local, formatted for
+  // <input type="datetime-local">.
+  function defaultDatetimeValue(): string {
+    const d = new Date();
+    d.setDate(d.getDate() + 1);
+    d.setHours(9, 0, 0, 0);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  }
+
+  return (
+    <section className="mt-8" data-testid="post-schedule-section">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Schedule</h2>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            One schedule entry per platform. Cancel and re-schedule if
+            you need to change a time.
+          </p>
+        </div>
+        {canSchedule && !adding ? (
+          <Button
+            onClick={() => {
+              setScheduledAt(defaultDatetimeValue());
+              setAdding(true);
+            }}
+            data-testid="schedule-add-button"
+          >
+            Add schedule
+          </Button>
+        ) : null}
+      </div>
+
+      {error ? (
+        <p
+          className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          role="alert"
+          data-testid="schedule-error"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {adding ? (
+        <form
+          onSubmit={handleCreate}
+          className="mt-4 rounded-lg border bg-card p-4"
+          data-testid="schedule-add-form"
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label
+                className="block text-sm font-medium"
+                htmlFor="schedule_platform"
+              >
+                Platform
+              </label>
+              <select
+                id="schedule_platform"
+                className="mt-1 w-full rounded-md border bg-background p-2 text-sm"
+                value={platform}
+                onChange={(e) => setPlatform(e.target.value as SocialPlatform)}
+                data-testid="schedule-add-platform"
+              >
+                {SUPPORTED_PLATFORMS.map((p) => (
+                  <option key={p} value={p}>
+                    {PLATFORM_LABEL[p]}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label
+                className="block text-sm font-medium"
+                htmlFor="schedule_at"
+              >
+                When
+              </label>
+              <input
+                id="schedule_at"
+                type="datetime-local"
+                required
+                className="mt-1 w-full rounded-md border bg-background p-2 text-sm"
+                value={scheduledAt}
+                onChange={(e) => setScheduledAt(e.target.value)}
+                data-testid="schedule-add-datetime"
+              />
+            </div>
+          </div>
+          <div className="mt-4 flex gap-2">
+            <Button
+              type="submit"
+              disabled={submitting}
+              data-testid="schedule-add-submit"
+            >
+              {submitting ? "Scheduling…" : "Schedule"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                setAdding(false);
+                setError(null);
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      ) : null}
+
+      {entries.length === 0 ? (
+        <div
+          className="mt-4 rounded-lg border bg-card p-6 text-sm text-muted-foreground"
+          data-testid="schedule-empty"
+        >
+          No schedule entries yet.
+          {canSchedule
+            ? " Click Add schedule to publish this post on a date and time."
+            : " An approver can add scheduled times for each platform."}
+        </div>
+      ) : (
+        <ul
+          className="mt-4 divide-y rounded-lg border bg-card"
+          data-testid="schedule-list"
+        >
+          {entries.map((e) => (
+            <li
+              key={e.id}
+              className="flex flex-wrap items-center justify-between gap-3 p-4"
+              data-testid={`schedule-row-${e.id}`}
+            >
+              <div>
+                <div className="font-medium">{PLATFORM_LABEL[e.platform]}</div>
+                <div className="text-sm text-muted-foreground tabular-nums">
+                  {new Date(e.scheduled_at).toLocaleString("en-AU", {
+                    weekday: "short",
+                    day: "numeric",
+                    month: "short",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </div>
+              </div>
+              {canSchedule ? (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleCancel(e.id)}
+                  disabled={cancellingId === e.id}
+                  data-testid={`schedule-cancel-${e.id}`}
+                >
+                  {cancellingId === e.id ? "Cancelling…" : "Cancel"}
+                </Button>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -9,14 +9,15 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session A
 - Started: 2026-05-03
-- Branch: feat/s1-12-connections-list
-- Slice: S1-12 — social connections list page. lib/platform/social/connections {list, types}.ts reads social_connections rows. Route GET /api/platform/social/connections gated by view_calendar. Page /company/social/connections shows platform + display_name + status + connected_at. Admin-only Reconnect button is a stub (toast); bundle.social OAuth flow lands in S1-13.
+- Branch: feat/s1-14-schedule-entries
+- Slice: S1-14 — schedule entries (L3 layer). lib + route + UI for createScheduleEntry / listScheduleEntries / cancelScheduleEntry. State guard: only approved posts. Auto-creates social_post_variant row if missing. No bundle.social dependency — QStash enqueue + publish-handler land in S1-15+.
 - Files claimed:
-  - lib/platform/social/connections/{types,list,index}.ts (new)
-  - app/api/platform/social/connections/route.ts (new)
-  - app/company/social/connections/page.tsx (new)
-  - components/SocialConnectionsList.tsx (new)
-  - lib/__tests__/social-connections.test.ts (new)
+  - lib/platform/social/scheduling/{types,create,list,cancel,index}.ts (new)
+  - app/api/platform/social/posts/[id]/schedule/route.ts (new)
+  - app/api/platform/social/posts/[id]/schedule/[entry_id]/route.ts (new)
+  - components/PostScheduleSection.tsx (new)
+  - app/company/social/posts/[id]/page.tsx (wire schedule section)
+  - lib/__tests__/social-scheduling.test.ts (new)
   - docs/WORK_IN_FLIGHT.md
 - Migration number reserved: none.
 - Expected completion: same session.

--- a/lib/__tests__/social-scheduling.test.ts
+++ b/lib/__tests__/social-scheduling.test.ts
@@ -1,0 +1,411 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import { createPostMaster } from "@/lib/platform/social/posts";
+import {
+  cancelScheduleEntry,
+  createScheduleEntry,
+  listScheduleEntries,
+} from "@/lib/platform/social/scheduling";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser, type SeededAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// S1-14 — schedule entries lib.
+// ---------------------------------------------------------------------------
+
+const COMPANY_A_ID = "abcdef00-0000-0000-0000-aaaaaaaa3333";
+const COMPANY_B_ID = "abcdef00-0000-0000-0000-bbbbbbbb3333";
+
+describe("lib/platform/social/scheduling", () => {
+  let creator: SeededAuthUser;
+
+  beforeAll(async () => {
+    creator = await seedAuthUser({
+      email: "s1-14-creator@opollo.test",
+      persistent: true,
+    });
+  });
+
+  beforeEach(async () => {
+    const svc = getServiceRoleClient();
+
+    const companies = await svc
+      .from("platform_companies")
+      .insert([
+        {
+          id: COMPANY_A_ID,
+          name: "Acme Co",
+          slug: "s1-14-acme",
+          domain: "s1-14-acme.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+          approval_default_rule: "any_one",
+        },
+        {
+          id: COMPANY_B_ID,
+          name: "Beta Inc",
+          slug: "s1-14-beta",
+          domain: "s1-14-beta.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+          approval_default_rule: "any_one",
+        },
+      ])
+      .select("id");
+    if (companies.error) {
+      throw new Error(
+        `seed companies: ${companies.error.code ?? "?"} ${companies.error.message}`,
+      );
+    }
+
+    const user = await svc
+      .from("platform_users")
+      .insert({
+        id: creator.id,
+        email: creator.email,
+        full_name: "Creator",
+        is_opollo_staff: false,
+      })
+      .select("id");
+    if (user.error) {
+      throw new Error(
+        `seed creator: ${user.error.code ?? "?"} ${user.error.message}`,
+      );
+    }
+
+    const membership = await svc
+      .from("platform_company_users")
+      .insert({
+        company_id: COMPANY_A_ID,
+        user_id: creator.id,
+        role: "approver",
+      })
+      .select("id");
+    if (membership.error) {
+      throw new Error(
+        `seed membership: ${membership.error.code ?? "?"} ${membership.error.message}`,
+      );
+    }
+  });
+
+  afterAll(async () => {
+    const svc = getServiceRoleClient();
+    if (creator) await svc.auth.admin.deleteUser(creator.id);
+  });
+
+  // Helper: create an approved post (bypasses the full submit/decide
+  // dance — those flows are tested elsewhere).
+  async function createApprovedPost(): Promise<string> {
+    const post = await createPostMaster({
+      companyId: COMPANY_A_ID,
+      masterText: "ready to schedule",
+      createdBy: creator.id,
+    });
+    if (!post.ok) throw new Error(`createApprovedPost: ${post.error.code}`);
+    const svc = getServiceRoleClient();
+    await svc
+      .from("social_post_master")
+      .update({ state: "approved" })
+      .eq("id", post.data.id);
+    return post.data.id;
+  }
+
+  function futureIso(daysFromNow = 7): string {
+    return new Date(Date.now() + daysFromNow * 24 * 60 * 60 * 1000).toISOString();
+  }
+
+  describe("createScheduleEntry", () => {
+    it("happy path — creates entry, auto-creates variant row", async () => {
+      const postId = await createApprovedPost();
+      const result = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "linkedin_personal",
+        scheduledAt: futureIso(7),
+        scheduledBy: creator.id,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.platform).toBe("linkedin_personal");
+      expect(result.data.cancelled_at).toBeNull();
+      expect(result.data.scheduled_by).toBe(creator.id);
+
+      // Variant row should have been auto-created.
+      const svc = getServiceRoleClient();
+      const variant = await svc
+        .from("social_post_variant")
+        .select("is_custom")
+        .eq("post_master_id", postId)
+        .eq("platform", "linkedin_personal")
+        .single();
+      expect(variant.error).toBeNull();
+      expect(variant.data?.is_custom).toBe(false);
+    });
+
+    it("rejects past scheduled_at", async () => {
+      const postId = await createApprovedPost();
+      const result = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "x",
+        scheduledAt: new Date(Date.now() - 1000).toISOString(),
+        scheduledBy: creator.id,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("rejects scheduling a draft post with INVALID_STATE", async () => {
+      const post = await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "still draft",
+        createdBy: creator.id,
+      });
+      expect(post.ok).toBe(true);
+      if (!post.ok) return;
+
+      const result = await createScheduleEntry({
+        postMasterId: post.data.id,
+        companyId: COMPANY_A_ID,
+        platform: "linkedin_personal",
+        scheduledAt: futureIso(),
+        scheduledBy: creator.id,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("INVALID_STATE");
+    });
+
+    it("rejects double-scheduling the same platform with INVALID_STATE", async () => {
+      const postId = await createApprovedPost();
+      const first = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "facebook_page",
+        scheduledAt: futureIso(7),
+        scheduledBy: creator.id,
+      });
+      expect(first.ok).toBe(true);
+
+      const second = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "facebook_page",
+        scheduledAt: futureIso(8),
+        scheduledBy: creator.id,
+      });
+      expect(second.ok).toBe(false);
+      if (second.ok) return;
+      expect(second.error.code).toBe("INVALID_STATE");
+    });
+
+    it("allows scheduling on different platforms simultaneously", async () => {
+      const postId = await createApprovedPost();
+      const a = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "linkedin_personal",
+        scheduledAt: futureIso(5),
+        scheduledBy: creator.id,
+      });
+      const b = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "x",
+        scheduledAt: futureIso(6),
+        scheduledBy: creator.id,
+      });
+      expect(a.ok && b.ok).toBe(true);
+    });
+
+    it("allows re-scheduling after cancellation", async () => {
+      const postId = await createApprovedPost();
+      const first = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "gbp",
+        scheduledAt: futureIso(3),
+        scheduledBy: creator.id,
+      });
+      expect(first.ok).toBe(true);
+      if (!first.ok) return;
+
+      const cancelled = await cancelScheduleEntry({
+        entryId: first.data.id,
+        companyId: COMPANY_A_ID,
+      });
+      expect(cancelled.ok).toBe(true);
+
+      const reschedule = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "gbp",
+        scheduledAt: futureIso(10),
+        scheduledBy: creator.id,
+      });
+      expect(reschedule.ok).toBe(true);
+    });
+
+    it("returns NOT_FOUND for cross-company access", async () => {
+      const postId = await createApprovedPost();
+      const result = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_B_ID,
+        platform: "linkedin_personal",
+        scheduledAt: futureIso(),
+        scheduledBy: creator.id,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("listScheduleEntries", () => {
+    it("returns active entries ordered by scheduled_at asc", async () => {
+      const postId = await createApprovedPost();
+      await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "linkedin_personal",
+        scheduledAt: futureIso(10),
+        scheduledBy: creator.id,
+      });
+      await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "x",
+        scheduledAt: futureIso(3),
+        scheduledBy: creator.id,
+      });
+
+      const result = await listScheduleEntries({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.entries.length).toBe(2);
+      // x first (sooner), linkedin second.
+      expect(result.data.entries[0]?.platform).toBe("x");
+      expect(result.data.entries[1]?.platform).toBe("linkedin_personal");
+    });
+
+    it("excludes cancelled entries by default", async () => {
+      const postId = await createApprovedPost();
+      const created = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "linkedin_personal",
+        scheduledAt: futureIso(),
+        scheduledBy: creator.id,
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+      await cancelScheduleEntry({
+        entryId: created.data.id,
+        companyId: COMPANY_A_ID,
+      });
+
+      const result = await listScheduleEntries({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.entries).toEqual([]);
+
+      const withCancelled = await listScheduleEntries({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        includeCancelled: true,
+      });
+      expect(withCancelled.ok).toBe(true);
+      if (!withCancelled.ok) return;
+      expect(withCancelled.data.entries.length).toBe(1);
+      expect(withCancelled.data.entries[0]?.cancelled_at).not.toBeNull();
+    });
+
+    it("returns NOT_FOUND for cross-company access", async () => {
+      const postId = await createApprovedPost();
+      const result = await listScheduleEntries({
+        postMasterId: postId,
+        companyId: COMPANY_B_ID,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("cancelScheduleEntry", () => {
+    it("happy path — sets cancelled_at, idempotent on repeat", async () => {
+      const postId = await createApprovedPost();
+      const created = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "linkedin_personal",
+        scheduledAt: futureIso(),
+        scheduledBy: creator.id,
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+
+      const first = await cancelScheduleEntry({
+        entryId: created.data.id,
+        companyId: COMPANY_A_ID,
+      });
+      expect(first.ok).toBe(true);
+      if (!first.ok) return;
+      expect(first.data.cancelled_at).not.toBeNull();
+
+      const second = await cancelScheduleEntry({
+        entryId: created.data.id,
+        companyId: COMPANY_A_ID,
+      });
+      expect(second.ok).toBe(false);
+      if (second.ok) return;
+      expect(second.error.code).toBe("INVALID_STATE");
+    });
+
+    it("returns NOT_FOUND for cross-company access", async () => {
+      const postId = await createApprovedPost();
+      const created = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_A_ID,
+        platform: "linkedin_personal",
+        scheduledAt: futureIso(),
+        scheduledBy: creator.id,
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+
+      const result = await cancelScheduleEntry({
+        entryId: created.data.id,
+        companyId: COMPANY_B_ID,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns NOT_FOUND for missing entry id", async () => {
+      const result = await cancelScheduleEntry({
+        entryId: "00000000-0000-0000-0000-000000000fff",
+        companyId: COMPANY_A_ID,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+  });
+});

--- a/lib/platform/social/scheduling/cancel.ts
+++ b/lib/platform/social/scheduling/cancel.ts
@@ -1,0 +1,158 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type {
+  CancelScheduleEntryInput,
+  ScheduleEntry,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// S1-14 — cancel a non-cancelled schedule entry.
+//
+// Atomic UPDATE WHERE cancelled_at IS NULL. Concurrent cancels
+// converge: one transitions, the others see 0 rows and return
+// INVALID_STATE. Cross-company access caught by checking the entry's
+// variant's post belongs to companyId.
+//
+// QStash message cancellation lands when QStash enqueue lands
+// (S1-15+). Until then, the publish-handler will pick up the entry
+// and skip it because cancelled_at is non-null.
+// ---------------------------------------------------------------------------
+
+export async function cancelScheduleEntry(
+  input: CancelScheduleEntryInput,
+): Promise<ApiResponse<ScheduleEntry>> {
+  if (!input.entryId) return validation("Entry id is required.");
+  if (!input.companyId) return validation("Company id is required.");
+
+  const svc = getServiceRoleClient();
+
+  // Resolve entry → variant → post → company. Two reads + atomic
+  // UPDATE rather than one fancy embed (multi-FK pitfall avoided).
+  const entry = await svc
+    .from("social_schedule_entries")
+    .select(
+      "id, post_variant_id, scheduled_at, qstash_message_id, scheduled_by, cancelled_at, created_at",
+    )
+    .eq("id", input.entryId)
+    .maybeSingle();
+  if (entry.error) {
+    logger.error("social.scheduling.cancel.entry_lookup_failed", {
+      err: entry.error.message,
+    });
+    return internal(`Failed to read entry: ${entry.error.message}`);
+  }
+  if (!entry.data) return notFound();
+
+  const variant = await svc
+    .from("social_post_variant")
+    .select("post_master_id")
+    .eq("id", entry.data.post_variant_id as string)
+    .maybeSingle();
+  if (variant.error || !variant.data) {
+    return notFound();
+  }
+
+  const post = await svc
+    .from("social_post_master")
+    .select("id")
+    .eq("id", variant.data.post_master_id as string)
+    .eq("company_id", input.companyId)
+    .maybeSingle();
+  if (post.error) {
+    logger.error("social.scheduling.cancel.post_lookup_failed", {
+      err: post.error.message,
+    });
+    return internal(`Failed to scope: ${post.error.message}`);
+  }
+  if (!post.data) {
+    // Entry exists but in another company. Same NOT_FOUND envelope to
+    // avoid leaking cross-company existence.
+    return notFound();
+  }
+
+  if ((entry.data as ScheduleEntry).cancelled_at) {
+    return invalidState("Entry is already cancelled.");
+  }
+
+  const update = await svc
+    .from("social_schedule_entries")
+    .update({ cancelled_at: new Date().toISOString() })
+    .eq("id", input.entryId)
+    .is("cancelled_at", null)
+    .select(
+      "id, post_variant_id, scheduled_at, qstash_message_id, scheduled_by, cancelled_at, created_at",
+    )
+    .maybeSingle();
+  if (update.error) {
+    logger.error("social.scheduling.cancel.update_failed", {
+      err: update.error.message,
+    });
+    return internal(`Failed to cancel: ${update.error.message}`);
+  }
+  if (!update.data) {
+    // Race: another caller cancelled between our lookup and update.
+    return invalidState("Entry was cancelled concurrently.");
+  }
+
+  return {
+    ok: true,
+    data: update.data as ScheduleEntry,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(message: string): ApiResponse<ScheduleEntry> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function notFound(): ApiResponse<ScheduleEntry> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message: "No schedule entry with that id in this company.",
+      retryable: false,
+      suggested_action: "Check the entry id.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function invalidState(message: string): ApiResponse<ScheduleEntry> {
+  return {
+    ok: false,
+    error: {
+      code: "INVALID_STATE",
+      message,
+      retryable: false,
+      suggested_action: "Reload and try again if needed.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<ScheduleEntry> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/scheduling/create.ts
+++ b/lib/platform/social/scheduling/create.ts
@@ -1,0 +1,224 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { SUPPORTED_PLATFORMS } from "@/lib/platform/social/variants/types";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type {
+  CreateScheduleEntryInput,
+  ScheduleEntryWithPlatform,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// S1-14 — schedule a single (post, platform, datetime) tuple.
+//
+// Steps:
+//   1. Verify post is in 'approved' state for this company.
+//   2. Verify scheduled_at is in the future.
+//   3. Ensure a social_post_variant row exists for (post, platform).
+//      We can't reuse upsertVariant because that lib gates on
+//      state='draft'; an approved post needs a different path. We
+//      just insert with is_custom=false (variant_text=null) so the
+//      publish layer falls back to master_text.
+//   4. Verify no non-cancelled schedule entry already exists for the
+//      variant (prevents accidental double-publish).
+//   5. INSERT the schedule entry.
+//
+// QStash enqueue is intentionally NOT done here. The publish-handler
+// route lands in S1-15+ when bundle.social wiring is ready; until
+// then a backfill cron will pick up entries lacking qstash_message_id.
+//
+// Caller is responsible for canDo("schedule_post", company_id).
+// ---------------------------------------------------------------------------
+
+export async function createScheduleEntry(
+  input: CreateScheduleEntryInput,
+): Promise<ApiResponse<ScheduleEntryWithPlatform>> {
+  if (!input.postMasterId) return validation("Post id is required.");
+  if (!input.companyId) return validation("Company id is required.");
+  if (!SUPPORTED_PLATFORMS.includes(input.platform)) {
+    return validation(`Unsupported platform: ${input.platform}.`);
+  }
+
+  const scheduledAtMs = Date.parse(input.scheduledAt);
+  if (Number.isNaN(scheduledAtMs)) {
+    return validation("scheduled_at must be a valid ISO timestamp.");
+  }
+  if (scheduledAtMs <= Date.now()) {
+    return validation("scheduled_at must be in the future.");
+  }
+
+  const svc = getServiceRoleClient();
+
+  // 1. Parent post must exist + be approved.
+  const post = await svc
+    .from("social_post_master")
+    .select("id, state")
+    .eq("id", input.postMasterId)
+    .eq("company_id", input.companyId)
+    .maybeSingle();
+  if (post.error) {
+    logger.error("social.scheduling.create.post_lookup_failed", {
+      err: post.error.message,
+      post_id: input.postMasterId,
+    });
+    return internal(`Failed to read post: ${post.error.message}`);
+  }
+  if (!post.data) return notFound();
+
+  if (post.data.state !== "approved") {
+    return invalidState(
+      `Post is in '${post.data.state}', not 'approved'. Only approved posts can be scheduled.`,
+    );
+  }
+
+  // 2. Ensure the variant row exists. Use upsert with onConflict so
+  // concurrent schedule attempts on the same (post, platform) converge
+  // to one row.
+  const variantUpsert = await svc
+    .from("social_post_variant")
+    .upsert(
+      {
+        post_master_id: input.postMasterId,
+        platform: input.platform,
+        // Don't touch variant_text or is_custom on conflict — preserve
+        // any operator-authored override.
+      },
+      {
+        onConflict: "post_master_id,platform",
+        ignoreDuplicates: true,
+      },
+    )
+    .select("id")
+    .maybeSingle();
+  if (variantUpsert.error) {
+    logger.error("social.scheduling.create.variant_upsert_failed", {
+      err: variantUpsert.error.message,
+      post_id: input.postMasterId,
+      platform: input.platform,
+    });
+    return internal(
+      `Failed to ensure variant row: ${variantUpsert.error.message}`,
+    );
+  }
+
+  // ignoreDuplicates returns no row on conflict; need a second read
+  // to get the variant id either way.
+  let variantId: string | null = (variantUpsert.data?.id as string) ?? null;
+  if (!variantId) {
+    const variantRead = await svc
+      .from("social_post_variant")
+      .select("id")
+      .eq("post_master_id", input.postMasterId)
+      .eq("platform", input.platform)
+      .maybeSingle();
+    if (variantRead.error || !variantRead.data) {
+      return internal(
+        `Variant row missing after upsert: ${variantRead.error?.message ?? "no row"}`,
+      );
+    }
+    variantId = variantRead.data.id as string;
+  }
+
+  // 3. Reject if a non-cancelled schedule already exists.
+  const existing = await svc
+    .from("social_schedule_entries")
+    .select("id, scheduled_at")
+    .eq("post_variant_id", variantId)
+    .is("cancelled_at", null)
+    .maybeSingle();
+  if (existing.error) {
+    logger.error("social.scheduling.create.dup_check_failed", {
+      err: existing.error.message,
+    });
+    return internal(`Failed dup check: ${existing.error.message}`);
+  }
+  if (existing.data) {
+    return invalidState(
+      `An active schedule entry already exists for this platform (scheduled at ${existing.data.scheduled_at}). Cancel it first if you want to reschedule.`,
+    );
+  }
+
+  // 4. Insert.
+  const insert = await svc
+    .from("social_schedule_entries")
+    .insert({
+      post_variant_id: variantId,
+      scheduled_at: input.scheduledAt,
+      scheduled_by: input.scheduledBy,
+    })
+    .select(
+      "id, post_variant_id, scheduled_at, qstash_message_id, scheduled_by, cancelled_at, created_at",
+    )
+    .single();
+  if (insert.error) {
+    logger.error("social.scheduling.create.insert_failed", {
+      err: insert.error.message,
+      code: insert.error.code,
+    });
+    return internal(`Failed to create schedule entry: ${insert.error.message}`);
+  }
+
+  return {
+    ok: true,
+    data: {
+      ...(insert.data as ScheduleEntryWithPlatform),
+      platform: input.platform,
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(message: string): ApiResponse<ScheduleEntryWithPlatform> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function notFound(): ApiResponse<ScheduleEntryWithPlatform> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message: "No post with that id in this company.",
+      retryable: false,
+      suggested_action: "Check the post id.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function invalidState(message: string): ApiResponse<ScheduleEntryWithPlatform> {
+  return {
+    ok: false,
+    error: {
+      code: "INVALID_STATE",
+      message,
+      retryable: false,
+      suggested_action:
+        "Reload the page; the post or schedule may have moved.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<ScheduleEntryWithPlatform> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/scheduling/index.ts
+++ b/lib/platform/social/scheduling/index.ts
@@ -1,0 +1,10 @@
+export { cancelScheduleEntry } from "./cancel";
+export { createScheduleEntry } from "./create";
+export { listScheduleEntries } from "./list";
+export type {
+  CancelScheduleEntryInput,
+  CreateScheduleEntryInput,
+  ListScheduleEntriesInput,
+  ScheduleEntry,
+  ScheduleEntryWithPlatform,
+} from "./types";

--- a/lib/platform/social/scheduling/list.ts
+++ b/lib/platform/social/scheduling/list.ts
@@ -1,0 +1,153 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type {
+  ListScheduleEntriesInput,
+  ScheduleEntryWithPlatform,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// S1-14 — list schedule entries for a post.
+//
+// Joins social_schedule_entries → social_post_variant to surface the
+// variant's platform alongside the entry. Two queries (lookup variants
+// for the post first, then entries) avoids the multi-FK embed gotcha
+// from memory feedback_postgrest_embed_ambiguous_fk.md.
+//
+// Caller is responsible for canDo("view_calendar", company_id).
+// ---------------------------------------------------------------------------
+
+export async function listScheduleEntries(
+  input: ListScheduleEntriesInput,
+): Promise<ApiResponse<{ entries: ScheduleEntryWithPlatform[] }>> {
+  if (!input.postMasterId) return validation("Post id is required.");
+  if (!input.companyId) return validation("Company id is required.");
+
+  const svc = getServiceRoleClient();
+
+  // Verify post belongs to this company; saves a leak across companies
+  // even though the entries themselves don't carry company_id.
+  const post = await svc
+    .from("social_post_master")
+    .select("id")
+    .eq("id", input.postMasterId)
+    .eq("company_id", input.companyId)
+    .maybeSingle();
+  if (post.error) {
+    logger.error("social.scheduling.list.post_lookup_failed", {
+      err: post.error.message,
+    });
+    return internal(`Failed to read post: ${post.error.message}`);
+  }
+  if (!post.data) return notFound();
+
+  // Resolve variant ids + their platforms for this post.
+  const variants = await svc
+    .from("social_post_variant")
+    .select("id, platform")
+    .eq("post_master_id", input.postMasterId);
+  if (variants.error) {
+    logger.error("social.scheduling.list.variants_failed", {
+      err: variants.error.message,
+    });
+    return internal(`Failed to list variants: ${variants.error.message}`);
+  }
+
+  const variantIds = (variants.data ?? []).map((v) => v.id as string);
+  if (variantIds.length === 0) {
+    return {
+      ok: true,
+      data: { entries: [] },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  let query = svc
+    .from("social_schedule_entries")
+    .select(
+      "id, post_variant_id, scheduled_at, qstash_message_id, scheduled_by, cancelled_at, created_at",
+    )
+    .in("post_variant_id", variantIds)
+    .order("scheduled_at", { ascending: true });
+
+  if (!input.includeCancelled) {
+    query = query.is("cancelled_at", null);
+  }
+
+  const entries = await query;
+  if (entries.error) {
+    logger.error("social.scheduling.list.entries_failed", {
+      err: entries.error.message,
+    });
+    return internal(`Failed to list entries: ${entries.error.message}`);
+  }
+
+  // Build a variant_id → platform lookup so we can decorate each entry.
+  const platformByVariant = new Map<string, ScheduleEntryWithPlatform["platform"]>();
+  for (const v of variants.data ?? []) {
+    platformByVariant.set(
+      v.id as string,
+      v.platform as ScheduleEntryWithPlatform["platform"],
+    );
+  }
+
+  const decorated: ScheduleEntryWithPlatform[] = (entries.data ?? []).map(
+    (e) => ({
+      ...(e as Omit<ScheduleEntryWithPlatform, "platform">),
+      platform:
+        platformByVariant.get(e.post_variant_id as string) ?? "linkedin_personal",
+    }),
+  );
+
+  return {
+    ok: true,
+    data: { entries: decorated },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(
+  message: string,
+): ApiResponse<{ entries: ScheduleEntryWithPlatform[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function notFound(): ApiResponse<{ entries: ScheduleEntryWithPlatform[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message: "No post with that id in this company.",
+      retryable: false,
+      suggested_action: "Check the post id.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(
+  message: string,
+): ApiResponse<{ entries: ScheduleEntryWithPlatform[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/scheduling/types.ts
+++ b/lib/platform/social/scheduling/types.ts
@@ -1,0 +1,40 @@
+import type { SocialPlatform } from "@/lib/platform/social/variants/types";
+
+export type ScheduleEntry = {
+  id: string;
+  post_variant_id: string;
+  scheduled_at: string;
+  qstash_message_id: string | null;
+  scheduled_by: string | null;
+  cancelled_at: string | null;
+  created_at: string;
+};
+
+// Read shape for the operator UI: includes the variant's platform so
+// the table can render "LinkedIn — Tue 12 May 09:00" without joining
+// in the client.
+export type ScheduleEntryWithPlatform = ScheduleEntry & {
+  platform: SocialPlatform;
+};
+
+export type CreateScheduleEntryInput = {
+  postMasterId: string;
+  companyId: string;
+  platform: SocialPlatform;
+  // ISO timestamp; must be in the future.
+  scheduledAt: string;
+  // The actor who scheduled (audit). Pass gate.userId from the route.
+  scheduledBy: string | null;
+};
+
+export type ListScheduleEntriesInput = {
+  postMasterId: string;
+  companyId: string;
+  // When true, include cancelled entries (default false).
+  includeCancelled?: boolean;
+};
+
+export type CancelScheduleEntryInput = {
+  entryId: string;
+  companyId: string;
+};


### PR DESCRIPTION
## Summary
Lib + route + UI for creating, listing, and cancelling `social_schedule_entries`. **Doesn't depend on bundle.social** — the QStash enqueue + publish-handler land in S1-15+ when the OAuth flow is wired. Until then, schedule rows sit in the DB and the publish layer picks them up later.

## Changes
- `lib/platform/social/scheduling/create.ts` — state guard (`approved` only), future-time guard, ensures `social_post_variant` row exists (upsert with `ignoreDuplicates`), refuses double-scheduling per platform.
- `lib/platform/social/scheduling/list.ts` — ordered by `scheduled_at` asc; excludes cancelled by default. Two-query lookup (variants, then entries) sidesteps the multi-FK embed pitfall.
- `lib/platform/social/scheduling/cancel.ts` — atomic UPDATE WHERE `cancelled_at IS NULL`. Concurrent cancels converge.
- `POST/GET /api/platform/social/posts/[id]/schedule` (canDo `schedule_post` for POST, `view_calendar` for GET) + `DELETE /[entry_id]` (`schedule_post`).
- `components/PostScheduleSection.tsx` — list + add form on the post detail page when state='approved'. Browser-local datetime input converted to ISO with the browser's timezone.
- Detail page wires the section conditionally via an inline async helper.
- Tests: happy path, past-time rejection, draft INVALID_STATE, double-schedule INVALID_STATE, multi-platform OK, re-schedule after cancel, cross-company NOT_FOUND, list ordering + cancelled toggle, cancel idempotency.

## Risks identified and mitigated
- **Variant row race during schedule**: upsert with `ignoreDuplicates` + follow-up read converges concurrent attempts.
- **Double-publish on the same `(post, platform)`**: app-side check before insert (no UNIQUE in schema yet); concurrent inserts could still both succeed within the race window. Acceptable for V1 — the publish-handler will dedup further when it lands.
- **Scheduling against a non-current variant**: the schedule entry binds to a specific `variant_id` at insert time; the publish picks up the latest `variant_text` at publish time. Documented behaviour.
- **Cross-company writes**: lib filters by `company_id` at the post read; route gate authorises against body's `company_id`; RLS layered.
- **Auto-merge eligible**: pure data-layer + UI, no money / external service / WP mutation.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean — both routes registered
- [ ] CI Vitest run — Docker not available locally; deferring to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)