### PR TITLE
refactor(audit): extract constantTimeEqual to lib/crypto-compare (PLATFORM-AUDIT PR10)

### DIFF
--- a/app/api/cron/budget-reset/route.ts
+++ b/app/api/cron/budget-reset/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { timingSafeEqual } from "node:crypto";
 
+import { constantTimeEqual } from "@/lib/crypto-compare";
 import { logger } from "@/lib/logger";
 import { resetExpiredBudgets } from "@/lib/tenant-budgets";
 
@@ -23,17 +23,6 @@ import { resetExpiredBudgets } from "@/lib/tenant-budgets";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, "utf8");
-  const bBuf = Buffer.from(b, "utf8");
-  if (aBuf.length !== bBuf.length) {
-    const filler = Buffer.alloc(aBuf.length);
-    timingSafeEqual(aBuf, filler);
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
-}
 
 function authorised(req: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;

--- a/app/api/cron/optimiser-monitor-rollouts/route.ts
+++ b/app/api/cron/optimiser-monitor-rollouts/route.ts
@@ -1,8 +1,6 @@
-import { Buffer } from "node:buffer";
-import { timingSafeEqual } from "node:crypto";
-
 import { NextResponse, type NextRequest } from "next/server";
 
+import { constantTimeEqual } from "@/lib/crypto-compare";
 import { logger } from "@/lib/logger";
 import { fetchRolloutMetrics } from "@/lib/optimiser/staged-rollout/metrics";
 import {
@@ -33,17 +31,6 @@ import {
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, "utf8");
-  const bBuf = Buffer.from(b, "utf8");
-  if (aBuf.length !== bBuf.length) {
-    const filler = Buffer.alloc(aBuf.length);
-    timingSafeEqual(aBuf, filler);
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
-}
 
 function authorised(req: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;

--- a/app/api/cron/process-batch/route.ts
+++ b/app/api/cron/process-batch/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { timingSafeEqual } from "node:crypto";
 
+import { constantTimeEqual } from "@/lib/crypto-compare";
 import {
   DEFAULT_LEASE_MS,
   leaseNextPage,
@@ -42,17 +42,6 @@ export const dynamic = "force-dynamic";
 // one tick processes one slot and returns in well under a minute; the
 // cap here is belt-and-suspenders for a stuck heartbeat loop.
 export const maxDuration = 299;
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, "utf8");
-  const bBuf = Buffer.from(b, "utf8");
-  if (aBuf.length !== bBuf.length) {
-    const filler = Buffer.alloc(aBuf.length);
-    timingSafeEqual(aBuf, filler);
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
-}
 
 function authorised(req: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;

--- a/app/api/cron/process-brief-runner/route.ts
+++ b/app/api/cron/process-brief-runner/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { timingSafeEqual } from "node:crypto";
 
+import { constantTimeEqual } from "@/lib/crypto-compare";
 import {
   dummyAnthropicCall,
   dummyVisualRender,
@@ -48,17 +48,6 @@ export const dynamic = "force-dynamic";
 // tick typically completes in under 30s (one page's text + visual
 // passes); the ceiling is belt-and-suspenders for a stuck heartbeat.
 export const maxDuration = 299;
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, "utf8");
-  const bBuf = Buffer.from(b, "utf8");
-  if (aBuf.length !== bBuf.length) {
-    const filler = Buffer.alloc(aBuf.length);
-    timingSafeEqual(aBuf, filler);
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
-}
 
 function authorised(req: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;

--- a/app/api/cron/process-regenerations/route.ts
+++ b/app/api/cron/process-regenerations/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { timingSafeEqual } from "node:crypto";
 
+import { constantTimeEqual } from "@/lib/crypto-compare";
 import { logger } from "@/lib/logger";
 import {
   DEFAULT_REGEN_LEASE_MS,
@@ -47,17 +47,6 @@ import {
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const maxDuration = 299;
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, "utf8");
-  const bBuf = Buffer.from(b, "utf8");
-  if (aBuf.length !== bBuf.length) {
-    const filler = Buffer.alloc(aBuf.length);
-    timingSafeEqual(aBuf, filler);
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
-}
 
 function authorised(req: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;

--- a/app/api/cron/process-transfer/route.ts
+++ b/app/api/cron/process-transfer/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { timingSafeEqual } from "node:crypto";
 
+import { constantTimeEqual } from "@/lib/crypto-compare";
 import { logger } from "@/lib/logger";
 import {
   DEFAULT_LEASE_MS,
@@ -40,17 +40,6 @@ export const dynamic = "force-dynamic";
 // 299s keeps us just under Vercel's 300s function ceiling — belt-
 // and-suspenders for a stuck heartbeat loop.
 export const maxDuration = 299;
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, "utf8");
-  const bBuf = Buffer.from(b, "utf8");
-  if (aBuf.length !== bBuf.length) {
-    const filler = Buffer.alloc(aBuf.length);
-    timingSafeEqual(aBuf, filler);
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
-}
 
 function authorised(req: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;

--- a/app/api/emergency/route.ts
+++ b/app/api/emergency/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { timingSafeEqual } from "node:crypto";
 
 import { revokeUserSessions } from "@/lib/auth-revoke";
+import { constantTimeEqual } from "@/lib/crypto-compare";
 import { readJsonBody } from "@/lib/http";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -69,20 +69,6 @@ const ActionSchema = z.discriminatedUnion("action", [
 // targets and the route is reachable without Supabase — any
 // misconfiguration that sets e.g. "changeme" would be catastrophic.
 const MIN_KEY_LENGTH = 32;
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, "utf8");
-  const bBuf = Buffer.from(b, "utf8");
-  if (aBuf.length !== bBuf.length) {
-    // timingSafeEqual throws on length mismatch; compare equal-length
-    // dummies so the length-mismatch path takes roughly the same time
-    // as a content mismatch.
-    const filler = Buffer.alloc(aBuf.length);
-    timingSafeEqual(aBuf, filler);
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
-}
 
 function extractKey(req: Request): string | null {
   const custom = req.headers.get("x-opollo-emergency-key");

--- a/app/api/ops/reset-admin-password/route.ts
+++ b/app/api/ops/reset-admin-password/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { timingSafeEqual } from "node:crypto";
 
+import { constantTimeEqual } from "@/lib/crypto-compare";
 import { readJsonBody } from "@/lib/http";
 import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -42,17 +42,6 @@ const BodySchema = z.object({
   email: z.string().email().max(320),
   new_password: z.string().min(MIN_PASSWORD_LENGTH).max(256),
 });
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, "utf8");
-  const bBuf = Buffer.from(b, "utf8");
-  if (aBuf.length !== bBuf.length) {
-    const filler = Buffer.alloc(aBuf.length);
-    timingSafeEqual(aBuf, filler);
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
-}
 
 function extractKey(req: Request): string | null {
   const custom = req.headers.get("x-opollo-emergency-key");

--- a/app/api/ops/self-probe/route.ts
+++ b/app/api/ops/self-probe/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { timingSafeEqual } from "node:crypto";
 import * as Sentry from "@sentry/nextjs";
+
+import { constantTimeEqual } from "@/lib/crypto-compare";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
 import {
@@ -42,17 +43,6 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 30;
 
 const MIN_KEY_LENGTH = 32;
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, "utf8");
-  const bBuf = Buffer.from(b, "utf8");
-  if (aBuf.length !== bBuf.length) {
-    const filler = Buffer.alloc(aBuf.length);
-    timingSafeEqual(aBuf, filler);
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
-}
 
 function hasEmergencyKey(req: NextRequest): boolean {
   const expected = process.env.OPOLLO_EMERGENCY_KEY;

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -530,7 +530,7 @@ Reports live at:
 #### Tech-debt (bundled cleanup, no urgency)
 
 - **[M15-4 #14] 12 local `errorJson()` helpers across route files.** Migration to `lib/http.respond()` / `lib/http.validationError()` incomplete. Large mechanical diff.
-- **[M15-4 #15] 7 copies of `constantTimeEqual` across cron + ops routes.** Move to `lib/http.ts` or `lib/crypto-compare.ts`.
+- ~~**[M15-4 #15] 7 copies of `constantTimeEqual` across cron + ops routes.**~~ Extracted to `lib/crypto-compare.ts` 2026-05-03 — PR #510. 9 files deduplicated: cron/budget-reset, cron/optimiser-monitor-rollouts, cron/process-batch, cron/process-brief-runner, cron/process-regenerations, cron/process-transfer, emergency, ops/reset-admin-password, ops/self-probe.
 - ~~**[M15-4 #16] `"INVALID_STATE"` error code in `admin/batch/[id]/cancel` not in `ERROR_CODES` enum**.~~ Added to `lib/tool-schemas.ts` ERROR_CODES + errorCodeToStatus 409 mapping (2026-04-29).
 - ~~**[M15-4 #17] `admin/sites/[id]/budget` admin-only while siblings allow admin+operator.**~~ Comment added in route handler explaining the financial-control rationale (2026-04-29).
 - ~~**[M15-4 #18] `/api/health` envelope outlier** — no `ok` field.~~ Deviation documented in route comment (2026-04-29).

--- a/lib/crypto-compare.ts
+++ b/lib/crypto-compare.ts
@@ -1,0 +1,15 @@
+import { timingSafeEqual } from "node:crypto";
+
+// Constant-time string comparison to prevent timing attacks on secret values
+// (cron auth tokens, ops keys, emergency keys). Uses timingSafeEqual to
+// ensure comparison time is independent of where strings differ.
+export function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf8");
+  const bBuf = Buffer.from(b, "utf8");
+  if (aBuf.length !== bBuf.length) {
+    const filler = Buffer.alloc(aBuf.length);
+    timingSafeEqual(aBuf, filler);
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}


### PR DESCRIPTION
## Summary

Closes **BACKLOG M15-4 #15** — 9 identical local copies of `constantTimeEqual` across cron + ops routes, consolidated into `lib/crypto-compare.ts`.

**Files updated:** cron/budget-reset, cron/optimiser-monitor-rollouts, cron/process-batch, cron/process-brief-runner, cron/process-regenerations, cron/process-transfer, emergency, ops/reset-admin-password, ops/self-probe.

No behaviour change — same `timingSafeEqual` implementation with the same length-mismatch constant-time padding.

## Risks identified and mitigated

- **Security-sensitive function**: `constantTimeEqual` is used for secret/key comparisons on cron auth and ops routes. The implementation in `lib/crypto-compare.ts` is byte-for-byte identical to all 9 prior copies — verified by inspection. No logic changes.
- **Pre-existing typecheck failures**: `cap/generate/route.ts` and `cap-generator.test.ts` — unrelated to this change.
- **No write-safety hotspots**: pure extraction refactor, no DB writes.

## Test plan
- [x] `npm run typecheck` — 0 new errors
- [x] `npm run lint` — clean
- [x] `npm run audit:static` — 0 HIGH issues
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)