### PR TITLE
feat(s1-53): persist reviewer comment on post + display on detail

### DIFF
--- a/components/SocialPostDetailClient.tsx
+++ b/components/SocialPostDetailClient.tsx
@@ -508,6 +508,17 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
         </p>
       ) : null}
 
+      {post.state === "changes_requested" && post.reviewer_comment ? (
+        <div
+          className="mt-4 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200"
+          role="note"
+          data-testid="reviewer-comment-banner"
+        >
+          <p className="font-medium">Reviewer note</p>
+          <p className="mt-0.5 whitespace-pre-wrap">{post.reviewer_comment}</p>
+        </div>
+      ) : null}
+
       <div className="mt-6 rounded-lg border bg-card p-4">
         {editing ? (
           <form onSubmit={handleSave} data-testid="edit-post-form">

--- a/lib/platform/social/posts/get.ts
+++ b/lib/platform/social/posts/get.ts
@@ -31,7 +31,7 @@ export async function getPostMaster(args: {
   const result = await svc
     .from("social_post_master")
     .select(
-      "id, company_id, state, source_type, master_text, link_url, created_by, created_at, updated_at, state_changed_at",
+      "id, company_id, state, source_type, master_text, link_url, created_by, created_at, updated_at, state_changed_at, reviewer_comment",
     )
     .eq("id", args.postId)
     .eq("company_id", args.companyId)

--- a/lib/platform/social/posts/transitions.ts
+++ b/lib/platform/social/posts/transitions.ts
@@ -265,7 +265,7 @@ export async function reopenForEditing(args: {
   // the now-current state.
   const update = await svc
     .from("social_post_master")
-    .update({ state: "draft" })
+    .update({ state: "draft", reviewer_comment: null })
     .eq("id", args.postId)
     .eq("company_id", args.companyId)
     .eq("state", "changes_requested")
@@ -700,9 +700,10 @@ export async function requestChanges(args: {
 
   const svc = getServiceRoleClient();
 
+  const comment = args.comment?.trim() || null;
   const update = await svc
     .from("social_post_master")
-    .update({ state: "changes_requested" })
+    .update({ state: "changes_requested", reviewer_comment: comment })
     .eq("id", args.postId)
     .eq("company_id", args.companyId)
     .eq("state", "pending_client_approval")
@@ -738,7 +739,7 @@ export async function requestChanges(args: {
       postId: update.data.id as string,
       postState: "changes_requested",
       createdBy: (update.data.created_by as string | null) ?? null,
-      comment: args.comment?.trim() || null,
+      comment,
     },
     timestamp: new Date().toISOString(),
   };

--- a/lib/platform/social/posts/types.ts
+++ b/lib/platform/social/posts/types.ts
@@ -27,6 +27,7 @@ export type PostMaster = {
   created_at: string;
   updated_at: string;
   state_changed_at: string;
+  reviewer_comment: string | null;
 };
 
 export type PostMasterListItem = {

--- a/supabase/migrations/0078_post_master_reviewer_comment.sql
+++ b/supabase/migrations/0078_post_master_reviewer_comment.sql
@@ -1,0 +1,11 @@
+-- S1-53 — persist reviewer comment on request-changes.
+--
+-- Stores the latest reviewer note on the post row so the editor can see
+-- what needs fixing without relying solely on the notification email.
+-- Cleared on reopen-for-editing so a stale comment from a prior cycle
+-- doesn't persist across resubmissions.
+--
+-- Column is nullable; NULL means no comment was provided (or the post
+-- was never in changes_requested).
+ALTER TABLE social_post_master
+  ADD COLUMN IF NOT EXISTS reviewer_comment TEXT;


### PR DESCRIPTION
## S1-53 — Persist reviewer comment and surface on post detail

### What changed
- **Migration 0078** — `ALTER TABLE social_post_master ADD COLUMN IF NOT EXISTS reviewer_comment TEXT`
- **`lib/platform/social/posts/types.ts`** — added `reviewer_comment: string | null` to `PostMaster`
- **`lib/platform/social/posts/get.ts`** — added `reviewer_comment` to the SELECT list
- **`lib/platform/social/posts/transitions.ts`** — `requestChanges` writes `reviewer_comment` (trimmed, null when blank); `reopenForEditing` clears it to null
- **`components/SocialPostDetailClient.tsx`** — amber callout banner rendered when `state === "changes_requested"` and `reviewer_comment` is non-null

### Why
S1-52 threaded the reviewer comment through the notification dispatch so the editor's in-app notification body showed the reason. S1-53 persists it on the post row so the editor can see it later when they navigate directly to the post detail — the notification is ephemeral; the post is not.

### Risks identified and mitigated
- **Stale comment across resubmission cycles** — cleared by `reopenForEditing` before the editor re-submits; no residue from a prior cycle.
- **NULL safety** — column is nullable; existing rows and paths that don't supply a comment stay null. The UI callout only renders when both state and comment are set, so there's no rendering regression.
- **E2E omission** — purely lib + UI change on a company-facing route; no new admin route or form. The Supabase-stack CI failure pre-dates this workstream (0031 collision). Noting omission in PR description per CLAUDE.md.

### Closes
S1-53