### PR TITLE
S1-24: variant media picker

### DIFF
--- a/app/api/platform/social/posts/[id]/variants/route.ts
+++ b/app/api/platform/social/posts/[id]/variants/route.ts
@@ -36,6 +36,9 @@ const PutSchema = z.object({
     "gbp",
   ]),
   variant_text: z.string().max(10_000).nullable().optional(),
+  // S1-24: media attachments. Pass undefined to leave the existing
+  // array untouched; pass [] to clear; pass [uuid, ...] to overwrite.
+  media_asset_ids: z.array(z.string().uuid()).max(20).optional(),
 });
 
 function errorJson(
@@ -147,6 +150,7 @@ export async function PUT(
     companyId: parsed.data.company_id,
     platform: parsed.data.platform,
     variantText: parsed.data.variant_text ?? null,
+    mediaAssetIds: parsed.data.media_asset_ids,
   });
   if (!result.ok) {
     return errorJson(

--- a/components/PostVariantsSection.tsx
+++ b/components/PostVariantsSection.tsx
@@ -39,6 +39,9 @@ export function PostVariantsSection({
   const [editingPlatform, setEditingPlatform] =
     useState<SocialPlatform | null>(null);
   const [draftText, setDraftText] = useState("");
+  // S1-24: newline-separated media asset ids. /company/social/media's
+  // Copy id button is the source. Empty textarea on save = clear.
+  const [draftMedia, setDraftMedia] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -47,6 +50,7 @@ export function PostVariantsSection({
     // Seed editor with current override OR master text so the user can
     // tweak from where things stand.
     setDraftText(r.variant?.is_custom ? (r.variant.variant_text ?? "") : (masterText ?? ""));
+    setDraftMedia((r.variant?.media_asset_ids ?? []).join("\n"));
     setError(null);
   }
 
@@ -55,6 +59,10 @@ export function PostVariantsSection({
     setError(null);
     try {
       const trimmed = draftText.trim();
+      const mediaIds = draftMedia
+        .split(/[\s,]+/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
       const res = await fetch(
         `/api/platform/social/posts/${postId}/variants`,
         {
@@ -64,6 +72,7 @@ export function PostVariantsSection({
             company_id: companyId,
             platform,
             variant_text: trimmed.length === 0 ? null : trimmed,
+            media_asset_ids: mediaIds,
           }),
         },
       );
@@ -91,6 +100,7 @@ export function PostVariantsSection({
       );
       setEditingPlatform(null);
       setDraftText("");
+      setDraftMedia("");
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -146,16 +156,27 @@ export function PostVariantsSection({
                     )}
                   </div>
                   {!editing ? (
-                    <p
-                      className="mt-2 whitespace-pre-wrap text-sm"
-                      data-testid={`variant-text-${r.platform}`}
-                    >
-                      {r.effective_text ?? (
-                        <span className="text-muted-foreground">
-                          — No copy —
-                        </span>
-                      )}
-                    </p>
+                    <>
+                      <p
+                        className="mt-2 whitespace-pre-wrap text-sm"
+                        data-testid={`variant-text-${r.platform}`}
+                      >
+                        {r.effective_text ?? (
+                          <span className="text-muted-foreground">
+                            — No copy —
+                          </span>
+                        )}
+                      </p>
+                      {(r.variant?.media_asset_ids?.length ?? 0) > 0 ? (
+                        <p
+                          className="mt-1 text-sm text-muted-foreground"
+                          data-testid={`variant-media-count-${r.platform}`}
+                        >
+                          {r.variant!.media_asset_ids.length} media
+                          asset{r.variant!.media_asset_ids.length === 1 ? "" : "s"} attached
+                        </p>
+                      ) : null}
+                    </>
                   ) : null}
                 </div>
                 {canEdit && !editing ? (
@@ -180,6 +201,17 @@ export function PostVariantsSection({
                     placeholder="Leave blank to clear the override and use the master copy."
                     data-testid={`variant-textarea-${r.platform}`}
                   />
+                  <label className="mt-2 block text-sm font-medium">
+                    Media asset ids
+                    <textarea
+                      className="mt-1 w-full rounded-md border bg-background p-2 text-sm font-mono"
+                      rows={3}
+                      value={draftMedia}
+                      onChange={(e) => setDraftMedia(e.target.value)}
+                      placeholder="One UUID per line. Copy from /company/social/media."
+                      data-testid={`variant-media-textarea-${r.platform}`}
+                    />
+                  </label>
                   <div className="mt-2 flex flex-wrap gap-2">
                     <Button
                       size="sm"
@@ -195,6 +227,7 @@ export function PostVariantsSection({
                       onClick={() => {
                         setEditingPlatform(null);
                         setDraftText("");
+                        setDraftMedia("");
                         setError(null);
                       }}
                     >

--- a/lib/__tests__/social-variants-media.test.ts
+++ b/lib/__tests__/social-variants-media.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { upsertVariant } from "@/lib/platform/social/variants";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// S1-24 — upsertVariant with media_asset_ids guard.
+// ---------------------------------------------------------------------------
+
+const COMPANY_A = "abcdef00-0000-0000-0000-aaaaaaaa2424";
+const COMPANY_B = "abcdef00-0000-0000-0000-bbbbbbbb2424";
+
+async function seedCompanyAndPost(companyId: string): Promise<string> {
+  const svc = getServiceRoleClient();
+  const co = await svc.from("platform_companies").insert({
+    id: companyId,
+    name: `S1-24 ${companyId.slice(-4)}`,
+    slug: `s1-24-${companyId.slice(-4)}`,
+    domain: `s1-24-${companyId.slice(-4)}.test`,
+    is_opollo_internal: false,
+    timezone: "Australia/Melbourne",
+    approval_default_rule: "any_one",
+  });
+  if (co.error) throw new Error(`seed company: ${co.error.message}`);
+
+  const master = await svc
+    .from("social_post_master")
+    .insert({
+      company_id: companyId,
+      state: "draft",
+      source_type: "manual",
+      master_text: "hi",
+    })
+    .select("id")
+    .single();
+  if (master.error) throw new Error(`seed master: ${master.error.message}`);
+  return master.data.id as string;
+}
+
+async function seedAsset(companyId: string): Promise<string> {
+  const svc = getServiceRoleClient();
+  const r = await svc
+    .from("social_media_assets")
+    .insert({
+      company_id: companyId,
+      storage_path: `s1-24/${Math.random().toString(36).slice(2, 10)}`,
+      mime_type: "image/jpeg",
+      bytes: 1,
+      source_url: "https://cdn.test/x.jpg",
+    })
+    .select("id")
+    .single();
+  if (r.error) throw new Error(`seed asset: ${r.error.message}`);
+  return r.data.id as string;
+}
+
+beforeEach(async () => {
+  // truncateAll runs first; we just seed afresh.
+});
+
+describe("upsertVariant — media_asset_ids", () => {
+  it("attaches media ids that belong to the company", async () => {
+    const postId = await seedCompanyAndPost(COMPANY_A);
+    const assetId = await seedAsset(COMPANY_A);
+
+    const result = await upsertVariant({
+      postMasterId: postId,
+      companyId: COMPANY_A,
+      platform: "linkedin_personal",
+      variantText: null,
+      mediaAssetIds: [assetId],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.media_asset_ids).toEqual([assetId]);
+  });
+
+  it("rejects ids that belong to another company", async () => {
+    const postId = await seedCompanyAndPost(COMPANY_A);
+    await seedCompanyAndPost(COMPANY_B);
+    const otherAssetId = await seedAsset(COMPANY_B);
+
+    const result = await upsertVariant({
+      postMasterId: postId,
+      companyId: COMPANY_A,
+      platform: "linkedin_personal",
+      variantText: null,
+      mediaAssetIds: [otherAssetId],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("clears existing media when [] is passed", async () => {
+    const postId = await seedCompanyAndPost(COMPANY_A);
+    const a = await seedAsset(COMPANY_A);
+    const b = await seedAsset(COMPANY_A);
+
+    await upsertVariant({
+      postMasterId: postId,
+      companyId: COMPANY_A,
+      platform: "x",
+      variantText: "first",
+      mediaAssetIds: [a, b],
+    });
+    const second = await upsertVariant({
+      postMasterId: postId,
+      companyId: COMPANY_A,
+      platform: "x",
+      variantText: "second",
+      mediaAssetIds: [],
+    });
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.data.media_asset_ids).toEqual([]);
+    expect(second.data.variant_text).toBe("second");
+  });
+
+  it("preserves existing media when undefined is passed", async () => {
+    const postId = await seedCompanyAndPost(COMPANY_A);
+    const a = await seedAsset(COMPANY_A);
+
+    await upsertVariant({
+      postMasterId: postId,
+      companyId: COMPANY_A,
+      platform: "facebook_page",
+      variantText: "with media",
+      mediaAssetIds: [a],
+    });
+    const second = await upsertVariant({
+      postMasterId: postId,
+      companyId: COMPANY_A,
+      platform: "facebook_page",
+      variantText: "text-only edit",
+      // mediaAssetIds omitted
+    });
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.data.media_asset_ids).toEqual([a]);
+    expect(second.data.variant_text).toBe("text-only edit");
+  });
+});

--- a/lib/platform/social/variants/types.ts
+++ b/lib/platform/social/variants/types.ts
@@ -53,6 +53,12 @@ export type UpsertVariantInput = {
   // Empty / whitespace-only collapses to null (resets to "use master").
   // is_custom is derived: non-null variant_text → true; null → false.
   variantText: string | null;
+  // S1-24: optional media attachments. When present (including empty
+  // []), the column is overwritten — pass undefined to leave the
+  // existing array untouched on upsert. Each id must reference a
+  // social_media_assets row in the same company; the lib enforces
+  // this guard.
+  mediaAssetIds?: string[];
 };
 
 export type ListVariantsInput = {

--- a/lib/platform/social/variants/upsert.ts
+++ b/lib/platform/social/variants/upsert.ts
@@ -49,6 +49,27 @@ export async function upsertVariant(
 
   const svc = getServiceRoleClient();
 
+  // S1-24: validate media_asset_ids belong to this company. We require
+  // every passed id to resolve before doing the upsert so a malicious
+  // payload can't attach assets the operator doesn't own.
+  if (input.mediaAssetIds && input.mediaAssetIds.length > 0) {
+    const assets = await svc
+      .from("social_media_assets")
+      .select("id")
+      .eq("company_id", input.companyId)
+      .in("id", input.mediaAssetIds);
+    if (assets.error) {
+      return internal(`Asset check failed: ${assets.error.message}`);
+    }
+    const foundIds = new Set((assets.data ?? []).map((a) => a.id as string));
+    const missing = input.mediaAssetIds.filter((id) => !foundIds.has(id));
+    if (missing.length > 0) {
+      return validation(
+        `Unknown media asset id(s) for this company: ${missing.join(", ")}.`,
+      );
+    }
+  }
+
   // Verify parent post exists in this company AND is still a draft.
   const parent = await svc
     .from("social_post_master")
@@ -83,17 +104,20 @@ export async function upsertVariant(
 
   // Postgres upsert: insert-or-update on the UNIQUE (post_master_id,
   // platform) constraint. Two concurrent calls converge to one row.
+  // media_asset_ids is included only when the caller passed it,
+  // preserving the existing array on text-only edits.
+  const row: Record<string, unknown> = {
+    post_master_id: input.postMasterId,
+    platform: input.platform,
+    variant_text: cleaned,
+    is_custom: isCustom,
+  };
+  if (input.mediaAssetIds !== undefined) {
+    row.media_asset_ids = input.mediaAssetIds;
+  }
   const upsert = await svc
     .from("social_post_variant")
-    .upsert(
-      {
-        post_master_id: input.postMasterId,
-        platform: input.platform,
-        variant_text: cleaned,
-        is_custom: isCustom,
-      },
-      { onConflict: "post_master_id,platform" },
-    )
+    .upsert(row, { onConflict: "post_master_id,platform" })
     .select(
       "id, post_master_id, platform, connection_id, variant_text, is_custom, scheduled_at, media_asset_ids, created_at, updated_at",
     )


### PR DESCRIPTION
## Summary

Wires `media_asset_ids` through the variant editor so operators can attach images/videos from the media library (S1-23) to per-platform variants. Once attached, the publish path (S1-22) resolves them to bundle.social `uploadIds` and posts with media.

## What's new

- **Lib `upsertVariant`** — accepts optional `mediaAssetIds: string[]`. When passed, validates every id belongs to the same company (cross-company attachment refused with `VALIDATION_FAILED`). When omitted, the existing array is preserved. Empty array overwrites with `[]`.
- **Route** `PUT /api/platform/social/posts/[id]/variants` — body adds optional `media_asset_ids` (uuid[], max 20).
- **UI `PostVariantsSection`** — edit form gains a "Media asset ids" textarea (paste from `/company/social/media`'s Copy id button). Read view shows "N media assets attached" pill when populated.

## Risks identified and mitigated

- **Cross-company attachment** — lib's batch `IN` query against `social_media_assets WHERE company_id=...` rejects unknown ids with a clear error listing the offending uuids.
- **Accidental clear on text-only edit** — UI seeds the textarea with existing ids on Edit; if operator only changes text, save re-sends the same ids. Empty textarea = explicit clear.
- **Massive arrays exhausting the post body** — zod `max(20)` on the route caps it; bundle.social platforms cap separately (LinkedIn=10, etc).
- **Operator pastes wrong UUID** — lib's company-scoped batch lookup fails with `VALIDATION_FAILED` listing the missing ids.

## Tests

`lib/__tests__/social-variants-media.test.ts`: happy attach, cross-company refusal, explicit clear via `[]`, implicit preserve via `undefined`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint <S1-24 files>` — clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` — green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)