### PR TITLE
fix(security): add auth gates to 4 public GET routes (M15-4 #8)

### DIFF
--- a/app/api/design-systems/[id]/components/route.ts
+++ b/app/api/design-systems/[id]/components/route.ts
@@ -21,6 +21,10 @@ type RouteContext = { params: { id: string } };
 
 // GET /api/design-systems/[id]/components — list components for a design system.
 export async function GET(_req: Request, ctx: RouteContext) {
+  // PLATFORM-AUDIT M15-4 #8: previously unguarded — matched by middleware only.
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;
   return respond(await listComponents(param.value));

--- a/app/api/design-systems/[id]/templates/route.ts
+++ b/app/api/design-systems/[id]/templates/route.ts
@@ -18,6 +18,10 @@ type RouteContext = { params: { id: string } };
 
 // GET /api/design-systems/[id]/templates
 export async function GET(_req: Request, ctx: RouteContext) {
+  // PLATFORM-AUDIT M15-4 #8: previously unguarded — matched by middleware only.
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;
   return respond(await listTemplates(param.value));

--- a/app/api/sites/[id]/design-systems/route.ts
+++ b/app/api/sites/[id]/design-systems/route.ts
@@ -17,6 +17,10 @@ type RouteContext = { params: { id: string } };
 
 // GET /api/sites/[id]/design-systems — list versions for a site.
 export async function GET(_req: Request, ctx: RouteContext) {
+  // PLATFORM-AUDIT M15-4 #8: previously unguarded — matched by middleware only.
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
   const param = validateUuidParam(ctx.params.id, "id");
   if (!param.ok) return param.response;
   return respond(await listDesignSystems(param.value));

--- a/app/api/sites/[id]/route.ts
+++ b/app/api/sites/[id]/route.ts
@@ -53,6 +53,11 @@ export async function GET(
   _req: Request,
   { params }: { params: { id: string } },
 ) {
+  // PLATFORM-AUDIT M15-4 #8: site data was previously readable by any caller
+  // relying only on middleware. Defence-in-depth gate matches PATCH/DELETE.
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
   // Never include credentials in a response served over HTTP. Internal
   // consumers (chat route) must call getSite directly with includeCredentials.
   const result = await getSite(params.id, { includeCredentials: false });

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -487,7 +487,7 @@ Reports live at:
 #### Security / auth tightening (next security review pass)
 
 - **[M15-4 #3] `tools/*` write routes have no session requirement.** `tools/publish_page`, `tools/update_page`, `tools/delete_page` are reachable with just a rate-limit token. M15-7 Phase 3b (#134) pinned current behaviour in tests; when auth gets tightened, tests will need to update. Scope: add `requireAdminForApi(['admin', 'operator'])` to the three write routes + refresh the tests.
-- **[M15-4 #8] 6 public GET routes have no route-level auth gate.** `sites/list`, `sites/[id]`, `sites/[id]/design-systems`, `design-systems/[id]/components`, `design-systems/[id]/templates`, `design-systems/[id]/preview` rely entirely on middleware. Defense-in-depth gap. Scope: add `requireAdminForApi()` to each; cost is one import + one check per route.
+- ~~**[M15-4 #8] 6 public GET routes have no route-level auth gate.**~~ Fixed 2026-05-03 — added `requireAdminForApi(["super_admin","admin"])` to GET handlers in `sites/[id]`, `sites/[id]/design-systems`, `design-systems/[id]/components`, `design-systems/[id]/templates`. `sites/list` and `design-systems/[id]/preview` already had gates per PLATFORM-AUDIT PR3 (#386).
 - **[M15-4 #11] `tools/*` routes don't seed `runWithWpCredentials()` context.** Direct POST outside the chat flow → executor uses empty AsyncLocalStorage context. Needs verification that direct calls fail safely. Scope: either (a) remove the tools routes if only used internally by chat, or (b) seed context from the request body's `site_id`.
 - **[M15-5 #12] `image_usage` RLS excludes `viewer` role.** Asymmetry vs `image_library` + `image_metadata`. Check if intentional; if so, comment the migration; if not, align the policy.
 


### PR DESCRIPTION
## Summary

Adds `requireAdminForApi([super_admin,admin])` to 4 GET handlers that previously relied entirely on Next.js middleware for authentication (defense-in-depth gap per PLATFORM-AUDIT M15-4 #8).

Routes fixed:
- `GET /api/sites/[id]` — site record (no credentials, but site names/URLs/status are admin data)
- `GET /api/sites/[id]/design-systems` — design-system version list for a site
- `GET /api/design-systems/[id]/components` — component registry for a design system
- `GET /api/design-systems/[id]/templates` — template registry for a design system

`sites/list` and `design-systems/[id]/preview` already had route-level gates added in PLATFORM-AUDIT PR3 (#386) and are not touched here.

## Risks identified and mitigated

- No schema/DB changes, no new dependencies.
- Breaking change for unauthenticated callers: correct — these routes serve admin-only data and should 401 for unauthenticated requests. No client-side code calls these without an active admin session.
- The existing GET handlers for components and templates are used by the design system admin UI, which is already behind the admin middleware. Adding a redundant route-level check has no observable impact on legitimate traffic.

## Test plan

- CI lint / typecheck / build / static-audit (no new HIGH issues)
- E2E: design-system flows hit these GET endpoints; rate-limit is not wired to these routes (they stay ungated for rate-limiting), so existing tests unaffected
- Pure server-side security change; no UI diff