### PR TITLE
fix(auth): revert users/list gate to super_admin-only + fix test seeds

### DIFF
--- a/app/api/admin/users/list/route.ts
+++ b/app/api/admin/users/list/route.ts
@@ -35,7 +35,7 @@ export type AdminUserRow = {
 };
 
 export async function GET(): Promise<NextResponse> {
-  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  const gate = await requireAdminForApi({ roles: ["super_admin"] });
   if (gate.kind === "deny") return gate.response;
 
   const svc = getServiceRoleClient();

--- a/lib/__tests__/admin-users-list.test.ts
+++ b/lib/__tests__/admin-users-list.test.ts
@@ -138,7 +138,7 @@ describe("GET /api/admin/users/list: payload", () => {
   });
 
   it("returns every opollo_users row for an admin, newest first", async () => {
-    const admin = await seedAuthUser({ role: "admin" });
+    const admin = await seedAuthUser({ role: "super_admin" });
     // Seed a second user; the two timestamps are usually close enough
     // that ordering by created_at desc is still deterministic because
     // the second insert's now() > the first's.
@@ -162,8 +162,8 @@ describe("GET /api/admin/users/list: payload", () => {
   });
 
   it("includes revoked_at on a revoked row", async () => {
-    const admin = await seedAuthUser({ role: "admin" });
-    const target = await seedAuthUser({ role: "admin" });
+    const admin = await seedAuthUser({ role: "super_admin" });
+    const target = await seedAuthUser({ role: "super_admin" });
 
     const svc = getServiceRoleClient();
     const { error: updateErr } = await svc


### PR DESCRIPTION
## What and why

PR #583 incorrectly widened the `admin/users/list` gate to `["super_admin", "admin"]` based on a misread of PR #392. The existing test **"returns 403 when the caller is an operator (admin-only)"** seeds `role: "admin"` and expects 403 — which is direct evidence the gate was always intended to be `super_admin`-only.

Timeline of the confusion:
1. PR #392 (PLATFORM-AUDIT) set the gate to `["super_admin", "admin"]` — this was incorrect, but CI couldn't catch it because the Supabase stack was broken at the time (pre-existing migration collision).
2. PR #579 (spec-drift repair) restored `["super_admin"]` only — this was accidentally correct.
3. PR #583 re-widened to `["super_admin", "admin"]` on my recommendation — wrong. CI caught it with the 403 test.

**This PR:** restores `["super_admin"]` and corrects the two payload test seeds (which should call with `super_admin`, the allowed role).

The slug guard from #583 is already on main and is not touched here.

## Risks identified and mitigated

- **Auth regression direction:** narrowing back to `super_admin`-only. No privilege widening.
- **Write safety:** no schema changes, no DB writes.

## Test plan

- [ ] CI `test` passes — specifically "returns 403 when the caller is an operator" stays 403
- [ ] "returns every opollo_users row for an admin" seeds super_admin and gets 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)