### PR TITLE
feat(s1-25): company social calendar view

### DIFF
--- a/app/company/social/calendar/page.tsx
+++ b/app/company/social/calendar/page.tsx
@@ -1,0 +1,77 @@
+import { redirect } from "next/navigation";
+
+import { SocialCalendarClient } from "@/components/SocialCalendarClient";
+import { H1, Lead } from "@/components/ui/typography";
+import { getCurrentPlatformSession } from "@/lib/platform/auth";
+import { listCompanyScheduleEntries } from "@/lib/platform/social/scheduling";
+
+// ---------------------------------------------------------------------------
+// S1-25 — customer calendar view at /company/social/calendar.
+//
+// Server-rendered. Fetches a 30-day forward window of non-cancelled
+// schedule entries, hands to the client component for filtering +
+// rendering. Re-fetch on navigation (force-dynamic).
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+const WINDOW_DAYS = 30;
+
+export default async function CompanySocialCalendarPage() {
+  const session = await getCurrentPlatformSession();
+  if (!session) {
+    redirect(`/login?next=${encodeURIComponent("/company/social/calendar")}`);
+  }
+  if (!session.company) {
+    return (
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm">
+        <p className="font-medium">Account not provisioned to a company.</p>
+        <p className="mt-1 text-muted-foreground">
+          Your account isn&apos;t a member of any company on the platform
+          yet. Ask an admin to invite you, or contact Opollo support.
+        </p>
+      </div>
+    );
+  }
+
+  const now = new Date();
+  const windowEnd = new Date(now.getTime() + WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+  const result = await listCompanyScheduleEntries({
+    companyId: session.company.companyId,
+    fromIso: now.toISOString(),
+    toIso: windowEnd.toISOString(),
+  });
+
+  return (
+    <main className="mx-auto max-w-4xl p-6">
+      <header>
+        <H1>Calendar</H1>
+        <Lead className="mt-0.5">
+          Everything queued for the next {WINDOW_DAYS} days. Click an entry
+          to open the post.
+        </Lead>
+      </header>
+      <div className="mt-6">
+        {result.ok ? (
+          <SocialCalendarClient
+            entries={result.data.entries.map((e) => ({
+              id: e.id,
+              post_master_id: e.post_master_id,
+              platform: e.platform,
+              scheduled_at: e.scheduled_at,
+              preview: e.preview,
+            }))}
+          />
+        ) : (
+          <div
+            className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+            role="alert"
+          >
+            Failed to load calendar: {result.error.message}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/components/SocialCalendarClient.tsx
+++ b/components/SocialCalendarClient.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import {
+  PLATFORM_LABEL,
+  type SocialPlatform,
+} from "@/lib/platform/social/variants/types";
+
+// ---------------------------------------------------------------------------
+// S1-25 — calendar list view.
+//
+// Server fetches a 30-day window of non-cancelled schedule entries.
+// The component groups by date (YYYY-MM-DD in the company's timezone
+// — for V1 we fall back to the operator's browser timezone since
+// platform_companies.timezone isn't threaded through the page yet),
+// and offers a platform filter chip-row.
+//
+// Each entry links to /company/social/posts/[post_master_id] for
+// detail + edit + retry.
+// ---------------------------------------------------------------------------
+
+type Entry = {
+  id: string;
+  post_master_id: string;
+  platform: SocialPlatform;
+  scheduled_at: string;
+  preview: string | null;
+};
+
+type Props = {
+  entries: Entry[];
+};
+
+const PLATFORMS: SocialPlatform[] = [
+  "linkedin_personal",
+  "linkedin_company",
+  "facebook_page",
+  "x",
+  "gbp",
+];
+
+function dayKey(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-AU", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function timeLabel(iso: string): string {
+  return new Date(iso).toLocaleTimeString("en-AU", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+const PLATFORM_PILL: Record<SocialPlatform, string> = {
+  linkedin_personal: "bg-blue-100 text-blue-900",
+  linkedin_company: "bg-blue-100 text-blue-900",
+  facebook_page: "bg-indigo-100 text-indigo-900",
+  x: "bg-slate-200 text-slate-900",
+  gbp: "bg-emerald-100 text-emerald-900",
+};
+
+export function SocialCalendarClient({ entries }: Props) {
+  const [filter, setFilter] = useState<SocialPlatform | "all">("all");
+
+  const visible = useMemo(
+    () => entries.filter((e) => filter === "all" || e.platform === filter),
+    [entries, filter],
+  );
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Entry[]>();
+    for (const e of visible) {
+      const key = dayKey(e.scheduled_at);
+      const arr = map.get(key) ?? [];
+      arr.push(e);
+      map.set(key, arr);
+    }
+    return Array.from(map.entries());
+  }, [visible]);
+
+  return (
+    <div data-testid="social-calendar">
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setFilter("all")}
+          className={`rounded-full px-3 py-1 text-sm font-medium ${
+            filter === "all"
+              ? "bg-primary text-primary-foreground"
+              : "border bg-background"
+          }`}
+          data-testid="calendar-filter-all"
+        >
+          All
+        </button>
+        {PLATFORMS.map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => setFilter(p)}
+            className={`rounded-full px-3 py-1 text-sm font-medium ${
+              filter === p
+                ? "bg-primary text-primary-foreground"
+                : "border bg-background"
+            }`}
+            data-testid={`calendar-filter-${p}`}
+          >
+            {PLATFORM_LABEL[p]}
+          </button>
+        ))}
+      </div>
+
+      {grouped.length === 0 ? (
+        <div
+          className="rounded-md border bg-card p-8 text-center text-sm text-muted-foreground"
+          data-testid="calendar-empty"
+        >
+          Nothing scheduled in the next 30 days
+          {filter === "all" ? "" : ` for ${PLATFORM_LABEL[filter]}`}.
+        </div>
+      ) : (
+        <ol className="space-y-6" data-testid="calendar-days">
+          {grouped.map(([day, items]) => (
+            <li key={day}>
+              <h3 className="mb-2 text-base font-semibold">{day}</h3>
+              <ul className="divide-y rounded-lg border bg-card">
+                {items.map((e) => (
+                  <li
+                    key={e.id}
+                    className="flex items-start gap-3 p-3"
+                    data-testid={`calendar-entry-${e.id}`}
+                  >
+                    <div className="w-16 shrink-0 text-sm font-medium tabular-nums">
+                      {timeLabel(e.scheduled_at)}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span
+                          className={`rounded-full px-2 py-0.5 text-sm font-medium ${PLATFORM_PILL[e.platform]}`}
+                        >
+                          {PLATFORM_LABEL[e.platform]}
+                        </span>
+                      </div>
+                      <a
+                        href={`/company/social/posts/${e.post_master_id}`}
+                        className="mt-1 block break-words text-sm text-primary underline"
+                      >
+                        {e.preview ?? "(no copy)"}
+                      </a>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/lib/__tests__/social-calendar.test.ts
+++ b/lib/__tests__/social-calendar.test.ts
@@ -1,0 +1,308 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import { createPostMaster } from "@/lib/platform/social/posts";
+import {
+  createScheduleEntry,
+  cancelScheduleEntry,
+  listCompanyScheduleEntries,
+} from "@/lib/platform/social/scheduling";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedAuthUser, type SeededAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// S1-25 — listCompanyScheduleEntries (calendar view lib).
+// ---------------------------------------------------------------------------
+
+const COMPANY_CAL_ID = "caddd000-0000-0000-0000-ca1enda000001";
+
+describe("lib/platform/social/scheduling/list-company", () => {
+  let creator: SeededAuthUser;
+
+  beforeAll(async () => {
+    creator = await seedAuthUser({
+      email: "s1-25-calendar@opollo.test",
+      persistent: true,
+    });
+  });
+
+  beforeEach(async () => {
+    const svc = getServiceRoleClient();
+
+    const co = await svc
+      .from("platform_companies")
+      .insert({
+        id: COMPANY_CAL_ID,
+        name: "Calendar Co",
+        slug: "s1-25-calco",
+        domain: "s1-25-calco.test",
+        is_opollo_internal: false,
+        timezone: "Australia/Melbourne",
+        approval_default_rule: "any_one",
+      })
+      .select("id");
+    if (co.error) throw new Error(`seed company: ${co.error.message}`);
+
+    const usr = await svc
+      .from("platform_users")
+      .insert({
+        id: creator.id,
+        email: creator.email,
+        full_name: "Calendar Creator",
+        is_opollo_staff: false,
+      })
+      .select("id");
+    if (usr.error) throw new Error(`seed user: ${usr.error.message}`);
+
+    const mem = await svc
+      .from("platform_company_users")
+      .insert({
+        company_id: COMPANY_CAL_ID,
+        user_id: creator.id,
+        role: "approver",
+      })
+      .select("id");
+    if (mem.error) throw new Error(`seed membership: ${mem.error.message}`);
+  });
+
+  afterAll(async () => {
+    const svc = getServiceRoleClient();
+    if (creator) await svc.auth.admin.deleteUser(creator.id);
+  });
+
+  async function createApprovedPost(masterText = "hello world"): Promise<string> {
+    const post = await createPostMaster({
+      companyId: COMPANY_CAL_ID,
+      masterText,
+      createdBy: creator.id,
+    });
+    if (!post.ok) throw new Error(`createApprovedPost: ${post.error.code}`);
+    const svc = getServiceRoleClient();
+    await svc
+      .from("social_post_master")
+      .update({ state: "approved" })
+      .eq("id", post.data.id);
+    return post.data.id;
+  }
+
+  function futureIso(daysFromNow = 7): string {
+    return new Date(Date.now() + daysFromNow * 24 * 60 * 60 * 1000).toISOString();
+  }
+
+  function windowArgs(days = 30) {
+    const now = new Date();
+    const end = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+    return { fromIso: now.toISOString(), toIso: end.toISOString() };
+  }
+
+  describe("validation", () => {
+    it("rejects missing companyId", async () => {
+      const r = await listCompanyScheduleEntries({
+        companyId: "",
+        ...windowArgs(),
+      });
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("rejects missing fromIso", async () => {
+      const r = await listCompanyScheduleEntries({
+        companyId: COMPANY_CAL_ID,
+        fromIso: "",
+        toIso: futureIso(),
+      });
+      expect(r.ok).toBe(false);
+    });
+
+    it("rejects invalid fromIso", async () => {
+      const r = await listCompanyScheduleEntries({
+        companyId: COMPANY_CAL_ID,
+        fromIso: "not-a-date",
+        toIso: futureIso(),
+      });
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("rejects fromIso > toIso", async () => {
+      const r = await listCompanyScheduleEntries({
+        companyId: COMPANY_CAL_ID,
+        fromIso: futureIso(10),
+        toIso: futureIso(1),
+      });
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.error.code).toBe("VALIDATION_FAILED");
+    });
+  });
+
+  describe("happy path", () => {
+    it("returns [] when company has no posts", async () => {
+      const r = await listCompanyScheduleEntries({
+        companyId: COMPANY_CAL_ID,
+        ...windowArgs(),
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.data.entries).toEqual([]);
+    });
+
+    it("returns scheduled entries in window ordered by scheduled_at asc", async () => {
+      const postId = await createApprovedPost("First post");
+      await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_CAL_ID,
+        platform: "linkedin_personal",
+        scheduledAt: futureIso(10),
+        scheduledBy: creator.id,
+      });
+      await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_CAL_ID,
+        platform: "x",
+        scheduledAt: futureIso(3),
+        scheduledBy: creator.id,
+      });
+
+      const r = await listCompanyScheduleEntries({
+        companyId: COMPANY_CAL_ID,
+        ...windowArgs(30),
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.data.entries.length).toBeGreaterThanOrEqual(2);
+      // First entry is the sooner one (x at +3d).
+      const entryPlatforms = r.data.entries.map((e) => e.platform);
+      expect(entryPlatforms.indexOf("x")).toBeLessThan(
+        entryPlatforms.indexOf("linkedin_personal"),
+      );
+    });
+
+    it("includes post_master_id and preview on each entry", async () => {
+      const postId = await createApprovedPost("Hello from calendar");
+      await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_CAL_ID,
+        platform: "facebook_page",
+        scheduledAt: futureIso(5),
+        scheduledBy: creator.id,
+      });
+
+      const r = await listCompanyScheduleEntries({
+        companyId: COMPANY_CAL_ID,
+        ...windowArgs(),
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      const entry = r.data.entries.find((e) => e.post_master_id === postId);
+      expect(entry).toBeDefined();
+      expect(entry?.platform).toBe("facebook_page");
+      expect(entry?.preview).toBe("Hello from calendar");
+    });
+
+    it("truncates preview at 80 chars with ellipsis", async () => {
+      const longText = "A".repeat(100);
+      const postId = await createApprovedPost(longText);
+      await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_CAL_ID,
+        platform: "gbp",
+        scheduledAt: futureIso(2),
+        scheduledBy: creator.id,
+      });
+
+      const r = await listCompanyScheduleEntries({
+        companyId: COMPANY_CAL_ID,
+        ...windowArgs(),
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      const entry = r.data.entries.find((e) => e.post_master_id === postId);
+      expect(entry?.preview).toMatch(/^A{80}…$/);
+    });
+
+    it("excludes cancelled entries by default", async () => {
+      const postId = await createApprovedPost("cancelled post");
+      const created = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_CAL_ID,
+        platform: "x",
+        scheduledAt: futureIso(4),
+        scheduledBy: creator.id,
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+      await cancelScheduleEntry({
+        entryId: created.data.id,
+        companyId: COMPANY_CAL_ID,
+      });
+
+      const r = await listCompanyScheduleEntries({
+        companyId: COMPANY_CAL_ID,
+        ...windowArgs(),
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      const found = r.data.entries.find((e) => e.post_master_id === postId);
+      expect(found).toBeUndefined();
+    });
+
+    it("includes cancelled entries when includeCancelled=true", async () => {
+      const postId = await createApprovedPost("will be cancelled");
+      const created = await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_CAL_ID,
+        platform: "linkedin_company",
+        scheduledAt: futureIso(6),
+        scheduledBy: creator.id,
+      });
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+      await cancelScheduleEntry({
+        entryId: created.data.id,
+        companyId: COMPANY_CAL_ID,
+      });
+
+      const r = await listCompanyScheduleEntries({
+        companyId: COMPANY_CAL_ID,
+        fromIso: new Date().toISOString(),
+        toIso: futureIso(30),
+        includeCancelled: true,
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      const entry = r.data.entries.find((e) => e.post_master_id === postId);
+      expect(entry).toBeDefined();
+      expect(entry?.cancelled_at).not.toBeNull();
+    });
+
+    it("excludes entries outside the time window", async () => {
+      const postId = await createApprovedPost("far future post");
+      await createScheduleEntry({
+        postMasterId: postId,
+        companyId: COMPANY_CAL_ID,
+        platform: "linkedin_personal",
+        scheduledAt: futureIso(60),
+        scheduledBy: creator.id,
+      });
+
+      const r = await listCompanyScheduleEntries({
+        companyId: COMPANY_CAL_ID,
+        ...windowArgs(30),
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      const found = r.data.entries.find((e) => e.post_master_id === postId);
+      expect(found).toBeUndefined();
+    });
+  });
+});

--- a/lib/platform/social/scheduling/index.ts
+++ b/lib/platform/social/scheduling/index.ts
@@ -1,6 +1,11 @@
 export { cancelScheduleEntry } from "./cancel";
 export { createScheduleEntry } from "./create";
 export { listScheduleEntries } from "./list";
+export {
+  listCompanyScheduleEntries,
+  type CompanyScheduleEntry,
+  type ListCompanyEntriesInput,
+} from "./list-company";
 export type {
   CancelScheduleEntryInput,
   CreateScheduleEntryInput,

--- a/lib/platform/social/scheduling/list-company.ts
+++ b/lib/platform/social/scheduling/list-company.ts
@@ -1,0 +1,202 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+import type { SocialPlatform } from "@/lib/platform/social/variants/types";
+
+// ---------------------------------------------------------------------------
+// S1-25 — list schedule entries for a whole company in a date window.
+//
+// Powers the calendar view at /company/social/calendar. Joins
+// schedule_entries → variants → post_master so we can render
+//   "12 May 09:00 — LinkedIn — 'Hello world…'"
+// without N round trips per row.
+//
+// Multi-FK embed avoidance (memory note): we go in two reads:
+//   1. variants WHERE post_master_id IN (company's posts) → variant
+//      ids + platform + master snippet. We pull master.id +
+//      master_text via a single embed since variant has only one FK
+//      to master. Cheap.
+//   2. schedule_entries WHERE post_variant_id IN (variant ids) AND
+//      scheduled_at BETWEEN from AND to.
+// ---------------------------------------------------------------------------
+
+const PREVIEW_CHAR_LIMIT = 80;
+
+export type CompanyScheduleEntry = {
+  id: string;
+  post_variant_id: string;
+  post_master_id: string;
+  platform: SocialPlatform;
+  scheduled_at: string;
+  cancelled_at: string | null;
+  preview: string | null;
+};
+
+export type ListCompanyEntriesInput = {
+  companyId: string;
+  fromIso: string; // inclusive lower bound
+  toIso: string; // inclusive upper bound
+  includeCancelled?: boolean;
+};
+
+export async function listCompanyScheduleEntries(
+  input: ListCompanyEntriesInput,
+): Promise<ApiResponse<{ entries: CompanyScheduleEntry[] }>> {
+  if (!input.companyId) return validation("companyId required.");
+  if (!input.fromIso || !input.toIso) {
+    return validation("fromIso + toIso required.");
+  }
+  if (Number.isNaN(Date.parse(input.fromIso))) {
+    return validation("fromIso must be a valid ISO timestamp.");
+  }
+  if (Number.isNaN(Date.parse(input.toIso))) {
+    return validation("toIso must be a valid ISO timestamp.");
+  }
+  if (Date.parse(input.fromIso) > Date.parse(input.toIso)) {
+    return validation("fromIso must be <= toIso.");
+  }
+
+  const svc = getServiceRoleClient();
+
+  // Step 1: company's posts.
+  const posts = await svc
+    .from("social_post_master")
+    .select("id, master_text")
+    .eq("company_id", input.companyId);
+  if (posts.error) {
+    logger.error("social.scheduling.list_company.posts_failed", {
+      err: posts.error.message,
+    });
+    return internal(`Failed to read posts: ${posts.error.message}`);
+  }
+  if (!posts.data || posts.data.length === 0) {
+    return {
+      ok: true,
+      data: { entries: [] },
+      timestamp: new Date().toISOString(),
+    };
+  }
+  const postIds = posts.data.map((p) => p.id as string);
+  const postTextById = new Map<string, string | null>();
+  for (const p of posts.data) {
+    postTextById.set(p.id as string, (p.master_text as string | null) ?? null);
+  }
+
+  // Step 2: variants for those posts.
+  const variants = await svc
+    .from("social_post_variant")
+    .select("id, post_master_id, platform, variant_text, is_custom")
+    .in("post_master_id", postIds);
+  if (variants.error) {
+    logger.error("social.scheduling.list_company.variants_failed", {
+      err: variants.error.message,
+    });
+    return internal(`Failed to read variants: ${variants.error.message}`);
+  }
+  if (!variants.data || variants.data.length === 0) {
+    return {
+      ok: true,
+      data: { entries: [] },
+      timestamp: new Date().toISOString(),
+    };
+  }
+  type VariantRow = {
+    id: string;
+    post_master_id: string;
+    platform: SocialPlatform;
+    variant_text: string | null;
+    is_custom: boolean;
+  };
+  const variantById = new Map<string, VariantRow>();
+  for (const v of variants.data) {
+    variantById.set(v.id as string, {
+      id: v.id as string,
+      post_master_id: v.post_master_id as string,
+      platform: v.platform as SocialPlatform,
+      variant_text: (v.variant_text as string | null) ?? null,
+      is_custom: Boolean(v.is_custom),
+    });
+  }
+  const variantIds = Array.from(variantById.keys());
+
+  // Step 3: schedule_entries in window.
+  let query = svc
+    .from("social_schedule_entries")
+    .select("id, post_variant_id, scheduled_at, cancelled_at")
+    .in("post_variant_id", variantIds)
+    .gte("scheduled_at", input.fromIso)
+    .lte("scheduled_at", input.toIso)
+    .order("scheduled_at", { ascending: true });
+  if (!input.includeCancelled) {
+    query = query.is("cancelled_at", null);
+  }
+  const entries = await query;
+  if (entries.error) {
+    logger.error("social.scheduling.list_company.entries_failed", {
+      err: entries.error.message,
+    });
+    return internal(`Failed to read entries: ${entries.error.message}`);
+  }
+
+  const decorated: CompanyScheduleEntry[] = (entries.data ?? []).map((e) => {
+    const variant = variantById.get(e.post_variant_id as string)!;
+    const text = variant.is_custom
+      ? variant.variant_text
+      : postTextById.get(variant.post_master_id) ?? variant.variant_text;
+    const trimmed = (text ?? "").trim();
+    const preview =
+      trimmed.length === 0
+        ? null
+        : trimmed.length <= PREVIEW_CHAR_LIMIT
+          ? trimmed
+          : `${trimmed.slice(0, PREVIEW_CHAR_LIMIT)}…`;
+    return {
+      id: e.id as string,
+      post_variant_id: variant.id,
+      post_master_id: variant.post_master_id,
+      platform: variant.platform,
+      scheduled_at: e.scheduled_at as string,
+      cancelled_at: (e.cancelled_at as string | null) ?? null,
+      preview,
+    };
+  });
+
+  return {
+    ok: true,
+    data: { entries: decorated },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function validation(
+  message: string,
+): ApiResponse<{ entries: CompanyScheduleEntry[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "VALIDATION_FAILED",
+      message,
+      retryable: false,
+      suggested_action: "Fix the input and resubmit.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function internal(
+  message: string,
+): ApiResponse<{ entries: CompanyScheduleEntry[] }> {
+  return {
+    ok: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message,
+      retryable: false,
+      suggested_action: "Retry. If the error persists, contact support.",
+    },
+    timestamp: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `listCompanyScheduleEntries` lib (`lib/platform/social/scheduling/list-company.ts`): 3-read chain (posts by company → variants IN those posts → schedule_entries in date window), avoids multi-FK PostgREST embed, returns preview truncated at 80 chars
- Adds `SocialCalendarClient` — platform filter chips (All + 5 platforms), group-by-date ordered list, each entry links to `/company/social/posts/[post_master_id]`
- Adds `/company/social/calendar` server page — 30-day forward window, force-dynamic, handles no-company state
- 9 test cases covering validation, happy path ordering, preview truncation, cancelled entry exclusion/inclusion, and out-of-window filtering

## Risks identified and mitigated

- **3 separate reads (no JOIN)**: avoids the multi-FK PostgREST embed pitfall. All reads are indexed (PK / FK lookups). For companies with many posts the variant IN-list could grow; for V1 volume this is fine.
- **No write path**: read-only; no concurrency risk.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run audit:static` — 0 HIGH
- [x] `npm run build` — clean, new route appears in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)