### PR TITLE
feat(data-conventions): add created_by + updated_by to sites (DC-1)

### DIFF
--- a/app/api/admin/sites/[id]/onboarding/route.ts
+++ b/app/api/admin/sites/[id]/onboarding/route.ts
@@ -76,12 +76,12 @@ export async function POST(
   }
 
   const supabase = getServiceRoleClient();
-  // audit columns not yet on sites — DATA_CONVENTIONS rollout pending
   const upd = await supabase
     .from("sites")
     .update({
       site_mode: parsed.data.site_mode,
       updated_at: new Date().toISOString(),
+      updated_by: gate.user?.id ?? null,
     })
     .eq("id", params.id)
     .select("id, site_mode")

--- a/app/api/admin/sites/[id]/setup/extract/save/route.ts
+++ b/app/api/admin/sites/[id]/setup/extract/save/route.ts
@@ -104,7 +104,6 @@ export async function POST(
   }
 
   const supabase = getServiceRoleClient();
-  // audit columns not yet on sites — DATA_CONVENTIONS rollout pending
   const upd = await supabase
     .from("sites")
     .update({
@@ -112,6 +111,7 @@ export async function POST(
       extracted_css_classes: parsed.data.extracted_css_classes,
       design_direction_status: "approved",
       updated_at: new Date().toISOString(),
+      updated_by: gate.user?.id ?? null,
     })
     .eq("id", params.id)
     .eq("site_mode", "copy_existing")

--- a/app/api/admin/sites/[id]/use-image-library/route.ts
+++ b/app/api/admin/sites/[id]/use-image-library/route.ts
@@ -64,12 +64,12 @@ export async function POST(
   }
 
   const supabase = getServiceRoleClient();
-  // audit columns not yet on sites — DATA_CONVENTIONS rollout pending
   const upd = await supabase
     .from("sites")
     .update({
       use_image_library: parsed.data.enabled,
       updated_at: new Date().toISOString(),
+      updated_by: gate.user?.id ?? null,
     })
     .eq("id", params.id)
     .select("id, use_image_library")

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -24,7 +24,7 @@ Sort order: strongest "pick up when" signal at the top. Rows with no signal move
 
 ---
 
-## DATA_CONVENTIONS rollout — add audit columns to `sites` (opened 2026-05-02 during UAT §3.1.2)
+## ~~DATA_CONVENTIONS rollout — add audit columns to `sites`~~ (shipped 2026-05-03, PR #491)
 
 **Tags:** `schema`, `data-conventions`, `tech-debt`
 

--- a/supabase/migrations/0079_sites_audit_columns.sql
+++ b/supabase/migrations/0079_sites_audit_columns.sql
@@ -1,0 +1,8 @@
+-- DATA_CONVENTIONS rollout: add created_by + updated_by to sites.
+-- Both nullable (no historical attribution for existing rows).
+-- FK to opollo_users with ON DELETE SET NULL so user deletion doesn't
+-- orphan site rows.
+
+ALTER TABLE sites
+  ADD COLUMN IF NOT EXISTS created_by uuid REFERENCES opollo_users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS updated_by uuid REFERENCES opollo_users(id) ON DELETE SET NULL;


### PR DESCRIPTION
﻿## Summary

- Migration 0079: adds `created_by uuid` and `updated_by uuid` nullable columns to the `sites` table (DATA_CONVENTIONS rollout)
- Restores the three writes that were surgically dropped during UAT: `onboarding/route.ts`, `use-image-library/route.ts`, `setup/extract/save/route.ts`
- Marks DC-1 as shipped in `docs/BACKLOG.md`

## Risks identified and mitigated

- **Nullable columns, no default**: both columns are `NULL`-able with no default, so existing rows are unaffected and the migration is zero-downtime.
- **No RLS change**: columns carry UUIDs from `auth.users`; read access follows the existing admin gate already on every consumer route.
- **Three write sites verified**: each restored `updated_by` write is inside a gate-checked handler; no privilege escalation surface.

## Test plan

- [ ] lint + typecheck + build pass
- [ ] `audit:static` returns 0 HIGH findings
- [ ] Migration applies cleanly on a fresh local stack (`supabase db reset`)
- [ ] Onboarding, image-library toggle, and extract-save routes write `updated_by` correctly after migration

Closes #DC-1
