### PR TITLE
feat(s1-57): cursor pagination for media library

### DIFF
--- a/app/api/platform/social/media/route.ts
+++ b/app/api/platform/social/media/route.ts
@@ -57,14 +57,18 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const gate = await requireCanDoForApi(companyId, "view_calendar");
   if (gate.kind === "deny") return gate.response;
 
-  const result = await listMediaAssets({ companyId });
+  const before = url.searchParams.get("before") ?? undefined;
+  const limitRaw = url.searchParams.get("limit");
+  const limit = limitRaw ? Number(limitRaw) : undefined;
+
+  const result = await listMediaAssets({ companyId, before, limit });
   if (!result.ok) {
     return errorJson(result.error.code, result.error.message, 500);
   }
   return NextResponse.json(
     {
       ok: true,
-      data: result.data,
+      data: { assets: result.data.assets, next_cursor: result.data.nextCursor },
       timestamp: new Date().toISOString(),
     },
     { status: 200 },

--- a/app/company/social/media/page.tsx
+++ b/app/company/social/media/page.tsx
@@ -55,6 +55,7 @@ export default async function CompanySocialMediaPage() {
           <MediaLibraryClient
             companyId={companyId}
             initialAssets={listResult.data.assets}
+            initialNextCursor={listResult.data.nextCursor}
             canEdit={canEdit}
           />
         ) : (

--- a/components/MediaLibraryClient.tsx
+++ b/components/MediaLibraryClient.tsx
@@ -6,12 +6,8 @@ import { Button } from "@/components/ui/button";
 
 // ---------------------------------------------------------------------------
 // S1-23 — media library client component.
-//
-// V1 surface: the operator pastes an https URL + optional mime/bytes
-// → POSTs to /api/platform/social/media → row prepended to the list.
-// Each row shows a thumbnail (image/* via <img>, others a mime
-// badge) + the URL + bytes + a copy-id affordance for use by the
-// future variant-attach flow.
+// S1-57 — cursor pagination; "Load more" fetches the next page from the API
+//          using the created_at cursor returned by the server.
 // ---------------------------------------------------------------------------
 
 type Asset = {
@@ -29,6 +25,7 @@ type Asset = {
 type Props = {
   companyId: string;
   initialAssets: Asset[];
+  initialNextCursor: string | null;
   canEdit: boolean;
 };
 
@@ -50,12 +47,15 @@ function formatDate(iso: string): string {
 export function MediaLibraryClient({
   companyId,
   initialAssets,
+  initialNextCursor,
   canEdit,
 }: Props) {
   const [assets, setAssets] = useState(initialAssets);
+  const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor);
   const [showForm, setShowForm] = useState(false);
   const [url, setUrl] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
@@ -86,6 +86,23 @@ export function MediaLibraryClient({
       setShowForm(false);
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  async function handleLoadMore() {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const params = new URLSearchParams({ company_id: companyId, before: nextCursor });
+      const res = await fetch(`/api/platform/social/media?${params.toString()}`);
+      const json = (await res.json()) as
+        | { ok: true; data: { assets: Asset[]; next_cursor: string | null } }
+        | { ok: false; error: { message: string } };
+      if (!res.ok || !json.ok) return;
+      setAssets((prev) => [...prev, ...json.data.assets]);
+      setNextCursor(json.data.next_cursor);
+    } finally {
+      setLoadingMore(false);
     }
   }
 
@@ -164,56 +181,69 @@ export function MediaLibraryClient({
           {canEdit ? " Click Add asset to upload your first." : ""}
         </div>
       ) : (
-        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {assets.map((a) => (
-            <li
-              key={a.id}
-              className="overflow-hidden rounded-lg border bg-card"
-              data-testid={`media-row-${a.id}`}
-            >
-              {a.source_url && a.mime_type.startsWith("image/") ? (
-                // Use <img> rather than next/image — these are external
-                // URLs we don't control + they don't go through the Next
-                // image optimiser.
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={a.source_url}
-                  alt=""
-                  className="h-40 w-full object-cover"
-                  loading="lazy"
-                />
-              ) : (
-                <div className="flex h-40 w-full items-center justify-center bg-muted text-sm text-muted-foreground">
-                  {a.mime_type}
+        <>
+          <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {assets.map((a) => (
+              <li
+                key={a.id}
+                className="overflow-hidden rounded-lg border bg-card"
+                data-testid={`media-row-${a.id}`}
+              >
+                {a.source_url && a.mime_type.startsWith("image/") ? (
+                  // Use <img> rather than next/image — these are external
+                  // URLs we don't control + they don't go through the Next
+                  // image optimiser.
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={a.source_url}
+                    alt=""
+                    className="h-40 w-full object-cover"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="flex h-40 w-full items-center justify-center bg-muted text-sm text-muted-foreground">
+                    {a.mime_type}
+                  </div>
+                )}
+                <div className="p-3">
+                  <div className="break-all text-sm">
+                    {a.source_url ?? a.storage_path}
+                  </div>
+                  <div className="mt-1 flex items-center justify-between text-sm text-muted-foreground">
+                    <span>{formatBytes(a.bytes)}</span>
+                    <span>{formatDate(a.created_at)}</span>
+                  </div>
+                  <div className="mt-2 flex items-center gap-2 text-sm">
+                    <button
+                      type="button"
+                      className="text-primary underline"
+                      onClick={() => copyId(a.id)}
+                      data-testid={`media-copy-${a.id}`}
+                    >
+                      {copiedId === a.id ? "Copied" : "Copy id"}
+                    </button>
+                    {a.bundle_upload_id ? (
+                      <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-900">
+                        uploaded
+                      </span>
+                    ) : null}
+                  </div>
                 </div>
-              )}
-              <div className="p-3">
-                <div className="break-all text-sm">
-                  {a.source_url ?? a.storage_path}
-                </div>
-                <div className="mt-1 flex items-center justify-between text-sm text-muted-foreground">
-                  <span>{formatBytes(a.bytes)}</span>
-                  <span>{formatDate(a.created_at)}</span>
-                </div>
-                <div className="mt-2 flex items-center gap-2 text-sm">
-                  <button
-                    type="button"
-                    className="text-primary underline"
-                    onClick={() => copyId(a.id)}
-                    data-testid={`media-copy-${a.id}`}
-                  >
-                    {copiedId === a.id ? "Copied" : "Copy id"}
-                  </button>
-                  {a.bundle_upload_id ? (
-                    <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-900">
-                      uploaded
-                    </span>
-                  ) : null}
-                </div>
-              </div>
-            </li>
-          ))}
-        </ul>
+              </li>
+            ))}
+          </ul>
+          {nextCursor ? (
+            <div className="mt-6 flex justify-center" data-testid="media-load-more">
+              <Button
+                variant="outline"
+                onClick={handleLoadMore}
+                disabled={loadingMore}
+              >
+                {loadingMore ? "Loading…" : "Load more"}
+              </Button>
+            </div>
+          ) : null}
+        </>
       )}
     </div>
   );

--- a/lib/platform/social/media/list.ts
+++ b/lib/platform/social/media/list.ts
@@ -6,11 +6,13 @@ import type { ApiResponse } from "@/lib/tool-schemas";
 
 // ---------------------------------------------------------------------------
 // S1-23 — list a company's social_media_assets, newest first.
-//
-// Capped at 200 V1 (single library page; pagination is a future
-// concern when libraries get large). Returns the fields the picker
-// + library page need.
+// S1-57 — cursor pagination via created_at; default 50 rows, max 100.
+//          Caller passes `before` (created_at ISO of last asset seen) to
+//          fetch the next page.
 // ---------------------------------------------------------------------------
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
 
 export type MediaAsset = {
   id: string;
@@ -26,19 +28,23 @@ export type MediaAsset = {
 
 export async function listMediaAssets(args: {
   companyId: string;
-}): Promise<ApiResponse<{ assets: MediaAsset[] }>> {
+  before?: string;
+  limit?: number;
+}): Promise<ApiResponse<{ assets: MediaAsset[]; nextCursor: string | null }>> {
   if (!args.companyId) {
     return validation("companyId required.");
   }
+  const pageSize = Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
   const svc = getServiceRoleClient();
-  const result = await svc
+  const base = svc
     .from("social_media_assets")
     .select(
       "id, source_url, storage_path, mime_type, bytes, width, height, bundle_upload_id, created_at",
     )
     .eq("company_id", args.companyId)
     .order("created_at", { ascending: false })
-    .limit(200);
+    .limit(pageSize + 1);
+  const result = await (args.before ? base.lt("created_at", args.before) : base);
   if (result.error) {
     logger.error("social.media.list.failed", {
       err: result.error.message,
@@ -46,7 +52,10 @@ export async function listMediaAssets(args: {
     });
     return internal(`Failed to read assets: ${result.error.message}`);
   }
-  const assets: MediaAsset[] = (result.data ?? []).map((r) => ({
+  const rows = result.data ?? [];
+  const hasMore = rows.length > pageSize;
+  const page = hasMore ? rows.slice(0, pageSize) : rows;
+  const assets: MediaAsset[] = page.map((r) => ({
     id: r.id as string,
     source_url: (r.source_url as string | null) ?? null,
     storage_path: r.storage_path as string,
@@ -57,14 +66,15 @@ export async function listMediaAssets(args: {
     bundle_upload_id: (r.bundle_upload_id as string | null) ?? null,
     created_at: r.created_at as string,
   }));
+  const nextCursor = hasMore ? (page[page.length - 1].created_at as string) : null;
   return {
     ok: true,
-    data: { assets },
+    data: { assets, nextCursor },
     timestamp: new Date().toISOString(),
   };
 }
 
-function validation(message: string): ApiResponse<{ assets: MediaAsset[] }> {
+function validation(message: string): ApiResponse<{ assets: MediaAsset[]; nextCursor: string | null }> {
   return {
     ok: false,
     error: {
@@ -77,7 +87,7 @@ function validation(message: string): ApiResponse<{ assets: MediaAsset[] }> {
   };
 }
 
-function internal(message: string): ApiResponse<{ assets: MediaAsset[] }> {
+function internal(message: string): ApiResponse<{ assets: MediaAsset[]; nextCursor: string | null }> {
   return {
     ok: false,
     error: {


### PR DESCRIPTION
## S1-57 — Media library cursor pagination

Replaces the hard 200-row cap in \`listMediaAssets\` with cursor pagination and adds a **Load more** button to the media library UI.

### Changes

**\`lib/platform/social/media/list.ts\`**
- Adds \`before?: string\` (ISO \`created_at\` cursor) and \`limit?: number\` (default 50, max 100) params.
- Fetches \`pageSize + 1\` rows; extra row signals more data exists — strips it and returns \`nextCursor = last asset's created_at\`.
- Return type: \`ApiResponse<{ assets: MediaAsset[]; nextCursor: string | null }>\`.

**\`app/api/platform/social/media/route.ts\`** (GET)
- Reads \`?before=<ISO>&limit=<n>\` from query params.
- Returns \`next_cursor\` (snake_case) in the response envelope.

**\`app/company/social/media/page.tsx\`**
- Passes \`initialNextCursor\` from the first-page result to \`MediaLibraryClient\`.

**\`components/MediaLibraryClient.tsx\`**
- Adds \`initialNextCursor: string | null\` prop and \`nextCursor\` state.
- "Load more" button appears below the grid when \`nextCursor !== null\`; appends next page of assets.

### Risks identified and mitigated
- **Read-only** — no writes, no state transitions, no billed calls.
- **Cursor collision:** \`created_at\` timestamps that collide across rows drop boundary items. Acceptable for V1; composite cursor deferred.
- **Backwards compat:** GET envelope adds \`next_cursor\` alongside \`assets\`; existing callers unaffected.

E2E omitted — purely lib/route/component change with no new admin route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)