### PR TITLE
fix: restore admin gate on users/list + generateSlug empty-input guard

### DIFF
--- a/app/api/admin/users/list/route.ts
+++ b/app/api/admin/users/list/route.ts
@@ -35,7 +35,7 @@ export type AdminUserRow = {
 };
 
 export async function GET(): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["super_admin"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const svc = getServiceRoleClient();

--- a/lib/__tests__/admin-users-list.test.ts
+++ b/lib/__tests__/admin-users-list.test.ts
@@ -138,7 +138,7 @@ describe("GET /api/admin/users/list: payload", () => {
   });
 
   it("returns every opollo_users row for an admin, newest first", async () => {
-    const admin = await seedAuthUser({ role: "super_admin" });
+    const admin = await seedAuthUser({ role: "admin" });
     // Seed a second user; the two timestamps are usually close enough
     // that ordering by created_at desc is still deterministic because
     // the second insert's now() > the first's.
@@ -162,8 +162,8 @@ describe("GET /api/admin/users/list: payload", () => {
   });
 
   it("includes revoked_at on a revoked row", async () => {
-    const admin = await seedAuthUser({ role: "super_admin" });
-    const target = await seedAuthUser({ role: "super_admin" });
+    const admin = await seedAuthUser({ role: "admin" });
+    const target = await seedAuthUser({ role: "admin" });
 
     const svc = getServiceRoleClient();
     const { error: updateErr } = await svc

--- a/lib/__tests__/slug.test.ts
+++ b/lib/__tests__/slug.test.ts
@@ -14,6 +14,11 @@ describe("generateSlug", () => {
     expect(generateSlug("the a an")).toBe("a");
   });
 
+  it("returns empty string for empty input without throwing", () => {
+    expect(generateSlug("")).toBe("");
+    expect(generateSlug("   ")).toBe("");
+  });
+
   it("strips diacritics", () => {
     expect(generateSlug("Café du Monde")).toBe("cafe-monde");
   });

--- a/lib/slug.ts
+++ b/lib/slug.ts
@@ -46,7 +46,7 @@ export function generateSlug(raw: string): string {
   const meaningful = words.filter((w) => !SLUG_STOP_WORDS.has(w));
   if (meaningful.length > 0) {
     s = meaningful.join(" ");
-  } else {
+  } else if (words.length > 0) {
     s = words.reduce((shortest, w) => (w.length < shortest.length ? w : shortest));
   }
 


### PR DESCRIPTION
## Summary

Two regressions introduced by the spec-drift repair work (PRs #579–581), found during post-merge review.

### 1 — `admin/users/list` gate regression

`app/api/admin/users/list/route.ts` was accidentally narrowed from `["super_admin", "admin"]` to `["super_admin"]` only. PR #392 (PLATFORM-AUDIT PR3) explicitly set it to allow both roles — `admin` users (formerly operators) need to see the user list to do their job. The spec-drift repair carried the wrong role name in the seed, which masked that the gate had been tightned.

**Fix:** restore `roles: ["super_admin", "admin"]` and revert the test seeds from `super_admin` back to `admin` so the test exercises the correct role.

### 2 — `generateSlug("")` TypeError

The all-stop-words fallback was changed from `words.join(" ")` to `words.reduce(...)`. `Array.prototype.reduce` without an initial value throws `TypeError: Reduce of empty array with no initial value` when the array is empty — reachable via `generateSlug("")` or `generateSlug("   ")`. The old code returned `""` safely.

**Fix:** add `words.length > 0` guard before the reduce, leaving the empty case as an implicit `s = ""` (from the initial `s = raw.trim().toLowerCase()`). Added two test cases to pin the safe behaviour.

## Risks identified and mitigated

- **Write safety:** no schema changes, no DB writes, no external calls. Both fixes are pure app-layer.
- **Auth regression direction:** restoring `["super_admin", "admin"]` widens access back to what PR #392 intended — not a privilege escalation beyond the prior deliberate design.
- **generateSlug empty guard:** guards against a crash; the empty-string return is the only sane result. No callers currently pass empty strings, but the boundary should be safe.

## Test plan

- [ ] CI `test` job passes
- [ ] `generateSlug("")` and `generateSlug("   ")` return `""` (new test cases)
- [ ] `admin` role can reach `GET /api/admin/users/list` without 403 (existing test, re-seeded correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)