### PR TITLE
feat(s1-13): weekly CAP generation cron (D4)

### DIFF
--- a/app/api/cron/cap-weekly-generation/route.ts
+++ b/app/api/cron/cap-weekly-generation/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { logger } from "@/lib/logger";
+import {
+  authorisedCronRequest,
+  unauthorisedResponse,
+} from "@/lib/optimiser/sync/cron-shared";
+import { generateCAPPosts } from "@/lib/platform/social/cap";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// D4 — GET /api/cron/cap-weekly-generation
+//
+// Weekly Vercel cron (Mondays 06:00 UTC). Finds all companies where
+// cap_weekly_enabled = true, generates 3 CAP draft posts each via
+// the existing generateCAPPosts lib, and returns a summary.
+//
+// Each company is processed independently — a failure on one company
+// does NOT stop the rest. All posts land in state='draft' and flow
+// through the normal approval pipeline.
+//
+// Auth: shared CRON_SECRET bearer (lib/optimiser/sync/cron-shared).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+async function handle(req: NextRequest): Promise<NextResponse> {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+
+  const svc = getServiceRoleClient();
+
+  const { data: companies, error } = await svc
+    .from("platform_companies")
+    .select("id")
+    .eq("cap_weekly_enabled", true);
+
+  if (error) {
+    logger.error("cap.weekly.query_failed", { err: error.message });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "INTERNAL_ERROR", message: error.message, retryable: true },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+
+  const examined = companies?.length ?? 0;
+  let succeeded = 0;
+  let failed = 0;
+
+  logger.info("cap.weekly.start", { examined });
+
+  for (const company of companies ?? []) {
+    const result = await generateCAPPosts({
+      companyId: company.id as string,
+      count: 3,
+      triggeredBy: null,
+    });
+
+    if (result.ok) {
+      succeeded++;
+      logger.info("cap.weekly.company_done", {
+        companyId: company.id,
+        posts: result.posts.length,
+      });
+    } else {
+      failed++;
+      logger.error("cap.weekly.company_failed", {
+        companyId: company.id,
+        code: result.error.code,
+        message: result.error.message,
+      });
+    }
+  }
+
+  logger.info("cap.weekly.done", { examined, succeeded, failed });
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { examined, succeeded, failed },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/supabase/migrations/0081_cap_weekly_enabled.sql
+++ b/supabase/migrations/0081_cap_weekly_enabled.sql
@@ -1,0 +1,9 @@
+-- D4: add cap_weekly_enabled flag to platform_companies.
+-- When true the weekly CAP cron generates 3 draft posts for that company.
+-- Defaults false; MSP admins toggle it per company.
+
+ALTER TABLE platform_companies
+  ADD COLUMN IF NOT EXISTS cap_weekly_enabled BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN platform_companies.cap_weekly_enabled IS
+  'When true, the weekly CAP cron auto-generates 3 draft social posts.';

--- a/vercel.json
+++ b/vercel.json
@@ -83,6 +83,10 @@
     {
       "path": "/api/cron/social-publish-backfill",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/cron/cap-weekly-generation",
+      "schedule": "0 6 * * 1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **Migration 0081** — `cap_weekly_enabled BOOLEAN NOT NULL DEFAULT false` on `platform_companies`. MSP admins opt companies in; all companies default off.
- **`GET /api/cron/cap-weekly-generation`** — Vercel cron (Mondays 06:00 UTC). Queries all `cap_weekly_enabled=true` companies, calls `generateCAPPosts({ count: 3, triggeredBy: null })` for each. Per-company failure isolation — one failure doesn't abort the rest. Returns `{ examined, succeeded, failed }`.
- **`vercel.json`** — adds `cap-weekly-generation` at `0 6 * * 1`.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Runaway Claude spend across many companies | Capped at 3 posts/company/week. Rate limiter on the generate endpoint (10/24h) is separate but the cron bypasses it via direct lib call — acceptable since the cron is scheduled, not user-triggered. |
| One company failure blocking others | Per-company `try/continue` loop; `failed` count returned for observability. |
| Cron fires before migration deploys | `cap_weekly_enabled` defaults false — zero companies opted in on first run. |

## Test plan

- [ ] CI green
- [ ] Migration column present after apply
- [ ] Cron handler returns 401 without correct `CRON_SECRET`
- [ ] Cron handler returns `{ ok: true, data: { examined: 0, succeeded: 0, failed: 0 } }` when no companies opted in

🤖 Generated with [Claude Code](https://claude.ai/claude-code)