### PR TITLE
feat(images): exif backfill cron for image_library captions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: actions/cache@v5
         id: cache-node-modules
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: actions/cache@v5
         id: cache-node-modules
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: actions/cache@v5
         id: cache-node-modules
@@ -150,7 +150,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: actions/cache@v5
         id: cache-node-modules
@@ -177,7 +177,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - uses: actions/cache@v5
         id: cache-node-modules

--- a/app/api/cron/backfill-image-captions/route.ts
+++ b/app/api/cron/backfill-image-captions/route.ts
@@ -1,0 +1,213 @@
+import "server-only";
+
+import { type NextRequest, NextResponse } from "next/server";
+
+import { constantTimeEqual } from "@/lib/crypto-compare";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import exifr from "exifr";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+function authorised(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || secret.length < 16) return false;
+  const header = req.headers.get("authorization") ?? "";
+  if (!header.toLowerCase().startsWith("bearer ")) return false;
+  return constantTimeEqual(header.slice(7).trim(), secret);
+}
+
+// ---------------------------------------------------------------------------
+// Cloudflare Images blob endpoint — returns original uploaded file
+// with IPTC/EXIF/XMP intact (delivery CDN strips metadata).
+// ---------------------------------------------------------------------------
+
+const BATCH_SIZE = 50;
+const MAX_BYTES = 20 * 1024 * 1024;
+
+function blobUrl(accountId: string, cloudflareId: string): string {
+  return `https://api.cloudflare.com/client/v4/accounts/${accountId}/images/v1/${encodeURIComponent(cloudflareId)}/blob`;
+}
+
+async function fetchOriginalBytes(
+  accountId: string,
+  apiToken: string,
+  cloudflareId: string,
+): Promise<Uint8Array | null> {
+  try {
+    const res = await fetch(blobUrl(accountId, cloudflareId), {
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        Range: `bytes=0-${MAX_BYTES - 1}`,
+      },
+    });
+    if (!res.ok && res.status !== 206) {
+      logger.warn("backfill.blob_fetch_failed", { cloudflare_id: cloudflareId, status: res.status });
+      return null;
+    }
+    return new Uint8Array(await res.arrayBuffer());
+  } catch (err) {
+    logger.warn("backfill.blob_fetch_error", {
+      cloudflare_id: cloudflareId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// EXIF extraction
+// ---------------------------------------------------------------------------
+
+type ExifResult = {
+  caption: string | null;
+  altText: string | null;
+  tags: string[];
+};
+
+async function extractExif(bytes: Uint8Array): Promise<ExifResult> {
+  try {
+    const meta = await exifr.parse(Buffer.from(bytes), { iptc: true, exif: true, xmp: true });
+    if (!meta) return { caption: null, altText: null, tags: [] };
+
+    const rawCaption =
+      (meta["Caption-Abstract"] as string | undefined) ??
+      (meta.description as string | undefined) ??
+      (meta.Headline as string | undefined) ??
+      null;
+
+    const rawAlt =
+      (meta.Headline as string | undefined) ??
+      (meta.ObjectName as string | undefined) ??
+      (meta.Title as string | undefined) ??
+      null;
+
+    const rawTags: unknown = (meta.Keywords as unknown) ?? (meta.Subject as unknown) ?? [];
+    const tagsArr = Array.isArray(rawTags) ? rawTags : rawTags ? [rawTags] : [];
+    const tags = tagsArr
+      .map((t: unknown) => String(t).trim().toLowerCase())
+      .filter(Boolean)
+      .slice(0, 12);
+
+    const caption = rawCaption ? String(rawCaption).trim().slice(0, 150) || null : null;
+    const altText = rawAlt ? String(rawAlt).trim().slice(0, 100) || null : null;
+
+    return { caption, altText, tags };
+  } catch {
+    return { caption: null, altText: null, tags: [] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export async function GET(req: NextRequest) {
+  if (!authorised(req)) {
+    return NextResponse.json({ error: "Unauthorised" }, { status: 401 });
+  }
+
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_IMAGES_API_TOKEN;
+  if (!accountId || !apiToken) {
+    logger.error("backfill.missing_cf_credentials", {});
+    return NextResponse.json({ error: "Missing Cloudflare credentials" }, { status: 500 });
+  }
+
+  const supabase = getServiceRoleClient();
+
+  // Fetch next batch of images that still need captions.
+  const { data: rows, error } = await supabase
+    .from("image_library")
+    .select("id, cloudflare_id, filename, tags")
+    .is("deleted_at", null)
+    .or("caption.is.null,caption.eq.")
+    .order("created_at", { ascending: true })
+    .limit(BATCH_SIZE);
+
+  if (error) {
+    logger.error("backfill.db_query_failed", { error: error.message });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const total = rows?.length ?? 0;
+  let exifSaved = 0;
+  let noData = 0;
+  let fetchErrors = 0;
+
+  for (const row of rows ?? []) {
+    const cloudflareId = row.cloudflare_id as string | null;
+    if (!cloudflareId) {
+      noData++;
+      continue;
+    }
+
+    const bytes = await fetchOriginalBytes(accountId, apiToken, cloudflareId);
+    if (!bytes) {
+      fetchErrors++;
+      continue;
+    }
+
+    const exif = await extractExif(bytes);
+    if (!exif.caption && !exif.altText) {
+      logger.debug("backfill.no_exif", { image_id: row.id, filename: row.filename });
+      noData++;
+      continue;
+    }
+
+    const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    if (exif.caption) patch.caption = exif.caption;
+    if (exif.altText) patch.alt_text = exif.altText;
+    if (exif.tags.length > 0) {
+      const existing = Array.isArray(row.tags) ? (row.tags as string[]) : [];
+      patch.tags = Array.from(new Set([...existing, ...exif.tags]));
+    }
+
+    const { error: updateErr } = await supabase
+      .from("image_library")
+      .update(patch)
+      .eq("id", row.id)
+      .is("caption", null); // idempotency guard
+
+    if (updateErr) {
+      logger.error("backfill.update_failed", { image_id: row.id, error: updateErr.message });
+      fetchErrors++;
+    } else {
+      logger.info("backfill.exif_saved", {
+        image_id: row.id,
+        filename: row.filename,
+        caption: exif.caption?.slice(0, 60),
+      });
+      exifSaved++;
+    }
+  }
+
+  // Check how many still remain for the response payload.
+  const { count: remaining } = await supabase
+    .from("image_library")
+    .select("id", { count: "exact", head: true })
+    .is("deleted_at", null)
+    .or("caption.is.null,caption.eq.");
+
+  logger.info("backfill.tick_complete", {
+    processed: total,
+    exif_saved: exifSaved,
+    no_data: noData,
+    errors: fetchErrors,
+    remaining: remaining ?? "?",
+  });
+
+  return NextResponse.json({
+    processed: total,
+    exif_saved: exifSaved,
+    no_data: noData,
+    errors: fetchErrors,
+    remaining: remaining ?? null,
+    done: (remaining ?? 1) === 0,
+  });
+}

--- a/lib/__tests__/m16-wp-publisher.test.ts
+++ b/lib/__tests__/m16-wp-publisher.test.ts
@@ -236,10 +236,32 @@ async function seedM16SlotAndPages(prefix: string) {
     .single();
   if (pErr || !pageRow) throw new Error(`page insert: ${pErr?.message ?? "no row"}`);
 
+  // Design system + template (generation_jobs.template_id is NOT NULL)
+  const { data: dsRow, error: dsErr } = await svc
+    .from("design_systems")
+    .insert({ site_id: site.id, version: 1, tokens_css: "", base_styles: "" })
+    .select("id")
+    .single();
+  if (dsErr || !dsRow) throw new Error(`ds insert: ${dsErr?.message ?? "no row"}`);
+
+  const { data: tmplRow, error: tmplErr } = await svc
+    .from("design_templates")
+    .insert({
+      design_system_id: dsRow.id,
+      page_type: "homepage",
+      name: "homepage-default",
+      composition: [],
+      required_fields: {},
+      is_default: true,
+    })
+    .select("id")
+    .single();
+  if (tmplErr || !tmplRow) throw new Error(`template insert: ${tmplErr?.message ?? "no row"}`);
+
   // Batch job
   const { data: job, error: jErr } = await svc
     .from("generation_jobs")
-    .insert({ site_id: site.id, status: "running", requested_count: 1, succeeded_count: 0, failed_count: 0 })
+    .insert({ site_id: site.id, template_id: tmplRow.id, status: "running", requested_count: 1, succeeded_count: 0, failed_count: 0 })
     .select("id")
     .single();
   if (jErr || !job) throw new Error(`job insert: ${jErr?.message ?? "no row"}`);

--- a/scripts/backfill-image-captions.ts
+++ b/scripts/backfill-image-captions.ts
@@ -1,29 +1,27 @@
 /**
  * Backfill captions for image_library rows that have no caption.
  *
- * EXIF-first strategy: reads IPTC/EXIF/XMP metadata before calling Claude.
- * iStock images typically have Caption-Abstract + Headline populated, so
- * most can be captioned for free. Only images with no EXIF caption fall back
- * to Claude Haiku vision.
+ * EXIF-only strategy — no Claude/Anthropic API calls.
  *
- * COST ESTIMATE (claude-haiku-4-5-20251001):
- *   - Only images WITHOUT usable EXIF caption need Claude calls
- *   - Run --dry-run first to see the EXIF vs Claude split and actual cost
- *   - Full Claude fallback: ~$0.62 for 1,777 images (worst case)
+ * WHY blob endpoint, not delivery URL:
+ *   Cloudflare Images strips IPTC/EXIF/XMP on delivery for optimisation.
+ *   The management API /blob endpoint returns the original uploaded file
+ *   with metadata intact. iStock images have rich Caption-Abstract,
+ *   Headline, and Keywords fields in IPTC, so almost all can be captioned
+ *   for free.
  *
- * Rate limiting: BETWEEN_IMAGES_DELAY_MS applies only after Claude calls.
- *   EXIF-only images have no inter-image delay (no API call involved).
- * Retry: up to 3 attempts with exponential backoff (15 s, 30 s, 60 s) on 429.
+ * Required env vars (add to .env.local):
+ *   SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY
+ *   CLOUDFLARE_ACCOUNT_ID
+ *   CLOUDFLARE_IMAGES_API_TOKEN
+ *
  * Resume-safe: only processes rows where caption IS NULL or empty.
  *
  * Usage:
- *   npx tsx scripts/backfill-image-captions.ts              # EXIF-first, Claude fallback
- *   npx tsx scripts/backfill-image-captions.ts --dry-run    # download+EXIF, no writes, cost estimate
- *   npx tsx scripts/backfill-image-captions.ts --exif-only  # EXIF only, skip Claude entirely
- *   BETWEEN_IMAGES_DELAY=5000 npx tsx scripts/backfill-image-captions.ts
+ *   set -a && source .env.local && set +a
+ *   npx tsx scripts/backfill-image-captions.ts
  */
 
-import Anthropic from "@anthropic-ai/sdk";
 import { createClient } from "@supabase/supabase-js";
 import exifr from "exifr";
 
@@ -31,18 +29,8 @@ import exifr from "exifr";
 // Config
 // ---------------------------------------------------------------------------
 
-const BATCH_SIZE = parseInt(process.env.BATCH_SIZE ?? "", 10) || 10;
-// Delay between batches (group of BATCH_SIZE images).
-const BATCH_DELAY_MS = parseInt(process.env.BATCH_DELAY ?? "", 10) || 15_000;
-// Delay between individual Claude API calls to stay ≤ 4.6 req/min (under 5/min org limit).
-// Only applied after Claude calls — EXIF-only images have no delay.
-// Set BETWEEN_IMAGES_DELAY=0 if the org rate limit has been raised.
-const BETWEEN_IMAGES_DELAY_MS = parseInt(process.env.BETWEEN_IMAGES_DELAY ?? "", 10) || 13_000;
-const MAX_RETRIES = 3;
-const MAX_IMAGE_BYTES = 4 * 1024 * 1024; // 4 MB — well under Anthropic's limit
-
-const DRY_RUN = process.argv.includes("--dry-run");
-const EXIF_ONLY = process.argv.includes("--exif-only");
+const BATCH_SIZE = parseInt(process.env.BATCH_SIZE ?? "", 10) || 20;
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024; // 20 MB — blob endpoint gives original
 
 // ---------------------------------------------------------------------------
 // Clients
@@ -50,49 +38,49 @@ const EXIF_ONLY = process.argv.includes("--exif-only");
 
 const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-const anthropicKey = process.env.ANTHROPIC_API_KEY;
+const cfAccountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+const cfApiToken = process.env.CLOUDFLARE_IMAGES_API_TOKEN;
 
 if (!supabaseUrl || !supabaseKey) {
   console.error("Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY");
   process.exit(1);
 }
-if (!anthropicKey && !EXIF_ONLY) {
-  console.error("Missing ANTHROPIC_API_KEY (required unless running --exif-only)");
+if (!cfAccountId || !cfApiToken) {
+  console.error(
+    "Missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_IMAGES_API_TOKEN\n" +
+      "These are needed to fetch original image files (with EXIF intact) from Cloudflare.\n" +
+      "Add them to .env.local — they are the same credentials used for uploads.",
+  );
   process.exit(1);
 }
 
 const svc = createClient(supabaseUrl, supabaseKey, { auth: { persistSession: false } });
-const anthropic = anthropicKey ? new Anthropic({ apiKey: anthropicKey }) : null;
 
-const cloudflareHash = process.env.CLOUDFLARE_IMAGES_HASH;
-if (!cloudflareHash) {
-  console.error("Missing CLOUDFLARE_IMAGES_HASH");
-  process.exit(1);
-}
-
-function deliveryUrl(cloudflareId: string): string {
-  return `https://imagedelivery.net/${cloudflareHash}/${cloudflareId}/public`;
+// Cloudflare Images management API blob endpoint — returns the original
+// uploaded file with all IPTC/EXIF/XMP metadata intact.
+function blobUrl(cloudflareId: string): string {
+  const encoded = encodeURIComponent(cloudflareId);
+  return `https://api.cloudflare.com/client/v4/accounts/${cfAccountId}/images/v1/${encoded}/blob`;
 }
 
 // ---------------------------------------------------------------------------
-// Image fetch
+// Image fetch (via management API to preserve EXIF)
 // ---------------------------------------------------------------------------
 
-async function fetchImageBytes(
-  url: string,
-): Promise<{ bytes: Uint8Array; contentType: string } | null> {
+async function fetchOriginalBytes(cloudflareId: string): Promise<Uint8Array | null> {
+  const url = blobUrl(cloudflareId);
   try {
     const res = await fetch(url, {
-      headers: { Range: `bytes=0-${MAX_IMAGE_BYTES - 1}` },
+      headers: {
+        Authorization: `Bearer ${cfApiToken}`,
+        Range: `bytes=0-${MAX_IMAGE_BYTES - 1}`,
+      },
     });
-    if (!res.ok && res.status !== 206 && res.status !== 200) {
-      console.warn(`  fetch ${res.status}: ${url}`);
+    if (!res.ok && res.status !== 206) {
+      console.warn(`  CF blob ${res.status} for ${cloudflareId}`);
       return null;
     }
-    const buf = await res.arrayBuffer();
-    const bytes = new Uint8Array(buf);
-    const contentType = res.headers.get("content-type") ?? "image/jpeg";
-    return { bytes, contentType: contentType.split(";")[0].trim() };
+    return new Uint8Array(await res.arrayBuffer());
   } catch (err) {
     console.warn(`  fetch error: ${err instanceof Error ? err.message : String(err)}`);
     return null;
@@ -149,123 +137,11 @@ async function extractExifMetadata(bytes: Uint8Array): Promise<ExifResult> {
 }
 
 // ---------------------------------------------------------------------------
-// Claude captioning (fallback)
-// ---------------------------------------------------------------------------
-
-function isRateLimitError(err: unknown): boolean {
-  if (err instanceof Error) {
-    const msg = err.message;
-    if (msg.includes("rate_limit_error") || msg.includes("429")) return true;
-  }
-  if (typeof err === "object" && err !== null && "status" in err) {
-    return (err as { status: number }).status === 429;
-  }
-  return false;
-}
-
-async function generateCaptionWithClaude(
-  bytes: Uint8Array,
-  mimeType: string,
-): Promise<ExifResult> {
-  if (!anthropic) throw new Error("Anthropic client not initialised");
-
-  const validTypes = ["image/jpeg", "image/png", "image/webp", "image/gif"];
-  const mediaType = validTypes.includes(mimeType)
-    ? (mimeType as "image/jpeg" | "image/png" | "image/webp" | "image/gif")
-    : "image/jpeg";
-
-  const base64 = Buffer.from(bytes).toString("base64");
-  const RETRY_WAITS_MS = [15_000, 30_000, 60_000];
-
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    try {
-      const msg = await anthropic.messages.create({
-        model: "claude-haiku-4-5-20251001",
-        max_tokens: 300,
-        messages: [
-          {
-            role: "user",
-            content: [
-              {
-                type: "image",
-                source: { type: "base64", media_type: mediaType, data: base64 },
-              },
-              {
-                type: "text",
-                text: [
-                  "Describe this image concisely for use in a business/marketing context.",
-                  "Reply in exactly this format (one item per line):",
-                  "CAPTION: <one sentence description, max 150 chars>",
-                  "ALT: <short accessibility alt text, max 100 chars>",
-                  "TAGS: <comma-separated keywords, max 5 tags>",
-                ].join("\n"),
-              },
-            ],
-          },
-        ],
-      });
-
-      const text = msg.content[0]?.type === "text" ? msg.content[0].text : "";
-      const captionMatch = /^CAPTION:\s*(.+)/m.exec(text);
-      const altMatch = /^ALT:\s*(.+)/m.exec(text);
-      const tagsMatch = /^TAGS:\s*(.+)/m.exec(text);
-
-      const caption = captionMatch?.[1]?.trim().slice(0, 150) ?? null;
-      const altText = altMatch?.[1]?.trim().slice(0, 100) ?? null;
-      const tags = tagsMatch?.[1]
-        ? tagsMatch[1]
-            .split(",")
-            .map((t) => t.trim().toLowerCase())
-            .filter(Boolean)
-            .slice(0, 5)
-        : [];
-
-      return { caption, altText, tags };
-    } catch (err) {
-      if (isRateLimitError(err) && attempt < MAX_RETRIES) {
-        const waitMs = RETRY_WAITS_MS[attempt] ?? 60_000;
-        console.warn(
-          `  → rate limited, waiting ${waitMs / 1000}s (retry ${attempt + 1}/${MAX_RETRIES})...`,
-        );
-        await new Promise((r) => setTimeout(r, waitMs));
-        continue;
-      }
-      throw err;
-    }
-  }
-
-  throw new Error("generateCaptionWithClaude: max retries exceeded");
-}
-
-// ---------------------------------------------------------------------------
-// Progress display
-// ---------------------------------------------------------------------------
-
-function printProgress(opts: {
-  processed: number;
-  total: number | string;
-  exifCount: number;
-  claudeCount: number;
-  skipped: number;
-  errors: number;
-}) {
-  const remaining =
-    typeof opts.total === "number" ? opts.total - opts.processed : "?";
-  console.log(
-    `  [Progress] EXIF: ${opts.exifCount} | Claude: ${opts.claudeCount} | Skipped: ${opts.skipped} | Errors: ${opts.errors} | Remaining: ${remaining}`,
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const mode = DRY_RUN ? "DRY RUN" : EXIF_ONLY ? "LIVE — EXIF only (no Claude)" : "LIVE — EXIF-first, Claude fallback";
-  console.log(`Backfill mode: ${mode}`);
-  console.log(
-    `Batch size: ${BATCH_SIZE} | Batch delay: ${BATCH_DELAY_MS}ms | Between Claude calls: ${BETWEEN_IMAGES_DELAY_MS}ms\n`,
-  );
+  console.log("Backfill mode: LIVE — EXIF only via Cloudflare blob endpoint (no Claude API calls)\n");
 
   const { count } = await svc
     .from("image_library")
@@ -277,17 +153,15 @@ async function main() {
   console.log(`Images needing captions: ${total}\n`);
 
   let processed = 0;
-  let updated = 0;
-  let skipped = 0;
-  let errors = 0;
   let exifCount = 0;
-  let claudeCount = 0;
+  let noData = 0;
+  let errors = 0;
   let offset = 0;
 
   while (true) {
     const { data: rows, error } = await svc
       .from("image_library")
-      .select("id, cloudflare_id, filename, caption, alt_text, tags")
+      .select("id, cloudflare_id, filename, caption, tags")
       .is("deleted_at", null)
       .or("caption.is.null,caption.eq.")
       .order("created_at", { ascending: true })
@@ -301,154 +175,77 @@ async function main() {
 
     for (const row of rows) {
       processed++;
-      console.log(`[${processed}/${total}] ${row.id} (${row.filename ?? "no-filename"})`);
 
-      // Resume-safe: skip if caption already set.
+      // Resume-safe: skip if caption already set (handles race with offset drift).
       if (row.caption && (row.caption as string).trim().length > 0) {
-        console.log(`  → already has caption, skipping`);
-        skipped++;
+        noData++;
         continue;
       }
 
       const cloudflareId = row.cloudflare_id as string | null;
       if (!cloudflareId) {
-        console.log(`  → no cloudflare_id, skipping`);
-        skipped++;
+        console.log(`[${processed}/${total}] ${row.id} — no cloudflare_id, skipping`);
+        noData++;
         continue;
       }
 
-      const url = deliveryUrl(cloudflareId);
-
-      // ----- Dry-run path: download image, run EXIF, report — no writes -----
-      if (DRY_RUN) {
-        const fetchResult = await fetchImageBytes(url);
-        if (!fetchResult) {
-          console.log(`  → DRY RUN: fetch failed`);
-          errors++;
-          continue;
-        }
-
-        const exif = await extractExifMetadata(fetchResult.bytes);
-        const hasExif = Boolean(exif.caption && exif.altText);
-
-        if (hasExif) {
-          exifCount++;
-          console.log(`  → DRY RUN (EXIF): caption="${exif.caption}" alt="${exif.altText}" tags=[${exif.tags.join(", ")}]`);
-        } else if (EXIF_ONLY) {
-          skipped++;
-          console.log(`  → DRY RUN (EXIF-only): no EXIF data, would skip`);
-        } else {
-          claudeCount++;
-          console.log(`  → DRY RUN (Claude): no EXIF, would call Claude Haiku`);
-        }
-        continue;
-      }
-
-      // ----- Live path -----
-      const fetchResult = await fetchImageBytes(url);
-      if (!fetchResult) {
-        console.log(`  → fetch failed, skipping`);
+      const bytes = await fetchOriginalBytes(cloudflareId);
+      if (!bytes) {
         errors++;
         continue;
       }
 
-      if (fetchResult.bytes.length > MAX_IMAGE_BYTES) {
+      const exif = await extractExifMetadata(bytes);
+      const hasData = Boolean(exif.caption || exif.altText);
+
+      if (!hasData) {
         console.log(
-          `  → image too large (${Math.round(fetchResult.bytes.length / 1024 / 1024)}MB), skipping`,
+          `[${processed}/${total}] ${row.filename ?? row.id} — No EXIF data — skipping`,
         );
-        skipped++;
+        noData++;
         continue;
       }
 
-      // Step 1: try EXIF extraction.
-      const exif = await extractExifMetadata(fetchResult.bytes);
-      const hasExif = Boolean(exif.caption && exif.altText);
-
-      let result: ExifResult;
-      let source: "exif" | "claude";
-
-      if (hasExif) {
-        result = exif;
-        source = "exif";
-        exifCount++;
-        console.log(`  → EXIF: caption="${result.caption}" alt="${result.altText}" tags=[${result.tags.join(", ")}]`);
-      } else if (EXIF_ONLY) {
-        console.log(`  → no EXIF data, skipping (--exif-only)`);
-        skipped++;
-        continue;
-      } else {
-        // Step 2: fall back to Claude.
-        console.log(`  → no EXIF, calling Claude Haiku...`);
-        try {
-          result = await generateCaptionWithClaude(fetchResult.bytes, fetchResult.contentType);
-          source = "claude";
-          claudeCount++;
-          console.log(`  → Claude: caption="${result.caption}" alt="${result.altText}" tags=[${result.tags.join(", ")}]`);
-        } catch (err) {
-          console.error(
-            `  → Anthropic error: ${err instanceof Error ? err.message : String(err)}`,
-          );
-          errors++;
-          continue;
-        }
-      }
-
-      // Persist to DB.
-      const patch: Record<string, unknown> = {
-        updated_at: new Date().toISOString(),
-      };
-      if (result.caption) patch.caption = result.caption;
-      if (result.altText) patch.alt_text = result.altText;
-      if (result.tags.length > 0) {
+      const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+      if (exif.caption) patch.caption = exif.caption;
+      if (exif.altText) patch.alt_text = exif.altText;
+      if (exif.tags.length > 0) {
         const existing = Array.isArray(row.tags) ? (row.tags as string[]) : [];
-        patch.tags = Array.from(new Set([...existing, ...result.tags]));
+        patch.tags = Array.from(new Set([...existing, ...exif.tags]));
       }
 
       const { error: updateError } = await svc
         .from("image_library")
         .update(patch)
         .eq("id", row.id)
-        .is("caption", null); // Idempotency guard.
+        .is("caption", null); // idempotency guard
 
       if (updateError) {
-        console.error(`  → DB update error: ${updateError.message}`);
+        console.error(`[${processed}/${total}] ${row.id} — DB error: ${updateError.message}`);
         errors++;
       } else {
-        console.log(`  → updated ✓ [${source}]`);
-        updated++;
+        console.log(
+          `[${processed}/${total}] ${row.filename ?? row.id} — EXIF ✓  caption="${exif.caption?.slice(0, 60)}" alt="${exif.altText}"`,
+        );
+        exifCount++;
       }
 
-      // Rate-limit delay — only needed after Claude calls.
-      if (source === "claude" && BETWEEN_IMAGES_DELAY_MS > 0) {
-        await new Promise((r) => setTimeout(r, BETWEEN_IMAGES_DELAY_MS));
+      if (processed % 50 === 0) {
+        console.log(
+          `  --- Progress ${processed} of ${total} — EXIF: ${exifCount} | No data: ${noData} | Errors: ${errors}`,
+        );
       }
     }
-
-    // Show running totals after each batch.
-    printProgress({ processed, total, exifCount, claudeCount, skipped, errors });
 
     offset += BATCH_SIZE;
-
-    if (rows.length === BATCH_SIZE) {
-      await new Promise((r) => setTimeout(r, BATCH_DELAY_MS));
-    }
+    if (!rows || rows.length < BATCH_SIZE) break;
   }
 
   console.log(`\n--- Done ---`);
-  console.log(`Processed: ${processed} | Updated: ${updated} | Skipped: ${skipped} | Errors: ${errors}`);
-  console.log(`Sources: EXIF: ${exifCount} | Claude: ${claudeCount}`);
-
-  if (DRY_RUN) {
-    const estimatedCost = claudeCount * 0.00035; // ~$0.00035/image at Haiku pricing
-    console.log(`\nDry-run summary:`);
-    console.log(`  Would use EXIF:   ${exifCount} images (free)`);
-    console.log(`  Would use Claude: ${claudeCount} images (~$${estimatedCost.toFixed(3)} est.)`);
-    console.log(`  Would skip:       ${skipped} images (no cloudflare_id or already captioned)`);
-    if (EXIF_ONLY) {
-      console.log(`  (--exif-only: ${total - exifCount - skipped} images with no EXIF would be left uncaptioned)`);
-    }
-    console.log(`(Dry run — no changes written)`);
-  }
+  console.log(`Processed:  ${processed}`);
+  console.log(`EXIF saves: ${exifCount}`);
+  console.log(`No data:    ${noData}`);
+  console.log(`Errors:     ${errors}`);
 }
 
 main().catch((err) => {

--- a/vercel.json
+++ b/vercel.json
@@ -95,6 +95,10 @@
     {
       "path": "/api/cron/drift-detect",
       "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/backfill-image-captions",
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds `/api/cron/backfill-image-captions` — runs every 5 minutes on Vercel, processes 50 images per tick, becomes a no-op once all images have captions.

**Why a cron and not the existing script:** `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_IMAGES_API_TOKEN` are marked Sensitive in Vercel and are excluded from `vercel env pull`, so they're unavailable locally. The cron runs on Vercel where all secrets are injected at runtime.

**Why blob endpoint, not delivery URL:** Cloudflare Images strips IPTC/EXIF/XMP on delivery for optimisation. The management API `/blob` endpoint returns the original uploaded file with metadata intact. Confirmed by fetching `iStock-2228257817.jpg` via delivery URL (no metadata) vs. the blob endpoint (has `Caption-Abstract`, `Headline`, `Keywords`).

**Per tick:**
1. Fetch next 50 `image_library` rows where `caption IS NULL`
2. Download original via `GET /accounts/{id}/images/v1/{cf_id}/blob` with `Authorization: Bearer`
3. Parse with `exifr` (iptc + exif + xmp):
   - `caption` ← `Caption-Abstract` ?? `description` ?? `Headline`
   - `alt_text` ← `Headline` ?? `ObjectName` ?? `Title`
   - `tags` ← `Keywords` ?? `Subject`, max 12
4. Save if `caption OR alt_text` found; log + skip if neither
5. Return JSON: `{ processed, exif_saved, no_data, errors, remaining, done }`

**Resume-safe:** UPDATE guarded by `.is("caption", null)` — concurrent ticks or retries are idempotent.

**At current batch size:** 1,703 images ÷ 50/tick × 5 min/tick = ~2.8 hours to complete. Vercel's 299s function limit is not a concern (50 images at ~1s each = ~50s/tick).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — route compiles, appears in build output
- [ ] After merge + deploy: monitor Vercel function logs for `backfill.tick_complete` events
- [ ] After ~3 hours: verify `SELECT count(*) - count(caption) FROM image_library` drops to near-0

## Risks identified and mitigated

- **Cloudflare rate limits on blob endpoint:** 50 sequential fetches/tick is well within Cloudflare's API limits. No parallel fetching.
- **Idempotency:** `.is("caption", null)` guard means re-runs don't overwrite manually-set captions or race with other ticks.
- **Images with no EXIF:** Logged as `backfill.no_exif` at debug level, counted in `no_data`. Not an error — some images legitimately have no metadata.
- **Cron becomes permanent noise after backfill completes:** When `remaining == 0` the route exits after the empty DB query — trivial cost. Can be removed in a follow-up cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)