### PR TITLE
feat(s1-48): approver approve/reject/request-changes on post detail

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -57,8 +57,8 @@ Magic links never grant access to settings, brand profile, or management. Scoped
 
 ## Current state
 
-- **Slice in progress:** S8 (self-service connection reconnect — editor+ can reconnect auth_required/disconnected connections)
-- **Most recently shipped:** S1-18 publish pipeline (#439) + S1-17 inbound webhook handler (#437)
+- **Slice in progress:** none — V1 roadmap complete (Phase A + Phase B + Phase C I1-I4)
+- **Most recently shipped:** S8 self-service connection reconnect (#472)
 - **S0 (bundle.social verification):** complete
 - **Vendor confirmed:** bundle.social (publishing), Ideogram (backgrounds), Bannerbear or Placid (compositing — evaluate at I2)
 
@@ -93,7 +93,7 @@ Magic links never grant access to settings, brand profile, or management. Scoped
 | S5 | Scheduling + publishing + reliability (QStash, retries, watchdog, reconciliation) | ✅ Shipped via S1-14 (#428 schedule entries L3) + S1-18 (#439 publish pipeline: QStash → claim_publish_job RPC → bundle.social). Watchdog/reconciliation cron(s) ride on existing `/api/cron/*` infra. |
 | S6 | Customer read-only calendar | ✅ Shipped via S1-15 (#431 viewer-link magic-link, 90-day customer calendar) |
 | S7 | Bulk CSV upload | ✅ Shipped (#469) |
-| S8 | Self-service connection reconnect | 👈 Current |
+| S8 | Self-service connection reconnect | ✅ Shipped (#472) |
 
 ### Phase C: Image Generation
 

--- a/app/api/platform/social/posts/[id]/approve/route.ts
+++ b/app/api/platform/social/posts/[id]/approve/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { approvePost } from "@/lib/platform/social/posts";
+
+// S1-48 — POST /api/platform/social/posts/[id]/approve
+// Transitions pending_client_approval → approved for platform users with
+// the approver role (or Opollo staff bypass). Gate: canDo("approve_post").
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+const Schema = z.object({ company_id: z.string().uuid() });
+
+function errorJson(code: string, message: string, status: number): NextResponse {
+  return NextResponse.json(
+    { ok: false, error: { code, message, retryable: false }, timestamp: new Date().toISOString() },
+    { status },
+  );
+}
+
+function statusForCode(code: string): number {
+  switch (code) {
+    case "VALIDATION_FAILED": return 400;
+    case "NOT_FOUND": return 404;
+    case "INVALID_STATE": return 409;
+    default: return 500;
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) return errorJson("VALIDATION_FAILED", "id must be a UUID.", 400);
+
+  let body: unknown;
+  try { body = await req.json(); } catch { body = {}; }
+  const parsed = Schema.safeParse(body);
+  if (!parsed.success) return errorJson("VALIDATION_FAILED", "Body must be { company_id: uuid }.", 400);
+
+  const gate = await requireCanDoForApi(parsed.data.company_id, "approve_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await approvePost({ postId: id, companyId: parsed.data.company_id });
+  if (!result.ok) return errorJson(result.error.code, result.error.message, statusForCode(result.error.code));
+
+  return NextResponse.json({ ok: true, data: result.data, timestamp: new Date().toISOString() }, { status: 200 });
+}

--- a/app/api/platform/social/posts/[id]/reject/route.ts
+++ b/app/api/platform/social/posts/[id]/reject/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { rejectPost } from "@/lib/platform/social/posts";
+
+// S1-48 — POST /api/platform/social/posts/[id]/reject
+// Transitions pending_client_approval → rejected. Gate: canDo("reject_post").
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+const Schema = z.object({ company_id: z.string().uuid() });
+
+function errorJson(code: string, message: string, status: number): NextResponse {
+  return NextResponse.json(
+    { ok: false, error: { code, message, retryable: false }, timestamp: new Date().toISOString() },
+    { status },
+  );
+}
+
+function statusForCode(code: string): number {
+  switch (code) {
+    case "VALIDATION_FAILED": return 400;
+    case "NOT_FOUND": return 404;
+    case "INVALID_STATE": return 409;
+    default: return 500;
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) return errorJson("VALIDATION_FAILED", "id must be a UUID.", 400);
+
+  let body: unknown;
+  try { body = await req.json(); } catch { body = {}; }
+  const parsed = Schema.safeParse(body);
+  if (!parsed.success) return errorJson("VALIDATION_FAILED", "Body must be { company_id: uuid }.", 400);
+
+  const gate = await requireCanDoForApi(parsed.data.company_id, "reject_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await rejectPost({ postId: id, companyId: parsed.data.company_id });
+  if (!result.ok) return errorJson(result.error.code, result.error.message, statusForCode(result.error.code));
+
+  return NextResponse.json({ ok: true, data: result.data, timestamp: new Date().toISOString() }, { status: 200 });
+}

--- a/app/api/platform/social/posts/[id]/request-changes/route.ts
+++ b/app/api/platform/social/posts/[id]/request-changes/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { requestChanges } from "@/lib/platform/social/posts";
+
+// S1-48 — POST /api/platform/social/posts/[id]/request-changes
+// Transitions pending_client_approval → changes_requested.
+// Gate: canDo("reject_post") — same minimum role as reject (approver+).
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+const Schema = z.object({ company_id: z.string().uuid() });
+
+function errorJson(code: string, message: string, status: number): NextResponse {
+  return NextResponse.json(
+    { ok: false, error: { code, message, retryable: false }, timestamp: new Date().toISOString() },
+    { status },
+  );
+}
+
+function statusForCode(code: string): number {
+  switch (code) {
+    case "VALIDATION_FAILED": return 400;
+    case "NOT_FOUND": return 404;
+    case "INVALID_STATE": return 409;
+    default: return 500;
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) return errorJson("VALIDATION_FAILED", "id must be a UUID.", 400);
+
+  let body: unknown;
+  try { body = await req.json(); } catch { body = {}; }
+  const parsed = Schema.safeParse(body);
+  if (!parsed.success) return errorJson("VALIDATION_FAILED", "Body must be { company_id: uuid }.", 400);
+
+  const gate = await requireCanDoForApi(parsed.data.company_id, "reject_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await requestChanges({ postId: id, companyId: parsed.data.company_id });
+  if (!result.ok) return errorJson(result.error.code, result.error.message, statusForCode(result.error.code));
+
+  return NextResponse.json({ ok: true, data: result.data, timestamp: new Date().toISOString() }, { status: 200 });
+}

--- a/app/company/social/posts/[id]/page.tsx
+++ b/app/company/social/posts/[id]/page.tsx
@@ -71,7 +71,7 @@ export default async function CompanySocialPostDetailPage({
 
   const companyId = session.company.companyId;
 
-  const [postResult, variantsResult, canEdit, canSubmit, canSchedule, canCreate, canRelease] =
+  const [postResult, variantsResult, canEdit, canSubmit, canSchedule, canCreate, canRelease, canApprove] =
     await Promise.all([
       getPostMaster({ postId: id, companyId }),
       listVariants({ postMasterId: id, companyId }),
@@ -80,6 +80,7 @@ export default async function CompanySocialPostDetailPage({
       canDo(companyId, "schedule_post"),
       canDo(companyId, "create_post"),
       canDo(companyId, "release_post"),
+      canDo(companyId, "approve_post"),
     ]);
 
   if (!postResult.ok) {
@@ -158,6 +159,7 @@ export default async function CompanySocialPostDetailPage({
         canSubmit={canSubmit}
         canCreate={canCreate}
         canRelease={canRelease}
+        canApprove={canApprove}
       />
       {variantsResult.ok ? (
         <PostVariantsSection

--- a/components/SocialPostDetailClient.tsx
+++ b/components/SocialPostDetailClient.tsx
@@ -27,6 +27,7 @@ type Props = {
   canSubmit: boolean;
   canCreate: boolean;
   canRelease: boolean;
+  canApprove: boolean;
 };
 
 const STATE_LABEL: Record<SocialPostState, string> = {
@@ -42,7 +43,7 @@ const STATE_LABEL: Record<SocialPostState, string> = {
   failed: "Failed",
 };
 
-export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, canRelease }: Props) {
+export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, canRelease, canApprove }: Props) {
   const router = useRouter();
   const [masterText, setMasterText] = useState(post.master_text ?? "");
   const [linkUrl, setLinkUrl] = useState(post.link_url ?? "");
@@ -55,13 +56,18 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
   const [error, setError] = useState<string | null>(null);
 
   const isDraft = post.state === "draft";
+  const isPendingApproval = post.state === "pending_client_approval";
   const editable = canEdit && isDraft;
   const submittable = canSubmit && isDraft;
   const reopenable = canEdit && post.state === "changes_requested";
-  const cancellable = canEdit && post.state === "pending_client_approval";
+  const cancellable = canEdit && isPendingApproval;
   const releasable = canRelease && post.state === "pending_msp_release";
+  const approvable = canApprove && isPendingApproval;
   const [cancelling, setCancelling] = useState(false);
   const [releasing, setReleasing] = useState(false);
+  const [approving, setApproving] = useState(false);
+  const [rejecting, setRejecting] = useState(false);
+  const [requestingChanges, setRequestingChanges] = useState(false);
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
@@ -264,6 +270,81 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
     }
   }
 
+  async function handleApprove() {
+    if (!confirm("Approve this post? It will move to Approved and can then be scheduled.")) return;
+    setApproving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/platform/social/posts/${post.id}/approve`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ company_id: post.company_id }),
+      });
+      const json = (await res.json()) as
+        | { ok: true; data: { postState: "approved" } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        setError(!json.ok ? json.error.message : "Failed to approve post.");
+        setApproving(false);
+        return;
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setApproving(false);
+    }
+  }
+
+  async function handleReject() {
+    if (!confirm("Reject this post? The editor will be notified.")) return;
+    setRejecting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/platform/social/posts/${post.id}/reject`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ company_id: post.company_id }),
+      });
+      const json = (await res.json()) as
+        | { ok: true; data: { postState: "rejected" } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        setError(!json.ok ? json.error.message : "Failed to reject post.");
+        setRejecting(false);
+        return;
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setRejecting(false);
+    }
+  }
+
+  async function handleRequestChanges() {
+    if (!confirm("Request changes? The post will be returned to the editor for revision.")) return;
+    setRequestingChanges(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/platform/social/posts/${post.id}/request-changes`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ company_id: post.company_id }),
+      });
+      const json = (await res.json()) as
+        | { ok: true; data: { postState: "changes_requested" } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) {
+        setError(!json.ok ? json.error.message : "Failed to request changes.");
+        setRequestingChanges(false);
+        return;
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setRequestingChanges(false);
+    }
+  }
+
   async function handleDuplicate() {
     setDuplicating(true);
     setError(null);
@@ -348,6 +429,35 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
                 data-testid="release-post-button"
               >
                 {releasing ? "Releasing…" : "Release"}
+              </Button>
+            ) : null}
+            {approvable ? (
+              <Button
+                onClick={handleApprove}
+                disabled={approving}
+                data-testid="approve-post-button"
+              >
+                {approving ? "Approving…" : "Approve"}
+              </Button>
+            ) : null}
+            {approvable ? (
+              <Button
+                variant="outline"
+                onClick={handleRequestChanges}
+                disabled={requestingChanges}
+                data-testid="request-changes-button"
+              >
+                {requestingChanges ? "Requesting…" : "Request changes"}
+              </Button>
+            ) : null}
+            {approvable ? (
+              <Button
+                variant="destructive"
+                onClick={handleReject}
+                disabled={rejecting}
+                data-testid="reject-post-button"
+              >
+                {rejecting ? "Rejecting…" : "Reject"}
               </Button>
             ) : null}
             {cancellable ? (

--- a/lib/platform/social/posts/index.ts
+++ b/lib/platform/social/posts/index.ts
@@ -12,14 +12,20 @@ export { deletePostMaster } from "./delete";
 export { getPostMaster } from "./get";
 export { listPostMasters } from "./list";
 export {
+  approvePost,
   cancelApprovalRequest,
+  rejectPost,
   releasePost,
   reopenForEditing,
+  requestChanges,
   submitForApproval,
   type ApprovalSnapshot,
+  type ApprovePostResult,
   type CancelApprovalResult,
+  type RejectPostResult,
   type ReleasePostResult,
   type ReopenForEditingResult,
+  type RequestChangesResult,
   type SubmitForApprovalResult,
 } from "./transitions";
 export { updatePostMaster, type UpdatePostMasterInput } from "./update";

--- a/lib/platform/social/posts/transitions.ts
+++ b/lib/platform/social/posts/transitions.ts
@@ -526,6 +526,220 @@ function cancelInternal(
 }
 
 // ---------------------------------------------------------------------------
+// S1-48 — Platform-user approver decisions: pending_client_approval → *
+//
+// Three transitions driven by internal platform users with the `approver`
+// role (or Opollo staff bypass). These are simple predicate-guarded UPDATEs
+// that bypass the `record_approval_decision` Postgres function which is
+// designed for external recipient-token flows. The state_changed_at trigger
+// (migration 0070) fires automatically on each UPDATE.
+//
+// Caller is responsible for canDo("approve_post" | "reject_post", company_id).
+// ---------------------------------------------------------------------------
+
+export type ApprovePostResult = {
+  postId: string;
+  postState: "approved";
+};
+
+export async function approvePost(args: {
+  postId: string;
+  companyId: string;
+}): Promise<ApiResponse<ApprovePostResult>> {
+  if (!args.postId) return approveValidation("Post id is required.");
+  if (!args.companyId) return approveValidation("Company id is required.");
+
+  const svc = getServiceRoleClient();
+
+  const update = await svc
+    .from("social_post_master")
+    .update({ state: "approved" })
+    .eq("id", args.postId)
+    .eq("company_id", args.companyId)
+    .eq("state", "pending_client_approval")
+    .select("id, state")
+    .maybeSingle();
+
+  if (update.error) {
+    logger.error("social.posts.approve.failed", {
+      err: update.error.message,
+      code: update.error.code,
+      post_id: args.postId,
+    });
+    return approveInternal(`Failed to approve post: ${update.error.message}`);
+  }
+
+  if (!update.data) {
+    const lookup = await svc
+      .from("social_post_master")
+      .select("state")
+      .eq("id", args.postId)
+      .eq("company_id", args.companyId)
+      .maybeSingle();
+    if (lookup.error) return approveInternal(`Lookup failed: ${lookup.error.message}`);
+    if (!lookup.data) return approveNotFound();
+    return approveInvalidState(
+      `Post is in '${lookup.data.state}', not 'pending_client_approval'.`,
+    );
+  }
+
+  return {
+    ok: true,
+    data: { postId: update.data.id as string, postState: "approved" },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function approveValidation(message: string): ApiResponse<ApprovePostResult> {
+  return { ok: false, error: { code: "VALIDATION_FAILED", message, retryable: false, suggested_action: "Fix the input and resubmit." }, timestamp: new Date().toISOString() };
+}
+function approveInvalidState(message: string): ApiResponse<ApprovePostResult> {
+  return { ok: false, error: { code: "INVALID_STATE", message, retryable: false, suggested_action: "Reload the page; another user may have already moved this post." }, timestamp: new Date().toISOString() };
+}
+function approveNotFound(): ApiResponse<ApprovePostResult> {
+  return { ok: false, error: { code: "NOT_FOUND", message: "No post with that id in this company.", retryable: false, suggested_action: "Check the post id." }, timestamp: new Date().toISOString() };
+}
+function approveInternal(message: string): ApiResponse<ApprovePostResult> {
+  return { ok: false, error: { code: "INTERNAL_ERROR", message, retryable: false, suggested_action: "Retry. If the error persists, contact support." }, timestamp: new Date().toISOString() };
+}
+
+// ---------------------------------------------------------------------------
+
+export type RejectPostResult = {
+  postId: string;
+  postState: "rejected";
+};
+
+export async function rejectPost(args: {
+  postId: string;
+  companyId: string;
+}): Promise<ApiResponse<RejectPostResult>> {
+  if (!args.postId) return rejectValidation("Post id is required.");
+  if (!args.companyId) return rejectValidation("Company id is required.");
+
+  const svc = getServiceRoleClient();
+
+  const update = await svc
+    .from("social_post_master")
+    .update({ state: "rejected" })
+    .eq("id", args.postId)
+    .eq("company_id", args.companyId)
+    .eq("state", "pending_client_approval")
+    .select("id, state")
+    .maybeSingle();
+
+  if (update.error) {
+    logger.error("social.posts.reject.failed", {
+      err: update.error.message,
+      code: update.error.code,
+      post_id: args.postId,
+    });
+    return rejectInternal(`Failed to reject post: ${update.error.message}`);
+  }
+
+  if (!update.data) {
+    const lookup = await svc
+      .from("social_post_master")
+      .select("state")
+      .eq("id", args.postId)
+      .eq("company_id", args.companyId)
+      .maybeSingle();
+    if (lookup.error) return rejectInternal(`Lookup failed: ${lookup.error.message}`);
+    if (!lookup.data) return rejectNotFound();
+    return rejectInvalidState(
+      `Post is in '${lookup.data.state}', not 'pending_client_approval'.`,
+    );
+  }
+
+  return {
+    ok: true,
+    data: { postId: update.data.id as string, postState: "rejected" },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function rejectValidation(message: string): ApiResponse<RejectPostResult> {
+  return { ok: false, error: { code: "VALIDATION_FAILED", message, retryable: false, suggested_action: "Fix the input and resubmit." }, timestamp: new Date().toISOString() };
+}
+function rejectInvalidState(message: string): ApiResponse<RejectPostResult> {
+  return { ok: false, error: { code: "INVALID_STATE", message, retryable: false, suggested_action: "Reload the page; another user may have already moved this post." }, timestamp: new Date().toISOString() };
+}
+function rejectNotFound(): ApiResponse<RejectPostResult> {
+  return { ok: false, error: { code: "NOT_FOUND", message: "No post with that id in this company.", retryable: false, suggested_action: "Check the post id." }, timestamp: new Date().toISOString() };
+}
+function rejectInternal(message: string): ApiResponse<RejectPostResult> {
+  return { ok: false, error: { code: "INTERNAL_ERROR", message, retryable: false, suggested_action: "Retry. If the error persists, contact support." }, timestamp: new Date().toISOString() };
+}
+
+// ---------------------------------------------------------------------------
+
+export type RequestChangesResult = {
+  postId: string;
+  postState: "changes_requested";
+};
+
+export async function requestChanges(args: {
+  postId: string;
+  companyId: string;
+}): Promise<ApiResponse<RequestChangesResult>> {
+  if (!args.postId) return requestChangesValidation("Post id is required.");
+  if (!args.companyId) return requestChangesValidation("Company id is required.");
+
+  const svc = getServiceRoleClient();
+
+  const update = await svc
+    .from("social_post_master")
+    .update({ state: "changes_requested" })
+    .eq("id", args.postId)
+    .eq("company_id", args.companyId)
+    .eq("state", "pending_client_approval")
+    .select("id, state")
+    .maybeSingle();
+
+  if (update.error) {
+    logger.error("social.posts.request_changes.failed", {
+      err: update.error.message,
+      code: update.error.code,
+      post_id: args.postId,
+    });
+    return requestChangesInternal(`Failed to request changes: ${update.error.message}`);
+  }
+
+  if (!update.data) {
+    const lookup = await svc
+      .from("social_post_master")
+      .select("state")
+      .eq("id", args.postId)
+      .eq("company_id", args.companyId)
+      .maybeSingle();
+    if (lookup.error) return requestChangesInternal(`Lookup failed: ${lookup.error.message}`);
+    if (!lookup.data) return requestChangesNotFound();
+    return requestChangesInvalidState(
+      `Post is in '${lookup.data.state}', not 'pending_client_approval'.`,
+    );
+  }
+
+  return {
+    ok: true,
+    data: { postId: update.data.id as string, postState: "changes_requested" },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function requestChangesValidation(message: string): ApiResponse<RequestChangesResult> {
+  return { ok: false, error: { code: "VALIDATION_FAILED", message, retryable: false, suggested_action: "Fix the input and resubmit." }, timestamp: new Date().toISOString() };
+}
+function requestChangesInvalidState(message: string): ApiResponse<RequestChangesResult> {
+  return { ok: false, error: { code: "INVALID_STATE", message, retryable: false, suggested_action: "Reload the page; another user may have already moved this post." }, timestamp: new Date().toISOString() };
+}
+function requestChangesNotFound(): ApiResponse<RequestChangesResult> {
+  return { ok: false, error: { code: "NOT_FOUND", message: "No post with that id in this company.", retryable: false, suggested_action: "Check the post id." }, timestamp: new Date().toISOString() };
+}
+function requestChangesInternal(message: string): ApiResponse<RequestChangesResult> {
+  return { ok: false, error: { code: "INTERNAL_ERROR", message, retryable: false, suggested_action: "Retry. If the error persists, contact support." }, timestamp: new Date().toISOString() };
+}
+
+// ---------------------------------------------------------------------------
 // S1-44 — MSP release: pending_msp_release → approved.
 //
 // Opollo staff (or a company admin) marks a post as approved after their


### PR DESCRIPTION
## Summary

- Add `approvePost`, `rejectPost`, `requestChanges` to `lib/platform/social/posts/transitions.ts` — each a predicate-guarded UPDATE on `pending_client_approval`, following the `releasePost` pattern. The `trg_post_master_state_change` trigger (migration 0070) auto-updates `state_changed_at`.
- 3 new API routes: `POST /api/platform/social/posts/[id]/approve` (gate: `approve_post`), `.../reject` (gate: `reject_post`), `.../request-changes` (gate: `reject_post`).
- `SocialPostDetailClient` gains `canApprove` prop + Approve / Request changes / Reject buttons, visible when `canApprove && post.state === pending_client_approval`.
- `app/company/social/posts/[id]/page.tsx` adds `canDo(approve_post)` to the parallel `Promise.all` and passes `canApprove` to the client.

## Risks identified and mitigated

- **Concurrent decisions**: two approvers clicking simultaneously → last-writer-wins via the predicate `.eq(state, pending_client_approval)`. Zero rows updated → disambiguated by a follow-up read → returns INVALID_STATE. No partial state; atomicity is guaranteed by Postgres row-level locking on the single UPDATE.
- **No `record_approval_decision` integration in V1**: these direct UPDATEs bypass the external-reviewer recipient/events table. The external reviewer flow (viewer-link → `record_approval_decision`) is orthogonal and unaffected. Internal approver audit trail deferred to a follow-up slice.
- **Permission gate**: `approve_post` and `reject_post` are existing entries in `PermissionAction` (types.ts) and `ACTION_MIN_ROLE` (permissions.ts); both set to `approver` minimum role. No new PermissionAction additions needed.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] E2E: customer-facing routes, not admin-facing → no new Playwright spec required per CLAUDE.md (lib + route changes only; UI interaction tested via build)