### PR TITLE
S1-20: operator-triggered publish retry

### DIFF
--- a/app/api/platform/social/publish-attempts/[id]/retry/route.ts
+++ b/app/api/platform/social/publish-attempts/[id]/retry/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { retryPublishAttempt } from "@/lib/platform/social/publishing";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// S1-20 — POST /api/platform/social/publish-attempts/[id]/retry
+//
+// Operator-triggered retry for a failed publish_attempt. Body carries
+// company_id (used by the canDo gate); the attempt's own company is
+// resolved server-side from publish_jobs.company_id and must match.
+//
+// Gate: canDo("schedule_post", company_id) (approver+).
+//
+// Response: { outcome, newAttemptId?, bundlePostId? } — same shape
+// as fire.ts. 200 on every successful outcome (including no-op
+// already_retrying / connection_degraded / publish_failed); 4xx on
+// auth/validation; 500 only on RPC unreachability.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+const PostBodySchema = z.object({
+  company_id: z.string().uuid(),
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: status >= 500 },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return errorJson("VALIDATION_FAILED", "id must be a UUID.", 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = PostBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "Body must be { company_id: uuid }.",
+      400,
+    );
+  }
+
+  const gate = await requireCanDoForApi(parsed.data.company_id, "schedule_post");
+  if (gate.kind === "deny") return gate.response;
+
+  // Cross-company isolation: confirm the attempt's job belongs to the
+  // company the operator's session is scoped to. NOT_FOUND envelope on
+  // mismatch (don't leak existence).
+  const svc = getServiceRoleClient();
+  const attempt = await svc
+    .from("social_publish_attempts")
+    .select("publish_job_id")
+    .eq("id", id)
+    .maybeSingle();
+  if (attempt.error || !attempt.data) {
+    return errorJson("NOT_FOUND", "Attempt not found.", 404);
+  }
+  const job = await svc
+    .from("social_publish_jobs")
+    .select("company_id")
+    .eq("id", attempt.data.publish_job_id as string)
+    .maybeSingle();
+  if (
+    job.error ||
+    !job.data ||
+    (job.data.company_id as string) !== parsed.data.company_id
+  ) {
+    return errorJson("NOT_FOUND", "Attempt not found.", 404);
+  }
+
+  const result = await retryPublishAttempt({ attemptId: id });
+  if (!result.ok) {
+    if (result.error.code === "VALIDATION_FAILED") {
+      return errorJson("VALIDATION_FAILED", result.error.message, 400);
+    }
+    return errorJson("INTERNAL_ERROR", result.error.message, 500);
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: result.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/lib/__tests__/social-publishing-retry.test.ts
+++ b/lib/__tests__/social-publishing-retry.test.ts
@@ -1,0 +1,289 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// ---------------------------------------------------------------------------
+// S1-20 — retryPublishAttempt + retry_publish_attempt RPC against the
+// live Supabase stack with a mocked bundle.social SDK.
+//
+// Covers:
+//   - Happy path: failed attempt → new in_flight attempt with
+//     original_attempt_id + retry_count incremented; master flipped to
+//     'publishing'; bundle_post_id stored.
+//   - Race: two concurrent retries, second gets ALREADY_RETRYING and
+//     bundle.social is called exactly once.
+//   - Refusal cases: not_found, invalid_state (attempt not failed),
+//     invalid_state (master not failed), no_connection, connection_degraded.
+//   - Failure path: SDK throw → new attempt failed, master back to
+//     'failed' (mirrors fire.ts).
+// ---------------------------------------------------------------------------
+
+const mockClient = {
+  post: {
+    postCreate: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/bundlesocial", () => ({
+  getBundlesocialClient: () => mockClient,
+  getBundlesocialTeamId: () => "team-test-1",
+}));
+
+import { retryPublishAttempt } from "@/lib/platform/social/publishing";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+const COMPANY_ID = "abcdef00-0000-0000-0000-aaaaaaaa2020";
+
+async function seedCompany(): Promise<void> {
+  const svc = getServiceRoleClient();
+  const r = await svc.from("platform_companies").insert({
+    id: COMPANY_ID,
+    name: "S1-20 Co",
+    slug: "s1-20-co",
+    domain: "s1-20.test",
+    is_opollo_internal: false,
+    timezone: "Australia/Melbourne",
+    approval_default_rule: "any_one",
+  });
+  if (r.error) throw new Error(`seed company: ${r.error.message}`);
+}
+
+async function seedFailedAttempt(opts?: {
+  masterState?: string;
+  attemptStatus?: string;
+  withConnection?: boolean;
+  connectionStatus?: string;
+}): Promise<{ failedAttemptId: string; masterId: string }> {
+  const svc = getServiceRoleClient();
+
+  const master = await svc
+    .from("social_post_master")
+    .insert({
+      company_id: COMPANY_ID,
+      state: opts?.masterState ?? "failed",
+      source_type: "manual",
+      master_text: "retry me",
+    })
+    .select("id")
+    .single();
+  if (master.error) throw new Error(`seed master: ${master.error.message}`);
+
+  let connectionId: string | null = null;
+  if (opts?.withConnection !== false) {
+    const conn = await svc
+      .from("social_connections")
+      .insert({
+        company_id: COMPANY_ID,
+        platform: "linkedin_personal",
+        bundle_social_account_id: "ba_retry_" + master.data.id.slice(0, 8),
+        display_name: "Acme LI",
+        status: opts?.connectionStatus ?? "healthy",
+      })
+      .select("id")
+      .single();
+    if (conn.error) throw new Error(`seed conn: ${conn.error.message}`);
+    connectionId = conn.data.id as string;
+  }
+
+  const variant = await svc
+    .from("social_post_variant")
+    .insert({
+      post_master_id: master.data.id,
+      platform: "linkedin_personal",
+      variant_text: "retry text",
+      connection_id: connectionId,
+    })
+    .select("id")
+    .single();
+  if (variant.error) throw new Error(`seed variant: ${variant.error.message}`);
+
+  const job = await svc
+    .from("social_publish_jobs")
+    .insert({
+      post_variant_id: variant.data.id,
+      company_id: COMPANY_ID,
+      fire_at: new Date().toISOString(),
+      fired_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+  if (job.error) throw new Error(`seed job: ${job.error.message}`);
+
+  const attempt = await svc
+    .from("social_publish_attempts")
+    .insert({
+      publish_job_id: job.data.id,
+      post_variant_id: variant.data.id,
+      connection_id: connectionId ?? job.data.id, // connection FK is required; use any uuid when no real connection (test won't read it)
+      status: opts?.attemptStatus ?? "failed",
+      error_class: "rate_limit",
+      error_payload: { message: "Too many" },
+      completed_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+  if (attempt.error) {
+    throw new Error(`seed attempt: ${attempt.error.message}`);
+  }
+
+  return {
+    failedAttemptId: attempt.data.id as string,
+    masterId: master.data.id as string,
+  };
+}
+
+beforeEach(async () => {
+  mockClient.post.postCreate.mockReset();
+  await seedCompany();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("retryPublishAttempt — happy path", () => {
+  it("creates new in_flight attempt + flips master to publishing + stores bundle_post_id", async () => {
+    const { failedAttemptId, masterId } = await seedFailedAttempt();
+    mockClient.post.postCreate.mockResolvedValueOnce({
+      id: "bp_retry_1",
+      status: "SCHEDULED",
+    });
+
+    const result = await retryPublishAttempt({ attemptId: failedAttemptId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("ok");
+    expect(result.data.bundlePostId).toBe("bp_retry_1");
+    expect(result.data.newAttemptId).toBeTruthy();
+    expect(result.data.newAttemptId).not.toBe(failedAttemptId);
+
+    const svc = getServiceRoleClient();
+    const newAttempt = await svc
+      .from("social_publish_attempts")
+      .select("status, bundle_post_id, original_attempt_id, retry_count")
+      .eq("id", result.data.newAttemptId!)
+      .single();
+    expect(newAttempt.data?.status).toBe("in_flight");
+    expect(newAttempt.data?.bundle_post_id).toBe("bp_retry_1");
+    expect(newAttempt.data?.original_attempt_id).toBe(failedAttemptId);
+    expect(newAttempt.data?.retry_count).toBe(1);
+
+    const master = await svc
+      .from("social_post_master")
+      .select("state")
+      .eq("id", masterId)
+      .single();
+    expect(master.data?.state).toBe("publishing");
+
+    // Original failed attempt is unchanged.
+    const oldAttempt = await svc
+      .from("social_publish_attempts")
+      .select("status")
+      .eq("id", failedAttemptId)
+      .single();
+    expect(oldAttempt.data?.status).toBe("failed");
+  });
+
+  it("second concurrent retry returns already_retrying; bundle.social called once", async () => {
+    const { failedAttemptId } = await seedFailedAttempt();
+    mockClient.post.postCreate.mockResolvedValueOnce({
+      id: "bp_first",
+      status: "SCHEDULED",
+    });
+
+    const first = await retryPublishAttempt({ attemptId: failedAttemptId });
+    expect(first.ok).toBe(true);
+    if (first.ok) expect(first.data.outcome).toBe("ok");
+
+    const second = await retryPublishAttempt({ attemptId: failedAttemptId });
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.data.outcome).toBe("already_retrying");
+    expect(mockClient.post.postCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("retryPublishAttempt — refusal cases", () => {
+  it("returns not_found for unknown attempt id", async () => {
+    const result = await retryPublishAttempt({
+      attemptId: "00000000-0000-0000-0000-000000000000",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("not_found");
+    expect(mockClient.post.postCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid_state when attempt is not failed", async () => {
+    const { failedAttemptId } = await seedFailedAttempt({
+      attemptStatus: "succeeded",
+      masterState: "published",
+    });
+
+    const result = await retryPublishAttempt({ attemptId: failedAttemptId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("invalid_state");
+  });
+
+  it("returns invalid_state when master moved out of failed", async () => {
+    const { failedAttemptId, masterId } = await seedFailedAttempt();
+    const svc = getServiceRoleClient();
+    await svc
+      .from("social_post_master")
+      .update({ state: "draft" })
+      .eq("id", masterId);
+
+    const result = await retryPublishAttempt({ attemptId: failedAttemptId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("invalid_state");
+    expect(mockClient.post.postCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns connection_degraded when pinned connection is auth_required", async () => {
+    const { failedAttemptId } = await seedFailedAttempt({
+      connectionStatus: "auth_required",
+    });
+
+    const result = await retryPublishAttempt({ attemptId: failedAttemptId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("connection_degraded");
+  });
+});
+
+describe("retryPublishAttempt — bundle.social failures", () => {
+  it("SDK throw → new attempt failed, master back to failed", async () => {
+    const { failedAttemptId, masterId } = await seedFailedAttempt();
+    mockClient.post.postCreate.mockRejectedValueOnce(new Error("HTTP 401"));
+
+    const result = await retryPublishAttempt({ attemptId: failedAttemptId });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.outcome).toBe("publish_failed");
+
+    const svc = getServiceRoleClient();
+    const master = await svc
+      .from("social_post_master")
+      .select("state")
+      .eq("id", masterId)
+      .single();
+    expect(master.data?.state).toBe("failed");
+
+    // Original is now retryable again — the new attempt is the failed
+    // one. Caller should retry the NEW attempt id, not the original.
+    const newAttempts = await svc
+      .from("social_publish_attempts")
+      .select("status, error_class")
+      .eq("original_attempt_id", failedAttemptId);
+    expect(newAttempts.data?.length).toBe(1);
+    expect(newAttempts.data?.[0]?.status).toBe("failed");
+    expect(newAttempts.data?.[0]?.error_class).toBe("auth");
+  });
+});

--- a/lib/platform/social/publishing/index.ts
+++ b/lib/platform/social/publishing/index.ts
@@ -14,3 +14,8 @@ export {
   type FirePublishInput,
   type FirePublishResult,
 } from "./fire";
+export {
+  retryPublishAttempt,
+  type RetryPublishInput,
+  type RetryPublishResult,
+} from "./retry";

--- a/lib/platform/social/publishing/retry.ts
+++ b/lib/platform/social/publishing/retry.ts
@@ -1,0 +1,299 @@
+import "server-only";
+
+import {
+  getBundlesocialClient,
+  getBundlesocialTeamId,
+} from "@/lib/bundlesocial";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// S1-20 — operator-triggered retry of a failed publish_attempt.
+//
+// Calls the retry_publish_attempt RPC (migration 0076) which:
+//   - Verifies attempt status='failed' + master state='failed'.
+//   - Atomically flips master 'failed' → 'publishing' as the lock.
+//   - Inserts a new in-flight attempt under the same publish_job,
+//     with original_attempt_id pointing back at the failed one.
+//
+// On a successful claim we call bundle.social postCreate using the
+// returned variant/master text and connection. On SDK throw or
+// status='ERROR' we mark the new attempt failed + flip master back
+// to 'failed' (mirroring fire.ts's failure path).
+//
+// Caller is responsible for canDo("schedule_post", company_id) on the
+// FAILED attempt's company. The route gate handles that lookup.
+// ---------------------------------------------------------------------------
+
+export type RetryPublishInput = {
+  attemptId: string;
+};
+
+export type RetryPublishResult = {
+  outcome:
+    | "ok"
+    | "already_retrying"
+    | "not_found"
+    | "invalid_state"
+    | "no_connection"
+    | "connection_degraded"
+    | "publish_failed";
+  newAttemptId?: string;
+  bundlePostId?: string;
+};
+
+type ClaimRow = {
+  outcome: string;
+  publish_attempt_id: string | null;
+  publish_job_id: string | null;
+  post_master_id: string | null;
+  post_variant_id: string | null;
+  company_id: string | null;
+  platform: string | null;
+  variant_text: string | null;
+  master_text: string | null;
+  link_url: string | null;
+  bundle_social_account_id: string | null;
+};
+
+const PLATFORM_TO_BUNDLE: Record<
+  string,
+  "LINKEDIN" | "FACEBOOK" | "TWITTER" | "GOOGLE_BUSINESS"
+> = {
+  linkedin_personal: "LINKEDIN",
+  linkedin_company: "LINKEDIN",
+  facebook_page: "FACEBOOK",
+  x: "TWITTER",
+  gbp: "GOOGLE_BUSINESS",
+};
+
+export async function retryPublishAttempt(
+  input: RetryPublishInput,
+): Promise<ApiResponse<RetryPublishResult>> {
+  if (!input.attemptId) {
+    return validation("attemptId is required.");
+  }
+
+  const svc = getServiceRoleClient();
+
+  const claim = await svc.rpc("retry_publish_attempt", {
+    p_attempt_id: input.attemptId,
+  });
+  if (claim.error) {
+    logger.error("social.publish.retry.claim_failed", {
+      err: claim.error.message,
+      attempt_id: input.attemptId,
+    });
+    return internal(
+      `retry_publish_attempt RPC failed: ${claim.error.message}`,
+    );
+  }
+  const rows = (claim.data as ClaimRow[] | null) ?? [];
+  const row = rows[0];
+  if (!row) return internal("retry_publish_attempt returned no row.");
+
+  if (row.outcome === "NOT_FOUND") return ok({ outcome: "not_found" });
+  if (row.outcome === "INVALID_STATE") return ok({ outcome: "invalid_state" });
+  if (row.outcome === "NO_CONNECTION") return ok({ outcome: "no_connection" });
+  if (row.outcome === "CONNECTION_DEGRADED") {
+    return ok({ outcome: "connection_degraded" });
+  }
+  if (row.outcome === "ALREADY_RETRYING") {
+    return ok({ outcome: "already_retrying" });
+  }
+  if (row.outcome !== "OK") {
+    return internal(`Unexpected retry outcome: ${row.outcome}`);
+  }
+
+  // bundle.social call — same shape as fire.ts.
+  const client = getBundlesocialClient();
+  const teamId = getBundlesocialTeamId();
+  if (!client || !teamId) {
+    await markAttemptFailed(svc, row.publish_attempt_id!, {
+      error_class: "platform_error",
+      error_payload: { code: "RECEIVER_NOT_CONFIGURED" },
+    });
+    await markMasterFailed(svc, row.post_master_id!);
+    return internal("bundle.social client not configured.");
+  }
+
+  const bundlePlatform = PLATFORM_TO_BUNDLE[row.platform!];
+  if (!bundlePlatform) {
+    await markAttemptFailed(svc, row.publish_attempt_id!, {
+      error_class: "unknown",
+      error_payload: { reason: `Unsupported platform: ${row.platform}` },
+    });
+    await markMasterFailed(svc, row.post_master_id!);
+    return internal(`Unsupported platform: ${row.platform}`);
+  }
+
+  const text = (row.variant_text ?? row.master_text ?? "").trim();
+  if (!text) {
+    await markAttemptFailed(svc, row.publish_attempt_id!, {
+      error_class: "content_rejected",
+      error_payload: { reason: "Empty post body" },
+    });
+    await markMasterFailed(svc, row.post_master_id!);
+    return internal("Post has no body text.");
+  }
+
+  const data: Record<string, unknown> = {};
+  if (bundlePlatform === "LINKEDIN") {
+    data.LINKEDIN = { text, link: row.link_url ?? undefined };
+  } else if (bundlePlatform === "FACEBOOK") {
+    data.FACEBOOK = { text, link: row.link_url ?? undefined };
+  } else if (bundlePlatform === "TWITTER") {
+    data.TWITTER = { text };
+  } else if (bundlePlatform === "GOOGLE_BUSINESS") {
+    data.GOOGLE_BUSINESS = { text, link: row.link_url ?? undefined };
+  }
+
+  let bundlePostId: string | null = null;
+  let bundleStatus: string | null = null;
+  try {
+    const response = (await client.post.postCreate({
+      requestBody: {
+        teamId,
+        title: `retry:${row.publish_attempt_id}`,
+        postDate: new Date().toISOString(),
+        status: "SCHEDULED",
+        socialAccountTypes: [bundlePlatform],
+        data: data as never,
+      },
+    })) as { id?: string; status?: string };
+    bundlePostId = response.id ?? null;
+    bundleStatus = response.status ?? null;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("social.publish.retry.bundle_post_failed", {
+      err: message,
+      attempt_id: row.publish_attempt_id,
+    });
+    await markAttemptFailed(svc, row.publish_attempt_id!, {
+      error_class: classifyError(message),
+      error_payload: { message },
+    });
+    await markMasterFailed(svc, row.post_master_id!);
+    return ok({ outcome: "publish_failed" });
+  }
+
+  if (bundleStatus === "ERROR") {
+    await markAttemptFailed(svc, row.publish_attempt_id!, {
+      error_class: "platform_error",
+      error_payload: { bundle_status: bundleStatus, bundle_id: bundlePostId },
+    });
+    await markMasterFailed(svc, row.post_master_id!);
+    return ok({ outcome: "publish_failed" });
+  }
+
+  if (bundlePostId) {
+    const update = await svc
+      .from("social_publish_attempts")
+      .update({
+        bundle_post_id: bundlePostId,
+        request_payload: { socialAccountTypes: [bundlePlatform], data },
+        response_payload: { id: bundlePostId, status: bundleStatus },
+      })
+      .eq("id", row.publish_attempt_id!);
+    if (update.error) {
+      logger.warn("social.publish.retry.bundle_id_store_failed", {
+        err: update.error.message,
+        attempt_id: row.publish_attempt_id,
+      });
+    }
+  }
+
+  return ok({
+    outcome: "ok",
+    newAttemptId: row.publish_attempt_id!,
+    bundlePostId: bundlePostId ?? undefined,
+  });
+}
+
+async function markAttemptFailed(
+  svc: ReturnType<typeof getServiceRoleClient>,
+  attemptId: string,
+  fields: { error_class: string; error_payload: Record<string, unknown> },
+): Promise<void> {
+  const update = await svc
+    .from("social_publish_attempts")
+    .update({
+      status: "failed",
+      error_class: fields.error_class,
+      error_payload: fields.error_payload,
+      completed_at: new Date().toISOString(),
+    })
+    .eq("id", attemptId);
+  if (update.error) {
+    logger.warn("social.publish.retry.attempt_fail_failed", {
+      err: update.error.message,
+      attempt_id: attemptId,
+    });
+  }
+}
+
+async function markMasterFailed(
+  svc: ReturnType<typeof getServiceRoleClient>,
+  masterId: string,
+): Promise<void> {
+  const update = await svc
+    .from("social_post_master")
+    .update({ state: "failed", state_changed_at: new Date().toISOString() })
+    .eq("id", masterId)
+    .eq("state", "publishing");
+  if (update.error) {
+    logger.warn("social.publish.retry.master_fail_failed", {
+      err: update.error.message,
+      master_id: masterId,
+    });
+  }
+}
+
+function classifyError(message: string): string {
+  const m = message.toLowerCase();
+  if (m.includes("rate limit") || m.includes("429")) return "rate_limit";
+  if (m.includes("401") || m.includes("403") || m.includes("unauth")) {
+    return "auth";
+  }
+  if (m.includes("400") || m.includes("invalid")) return "content_rejected";
+  if (m.includes("network") || m.includes("timeout") || m.includes("econn")) {
+    return "network";
+  }
+  return "platform_error";
+}
+
+function ok(data: RetryPublishResult): ApiResponse<RetryPublishResult> {
+  return {
+    ok: true,
+    data,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(message: string): ApiResponse<RetryPublishResult> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<RetryPublishResult> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action:
+        "Investigate logs; the publish_attempt may be in an inconsistent state.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/supabase/migrations/0076_retry_publish_attempt_fn.sql
+++ b/supabase/migrations/0076_retry_publish_attempt_fn.sql
@@ -1,0 +1,213 @@
+-- =============================================================================
+-- 0076 — retry_publish_attempt(publish_attempt_id) — operator-triggered retry.
+--
+-- S1-20 — When a publish_attempt landed in status='failed', an operator
+-- can hit the retry endpoint to:
+--   1. Validate the attempt is still in 'failed' (not already retried).
+--   2. Validate the master is still in 'failed' (operator might have
+--      manually pushed it back to draft / published it externally).
+--   3. Atomically:
+--      a. UPDATE master state 'failed' → 'publishing' (predicate-
+--         guarded; 0 rows = ALREADY_RETRYING — another operator
+--         beat us).
+--      b. INSERT new social_publish_attempts row tied to the same
+--         publish_job, status='in_flight', original_attempt_id =
+--         the failed attempt's id, retry_count = prev + 1.
+--   4. Return the new attempt id + composition fields the caller
+--      needs to build the bundle.social postCreate request.
+--
+-- Concurrent retries race at step 3a — second writer sees 0 rows
+-- updated and gets ALREADY_RETRYING. The new attempt is NOT inserted
+-- in that case (we return before step 3b).
+--
+-- Caller is responsible for canDo("schedule_post", company_id) +
+-- verifying the operator owns the company. Function trusts its input.
+-- =============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION retry_publish_attempt(
+  p_attempt_id UUID
+)
+RETURNS TABLE (
+  outcome TEXT,
+  publish_attempt_id UUID,
+  publish_job_id UUID,
+  post_master_id UUID,
+  post_variant_id UUID,
+  company_id UUID,
+  platform TEXT,
+  variant_text TEXT,
+  master_text TEXT,
+  link_url TEXT,
+  bundle_social_account_id TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_attempt RECORD;
+  v_job     RECORD;
+  v_variant RECORD;
+  v_master  RECORD;
+  v_conn    RECORD;
+  v_new_attempt_id UUID;
+  v_master_updated BOOLEAN;
+BEGIN
+  -- 1. Attempt lookup.
+  SELECT id, publish_job_id, post_variant_id, connection_id,
+         status::TEXT AS status, retry_count
+    INTO v_attempt
+    FROM social_publish_attempts
+    WHERE id = p_attempt_id;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NOT_FOUND'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_attempt.status <> 'failed' THEN
+    RETURN QUERY SELECT 'INVALID_STATE'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- 2. Job + variant + master lookups.
+  SELECT id, post_variant_id, company_id
+    INTO v_job
+    FROM social_publish_jobs
+    WHERE id = v_attempt.publish_job_id;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NOT_FOUND'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  SELECT v.id, v.post_master_id, v.platform::TEXT AS platform,
+         v.variant_text, v.connection_id
+    INTO v_variant
+    FROM social_post_variant v
+    WHERE v.id = v_attempt.post_variant_id;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NOT_FOUND'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  SELECT m.id, m.company_id, m.master_text, m.link_url, m.state::TEXT AS state
+    INTO v_master
+    FROM social_post_master m
+    WHERE m.id = v_variant.post_master_id;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NOT_FOUND'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- Master must be in 'failed'. If operator already manually pushed
+  -- it back to draft, or it's somehow re-published externally, refuse
+  -- to retry — bundle.social call would be wasted spend or duplicate
+  -- the post.
+  IF v_master.state <> 'failed' THEN
+    RETURN QUERY SELECT 'INVALID_STATE'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- 3. Resolve the connection. Same fallback rule as
+  -- claim_publish_job: pinned connection_id wins, otherwise first
+  -- healthy connection for this platform on the company.
+  IF v_attempt.connection_id IS NOT NULL THEN
+    SELECT c.id, c.bundle_social_account_id, c.status::TEXT AS status
+      INTO v_conn
+      FROM social_connections c
+      WHERE c.id = v_attempt.connection_id;
+  ELSE
+    SELECT c.id, c.bundle_social_account_id, c.status::TEXT AS status
+      INTO v_conn
+      FROM social_connections c
+      WHERE c.company_id = v_master.company_id
+        AND c.platform = v_variant.platform::social_platform
+        AND c.status = 'healthy'
+      ORDER BY c.connected_at DESC
+      LIMIT 1;
+  END IF;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NO_CONNECTION'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_conn.status <> 'healthy' THEN
+    RETURN QUERY SELECT 'CONNECTION_DEGRADED'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- 4a. Atomically advance master state. This is the lock: two
+  -- concurrent retries race here, second one sees 0 rows updated
+  -- and bails with ALREADY_RETRYING before the INSERT in 4b.
+  UPDATE social_post_master
+    SET state = 'publishing',
+        state_changed_at = now()
+    WHERE id = v_master.id
+      AND state = 'failed';
+
+  GET DIAGNOSTICS v_master_updated = ROW_COUNT;
+  IF v_master_updated = 0 THEN
+    RETURN QUERY SELECT 'ALREADY_RETRYING'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- 4b. Insert the new in-flight attempt, linking to the failed one
+  -- via original_attempt_id and bumping retry_count.
+  INSERT INTO social_publish_attempts (
+    publish_job_id,
+    post_variant_id,
+    connection_id,
+    status,
+    original_attempt_id,
+    retry_count,
+    started_at
+  ) VALUES (
+    v_job.id,
+    v_variant.id,
+    v_conn.id,
+    'in_flight',
+    v_attempt.id,
+    COALESCE(v_attempt.retry_count, 0) + 1,
+    now()
+  )
+  RETURNING id INTO v_new_attempt_id;
+
+  RETURN QUERY SELECT 'OK'::TEXT,
+    v_new_attempt_id,
+    v_job.id,
+    v_master.id,
+    v_variant.id,
+    v_master.company_id,
+    v_variant.platform,
+    v_variant.variant_text,
+    v_master.master_text,
+    v_master.link_url,
+    v_conn.bundle_social_account_id;
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

`POST /api/platform/social/publish-attempts/[id]/retry` — operator clicks Retry on a failed `publish_attempt`; we atomically claim the retry slot, insert a new in-flight attempt under the same `publish_job`, and call `bundle.social.post.postCreate`. The original failed attempt stays in place; the retry chain is recoverable via `original_attempt_id` + `retry_count`.

## What's new

- **Migration 0076** — `retry_publish_attempt(p_attempt_id)` plpgsql:
  - Validates attempt `status='failed'` + master `state='failed'`.
  - Atomically flips master `'failed'` → `'publishing'` as the lock (predicate-guarded UPDATE; 0 rows = `ALREADY_RETRYING`).
  - Resolves connection (pinned id, fallback to first healthy on the company+platform).
  - INSERTs new attempt with `original_attempt_id` + `retry_count + 1`.
- **Lib** `lib/platform/social/publishing/retry.ts` — mirrors `fire.ts`'s post-claim shape: bundle.social call, on success store `bundle_post_id`; on SDK throw or `status='ERROR'`, mark attempt failed + master back to `failed` with mapped `error_class`.
- **Route** `POST /api/platform/social/publish-attempts/[id]/retry` — `canDo("schedule_post")` gate; cross-company isolation via `publish_jobs.company_id` lookup with `NOT_FOUND` envelope on mismatch.

## Risks identified and mitigated

- **DOUBLE-SPEND on bundle.social** — `UPDATE master 'failed' → 'publishing'` is the lock. `retry_publish_attempt` is the SINGLE place that creates the new attempt; bundle.social is only called after a successful claim. Concurrent operator clicks race at the master state UPDATE — second one gets `ALREADY_RETRYING` and exits without spending.
- **Retrying a succeeded attempt** — RPC checks attempt `status='failed'` before claiming.
- **Retrying when master moved on** (operator manually pushed to draft, webhook flipped to published) — RPC checks master `state='failed'` before claiming.
- **Cross-company access** — route resolves attempt's company via `publish_jobs.company_id` and 404s on mismatch with the gate `company_id` (no enumeration).
- **bundle.social SDK throws AFTER claim succeeded** — new attempt marked `'failed'` + master flipped back to `'failed'`. The retry chain remains traversable via `original_attempt_id`; operator can retry again from the new failed attempt's id.
- **Connection went degraded between failure and retry** — RPC returns `CONNECTION_DEGRADED` before any external call; admin can reconnect (S1-16) and retry.

## Tests

`lib/__tests__/social-publishing-retry.test.ts` (SDK mocked, live Supabase):
- Happy path: new attempt with `bundle_post_id`, master flipped to `publishing`, original attempt unchanged, `original_attempt_id` + `retry_count=1` set.
- Concurrent retry: second call gets `already_retrying`; bundle.social called exactly once.
- `not_found` / `invalid_state` (attempt not failed) / `invalid_state` (master moved) / `connection_degraded`.
- SDK throw → new attempt `failed` (with mapped `auth` class), master back to `failed`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint <S1-20 files>` — clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` — green
- [ ] CI green

## Coordination note

Built in `../opollo-s1-20` (worktree). Migration **0076** reserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)