### PR TITLE
fix(run-page): align Live badge baseline + drop poll interval to 2s

### DIFF
--- a/components/BriefRunClient.tsx
+++ b/components/BriefRunClient.tsx
@@ -361,11 +361,19 @@ export function BriefRunClient({
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold">{brief.title}</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Run surface for <span className="font-medium">{siteName}</span>
+          {/* UAT (2026-05-03 round-3): converted the run-status line from
+              a <p> with inline pills to a flex row so the status pill +
+              Live badge baseline-align cleanly with the prose. The pills
+              have padding-y of their own; baseline alignment inside a
+              text-sm <p> dropped them ~1px below the text and read as
+              broken to operators. */}
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+            <span>
+              Run surface for <span className="font-medium">{siteName}</span>
+            </span>
             {activeRun && (
               <>
-                {" — "}
+                <span aria-hidden className="text-muted-foreground/60">—</span>
                 {/* RS-5 — when a specific page is awaiting review, the
                     run-level pill becomes a clickable shortcut showing
                     the ordinal so the operator knows exactly which page
@@ -423,7 +431,7 @@ export function BriefRunClient({
                 Live
               </span>
             )}
-          </p>
+          </div>
         </div>
         {isRunActive && (
           <Button

--- a/lib/use-poll.ts
+++ b/lib/use-poll.ts
@@ -44,7 +44,12 @@ export interface UsePollResult<T> {
   refresh: () => Promise<void>;
 }
 
-const DEFAULT_INTERVAL_MS = 4000;
+// UAT (2026-05-03 round-3): bumped from 4000ms to 2000ms so the run
+// page reflects state changes faster. The snapshot endpoint is cheap
+// (one PostgREST read + one Supabase row count); 2s is well within the
+// budget for an admin-facing surface and operators noticed the prior
+// 4s cadence as a perceptible lag.
+const DEFAULT_INTERVAL_MS = 2000;
 
 export function usePoll<T>(
   url: string | null,


### PR DESCRIPTION
Two run-page polish items from UAT round-3. (1) Live badge sat ~1px below the prose baseline because inline-flex pills don't align baseline-to-baseline with text-sm prose at the same line-height. Converted the run-status row from <p> with inline pills to a flex container with items-center. (2) Bumped usePoll default interval from 4s to 2s — operators perceived 4s as a noticeable lag between state changes. Snapshot endpoint is cheap (one PostgREST + one Supabase row count); 2s is well within budget.