### PR TITLE
test(s1-39): unit tests for listPostMasters search + pagination

### DIFF
--- a/lib/__tests__/social-posts.test.ts
+++ b/lib/__tests__/social-posts.test.ts
@@ -309,6 +309,100 @@ describe("lib/platform/social/posts", () => {
       ]);
       expect(ids.size).toBe(4);
     });
+
+    it("filters by q (case-insensitive ILIKE on master_text)", async () => {
+      await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "Hello LinkedIn world",
+        createdBy: creator.id,
+      });
+      await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "Facebook announcement post",
+        createdBy: creator.id,
+      });
+      await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "LINKEDIN exclusive content",
+        createdBy: creator.id,
+      });
+
+      const result = await listPostMasters({
+        companyId: COMPANY_A_ID,
+        q: "linkedin",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.posts.length).toBe(2);
+      result.data.posts.forEach((p) =>
+        expect(p.master_text?.toLowerCase()).toContain("linkedin"),
+      );
+    });
+
+    it("q with blank / whitespace-only term returns all posts", async () => {
+      for (let i = 0; i < 3; i++) {
+        await createPostMaster({
+          companyId: COMPANY_A_ID,
+          masterText: `post ${i}`,
+          createdBy: creator.id,
+        });
+      }
+      const result = await listPostMasters({
+        companyId: COMPANY_A_ID,
+        q: "   ",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.posts.length).toBe(3);
+    });
+
+    it("withCount returns accurate totalCount", async () => {
+      for (let i = 0; i < 6; i++) {
+        await createPostMaster({
+          companyId: COMPANY_A_ID,
+          masterText: `count post ${i}`,
+          createdBy: creator.id,
+        });
+      }
+      const page1 = await listPostMasters({
+        companyId: COMPANY_A_ID,
+        limit: 4,
+        offset: 0,
+        withCount: true,
+      });
+      expect(page1.ok).toBe(true);
+      if (!page1.ok) return;
+      expect(page1.data.posts.length).toBe(4);
+      expect(page1.data.totalCount).toBe(6);
+    });
+
+    it("withCount + q counts only matching rows", async () => {
+      await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "match me please",
+        createdBy: creator.id,
+      });
+      await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "ignore this one",
+        createdBy: creator.id,
+      });
+      await createPostMaster({
+        companyId: COMPANY_A_ID,
+        masterText: "match me also",
+        createdBy: creator.id,
+      });
+
+      const result = await listPostMasters({
+        companyId: COMPANY_A_ID,
+        q: "match",
+        withCount: true,
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.posts.length).toBe(2);
+      expect(result.data.totalCount).toBe(2);
+    });
   });
 
   describe("getPostMaster", () => {


### PR DESCRIPTION
## Summary

Adds 4 integration test cases to `lib/__tests__/social-posts.test.ts` to cover the S1-37 (search) and S1-38 (pagination) features:

1. **`q` filters case-insensitively** — seeds 3 posts, searches "linkedin" (lowercase), expects 2 matches (case-insensitive ILIKE).
2. **whitespace-only `q` returns all posts** — seeds 3 posts, passes `q: "   "`, expects all 3 back (blank term = no filter).
3. **`withCount` returns accurate `totalCount`** — seeds 6 posts, fetches page of 4 with `withCount: true`, verifies `totalCount === 6`.
4. **`withCount + q` counts only matching rows** — seeds 3 posts (2 matching "match"), verifies `totalCount === 2`.

## Risks identified and mitigated

- Test-only change; no production code modified.
- Tests use the same seed/teardown pattern as existing `social-posts.test.ts`; no new infra needed.

## Test plan

- [ ] `npm run test -- social-posts` passes all new cases
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)