### PR TITLE
fix(platform): Opollo staff can access social platform

### DIFF
--- a/app/admin/companies/[id]/page.tsx
+++ b/app/admin/companies/[id]/page.tsx
@@ -1,7 +1,9 @@
 import { notFound } from "next/navigation";
 
 import { PlatformCompanyDetail } from "@/components/PlatformCompanyDetail";
+import { getCurrentPlatformSession } from "@/lib/platform/auth";
 import { getPlatformCompany } from "@/lib/platform/companies";
+import { joinCompanyAsAdmin } from "../_actions";
 
 // P3-3 — Opollo admin company detail. Server-rendered. Loads company +
 // members + pending invitations via a single lib helper that fans out
@@ -15,7 +17,11 @@ export default async function CompanyDetailPage({
 }: {
   params: { id: string };
 }) {
-  const result = await getPlatformCompany(params.id);
+  const [result, session] = await Promise.all([
+    getPlatformCompany(params.id),
+    getCurrentPlatformSession(),
+  ]);
+
   if (!result.ok) {
     if (result.error.code === "NOT_FOUND") notFound();
     return (
@@ -27,5 +33,21 @@ export default async function CompanyDetailPage({
       </div>
     );
   }
-  return <PlatformCompanyDetail detail={result.data} />;
+
+  const isCurrentUserMember =
+    !!session &&
+    result.data.members.some((m) => m.user_id === session.userId);
+
+  const boundJoinAction = session?.isOpolloStaff
+    ? joinCompanyAsAdmin.bind(null, params.id)
+    : null;
+
+  return (
+    <PlatformCompanyDetail
+      detail={result.data}
+      isOpolloStaff={session?.isOpolloStaff ?? false}
+      isCurrentUserMember={isCurrentUserMember}
+      joinAction={boundJoinAction}
+    />
+  );
 }

--- a/app/admin/companies/_actions.ts
+++ b/app/admin/companies/_actions.ts
@@ -1,0 +1,44 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { logger } from "@/lib/logger";
+import { getCurrentPlatformSession } from "@/lib/platform/auth";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// Opollo-staff-only: add the current operator to a company as admin.
+// Removes any existing company membership first (V1: one company per user).
+// Redirects to /company on success so the operator can immediately start
+// using the social platform in the context of the chosen company.
+export async function joinCompanyAsAdmin(companyId: string): Promise<void> {
+  const session = await getCurrentPlatformSession();
+  if (!session?.isOpolloStaff) {
+    throw new Error("Unauthorized: Opollo staff only");
+  }
+
+  const svc = getServiceRoleClient();
+
+  // Remove any existing membership (V1 unique constraint: one company per user).
+  await svc
+    .from("platform_company_users")
+    .delete()
+    .eq("user_id", session.userId);
+
+  const { error } = await svc.from("platform_company_users").insert({
+    company_id: companyId,
+    user_id: session.userId,
+    role: "admin",
+    added_by: session.userId,
+  });
+
+  if (error) {
+    logger.error("platform.admin.join_company.failed", {
+      err: error.message,
+      company_id: companyId,
+      user_id: session.userId,
+    });
+    throw new Error(`Failed to join company: ${error.message}`);
+  }
+
+  redirect("/company");
+}

--- a/app/company/page.tsx
+++ b/app/company/page.tsx
@@ -28,6 +28,26 @@ export default async function CompanyLandingPage() {
   }
 
   if (!session.company) {
+    if (session.isOpolloStaff) {
+      return (
+        <main className="mx-auto max-w-3xl p-6 text-sm">
+          <div className="rounded-md border border-amber-300 bg-amber-50 p-4">
+            <p className="font-medium">No company selected.</p>
+            <p className="mt-1 text-muted-foreground">
+              You&apos;re logged in as Opollo staff. To view a company&apos;s
+              social media, open the company in the admin panel and click
+              &ldquo;Join as admin&rdquo;.
+            </p>
+            <Link
+              href="/admin/companies"
+              className="mt-3 inline-flex items-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Go to Companies →
+            </Link>
+          </div>
+        </main>
+      );
+    }
     return (
       <main className="mx-auto max-w-3xl p-6 text-sm">
         <div className="rounded-md border border-amber-300 bg-amber-50 p-4">

--- a/components/PlatformCompanyDetail.tsx
+++ b/components/PlatformCompanyDetail.tsx
@@ -9,7 +9,17 @@ import type { CompanyDetail } from "@/lib/platform/companies";
 // of members with their role, and any pending invitations. Action
 // buttons (invite, revoke) land in P3-4.
 
-export function PlatformCompanyDetail({ detail }: { detail: CompanyDetail }) {
+export function PlatformCompanyDetail({
+  detail,
+  isOpolloStaff = false,
+  isCurrentUserMember = false,
+  joinAction = null,
+}: {
+  detail: CompanyDetail;
+  isOpolloStaff?: boolean;
+  isCurrentUserMember?: boolean;
+  joinAction?: ((formData: FormData) => Promise<void>) | null;
+}) {
   const { company, members, pending_invitations } = detail;
 
   return (
@@ -41,6 +51,44 @@ export function PlatformCompanyDetail({ detail }: { detail: CompanyDetail }) {
           )}
         </Lead>
       </header>
+
+      {isOpolloStaff && (
+        <section
+          className="rounded-lg border border-primary/30 bg-primary/5 px-4 py-3"
+          aria-label="Staff access"
+          data-testid="staff-join-section"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium">Opollo staff access</p>
+              <p className="text-sm text-muted-foreground">
+                {isCurrentUserMember
+                  ? "You are a member of this company. Go to the social platform to manage posts."
+                  : "Join this company as admin to manage their social media posts."}
+              </p>
+            </div>
+            {isCurrentUserMember ? (
+              <Link
+                href="/company"
+                className="inline-flex items-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                data-testid="staff-go-to-platform-link"
+              >
+                Go to platform →
+              </Link>
+            ) : joinAction ? (
+              <form action={joinAction}>
+                <button
+                  type="submit"
+                  className="inline-flex items-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                  data-testid="staff-join-button"
+                >
+                  Join as admin
+                </button>
+              </form>
+            ) : null}
+          </div>
+        </section>
+      )}
 
       <section
         className="rounded-lg border bg-card"

--- a/lib/platform/auth/current-user.ts
+++ b/lib/platform/auth/current-user.ts
@@ -41,7 +41,29 @@ export async function getCurrentPlatformSession(
     .eq("id", userId)
     .maybeSingle();
 
-  if (profileResult.error || !profileResult.data) return null;
+  if (profileResult.error) return null;
+
+  // Auto-provision: design intent (types.ts) is that Opollo operators have BOTH
+  // an opollo_users row AND a platform_users row with is_opollo_staff=true.
+  // When the platform_users row is missing (e.g. operator never manually seeded),
+  // check opollo_users and create the missing row rather than redirecting to /login.
+  if (!profileResult.data) {
+    const opolloResult = await svc
+      .from("opollo_users")
+      .select("id")
+      .eq("id", userId)
+      .maybeSingle();
+
+    if (opolloResult.error || !opolloResult.data) return null;
+
+    // UPSERT is safe against concurrent first-access requests.
+    await svc
+      .from("platform_users")
+      .upsert({ id: userId, email, is_opollo_staff: true }, { onConflict: "id" });
+
+    // No company membership by default — staff must join a company from /admin/companies.
+    return { userId, email, isOpolloStaff: true, company: null };
+  }
 
   const membershipResult = await svc
     .from("platform_company_users")


### PR DESCRIPTION
## Problem

Clicking **Social** in the admin sidebar redirected to `/login` in a loop.

**Root cause:** `getCurrentPlatformSession()` returns `null` when no `platform_users` row exists for the authenticated user. Opollo operators (who have `opollo_users` rows) were never seeded into `platform_users`, so every visit to `/company/*` triggered the redirect loop.

## Changes

### `lib/platform/auth/current-user.ts`
Auto-provision a `platform_users` row for Opollo operators on first platform access. When no `platform_users` row is found, the function now checks `opollo_users` — if the user is an Opollo operator, an UPSERT creates the missing `platform_users` row with `is_opollo_staff=true`. This matches the documented design intent ("Opollo staff have BOTH an opollo_users row AND a platform_users row").

### `app/company/page.tsx`
When `isOpolloStaff && !company`, show a staff-specific message with a link to `/admin/companies` instead of the generic "ask an admin to invite you" text.

### `app/admin/companies/[id]/page.tsx` + `components/PlatformCompanyDetail.tsx`
Added **Opollo staff access** card to the company detail page. Staff can click **Join as admin** to self-assign to that company and redirect to `/company` to start using the social platform.

### `app/admin/companies/_actions.ts`
Server action `joinCompanyAsAdmin` — verifies caller is Opollo staff, removes any existing company membership (V1: one user per company), inserts new membership with role=admin, redirects to `/company`.

## Flow after this fix

1. Steven clicks **Social** in AdminSidebar → `/company/social/posts`
2. Layout calls `getCurrentPlatformSession()` → auto-provisions `platform_users` row → returns `{ isOpolloStaff: true, company: null }`
3. Layout sees `!company` → redirects to `/company`
4. `/company` shows "You're Opollo staff, join a company from the admin panel" + **Go to Companies** button
5. Steven opens a company at `/admin/companies/[id]` → sees **Join as admin** button
6. Clicks it → joins company as admin → redirected to `/company` with full dashboard access
7. From `/company`, all social platform links work normally

## Risks identified and mitigated

- **Concurrent first-access UPSERT race**: mitigated via `upsert(..., { onConflict: "id" })` — idempotent
- **V1 one-company-per-user constraint**: `joinCompanyAsAdmin` DELETEs existing membership before INSERT — safe, intentional switch
- **Unauthorised use of join action**: verified via `isOpolloStaff` session check before any write; non-staff callers get an exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)