### PR TITLE
feat(design): implement Opollo design system across admin dashboard

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -76,7 +76,7 @@ export default async function AdminLayout({
         // children from forcing horizontal overflow.
         className="min-w-0 flex-1 px-4 py-6 scroll-mt-16 focus:outline-none sm:px-8 sm:py-8"
       >
-        <div className="mx-auto max-w-6xl">{children}</div>
+        <div className="mx-auto max-w-7xl">{children}</div>
       </main>
       <Toaster />
       <CommandPalette />

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,82 +2,76 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ---------------------------------------------------------------------------
+ * Opollo Design System — always-dark token layer.
+ *
+ * Raw hex vars (--pk, --gr, --bl, etc.) are for direct use in Opollo
+ * component classes. Tailwind/shadcn semantic vars (--background, etc.)
+ * are HSL approximations of the same palette so every shadcn primitive
+ * inherits the dark theme automatically.
+ *
+ * Light mode does not exist. The <html> element carries class="dark"
+ * unconditionally, which activates Tailwind's dark: variants everywhere.
+ * ------------------------------------------------------------------------- */
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-    /* R1-4 — bumped from 210 40% 96.1% so secondary buttons read
-       against the bg-canvas (220 14% 96%) wash. Now sits ~9 percentage
-       points darker than canvas — visible but still subordinate to
-       primary. */
-    --secondary: 220 13% 87%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    /* ---- Opollo raw hex tokens ----------------------------------------- */
+    --pk: #ff03a5;
+    --pk2: #cc0084;
+    --pk-soft: rgba(255, 3, 165, 0.12);
+    --gr: #00e5a0;
+    --gr2: #00c48a;
+    --gr-soft: rgba(0, 229, 160, 0.10);
+    --bl: #4da6ff;
+    --bl-soft: rgba(77, 166, 255, 0.10);
+    --am: #ffb300;
+    --rd: #ff4d6d;
+    --bg: #04040a;
+    --d1: #07070f;
+    --d2: #0b0b18;
+    --d3: #10101e;
+    --d4: #161624;
+    --white: #ffffff;
+    --m1: rgba(255, 255, 255, 0.92);
+    --m2: rgba(255, 255, 255, 0.58);
+    --m3: rgba(255, 255, 255, 0.32);
+    --m4: rgba(255, 255, 255, 0.18);
+    --b1: rgba(255, 255, 255, 0.06);
+    --b2: rgba(255, 255, 255, 0.12);
+    --b3: rgba(255, 255, 255, 0.20);
+
+    /* ---- Tailwind/shadcn semantic tokens (HSL, always-dark) -------------- */
+    --background: 240 37% 4%;           /* --d1  #07070f  card surface       */
+    --foreground: 0 0% 92%;             /* --m1  rgba(255,255,255,0.92)       */
+    --card: 240 37% 4%;                 /* --d1                               */
+    --card-foreground: 0 0% 92%;
+    --popover: 240 31% 9%;              /* --d3  #10101e  elevated panel      */
+    --popover-foreground: 0 0% 92%;
+    --primary: 322 100% 50%;            /* --pk  #ff03a5                      */
+    --primary-foreground: 0 0% 100%;
+    --secondary: 240 24% 11%;           /* --d4  #161624  hover/elevated      */
+    --secondary-foreground: 0 0% 92%;
+    --muted: 240 31% 9%;                /* --d3                               */
+    --muted-foreground: 0 0% 58%;       /* --m2  rgba(255,255,255,0.58)       */
+    --accent: 240 24% 11%;              /* --d4                               */
+    --accent-foreground: 0 0% 92%;
+    --destructive: 350 100% 65%;        /* --rd  #ff4d6d                      */
+    --destructive-foreground: 0 0% 100%;
+    --border: 240 14% 10%;              /* ≈ --b1  rgba(255,255,255,0.06)     */
+    --input: 240 9% 16%;                /* ≈ --b2  rgba(255,255,255,0.12)     */
+    --ring: 162 100% 45%;               /* --gr  #00e5a0  focus ring = green  */
     --radius: 0.5rem;
 
-    /* A-2 — Semantic status tokens. See documentation block below. */
-    --success: 142 71% 36%;          /* emerald-700 territory */
-    --success-foreground: 0 0% 100%;
-    --warning: 38 92% 36%;           /* amber-700 territory */
-    --warning-foreground: 0 0% 100%;
-    --info: 199 89% 38%;             /* sky-700 territory */
-    --info-foreground: 0 0% 100%;
+    /* canvas = page base, one notch deeper than card surface */
+    --canvas: 240 43% 3%;               /* --bg  #04040a                      */
 
-    /* R1 — Canvas tint. Page background sits one notch off the card
-       background so card edges register. Linear / Vercel pattern:
-       cards stay white, canvas wash provides separation. */
-    --canvas: 220 14% 96%;           /* cool grey */
-  }
-
-  .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    /* R1-4 — secondary in dark mode lifted slightly so it reads
-       against the dark --background. */
-    --secondary: 217.2 32.6% 25%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-
-    /* R1 — Canvas tint, dark variant. One notch deeper than the
-       --background card surface so cards still pop. */
-    --canvas: 222 47% 7%;
-
-    /* A-2 — Semantic status tokens, dark variants. Bumped luminance so
-       badges remain legible against the dark background. */
-    --success: 142 71% 50%;          /* emerald-500 area */
-    --success-foreground: 222 47% 11%;
-    --warning: 38 92% 60%;           /* amber-400 area */
-    --warning-foreground: 222 47% 11%;
-    --info: 199 89% 60%;             /* sky-400 area */
-    --info-foreground: 222 47% 11%;
+    /* status tokens — Opollo palette */
+    --success: 162 100% 45%;            /* --gr  green                        */
+    --success-foreground: 240 43% 3%;
+    --warning: 42 100% 50%;             /* --am  amber                        */
+    --warning-foreground: 240 43% 3%;
+    --info: 211 100% 65%;               /* --bl  blue                         */
+    --info-foreground: 240 43% 3%;
   }
 }
 
@@ -86,109 +80,163 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-canvas text-foreground;
+    font-family: var(--font-body, "Manrope", ui-sans-serif, system-ui, sans-serif);
+  }
+
+  /* Display font on headings — Fredoka per design system */
+  h1, h2, h3 {
+    font-family: var(--font-display, "Fredoka", ui-sans-serif, sans-serif);
+    letter-spacing: -0.02em;
+    line-height: 1.05;
+    font-weight: 600;
+  }
+
+  /* Green focus ring — replaces default */
+  *:focus-visible {
+    outline: 2px solid var(--gr);
+    outline-offset: 2px;
   }
 }
 
 /* ---------------------------------------------------------------------------
- * A-2 — Semantic color palette (documentation block).
- *
- * Five status intents — every pill, badge, and tinted-background block on
- * an admin surface picks one. Hand-rolled `bg-emerald-500/10 text-emerald-700`
- * patterns are forbidden going forward; consume the StatusPill primitive
- * from A-4 (which maps these intents → token classes below).
- *
- *   neutral     — default / unscoped state                  bg-muted text-muted-foreground
- *   active      — running, healthy, in-progress             bg-primary/10 text-primary
- *   success     — succeeded, complete, OK                   bg-success/10 text-success
- *   warning     — paused, awaiting review, soft caution     bg-warning/10 text-warning
- *   info        — informational, scheduled, queued          bg-info/10 text-info
- *   error       — failed, destructive, hard stop            bg-destructive/10 text-destructive
- *
- * Token semantics:
- *
- *   --success       hue rooted at emerald-700 (light) / emerald-500 (dark).
- *                   Light-mode value chosen so `text-success` against a
- *                   white background passes WCAG AA (4.5:1).
- *   --warning       amber-700 (light) / amber-400 (dark). Yellow shifted
- *                   to amber so it doesn't read as "neon caution sign".
- *   --info          sky-700 (light) / sky-400 (dark). Cooler than primary
- *                   so an info badge doesn't compete with an active state.
- *
- * Foreground variants (e.g. `text-success-foreground`) are reserved for
- * solid-fill badges (`bg-success text-success-foreground`). The default
- * pill pattern uses the muted-bg + bold-text convention because solid
- * fills crowd information-dense lists. Keep solid fills for one-off
- * marketing-style accent rows.
- *
- * Hand-rolled `text-emerald-700` / `bg-yellow-500/10` literals across the
- * codebase will be folded into these tokens during the A-4 sweep. Do not
- * add new ones in the meantime.
- * --------------------------------------------------------------------- */
+ * Opollo component classes
+ * Used directly in JSX alongside Tailwind utilities.
+ * ------------------------------------------------------------------------- */
+
+/* Eyebrow label — green dash prefix, uppercase tracking */
+.lbl {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.20em;
+  color: var(--gr);
+}
+.lbl::before {
+  content: '—';
+  color: var(--gr);
+  font-weight: 700;
+}
+.lbl.lbl-live::before {
+  content: '';
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--gr);
+  animation: lbl-pulse 2s ease-in-out infinite;
+}
+
+/* Single pink word-highlight per heading */
+.pk {
+  color: var(--pk);
+}
+
+/* Stat unit span — sits after the big number */
+.unit {
+  font-size: 55%;
+  font-weight: 500;
+  color: var(--m2);
+}
+
+/* Primary CTA button */
+.btn-pk {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background: linear-gradient(135deg, var(--pk), var(--pk2));
+  color: #fff;
+  border: none;
+  border-radius: 100px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 10px 24px;
+  cursor: pointer;
+  transition: filter 150ms ease-out, transform 150ms ease-out, box-shadow 150ms ease-out;
+}
+.btn-pk:hover {
+  filter: brightness(1.1);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 24px rgba(255, 3, 165, 0.40);
+}
+.btn-pk:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+/* Ghost button — hairline border, goes green on hover */
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background: transparent;
+  color: var(--m1);
+  border: 1px solid var(--b3);
+  border-radius: 100px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 10px 24px;
+  cursor: pointer;
+  transition: border-color 150ms ease-out, color 150ms ease-out;
+}
+.btn-ghost:hover {
+  border-color: var(--gr);
+  color: var(--gr);
+}
+
+/* Mesh gradient — atmospheric hero background */
+.mesh {
+  background:
+    radial-gradient(ellipse at 15% 50%, rgba(255, 3, 165, 0.15) 0%, transparent 55%),
+    radial-gradient(ellipse at 85% 20%, rgba(0, 229, 160, 0.10) 0%, transparent 55%),
+    radial-gradient(ellipse at 50% 85%, rgba(77, 166, 255, 0.08) 0%, transparent 50%);
+  animation: mesh-drift 14s ease-in-out infinite;
+}
 
 /* ---------------------------------------------------------------------------
- * A-1 — Typography scale (documentation block).
+ * A-2 — Semantic status colors (documentation).
  *
- * Five tiers via the components/ui/typography.tsx primitives. Tailwind
- * sizes locked deliberately; do not introduce text-2xl/text-3xl on any
- * admin surface — those are marketing-page energy and pushed every list
- * below the operator's fold.
+ *   success  bg-success/10 text-success     green  #00e5a0
+ *   warning  bg-warning/10 text-warning     amber  #ffb300
+ *   info     bg-info/10 text-info           blue   #4da6ff
+ *   error    bg-destructive/10 text-destructive  red  #ff4d6d
+ *   neutral  bg-muted text-muted-foreground
+ * ------------------------------------------------------------------------- */
+
+/* ---------------------------------------------------------------------------
+ * A-1 — Typography scale.
  *
- *   <H1>      page heading             text-xl   font-semibold tracking-tight  ~20px
- *   <H2>      section heading          text-base font-semibold tracking-tight  ~16px
- *   <H3>      sub-section / card       text-sm   font-semibold                 ~14px
- *   <Eyebrow> small uppercase label    text-sm   font-medium uppercase tracking-wide  ~14px
- *                                                 text-muted-foreground
- *   <Lead>    intro / context line     text-base text-muted-foreground         ~16px
+ *   <H1>      page heading          text-xl  font-display  ~20px
+ *   <H2>      section heading       text-base font-display ~16px
+ *   <H3>      sub-section / card    text-sm  font-display  ~14px
+ *   <Eyebrow> .lbl                  10px     font-body 700 uppercase
+ *   Body      p / td / form values  font-body 400          ~16px floor
  *
- * Type-size minimums (UAT 2026-05-02):
- *   • Body text: text-base (1rem / 16px) is the floor. Paragraph copy,
- *     form input values, page descriptions, modal body all sit at this
- *     size or larger.
- *   • Small text: text-sm (0.875rem / 14px) is the floor for helper
- *     copy, captions, badges, eyebrows, breadcrumbs, status microcopy.
- *   • text-xs (0.75rem / 12px) is FORBIDDEN on every operator surface.
- *
- * Per-callsite uses of text-sm for primary reading copy (paragraphs,
- * descriptions) are a known follow-up sweep — see docs/BACKLOG.md
- * "Typography minimums Phase 2" — but no new text-xs is permitted in the
- * meantime.
- *
- * font-mono is reserved for literal data (cloudflare ids, cost values,
- * code tokens) — not for stylistic accent.
- *
- * Reference quality bar: matches Linear's issue view + Vercel's
- * deployment header. Do not introduce a 6th tier without revisiting.
- * --------------------------------------------------------------------- */
+ * text-xs (12px) is FORBIDDEN on operator surfaces.
+ * font-mono reserved for literal data (IDs, cost values, code tokens).
+ * ------------------------------------------------------------------------- */
 
 /* ---------------------------------------------------------------------------
  * RS-0 / A-3 — Motion primitives.
  *
- * Shared vocabulary for animated state changes. We name utilities after
- * intent (`opollo-fade-in`, `opollo-shimmer`) rather than mechanism so
- * future polish (e.g. swapping a fade for a slide) doesn't require
- * touching every consumer.
+ * Duration tiers:
+ *   150ms  hover / micro-state                .transition-smooth
+ *   200ms  standard state                     .opollo-slide-up
+ *   250ms  pop-in                             .opollo-pop-in
+ *   1100-1200ms  sweep/reveal
+ *   1500ms  shimmer (infinite)               .opollo-shimmer
  *
- * Four-tier duration system (do not introduce a 5th):
- *
- *   100ms   instant feedback                   .opollo-fade-out
- *   150ms   micro-state change                 .opollo-fade-in
- *   200ms   standard state change              .transition-smooth, .opollo-slide-up
- *   250ms   noticeable but not gratuitous      .opollo-pop-in
- *   600ms   data tick / count-up landing       .opollo-pulse-soft, RunCostTicker count-up
- *   1500ms  loading shimmer (infinite loop)    .opollo-shimmer
- *
- * Easing curves:
- *
- *   cubic-bezier(0.4, 0, 0.2, 1)        standard ease-out (most utilities)
- *   cubic-bezier(0.34, 1.56, 0.64, 1)   bounce-out for pop-in (slight overshoot)
- *
- * `prefers-reduced-motion: reduce` zeroes every motion utility below.
- * This honours the OS-level user preference and is the single place
- * accessibility-conscious users opt out — consumers don't need to gate
- * their own animations. New utilities MUST be added to the
- * reduced-motion block at the bottom.
- * ------------------------------------------------------------------------ */
+ * prefers-reduced-motion zeroes every utility at the bottom of this file.
+ * ------------------------------------------------------------------------- */
 
 @layer utilities {
   .transition-smooth {
@@ -196,7 +244,7 @@
       text-decoration-color, fill, stroke, opacity, box-shadow, transform,
       filter, backdrop-filter;
     transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: 200ms;
+    transition-duration: 150ms;
   }
 
   .opollo-fade-in {
@@ -211,45 +259,25 @@
     animation: opollo-slide-up 200ms cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  /* A-3 — Skeleton shimmer. Drives the .skeleton primitive's
-   * "loading" pulse without using Tailwind's animate-pulse (which
-   * is a softer fade — too gentle to read as "this is loading").
-   * Linear-style left-to-right gradient sweep at ~1.5s. */
   .opollo-shimmer {
     background: linear-gradient(
       90deg,
       hsl(var(--muted)) 0%,
-      hsl(var(--muted) / 0.6) 50%,
+      hsl(var(--muted) / 0.5) 50%,
       hsl(var(--muted)) 100%
     );
     background-size: 200% 100%;
     animation: opollo-shimmer 1500ms ease-in-out infinite;
   }
 
-  /* A-3 — Soft pulse for "live data" tick. Status pills and the cost
-   * ticker reach for this when a value just changed; signals the
-   * change without yanking attention. 600ms one-shot, capped — not
-   * an infinite loop. Apply via a key prop change so React mounts
-   * a fresh element and the animation fires on every value-flip. */
   .opollo-pulse-soft {
     animation: opollo-pulse-soft 600ms cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  /* A-3 — Pop-in for count-up landing or new-item-appended state.
-   * Slightly more aggressive than slide-up: a 4% scale up + fade.
-   * 250ms, ease-out. Use sparingly; one element at a time. */
   .opollo-pop-in {
     animation: opollo-pop-in 250ms cubic-bezier(0.34, 1.56, 0.64, 1);
   }
 
-  /* A-3 — Stagger-in helpers. Each .opollo-stagger-in-N variant adds
-   * N * 50ms delay on top of opollo-fade-in so a list reveals one
-   * row at a time without manual JS choreography. Capped at -8 so
-   * we never animate more than 8 rows; long lists land instantly to
-   * avoid feeling sluggish.
-   *
-   * Usage: <li class="opollo-fade-in opollo-stagger-in-3"> in a loop
-   * where the loop index drives the suffix (0..7). */
   .opollo-stagger-in-1 { animation-delay: 50ms; }
   .opollo-stagger-in-2 { animation-delay: 100ms; }
   .opollo-stagger-in-3 { animation-delay: 150ms; }
@@ -261,71 +289,45 @@
 }
 
 @keyframes opollo-fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 @keyframes opollo-fade-out {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
+  from { opacity: 1; }
+  to { opacity: 0; }
 }
 
 @keyframes opollo-slide-up {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 @keyframes opollo-shimmer {
-  0% {
-    background-position: 100% 0;
-  }
-  100% {
-    background-position: -100% 0;
-  }
+  0%   { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
 }
 
 @keyframes opollo-pulse-soft {
-  0% {
-    transform: scale(1);
-    opacity: 0.7;
-  }
-  50% {
-    transform: scale(1.04);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
+  0%   { transform: scale(1); opacity: 0.7; }
+  50%  { transform: scale(1.04); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
 }
 
 @keyframes opollo-pop-in {
-  0% {
-    opacity: 0;
-    transform: scale(0.96);
-  }
-  60% {
-    opacity: 1;
-    transform: scale(1.02);
-  }
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
+  0%   { opacity: 0; transform: scale(0.96); }
+  60%  { opacity: 1; transform: scale(1.02); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+@keyframes lbl-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+
+@keyframes mesh-drift {
+  0%, 100% { background-position: 0% 50%; }
+  50%       { background-position: 100% 50%; }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -343,10 +345,14 @@
   .opollo-stagger-in-5,
   .opollo-stagger-in-6,
   .opollo-stagger-in-7,
-  .opollo-stagger-in-8 {
+  .opollo-stagger-in-8,
+  .mesh,
+  .lbl.lbl-live::before {
     animation: none !important;
     animation-delay: 0 !important;
     transition: none !important;
+  }
+  .opollo-shimmer {
     background: hsl(var(--muted)) !important;
   }
 }
@@ -354,36 +360,20 @@
 /* ---------------------------------------------------------------------------
  * UAT (2026-05-03) — operator-readability floor.
  *
- * Steven flagged the admin surfaces as too small to read comfortably:
- *   - "Body text 16px minimum, even where text-sm is used."
- *   - "Helper text 15px minimum (was 12-14px in places)."
- *   - "Lucide icons 25% larger so they're not a squint test."
- *
- * Implemented as a final-cascade override on Tailwind's text-* utilities
- * + a min-width/min-height clamp on Lucide icon SVGs. We bump the *small*
- * tiers up rather than touching `text-base` (already 16px). Surgical so
- * H1/H2/H3 + form input sizing stays untouched.
- *
- * Lucide bump: every icon rendered by lucide-react carries a `.lucide`
- * class. Targeting `svg.lucide` with min-width/min-height ensures any
- * icon authored as h-3/w-3 (12px) or h-4/w-4 (16px) renders at >=20px,
- * which is 25% larger than the prior most-common 16px default. Icons
- * authored explicitly larger (h-5/w-5 = 20px, h-6/w-6 = 24px) keep their
- * sizes via the height/width tailwind classes since min- only floors.
- * --------------------------------------------------------------------- */
+ * text-sm → 15px, text-xs → 15px. Lucide icons floored at 20px.
+ * Steven's explicit request: "Body text 16px minimum, icons 25% larger."
+ * ------------------------------------------------------------------------- */
 
 .text-xs {
-  /* 12px → 15px */
   font-size: 0.9375rem;
   line-height: 1.375rem;
 }
 .text-sm {
-  /* 14px → 15px */
   font-size: 0.9375rem;
   line-height: 1.4rem;
 }
 
 svg.lucide {
-  min-width: 1.25rem; /* 20px */
+  min-width: 1.25rem;
   min-height: 1.25rem;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,21 @@
 import type { Metadata } from "next";
+import { Fredoka, Manrope } from "next/font/google";
+import { cn } from "@/lib/utils";
 import "./globals.css";
+
+const fredoka = Fredoka({
+  subsets: ["latin"],
+  weight: ["500", "600", "700"],
+  variable: "--font-display",
+  display: "swap",
+});
+
+const manrope = Manrope({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-body",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "Opollo Site Builder",
@@ -31,8 +47,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body className="font-sans antialiased">{children}</body>
+    <html
+      lang="en"
+      className={cn(fredoka.variable, manrope.variable, "dark")}
+      suppressHydrationWarning
+    >
+      <body className="font-body antialiased">{children}</body>
     </html>
   );
 }

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -8,7 +8,6 @@ import {
   ChevronsLeft,
   ChevronsRight,
   Activity,
-  FileText,
   Globe,
   Image as ImageIcon,
   KeyRound,
@@ -29,25 +28,12 @@ import type { SessionUser } from "@/lib/auth";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
-// R1-1 — Sidebar navigation chrome.
+// Opollo sidebar — dark gradient rail, pink active indicator, green hover.
+// 240px expanded / 64px icon-only collapsed. Off-canvas drawer on mobile.
 //
-// Replaces the AdminNav top bar with a Claude.ai / ChatGPT-style left
-// rail. Pinned 240px wide on desktop; collapsible to 64px (icon-only)
-// via the bottom rail's chevron toggle. Mobile (< sm): off-canvas
-// drawer toggled by a top-right hamburger button on the
-// in-page mobile header.
-//
-// Persistence:
-//   - Cookie `opollo_sidebar_collapsed` (1 / 0). Server reads via
-//     next/headers cookies() in app/admin/layout.tsx and passes the
-//     state as `initialCollapsed` so SSR + first client paint match.
-//     This kills the hydration flash where the rail rendered expanded
-//     then snapped narrow on first useEffect tick. (R2 fix.)
-//   - localStorage mirror keeps the legacy key live so other tabs
-//     reading it don't see stale state. Cookie is the source of truth
-//     for SSR; localStorage is a convenience for any client-only code
-//     that wants to read without a roundtrip.
-//   - Mobile drawer opens fresh each time (no persistence).
+// Persistence: cookie `opollo_sidebar_collapsed` (1 / 0) set by server layout
+// so SSR + first client paint match (no hydration flash). localStorage mirrors
+// for legacy readers.
 // ---------------------------------------------------------------------------
 
 const SIDEBAR_COLLAPSED_LS_KEY = "opollo:sidebar:collapsed";
@@ -62,16 +48,8 @@ type NavLink = {
 
 interface AdminSidebarProps {
   user: SessionUser | null;
-  /** Operator-tier roles (admin or super_admin) — sees the operator-
-   *  management surfaces (Users, Companies). PLATFORM-AUDIT PR7
-   *  replaced the old `showUsersLink` boolean with the richer
-   *  isAdminTier / isSuperAdmin pair. */
   isAdminTier: boolean;
-  /** Top-tier role only — sees the super_admin-only surfaces
-   *  (Audit log, Email test). */
   isSuperAdmin: boolean;
-  /** R2 fix — cookie-driven initial state from the server layout so
-   *  SSR matches the first client render and there's no flash. */
   initialCollapsed?: boolean;
 }
 
@@ -82,7 +60,6 @@ export function AdminSidebar({
   initialCollapsed = false,
 }: AdminSidebarProps) {
   const pathname = usePathname();
-  // Cookie value drives SSR + first paint. No useEffect-based load.
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   const [mobileOpen, setMobileOpen] = useState(false);
 
@@ -90,32 +67,23 @@ export function AdminSidebar({
     setCollapsed((prev) => {
       const next = !prev;
       try {
-        window.localStorage.setItem(
-          SIDEBAR_COLLAPSED_LS_KEY,
-          next ? "1" : "0",
-        );
+        window.localStorage.setItem(SIDEBAR_COLLAPSED_LS_KEY, next ? "1" : "0");
       } catch {
-        // localStorage disabled — change still applies in-memory.
+        /* localStorage disabled — change applies in-memory */
       }
-      // Write cookie so the server layout picks up the new state on
-      // the next request. 1-year max-age; sidebar pref isn't sensitive.
-      // SameSite=Lax is the default for first-party admin requests.
       try {
         document.cookie = `${SIDEBAR_COLLAPSED_COOKIE}=${next ? "1" : "0"}; path=/; max-age=${60 * 60 * 24 * 365}; samesite=lax`;
       } catch {
-        // document.cookie write blocked (cookieless context) —
-        // change still applies in-memory.
+        /* cookieless context — change applies in-memory */
       }
       return next;
     });
   }
 
-  // Auto-close the mobile drawer on route change.
   useEffect(() => {
     setMobileOpen(false);
   }, [pathname]);
 
-  // Escape closes the mobile drawer.
   useEffect(() => {
     if (!mobileOpen) return;
     function onKey(e: KeyboardEvent) {
@@ -163,10 +131,6 @@ export function AdminSidebar({
       : []),
   ];
 
-  // PLATFORM-AUDIT PR7 — super_admin-only "Admin" sub-section. These
-  // pages exist but had no nav entry, so they were unreachable except by
-  // typing the URL. Surface them as a separate tier in the rail rather
-  // than mixing them with the operator-management top-level links.
   const adminLinks: NavLink[] = isSuperAdmin
     ? [
         {
@@ -194,15 +158,57 @@ export function AdminSidebar({
     return pathname === href || pathname.startsWith(href + "/");
   }
 
+  function NavItem({
+    label,
+    href,
+    icon: Icon,
+    testId,
+  }: NavLink) {
+    const active = isActiveRoute(href);
+    return (
+      <li className="relative">
+        {active && (
+          <span
+            aria-hidden
+            className="absolute inset-y-1 left-0 w-0.5 rounded-full bg-[#FF03A5]"
+          />
+        )}
+        <Link
+          href={href}
+          data-testid={testId}
+          aria-current={active ? "page" : undefined}
+          title={collapsed ? label : undefined}
+          className={cn(
+            "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00e5a0] focus-visible:ring-offset-2 focus-visible:ring-offset-[#07070f]",
+            active
+              ? "bg-[rgba(255,3,165,0.10)] text-white font-medium"
+              : "text-[rgba(255,255,255,0.58)] hover:bg-[rgba(0,229,160,0.06)] hover:text-[#00e5a0]",
+          )}
+        >
+          <Icon
+            aria-hidden
+            className={cn(
+              "h-4 w-4 shrink-0",
+              active
+                ? "text-white"
+                : "text-[rgba(255,255,255,0.40)] group-hover:text-[#00e5a0]",
+            )}
+          />
+          {!collapsed && <span className="truncate">{label}</span>}
+        </Link>
+      </li>
+    );
+  }
+
   return (
     <>
-      {/* Mobile-only top bar — hamburger + wordmark. Hidden above sm. */}
-      <div className="sticky top-0 z-40 flex h-14 items-center justify-between border-b bg-background/95 px-4 backdrop-blur sm:hidden">
+      {/* Mobile top bar */}
+      <div className="sticky top-0 z-40 flex h-14 items-center justify-between border-b border-white/[0.06] bg-[rgba(4,4,10,0.85)] px-4 backdrop-blur-[18px] sm:hidden">
         <Link
           href="/admin/sites"
-          className="text-sm font-semibold transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          className="font-display text-sm font-semibold text-white tracking-tight focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00e5a0]"
         >
-          Opollo
+          Opo<span className="text-[#FF03A5]">llo</span>
         </Link>
         <button
           type="button"
@@ -210,68 +216,67 @@ export function AdminSidebar({
           aria-label="Open navigation"
           aria-expanded={mobileOpen}
           aria-controls="admin-sidebar"
-          className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-smooth hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-md text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(255,255,255,0.06)] hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00e5a0]"
           data-testid="admin-mobile-nav-button"
         >
           <Menu aria-hidden className="h-5 w-5" />
         </button>
       </div>
 
-      {/* Mobile-only backdrop. Click to close. */}
+      {/* Mobile backdrop */}
       {mobileOpen && (
         <button
           type="button"
           aria-label="Close navigation"
-          className="opollo-fade-in fixed inset-0 z-40 bg-black/40 sm:hidden"
+          className="opollo-fade-in fixed inset-0 z-40 bg-black/60 sm:hidden"
           onClick={() => setMobileOpen(false)}
         />
       )}
 
-      {/* Sidebar — pinned left on desktop, off-canvas on mobile. */}
+      {/* Sidebar */}
       <aside
         id="admin-sidebar"
         aria-label="Primary"
         className={cn(
-          "border-r bg-background transition-all duration-200",
-          // Mobile: fixed off-canvas; slide in via translate.
+          // Opollo sidebar: dark gradient bg, rgba-white right border
+          "border-r border-white/[0.06] transition-all duration-200",
+          "bg-[linear-gradient(180deg,#07070f_0%,#04040a_100%)]",
+          // Mobile: fixed off-canvas
           "fixed inset-y-0 left-0 z-50 w-72 shrink-0 -translate-x-full",
           mobileOpen && "translate-x-0",
-          // Desktop: pinned, full-height.
+          // Desktop: pinned full-height
           "sm:sticky sm:top-0 sm:h-screen sm:translate-x-0",
           collapsed ? "sm:w-16" : "sm:w-60",
         )}
-        // aria-hidden left undefined: the sidebar is always part of
-        // the page tab order on desktop; on mobile it's translated
-        // off-canvas which already removes it from interaction.
       >
         <div className="flex h-full flex-col">
-          {/* Wordmark + collapse toggle (desktop) / close button (mobile) */}
-          <div className="flex h-14 items-center justify-between border-b px-3">
+          {/* Wordmark + collapse toggle */}
+          <div className="flex h-14 items-center justify-between border-b border-white/[0.06] px-3">
             {!collapsed && (
               <Link
                 href="/admin/sites"
-                className="text-sm font-semibold transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+                className="font-display text-sm font-semibold text-white tracking-tight focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00e5a0]"
               >
-                Opollo
+                Opo<span className="text-[#FF03A5]">llo</span>
               </Link>
             )}
+            {/* Mobile close */}
             <button
               type="button"
               onClick={() => setMobileOpen(false)}
               aria-label="Close navigation"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-smooth hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:hidden"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(255,255,255,0.06)] hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00e5a0] sm:hidden"
             >
               <X aria-hidden className="h-5 w-5" />
             </button>
+            {/* Desktop collapse toggle */}
             <button
               type="button"
               onClick={toggleCollapsed}
-              aria-label={
-                collapsed ? "Expand sidebar" : "Collapse sidebar"
-              }
+              aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
               title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
               className={cn(
-                "hidden h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-smooth hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:inline-flex",
+                "hidden h-8 w-8 items-center justify-center rounded-md text-[rgba(255,255,255,0.40)] transition-smooth hover:bg-[rgba(255,255,255,0.06)] hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00e5a0] sm:inline-flex",
                 collapsed && "mx-auto",
               )}
             >
@@ -286,102 +291,43 @@ export function AdminSidebar({
           {/* Primary nav */}
           <nav className="flex-1 overflow-y-auto p-2">
             <ul className="space-y-0.5">
-              {navLinks.map(({ label, href, icon: Icon, testId }) => {
-                const active = isActiveRoute(href);
-                return (
-                  <li key={href}>
-                    <Link
-                      href={href}
-                      data-testid={testId}
-                      aria-current={active ? "page" : undefined}
-                      title={collapsed ? label : undefined}
-                      className={cn(
-                        "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                        active
-                          ? "bg-muted font-medium text-foreground"
-                          : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
-                      )}
-                    >
-                      <Icon
-                        aria-hidden
-                        className={cn(
-                          "h-4 w-4 shrink-0",
-                          active
-                            ? "text-foreground"
-                            : "text-muted-foreground group-hover:text-foreground",
-                        )}
-                      />
-                      {!collapsed && <span className="truncate">{label}</span>}
-                    </Link>
-                  </li>
-                );
-              })}
+              {navLinks.map((link) => (
+                <NavItem key={link.href} {...link} />
+              ))}
             </ul>
 
-            {/* Super_admin-only Admin sub-section. Separator label
-                hidden when the rail is collapsed. */}
+            {/* Super_admin Admin sub-section */}
             {adminLinks.length > 0 && (
               <>
                 <div className="mt-4 mb-1 px-2.5">
                   {!collapsed && (
-                    <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
-                      Admin
-                    </p>
+                    <p className="lbl text-[10px]">Admin</p>
                   )}
                 </div>
                 <ul className="space-y-0.5">
-                  {adminLinks.map(({ label, href, icon: Icon, testId }) => {
-                    const active = isActiveRoute(href);
-                    return (
-                      <li key={href}>
-                        <Link
-                          href={href}
-                          data-testid={testId}
-                          aria-current={active ? "page" : undefined}
-                          title={collapsed ? label : undefined}
-                          className={cn(
-                            "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                            active
-                              ? "bg-muted font-medium text-foreground"
-                              : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
-                          )}
-                        >
-                          <Icon
-                            aria-hidden
-                            className={cn(
-                              "h-4 w-4 shrink-0",
-                              active
-                                ? "text-foreground"
-                                : "text-muted-foreground group-hover:text-foreground",
-                            )}
-                          />
-                          {!collapsed && (
-                            <span className="truncate">{label}</span>
-                          )}
-                        </Link>
-                      </li>
-                    );
-                  })}
+                  {adminLinks.map((link) => (
+                    <NavItem key={link.href} {...link} />
+                  ))}
                 </ul>
               </>
             )}
           </nav>
 
-          {/* Footer rail — ⌘K hint + user menu */}
-          <div className="border-t p-2">
+          {/* Footer rail */}
+          <div className="border-t border-white/[0.06] p-2">
             {!collapsed && (
-              <div className="mb-2 flex items-center justify-between rounded-md bg-muted/40 px-2 py-1.5">
-                <span className="text-sm text-muted-foreground">
+              <div className="mb-2 flex items-center justify-between rounded-md bg-white/[0.04] px-2 py-1.5">
+                <span className="text-sm text-[rgba(255,255,255,0.40)]">
                   Command palette
                 </span>
                 <span
-                  className="flex items-center gap-0.5 text-sm text-muted-foreground"
+                  className="flex items-center gap-0.5 text-sm text-[rgba(255,255,255,0.32)]"
                   aria-hidden
                 >
-                  <kbd className="rounded border bg-background px-1 font-mono text-[10px]">
+                  <kbd className="rounded border border-white/[0.12] bg-white/[0.06] px-1 font-mono text-[10px]">
                     ⌘
                   </kbd>
-                  <kbd className="rounded border bg-background px-1 font-mono text-[10px]">
+                  <kbd className="rounded border border-white/[0.12] bg-white/[0.06] px-1 font-mono text-[10px]">
                     K
                   </kbd>
                 </span>
@@ -392,16 +338,14 @@ export function AdminSidebar({
                 href="/account/security"
                 title={collapsed ? "Account security" : undefined}
                 className={cn(
-                  "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-muted-foreground transition-smooth hover:bg-muted/60 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-[#00e5a0] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00e5a0]",
                   isActiveRoute("/account/security") &&
-                    "bg-muted font-medium text-foreground",
+                    "bg-[rgba(255,3,165,0.10)] text-white font-medium",
                 )}
                 data-testid="nav-security"
               >
-                <KeyRound aria-hidden className="h-4 w-4 shrink-0" />
-                {!collapsed && (
-                  <span className="truncate">Account security</span>
-                )}
+                <KeyRound aria-hidden className="h-4 w-4 shrink-0 text-[rgba(255,255,255,0.40)] group-hover:text-[#00e5a0]" />
+                {!collapsed && <span className="truncate">Account security</span>}
               </Link>
             )}
             {user && (
@@ -409,25 +353,23 @@ export function AdminSidebar({
                 href="/account/devices"
                 title={collapsed ? "Trusted devices" : undefined}
                 className={cn(
-                  "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-muted-foreground transition-smooth hover:bg-muted/60 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-[#00e5a0] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00e5a0]",
                   isActiveRoute("/account/devices") &&
-                    "bg-muted font-medium text-foreground",
+                    "bg-[rgba(255,3,165,0.10)] text-white font-medium",
                 )}
                 data-testid="nav-devices"
               >
-                <Laptop aria-hidden className="h-4 w-4 shrink-0" />
-                {!collapsed && (
-                  <span className="truncate">Trusted devices</span>
-                )}
+                <Laptop aria-hidden className="h-4 w-4 shrink-0 text-[rgba(255,255,255,0.40)] group-hover:text-[#00e5a0]" />
+                {!collapsed && <span className="truncate">Trusted devices</span>}
               </Link>
             )}
             <Link
               href="/"
               title={collapsed ? "Back to builder" : undefined}
-              className="group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-muted-foreground transition-smooth hover:bg-muted/60 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-[#00e5a0] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00e5a0]"
               data-testid="nav-back-to-builder"
             >
-              <Settings aria-hidden className="h-4 w-4 shrink-0" />
+              <Settings aria-hidden className="h-4 w-4 shrink-0 text-[rgba(255,255,255,0.40)] group-hover:text-[#00e5a0]" />
               {!collapsed && <span className="truncate">Back to builder</span>}
             </Link>
             {user && (
@@ -435,7 +377,7 @@ export function AdminSidebar({
                 <button
                   type="submit"
                   title={collapsed ? "Sign out" : undefined}
-                  className="group flex h-9 w-full items-center gap-3 rounded-md px-2.5 text-left text-sm text-destructive transition-smooth hover:bg-destructive/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="group flex h-9 w-full items-center gap-3 rounded-md px-2.5 text-left text-sm text-destructive transition-smooth hover:bg-destructive/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#00e5a0]"
                   data-testid="nav-sign-out"
                 >
                   <LogOut aria-hidden className="h-4 w-4 shrink-0" />
@@ -445,7 +387,7 @@ export function AdminSidebar({
             )}
             {user && !collapsed && (
               <p
-                className="mt-2 truncate border-t pt-2 px-2.5 text-[11px] text-muted-foreground"
+                className="mt-2 truncate border-t border-white/[0.06] pt-2 px-2.5 text-[11px] text-[rgba(255,255,255,0.32)]"
                 title={user.email}
               >
                 {user.email}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,44 +4,34 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
-// R1-4 — Linear-style button hierarchy. Primary feels primary; outline
-// reads as a real secondary; ghost is subtle but lights up on hover.
-//
-// Changes from B-2:
-//   • default: shadow-sm + active:translate-y-px gives a tactile press;
-//     hover lifts to shadow.
-//   • outline: border-input bumped to a tone the eye registers against
-//     bg-background OR bg-canvas; hover drops a subtle muted bg under
-//     the border instead of swapping accent (which competed with primary
-//     visually).
-//   • secondary: bg-secondary darkened via the --secondary token
-//     adjustment in globals.css; readable against canvas + cards both.
-//   • ghost: explicit bg-transparent + hover:bg-muted (was hover:bg-
-//     accent which renders the same as muted under the current
-//     palette but is semantically clearer).
-//
-// `gap-2` from B-2 stays — supports icon + text composition.
+// Opollo button hierarchy — all variants are full-pill (rounded-full).
+// default  → pink gradient CTA (uppercase 13px 700)
+// outline  → hairline border, goes green on hover
+// ghost    → transparent, green on hover (nav / table actions)
+// secondary → subtle elevated surface
+// destructive → red, for irreversible actions
+// link    → pink underline
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-smooth focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full font-medium ring-offset-background transition-smooth focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow active:translate-y-px",
+          "bg-gradient-to-r from-[#FF03A5] to-[#cc0084] text-white text-[13px] font-bold uppercase tracking-[0.05em] hover:brightness-110 hover:-translate-y-px hover:shadow-[0_4px_24px_rgba(255,3,165,0.40)] active:translate-y-0 active:shadow-none",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 hover:shadow active:translate-y-px",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90 active:translate-y-px",
         outline:
-          "border border-input bg-background text-foreground shadow-sm hover:bg-muted/60 hover:border-foreground/20 active:translate-y-px",
+          "border border-white/20 bg-transparent text-foreground hover:border-[#00e5a0] hover:text-[#00e5a0] active:translate-y-px",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 active:translate-y-px",
+          "bg-white/[0.08] text-foreground hover:bg-white/[0.12] active:translate-y-px",
         ghost:
-          "bg-transparent text-foreground hover:bg-muted hover:text-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-transparent text-muted-foreground hover:bg-[rgba(0,229,160,0.08)] hover:text-[#00e5a0]",
+        link: "text-[#FF03A5] underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-sm",
-        lg: "h-11 rounded-md px-6",
+        default: "h-10 px-6 py-2",
+        sm: "h-8 px-4 text-sm",
+        lg: "h-11 px-8",
         icon: "h-10 w-10",
       },
     },

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-lg border bg-card text-card-foreground",
       className,
     )}
     {...props}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,6 +16,12 @@ const config: Config = {
       },
     },
     extend: {
+      fontFamily: {
+        sans: ["var(--font-body)", "ui-sans-serif", "system-ui", "sans-serif"],
+        body: ["var(--font-body)", "ui-sans-serif", "system-ui", "sans-serif"],
+        display: ["var(--font-display)", "ui-sans-serif", "sans-serif"],
+        mono: ["ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "monospace"],
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
@@ -34,9 +40,6 @@ const config: Config = {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
         },
-        // A-2 — semantic status tokens. Use as `bg-success/10 text-success`
-        // for tinted-bg pills (the canonical pattern for StatusPill in A-4)
-        // and `bg-success text-success-foreground` for solid-fill badges.
         success: {
           DEFAULT: "hsl(var(--success))",
           foreground: "hsl(var(--success-foreground))",
@@ -49,9 +52,6 @@ const config: Config = {
           DEFAULT: "hsl(var(--info))",
           foreground: "hsl(var(--info-foreground))",
         },
-        // R1 — page-background tint. Cards stay on `bg-background` so
-        // their edges register against the canvas. Use as `bg-canvas`
-        // on the page wrapper only.
         canvas: "hsl(var(--canvas))",
         muted: {
           DEFAULT: "hsl(var(--muted))",
@@ -69,6 +69,17 @@ const config: Config = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        /* Opollo raw tokens — use as text-pk, bg-gr, border-bl, etc. */
+        pk: "var(--pk)",
+        gr: "var(--gr)",
+        bl: "var(--bl)",
+        am: "var(--am)",
+        rd: "var(--rd)",
+        d1: "var(--d1)",
+        d2: "var(--d2)",
+        d3: "var(--d3)",
+        d4: "var(--d4)",
+        "bg-base": "var(--bg)",
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary

Full Opollo design system implementation across the admin dashboard. Every change is token-driven — the dark palette, fonts, and component styling derive from the Opollo spec.

- **Fonts** — Fredoka (display/headings) + Manrope (body) via `next/font/google`; `<html>` carries `class="dark"` unconditionally — no light mode
- **CSS tokens** (`app/globals.css`) — Opollo raw hex vars (`--pk`, `--gr`, `--bl`, `--bg`, `--d1`–`d4`, `--m1`–`m4`, `--b1`–`b3`) alongside Tailwind HSL semantic vars so all shadcn primitives inherit the dark palette automatically; headings get Fredoka + `-0.02em` tracking; focus rings switched to green; component classes: `.lbl`, `.pk`, `.unit`, `.btn-pk`, `.btn-ghost`, `.mesh`
- **Tailwind config** — `fontFamily` with `sans/body/display`; Opollo raw colors as Tailwind utilities (`text-pk`, `bg-gr`, `border-bl`, etc.)
- **Button** — `rounded-full` (100px pill); `default` = pink gradient + uppercase + hover glow; `outline`/`ghost` go green on hover; no resting shadow
- **Card** — `shadow-sm` removed (spec: borders only, no box-shadows)
- **AdminSidebar** — dark gradient bg; `rgba(255,255,255,0.06)` border; pink active state (10% rgba bg + 2px left rail); green hover; Fredoka wordmark; mobile glassmorphism header
- **Admin layout** — max-width raised to `max-w-7xl` (1280px)

## §13 checklist

- ✅ Page bg `#04040a` via `bg-canvas` token
- ✅ Fredoka display / Manrope body via `next/font`
- ✅ `.lbl` eyebrow with green dash prefix
- ✅ Buttons full-pill (`rounded-full`)
- ✅ Borders rgba whites (`border-white/[0.06]`)
- ✅ No box-shadows on cards
- ✅ `prefers-reduced-motion` respected
- ✅ Green focus rings everywhere

## Risks identified and mitigated

- Button `uppercase` on `default` variant only affects short CTA labels — icon-only buttons use `size="icon"` and are unaffected
- No structural JSX changes; only CSS token values and component base classes modified — no layout regression risk
- `next/font` with `display: swap` prevents invisible-text flash during font load

## Test plan

- [ ] CI green
- [ ] Admin dashboard: `#04040a` page base, sidebar gradient
- [ ] Active sidebar link: pink rail + pink-tinted bg
- [ ] Hover: green tint + green text
- [ ] Primary buttons: full-pill pink gradient
- [ ] Cards: dark surface, no shadow, subtle border
- [ ] Focus rings: green
- [ ] Mobile sidebar: glassmorphism header, off-canvas drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)