### PR TITLE
S1-19: publish-route wiring + backfill cron

### DIFF
--- a/app/api/cron/social-publish-backfill/route.ts
+++ b/app/api/cron/social-publish-backfill/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { logger } from "@/lib/logger";
+import {
+  authorisedCronRequest,
+  unauthorisedResponse,
+} from "@/lib/optimiser/sync/cron-shared";
+import { backfillScheduledPublishes } from "@/lib/platform/social/publishing";
+
+// ---------------------------------------------------------------------------
+// S1-19 — GET /api/cron/social-publish-backfill
+//
+// Vercel cron tick. Walks future-dated, non-cancelled
+// social_schedule_entries with NULL qstash_message_id and re-enqueues
+// them via QStash. Idempotent across reruns: a successful enqueue
+// stamps qstash_message_id, so the next tick skips the row. The
+// QStash deduplicationId on the publish itself guards against
+// double-enqueue if two ticks race.
+//
+// No-op when QSTASH_TOKEN is unset (clean exit, status='skipped').
+//
+// Auth: shared CRON_SECRET bearer (lib/optimiser/sync/cron-shared).
+// Vercel cron job adds the header automatically.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+async function handle(req: NextRequest): Promise<NextResponse> {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+
+  const origin =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ??
+    new URL(req.url).origin;
+
+  const result = await backfillScheduledPublishes({ origin });
+  if (!result.ok) {
+    logger.error("social.publish.backfill.cron_failed", {
+      err: result.error.message,
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: result.error,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+
+  logger.info("social.publish.backfill.cron_ok", {
+    status: result.data.status,
+    ...(result.data.status === "ok"
+      ? {
+          examined: result.data.examined,
+          enqueued: result.data.enqueued,
+          failed: result.data.failed,
+        }
+      : { reason: result.data.reason }),
+  });
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: result.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/app/api/platform/social/posts/[id]/schedule/route.ts
+++ b/app/api/platform/social/posts/[id]/schedule/route.ts
@@ -143,12 +143,17 @@ export async function POST(
   const gate = await requireCanDoForApi(parsed.data.company_id, "schedule_post");
   if (gate.kind === "deny") return gate.response;
 
+  const origin =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ??
+    new URL(req.url).origin;
+
   const result = await createScheduleEntry({
     postMasterId: id,
     companyId: parsed.data.company_id,
     platform: parsed.data.platform,
     scheduledAt: parsed.data.scheduled_at,
     scheduledBy: gate.userId,
+    origin,
   });
   if (!result.ok) {
     return errorJson(

--- a/lib/__tests__/social-publishing-backfill.test.ts
+++ b/lib/__tests__/social-publishing-backfill.test.ts
@@ -1,0 +1,212 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// ---------------------------------------------------------------------------
+// S1-19 — backfillScheduledPublishes against the live Supabase stack
+// with a mocked QStash client.
+//
+// Covers:
+//   - QSTASH_TOKEN unset → status='skipped', no DB read.
+//   - Picks up future-dated, non-cancelled rows with NULL message id.
+//   - Skips rows that already have a message_id (idempotent reruns).
+//   - Skips cancelled rows.
+//   - Skips past-dated rows (we never auto-fire late).
+//   - Stores the new message_id back on the row (verified via DB read).
+//   - Per-row enqueue failure counted as `failed`, doesn't abort the batch.
+// ---------------------------------------------------------------------------
+
+const mockClient = {
+  publishJSON: vi.fn(),
+  messages: {
+    delete: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/qstash", async () => {
+  return {
+    getQstashClient: () => mockClient,
+    getQstashReceiver: () => null,
+    verifyQstashSignature: async () => ({
+      ok: false,
+      reason: "no_receiver" as const,
+    }),
+    __resetQstashForTests: () => {},
+  };
+});
+
+import { backfillScheduledPublishes } from "@/lib/platform/social/publishing";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+const COMPANY_ID = "abcdef00-0000-0000-0000-aaaaaaaa1919";
+
+async function seedCompany(): Promise<void> {
+  const svc = getServiceRoleClient();
+  const r = await svc.from("platform_companies").insert({
+    id: COMPANY_ID,
+    name: "S1-19 Co",
+    slug: "s1-19-co",
+    domain: "s1-19.test",
+    is_opollo_internal: false,
+    timezone: "Australia/Melbourne",
+    approval_default_rule: "any_one",
+  });
+  if (r.error) throw new Error(`seed company: ${r.error.message}`);
+}
+
+async function seedScheduleEntry(opts: {
+  scheduledAt: string;
+  qstashMessageId?: string | null;
+  cancelledAt?: string | null;
+}): Promise<string> {
+  const svc = getServiceRoleClient();
+  const master = await svc
+    .from("social_post_master")
+    .insert({
+      company_id: COMPANY_ID,
+      state: "approved",
+      source_type: "manual",
+      master_text: "hello",
+    })
+    .select("id")
+    .single();
+  if (master.error) throw new Error(`seed master: ${master.error.message}`);
+
+  const variant = await svc
+    .from("social_post_variant")
+    .insert({
+      post_master_id: master.data.id,
+      platform: "linkedin_personal",
+      variant_text: "hi",
+    })
+    .select("id")
+    .single();
+  if (variant.error) throw new Error(`seed variant: ${variant.error.message}`);
+
+  const entry = await svc
+    .from("social_schedule_entries")
+    .insert({
+      post_variant_id: variant.data.id,
+      scheduled_at: opts.scheduledAt,
+      qstash_message_id: opts.qstashMessageId ?? null,
+      cancelled_at: opts.cancelledAt ?? null,
+    })
+    .select("id")
+    .single();
+  if (entry.error) throw new Error(`seed entry: ${entry.error.message}`);
+  return entry.data.id as string;
+}
+
+const ORIGIN = "https://opollo.test";
+
+beforeEach(async () => {
+  mockClient.publishJSON.mockReset();
+  mockClient.messages.delete.mockReset();
+  await seedCompany();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("backfillScheduledPublishes — env gating", () => {
+  it("returns skipped when QSTASH_TOKEN unset", async () => {
+    const prior = process.env.QSTASH_TOKEN;
+    delete process.env.QSTASH_TOKEN;
+    try {
+      const result = await backfillScheduledPublishes({ origin: ORIGIN });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.status).toBe("skipped");
+      expect(mockClient.publishJSON).not.toHaveBeenCalled();
+    } finally {
+      if (prior !== undefined) process.env.QSTASH_TOKEN = prior;
+    }
+  });
+});
+
+describe("backfillScheduledPublishes — row selection", () => {
+  beforeEach(() => {
+    process.env.QSTASH_TOKEN = "test-token";
+  });
+
+  it("enqueues future-dated, NULL-message rows and stamps message_id", async () => {
+    const futureIso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const entryId = await seedScheduleEntry({ scheduledAt: futureIso });
+    mockClient.publishJSON.mockResolvedValueOnce({ messageId: "msg_abc" });
+
+    const result = await backfillScheduledPublishes({ origin: ORIGIN });
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.data.status !== "ok") return;
+    expect(result.data.examined).toBe(1);
+    expect(result.data.enqueued).toBe(1);
+    expect(result.data.failed).toBe(0);
+
+    const svc = getServiceRoleClient();
+    const row = await svc
+      .from("social_schedule_entries")
+      .select("qstash_message_id")
+      .eq("id", entryId)
+      .single();
+    expect(row.data?.qstash_message_id).toBe("msg_abc");
+  });
+
+  it("skips rows that already have a message_id", async () => {
+    const futureIso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    await seedScheduleEntry({
+      scheduledAt: futureIso,
+      qstashMessageId: "msg_existing",
+    });
+
+    const result = await backfillScheduledPublishes({ origin: ORIGIN });
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.data.status !== "ok") return;
+    expect(result.data.examined).toBe(0);
+    expect(mockClient.publishJSON).not.toHaveBeenCalled();
+  });
+
+  it("skips cancelled rows", async () => {
+    const futureIso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    await seedScheduleEntry({
+      scheduledAt: futureIso,
+      cancelledAt: new Date().toISOString(),
+    });
+
+    const result = await backfillScheduledPublishes({ origin: ORIGIN });
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.data.status !== "ok") return;
+    expect(result.data.examined).toBe(0);
+  });
+
+  it("skips past-dated rows", async () => {
+    const pastIso = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    await seedScheduleEntry({ scheduledAt: pastIso });
+
+    const result = await backfillScheduledPublishes({ origin: ORIGIN });
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.data.status !== "ok") return;
+    expect(result.data.examined).toBe(0);
+  });
+
+  it("counts per-row enqueue failures without aborting", async () => {
+    const futureIso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    await seedScheduleEntry({ scheduledAt: futureIso });
+    await seedScheduleEntry({ scheduledAt: futureIso });
+
+    mockClient.publishJSON
+      .mockResolvedValueOnce({ messageId: "msg_ok" })
+      .mockRejectedValueOnce(new Error("HTTP 500"));
+
+    const result = await backfillScheduledPublishes({ origin: ORIGIN });
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.data.status !== "ok") return;
+    expect(result.data.examined).toBe(2);
+    expect(result.data.enqueued).toBe(1);
+    expect(result.data.failed).toBe(1);
+  });
+});

--- a/lib/platform/social/publishing/backfill.ts
+++ b/lib/platform/social/publishing/backfill.ts
@@ -1,0 +1,142 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import { enqueueScheduledPublish } from "./enqueue";
+
+// ---------------------------------------------------------------------------
+// S1-19 — backfill QStash messages for schedule entries that were
+// created without a working QStash client (env unset at create time,
+// QStash transient outage, etc).
+//
+// Walks social_schedule_entries WHERE qstash_message_id IS NULL AND
+// cancelled_at IS NULL AND scheduled_at >= now() (entries already in
+// the past would fire-immediately; we let those go via a separate
+// "force fire" admin action rather than silently spamming bundle.social).
+//
+// For each row, calls enqueueScheduledPublish. The enqueue lib itself
+// stores the new messageId on success. Idempotent across reruns:
+// successful enqueues populate qstash_message_id, so the next backfill
+// pass skips them. The deduplicationId on the QStash publish also
+// guards against double-enqueue if two backfill ticks race.
+//
+// Only runs when QSTASH_TOKEN is configured. When absent, returns
+// { skipped: 'no_qstash' } so the cron tick is a clean no-op.
+// ---------------------------------------------------------------------------
+
+export type BackfillInput = {
+  origin: string;
+  // Optional cap to keep cron ticks bounded. Default 100.
+  limit?: number;
+};
+
+export type BackfillResult =
+  | {
+      status: "ok";
+      examined: number;
+      enqueued: number;
+      failed: number;
+    }
+  | { status: "skipped"; reason: "no_qstash" };
+
+export async function backfillScheduledPublishes(
+  input: BackfillInput,
+): Promise<ApiResponse<BackfillResult>> {
+  if (!input.origin) return validation("origin is required.");
+
+  // Cheap pre-check so we don't even read from the DB if QStash is
+  // unconfigured. We probe via process.env directly because the
+  // enqueue lib's no-op path still reads the row count, which is wasted
+  // work in the env-unset case.
+  if (!process.env.QSTASH_TOKEN) {
+    return {
+      ok: true,
+      data: { status: "skipped", reason: "no_qstash" },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  const limit = Math.max(1, Math.min(input.limit ?? 100, 500));
+  const svc = getServiceRoleClient();
+
+  const nowIso = new Date().toISOString();
+  const rows = await svc
+    .from("social_schedule_entries")
+    .select("id, scheduled_at")
+    .is("qstash_message_id", null)
+    .is("cancelled_at", null)
+    .gte("scheduled_at", nowIso)
+    .order("scheduled_at", { ascending: true })
+    .limit(limit);
+
+  if (rows.error) {
+    logger.error("social.publish.backfill.read_failed", {
+      err: rows.error.message,
+    });
+    return internal(`Backfill read failed: ${rows.error.message}`);
+  }
+
+  const candidates = rows.data ?? [];
+  let enqueued = 0;
+  let failed = 0;
+
+  for (const row of candidates) {
+    const result = await enqueueScheduledPublish({
+      scheduleEntryId: row.id as string,
+      scheduledAt: row.scheduled_at as string,
+      origin: input.origin,
+    });
+    if (result.ok && result.data.messageId) {
+      enqueued += 1;
+    } else if (result.ok) {
+      // QStash unconfigured mid-loop (shouldn't happen — pre-check
+      // above) — count as failed without spamming logs.
+      failed += 1;
+    } else {
+      failed += 1;
+      logger.warn("social.publish.backfill.entry_failed", {
+        err: result.error.message,
+        schedule_entry_id: row.id,
+      });
+    }
+  }
+
+  return {
+    ok: true,
+    data: {
+      status: "ok",
+      examined: candidates.length,
+      enqueued,
+      failed,
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(message: string): ApiResponse<BackfillResult> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<BackfillResult> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: true,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/publishing/index.ts
+++ b/lib/platform/social/publishing/index.ts
@@ -1,4 +1,9 @@
 export {
+  backfillScheduledPublishes,
+  type BackfillInput,
+  type BackfillResult,
+} from "./backfill";
+export {
   cancelScheduledPublish,
   enqueueScheduledPublish,
   type EnqueuePublishInput,

--- a/vercel.json
+++ b/vercel.json
@@ -79,6 +79,10 @@
     {
       "path": "/api/cron/optimiser-sync-vercel-logs",
       "schedule": "0 11 * * *"
+    },
+    {
+      "path": "/api/cron/social-publish-backfill",
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two small wires onto S1-18's publish pipeline so it actually runs end-to-end in production.

## What's new

1. **POST `/api/platform/social/posts/[id]/schedule`** now passes `origin` into `createScheduleEntry`, so QStash actually gets enqueued at schedule-creation time. Origin resolves from `NEXT_PUBLIC_SITE_URL` with fallback to the request URL.

2. **New cron `/api/cron/social-publish-backfill`** (every 5m). Walks future-dated, non-cancelled `social_schedule_entries` where `qstash_message_id IS NULL` and re-enqueues. Idempotent across reruns (qstash_message_id is the skip flag; QStash deduplicationId guards against double-enqueue race). No-op when `QSTASH_TOKEN` unset.

## Risks identified and mitigated

- **Backfill enqueueing the same row twice** — QStash `deduplicationId` (`'social-publish-${id}'`) makes the second `publishJSON` return the existing messageId; no duplicate queued message. The backfill also stamps `qstash_message_id` back, so the next tick filters the row out.
- **Backfill firing on past-dated rows** — explicit `gte('scheduled_at', now())` filter; we never auto-fire late entries (manual operator action only).
- **Backfill running before QSTASH provisioning** — pre-checks `process.env.QSTASH_TOKEN`; returns `status='skipped'` without DB reads.
- **Origin missing from cron context** — falls back to `NEXT_PUBLIC_SITE_URL` then `req.url`; both populated by Vercel for cron requests.
- **Per-row failure aborting the batch** — counted as `failed`, loop continues. Errors logged but cron returns 200 so Vercel doesn't flag the tick as broken on a single QStash hiccup.

## Tests

`lib/__tests__/social-publishing-backfill.test.ts` (QStash mocked, live Supabase): QSTASH unset short-circuit, future-dated row gets enqueued + message_id stamped, already-enqueued rows skipped, cancelled rows skipped, past-dated rows skipped, per-row failure counting.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint <S1-19 files>` — clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` — green
- [ ] CI green
- [ ] Smoke from staging once QSTASH + bundle.social envs are live: schedule a post → verify `qstash_message_id` populated → wait → verify publish_attempt row appears with bundle_post_id

## Coordination note

Built in `../opollo-s1-19` (worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)