### PR TITLE
fix(qa): site-builder sweep — cron auth dedup, structured logger, sync-failed banner

### DIFF
--- a/app/api/cron/drift-detect/route.ts
+++ b/app/api/cron/drift-detect/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { timingSafeEqual } from "node:crypto";
 
+import { constantTimeEqual } from "@/lib/crypto-compare";
 import { runDriftDetector } from "@/lib/drift-detector";
 import { getSite } from "@/lib/sites";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -25,17 +25,6 @@ import { logger } from "@/lib/logger";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const maxDuration = 299;
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, "utf8");
-  const bBuf = Buffer.from(b, "utf8");
-  if (aBuf.length !== bBuf.length) {
-    const filler = Buffer.alloc(aBuf.length);
-    timingSafeEqual(aBuf, filler);
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
-}
 
 function authorised(req: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;

--- a/app/api/cron/render-pages/route.ts
+++ b/app/api/cron/render-pages/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { timingSafeEqual } from "node:crypto";
 
+import { constantTimeEqual } from "@/lib/crypto-compare";
 import { runRenderWorker } from "@/lib/render-worker";
 import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -19,17 +19,6 @@ import { getServiceRoleClient } from "@/lib/supabase";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const maxDuration = 299;
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, "utf8");
-  const bBuf = Buffer.from(b, "utf8");
-  if (aBuf.length !== bBuf.length) {
-    const filler = Buffer.alloc(aBuf.length);
-    timingSafeEqual(aBuf, filler);
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
-}
 
 function authorised(req: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;

--- a/app/company/social/connections/page.tsx
+++ b/app/company/social/connections/page.tsx
@@ -61,6 +61,17 @@ function ConnectBanner({ params }: { params: SearchParams }) {
       </div>
     );
   }
+  if (params.connect === "sync-failed") {
+    return (
+      <div
+        className="mb-4 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
+        role="alert"
+        data-testid="connect-banner-sync-failed"
+      >
+        Accounts may be connected but sync is still pending — try Refresh.
+      </div>
+    );
+  }
   const detail =
     params.reason && REASON_LABEL[params.reason]
       ? REASON_LABEL[params.reason]

--- a/docs/QA-ISSUES.md
+++ b/docs/QA-ISSUES.md
@@ -112,6 +112,42 @@ components, and webhooks. Typecheck ✓ Lint ✓. Tests require Docker (not run)
 
 | # | File | Issue | Suggested fix |
 |---|------|-------|---------------|
-| S-4 | `app/company/social/connections/page.tsx` | `connect=sync-failed` banner shows generic "The connection couldn't be completed." — `sync.error.code` (e.g. "INTERNAL_ERROR") isn't in `REASON_LABEL` | Add a `sync-failed` case with "Accounts may be connected but sync is still pending — try Refresh." |
+| S-4 | `app/company/social/connections/page.tsx` | `connect=sync-failed` banner shows generic "The connection couldn't be completed." — `sync.error.code` (e.g. "INTERNAL_ERROR") isn't in `REASON_LABEL` | ✅ Fixed — PR #TODO (site-builder-qa-sweep) |
 | S-5 | `lib/platform/social/cap/image-trigger.ts:108` | `bytes: 0` hardcoded in `social_media_assets` insert — file size not tracked for CAP images | Expose bytes from `generateWithFallback` or read from Supabase Storage stat after upload |
 | S-6 | `components/SocialPostDetailClient.tsx`, `components/PostScheduleSection.tsx` | `window.confirm()` / `window.prompt()` used for destructive actions (delete, submit, cancel-approval, reject, request-changes, schedule-cancel) — native browser dialogs, poor mobile UX | Replace with shadcn/ui `AlertDialog` + a `CommentDialog` (text-input variant); candidate for a dedicated polish slice |
+
+---
+
+## Site-builder broad sweep — 2026-05-04
+
+Full audit of auth, admin API routes, cron routes, chat route, `lib/batch-publisher.ts`,
+`lib/brief-runner.ts`, `lib/rate-limit.ts`, `lib/encryption.ts`, migration history,
+and component-level code paths. Typecheck ✓ Lint ✓.
+
+### Fixed in PR #TODO (fix/site-builder-qa-sweep)
+
+| # | File | Issue | Fix |
+|---|------|-------|-----|
+| B-1 | `lib/generator-payload.ts` | `console.warn` in production code path — bypasses structured logger, won't reach Axiom, no request ID attached | Replaced with `logger.warn(...)` |
+| B-2 | `app/api/cron/drift-detect/route.ts` | Local inline `constantTimeEqual` duplicating `@/lib/crypto-compare` — maintenance risk if shared impl ever gets a fix | Removed inline copy, import from shared module |
+| B-3 | `app/api/cron/render-pages/route.ts` | Same as B-2 | Removed inline copy, import from shared module |
+| B-4 | `app/company/social/connections/page.tsx` | `?connect=sync-failed` banner fell through to generic error message (S-4 from social sweep) | Added explicit amber warning: "Accounts may be connected but sync is still pending — try Refresh." |
+
+### No issues found (areas confirmed clean)
+
+| Area | Files reviewed | Result |
+|---|---|---|
+| Auth architecture | `lib/auth.ts`, `middleware.ts`, `lib/admin-gate.ts`, `lib/encryption.ts` | ✅ Clean |
+| Chat route | `app/api/chat/route.ts` | ✅ Clean — rate-limited, auth-gated, no tool injection, SSE error redaction correct |
+| Batch publisher | `lib/batch-publisher.ts` (527 lines) | ✅ Clean — advisory lock, SAVEPOINT adoption, idempotent WP GET-first |
+| Cron auth (all 24 routes) | Bearer CRON_SECRET via `@/lib/crypto-compare` (now consistent) | ✅ Clean |
+| Admin API routes | Sites, register, users, batch — all use `requireAdminForApi` gate, Zod validation, structured logger | ✅ Clean |
+| Rate limiting | `lib/rate-limit.ts` | ✅ Clean — fail-open semantics, all sensitive routes covered |
+| Migration history | 0001–0087 | ✅ Clean — sequential, soft-delete consistent |
+| `console.log` in production paths | All lib + app .ts/.tsx | ✅ Only `emergency/route.ts` (intentional, documented) and `logger.ts` sink (intentional) |
+
+### Logged as debt (not fixed)
+
+| # | File | Issue | Suggested fix |
+|---|------|-------|---------------|
+| B-5 | `lib/brief-runner.ts:2507,2628` | `projectedIterationCostCents = 10`, `projectedRevCostCents = 15` hardcoded — will drift from actual model pricing | Move to a named constant or config table; recalibrate against Sonnet pricing |

--- a/lib/generator-payload.ts
+++ b/lib/generator-payload.ts
@@ -12,6 +12,7 @@
  */
 
 import type { PageType, SharedContentType } from './types/page-document';
+import { logger } from "@/lib/logger";
 
 // ─── HARD CAPS ─────────────────────────────────────────────────────────────
 // Change these only with a milestone. Never relax without a measured reason.
@@ -202,12 +203,12 @@ export function buildGeneratorPayload(opts: BuildPayloadOptions): GeneratorPaylo
 
 function capArray<T>(arr: T[], max: number, name: string): T[] {
   if (arr.length <= max) return arr;
-  console.warn(`[generator-payload] ${name} truncated from ${arr.length} to ${max}`);
+  logger.warn("generator-payload.truncated", { field: name, from: arr.length, to: max });
   return arr.slice(0, max);
 }
 
 function truncateChars(str: string, max: number, name: string): string {
   if (str.length <= max) return str;
-  console.warn(`[generator-payload] ${name} truncated from ${str.length} to ${max} chars`);
+  logger.warn("generator-payload.truncated_chars", { field: name, from: str.length, to: max });
   return str.slice(0, max);
 }


### PR DESCRIPTION
## Summary

Site-builder broad QA sweep findings. All changes are LOW severity quality fixes.

- **B-1** (`lib/generator-payload.ts`): Two `console.warn` calls in the truncation helpers were bypassing the structured logger. Replaced with `logger.warn(...)` so truncation events reach Axiom with request IDs.
- **B-2/B-3** (`app/api/cron/drift-detect`, `app/api/cron/render-pages`): Both routes had an inline copy of `constantTimeEqual` instead of importing from `@/lib/crypto-compare`. Removed the duplicates; both now use the shared implementation.
- **B-4** (`app/company/social/connections/page.tsx`): The `?connect=sync-failed` redirect from the callback was falling through to a generic "The connection couldn't be completed." error banner (S-4 from social QA sweep). Added an explicit amber warning: "Accounts may be connected but sync is still pending — try Refresh."

## Areas confirmed clean (no changes needed)

- Auth: `lib/auth.ts`, `middleware.ts`, `lib/admin-gate.ts`, `lib/encryption.ts`
- Chat route: auth-gated, rate-limited, SSE error redaction correct
- Batch publisher (`lib/batch-publisher.ts`): advisory lock, SAVEPOINT adoption, idempotent GET-first — all correct
- All 24 cron routes: Bearer CRON_SECRET via `constantTimeEqual` (now consistently from shared module)
- Admin API routes: `requireAdminForApi` gate, Zod validation, structured logger throughout
- Rate limiting: fail-open semantics, all sensitive routes covered
- Migration history (0001–0087): sequential, soft-delete consistent

## Logged as debt (not fixed here)

- **B-5**: `projectedIterationCostCents = 10` / `projectedRevCostCents = 15` hardcoded in `lib/brief-runner.ts` — should be named constants calibrated against current model pricing.

## Test plan

- [x] `npm run lint` — 0 warnings
- [x] `npm run typecheck` — 0 errors
- [x] B-4 (sync-failed banner): `ConnectBanner` renders amber "Accounts may be connected…" when `?connect=sync-failed`
- [ ] Unit tests require Docker (not run locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)