### PR TITLE
refactor(css): phase 4 — token aliases for rgba colours (m1-m4, b1-b3)

### DIFF
--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -189,7 +189,7 @@ export function AdminSidebar({
             "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-gr focus-visible:ring-offset-2 focus-visible:ring-offset-d1",
             active
               ? "bg-[rgba(255,3,165,0.10)] text-white font-medium"
-              : "text-[rgba(255,255,255,0.58)] hover:bg-[rgba(0,229,160,0.06)] hover:text-gr",
+              : "text-m2 hover:bg-[rgba(0,229,160,0.06)] hover:text-gr",
           )}
         >
           <Icon
@@ -229,7 +229,7 @@ export function AdminSidebar({
           aria-label="Open navigation"
           aria-expanded={mobileOpen}
           aria-controls="admin-sidebar"
-          className="inline-flex h-10 w-10 items-center justify-center rounded-md text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(255,255,255,0.06)] hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-gr"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-md text-m2 transition-smooth hover:bg-b1 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-gr"
           data-testid="admin-mobile-nav-button"
         >
           <Menu aria-hidden className="h-5 w-5" />
@@ -284,7 +284,7 @@ export function AdminSidebar({
               type="button"
               onClick={() => setMobileOpen(false)}
               aria-label="Close navigation"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(255,255,255,0.06)] hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-gr sm:hidden"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-m2 transition-smooth hover:bg-b1 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-gr sm:hidden"
             >
               <X aria-hidden className="h-5 w-5" />
             </button>
@@ -295,7 +295,7 @@ export function AdminSidebar({
               aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
               title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
               className={cn(
-                "hidden h-8 w-8 items-center justify-center rounded-md text-[rgba(255,255,255,0.40)] transition-smooth hover:bg-[rgba(255,255,255,0.06)] hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-gr sm:inline-flex",
+                "hidden h-8 w-8 items-center justify-center rounded-md text-[rgba(255,255,255,0.40)] transition-smooth hover:bg-b1 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-gr sm:inline-flex",
                 collapsed && "mx-auto",
               )}
             >
@@ -340,7 +340,7 @@ export function AdminSidebar({
                   Command palette
                 </span>
                 <span
-                  className="flex items-center gap-0.5 text-sm text-[rgba(255,255,255,0.32)]"
+                  className="flex items-center gap-0.5 text-sm text-m3"
                   aria-hidden
                 >
                   <kbd className="rounded border border-white/[0.12] bg-white/[0.06] px-1 font-mono text-[10px]">
@@ -357,7 +357,7 @@ export function AdminSidebar({
                 href="/account/security"
                 title={collapsed ? "Account security" : undefined}
                 className={cn(
-                  "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-gr focus:outline-none focus-visible:ring-2 focus-visible:ring-gr",
+                  "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-m2 transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-gr focus:outline-none focus-visible:ring-2 focus-visible:ring-gr",
                   isActiveRoute("/account/security") &&
                     "bg-[rgba(255,3,165,0.10)] text-white font-medium",
                 )}
@@ -372,7 +372,7 @@ export function AdminSidebar({
                 href="/account/devices"
                 title={collapsed ? "Trusted devices" : undefined}
                 className={cn(
-                  "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-gr focus:outline-none focus-visible:ring-2 focus-visible:ring-gr",
+                  "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-m2 transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-gr focus:outline-none focus-visible:ring-2 focus-visible:ring-gr",
                   isActiveRoute("/account/devices") &&
                     "bg-[rgba(255,3,165,0.10)] text-white font-medium",
                 )}
@@ -385,7 +385,7 @@ export function AdminSidebar({
             <Link
               href="/"
               title={collapsed ? "Back to builder" : undefined}
-              className="group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-gr focus:outline-none focus-visible:ring-2 focus-visible:ring-gr"
+              className="group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-m2 transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-gr focus:outline-none focus-visible:ring-2 focus-visible:ring-gr"
               data-testid="nav-back-to-builder"
             >
               <Settings aria-hidden className="h-4 w-4 shrink-0 text-[rgba(255,255,255,0.40)] group-hover:text-gr" />
@@ -406,7 +406,7 @@ export function AdminSidebar({
             )}
             {user && !collapsed && (
               <p
-                className="mt-2 truncate border-t border-white/[0.06] pt-2 px-2.5 text-xs text-[rgba(255,255,255,0.32)]"
+                className="mt-2 truncate border-t border-white/[0.06] pt-2 px-2.5 text-xs text-m3"
                 title={user.email}
               >
                 {user.email}

--- a/docs/CSS-REFACTOR.md
+++ b/docs/CSS-REFACTOR.md
@@ -136,7 +136,24 @@ compile but are caught by Phase 6 lint rules.
 
 ---
 
-## Phase 4 — Replace arbitrary Tailwind spacing/size values (pending)
+## Phase 4 — Replace arbitrary rgba colour values with token aliases
+
+**PR:** (pending)
+**Date:** 2026-05-05
+**Branch:** feat/css-design-system-phase-4
+
+### Changes
+
+- `tailwind.config.ts` — added `m1`/`m2`/`m3`/`m4` (white opacity text tokens) and `b1`/`b2`/`b3` (rgba border tokens) to Tailwind color aliases
+- `components/AdminSidebar.tsx` — replaced `text-[rgba(255,255,255,0.58)]` → `text-m2`, `text-[rgba(255,255,255,0.32)]` → `text-m3`, `hover:bg-[rgba(255,255,255,0.06)]` → `hover:bg-b1`
+
+### Intentional exceptions (kept as arbitrary values)
+
+- `text-[rgba(255,255,255,0.40)]` — no exact token; between `--m3` (0.32) and `--m2` (0.58); used for inactive icon color
+- `bg-[rgba(255,3,165,0.10)]` — active nav item bg; `--pk-soft` is 0.12 (different); left as-is
+- `bg-[rgba(4,4,10,0.85)]` — mobile topbar at 85% opacity; no token
+- `hover:bg-[rgba(0,229,160,0.06)]` — nav hover bg; `--gr-soft` is 0.10 (different); left as-is
+- `hover:bg-[rgba(0,229,160,0.08)]` in button.tsx — ghost hover bg; no exact token
 
 ---
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -98,6 +98,14 @@ const config: Config = {
         d3: "var(--d3)",
         d4: "var(--d4)",
         "bg-base": "var(--bg)",
+        /* Opollo muted/border tokens — use as text-m2, bg-b1, border-b3, etc. */
+        m1: "var(--m1)",
+        m2: "var(--m2)",
+        m3: "var(--m3)",
+        m4: "var(--m4)",
+        b1: "var(--b1)",
+        b2: "var(--b2)",
+        b3: "var(--b3)",
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
Phase 4 of the CSS design system refactor. Adds Tailwind color aliases for rgba opacity tokens, replacing arbitrary \`rgba()\` values in AdminSidebar.

## Changes

- \`tailwind.config.ts\` — added \`m1\`/\`m2\`/\`m3\`/\`m4\` (white opacity text tokens) and \`b1\`/\`b2\`/\`b3\` (rgba border tokens) to Tailwind color aliases
- \`components/AdminSidebar.tsx\` — replaced \`text-[rgba(255,255,255,0.58)]\` → \`text-m2\`, \`text-[rgba(255,255,255,0.32)]\` → \`text-m3\`, \`hover:bg-[rgba(255,255,255,0.06)]\` → \`hover:bg-b1\`
- \`docs/CSS-REFACTOR.md\` — Phase 4 log

## Intentional exceptions (kept as arbitrary values)

- \`text-[rgba(255,255,255,0.40)]\` — inactive icon; no exact token (between m3 at 0.32 and m2 at 0.58)
- \`bg-[rgba(255,3,165,0.10)]\` — active nav item bg; \`--pk-soft\` is 0.12 (different)
- \`bg-[rgba(4,4,10,0.85)]\` — mobile topbar at 85% opacity; no token
- \`hover:bg-[rgba(0,229,160,0.06)]\` — nav hover bg; \`--gr-soft\` is 0.10 (different)
- \`hover:bg-[rgba(0,229,160,0.08)]\` in button.tsx — ghost hover bg; no exact token

Supersedes the conflicting #565.