### PR TITLE
feat(s1-15): viewer-link magic-link flow (90-day customer calendar)

### DIFF
--- a/app/api/platform/social/viewer-links/[id]/route.ts
+++ b/app/api/platform/social/viewer-links/[id]/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { revokeViewerLink } from "@/lib/platform/social/viewer-links";
+
+// ---------------------------------------------------------------------------
+// S1-15 — DELETE /api/platform/social/viewer-links/[id]
+//
+// Soft-revoke. Atomic UPDATE WHERE revoked_at IS NULL converges
+// concurrent revokes. Gate: canDo("manage_invitations").
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+function statusForCode(code: string): number {
+  switch (code) {
+    case "VALIDATION_FAILED":
+      return 400;
+    case "NOT_FOUND":
+      return 404;
+    case "INVALID_STATE":
+      return 409;
+    default:
+      return 500;
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return errorJson("VALIDATION_FAILED", "id must be a UUID.", 400);
+  }
+  const companyId = new URL(req.url).searchParams.get("company_id");
+  if (!companyId || !UUID_RE.test(companyId)) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "company_id query parameter (uuid) is required.",
+      400,
+    );
+  }
+
+  const gate = await requireCanDoForApi(companyId, "manage_invitations");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await revokeViewerLink({ linkId: id, companyId });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      statusForCode(result.error.code),
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { link: result.data },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/platform/social/viewer-links/route.ts
+++ b/app/api/platform/social/viewer-links/route.ts
@@ -1,0 +1,157 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import {
+  createViewerLink,
+  listViewerLinks,
+} from "@/lib/platform/social/viewer-links";
+
+// ---------------------------------------------------------------------------
+// S1-15 — viewer-link admin endpoints.
+//
+//   GET /api/platform/social/viewer-links?company_id=&include_inactive=
+//     canDo("manage_invitations") — admin-only.
+//
+//   POST /api/platform/social/viewer-links
+//     Body { company_id, recipient_email?, recipient_name?, expires_at? }
+//     canDo("manage_invitations"). Returns the link row + raw token.
+//     Caller surfaces the URL (origin + /viewer/<rawToken>) to the
+//     admin who shares it externally.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+const PostBodySchema = z.object({
+  company_id: z.string().uuid(),
+  recipient_email: z.string().email().max(254).nullable().optional(),
+  recipient_name: z.string().max(200).nullable().optional(),
+  expires_at: z.string().datetime().optional(),
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: {
+        code,
+        message,
+        retryable: false,
+        ...(details ? { details } : {}),
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+function statusForCode(code: string): number {
+  switch (code) {
+    case "VALIDATION_FAILED":
+      return 400;
+    case "NOT_FOUND":
+      return 404;
+    case "INVALID_STATE":
+      return 409;
+    default:
+      return 500;
+  }
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const url = new URL(req.url);
+  const companyId = url.searchParams.get("company_id");
+  if (!companyId || !UUID_RE.test(companyId)) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "company_id query parameter (uuid) is required.",
+      400,
+    );
+  }
+  const includeInactive = url.searchParams.get("include_inactive") === "true";
+
+  const gate = await requireCanDoForApi(companyId, "manage_invitations");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await listViewerLinks({ companyId, includeInactive });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      statusForCode(result.error.code),
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: result.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = PostBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "Body must be { company_id: uuid, recipient_email?, recipient_name?, expires_at? }.",
+      400,
+      { issues: parsed.error.issues },
+    );
+  }
+
+  const gate = await requireCanDoForApi(
+    parsed.data.company_id,
+    "manage_invitations",
+  );
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await createViewerLink({
+    companyId: parsed.data.company_id,
+    recipientEmail: parsed.data.recipient_email ?? null,
+    recipientName: parsed.data.recipient_name ?? null,
+    expiresAt: parsed.data.expires_at,
+    createdBy: gate.userId,
+  });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      statusForCode(result.error.code),
+    );
+  }
+
+  // Build the public URL the admin shares. Origin pinned via
+  // NEXT_PUBLIC_SITE_URL (production-correct), falls back to the
+  // request origin for dev / preview.
+  const origin =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ??
+    new URL(req.url).origin;
+  const url = `${origin}/viewer/${result.data.rawToken}`;
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { link: result.data.link, url },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 201 },
+  );
+}

--- a/app/company/social/sharing/page.tsx
+++ b/app/company/social/sharing/page.tsx
@@ -1,0 +1,88 @@
+import { redirect } from "next/navigation";
+
+import { ViewerLinksManager } from "@/components/ViewerLinksManager";
+import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
+import { listViewerLinks } from "@/lib/platform/social/viewer-links";
+
+// ---------------------------------------------------------------------------
+// S1-15 — admin-only page to manage viewer-link sharing.
+//
+// Same gating shape as /company/users:
+//   1. No session → /login.
+//   2. No company membership → "Not provisioned" envelope.
+//   3. Non-admin role → "Admins only" panel.
+//
+// canDo("manage_invitations") is the threshold: admins-only, since
+// these links are public-facing and have no further auth check.
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+export default async function CompanySocialSharingPage() {
+  const session = await getCurrentPlatformSession();
+  if (!session) {
+    redirect(`/login?next=${encodeURIComponent("/company/social/sharing")}`);
+  }
+
+  if (!session.company) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-sm">
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-4">
+          <p className="font-medium">Account not provisioned to a company.</p>
+          <p className="mt-1 text-muted-foreground">
+            Your account isn&apos;t a member of any company on the
+            platform yet. Ask an admin to invite you, or contact
+            Opollo support.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const companyId = session.company.companyId;
+  const isAdmin = await canDo(companyId, "manage_invitations");
+  if (!isAdmin) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-sm">
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-destructive">
+          <p className="font-medium">Admins only.</p>
+          <p className="mt-1">
+            Only admins can manage calendar-sharing links. Ask an admin
+            in your company to share the calendar with you, or to
+            promote your role.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const linksResult = await listViewerLinks({ companyId });
+
+  return (
+    <main className="mx-auto max-w-4xl p-6 space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Calendar sharing</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Mint 90-day read-only links to share the content calendar
+          with clients or stakeholders. They don&apos;t need an Opollo
+          account.
+        </p>
+      </header>
+
+      {linksResult.ok ? (
+        <ViewerLinksManager
+          companyId={companyId}
+          initialLinks={linksResult.data.links}
+        />
+      ) : (
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+          role="alert"
+          data-testid="viewer-links-load-error"
+        >
+          Failed to load viewer links: {linksResult.error.message}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/viewer/[token]/page.tsx
+++ b/app/viewer/[token]/page.tsx
@@ -1,0 +1,230 @@
+import {
+  PLATFORM_LABEL,
+  type SocialPlatform,
+} from "@/lib/platform/social/variants/types";
+import { resolveViewerLink } from "@/lib/platform/social/viewer-links";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// S1-15 — public read-only calendar at /viewer/[token].
+//
+// Token IS the auth (SHA-256 hash → social_viewer_links row). Renders
+// the company's posts that are approved / scheduled / published in a
+// 90-day window centred on now (60 forward, 30 back). No interactive
+// surface — the recipient can see what's coming and what's gone live,
+// nothing else.
+//
+// Layout choice: list grouped by date rather than a calendar grid.
+// V1 priority is "show me the schedule" not "drag-and-drop", and a
+// list works at every viewport size without bespoke layout code.
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+const FORWARD_DAYS = 60;
+const BACK_DAYS = 30;
+
+type SchedulePreview = {
+  id: string;
+  scheduled_at: string;
+  platform: SocialPlatform;
+  master_text: string | null;
+  link_url: string | null;
+};
+
+export default async function ViewerLinkPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+
+  if (!/^[0-9a-f]{64}$/i.test(token)) {
+    return <InvalidLink />;
+  }
+
+  const resolved = await resolveViewerLink(token);
+  if (!resolved.ok) {
+    return <InvalidLink />;
+  }
+
+  const { company } = resolved.data;
+
+  // Read scheduled entries for the company in the window. Three-step:
+  //   1. variants for the company's posts
+  //   2. schedule_entries (non-cancelled) joined to the variants
+  //   3. enrich with platform + master_text/link_url for the renderer
+  // Done with two queries; PostgREST embeds across multi-FK tables
+  // are flaky (memory: feedback_postgrest_embed_ambiguous_fk).
+  const svc = getServiceRoleClient();
+
+  const now = Date.now();
+  const fromIso = new Date(now - BACK_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const toIso = new Date(now + FORWARD_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+  // Posts in viewer-relevant states.
+  const posts = await svc
+    .from("social_post_master")
+    .select("id, master_text, link_url")
+    .eq("company_id", company.id)
+    .in("state", ["approved", "scheduled", "published"]);
+  const postById = new Map<
+    string,
+    { master_text: string | null; link_url: string | null }
+  >();
+  for (const p of posts.data ?? []) {
+    postById.set(p.id as string, {
+      master_text: (p.master_text as string | null) ?? null,
+      link_url: (p.link_url as string | null) ?? null,
+    });
+  }
+
+  let entries: SchedulePreview[] = [];
+  if (postById.size > 0) {
+    const variants = await svc
+      .from("social_post_variant")
+      .select("id, post_master_id, platform")
+      .in("post_master_id", Array.from(postById.keys()));
+    const variantInfo = new Map<
+      string,
+      { post_id: string; platform: SocialPlatform }
+    >();
+    for (const v of variants.data ?? []) {
+      variantInfo.set(v.id as string, {
+        post_id: v.post_master_id as string,
+        platform: v.platform as SocialPlatform,
+      });
+    }
+
+    const variantIds = Array.from(variantInfo.keys());
+    if (variantIds.length > 0) {
+      const schedule = await svc
+        .from("social_schedule_entries")
+        .select("id, post_variant_id, scheduled_at")
+        .in("post_variant_id", variantIds)
+        .is("cancelled_at", null)
+        .gte("scheduled_at", fromIso)
+        .lte("scheduled_at", toIso)
+        .order("scheduled_at", { ascending: true });
+      entries = (schedule.data ?? [])
+        .map((s) => {
+          const v = variantInfo.get(s.post_variant_id as string);
+          if (!v) return null;
+          const post = postById.get(v.post_id);
+          if (!post) return null;
+          return {
+            id: s.id as string,
+            scheduled_at: s.scheduled_at as string,
+            platform: v.platform,
+            master_text: post.master_text,
+            link_url: post.link_url,
+          } satisfies SchedulePreview;
+        })
+        .filter((x): x is SchedulePreview => x !== null);
+    }
+  }
+
+  // Group by local date for rendering.
+  const grouped = groupByLocalDate(entries, company.timezone);
+
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <header>
+        <h1 className="text-2xl font-semibold">
+          {company.name} — content calendar
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {grouped.length === 0
+            ? "Nothing scheduled in the visible window. Check back soon."
+            : `Showing posts from the last ${BACK_DAYS} days through the next ${FORWARD_DAYS}.`}
+        </p>
+      </header>
+
+      {grouped.length === 0 ? null : (
+        <ol className="mt-6 space-y-6" data-testid="viewer-calendar">
+          {grouped.map(({ dateLabel, items }) => (
+            <li key={dateLabel}>
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                {dateLabel}
+              </h2>
+              <ul className="mt-2 divide-y rounded-lg border bg-card">
+                {items.map((e) => (
+                  <li
+                    key={e.id}
+                    className="p-4"
+                    data-testid={`viewer-entry-${e.id}`}
+                  >
+                    <div className="flex flex-wrap items-baseline justify-between gap-2">
+                      <span className="font-medium">
+                        {PLATFORM_LABEL[e.platform] ?? e.platform}
+                      </span>
+                      <time className="text-sm text-muted-foreground tabular-nums">
+                        {new Date(e.scheduled_at).toLocaleString("en-AU", {
+                          hour: "2-digit",
+                          minute: "2-digit",
+                          timeZone: company.timezone,
+                        })}
+                      </time>
+                    </div>
+                    {e.master_text ? (
+                      <p className="mt-2 whitespace-pre-wrap text-sm">
+                        {e.master_text}
+                      </p>
+                    ) : null}
+                    {e.link_url ? (
+                      <p className="mt-2 truncate text-sm">
+                        <a
+                          href={e.link_url}
+                          target="_blank"
+                          rel="noreferrer noopener"
+                          className="text-primary hover:underline"
+                        >
+                          {e.link_url}
+                        </a>
+                      </p>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ol>
+      )}
+    </main>
+  );
+}
+
+function groupByLocalDate(
+  entries: SchedulePreview[],
+  timezone: string,
+): Array<{ dateLabel: string; items: SchedulePreview[] }> {
+  const buckets = new Map<string, SchedulePreview[]>();
+  for (const e of entries) {
+    const dateLabel = new Date(e.scheduled_at).toLocaleDateString("en-AU", {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+      timeZone: timezone,
+    });
+    const bucket = buckets.get(dateLabel) ?? [];
+    bucket.push(e);
+    buckets.set(dateLabel, bucket);
+  }
+  return Array.from(buckets.entries()).map(([dateLabel, items]) => ({
+    dateLabel,
+    items,
+  }));
+}
+
+function InvalidLink() {
+  return (
+    <main className="mx-auto max-w-xl p-6 text-sm">
+      <h1 className="text-xl font-semibold">Calendar link not valid</h1>
+      <p className="mt-3 text-muted-foreground">
+        This link is invalid, has expired, or has been revoked. Ask the
+        team that sent it for a fresh one.
+      </p>
+    </main>
+  );
+}

--- a/components/ViewerLinksManager.tsx
+++ b/components/ViewerLinksManager.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+// ---------------------------------------------------------------------------
+// S1-15 — admin manager for /viewer/[token] links.
+//
+// Renders the active links table + an inline create form. On create we
+// surface the URL for one-time copy (the raw token never goes back to
+// disk). Revoking soft-removes from the active list.
+// ---------------------------------------------------------------------------
+
+type Link = {
+  id: string;
+  recipient_email: string | null;
+  recipient_name: string | null;
+  expires_at: string;
+  revoked_at: string | null;
+  last_viewed_at: string | null;
+  created_at: string;
+};
+
+type Props = {
+  companyId: string;
+  initialLinks: Link[];
+};
+
+export function ViewerLinksManager({ companyId, initialLinks }: Props) {
+  const [links, setLinks] = useState(initialLinks);
+  const [adding, setAdding] = useState(false);
+  const [recipientEmail, setRecipientEmail] = useState("");
+  const [recipientName, setRecipientName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [justCreatedUrl, setJustCreatedUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setJustCreatedUrl(null);
+    try {
+      const res = await fetch("/api/platform/social/viewer-links", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          company_id: companyId,
+          recipient_email: recipientEmail.trim() || null,
+          recipient_name: recipientName.trim() || null,
+        }),
+      });
+      const json = (await res.json()) as
+        | { ok: true; data: { link: Link; url: string } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        const msg = !json.ok ? json.error.message : "Failed to create link.";
+        setError(msg);
+        return;
+      }
+      setLinks((prev) => [json.data.link, ...prev]);
+      setJustCreatedUrl(json.data.url);
+      setRecipientEmail("");
+      setRecipientName("");
+      setAdding(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleRevoke(id: string) {
+    if (!confirm("Revoke this calendar link? Anyone using it will lose access immediately."))
+      return;
+    setRevokingId(id);
+    setError(null);
+    try {
+      const url = `/api/platform/social/viewer-links/${id}?company_id=${encodeURIComponent(companyId)}`;
+      const res = await fetch(url, { method: "DELETE" });
+      const json = (await res.json()) as
+        | { ok: true; data: { link: Link } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        const msg = !json.ok ? json.error.message : "Failed to revoke.";
+        setError(msg);
+        return;
+      }
+      setLinks((prev) => prev.filter((l) => l.id !== id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRevokingId(null);
+    }
+  }
+
+  async function copy(url: string) {
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      /* noop */
+    }
+  }
+
+  return (
+    <section data-testid="viewer-links-manager">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Calendar sharing</h2>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            90-day read-only links to the content calendar. Recipients
+            don&apos;t need an Opollo account.
+          </p>
+        </div>
+        {!adding ? (
+          <Button
+            onClick={() => {
+              setAdding(true);
+              setError(null);
+              setJustCreatedUrl(null);
+            }}
+            data-testid="viewer-links-add-button"
+          >
+            Create link
+          </Button>
+        ) : null}
+      </div>
+
+      {error ? (
+        <p
+          className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          role="alert"
+          data-testid="viewer-links-error"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {justCreatedUrl ? (
+        <div
+          className="mt-4 rounded-md border border-emerald-300 bg-emerald-50 p-4 text-sm text-emerald-900"
+          data-testid="viewer-links-just-created"
+        >
+          <p className="font-medium">Link created. Copy it now — we won&apos;t show the URL again.</p>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <code className="break-all rounded bg-white px-2 py-1 text-sm">
+              {justCreatedUrl}
+            </code>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => copy(justCreatedUrl)}
+              data-testid="viewer-links-copy"
+            >
+              Copy
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {adding ? (
+        <form
+          onSubmit={handleCreate}
+          className="mt-4 rounded-lg border bg-card p-4"
+          data-testid="viewer-links-add-form"
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium" htmlFor="vl_email">
+                Recipient email (optional)
+              </label>
+              <input
+                id="vl_email"
+                type="email"
+                className="mt-1 w-full rounded-md border bg-background p-2 text-sm"
+                value={recipientEmail}
+                onChange={(e) => setRecipientEmail(e.target.value)}
+                data-testid="viewer-links-add-email"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium" htmlFor="vl_name">
+                Recipient name (optional)
+              </label>
+              <input
+                id="vl_name"
+                type="text"
+                className="mt-1 w-full rounded-md border bg-background p-2 text-sm"
+                value={recipientName}
+                onChange={(e) => setRecipientName(e.target.value)}
+                data-testid="viewer-links-add-name"
+              />
+            </div>
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Email + name are for your audit log only. The token is the
+            auth, not the email — anyone with the URL can view.
+          </p>
+          <div className="mt-3 flex gap-2">
+            <Button
+              type="submit"
+              disabled={submitting}
+              data-testid="viewer-links-add-submit"
+            >
+              {submitting ? "Creating…" : "Create link"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                setAdding(false);
+                setError(null);
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      ) : null}
+
+      {links.length === 0 ? (
+        <div
+          className="mt-4 rounded-lg border bg-card p-6 text-sm text-muted-foreground"
+          data-testid="viewer-links-empty"
+        >
+          No active calendar-sharing links. Create one to share the
+          calendar with a client or stakeholder.
+        </div>
+      ) : (
+        <ul
+          className="mt-4 divide-y rounded-lg border bg-card"
+          data-testid="viewer-links-list"
+        >
+          {links.map((l) => (
+            <li
+              key={l.id}
+              className="flex flex-wrap items-center justify-between gap-3 p-4"
+              data-testid={`viewer-link-row-${l.id}`}
+            >
+              <div>
+                <div className="font-medium">
+                  {l.recipient_name?.trim()
+                    ? `${l.recipient_name} (${l.recipient_email ?? "—"})`
+                    : (l.recipient_email ?? "Unnamed link")}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  Expires{" "}
+                  {new Date(l.expires_at).toLocaleDateString("en-AU", {
+                    day: "numeric",
+                    month: "short",
+                    year: "numeric",
+                  })}
+                  {l.last_viewed_at
+                    ? ` • Last viewed ${new Date(
+                        l.last_viewed_at,
+                      ).toLocaleString("en-AU", {
+                        day: "numeric",
+                        month: "short",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}`
+                    : " • Never viewed"}
+                </div>
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => handleRevoke(l.id)}
+                disabled={revokingId === l.id}
+                data-testid={`viewer-link-revoke-${l.id}`}
+              >
+                {revokingId === l.id ? "Revoking…" : "Revoke"}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -9,15 +9,17 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 ---
 ## Session A
 - Started: 2026-05-03
-- Branch: feat/s1-14-schedule-entries
-- Slice: S1-14 — schedule entries (L3 layer). lib + route + UI for createScheduleEntry / listScheduleEntries / cancelScheduleEntry. State guard: only approved posts. Auto-creates social_post_variant row if missing. No bundle.social dependency — QStash enqueue + publish-handler land in S1-15+.
+- Branch: feat/s1-15-viewer-links
+- Slice: S1-15 — customer viewer-link magic-link flow. lib/platform/social/viewer-links {create,list,resolve,revoke}.ts mints 90-day SHA-256 tokens. Admin POST/GET /api/platform/social/viewer-links + DELETE /[id] (canDo manage_invitations). Public /viewer/[token] renders read-only company calendar. Admin page /company/social/sharing.
 - Files claimed:
-  - lib/platform/social/scheduling/{types,create,list,cancel,index}.ts (new)
-  - app/api/platform/social/posts/[id]/schedule/route.ts (new)
-  - app/api/platform/social/posts/[id]/schedule/[entry_id]/route.ts (new)
-  - components/PostScheduleSection.tsx (new)
-  - app/company/social/posts/[id]/page.tsx (wire schedule section)
-  - lib/__tests__/social-scheduling.test.ts (new)
+  - lib/platform/social/viewer-links/{types,create,list,resolve,revoke,index}.ts (new)
+  - app/api/platform/social/viewer-links/route.ts (new)
+  - app/api/platform/social/viewer-links/[id]/route.ts (new)
+  - app/viewer/[token]/page.tsx (new — public read-only calendar)
+  - app/company/social/sharing/page.tsx (new — admin manager)
+  - components/ViewerLinksManager.tsx (new)
+  - middleware.ts (allow /viewer/* unauthenticated)
+  - lib/__tests__/social-viewer-links.test.ts (new)
   - docs/WORK_IN_FLIGHT.md
 - Migration number reserved: none.
 - Expected completion: same session.

--- a/lib/__tests__/social-viewer-links.test.ts
+++ b/lib/__tests__/social-viewer-links.test.ts
@@ -1,0 +1,332 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import { hashToken } from "@/lib/platform/invitations";
+import {
+  createViewerLink,
+  listViewerLinks,
+  resolveViewerLink,
+  revokeViewerLink,
+} from "@/lib/platform/social/viewer-links";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser, type SeededAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// S1-15 — viewer-links lib (create / list / resolve / revoke).
+// ---------------------------------------------------------------------------
+
+const COMPANY_A_ID = "abcdef00-0000-0000-0000-aaaaaaaa4444";
+const COMPANY_B_ID = "abcdef00-0000-0000-0000-bbbbbbbb4444";
+
+describe("lib/platform/social/viewer-links", () => {
+  let creator: SeededAuthUser;
+
+  beforeAll(async () => {
+    creator = await seedAuthUser({
+      email: "s1-15-creator@opollo.test",
+      persistent: true,
+    });
+  });
+
+  beforeEach(async () => {
+    const svc = getServiceRoleClient();
+
+    const companies = await svc
+      .from("platform_companies")
+      .insert([
+        {
+          id: COMPANY_A_ID,
+          name: "Acme Co",
+          slug: "s1-15-acme",
+          domain: "s1-15-acme.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+          approval_default_rule: "any_one",
+        },
+        {
+          id: COMPANY_B_ID,
+          name: "Beta Inc",
+          slug: "s1-15-beta",
+          domain: "s1-15-beta.test",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+          approval_default_rule: "any_one",
+        },
+      ])
+      .select("id");
+    if (companies.error) {
+      throw new Error(
+        `seed companies: ${companies.error.code ?? "?"} ${companies.error.message}`,
+      );
+    }
+
+    const user = await svc
+      .from("platform_users")
+      .insert({
+        id: creator.id,
+        email: creator.email,
+        full_name: "Creator",
+        is_opollo_staff: false,
+      })
+      .select("id");
+    if (user.error) {
+      throw new Error(
+        `seed creator: ${user.error.code ?? "?"} ${user.error.message}`,
+      );
+    }
+  });
+
+  afterAll(async () => {
+    const svc = getServiceRoleClient();
+    if (creator) await svc.auth.admin.deleteUser(creator.id);
+  });
+
+  describe("createViewerLink", () => {
+    it("happy path — returns row + raw token; only the hash hits disk", async () => {
+      const result = await createViewerLink({
+        companyId: COMPANY_A_ID,
+        recipientEmail: "Client@External.Test",
+        recipientName: "Client Co",
+        createdBy: creator.id,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.rawToken).toMatch(/^[0-9a-f]{64}$/);
+      expect(result.data.link.recipient_email).toBe("client@external.test");
+      expect(result.data.link.recipient_name).toBe("Client Co");
+      expect(result.data.link.created_by).toBe(creator.id);
+
+      const svc = getServiceRoleClient();
+      const row = await svc
+        .from("social_viewer_links")
+        .select("token_hash")
+        .eq("id", result.data.link.id)
+        .single();
+      expect(row.error).toBeNull();
+      expect(row.data?.token_hash).toBe(hashToken(result.data.rawToken));
+      expect(row.data?.token_hash).not.toBe(result.data.rawToken);
+    });
+
+    it("rejects past expires_at", async () => {
+      const result = await createViewerLink({
+        companyId: COMPANY_A_ID,
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+        createdBy: creator.id,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("normalises email + treats whitespace-only name as null", async () => {
+      const result = await createViewerLink({
+        companyId: COMPANY_A_ID,
+        recipientEmail: "  MIXED@example.test  ",
+        recipientName: "   ",
+        createdBy: creator.id,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.link.recipient_email).toBe("mixed@example.test");
+      expect(result.data.link.recipient_name).toBeNull();
+    });
+  });
+
+  describe("listViewerLinks", () => {
+    it("returns active links by default; includeInactive surfaces revoked + expired", async () => {
+      const svc = getServiceRoleClient();
+
+      // Active.
+      const active = await createViewerLink({
+        companyId: COMPANY_A_ID,
+        recipientEmail: "active@external.test",
+        createdBy: creator.id,
+      });
+      expect(active.ok).toBe(true);
+      if (!active.ok) return;
+
+      // Revoked.
+      const revoked = await createViewerLink({
+        companyId: COMPANY_A_ID,
+        recipientEmail: "revoked@external.test",
+        createdBy: creator.id,
+      });
+      expect(revoked.ok).toBe(true);
+      if (!revoked.ok) return;
+      await svc
+        .from("social_viewer_links")
+        .update({ revoked_at: new Date().toISOString() })
+        .eq("id", revoked.data.link.id);
+
+      // Expired.
+      await svc.from("social_viewer_links").insert({
+        company_id: COMPANY_A_ID,
+        token_hash: "0".repeat(64),
+        expires_at: new Date(Date.now() - 1000).toISOString(),
+        created_by: creator.id,
+      });
+
+      const activeOnly = await listViewerLinks({ companyId: COMPANY_A_ID });
+      expect(activeOnly.ok).toBe(true);
+      if (!activeOnly.ok) return;
+      expect(activeOnly.data.links.length).toBe(1);
+      expect(activeOnly.data.links[0]?.recipient_email).toBe(
+        "active@external.test",
+      );
+
+      const all = await listViewerLinks({
+        companyId: COMPANY_A_ID,
+        includeInactive: true,
+      });
+      expect(all.ok).toBe(true);
+      if (!all.ok) return;
+      expect(all.data.links.length).toBe(3);
+    });
+
+    it("isolates company A from company B", async () => {
+      await createViewerLink({
+        companyId: COMPANY_A_ID,
+        recipientEmail: "a@external.test",
+        createdBy: creator.id,
+      });
+      await createViewerLink({
+        companyId: COMPANY_B_ID,
+        recipientEmail: "b@external.test",
+        createdBy: creator.id,
+      });
+
+      const aResult = await listViewerLinks({ companyId: COMPANY_A_ID });
+      const bResult = await listViewerLinks({ companyId: COMPANY_B_ID });
+      expect(aResult.ok && bResult.ok).toBe(true);
+      if (!aResult.ok || !bResult.ok) return;
+      expect(aResult.data.links.length).toBe(1);
+      expect(bResult.data.links.length).toBe(1);
+      expect(aResult.data.links[0]?.recipient_email).toBe("a@external.test");
+      expect(bResult.data.links[0]?.recipient_email).toBe("b@external.test");
+    });
+  });
+
+  describe("resolveViewerLink", () => {
+    it("happy path — returns link + company on a valid token", async () => {
+      const created = await createViewerLink({
+        companyId: COMPANY_A_ID,
+        recipientEmail: "viewer@external.test",
+        createdBy: creator.id,
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+
+      const resolved = await resolveViewerLink(created.data.rawToken);
+      expect(resolved.ok).toBe(true);
+      if (!resolved.ok) return;
+      expect(resolved.data.company.name).toBe("Acme Co");
+      expect(resolved.data.link.id).toBe(created.data.link.id);
+    });
+
+    it("returns NOT_FOUND for a malformed token", async () => {
+      const resolved = await resolveViewerLink("not-a-token");
+      expect(resolved.ok).toBe(false);
+      if (resolved.ok) return;
+      expect(resolved.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns NOT_FOUND for a phantom token", async () => {
+      const resolved = await resolveViewerLink("0".repeat(64));
+      expect(resolved.ok).toBe(false);
+      if (resolved.ok) return;
+      expect(resolved.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns NOT_FOUND when revoked", async () => {
+      const created = await createViewerLink({
+        companyId: COMPANY_A_ID,
+        createdBy: creator.id,
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+
+      const svc = getServiceRoleClient();
+      await svc
+        .from("social_viewer_links")
+        .update({ revoked_at: new Date().toISOString() })
+        .eq("id", created.data.link.id);
+
+      const resolved = await resolveViewerLink(created.data.rawToken);
+      expect(resolved.ok).toBe(false);
+      if (resolved.ok) return;
+      expect(resolved.error.code).toBe("NOT_FOUND");
+    });
+
+    it("returns NOT_FOUND when expired", async () => {
+      const svc = getServiceRoleClient();
+      const created = await createViewerLink({
+        companyId: COMPANY_A_ID,
+        createdBy: creator.id,
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+
+      // Stamp expiry into the past after the fact.
+      await svc
+        .from("social_viewer_links")
+        .update({ expires_at: new Date(Date.now() - 1000).toISOString() })
+        .eq("id", created.data.link.id);
+
+      const resolved = await resolveViewerLink(created.data.rawToken);
+      expect(resolved.ok).toBe(false);
+      if (resolved.ok) return;
+      expect(resolved.error.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("revokeViewerLink", () => {
+    it("happy path — sets revoked_at; second revoke returns INVALID_STATE", async () => {
+      const created = await createViewerLink({
+        companyId: COMPANY_A_ID,
+        createdBy: creator.id,
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+
+      const first = await revokeViewerLink({
+        linkId: created.data.link.id,
+        companyId: COMPANY_A_ID,
+      });
+      expect(first.ok).toBe(true);
+      if (!first.ok) return;
+      expect(first.data.revoked_at).not.toBeNull();
+
+      const second = await revokeViewerLink({
+        linkId: created.data.link.id,
+        companyId: COMPANY_A_ID,
+      });
+      expect(second.ok).toBe(false);
+      if (second.ok) return;
+      expect(second.error.code).toBe("INVALID_STATE");
+    });
+
+    it("returns NOT_FOUND for cross-company access", async () => {
+      const created = await createViewerLink({
+        companyId: COMPANY_A_ID,
+        createdBy: creator.id,
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+
+      const result = await revokeViewerLink({
+        linkId: created.data.link.id,
+        companyId: COMPANY_B_ID,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.code).toBe("NOT_FOUND");
+    });
+  });
+});

--- a/lib/platform/social/viewer-links/create.ts
+++ b/lib/platform/social/viewer-links/create.ts
@@ -1,0 +1,110 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { generateRawToken, hashToken } from "@/lib/platform/invitations";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type {
+  CreateViewerLinkInput,
+  CreateViewerLinkResult,
+  ViewerLink,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// S1-15 — mint a new viewer link.
+//
+// Default 90-day TTL. Returns the raw token ONCE so the route can build
+// the URL the admin pastes into an external email; only the SHA-256
+// hash hits disk. Same token shape as platform_invitations + social
+// approval recipients.
+//
+// Caller is responsible for canDo("manage_invitations", company_id) —
+// sharing externally is admin-level (matches the invitation surface).
+// ---------------------------------------------------------------------------
+
+const VIEWER_LINK_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+export async function createViewerLink(
+  input: CreateViewerLinkInput,
+): Promise<ApiResponse<CreateViewerLinkResult>> {
+  if (!input.companyId) return validation("Company id is required.");
+
+  const recipientEmail = normaliseEmail(input.recipientEmail);
+  const recipientName = input.recipientName?.trim() || null;
+  const expiresAt =
+    input.expiresAt ?? new Date(Date.now() + VIEWER_LINK_TTL_MS).toISOString();
+
+  if (Date.parse(expiresAt) <= Date.now()) {
+    return validation("expires_at must be in the future.");
+  }
+
+  const rawToken = generateRawToken();
+  const tokenHash = hashToken(rawToken);
+
+  const svc = getServiceRoleClient();
+  const insert = await svc
+    .from("social_viewer_links")
+    .insert({
+      company_id: input.companyId,
+      token_hash: tokenHash,
+      recipient_email: recipientEmail,
+      recipient_name: recipientName,
+      expires_at: expiresAt,
+      created_by: input.createdBy,
+    })
+    .select(
+      "id, company_id, recipient_email, recipient_name, expires_at, revoked_at, last_viewed_at, created_by, created_at",
+    )
+    .single();
+
+  if (insert.error) {
+    logger.error("social.viewer_links.create.failed", {
+      err: insert.error.message,
+      code: insert.error.code,
+      company_id: input.companyId,
+    });
+    return internal(`Failed to create viewer link: ${insert.error.message}`);
+  }
+
+  return {
+    ok: true,
+    data: {
+      link: insert.data as ViewerLink,
+      rawToken,
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function normaliseEmail(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function validation(message: string): ApiResponse<CreateViewerLinkResult> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<CreateViewerLinkResult> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/viewer-links/index.ts
+++ b/lib/platform/social/viewer-links/index.ts
@@ -1,0 +1,10 @@
+export { createViewerLink } from "./create";
+export { listViewerLinks } from "./list";
+export { resolveViewerLink } from "./resolve";
+export { revokeViewerLink } from "./revoke";
+export type {
+  CreateViewerLinkInput,
+  CreateViewerLinkResult,
+  ListViewerLinksInput,
+  ViewerLink,
+} from "./types";

--- a/lib/platform/social/viewer-links/list.ts
+++ b/lib/platform/social/viewer-links/list.ts
@@ -1,0 +1,78 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { ListViewerLinksInput, ViewerLink } from "./types";
+
+// ---------------------------------------------------------------------------
+// S1-15 — list viewer links for a company.
+//
+// Default: only active (not revoked, not expired). includeInactive=true
+// surfaces history for the admin UI's "show old links" toggle.
+//
+// Caller is responsible for canDo("manage_invitations", company_id).
+// ---------------------------------------------------------------------------
+
+export async function listViewerLinks(
+  input: ListViewerLinksInput,
+): Promise<ApiResponse<{ links: ViewerLink[] }>> {
+  if (!input.companyId) return validation("Company id is required.");
+
+  const svc = getServiceRoleClient();
+  let query = svc
+    .from("social_viewer_links")
+    .select(
+      "id, company_id, recipient_email, recipient_name, expires_at, revoked_at, last_viewed_at, created_by, created_at",
+    )
+    .eq("company_id", input.companyId)
+    .order("created_at", { ascending: false });
+
+  if (!input.includeInactive) {
+    query = query
+      .is("revoked_at", null)
+      .gte("expires_at", new Date().toISOString());
+  }
+
+  const result = await query;
+  if (result.error) {
+    logger.error("social.viewer_links.list.failed", {
+      err: result.error.message,
+      company_id: input.companyId,
+    });
+    return internal(`Failed to list viewer links: ${result.error.message}`);
+  }
+
+  return {
+    ok: true,
+    data: { links: (result.data ?? []) as ViewerLink[] },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(message: string): ApiResponse<{ links: ViewerLink[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<{ links: ViewerLink[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/viewer-links/resolve.ts
+++ b/lib/platform/social/viewer-links/resolve.ts
@@ -1,0 +1,125 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { hashToken } from "@/lib/platform/invitations";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { ViewerLink } from "./types";
+
+// ---------------------------------------------------------------------------
+// S1-15 — public token-as-auth resolver for /viewer/[token].
+//
+// Hash + lookup. Validates: not revoked, not expired. Best-effort
+// last_viewed_at refresh on every successful resolve so the admin
+// surface can show "last seen by viewer X minutes ago" without a
+// separate ping endpoint.
+//
+// NOT_FOUND envelopes for:
+//   - malformed token shape
+//   - token doesn't match any row
+//   - row is revoked
+//   - row is past expires_at
+//
+// All collapse to the same generic "this link is invalid or expired"
+// envelope so the public viewer can't enumerate states.
+// ---------------------------------------------------------------------------
+
+export async function resolveViewerLink(
+  rawToken: string,
+): Promise<
+  ApiResponse<{
+    link: ViewerLink;
+    company: { id: string; name: string; timezone: string };
+  }>
+> {
+  if (!rawToken || !/^[0-9a-f]{64}$/i.test(rawToken)) {
+    return notFound();
+  }
+
+  const tokenHash = hashToken(rawToken);
+  const svc = getServiceRoleClient();
+
+  const link = await svc
+    .from("social_viewer_links")
+    .select(
+      "id, company_id, recipient_email, recipient_name, expires_at, revoked_at, last_viewed_at, created_by, created_at",
+    )
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+  if (link.error) {
+    logger.error("social.viewer_links.resolve.lookup_failed", {
+      err: link.error.message,
+    });
+    return internal(`Failed to read viewer link: ${link.error.message}`);
+  }
+  if (!link.data) return notFound();
+
+  const linkRow = link.data as ViewerLink;
+  if (linkRow.revoked_at) return notFound();
+  if (Date.parse(linkRow.expires_at) <= Date.now()) return notFound();
+
+  const company = await svc
+    .from("platform_companies")
+    .select("id, name, timezone")
+    .eq("id", linkRow.company_id)
+    .maybeSingle();
+  if (company.error || !company.data) {
+    return internal("Company missing for this viewer link.");
+  }
+
+  // Best-effort last_viewed_at refresh. Failure here doesn't fail the
+  // resolve — the viewer should still see the calendar.
+  void svc
+    .from("social_viewer_links")
+    .update({ last_viewed_at: new Date().toISOString() })
+    .eq("id", linkRow.id)
+    .then((r) => {
+      if (r.error) {
+        logger.warn("social.viewer_links.resolve.last_viewed_update_failed", {
+          err: r.error.message,
+        });
+      }
+    });
+
+  return {
+    ok: true,
+    data: {
+      link: linkRow,
+      company: company.data as { id: string; name: string; timezone: string },
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function notFound(): ApiResponse<{
+  link: ViewerLink;
+  company: { id: string; name: string; timezone: string };
+}> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message: "This calendar link is invalid or has expired.",
+      retryable: false,
+      suggested_action: "Ask the team that sent the link for a fresh one.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<{
+  link: ViewerLink;
+  company: { id: string; name: string; timezone: string };
+}> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/viewer-links/revoke.ts
+++ b/lib/platform/social/viewer-links/revoke.ts
@@ -1,0 +1,121 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { ViewerLink } from "./types";
+
+// ---------------------------------------------------------------------------
+// S1-15 — soft-revoke a viewer link. Atomic UPDATE WHERE revoked_at
+// IS NULL handles concurrent revokes; second caller sees INVALID_STATE.
+//
+// Caller is responsible for canDo("manage_invitations", company_id).
+// ---------------------------------------------------------------------------
+
+export async function revokeViewerLink(args: {
+  linkId: string;
+  companyId: string;
+}): Promise<ApiResponse<ViewerLink>> {
+  if (!args.linkId) return validation("Link id is required.");
+  if (!args.companyId) return validation("Company id is required.");
+
+  const svc = getServiceRoleClient();
+
+  // Lookup first so we can return NOT_FOUND for cross-company access
+  // distinctly from already-revoked.
+  const lookup = await svc
+    .from("social_viewer_links")
+    .select("id, revoked_at")
+    .eq("id", args.linkId)
+    .eq("company_id", args.companyId)
+    .maybeSingle();
+  if (lookup.error) {
+    logger.error("social.viewer_links.revoke.lookup_failed", {
+      err: lookup.error.message,
+    });
+    return internal(`Failed to read viewer link: ${lookup.error.message}`);
+  }
+  if (!lookup.data) return notFound();
+  if (lookup.data.revoked_at) {
+    return invalidState("Viewer link is already revoked.");
+  }
+
+  const update = await svc
+    .from("social_viewer_links")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", args.linkId)
+    .eq("company_id", args.companyId)
+    .is("revoked_at", null)
+    .select(
+      "id, company_id, recipient_email, recipient_name, expires_at, revoked_at, last_viewed_at, created_by, created_at",
+    )
+    .maybeSingle();
+  if (update.error) {
+    logger.error("social.viewer_links.revoke.update_failed", {
+      err: update.error.message,
+    });
+    return internal(`Failed to revoke: ${update.error.message}`);
+  }
+  if (!update.data) {
+    return invalidState("Viewer link was revoked concurrently.");
+  }
+
+  return {
+    ok: true,
+    data: update.data as ViewerLink,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(message: string): ApiResponse<ViewerLink> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function notFound(): ApiResponse<ViewerLink> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message: "No viewer link with that id in this company.",
+      retryable: false,
+      suggested_action: "Check the link id.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function invalidState(message: string): ApiResponse<ViewerLink> {
+  return {
+    ok: false,
+    error: {
+      code: "INVALID_STATE",
+      message,
+      retryable: false,
+      suggested_action: "Reload and try again if needed.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<ViewerLink> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/viewer-links/types.ts
+++ b/lib/platform/social/viewer-links/types.ts
@@ -1,0 +1,41 @@
+// Mirrors social_viewer_links table in migration 0070.
+
+export type ViewerLink = {
+  id: string;
+  company_id: string;
+  recipient_email: string | null;
+  recipient_name: string | null;
+  expires_at: string;
+  revoked_at: string | null;
+  last_viewed_at: string | null;
+  created_by: string | null;
+  created_at: string;
+};
+
+export type CreateViewerLinkInput = {
+  companyId: string;
+  // Optional — when set, surfaces in the admin list as "shared with X".
+  // The token is the auth, not the email; multiple recipients can use the
+  // same link if it's forwarded.
+  recipientEmail?: string | null;
+  recipientName?: string | null;
+  // Default 90 days; caller can override (e.g. shorter for sensitive
+  // sharing, or longer for ongoing client visibility).
+  expiresAt?: string;
+  createdBy: string | null;
+};
+
+export type CreateViewerLinkResult = {
+  link: ViewerLink;
+  // Raw token returned ONCE for the link URL. NEVER stored; only the
+  // SHA-256 hash lands in token_hash. Caller surfaces the URL to the
+  // admin who shares it externally.
+  rawToken: string;
+};
+
+export type ListViewerLinksInput = {
+  companyId: string;
+  // V1 default: only active (not revoked, not expired). Admin UI can
+  // toggle this to see history.
+  includeInactive?: boolean;
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -119,6 +119,11 @@ function isPublicPath(pathname: string): boolean {
   // SHA-256 hash against social_approval_recipients.token_hash
   // before calling the migration-0072 atomic decision recorder.
   if (pathname.startsWith("/api/approve/")) return true;
+  // /viewer/<token> — public read-only customer calendar (S1-15).
+  // Token IS the auth (SHA-256 hash → social_viewer_links.token_hash).
+  // External recipients aren't platform users; the link must work
+  // pre-session.
+  if (pathname.startsWith("/viewer/")) return true;
   // All /api/auth/* endpoints (login, logout-not-applicable-here,
   // callback, future invite/reset routes) are by definition pre-session.
   if (pathname.startsWith("/api/auth/")) return true;


### PR DESCRIPTION
## Summary
Admins can mint shareable read-only calendar links for clients + stakeholders without requiring an Opollo account. Token-as-auth (SHA-256 hash → `social_viewer_links.token_hash`). 90-day default TTL, revocable.

## Changes
- `lib/platform/social/viewer-links/create.ts` — returns row + raw token ONCE; only the hash hits disk. Default 90-day expiry overridable.
- `lib/platform/social/viewer-links/list.ts` — active by default; `includeInactive` surfaces revoked + expired for admin history.
- `lib/platform/social/viewer-links/resolve.ts` — public token-as-auth resolver. Hash + lookup + revoke / expiry checks all collapse to the same `NOT_FOUND` envelope so the public viewer can't enumerate states. Best-effort `last_viewed_at` refresh.
- `lib/platform/social/viewer-links/revoke.ts` — atomic UPDATE WHERE `revoked_at IS NULL`; concurrent revokes converge.
- `POST/GET /api/platform/social/viewer-links` + `DELETE /[id]` — gated by `canDo("manage_invitations")` (admin-only). POST returns the link row + the public URL the admin pastes externally; raw token not surfaced again.
- `middleware.ts` — `/viewer/*` added to public paths.
- `/viewer/[token]` page — server-component renders the company calendar for posts in `(approved, scheduled, published)` within a 60-day forward + 30-day back window. Grouped by local date. Three-step read (posts → variants → schedule_entries) avoids the multi-FK embed pitfall.
- `/company/social/sharing` — admin-only manager. List + create form + copy-link toast + revoke button.
- Tests (12 cases): create happy path with hash verification, past-expiry rejection, normalisation, list active vs all, cross-company isolation, resolve happy path, malformed token, phantom token, revoked → NOT_FOUND, expired → NOT_FOUND, revoke idempotency, cross-company NOT_FOUND on revoke.

## Risks identified and mitigated
- **Token leakage**: SHA-256 hash on disk; raw token returned ONCE in the POST 201 envelope. Client UI surfaces a single "copy this now" panel, won't show again.
- **Enumeration via NOT_FOUND state-leak**: malformed / phantom / revoked / expired all return identical envelopes from `resolveViewerLink` so attackers can't probe state.
- **`last_viewed_at` refresh failure**: best-effort; logged but doesn't fail the resolve. Viewer still sees the calendar.
- **Cross-company sharing leak**: every lib op filters by `company_id`; route gate authorises against body's `company_id`; RLS layered.
- **Permission gating**: `manage_invitations` (admin-only) — sharing externally is admin-level. Viewers + editors use the calendar themselves at `/company/social/posts`.
- **`/viewer/*` in middleware public paths**: documented next to `/invite/<token>` and `/approve/<token>`; same token-as-auth pattern.
- **Auto-merge eligible**: write-only on `social_viewer_links` + read-only across other tables; no money / external service / WP mutation.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` clean — both API routes + viewer page + sharing page registered
- [ ] CI Vitest run — Docker not available locally; deferring to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)