### PR TITLE
fix(qa): esc() apostrophe encoding + entity-only sanitization (CodeQL)

### DIFF
--- a/lib/__tests__/m16-component-registry.test.ts
+++ b/lib/__tests__/m16-component-registry.test.ts
@@ -464,8 +464,10 @@ describe("all render functions — XSS safety", () => {
   )("%s:%s does not render raw XSS payload", (_type, _variant, def) => {
     const p = { ...def.defaultProps, id: SECTION_ID, heading: xssPayload, headline: xssPayload };
     const html = def.render(p, "preview");
+    // Payload must be entity-encoded — raw < prevents browser from parsing
+    // the injected string as an HTML element (onerror= in text content is harmless).
     expect(html).not.toContain("<img src=x");
-    expect(html).not.toContain("onerror=");
+    expect(html).toContain("&lt;img src=x");
   });
 });
 

--- a/lib/component-registry.ts
+++ b/lib/component-registry.ts
@@ -135,7 +135,8 @@ function esc(s: unknown): string {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
 }
 
 type CtaShape = { text?: string; url?: string; variant?: string };

--- a/lib/component-registry.ts
+++ b/lib/component-registry.ts
@@ -131,7 +131,6 @@ function esc(s: unknown): string {
   if (s == null) return '';
   if (typeof s === 'object') return '';
   return String(s)
-    .replace(/on[a-z]+\s*=/gi, '')
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')


### PR DESCRIPTION
## Summary

Two follow-up fixes to PR #539 that were pushed after that PR auto-merged.

- **Apostrophe encoding** — add `.replace(/'/g, '&#x27;')` to `esc()` so the `CTABanner:card` test (`expect(html).toContain("Let&#x27;s talk")`) passes. The test was pre-existing and failing on main since the component registry was written.

- **Remove `on*=` stripping (CodeQL fix)** — PR #539 added `.replace(/on[a-z]+\s*=/gi, '')` to strip event-handler patterns. CodeQL flagged this as `js/incomplete-multi-character-sanitization` — stripping-based sanitization is inherently incomplete. The correct defence is entity-encoding `<` and `>`, which prevents the browser from parsing the text as an HTML element at all. `onerror=` as a literal substring in text content between entity-encoded tags is harmless. Updated the XSS safety test assertion from `expect(html).not.toContain("onerror=")` to `expect(html).toContain("&lt;img src=x")` — verifying encoding actually occurred.

## Test plan

- [ ] `lib/__tests__/m16-component-registry.test.ts` — `CTABanner:card > renders with card class` now passes (apostrophe encoded)
- [ ] `lib/__tests__/m16-component-registry.test.ts` XSS safety suite — all 20 variants pass with entity-encoding check
- [ ] CodeQL `js/incomplete-multi-character-sanitization` alert cleared

## Risks identified and mitigated

- Removing `on*=` stripping: safe because all render functions use `esc()` on text content only (between element tags). Event handlers only execute in attribute positions within HTML tags — `<` encoding prevents the injected string from being parsed as a tag. Verified by checking all `esc()` call sites in `lib/component-registry.ts`.
- `&#x27;` encoding of apostrophes: browser renders `&#x27;` identically to `'` in text content, no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)