### PR TITLE
fix(e2e): second-round spec drift repair — TipTap, wizard step, reprompt mode, DOM alignment

### DIFF
--- a/e2e/auth-passwords.spec.ts
+++ b/e2e/auth-passwords.spec.ts
@@ -343,7 +343,7 @@ test.describe.serial("M14-5 recovery email-link callback hop (audit PR 4)", () =
     // Navigate. Playwright follows the verify → callback redirect
     // chain. End state: /auth/reset-password with a session cookie.
     await page.goto(actionLink);
-    await page.waitForURL(/\/auth\/reset-password/, { timeout: 15_000 });
+    await page.waitForURL(/\/auth\/reset-password/, { timeout: 30_000 });
 
     // Negative assertion: we did NOT land on the no-session "link
     // expired" surface. That would mean the redirect chain delivered

--- a/e2e/briefs-full-loop.spec.ts
+++ b/e2e/briefs-full-loop.spec.ts
@@ -181,7 +181,7 @@ test.describe("M12-6 briefs — full-loop run", () => {
 
     // 4. Re-render the surface. Approve button on page 0 should appear.
     await page.reload();
-    const page1Card = page.getByRole("heading", { name: /1\. Page 1/ }).locator("..").locator("..");
+    const page1Card = page.getByRole("heading", { name: /1\. Page 1/ }).locator("../../..");
     await expect(page1Card.getByText(/Awaiting review/i).first()).toBeVisible();
     await page1Card.getByRole("button", { name: /approve this page/i }).click();
 
@@ -195,7 +195,7 @@ test.describe("M12-6 briefs — full-loop run", () => {
 
     await page.reload();
     await auditA11y(page, testInfo);
-    const page2Card = page.getByRole("heading", { name: /2\. Page 2/ }).locator("..").locator("..");
+    const page2Card = page.getByRole("heading", { name: /2\. Page 2/ }).locator("../../..");
     await expect(page2Card.getByText(/Awaiting review/i).first()).toBeVisible();
     await page2Card.getByRole("button", { name: /approve this page/i }).click();
 

--- a/e2e/design-discovery.spec.ts
+++ b/e2e/design-discovery.spec.ts
@@ -322,7 +322,7 @@ test.describe("design discovery wizard", () => {
     await page.waitForURL(new RegExp(`/admin/sites/${id}/setup\\?step=2`));
 
     await expect(page.getByTestId("setup-step-2")).toBeVisible();
-    await page.getByTestId("tov-skip").click();
+    await page.getByTestId("setup-step-2-skip").click();
     await page.waitForURL(new RegExp(`/admin/sites/${id}/setup\\?step=3`));
 
     await expect(page.getByTestId("setup-step-3")).toBeVisible();

--- a/e2e/design-discovery.spec.ts
+++ b/e2e/design-discovery.spec.ts
@@ -311,7 +311,7 @@ test.describe("design discovery wizard", () => {
   test("skip path: skip both steps → done with using-defaults messaging", async ({
     page,
   }) => {
-    test.setTimeout(60_000);
+    test.setTimeout(90_000);
     const id = await createSiteAndOpenSetup(
       page,
       `DD Skip ${Date.now()}`,

--- a/e2e/m16-site-graph.spec.ts
+++ b/e2e/m16-site-graph.spec.ts
@@ -160,7 +160,7 @@ test.describe("M16 — Blueprint review", () => {
     // Wait for the page to load the blueprint data
     await expect(page.getByText("E2E Test Brand")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText(/homepage/i)).toBeVisible();
-    await expect(page.getByText(/service/i)).toBeVisible();
+    await expect(page.getByText(/service/i).first()).toBeVisible();
   });
 
   test("blueprint review page shows 'Draft' status badge", async ({ page }) => {

--- a/e2e/optimiser-onboarding.spec.ts
+++ b/e2e/optimiser-onboarding.spec.ts
@@ -43,6 +43,10 @@ test.describe("optimiser — onboarding wizard", () => {
     await page.getByRole("button", { name: /create client/i }).click();
     await page.waitForURL(/\/optimiser\/onboarding\/[0-9a-f-]{36}/);
 
+    // Navigate to the Client details step via the sidebar (deriveStep may
+    // default to "ads" when Google Ads is not yet connected).
+    await page.getByRole("button", { name: /client details/i }).first().click();
+
     // Step 1 (client details) is the default landing step. Re-save to
     // exercise the PATCH path.
     await expect(

--- a/e2e/optimiser-proposal-review.spec.ts
+++ b/e2e/optimiser-proposal-review.spec.ts
@@ -79,6 +79,9 @@ test.describe("optimiser — proposal review", () => {
     });
 
     await page.goto(`/optimiser/proposals/${proposal.id}`);
+    // RepromptForm defaults to "controlled" mode; switch to "free" to
+    // expose the "Augment the brief" freeform textarea.
+    await page.getByRole("button", { name: /free reprompt/i }).click();
     await page
       .getByPlaceholder(/Augment the brief/)
       .fill("Keep the existing testimonial component.");

--- a/e2e/posts-new.spec.ts
+++ b/e2e/posts-new.spec.ts
@@ -52,8 +52,8 @@ test.describe("/admin/posts/new — top-level entry", () => {
     await expect(firstOption).toBeVisible();
     await firstOption.click();
 
-    // Composer textarea appears once a site is bound.
-    await expect(page.locator("#post-composer-input")).toBeVisible();
+    // Composer (TipTap ProseMirror) appears once a site is bound.
+    await expect(page.locator(".ProseMirror")).toBeVisible();
 
     await auditA11y(page, testInfo);
   });
@@ -115,9 +115,9 @@ test.describe("/admin/posts/new — top-level entry", () => {
     const panel = page.getByTestId("post-advanced-panel");
     await expect(panel).toHaveCount(0);
 
-    // Type into the textarea + title; autosave fires after the 800ms
-    // debounce.
-    const composer = page.locator("#post-composer-input");
+    // Type into the composer (TipTap ProseMirror); autosave fires after
+    // the 800ms debounce.
+    const composer = page.locator(".ProseMirror");
     await composer.fill("Hello world body for autosave probe.");
     await page.locator("#post-title").fill("Autosave probe");
 
@@ -146,7 +146,7 @@ test.describe("/admin/posts/new — top-level entry", () => {
     await expect(page.locator("#post-title")).toHaveValue(
       /autosave probe/i,
     );
-    await expect(page.locator("#post-composer-input")).toHaveValue(
+    await expect(page.locator(".ProseMirror")).toContainText(
       /hello world body for autosave probe/i,
     );
 

--- a/e2e/posts-pipeline.spec.ts
+++ b/e2e/posts-pipeline.spec.ts
@@ -154,8 +154,7 @@ async function approvePageViaUI(opts: {
   const escaped = opts.pageTitle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const card = opts.page
     .getByRole("heading", { name: new RegExp(`1\\. ${escaped}`) })
-    .locator("..")
-    .locator("..");
+    .locator("../../..");
   await expect(card.getByText(/Awaiting review/i).first()).toBeVisible();
   await card.getByRole("button", { name: /approve this page/i }).click();
 }


### PR DESCRIPTION
## Summary

Completes the E2E spec drift repair started in PR #582. Two commits not captured in the squash merge:

- **strict mode / `.first()`** — `m16-site-graph`: `getByText(/service/i)` matched 3 elements (slug cell, badge, label); add `.first()`
- **design-discovery skip path timeout** — `createSiteAndOpenSetup` consumes ~40-50s in CI; bump 60 s → 90 s
- **optimiser-onboarding wrong default step** — `deriveStep()` returns `"ads"` for un-onboarded clients (no Google Ads connection); click sidebar "Client details" button before asserting heading
- **optimiser-proposal-review reprompt mode** — `getByPlaceholder(/Augment the brief/)` only exists in `"free"` mode of `RepromptForm`; click "Free reprompt" toggle first
- **posts-new TipTap replacement** — `#post-composer-input` (old `<textarea>`) replaced by TipTap `RichTextEditor`; use `.ProseMirror` selector; `toHaveValue()` → `toContainText()` for contenteditable
- **briefs-full-loop / posts-pipeline locator** — `PagePreview` is a sibling of the flex div, not inside it; locator chain 3 levels up from `h3`
- **design-discovery `tov-skip`** — always-visible skip is on `SetupWizard`, not on the tone step; button is `setup-step-2-skip`
- **auth-passwords recovery** — extend `waitForURL` timeout to 30 s (Supabase redirect chain needs more than 15 s in CI)

## Risks identified and mitigated

Test-only changes. No production code modified. No write-safety concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)