### PR TITLE
fix(ci): bump ci.yml test job to Node 22 for native WebSocket support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: actions/cache@v5
         id: cache-node-modules
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: actions/cache@v5
         id: cache-node-modules
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: actions/cache@v5
         id: cache-node-modules
@@ -150,7 +150,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: actions/cache@v5
         id: cache-node-modules
@@ -177,7 +177,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: actions/cache@v5
         id: cache-node-modules


### PR DESCRIPTION
## Summary

- `@supabase/realtime-js` requires native WebSocket, GA in Node 22. Node 20 throws at `createClient()` time, failing all Supabase-backed Vitest tests with "Node.js 20 detected without native WebSocket support."
- PR #572 already bumped `e2e.yml` and `screenshots.yml` to Node 22. This brings `ci.yml` (which runs the `test` job) into parity.
- Companion to PR #574 which fixed the test-data and schema bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)