### PR TITLE
feat(i2): compositeImage() with Bannerbear provider, Placid stub

### DIFF
--- a/_env_social.example
+++ b/_env_social.example
@@ -52,9 +52,13 @@ MOOD_BOARD_COUNT=4
 # provider's keys are required at runtime; the other set can be blank.
 COMPOSITING_PROVIDER=bannerbear
 BANNERBEAR_API_KEY=
-BANNERBEAR_PROJECT_ID=
+# Template UIDs — one per aspect ratio. Create in app.bannerbear.com; each
+# template needs 3 named layers: "background", "text_zone", "logo".
+BANNERBEAR_TEMPLATE_1080x1080=
+BANNERBEAR_TEMPLATE_1080x1350=
+BANNERBEAR_TEMPLATE_1920x1080=
+BANNERBEAR_TEMPLATE_1080x1920=
 PLACID_API_KEY=
-PLACID_PROJECT_ID=
 
 # ----- Magic-link base URLs --------------------------------------------------
 # Public-facing surfaces for approval / read-only calendar magic links.

--- a/lib/__tests__/image-compositing.test.ts
+++ b/lib/__tests__/image-compositing.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { TEXT_ZONE_MAP } from "@/lib/image/compositing/text-zones";
+import type { CompositionType } from "@/lib/image/types";
+
+// Unit tests for the text-zone map and pixel coordinate conversion.
+// The conversion logic is inline in bannerbear.ts; we test the TEXT_ZONE_MAP
+// contract here so a future maintainer can't shift coordinates without
+// breaking these assertions.
+
+function toPixels(
+  zonePercent: { x: number; y: number; width: number; height: number },
+  imgWidth: number,
+  imgHeight: number,
+) {
+  return {
+    x: Math.round((zonePercent.x / 100) * imgWidth),
+    y: Math.round((zonePercent.y / 100) * imgHeight),
+    w: Math.round((zonePercent.width / 100) * imgWidth),
+    h: Math.round((zonePercent.height / 100) * imgHeight),
+  };
+}
+
+describe("TEXT_ZONE_MAP", () => {
+  it("all composition types are defined", () => {
+    const types: CompositionType[] = [
+      "split_layout",
+      "gradient_fade",
+      "full_background",
+      "geometric",
+      "texture",
+    ];
+    for (const t of types) {
+      expect(TEXT_ZONE_MAP[t], `${t} should be defined`).toBeDefined();
+    }
+  });
+
+  it("all zone values are valid percents (0–100)", () => {
+    for (const [type, zone] of Object.entries(TEXT_ZONE_MAP)) {
+      expect(zone.x, `${type}.x`).toBeGreaterThanOrEqual(0);
+      expect(zone.y, `${type}.y`).toBeGreaterThanOrEqual(0);
+      expect(zone.width, `${type}.width`).toBeGreaterThan(0);
+      expect(zone.height, `${type}.height`).toBeGreaterThan(0);
+      expect(zone.x + zone.width, `${type} x+width`).toBeLessThanOrEqual(100);
+      expect(zone.y + zone.height, `${type} y+height`).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("split_layout text zone is on the right side", () => {
+    const zone = TEXT_ZONE_MAP.split_layout;
+    // Right side: x > 50%
+    expect(zone.x).toBeGreaterThan(50);
+  });
+
+  it("gradient_fade text zone is on the left side", () => {
+    const zone = TEXT_ZONE_MAP.gradient_fade;
+    expect(zone.x).toBeLessThan(20);
+    expect(zone.x + zone.width).toBeLessThan(60);
+  });
+
+  it("full_background text zone is in the lower third", () => {
+    const zone = TEXT_ZONE_MAP.full_background;
+    expect(zone.y).toBeGreaterThan(60);
+  });
+});
+
+describe("pixel conversion for 1080×1080 frame", () => {
+  it("split_layout produces expected pixel bounds", () => {
+    const px = toPixels(TEXT_ZONE_MAP.split_layout, 1080, 1080);
+    // x should be ~626px (58% of 1080)
+    expect(px.x).toBe(Math.round(0.58 * 1080));
+    // width should be ~400px (37% of 1080)
+    expect(px.w).toBe(Math.round(0.37 * 1080));
+    // Text zone must not overflow the frame
+    expect(px.x + px.w).toBeLessThanOrEqual(1080);
+  });
+
+  it("full_background zone starts in the lower third for 1920×1080", () => {
+    const px = toPixels(TEXT_ZONE_MAP.full_background, 1920, 1080);
+    // y should be ~734px (68% of 1080)
+    expect(px.y).toBeGreaterThan(650);
+    expect(px.w).toBeGreaterThan(1600); // 90% of 1920
+  });
+});

--- a/lib/image/compositing/bannerbear.ts
+++ b/lib/image/compositing/bannerbear.ts
@@ -1,0 +1,297 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import type { CompositeInput, CompositeResult } from "./index";
+
+// Bannerbear compositing provider.
+//
+// Template setup (one-time, per aspect ratio):
+//   1. Create a template in app.bannerbear.com for each aspect ratio.
+//   2. Each template needs 3 named layers:
+//      - "background"  — image layer (full frame)
+//      - "text_zone"   — text layer (we override x_offset/y_offset/width/height)
+//      - "logo"        — image layer (optional, shown only when logo is provided)
+//   3. Set the template UID in the env vars:
+//      BANNERBEAR_TEMPLATE_1080x1080  (1:1)
+//      BANNERBEAR_TEMPLATE_1080x1350  (4:5)
+//      BANNERBEAR_TEMPLATE_1920x1080  (16:9)
+//      BANNERBEAR_TEMPLATE_1080x1920  (9:16)
+//
+// Bannerbear modifications doc: https://www.bannerbear.com/help/articles/modifications/
+
+const BANNERBEAR_API = "https://api.bannerbear.com/v2";
+const IMAGE_GEN_BUCKET =
+  process.env.IMAGE_GENERATION_BUCKET ?? "generated-images";
+
+// Dimensions map for aspect-ratio → template env key
+const DIMENSION_KEY_MAP: Record<string, string> = {
+  "1080x1080": "BANNERBEAR_TEMPLATE_1080x1080",
+  "1080x1350": "BANNERBEAR_TEMPLATE_1080x1350",
+  "1920x1080": "BANNERBEAR_TEMPLATE_1920x1080",
+  "1080x1920": "BANNERBEAR_TEMPLATE_1080x1920",
+};
+
+// Logo position → pixel offsets as percent of frame (for the Bannerbear logo layer)
+const LOGO_POSITIONS: Record<
+  NonNullable<CompositeInput["logo"]>["position"],
+  (w: number, h: number, sizePercent: number, padding: number) => { x: number; y: number; width: number }
+> = {
+  "top-right": (w, _h, s, p) => ({
+    x: w - Math.round((s / 100) * w) - p,
+    y: p,
+    width: Math.round((s / 100) * w),
+  }),
+  "bottom-right": (w, h, s, p) => ({
+    x: w - Math.round((s / 100) * w) - p,
+    y: h - Math.round((s / 100) * w) - p,
+    width: Math.round((s / 100) * w),
+  }),
+  "bottom-left": (_w, h, s, p) => ({
+    x: p,
+    y: h - Math.round((s / 100) * _w) - p,
+    width: Math.round((s / 100) * _w),
+  }),
+  "watermark-center": (w, h, s, _p) => ({
+    x: Math.round((w - (s / 100) * w) / 2),
+    y: Math.round((h - (s / 100) * w) / 2),
+    width: Math.round((s / 100) * w),
+  }),
+};
+
+interface BannerbearModification {
+  name: string;
+  text?: string;
+  image_url?: string;
+  x_offset?: number;
+  y_offset?: number;
+  width?: number;
+  height?: number;
+  color?: string;
+  font_family?: string;
+  font_size?: number;
+  text_align?: string;
+  visible?: boolean;
+}
+
+interface BannerbearResponse {
+  uid: string;
+  status: "pending" | "completed" | "failed";
+  image_url: string | null;
+  image_url_png: string | null;
+}
+
+function resolveTemplateUid(width: number, height: number): string {
+  const key = `${width}x${height}`;
+  const envKey = DIMENSION_KEY_MAP[key];
+  if (!envKey) {
+    throw new Error(
+      `No Bannerbear template mapping for ${key}. Add to DIMENSION_KEY_MAP.`,
+    );
+  }
+  const uid = process.env[envKey];
+  if (!uid) {
+    throw new Error(
+      `${envKey} is not set. Create a Bannerbear template for ${key} and set the UID.`,
+    );
+  }
+  return uid;
+}
+
+async function getBackgroundSignedUrl(
+  storagePath: string,
+): Promise<string> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase.storage
+    .from(IMAGE_GEN_BUCKET)
+    .createSignedUrl(storagePath, 3600);
+  if (error || !data?.signedUrl) {
+    throw new Error(
+      `Failed to get signed URL for ${storagePath}: ${error?.message ?? "no URL"}`,
+    );
+  }
+  return data.signedUrl;
+}
+
+async function pollUntilComplete(
+  uid: string,
+  apiKey: string,
+  maxWaitMs = 60_000,
+): Promise<BannerbearResponse> {
+  const start = Date.now();
+  const delay = 2000;
+
+  while (Date.now() - start < maxWaitMs) {
+    await new Promise((r) => setTimeout(r, delay));
+
+    const res = await fetch(`${BANNERBEAR_API}/images/${uid}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (!res.ok) {
+      throw new Error(`Bannerbear poll ${uid} returned ${res.status}`);
+    }
+    const data = (await res.json()) as BannerbearResponse;
+    if (data.status === "completed") return data;
+    if (data.status === "failed") {
+      throw new Error(`Bannerbear image ${uid} failed`);
+    }
+  }
+  throw new Error(`Bannerbear image ${uid} timed out after ${maxWaitMs}ms`);
+}
+
+async function downloadAndStoreComposite(
+  imageUrl: string,
+  companyId: string,
+  format: "jpeg" | "png",
+): Promise<string> {
+  const res = await fetch(imageUrl);
+  if (!res.ok) {
+    throw new Error(`Failed to download composite from Bannerbear: ${res.status}`);
+  }
+
+  const buffer = Buffer.from(await res.arrayBuffer());
+  const ext = format === "png" ? "png" : "jpg";
+  const storagePath = `${companyId}/composite/${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
+
+  const supabase = getServiceRoleClient();
+  const { error } = await supabase.storage
+    .from(IMAGE_GEN_BUCKET)
+    .upload(storagePath, buffer, {
+      contentType: format === "png" ? "image/png" : "image/jpeg",
+      upsert: false,
+    });
+
+  if (error) {
+    throw new Error(`Failed to store composite: ${error.message}`);
+  }
+  return storagePath;
+}
+
+// Determine the company ID from the background storage path.
+// Convention: `<companyId>/generated/<filename>` → `<companyId>`.
+function extractCompanyId(storagePath: string): string {
+  const parts = storagePath.split("/");
+  return parts[0] ?? "unknown";
+}
+
+export async function compositeBannerbear(
+  input: CompositeInput,
+): Promise<CompositeResult> {
+  const apiKey = process.env.BANNERBEAR_API_KEY;
+  if (!apiKey) throw new Error("BANNERBEAR_API_KEY is not set");
+
+  const start = Date.now();
+  const { outputWidth: w, outputHeight: h } = input;
+  const templateUid = resolveTemplateUid(w, h);
+  const bgUrl = await getBackgroundSignedUrl(input.backgroundStoragePath);
+
+  const modifications: BannerbearModification[] = [];
+
+  // Background layer
+  modifications.push({ name: "background", image_url: bgUrl });
+
+  // Text zones (we take the first zone for now; multi-zone is I4+)
+  const primaryZone = input.textZones[0];
+  if (primaryZone) {
+    const zoneX = Math.round((primaryZone.x / 100) * w);
+    const zoneY = Math.round((primaryZone.y / 100) * h);
+    const zoneW = Math.round((primaryZone.width / 100) * w);
+    const zoneH = Math.round((primaryZone.height / 100) * h);
+
+    // For overlay colour: pass a background color on the text layer
+    const textColor =
+      primaryZone.colour === "white"
+        ? "#FFFFFF"
+        : primaryZone.colour === "dark"
+          ? "#1A1A1A"
+          : "#FFFFFF"; // overlay: white text with semi-transparent bg (handled in template)
+
+    modifications.push({
+      name: "text_zone",
+      text: primaryZone.text,
+      x_offset: zoneX,
+      y_offset: zoneY,
+      width: zoneW,
+      height: zoneH,
+      color: textColor,
+      font_family: primaryZone.fontFamily,
+      font_size: Math.min(primaryZone.maxFontSize, Math.floor(zoneH / 4)),
+      text_align: primaryZone.alignment,
+    });
+  }
+
+  // Logo layer
+  if (input.logo) {
+    const logoCalc = LOGO_POSITIONS[input.logo.position](
+      w,
+      h,
+      input.logo.sizePercent,
+      input.logo.padding,
+    );
+    modifications.push({
+      name: "logo",
+      image_url: input.logo.url,
+      x_offset: logoCalc.x,
+      y_offset: logoCalc.y,
+      width: logoCalc.width,
+      visible: true,
+    });
+  } else {
+    modifications.push({ name: "logo", visible: false });
+  }
+
+  // Create image in Bannerbear
+  const createRes = await fetch(`${BANNERBEAR_API}/images`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      template: templateUid,
+      modifications,
+    }),
+  });
+
+  if (!createRes.ok) {
+    const body = await createRes.text();
+    throw new Error(
+      `Bannerbear create image failed ${createRes.status}: ${body.slice(0, 200)}`,
+    );
+  }
+
+  const created = (await createRes.json()) as BannerbearResponse;
+  logger.info("Bannerbear image creation started", { uid: created.uid });
+
+  // Synchronous response if status=completed immediately (unlikely but handle it)
+  const completed =
+    created.status === "completed"
+      ? created
+      : await pollUntilComplete(created.uid, apiKey);
+
+  const imageUrl =
+    input.outputFormat === "png"
+      ? (completed.image_url_png ?? completed.image_url)
+      : completed.image_url;
+
+  if (!imageUrl) {
+    throw new Error(`Bannerbear completed but no image URL for ${created.uid}`);
+  }
+
+  const companyId = extractCompanyId(input.backgroundStoragePath);
+  const storagePath = await downloadAndStoreComposite(
+    imageUrl,
+    companyId,
+    input.outputFormat,
+  );
+
+  const durationMs = Date.now() - start;
+  logger.info("Bannerbear composite complete", {
+    uid: created.uid,
+    storagePath,
+    durationMs,
+  });
+
+  return { storagePath, provider: "bannerbear", durationMs };
+}

--- a/lib/image/compositing/index.ts
+++ b/lib/image/compositing/index.ts
@@ -26,10 +26,21 @@ export interface CompositeResult {
 }
 
 // Compositing abstraction — product code ONLY calls this function.
-// Provider implementations land in I2 (Bannerbear or Placid evaluation).
+// Provider is selected by COMPOSITING_PROVIDER env var (default: bannerbear).
+// New providers: add a case here + implement in a new file.
 export async function compositeImage(
-  _input: CompositeInput,
+  input: CompositeInput,
 ): Promise<CompositeResult> {
-  // I2: Bannerbear or Placid implementation selected via COMPOSITING_PROVIDER env var.
-  throw new Error("compositeImage: not implemented until I2");
+  const { compositeBannerbear } = await import("./bannerbear");
+  const { compositePlacid } = await import("./placid");
+
+  const provider = process.env.COMPOSITING_PROVIDER ?? "bannerbear";
+  switch (provider) {
+    case "bannerbear":
+      return compositeBannerbear(input);
+    case "placid":
+      return compositePlacid(input);
+    default:
+      throw new Error(`Unknown compositing provider: ${provider}`);
+  }
 }

--- a/lib/image/compositing/placid.ts
+++ b/lib/image/compositing/placid.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import type { CompositeInput, CompositeResult } from "./index";
+
+// Placid compositing provider — stub for I2 evaluation.
+//
+// Placid uses a similar template + modifications model to Bannerbear:
+//   POST /api/render with { template_uuid, layers: [...] }
+//
+// Key differences from Bannerbear:
+// - Layers addressed by UUID (not name); UIDs come from the template editor
+// - Response includes `image_url` synchronously when `wait: true`
+// - Pricing: per-render credit model (vs Bannerbear's subscription)
+//
+// Evaluation outcome (I2): Bannerbear selected as primary provider because:
+// 1. Named layers (not UUID) are easier to maintain in code
+// 2. Asynchronous webhook pattern is better for high-volume generation
+// 3. Stronger modifier support (x_offset, y_offset, width, height overrides)
+//    needed for our dynamic text-zone positioning
+// 4. Better template version control
+//
+// If requirements change (e.g. synchronous generation needed, or Bannerbear
+// pricing becomes unfavourable), implement this stub.
+export async function compositePlacid(
+  _input: CompositeInput,
+): Promise<CompositeResult> {
+  throw new Error(
+    "Placid provider is not implemented. Set COMPOSITING_PROVIDER=bannerbear.",
+  );
+}


### PR DESCRIPTION
## Summary

- **`lib/image/compositing/bannerbear.ts`** — `compositeBannerbear()`: full Bannerbear API integration
  - One template per aspect ratio (env vars `BANNERBEAR_TEMPLATE_1080x1080`, `_1080x1350`, `_1920x1080`, `_1080x1920`)
  - Each template has 3 named layers: `background` (image), `text_zone` (text), `logo` (image, optional)
  - Text zone pixel coordinates derived from `TEXT_ZONE_MAP` + frame dimensions → passed as `x_offset / y_offset / width / height` modifications
  - Polls `/v2/images/:uid` until `status=completed` (2s interval, 60s timeout)
  - Downloads composite immediately → uploads to Supabase Storage (never stores Bannerbear URL)
- **`lib/image/compositing/placid.ts`** — stub that throws with evaluation rationale comment
- **`lib/image/compositing/index.ts`** — `compositeImage()` now dispatches to real providers; dynamic imports to keep server-only boundary
- **`lib/__tests__/image-compositing.test.ts`** — `TEXT_ZONE_MAP` contract tests (all types defined, valid percents, positional invariants) + pixel conversion assertions
- **`_env_social.example`** — `BANNERBEAR_TEMPLATE_*` vars documented

## Provider evaluation: Bannerbear over Placid

| Criterion | Bannerbear | Placid |
|-----------|-----------|--------|
| Layer addressing | **Named** (maintainable in code) | UUID (requires dashboard lookup) |
| Dynamic positioning | **x/y/width/height overrides** on any layer | Fixed layout per template |
| Async model | **Webhook + poll** (suits batch generation) | `wait=true` sync (blocks request thread) |
| Text zone strategy | Single template per aspect ratio + dynamic coords | One template per composition × aspect ratio = 20 templates |

Decision: **Bannerbear**. `COMPOSITING_PROVIDER=bannerbear` is the default.

## One-time operational setup required

Before compositing works in production:
1. Create 4 Bannerbear templates (one per aspect ratio) at app.bannerbear.com
2. Each template needs layers named exactly: `background`, `text_zone`, `logo`
3. Set the 4 `BANNERBEAR_TEMPLATE_*` env vars in Vercel with the template UIDs

## Risks identified and mitigated

- **Template UIDs missing** — `resolveTemplateUid()` throws a clear error naming the missing env var; won't silently fall through
- **Bannerbear poll timeout** — 60s ceiling per image; if exceeded, throws; the outer `generateWithFallback()` in handler.ts catches and falls back to stock
- **Logo signed URL staleness** — callers must pass fresh signed URLs at composite time (not upload-time); documented in the skill
- **Multi-zone** — `compositeImage()` accepts `textZones[]` but Bannerbear's `text_zone` layer handles one zone; I4 (mood board) can extend to multi-zone when needed; we take `textZones[0]` for now
- **No new migration** — I2 is pure TypeScript; no schema changes

## Test plan
- [ ] `npm run typecheck` — clean ✅
- [ ] `npm run lint` — clean ✅
- [ ] `npm run audit:static` — 0 HIGH ✅
- [ ] `npm run build` — CI confirms
- [ ] End-to-end compositing: set `BANNERBEAR_API_KEY` + create templates → call `compositeImage()` from a test script

🤖 Generated with [Claude Code](https://claude.com/claude-code)