### PR TITLE
test(cron-routes): process-batch + regen handler tests + env + schema docs (M15-6 #5, #8; M15-3 #13; M15-2 #8)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -194,6 +194,12 @@ BUNDLE_SOCIAL_API=
 BUNDLE_SOCIAL_TEAMID=
 BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET=
 
+# --- Bundle analyser (local dev only) ---------------------------------------
+# Set ANALYZE=true to generate @next/bundle-analyzer reports during `next
+# build`. Use via `npm run analyze`; not a Vercel/CI env var — only useful
+# locally. See next.config.mjs for the withBundleAnalyzer wrapper.
+# ANALYZE=true
+
 # --- Log level (optional) --------------------------------------------------
 # debug | info | warn | error. Defaults to "info" in production, "debug"
 # in non-prod. Below-threshold calls are O(1) — no string building.

--- a/lib/__tests__/cron-process-batch-route.test.ts
+++ b/lib/__tests__/cron-process-batch-route.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Route handler tests for GET|POST /api/cron/process-batch (M15-6 #5).
+//
+// Covers: auth guard (no header, wrong secret, unset secret), no-work tick,
+// slot-processed tick, ANTHROPIC_API_KEY routing, and 500 error handling.
+// All batch-worker calls are mocked — worker internals are well-covered by
+// their own suite; this suite pins the HTTP entry point.
+// ---------------------------------------------------------------------------
+
+const mockConstantTimeEqual = vi.hoisted(() => vi.fn());
+const mockReapExpiredLeases = vi.hoisted(() => vi.fn());
+const mockLeaseNextPage = vi.hoisted(() => vi.fn());
+const mockProcessSlotAnthropic = vi.hoisted(() => vi.fn());
+const mockProcessSlotDummy = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/crypto-compare", () => ({
+  constantTimeEqual: mockConstantTimeEqual,
+}));
+
+vi.mock("@/lib/batch-worker", () => ({
+  DEFAULT_LEASE_MS: 300_000,
+  reapExpiredLeases: mockReapExpiredLeases,
+  leaseNextPage: mockLeaseNextPage,
+  processSlotAnthropic: mockProcessSlotAnthropic,
+  processSlotDummy: mockProcessSlotDummy,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, POST } from "@/app/api/cron/process-batch/route";
+
+function makeRequest(method: "GET" | "POST" = "GET", authHeader?: string): Request {
+  return new Request("http://localhost/api/cron/process-batch", {
+    method,
+    headers: authHeader ? { authorization: authHeader } : {},
+  });
+}
+
+beforeEach(() => {
+  process.env.CRON_SECRET = "a".repeat(32);
+  delete process.env.ANTHROPIC_API_KEY;
+  mockConstantTimeEqual.mockReset().mockReturnValue(false);
+  mockReapExpiredLeases.mockReset().mockResolvedValue({ reapedCount: 0 });
+  mockLeaseNextPage.mockReset().mockResolvedValue(null);
+  mockProcessSlotAnthropic.mockReset().mockResolvedValue(undefined);
+  mockProcessSlotDummy.mockReset().mockResolvedValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+describe("GET /api/cron/process-batch — auth", () => {
+  it("401 when no authorization header", async () => {
+    const res = await GET(makeRequest("GET") as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("401 when header doesn't match", async () => {
+    mockConstantTimeEqual.mockReturnValue(false);
+    const res = await GET(makeRequest("GET", "Bearer wrong-secret") as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+  });
+
+  it("401 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(makeRequest("GET", "Bearer any-secret") as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-work tick (no slot available)
+// ---------------------------------------------------------------------------
+
+describe("GET /api/cron/process-batch — no-work tick", () => {
+  it("200 — returns reapedCount and null processedSlotId when no slot", async () => {
+    mockConstantTimeEqual.mockReturnValue(true);
+    mockReapExpiredLeases.mockResolvedValue({ reapedCount: 3 });
+    mockLeaseNextPage.mockResolvedValue(null);
+
+    const res = await GET(makeRequest("GET", "Bearer valid") as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.reapedCount).toBe(3);
+    expect(body.data.processedSlotId).toBeNull();
+    expect(typeof body.timestamp).toBe("string");
+    expect(mockProcessSlotDummy).not.toHaveBeenCalled();
+    expect(mockProcessSlotAnthropic).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slot-processed tick — dummy path (no ANTHROPIC_API_KEY)
+// ---------------------------------------------------------------------------
+
+describe("GET /api/cron/process-batch — dummy processor path", () => {
+  it("200 — calls processSlotDummy when ANTHROPIC_API_KEY unset", async () => {
+    mockConstantTimeEqual.mockReturnValue(true);
+    mockLeaseNextPage.mockResolvedValue({ id: "slot-abc" });
+
+    const res = await GET(makeRequest("GET", "Bearer valid") as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.processedSlotId).toBe("slot-abc");
+    expect(mockProcessSlotDummy).toHaveBeenCalledWith("slot-abc", expect.any(String));
+    expect(mockProcessSlotAnthropic).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slot-processed tick — Anthropic path (ANTHROPIC_API_KEY set)
+// ---------------------------------------------------------------------------
+
+describe("GET /api/cron/process-batch — Anthropic processor path", () => {
+  it("200 — calls processSlotAnthropic when ANTHROPIC_API_KEY is set", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+    mockConstantTimeEqual.mockReturnValue(true);
+    mockLeaseNextPage.mockResolvedValue({ id: "slot-xyz" });
+
+    const res = await GET(makeRequest("GET", "Bearer valid") as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.processedSlotId).toBe("slot-xyz");
+    expect(mockProcessSlotAnthropic).toHaveBeenCalledWith("slot-xyz", expect.any(String));
+    expect(mockProcessSlotDummy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST symmetry
+// ---------------------------------------------------------------------------
+
+describe("POST /api/cron/process-batch", () => {
+  it("200 — POST goes through the same handle()", async () => {
+    mockConstantTimeEqual.mockReturnValue(true);
+
+    const res = await POST(makeRequest("POST", "Bearer valid") as Parameters<typeof POST>[0]);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("401 — POST also checks auth", async () => {
+    mockConstantTimeEqual.mockReturnValue(false);
+
+    const res = await POST(makeRequest("POST", "Bearer bad") as Parameters<typeof POST>[0]);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe("GET /api/cron/process-batch — error handling", () => {
+  it("500 — runTick throws → structured INTERNAL_ERROR response", async () => {
+    mockConstantTimeEqual.mockReturnValue(true);
+    mockReapExpiredLeases.mockRejectedValue(new Error("DB connection lost"));
+
+    const res = await GET(makeRequest("GET", "Bearer valid") as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.message).toContain("DB connection lost");
+    expect(body.error.retryable).toBe(true);
+  });
+});

--- a/lib/__tests__/cron-process-regenerations-route.test.ts
+++ b/lib/__tests__/cron-process-regenerations-route.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Route handler tests for GET|POST /api/cron/process-regenerations (M15-6 #8).
+//
+// Covers: auth guard, no-work tick, succeeded/failed/creds-missing outcomes,
+// and 500 error handling. The WP_CREDS_MISSING *terminal failure + DB write*
+// is already covered by cron-process-regenerations-wp-creds.test.ts (E2E
+// against the real Supabase stack). This file covers the HTTP envelope layer
+// with fully mocked worker internals.
+// ---------------------------------------------------------------------------
+
+const mockConstantTimeEqual = vi.hoisted(() => vi.fn());
+const mockReapExpiredRegenLeases = vi.hoisted(() => vi.fn());
+const mockLeaseNextRegenJob = vi.hoisted(() => vi.fn());
+const mockProcessRegenJob = vi.hoisted(() => vi.fn());
+const mockGetSite = vi.hoisted(() => vi.fn());
+const mockWpGetPage = vi.hoisted(() => vi.fn());
+const mockWpUpdatePage = vi.hoisted(() => vi.fn());
+const mockGetServiceRoleClient = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/crypto-compare", () => ({
+  constantTimeEqual: mockConstantTimeEqual,
+}));
+
+vi.mock("@/lib/regeneration-worker", () => ({
+  DEFAULT_REGEN_LEASE_MS: 300_000,
+  reapExpiredRegenLeases: mockReapExpiredRegenLeases,
+  leaseNextRegenJob: mockLeaseNextRegenJob,
+  processRegenJob: mockProcessRegenJob,
+}));
+
+vi.mock("@/lib/sites", () => ({
+  getSite: mockGetSite,
+}));
+
+vi.mock("@/lib/wordpress", () => ({
+  wpGetPage: mockWpGetPage,
+  wpUpdatePage: mockWpUpdatePage,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock the dynamic import of @/lib/supabase inside the route's creds-missing branch.
+const mockUpdate = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+const mockFrom = vi.fn().mockReturnValue({ update: mockUpdate });
+mockGetServiceRoleClient.mockReturnValue({ from: mockFrom });
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: mockGetServiceRoleClient,
+}));
+
+import { GET, POST } from "@/app/api/cron/process-regenerations/route";
+
+const VALID_CREDS = {
+  wp_user: "admin",
+  wp_app_password: "pass",
+};
+
+const VALID_SITE = {
+  id: "site-1",
+  wp_url: "https://wp.test",
+  name: "Test",
+  status: "active",
+};
+
+function makeRequest(method: "GET" | "POST" = "GET", authHeader?: string): Request {
+  return new Request("http://localhost/api/cron/process-regenerations", {
+    method,
+    headers: authHeader ? { authorization: authHeader } : {},
+  });
+}
+
+beforeEach(() => {
+  process.env.CRON_SECRET = "a".repeat(32);
+  mockConstantTimeEqual.mockReset().mockReturnValue(false);
+  mockReapExpiredRegenLeases.mockReset().mockResolvedValue({ reapedCount: 0 });
+  mockLeaseNextRegenJob.mockReset().mockResolvedValue(null);
+  mockProcessRegenJob.mockReset().mockResolvedValue({ ok: true });
+  mockGetSite.mockReset().mockResolvedValue({
+    ok: true,
+    data: { site: VALID_SITE, credentials: VALID_CREDS },
+  });
+  mockWpGetPage.mockReset();
+  mockWpUpdatePage.mockReset();
+  mockFrom.mockClear();
+  mockUpdate.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+describe("GET /api/cron/process-regenerations — auth", () => {
+  it("401 when no authorization header", async () => {
+    const res = await GET(makeRequest("GET") as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("401 when header doesn't match", async () => {
+    mockConstantTimeEqual.mockReturnValue(false);
+    const res = await GET(makeRequest("GET", "Bearer wrong") as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+  });
+
+  it("401 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(makeRequest("GET", "Bearer any") as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-work tick
+// ---------------------------------------------------------------------------
+
+describe("GET /api/cron/process-regenerations — no-work tick", () => {
+  it("200 — returns no-work outcome when queue is empty", async () => {
+    mockConstantTimeEqual.mockReturnValue(true);
+    mockReapExpiredRegenLeases.mockResolvedValue({ reapedCount: 2 });
+    mockLeaseNextRegenJob.mockResolvedValue(null);
+
+    const res = await GET(makeRequest("GET", "Bearer valid") as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.outcome).toBe("no-work");
+    expect(body.data.reapedCount).toBe(2);
+    expect(body.data.processedJobId).toBeNull();
+    expect(mockProcessRegenJob).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Succeeded outcome
+// ---------------------------------------------------------------------------
+
+describe("GET /api/cron/process-regenerations — succeeded outcome", () => {
+  it("200 — returns succeeded when processRegenJob returns ok:true", async () => {
+    mockConstantTimeEqual.mockReturnValue(true);
+    mockLeaseNextRegenJob.mockResolvedValue({ id: "job-1", site_id: "site-1", page_id: "page-1" });
+
+    // Supabase pages query for slug
+    mockGetServiceRoleClient.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({ data: { slug: "my-page" }, error: null }),
+          }),
+        }),
+        update: mockUpdate,
+      }),
+    });
+
+    mockProcessRegenJob.mockResolvedValue({ ok: true });
+
+    const res = await GET(makeRequest("GET", "Bearer valid") as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.outcome).toBe("succeeded");
+    expect(body.data.processedJobId).toBe("job-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failed outcome
+// ---------------------------------------------------------------------------
+
+describe("GET /api/cron/process-regenerations — failed outcome", () => {
+  it("200 — returns failed when processRegenJob returns ok:false", async () => {
+    mockConstantTimeEqual.mockReturnValue(true);
+    mockLeaseNextRegenJob.mockResolvedValue({ id: "job-2", site_id: "site-1", page_id: "page-2" });
+
+    mockGetServiceRoleClient.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+        update: mockUpdate,
+      }),
+    });
+
+    mockProcessRegenJob.mockResolvedValue({ ok: false, error: { code: "WP_API_ERROR" } });
+
+    const res = await GET(makeRequest("GET", "Bearer valid") as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.outcome).toBe("failed");
+    expect(body.data.processedJobId).toBe("job-2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Creds-missing outcome (HTTP envelope; DB-write side-effect tested in E2E suite)
+// ---------------------------------------------------------------------------
+
+describe("GET /api/cron/process-regenerations — creds-missing outcome", () => {
+  it("200 — returns creds-missing when getSite has no credentials", async () => {
+    mockConstantTimeEqual.mockReturnValue(true);
+    mockLeaseNextRegenJob.mockResolvedValue({ id: "job-3", site_id: "site-1", page_id: "page-3" });
+    mockGetSite.mockResolvedValue({ ok: true, data: { site: VALID_SITE, credentials: null } });
+
+    const eqFn = vi.fn().mockResolvedValue({ error: null });
+    const updateFn = vi.fn().mockReturnValue({ eq: eqFn });
+    mockGetServiceRoleClient.mockReturnValue({ from: vi.fn().mockReturnValue({ update: updateFn }) });
+
+    const res = await GET(makeRequest("GET", "Bearer valid") as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.outcome).toBe("creds-missing");
+    expect(body.data.processedJobId).toBe("job-3");
+    expect(mockProcessRegenJob).not.toHaveBeenCalled();
+  });
+
+  it("200 — returns creds-missing when getSite itself fails", async () => {
+    mockConstantTimeEqual.mockReturnValue(true);
+    mockLeaseNextRegenJob.mockResolvedValue({ id: "job-4", site_id: "site-1", page_id: "page-4" });
+    mockGetSite.mockResolvedValue({
+      ok: false,
+      error: { code: "NOT_FOUND", message: "Site not found", retryable: false, suggested_action: "" },
+    });
+
+    const eqFn = vi.fn().mockResolvedValue({ error: null });
+    const updateFn = vi.fn().mockReturnValue({ eq: eqFn });
+    mockGetServiceRoleClient.mockReturnValue({ from: vi.fn().mockReturnValue({ update: updateFn }) });
+
+    const res = await GET(makeRequest("GET", "Bearer valid") as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.outcome).toBe("creds-missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST symmetry
+// ---------------------------------------------------------------------------
+
+describe("POST /api/cron/process-regenerations", () => {
+  it("200 — POST also dispatches through handle()", async () => {
+    mockConstantTimeEqual.mockReturnValue(true);
+
+    const res = await POST(makeRequest("POST", "Bearer valid") as Parameters<typeof POST>[0]);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  it("401 — POST also checks auth", async () => {
+    mockConstantTimeEqual.mockReturnValue(false);
+
+    const res = await POST(makeRequest("POST", "Bearer bad") as Parameters<typeof POST>[0]);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe("GET /api/cron/process-regenerations — error handling", () => {
+  it("500 — runTick throws → structured INTERNAL_ERROR response", async () => {
+    mockConstantTimeEqual.mockReturnValue(true);
+    mockReapExpiredRegenLeases.mockRejectedValue(new Error("Lease reap failed"));
+
+    const res = await GET(makeRequest("GET", "Bearer valid") as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("INTERNAL_ERROR");
+    expect(body.error.message).toContain("Lease reap failed");
+    expect(body.error.retryable).toBe(true);
+  });
+});

--- a/supabase/migrations/0086_schema_docs_m15_2_8.sql
+++ b/supabase/migrations/0086_schema_docs_m15_2_8.sql
@@ -1,0 +1,25 @@
+-- M15-2 #8 — Document event-table PK type inconsistency.
+--
+-- generation_events and regeneration_events use bigserial PKs (appended
+-- in the original M3/M7 schemas for append-only log performance). transfer_events
+-- uses uuid (M4 schema, different author convention). The mismatch is cosmetic
+-- today — the three tables are never queried together. A future unified event
+-- stream would need a migration to normalise them. Until then, this comment
+-- surfaces the deviation for reviewers and M15-8 type generation.
+
+COMMENT ON TABLE generation_events IS
+  'Append-only event log for generation_jobs slots. PK is bigserial (not uuid) — '
+  'this is intentional for append-performance in the original M3 schema. '
+  'transfer_events uses uuid PKs; regeneration_events matches this bigserial convention. '
+  'Normalise to uuid if a unified event stream is ever built (M15-2 #8).';
+
+COMMENT ON TABLE regeneration_events IS
+  'Append-only event log for regeneration_jobs. PK is bigserial (not uuid) — '
+  'matches generation_events convention from M3, differs from transfer_events (uuid). '
+  'Cosmetic inconsistency; normalise with generation_events if a unified event stream '
+  'is ever built (M15-2 #8).';
+
+COMMENT ON TABLE transfer_events IS
+  'Append-only event log for transfer_jobs. PK is uuid (M4 schema convention), '
+  'unlike generation_events and regeneration_events which use bigserial. '
+  'Cosmetic inconsistency; normalise if a unified event stream is ever built (M15-2 #8).';


### PR DESCRIPTION
## Summary

Four backlog items in one PR:

### M15-6 #5 — `lib/__tests__/cron-process-batch-route.test.ts`
Route handler tests for `GET|POST /api/cron/process-batch`:
- Auth: no header → 401, wrong secret → 401, unset CRON_SECRET → 401
- No-work tick: returns null processedSlotId when queue is empty
- Dummy path: calls processSlotDummy when ANTHROPIC_API_KEY unset
- Anthropic path: calls processSlotAnthropic when ANTHROPIC_API_KEY set
- POST symmetry + error 500 path

### M15-6 #8 — `lib/__tests__/cron-process-regenerations-route.test.ts`
Route handler tests for `GET|POST /api/cron/process-regenerations` (the WP_CREDS_MISSING DB-write side-effect is already covered by the existing E2E suite):
- Auth: 401 paths
- No-work: `outcome: "no-work"` when queue is empty
- Succeeded / failed: mirrors `processRegenJob` ok/fail
- Creds-missing: `outcome: "creds-missing"` when getSite has no credentials OR getSite fails
- POST symmetry + error 500

### M15-3 #13 — `.env.local.example` ANALYZE block
Documents that `ANALYZE=true` is a local-dev-only flag (not a Vercel env var) used by `npm run analyze`.

### M15-2 #8 — `supabase/migrations/0086_schema_docs_m15_2_8.sql`
`COMMENT ON TABLE` for `generation_events`, `regeneration_events`, `transfer_events` to document the bigserial/uuid PK inconsistency and flag the normalisation path.

## E2E omitted
All code changes are test files, env documentation, and a no-op SQL comment migration. No UI surface.

## Risks identified and mitigated
No write-safety hotspots — new tests only, env example comment, and SQL COMMENT statements (no schema mutation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)