### PR TITLE
test(health): degraded-branch coverage for GET /api/health (M15-6 #17)

### DIFF
--- a/lib/__tests__/health-route-degraded.test.ts
+++ b/lib/__tests__/health-route-degraded.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Degraded-branch tests for GET /api/health (M15-6 #17).
+//
+// The happy path (both probes ok → 200) is covered in health-route.test.ts.
+// This file covers:
+//   - supabase probe fails → 503 degraded
+//   - budget_reset_backlog probe fails → 503 degraded
+//   - both probes fail → 503 degraded
+//   - a probe throws → outer catch returns structured 503
+// ---------------------------------------------------------------------------
+
+const mockCheckSupabase = vi.hoisted(() => vi.fn());
+const mockCheckBudgetResetBacklog = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/health-checks", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/health-checks")>(
+    "@/lib/health-checks",
+  );
+  return {
+    ...actual,
+    checkSupabase: mockCheckSupabase,
+    checkBudgetResetBacklog: mockCheckBudgetResetBacklog,
+  };
+});
+
+import { GET } from "@/app/api/health/route";
+
+const SUPABASE_OK = { result: "ok" as const, latency_ms: 5 };
+const BACKLOG_OK = { result: "ok" as const, count: 0, sample: [], latency_ms: 8 };
+
+beforeEach(() => {
+  mockCheckSupabase.mockReset().mockResolvedValue(SUPABASE_OK);
+  mockCheckBudgetResetBacklog.mockReset().mockResolvedValue(BACKLOG_OK);
+});
+
+describe("GET /api/health — degraded branches", () => {
+  it("503 when supabase probe returns fail", async () => {
+    mockCheckSupabase.mockResolvedValue({
+      result: "fail",
+      latency_ms: 12,
+      error: "connection refused",
+    });
+
+    const res = await GET();
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.status).toBe("degraded");
+    expect(body.checks.supabase).toBe("fail");
+    expect(body.checks.supabase_error).toBe("connection refused");
+    expect(body.checks.budget_reset_backlog).toBe("ok");
+  });
+
+  it("503 when budget_reset_backlog probe returns fail", async () => {
+    mockCheckBudgetResetBacklog.mockResolvedValue({
+      result: "fail",
+      count: 2,
+      sample: ["site-a", "site-b"],
+      latency_ms: 14,
+    });
+
+    const res = await GET();
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.status).toBe("degraded");
+    expect(body.checks.supabase).toBe("ok");
+    expect(body.checks.budget_reset_backlog).toBe("fail");
+    expect(body.checks.budget_reset_backlog_count).toBe(2);
+    expect(body.checks.budget_reset_backlog_sample).toEqual(["site-a", "site-b"]);
+  });
+
+  it("503 when both probes fail", async () => {
+    mockCheckSupabase.mockResolvedValue({
+      result: "fail",
+      latency_ms: 5,
+      error: "db unreachable",
+    });
+    mockCheckBudgetResetBacklog.mockResolvedValue({
+      result: "fail",
+      count: 1,
+      sample: ["site-x"],
+      latency_ms: 6,
+      error: "query timeout",
+    });
+
+    const res = await GET();
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.status).toBe("degraded");
+    expect(body.checks.supabase).toBe("fail");
+    expect(body.checks.budget_reset_backlog).toBe("fail");
+    expect(body.checks.budget_reset_backlog_error).toBe("query timeout");
+  });
+
+  it("503 when a probe throws — outer catch returns structured degraded body", async () => {
+    mockCheckSupabase.mockRejectedValue(new Error("unexpected crash"));
+
+    const res = await GET();
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.status).toBe("degraded");
+    expect(body.checks.probe_error).toBe("unexpected crash");
+    // Build fields are still present even in the error path
+    expect(typeof body.build.commit).toBe("string");
+    expect(typeof body.timestamp).toBe("string");
+  });
+
+  it("200 when both probes return ok (sanity — mocked happy path)", async () => {
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(body.checks.supabase).toBe("ok");
+    expect(body.checks.budget_reset_backlog).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `lib/__tests__/health-route-degraded.test.ts` — test coverage for the `503 degraded` branches of `GET /api/health`. Closes M15-6 #17 from docs/BACKLOG.md.

The existing `health-route.test.ts` only covered the 200 happy path (both probes ok). This file adds:

| Test | Coverage |
|---|---|
| `supabase` probe returns `"fail"` | 503, `supabase_error` surfaced in body |
| `budget_reset_backlog` probe returns `"fail"` | 503, `budget_reset_backlog_count` + `_sample` surfaced |
| Both probes fail | 503, both check fields degrade |
| A probe throws | Outer `try/catch` returns `503 { checks: { probe_error: "..." } }` |
| Both probes ok (mocked) | 200 sanity check against the mock setup |

Mocks `checkSupabase` and `checkBudgetResetBacklog` via `vi.mock`/`vi.hoisted` — no DB access required. `budget_reset_backlog_error` field in the degraded body is also exercised (was untested).

## Risks identified and mitigated

- New test file only; no production code changed.
- Mocks are scoped to this file; `health-route.test.ts` still hits the real Supabase stack for the integration happy-path test.

## E2E note

Unit layer only. The health endpoint is public and probes DB — integration covered by the existing test.