### PR TITLE
chore: ignore .claude/scheduled_tasks.lock runtime file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ scripts/output/
 .claude/settings.local.json
 .claude/settings.json.txt
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 
 # Supabase CLI temp dir (project ref cache, etc.). Ephemeral.
 supabase/.temp/


### PR DESCRIPTION
Adds `.claude/scheduled_tasks.lock` to `.gitignore`. This is a Claude Code runtime file created during background task scheduling — it's ephemeral, per-developer, and should never be tracked.

Part of the repo cleanup that removed 25+ stale git worktrees nested inside the repo directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)