### PR TITLE
fix(css): phase 5+6 — typography lint update + 4 missed font violations

### DIFF
--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -189,7 +189,7 @@ export function AdminSidebar({
             "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-gr focus-visible:ring-offset-2 focus-visible:ring-offset-d1",
             active
               ? "bg-[rgba(255,3,165,0.10)] text-white font-medium"
-              : "text-[rgba(255,255,255,0.58)] hover:bg-[rgba(0,229,160,0.06)] hover:text-gr",
+              : "text-m2 hover:bg-[rgba(0,229,160,0.06)] hover:text-gr",
           )}
         >
           <Icon
@@ -229,7 +229,7 @@ export function AdminSidebar({
           aria-label="Open navigation"
           aria-expanded={mobileOpen}
           aria-controls="admin-sidebar"
-          className="inline-flex h-10 w-10 items-center justify-center rounded-md text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(255,255,255,0.06)] hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-gr"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-md text-m2 transition-smooth hover:bg-b1 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-gr"
           data-testid="admin-mobile-nav-button"
         >
           <Menu aria-hidden className="h-5 w-5" />
@@ -284,7 +284,7 @@ export function AdminSidebar({
               type="button"
               onClick={() => setMobileOpen(false)}
               aria-label="Close navigation"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(255,255,255,0.06)] hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-gr sm:hidden"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-m2 transition-smooth hover:bg-b1 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-gr sm:hidden"
             >
               <X aria-hidden className="h-5 w-5" />
             </button>
@@ -295,7 +295,7 @@ export function AdminSidebar({
               aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
               title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
               className={cn(
-                "hidden h-8 w-8 items-center justify-center rounded-md text-[rgba(255,255,255,0.40)] transition-smooth hover:bg-[rgba(255,255,255,0.06)] hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-gr sm:inline-flex",
+                "hidden h-8 w-8 items-center justify-center rounded-md text-[rgba(255,255,255,0.40)] transition-smooth hover:bg-b1 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-gr sm:inline-flex",
                 collapsed && "mx-auto",
               )}
             >
@@ -340,7 +340,7 @@ export function AdminSidebar({
                   Command palette
                 </span>
                 <span
-                  className="flex items-center gap-0.5 text-sm text-[rgba(255,255,255,0.32)]"
+                  className="flex items-center gap-0.5 text-sm text-m3"
                   aria-hidden
                 >
                   <kbd className="rounded border border-white/[0.12] bg-white/[0.06] px-1 font-mono text-[10px]">
@@ -357,7 +357,7 @@ export function AdminSidebar({
                 href="/account/security"
                 title={collapsed ? "Account security" : undefined}
                 className={cn(
-                  "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-gr focus:outline-none focus-visible:ring-2 focus-visible:ring-gr",
+                  "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-m2 transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-gr focus:outline-none focus-visible:ring-2 focus-visible:ring-gr",
                   isActiveRoute("/account/security") &&
                     "bg-[rgba(255,3,165,0.10)] text-white font-medium",
                 )}
@@ -372,7 +372,7 @@ export function AdminSidebar({
                 href="/account/devices"
                 title={collapsed ? "Trusted devices" : undefined}
                 className={cn(
-                  "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-gr focus:outline-none focus-visible:ring-2 focus-visible:ring-gr",
+                  "group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-m2 transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-gr focus:outline-none focus-visible:ring-2 focus-visible:ring-gr",
                   isActiveRoute("/account/devices") &&
                     "bg-[rgba(255,3,165,0.10)] text-white font-medium",
                 )}
@@ -385,7 +385,7 @@ export function AdminSidebar({
             <Link
               href="/"
               title={collapsed ? "Back to builder" : undefined}
-              className="group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-[rgba(255,255,255,0.58)] transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-gr focus:outline-none focus-visible:ring-2 focus-visible:ring-gr"
+              className="group flex h-9 items-center gap-3 rounded-md px-2.5 text-sm text-m2 transition-smooth hover:bg-[rgba(0,229,160,0.06)] hover:text-gr focus:outline-none focus-visible:ring-2 focus-visible:ring-gr"
               data-testid="nav-back-to-builder"
             >
               <Settings aria-hidden className="h-4 w-4 shrink-0 text-[rgba(255,255,255,0.40)] group-hover:text-gr" />
@@ -406,7 +406,7 @@ export function AdminSidebar({
             )}
             {user && !collapsed && (
               <p
-                className="mt-2 truncate border-t border-white/[0.06] pt-2 px-2.5 text-xs text-[rgba(255,255,255,0.32)]"
+                className="mt-2 truncate border-t border-white/[0.06] pt-2 px-2.5 text-xs text-m3"
                 title={user.email}
               >
                 {user.email}

--- a/components/ConceptReviewCards.tsx
+++ b/components/ConceptReviewCards.tsx
@@ -257,11 +257,11 @@ function ConceptCard({
 function MicroUiPreview({ micro }: { micro: ConceptResult["micro_ui"] }) {
   return (
     <div className="mt-3 rounded-md border bg-muted/10 p-2">
-      <p className="mb-1 text-[10px] font-medium text-muted-foreground">
+      <p className="mb-1 text-xs font-medium text-muted-foreground">
         Micro UI
       </p>
       <div
-        className="grid gap-1.5 text-[10px] text-foreground [&_*]:!max-w-full [&_*]:!box-border"
+        className="grid gap-1.5 text-xs text-foreground [&_*]:!max-w-full [&_*]:!box-border"
         data-testid="concept-micro-ui"
       >
         <div
@@ -299,7 +299,7 @@ function BeforeAfterPanel({
       </p>
       <div className="mt-3 grid gap-4 md:grid-cols-2">
         <div>
-          <p className="text-[10px] font-medium text-muted-foreground">
+          <p className="text-xs font-medium text-muted-foreground">
             Your reference
           </p>
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -312,7 +312,7 @@ function BeforeAfterPanel({
           />
         </div>
         <div>
-          <p className="text-[10px] font-medium text-muted-foreground">
+          <p className="text-xs font-medium text-muted-foreground">
             Our interpretation
           </p>
           <div

--- a/docs/CSS-REFACTOR.md
+++ b/docs/CSS-REFACTOR.md
@@ -157,8 +157,39 @@ compile but are caught by Phase 6 lint rules.
 
 ---
 
-## Phase 5 — Inline styles audit and cleanup (pending)
+## Phase 5 — Inline styles audit
+
+**Result:** No-op — all 22 inline styles are justified.
+
+Categories found:
+- **Dynamic color/font previews** — `style={{ background: color }}`, `style={{ fontFamily: ... }}` in concept review, design extraction, and brand-editor components. Values come from design tokens or user input; cannot be Tailwind classes.
+- **Dynamic dimensions** — `style={{ width: pct + "%" }}`, `style={{ maxHeight: ... }}` in progress bars and scroll containers. Computed at runtime.
+- **SVG dimensions** — `style={{ width, height }}` in ScoreSparkline. Passed as props.
+- **Email HTML templates** — `lib/email/templates/`. Email clients require inline styles; CSS classes don't work in email.
+
+No changes made. All inline styles are intentional.
 
 ---
 
-## Phase 6 — Lint enforcement (pending)
+## Phase 6 — Lint enforcement
+
+**PR:** (pending)
+**Date:** 2026-05-05
+**Branch:** feat/css-design-system-phase-5
+
+### Changes
+
+- `scripts/audit.ts` (`check5_typography`):
+  - Removed stale `text-xs` check (text-xs is now 15px — not a violation)
+  - Added `arbitraryFontRe` to flag `text-[9px]` through `text-[14px]` as LOW severity
+  - Updated inline `fsPxRe` threshold from 14px to 15px
+  - Updated messages to reference the 15px floor and CSS-REFACTOR.md
+- `components/ConceptReviewCards.tsx` — fixed 4 missed violations (lines 260, 264, 302, 315 — "Micro UI", "Your reference", "Our interpretation" labels)
+
+### Remaining LOW-severity intentional exceptions in audit output
+
+These will appear in `npm run audit:static` but are LOW (non-blocking) and all documented above in Phase 2:
+- Keyboard symbols `<kbd>` (⌘K, ↵, esc)
+- Color swatch badges (`text-[9px]` in ConceptReviewCards, `text-[10px]` in MoodBoardStrip etc.)
+- Notification count badge
+- `components/ui/button.tsx text-[13px]` (design spec)

--- a/docs/CSS-REFACTOR.md
+++ b/docs/CSS-REFACTOR.md
@@ -136,7 +136,24 @@ compile but are caught by Phase 6 lint rules.
 
 ---
 
-## Phase 4 — Replace arbitrary Tailwind spacing/size values (pending)
+## Phase 4 — Replace arbitrary rgba colour values with token aliases
+
+**PR:** (pending)
+**Date:** 2026-05-05
+**Branch:** feat/css-design-system-phase-4
+
+### Changes
+
+- `tailwind.config.ts` — added `m1`/`m2`/`m3`/`m4` (white opacity text tokens) and `b1`/`b2`/`b3` (rgba border tokens) to Tailwind color aliases
+- `components/AdminSidebar.tsx` — replaced `text-[rgba(255,255,255,0.58)]` → `text-m2`, `text-[rgba(255,255,255,0.32)]` → `text-m3`, `hover:bg-[rgba(255,255,255,0.06)]` → `hover:bg-b1`
+
+### Intentional exceptions (kept as arbitrary values)
+
+- `text-[rgba(255,255,255,0.40)]` — no exact token; between `--m3` (0.32) and `--m2` (0.58); used for inactive icon color
+- `bg-[rgba(255,3,165,0.10)]` — active nav item bg; `--pk-soft` is 0.12 (different); left as-is
+- `bg-[rgba(4,4,10,0.85)]` — mobile topbar at 85% opacity; no token
+- `hover:bg-[rgba(0,229,160,0.06)]` — nav hover bg; `--gr-soft` is 0.10 (different); left as-is
+- `hover:bg-[rgba(0,229,160,0.08)]` in button.tsx — ghost hover bg; no exact token
 
 ---
 

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -574,11 +574,19 @@ function check5_typography(): Issue[] {
   const issues: Issue[] = [];
   const roots = ["app", "components", "lib"];
 
-  // text-xs occurrences.
-  const textXsRe = /\btext-xs\b/;
-  // Inline fontSize below 14px.
+  // Arbitrary Tailwind font sizes below 15px — text-[10px] through text-[14px].
+  // text-xs and text-sm are VALID (both compile to 15px via tailwind.config.ts).
+  // Known intentional exceptions at <15px:
+  //   - .lbl eyebrow labels (10px per design spec) — uses CSS class, not Tailwind
+  //   - .btn-pk / .btn-ghost (13px per design spec) — uses CSS class, not Tailwind
+  //   - keyboard shortcut symbols (<kbd>) — decorative chrome
+  //   - color swatch labels in design-wizard — decorative
+  //   - notification count badge (layout-constrained 16px circle)
+  //   - components/ui/button.tsx text-[13px] — design spec button text
+  const arbitraryFontRe = /\btext-\[([0-9]|1[0-4])px\]/;
+  // Inline fontSize below 15px.
   const fsPxRe =
-    /fontSize\s*:\s*["']?(0\.[0-7]\d*rem|[1-9]px|1[0-3]px|0\.[0-7]\d*em)["']?/;
+    /fontSize\s*:\s*["']?(0\.[0-7]\d*rem|[1-9]px|1[0-4]px|0\.[0-7]\d*em)["']?/;
 
   for (const root of roots) {
     const dir = join(REPO_ROOT, root);
@@ -590,13 +598,14 @@ function check5_typography(): Issue[] {
       const state = { inBlock: false };
       lines.forEach((ln, i) => {
         const stripped = stripComments(ln, state, isCss);
-        if (textXsRe.test(stripped)) {
+        if (arbitraryFontRe.test(stripped)) {
           issues.push({
             category: "typography-minimums",
             severity: "LOW",
             file: rel,
             line: i + 1,
-            message: "text-xs (12px) is below the 0.875rem / 14px floor — uplift to text-sm (RULES.md #7)",
+            message:
+              "Arbitrary sub-15px font size — use text-xs (15px) instead, or document as intentional exception in CSS-REFACTOR.md",
           });
         }
         if (fsPxRe.test(stripped)) {
@@ -605,7 +614,7 @@ function check5_typography(): Issue[] {
             severity: "LOW",
             file: rel,
             line: i + 1,
-            message: "Inline fontSize is below the 14px floor (RULES.md #7)",
+            message: "Inline fontSize is below the 15px floor (RULES.md #7)",
           });
         }
       });

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -98,6 +98,14 @@ const config: Config = {
         d3: "var(--d3)",
         d4: "var(--d4)",
         "bg-base": "var(--bg)",
+        /* Opollo muted/border tokens — use as text-m2, bg-b1, border-b3, etc. */
+        m1: "var(--m1)",
+        m2: "var(--m2)",
+        m3: "var(--m3)",
+        m4: "var(--m4)",
+        b1: "var(--b1)",
+        b2: "var(--b2)",
+        b3: "var(--b3)",
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
Phases 5 and 6 of the CSS design system refactor.

## Phase 5 — Inline styles audit

No-op. All 22 inline styles are justified (dynamic color/font previews, runtime dimensions, SVG props, email templates). See docs/CSS-REFACTOR.md for the full audit.

## Phase 6 — Lint enforcement

- \`scripts/audit.ts\` (\`check5_typography\`):
  - Removed stale \`text-xs\` check (text-xs is now 15px — not a violation)
  - Added \`arbitraryFontRe\` to flag \`text-[9px]\` through \`text-[14px]\` as LOW severity
  - Updated inline \`fsPxRe\` threshold from 14px to 15px
  - Updated messages to reference the 15px floor and CSS-REFACTOR.md
- \`components/ConceptReviewCards.tsx\` — fixed 4 missed violations (lines 260, 264, 302, 315 — "Micro UI", "Your reference", "Our interpretation" labels)

## Remaining LOW-severity intentional exceptions in audit output

These appear in \`npm run audit:static\` as LOW (non-blocking), all documented in CSS-REFACTOR.md Phase 2:
- Keyboard symbols \`<kbd>\` (⌘K, ↵, esc)
- Color swatch badges (\`text-[9px]\` in ConceptReviewCards, \`text-[10px]\` in MoodBoardStrip etc.)
- Notification count badge
- \`components/ui/button.tsx text-[13px]\` (design spec)