### PR TITLE
fix(qa): replace window.confirm/prompt with ConfirmDialog, add social E2E, fix E2E timeout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
   e2e:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       # Force the admin gate ON so E2E exercises the real Supabase
       # Auth flow (matches the webServer config in playwright.config).

--- a/components/PendingInvitesTable.tsx
+++ b/components/PendingInvitesTable.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { formatRelativeTime } from "@/lib/utils";
 
 // AUTH-FOUNDATION P3.3 — pending-invites table on /admin/users.
@@ -24,9 +25,9 @@ export function PendingInvitesTable({
 }) {
   const router = useRouter();
   const [revoking, setRevoking] = useState<string | null>(null);
+  const [pendingRevoke, setPendingRevoke] = useState<{ id: string; email: string } | null>(null);
 
   async function revoke(id: string, email: string) {
-    if (!window.confirm(`Revoke pending invite for ${email}?`)) return;
     setRevoking(id);
     try {
       const res = await fetch(
@@ -53,6 +54,16 @@ export function PendingInvitesTable({
   }
 
   return (
+    <>
+      <ConfirmDialog
+        open={pendingRevoke !== null}
+        onOpenChange={(o) => !o && setPendingRevoke(null)}
+        title="Revoke this invite?"
+        description={pendingRevoke ? `Remove the pending invite for ${pendingRevoke.email}. They will not be able to use the invite link.` : undefined}
+        confirmLabel="Revoke invite"
+        confirmVariant="destructive"
+        onConfirm={() => pendingRevoke && void revoke(pendingRevoke.id, pendingRevoke.email)}
+      />
     <div className="rounded-md border">
       <table className="w-full text-sm">
         <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
@@ -104,7 +115,7 @@ export function PendingInvitesTable({
                 <td className="px-2 py-2 text-right">
                   <button
                     type="button"
-                    onClick={() => void revoke(inv.id, inv.email)}
+                    onClick={() => setPendingRevoke({ id: inv.id, email: inv.email })}
                     disabled={revoking === inv.id}
                     className="rounded border px-2 py-0.5 text-sm text-destructive transition-smooth hover:bg-destructive/10 disabled:opacity-60"
                     data-testid="invite-revoke-button"
@@ -118,5 +129,6 @@ export function PendingInvitesTable({
         </tbody>
       </table>
     </div>
+    </>
   );
 }

--- a/components/RegenerateButton.tsx
+++ b/components/RegenerateButton.tsx
@@ -4,11 +4,12 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 // ---------------------------------------------------------------------------
 // M7-4 — Re-generate button.
 //
-// Click → window.confirm → POST /regenerate → 202 with job_id.
+// Click → ConfirmDialog → POST /regenerate → 202 with job_id.
 // When there's an in-flight job (pending or running), the button
 // disables and a sibling polling effect drives router.refresh every
 // 2s so the detail page's server-rendered history panel picks up the
@@ -31,6 +32,7 @@ export function RegenerateButton({
   inFlightJobStatus: "pending" | "running" | null;
 }) {
   const router = useRouter();
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -47,12 +49,7 @@ export function RegenerateButton({
     return () => window.clearInterval(interval);
   }, [inFlight, router]);
 
-  async function handleClick() {
-    if (submitting || inFlight) return;
-    const confirmed = window.confirm(
-      "Re-generate this page? Anthropic will be called (costs tokens) and WordPress will be updated with the new HTML on success. This can't be cancelled mid-flight once the API call is in progress.",
-    );
-    if (!confirmed) return;
+  async function handleConfirmed() {
     setSubmitting(true);
     setError(null);
     try {
@@ -80,10 +77,19 @@ export function RegenerateButton({
 
   return (
     <div className="flex flex-col items-end gap-1">
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        title="Re-generate this page?"
+        description="Anthropic will be called (costs tokens) and WordPress will be updated with the new HTML on success. This can't be cancelled mid-flight once the API call is in progress."
+        confirmLabel="Re-generate"
+        confirmVariant="destructive"
+        onConfirm={() => void handleConfirmed()}
+      />
       <Button
         variant="outline"
         size="sm"
-        onClick={handleClick}
+        onClick={() => { if (!submitting && !inFlight) setConfirmOpen(true); }}
         disabled={submitting || inFlight}
         data-testid="regenerate-button"
       >

--- a/components/RichTextEditor.tsx
+++ b/components/RichTextEditor.tsx
@@ -5,7 +5,7 @@ import StarterKit from "@tiptap/starter-kit";
 import Link from "@tiptap/extension-link";
 import Placeholder from "@tiptap/extension-placeholder";
 import CharacterCount from "@tiptap/extension-character-count";
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Bold,
   Italic,
@@ -19,6 +19,15 @@ import {
   Undo,
   Redo,
 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -53,6 +62,9 @@ export function RichTextEditor({
   disabled = false,
   className,
 }: RichTextEditorProps) {
+  const [linkDialogOpen, setLinkDialogOpen] = useState(false);
+  const linkInputRef = useRef<HTMLInputElement>(null);
+
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -173,9 +185,7 @@ export function RichTextEditor({
             if (editor?.isActive("link")) {
               editor.chain().focus().unsetLink().run();
             } else {
-              // eslint-disable-next-line no-alert
-              const url = window.prompt("Link URL");
-              if (url) editor?.chain().focus().setLink({ href: url }).run();
+              setLinkDialogOpen(true);
             }
           }}
           active={editor?.isActive("link")}
@@ -212,6 +222,43 @@ export function RichTextEditor({
 
       {/* Editor area */}
       <EditorContent editor={editor} />
+
+      {/* Link insert dialog */}
+      <Dialog open={linkDialogOpen} onOpenChange={setLinkDialogOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Insert link</DialogTitle>
+          </DialogHeader>
+          <Input
+            ref={linkInputRef}
+            type="url"
+            placeholder="https://example.com"
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                const url = linkInputRef.current?.value.trim() ?? "";
+                if (url) editor?.chain().focus().setLink({ href: url }).run();
+                setLinkDialogOpen(false);
+              }
+            }}
+          />
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setLinkDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                const url = linkInputRef.current?.value.trim() ?? "";
+                if (url) editor?.chain().focus().setLink({ href: url }).run();
+                setLinkDialogOpen(false);
+              }}
+            >
+              Insert
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/components/TrustedDevicesList.tsx
+++ b/components/TrustedDevicesList.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { formatRelativeTime } from "@/lib/utils";
 
 // AUTH-FOUNDATION P4.4 — Trusted-devices listing on /account/devices.
@@ -34,9 +35,10 @@ export function TrustedDevicesList({
   const router = useRouter();
   const [revokingId, setRevokingId] = useState<string | null>(null);
   const [revokingOthers, setRevokingOthers] = useState(false);
+  const [pendingOne, setPendingOne] = useState<{ id: string; label: string } | null>(null);
+  const [pendingOthers, setPendingOthers] = useState(false);
 
   async function revokeOne(id: string, label: string) {
-    if (!window.confirm(`Sign out ${label}? It will need email approval again on its next sign-in.`)) return;
     setRevokingId(id);
     try {
       const res = await fetch(
@@ -58,7 +60,6 @@ export function TrustedDevicesList({
   }
 
   async function revokeOthers() {
-    if (!window.confirm("Sign out every device other than this one?")) return;
     setRevokingOthers(true);
     try {
       const res = await fetch("/api/account/devices/sign-out-others", {
@@ -88,12 +89,30 @@ export function TrustedDevicesList({
 
   return (
     <div className="space-y-4">
+      <ConfirmDialog
+        open={pendingOne !== null}
+        onOpenChange={(o) => !o && setPendingOne(null)}
+        title="Sign out this device?"
+        description={pendingOne ? `${pendingOne.label} will need email approval again on its next sign-in.` : undefined}
+        confirmLabel="Sign out"
+        confirmVariant="destructive"
+        onConfirm={() => pendingOne && void revokeOne(pendingOne.id, pendingOne.label)}
+      />
+      <ConfirmDialog
+        open={pendingOthers}
+        onOpenChange={(o) => !o && setPendingOthers(false)}
+        title="Sign out all other devices?"
+        description="Every device except this one will need email approval on its next sign-in."
+        confirmLabel="Sign out others"
+        confirmVariant="destructive"
+        onConfirm={() => void revokeOthers()}
+      />
       {showRevokeOthers && (
         <div className="flex justify-end">
           <Button
             type="button"
             variant="outline"
-            onClick={() => void revokeOthers()}
+            onClick={() => setPendingOthers(true)}
             disabled={revokingOthers}
             data-testid="revoke-other-devices"
           >
@@ -145,7 +164,7 @@ export function TrustedDevicesList({
                   <td className="px-2 py-2 text-right">
                     <button
                       type="button"
-                      onClick={() => void revokeOne(d.id, label)}
+                      onClick={() => setPendingOne({ id: d.id, label })}
                       disabled={revokingId === d.id}
                       className="rounded border px-2 py-0.5 text-sm text-destructive transition-smooth hover:bg-destructive/10 disabled:opacity-60"
                       data-testid="revoke-device"

--- a/e2e/social.spec.ts
+++ b/e2e/social.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+
+import { auditA11y, signInAsCompanyAdmin } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Social platform E2E — /company/social/*
+//
+// Scope:
+//   1. Posts list loads with table + new-post button visible
+//   2. New post button opens the compose form
+//   3. Connections page loads with connections container
+//   4. Analytics page loads with chart or empty-state
+//   5. Media library page loads with library container
+//   6. auditA11y on each visited page
+//
+// Out of scope:
+//   OAuth connection flow (needs external bundle.social callback).
+//   Post publish flow (needs a real WP backend).
+//   Full compose → save round-trip (covered by unit layer).
+// ---------------------------------------------------------------------------
+
+test.describe("social platform", () => {
+  test.beforeEach(async ({ page }) => {
+    await signInAsCompanyAdmin(page);
+  });
+
+  test("posts list loads and shows key UI", async ({ page }, testInfo) => {
+    await page.goto("/company/social/posts");
+    await expect(page).toHaveURL(/\/company\/social\/posts/);
+
+    // Table container is rendered (may be empty but must be present).
+    await expect(
+      page.getByTestId("social-posts-table"),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // New-post button present for company-admin role.
+    await expect(page.getByTestId("new-post-button")).toBeVisible();
+
+    await auditA11y(page, testInfo);
+  });
+
+  test("new post button opens compose form", async ({ page }, testInfo) => {
+    await page.goto("/company/social/posts");
+    await page.getByTestId("new-post-button").click();
+
+    // Compose form should become visible.
+    await expect(
+      page.getByTestId("new-post-form"),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await auditA11y(page, testInfo);
+  });
+
+  test("connections page loads", async ({ page }, testInfo) => {
+    await page.goto("/company/social/connections");
+    await expect(page).toHaveURL(/\/company\/social\/connections/);
+
+    // Either the connections wrapper or an error banner must render.
+    const wrapper = page.getByTestId("connections-list-wrapper");
+    const errBanner = page.getByTestId("connections-error");
+    await expect(wrapper.or(errBanner)).toBeVisible({ timeout: 15_000 });
+
+    // Heading must be present regardless of data state.
+    await expect(page.getByRole("heading", { name: /social connections/i })).toBeVisible();
+
+    await auditA11y(page, testInfo);
+  });
+
+  test("analytics page loads", async ({ page }, testInfo) => {
+    await page.goto("/company/social/analytics");
+    await expect(page).toHaveURL(/\/company\/social\/analytics/);
+
+    // The analytics client, an empty state, or an error must render.
+    // We look for any element with a role=main or the known test ids.
+    const analyticsEmpty = page.getByTestId("analytics-empty");
+    const analyticsError = page.getByTestId("analytics-error");
+    const mainContent = page.locator("main");
+    await expect(
+      analyticsEmpty.or(analyticsError).or(mainContent),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await auditA11y(page, testInfo);
+  });
+
+  test("media library page loads", async ({ page }, testInfo) => {
+    await page.goto("/company/social/media");
+    await expect(page).toHaveURL(/\/company\/social\/media/);
+
+    // Media library container must render.
+    await expect(page.getByTestId("media-library")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Heading must be present.
+    await expect(page.getByRole("heading", { name: /media library/i })).toBeVisible();
+
+    await auditA11y(page, testInfo);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
       : "npm run dev",
     url: BASE_URL,
     reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
+    timeout: 240_000,
     env: {
       // Opt-in: Playwright runs with FEATURE_SUPABASE_AUTH=true so the
       // admin-layout gate is on and the sign-in flow is exercised.


### PR DESCRIPTION
## Summary

- **4 admin components** — `window.confirm` / `window.prompt` replaced with shadcn `ConfirmDialog` (3 components) and a `Dialog + Input` (RichTextEditor link URL). Consistent with the rest of the admin surface. Affected: `PendingInvitesTable`, `RegenerateButton`, `TrustedDevicesList`, `RichTextEditor`.
- **`e2e/social.spec.ts`** — New Playwright spec covering the social platform happy paths: posts list visible + new-post button opens compose form, connections page renders, analytics page renders, media library renders. `auditA11y` called on every visited page per CLAUDE.md.
- **E2E timeout fix** — `playwright.config.ts` `webServer.timeout` 120 s → 240 s. Root cause: `npm run build && npm run start` in CI takes ~1m47s for build alone, which exceeded the old 120 s limit before the server could start. Job `timeout-minutes` in `e2e.yml` bumped from 20 → 30 to match.

## Test plan

- [ ] Typecheck: `npm run typecheck` — passes
- [ ] Lint: `npm run lint` — no warnings or errors
- [ ] Social E2E: `npm run test:e2e -- e2e/social.spec.ts` (requires `supabase start`)
- [ ] CI: all checks green

## Risks identified and mitigated

- No write-path changes — all fixes are UI-layer (dialog state) and test infra.
- `ConfirmDialog` is an existing component; no new dependencies.
- E2E timeout increase is additive; no regression risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)