### PR TITLE
fix(e2e): use preflight-blocker testid + restore admin users/list gate + guard generateSlug

### DIFF
--- a/app/api/admin/users/list/route.ts
+++ b/app/api/admin/users/list/route.ts
@@ -35,7 +35,7 @@ export type AdminUserRow = {
 };
 
 export async function GET(): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["super_admin"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const svc = getServiceRoleClient();

--- a/e2e/posts.spec.ts
+++ b/e2e/posts.spec.ts
@@ -132,22 +132,16 @@ test.describe("M13-4 posts — admin surface", () => {
     const iframe = page.locator('iframe[sandbox=""]');
     await expect(iframe).toBeVisible();
 
-    // The E2E test site almost certainly doesn't have a real WP backend
-    // behind its wp_url (it's a fixture site from global-setup).
-    // preflight should surface some kind of blocker — either
-    // REST_UNREACHABLE or AUTH_CAPABILITY_MISSING. Assert a blocker
-    // banner is present rather than pinning the exact code.
-    const blockerBanner = page.locator('[role="alert"]').filter({
-      hasText: /can't publish|WordPress REST|WP Admin|app password/i,
-    });
-    // Either the blocker OR the Publish button is visible, depending on
-    // the test site's WP state. We don't pin which, because that's
-    // environment-dependent; either is acceptable.
-    const publishOrBlocker = (await blockerBanner.count()) > 0
-      ? "blocker"
-      : (await page.getByRole("button", { name: /^publish to WP$/i }).count()) > 0
-        ? "publish"
-        : "neither";
+    // The E2E test site has no real WP backend (wp_url = https://e2e.test),
+    // so preflight returns a network-error blocker. The Alert renders with
+    // data-testid="preflight-blocker" regardless of which blocker code fires.
+    // Either the blocker OR the Publish button is visible depending on WP state.
+    const publishOrBlocker =
+      (await page.getByTestId("preflight-blocker").count()) > 0
+        ? "blocker"
+        : (await page.getByRole("button", { name: /publish to WP/i }).count()) > 0
+          ? "publish"
+          : "neither";
     expect(publishOrBlocker).not.toBe("neither");
 
     await auditA11y(page, testInfo);

--- a/lib/__tests__/admin-users-list.test.ts
+++ b/lib/__tests__/admin-users-list.test.ts
@@ -138,7 +138,7 @@ describe("GET /api/admin/users/list: payload", () => {
   });
 
   it("returns every opollo_users row for an admin, newest first", async () => {
-    const admin = await seedAuthUser({ role: "super_admin" });
+    const admin = await seedAuthUser({ role: "admin" });
     // Seed a second user; the two timestamps are usually close enough
     // that ordering by created_at desc is still deterministic because
     // the second insert's now() > the first's.
@@ -162,8 +162,8 @@ describe("GET /api/admin/users/list: payload", () => {
   });
 
   it("includes revoked_at on a revoked row", async () => {
-    const admin = await seedAuthUser({ role: "super_admin" });
-    const target = await seedAuthUser({ role: "super_admin" });
+    const admin = await seedAuthUser({ role: "admin" });
+    const target = await seedAuthUser({ role: "admin" });
 
     const svc = getServiceRoleClient();
     const { error: updateErr } = await svc

--- a/lib/__tests__/slug.test.ts
+++ b/lib/__tests__/slug.test.ts
@@ -14,6 +14,11 @@ describe("generateSlug", () => {
     expect(generateSlug("the a an")).toBe("a");
   });
 
+  it("returns empty string for empty input without throwing", () => {
+    expect(generateSlug("")).toBe("");
+    expect(generateSlug("   ")).toBe("");
+  });
+
   it("strips diacritics", () => {
     expect(generateSlug("Café du Monde")).toBe("cafe-monde");
   });

--- a/lib/slug.ts
+++ b/lib/slug.ts
@@ -46,7 +46,7 @@ export function generateSlug(raw: string): string {
   const meaningful = words.filter((w) => !SLUG_STOP_WORDS.has(w));
   if (meaningful.length > 0) {
     s = meaningful.join(" ");
-  } else {
+  } else if (words.length > 0) {
     s = words.reduce((shortest, w) => (w.length < shortest.length ? w : shortest));
   }
 


### PR DESCRIPTION
## Summary

- **`e2e/posts.spec.ts`**: The posts detail spec was using `[role="alert"]`/`[role="status"]` + text matching to find the preflight blocker, which was fragile (the `warning` variant uses `role="status"` not `"alert"`, and the NETWORK_ERROR blocker text didn't match the old regex). Switched to `data-testid="preflight-blocker"` — added that testid to `PostDetailClient.tsx` in the companion fix already merged in #581.

- **`app/api/admin/users/list/route.ts`**: PR #392 (PLATFORM-AUDIT PR3) deliberately allowed both `[super_admin, admin]` on the users list endpoint; the spec-drift repair in #581 accidentally narrowed it to `super_admin` only. Restored.

- **`lib/slug.ts`**: `generateSlug('')` was calling `.reduce()` on an empty array, throwing `TypeError: Reduce of empty array with no initial value`. Added a `words.length > 0` guard; returns `''` for empty/whitespace input.

- **`lib/__tests__/admin-users-list.test.ts`**: Seeds corrected back to `role: admin` to match the now-correct gate.

- **`lib/__tests__/slug.test.ts`**: Added empty-string and whitespace-only cases.

## Risks identified and mitigated

- No schema changes, no write-path mutations. All changes are test/guard fixes.
- The `generateSlug` guard returns `''` for empty input; no callers in the codebase pass empty strings (all call-sites pass validated `name` fields from the site creation form), so no behavioural change in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)