### PR TITLE
fix(m16-8): typecheck — Role type, ErrorCode union, Promise wrap, page_type key

### DIFF
--- a/app/api/sites/[id]/blueprints/[blueprint_id]/publish-site/route.ts
+++ b/app/api/sites/[id]/blueprints/[blueprint_id]/publish-site/route.ts
@@ -19,7 +19,7 @@ type RouteContext = { params: { id: string; blueprint_id: string } };
 // Idempotent. Safe to call repeatedly (all WP operations are upserts).
 // Does NOT publish individual pages — that is handled by the batch publisher.
 export async function POST(_req: Request, ctx: RouteContext) {
-  const gate = await requireAdminForApi({ roles: ["super_admin", "admin", "operator"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const siteParam = validateUuidParam(ctx.params.id, "id");

--- a/lib/__tests__/m16-page-generator.test.ts
+++ b/lib/__tests__/m16-page-generator.test.ts
@@ -47,7 +47,7 @@ async function seedBlueprintAndRoutes(siteId: string) {
 
   // Upsert the route
   const routeResult = await upsertRoutesFromPlan(siteId, [
-    { slug: "/", pageType: "homepage", label: "Home", priority: 1 },
+    { slug: "/", page_type: "homepage", label: "Home", priority: 1 },
   ]);
   if (!routeResult.ok) throw new Error("seedBlueprintAndRoutes: upsert routes failed");
   const routes = await listActiveRoutes(siteId);

--- a/lib/batch-publisher.ts
+++ b/lib/batch-publisher.ts
@@ -436,10 +436,12 @@ export async function publishSlot(
         const contentHash = await computeContentHash(wpBoundHtml);
         const svc = getServiceRoleClient();
         m16PostPublishTasks.push(
-          svc
-            .from("route_registry")
-            .update({ wp_content_hash: contentHash })
-            .eq("id", publishCtx.m16_route_id),
+          Promise.resolve(
+            svc
+              .from("route_registry")
+              .update({ wp_content_hash: contentHash })
+              .eq("id", publishCtx.m16_route_id),
+          ),
         );
       }
 

--- a/lib/tool-schemas.ts
+++ b/lib/tool-schemas.ts
@@ -62,6 +62,10 @@ export const ERROR_CODES = [
   // admin/batch/[id]/cancel into the canonical vocabulary so any future
   // caller using respond() routes through errorCodeToStatus.
   "INVALID_STATE",
+  // M16-8 — WordPress site-publish route codes.
+  "WP_CREDENTIALS_MISSING",
+  "BLUEPRINT_NOT_FOUND",
+  "BLUEPRINT_MISMATCH",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];


### PR DESCRIPTION
## Fix typecheck failures introduced with M16-8 (#522)

Four type errors flagged by CI typecheck on main after the M16-8 squash merge:

| File | Error | Fix |
|---|---|---|
| `lib/tool-schemas.ts` | `"WP_CREDENTIALS_MISSING"`, `"BLUEPRINT_NOT_FOUND"`, `"BLUEPRINT_MISMATCH"` not in `ErrorCode` union | Add 3 codes to `ERROR_CODES` |
| `app/api/sites/[id]/blueprints/[blueprint_id]/publish-site/route.ts` | `"operator"` not in `Role = "super_admin" \| "admin" \| "user"` | Remove `"operator"` from roles list |
| `lib/batch-publisher.ts` | `PostgrestFilterBuilder` not assignable to `Promise<unknown>` in `m16PostPublishTasks` | Wrap in `Promise.resolve()` |
| `lib/__tests__/m16-page-generator.test.ts` | `pageType` not in `RoutePlanItem` (should be `page_type`) — pre-existing typo from M16-6 squash | Rename key |

No behaviour change. The error codes added to `ERROR_CODES` now map through `errorCodeToStatus` (all default to 400 — appropriate for config/validation failures at the publish-site route).

## Test plan

- [ ] `npm run typecheck` passes
- [ ] CI typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)