### PR TITLE
fix(preview): richer iframe shim — buttons, cards, grids, hero treatment

### DIFF
--- a/lib/preview-iframe-wrapper.ts
+++ b/lib/preview-iframe-wrapper.ts
@@ -95,6 +95,126 @@ const SHIM_STYLESHEET = `
     margin: 0 0 1rem;
     padding-left: 1.5rem;
   }
+
+  /* Section rhythm — first section reads as a hero, alternating
+     sections get a subtle alt background so the page doesn't look
+     like one slab of white. Operators flagged "all pages look
+     black-and-white"; this shim is what fills the gap when the
+     model emits site-prefixed class names that don't match any
+     loaded theme CSS. */
+  [data-opollo]:first-of-type {
+    padding-top: 4rem;
+    padding-bottom: 4rem;
+  }
+  [data-opollo]:first-of-type h1 {
+    font-size: 3rem;
+    line-height: 1.1;
+  }
+  [data-opollo]:nth-of-type(even) {
+    background: var(--ds-color-bg-alt);
+  }
+
+  /* Button-shaped affordances — match common class-name patterns so
+     buttons render as filled primary even when the site-prefix class
+     has no CSS attached. */
+  [data-opollo] button,
+  [data-opollo] a[class*="btn"],
+  [data-opollo] a[class*="button"],
+  [data-opollo] a[class*="cta"],
+  [data-opollo] [class*="button"] > a,
+  [data-opollo] [class*="cta"] > a {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    border-radius: var(--ds-radius);
+    background: var(--ds-color-primary);
+    color: #ffffff !important;
+    text-decoration: none !important;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    transition: opacity 0.15s;
+  }
+  [data-opollo] button:hover,
+  [data-opollo] a[class*="btn"]:hover,
+  [data-opollo] a[class*="button"]:hover,
+  [data-opollo] a[class*="cta"]:hover {
+    opacity: 0.9;
+  }
+
+  /* Card-shaped containers — anything the model named "card",
+     "feature", "service", "tile", "item" gets card chrome. */
+  [data-opollo] [class*="card"],
+  [data-opollo] [class*="feature"],
+  [data-opollo] [class*="service"],
+  [data-opollo] [class*="tile"],
+  [data-opollo] [class*="item"] {
+    background: var(--ds-color-bg);
+    border: 1px solid #e5e7eb;
+    border-radius: var(--ds-radius);
+    padding: 1.5rem;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  }
+  /* Don't double-pad cards inside cards (e.g. card containing a
+     "service-item" nested div). The outer wins. */
+  [data-opollo] [class*="card"] [class*="card"],
+  [data-opollo] [class*="feature"] [class*="feature"],
+  [data-opollo] [class*="service"] [class*="service"],
+  [data-opollo] [class*="item"] [class*="item"] {
+    border: none;
+    box-shadow: none;
+    padding: 0;
+  }
+
+  /* Grid containers — anything named "grid", "row", "columns",
+     "cards" lays out as a responsive auto-fit grid. */
+  [data-opollo] [class*="grid"],
+  [data-opollo] [class*="cards"],
+  [data-opollo] [class*="columns"] {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+  }
+
+  /* Centered/hero text containers. */
+  [data-opollo] [class*="hero"],
+  [data-opollo] [class*="header"] {
+    text-align: center;
+  }
+  [data-opollo] [class*="hero"] h1,
+  [data-opollo] [class*="hero"] h2 {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 720px;
+  }
+
+  /* Form chrome so contact/lead-capture sections aren't bare. */
+  [data-opollo] input[type="text"],
+  [data-opollo] input[type="email"],
+  [data-opollo] input[type="tel"],
+  [data-opollo] textarea {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border: 1px solid #d1d5db;
+    border-radius: var(--ds-radius);
+    font-size: 1rem;
+    font-family: inherit;
+    background: #ffffff;
+  }
+  [data-opollo] label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 0.375rem;
+  }
+
+  /* Blockquote / callout chrome. */
+  [data-opollo] blockquote {
+    margin: 1.5rem 0;
+    padding: 1rem 1.5rem;
+    border-left: 4px solid var(--ds-color-primary);
+    background: var(--ds-color-bg-alt);
+    font-style: italic;
+    color: var(--ds-color-text);
+  }
 `;
 
 export interface PreviewWrapOptions {


### PR DESCRIPTION
## Summary

- Operators flagged all previewed pages looking black-and-white — the shim only had typography rules, so any site-prefix class the model emitted had no CSS to match
- Added visual structure rules keyed on class-name pattern matching (`*card*`, `*button*`, `*grid*`, `*hero*`, etc.) so generated content renders with readable colour, shape, and layout in the preview iframe without needing the actual customer theme
- Does not affect production rendering — shim is only loaded in the `srcdoc` iframe inside `BriefRunClient`

## What changed

- `lib/preview-iframe-wrapper.ts` — shim stylesheet additions only (no logic change):
  - Hero treatment on `:first-of-type` section (4rem padding, larger h1)
  - Alternating `nth-of-type(even)` section backgrounds (alt-grey)
  - Filled-primary button selectors (`*btn*`, `*button*`, `*cta*` class patterns + `<button>` elements)
  - Card chrome for `*card*`, `*feature*`, `*service*`, `*tile*`, `*item*` containers
  - Auto-fit CSS grid for `*grid*`, `*cards*`, `*columns*` containers
  - Centered layout for `*hero*`, `*header*` wrappers
  - Form fields + blockquote baseline

## Risks identified and mitigated

- **False-positive card styling**: class-name pattern matching is broad; a div with class `cart-item` would get card padding. Accepted — wrong-positive card chrome is far less noticeable than no styling at all.
- **Nested card double-padding**: scoped with a specificity override (`[class*="card"] [class*="card"]`) to strip border/shadow/padding from nested card containers.
- **Path-A passthrough unchanged**: existing tests verify the `<!DOCTYPE>`/`<html>` passthrough is untouched. All existing test assertions still green.
- **No change to production render path**: `wrapForPreview` is called only in the iframe srcdoc pipeline, never in the batch worker or WP publish path.

## Test plan

- [ ] Existing unit tests in `lib/__tests__/preview-iframe-wrapper.test.ts` still pass (CI)
- [ ] Open any brief run page on staging, expand a page — confirm hero/card/button sections render with colour and layout (not plain text)
- [ ] Verify a page with Elementor stylesheets injected (copy_existing site) still renders correctly alongside the shim

🤖 Generated with [Claude Code](https://claude.com/claude-code)