### PR TITLE
fix(security): rate-limit 13 sensitive routes (M15-4 #9)

### DIFF
--- a/app/api/admin/sites/[id]/budget/route.ts
+++ b/app/api/admin/sites/[id]/budget/route.ts
@@ -3,6 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 import { updateTenantBudget } from "@/lib/tenant-budgets";
 import { errorCodeToStatus } from "@/lib/tool-schemas";
 
@@ -77,6 +78,9 @@ export async function PATCH(
   // not a drive-by widening.
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("admin_write", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   if (!UUID_RE.test(params.id)) {
     return errorJson("VALIDATION_FAILED", "Site id must be a UUID.", 400);

--- a/app/api/admin/users/[id]/reinstate/route.ts
+++ b/app/api/admin/users/[id]/reinstate/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { logger } from "@/lib/logger";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -44,6 +45,9 @@ export async function POST(
 ): Promise<NextResponse> {
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("user_mgmt", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const userId = params.id;
   if (!UUID_RE.test(userId)) {

--- a/app/api/admin/users/[id]/revoke/route.ts
+++ b/app/api/admin/users/[id]/revoke/route.ts
@@ -4,6 +4,7 @@ import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { countActiveAdmins } from "@/lib/auth";
 import { revokeUserSessions } from "@/lib/auth-revoke";
 import { logger } from "@/lib/logger";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -64,6 +65,9 @@ export async function POST(
 ): Promise<NextResponse> {
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("user_mgmt", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const userId = params.id;
   if (!UUID_RE.test(userId)) {

--- a/app/api/admin/users/[id]/role/route.ts
+++ b/app/api/admin/users/[id]/role/route.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { countActiveAdmins } from "@/lib/auth";
 import { logger } from "@/lib/logger";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -73,6 +74,9 @@ export async function PATCH(
 ): Promise<NextResponse> {
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("user_mgmt", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const userId = params.id;
   if (!UUID_RE.test(userId)) {

--- a/app/api/briefs/upload/route.ts
+++ b/app/api/briefs/upload/route.ts
@@ -8,6 +8,7 @@ import {
   uploadBrief,
   type BriefMimeType,
 } from "@/lib/briefs";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 import {
   errorCodeToStatus,
@@ -61,6 +62,9 @@ function validationError(message: string, details?: Record<string, unknown>): Ne
 export async function POST(req: Request): Promise<NextResponse> {
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("briefs_upload", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   let form: FormData;
   try {

--- a/app/api/design-systems/[id]/activate/route.ts
+++ b/app/api/design-systems/[id]/activate/route.ts
@@ -7,6 +7,7 @@ import {
   respond,
   validateUuidParam,
 } from "@/lib/http";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 
@@ -20,6 +21,9 @@ const BodySchema = z.object({
 export async function POST(req: Request, ctx: { params: { id: string } }) {
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("admin_write", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;

--- a/app/api/design-systems/[id]/archive/route.ts
+++ b/app/api/design-systems/[id]/archive/route.ts
@@ -7,6 +7,7 @@ import {
   respond,
   validateUuidParam,
 } from "@/lib/http";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 
@@ -20,6 +21,9 @@ const BodySchema = z.object({
 export async function POST(req: Request, ctx: { params: { id: string } }) {
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("admin_write", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;

--- a/app/api/design-systems/[id]/components/[cid]/route.ts
+++ b/app/api/design-systems/[id]/components/[cid]/route.ts
@@ -13,6 +13,7 @@ import {
   validationError,
   validateUuidParam,
 } from "@/lib/http";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 import { validateScopedCss } from "@/lib/scope-prefix";
 
 export const runtime = "nodejs";
@@ -33,6 +34,9 @@ const PatchBodySchema = UpdateDesignComponentSchema.and(
 export async function PATCH(req: Request, ctx: RouteContext) {
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("admin_write", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const dsParam = validateUuidParam(ctx.params.id, "id");
   if (!dsParam.ok) return dsParam.response;
@@ -68,6 +72,9 @@ export async function PATCH(req: Request, ctx: RouteContext) {
 export async function DELETE(req: Request, ctx: RouteContext) {
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("admin_write", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const dsParam = validateUuidParam(ctx.params.id, "id");
   if (!dsParam.ok) return dsParam.response;

--- a/app/api/design-systems/[id]/components/route.ts
+++ b/app/api/design-systems/[id]/components/route.ts
@@ -13,6 +13,7 @@ import {
   validationError,
   validateUuidParam,
 } from "@/lib/http";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 import { validateScopedCss } from "@/lib/scope-prefix";
 
 export const runtime = "nodejs";
@@ -39,6 +40,9 @@ const CreateBodySchema = CreateDesignComponentSchema.omit({
 export async function POST(req: Request, ctx: RouteContext) {
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("admin_write", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;

--- a/app/api/design-systems/[id]/preview/route.ts
+++ b/app/api/design-systems/[id]/preview/route.ts
@@ -4,6 +4,7 @@ import { getDesignSystem } from "@/lib/design-systems";
 import { listComponents } from "@/lib/components";
 import { listTemplates } from "@/lib/templates";
 import { respond, validateUuidParam } from "@/lib/http";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 
 export const runtime = "nodejs";
 
@@ -18,6 +19,9 @@ export async function GET(_req: Request, ctx: { params: { id: string } }) {
   // depth; consistent with sibling /api/design-systems/[id] routes).
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("admin_write", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;

--- a/app/api/design-systems/[id]/templates/[tid]/route.ts
+++ b/app/api/design-systems/[id]/templates/[tid]/route.ts
@@ -12,6 +12,7 @@ import {
   validationError,
   validateUuidParam,
 } from "@/lib/http";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 import { validateCompositionRefs } from "../_helpers";
 
 export const runtime = "nodejs";
@@ -33,6 +34,9 @@ const PatchBodySchema = UpdateDesignTemplateSchema.and(
 export async function PATCH(req: Request, ctx: RouteContext) {
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("admin_write", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const dsParam = validateUuidParam(ctx.params.id, "id");
   if (!dsParam.ok) return dsParam.response;
@@ -61,6 +65,9 @@ export async function PATCH(req: Request, ctx: RouteContext) {
 export async function DELETE(req: Request, ctx: RouteContext) {
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("admin_write", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const dsParam = validateUuidParam(ctx.params.id, "id");
   if (!dsParam.ok) return dsParam.response;

--- a/app/api/design-systems/[id]/templates/route.ts
+++ b/app/api/design-systems/[id]/templates/route.ts
@@ -10,6 +10,7 @@ import {
   respond,
   validateUuidParam,
 } from "@/lib/http";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 import { validateCompositionRefs } from "./_helpers";
 
 export const runtime = "nodejs";
@@ -36,6 +37,9 @@ const CreateBodySchema = CreateDesignTemplateSchema.omit({
 export async function POST(req: Request, ctx: RouteContext) {
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("admin_write", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;

--- a/app/api/sites/list/route.ts
+++ b/app/api/sites/list/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 import { listSites } from "@/lib/sites";
 import { errorCodeToStatus } from "@/lib/tool-schemas";
 
@@ -13,6 +14,9 @@ export async function GET() {
   // surfacing the full sites list to any caller including unauthenticated.
   const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("admin_write", `user:${gate.user?.id ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const result = await listSites();
   const status = result.ok ? 200 : errorCodeToStatus(result.error.code);

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -513,7 +513,7 @@ Reports live at:
 
 #### Rate-limiting coverage (next rate-limit slice)
 
-- **[M15-4 #9] 9 sensitive routes without a rate limit.** User-mgmt (revoke, reinstate, role), budget PATCH, briefs upload (10MB), design-system writes, `sites/list`, `design-systems/[id]/preview`. Scope: add named buckets in `lib/rate-limit.ts` (`user_mgmt`, `admin_write`, `briefs`); wire each route.
+- ~~**[M15-4 #9] 9 sensitive routes without a rate limit.**~~ Fixed 2026-05-03 — added `user_mgmt` (20/1h), `admin_write` (60/1h), `briefs_upload` (10/1h) buckets in `lib/rate-limit.ts`; wired into revoke, reinstate, role, budget PATCH, briefs upload, design-system activate/archive/components/templates, `sites/list`, and `design-systems/[id]/preview`.
 
 #### Schema + constraint polish (next migration slice)
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -39,7 +39,10 @@ export type LimiterName =
   | "password_reset"
   | "test_connection"
   | "auth_2fa"
-  | "csv_upload";
+  | "csv_upload"
+  | "user_mgmt"
+  | "admin_write"
+  | "briefs_upload";
 
 type LimiterConfig = {
   requests: number;
@@ -82,6 +85,18 @@ const CONFIGS: Record<LimiterName, LimiterConfig> = {
   // defaults. Keyed on "company:<uuid>" so different companies don't
   // share the bucket.
   csv_upload: { requests: 3, window: "1 h" },
+  // M15-4 #9: user-management mutations (revoke, reinstate, role change).
+  // Admin-only; 20/hour is generous for legitimate use (a team of 5
+  // churning through a user list) while blocking automated scanning.
+  user_mgmt: { requests: 20, window: "1 h" },
+  // M15-4 #9: miscellaneous admin writes (budget PATCH, design-system
+  // writes, sites/list). 60/hour per authenticated admin covers normal
+  // dashboard use without opening bulk-mutation paths.
+  admin_write: { requests: 60, window: "1 h" },
+  // M15-4 #9: brief file upload endpoint. Each call parses up to 10 MB
+  // of markdown; 10/hour prevents runaway re-uploads during a single
+  // session while leaving headroom for retries.
+  briefs_upload: { requests: 10, window: "1 h" },
 };
 
 export type RateLimitResult =


### PR DESCRIPTION
## Summary

Adds three named sliding-window buckets to `lib/rate-limit.ts` and wires them into 13 previously-unguarded route handlers.

New buckets:
- user_mgmt (20 req/h): revoke, reinstate, role
- admin_write (60 req/h): budget PATCH, design-system activate/archive/components/templates, sites/list, design-systems/[id]/preview
- briefs_upload (10 req/h): briefs upload (10 MB parse per call)

Pattern (identical to existing rate-limited routes):
```ts
const rl = await checkRateLimit(user_mgmt, `user:${gate.user?.id ?? unknown}`);
if (!rl.ok) return rateLimitExceeded(rl);
```

Fail-open semantics preserved: no Upstash configured -> pass-through. BACKLOG M15-4 #9 marked shipped.

## Risks identified and mitigated

- No DB / schema changes — pure in-memory sliding-window via Upstash. Fail-open means no new availability risk.
- Bucket granularity: admin_write 60/h covers normal dashboard use; user_mgmt 20/h is generous for a team iterating on a user list; briefs_upload 10/h caps the heavy parse path.
- unknown identifier fallback: if gate.user is null after auth passes, the request lands in a shared user:unknown bucket rather than failing open. Auth gate should always populate gate.user for a valid session.

## Test plan

- CI lint / typecheck / build / static-audit (no new HIGH issues)
- Unit: lib/rate-limit.ts changes are additive; existing rate-limit tests still pass
- E2E: rate-limit is fail-open in CI (no Upstash), so existing tests are unaffected