### PR TITLE
feat(data-conventions): sites audit columns — created_by + updated_by

### DIFF
--- a/app/api/admin/sites/[id]/onboarding/route.ts
+++ b/app/api/admin/sites/[id]/onboarding/route.ts
@@ -76,12 +76,12 @@ export async function POST(
   }
 
   const supabase = getServiceRoleClient();
-  // audit columns not yet on sites — DATA_CONVENTIONS rollout pending
   const upd = await supabase
     .from("sites")
     .update({
       site_mode: parsed.data.site_mode,
       updated_at: new Date().toISOString(),
+      updated_by: gate.user?.id ?? null,
     })
     .eq("id", params.id)
     .select("id, site_mode")

--- a/app/api/admin/sites/[id]/setup/extract/save/route.ts
+++ b/app/api/admin/sites/[id]/setup/extract/save/route.ts
@@ -104,7 +104,6 @@ export async function POST(
   }
 
   const supabase = getServiceRoleClient();
-  // audit columns not yet on sites — DATA_CONVENTIONS rollout pending
   const upd = await supabase
     .from("sites")
     .update({
@@ -112,6 +111,7 @@ export async function POST(
       extracted_css_classes: parsed.data.extracted_css_classes,
       design_direction_status: "approved",
       updated_at: new Date().toISOString(),
+      updated_by: gate.user?.id ?? null,
     })
     .eq("id", params.id)
     .eq("site_mode", "copy_existing")

--- a/app/api/admin/sites/[id]/use-image-library/route.ts
+++ b/app/api/admin/sites/[id]/use-image-library/route.ts
@@ -64,12 +64,12 @@ export async function POST(
   }
 
   const supabase = getServiceRoleClient();
-  // audit columns not yet on sites — DATA_CONVENTIONS rollout pending
   const upd = await supabase
     .from("sites")
     .update({
       use_image_library: parsed.data.enabled,
       updated_at: new Date().toISOString(),
+      updated_by: gate.user?.id ?? null,
     })
     .eq("id", params.id)
     .select("id, use_image_library")

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -24,7 +24,7 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
-## DATA_CONVENTIONS rollout — add audit columns to `sites` (opened 2026-05-02 during UAT §3.1.2)
+## ~~DATA_CONVENTIONS rollout — add audit columns to `sites`~~ (shipped 2026-05-03, PR #491)
 
 **Tags:** `schema`, `data-conventions`, `tech-debt`
 

--- a/supabase/migrations/0079_sites_audit_columns.sql
+++ b/supabase/migrations/0079_sites_audit_columns.sql
@@ -1,0 +1,8 @@
+-- DATA_CONVENTIONS rollout: add created_by + updated_by to sites.
+-- Both nullable (no historical attribution for existing rows).
+-- FK to opollo_users with ON DELETE SET NULL so user deletion doesn't
+-- orphan site rows.
+
+ALTER TABLE sites
+  ADD COLUMN IF NOT EXISTS created_by uuid REFERENCES opollo_users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS updated_by uuid REFERENCES opollo_users(id) ON DELETE SET NULL;


### PR DESCRIPTION
## DATA_CONVENTIONS rollout — `sites` audit columns

Closes the backlog entry opened during UAT §3.1.2.

### What changed

**Migration 0079** — `ALTER TABLE sites ADD COLUMN IF NOT EXISTS created_by/updated_by uuid REFERENCES opollo_users(id) ON DELETE SET NULL`. Both nullable; existing rows stay NULL (no historical backfill available).

**Three routes restored** — `updated_by: gate.user?.id ?? null` write was dropped in a surgical UAT-blocker fix. This PR restores it now that the column exists:
- `POST /api/admin/sites/[id]/onboarding`
- `POST /api/admin/sites/[id]/use-image-library`
- `POST /api/admin/sites/[id]/setup/extract/save`

**BACKLOG** — entry struck through as shipped.

### No E2E needed

Schema migration + three internal route writes — no new admin UI surface. The routes already had E2E coverage through the onboarding / settings flows.

### Risks identified and mitigated

- **Nullable columns** — both `created_by`/`updated_by` are nullable; `ON DELETE SET NULL` prevents FK violations on user deletion. No NOT NULL risk.
- **Existing rows** — `IF NOT EXISTS` guard; existing rows receive NULL (acceptable per DATA_CONVENTIONS.md).
- **`gate.user` nullable path** — `gate.user?.id ?? null` handles the break-glass kill-switch path where Supabase auth is off (`FEATURE_SUPABASE_AUTH` unset); column receives NULL in that edge case (correct behaviour — no actor to attribute).
- **Write safety** — these are simple UPDATE writes with no concurrency invariants; no advisory lock needed.