### PR TITLE
S1-23: media library — create + list routes + customer page

### DIFF
--- a/app/api/platform/social/media/route.ts
+++ b/app/api/platform/social/media/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import {
+  createMediaAsset,
+  listMediaAssets,
+} from "@/lib/platform/social/media";
+
+// ---------------------------------------------------------------------------
+// S1-23 — media library endpoints.
+//
+// GET  /api/platform/social/media?company_id=<uuid>
+//      canDo("view_calendar") (viewer+).
+//
+// POST /api/platform/social/media
+//      Body { company_id, source_url, mime_type?, bytes? }
+//      canDo("edit_post") (editor+). Creates a social_media_assets
+//      row pointing at a public URL. Future slice can add multipart
+//      upload landing in Supabase Storage.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+const PostBodySchema = z.object({
+  company_id: z.string().uuid(),
+  source_url: z.string().url().startsWith("https://"),
+  mime_type: z.string().optional(),
+  bytes: z.number().int().positive().optional(),
+});
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const url = new URL(req.url);
+  const companyId = url.searchParams.get("company_id");
+  if (!companyId || !UUID_RE.test(companyId)) {
+    return errorJson("VALIDATION_FAILED", "company_id required.", 400);
+  }
+  const gate = await requireCanDoForApi(companyId, "view_calendar");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await listMediaAssets({ companyId });
+  if (!result.ok) {
+    return errorJson(result.error.code, result.error.message, 500);
+  }
+  return NextResponse.json(
+    {
+      ok: true,
+      data: result.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const parsed = PostBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "Body must be { company_id: uuid, source_url: https url, mime_type?, bytes? }.",
+      400,
+    );
+  }
+
+  const gate = await requireCanDoForApi(parsed.data.company_id, "edit_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await createMediaAsset({
+    companyId: parsed.data.company_id,
+    sourceUrl: parsed.data.source_url,
+    mimeType: parsed.data.mime_type,
+    bytes: parsed.data.bytes,
+    uploadedBy: gate.userId,
+  });
+  if (!result.ok) {
+    return errorJson(
+      result.error.code,
+      result.error.message,
+      result.error.code === "VALIDATION_FAILED" ? 400 : 500,
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { asset: result.data },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 201 },
+  );
+}

--- a/app/company/social/media/page.tsx
+++ b/app/company/social/media/page.tsx
@@ -1,0 +1,71 @@
+import { redirect } from "next/navigation";
+
+import { MediaLibraryClient } from "@/components/MediaLibraryClient";
+import { H1, Lead } from "@/components/ui/typography";
+import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
+import { listMediaAssets } from "@/lib/platform/social/media";
+
+// ---------------------------------------------------------------------------
+// S1-23 — customer media library at /company/social/media.
+//
+// Server-rendered. Same gating pattern as the rest of /company:
+//   1. No session → /login.
+//   2. No company membership → "Not provisioned" envelope.
+//
+// Read gate: viewer+ (canDo("view_calendar")). Add gate: editor+
+// (canDo("edit_post")).
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+export default async function CompanySocialMediaPage() {
+  const session = await getCurrentPlatformSession();
+  if (!session) {
+    redirect(`/login?next=${encodeURIComponent("/company/social/media")}`);
+  }
+  if (!session.company) {
+    return (
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm">
+        <p className="font-medium">Account not provisioned to a company.</p>
+        <p className="mt-1 text-muted-foreground">
+          Your account isn&apos;t a member of any company on the platform
+          yet. Ask an admin to invite you, or contact Opollo support.
+        </p>
+      </div>
+    );
+  }
+
+  const companyId = session.company.companyId;
+  const [listResult, canEdit] = await Promise.all([
+    listMediaAssets({ companyId }),
+    canDo(companyId, "edit_post"),
+  ]);
+
+  return (
+    <main className="mx-auto max-w-6xl p-6">
+      <header>
+        <H1>Media library</H1>
+        <Lead className="mt-0.5">
+          Reusable images and video for your social posts. Add an asset
+          here, then attach by id when scheduling.
+        </Lead>
+      </header>
+      <div className="mt-6">
+        {listResult.ok ? (
+          <MediaLibraryClient
+            companyId={companyId}
+            initialAssets={listResult.data.assets}
+            canEdit={canEdit}
+          />
+        ) : (
+          <div
+            className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+            role="alert"
+          >
+            Failed to load media: {listResult.error.message}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/components/MediaLibraryClient.tsx
+++ b/components/MediaLibraryClient.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+// ---------------------------------------------------------------------------
+// S1-23 — media library client component.
+//
+// V1 surface: the operator pastes an https URL + optional mime/bytes
+// → POSTs to /api/platform/social/media → row prepended to the list.
+// Each row shows a thumbnail (image/* via <img>, others a mime
+// badge) + the URL + bytes + a copy-id affordance for use by the
+// future variant-attach flow.
+// ---------------------------------------------------------------------------
+
+type Asset = {
+  id: string;
+  source_url: string | null;
+  storage_path: string;
+  mime_type: string;
+  bytes: number;
+  width: number | null;
+  height: number | null;
+  bundle_upload_id: string | null;
+  created_at: string;
+};
+
+type Props = {
+  companyId: string;
+  initialAssets: Asset[];
+  canEdit: boolean;
+};
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString("en-AU", {
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function MediaLibraryClient({
+  companyId,
+  initialAssets,
+  canEdit,
+}: Props) {
+  const [assets, setAssets] = useState(initialAssets);
+  const [showForm, setShowForm] = useState(false);
+  const [url, setUrl] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (!url.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/platform/social/media", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          company_id: companyId,
+          source_url: url.trim(),
+        }),
+      });
+      const json = (await res.json()) as
+        | { ok: true; data: { asset: Asset } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        const msg = !json.ok ? json.error.message : "Failed to add asset.";
+        setError(msg);
+        return;
+      }
+      setAssets([json.data.asset, ...assets]);
+      setUrl("");
+      setShowForm(false);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function copyId(id: string) {
+    navigator.clipboard?.writeText(id);
+    setCopiedId(id);
+    window.setTimeout(() => setCopiedId(null), 1500);
+  }
+
+  return (
+    <div data-testid="media-library">
+      {canEdit ? (
+        <div className="mb-4 flex flex-wrap items-center justify-end gap-2">
+          {showForm ? null : (
+            <Button
+              onClick={() => setShowForm(true)}
+              data-testid="media-add-button"
+            >
+              Add asset
+            </Button>
+          )}
+        </div>
+      ) : null}
+
+      {showForm ? (
+        <form
+          onSubmit={handleAdd}
+          className="mb-4 rounded-md border bg-card p-4"
+          data-testid="media-add-form"
+        >
+          <label className="block text-sm font-medium">
+            Asset URL
+            <input
+              type="url"
+              required
+              placeholder="https://cdn.example.com/image.jpg"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              className="mt-1 block w-full rounded-md border bg-background px-3 py-2 text-sm"
+              data-testid="media-url-input"
+            />
+          </label>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Must be an https URL accessible from bundle.social.
+          </p>
+          {error ? (
+            <p className="mt-2 text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+          <div className="mt-3 flex items-center gap-2">
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Adding…" : "Add asset"}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                setShowForm(false);
+                setUrl("");
+                setError(null);
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      ) : null}
+
+      {assets.length === 0 ? (
+        <div
+          className="rounded-md border bg-card p-8 text-center text-sm text-muted-foreground"
+          data-testid="media-empty"
+        >
+          No media assets yet.
+          {canEdit ? " Click Add asset to upload your first." : ""}
+        </div>
+      ) : (
+        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {assets.map((a) => (
+            <li
+              key={a.id}
+              className="overflow-hidden rounded-lg border bg-card"
+              data-testid={`media-row-${a.id}`}
+            >
+              {a.source_url && a.mime_type.startsWith("image/") ? (
+                // Use <img> rather than next/image — these are external
+                // URLs we don't control + they don't go through the Next
+                // image optimiser.
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={a.source_url}
+                  alt=""
+                  className="h-40 w-full object-cover"
+                  loading="lazy"
+                />
+              ) : (
+                <div className="flex h-40 w-full items-center justify-center bg-muted text-sm text-muted-foreground">
+                  {a.mime_type}
+                </div>
+              )}
+              <div className="p-3">
+                <div className="break-all text-sm">
+                  {a.source_url ?? a.storage_path}
+                </div>
+                <div className="mt-1 flex items-center justify-between text-sm text-muted-foreground">
+                  <span>{formatBytes(a.bytes)}</span>
+                  <span>{formatDate(a.created_at)}</span>
+                </div>
+                <div className="mt-2 flex items-center gap-2 text-sm">
+                  <button
+                    type="button"
+                    className="text-primary underline"
+                    onClick={() => copyId(a.id)}
+                    data-testid={`media-copy-${a.id}`}
+                  >
+                    {copiedId === a.id ? "Copied" : "Copy id"}
+                  </button>
+                  {a.bundle_upload_id ? (
+                    <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-900">
+                      uploaded
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/lib/__tests__/social-media-library.test.ts
+++ b/lib/__tests__/social-media-library.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createMediaAsset,
+  listMediaAssets,
+} from "@/lib/platform/social/media";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// S1-23 — createMediaAsset + listMediaAssets against the live
+// Supabase stack. fetch is mocked to avoid hitting the network for
+// HEAD probes.
+// ---------------------------------------------------------------------------
+
+const COMPANY_A = "abcdef00-0000-0000-0000-aaaaaaaa2323";
+const COMPANY_B = "abcdef00-0000-0000-0000-bbbbbbbb2323";
+
+beforeEach(async () => {
+  vi.restoreAllMocks();
+  // Default: HEAD returns 404 so the lib falls through to defaults.
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(null, { status: 404 }),
+  );
+
+  const svc = getServiceRoleClient();
+  for (const [id, slug] of [
+    [COMPANY_A, "s1-23-a"],
+    [COMPANY_B, "s1-23-b"],
+  ] as const) {
+    const r = await svc.from("platform_companies").insert({
+      id,
+      name: `S1-23 ${slug}`,
+      slug,
+      domain: `${slug}.test`,
+      is_opollo_internal: false,
+      timezone: "Australia/Melbourne",
+      approval_default_rule: "any_one",
+    });
+    if (r.error) throw new Error(`seed company ${slug}: ${r.error.message}`);
+  }
+});
+
+describe("createMediaAsset", () => {
+  it("rejects http urls (https-only enforced)", async () => {
+    const result = await createMediaAsset({
+      companyId: COMPANY_A,
+      sourceUrl: "http://insecure.test/a.jpg",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("creates an asset with operator-supplied mime + bytes when HEAD fails", async () => {
+    const result = await createMediaAsset({
+      companyId: COMPANY_A,
+      sourceUrl: "https://cdn.test/a.jpg",
+      mimeType: "image/jpeg",
+      bytes: 12345,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.mime_type).toBe("image/jpeg");
+    expect(result.data.bytes).toBe(12345);
+    expect(result.data.source_url).toBe("https://cdn.test/a.jpg");
+  });
+
+  it("uses HEAD response for mime + bytes when probe succeeds", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(null, {
+        status: 200,
+        headers: {
+          "content-type": "image/png; charset=binary",
+          "content-length": "98765",
+        },
+      }),
+    );
+
+    const result = await createMediaAsset({
+      companyId: COMPANY_A,
+      sourceUrl: "https://cdn.test/b.png",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.mime_type).toBe("image/png");
+    expect(result.data.bytes).toBe(98765);
+  });
+});
+
+describe("listMediaAssets", () => {
+  it("returns assets newest first, scoped to company", async () => {
+    await createMediaAsset({
+      companyId: COMPANY_A,
+      sourceUrl: "https://cdn.test/older.jpg",
+      mimeType: "image/jpeg",
+      bytes: 1,
+    });
+    await createMediaAsset({
+      companyId: COMPANY_A,
+      sourceUrl: "https://cdn.test/newer.jpg",
+      mimeType: "image/jpeg",
+      bytes: 2,
+    });
+    await createMediaAsset({
+      companyId: COMPANY_B,
+      sourceUrl: "https://cdn.test/other-co.jpg",
+      mimeType: "image/jpeg",
+      bytes: 3,
+    });
+
+    const result = await listMediaAssets({ companyId: COMPANY_A });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.assets.length).toBe(2);
+    expect(result.data.assets[0]?.source_url).toBe("https://cdn.test/newer.jpg");
+    expect(result.data.assets[1]?.source_url).toBe("https://cdn.test/older.jpg");
+  });
+
+  it("returns empty for a company with no assets", async () => {
+    const result = await listMediaAssets({ companyId: COMPANY_B });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.assets).toEqual([]);
+  });
+});

--- a/lib/platform/social/media/create.ts
+++ b/lib/platform/social/media/create.ts
@@ -1,0 +1,134 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// S1-23 — create a social_media_assets row from a public URL.
+//
+// V1 input is just the URL + mime type + size hint. Future slices can
+// add a multipart upload that lands in Supabase Storage and populates
+// storage_path; the resolveBundleUploadId resolver supports both.
+//
+// We do a HEAD probe of the URL to confirm reachability and capture
+// the actual content-length / content-type if the operator didn't
+// pass them (best-effort; failure doesn't block creation since the
+// asset may live behind auth that responds 401 to HEAD but 200 to a
+// signed GET).
+//
+// storage_path is required by the schema; for URL-only assets we
+// store the URL there too as a stable per-row identifier so future
+// migrations don't have to handle nulls.
+//
+// Caller is responsible for canDo("edit_post") — assets are scoped to
+// the company; only members can create.
+// ---------------------------------------------------------------------------
+
+export type CreateMediaAssetInput = {
+  companyId: string;
+  sourceUrl: string;
+  mimeType?: string;
+  bytes?: number;
+  uploadedBy?: string | null;
+};
+
+export type CreateMediaAssetResult = {
+  id: string;
+  source_url: string;
+  mime_type: string;
+  bytes: number;
+};
+
+const URL_RE = /^https:\/\/[^\s]+$/;
+
+export async function createMediaAsset(
+  input: CreateMediaAssetInput,
+): Promise<ApiResponse<CreateMediaAssetResult>> {
+  if (!input.companyId) return validation("companyId required.");
+  if (!input.sourceUrl) return validation("sourceUrl required.");
+  if (!URL_RE.test(input.sourceUrl)) {
+    return validation("sourceUrl must be an https URL.");
+  }
+
+  // Best-effort HEAD probe. Fall through to the operator-supplied
+  // metadata when the server doesn't allow HEAD.
+  let probedMime = input.mimeType ?? "application/octet-stream";
+  let probedBytes = input.bytes ?? 0;
+  try {
+    const head = await fetch(input.sourceUrl, { method: "HEAD" });
+    if (head.ok) {
+      const ct = head.headers.get("content-type");
+      if (ct && !input.mimeType) probedMime = ct.split(";")[0]!.trim();
+      const cl = head.headers.get("content-length");
+      if (cl && !input.bytes) {
+        const n = Number.parseInt(cl, 10);
+        if (Number.isFinite(n) && n > 0) probedBytes = n;
+      }
+    }
+  } catch (err) {
+    // Network failure or invalid URL — log + continue with defaults.
+    logger.info("social.media.create.head_probe_failed", {
+      err: err instanceof Error ? err.message : String(err),
+      source_url: input.sourceUrl,
+    });
+  }
+
+  const svc = getServiceRoleClient();
+  const insert = await svc
+    .from("social_media_assets")
+    .insert({
+      company_id: input.companyId,
+      storage_path: input.sourceUrl,
+      mime_type: probedMime,
+      bytes: probedBytes,
+      source_url: input.sourceUrl,
+      uploaded_by: input.uploadedBy ?? null,
+    })
+    .select("id, source_url, mime_type, bytes")
+    .single();
+  if (insert.error) {
+    logger.error("social.media.create.insert_failed", {
+      err: insert.error.message,
+      code: insert.error.code,
+    });
+    return internal(`Failed to create asset: ${insert.error.message}`);
+  }
+
+  return {
+    ok: true,
+    data: {
+      id: insert.data.id as string,
+      source_url: insert.data.source_url as string,
+      mime_type: insert.data.mime_type as string,
+      bytes: Number(insert.data.bytes ?? 0),
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(message: string): ApiResponse<CreateMediaAssetResult> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<CreateMediaAssetResult> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/media/index.ts
+++ b/lib/platform/social/media/index.ts
@@ -1,4 +1,10 @@
 export {
+  createMediaAsset,
+  type CreateMediaAssetInput,
+  type CreateMediaAssetResult,
+} from "./create";
+export { listMediaAssets, type MediaAsset } from "./list";
+export {
   resolveBundleUploadId,
   resolveBundleUploadIds,
   type ResolveBundleUploadInput,

--- a/lib/platform/social/media/list.ts
+++ b/lib/platform/social/media/list.ts
@@ -1,0 +1,91 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// S1-23 — list a company's social_media_assets, newest first.
+//
+// Capped at 200 V1 (single library page; pagination is a future
+// concern when libraries get large). Returns the fields the picker
+// + library page need.
+// ---------------------------------------------------------------------------
+
+export type MediaAsset = {
+  id: string;
+  source_url: string | null;
+  storage_path: string;
+  mime_type: string;
+  bytes: number;
+  width: number | null;
+  height: number | null;
+  bundle_upload_id: string | null;
+  created_at: string;
+};
+
+export async function listMediaAssets(args: {
+  companyId: string;
+}): Promise<ApiResponse<{ assets: MediaAsset[] }>> {
+  if (!args.companyId) {
+    return validation("companyId required.");
+  }
+  const svc = getServiceRoleClient();
+  const result = await svc
+    .from("social_media_assets")
+    .select(
+      "id, source_url, storage_path, mime_type, bytes, width, height, bundle_upload_id, created_at",
+    )
+    .eq("company_id", args.companyId)
+    .order("created_at", { ascending: false })
+    .limit(200);
+  if (result.error) {
+    logger.error("social.media.list.failed", {
+      err: result.error.message,
+      company_id: args.companyId,
+    });
+    return internal(`Failed to read assets: ${result.error.message}`);
+  }
+  const assets: MediaAsset[] = (result.data ?? []).map((r) => ({
+    id: r.id as string,
+    source_url: (r.source_url as string | null) ?? null,
+    storage_path: r.storage_path as string,
+    mime_type: r.mime_type as string,
+    bytes: Number(r.bytes ?? 0),
+    width: (r.width as number | null) ?? null,
+    height: (r.height as number | null) ?? null,
+    bundle_upload_id: (r.bundle_upload_id as string | null) ?? null,
+    created_at: r.created_at as string,
+  }));
+  return {
+    ok: true,
+    data: { assets },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(message: string): ApiResponse<{ assets: MediaAsset[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(message: string): ApiResponse<{ assets: MediaAsset[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary

Operator surface for managing `social_media_assets`. V1 takes an https URL (uploadCreateFromUrl-friendly per S1-22); future slice can add multipart upload landing in Supabase Storage.

## What's new

- **Lib**
  - `createMediaAsset({companyId, sourceUrl, mimeType?, bytes?, uploadedBy?})` — HEAD-probes the URL for content-type/length when not supplied; inserts the row with `source_url` AND `storage_path` set to the URL (`storage_path` is NOT NULL in the schema; URL is a stable per-row identifier until Storage upload lands).
  - `listMediaAssets({companyId})` — newest first, capped at 200.

- **Routes**
  - `GET /api/platform/social/media?company_id=...` (canDo `view_calendar`)
  - `POST /api/platform/social/media` (canDo `edit_post`). Body `{ company_id, source_url, mime_type?, bytes? }`.

- **UI**
  - `/company/social/media` — server-rendered library page.
  - `MediaLibraryClient` — add-asset form, grid view with thumbnails, copy-id affordance for the future variant-attach flow, "uploaded" pill when `bundle_upload_id` is cached.

## Risks identified and mitigated

- **SSRF via HEAD probe** — restricted to https-only URLs (zod regex). Future hardening could deny private IP ranges; V1 accepts public URLs only by convention.
- **bundle.social fetching from a private URL** — same constraint; `source_url` must be publicly reachable so bundle.social can pull it during `uploadCreateFromUrl`.
- **Cross-company access** — every read/write filters by `companyId` derived from the `canDo` gate; routes 4xx without leaking row existence.
- **Arbitrary image URLs in the UI** — uses `<img>` (not `next/image`) with `loading=lazy` + empty alt; no `next.config` domain whitelist needed; rendered inside the operator dashboard only (not a public surface).

## Tests

`lib/__tests__/social-media-library.test.ts`: https-only validation, HEAD-fail fallback to operator-supplied metadata, HEAD-success metadata pickup, list ordering newest first, cross-company isolation, empty company.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint <S1-23 files>` — clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` — green
- [ ] CI green

## Coordination note

Built in `../opollo-s1-23` (worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)