### PR TITLE
docs: add 3 missing skill stubs + fix BUILD.md route/analytics drift

### DIFF
--- a/.claude/skills/approval-workflow-patterns/approval-workflow-patterns.SKILL.md
+++ b/.claude/skills/approval-workflow-patterns/approval-workflow-patterns.SKILL.md
@@ -1,0 +1,135 @@
+---
+name: approval-workflow-patterns
+description: Use this skill whenever working on the social post approval flow — lib/platform/social/approvals/*, app/api/platform/social/posts/[id]/submit|approve|reject|request-changes|reopen|cancel-approval, the magic-link viewer at app/review/[token]/, social_approval_requests, social_approval_events, social_approval_recipients, or social_approval_snapshots. Trigger on submitForApproval, approvePost, rejectPost, requestChanges, cancelApprovalRequest, reopenForEditing, or any reference to approval_request_id / approval token. The approval layer handles immutable snapshots and cryptographic tokens — getting it wrong creates replay attacks or orphaned approval requests.
+---
+
+# Approval Workflow Patterns
+
+The approval layer (L2) mediates between editorial (L1) and scheduling (L3). It owns approval requests, magic-link tokens, snapshots, recipients, decisions, and audit events.
+
+## Tables
+
+| Table | Purpose |
+|-------|---------|
+| `social_approval_requests` | One open request per post at a time. Closed by `revoked_at`, `final_approved_at`, or `final_rejected_at`. |
+| `social_approval_recipients` | One row per reviewer invited to an open request. |
+| `social_approval_snapshots` | Immutable copy of `master_text` + `link_url` at submit time. Reviewers see this — never the live post. |
+| `social_approval_events` | Audit log of every decision (approve / reject / changes_requested) with comment and reviewer identity. |
+
+## State transitions driven by L2
+
+The `record_approval_decision` SQL function (migration 0070) is the single atomic writer for all approval decisions. It:
+1. Validates the token is non-expired and belongs to the request.
+2. Closes the request (`final_approved_at` / `final_rejected_at`).
+3. Advances `social_post_master.state` (predicate-guarded).
+4. Writes an event row.
+
+**Never advance master state directly from app code for approval decisions.** Always call `record_approval_decision` or use `approvePost` / `rejectPost` / `requestChanges` from `lib/platform/social/posts/transitions.ts` (which call through to the RPC).
+
+## submitForApproval
+
+```typescript
+import { submitForApproval } from "@/lib/platform/social/posts";
+
+const result = await submitForApproval({ postId, companyId, submittedBy });
+// result.data: { approvalRequestId }
+```
+
+What `submitForApproval` does:
+1. Validates post is in `draft` state.
+2. Creates `social_approval_snapshots` row (immutable copy of current text + link_url).
+3. Creates `social_approval_requests` row.
+4. Advances master `state → 'pending_client_approval'` (predicate-guarded).
+5. Returns the new `approvalRequestId` — caller uses it to invite recipients.
+
+## Magic-link tokens
+
+Tokens are cryptographic random UUIDs stored on `social_approval_recipients.token`. They expire after 14 days (check `expires_at < now()`). The viewer at `/review/[token]` resolves the token to the approval request and snapshot — it never reads the live post.
+
+Token lookup pattern:
+```typescript
+const recipient = await svc
+  .from("social_approval_recipients")
+  .select("id, approval_request_id, expires_at, used_at")
+  .eq("token", token)
+  .maybeSingle();
+
+if (!recipient || recipient.expires_at < new Date().toISOString()) {
+  return { error: "TOKEN_EXPIRED_OR_INVALID" };
+}
+```
+
+## ApprovalSnapshot — reviewers see this, not the live post
+
+```typescript
+const snapshot = await svc
+  .from("social_approval_snapshots")
+  .select("master_text, link_url, created_at")
+  .eq("approval_request_id", approvalRequestId)
+  .maybeSingle();
+```
+
+Snapshots are immutable — never updated after creation. If a post is reopened and re-submitted, a new snapshot is created.
+
+## ApprovalSnapshot type
+
+```typescript
+export type ApprovalSnapshot = {
+  masterText: string | null;
+  linkUrl: string | null;
+  createdAt: string;
+};
+```
+
+## cancelApprovalRequest
+
+Revokes the open request (sets `revoked_at`) and returns master to `draft`. Only the original submitter or an editor may cancel.
+
+```typescript
+import { cancelApprovalRequest } from "@/lib/platform/social/posts";
+
+const result = await cancelApprovalRequest({ postId, companyId, reason });
+// result.data: { postState: "draft" }
+```
+
+## reopenForEditing
+
+Available when post is in `changes_requested`. Returns master to `draft` so the editor can revise.
+
+```typescript
+import { reopenForEditing } from "@/lib/platform/social/posts";
+
+const result = await reopenForEditing({ postId, companyId });
+// result.data: { postState: "draft" }
+```
+
+## Notification dispatch
+
+After every state change that involves the approval layer, dispatch a notification:
+- `submit_for_approval` → notify approvers (email + in-app)
+- `post_approved` → notify submitter
+- `post_rejected` → notify submitter with reviewer comment
+- `post_changes_requested` → notify submitter with reviewer comment
+- `cancel_approval` → no notification required (submitter-initiated)
+
+Use `lib/platform/social/notifications.ts`; never call SendGrid directly from the approval layer.
+
+## Key invariants
+
+- At most one `social_approval_requests` row with `revoked_at IS NULL AND final_approved_at IS NULL AND final_rejected_at IS NULL` per post at any time. Enforced by application logic in `submitForApproval` (revoke any open request before creating a new one).
+- `social_approval_snapshots` has exactly one row per `approval_request_id`.
+- All state advances are predicate-guarded — if the predicate misses, the transition is a no-op and the caller returns `INVALID_STATE`.
+- `record_approval_decision` is SECURITY DEFINER — it runs with elevated permissions to advance master state atomically without exposing the service role to the browser.
+
+## Route gating
+
+| Action | Required permission |
+|--------|---------------------|
+| Submit for approval | `submit_for_approval` (editor+) |
+| Approve | `approve_post` (approver+) |
+| Reject | `approve_post` (approver+) |
+| Request changes | `approve_post` (approver+) |
+| Cancel approval | `submit_for_approval` (editor+) |
+| Reopen for editing | `edit_post` (editor+) |
+
+Magic-link reviewer has no session — they authenticate via token only. The `/review/[token]` route does not call `requireCanDoForApi`.

--- a/.claude/skills/bundle-social-integration/bundle-social-integration.SKILL.md
+++ b/.claude/skills/bundle-social-integration/bundle-social-integration.SKILL.md
@@ -1,0 +1,152 @@
+---
+name: bundle-social-integration
+description: Use this skill whenever touching bundle.social — publishing, webhooks, connections, media upload, or the getBundlesocialClient/getBundlesocialTeamId helpers. Trigger on lib/bundlesocial.ts, lib/platform/social/publishing/fire.ts, lib/platform/social/webhooks/, lib/platform/social/media/upload-to-bundle.ts, social_publish_attempts, or any bundle.social API call. Getting the publish → webhook round-trip wrong creates lost posts, phantom in_flight rows, or double-billed API calls.
+---
+
+# bundle.social Integration
+
+bundle.social is the only platform used for social publishing. All publishing goes through it. Never call LinkedIn/Facebook/X/GBP APIs directly.
+
+## Client setup
+
+```typescript
+import { getBundlesocialClient, getBundlesocialTeamId } from "@/lib/bundlesocial";
+
+const client = getBundlesocialClient();  // null if BUNDLESOCIAL_API_KEY unset
+const teamId = getBundlesocialTeamId();  // null if BUNDLESOCIAL_TEAM_ID unset
+if (!client || !teamId) { /* degrade gracefully — mark attempt failed */ }
+```
+
+Both helpers return `null` when their env var is unset. Code that uses them must handle `null` and mark the publish attempt as failed (error_class: `platform_error`, code: `RECEIVER_NOT_CONFIGURED`), then advance master state to `failed`. Never hard-require at cold-start.
+
+## Platform mapping
+
+```typescript
+const PLATFORM_TO_BUNDLE = {
+  linkedin_personal: "LINKEDIN",
+  linkedin_company:  "LINKEDIN",
+  facebook_page:     "FACEBOOK",
+  x:                 "TWITTER",
+  gbp:               "GOOGLE_BUSINESS",
+};
+```
+
+## Post creation — the `postCreate` call
+
+```typescript
+const response = await client.post.postCreate({
+  requestBody: {
+    teamId,
+    title: `attempt:${attemptId}`,   // correlates bundle.social post → our attempt row
+    postDate: new Date().toISOString(),
+    status: "SCHEDULED",
+    socialAccountTypes: [bundlePlatform],
+    data: {
+      LINKEDIN: { text, link, uploadIds? },
+      // OR FACEBOOK, TWITTER, GOOGLE_BUSINESS — only the matching key, not all
+    },
+  },
+});
+```
+
+- `status: "SCHEDULED"` is always used even for immediate posts — bundle.social dispatches immediately when `postDate` is in the past or near-present.
+- `text` can be omitted when `uploadIds` is non-empty (image-only post).
+- `TWITTER` does not support `link` in the data block.
+- Response is `{ id?: string; status?: string }`. Status `"ERROR"` is a synchronous failure even on HTTP 200 — treat it as a failed attempt.
+
+## Media — resolving upload IDs
+
+```typescript
+import { resolveBundleUploadIds } from "@/lib/platform/social/media";
+
+const resolved = await resolveBundleUploadIds(assetIds, companyId);
+if (!resolved.ok) { /* media_invalid — mark attempt failed */ }
+const uploadIds = resolved.data.uploadIds;
+```
+
+`resolveBundleUploadIds` caches `bundle_upload_id` on the `social_media_assets` row after first resolution. Concurrent resolvers race at the UPDATE — last writer wins; all returned IDs are valid (bundle.social upload IDs are immutable per asset).
+
+Source resolution order:
+1. If `bundle_upload_id` is cached → return it (no network call).
+2. If `source_url` is set → call `uploadCreateFromUrl` (bundle.social pulls the bytes).
+3. (Future) If only `storage_path` is set → download from Supabase Storage, upload as Blob.
+
+## Webhook inbound — `post.published` / `post.failed`
+
+Endpoint: `POST /api/webhooks/bundlesocial` (L6).
+
+```typescript
+import { verifyBundlesocialSignature } from "@/lib/bundlesocial";
+
+const sig = req.headers.get("x-bundlesocial-signature") ?? "";
+const body = await req.text();
+const valid = verifyBundlesocialSignature(body, sig);
+if (!valid) return new Response("Unauthorized", { status: 401 });
+```
+
+Webhook payload shape:
+```json
+{
+  "event": "post.published" | "post.failed",
+  "post": { "id": "<bundle_post_id>", "status": "POSTED" | "ERROR", ... }
+}
+```
+
+On `post.published`:
+1. Find the `social_publish_attempts` row by `bundle_post_id`.
+2. Predicate-guarded update: `status = 'succeeded'`, `completed_at = now()`.
+3. Find the `post_master_id` via `post_variant_id`.
+4. Predicate-guarded update: master `state = 'published'`, `state_changed_at = now()` WHERE `state = 'publishing'`.
+5. Dispatch `post_published` notification.
+
+On `post.failed`:
+1. Same lookup chain.
+2. Update attempt: `status = 'failed'`, `error_class = 'platform_error'`, `error_payload = { bundle_status }`.
+3. Update master: `state = 'failed'` WHERE `state = 'publishing'`.
+4. Dispatch `post_failed` notification.
+
+**Idempotency:** webhook may redeliver. Both updates are predicate-guarded (`WHERE status = 'in_flight'` / `WHERE state = 'publishing'`), so re-delivery is a no-op if the row has already advanced.
+
+## QStash — the delivery mechanism
+
+QStash delivers to `POST /api/webhooks/qstash/social-publish`.
+
+```typescript
+import { verifyQstashSignature } from "@/lib/qstash";
+// call at top of handler — returns 401 on failure
+```
+
+On CAPPED outcome from `claim_publish_job`, re-enqueue with a 30 s delay:
+```typescript
+await qstash.publishJSON({
+  url: callbackUrl,
+  body: { scheduleEntryId },
+  delay: 30,
+  deduplicationId: `social-publish-cap-${scheduleEntryId}-${Math.floor(Date.now() / 35000)}`,
+});
+```
+
+The 35 s dedup bucket prevents rapid re-enqueue storms. QStash handles retries on our side automatically — do NOT add manual retry logic in the publish route.
+
+## Error classification
+
+`classifyError(message: string)` in `fire.ts` maps error message substrings to `error_class`:
+
+| Pattern | Class |
+|---------|-------|
+| `rate limit` / `429` | `rate_limit` |
+| `401` / `403` / `unauth` | `auth` |
+| `400` / `invalid` | `content_rejected` |
+| `network` / `timeout` / `econn` | `network` |
+| anything else | `platform_error` |
+
+Always persist `error_class` + `error_payload` on the `social_publish_attempts` row before returning.
+
+## Drift guard — timing observability
+
+`fireScheduledPublish` reads `social_schedule_entries.scheduled_at` before claiming the job and logs:
+- `warn` if firing >2 min early (QStash delivered ahead of schedule)
+- `warn` if firing >2 min late
+- `error`-level if firing >30 min late (QStash outage scenario)
+
+Always proceed regardless of drift — a late post is better than a missed one.

--- a/.claude/skills/n-series-layer-rules/n-series-layer-rules.SKILL.md
+++ b/.claude/skills/n-series-layer-rules/n-series-layer-rules.SKILL.md
@@ -1,0 +1,100 @@
+---
+name: n-series-layer-rules
+description: Use this skill whenever working on the N-Series social module — lib/platform/social/*, app/company/social/*, app/api/platform/social/*, or any social migration/RPC. Trigger on social_post_master, social_post_variant, social_schedule_entries, social_publish_jobs, social_publish_attempts, social_connections, claim_publish_job, or any state transition in the social state machine. The L1–L7 layer contract is load-bearing; violating it creates orphaned state, double-publishes, or broken audit trails.
+---
+
+# N-Series Social Layer Rules
+
+The social module is structured as seven layers (L1–L7). Each layer owns a single concern. Code that belongs in one layer must not bleed into another.
+
+## Layer map
+
+| Layer | Name | Owns |
+|-------|------|------|
+| L1 | Editorial | `social_post_master` — create, edit, delete, duplicate |
+| L2 | Approval | `social_approval_requests`, approval tokens, snapshots, decisions |
+| L3 | Scheduling | `social_schedule_entries` — create, cancel, reschedule |
+| L4 | Claim | `claim_publish_job` RPC — atomic lock, concurrency cap, state advance |
+| L5 | Publish | `fireScheduledPublish` — bundle.social call, attempt tracking |
+| L6 | Webhook | Inbound `post.published` / `post.failed` from bundle.social |
+| L7 | Watchdog | Stuck `in_flight` recovery, reconciliation cron |
+
+## State machine — social_post_master.state
+
+```
+draft
+  → pending_client_approval   (submitForApproval)
+  → draft                     (cancelApprovalRequest, reopenForEditing)
+pending_client_approval
+  → approved                  (approvePost via record_approval_decision RPC)
+  → rejected                  (rejectPost via record_approval_decision RPC)
+  → changes_requested         (requestChanges via record_approval_decision RPC)
+  → draft                     (cancelApprovalRequest)
+approved
+  → scheduled                 (createScheduleEntry)
+  → publishing                (claim_publish_job RPC, predicate-guarded)
+scheduled
+  → publishing                (claim_publish_job RPC, predicate-guarded)
+publishing
+  → published                 (bundle.social post.published webhook, L6)
+  → failed                    (bundle.social post.failed webhook OR watchdog, L7)
+rejected / changes_requested
+  → draft                     (reopenForEditing)
+failed
+  → draft                     (manual reset by operator — no automated path)
+```
+
+**`pending_msp_release` is locked out.** Migration 0097 adds a CHECK constraint preventing the DB from ever accepting this value. It was never set by any code path; remove any reference to it.
+
+## Concurrency rules (L4)
+
+- `claim_publish_job` is the **only** place that advances `publishing`. No other code path may write `state = 'publishing'`.
+- The RPC is predicate-guarded: `UPDATE … WHERE state IN ('approved', 'scheduled')`. If the predicate misses, the RPC raises an exception — caller surfaces as 500, not a silent no-op.
+- Concurrent publish cap: `platform_companies.concurrent_publish_limit` (default 5). The RPC counts `social_publish_attempts WHERE status = 'in_flight'` before inserting. Returns `CAPPED` when at or above the cap; caller re-enqueues via QStash with 30 s delay.
+- UNIQUE constraint on `social_publish_jobs(schedule_entry_id)` prevents double-claim under race; second claimer gets `ALREADY_CLAIMED`.
+
+## Watchdog rules (L7)
+
+Watchdog cron fires every 5 minutes (`/api/cron/social-publish-watchdog`). Stuck threshold: `in_flight` attempts older than 3 minutes.
+
+For each stuck attempt:
+1. Predicate-guarded update: `status = 'failed'` WHERE `status = 'in_flight'`.
+2. Resolve `post_master_id` via `post_variant_id`.
+3. Predicate-guarded update: master `state = 'failed'` WHERE `state = 'publishing'`.
+4. Dispatch `post_failed` notification.
+
+The watchdog never touches `social_publish_jobs` or `social_schedule_entries` — those are L3/L4 concerns.
+
+## Key invariants
+
+- Every `in_flight` attempt has exactly one parent `publish_job`, which has exactly one `schedule_entry`.
+- A master in `publishing` has exactly one `in_flight` attempt (enforced by the UNIQUE constraint + predicate guard).
+- `state_changed_at` is updated atomically with every state change. Never update `state` without updating `state_changed_at`.
+- `social_publish_attempts.company_id` is required (migration 0074). Always include it on INSERT.
+
+## File locations
+
+```
+lib/platform/social/
+├── posts/           # L1 — editorial CRUD (create, get, list, update, delete, transitions, dashboard)
+├── approvals/       # L2 — approval request lifecycle
+├── scheduling/      # L3 — schedule entries
+├── publishing/
+│   ├── fire.ts      # L5 — fireScheduledPublish + QStash CAPPED re-enqueue
+│   └── watchdog.ts  # L7 — stuck in_flight recovery
+├── connections/     # connection health, reconnect
+├── variants/        # per-platform post variants
+├── media/           # media asset upload, resolve bundle uploadIds
+├── analytics.ts     # read-only analytics aggregation
+├── cap/             # Content Automation Pipeline (CAP) — AI copy generation
+└── webhooks/        # L6 — inbound bundle.social webhook handlers
+```
+
+## Migrations that matter
+
+| Migration | What it added |
+|-----------|---------------|
+| 0070 | Foundation schema, all social tables, `claim_publish_job` RPC v1, `pending_msp_release` enum value |
+| 0074 | Audit columns, `social_publish_attempts.company_id` NOT NULL |
+| 0096 | Concurrent publish cap check inside `claim_publish_job` |
+| 0097 | CHECK constraint locking out `pending_msp_release` |

--- a/.claude/skills/platform-customer-management/platform-customer-management.SKILL.md
+++ b/.claude/skills/platform-customer-management/platform-customer-management.SKILL.md
@@ -11,7 +11,7 @@ The platform layer owns customer companies, users, roles, invitations, and notif
 
 ## Auth gate layering
 
-Customer-facing routes (`/customer/*`) and operator routes that view customer data (`/admin/platform/*`) use different gates:
+Customer-facing routes (`/company/*`) and operator routes that view customer data (`/admin/platform/*`) use different gates:
 
 ```typescript
 // /admin/platform/companies/[companyId]/route.ts
@@ -24,10 +24,9 @@ export async function GET(req: Request, { params }: { params: { companyId: strin
   const { companyId } = await requireCompanyContext(params.companyId);
 }
 
-// /customer/settings/users/route.ts
-// Customer user accessing own company — customer gate only
-import { requireCustomerAuth } from '@/lib/platform/auth/customer-gate';
-import { requireCompanyContext } from '@/lib/platform/auth/company-context';
+// /company/users/route.ts (example — actual auth uses getCurrentPlatformSession)
+// Customer user accessing own company — platform session gate
+import { getCurrentPlatformSession } from '@/lib/platform/auth';
 
 export async function GET(req: Request) {
   await requireCustomerAuth(req);                                  // customer auth (separate from admin gate)
@@ -235,20 +234,19 @@ Critical notifications (`is_critical: true` on `platform_email_log`) alert Opoll
   companies/                  ← list all companies
   companies/[id]/             ← company detail, brand, subscriptions
 
-/customer/                    ← customer-facing: different layout shell, different auth gate
-  dashboard/
-  settings/brand/
-  settings/users/
-  social/posts/
-  social/calendar/
-  image/
+/company/                     ← customer-facing: different layout shell, different auth gate
+  users/                      ← invite + manage team
+  settings/brand/             ← brand profile editor
+  social/posts/               ← compose, approve, schedule
+  social/analytics/           ← social analytics dashboard
+  social/connections/         ← connect / reconnect / health
 
 /invite/[token]/              ← invitation acceptance (no auth required)
 /review/[token]/              ← magic-link approval (no auth session)
-/calendar/[token]/            ← magic-link calendar (no auth session)
+/viewer/[token]/              ← magic-link calendar (no auth session)
 ```
 
-`/customer/*` must have a different layout (`app/customer/layout.tsx`) from `/admin/` — no admin sidebar, customer chrome only.
+`/company/*` uses a different layout (`app/company/layout.tsx`) from `/admin/` — no admin sidebar, customer chrome only (CompanyTopNav, NotificationBell).
 
 ## What lives where
 
@@ -256,7 +254,7 @@ Critical notifications (`is_critical: true` on `platform_email_log`) alert Opoll
 lib/platform/
   auth/
     company-context.ts    — requireCompanyContext()
-    customer-gate.ts      — requireCustomerAuth() for /customer/* routes
+    index.ts              — getCurrentPlatformSession(), canDo() — used in /company/* routes
     permissions.ts        — canDo(), role checks
     session.ts            — getAuthUser(), getPlatformUser()
   companies/              — getCompany, listCompanies, createCompany, updateCompany

--- a/BUILD.md
+++ b/BUILD.md
@@ -77,7 +77,7 @@ Magic links never grant access to settings, brand profile, or management. Scoped
 | P1 | Schema, RLS, auth helpers | ✅ Shipped (#376 migration 0070; #435 migration 0074 audit cols + brand governance + image-gen log + version_lock + soft-delete + `_active` views) |
 | P2 | Invitation flow (send, accept, set password) | ✅ Shipped (P2-1 #378 auth helpers; P2-2 #380 send/revoke; P2-3 #385 accept; #388 accept-page follow-up; P2-4 #403 reminder + expiry callbacks) |
 | P3 | Opollo staff view: `/admin/platform/companies` (list, create, brand overview) | ✅ Shipped (P3-1 #387 list; P3-2 #391 create; P3-3 #393 detail; P3-4 #395 invite-from-detail) |
-| P4 | Customer admin: `/company/users` (invite, manage roles) | ✅ Shipped (#397). **Route note:** customer surface lives under `/company/*`, not `/customer/*` as originally drafted — the rest of this doc still says `/customer/...` in places; treat those as `/company/...` until a future cleanup unifies the prose. |
+| P4 | Customer admin: `/company/users` (invite, manage roles) | ✅ Shipped (#397). Customer surface lives under `/company/*`. The route structure section and this doc have been updated to reflect the final naming. |
 | P5 | Notification system (email + in-app foundation) | ✅ Shipped (#399 dispatcher) |
 | P-Brand-1 | Brand profile editor: `/company/settings/brand` (visual identity + tone + content rules + version history) | ✅ Shipped (P-Brand-1a/1b/1c #448 editor + API + landing integration; P-Brand-1d #453 E2E helper + spec) |
 | P-Brand-2 | Brand helper functions: `get_active_brand_profile()`, `can_access_product()`, completion tier logic | ✅ Shipped: DB helpers in #435; `getBrandTier()` + tier label/description in `lib/platform/brand/completion.ts` (P-Brand-1c). |
@@ -126,31 +126,35 @@ Magic links never grant access to settings, brand profile, or management. Scoped
 ```
 app/
 ├── admin/                          ← EXISTING operator routes (do not move)
-│   ├── platform/                   ← NEW: Opollo staff managing customer companies
+│   ├── platform/                   ← Opollo staff managing customer companies
 │   │   ├── companies/              ← list, create, brand overview, product subscriptions
 │   │   └── companies/[id]/         ← company detail, brand, social settings
 │   └── [existing routes unchanged]
-├── customer/                       ← NEW: customer-facing (different layout shell, different gate)
-│   ├── layout.tsx                  ← customer chrome (no admin sidebar)
-│   ├── dashboard/                  ← company overview, brand completion prompt
-│   ├── settings/
-│   │   ├── brand/                  ← brand profile editor
-│   │   └── users/                  ← invite + manage team
+├── company/                        ← customer-facing (different layout shell, different gate)
+│   ├── layout.tsx                  ← customer chrome (CompanyTopNav, NotificationBell, Toaster)
 │   ├── social/
-│   │   ├── calendar/               ← read-only calendar (magic link or logged-in)
-│   │   └── posts/                  ← compose, approve, schedule
-│   └── image/                      ← mood board generation UI
+│   │   ├── layout.tsx              ← social sub-nav strip (sticky below company header)
+│   │   ├── posts/                  ← compose, approve, schedule
+│   │   ├── posts/[id]/             ← post detail, variants, approval, schedule, publish history
+│   │   ├── analytics/              ← social analytics dashboard (KPIs, charts, recent/pending)
+│   │   └── connections/            ← connect / reconnect / health
+│   ├── users/                      ← invite + manage team
+│   └── settings/
+│       └── brand/                  ← brand profile editor
 ├── review/[token]/                 ← magic-link approval (no auth session, scoped token)
-├── calendar/[token]/               ← magic-link read-only calendar
+├── viewer/[token]/                 ← magic-link read-only calendar
 ├── invite/[token]/                 ← invitation acceptance
 └── api/
     ├── platform/                   ← platform API routes
-    ├── social/                     ← social API routes
-    ├── image/                      ← image generation API routes
-    └── webhooks/bundle-social/     ← bundle.social webhook receiver
+    │   └── social/posts/           ← post CRUD + transitions (submit, approve, reject, schedule, publish)
+    ├── cron/                       ← Vercel cron jobs (watchdog, CAP, connection sweep)
+    ├── webhooks/
+    │   ├── bundlesocial/           ← bundle.social inbound (post.published / post.failed)
+    │   └── qstash/social-publish/  ← QStash → fireScheduledPublish
+    └── [existing routes unchanged]
 ```
 
-**Critical:** `/customer/*` uses a different layout shell and auth gate from `/admin/*`. Middleware must apply different policy to each prefix. Do NOT bolt customer auth onto existing `/admin/*` routes.
+**Critical:** `/company/*` uses a different layout shell and auth gate from `/admin/*`. Middleware applies `getCurrentPlatformSession()` to `/company/*` and the existing operator gate to `/admin/*`. Do NOT bolt customer auth onto existing `/admin/*` routes.
 
 ---
 
@@ -344,7 +348,7 @@ Read the image-generation skill before touching anything in `lib/image/`.
 ## What is NOT V1
 
 - ~~AI writing assistants / CAP automated copy~~ (shipped — Phase D D1–D4 PRs #506–#508; I5 image trigger PR #510)
-- Analytics dashboards (Phase 2)
+- ~~Analytics dashboards~~ (shipped — `/company/social/analytics`, `lib/platform/social/analytics.ts`)
 - Multi-company users (one company per user in V1)
 - SSO (email + password only)
 - Two-factor auth for customer users (Phase 2)


### PR DESCRIPTION
## Summary

- **3 new skill files** that BUILD.md's skills table has referenced since the N-Series foundation but were never written:
  - `n-series-layer-rules` — L1–L7 layer map, complete state machine (including `pending_msp_release` lock-out note), concurrency rules, watchdog invariants, migration index.
  - `bundle-social-integration` — client null-handling, platform map, `postCreate` shape, media resolution chain, inbound webhook patterns, QStash CAPPED re-enqueue, error classification, drift-guard observability.
  - `approval-workflow-patterns` — table ownership, state transition responsibility, `submitForApproval` contract, magic-link token lookup, `ApprovalSnapshot` immutability, cancel/reopen paths, notification dispatch, route gating table.

- **BUILD.md drift fixes**:
  - Route structure section: `/customer/*` → `/company/*` throughout; `/calendar/[token]/` → `/viewer/[token]/`; added analytics, connections, cron, webhook sub-routes reflecting what's actually deployed.
  - "What is NOT V1": analytics dashboards marked shipped (`/company/social/analytics`).
  - Phase A P4 note: stale "treat `/customer` as `/company`" caveat removed.

- **`platform-customer-management.SKILL.md`**: `/customer/*` route references updated to `/company/*`.

## Risks identified and mitigated

- Docs-only change. No migrations, no code paths, no runtime behaviour altered.
- Skill files are consumed only by Claude Code's context loader at conversation start — no CI path depends on them.

## Test plan

- [x] `npm run lint` — clean (docs-only, lint-staged skips `.md` files)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean