### PR TITLE
S1-18: publish pipeline (QStash → claim_publish_job → bundle.social)

### DIFF
--- a/app/api/webhooks/qstash/social-publish/route.ts
+++ b/app/api/webhooks/qstash/social-publish/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { logger } from "@/lib/logger";
+import { fireScheduledPublish } from "@/lib/platform/social/publishing";
+import { verifyQstashSignature } from "@/lib/qstash";
+
+// ---------------------------------------------------------------------------
+// S1-18 — POST /api/webhooks/qstash/social-publish
+//
+// QStash callback. Fires at the schedule entry's scheduled_at, triggers
+// the atomic claim_publish_job RPC + bundle.social postCreate via
+// fireScheduledPublish.
+//
+// Response policy (matches QStash retry behaviour):
+//   - 401 INVALID_SIGNATURE: bad/missing Upstash-Signature.
+//   - 503 RECEIVER_NOT_CONFIGURED: signing key unset (dev/test).
+//   - 400 VALIDATION_FAILED: body parse failure.
+//   - 200 ok: every successful path including no-op outcomes
+//     (already_claimed / cancelled / invalid_state). Stops QStash retries.
+//   - 500 INTERNAL_ERROR: claim_publish_job RPC failure (DB unreachable).
+//     QStash retries.
+//
+// Auth: signature verification IS the auth. Allowlisted in
+// scripts/audit.ts via verifyQstashSignature.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const BodySchema = z.object({
+  scheduleEntryId: z.string().uuid(),
+});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const rawBody = await req.text();
+
+  const verify = await verifyQstashSignature({
+    signature: req.headers.get("upstash-signature"),
+    rawBody,
+  });
+  if (!verify.ok) {
+    logger.warn("social.publish.callback.unauthorized", {
+      reason: verify.reason,
+    });
+    if (verify.reason === "no_receiver") {
+      return errorEnvelope(
+        "RECEIVER_NOT_CONFIGURED",
+        "QSTASH_CURRENT_SIGNING_KEY is not configured.",
+        503,
+      );
+    }
+    return errorEnvelope(
+      "INVALID_SIGNATURE",
+      "Invalid or missing Upstash-Signature.",
+      401,
+    );
+  }
+
+  let parsed: z.infer<typeof BodySchema>;
+  try {
+    parsed = BodySchema.parse(JSON.parse(rawBody));
+  } catch (err) {
+    return errorEnvelope(
+      "VALIDATION_FAILED",
+      `Invalid body: ${err instanceof Error ? err.message : String(err)}`,
+      400,
+    );
+  }
+
+  const result = await fireScheduledPublish({
+    scheduleEntryId: parsed.scheduleEntryId,
+  });
+
+  if (!result.ok) {
+    if (result.error.code === "VALIDATION_FAILED") {
+      return errorEnvelope("VALIDATION_FAILED", result.error.message, 400);
+    }
+    // INTERNAL_ERROR returns 500 so QStash retries.
+    return errorEnvelope("INTERNAL_ERROR", result.error.message, 500);
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: result.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}
+
+function errorEnvelope(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: status >= 500 },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}

--- a/lib/__tests__/social-publishing-fire.test.ts
+++ b/lib/__tests__/social-publishing-fire.test.ts
@@ -1,0 +1,301 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// ---------------------------------------------------------------------------
+// S1-18 — fireScheduledPublish + claim_publish_job RPC against the
+// live Supabase stack with a mocked bundle.social SDK.
+//
+// Covers:
+//   - claim_publish_job RPC outcomes: OK, CANCELLED, INVALID_STATE,
+//     NO_CONNECTION, CONNECTION_DEGRADED, ALREADY_CLAIMED.
+//   - Successful publish → bundle_post_id stored on attempt; master
+//     stays in 'publishing' (webhook flips to 'published' later).
+//   - Bundle SDK throw → attempt failed, master flipped to 'failed'.
+//   - Bundle SDK returns status='ERROR' → same failure path.
+//   - Empty post body short-circuits before bundle.social call.
+// ---------------------------------------------------------------------------
+
+const mockClient = {
+  post: {
+    postCreate: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/bundlesocial", () => ({
+  getBundlesocialClient: () => mockClient,
+  getBundlesocialTeamId: () => "team-test-1",
+}));
+
+import { fireScheduledPublish } from "@/lib/platform/social/publishing";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+const COMPANY_ID = "abcdef00-0000-0000-0000-aaaaaaaa1818";
+
+async function seedCompany(): Promise<void> {
+  const svc = getServiceRoleClient();
+  const r = await svc.from("platform_companies").insert({
+    id: COMPANY_ID,
+    name: "S1-18 Co",
+    slug: "s1-18-co",
+    domain: "s1-18.test",
+    is_opollo_internal: false,
+    timezone: "Australia/Melbourne",
+    approval_default_rule: "any_one",
+  });
+  if (r.error) throw new Error(`seed company: ${r.error.message}`);
+}
+
+async function seedChain(opts: {
+  masterState?: string;
+  variantText?: string | null;
+  masterText?: string | null;
+  connectionStatus?: string;
+  withConnection?: boolean;
+}): Promise<{ scheduleEntryId: string; masterId: string; attemptIdAfter?: string }> {
+  const svc = getServiceRoleClient();
+
+  const master = await svc
+    .from("social_post_master")
+    .insert({
+      company_id: COMPANY_ID,
+      state: opts.masterState ?? "approved",
+      source_type: "manual",
+      master_text: opts.masterText ?? "Hello world",
+    })
+    .select("id")
+    .single();
+  if (master.error) throw new Error(`seed master: ${master.error.message}`);
+
+  let connectionId: string | null = null;
+  if (opts.withConnection !== false) {
+    const conn = await svc
+      .from("social_connections")
+      .insert({
+        company_id: COMPANY_ID,
+        platform: "linkedin_personal",
+        bundle_social_account_id: "ba_acct_" + master.data.id.slice(0, 8),
+        display_name: "Acme LI",
+        status: opts.connectionStatus ?? "healthy",
+      })
+      .select("id")
+      .single();
+    if (conn.error) throw new Error(`seed conn: ${conn.error.message}`);
+    connectionId = conn.data.id as string;
+  }
+
+  const variant = await svc
+    .from("social_post_variant")
+    .insert({
+      post_master_id: master.data.id,
+      platform: "linkedin_personal",
+      variant_text: opts.variantText ?? null,
+      connection_id: connectionId,
+    })
+    .select("id")
+    .single();
+  if (variant.error) throw new Error(`seed variant: ${variant.error.message}`);
+
+  const entry = await svc
+    .from("social_schedule_entries")
+    .insert({
+      post_variant_id: variant.data.id,
+      scheduled_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+  if (entry.error) throw new Error(`seed entry: ${entry.error.message}`);
+
+  return { scheduleEntryId: entry.data.id as string, masterId: master.data.id as string };
+}
+
+beforeEach(async () => {
+  mockClient.post.postCreate.mockReset();
+  await seedCompany();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fireScheduledPublish — happy path", () => {
+  it("claims, calls bundle.social, stores bundle_post_id; master stays in 'publishing'", async () => {
+    const { scheduleEntryId, masterId } = await seedChain({});
+    mockClient.post.postCreate.mockResolvedValueOnce({
+      id: "bp_123",
+      status: "SCHEDULED",
+    });
+
+    const result = await fireScheduledPublish({ scheduleEntryId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("ok");
+    expect(result.data.bundlePostId).toBe("bp_123");
+    expect(result.data.publishAttemptId).toBeTruthy();
+
+    const svc = getServiceRoleClient();
+    const attempt = await svc
+      .from("social_publish_attempts")
+      .select("status, bundle_post_id")
+      .eq("id", result.data.publishAttemptId!)
+      .single();
+    // Webhook (S1-17) flips status to 'succeeded' later; for now still in_flight.
+    expect(attempt.data?.status).toBe("in_flight");
+    expect(attempt.data?.bundle_post_id).toBe("bp_123");
+
+    const master = await svc
+      .from("social_post_master")
+      .select("state")
+      .eq("id", masterId)
+      .single();
+    expect(master.data?.state).toBe("publishing");
+  });
+
+  it("uses variant_text when set, master_text otherwise", async () => {
+    const { scheduleEntryId } = await seedChain({
+      variantText: "variant-specific copy",
+      masterText: "master fallback",
+    });
+    mockClient.post.postCreate.mockResolvedValueOnce({
+      id: "bp_v",
+      status: "SCHEDULED",
+    });
+
+    await fireScheduledPublish({ scheduleEntryId });
+    const callArg = mockClient.post.postCreate.mock.calls[0]?.[0];
+    expect(callArg?.requestBody?.data?.LINKEDIN?.text).toBe(
+      "variant-specific copy",
+    );
+  });
+});
+
+describe("fireScheduledPublish — claim outcomes", () => {
+  it("returns cancelled when schedule entry is cancelled", async () => {
+    const { scheduleEntryId } = await seedChain({});
+    const svc = getServiceRoleClient();
+    await svc
+      .from("social_schedule_entries")
+      .update({ cancelled_at: new Date().toISOString() })
+      .eq("id", scheduleEntryId);
+
+    const result = await fireScheduledPublish({ scheduleEntryId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("cancelled");
+    expect(mockClient.post.postCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid_state when master is not approved/scheduled", async () => {
+    const { scheduleEntryId } = await seedChain({ masterState: "draft" });
+    const result = await fireScheduledPublish({ scheduleEntryId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("invalid_state");
+    expect(mockClient.post.postCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns no_connection when no connection exists for the platform", async () => {
+    const { scheduleEntryId } = await seedChain({ withConnection: false });
+    const result = await fireScheduledPublish({ scheduleEntryId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("no_connection");
+    expect(mockClient.post.postCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns connection_degraded when pinned connection is auth_required", async () => {
+    const { scheduleEntryId } = await seedChain({
+      connectionStatus: "auth_required",
+    });
+    const result = await fireScheduledPublish({ scheduleEntryId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("connection_degraded");
+    expect(mockClient.post.postCreate).not.toHaveBeenCalled();
+  });
+
+  it("second concurrent fire returns already_claimed", async () => {
+    const { scheduleEntryId } = await seedChain({});
+    mockClient.post.postCreate.mockResolvedValueOnce({
+      id: "bp_first",
+      status: "SCHEDULED",
+    });
+
+    const first = await fireScheduledPublish({ scheduleEntryId });
+    expect(first.ok).toBe(true);
+    if (first.ok) expect(first.data.outcome).toBe("ok");
+
+    const second = await fireScheduledPublish({ scheduleEntryId });
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.data.outcome).toBe("already_claimed");
+    // bundle.social was called exactly once.
+    expect(mockClient.post.postCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("fireScheduledPublish — bundle.social failures", () => {
+  it("SDK throw → attempt failed, master 'failed'", async () => {
+    const { scheduleEntryId, masterId } = await seedChain({});
+    mockClient.post.postCreate.mockRejectedValueOnce(new Error("HTTP 429"));
+
+    const result = await fireScheduledPublish({ scheduleEntryId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("publish_failed");
+
+    const svc = getServiceRoleClient();
+    const attempts = await svc
+      .from("social_publish_attempts")
+      .select("status, error_class")
+      .order("started_at", { ascending: false })
+      .limit(1);
+    expect(attempts.data?.[0]?.status).toBe("failed");
+    expect(attempts.data?.[0]?.error_class).toBe("rate_limit");
+
+    const master = await svc
+      .from("social_post_master")
+      .select("state")
+      .eq("id", masterId)
+      .single();
+    expect(master.data?.state).toBe("failed");
+  });
+
+  it("SDK returns status=ERROR → attempt failed", async () => {
+    const { scheduleEntryId, masterId } = await seedChain({});
+    mockClient.post.postCreate.mockResolvedValueOnce({
+      id: "bp_err",
+      status: "ERROR",
+    });
+
+    const result = await fireScheduledPublish({ scheduleEntryId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("publish_failed");
+
+    const svc = getServiceRoleClient();
+    const master = await svc
+      .from("social_post_master")
+      .select("state")
+      .eq("id", masterId)
+      .single();
+    expect(master.data?.state).toBe("failed");
+  });
+
+  it("empty post body short-circuits before SDK call", async () => {
+    const { scheduleEntryId } = await seedChain({
+      variantText: "",
+      masterText: "",
+    });
+    const result = await fireScheduledPublish({ scheduleEntryId });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("INTERNAL_ERROR");
+    expect(mockClient.post.postCreate).not.toHaveBeenCalled();
+  });
+});

--- a/lib/platform/social/publishing/enqueue.ts
+++ b/lib/platform/social/publishing/enqueue.ts
@@ -1,0 +1,195 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getQstashClient } from "@/lib/qstash";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// S1-18 — enqueue a QStash callback for a scheduled publish.
+//
+// Called from createScheduleEntry (after the row is inserted) with
+// the entry id + the absolute scheduled_at. Schedules a single QStash
+// message that POSTs back to /api/webhooks/qstash/social-publish at
+// the scheduled time. Stores the QStash messageId on the schedule
+// entry so cancellation can call back.
+//
+// Idempotency:
+//   - QStash deduplicationId = `social-publish-${scheduleEntryId}`. If
+//     this lib runs twice (route retry) the second publishJSON returns
+//     the same messageId without duplicating the queued job.
+//   - The schedule_entry's qstash_message_id is set unconditionally
+//     after a successful publishJSON; any prior id was for the SAME
+//     logical scheduled job (per the deduplicationId scope).
+//
+// Degraded path: when QSTASH_TOKEN is unset (local dev without
+// Upstash, CI without provisioning) we no-op + log. The schedule entry
+// row still exists; an operator-triggered backfill cron (future slice)
+// can re-enqueue once QSTASH is wired.
+// ---------------------------------------------------------------------------
+
+export type EnqueuePublishInput = {
+  scheduleEntryId: string;
+  scheduledAt: string; // ISO timestamp
+  origin: string; // e.g. https://app.opollo.com
+};
+
+export type EnqueuePublishResult = {
+  messageId: string | null; // null when QSTASH not configured
+};
+
+export async function enqueueScheduledPublish(
+  input: EnqueuePublishInput,
+): Promise<ApiResponse<EnqueuePublishResult>> {
+  if (!input.scheduleEntryId) return validation("scheduleEntryId required.");
+  if (!input.scheduledAt) return validation("scheduledAt required.");
+  if (!input.origin) return validation("origin required.");
+
+  const fireAtMs = Date.parse(input.scheduledAt);
+  if (Number.isNaN(fireAtMs)) {
+    return validation("scheduledAt must be a valid ISO timestamp.");
+  }
+
+  const client = getQstashClient();
+  if (!client) {
+    logger.info("social.publish.enqueue.skipped_no_qstash", {
+      schedule_entry_id: input.scheduleEntryId,
+    });
+    return {
+      ok: true,
+      data: { messageId: null },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  // QStash takes a delay in seconds. For past/now timestamps we still
+  // enqueue at delay=1 so the callback fires immediately rather than
+  // silently dropping (createScheduleEntry already rejected past
+  // timestamps but a backfill caller might pass one).
+  const delaySeconds = Math.max(1, Math.floor((fireAtMs - Date.now()) / 1000));
+
+  const callbackUrl = `${input.origin.replace(/\/+$/, "")}/api/webhooks/qstash/social-publish`;
+
+  let messageId: string | null = null;
+  try {
+    const response = (await client.publishJSON({
+      url: callbackUrl,
+      body: { scheduleEntryId: input.scheduleEntryId },
+      delay: delaySeconds,
+      // Idempotent across re-enqueues for the same logical job. QStash
+      // returns the existing messageId on collision.
+      deduplicationId: `social-publish-${input.scheduleEntryId}`,
+    })) as { messageId?: string };
+    messageId = response.messageId ?? null;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("social.publish.enqueue.publish_failed", {
+      err: message,
+      schedule_entry_id: input.scheduleEntryId,
+    });
+    return internal(`QStash publish failed: ${message}`);
+  }
+
+  if (messageId) {
+    const svc = getServiceRoleClient();
+    const update = await svc
+      .from("social_schedule_entries")
+      .update({ qstash_message_id: messageId })
+      .eq("id", input.scheduleEntryId);
+    if (update.error) {
+      // Log but don't fail — the QStash job is queued, the messageId
+      // just isn't stored. Cancellation lookup will fall through to
+      // best-effort behaviour (the schedule_entry.cancelled_at flag is
+      // the source of truth; the publish callback re-checks it).
+      logger.warn("social.publish.enqueue.message_id_update_failed", {
+        err: update.error.message,
+        schedule_entry_id: input.scheduleEntryId,
+      });
+    }
+  }
+
+  return {
+    ok: true,
+    data: { messageId },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// Cancel a previously-enqueued QStash callback. Called from
+// cancelScheduleEntry after it stamps the entry's cancelled_at.
+//
+// Best-effort: a failure here just means the callback might still fire
+// at scheduled_at, but the schedule_entry.cancelled_at gate inside
+// claim_publish_job (migration 0075) is the source of truth — the
+// fired callback will return CANCELLED and skip the publish.
+export async function cancelScheduledPublish(
+  messageId: string | null,
+): Promise<ApiResponse<{ cancelled: boolean }>> {
+  if (!messageId) {
+    return {
+      ok: true,
+      data: { cancelled: false },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  const client = getQstashClient();
+  if (!client) {
+    return {
+      ok: true,
+      data: { cancelled: false },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  try {
+    await client.messages.delete(messageId);
+    return {
+      ok: true,
+      data: { cancelled: true },
+      timestamp: new Date().toISOString(),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // 404 from QStash = already delivered or already cancelled — both
+    // are fine outcomes for our use case.
+    if (message.includes("404") || message.toLowerCase().includes("not found")) {
+      return {
+        ok: true,
+        data: { cancelled: false },
+        timestamp: new Date().toISOString(),
+      };
+    }
+    logger.warn("social.publish.enqueue.cancel_failed", {
+      err: message,
+      message_id: messageId,
+    });
+    return internal(`QStash cancel failed: ${message}`);
+  }
+}
+
+function validation<T>(message: string): ApiResponse<T> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal<T>(message: string): ApiResponse<T> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: true,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/publishing/fire.ts
+++ b/lib/platform/social/publishing/fire.ts
@@ -1,0 +1,330 @@
+import "server-only";
+
+import {
+  getBundlesocialClient,
+  getBundlesocialTeamId,
+} from "@/lib/bundlesocial";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// S1-18 — fire a scheduled publish (called by the QStash callback).
+//
+// Flow:
+//   1. RPC claim_publish_job(scheduleEntryId) — atomic state advance,
+//      job + attempt rows inserted, master state → 'publishing'.
+//      Outcome 'OK' = we own the publish; anything else = no-op.
+//   2. Compose bundle.social postCreate request from the claim's
+//      returned variant_text/master_text + bundle_social_account_id.
+//   3. Call client.post.postCreate. Status 'POSTED' / 'SCHEDULED' /
+//      'PROCESSING' = success — store the bundle.social post id on
+//      the attempt. Status 'ERROR' = treat as failure.
+//   4. The actual platform-side success / failure lands as a
+//      bundle.social webhook later (post.published / post.failed) —
+//      that's S1-17's job to flip status to 'succeeded' / 'failed'
+//      and advance master state. Until that arrives the attempt
+//      stays in 'in_flight' (or 'unknown' if the bundle.social call
+//      itself errored).
+//
+// Note we deliberately do NOT spend twice on retries: claim_publish_job
+// is the single place that locks the schedule_entry; if it returns
+// ALREADY_CLAIMED the caller exits without calling bundle.social again.
+// QStash redelivery is benign.
+// ---------------------------------------------------------------------------
+
+export type FirePublishInput = {
+  scheduleEntryId: string;
+};
+
+export type FirePublishResult = {
+  outcome:
+    | "ok"
+    | "already_claimed"
+    | "cancelled"
+    | "not_found"
+    | "invalid_state"
+    | "no_connection"
+    | "connection_degraded"
+    | "publish_failed";
+  publishJobId?: string;
+  publishAttemptId?: string;
+  bundlePostId?: string;
+};
+
+type ClaimRow = {
+  outcome: string;
+  publish_job_id: string | null;
+  publish_attempt_id: string | null;
+  post_master_id: string | null;
+  post_variant_id: string | null;
+  company_id: string | null;
+  platform: string | null;
+  variant_text: string | null;
+  master_text: string | null;
+  link_url: string | null;
+  bundle_social_account_id: string | null;
+};
+
+const PLATFORM_TO_BUNDLE: Record<
+  string,
+  "LINKEDIN" | "FACEBOOK" | "TWITTER" | "GOOGLE_BUSINESS"
+> = {
+  linkedin_personal: "LINKEDIN",
+  linkedin_company: "LINKEDIN",
+  facebook_page: "FACEBOOK",
+  x: "TWITTER",
+  gbp: "GOOGLE_BUSINESS",
+};
+
+export async function fireScheduledPublish(
+  input: FirePublishInput,
+): Promise<ApiResponse<FirePublishResult>> {
+  if (!input.scheduleEntryId) {
+    return validation("scheduleEntryId is required.");
+  }
+
+  const svc = getServiceRoleClient();
+
+  // Step 1: atomic claim.
+  const claimResult = await svc.rpc("claim_publish_job", {
+    p_schedule_entry_id: input.scheduleEntryId,
+  });
+  if (claimResult.error) {
+    logger.error("social.publish.fire.claim_failed", {
+      err: claimResult.error.message,
+      schedule_entry_id: input.scheduleEntryId,
+    });
+    return internal(`claim_publish_job RPC failed: ${claimResult.error.message}`);
+  }
+  const rows = (claimResult.data as ClaimRow[] | null) ?? [];
+  const claim = rows[0];
+  if (!claim) {
+    return internal("claim_publish_job returned no row.");
+  }
+
+  if (claim.outcome === "NOT_FOUND") {
+    return ok({ outcome: "not_found" });
+  }
+  if (claim.outcome === "CANCELLED") {
+    return ok({ outcome: "cancelled" });
+  }
+  if (claim.outcome === "INVALID_STATE") {
+    return ok({ outcome: "invalid_state" });
+  }
+  if (claim.outcome === "NO_CONNECTION") {
+    return ok({ outcome: "no_connection" });
+  }
+  if (claim.outcome === "CONNECTION_DEGRADED") {
+    return ok({ outcome: "connection_degraded" });
+  }
+  if (claim.outcome === "ALREADY_CLAIMED") {
+    return ok({ outcome: "already_claimed" });
+  }
+  if (claim.outcome !== "OK") {
+    return internal(`Unexpected claim outcome: ${claim.outcome}`);
+  }
+
+  // Step 2: bundle.social call.
+  const client = getBundlesocialClient();
+  const teamId = getBundlesocialTeamId();
+  if (!client || !teamId) {
+    // We've already claimed the job + advanced master state. Mark the
+    // attempt failed so the next manual retry path can pick it up;
+    // master state will be flipped to 'failed' by the operator (or
+    // the future cleanup cron). Don't re-enter the QStash queue.
+    await markAttemptFailed(svc, claim.publish_attempt_id!, {
+      error_class: "platform_error",
+      error_payload: { code: "RECEIVER_NOT_CONFIGURED" },
+    });
+    await markMasterFailed(svc, claim.post_master_id!);
+    return internal("bundle.social client not configured.");
+  }
+
+  const bundlePlatform = PLATFORM_TO_BUNDLE[claim.platform!];
+  if (!bundlePlatform) {
+    await markAttemptFailed(svc, claim.publish_attempt_id!, {
+      error_class: "unknown",
+      error_payload: { reason: `Unsupported platform: ${claim.platform}` },
+    });
+    await markMasterFailed(svc, claim.post_master_id!);
+    return internal(`Unsupported platform: ${claim.platform}`);
+  }
+
+  const text = (claim.variant_text ?? claim.master_text ?? "").trim();
+  if (!text) {
+    await markAttemptFailed(svc, claim.publish_attempt_id!, {
+      error_class: "content_rejected",
+      error_payload: { reason: "Empty post body" },
+    });
+    await markMasterFailed(svc, claim.post_master_id!);
+    return internal("Post has no body text.");
+  }
+
+  // Compose the data block per bundle.social platform shape. V1: text
+  // only; media uploads are S1-19+.
+  const data: Record<string, unknown> = {};
+  if (bundlePlatform === "LINKEDIN") {
+    data.LINKEDIN = { text, link: claim.link_url ?? undefined };
+  } else if (bundlePlatform === "FACEBOOK") {
+    data.FACEBOOK = { text, link: claim.link_url ?? undefined };
+  } else if (bundlePlatform === "TWITTER") {
+    data.TWITTER = { text };
+  } else if (bundlePlatform === "GOOGLE_BUSINESS") {
+    data.GOOGLE_BUSINESS = { text, link: claim.link_url ?? undefined };
+  }
+
+  let bundlePostId: string | null = null;
+  let bundleStatus: string | null = null;
+  try {
+    const response = (await client.post.postCreate({
+      requestBody: {
+        teamId,
+        title: `attempt:${claim.publish_attempt_id}`,
+        postDate: new Date().toISOString(),
+        status: "SCHEDULED",
+        socialAccountTypes: [bundlePlatform],
+        data: data as never,
+      },
+    })) as { id?: string; status?: string };
+    bundlePostId = response.id ?? null;
+    bundleStatus = response.status ?? null;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("social.publish.fire.bundle_post_failed", {
+      err: message,
+      attempt_id: claim.publish_attempt_id,
+    });
+    await markAttemptFailed(svc, claim.publish_attempt_id!, {
+      error_class: classifyError(message),
+      error_payload: { message },
+    });
+    await markMasterFailed(svc, claim.post_master_id!);
+    return ok({ outcome: "publish_failed" });
+  }
+
+  // bundle.social may return status='ERROR' synchronously even with a
+  // 200 response — treat that as a failure.
+  if (bundleStatus === "ERROR") {
+    await markAttemptFailed(svc, claim.publish_attempt_id!, {
+      error_class: "platform_error",
+      error_payload: { bundle_status: bundleStatus, bundle_id: bundlePostId },
+    });
+    await markMasterFailed(svc, claim.post_master_id!);
+    return ok({ outcome: "publish_failed" });
+  }
+
+  // Success path: store the bundle.social post id on the attempt.
+  // Webhook (S1-17) will flip status to 'succeeded' on post.published
+  // and master state to 'published'. Until then attempt stays
+  // 'in_flight' which the dashboard surfaces as "publishing…".
+  if (bundlePostId) {
+    const update = await svc
+      .from("social_publish_attempts")
+      .update({
+        bundle_post_id: bundlePostId,
+        request_payload: { socialAccountTypes: [bundlePlatform], data },
+        response_payload: { id: bundlePostId, status: bundleStatus },
+      })
+      .eq("id", claim.publish_attempt_id!);
+    if (update.error) {
+      logger.warn("social.publish.fire.bundle_id_store_failed", {
+        err: update.error.message,
+        attempt_id: claim.publish_attempt_id,
+      });
+    }
+  }
+
+  return ok({
+    outcome: "ok",
+    publishJobId: claim.publish_job_id!,
+    publishAttemptId: claim.publish_attempt_id!,
+    bundlePostId: bundlePostId ?? undefined,
+  });
+}
+
+async function markAttemptFailed(
+  svc: ReturnType<typeof getServiceRoleClient>,
+  attemptId: string,
+  fields: { error_class: string; error_payload: Record<string, unknown> },
+): Promise<void> {
+  const update = await svc
+    .from("social_publish_attempts")
+    .update({
+      status: "failed",
+      error_class: fields.error_class,
+      error_payload: fields.error_payload,
+      completed_at: new Date().toISOString(),
+    })
+    .eq("id", attemptId);
+  if (update.error) {
+    logger.warn("social.publish.fire.attempt_fail_failed", {
+      err: update.error.message,
+      attempt_id: attemptId,
+    });
+  }
+}
+
+async function markMasterFailed(
+  svc: ReturnType<typeof getServiceRoleClient>,
+  masterId: string,
+): Promise<void> {
+  const update = await svc
+    .from("social_post_master")
+    .update({ state: "failed", state_changed_at: new Date().toISOString() })
+    .eq("id", masterId)
+    .eq("state", "publishing");
+  if (update.error) {
+    logger.warn("social.publish.fire.master_fail_failed", {
+      err: update.error.message,
+      master_id: masterId,
+    });
+  }
+}
+
+function classifyError(message: string): string {
+  const m = message.toLowerCase();
+  if (m.includes("rate limit") || m.includes("429")) return "rate_limit";
+  if (m.includes("401") || m.includes("403") || m.includes("unauth")) {
+    return "auth";
+  }
+  if (m.includes("400") || m.includes("invalid")) return "content_rejected";
+  if (m.includes("network") || m.includes("timeout") || m.includes("econn")) {
+    return "network";
+  }
+  return "platform_error";
+}
+
+function ok(data: FirePublishResult): ApiResponse<FirePublishResult> {
+  return {
+    ok: true,
+    data,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(message: string): ApiResponse<FirePublishResult> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<FirePublishResult> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Investigate logs; the publish_attempt may be in an inconsistent state.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/publishing/index.ts
+++ b/lib/platform/social/publishing/index.ts
@@ -1,0 +1,11 @@
+export {
+  cancelScheduledPublish,
+  enqueueScheduledPublish,
+  type EnqueuePublishInput,
+  type EnqueuePublishResult,
+} from "./enqueue";
+export {
+  fireScheduledPublish,
+  type FirePublishInput,
+  type FirePublishResult,
+} from "./fire";

--- a/lib/platform/social/scheduling/cancel.ts
+++ b/lib/platform/social/scheduling/cancel.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { logger } from "@/lib/logger";
+import { cancelScheduledPublish } from "@/lib/platform/social/publishing";
 import { getServiceRoleClient } from "@/lib/supabase";
 import type { ApiResponse } from "@/lib/tool-schemas";
 
@@ -96,6 +97,19 @@ export async function cancelScheduleEntry(
   if (!update.data) {
     // Race: another caller cancelled between our lookup and update.
     return invalidState("Entry was cancelled concurrently.");
+  }
+
+  // S1-18 — best-effort QStash message cancel. If this fails the
+  // callback may still fire, but claim_publish_job's CANCELLED gate
+  // (migration 0075) is the source of truth and will skip publishing.
+  const cancelResult = await cancelScheduledPublish(
+    (update.data as ScheduleEntry).qstash_message_id,
+  );
+  if (!cancelResult.ok) {
+    logger.warn("social.scheduling.cancel.qstash_cancel_failed", {
+      err: cancelResult.error.message,
+      entry_id: input.entryId,
+    });
   }
 
   return {

--- a/lib/platform/social/scheduling/create.ts
+++ b/lib/platform/social/scheduling/create.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { logger } from "@/lib/logger";
+import { enqueueScheduledPublish } from "@/lib/platform/social/publishing";
 import { SUPPORTED_PLATFORMS } from "@/lib/platform/social/variants/types";
 import { getServiceRoleClient } from "@/lib/supabase";
 import type { ApiResponse } from "@/lib/tool-schemas";
@@ -160,10 +161,37 @@ export async function createScheduleEntry(
     return internal(`Failed to create schedule entry: ${insert.error.message}`);
   }
 
+  const entry = insert.data as ScheduleEntryWithPlatform;
+
+  // S1-18 — enqueue the QStash callback. Best-effort: enqueue failure
+  // does NOT roll back the schedule entry. The row remains and can be
+  // re-enqueued by a backfill cron (future slice). Skipped silently when
+  // the caller didn't pass an origin (e.g. lib-only test paths).
+  if (input.origin) {
+    const enqueue = await enqueueScheduledPublish({
+      scheduleEntryId: entry.id,
+      scheduledAt: input.scheduledAt,
+      origin: input.origin,
+    });
+    if (!enqueue.ok) {
+      logger.warn("social.scheduling.create.enqueue_failed", {
+        err: enqueue.error.message,
+        schedule_entry_id: entry.id,
+      });
+      // Update the in-memory row with the message id we tried to set
+      // (still null) — the DB row was already updated by the lib.
+    } else if (enqueue.data.messageId) {
+      // enqueue lib already wrote the messageId back to the row; reflect
+      // it in the response without a re-read.
+      (entry as { qstash_message_id: string | null }).qstash_message_id =
+        enqueue.data.messageId;
+    }
+  }
+
   return {
     ok: true,
     data: {
-      ...(insert.data as ScheduleEntryWithPlatform),
+      ...entry,
       platform: input.platform,
     },
     timestamp: new Date().toISOString(),

--- a/lib/platform/social/scheduling/types.ts
+++ b/lib/platform/social/scheduling/types.ts
@@ -25,6 +25,10 @@ export type CreateScheduleEntryInput = {
   scheduledAt: string;
   // The actor who scheduled (audit). Pass gate.userId from the route.
   scheduledBy: string | null;
+  // Absolute origin (e.g. https://app.opollo.com) used to mint the
+  // QStash callback URL. Optional — when omitted (or QStash unset),
+  // the schedule entry is created without enqueuing.
+  origin?: string;
 };
 
 export type ListScheduleEntriesInput = {

--- a/supabase/migrations/0075_claim_publish_job_fn.sql
+++ b/supabase/migrations/0075_claim_publish_job_fn.sql
@@ -1,0 +1,229 @@
+-- =============================================================================
+-- 0075 — claim_publish_job(schedule_entry_id) — atomic publish-job claim.
+--
+-- S1-18 — When a QStash callback fires for a scheduled post, this
+-- function:
+--   1. Looks up the schedule_entry, ensures it's not cancelled.
+--   2. Looks up the variant + master, ensures the master is in
+--      'approved' or 'scheduled' state.
+--   3. Atomically:
+--      a. INSERTs a social_publish_jobs row keyed on schedule_entry_id
+--         (UNIQUE partial index added below — first writer wins).
+--      b. INSERTs a social_publish_attempts row with status='in_flight'.
+--      c. Predicate-guarded UPDATE on social_post_master to
+--         transition state → 'publishing'.
+--   4. Returns the job_id, attempt_id, master/variant fields the caller
+--      needs to compose the bundle.social postCreate request.
+--
+-- Concurrent fires (QStash redelivery, manual retry) race at the
+-- INSERT in step 3a — second writer hits the UNIQUE violation and
+-- gets 'ALREADY_CLAIMED'. Master state guard (step 3c) covers
+-- the case where someone manually advanced the post out of
+-- approved/scheduled before the QStash callback fired.
+--
+-- Caller is responsible for verifying the QStash signature before
+-- calling this RPC. The function itself trusts its input.
+-- =============================================================================
+
+BEGIN;
+
+-- Add a UNIQUE INDEX so concurrent claims race deterministically.
+-- Partial because schedule_entry_id is nullable (ON DELETE SET NULL on
+-- the FK) — we don't want every NULL row to collide.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_publish_jobs_schedule_entry
+  ON social_publish_jobs(schedule_entry_id)
+  WHERE schedule_entry_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION claim_publish_job(
+  p_schedule_entry_id UUID
+)
+RETURNS TABLE (
+  outcome TEXT,
+  publish_job_id UUID,
+  publish_attempt_id UUID,
+  post_master_id UUID,
+  post_variant_id UUID,
+  company_id UUID,
+  platform TEXT,
+  variant_text TEXT,
+  master_text TEXT,
+  link_url TEXT,
+  bundle_social_account_id TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_entry  RECORD;
+  v_variant RECORD;
+  v_master RECORD;
+  v_conn   RECORD;
+  v_job_id UUID;
+  v_attempt_id UUID;
+BEGIN
+  -- 1. Schedule entry lookup.
+  SELECT id, post_variant_id, scheduled_at, cancelled_at
+    INTO v_entry
+    FROM social_schedule_entries
+    WHERE id = p_schedule_entry_id;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NOT_FOUND'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_entry.cancelled_at IS NOT NULL THEN
+    RETURN QUERY SELECT 'CANCELLED'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- 2. Variant + master lookup.
+  SELECT v.id, v.post_master_id, v.platform::TEXT AS platform,
+         v.variant_text, v.connection_id
+    INTO v_variant
+    FROM social_post_variant v
+    WHERE v.id = v_entry.post_variant_id;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NOT_FOUND'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  SELECT m.id, m.company_id, m.master_text, m.link_url, m.state::TEXT AS state
+    INTO v_master
+    FROM social_post_master m
+    WHERE m.id = v_variant.post_master_id;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NOT_FOUND'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- Master must be in a publishable state. Anything else (rejected,
+  -- already-published, manually pushed back to draft) means we should
+  -- NOT publish — bundle.social call would be wasted spend.
+  IF v_master.state NOT IN ('approved', 'scheduled') THEN
+    RETURN QUERY SELECT 'INVALID_STATE'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- 3a. Resolve the connection. The variant may have a pinned
+  -- connection_id, otherwise fall back to the first healthy connection
+  -- for this platform on the master's company.
+  IF v_variant.connection_id IS NOT NULL THEN
+    SELECT c.id, c.bundle_social_account_id, c.status::TEXT AS status
+      INTO v_conn
+      FROM social_connections c
+      WHERE c.id = v_variant.connection_id;
+  ELSE
+    SELECT c.id, c.bundle_social_account_id, c.status::TEXT AS status
+      INTO v_conn
+      FROM social_connections c
+      WHERE c.company_id = v_master.company_id
+        AND c.platform = v_variant.platform::social_platform
+        AND c.status = 'healthy'
+      ORDER BY c.connected_at DESC
+      LIMIT 1;
+  END IF;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NO_CONNECTION'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_conn.status <> 'healthy' THEN
+    RETURN QUERY SELECT 'CONNECTION_DEGRADED'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- 3b. Atomically claim the publish-job slot. UNIQUE on
+  -- schedule_entry_id (added by this migration) makes this a hard
+  -- racing point: second concurrent fire raises 23505 → ALREADY_CLAIMED.
+  BEGIN
+    INSERT INTO social_publish_jobs (
+      schedule_entry_id,
+      post_variant_id,
+      company_id,
+      fire_at,
+      fired_at
+    ) VALUES (
+      p_schedule_entry_id,
+      v_variant.id,
+      v_master.company_id,
+      v_entry.scheduled_at,
+      now()
+    )
+    RETURNING id INTO v_job_id;
+  EXCEPTION
+    WHEN unique_violation THEN
+      RETURN QUERY SELECT 'ALREADY_CLAIMED'::TEXT,
+        NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+        NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+      RETURN;
+  END;
+
+  -- 3c. Insert the in-flight attempt row.
+  INSERT INTO social_publish_attempts (
+    publish_job_id,
+    post_variant_id,
+    connection_id,
+    status,
+    started_at
+  ) VALUES (
+    v_job_id,
+    v_variant.id,
+    v_conn.id,
+    'in_flight',
+    now()
+  )
+  RETURNING id INTO v_attempt_id;
+
+  -- 3d. Advance master state — predicate-guarded so manual interventions
+  -- between steps 2 and 3d don't get steamrolled. The state check at
+  -- step 2 already passed but the master may have moved while we were
+  -- inserting the job/attempt; if so, abort by raising INVALID_STATE
+  -- so the caller treats the attempt as orphaned (it'll be marked
+  -- failed by the cleanup path).
+  UPDATE social_post_master
+    SET state = 'publishing',
+        state_changed_at = now()
+    WHERE id = v_master.id
+      AND state IN ('approved', 'scheduled');
+
+  IF NOT FOUND THEN
+    -- Race: master moved out of approved/scheduled between step 2 and
+    -- step 3d. Roll the inserts back by raising — the calling
+    -- transaction (this RPC) gets aborted automatically.
+    RAISE EXCEPTION 'INVALID_STATE: master moved during claim';
+  END IF;
+
+  RETURN QUERY SELECT 'OK'::TEXT,
+    v_job_id,
+    v_attempt_id,
+    v_master.id,
+    v_variant.id,
+    v_master.company_id,
+    v_variant.platform,
+    v_variant.variant_text,
+    v_master.master_text,
+    v_master.link_url,
+    v_conn.bundle_social_account_id;
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

End-to-end L4 publishing path. `createScheduleEntry` now enqueues a QStash callback at `scheduled_at`; the callback claims the publish slot atomically via `claim_publish_job` RPC and calls `bundle.social.post.postCreate`. The `post.published` / `post.failed` webhooks (S1-17) finalise the master state.

## What's new

- **Migration 0075** — `claim_publish_job(schedule_entry_id)` plpgsql:
  - UNIQUE INDEX on `social_publish_jobs(schedule_entry_id)` WHERE NOT NULL → concurrent fires race deterministically.
  - Validates: schedule not cancelled, master state IN (`approved`,`scheduled`), connection healthy.
  - Atomically inserts job + in-flight attempt; advances master → `publishing` (predicate-guarded).
  - Outcomes: `OK` / `NOT_FOUND` / `CANCELLED` / `INVALID_STATE` / `NO_CONNECTION` / `CONNECTION_DEGRADED` / `ALREADY_CLAIMED`.

- **Lib**
  - `lib/platform/social/publishing/enqueue.ts` — QStash `publishJSON` with `deduplicationId='social-publish-${scheduleEntryId}'` (idempotent re-enqueue). Stores `qstash_message_id` on the schedule_entry. Cancel helper deletes the QStash message; 404 is fine.
  - `lib/platform/social/publishing/fire.ts` — calls the RPC, composes per-platform post body (LINKEDIN/FACEBOOK/TWITTER/GOOGLE_BUSINESS), calls bundle.social. On success stores `bundle_post_id`; on failure marks attempt + master `failed` with mapped `error_class`.

- **Routes**
  - `POST /api/webhooks/qstash/social-publish` — verifies Upstash-Signature, calls `fireScheduledPublish`. 200 on every successful outcome (including no-op `already_claimed`/`cancelled`/`invalid_state`); 401|503 on signature failure; 500 only on RPC unreachability.

- **Wired**
  - `createScheduleEntry` accepts optional `origin` and calls `enqueueScheduledPublish` after the row insert (best-effort; row remains on enqueue failure).
  - `cancelScheduleEntry` calls `cancelScheduledPublish` for the stored `qstash_message_id` (best-effort; `cancelled_at` gate inside `claim_publish_job` is the source of truth).

## Risks identified and mitigated

- **DOUBLE-SPEND on bundle.social** — UNIQUE INDEX on `social_publish_jobs(schedule_entry_id)` is the lock. `claim_publish_job` is the SINGLE place that creates a job row; bundle.social is only called after a successful claim. Concurrent QStash redeliveries race at the index — second one gets `ALREADY_CLAIMED` and exits without spending.
- **QSTASH redelivery on transient 5xx** — `deduplicationId` on publish prevents re-queuing; route returns 200 on every successful outcome including no-op variants so QStash stops retrying after a successful claim.
- **Cancellation race** (operator cancels while QStash callback is mid-fire) — `claim_publish_job` re-checks `cancelled_at` first; if set, returns `CANCELLED` before INSERTing. Window between the check and the master state UPDATE is covered by the predicate guard (`state IN approved|scheduled`) — if master was advanced manually, the function `RAISE`s and rolls the inserts back.
- **Master state advanced manually mid-claim** — UPDATE … WHERE state IN (`approved`,`scheduled`) predicate; if no rows match the function `RAISE`s which aborts the transaction and rolls back the job/attempt inserts.
- **bundle.social SDK throws AFTER claim succeeded** — attempt marked `failed` + master flipped to `failed` with `error_class` mapped from the exception message. No double-charge: bundle.social never saw this attempt.
- **bundle.social returns status='ERROR' synchronously** — same failure path. Idempotency at the platform level: bundle.social may still have created a post row, but our master state is `failed` and ops can manually clean up via their dashboard.
- **Connection degraded after schedule was created** — `claim_publish_job` returns `CONNECTION_DEGRADED` before any external call; admin can reconnect (S1-16) and reschedule.
- **Empty post body slipping through** — explicit check before bundle.social call; attempt marked `failed` with `content_rejected`.
- **`QSTASH_TOKEN` unset in dev/test** — enqueue + cancel are no-op (logs). Schedule entries still exist; an operator-triggered backfill cron (future slice) can re-enqueue.

**Deferred to S1-19+:** media uploads (uploadIds in postCreate.data), retries with backoff, backfill cron for entries lacking `qstash_message_id`, idempotent INSERT for connection_alert from publish-side failures.

## Tests

`lib/__tests__/social-publishing-fire.test.ts` (SDK mocked, live Supabase):
- Happy path: bundle_post_id stored on attempt, master in `publishing` (webhook flips to `published`).
- variant_text vs master_text fallback.
- Every claim outcome: cancelled, invalid_state, no_connection, connection_degraded, already_claimed via second concurrent fire.
- SDK throw classification (HTTP 429 → `rate_limit`).
- bundle.social `status='ERROR'` → failure path.
- Empty post body short-circuits before SDK call.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint <S1-18 files>` — clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` — green; QStash callback route compiled
- [ ] CI green
- [ ] Smoke from staging once `QSTASH_TOKEN` + `BUNDLE_SOCIAL_API` + `BUNDLE_SOCIAL_TEAMID` are live: schedule a post → wait for fire_at → verify bundle_post_id appears on attempt → wait for `post.published` webhook → verify master state goes to `published`.

## Coordination note

Built in `../opollo-s1-18` (worktree). Migration **0075** reserved for this slice; verified no parallel session has reserved it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)