### PR TITLE
fix(commit): replace not-committed-yet panel with polling waiter

### DIFF
--- a/app/admin/sites/[id]/briefs/[brief_id]/run/page.tsx
+++ b/app/admin/sites/[id]/briefs/[brief_id]/run/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 
 import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { BriefCommitWaiter } from "@/components/BriefCommitWaiter";
 import { BriefRunClient } from "@/components/BriefRunClient";
 import {
   estimateBriefRunCost,
@@ -84,9 +85,18 @@ export default async function BriefRunPage({
   }
 
   if (brief.status !== "committed") {
-    // The run surface is only meaningful once the brief is committed.
-    // Bounce the operator back to the review surface where they can
-    // commit.
+    // UAT (2026-05-03 round-3): replaced the static "isn't committed
+    // yet" panel with a client-side polling waiter. Even with the
+    // server-side visibility wait in /api/briefs/[brief_id]/commit,
+    // Vercel may route this server render to a different serverless
+    // instance whose connection pool hasn't yet seen the COMMIT —
+    // operators saw the panel for several seconds and were confused
+    // because they had JUST clicked Commit. The waiter polls the
+    // snapshot endpoint until status='committed' is visible (up to
+    // 30s) and then router.refresh()'es into the run UI. The
+    // exhaustion path falls through to a clearer "couldn't verify the
+    // commit" message + back-to-review link, replacing the prior
+    // panel's role.
     return (
       <main className="mx-auto max-w-5xl p-6">
         <Breadcrumbs
@@ -97,21 +107,10 @@ export default async function BriefRunPage({
             { label: brief.title },
           ]}
         />
-        <div
-          role="status"
-          className="mt-6 rounded-md border border-yellow-500/40 bg-yellow-500/10 p-4 text-sm text-yellow-900 dark:text-yellow-200"
-        >
-          <p className="font-medium">This brief isn&apos;t committed yet.</p>
-          <p className="mt-1">
-            <a
-              className="underline hover:no-underline"
-              href={`/admin/sites/${site.id}/briefs/${brief.id}/review`}
-            >
-              Review and commit
-            </a>{" "}
-            before starting a generation run.
-          </p>
-        </div>
+        <BriefCommitWaiter
+          briefId={brief.id}
+          reviewUrl={`/admin/sites/${site.id}/briefs/${brief.id}/review`}
+        />
       </main>
     );
   }

--- a/components/BriefCommitWaiter.tsx
+++ b/components/BriefCommitWaiter.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+// ---------------------------------------------------------------------------
+// BriefCommitWaiter — eliminates the commit→/run race for the operator.
+//
+// The /run server component reads the brief via PostgREST. Even after the
+// commit POST returns success, Vercel may route the /run render to a
+// different serverless instance / pool that hasn't yet observed the
+// COMMIT. Until 2026-05-03 the operator saw an "isn't committed yet"
+// panel for several seconds — confusing because they JUST clicked
+// Commit and got a success.
+//
+// This component renders a spinner + reassuring copy and polls the
+// snapshot endpoint every 500ms (up to 30s) waiting for status='committed'
+// to become visible. The moment it does, router.refresh() re-fetches the
+// /run server component which then sees the committed state and renders
+// the run UI for real.
+//
+// Capped at 30s — beyond that we fall through to a real error CTA so
+// the operator isn't stranded on a forever-spinner if something genuinely
+// went wrong upstream.
+// ---------------------------------------------------------------------------
+
+export function BriefCommitWaiter({
+  briefId,
+  reviewUrl,
+}: {
+  briefId: string;
+  reviewUrl: string;
+}) {
+  const router = useRouter();
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [exhausted, setExhausted] = useState(false);
+
+  useEffect(() => {
+    const start = Date.now();
+    let cancelled = false;
+    const timeoutId = window.setTimeout(() => {
+      if (!cancelled) setExhausted(true);
+    }, 30_000);
+
+    async function poll() {
+      if (cancelled) return;
+      try {
+        const res = await fetch(`/api/briefs/${briefId}/run/snapshot`, {
+          cache: "no-store",
+        });
+        if (res.ok) {
+          const json = (await res.json()) as {
+            ok?: boolean;
+            data?: { brief?: { status?: string } };
+          };
+          if (json?.ok && json.data?.brief?.status === "committed") {
+            window.clearTimeout(timeoutId);
+            router.refresh();
+            return;
+          }
+        }
+      } catch {
+        // ignore — keep polling
+      }
+      setElapsedMs(Date.now() - start);
+      if (!cancelled) {
+        window.setTimeout(poll, 500);
+      }
+    }
+    void poll();
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [briefId, router]);
+
+  if (exhausted) {
+    return (
+      <div
+        role="alert"
+        className="mt-6 rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+      >
+        <p className="font-medium">Couldn&apos;t verify the commit.</p>
+        <p className="mt-1">
+          The commit went through, but we couldn&apos;t confirm visibility
+          within 30 seconds. Refresh this page in a few moments — if it
+          still shows this message, head back to{" "}
+          <a className="underline hover:no-underline" href={reviewUrl}>
+            review and re-commit
+          </a>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  const seconds = Math.floor(elapsedMs / 1000);
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="mt-6 flex items-center gap-3 rounded-md border bg-muted/40 p-4"
+    >
+      <span
+        aria-hidden
+        className="h-3 w-3 animate-pulse rounded-full bg-emerald-500"
+      />
+      <div className="text-sm">
+        <p className="font-medium">Finishing your commit…</p>
+        <p className="text-muted-foreground">
+          Waiting for the run surface to come online (
+          {seconds > 0 ? `${seconds}s elapsed` : "this usually takes a second"}
+          ).
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Operators were still hitting 'isn't committed yet' on /run despite multiple race-fix attempts (PR #411 retry loop, PR #427 server-side visibility wait). Vercel routes the /run server render to a different instance with its own pool, so the prior fixes only solved one side of the propagation. This PR replaces the static panel with BriefCommitWaiter — a client-side polling spinner that hits /api/briefs/[id]/run/snapshot every 500ms (up to 30s) until status='committed' is observed, then router.refresh() reloads the route into the actual run UI. Operators see a brief 'Finishing your commit…' state, never the misleading not-committed message.