### PR TITLE
fix(sites): sites showing Pending Pairing after credential wipe

### DIFF
--- a/lib/__tests__/sites-credentials.test.ts
+++ b/lib/__tests__/sites-credentials.test.ts
@@ -21,7 +21,7 @@ import { seedSite } from "./_helpers";
 
 async function seedSiteWithoutCredentials(): Promise<{ id: string }> {
   const svc = getServiceRoleClient();
-  const prefix = `cr${Math.random().toString(36).slice(2, 6)}`;
+  const prefix = Math.random().toString(36).slice(2, 6);
   const { data, error } = await svc
     .from("sites")
     .insert({

--- a/lib/__tests__/sites-credentials.test.ts
+++ b/lib/__tests__/sites-credentials.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { getSite, updateSiteCredentials } from "@/lib/sites";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import { seedSite } from "./_helpers";
+
+// ---------------------------------------------------------------------------
+// Regression tests for the pending_pairing / credential upsert bugs.
+//
+// Migration 0056 deleted every site_credentials row and reset all sites to
+// pending_pairing. Prior to this fix:
+//
+//   1. getSite with includeCredentials:true returned NOT_FOUND (404) when
+//      the credentials row was missing, blocking the edit page.
+//   2. updateSiteCredentials used UPDATE on site_credentials — a no-op when
+//      the row doesn't exist — so credentials could never be saved post-0056.
+//   3. Even when credentials were rotated, the site status stayed
+//      pending_pairing forever because nothing flipped it back to active.
+// ---------------------------------------------------------------------------
+
+async function seedSiteWithoutCredentials(): Promise<{ id: string }> {
+  const svc = getServiceRoleClient();
+  const prefix = `cr${Math.random().toString(36).slice(2, 6)}`;
+  const { data, error } = await svc
+    .from("sites")
+    .insert({
+      name: `Credential Test ${prefix}`,
+      wp_url: `https://${prefix}.test`,
+      prefix,
+      status: "pending_pairing",
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`seed failed: ${error?.message}`);
+  await svc.from("site_credentials").delete().eq("site_id", data.id as string);
+  return { id: data.id as string };
+}
+
+describe("getSite with missing credentials row", () => {
+  it("returns ok:true with credentials:null instead of NOT_FOUND", async () => {
+    const { id } = await seedSiteWithoutCredentials();
+    const result = await getSite(id, { includeCredentials: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.credentials).toBeNull();
+    expect(result.data.site.id).toBe(id);
+  });
+});
+
+describe("updateSiteCredentials upsert + status flip", () => {
+  it("inserts a credentials row when none exists (post-migration-0056 case)", async () => {
+    const { id } = await seedSiteWithoutCredentials();
+    const result = await updateSiteCredentials(id, {
+      wp_user: "admin",
+      wp_app_password: "xxxx xxxx xxxx xxxx xxxx xxxx",
+    });
+    expect(result.ok).toBe(true);
+
+    const svc = getServiceRoleClient();
+    const { data } = await svc
+      .from("site_credentials")
+      .select("wp_user")
+      .eq("site_id", id)
+      .maybeSingle();
+    expect(data?.wp_user).toBe("admin");
+  });
+
+  it("flips pending_pairing to active after a full credential save", async () => {
+    const { id } = await seedSiteWithoutCredentials();
+    const before = await getSite(id);
+    expect(before.ok).toBe(true);
+    if (!before.ok) return;
+    expect(before.data.site.status).toBe("pending_pairing");
+
+    await updateSiteCredentials(id, {
+      wp_user: "admin",
+      wp_app_password: "xxxx xxxx xxxx xxxx xxxx xxxx",
+    });
+
+    const after = await getSite(id);
+    expect(after.ok).toBe(true);
+    if (!after.ok) return;
+    expect(after.data.site.status).toBe("active");
+  });
+
+  it("does not flip paused sites to active during credential rotation", async () => {
+    const svc = getServiceRoleClient();
+    const site = await seedSite();
+    await svc.from("site_credentials").insert({
+      site_id: site.id,
+      wp_user: "paused-user",
+      site_secret_encrypted: "\\x00",
+      iv: "\\x00",
+      key_version: 1,
+    });
+    await svc.from("sites").update({ status: "paused" }).eq("id", site.id);
+
+    await updateSiteCredentials(site.id, {
+      wp_user: "paused-user",
+      wp_app_password: "zzzz zzzz zzzz zzzz zzzz zzzz",
+    });
+
+    const after = await getSite(site.id);
+    expect(after.ok).toBe(true);
+    if (!after.ok) return;
+    expect(after.data.site.status).toBe("paused");
+  });
+});

--- a/lib/sites.ts
+++ b/lib/sites.ts
@@ -273,16 +273,12 @@ async function getSiteImpl(
     });
   }
   if (!cred) {
+    // Site exists but credentials were wiped (e.g. migration 0056). Return
+    // ok:true with null credentials so the edit page can still load and let
+    // the operator re-enter them — rather than serving a 404.
     return {
-      ok: false,
-      error: {
-        code: "NOT_FOUND",
-        message: `Site ${id} has no credentials row.`,
-        details: { id },
-        retryable: false,
-        suggested_action:
-          "Data integrity issue — re-register the site or restore credentials.",
-      },
+      ok: true,
+      data: { site: site as SiteRecord, credentials: null },
       timestamp: now(),
     };
   }
@@ -507,22 +503,41 @@ export async function updateSiteCredentials(
       }
     }
 
-    const { error } = await supabase
-      .from("site_credentials")
-      .update(update)
-      .eq("site_id", id);
-    if (error) {
-      return internalError("Failed to update site credentials.", {
-        supabase_error: error,
-      });
+    // Migration 0056 deleted every site_credentials row. A plain UPDATE
+    // silently does nothing when there is no existing row. Use UPSERT when
+    // we have a full credential set (both user + encrypted password) so the
+    // row is created if missing; fall back to UPDATE for partial patches.
+    const hasFullCredentials =
+      patch.wp_user !== undefined && patch.wp_app_password !== undefined;
+
+    if (hasFullCredentials) {
+      const { error } = await supabase
+        .from("site_credentials")
+        .upsert({ site_id: id, ...update }, { onConflict: "site_id" });
+      if (error) {
+        return internalError("Failed to upsert site credentials.", {
+          supabase_error: error,
+        });
+      }
+    } else {
+      const { error } = await supabase
+        .from("site_credentials")
+        .update(update)
+        .eq("site_id", id);
+      if (error) {
+        return internalError("Failed to update site credentials.", {
+          supabase_error: error,
+        });
+      }
     }
 
-    // Bump the parent sites.updated_at so the list page's "updated"
-    // column reflects the credential rotation.
+    // After a successful credential save, flip pending_pairing → active.
+    // Only touches pending_pairing — paused/active/removed are left alone.
     await supabase
       .from("sites")
-      .update({ updated_at: new Date().toISOString() })
-      .eq("id", id);
+      .update({ status: "active", updated_at: new Date().toISOString() })
+      .eq("id", id)
+      .eq("status", "pending_pairing");
 
     return { ok: true, data: { updated: true }, timestamp: now() };
   } catch (err) {


### PR DESCRIPTION
## Problem

Three compounding bugs caused all sites to show **Pending Pairing** after migration 0056 wiped `site_credentials` and reset every site's status.

### Bug 1 — Edit page served 404 instead of loading
`getSite(id, { includeCredentials: true })` returned `NOT_FOUND` when the credentials row was missing, even when the site row existed. The edit page called `notFound()` on that code, so operators couldn't even reach the form to re-enter credentials.

### Bug 2 — Credentials never saved after re-entry
`updateSiteCredentials` used `UPDATE site_credentials WHERE site_id = ...`. Since migration 0056 ran `DELETE FROM site_credentials`, there was no row to update — the UPDATE silently affected 0 rows. The operator's new credentials were never persisted.

### Bug 3 — Status never flipped back to Active
Even if credentials had been saved, `updateSiteCredentials` never changed `sites.status`. The site stayed `pending_pairing` indefinitely, no matter how many times the operator re-authenticated.

### Duplicate site names ("testme" × 3)
Data issue, not a code bug. The list query correctly returns distinct rows by ID. The three "testme" sites are genuine separate rows created manually. Operators can archive extras via the site Actions menu.

## Fix

**`lib/sites.ts`**

1. `getSite` with missing credentials row → return `ok: true, credentials: null` instead of `ok: false, NOT_FOUND`. The site exists; it just has no credentials. The edit page already handles `hasStoredCredentials={false}` correctly.

2. `updateSiteCredentials` → UPSERT when a full credential set (both `wp_user` + `wp_app_password`) is provided, so the row is inserted when it's missing. Falls back to UPDATE for partial patches (username-only rotation on an existing row).

3. After a successful credential save, flip `sites.status` from `pending_pairing` to `active`. Only flips `pending_pairing` rows — `paused`, `active`, and `removed` are left unchanged.

## Risks identified and mitigated

- **Status flip only targets pending_pairing**: `WHERE status = 'pending_pairing'` ensures we don't accidentally reactivate paused or archived sites.
- **Partial credential updates**: The `hasFullCredentials` guard ensures we only UPSERT when we have enough data for a complete row; partial updates still go through the existing UPDATE path.
- **No migration needed**: All changes are at the application layer; the DB schema is untouched.

## Test plan

- New test file `lib/__tests__/sites-credentials.test.ts` covers all three scenarios:
  - `getSite` with missing credentials row returns `ok:true, credentials:null`
  - Upsert inserts a credentials row when none exists
  - Status flips `pending_pairing → active` after full credential save
  - Status stays `paused` when rotating credentials on a paused site

🤖 Generated with [Claude Code](https://claude.com/claude-code)