### PR TITLE
feat(nav): add Social link to AdminSidebar + Sharing card to company dashboard

### DIFF
--- a/app/company/page.tsx
+++ b/app/company/page.tsx
@@ -139,6 +139,18 @@ export default async function CompanyLandingPage() {
             Images and videos attached to posts.
           </div>
         </Link>
+        {isAdmin ? (
+          <Link
+            href="/company/social/sharing"
+            className="block rounded-md border bg-card p-4 hover:border-primary/40"
+            data-testid="dashboard-link-sharing"
+          >
+            <div className="font-medium">Calendar sharing</div>
+            <div className="mt-1 text-base text-muted-foreground">
+              Mint read-only links to share the calendar with clients.
+            </div>
+          </Link>
+        ) : null}
         <Link
           href="/company/users"
           className="block rounded-md border bg-card p-4 hover:border-primary/40"

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -17,6 +17,7 @@ import {
   Menu,
   PenSquare,
   Settings,
+  Share2,
   ShieldCheck,
   Users,
   Workflow,
@@ -112,6 +113,12 @@ export function AdminSidebar({
       href: "/admin/images",
       icon: ImageIcon,
       testId: "nav-images",
+    },
+    {
+      label: "Social",
+      href: "/company/social/posts",
+      icon: Share2,
+      testId: "nav-social",
     },
     ...(isAdminTier
       ? [


### PR DESCRIPTION
## Summary

Audit of all social platform feature reachability revealed one critical gap and one minor gap.

**Critical gap fixed:** `AdminSidebar` had zero links to the social platform (`/company/social/*`). The only way to reach it was to type the URL directly. Added a **Social** nav item (Share2 icon) pointing to `/company/social/posts` — this unlocks all six social tabs via the sticky `SocialNavClient` tab bar.

**Minor gap fixed:** The `/company` dashboard listed Posts, Calendar, Connections, and Media but omitted the **Calendar sharing** page (`/company/social/sharing`). Added a sharing card (admin-only, same guard as the page itself).

## Full reachability map

| Feature | Route | Was linked? | After this PR |
|---|---|---|---|
| Social posts list | `/company/social/posts` | ❌ unreachable from admin | ✓ AdminSidebar → Social |
| Create new post | inline on posts list (`canCreate` gate) | ❌ unreachable | ✓ via posts list |
| Generate with AI (CAP) | `CAPGenerateModal` on posts list | ❌ unreachable | ✓ via posts list |
| Social account connections | `/company/social/connections` | ❌ unreachable from admin | ✓ via SocialNavClient |
| Post approval workflow | on post detail + `/approve/[token]` magic link | ❌ unreachable from admin | ✓ via posts list → detail |
| Scheduled posts | `/company/social/posts?state=scheduled` + Calendar | ❌ unreachable | ✓ via posts list / Calendar tab |
| Published post history | `/company/social/posts?state=published` + post detail | ❌ unreachable | ✓ via posts list |
| Social media image library | `/company/social/media` | ❌ unreachable from admin | ✓ via SocialNavClient |
| Calendar sharing | `/company/social/sharing` | in tab nav, not dashboard | ✓ + added to dashboard (admin only) |
| **Platform analytics** | **no page exists** | **not built** | **no UI yet — not in scope** |

## Risks identified and mitigated

- Navigation-only change. No data writes, no auth changes. The social section has its own session gate (`getCurrentPlatformSession`) regardless of how the user gets there.
- `isAdmin` guard on the Sharing dashboard card matches the `canDo("manage_invitations")` gate already on the page itself.