### PR TITLE
fix(typo): phase 2 text-sm-as-body callsite sweep

### DIFF
--- a/app/approve/[token]/page.tsx
+++ b/app/approve/[token]/page.tsx
@@ -79,7 +79,7 @@ export default async function ApproveViewerPage({
         <h1 className="text-2xl font-semibold">
           {company.name} — approval request
         </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
+        <p className="mt-2 text-base text-muted-foreground">
           {recipient.name?.trim() ? `Hi ${recipient.name},` : "Hi,"}{" "}
           {company.name} would like your decision on the social post
           below. {snapshot.submitted_at
@@ -107,13 +107,13 @@ function SnapshotReadOnly({ snapshot }: { snapshot: Snapshot }) {
       <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
         Master copy
       </h2>
-      <p className="mt-2 whitespace-pre-wrap text-sm">
+      <p className="mt-2 whitespace-pre-wrap text-base">
         {snapshot.master_text ?? (
           <span className="text-muted-foreground">— No copy —</span>
         )}
       </p>
       {snapshot.link_url ? (
-        <p className="mt-3 text-sm">
+        <p className="mt-3 text-base">
           <span className="text-muted-foreground">Link: </span>
           <a
             href={snapshot.link_url}
@@ -135,7 +135,7 @@ function SnapshotReadOnly({ snapshot }: { snapshot: Snapshot }) {
             {snapshot.variants.map((v) => (
               <li
                 key={v.platform}
-                className="p-3 text-sm"
+                className="p-3 text-base"
                 data-testid={`approval-variant-${v.platform}`}
               >
                 <div className="font-medium">

--- a/app/auth-error/page.tsx
+++ b/app/auth-error/page.tsx
@@ -20,7 +20,7 @@ export default function AuthErrorPage() {
   return (
     <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-4 p-6 text-center">
       <h1 className="text-xl font-semibold">Authentication error</h1>
-      <p className="text-sm text-muted-foreground">
+      <p className="text-base text-muted-foreground">
         We couldn&rsquo;t verify your session. Try signing in again — if this
         keeps happening, contact an operator.
       </p>

--- a/app/company/page.tsx
+++ b/app/company/page.tsx
@@ -74,7 +74,7 @@ export default async function CompanyLandingPage() {
     <main className="mx-auto max-w-5xl p-6 space-y-6">
       <header>
         <h1 className="text-2xl font-semibold">Welcome back</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-1 text-base text-muted-foreground">
           Here&apos;s where your social content sits today.
         </p>
       </header>
@@ -87,7 +87,7 @@ export default async function CompanyLandingPage() {
         <SocialPostsDashboardCard stats={statsResult.data} />
       ) : (
         <div
-          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive"
           role="alert"
           data-testid="dashboard-stats-error"
         >
@@ -105,7 +105,7 @@ export default async function CompanyLandingPage() {
           data-testid="dashboard-link-posts"
         >
           <div className="font-medium">Social posts</div>
-          <div className="mt-1 text-sm text-muted-foreground">
+          <div className="mt-1 text-base text-muted-foreground">
             Drafts, approvals, scheduling, audit trail.
           </div>
         </Link>
@@ -115,7 +115,7 @@ export default async function CompanyLandingPage() {
           data-testid="dashboard-link-calendar"
         >
           <div className="font-medium">Calendar</div>
-          <div className="mt-1 text-sm text-muted-foreground">
+          <div className="mt-1 text-base text-muted-foreground">
             30-day view of everything queued to publish.
           </div>
         </Link>
@@ -125,7 +125,7 @@ export default async function CompanyLandingPage() {
           data-testid="dashboard-link-connections"
         >
           <div className="font-medium">Connections</div>
-          <div className="mt-1 text-sm text-muted-foreground">
+          <div className="mt-1 text-base text-muted-foreground">
             Linked social accounts and platform status.
           </div>
         </Link>
@@ -135,7 +135,7 @@ export default async function CompanyLandingPage() {
           data-testid="dashboard-link-media"
         >
           <div className="font-medium">Media library</div>
-          <div className="mt-1 text-sm text-muted-foreground">
+          <div className="mt-1 text-base text-muted-foreground">
             Images and videos attached to posts.
           </div>
         </Link>
@@ -145,7 +145,7 @@ export default async function CompanyLandingPage() {
           data-testid="dashboard-link-users"
         >
           <div className="font-medium">Users</div>
-          <div className="mt-1 text-sm text-muted-foreground">
+          <div className="mt-1 text-base text-muted-foreground">
             Manage team members and pending invitations.
           </div>
         </Link>
@@ -156,7 +156,7 @@ export default async function CompanyLandingPage() {
             data-testid="dashboard-link-brand"
           >
             <div className="font-medium">Brand profile</div>
-            <div className="mt-1 text-sm text-muted-foreground">
+            <div className="mt-1 text-base text-muted-foreground">
               Visual identity + tone + content rules. Drives every output.
             </div>
           </Link>
@@ -168,7 +168,7 @@ export default async function CompanyLandingPage() {
             data-testid="dashboard-link-image-generator"
           >
             <div className="font-medium">Image generator</div>
-            <div className="mt-1 text-sm text-muted-foreground">
+            <div className="mt-1 text-base text-muted-foreground">
               Generate mood board backgrounds for your social posts.
             </div>
           </Link>
@@ -197,7 +197,7 @@ function BrandCompletionBanner({ tier }: { tier: "none" | "minimal" }) {
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <p className="text-base font-semibold">{heading}</p>
-          <p className="mt-1 text-sm text-muted-foreground">{body}</p>
+          <p className="mt-1 text-base text-muted-foreground">{body}</p>
         </div>
         <Link
           href="/company/settings/brand"

--- a/app/company/social/calendar/page.tsx
+++ b/app/company/social/calendar/page.tsx
@@ -35,7 +35,7 @@ export default async function CompanySocialCalendarPage({ searchParams }: Props)
   }
   if (!session.company) {
     return (
-      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm">
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-base">
         <p className="font-medium">Account not provisioned to a company.</p>
         <p className="mt-1 text-muted-foreground">
           Your account isn&apos;t a member of any company on the platform
@@ -77,7 +77,7 @@ export default async function CompanySocialCalendarPage({ searchParams }: Props)
           />
         ) : (
           <div
-            className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+            className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive"
             role="alert"
           >
             Failed to load calendar: {result.error.message}

--- a/app/company/social/media/page.tsx
+++ b/app/company/social/media/page.tsx
@@ -25,7 +25,7 @@ export default async function CompanySocialMediaPage() {
   }
   if (!session.company) {
     return (
-      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm">
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-base">
         <p className="font-medium">Account not provisioned to a company.</p>
         <p className="mt-1 text-muted-foreground">
           Your account isn&apos;t a member of any company on the platform
@@ -59,7 +59,7 @@ export default async function CompanySocialMediaPage() {
           />
         ) : (
           <div
-            className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+            className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive"
             role="alert"
           >
             Failed to load media: {listResult.error.message}

--- a/app/company/social/posts/page.tsx
+++ b/app/company/social/posts/page.tsx
@@ -49,7 +49,7 @@ export default async function CompanySocialPostsPage({ searchParams }: Props) {
 
   if (!session.company) {
     return (
-      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm">
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-base">
         <p className="font-medium">Account not provisioned to a company.</p>
         <p className="mt-1 text-muted-foreground">
           Your account isn&apos;t a member of any company on the platform
@@ -95,7 +95,7 @@ export default async function CompanySocialPostsPage({ searchParams }: Props) {
   if (!postsResult.ok) {
     return (
       <div
-        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive"
         role="alert"
       >
         Failed to load posts: {postsResult.error.message}

--- a/app/company/users/page.tsx
+++ b/app/company/users/page.tsx
@@ -28,7 +28,7 @@ export default async function CompanyUsersPage() {
 
   if (!session.company) {
     return (
-      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm">
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-base">
         <p className="font-medium">Account not provisioned to a company.</p>
         <p className="mt-1 text-muted-foreground">
           Your account isn&apos;t a member of any company on the platform
@@ -42,7 +42,7 @@ export default async function CompanyUsersPage() {
     session.isOpolloStaff || session.company.role === "admin";
   if (!isAdmin) {
     return (
-      <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+      <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive">
         <p className="font-medium">Admins only.</p>
         <p className="mt-1">
           Only admins can manage company users. Ask an admin in your
@@ -56,7 +56,7 @@ export default async function CompanyUsersPage() {
   if (!detailResult.ok) {
     return (
       <div
-        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive"
         role="alert"
       >
         Failed to load company: {detailResult.error.message}

--- a/app/optimiser/page.tsx
+++ b/app/optimiser/page.tsx
@@ -69,7 +69,7 @@ export default async function OptimiserHomePage({
       <header className="flex flex-wrap items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Page browser</h1>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-base text-muted-foreground">
             All managed landing pages, with state, data reliability, and key metrics.
           </p>
         </div>
@@ -101,13 +101,13 @@ function EmptyState({ clientsExist }: { clientsExist: boolean }) {
     <div className="space-y-6">
       <header>
         <h1 className="text-2xl font-semibold tracking-tight">Optimiser</h1>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-base text-muted-foreground">
           Autonomous Landing Page Optimisation Engine — Phase 1.
         </p>
       </header>
       <section className="rounded-lg border border-dashed border-border bg-card p-8 text-center">
         <h2 className="text-lg font-medium">No onboarded clients yet</h2>
-        <p className="mt-2 text-sm text-muted-foreground">
+        <p className="mt-2 text-base text-muted-foreground">
           {clientsExist
             ? "Continue an in-progress onboarding to see the page browser."
             : "Start by adding a client through the onboarding wizard."}

--- a/app/viewer/[token]/page.tsx
+++ b/app/viewer/[token]/page.tsx
@@ -133,7 +133,7 @@ export default async function ViewerLinkPage({
         <h1 className="text-2xl font-semibold">
           {company.name} — content calendar
         </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
+        <p className="mt-2 text-base text-muted-foreground">
           {grouped.length === 0
             ? "Nothing scheduled in the visible window. Check back soon."
             : `Showing posts from the last ${BACK_DAYS} days through the next ${FORWARD_DAYS}.`}
@@ -167,12 +167,12 @@ export default async function ViewerLinkPage({
                       </time>
                     </div>
                     {e.master_text ? (
-                      <p className="mt-2 whitespace-pre-wrap text-sm">
+                      <p className="mt-2 whitespace-pre-wrap text-base">
                         {e.master_text}
                       </p>
                     ) : null}
                     {e.link_url ? (
-                      <p className="mt-2 truncate text-sm">
+                      <p className="mt-2 truncate text-base">
                         <a
                           href={e.link_url}
                           target="_blank"

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,7 +6,7 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
-## Typography minimums Phase 2 — `text-sm`-as-body callsite sweep (opened 2026-05-02 during UAT)
+## ~~Typography minimums Phase 2 — `text-sm`-as-body callsite sweep~~ (shipped 2026-05-03, PR #492)
 
 **Tags:** `ux`, `typography`, `tech-debt`
 


### PR DESCRIPTION
## Summary

Typography Phase 2 — per-callsite audit of `text-sm` body copy.

**Classification rules applied:**
- BODY copy (descriptions, alert prose, post content, page taglines) → `text-base` (1rem/16px)
- SMALL text (eyebrows, timestamps, badge spans, nav links, form inputs, table cells) → kept at `text-sm` (0.875rem/14px)

**Files changed (10):**
- `app/company/page.tsx` — dashboard tagline, card descriptions, brand-completion banner body, error alert
- `app/company/social/posts/page.tsx` — not-provisioned amber alert, error alert
- `app/company/social/calendar/page.tsx` — not-provisioned amber alert, error alert
- `app/company/social/media/page.tsx` — not-provisioned amber alert, error alert
- `app/company/users/page.tsx` — not-provisioned + forbidden + load-error alerts
- `app/auth-error/page.tsx` — session-error description paragraph
- `app/optimiser/page.tsx` — page browser tagline, empty-state descriptions
- `app/viewer/[token]/page.tsx` — calendar window description, post master text, link URL
- `app/approve/[token]/page.tsx` — approval request description, master copy body, link text, per-platform variant list items
- `docs/BACKLOG.md` — mark entry as shipped

**Explicitly excluded** (cascade risk or semantic role):
- `<main className="... text-sm">` page containers
- `<h2 className="text-sm font-semibold uppercase tracking-wide ...">` heading eyebrows
- `<time className="text-sm ...">` timestamps
- `<span>` badge elements
- Form input selects and labels
- `H3` primitive (hierarchy concern, deferred per BACKLOG note)

## Risks identified and mitigated

Purely a Tailwind className change — no logic, no DB writes, no API calls. Risk: visual overflow/truncation on bumped copy. Mitigated by build passing and manual classification audit; no layout-critical paths touched. E2E spec not required (no new routes/forms added).

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] Visual pass on customer surfaces at `/company`, `/company/social/*`, `/approve/[token]`, `/viewer/[token]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)