### PR TITLE
fix(e2e): third-round spec drift — clarity label, budget reset, autosave TipTap

### DIFF
--- a/components/optimiser/OnboardingWizard.tsx
+++ b/components/optimiser/OnboardingWizard.tsx
@@ -435,8 +435,9 @@ function ClarityStep({
         is recorded.
       </p>
       <div className="space-y-2">
-        <label className="block text-sm font-medium">Clarity API token</label>
+        <label htmlFor="clarity-api-token" className="block text-sm font-medium">Clarity API token</label>
         <Input
+          id="clarity-api-token"
           type="password"
           value={token}
           onChange={(e) => setToken(e.target.value)}

--- a/e2e/pages.spec.ts
+++ b/e2e/pages.spec.ts
@@ -111,6 +111,13 @@ test.describe("pages admin surface", () => {
   test.beforeEach(async ({ page }) => {
     siteId = await lookupTestSiteId();
     pageIds = await seedPages(siteId);
+    // Reset budget usage so regen tests aren't blocked by BUDGET_EXCEEDED
+    // from prior tests in the same run (e.g. briefs-full-loop consuming
+    // daily_usage_cents before pages:212 / pages:247 run).
+    await serviceRoleClient()
+      .from("tenant_cost_budgets")
+      .update({ daily_usage_cents: 0, monthly_usage_cents: 0 })
+      .eq("site_id", siteId);
     await signInAsAdmin(page);
   });
 

--- a/e2e/posts-new.spec.ts
+++ b/e2e/posts-new.spec.ts
@@ -115,16 +115,20 @@ test.describe("/admin/posts/new — top-level entry", () => {
     const panel = page.getByTestId("post-advanced-panel");
     await expect(panel).toHaveCount(0);
 
-    // Type into the composer (TipTap ProseMirror); autosave fires after
-    // the 800ms debounce.
+    // Type into the composer (TipTap ProseMirror). Use pressSequentially so
+    // TipTap's key-event handlers fire and update the React state that the
+    // autosave debounce watches.
     const composer = page.locator(".ProseMirror");
-    await composer.fill("Hello world body for autosave probe.");
+    await composer.click();
+    await composer.pressSequentially("Hello world body for autosave probe.");
     await page.locator("#post-title").fill("Autosave probe");
 
-    // Save indicator surfaces.
+    // Wait for the autosave to COMPLETE (localStorage written), not just
+    // started. "Saving…" fires immediately; "Saved ·" fires after the 800ms
+    // debounce callback runs.
     await expect(page.getByTestId("post-save-status")).toContainText(
-      /saving|saved/i,
-      { timeout: 5000 },
+      /saved ·/i,
+      { timeout: 8000 },
     );
 
     // Open the disclosure manually.


### PR DESCRIPTION
## Summary

Three targeted fixes for remaining E2E spec drift after PRs #582 and #595:

- **OnboardingWizard ClarityStep** — `<label>` for "Clarity API token" had no `htmlFor` and `<Input>` had no `id`; `getByLabel('Clarity API token')` timed out. Added `htmlFor="clarity-api-token"` + `id="clarity-api-token"`.
- **pages.spec.ts `beforeEach`** — `daily_usage_cents` accumulates across tests in the same CI run (briefs-full-loop consumes budget before pages:212/247 run). Reset both usage counters to 0 before each pages test via the service-role client.
- **posts-new.spec.ts autosave** — Two issues:
  1. `fill()` on ProseMirror bypasses TipTap's key-event handlers so `composerValue.text` never updates and the body isn't persisted. Switched to `click()` + `pressSequentially()`.
  2. Test waited for `'saving|saved'` which matches "Saving…" (fires immediately when the debounce starts) — not "Saved ·" (fires 800ms later when localStorage is actually written). If the page reloads before the 800ms timer fires, nothing is saved. Changed to wait for `/saved ·/i`.

## Risks identified and mitigated

Test-only changes plus a one-line `htmlFor`/`id` addition to a component label. No production logic modified. No write-safety concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)