### PR TITLE
feat(n-series): concurrent publish cap in claim_publish_job + CAPPED retry

### DIFF
--- a/lib/platform/social/publishing/fire.ts
+++ b/lib/platform/social/publishing/fire.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/bundlesocial";
 import { logger } from "@/lib/logger";
 import { resolveBundleUploadIds } from "@/lib/platform/social/media";
+import { getQstashClient } from "@/lib/qstash";
 import { getServiceRoleClient } from "@/lib/supabase";
 import type { ApiResponse } from "@/lib/tool-schemas";
 
@@ -43,6 +44,7 @@ export type FirePublishResult = {
     | "ok"
     | "already_claimed"
     | "cancelled"
+    | "capped"
     | "not_found"
     | "invalid_state"
     | "no_connection"
@@ -121,6 +123,35 @@ export async function fireScheduledPublish(
   }
   if (claim.outcome === "ALREADY_CLAIMED") {
     return ok({ outcome: "already_claimed" });
+  }
+  if (claim.outcome === "CAPPED") {
+    // Re-enqueue with a 30s delay so the claim is retried once the
+    // in-flight pipeline drains. Deduplication bucket of 35s prevents
+    // multiple rapid re-enqueues for the same entry.
+    const qstash = getQstashClient();
+    if (qstash) {
+      const origin =
+        process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ?? "";
+      const callbackUrl = `${origin}/api/webhooks/qstash/social-publish`;
+      const dedupBucket = Math.floor(Date.now() / 35000);
+      try {
+        await qstash.publishJSON({
+          url: callbackUrl,
+          body: { scheduleEntryId: input.scheduleEntryId },
+          delay: 30,
+          deduplicationId: `social-publish-cap-${input.scheduleEntryId}-${dedupBucket}`,
+        });
+      } catch (err) {
+        logger.warn("social.publish.fire.cap_reenqueue_failed", {
+          err: err instanceof Error ? err.message : String(err),
+          schedule_entry_id: input.scheduleEntryId,
+        });
+      }
+    }
+    logger.info("social.publish.fire.capped", {
+      schedule_entry_id: input.scheduleEntryId,
+    });
+    return ok({ outcome: "capped" });
   }
   if (claim.outcome !== "OK") {
     return internal(`Unexpected claim outcome: ${claim.outcome}`);

--- a/supabase/migrations/0096_claim_publish_job_cap_check.sql
+++ b/supabase/migrations/0096_claim_publish_job_cap_check.sql
@@ -1,0 +1,229 @@
+-- 0096 — Add concurrent publish cap check to claim_publish_job.
+--
+-- platform_companies.concurrent_publish_limit (DEFAULT 5, added in 0070) has
+-- existed since the foundation migration but was never enforced at runtime.
+-- This migration adds an enforcement point inside claim_publish_job: before
+-- inserting the publish_job row the function counts in-flight attempts for the
+-- company and short-circuits with 'CAPPED' if the count meets or exceeds the
+-- limit.
+--
+-- Safety properties:
+--   - The count is approximate: two concurrent claims could both pass the check
+--     if they race the INSERT. The UNIQUE constraint on social_publish_jobs
+--     (schedule_entry_id) means only one INSERT succeeds; the other returns
+--     ALREADY_CLAIMED. So the cap can be exceeded by at most 1 at a time under
+--     race conditions — acceptable for a soft throughput limit.
+--   - CAPPED does not insert any rows, so the caller can safely re-enqueue the
+--     schedule_entry_id via QStash with a 30-second delay and retry once the
+--     pipeline has drained.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION claim_publish_job(
+  p_schedule_entry_id UUID
+)
+RETURNS TABLE (
+  outcome TEXT,
+  publish_job_id UUID,
+  publish_attempt_id UUID,
+  post_master_id UUID,
+  post_variant_id UUID,
+  company_id UUID,
+  platform TEXT,
+  variant_text TEXT,
+  master_text TEXT,
+  link_url TEXT,
+  bundle_social_account_id TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_entry  RECORD;
+  v_variant RECORD;
+  v_master RECORD;
+  v_conn   RECORD;
+  v_job_id UUID;
+  v_attempt_id UUID;
+  v_in_flight INT;
+  v_cap INT;
+BEGIN
+  -- 1. Schedule entry lookup. Table-qualify post_variant_id to avoid
+  --    ambiguity with the RETURNS TABLE output column.
+  SELECT s.id, s.post_variant_id, s.scheduled_at, s.cancelled_at
+    INTO v_entry
+    FROM social_schedule_entries s
+    WHERE s.id = p_schedule_entry_id;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NOT_FOUND'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_entry.cancelled_at IS NOT NULL THEN
+    RETURN QUERY SELECT 'CANCELLED'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- 2. Variant + master lookup.
+  SELECT v.id, v.post_master_id, v.platform::TEXT AS platform,
+         v.variant_text, v.connection_id
+    INTO v_variant
+    FROM social_post_variant v
+    WHERE v.id = v_entry.post_variant_id;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NOT_FOUND'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  SELECT m.id, m.company_id, m.master_text, m.link_url, m.state::TEXT AS state
+    INTO v_master
+    FROM social_post_master m
+    WHERE m.id = v_variant.post_master_id;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NOT_FOUND'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- Master must be in a publishable state.
+  IF v_master.state NOT IN ('approved', 'scheduled') THEN
+    RETURN QUERY SELECT 'INVALID_STATE'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- 2b. Concurrent publish cap check.
+  --     Read the company's limit; fall back to 5 if the row is missing.
+  SELECT COALESCE(pc.concurrent_publish_limit, 5)
+    INTO v_cap
+    FROM platform_companies pc
+    WHERE pc.id = v_master.company_id;
+
+  IF NOT FOUND THEN
+    v_cap := 5;
+  END IF;
+
+  SELECT COUNT(*)::INT
+    INTO v_in_flight
+    FROM social_publish_attempts spa
+    WHERE spa.company_id = v_master.company_id
+      AND spa.status = 'in_flight';
+
+  IF v_in_flight >= v_cap THEN
+    RETURN QUERY SELECT 'CAPPED'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- 3a. Resolve the connection.
+  IF v_variant.connection_id IS NOT NULL THEN
+    SELECT c.id, c.bundle_social_account_id, c.status::TEXT AS status
+      INTO v_conn
+      FROM social_connections c
+      WHERE c.id = v_variant.connection_id;
+  ELSE
+    SELECT c.id, c.bundle_social_account_id, c.status::TEXT AS status
+      INTO v_conn
+      FROM social_connections c
+      WHERE c.company_id = v_master.company_id
+        AND c.platform = v_variant.platform::social_platform
+        AND c.status = 'healthy'
+      ORDER BY c.connected_at DESC
+      LIMIT 1;
+  END IF;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'NO_CONNECTION'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_conn.status <> 'healthy' THEN
+    RETURN QUERY SELECT 'CONNECTION_DEGRADED'::TEXT,
+      NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+      NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+    RETURN;
+  END IF;
+
+  -- 3b. Atomically claim the publish-job slot.
+  BEGIN
+    INSERT INTO social_publish_jobs (
+      schedule_entry_id,
+      post_variant_id,
+      company_id,
+      fire_at,
+      fired_at
+    ) VALUES (
+      p_schedule_entry_id,
+      v_variant.id,
+      v_master.company_id,
+      v_entry.scheduled_at,
+      now()
+    )
+    RETURNING id INTO v_job_id;
+  EXCEPTION
+    WHEN unique_violation THEN
+      RETURN QUERY SELECT 'ALREADY_CLAIMED'::TEXT,
+        NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID, NULL::UUID,
+        NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT, NULL::TEXT;
+      RETURN;
+  END;
+
+  -- 3c. Insert the in-flight attempt row. company_id is required (0074).
+  INSERT INTO social_publish_attempts (
+    publish_job_id,
+    post_variant_id,
+    company_id,
+    connection_id,
+    status,
+    started_at
+  ) VALUES (
+    v_job_id,
+    v_variant.id,
+    v_master.company_id,
+    v_conn.id,
+    'in_flight',
+    now()
+  )
+  RETURNING id INTO v_attempt_id;
+
+  -- 3d. Advance master state — predicate-guarded.
+  UPDATE social_post_master
+    SET state = 'publishing',
+        state_changed_at = now()
+    WHERE id = v_master.id
+      AND state IN ('approved', 'scheduled');
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'INVALID_STATE: master moved during claim';
+  END IF;
+
+  RETURN QUERY SELECT 'OK'::TEXT,
+    v_job_id,
+    v_attempt_id,
+    v_master.id,
+    v_variant.id,
+    v_master.company_id,
+    v_variant.platform,
+    v_variant.variant_text,
+    v_master.master_text,
+    v_master.link_url,
+    v_conn.bundle_social_account_id;
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- `supabase/migrations/0096_claim_publish_job_cap_check.sql` — rewrites `claim_publish_job` to count in-flight attempts per company before inserting a publish job row; returns `'CAPPED'` if `COUNT(*) >= concurrent_publish_limit`
- `lib/platform/social/publishing/fire.ts` — imports QStash client, adds `'capped'` to `FirePublishResult.outcome`, handles CAPPED by re-enqueuing the `scheduleEntryId` with `delay: 30s` (dedup-bucketed to 35s intervals to prevent double-retry)

**Problem solved:** `platform_companies.concurrent_publish_limit` (DEFAULT 5, added in migration 0070) was never read at runtime. Without enforcement, a high-volume company could saturate bundle.social's API with concurrent requests.

## Design decisions

**CAPPED vs 503:** Returning 200 + re-enqueue (not 503) avoids QStash's built-in retry dashboard filling up with "failed" entries for a normal throughput condition.

**30-second delay:** bundle.social publishes complete within seconds; 30s gives the pipeline time to drain. The 35s dedup bucket means at most one re-enqueue per entry per 35-second window.

**Approximate enforcement:** Two concurrent claims racing the count check could both pass. The `UNIQUE` constraint on `social_publish_jobs.schedule_entry_id` means only one INSERT succeeds (the other returns `ALREADY_CLAIMED`), so the cap can be exceeded by at most 1 under race conditions — acceptable for a soft throughput limit.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Retry storm: CAPPED re-enqueues → still CAPPED → re-enqueues again | Dedup bucket prevents >1 retry per 35s per entry; publishes drain in seconds so second retry almost always succeeds |
| Cap race (two claims pass count check simultaneously) | UNIQUE constraint on publish_job INSERT absorbs the second; net effect: cap + 1 for one tick |
| QStash re-enqueue failure | Logged as `warn`; original 200 return still ends QStash retry for the delivered message |
| Migration run twice | `CREATE OR REPLACE FUNCTION` is idempotent |

## Test plan

- [ ] Lint + typecheck + build pass ✓ (pre-push)
- [ ] With `< concurrent_publish_limit` in-flight attempts: proceeds to publish as normal
- [ ] With `>= concurrent_publish_limit` in-flight attempts: RPC returns CAPPED, fire.ts re-enqueues, returns `ok({ outcome: 'capped' })`, QStash handler returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)