### PR TITLE
fix(test): remove stale pendingMspRelease from dashboard stats assertion

### DIFF
--- a/lib/__tests__/social-posts-dashboard.test.ts
+++ b/lib/__tests__/social-posts-dashboard.test.ts
@@ -115,7 +115,6 @@ describe("lib/platform/social/posts/dashboard", () => {
       approvedThisWeek: 0,
       changesRequested: 0,
       failed: 0,
-      pendingMspRelease: 0,
     });
   });
 


### PR DESCRIPTION
## Summary

- Removes `pendingMspRelease: 0` from the `toEqual` assertion in the "returns zeroes for an empty company" test in `lib/__tests__/social-posts-dashboard.test.ts`
- `pendingMspRelease` was removed from `SocialPostsStats` in PR #590 but this test fixture was not updated at the time, causing the `test` CI job to fail

## Test plan

- [ ] `test` CI job passes (this is the only change — the fix is a one-line deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)