### PR TITLE
feat(i4): mood board UI — style/composition selectors, image grid, 1-click select

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -57,7 +57,7 @@ Magic links never grant access to settings, brand profile, or management. Scoped
 
 ## Current state
 
-- **Slice in progress:** I3 (quality checks with sharp — luminance, safe zone, Laplacian variance)
+- **Slice in progress:** I4 (mood board UI — style selector, composition selector, 4–6 results, 1-click select)
 - **Most recently shipped:** S1-18 publish pipeline (#439) + S1-17 inbound webhook handler (#437)
 - **S0 (bundle.social verification):** complete
 - **Vendor confirmed:** bundle.social (publishing), Ideogram (backgrounds), Bannerbear or Placid (compositing — evaluate at I2)
@@ -99,10 +99,10 @@ Magic links never grant access to settings, brand profile, or management. Scoped
 
 | Slice | Scope | Status |
 |-------|-------|--------|
-| I1 | Ideogram client (backgrounds only, GLOBAL_NEGATIVE_PROMPT). Prompt engine (parameterised). Brand profile reader. Standard/premium routing. Stock fallback. image_generation_log writes. | 👈 Current |
+| I1 | Ideogram client (backgrounds only, GLOBAL_NEGATIVE_PROMPT). Prompt engine (parameterised). Brand profile reader. Standard/premium routing. Stock fallback. image_generation_log writes. | ✅ Shipped (#455) |
 | I2 | Evaluate Bannerbear vs Placid against 3 real client templates. Implement compositeImage() interface + winning provider. Text zones + logo positions. | ✅ Shipped (#457 Bannerbear primary, Placid stub, TEXT_ZONE_MAP pixel conversion) |
-| I3 | Failure handler: luminance check + safe zone check → retry → stock fallback → escalation. Quality check rules. | 👈 Current |
-| I4 | Mood board UI: style selector, composition selector, 4–6 results, 1-click select. | ❌ Pending |
+| I3 | Failure handler: luminance check + safe zone check → retry → stock fallback → escalation. Quality check rules. | ✅ Shipped (#459) |
+| I4 | Mood board UI: style selector, composition selector, 4–6 results, 1-click select. | 👈 Current |
 | I5 | CAP Phase 2: automated generation via source_type='cap' (Phase 2) | ❌ Pending (Phase 2 — see "What is NOT V1" further down) |
 
 **Rule:** finish one slice, CI green, PR merged, before starting the next.

--- a/app/api/platform/image/generate/route.ts
+++ b/app/api/platform/image/generate/route.ts
@@ -1,0 +1,193 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { logger } from "@/lib/logger";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getActiveBrandProfile } from "@/lib/platform/brand";
+import {
+  generateWithFallback,
+  getAllowedStyles,
+  validateStyleForBrand,
+} from "@/lib/image";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { AspectRatio, CompositionType, StyleId } from "@/lib/image";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/image/generate — I4 mood board generation
+//
+// Generates 4–6 background images for the customer to select from.
+// Each image goes through generateWithFallback() (Ideogram → quality
+// check → stock fallback if needed) and is stored in Supabase Storage.
+// Returns signed URLs for immediate display in the mood board UI.
+//
+// Auth: requires `create_post` permission (editor+ or Opollo staff).
+// Feature gate: IMAGE_FEATURE_MOOD_BOARD must be "true".
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 120; // Ideogram can take ~30s per image
+
+const IMAGE_GEN_BUCKET =
+  process.env.IMAGE_GENERATION_BUCKET ?? "generated-images";
+const SIGNED_URL_TTL = 3600; // 1 hour — sufficient for a UI session
+
+const GenerateSchema = z.object({
+  company_id: z.string().uuid(),
+  style_id: z.enum([
+    "clean_corporate",
+    "bold_promo",
+    "minimal_modern",
+    "editorial",
+    "product_focus",
+  ]),
+  composition_type: z.enum([
+    "split_layout",
+    "gradient_fade",
+    "full_background",
+    "geometric",
+    "texture",
+  ]),
+  aspect_ratio: z.enum([
+    "ASPECT_1_1",
+    "ASPECT_4_5",
+    "ASPECT_16_9",
+    "ASPECT_9_16",
+  ]),
+  count: z.number().int().min(1).max(6).default(4),
+  post_master_id: z.string().uuid().optional(),
+});
+
+export async function POST(req: NextRequest) {
+  if (process.env.IMAGE_FEATURE_MOOD_BOARD !== "true") {
+    return NextResponse.json(
+      { ok: false, error: { code: "FEATURE_DISABLED", message: "Mood board is not enabled." } },
+      { status: 403 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: { code: "VALIDATION_FAILED", message: "Invalid JSON body." } },
+      { status: 400 },
+    );
+  }
+
+  const parsed = GenerateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: { code: "VALIDATION_FAILED", message: parsed.error.message } },
+      { status: 400 },
+    );
+  }
+
+  const { company_id: companyId, style_id, composition_type, aspect_ratio, count, post_master_id } =
+    parsed.data;
+
+  const gateResult = await requireCanDoForApi(companyId, "create_post");
+  if (gateResult.kind === "deny") {
+    return gateResult.response;
+  }
+
+  const { userId } = gateResult;
+
+  // Validate style against brand profile (safe_mode + approved_style_ids)
+  const brand = await getActiveBrandProfile(companyId);
+  try {
+    validateStyleForBrand(style_id as StyleId, brand);
+  } catch {
+    const allowed = getAllowedStyles(brand).join(", ");
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "STYLE_BLOCKED",
+          message: `Style "${style_id}" is not available for this brand. Allowed: ${allowed}`,
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  logger.info("mood-board.generate.start", {
+    companyId,
+    styleId: style_id,
+    compositionType: composition_type,
+    aspectRatio: aspect_ratio,
+    count,
+    userId,
+  });
+
+  // Generate all images in parallel; use allSettled so partial failure
+  // doesn't abort the whole board.
+  const primaryColour = brand?.primary_colour ?? "#1A1A1A";
+  const industry = brand?.industry ?? undefined;
+
+  const generationTasks = Array.from({ length: count }, (_, i) =>
+    generateWithFallback({
+      styleId: style_id as StyleId,
+      primaryColour,
+      compositionType: composition_type as CompositionType,
+      aspectRatio: aspect_ratio as AspectRatio,
+      industry,
+      count: 1,
+      companyId,
+      brandProfileId: brand?.id,
+      brandProfileVersion: brand?.version,
+      postMasterId: post_master_id,
+      triggeredBy: userId,
+    }).then((images) => images[0]).catch((err) => {
+      logger.warn("mood-board.generate.partial-failure", {
+        companyId,
+        slot: i,
+        error: String(err),
+      });
+      return null;
+    }),
+  );
+
+  const results = await Promise.all(generationTasks);
+  const successful = results.filter(
+    (r): r is NonNullable<typeof r> => r !== null,
+  );
+
+  if (successful.length === 0) {
+    return NextResponse.json(
+      { ok: false, error: { code: "GENERATION_FAILED", message: "All image generation attempts failed." } },
+      { status: 502 },
+    );
+  }
+
+  // Get signed URLs for display
+  const supabase = getServiceRoleClient();
+  const images = await Promise.all(
+    successful.map(async (img) => {
+      const { data } = await supabase.storage
+        .from(IMAGE_GEN_BUCKET)
+        .createSignedUrl(img.storagePath, SIGNED_URL_TTL);
+      return {
+        storagePath: img.storagePath,
+        signedUrl: data?.signedUrl ?? null,
+        width: img.width,
+        height: img.height,
+        format: img.format,
+      };
+    }),
+  );
+
+  logger.info("mood-board.generate.complete", {
+    companyId,
+    requested: count,
+    generated: images.length,
+    userId,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    data: { images },
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/app/company/image/generate/page.tsx
+++ b/app/company/image/generate/page.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { MoodBoardClient } from "@/components/MoodBoardClient";
+import { getAllowedStyles } from "@/lib/image";
+import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
+import { getActiveBrandProfile } from "@/lib/platform/brand";
+
+// ---------------------------------------------------------------------------
+// I4 — mood board generator at /company/image/generate.
+//
+// Generates 4–6 background images via Ideogram (through the mood board
+// API at /api/platform/image/generate). Server component handles auth +
+// brand profile read; MoodBoardClient owns the interactive UI.
+//
+// Gates:
+//   1. IMAGE_FEATURE_MOOD_BOARD env flag → redirect /company if off.
+//   2. Session required (platform_users).
+//   3. create_post permission (editor+).
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+export default async function MoodBoardPage() {
+  if (process.env.IMAGE_FEATURE_MOOD_BOARD !== "true") {
+    redirect("/company");
+  }
+
+  const session = await getCurrentPlatformSession();
+  if (!session) {
+    redirect(`/login?next=${encodeURIComponent("/company/image/generate")}`);
+  }
+
+  if (!session.company) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-sm">
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-4">
+          <p className="font-medium">Account not provisioned to a company.</p>
+          <p className="mt-1 text-muted-foreground">
+            Your account isn&apos;t a member of any company on the platform
+            yet. Ask an admin to invite you, or contact Opollo support.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const companyId = session.company.companyId;
+
+  const [canCreate, brand] = await Promise.all([
+    canDo(companyId, "create_post"),
+    getActiveBrandProfile(companyId),
+  ]);
+
+  if (!canCreate) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-sm">
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-4">
+          <p className="font-medium">Permission denied.</p>
+          <p className="mt-1 text-muted-foreground">
+            Editor or admin permissions are required to generate images.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const allowedStyles = getAllowedStyles(brand);
+
+  return (
+    <main className="mx-auto max-w-5xl p-6">
+      <div className="mb-4 text-sm">
+        <Link
+          href="/company"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          ← Dashboard
+        </Link>
+      </div>
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold">Mood board generator</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Generate background images for your social posts. Click an image to
+          select it and copy its URL.
+        </p>
+      </header>
+      <MoodBoardClient
+        companyId={companyId}
+        allowedStyles={allowedStyles}
+        primaryColour={brand?.primary_colour ?? null}
+      />
+    </main>
+  );
+}

--- a/app/company/layout.tsx
+++ b/app/company/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+
+import { Toaster } from "@/components/ui/toaster";
+
+export default function CompanyLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      {children}
+      <Toaster />
+    </>
+  );
+}

--- a/app/company/page.tsx
+++ b/app/company/page.tsx
@@ -57,15 +57,18 @@ export default async function CompanyLandingPage() {
   // Brand tier drives the completion banner. Read in parallel with stats
   // so the page render isn't sequentialised; both are server-rendered
   // and degrade gracefully on null.
-  const [statsResult, brand] = await Promise.all([
+  const [statsResult, brand, canCreate] = await Promise.all([
     getSocialPostsStats({ companyId }),
     getActiveBrandProfile(companyId),
+    canDo(companyId, "create_post"),
   ]);
   const brandTier = getBrandTier(brand);
   const showCompletionBanner =
     brandTier === "none" || brandTier === "minimal";
   const isAdmin =
     session.isOpolloStaff || session.company.role === "admin";
+  const showImageGenerator =
+    process.env.IMAGE_FEATURE_MOOD_BOARD === "true" && canCreate;
 
   return (
     <main className="mx-auto max-w-5xl p-6 space-y-6">
@@ -155,6 +158,18 @@ export default async function CompanyLandingPage() {
             <div className="font-medium">Brand profile</div>
             <div className="mt-1 text-sm text-muted-foreground">
               Visual identity + tone + content rules. Drives every output.
+            </div>
+          </Link>
+        ) : null}
+        {showImageGenerator ? (
+          <Link
+            href="/company/image/generate"
+            className="block rounded-md border bg-card p-4 hover:border-primary/40"
+            data-testid="dashboard-link-image-generator"
+          >
+            <div className="font-medium">Image generator</div>
+            <div className="mt-1 text-sm text-muted-foreground">
+              Generate mood board backgrounds for your social posts.
             </div>
           </Link>
         ) : null}

--- a/components/MoodBoardClient.tsx
+++ b/components/MoodBoardClient.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+
+import type { AspectRatio, CompositionType, StyleId } from "@/lib/image/types";
+
+// ---------------------------------------------------------------------------
+// I4 — mood board UI client component.
+//
+// Receives brand-derived props from the server page; owns all interactive
+// state. Calls POST /api/platform/image/generate and renders a 2–3 col
+// grid of results. Clicking an image marks it selected + copies its
+// signed URL to the clipboard.
+// ---------------------------------------------------------------------------
+
+interface GeneratedImageResult {
+  storagePath: string;
+  signedUrl: string | null;
+  width: number;
+  height: number;
+  format: string;
+}
+
+const STYLE_LABELS: Record<StyleId, string> = {
+  clean_corporate: "Clean corporate",
+  bold_promo: "Bold promo",
+  minimal_modern: "Minimal modern",
+  editorial: "Editorial",
+  product_focus: "Product focus",
+};
+
+const COMPOSITION_LABELS: Record<CompositionType, string> = {
+  split_layout: "Split layout",
+  gradient_fade: "Gradient fade",
+  full_background: "Full background",
+  geometric: "Geometric",
+  texture: "Texture",
+};
+
+const ASPECT_RATIO_LABELS: Record<AspectRatio, string> = {
+  ASPECT_1_1: "1:1 Square",
+  ASPECT_4_5: "4:5 Portrait",
+  ASPECT_16_9: "16:9 Landscape",
+  ASPECT_9_16: "9:16 Story",
+};
+
+const ALL_COMPOSITIONS: CompositionType[] = [
+  "split_layout",
+  "gradient_fade",
+  "full_background",
+  "geometric",
+  "texture",
+];
+
+const ALL_ASPECT_RATIOS: AspectRatio[] = [
+  "ASPECT_1_1",
+  "ASPECT_4_5",
+  "ASPECT_16_9",
+  "ASPECT_9_16",
+];
+
+const COUNT_OPTIONS = [4, 5, 6] as const;
+
+interface Props {
+  companyId: string;
+  allowedStyles: StyleId[];
+  primaryColour: string | null;
+}
+
+export function MoodBoardClient({
+  companyId,
+  allowedStyles,
+  primaryColour: _primaryColour,
+}: Props) {
+  const [style, setStyle] = useState<StyleId>(
+    allowedStyles[0] ?? "clean_corporate",
+  );
+  const [composition, setComposition] = useState<CompositionType>(
+    "split_layout",
+  );
+  const [aspectRatio, setAspectRatio] = useState<AspectRatio>("ASPECT_1_1");
+  const [count, setCount] = useState<(typeof COUNT_OPTIONS)[number]>(4);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [images, setImages] = useState<GeneratedImageResult[]>([]);
+  const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+
+  async function generate() {
+    setIsLoading(true);
+    setError(null);
+    setImages([]);
+    setSelectedIdx(null);
+
+    try {
+      const res = await fetch("/api/platform/image/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          company_id: companyId,
+          style_id: style,
+          composition_type: composition,
+          aspect_ratio: aspectRatio,
+          count,
+        }),
+      });
+      const json = (await res.json()) as {
+        ok: boolean;
+        data?: { images: GeneratedImageResult[] };
+        error?: { code: string; message: string };
+      };
+      if (!json.ok) {
+        setError(json.error?.message ?? "Generation failed. Please try again.");
+        return;
+      }
+      setImages(json.data?.images ?? []);
+    } catch {
+      setError("Network error — please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function selectImage(idx: number) {
+    const img = images[idx];
+    if (!img?.signedUrl) {
+      toast.error("No URL available for this image.");
+      return;
+    }
+    setSelectedIdx(idx);
+    try {
+      await navigator.clipboard.writeText(img.signedUrl);
+      toast.success("Image URL copied to clipboard.");
+    } catch {
+      toast.error(
+        "Could not copy to clipboard — check browser permissions.",
+      );
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+        {/* Style selector */}
+        <div>
+          <p className="mb-1.5 text-sm font-medium">Style</p>
+          <div className="flex flex-wrap gap-1.5">
+            {allowedStyles.map((s) => (
+              <button
+                key={s}
+                type="button"
+                onClick={() => setStyle(s)}
+                className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+                  style === s
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-background hover:border-primary/50"
+                }`}
+              >
+                {STYLE_LABELS[s]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Composition selector */}
+        <div>
+          <p className="mb-1.5 text-sm font-medium">Composition</p>
+          <div className="flex flex-wrap gap-1.5">
+            {ALL_COMPOSITIONS.map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => setComposition(c)}
+                className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+                  composition === c
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-background hover:border-primary/50"
+                }`}
+              >
+                {COMPOSITION_LABELS[c]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Aspect ratio selector */}
+        <div>
+          <p className="mb-1.5 text-sm font-medium">Aspect ratio</p>
+          <div className="flex flex-wrap gap-1.5">
+            {ALL_ASPECT_RATIOS.map((ar) => (
+              <button
+                key={ar}
+                type="button"
+                onClick={() => setAspectRatio(ar)}
+                className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+                  aspectRatio === ar
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-background hover:border-primary/50"
+                }`}
+              >
+                {ASPECT_RATIO_LABELS[ar]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Count selector */}
+        <div>
+          <p className="mb-1.5 text-sm font-medium">Count</p>
+          <div className="flex gap-1.5">
+            {COUNT_OPTIONS.map((n) => (
+              <button
+                key={n}
+                type="button"
+                onClick={() => setCount(n)}
+                className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+                  count === n
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-background hover:border-primary/50"
+                }`}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Generate button */}
+      <div>
+        <button
+          type="button"
+          onClick={generate}
+          disabled={isLoading || allowedStyles.length === 0}
+          className="inline-flex min-w-[160px] items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+        >
+          {isLoading ? "Generating…" : "Generate images"}
+        </button>
+        {isLoading ? (
+          <p className="mt-2 text-xs text-muted-foreground">
+            This can take up to 60 seconds for {count} images — please wait.
+          </p>
+        ) : null}
+      </div>
+
+      {/* Error state */}
+      {error ? (
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {/* Results grid */}
+      {images.length > 0 ? (
+        <section aria-label="Generated images">
+          <p className="mb-3 text-sm text-muted-foreground">
+            {images.length} image{images.length !== 1 ? "s" : ""} generated.
+            Click an image to select it and copy its URL.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {images.map((img, idx) => {
+              const isSelected = selectedIdx === idx;
+              return (
+                <button
+                  key={img.storagePath}
+                  type="button"
+                  onClick={() => selectImage(idx)}
+                  aria-pressed={isSelected}
+                  aria-label={`Image ${idx + 1}${isSelected ? " (selected)" : ""}`}
+                  className={`group relative overflow-hidden rounded-md border-2 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                    isSelected
+                      ? "border-primary"
+                      : "border-transparent hover:border-primary/40"
+                  }`}
+                >
+                  {img.signedUrl ? (
+                    // Use <img> rather than next/image — Supabase Storage
+                    // signed URLs are external and don't go through the
+                    // Next.js image optimiser.
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={img.signedUrl}
+                      alt={`Generated background ${idx + 1}`}
+                      className="aspect-square w-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex aspect-square w-full items-center justify-center bg-muted text-xs text-muted-foreground">
+                      URL unavailable
+                    </div>
+                  )}
+
+                  {/* Hover / focus overlay */}
+                  <div
+                    className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+                    aria-hidden="true"
+                  >
+                    <span className="rounded-md bg-white px-3 py-1.5 text-xs font-medium text-black">
+                      {isSelected ? "Selected" : "Select"}
+                    </span>
+                  </div>
+
+                  {/* Selected checkmark badge */}
+                  {isSelected ? (
+                    <div
+                      className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground shadow"
+                      aria-hidden="true"
+                    >
+                      <svg
+                        viewBox="0 0 12 12"
+                        fill="none"
+                        className="h-3 w-3"
+                      >
+                        <path
+                          d="M2 6l3 3 5-5"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    </div>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Plan

I4 completes the mood board generation UI that sits on top of the I1–I3 Ideogram/quality-check pipeline.

### New API route: `POST /api/platform/image/generate`

- Feature-gated: `IMAGE_FEATURE_MOOD_BOARD === "true"` → 403 if off
- Body: `{ company_id, style_id, composition_type, aspect_ratio, count (1–6), post_master_id? }`
- Auth: `requireCanDoForApi(companyId, "create_post")` — editor+ or Opollo staff
- Validates requested `style_id` against brand profile (`safe_mode` + `approved_style_ids`)
- Generates `count` images in parallel via `generateWithFallback()` — partial failures degrade gracefully
- `maxDuration = 120` — Ideogram can take ~30s/image
- Returns signed URLs (TTL 3600s) from `generated-images` bucket

### New page: `/company/image/generate`

Server component: session gate → feature flag redirect → `canDo("create_post")` check → brand profile read + `getAllowedStyles()` → renders `MoodBoardClient`.

### New component: `MoodBoardClient`

Client component with:
- Style pill selector (filtered to `allowedStyles` from brand profile)
- Composition type pill selector (all 5 options)
- Aspect ratio pill selector (all 4 options)
- Count selector (4 / 5 / 6)
- Generate button with loading state + time-warning copy
- 2–3 col image grid with hover overlay
- 1-click select: marks image with checkmark badge + copies signed URL to clipboard via Sonner toast

### Supporting changes

- `app/company/layout.tsx` — minimal layout that mounts `<Toaster />` for all `/company/*` routes
- `app/company/page.tsx` — adds "Image generator" card to dashboard grid, gated by feature flag + `canDo("create_post")`
- `BUILD.md` — I1/I3 marked shipped; I4 current

## Risks identified and mitigated

| Risk | Mitigation |
|------|------------|
| Long Vercel function timeout | `maxDuration = 120` set; parallel generation so 6 × ~30s fits within window |
| All images fail | `GENERATION_FAILED` 502 only when `successful.length === 0`; partial success returns what we have |
| Style blocked by brand rules | Validated at API layer; `STYLE_BLOCKED` 403 before any Ideogram call |
| Signed URL expiry | TTL 3600s — well within a UI session; client shows `URL unavailable` if null |
| Clipboard permission denied | `navigator.clipboard` failure caught; toast error tells user to check browser permissions |
| Feature flag off | Page redirects `/company`; API returns 403; dashboard card hidden |

## Test plan

- [ ] `IMAGE_FEATURE_MOOD_BOARD` unset → `/company/image/generate` redirects `/company`; API returns 403
- [ ] Viewer role → 403 from API (no `create_post`)
- [ ] Editor role → can generate
- [ ] `safe_mode=true` brand → `bold_promo` + `editorial` absent from style selector
- [ ] Generate with count=4 → grid shows up to 4 images
- [ ] Click image → selected ring + checkmark badge + clipboard toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)