### PR TITLE
fix(qa): dedup constantTimeEqual in optimiser cron-shared

### DIFF
--- a/docs/QA-ISSUES.md
+++ b/docs/QA-ISSUES.md
@@ -112,7 +112,7 @@ components, and webhooks. Typecheck ✓ Lint ✓. Tests require Docker (not run)
 
 | # | File | Issue | Suggested fix |
 |---|------|-------|---------------|
-| S-4 | `app/company/social/connections/page.tsx` | `connect=sync-failed` banner shows generic "The connection couldn't be completed." — `sync.error.code` (e.g. "INTERNAL_ERROR") isn't in `REASON_LABEL` | ✅ Fixed — PR #TODO (site-builder-qa-sweep) |
+| S-4 | `app/company/social/connections/page.tsx` | `connect=sync-failed` banner shows generic "The connection couldn't be completed." — `sync.error.code` (e.g. "INTERNAL_ERROR") isn't in `REASON_LABEL` | ✅ Fixed — PR #546 |
 | S-5 | `lib/platform/social/cap/image-trigger.ts:108` | `bytes: 0` hardcoded in `social_media_assets` insert — file size not tracked for CAP images | Expose bytes from `generateWithFallback` or read from Supabase Storage stat after upload |
 | S-6 | `components/SocialPostDetailClient.tsx`, `components/PostScheduleSection.tsx` | `window.confirm()` / `window.prompt()` used for destructive actions (delete, submit, cancel-approval, reject, request-changes, schedule-cancel) — native browser dialogs, poor mobile UX | Replace with shadcn/ui `AlertDialog` + a `CommentDialog` (text-input variant); candidate for a dedicated polish slice |
 
@@ -124,7 +124,7 @@ Full audit of auth, admin API routes, cron routes, chat route, `lib/batch-publis
 `lib/brief-runner.ts`, `lib/rate-limit.ts`, `lib/encryption.ts`, migration history,
 and component-level code paths. Typecheck ✓ Lint ✓.
 
-### Fixed in PR #TODO (fix/site-builder-qa-sweep)
+### Fixed in PR #546 (fix/site-builder-qa-sweep)
 
 | # | File | Issue | Fix |
 |---|------|-------|-----|

--- a/lib/optimiser/sync/cron-shared.ts
+++ b/lib/optimiser/sync/cron-shared.ts
@@ -1,24 +1,13 @@
 import "server-only";
 import { NextResponse, type NextRequest } from "next/server";
-import { timingSafeEqual } from "node:crypto";
 
+import { constantTimeEqual } from "@/lib/crypto-compare";
 import { logger } from "@/lib/logger";
 
 // Shared cron-handler helpers for the optimiser sync routes. Mirrors
 // the existing /api/cron/process-batch authorisation pattern; lives
 // inside lib/optimiser so the route file at /api/cron/optimiser-sync-*
 // is a thin wrapper.
-
-function constantTimeEqual(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a, "utf8");
-  const bBuf = Buffer.from(b, "utf8");
-  if (aBuf.length !== bBuf.length) {
-    const filler = Buffer.alloc(aBuf.length);
-    timingSafeEqual(aBuf, filler);
-    return false;
-  }
-  return timingSafeEqual(aBuf, bBuf);
-}
 
 export function authorisedCronRequest(req: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;


### PR DESCRIPTION
## Summary

Follow-up to #546 — found one more inline `constantTimeEqual` copy in `lib/optimiser/sync/cron-shared.ts` that was missed in the first sweep (it's in the optimiser module subdirectory, not `app/api/cron/`). Same fix: remove the local implementation, import from `@/lib/crypto-compare`.

Also updates `docs/QA-ISSUES.md` to replace the `#TODO` PR placeholder in the site-builder sweep section with the actual PR #546.

## Changes

- `lib/optimiser/sync/cron-shared.ts`: remove local `constantTimeEqual` + `timingSafeEqual` import, use `@/lib/crypto-compare`
- `docs/QA-ISSUES.md`: PR reference fix

## Test plan

- [x] `npm run lint` — 0 warnings
- [x] All 13 optimiser cron routes use `authorisedCronRequest` from this file — all get the fix transitively

🤖 Generated with [Claude Code](https://claude.com/claude-code)