### PR TITLE
feat(s1-13): CAP image generation trigger (I5/E1)

### DIFF
--- a/lib/platform/social/cap/generator.ts
+++ b/lib/platform/social/cap/generator.ts
@@ -18,6 +18,7 @@ import {
   buildUserPrompt,
   PLATFORM_CHAR_LIMITS,
 } from "./prompt-builder";
+import { triggerCAPImageGen } from "./image-trigger";
 import type {
   CAPClaudeResponse,
   CAPGenerateInput,
@@ -172,6 +173,10 @@ export async function generateCAPPosts(
     }
 
     created.push({ postMasterId, masterText, variants: variantMap });
+
+    // I5 — fire-and-forget image generation. Runs after variants are
+    // upserted so the variant rows exist before the link step.
+    void triggerCAPImageGen({ companyId, postMasterId, brand });
   }
 
   if (created.length === 0) {

--- a/lib/platform/social/cap/image-trigger.ts
+++ b/lib/platform/social/cap/image-trigger.ts
@@ -1,0 +1,145 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { generateWithFallback, getAllowedStyles } from "@/lib/image";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { BrandProfile } from "@/lib/platform/brand/types";
+import type { GenerationParams, StyleId } from "@/lib/image/types";
+
+// ---------------------------------------------------------------------------
+// I5 — CAP image generation trigger.
+//
+// Called fire-and-forget after each social_post_master is created by the
+// CAP generator. Maps the active BrandProfile to GenerationParams, calls
+// generateWithFallback, creates a social_media_assets row, and links the
+// asset to all existing variants of the post.
+//
+// All failures are non-blocking — a failure here must NOT propagate to
+// the CAP generation result.
+//
+// Guard: skips silently when IDEOGRAM_API_KEY is unset (local / test).
+// ---------------------------------------------------------------------------
+
+const IMAGE_GEN_BUCKET = process.env.IMAGE_GENERATION_BUCKET ?? "generated-images";
+const SIGNED_URL_TTL_SECONDS = 365 * 24 * 3600; // 1 year
+
+const DEFAULT_STYLE: StyleId = "clean_corporate";
+const DEFAULT_COLOUR = "#1a56db";
+
+function brandToGenerationParams(
+  brand: BrandProfile | null,
+  companyId: string,
+  postMasterId: string,
+): GenerationParams {
+  const allowedStyles = getAllowedStyles(brand);
+  const styleId = allowedStyles[0] ?? DEFAULT_STYLE;
+  const primaryColour = brand?.primary_colour ?? DEFAULT_COLOUR;
+
+  return {
+    styleId,
+    primaryColour,
+    compositionType: "split_layout",
+    aspectRatio: "ASPECT_1_1",
+    model: "standard",
+    count: 1,
+    industry: brand?.industry ?? undefined,
+    companyId,
+    brandProfileId: brand?.id,
+    brandProfileVersion: brand?.version,
+    postMasterId,
+    triggeredBy: undefined,
+  };
+}
+
+export async function triggerCAPImageGen(opts: {
+  companyId: string;
+  postMasterId: string;
+  brand: BrandProfile | null;
+}): Promise<void> {
+  const { companyId, postMasterId, brand } = opts;
+
+  // Skip silently when image generation is not configured.
+  if (!process.env.IDEOGRAM_API_KEY) {
+    logger.debug("cap.image.skipped — IDEOGRAM_API_KEY not set", { postMasterId });
+    return;
+  }
+
+  const params = brandToGenerationParams(brand, companyId, postMasterId);
+
+  let images: Awaited<ReturnType<typeof generateWithFallback>>;
+  try {
+    images = await generateWithFallback(params);
+  } catch (err) {
+    logger.warn("cap.image.generate_failed", {
+      postMasterId,
+      companyId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  if (!images || images.length === 0) {
+    logger.warn("cap.image.no_images_returned", { postMasterId, companyId });
+    return;
+  }
+
+  const image = images[0]!;
+  const svc = getServiceRoleClient();
+
+  // Get a long-lived signed URL to serve as the public source_url.
+  const { data: signed, error: signedErr } = await svc.storage
+    .from(IMAGE_GEN_BUCKET)
+    .createSignedUrl(image.storagePath, SIGNED_URL_TTL_SECONDS);
+
+  if (signedErr || !signed?.signedUrl) {
+    logger.warn("cap.image.signed_url_failed", {
+      postMasterId,
+      path: image.storagePath,
+      err: signedErr?.message,
+    });
+    return;
+  }
+
+  // Persist the generated image as a social_media_assets row.
+  const { data: asset, error: assetErr } = await svc
+    .from("social_media_assets")
+    .insert({
+      company_id: companyId,
+      storage_path: image.storagePath,
+      mime_type: `image/${image.format ?? "jpeg"}`,
+      bytes: 0,
+      source_url: signed.signedUrl,
+      width: image.width ?? null,
+      height: image.height ?? null,
+    })
+    .select("id")
+    .single();
+
+  if (assetErr || !asset?.id) {
+    logger.warn("cap.image.asset_insert_failed", {
+      postMasterId,
+      err: assetErr?.message,
+    });
+    return;
+  }
+
+  const assetId = asset.id as string;
+
+  // Link the asset to all variants of this post (fresh drafts — no
+  // existing media_asset_ids to preserve).
+  const { error: variantErr } = await svc
+    .from("social_post_variant")
+    .update({ media_asset_ids: [assetId] })
+    .eq("post_master_id", postMasterId);
+
+  if (variantErr) {
+    logger.warn("cap.image.variant_link_failed", {
+      postMasterId,
+      assetId,
+      err: variantErr.message,
+    });
+    return;
+  }
+
+  logger.info("cap.image.done", { postMasterId, companyId, assetId });
+}


### PR DESCRIPTION
## Summary

`lib/platform/social/cap/image-trigger.ts` — new `triggerCAPImageGen()` function that:
1. Maps `BrandProfile` → `GenerationParams` (first allowed style, brand primary colour, `split_layout` composition, 1:1 aspect ratio)
2. Calls `generateWithFallback()` (existing pipeline — 2-attempt + stock fallback + quality checks)
3. Creates a `social_media_assets` row with a 1-year signed URL as `source_url` and the permanent storage path in `storage_path`
4. Links the asset to all variants of the post via `social_post_variant.media_asset_ids`

`generator.ts` fires the trigger as `void triggerCAPImageGen(...)` after variants are upserted — fire-and-forget, non-blocking.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Image gen failure blocks post creation | `void` fire-and-forget — errors are caught inside `triggerCAPImageGen` and logged, never propagated |
| IDEOGRAM_API_KEY unset in local/test | Early `process.env.IDEOGRAM_API_KEY` check; returns immediately with debug log |
| Overwriting existing variant media | CAP posts are brand-new drafts — no existing `media_asset_ids` to preserve |
| Signed URL expiry | 1-year TTL; long enough for practical use; refresh flow can be added in a later slice |
| Style blocked by brand safe_mode | `getAllowedStyles(brand)` already filters safe_mode + approved_style_ids — first result is always safe |

## Test plan

- [ ] CI green
- [ ] Without `IDEOGRAM_API_KEY`: CAP generation still returns posts (image step skipped)
- [ ] With `IDEOGRAM_API_KEY`: generated image linked to post variants

🤖 Generated with [Claude Code](https://claude.ai/claude-code)