### PR TITLE
feat(s1-37): server-side text search for social posts

### DIFF
--- a/app/company/social/posts/page.tsx
+++ b/app/company/social/posts/page.tsx
@@ -20,7 +20,9 @@ import { listPostMasters } from "@/lib/platform/social/posts";
 
 export const dynamic = "force-dynamic";
 
-export default async function CompanySocialPostsPage() {
+type Props = { searchParams: Promise<{ q?: string }> };
+
+export default async function CompanySocialPostsPage({ searchParams }: Props) {
   const session = await getCurrentPlatformSession();
   if (!session) {
     redirect(`/login?next=${encodeURIComponent("/company/social/posts")}`);
@@ -39,9 +41,11 @@ export default async function CompanySocialPostsPage() {
   }
 
   const companyId = session.company.companyId;
+  const { q } = await searchParams;
+  const searchTerm = q?.trim() ?? "";
 
   const [postsResult, canCreate] = await Promise.all([
-    listPostMasters({ companyId }),
+    listPostMasters({ companyId, q: searchTerm || undefined }),
     canDo(companyId, "create_post"),
   ]);
 
@@ -61,6 +65,7 @@ export default async function CompanySocialPostsPage() {
       companyId={companyId}
       initialPosts={postsResult.data.posts}
       canCreate={canCreate}
+      initialQ={searchTerm}
     />
   );
 }

--- a/components/SocialPostsListClient.tsx
+++ b/components/SocialPostsListClient.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { H1, Lead } from "@/components/ui/typography";
@@ -18,12 +19,18 @@ import type {
 // reloads on success. V1 keeps the create form inline + minimal
 // (master_text + link_url); a richer modal lands when variant /
 // scheduling slices arrive and the form needs more inputs.
+//
+// S1-37 — adds server-side text search via ?q= param. Submitting the
+// search form navigates to ?q=<term> which the page component passes
+// into listPostMasters (ILIKE on master_text). Client-side state
+// filters still apply on top of the server-filtered result set.
 // ---------------------------------------------------------------------------
 
 type Props = {
   companyId: string;
   initialPosts: PostMasterListItem[];
   canCreate: boolean;
+  initialQ?: string;
 };
 
 const STATE_PILL: Record<SocialPostState, string> = {
@@ -68,7 +75,9 @@ export function SocialPostsListClient({
   companyId,
   initialPosts,
   canCreate,
+  initialQ = "",
 }: Props) {
+  const router = useRouter();
   const [posts, setPosts] = useState(initialPosts);
   const [filter, setFilter] = useState<(typeof FILTER_TABS)[number]["key"]>("all");
   const [showCreate, setShowCreate] = useState(false);
@@ -76,11 +85,27 @@ export function SocialPostsListClient({
   const [linkUrl, setLinkUrl] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [searchInput, setSearchInput] = useState(initialQ);
+  const searchRef = useRef<HTMLInputElement>(null);
 
   const visible = useMemo(
     () => (filter === "all" ? posts : posts.filter((p) => p.state === filter)),
     [posts, filter],
   );
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    const term = searchInput.trim();
+    const url = term
+      ? `/company/social/posts?q=${encodeURIComponent(term)}`
+      : "/company/social/posts";
+    router.push(url);
+  }
+
+  function clearSearch() {
+    setSearchInput("");
+    router.push("/company/social/posts");
+  }
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
@@ -121,9 +146,11 @@ export function SocialPostsListClient({
         <div>
           <H1>Social posts</H1>
           <Lead className="mt-0.5">
-            {posts.length === 0
-              ? "No posts yet."
-              : `${posts.length} ${posts.length === 1 ? "post" : "posts"}.`}
+            {initialQ
+              ? `${posts.length} ${posts.length === 1 ? "result" : "results"} for "${initialQ}".`
+              : posts.length === 0
+                ? "No posts yet."
+                : `${posts.length} ${posts.length === 1 ? "post" : "posts"}.`}
           </Lead>
         </div>
         {canCreate ? (
@@ -135,6 +162,37 @@ export function SocialPostsListClient({
           </Button>
         ) : null}
       </div>
+
+      {/* Search bar */}
+      <form
+        onSubmit={handleSearch}
+        className="mt-4 flex items-center gap-2"
+        role="search"
+        aria-label="Search posts"
+      >
+        <input
+          ref={searchRef}
+          type="search"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="Search post copy…"
+          className="flex-1 rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          data-testid="posts-search-input"
+        />
+        <Button type="submit" variant="outline" data-testid="posts-search-submit">
+          Search
+        </Button>
+        {initialQ ? (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={clearSearch}
+            data-testid="posts-search-clear"
+          >
+            Clear
+          </Button>
+        ) : null}
+      </form>
 
       {showCreate && canCreate ? (
         <form
@@ -223,9 +281,11 @@ export function SocialPostsListClient({
       >
         {visible.length === 0 ? (
           <div className="p-8 text-center text-sm text-muted-foreground">
-            {posts.length === 0
-              ? "No posts yet — click New post to draft your first one."
-              : "No posts match this filter."}
+            {initialQ
+              ? `No posts found matching "${initialQ}".`
+              : posts.length === 0
+                ? "No posts yet — click New post to draft your first one."
+                : "No posts match this filter."}
           </div>
         ) : (
           <table className="w-full text-sm">

--- a/lib/platform/social/posts/list.ts
+++ b/lib/platform/social/posts/list.ts
@@ -48,6 +48,11 @@ export async function listPostMasters(
     query = query.in("state", input.states);
   }
 
+  const term = input.q?.trim();
+  if (term) {
+    query = query.ilike("master_text", `%${term}%`);
+  }
+
   const result = await query;
 
   if (result.error) {

--- a/lib/platform/social/posts/types.ts
+++ b/lib/platform/social/posts/types.ts
@@ -61,4 +61,6 @@ export type ListPostMastersInput = {
   // any single tab gets >200 rows in practice.
   limit?: number;
   offset?: number;
+  // Free-text search against master_text (ILIKE). Blank / undefined = no filter.
+  q?: string;
 };


### PR DESCRIPTION
## Summary

- `listPostMasters` gains an optional `q?: string` field → `ILIKE '%term%'` on `master_text` so search works beyond the 50-row client window.
- `/company/social/posts` page reads `?q=` from `searchParams` and passes it into `listPostMasters` + down to the client as `initialQ`.
- `SocialPostsListClient` adds a search bar (input + Search button). On submit navigates to `?q=<term>`; a **Clear** button appears when a search is active. The lead text updates to `"N results for 'term'."`.
- State-tab filtering still applies on top of the server-filtered result set.

## Risks identified and mitigated

- **ILIKE on large tables** — `social_post_master.master_text` is a text column; ILIKE with `%term%` requires a sequential scan. For the platform's current scale (single-company, hundreds of posts) this is fine; a GIN trigram index can be added if the table grows. No new migrations needed for V1.
- **Blank query** — empty/whitespace `q` is treated as no filter (falls through the guard); no risk of ILIKE with `%%`.

## Test plan

- [ ] Search "hello" returns only posts whose copy contains "hello" (case-insensitive)
- [ ] Empty search / clear button resets to full list
- [ ] State tabs still filter the search result set client-side
- [ ] ?q= in the URL is shareable / bookmark-able
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)