### PR TITLE
feat(s1-33): add failed/rejected/changes_requested filters to posts list

### DIFF
--- a/components/SocialPostsListClient.tsx
+++ b/components/SocialPostsListClient.tsx
@@ -56,9 +56,12 @@ const FILTER_TABS: Array<{ key: "all" | SocialPostState; label: string }> = [
   { key: "all", label: "All" },
   { key: "draft", label: "Drafts" },
   { key: "pending_client_approval", label: "Awaiting approval" },
+  { key: "changes_requested", label: "Changes requested" },
   { key: "approved", label: "Approved" },
   { key: "scheduled", label: "Scheduled" },
   { key: "published", label: "Published" },
+  { key: "failed", label: "Failed" },
+  { key: "rejected", label: "Rejected" },
 ];
 
 export function SocialPostsListClient({


### PR DESCRIPTION
## Summary

Adds three missing state filters to the posts list:
- **Changes requested** — posts the editor needs to revise before resubmitting
- **Failed** — posts where publishing failed; clicking through shows the retry button
- **Rejected** — posts that were explicitly rejected by an approver

Previously only All / Drafts / Awaiting approval / Approved / Scheduled / Published were available.

## Test plan

- [ ] typecheck / lint pass
- [ ] Filter tabs render in the correct order on /company/social/posts
- [ ] Each tab correctly shows matching posts (or empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)