### PR TITLE
feat(s1-54): optional reviewer comment on reject

### DIFF
--- a/app/api/platform/social/posts/[id]/reject/route.ts
+++ b/app/api/platform/social/posts/[id]/reject/route.ts
@@ -13,7 +13,10 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const UUID_RE = /^[0-9a-f-]{36}$/i;
-const Schema = z.object({ company_id: z.string().uuid() });
+const Schema = z.object({
+  company_id: z.string().uuid(),
+  comment: z.string().max(1000).trim().nullish(),
+});
 
 function errorJson(code: string, message: string, status: number): NextResponse {
   return NextResponse.json(
@@ -46,7 +49,8 @@ export async function POST(
   const gate = await requireCanDoForApi(parsed.data.company_id, "reject_post");
   if (gate.kind === "deny") return gate.response;
 
-  const result = await rejectPost({ postId: id, companyId: parsed.data.company_id });
+  const comment = parsed.data.comment ?? null;
+  const result = await rejectPost({ postId: id, companyId: parsed.data.company_id, comment });
   if (!result.ok) return errorJson(result.error.code, result.error.message, statusForCode(result.error.code));
 
   if (result.data.createdBy) {
@@ -56,6 +60,7 @@ export async function POST(
       postMasterId: id,
       submitterUserId: result.data.createdBy,
       decision: "rejected",
+      comment: result.data.comment ?? undefined,
     });
   }
 

--- a/components/SocialPostDetailClient.tsx
+++ b/components/SocialPostDetailClient.tsx
@@ -296,14 +296,18 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
   }
 
   async function handleReject() {
-    if (!confirm("Reject this post? The editor will be notified.")) return;
+    const comment = prompt(
+      "Reject this post? Enter a note for the editor (optional — leave blank to skip):",
+      "",
+    );
+    if (comment === null) return; // user dismissed
     setRejecting(true);
     setError(null);
     try {
       const res = await fetch(`/api/platform/social/posts/${post.id}/reject`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ company_id: post.company_id }),
+        body: JSON.stringify({ company_id: post.company_id, comment: comment.trim() || null }),
       });
       const json = (await res.json()) as
         | { ok: true; data: { postState: "rejected" } }
@@ -508,13 +512,15 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
         </p>
       ) : null}
 
-      {post.state === "changes_requested" && post.reviewer_comment ? (
+      {(post.state === "changes_requested" || post.state === "rejected") && post.reviewer_comment ? (
         <div
           className="mt-4 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200"
           role="note"
           data-testid="reviewer-comment-banner"
         >
-          <p className="font-medium">Reviewer note</p>
+          <p className="font-medium">
+            {post.state === "rejected" ? "Rejection note" : "Reviewer note"}
+          </p>
           <p className="mt-0.5 whitespace-pre-wrap">{post.reviewer_comment}</p>
         </div>
       ) : null}

--- a/components/SocialPostsListClient.tsx
+++ b/components/SocialPostsListClient.tsx
@@ -236,13 +236,13 @@ export function SocialPostsListClient({
           ? "reject"
           : "request-changes";
 
-    // Prompt for an optional comment when requesting changes.
+    // Prompt for an optional comment when requesting changes or rejecting.
     let comment: string | null = null;
-    if (kind === "requesting") {
-      const input = prompt(
-        "Request changes? Enter a note for the editor (optional — leave blank to skip):",
-        "",
-      );
+    if (kind === "requesting" || kind === "rejecting") {
+      const promptText = kind === "rejecting"
+        ? "Reject this post? Enter a note for the editor (optional — leave blank to skip):"
+        : "Request changes? Enter a note for the editor (optional — leave blank to skip):";
+      const input = prompt(promptText, "");
       if (input === null) return; // user dismissed
       comment = input.trim() || null;
     }

--- a/lib/__tests__/social-post-transitions.test.ts
+++ b/lib/__tests__/social-post-transitions.test.ts
@@ -680,6 +680,7 @@ describe("lib/platform/social/posts/submitForApproval", () => {
       if (!result.ok) return;
       expect(result.data.postState).toBe("rejected");
       expect(result.data.createdBy).toBe(creator.id);
+      expect(result.data.comment).toBeNull();
 
       const svc = getServiceRoleClient();
       const after = await svc
@@ -688,6 +689,38 @@ describe("lib/platform/social/posts/submitForApproval", () => {
         .eq("id", post.id)
         .single();
       expect(after.data?.state).toBe("rejected");
+    });
+
+    it("passes comment through to result when provided", async () => {
+      const { post } = await createPendingApprovalPost2("reject with comment");
+      const result = await rejectPost({
+        postId: post.id,
+        companyId: COMPANY_A_ID,
+        comment: "  Not aligned with brand guidelines.  ",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.comment).toBe("Not aligned with brand guidelines.");
+
+      const svc = getServiceRoleClient();
+      const after = await svc
+        .from("social_post_master")
+        .select("reviewer_comment")
+        .eq("id", post.id)
+        .single();
+      expect(after.data?.reviewer_comment).toBe("Not aligned with brand guidelines.");
+    });
+
+    it("returns comment: null when comment is empty or whitespace", async () => {
+      const { post } = await createPendingApprovalPost2("reject empty comment");
+      const result = await rejectPost({
+        postId: post.id,
+        companyId: COMPANY_A_ID,
+        comment: "   ",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.comment).toBeNull();
     });
 
     it("rejects reject on a draft post with INVALID_STATE", async () => {

--- a/lib/platform/notifications/dispatch.ts
+++ b/lib/platform/notifications/dispatch.ts
@@ -255,10 +255,10 @@ function renderInApp(
         title: `Your post was ${payload.decision}`,
         body: payload.decision === "approved"
           ? "Schedule it from the calendar when you're ready."
-          : payload.decision === "rejected"
-            ? "Open the post to see the feedback."
-            : payload.comment
-              ? payload.comment
+          : payload.comment
+            ? payload.comment
+            : payload.decision === "rejected"
+              ? "Open the post to see the feedback."
               : "Changes requested — review the post and resubmit.",
         actionUrl: `/company/social/posts/${payload.postMasterId}`,
       };
@@ -383,10 +383,10 @@ function renderEmailContent(
         lead:
           payload.decision === "approved"
             ? "Your post was approved and is ready to schedule."
-            : payload.decision === "rejected"
-              ? "Your post was rejected. Open it on Opollo to see the feedback."
-              : payload.comment
-                ? payload.comment
+            : payload.comment
+              ? payload.comment
+              : payload.decision === "rejected"
+                ? "Your post was rejected. Open it on Opollo to see the feedback."
                 : "Changes were requested on your post. Open it on Opollo to review.",
         action: {
           label: "Open post",

--- a/lib/platform/social/posts/transitions.ts
+++ b/lib/platform/social/posts/transitions.ts
@@ -614,20 +614,23 @@ export type RejectPostResult = {
   postId: string;
   postState: "rejected";
   createdBy: string | null;
+  comment: string | null;
 };
 
 export async function rejectPost(args: {
   postId: string;
   companyId: string;
+  comment?: string | null;
 }): Promise<ApiResponse<RejectPostResult>> {
   if (!args.postId) return rejectValidation("Post id is required.");
   if (!args.companyId) return rejectValidation("Company id is required.");
 
   const svc = getServiceRoleClient();
 
+  const comment = args.comment?.trim() || null;
   const update = await svc
     .from("social_post_master")
-    .update({ state: "rejected" })
+    .update({ state: "rejected", reviewer_comment: comment })
     .eq("id", args.postId)
     .eq("company_id", args.companyId)
     .eq("state", "pending_client_approval")
@@ -663,6 +666,7 @@ export async function rejectPost(args: {
       postId: update.data.id as string,
       postState: "rejected",
       createdBy: (update.data.created_by as string | null) ?? null,
+      comment,
     },
     timestamp: new Date().toISOString(),
   };


### PR DESCRIPTION
## S1-54 — Optional reviewer comment on reject

### What changed
- **`lib/platform/social/posts/transitions.ts`** — `rejectPost` accepts optional `comment?: string | null`; writes trimmed value (or null) to `reviewer_comment`; returns `comment` in result
- **`app/api/platform/social/posts/[id]/reject/route.ts`** — schema extended with `comment: z.string().max(1000).trim().nullish()`; passes to `rejectPost`; includes `comment` in the `approval_decided` dispatch
- **`lib/platform/notifications/dispatch.ts`** — `renderInApp` + `renderEmailContent`: for `approval_decided`, show `payload.comment` (if present) as the notification body for both `rejected` and `changes_requested` decisions; fall back to state-specific defaults when null
- **`components/SocialPostDetailClient.tsx`** — `handleReject` replaced `confirm()` with `prompt()` for optional reason; amber banner now renders for `state === "rejected"` with title "Rejection note" (vs "Reviewer note" for `changes_requested`)
- **`components/SocialPostsListClient.tsx`** — `handleRowAction` for `kind === "rejecting"` now prompts for an optional comment before firing the request
- **`lib/__tests__/social-post-transitions.test.ts`** — three new tests: happy-path asserts `comment: null`, comment-provided asserts trimmed value written to DB, whitespace comment asserts `comment: null`

### Why
S1-53 added the `reviewer_comment` column and wired it to `requestChanges`. The `reject` pathway had the same gap — a reviewer who rejects needs to leave a reason just as much as one who requests changes. This slice closes that gap, symmetrising the two pathways.

### Risks identified and mitigated
- **Column already exists** — `reviewer_comment` was added in migration 0078 (S1-53). No new migration needed.
- **`rejected` is terminal** — no `reopenForEditing` path; the comment persists on the row until the post is deleted or a future "reinstate" flow is added. Intentional — the editor can use Duplicate to start fresh.
- **Stale comment from prior `requestChanges` cycle** — `reopenForEditing` (S1-53) already clears `reviewer_comment` to null when the editor reopens the post. If the reviewer then rejects the re-submitted post, the new `reviewer_comment` overwrites null. Correct.
- **Null safety** — banner renders only when both state and comment are non-null. No regression on posts without a comment.

### E2E omission
Lib + UI change on a company-facing route; no new admin route, no new form. Supabase-stack CI failure pre-dates this workstream. Noted per CLAUDE.md.

### Closes
S1-54