### PR TITLE
feat(p-brand-1a): brand profile lib + read-only customer page

### DIFF
--- a/app/company/settings/brand/page.tsx
+++ b/app/company/settings/brand/page.tsx
@@ -1,0 +1,76 @@
+import { redirect } from "next/navigation";
+
+import { CustomerBrandProfileView } from "@/components/CustomerBrandProfileView";
+import { getCurrentPlatformSession } from "@/lib/platform/auth";
+import { getActiveBrandProfile } from "@/lib/platform/brand";
+import { getPlatformCompany } from "@/lib/platform/companies";
+
+// P-Brand-1a — Customer brand profile (read-only). Edit form lands in
+// P-Brand-1b. Mirrors the gate pattern in app/company/users/page.tsx:
+//
+//   1. No session → redirect to /login.
+//   2. Authenticated but no platform_users row → "Not provisioned".
+//   3. Customer non-admin → "Admins only" notice. Brand profile is
+//      configuration that controls every product's output, so admin-
+//      gated mirrors the user-management gate.
+//   4. Opollo staff → also allowed.
+
+export const dynamic = "force-dynamic";
+
+export default async function CompanyBrandPage() {
+  const session = await getCurrentPlatformSession();
+  if (!session) {
+    redirect(`/login?next=${encodeURIComponent("/company/settings/brand")}`);
+  }
+
+  if (!session.company) {
+    return (
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm">
+        <p className="font-medium">Account not provisioned to a company.</p>
+        <p className="mt-1 text-muted-foreground">
+          Your account isn&apos;t a member of any company on the platform
+          yet. Ask an admin to invite you, or contact Opollo support.
+        </p>
+      </div>
+    );
+  }
+
+  const isAdmin =
+    session.isOpolloStaff || session.company.role === "admin";
+  if (!isAdmin) {
+    return (
+      <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+        <p className="font-medium">Admins only.</p>
+        <p className="mt-1">
+          Only admins can view and edit the brand profile. Ask an admin
+          in your company to update your role if you need access.
+        </p>
+      </div>
+    );
+  }
+
+  const companyId = session.company.companyId;
+
+  const [companyResult, brand] = await Promise.all([
+    getPlatformCompany(companyId),
+    getActiveBrandProfile(companyId),
+  ]);
+
+  if (!companyResult.ok) {
+    return (
+      <div
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        role="alert"
+      >
+        Failed to load company: {companyResult.error.message}
+      </div>
+    );
+  }
+
+  return (
+    <CustomerBrandProfileView
+      company={companyResult.data.company}
+      brand={brand}
+    />
+  );
+}

--- a/components/CustomerBrandProfileView.tsx
+++ b/components/CustomerBrandProfileView.tsx
@@ -1,0 +1,354 @@
+import Link from "next/link";
+
+import { Eyebrow, H1, Lead } from "@/components/ui/typography";
+import {
+  type BrandProfile,
+  brandTierDescription,
+  brandTierLabel,
+  getBrandTier,
+} from "@/lib/platform/brand";
+import type { PlatformCompany } from "@/lib/platform/companies";
+
+// P-Brand-1a — read-only customer view of the active brand profile.
+// Edit form lands in P-Brand-1b; this slice ships the surface so
+// operators can confirm what's stored and we can wire it into the rest
+// of the platform UI (sidebar link, completion banners on /company,
+// etc.) without waiting for the form.
+//
+// Empty state: brand may legitimately be null (customer companies start
+// without a profile — only the Opollo internal company is seeded). Show
+// a "Get started" prompt rather than rendering an empty card.
+
+type Props = {
+  company: PlatformCompany;
+  brand: BrandProfile | null;
+};
+
+export function CustomerBrandProfileView({ company, brand }: Props) {
+  const tier = getBrandTier(brand);
+  const tierLabel = brandTierLabel(tier);
+  const tierDescription = brandTierDescription(tier);
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <H1>Brand profile</H1>
+        <Lead className="mt-1">
+          How <strong>{company.name}</strong> looks, sounds, and behaves
+          across every Opollo product.
+        </Lead>
+      </header>
+
+      {brand === null ? (
+        <EmptyState />
+      ) : (
+        <>
+          <TierCard
+            tier={tierLabel}
+            description={tierDescription}
+            version={brand.version}
+            updatedAt={brand.updated_at}
+            safeMode={brand.safe_mode}
+          />
+          <VisualIdentityCard brand={brand} />
+          <ToneOfVoiceCard brand={brand} />
+          <ContentGuardrailsCard brand={brand} />
+          <OperationalDefaultsCard brand={brand} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <section className="rounded-lg border border-dashed bg-muted/20 p-8 text-center">
+      <h2 className="text-lg font-semibold">No brand profile yet</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Set up your brand so we can tailor every post, page, and image
+        we generate to look and sound like you.
+      </p>
+      <p className="mt-4 text-sm text-muted-foreground">
+        The brand editor lands in the next slice. For now, ask Opollo
+        support to bootstrap your profile, or wait for the editor to
+        ship.
+      </p>
+    </section>
+  );
+}
+
+function TierCard({
+  tier,
+  description,
+  version,
+  updatedAt,
+  safeMode,
+}: {
+  tier: string;
+  description: string;
+  version: number;
+  updatedAt: string;
+  safeMode: boolean;
+}) {
+  return (
+    <section
+      className="rounded-lg border bg-card p-4"
+      aria-labelledby="brand-tier-heading"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <Eyebrow id="brand-tier-heading">Setup</Eyebrow>
+          <h2 className="mt-1 text-base font-semibold">{tier}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        </div>
+        <div className="text-right text-sm text-muted-foreground">
+          <div>Version {version}</div>
+          <div>Updated {formatDate(updatedAt)}</div>
+          {safeMode ? (
+            <div className="mt-1 inline-flex rounded-md bg-amber-100 px-2 py-0.5 text-sm font-medium text-amber-900">
+              Safe mode on
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function VisualIdentityCard({ brand }: { brand: BrandProfile }) {
+  return (
+    <section
+      className="rounded-lg border bg-card"
+      aria-labelledby="brand-visual-heading"
+    >
+      <header className="border-b px-4 py-3">
+        <h2 id="brand-visual-heading" className="text-base font-semibold">
+          Visual identity
+        </h2>
+      </header>
+      <div className="grid gap-6 p-4 md:grid-cols-2">
+        <Field label="Primary colour">
+          <ColourSwatch value={brand.primary_colour} />
+        </Field>
+        <Field label="Secondary colour">
+          <ColourSwatch value={brand.secondary_colour} />
+        </Field>
+        <Field label="Accent colour">
+          <ColourSwatch value={brand.accent_colour} />
+        </Field>
+        <Field label="Heading font">
+          <Value value={brand.heading_font} />
+        </Field>
+        <Field label="Body font">
+          <Value value={brand.body_font} />
+        </Field>
+        <Field label="Logos">
+          <LogoList
+            primary={brand.logo_primary_url}
+            dark={brand.logo_dark_url}
+            light={brand.logo_light_url}
+            icon={brand.logo_icon_url}
+          />
+        </Field>
+      </div>
+    </section>
+  );
+}
+
+function ToneOfVoiceCard({ brand }: { brand: BrandProfile }) {
+  return (
+    <section
+      className="rounded-lg border bg-card"
+      aria-labelledby="brand-tone-heading"
+    >
+      <header className="border-b px-4 py-3">
+        <h2 id="brand-tone-heading" className="text-base font-semibold">
+          Tone of voice
+        </h2>
+      </header>
+      <div className="grid gap-6 p-4 md:grid-cols-2">
+        <Field label="Formality">
+          <Value value={formatEnum(brand.formality)} />
+        </Field>
+        <Field label="Point of view">
+          <Value value={formatEnum(brand.point_of_view)} />
+        </Field>
+        <Field label="Personality traits">
+          <TagList values={brand.personality_traits} />
+        </Field>
+        <Field label="Voice examples">
+          <TagList values={brand.voice_examples} />
+        </Field>
+        <Field label="Preferred vocabulary">
+          <TagList values={brand.preferred_vocabulary} />
+        </Field>
+        <Field label="Avoided terms">
+          <TagList values={brand.avoided_terms} />
+        </Field>
+      </div>
+    </section>
+  );
+}
+
+function ContentGuardrailsCard({ brand }: { brand: BrandProfile }) {
+  return (
+    <section
+      className="rounded-lg border bg-card"
+      aria-labelledby="brand-content-heading"
+    >
+      <header className="border-b px-4 py-3">
+        <h2 id="brand-content-heading" className="text-base font-semibold">
+          Content guardrails
+        </h2>
+      </header>
+      <div className="grid gap-6 p-4 md:grid-cols-2">
+        <Field label="Industry">
+          <Value value={brand.industry} />
+        </Field>
+        <Field label="Focus topics">
+          <TagList values={brand.focus_topics} />
+        </Field>
+        <Field label="Avoided topics">
+          <TagList values={brand.avoided_topics} />
+        </Field>
+        <Field label="Content restrictions">
+          <TagList values={brand.content_restrictions} />
+        </Field>
+      </div>
+    </section>
+  );
+}
+
+function OperationalDefaultsCard({ brand }: { brand: BrandProfile }) {
+  return (
+    <section
+      className="rounded-lg border bg-card"
+      aria-labelledby="brand-ops-heading"
+    >
+      <header className="border-b px-4 py-3">
+        <h2 id="brand-ops-heading" className="text-base font-semibold">
+          Operational defaults
+        </h2>
+      </header>
+      <div className="grid gap-6 p-4 md:grid-cols-2">
+        <Field label="Approval required by default">
+          <Value value={brand.default_approval_required ? "Yes" : "No"} />
+        </Field>
+        <Field label="Approval rule">
+          <Value value={formatEnum(brand.default_approval_rule)} />
+        </Field>
+        <Field label="Hashtag strategy">
+          <Value value={formatEnum(brand.hashtag_strategy)} />
+        </Field>
+        <Field label="Max post length">
+          <Value value={formatEnum(brand.max_post_length)} />
+        </Field>
+      </div>
+    </section>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <Eyebrow>{label}</Eyebrow>
+      <div className="mt-1">{children}</div>
+    </div>
+  );
+}
+
+function Value({ value }: { value: string | null | undefined }) {
+  if (!value) {
+    return <span className="text-sm text-muted-foreground italic">Not set</span>;
+  }
+  return <span className="text-sm">{value}</span>;
+}
+
+function ColourSwatch({ value }: { value: string | null }) {
+  if (!value) return <Value value={null} />;
+  return (
+    <div className="flex items-center gap-3">
+      <span
+        aria-hidden
+        className="inline-block h-6 w-6 rounded-md border"
+        style={{ backgroundColor: value }}
+      />
+      <span className="text-sm font-mono">{value}</span>
+    </div>
+  );
+}
+
+function TagList({ values }: { values: string[] }) {
+  if (values.length === 0) return <Value value={null} />;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {values.map((v) => (
+        <span
+          key={v}
+          className="inline-flex rounded-md bg-muted px-2 py-0.5 text-sm"
+        >
+          {v}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function LogoList({
+  primary,
+  dark,
+  light,
+  icon,
+}: {
+  primary: string | null;
+  dark: string | null;
+  light: string | null;
+  icon: string | null;
+}) {
+  const variants: Array<{ label: string; url: string | null }> = [
+    { label: "Primary", url: primary },
+    { label: "Dark", url: dark },
+    { label: "Light", url: light },
+    { label: "Icon", url: icon },
+  ];
+  const present = variants.filter((v) => v.url);
+  if (present.length === 0) return <Value value={null} />;
+  return (
+    <ul className="space-y-1 text-sm">
+      {present.map((v) => (
+        <li key={v.label}>
+          <span className="font-medium">{v.label}: </span>
+          <Link
+            href={v.url ?? "#"}
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline underline-offset-2"
+          >
+            View
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function formatEnum(value: string | null | undefined): string | null {
+  if (!value) return null;
+  return value.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/lib/__tests__/platform-brand-completion.test.ts
+++ b/lib/__tests__/platform-brand-completion.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import { type BrandProfile, getBrandTier } from "@/lib/platform/brand";
+
+// P-Brand-1a — pure function. No DB. Asserts the tier ladder defined in
+// lib/platform/brand/completion.ts. The ladder is consumed by the
+// completion-prompt UI on /company and (eventually) by image generation
+// + CAP routing, so the boundary cases here are load-bearing.
+
+function baseBrand(): BrandProfile {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    company_id: "22222222-2222-2222-2222-222222222222",
+    version: 1,
+    is_active: true,
+    change_summary: null,
+    primary_colour: null,
+    secondary_colour: null,
+    accent_colour: null,
+    logo_primary_url: null,
+    logo_dark_url: null,
+    logo_light_url: null,
+    logo_icon_url: null,
+    heading_font: null,
+    body_font: null,
+    image_style: {},
+    approved_style_ids: [],
+    safe_mode: false,
+    personality_traits: [],
+    formality: null,
+    point_of_view: null,
+    preferred_vocabulary: [],
+    avoided_terms: [],
+    voice_examples: [],
+    focus_topics: [],
+    avoided_topics: [],
+    industry: null,
+    default_approval_required: true,
+    default_approval_rule: "any_one",
+    platform_overrides: {},
+    hashtag_strategy: "minimal",
+    max_post_length: "medium",
+    content_restrictions: [],
+    updated_by: null,
+    created_by: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+describe("lib/platform/brand/completion — getBrandTier", () => {
+  it("returns 'none' when brand is null (no profile yet)", () => {
+    expect(getBrandTier(null)).toBe("none");
+  });
+
+  it("returns 'none' when minimal fields are missing", () => {
+    expect(getBrandTier(baseBrand())).toBe("none");
+  });
+
+  it("returns 'none' when only one of the minimal pair is present", () => {
+    const onlyColour = { ...baseBrand(), primary_colour: "#FF03A5" };
+    expect(getBrandTier(onlyColour)).toBe("none");
+
+    const onlyLogo = {
+      ...baseBrand(),
+      logo_primary_url: "https://cdn.opollo.com/logo.svg",
+    };
+    expect(getBrandTier(onlyLogo)).toBe("none");
+  });
+
+  it("returns 'minimal' when primary colour + logo are set but tone fields are missing", () => {
+    const minimal: BrandProfile = {
+      ...baseBrand(),
+      primary_colour: "#FF03A5",
+      logo_primary_url: "https://cdn.opollo.com/logo.svg",
+    };
+    expect(getBrandTier(minimal)).toBe("minimal");
+  });
+
+  it("returns 'standard' when industry + formality + personality + focus topics are set", () => {
+    const standard: BrandProfile = {
+      ...baseBrand(),
+      primary_colour: "#FF03A5",
+      logo_primary_url: "https://cdn.opollo.com/logo.svg",
+      industry: "Technology / SaaS",
+      formality: "semi_formal",
+      personality_traits: ["professional", "approachable"],
+      focus_topics: ["cloud cost optimisation"],
+    };
+    expect(getBrandTier(standard)).toBe("standard");
+  });
+
+  it("does not promote to 'standard' if any one standard input is empty", () => {
+    const missingPersonality: BrandProfile = {
+      ...baseBrand(),
+      primary_colour: "#FF03A5",
+      logo_primary_url: "https://cdn.opollo.com/logo.svg",
+      industry: "Technology / SaaS",
+      formality: "semi_formal",
+      personality_traits: [], // missing
+      focus_topics: ["cloud cost optimisation"],
+    };
+    expect(getBrandTier(missingPersonality)).toBe("minimal");
+
+    const missingFocus: BrandProfile = {
+      ...baseBrand(),
+      primary_colour: "#FF03A5",
+      logo_primary_url: "https://cdn.opollo.com/logo.svg",
+      industry: "Technology / SaaS",
+      formality: "semi_formal",
+      personality_traits: ["professional"],
+      focus_topics: [], // missing
+    };
+    expect(getBrandTier(missingFocus)).toBe("minimal");
+  });
+
+  it("returns 'complete' when voice_examples + platform_overrides + image_style are populated", () => {
+    const complete: BrandProfile = {
+      ...baseBrand(),
+      primary_colour: "#FF03A5",
+      logo_primary_url: "https://cdn.opollo.com/logo.svg",
+      industry: "Technology / SaaS",
+      formality: "semi_formal",
+      personality_traits: ["professional", "approachable"],
+      focus_topics: ["cloud cost optimisation"],
+      voice_examples: ["Cut your AWS bill by 30% in 90 days, no code changes."],
+      platform_overrides: { linkedin: { use_hashtags: true } },
+      image_style: { mood: "clean modern", composition_notes: "spacious" },
+    };
+    expect(getBrandTier(complete)).toBe("complete");
+  });
+
+  it("does not promote to 'complete' if image_style is empty even when other fields are present", () => {
+    const almostComplete: BrandProfile = {
+      ...baseBrand(),
+      primary_colour: "#FF03A5",
+      logo_primary_url: "https://cdn.opollo.com/logo.svg",
+      industry: "Technology / SaaS",
+      formality: "semi_formal",
+      personality_traits: ["professional"],
+      focus_topics: ["cloud cost"],
+      voice_examples: ["sample"],
+      platform_overrides: { linkedin: {} },
+      image_style: {}, // empty
+    };
+    expect(getBrandTier(almostComplete)).toBe("standard");
+  });
+});

--- a/lib/__tests__/platform-brand-get.test.ts
+++ b/lib/__tests__/platform-brand-get.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getActiveBrandProfile } from "@/lib/platform/brand";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// P-Brand-1a — getActiveBrandProfile DB read.
+//
+// Asserts:
+//   - Returns null when company has no brand profile yet (the V1 default
+//     for customer companies; only the Opollo internal seed has one).
+//   - Returns the active row when one exists.
+//   - Returns the active row even when older inactive versions exist
+//     (the unique-active partial index guarantees at most one).
+//   - Returns null on a malformed UUID without throwing (defensive
+//     against route-level corruption).
+
+const COMPANY_NO_BRAND_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1";
+const COMPANY_HAS_BRAND_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2";
+
+describe("lib/platform/brand/get — getActiveBrandProfile", () => {
+  beforeAll(async () => {
+    const svc = getServiceRoleClient();
+    const seed = await svc
+      .from("platform_companies")
+      .insert([
+        {
+          id: COMPANY_NO_BRAND_ID,
+          name: "Brand-Test No-Brand Co",
+          slug: "p-brand-1a-no-brand",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+        },
+        {
+          id: COMPANY_HAS_BRAND_ID,
+          name: "Brand-Test Has-Brand Co",
+          slug: "p-brand-1a-has-brand",
+          is_opollo_internal: false,
+          timezone: "Australia/Melbourne",
+        },
+      ])
+      .select("id");
+    if (seed.error) {
+      throw new Error(`seed companies: ${seed.error.message}`);
+    }
+  });
+
+  afterAll(async () => {
+    const svc = getServiceRoleClient();
+    await svc
+      .from("platform_companies")
+      .delete()
+      .in("id", [COMPANY_NO_BRAND_ID, COMPANY_HAS_BRAND_ID]);
+  });
+
+  beforeEach(async () => {
+    const svc = getServiceRoleClient();
+    // Wipe brand rows for the test companies between tests so seeds are
+    // deterministic. Internal-company brand profile (from migration 0074
+    // seed) is untouched.
+    await svc
+      .from("platform_brand_profiles")
+      .delete()
+      .in("company_id", [COMPANY_NO_BRAND_ID, COMPANY_HAS_BRAND_ID]);
+  });
+
+  it("returns null when the company has no brand profile yet", async () => {
+    const result = await getActiveBrandProfile(COMPANY_NO_BRAND_ID);
+    expect(result).toBeNull();
+  });
+
+  it("returns the active row when one exists", async () => {
+    const svc = getServiceRoleClient();
+    const insert = await svc
+      .from("platform_brand_profiles")
+      .insert({
+        company_id: COMPANY_HAS_BRAND_ID,
+        version: 1,
+        is_active: true,
+        primary_colour: "#FF03A5",
+        secondary_colour: "#00E5A0",
+        heading_font: "EmBauhausW00",
+        industry: "Technology / SaaS",
+        formality: "semi_formal",
+        point_of_view: "first_person",
+      })
+      .select("id");
+    if (insert.error) throw new Error(`seed brand: ${insert.error.message}`);
+
+    const result = await getActiveBrandProfile(COMPANY_HAS_BRAND_ID);
+    expect(result).not.toBeNull();
+    expect(result?.company_id).toBe(COMPANY_HAS_BRAND_ID);
+    expect(result?.is_active).toBe(true);
+    expect(result?.version).toBe(1);
+    expect(result?.primary_colour).toBe("#FF03A5");
+    expect(result?.industry).toBe("Technology / SaaS");
+    expect(result?.formality).toBe("semi_formal");
+    // Defaults from the column DEFAULTs:
+    expect(result?.safe_mode).toBe(false);
+    expect(result?.personality_traits).toEqual([]);
+    expect(result?.image_style).toEqual({});
+  });
+
+  it("returns the active row when an older inactive version also exists", async () => {
+    const svc = getServiceRoleClient();
+    const seed = await svc
+      .from("platform_brand_profiles")
+      .insert([
+        {
+          company_id: COMPANY_HAS_BRAND_ID,
+          version: 1,
+          is_active: false,
+          change_summary: "v1 initial",
+          primary_colour: "#000000",
+        },
+        {
+          company_id: COMPANY_HAS_BRAND_ID,
+          version: 2,
+          is_active: true,
+          change_summary: "v2 brand refresh",
+          primary_colour: "#FF03A5",
+        },
+      ])
+      .select("id");
+    if (seed.error) throw new Error(`seed: ${seed.error.message}`);
+
+    const result = await getActiveBrandProfile(COMPANY_HAS_BRAND_ID);
+    expect(result).not.toBeNull();
+    expect(result?.version).toBe(2);
+    expect(result?.primary_colour).toBe("#FF03A5");
+    expect(result?.change_summary).toBe("v2 brand refresh");
+  });
+
+  it("returns null (not throws) on malformed UUID input", async () => {
+    const result = await getActiveBrandProfile("not-a-uuid");
+    expect(result).toBeNull();
+  });
+});

--- a/lib/platform/brand/completion.ts
+++ b/lib/platform/brand/completion.ts
@@ -1,0 +1,77 @@
+import type { BrandProfile } from "./types";
+
+// Brand completion tier — drives "set up your brand" prompts in the UI
+// and routes degraded-mode behaviour in image generation / CAP. Products
+// must continue to function at every tier; lower tiers just produce
+// less brand-tailored output.
+//
+// Tiers (in order — each row's check is a superset of the row below):
+//
+//   none      No active profile, OR profile exists but lacks both
+//             primary_colour AND a primary logo. Image generation falls
+//             back to neutral colour + no logo overlay; CAP uses
+//             generic tone defaults.
+//
+//   minimal   Has primary_colour + logo_primary_url but no industry /
+//             formality / personality / focus_topics. Image generation
+//             can use brand colour but tone is generic.
+//
+//   standard  Has minimal + industry + formality + at least one
+//             personality trait + at least one focus topic. CAP can
+//             write on-brand at a coarse grain.
+//
+//   complete  Has standard + voice_examples (so CAP has anchor copy) +
+//             platform_overrides set + image_style customised. Top-tier
+//             product output.
+
+export type BrandTier = "none" | "minimal" | "standard" | "complete";
+
+export function getBrandTier(brand: BrandProfile | null): BrandTier {
+  if (!brand) return "none";
+
+  const hasMinimal = !!(brand.primary_colour && brand.logo_primary_url);
+  if (!hasMinimal) return "none";
+
+  const hasStandard = !!(
+    brand.industry &&
+    brand.formality &&
+    brand.personality_traits.length > 0 &&
+    brand.focus_topics.length > 0
+  );
+  if (!hasStandard) return "minimal";
+
+  const hasComplete = !!(
+    brand.voice_examples.length > 0 &&
+    Object.keys(brand.platform_overrides).length > 0 &&
+    Object.keys(brand.image_style).length > 0
+  );
+  return hasComplete ? "complete" : "standard";
+}
+
+// Display copy for each tier. Used by the "complete your brand" prompt
+// and the brand profile page header.
+export function brandTierLabel(tier: BrandTier): string {
+  switch (tier) {
+    case "none":
+      return "Not started";
+    case "minimal":
+      return "Minimal";
+    case "standard":
+      return "Standard";
+    case "complete":
+      return "Complete";
+  }
+}
+
+export function brandTierDescription(tier: BrandTier): string {
+  switch (tier) {
+    case "none":
+      return "Add a primary colour and logo to start tailoring your content.";
+    case "minimal":
+      return "Add industry, tone, and focus topics so we can write on-brand for you.";
+    case "standard":
+      return "Add voice examples and platform-specific overrides for top-tier output.";
+    case "complete":
+      return "Your brand is fully set up.";
+  }
+}

--- a/lib/platform/brand/get.ts
+++ b/lib/platform/brand/get.ts
@@ -1,0 +1,46 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { BRAND_PROFILE_COLUMNS, type BrandProfile } from "./types";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Reads the active brand profile for a company. Returns null when the
+// company has no brand profile yet (legitimate — the seed fires only for
+// the Opollo internal company; customer companies start without one and
+// get one created at first-edit time). Per the brand-governance skill,
+// callers MUST degrade gracefully when this returns null — never throw.
+//
+// Service-role read. Caller is responsible for the route-boundary auth
+// gate (operator role / company membership).
+
+export async function getActiveBrandProfile(
+  companyId: string,
+): Promise<BrandProfile | null> {
+  if (!UUID_RE.test(companyId)) {
+    logger.warn("platform.brand.get.invalid_company_id", { companyId });
+    return null;
+  }
+
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("platform_brand_profiles")
+    .select(BRAND_PROFILE_COLUMNS)
+    .eq("company_id", companyId)
+    .eq("is_active", true)
+    .maybeSingle();
+
+  if (error) {
+    logger.error("platform.brand.get.failed", {
+      companyId,
+      err: error.message,
+    });
+    return null;
+  }
+  if (!data) return null;
+
+  return data as unknown as BrandProfile;
+}

--- a/lib/platform/brand/index.ts
+++ b/lib/platform/brand/index.ts
@@ -1,0 +1,23 @@
+// Public surface for lib/platform/brand. Outside callers MUST import
+// from "@/lib/platform/brand" — never from a sub-path. (Same module-
+// boundary rule the optimiser + invitations + companies modules follow.)
+
+export { getActiveBrandProfile } from "./get";
+export {
+  brandTierDescription,
+  brandTierLabel,
+  getBrandTier,
+  type BrandTier,
+} from "./completion";
+export {
+  BRAND_PROFILE_COLUMNS,
+  type BrandFormality,
+  type BrandHashtag,
+  type BrandImageStyle,
+  type BrandPlatformOverrides,
+  type BrandPostLength,
+  type BrandPov,
+  type BrandProfile,
+  type OpolloProduct,
+  type SocialApprovalRule,
+} from "./types";

--- a/lib/platform/brand/types.ts
+++ b/lib/platform/brand/types.ts
@@ -1,0 +1,116 @@
+// Platform brand profile shape — mirrors public.platform_brand_profiles
+// in supabase/migrations/0074_platform_audit_and_brand.sql.
+//
+// Brand profile is versioned: NEVER UPDATE the row directly. Always call
+// the update_brand_profile() RPC, which deactivates the current row and
+// inserts a new one with version+1. See platform-brand-governance skill.
+
+export type BrandFormality = "formal" | "semi_formal" | "casual";
+export type BrandPov = "first_person" | "third_person";
+export type BrandHashtag = "none" | "minimal" | "standard" | "heavy";
+export type BrandPostLength = "short" | "medium" | "long";
+export type SocialApprovalRule = "any_one" | "all_must";
+export type OpolloProduct =
+  | "site_builder"
+  | "social"
+  | "cap"
+  | "blog"
+  | "email";
+
+// JSONB fields are open-shape — operators write whatever the editor
+// surfaces. We type them as Record<string, unknown> rather than `any` so
+// downstream consumers either narrow at the read site or accept the
+// operator-supplied shape verbatim.
+export type BrandImageStyle = Record<string, unknown>;
+export type BrandPlatformOverrides = Record<string, unknown>;
+
+export type BrandProfile = {
+  id: string;
+  company_id: string;
+  version: number;
+  is_active: boolean;
+  change_summary: string | null;
+
+  // Visual identity
+  primary_colour: string | null;
+  secondary_colour: string | null;
+  accent_colour: string | null;
+  logo_primary_url: string | null;
+  logo_dark_url: string | null;
+  logo_light_url: string | null;
+  logo_icon_url: string | null;
+  heading_font: string | null;
+  body_font: string | null;
+  image_style: BrandImageStyle;
+  approved_style_ids: string[];
+  safe_mode: boolean;
+
+  // Tone of voice
+  personality_traits: string[];
+  formality: BrandFormality | null;
+  point_of_view: BrandPov | null;
+  preferred_vocabulary: string[];
+  avoided_terms: string[];
+  voice_examples: string[];
+
+  // Content guardrails
+  focus_topics: string[];
+  avoided_topics: string[];
+  industry: string | null;
+
+  // Operational defaults
+  default_approval_required: boolean;
+  default_approval_rule: SocialApprovalRule | null;
+  platform_overrides: BrandPlatformOverrides;
+  hashtag_strategy: BrandHashtag | null;
+  max_post_length: BrandPostLength | null;
+  content_restrictions: string[];
+
+  // Audit
+  updated_by: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+// Selected columns for the active-profile read. Mirrors the SELECT in
+// lib/platform/brand/get.ts so the row → BrandProfile mapping is a
+// straight cast.
+export const BRAND_PROFILE_COLUMNS = [
+  "id",
+  "company_id",
+  "version",
+  "is_active",
+  "change_summary",
+  "primary_colour",
+  "secondary_colour",
+  "accent_colour",
+  "logo_primary_url",
+  "logo_dark_url",
+  "logo_light_url",
+  "logo_icon_url",
+  "heading_font",
+  "body_font",
+  "image_style",
+  "approved_style_ids",
+  "safe_mode",
+  "personality_traits",
+  "formality",
+  "point_of_view",
+  "preferred_vocabulary",
+  "avoided_terms",
+  "voice_examples",
+  "focus_topics",
+  "avoided_topics",
+  "industry",
+  "default_approval_required",
+  "default_approval_rule",
+  "platform_overrides",
+  "hashtag_strategy",
+  "max_post_length",
+  "content_restrictions",
+  "updated_by",
+  "created_by",
+  "created_at",
+  "updated_at",
+].join(", ");


### PR DESCRIPTION
## Summary

First slice of P-Brand-1 (brand profile editor). Ships the read path so operators can navigate to `/company/settings/brand` and see what's stored. Edit form lands in P-Brand-1b.

- **lib/platform/brand/** — `types.ts` (full BrandProfile shape mirroring migration 0074), `get.ts` (`getActiveBrandProfile` — returns null, never throws, on missing profile or DB error), `completion.ts` (`getBrandTier` returning `none | minimal | standard | complete` — drives completion prompts + future image-gen routing), barrel `index.ts`. Outside callers import from `@/lib/platform/brand` only.
- **app/company/settings/brand/page.tsx** — server-rendered customer page. Gate mirror of `/company/users`: session → provisioned → admin-only → opollo staff allowed.
- **components/CustomerBrandProfileView.tsx** — read-only display: tier card (version + safe-mode badge), four sectioned cards for visual identity / tone of voice / content guardrails / operational defaults. Empty state when no profile exists.

## Tests

- `platform-brand-completion.test.ts` — 7 cases on the tier ladder including the "missing one input drops you down" boundaries.
- `platform-brand-get.test.ts` — DB-backed: null on no profile, returns active row, picks active over inactive (asserts the unique-active partial index from 0074), null on malformed UUID.

## Risks identified and mitigated

- **Brand reads must never throw** — products read this every generation. `getActiveBrandProfile` catches DB errors via `maybeSingle` + structured logger; never re-throws. Per the platform-brand-governance skill, "Degrade gracefully when brand is missing — never throw because brand is incomplete."
- **Shape drift between migration and TS type** — `BRAND_PROFILE_COLUMNS` is the single source for the SELECT column list AND the BrandProfile cast. Test asserts populated + default-NULL columns to catch drift.
- **No mutation in this slice** — no `version_lock` / RPC concerns. `update_brand_profile()` wrapper + the edit form land in P-Brand-1b.
- **Dead-route LOW finding** — `/company/settings/brand` has no inbound link yet; audit flags it as LOW. Expected (reachable via direct URL today). P-Brand-1b adds the sidebar link + completion prompt on `/company` that links here.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 warnings/errors
- [x] `npm run audit:static` — 0 HIGH (one new LOW dead-route on the new page; expected, gets removed when P-Brand-1b adds the sidebar link)
- [ ] CI: build + test + e2e green (the documented pre-existing reds in `m12-1-rls`/`m4-schema`/etc. remain — environmental, not introduced here)

## Next slice

P-Brand-1b: edit form + `update_brand_profile()` RPC wrapper + sidebar link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)