### PR TITLE
feat(s8): self-service connection reconnect for editor+ roles

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -57,7 +57,7 @@ Magic links never grant access to settings, brand profile, or management. Scoped
 
 ## Current state
 
-- **Slice in progress:** S7 (bulk CSV upload — 100 rows/upload, 3 uploads/hour/company, rate-limited)
+- **Slice in progress:** S8 (self-service connection reconnect — editor+ can reconnect auth_required/disconnected connections)
 - **Most recently shipped:** S1-18 publish pipeline (#439) + S1-17 inbound webhook handler (#437)
 - **S0 (bundle.social verification):** complete
 - **Vendor confirmed:** bundle.social (publishing), Ideogram (backgrounds), Bannerbear or Placid (compositing — evaluate at I2)
@@ -92,8 +92,8 @@ Magic links never grant access to settings, brand profile, or management. Scoped
 | S4 | Magic-link approval (snapshots, tokens, review UI, in-app for platform users) | ✅ Shipped via S1-5 (#412 submit), S1-6 (#414 recipients + email), S1-7 (#415 magic-link viewer + transactional decision), S1-8 (#417 decision notifications + audit), S1-9 (#418 reopen-for-editing), S1-10 (#420 cancel-approval) |
 | S5 | Scheduling + publishing + reliability (QStash, retries, watchdog, reconciliation) | ✅ Shipped via S1-14 (#428 schedule entries L3) + S1-18 (#439 publish pipeline: QStash → claim_publish_job RPC → bundle.social). Watchdog/reconciliation cron(s) ride on existing `/api/cron/*` infra. |
 | S6 | Customer read-only calendar | ✅ Shipped via S1-15 (#431 viewer-link magic-link, 90-day customer calendar) |
-| S7 | Bulk CSV upload | 👈 Current |
-| S8 | Self-service connection reconnect | ❌ Pending. Adjacent to S2 — operator-driven reconnect already works via the connect-portal; customer-driven self-service is the remaining gap. |
+| S7 | Bulk CSV upload | ✅ Shipped (#469) |
+| S8 | Self-service connection reconnect | 👈 Current |
 
 ### Phase C: Image Generation
 

--- a/app/api/platform/social/connections/reconnect/route.ts
+++ b/app/api/platform/social/connections/reconnect/route.ts
@@ -1,0 +1,140 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { logger } from "@/lib/logger";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { initiateBundlesocialConnect } from "@/lib/platform/social/connections";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/social/connections/reconnect — S8 self-service reconnect.
+//
+// Lowers the permission bar for reconnecting an *existing* disconnected or
+// auth_required social connection from admin-only (manage_connections) to
+// editor+ (reconnect_connection). Creating new connections, deleting, and
+// syncing remain admin-only via the /connect and /sync routes.
+//
+// Body: { company_id: uuid, connection_id: uuid }
+//
+// Flow:
+//   1. Gate: reconnect_connection (editor+).
+//   2. Validate: connection exists for this company AND is reconnectable
+//      (status = auth_required | disconnected). Returns 409 otherwise
+//      so the client can tell the user "that connection is healthy, no
+//      action needed" vs a generic error.
+//   3. Call initiateBundlesocialConnect with the connection's platform.
+//   4. Return { url } — caller redirects browser there for OAuth.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  company_id: z.string().uuid(),
+  connection_id: z.string().uuid(),
+});
+
+const RECONNECTABLE_STATUSES = ["auth_required", "disconnected"] as const;
+
+function errorJson(
+  code: string,
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: { code, message, retryable: false },
+      timestamp: new Date().toISOString(),
+    },
+    { status },
+  );
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return errorJson(
+      "VALIDATION_FAILED",
+      "Body must be { company_id: uuid, connection_id: uuid }.",
+      400,
+    );
+  }
+
+  const { company_id: companyId, connection_id: connectionId } = parsed.data;
+
+  // Auth gate — editor+ for reconnect, not manage_connections (admin).
+  const gate = await requireCanDoForApi(companyId, "reconnect_connection");
+  if (gate.kind === "deny") return gate.response;
+
+  // Validate connection belongs to this company and is in a reconnectable
+  // state. Service role bypasses RLS — the auth gate above already confirmed
+  // the caller is a member of this company.
+  const svc = getServiceRoleClient();
+  const { data: conn, error: connErr } = await svc
+    .from("social_connections")
+    .select("id, company_id, platform, status")
+    .eq("id", connectionId)
+    .eq("company_id", companyId)
+    .single();
+
+  if (connErr || !conn) {
+    return errorJson(
+      "NOT_FOUND",
+      "Connection not found or does not belong to this company.",
+      404,
+    );
+  }
+
+  const status = conn.status as string;
+  if (
+    !RECONNECTABLE_STATUSES.includes(
+      status as (typeof RECONNECTABLE_STATUSES)[number],
+    )
+  ) {
+    return errorJson(
+      "CONFLICT",
+      `Connection is currently "${status}" and does not need reconnecting.`,
+      409,
+    );
+  }
+
+  const origin =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ??
+    new URL(req.url).origin;
+  const redirectUrl = `${origin}/api/platform/social/connections/callback?company_id=${encodeURIComponent(companyId)}`;
+
+  logger.info("social.connections.reconnect.start", {
+    companyId,
+    connectionId,
+    platform: conn.platform,
+    userId: gate.userId,
+  });
+
+  const result = await initiateBundlesocialConnect({
+    companyId,
+    platforms: [conn.platform],
+    redirectUrl,
+  });
+
+  if (!result.ok) {
+    const statusCode = result.error.code === "VALIDATION_FAILED" ? 400 : 500;
+    return errorJson(result.error.code, result.error.message, statusCode);
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { url: result.data.url },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/company/social/connections/page.tsx
+++ b/app/company/social/connections/page.tsx
@@ -104,9 +104,10 @@ export default async function CompanySocialConnectionsPage({
 
   const companyId = session.company.companyId;
 
-  const [listResult, canManage] = await Promise.all([
+  const [listResult, canManage, canReconnect] = await Promise.all([
     listConnections({ companyId }),
     canDo(companyId, "manage_connections"),
+    canDo(companyId, "reconnect_connection"),
   ]);
 
   return (
@@ -126,6 +127,7 @@ export default async function CompanySocialConnectionsPage({
             companyId={companyId}
             connections={listResult.data.connections}
             canManage={canManage}
+            canReconnect={canReconnect}
           />
         ) : (
           <div

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -29,14 +29,19 @@ import {
 type Props = {
   companyId: string;
   connections: SocialConnection[];
-  // Admin-or-Opollo-staff. Drives create/reconnect/sync visibility.
+  // Admin-or-Opollo-staff. Drives create-new / sync visibility.
   canManage: boolean;
+  // Editor+. Drives per-row Reconnect button for auth_required/disconnected
+  // connections. Admins already have this via canManage; editors can
+  // reconnect but not create new connections (S8).
+  canReconnect: boolean;
 };
 
 export function SocialConnectionsList({
   companyId,
   connections,
   canManage,
+  canReconnect,
 }: Props) {
   const [busyRow, setBusyRow] = useState<string | null>(null);
   const [busyTop, setBusyTop] = useState<"connect" | "sync" | null>(null);
@@ -72,12 +77,25 @@ export function SocialConnectionsList({
     }
   }
 
-  async function handleReconnect(rowId: string, platform: SocialPlatform) {
+  async function handleReconnect(rowId: string) {
     setBusyRow(rowId);
+    setError(null);
     try {
-      await initiateConnect([platform]);
+      const res = await fetch("/api/platform/social/connections/reconnect", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ company_id: companyId, connection_id: rowId }),
+      });
+      const json = (await res.json()) as
+        | { ok: true; data: { url: string } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        setError(!json.ok ? json.error.message : "Failed to start reconnect.");
+        return;
+      }
+      window.location.href = json.data.url;
     } finally {
-      // No need to clear busyRow — the redirect happens on success.
+      // busyRow stays set until the redirect fires; clear on error path.
       setBusyRow(null);
     }
   }
@@ -215,13 +233,13 @@ export function SocialConnectionsList({
                     })}
                   </td>
                   <td className="px-4 py-3 text-right">
-                    {canManage &&
+                    {(canManage || canReconnect) &&
                     (c.status === "auth_required" ||
                       c.status === "disconnected") ? (
                       <Button
                         size="sm"
                         variant="ghost"
-                        onClick={() => handleReconnect(c.id, c.platform)}
+                        onClick={() => handleReconnect(c.id)}
                         disabled={busyRow === c.id || busyTop !== null}
                         data-testid={`connection-reconnect-${c.id}`}
                       >

--- a/lib/__tests__/platform-auth.test.ts
+++ b/lib/__tests__/platform-auth.test.ts
@@ -63,7 +63,7 @@ describe("lib/platform/auth — permissions logic (pure)", () => {
     expect(minRoleFor("manage_users")).toBe("admin");
     expect(minRoleFor("edit_company_settings")).toBe("admin");
     expect(minRoleFor("manage_connections")).toBe("admin");
-    expect(minRoleFor("reconnect_connection")).toBe("admin");
+    expect(minRoleFor("reconnect_connection")).toBe("editor");
     expect(minRoleFor("manage_invitations")).toBe("admin");
     expect(minRoleFor("receive_connection_alerts")).toBe("admin");
 

--- a/lib/__tests__/social-reconnect-permission.test.ts
+++ b/lib/__tests__/social-reconnect-permission.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { minRoleFor, roleSatisfies } from "@/lib/platform/auth";
+
+// ---------------------------------------------------------------------------
+// S8 — unit tests for the reconnect_connection permission change.
+//
+// Verifies:
+//   1. reconnect_connection is accessible to editor+ (not just admin).
+//   2. manage_connections still requires admin.
+//   3. The role hierarchy still works correctly around the boundary.
+// ---------------------------------------------------------------------------
+
+describe("reconnect_connection permission (S8)", () => {
+  it("requires editor as minimum role", () => {
+    expect(minRoleFor("reconnect_connection")).toBe("editor");
+  });
+
+  it("editor satisfies reconnect_connection", () => {
+    expect(roleSatisfies("editor", minRoleFor("reconnect_connection"))).toBe(true);
+  });
+
+  it("approver satisfies reconnect_connection", () => {
+    expect(roleSatisfies("approver", minRoleFor("reconnect_connection"))).toBe(true);
+  });
+
+  it("admin satisfies reconnect_connection", () => {
+    expect(roleSatisfies("admin", minRoleFor("reconnect_connection"))).toBe(true);
+  });
+
+  it("viewer does NOT satisfy reconnect_connection", () => {
+    expect(roleSatisfies("viewer", minRoleFor("reconnect_connection"))).toBe(false);
+  });
+});
+
+describe("manage_connections permission (unchanged)", () => {
+  it("still requires admin", () => {
+    expect(minRoleFor("manage_connections")).toBe("admin");
+  });
+
+  it("editor does NOT satisfy manage_connections", () => {
+    expect(roleSatisfies("editor", minRoleFor("manage_connections"))).toBe(false);
+  });
+
+  it("admin satisfies manage_connections", () => {
+    expect(roleSatisfies("admin", minRoleFor("manage_connections"))).toBe(true);
+  });
+});

--- a/lib/platform/auth/permissions.ts
+++ b/lib/platform/auth/permissions.ts
@@ -19,7 +19,11 @@ const ACTION_MIN_ROLE: Record<PermissionAction, CompanyRole> = {
   manage_users: "admin",
   edit_company_settings: "admin",
   manage_connections: "admin",
-  reconnect_connection: "admin",
+  // S8: editors+ can reconnect an existing disconnected/auth_required
+  // connection (re-OAuth on a credential that has expired). Creating new
+  // connections and deleting connections remain admin-only via
+  // manage_connections.
+  reconnect_connection: "editor",
   manage_invitations: "admin",
   create_post: "editor",
   edit_post: "editor",


### PR DESCRIPTION
## Plan

S8 closes the "customer-driven self-service" gap from BUILD.md. The existing `/connect` endpoint already lets company admins reconnect via bundle.social's hosted portal. What was missing: editors (and approvers) couldn't reconnect a disconnected connection themselves — they had to ask their company admin, who might have to ask Opollo support.

### What changes

**`reconnect_connection` permission: admin → editor**

`lib/platform/auth/permissions.ts` — The `reconnect_connection` action was already defined in the permission union (since the platform layer was designed) but gated at admin and never wired up. S8 lowers it to `editor` and hooks it up end-to-end.

The split is now clean:
- `manage_connections` (admin): create new connections, sync, delete
- `reconnect_connection` (editor+): re-OAuth an *existing* disconnected/auth_required connection

**New `POST /api/platform/social/connections/reconnect`**

Dedicated route for self-service reconnect:
1. Gate: `reconnect_connection` (editor+)
2. Validate: connection exists for the company AND is in `auth_required | disconnected` state. Returns 409 if the connection is already healthy — clear signal to the client.
3. Call `initiateBundlesocialConnect` with the connection's platform (looked up from DB)
4. Return `{ url }` — client redirects to bundle.social OAuth portal

The existing `/connect` route is untouched and stays admin-only.

**`SocialConnectionsList`**

- New `canReconnect: boolean` prop
- Per-row Reconnect button shows when `(canManage || canReconnect) && status is reconnectable`
- Reconnect button now calls the new `/reconnect` endpoint with `connection_id` (not `/connect` with platform)
- "Connect new account" and "Refresh" remain admin-only (`canManage`)

**Connections page**

Resolves `canReconnect` alongside `canManage` in the parallel fetch.

## Risks identified and mitigated

| Risk | Mitigation |
|------|------------|
| Editor triggers reconnect on a healthy connection | Route validates status is auth_required/disconnected; returns 409 CONFLICT otherwise |
| Editor reconnects a connection they don't own | Route validates company_id ownership via `.eq("company_id", companyId)` — can't reconnect another company's connection |
| Editor creates new connections via this route | Not possible — route requires an existing `connection_id`; no `platforms[]` param |
| Permission regression on manage_connections | Unit tests confirm manage_connections still requires admin |

## Test plan

- [ ] Editor logs in, sees Reconnect button on an `auth_required` connection
- [ ] Editor clicks Reconnect → redirected to bundle.social portal
- [ ] Viewer logs in → no Reconnect button visible
- [ ] `POST /reconnect` with a healthy connection → 409 CONFLICT
- [ ] `POST /reconnect` with a connection from a different company → 404
- [ ] Admin still sees "Connect new account" and "Refresh"; editor does not

## Unit tests (8)

`lib/__tests__/social-reconnect-permission.test.ts` — permission level, role satisfaction for all 4 roles against both `reconnect_connection` and `manage_connections`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)