### PR TITLE
S1-22: media uploads in bundle.social postCreate

### DIFF
--- a/lib/__tests__/social-media-upload-to-bundle.test.ts
+++ b/lib/__tests__/social-media-upload-to-bundle.test.ts
@@ -1,0 +1,240 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// ---------------------------------------------------------------------------
+// S1-22 — resolveBundleUploadId against the live Supabase stack with
+// a mocked bundle.social SDK.
+//
+// Covers:
+//   - Cache hit: bundle_upload_id already populated → return immediately
+//     without calling the SDK.
+//   - First resolution: source_url present → uploadCreateFromUrl,
+//     stores bundle_upload_id back.
+//   - Asset under another company → NOT_FOUND.
+//   - Asset with neither source_url nor bundle_upload_id → VALIDATION_FAILED.
+//   - SDK throw → INTERNAL_ERROR; cache NOT populated.
+//   - resolveBundleUploadIds: batch resolves and counts cached.
+// ---------------------------------------------------------------------------
+
+const mockClient = {
+  upload: {
+    uploadCreateFromUrl: vi.fn(),
+  },
+};
+
+vi.mock("@/lib/bundlesocial", () => ({
+  getBundlesocialClient: () => mockClient,
+  getBundlesocialTeamId: () => "team-test-1",
+}));
+
+import {
+  resolveBundleUploadId,
+  resolveBundleUploadIds,
+} from "@/lib/platform/social/media";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+const COMPANY_A = "abcdef00-0000-0000-0000-aaaaaaaa2222";
+const COMPANY_B = "abcdef00-0000-0000-0000-bbbbbbbb2222";
+
+async function seedCompanies(): Promise<void> {
+  const svc = getServiceRoleClient();
+  for (const [id, slug] of [
+    [COMPANY_A, "s1-22-a"],
+    [COMPANY_B, "s1-22-b"],
+  ] as const) {
+    const r = await svc.from("platform_companies").insert({
+      id,
+      name: `S1-22 ${slug}`,
+      slug,
+      domain: `${slug}.test`,
+      is_opollo_internal: false,
+      timezone: "Australia/Melbourne",
+      approval_default_rule: "any_one",
+    });
+    if (r.error) throw new Error(`seed company ${slug}: ${r.error.message}`);
+  }
+}
+
+async function seedAsset(opts: {
+  companyId: string;
+  sourceUrl?: string | null;
+  bundleUploadId?: string | null;
+}): Promise<string> {
+  const svc = getServiceRoleClient();
+  const r = await svc
+    .from("social_media_assets")
+    .insert({
+      company_id: opts.companyId,
+      storage_path: `s1-22/${Math.random().toString(36).slice(2, 10)}.jpg`,
+      mime_type: "image/jpeg",
+      bytes: 1024,
+      source_url: opts.sourceUrl ?? null,
+      bundle_upload_id: opts.bundleUploadId ?? null,
+    })
+    .select("id")
+    .single();
+  if (r.error) throw new Error(`seed asset: ${r.error.message}`);
+  return r.data.id as string;
+}
+
+beforeEach(async () => {
+  mockClient.upload.uploadCreateFromUrl.mockReset();
+  await seedCompanies();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveBundleUploadId", () => {
+  it("returns cached bundle_upload_id without SDK call", async () => {
+    const assetId = await seedAsset({
+      companyId: COMPANY_A,
+      sourceUrl: "https://cdn.test/a.jpg",
+      bundleUploadId: "bup_cached_1",
+    });
+    const result = await resolveBundleUploadId({
+      assetId,
+      companyId: COMPANY_A,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.bundleUploadId).toBe("bup_cached_1");
+    expect(result.data.cached).toBe(true);
+    expect(mockClient.upload.uploadCreateFromUrl).not.toHaveBeenCalled();
+  });
+
+  it("uploads from source_url + caches the id", async () => {
+    const assetId = await seedAsset({
+      companyId: COMPANY_A,
+      sourceUrl: "https://cdn.test/b.jpg",
+    });
+    mockClient.upload.uploadCreateFromUrl.mockResolvedValueOnce({
+      id: "bup_fresh_1",
+    });
+
+    const result = await resolveBundleUploadId({
+      assetId,
+      companyId: COMPANY_A,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.bundleUploadId).toBe("bup_fresh_1");
+    expect(result.data.cached).toBe(false);
+
+    const callArg =
+      mockClient.upload.uploadCreateFromUrl.mock.calls[0]?.[0];
+    expect(callArg?.requestBody?.url).toBe("https://cdn.test/b.jpg");
+    expect(callArg?.requestBody?.teamId).toBe("team-test-1");
+
+    // Second call returns from cache, no SDK call.
+    mockClient.upload.uploadCreateFromUrl.mockReset();
+    const second = await resolveBundleUploadId({
+      assetId,
+      companyId: COMPANY_A,
+    });
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.data.cached).toBe(true);
+    expect(mockClient.upload.uploadCreateFromUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns NOT_FOUND for asset under another company", async () => {
+    const assetId = await seedAsset({
+      companyId: COMPANY_B,
+      sourceUrl: "https://cdn.test/c.jpg",
+    });
+    const result = await resolveBundleUploadId({
+      assetId,
+      companyId: COMPANY_A,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("NOT_FOUND");
+    expect(mockClient.upload.uploadCreateFromUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns VALIDATION_FAILED when neither source_url nor cache present", async () => {
+    const assetId = await seedAsset({ companyId: COMPANY_A });
+    const result = await resolveBundleUploadId({
+      assetId,
+      companyId: COMPANY_A,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns INTERNAL_ERROR on SDK throw; cache NOT populated", async () => {
+    const assetId = await seedAsset({
+      companyId: COMPANY_A,
+      sourceUrl: "https://cdn.test/d.jpg",
+    });
+    mockClient.upload.uploadCreateFromUrl.mockRejectedValueOnce(
+      new Error("HTTP 500"),
+    );
+
+    const result = await resolveBundleUploadId({
+      assetId,
+      companyId: COMPANY_A,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("INTERNAL_ERROR");
+
+    const svc = getServiceRoleClient();
+    const row = await svc
+      .from("social_media_assets")
+      .select("bundle_upload_id")
+      .eq("id", assetId)
+      .single();
+    expect(row.data?.bundle_upload_id).toBeNull();
+  });
+});
+
+describe("resolveBundleUploadIds (batch)", () => {
+  it("resolves multiple assets and counts cached vs fresh", async () => {
+    const cachedId = await seedAsset({
+      companyId: COMPANY_A,
+      sourceUrl: "https://cdn.test/cached.jpg",
+      bundleUploadId: "bup_cached",
+    });
+    const freshId = await seedAsset({
+      companyId: COMPANY_A,
+      sourceUrl: "https://cdn.test/fresh.jpg",
+    });
+    mockClient.upload.uploadCreateFromUrl.mockResolvedValueOnce({
+      id: "bup_fresh",
+    });
+
+    const result = await resolveBundleUploadIds(
+      [cachedId, freshId],
+      COMPANY_A,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.uploadIds).toEqual(["bup_cached", "bup_fresh"]);
+    expect(result.data.cachedCount).toBe(1);
+    expect(mockClient.upload.uploadCreateFromUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts on first failure", async () => {
+    const okId = await seedAsset({
+      companyId: COMPANY_A,
+      sourceUrl: "https://cdn.test/ok.jpg",
+      bundleUploadId: "bup_ok",
+    });
+    const badId = await seedAsset({ companyId: COMPANY_A });
+
+    const result = await resolveBundleUploadIds([okId, badId], COMPANY_A);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION_FAILED");
+  });
+});

--- a/lib/platform/social/media/index.ts
+++ b/lib/platform/social/media/index.ts
@@ -1,0 +1,6 @@
+export {
+  resolveBundleUploadId,
+  resolveBundleUploadIds,
+  type ResolveBundleUploadInput,
+  type ResolveBundleUploadResult,
+} from "./upload-to-bundle";

--- a/lib/platform/social/media/upload-to-bundle.ts
+++ b/lib/platform/social/media/upload-to-bundle.ts
@@ -1,0 +1,215 @@
+import "server-only";
+
+import {
+  getBundlesocialClient,
+  getBundlesocialTeamId,
+} from "@/lib/bundlesocial";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// S1-22 — resolve a social_media_assets row to a bundle.social uploadId.
+//
+// First read the cached bundle_upload_id; if present, return it (no
+// network). Otherwise:
+//   1. If source_url is set, call uploadCreateFromUrl — bundle.social
+//      pulls the bytes themselves. Cheapest path.
+//   2. (Future) If only storage_path is set, download from Supabase
+//      Storage → upload as Blob via uploadCreate. Skipped in V1; row
+//      with neither column populated returns NO_SOURCE.
+//
+// On success, write bundle_upload_id + bundle_uploaded_at back so
+// the next caller hits the cache. Concurrent resolvers race at the
+// UPDATE — last writer wins, both end up with valid ids (bundle.
+// social's upload ids are immutable per upload, so ALL ids returned
+// for the same asset are valid; we just keep the latest).
+//
+// Cross-company: caller passes companyId; we filter the asset lookup
+// by it so a stolen asset id from another company errors with
+// NOT_FOUND envelope.
+// ---------------------------------------------------------------------------
+
+export type ResolveBundleUploadInput = {
+  assetId: string;
+  companyId: string;
+};
+
+export type ResolveBundleUploadResult = {
+  bundleUploadId: string;
+  cached: boolean;
+};
+
+export async function resolveBundleUploadId(
+  input: ResolveBundleUploadInput,
+): Promise<ApiResponse<ResolveBundleUploadResult>> {
+  if (!input.assetId) return validation("assetId required.");
+  if (!input.companyId) return validation("companyId required.");
+
+  const svc = getServiceRoleClient();
+
+  const asset = await svc
+    .from("social_media_assets")
+    .select(
+      "id, company_id, source_url, storage_path, bundle_upload_id, mime_type",
+    )
+    .eq("id", input.assetId)
+    .eq("company_id", input.companyId)
+    .maybeSingle();
+  if (asset.error) {
+    logger.error("social.media.resolve.read_failed", {
+      err: asset.error.message,
+      asset_id: input.assetId,
+    });
+    return internal(`Asset read failed: ${asset.error.message}`);
+  }
+  if (!asset.data) return notFound();
+
+  // Cache hit — return immediately, no network.
+  if (asset.data.bundle_upload_id) {
+    return {
+      ok: true,
+      data: {
+        bundleUploadId: asset.data.bundle_upload_id as string,
+        cached: true,
+      },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  const client = getBundlesocialClient();
+  const teamId = getBundlesocialTeamId();
+  if (!client || !teamId) {
+    return notConfigured(client ? "BUNDLE_SOCIAL_TEAMID" : "BUNDLE_SOCIAL_API");
+  }
+
+  const sourceUrl = asset.data.source_url as string | null;
+  if (!sourceUrl) {
+    // V1 only supports source_url. storage_path-only assets need a
+    // future slice that signs a Supabase Storage URL or downloads +
+    // re-uploads as a Blob.
+    return validation(
+      "Asset has no source_url; storage_path-only assets are not yet supported.",
+    );
+  }
+
+  let uploadId: string;
+  try {
+    const response = (await client.upload.uploadCreateFromUrl({
+      requestBody: { teamId, url: sourceUrl },
+    })) as { id?: string };
+    if (!response.id) {
+      return internal("bundle.social uploadCreateFromUrl returned no id.");
+    }
+    uploadId = response.id;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("social.media.resolve.bundle_upload_failed", {
+      err: message,
+      asset_id: input.assetId,
+    });
+    return internal(`bundle.social uploadCreateFromUrl failed: ${message}`);
+  }
+
+  const update = await svc
+    .from("social_media_assets")
+    .update({
+      bundle_upload_id: uploadId,
+      bundle_uploaded_at: new Date().toISOString(),
+    })
+    .eq("id", input.assetId);
+  if (update.error) {
+    // Don't fail the call — the upload landed; we just couldn't cache
+    // the id. The next call will re-upload. Log so we notice.
+    logger.warn("social.media.resolve.cache_write_failed", {
+      err: update.error.message,
+      asset_id: input.assetId,
+    });
+  }
+
+  return {
+    ok: true,
+    data: { bundleUploadId: uploadId, cached: false },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// Resolve many in sequence. We don't parallelise because bundle.social's
+// uploadCreateFromUrl rate limits aren't pinned; better to be polite.
+// The cache shortcut keeps repeat calls cheap.
+export async function resolveBundleUploadIds(
+  assetIds: string[],
+  companyId: string,
+): Promise<ApiResponse<{ uploadIds: string[]; cachedCount: number }>> {
+  const uploadIds: string[] = [];
+  let cachedCount = 0;
+  for (const assetId of assetIds) {
+    const result = await resolveBundleUploadId({ assetId, companyId });
+    if (!result.ok) {
+      return {
+        ok: false,
+        error: result.error,
+        timestamp: new Date().toISOString(),
+      };
+    }
+    uploadIds.push(result.data.bundleUploadId);
+    if (result.data.cached) cachedCount += 1;
+  }
+  return {
+    ok: true,
+    data: { uploadIds, cachedCount },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation<T>(message: string): ApiResponse<T> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function notFound<T>(): ApiResponse<T> {
+  return {
+    ok: false,
+    error: {
+      code: "NOT_FOUND",
+      message: "Asset not found in this company.",
+      retryable: false,
+      suggested_action: "Check the asset id.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function notConfigured<T>(envVar: string): ApiResponse<T> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message: `${envVar} not configured.`,
+      retryable: false,
+      suggested_action: "Provision the env var.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal<T>(message: string): ApiResponse<T> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: true,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/publishing/fire.ts
+++ b/lib/platform/social/publishing/fire.ts
@@ -5,6 +5,7 @@ import {
   getBundlesocialTeamId,
 } from "@/lib/bundlesocial";
 import { logger } from "@/lib/logger";
+import { resolveBundleUploadIds } from "@/lib/platform/social/media";
 import { getServiceRoleClient } from "@/lib/supabase";
 import type { ApiResponse } from "@/lib/tool-schemas";
 
@@ -152,26 +153,78 @@ export async function fireScheduledPublish(
   }
 
   const text = (claim.variant_text ?? claim.master_text ?? "").trim();
-  if (!text) {
+  // S1-22: pull media_asset_ids off the variant. Empty/null arrays
+  // mean text-only post, which is fine for every platform we support
+  // except platforms that require media (TikTok, Pinterest, etc) —
+  // not in our V1 set.
+  const variantMedia = await svc
+    .from("social_post_variant")
+    .select("media_asset_ids")
+    .eq("id", claim.post_variant_id!)
+    .maybeSingle();
+  if (variantMedia.error) {
     await markAttemptFailed(svc, claim.publish_attempt_id!, {
-      error_class: "content_rejected",
-      error_payload: { reason: "Empty post body" },
+      error_class: "platform_error",
+      error_payload: { reason: `media read failed: ${variantMedia.error.message}` },
     });
     await markMasterFailed(svc, claim.post_master_id!);
-    return internal("Post has no body text.");
+    return internal(`Variant media read failed: ${variantMedia.error.message}`);
+  }
+  const assetIds = ((variantMedia.data?.media_asset_ids as string[] | null) ?? []).filter(
+    (s): s is string => typeof s === "string" && s.length > 0,
+  );
+
+  // Either text or media must be present. A truly empty post is
+  // content_rejected.
+  if (!text && assetIds.length === 0) {
+    await markAttemptFailed(svc, claim.publish_attempt_id!, {
+      error_class: "content_rejected",
+      error_payload: { reason: "Empty post body and no media" },
+    });
+    await markMasterFailed(svc, claim.post_master_id!);
+    return internal("Post has no body text and no media.");
   }
 
-  // Compose the data block per bundle.social platform shape. V1: text
-  // only; media uploads are S1-19+.
+  // Resolve media_asset_ids → bundle.social uploadIds. Cached after
+  // first resolution per asset; retries are cheap.
+  let uploadIds: string[] = [];
+  if (assetIds.length > 0) {
+    const resolved = await resolveBundleUploadIds(assetIds, claim.company_id!);
+    if (!resolved.ok) {
+      await markAttemptFailed(svc, claim.publish_attempt_id!, {
+        error_class: "media_invalid",
+        error_payload: {
+          reason: resolved.error.message,
+          asset_ids: assetIds,
+        },
+      });
+      await markMasterFailed(svc, claim.post_master_id!);
+      return ok({ outcome: "publish_failed" });
+    }
+    uploadIds = resolved.data.uploadIds;
+  }
+
+  // Compose the data block per bundle.social platform shape.
+  // text is optional when media is present (some platforms allow
+  // image-only posts). uploadIds attached when populated.
   const data: Record<string, unknown> = {};
+  const platformBlock: Record<string, unknown> = {
+    text: text || undefined,
+  };
+  if (uploadIds.length > 0) {
+    platformBlock.uploadIds = uploadIds;
+  }
   if (bundlePlatform === "LINKEDIN") {
-    data.LINKEDIN = { text, link: claim.link_url ?? undefined };
+    data.LINKEDIN = { ...platformBlock, link: claim.link_url ?? undefined };
   } else if (bundlePlatform === "FACEBOOK") {
-    data.FACEBOOK = { text, link: claim.link_url ?? undefined };
+    data.FACEBOOK = { ...platformBlock, link: claim.link_url ?? undefined };
   } else if (bundlePlatform === "TWITTER") {
-    data.TWITTER = { text };
+    data.TWITTER = platformBlock;
   } else if (bundlePlatform === "GOOGLE_BUSINESS") {
-    data.GOOGLE_BUSINESS = { text, link: claim.link_url ?? undefined };
+    data.GOOGLE_BUSINESS = {
+      ...platformBlock,
+      link: claim.link_url ?? undefined,
+    };
   }
 
   let bundlePostId: string | null = null;

--- a/lib/platform/social/publishing/retry.ts
+++ b/lib/platform/social/publishing/retry.ts
@@ -5,6 +5,7 @@ import {
   getBundlesocialTeamId,
 } from "@/lib/bundlesocial";
 import { logger } from "@/lib/logger";
+import { resolveBundleUploadIds } from "@/lib/platform/social/media";
 import { getServiceRoleClient } from "@/lib/supabase";
 import type { ApiResponse } from "@/lib/tool-schemas";
 
@@ -129,24 +130,63 @@ export async function retryPublishAttempt(
   }
 
   const text = (row.variant_text ?? row.master_text ?? "").trim();
-  if (!text) {
+
+  // S1-22: pull media from the variant. Same shape as fire.ts.
+  const variantMedia = await svc
+    .from("social_post_variant")
+    .select("media_asset_ids")
+    .eq("id", row.post_variant_id!)
+    .maybeSingle();
+  if (variantMedia.error) {
     await markAttemptFailed(svc, row.publish_attempt_id!, {
-      error_class: "content_rejected",
-      error_payload: { reason: "Empty post body" },
+      error_class: "platform_error",
+      error_payload: { reason: `media read failed: ${variantMedia.error.message}` },
     });
     await markMasterFailed(svc, row.post_master_id!);
-    return internal("Post has no body text.");
+    return internal(`Variant media read failed: ${variantMedia.error.message}`);
+  }
+  const assetIds = ((variantMedia.data?.media_asset_ids as string[] | null) ?? []).filter(
+    (s): s is string => typeof s === "string" && s.length > 0,
+  );
+
+  if (!text && assetIds.length === 0) {
+    await markAttemptFailed(svc, row.publish_attempt_id!, {
+      error_class: "content_rejected",
+      error_payload: { reason: "Empty post body and no media" },
+    });
+    await markMasterFailed(svc, row.post_master_id!);
+    return internal("Post has no body text and no media.");
+  }
+
+  let uploadIds: string[] = [];
+  if (assetIds.length > 0) {
+    const resolved = await resolveBundleUploadIds(assetIds, row.company_id!);
+    if (!resolved.ok) {
+      await markAttemptFailed(svc, row.publish_attempt_id!, {
+        error_class: "media_invalid",
+        error_payload: { reason: resolved.error.message, asset_ids: assetIds },
+      });
+      await markMasterFailed(svc, row.post_master_id!);
+      return ok({ outcome: "publish_failed" });
+    }
+    uploadIds = resolved.data.uploadIds;
   }
 
   const data: Record<string, unknown> = {};
+  const platformBlock: Record<string, unknown> = {
+    text: text || undefined,
+  };
+  if (uploadIds.length > 0) {
+    platformBlock.uploadIds = uploadIds;
+  }
   if (bundlePlatform === "LINKEDIN") {
-    data.LINKEDIN = { text, link: row.link_url ?? undefined };
+    data.LINKEDIN = { ...platformBlock, link: row.link_url ?? undefined };
   } else if (bundlePlatform === "FACEBOOK") {
-    data.FACEBOOK = { text, link: row.link_url ?? undefined };
+    data.FACEBOOK = { ...platformBlock, link: row.link_url ?? undefined };
   } else if (bundlePlatform === "TWITTER") {
-    data.TWITTER = { text };
+    data.TWITTER = platformBlock;
   } else if (bundlePlatform === "GOOGLE_BUSINESS") {
-    data.GOOGLE_BUSINESS = { text, link: row.link_url ?? undefined };
+    data.GOOGLE_BUSINESS = { ...platformBlock, link: row.link_url ?? undefined };
   }
 
   let bundlePostId: string | null = null;

--- a/supabase/migrations/0077_social_media_assets_bundle_cache.sql
+++ b/supabase/migrations/0077_social_media_assets_bundle_cache.sql
@@ -1,0 +1,32 @@
+-- =============================================================================
+-- 0077 — social_media_assets bundle.social cache columns.
+--
+-- S1-22 — adds the columns needed to attach media to publish_attempts:
+--   source_url           — public HTTPS URL of the asset (for V1's
+--                          uploadCreateFromUrl path; future slices can
+--                          also support Supabase Storage download +
+--                          uploadCreate Blob).
+--   bundle_upload_id     — bundle.social's upload id for this asset.
+--                          Cached after first upload so retries (and
+--                          repeated uses across posts) don't re-upload.
+--   bundle_uploaded_at   — when the cache was populated. Used to expire
+--                          stale ids if bundle.social ever rotates them
+--                          (their docs don't pin a TTL — V1 treats the
+--                          cache as permanent).
+--
+-- Partial index on (company_id, bundle_upload_id) so the resolveByCache
+-- lookup is fast.
+-- =============================================================================
+
+BEGIN;
+
+ALTER TABLE social_media_assets
+  ADD COLUMN IF NOT EXISTS source_url TEXT,
+  ADD COLUMN IF NOT EXISTS bundle_upload_id TEXT,
+  ADD COLUMN IF NOT EXISTS bundle_uploaded_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_media_assets_bundle_upload
+  ON social_media_assets(company_id, bundle_upload_id)
+  WHERE bundle_upload_id IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Wires `social_media_assets` through to bundle.social `uploadIds` so publishes can attach images/videos. Cache-aware: assets resolved once, reused across retries.

## What's new

- **Migration 0077** — adds `source_url`, `bundle_upload_id`, `bundle_uploaded_at` to `social_media_assets`, plus a partial index `(company_id, bundle_upload_id) WHERE bundle_upload_id IS NOT NULL` for cache lookups.

- **Lib** `lib/platform/social/media/upload-to-bundle.ts`:
  - `resolveBundleUploadId({assetId, companyId})` — cache hit returns immediately; otherwise calls `uploadCreateFromUrl` with `source_url` and stores the result back. Cross-company isolation via `companyId` filter.
  - `resolveBundleUploadIds(assetIds, companyId)` — sequential batch resolver with cached count.

- **Wired into** `fire.ts` and `retry.ts`:
  - Read `variant.media_asset_ids` after a successful claim.
  - Resolve to `uploadIds` before composing `postCreate.data`.
  - Attach `uploadIds` per platform shape (LINKEDIN/FACEBOOK/TWITTER/GOOGLE_BUSINESS).
  - `text` now optional when media is present (image-only posts ok); truly empty (no text + no media) marks attempt `content_rejected`.
  - Resolution failure marks attempt `media_invalid` + flips master to `failed`; no bundle.social `postCreate` is attempted.

## Risks identified and mitigated

- **DOUBLE-UPLOAD** (re-spending bandwidth/quota on retries) — `bundle_upload_id` cached after first upload; cache hit short-circuits without SDK call. Concurrent resolvers race at the UPDATE (last-writer-wins); both end up with valid ids.
- **Asset stolen across companies** — `companyId` filter on the asset read returns `NOT_FOUND` for cross-company access; UI can never attach an asset it doesn't own.
- **bundle.social rate limits on uploadCreateFromUrl** — sequential resolution (not parallel) keeps the request fanout polite. Cache reuse means repeats don't re-upload.
- **Empty post slipping through** — text+media presence both checked before postCreate; empty short-circuits with `content_rejected`.
- **`source_url` null + `storage_path`-only assets** — V1 returns `VALIDATION_FAILED` with a clear message; future slice can sign Supabase Storage URL or download/re-upload.
- **Existing variants with NULL `media_asset_ids`** — read returns null, filter coerces to empty array, no behaviour change for text-only posts.

## Tests

`lib/__tests__/social-media-upload-to-bundle.test.ts` (SDK mocked, live Supabase): cache hit (no SDK), fresh resolve (SDK + cache write), cross-company `NOT_FOUND`, missing `source_url`, SDK throw (cache NOT populated), batch resolution counting cached vs fresh, batch abort on first failure.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint <S1-22 files>` — clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` — green
- [ ] CI green
- [ ] Smoke from staging once a media-asset row with `source_url` is seeded: schedule a post variant with `media_asset_ids=[uuid]` → fire → verify bundle.social receives `uploadIds` in the post body.

## Coordination note

Built in `../opollo-s1-22` (worktree). Migration **0077** reserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)