### PR TITLE
S1-21: publish history UI on post detail

### DIFF
--- a/app/api/platform/social/posts/[id]/publish-attempts/route.ts
+++ b/app/api/platform/social/posts/[id]/publish-attempts/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { listPublishAttempts } from "@/lib/platform/social/publishing";
+
+// ---------------------------------------------------------------------------
+// S1-21 — GET /api/platform/social/posts/[id]/publish-attempts
+//
+// Returns the publish_attempts history for a single post. Drives the
+// PostPublishHistorySection on the post detail page.
+//
+// Gate: canDo("view_calendar", company_id) — viewer+. Operators with
+// "schedule_post" are the ones who can press Retry, but anyone with
+// view_calendar can SEE the history.
+//
+// Query: ?company_id=<uuid>
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return errorJson("VALIDATION_FAILED", "id must be a UUID.", 400);
+  }
+
+  const url = new URL(req.url);
+  const companyId = url.searchParams.get("company_id");
+  if (!companyId || !UUID_RE.test(companyId)) {
+    return errorJson("VALIDATION_FAILED", "company_id query param required.", 400);
+  }
+
+  const gate = await requireCanDoForApi(companyId, "view_calendar");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await listPublishAttempts({
+    postMasterId: id,
+    companyId,
+  });
+  if (!result.ok) {
+    return errorJson(result.error.code, result.error.message, 500);
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: result.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/company/social/posts/[id]/page.tsx
+++ b/app/company/social/posts/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { PostApprovalSection } from "@/components/PostApprovalSection";
 import { PostDecisionsAudit } from "@/components/PostDecisionsAudit";
+import { PostPublishHistorySection } from "@/components/PostPublishHistorySection";
 import { PostScheduleSection } from "@/components/PostScheduleSection";
 import { PostVariantsSection } from "@/components/PostVariantsSection";
 import { SocialPostDetailClient } from "@/components/SocialPostDetailClient";
@@ -11,9 +12,16 @@ import {
   listRecipients,
 } from "@/lib/platform/social/approvals";
 import { getPostMaster } from "@/lib/platform/social/posts";
+import { listPublishAttempts } from "@/lib/platform/social/publishing";
 import { listScheduleEntries } from "@/lib/platform/social/scheduling";
 import { listVariants } from "@/lib/platform/social/variants";
 import { getServiceRoleClient } from "@/lib/supabase";
+
+const PUBLISH_VISIBLE_STATES = new Set([
+  "publishing",
+  "published",
+  "failed",
+]);
 
 const POST_DECISION_STATES = new Set([
   "approved",
@@ -175,7 +183,34 @@ export default async function CompanySocialPostDetailPage({
             canSchedule,
           })
         : null}
+      {PUBLISH_VISIBLE_STATES.has(postResult.data.state)
+        ? await renderPublishHistorySection({
+            postId: postResult.data.id,
+            companyId,
+            canRetry: canSchedule,
+          })
+        : null}
     </>
+  );
+}
+
+async function renderPublishHistorySection(args: {
+  postId: string;
+  companyId: string;
+  canRetry: boolean;
+}) {
+  const result = await listPublishAttempts({
+    postMasterId: args.postId,
+    companyId: args.companyId,
+  });
+  if (!result.ok) return null;
+  return (
+    <PostPublishHistorySection
+      postId={args.postId}
+      companyId={args.companyId}
+      initialAttempts={result.data.attempts}
+      canRetry={args.canRetry}
+    />
   );
 }
 

--- a/components/PostPublishHistorySection.tsx
+++ b/components/PostPublishHistorySection.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  PLATFORM_LABEL,
+  type SocialPlatform,
+} from "@/lib/platform/social/variants/types";
+
+// ---------------------------------------------------------------------------
+// S1-21 — publish history section on the post detail page.
+//
+// Visible when post.state IN ('publishing','published','failed') and
+// at least one publish_attempt row exists. Shows the chronological
+// list (newest first) with platform, status pill, completed_at, error
+// summary on failures, and a Retry button on each failed attempt
+// (admin/approver-only via canRetry).
+//
+// Retry POSTs to /api/platform/social/publish-attempts/[id]/retry.
+// On 200 ok with outcome='ok' or 'publish_failed' we re-fetch the
+// list (a new attempt landed). Other outcomes (already_retrying,
+// invalid_state, no_connection, connection_degraded) flash a banner
+// and don't re-fetch.
+// ---------------------------------------------------------------------------
+
+type Attempt = {
+  id: string;
+  platform: SocialPlatform;
+  status: string;
+  bundle_post_id: string | null;
+  platform_post_url: string | null;
+  error_class: string | null;
+  retry_count: number;
+  original_attempt_id: string | null;
+  started_at: string;
+  completed_at: string | null;
+};
+
+type Props = {
+  postId: string;
+  companyId: string;
+  initialAttempts: Attempt[];
+  canRetry: boolean;
+};
+
+const STATUS_PILL: Record<string, string> = {
+  pending: "bg-muted text-muted-foreground",
+  in_flight: "bg-amber-100 text-amber-900",
+  unknown: "bg-amber-100 text-amber-900",
+  succeeded: "bg-emerald-100 text-emerald-900",
+  failed: "bg-rose-100 text-rose-900",
+  reconciling: "bg-amber-100 text-amber-900",
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  pending: "Queued",
+  in_flight: "Publishing…",
+  unknown: "Pending confirmation",
+  succeeded: "Published",
+  failed: "Failed",
+  reconciling: "Reconciling",
+};
+
+const ERROR_LABEL: Record<string, string> = {
+  network: "Network error — retry may resolve",
+  rate_limit: "Rate-limited by the platform — retry shortly",
+  platform_error: "Platform-side error",
+  auth: "Authentication failed — reconnect the account",
+  content_rejected: "Platform rejected the content",
+  media_invalid: "Media could not be processed",
+  unknown: "Unknown error",
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString("en-AU", {
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function PostPublishHistorySection({
+  postId,
+  companyId,
+  initialAttempts,
+  canRetry,
+}: Props) {
+  const [attempts, setAttempts] = useState(initialAttempts);
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+  const [flash, setFlash] = useState<{ kind: "info" | "error"; message: string } | null>(
+    null,
+  );
+
+  async function refetch() {
+    const res = await fetch(
+      `/api/platform/social/posts/${postId}/publish-attempts?company_id=${encodeURIComponent(companyId)}`,
+    );
+    if (!res.ok) return;
+    const json = (await res.json()) as
+      | { ok: true; data: { attempts: Attempt[] } }
+      | { ok: false };
+    if (json.ok) setAttempts(json.data.attempts);
+  }
+
+  async function handleRetry(attemptId: string) {
+    setRetryingId(attemptId);
+    setFlash(null);
+    try {
+      const res = await fetch(
+        `/api/platform/social/publish-attempts/${attemptId}/retry`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ company_id: companyId }),
+        },
+      );
+      const json = (await res.json()) as
+        | { ok: true; data: { outcome: string } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        const msg = !json.ok ? json.error.message : "Failed to retry.";
+        setFlash({ kind: "error", message: msg });
+        return;
+      }
+      const outcome = json.data.outcome;
+      if (outcome === "ok") {
+        setFlash({ kind: "info", message: "Retry queued — new attempt in flight." });
+        await refetch();
+      } else if (outcome === "publish_failed") {
+        setFlash({
+          kind: "error",
+          message: "Retry hit a fresh failure — see the new attempt below.",
+        });
+        await refetch();
+      } else if (outcome === "already_retrying") {
+        setFlash({
+          kind: "info",
+          message:
+            "This attempt is already being retried — refresh to see the new one.",
+        });
+      } else if (outcome === "connection_degraded") {
+        setFlash({
+          kind: "error",
+          message:
+            "Connection needs reconnecting — visit Connections.",
+        });
+      } else if (outcome === "no_connection") {
+        setFlash({
+          kind: "error",
+          message: "No healthy connection for that platform.",
+        });
+      } else {
+        setFlash({ kind: "error", message: `Retry refused: ${outcome}.` });
+      }
+    } finally {
+      setRetryingId(null);
+    }
+  }
+
+  if (attempts.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      className="mt-6 rounded-lg border bg-card p-4"
+      data-testid="publish-history-section"
+    >
+      <header className="mb-3">
+        <h2 className="text-base font-semibold">Publish history</h2>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Per-platform attempts. Failures stay visible so you can retry.
+        </p>
+      </header>
+
+      {flash ? (
+        <div
+          className={
+            flash.kind === "info"
+              ? "mb-3 rounded-md border bg-muted px-3 py-2 text-sm text-muted-foreground"
+              : "mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          }
+          role={flash.kind === "error" ? "alert" : "status"}
+          data-testid="publish-history-flash"
+        >
+          {flash.message}
+        </div>
+      ) : null}
+
+      <ol className="divide-y">
+        {attempts.map((a) => (
+          <li
+            key={a.id}
+            className="flex items-start justify-between gap-4 py-3"
+            data-testid={`publish-attempt-${a.id}`}
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-medium">
+                  {PLATFORM_LABEL[a.platform] ?? a.platform}
+                </span>
+                <span
+                  className={`rounded-full px-2 py-0.5 text-sm font-medium ${STATUS_PILL[a.status] ?? "bg-muted text-muted-foreground"}`}
+                >
+                  {STATUS_LABEL[a.status] ?? a.status}
+                </span>
+                {a.retry_count > 0 ? (
+                  <span className="text-sm text-muted-foreground">
+                    retry #{a.retry_count}
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-1 text-sm text-muted-foreground">
+                Started {formatDate(a.started_at)}
+                {a.completed_at ? ` · finished ${formatDate(a.completed_at)}` : ""}
+              </div>
+              {a.platform_post_url ? (
+                <a
+                  href={a.platform_post_url}
+                  className="mt-1 block break-all text-sm text-primary underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View on platform
+                </a>
+              ) : null}
+              {a.status === "failed" && a.error_class ? (
+                <div className="mt-1 text-sm text-rose-700">
+                  {ERROR_LABEL[a.error_class] ?? a.error_class}
+                </div>
+              ) : null}
+            </div>
+            {canRetry && a.status === "failed" ? (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => handleRetry(a.id)}
+                disabled={retryingId === a.id}
+                data-testid={`publish-retry-${a.id}`}
+              >
+                {retryingId === a.id ? "Retrying…" : "Retry"}
+              </Button>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/lib/__tests__/social-publishing-list-attempts.test.ts
+++ b/lib/__tests__/social-publishing-list-attempts.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { listPublishAttempts } from "@/lib/platform/social/publishing";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// S1-21 — listPublishAttempts against the live Supabase stack.
+//
+// Covers:
+//   - Empty result for a post with no variants.
+//   - Returns attempts ordered by started_at desc.
+//   - Joins variant.platform onto each attempt.
+//   - Cross-company isolation: attempts under another company's job
+//     are filtered out.
+// ---------------------------------------------------------------------------
+
+const COMPANY_A = "abcdef00-0000-0000-0000-aaaaaaaa2121";
+const COMPANY_B = "abcdef00-0000-0000-0000-bbbbbbbb2121";
+
+async function seedCompanies(): Promise<void> {
+  const svc = getServiceRoleClient();
+  for (const [id, slug] of [
+    [COMPANY_A, "s1-21-a"],
+    [COMPANY_B, "s1-21-b"],
+  ] as const) {
+    const r = await svc.from("platform_companies").insert({
+      id,
+      name: `S1-21 ${slug}`,
+      slug,
+      domain: `${slug}.test`,
+      is_opollo_internal: false,
+      timezone: "Australia/Melbourne",
+      approval_default_rule: "any_one",
+    });
+    if (r.error) throw new Error(`seed company ${slug}: ${r.error.message}`);
+  }
+}
+
+async function seedAttempt(opts: {
+  companyId: string;
+  startedAt: string;
+  status?: string;
+  platform?: string;
+  postMasterId?: string;
+}): Promise<{ attemptId: string; postId: string }> {
+  const svc = getServiceRoleClient();
+
+  const masterId = opts.postMasterId;
+  let masterRow: { id: string };
+  if (masterId) {
+    masterRow = { id: masterId };
+  } else {
+    const master = await svc
+      .from("social_post_master")
+      .insert({
+        company_id: opts.companyId,
+        state: "publishing",
+        source_type: "manual",
+        master_text: "test",
+      })
+      .select("id")
+      .single();
+    if (master.error) throw new Error(`seed master: ${master.error.message}`);
+    masterRow = { id: master.data.id as string };
+  }
+
+  const variant = await svc
+    .from("social_post_variant")
+    .insert({
+      post_master_id: masterRow.id,
+      platform: opts.platform ?? "linkedin_personal",
+    })
+    .select("id")
+    .single();
+  if (variant.error) throw new Error(`seed variant: ${variant.error.message}`);
+
+  const conn = await svc
+    .from("social_connections")
+    .insert({
+      company_id: opts.companyId,
+      platform: opts.platform ?? "linkedin_personal",
+      bundle_social_account_id: "ba_" + variant.data.id.slice(0, 8),
+      status: "healthy",
+    })
+    .select("id")
+    .single();
+  if (conn.error) throw new Error(`seed conn: ${conn.error.message}`);
+
+  const job = await svc
+    .from("social_publish_jobs")
+    .insert({
+      post_variant_id: variant.data.id,
+      company_id: opts.companyId,
+      fire_at: new Date().toISOString(),
+      fired_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+  if (job.error) throw new Error(`seed job: ${job.error.message}`);
+
+  const attempt = await svc
+    .from("social_publish_attempts")
+    .insert({
+      publish_job_id: job.data.id,
+      post_variant_id: variant.data.id,
+      connection_id: conn.data.id,
+      status: opts.status ?? "succeeded",
+      started_at: opts.startedAt,
+      completed_at: opts.startedAt,
+    })
+    .select("id")
+    .single();
+  if (attempt.error) {
+    throw new Error(`seed attempt: ${attempt.error.message}`);
+  }
+
+  return {
+    attemptId: attempt.data.id as string,
+    postId: masterRow.id,
+  };
+}
+
+beforeEach(async () => {
+  await seedCompanies();
+});
+
+describe("listPublishAttempts", () => {
+  it("returns empty for a post with no variants", async () => {
+    const svc = getServiceRoleClient();
+    const master = await svc
+      .from("social_post_master")
+      .insert({
+        company_id: COMPANY_A,
+        state: "publishing",
+        source_type: "manual",
+        master_text: "lonely",
+      })
+      .select("id")
+      .single();
+
+    const result = await listPublishAttempts({
+      postMasterId: master.data!.id as string,
+      companyId: COMPANY_A,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.attempts).toEqual([]);
+  });
+
+  it("returns attempts ordered by started_at desc with platform joined", async () => {
+    const earlier = "2026-04-01T10:00:00Z";
+    const later = "2026-04-02T10:00:00Z";
+
+    const first = await seedAttempt({
+      companyId: COMPANY_A,
+      startedAt: earlier,
+      status: "failed",
+      platform: "linkedin_personal",
+    });
+    // Second attempt under same post (retry) — but a new variant for
+    // a different platform to test the join.
+    const second = await seedAttempt({
+      companyId: COMPANY_A,
+      startedAt: later,
+      status: "succeeded",
+      platform: "x",
+      postMasterId: first.postId,
+    });
+
+    const result = await listPublishAttempts({
+      postMasterId: first.postId,
+      companyId: COMPANY_A,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.attempts.length).toBe(2);
+    expect(result.data.attempts[0]?.id).toBe(second.attemptId);
+    expect(result.data.attempts[0]?.platform).toBe("x");
+    expect(result.data.attempts[0]?.status).toBe("succeeded");
+    expect(result.data.attempts[1]?.id).toBe(first.attemptId);
+    expect(result.data.attempts[1]?.platform).toBe("linkedin_personal");
+    expect(result.data.attempts[1]?.status).toBe("failed");
+  });
+
+  it("filters attempts under another company's job", async () => {
+    const a = await seedAttempt({
+      companyId: COMPANY_A,
+      startedAt: "2026-04-01T10:00:00Z",
+    });
+    const b = await seedAttempt({
+      companyId: COMPANY_B,
+      startedAt: "2026-04-02T10:00:00Z",
+    });
+
+    const result = await listPublishAttempts({
+      postMasterId: a.postId,
+      companyId: COMPANY_A,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.attempts.length).toBe(1);
+    expect(result.data.attempts[0]?.id).toBe(a.attemptId);
+
+    // Same call from B's perspective on B's own post id.
+    const resultB = await listPublishAttempts({
+      postMasterId: b.postId,
+      companyId: COMPANY_B,
+    });
+    expect(resultB.ok).toBe(true);
+    if (!resultB.ok) return;
+    expect(resultB.data.attempts.length).toBe(1);
+    expect(resultB.data.attempts[0]?.id).toBe(b.attemptId);
+  });
+});

--- a/lib/platform/social/publishing/index.ts
+++ b/lib/platform/social/publishing/index.ts
@@ -15,6 +15,11 @@ export {
   type FirePublishResult,
 } from "./fire";
 export {
+  listPublishAttempts,
+  type ListAttemptsInput,
+  type PublishAttempt,
+} from "./list-attempts";
+export {
   retryPublishAttempt,
   type RetryPublishInput,
   type RetryPublishResult,

--- a/lib/platform/social/publishing/list-attempts.ts
+++ b/lib/platform/social/publishing/list-attempts.ts
@@ -1,0 +1,181 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// S1-21 — list publish attempts for a single post.
+//
+// Returns attempts joined back to their variant (for platform) and
+// ordered by started_at desc — newest first so retries land at the
+// top. Cross-company isolation: every attempt's
+// publish_jobs.company_id must equal the caller's companyId; we filter
+// in the inner queries (no embed because publish_attempts has multiple
+// FKs that PostgREST can't disambiguate).
+//
+// V1 returns the raw attempt fields the UI needs; the component
+// formats. No pagination — V1 caps at 50 attempts per post which
+// is generous (5 retries × 10 platforms).
+// ---------------------------------------------------------------------------
+
+import type { SocialPlatform } from "@/lib/platform/social/variants/types";
+
+export type PublishAttempt = {
+  id: string;
+  publish_job_id: string;
+  post_variant_id: string;
+  platform: SocialPlatform;
+  status: string;
+  bundle_post_id: string | null;
+  platform_post_url: string | null;
+  error_class: string | null;
+  error_payload: Record<string, unknown> | null;
+  retry_count: number;
+  original_attempt_id: string | null;
+  started_at: string;
+  completed_at: string | null;
+};
+
+export type ListAttemptsInput = {
+  postMasterId: string;
+  companyId: string;
+};
+
+export async function listPublishAttempts(
+  input: ListAttemptsInput,
+): Promise<ApiResponse<{ attempts: PublishAttempt[] }>> {
+  if (!input.postMasterId) return validation("postMasterId is required.");
+  if (!input.companyId) return validation("companyId is required.");
+
+  const svc = getServiceRoleClient();
+
+  // Step 1: variants for the post (also gives us platform per variant).
+  const variants = await svc
+    .from("social_post_variant")
+    .select("id, platform")
+    .eq("post_master_id", input.postMasterId);
+  if (variants.error) {
+    logger.error("social.publish.list_attempts.variants_failed", {
+      err: variants.error.message,
+    });
+    return internal(`Failed to read variants: ${variants.error.message}`);
+  }
+  if (!variants.data || variants.data.length === 0) {
+    return {
+      ok: true,
+      data: { attempts: [] },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  const variantIdToPlatform = new Map<string, string>();
+  for (const v of variants.data) {
+    variantIdToPlatform.set(v.id as string, v.platform as string);
+  }
+  const variantIds = Array.from(variantIdToPlatform.keys());
+
+  // Step 2: attempts under those variants. We'd embed publish_jobs to
+  // confirm company_id, but supabase-js multi-FK pitfall (memory note);
+  // do the company check separately.
+  const attempts = await svc
+    .from("social_publish_attempts")
+    .select(
+      "id, publish_job_id, post_variant_id, status, bundle_post_id, platform_post_url, error_class, error_payload, retry_count, original_attempt_id, started_at, completed_at",
+    )
+    .in("post_variant_id", variantIds)
+    .order("started_at", { ascending: false })
+    .limit(50);
+  if (attempts.error) {
+    logger.error("social.publish.list_attempts.attempts_failed", {
+      err: attempts.error.message,
+    });
+    return internal(`Failed to read attempts: ${attempts.error.message}`);
+  }
+
+  if (!attempts.data || attempts.data.length === 0) {
+    return {
+      ok: true,
+      data: { attempts: [] },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  // Step 3: confirm every attempt's job belongs to this company. One
+  // batch read keyed off the unique job ids.
+  const jobIds = Array.from(
+    new Set(attempts.data.map((a) => a.publish_job_id as string)),
+  );
+  const jobs = await svc
+    .from("social_publish_jobs")
+    .select("id, company_id")
+    .in("id", jobIds);
+  if (jobs.error) {
+    logger.error("social.publish.list_attempts.jobs_failed", {
+      err: jobs.error.message,
+    });
+    return internal(`Failed to read jobs: ${jobs.error.message}`);
+  }
+  const jobToCompany = new Map<string, string>();
+  for (const j of jobs.data ?? []) {
+    jobToCompany.set(j.id as string, j.company_id as string);
+  }
+
+  const result: PublishAttempt[] = [];
+  for (const a of attempts.data) {
+    if (jobToCompany.get(a.publish_job_id as string) !== input.companyId) {
+      continue;
+    }
+    const platformText =
+      variantIdToPlatform.get(a.post_variant_id as string) ?? null;
+    if (!platformText) continue;
+    result.push({
+      id: a.id as string,
+      publish_job_id: a.publish_job_id as string,
+      post_variant_id: a.post_variant_id as string,
+      platform: platformText as SocialPlatform,
+      status: a.status as string,
+      bundle_post_id: (a.bundle_post_id as string | null) ?? null,
+      platform_post_url: (a.platform_post_url as string | null) ?? null,
+      error_class: (a.error_class as string | null) ?? null,
+      error_payload:
+        (a.error_payload as Record<string, unknown> | null) ?? null,
+      retry_count: (a.retry_count as number | null) ?? 0,
+      original_attempt_id: (a.original_attempt_id as string | null) ?? null,
+      started_at: a.started_at as string,
+      completed_at: (a.completed_at as string | null) ?? null,
+    });
+  }
+
+  return {
+    ok: true,
+    data: { attempts: result },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation<T>(message: string): ApiResponse<T> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal<T>(message: string): ApiResponse<T> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary

Surfaces `social_publish_attempts` on the post detail page when state IN (`publishing`,`published`,`failed`). Operators with `schedule_post` can click Retry on failed attempts (wired to S1-20's retry route).

## What's new

- **Lib** `lib/platform/social/publishing/list-attempts.ts` — returns up to 50 attempts under a post's variants, ordered by `started_at` desc. Joins `variant.platform` onto each attempt without a multi-FK embed (separate variant + job lookups; PostgREST embeds fail on multi-FK tables like `social_publish_attempts`). Cross-company isolation: confirms each attempt's `job.company_id` matches the caller's, drops mismatches.
- **Route** `GET /api/platform/social/posts/[id]/publish-attempts` — `canDo("view_calendar")` gate.
- **Component** `PostPublishHistorySection` — per-attempt row with platform, status pill, started/completed, error-class label on failures, "View on platform" link when bundle.social returned one. Retry button POSTs to S1-20's route; flash banner reflects the outcome (`already_retrying`, `publish_failed`, `connection_degraded`, etc); on actionable outcomes the section re-fetches.
- **Wired** into `app/company/social/posts/[id]/page.tsx` — visible only when `post.state IN ('publishing','published','failed')`.

## Risks identified and mitigated

- **Stale list after retry** — re-fetch happens on `outcome=ok|publish_failed` so the UI reflects the new attempt.
- **Retry button visible when post moved out of failed** (race) — server enforces master `state='failed'` check; UI surfaces the refusal as a flash banner.
- **View-on-platform URL trust** — comes from bundle.social's `postCreate` response; rendered with `rel='noopener noreferrer'`.
- **Cross-company access via direct API** — gate + lib both filter on `companyId`; no enumeration.

## Tests

`lib/__tests__/social-publishing-list-attempts.test.ts`:
- Empty result for a post with no variants.
- Order preserved across multiple variants/platforms (newest started_at first).
- Cross-company filtering: attempts under another company's job don't leak.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint <S1-21 files>` — clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` — green
- [ ] CI green
- [ ] Smoke from staging: schedule a post → wait for publish → verify history section appears with succeeded attempt; trigger a failure → verify Retry button appears + works.

## Coordination note

Built in `../opollo-s1-21` (worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)