### PR TITLE
fix(m12-6): save-draft version_lock bug + re-enable E2E happy path

### DIFF
--- a/components/BriefReviewClient.tsx
+++ b/components/BriefReviewClient.tsx
@@ -217,7 +217,7 @@ export function BriefReviewClient({
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          expected_version_lock: brief.version_lock,
+          expected_version_lock: latestBrief.version_lock,
           pages: pageUpdates,
         }),
       });

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -459,9 +459,9 @@ Captured during UAT prep in parallel with M15-7. Deferred to avoid collision in 
 
 Verified 2026-04-29: the post-commit panel in `BriefReviewClient.tsx` (~line 573) already renders user-friendly copy ("This brief is committed. You're ready to run the generator…") with two CTAs ("Back to briefs", "Open run surface →"). The dead-end + M12-5 jargon described in the original entry was fixed during M12-5 itself; the BACKLOG entry slipped through unmarked. Stale header comment updated in the same audit pass.
 
-## M12-6 — Save-Draft persistence for briefs review
+## ~~M12-6 — Save-Draft persistence for briefs review~~ (shipped 2026-05-03)
 
-Surfaced by the `fix(e2e)` slice (2026-04-24). The M12-1 slice plan §6.2 called for a "Save draft" button that persists `brief_pages` edits under `version_lock` before commit. That button was never implemented — the commit endpoint therefore 409s on any edit-then-commit flow because the client's hash is computed from in-memory edits while the server recomputes from unedited DB rows. The happy-path E2E in `e2e/briefs-review.spec.ts` is `test.fixme`'d until this lands. Pick up trigger: M12-6 starts. Scope: new `PATCH /api/briefs/[brief_id]/pages` endpoint + "Save draft" button wired into `BriefReviewClient.tsx` + re-enable the fixme'd test.
+PATCH endpoint at `app/api/briefs/[brief_id]/pages/route.ts` + "Save draft" button wired in `components/BriefReviewClient.tsx`. Fixed version_lock bug (`brief.version_lock` prop → `latestBrief.version_lock` state). E2E happy-path test re-enabled (commit confirm modal removed UAT 2026-05-03).
 
 ---
 
@@ -537,7 +537,7 @@ Reports live at:
   - `admin/sites/[id]/pages/[pageId]` PATCH
 - **[M15-6 #13] 6 of 7 tool JSON schemas untested.** `lib/tool-schemas.ts` — `searchImagesJsonSchema` tested; others aren't. Scope: parametric tests across all 7.
 - **[M15-6 #14] Tool lib implementations untested.** `lib/create-page.ts`, `lib/update-page.ts`, `lib/delete-page.ts`, `lib/get-page.ts`, `lib/list-pages.ts`, `lib/publish-page.ts`. M15-7 Phase 3b (#134) pins delegation at the route layer; the libs themselves wrap WP + Supabase calls with no dedicated tests. Scope: 2-3 hours per lib.
-- **[M15-6 #15] `briefs-review.spec.ts` upload→parse→commit E2E is `test.fixme`.** Blocked on M12-6 save-draft. Re-enable when M12-6 lands.
+- ~~**[M15-6 #15] `briefs-review.spec.ts` upload→parse→commit E2E is `test.fixme`.**~~ Shipped in M12-6 (2026-05-03).
 - **[M15-6 #17] `health-route.test.ts` only covers happy path.** Degraded branches untested. Scope: 1 hour.
 
 #### Tech-debt (bundled cleanup, no urgency)

--- a/e2e/briefs-review.spec.ts
+++ b/e2e/briefs-review.spec.ts
@@ -81,7 +81,6 @@ test.describe("M12-1 briefs — upload + review", () => {
     await signInAsAdmin(page);
   });
 
-  // TODO(M12-6): re-enable once the Save-Draft persistence gap lands.
   // M12-6 — exercises the full upload → edit → save draft → commit flow.
   test("upload → parse → commit happy path", async ({ page }, testInfo) => {
     test.setTimeout(60_000);
@@ -115,19 +114,20 @@ test.describe("M12-1 briefs — upload + review", () => {
 
     await auditA11y(page, testInfo);
 
-    // Save draft to persist edits to DB.
-    await page.getByRole("button", { name: /Save draft/i }).click();
+    // Save draft — wait for it to complete (button returns to "Save draft"
+    // once isSavingDraft resets to false). This persists in-memory edits to
+    // DB so the commit hash matches the server-side recomputation.
+    const saveDraftBtn = page.getByRole("button", { name: /Save draft/i });
+    await saveDraftBtn.click();
+    await expect(saveDraftBtn).toBeEnabled({ timeout: 10_000 });
 
-    // Commit.
+    // Commit. No confirm modal — it was removed (UAT 2026-05-03 round-3)
+    // because the double-confirm added friction on every routine commit.
+    // RS-3: successful commit redirects straight to the run surface.
     await page.getByRole("button", { name: /Commit page list/i }).click();
-    const confirmDialog = page.getByRole("dialog", { name: /Commit this page list\?/i });
-    await expect(confirmDialog).toBeVisible();
-    await confirmDialog.getByRole("button", { name: /^Commit page list$/i }).click();
-
-    // RS-3: successful commit redirects straight to the run surface;
-    // the operator never sees the intermediate "committed" panel.
     await page.waitForURL(
       /\/admin\/sites\/[0-9a-f-]{36}\/briefs\/[0-9a-f-]{36}\/run$/,
+      { timeout: 15_000 },
     );
     await expect(page.getByRole("button", { name: /Commit page list/i })).toHaveCount(0);
   });


### PR DESCRIPTION
## Summary

- **Bug fix** in `components/BriefReviewClient.tsx`: `handleSaveDraft` was reading `brief.version_lock` (the immutable prop passed at mount) instead of `latestBrief.version_lock` (the state updated after each save). Any second save-draft call would get a `VERSION_CONFLICT` because the server bumped the lock after the first save and the client kept sending the stale initial value.
- **E2E fix** in `e2e/briefs-review.spec.ts`: the happy-path test expected a commit-confirmation modal that was removed in UAT 2026-05-03 round-3. Updated to: (a) wait for Save-Draft to complete before clicking Commit, (b) assert on the `/run` URL redirect directly without a dialog step.
- **BACKLOG.md**: mark M12-6 shipped; mark M15-6 #15 (`briefs-review` E2E fixme) resolved.

## Risks identified and mitigated

- **version_lock bump race**: PATCH endpoint increments `version_lock` in a single UPDATE after all page updates succeed — the same pattern as the commit endpoint. No additional race surface introduced.
- **No schema changes**, no migrations, no new dependencies.
- **E2E only works when Supabase local stack is running** — pre-existing 0031 migration collision means CI e2e/test still fail at "Start Supabase local stack"; not caused by this PR.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm run audit:static` — 0 HIGH
- [ ] `e2e` / `test` — pre-existing 0031 collision (unrelated)