### PR TITLE
fix(audit): tools write-route auth + timeouts + readJsonBody (M15-4 #3/#6/#12)

### DIFF
--- a/app/api/tools/delete_page/route.ts
+++ b/app/api/tools/delete_page/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 
-import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
+import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { executeDeletePage } from "@/lib/delete-page";
+import { readJsonBody, validationError } from "@/lib/http";
 import {
   checkRateLimit,
   getClientIp,
@@ -12,18 +13,16 @@ import { errorCodeToStatus } from "@/lib/tool-schemas";
 export const runtime = "nodejs";
 
 export async function POST(req: Request) {
-  const supabase = createRouteAuthClient();
-  const user = await getCurrentUser(supabase);
-  const rlId = user ? `user:${user.id}` : `ip:${getClientIp(req)}`;
+  // PLATFORM-AUDIT M15-4 #3: previously session-optional — only rate-limited.
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const rlId = gate.user ? `user:${gate.user.id}` : `ip:${getClientIp(req)}`;
   const rl = await checkRateLimit("tools", rlId);
   if (!rl.ok) return rateLimitExceeded(rl);
 
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    body = {};
-  }
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body must be valid JSON.");
 
   const result = await executeDeletePage(body);
   const status = result.ok ? 200 : errorCodeToStatus(result.error.code);

--- a/app/api/tools/publish_page/route.ts
+++ b/app/api/tools/publish_page/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
-import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { readJsonBody, validationError } from "@/lib/http";
 import { executePublishPage } from "@/lib/publish-page";
 import {
   checkRateLimit,
@@ -12,18 +13,16 @@ import { errorCodeToStatus } from "@/lib/tool-schemas";
 export const runtime = "nodejs";
 
 export async function POST(req: Request) {
-  const supabase = createRouteAuthClient();
-  const user = await getCurrentUser(supabase);
-  const rlId = user ? `user:${user.id}` : `ip:${getClientIp(req)}`;
+  // PLATFORM-AUDIT M15-4 #3: previously session-optional — only rate-limited.
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const rlId = gate.user ? `user:${gate.user.id}` : `ip:${getClientIp(req)}`;
   const rl = await checkRateLimit("tools", rlId);
   if (!rl.ok) return rateLimitExceeded(rl);
 
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    body = {};
-  }
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body must be valid JSON.");
 
   const result = await executePublishPage(body);
   const status = result.ok ? 200 : errorCodeToStatus(result.error.code);

--- a/app/api/tools/update_page/route.ts
+++ b/app/api/tools/update_page/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
-import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { readJsonBody, validationError } from "@/lib/http";
 import {
   checkRateLimit,
   getClientIp,
@@ -12,18 +13,16 @@ import { errorCodeToStatus } from "@/lib/tool-schemas";
 export const runtime = "nodejs";
 
 export async function POST(req: Request) {
-  const supabase = createRouteAuthClient();
-  const user = await getCurrentUser(supabase);
-  const rlId = user ? `user:${user.id}` : `ip:${getClientIp(req)}`;
+  // PLATFORM-AUDIT M15-4 #3: previously session-optional — only rate-limited.
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const rlId = gate.user ? `user:${gate.user.id}` : `ip:${getClientIp(req)}`;
   const rl = await checkRateLimit("tools", rlId);
   if (!rl.ok) return rateLimitExceeded(rl);
 
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    body = {};
-  }
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body must be valid JSON.");
 
   const result = await executeUpdatePage(body);
   const status = result.ok ? 200 : errorCodeToStatus(result.error.code);

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -486,7 +486,7 @@ Reports live at:
 
 #### Security / auth tightening (next security review pass)
 
-- **[M15-4 #3] `tools/*` write routes have no session requirement.** `tools/publish_page`, `tools/update_page`, `tools/delete_page` are reachable with just a rate-limit token. M15-7 Phase 3b (#134) pinned current behaviour in tests; when auth gets tightened, tests will need to update. Scope: add `requireAdminForApi(['admin', 'operator'])` to the three write routes + refresh the tests.
+- ~~**[M15-4 #3] `tools/*` write routes have no session requirement.**~~ Fixed 2026-05-03 — `requireAdminForApi` added to `publish_page`, `update_page`, `delete_page`; tests updated; malformed-JSON now returns 400 instead of forwarding `{}` to executor.
 - **[M15-4 #8] 6 public GET routes have no route-level auth gate.** `sites/list`, `sites/[id]`, `sites/[id]/design-systems`, `design-systems/[id]/components`, `design-systems/[id]/templates`, `design-systems/[id]/preview` rely entirely on middleware. Defense-in-depth gap. Scope: add `requireAdminForApi()` to each; cost is one import + one check per route.
 - **[M15-4 #11] `tools/*` routes don't seed `runWithWpCredentials()` context.** Direct POST outside the chat flow → executor uses empty AsyncLocalStorage context. Needs verification that direct calls fail safely. Scope: either (a) remove the tools routes if only used internally by chat, or (b) seed context from the request body's `site_id`.
 - **[M15-5 #12] `image_usage` RLS excludes `viewer` role.** Asymmetry vs `image_library` + `image_metadata`. Check if intentional; if so, comment the migration; if not, align the policy.
@@ -494,7 +494,7 @@ Reports live at:
 #### Observability + write-safety hygiene (next defense-in-depth slice)
 
 - ~~**[M15-4 #5] `retryable: true` on VALIDATION_FAILED in 5 routes.**~~ Fixed 2026-04-29 — flipped to `retryable: false` in admin/images/[id], admin/sites/[id]/budget, admin/sites/[id]/pages/[pageId], admin/users/invite, admin/users/[id]/role. Migration to `lib/http.validationError()` deferred to M15-4 #14 tech-debt cleanup.
-- **[M15-4 #6] No timeouts on external-call fetches** anywhere in the codebase (only `Sentry.flush(5000)` exists). Hanging Anthropic/WP/Supabase/Upstash drains function pool. Scope: `withTimeout(promise, ms)` helper in `lib/http.ts`; wrap external calls. Suggested initial values: Anthropic 60s, WordPress 30s, Cloudflare 30s, Supabase 15s.
+- ~~**[M15-4 #6] No timeouts on external-call fetches.**~~ Partially fixed 2026-05-03: `withTimeout<T>` helper added to `lib/http.ts`; `AbortSignal.timeout(60_000)` wired into `lib/anthropic-call.ts`; `AbortSignal.timeout(30_000)` wired into `lib/wordpress.ts` `wpFetch`. Cloudflare and Supabase deferred — Cloudflare calls are async upload returns, Supabase client manages its own pool.
 - **[M15-4 #7] ~15 routes still have no structured logging.** Partial coverage via #132 (9 routes + 2 libs). Remaining: admin/batch POST, admin/images/[id] restore, admin/sites/[id]/budget, admin/sites/[id]/pages/[pageId] and its regenerate, auth/callback, design-systems/*, sites/register, sites/[id], sites/[id]/design-systems, sites/list, tools/* (all 7). Scope: add `logger.error()` on every error-return path; incremental, one route at a time.
 - **[M15-4 #12] Malformed JSON behavior inconsistent.** Old pattern (`try { body = req.json() } catch { body = {} }`) gives confusing "missing field" error; new pattern (`lib/http.readJsonBody`) gives clear "Request body must be valid JSON." Migration incomplete. Scope: migrate old-pattern routes to `readJsonBody` + `parseBodyWith`.
 

--- a/lib/__tests__/_tools-route-helpers.ts
+++ b/lib/__tests__/_tools-route-helpers.ts
@@ -21,8 +21,8 @@ export function makeJsonRequest(
 }
 
 /**
- * Build a POST Request whose body is NOT valid JSON.  The route's try/catch
- * around req.json() should fall back to `{}` and forward that to the executor.
+ * Build a POST Request whose body is NOT valid JSON.  Routes using readJsonBody
+ * will return 400 VALIDATION_FAILED before calling the executor.
  */
 export function makeMalformedRequest(
   url = "http://localhost:3000/api/tools/test",

--- a/lib/__tests__/tools-delete-page-route.test.ts
+++ b/lib/__tests__/tools-delete-page-route.test.ts
@@ -1,24 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
-// M15-7 Phase 3b — integration tests for app/api/tools/delete_page/route.ts
+// Integration tests for app/api/tools/delete_page/route.ts
 //
-// delete_page is a destructive write route that currently has no admin gate
-// (M15-4 finding #3).  These tests pin that behaviour as an intentional
-// drift signal for a future auth-tightening fix slice.
+// delete_page is a destructive write route gated by requireAdminForApi
+// (M15-4 #3 fix). Tests verify auth gate, rate limit, JSON parse guard, and
+// executor delegation.
 // ---------------------------------------------------------------------------
 
 const mockExecuteDeletePage = vi.hoisted(() => vi.fn());
-const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockRequireAdminForApi = vi.hoisted(() => vi.fn());
 const mockCheckRateLimit = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/delete-page", () => ({
   executeDeletePage: mockExecuteDeletePage,
 }));
 
-vi.mock("@/lib/auth", () => ({
-  createRouteAuthClient: () => ({}),
-  getCurrentUser: mockGetCurrentUser,
+vi.mock("@/lib/admin-api-gate", () => ({
+  requireAdminForApi: mockRequireAdminForApi,
 }));
 
 vi.mock("@/lib/rate-limit", async () => {
@@ -43,9 +42,11 @@ import {
   RATE_LIMIT_DENIED,
 } from "./_tools-route-helpers";
 
+const GATE_ALLOW = { kind: "allow" as const, user: { id: "user-1", email: "admin@test.com", role: "admin" as const } };
+
 beforeEach(() => {
   mockExecuteDeletePage.mockReset();
-  mockGetCurrentUser.mockReset().mockResolvedValue(null);
+  mockRequireAdminForApi.mockReset().mockResolvedValue(GATE_ALLOW);
   mockCheckRateLimit.mockReset().mockResolvedValue({ ok: true, limit: 120, remaining: 119, reset: 0 });
 });
 
@@ -76,14 +77,26 @@ describe("POST /api/tools/delete_page", () => {
     expect(body).toEqual(envelope);
   });
 
-  it("malformed JSON body → executor receives {} fallback", async () => {
-    const envelope = makeSuccessEnvelope({ page_id: 0, status: "trash" as const });
-    mockExecuteDeletePage.mockResolvedValue(envelope);
-
+  it("400 — malformed JSON body returns VALIDATION_FAILED; executor not called", async () => {
     const res = await POST(makeMalformedRequest());
 
-    expect(mockExecuteDeletePage).toHaveBeenCalledWith({});
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+    expect(mockExecuteDeletePage).not.toHaveBeenCalled();
+  });
+
+  it("401 — auth gate denial; executor is never called", async () => {
+    mockRequireAdminForApi.mockResolvedValue({
+      kind: "deny" as const,
+      response: new Response(JSON.stringify({ ok: false, error: { code: "UNAUTHORIZED" } }), { status: 401 }),
+    });
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(401);
+    expect(mockExecuteDeletePage).not.toHaveBeenCalled();
   });
 
   it("429 — rate-limit denial; executor is never called", async () => {

--- a/lib/__tests__/tools-publish-page-route.test.ts
+++ b/lib/__tests__/tools-publish-page-route.test.ts
@@ -1,24 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
-// M15-7 Phase 3b — integration tests for app/api/tools/publish_page/route.ts
+// Integration tests for app/api/tools/publish_page/route.ts
 //
-// publish_page is a write route (draft → publish) that currently has no admin
-// gate (M15-4 finding #3).  Tests pin current session-optional behaviour as
-// an intentional drift signal for a future auth-tightening fix slice.
+// publish_page is a write route (draft → publish) gated by requireAdminForApi
+// (M15-4 #3 fix). Tests verify auth gate, rate limit, JSON parse guard, and
+// executor delegation.
 // ---------------------------------------------------------------------------
 
 const mockExecutePublishPage = vi.hoisted(() => vi.fn());
-const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockRequireAdminForApi = vi.hoisted(() => vi.fn());
 const mockCheckRateLimit = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/publish-page", () => ({
   executePublishPage: mockExecutePublishPage,
 }));
 
-vi.mock("@/lib/auth", () => ({
-  createRouteAuthClient: () => ({}),
-  getCurrentUser: mockGetCurrentUser,
+vi.mock("@/lib/admin-api-gate", () => ({
+  requireAdminForApi: mockRequireAdminForApi,
 }));
 
 vi.mock("@/lib/rate-limit", async () => {
@@ -43,9 +42,11 @@ import {
   RATE_LIMIT_DENIED,
 } from "./_tools-route-helpers";
 
+const GATE_ALLOW = { kind: "allow" as const, user: { id: "user-1", email: "admin@test.com", role: "admin" as const } };
+
 beforeEach(() => {
   mockExecutePublishPage.mockReset();
-  mockGetCurrentUser.mockReset().mockResolvedValue(null);
+  mockRequireAdminForApi.mockReset().mockResolvedValue(GATE_ALLOW);
   mockCheckRateLimit.mockReset().mockResolvedValue({ ok: true, limit: 120, remaining: 119, reset: 0 });
 });
 
@@ -80,14 +81,26 @@ describe("POST /api/tools/publish_page", () => {
     expect(body).toEqual(envelope);
   });
 
-  it("malformed JSON body → executor receives {} fallback", async () => {
-    const envelope = makeSuccessEnvelope({ page_id: 0, status: "publish", published_url: "" });
-    mockExecutePublishPage.mockResolvedValue(envelope);
-
+  it("400 — malformed JSON body returns VALIDATION_FAILED; executor not called", async () => {
     const res = await POST(makeMalformedRequest());
 
-    expect(mockExecutePublishPage).toHaveBeenCalledWith({});
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+    expect(mockExecutePublishPage).not.toHaveBeenCalled();
+  });
+
+  it("401 — auth gate denial; executor is never called", async () => {
+    mockRequireAdminForApi.mockResolvedValue({
+      kind: "deny" as const,
+      response: new Response(JSON.stringify({ ok: false, error: { code: "UNAUTHORIZED" } }), { status: 401 }),
+    });
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(401);
+    expect(mockExecutePublishPage).not.toHaveBeenCalled();
   });
 
   it("429 — rate-limit denial; executor is never called", async () => {

--- a/lib/__tests__/tools-update-page-route.test.ts
+++ b/lib/__tests__/tools-update-page-route.test.ts
@@ -1,24 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
-// M15-7 Phase 3b — integration tests for app/api/tools/update_page/route.ts
+// Integration tests for app/api/tools/update_page/route.ts
 //
-// update_page is a write route that currently has no admin gate (M15-4
-// finding #3).  Tests pin current session-optional behaviour as an
-// intentional drift signal for a future auth-tightening fix slice.
+// update_page is a write route gated by requireAdminForApi (M15-4 #3 fix).
+// Tests verify auth gate, rate limit, JSON parse guard, and executor
+// delegation.
 // ---------------------------------------------------------------------------
 
 const mockExecuteUpdatePage = vi.hoisted(() => vi.fn());
-const mockGetCurrentUser = vi.hoisted(() => vi.fn());
+const mockRequireAdminForApi = vi.hoisted(() => vi.fn());
 const mockCheckRateLimit = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/update-page", () => ({
   executeUpdatePage: mockExecuteUpdatePage,
 }));
 
-vi.mock("@/lib/auth", () => ({
-  createRouteAuthClient: () => ({}),
-  getCurrentUser: mockGetCurrentUser,
+vi.mock("@/lib/admin-api-gate", () => ({
+  requireAdminForApi: mockRequireAdminForApi,
 }));
 
 vi.mock("@/lib/rate-limit", async () => {
@@ -43,9 +42,11 @@ import {
   RATE_LIMIT_DENIED,
 } from "./_tools-route-helpers";
 
+const GATE_ALLOW = { kind: "allow" as const, user: { id: "user-1", email: "admin@test.com", role: "admin" as const } };
+
 beforeEach(() => {
   mockExecuteUpdatePage.mockReset();
-  mockGetCurrentUser.mockReset().mockResolvedValue(null);
+  mockRequireAdminForApi.mockReset().mockResolvedValue(GATE_ALLOW);
   mockCheckRateLimit.mockReset().mockResolvedValue({ ok: true, limit: 120, remaining: 119, reset: 0 });
 });
 
@@ -84,14 +85,26 @@ describe("POST /api/tools/update_page", () => {
     expect(body).toEqual(envelope);
   });
 
-  it("malformed JSON body → executor receives {} fallback", async () => {
-    const envelope = makeSuccessEnvelope({ page_id: 0, status: "draft", modified_date: "" });
-    mockExecuteUpdatePage.mockResolvedValue(envelope);
-
+  it("400 — malformed JSON body returns VALIDATION_FAILED; executor not called", async () => {
     const res = await POST(makeMalformedRequest());
 
-    expect(mockExecuteUpdatePage).toHaveBeenCalledWith({});
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+    expect(mockExecuteUpdatePage).not.toHaveBeenCalled();
+  });
+
+  it("401 — auth gate denial; executor is never called", async () => {
+    mockRequireAdminForApi.mockResolvedValue({
+      kind: "deny" as const,
+      response: new Response(JSON.stringify({ ok: false, error: { code: "UNAUTHORIZED" } }), { status: 401 }),
+    });
+
+    const res = await POST(makeJsonRequest(VALID_BODY));
+
+    expect(res.status).toBe(401);
+    expect(mockExecuteUpdatePage).not.toHaveBeenCalled();
   });
 
   it("429 — rate-limit denial; executor is never called", async () => {

--- a/lib/anthropic-call.ts
+++ b/lib/anthropic-call.ts
@@ -137,6 +137,7 @@ export const defaultAnthropicCall: AnthropicCallFn = async (req) => {
       },
       {
         headers: { "Idempotency-Key": req.idempotency_key },
+        signal: AbortSignal.timeout(60_000),
       },
     );
   } catch (err) {

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -114,3 +114,19 @@ function formatZodIssues(err: ZodError): Array<{
     message: i.message,
   }));
 }
+
+// Race a promise against a timeout; rejects with "Request timed out after Xms"
+// if the promise doesn't settle first. Use for external calls (Anthropic, WP,
+// Cloudflare) where a hanging request would drain the serverless function pool.
+// Suggested ceilings: Anthropic 60 s, WordPress 30 s, Cloudflare 30 s.
+export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`Request timed out after ${ms}ms`)),
+        ms,
+      ),
+    ),
+  ]);
+}

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -140,7 +140,7 @@ async function wpFetch(
   let lastErr: unknown;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
-      const res = await fetch(url, { ...init, headers });
+      const res = await fetch(url, { ...init, headers, signal: AbortSignal.timeout(30_000) });
       if (res.status >= 500 && attempt < MAX_RETRIES) {
         await sleep(BASE_DELAY_MS * Math.pow(2, attempt));
         continue;


### PR DESCRIPTION
﻿## Summary

- **M15-4 #3** (`tools/*` write-route auth): add `requireAdminForApi` to `publish_page`, `update_page`, `delete_page`; tests updated with 401 case and corrected malformed-JSON behavior
- **M15-4 #6** (external-call timeouts): `withTimeout<T>` helper in `lib/http.ts`; `AbortSignal.timeout(60_000)` on `lib/anthropic-call.ts`; `AbortSignal.timeout(30_000)` per-attempt in `lib/wordpress.ts` `wpFetch`
- **M15-4 #12** (partial - readJsonBody migration): three tools write routes migrated from `try/catch req.json()` to `readJsonBody`; malformed bodies now return `400 VALIDATION_FAILED` instead of forwarding `{}` to executor

## Risks identified and mitigated

- **tools/* auth gate**: `requireAdminForApi` is fail-open when `FEATURE_SUPABASE_AUTH` is unset (current prod state). Adding the gate does not break the chat-tool invocation flow since chat already requires a session. Tests now mock `@/lib/admin-api-gate` directly rather than `@/lib/auth`.
- **AbortSignal.timeout**: Node 18.17+ API; Next.js 14 requires Node 18.17+. No runtime risk. Per-attempt timeout on WP means the existing retry loop (MAX_RETRIES=3) still fires on network errors; timeout fires only on hung connections, not slow-but-responding hosts.
- **withTimeout helper**: uses `Promise.race`; does not cancel the underlying in-flight request (no AbortController threaded through). The function completes in the background on Vercel but the response is sent quickly. Full cancellation is a follow-up.
- **readJsonBody migration**: malformed JSON change is a spec improvement. Updated tests confirm new 400 behavior.

## Deferred

- Cloudflare and Supabase timeouts deferred (#6 partial): Cloudflare upload is async, Supabase client manages its own connection pool.
- Remaining ~50 route files still using old `req.json()` pattern (#12 partial): large mechanical sweep, left for a dedicated cleanup PR.
