### PR TITLE
feat(images): server-side image metadata extraction job + admin trigger

### DIFF
--- a/app/admin/system/jobs/page.tsx
+++ b/app/admin/system/jobs/page.tsx
@@ -5,6 +5,7 @@ import path from "node:path";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { H1, H2, Lead } from "@/components/ui/typography";
 import { StatusPill } from "@/components/ui/status-pill";
+import { ImageMetadataJobTrigger } from "@/components/admin/ImageMetadataJobTrigger";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -68,6 +69,10 @@ const CRON_DESCRIPTIONS: Record<string, string> = {
   "/api/cron/optimiser-extract-patterns": "Mine successful proposals for reusable patterns.",
   "/api/cron/optimiser-sync-vercel-logs":
     "Pull Vercel function-error logs to surface bad deploys earlier.",
+  "/api/cron/extract-image-metadata":
+    "Extracts dimensions, dominant colour, and EXIF/IPTC metadata from original Cloudflare blobs. Writes to image_library + image_metadata. Idempotent — skips already-processed images.",
+  "/api/cron/backfill-image-captions":
+    "EXIF-only caption backfill for images that have a Cloudflare ID but no caption/alt_text yet.",
 };
 
 function describeSchedule(schedule: string): string {
@@ -275,6 +280,17 @@ export default async function SystemJobsPage() {
           than 2 minutes or failed rows present. Check the table below.
         </div>
       )}
+
+      <section className="mt-6">
+        <H2>Library maintenance</H2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          One-off and on-demand jobs for the image library. Each batch processes
+          up to 10 images; run repeatedly until all images are done.
+        </p>
+        <div className="mt-3">
+          <ImageMetadataJobTrigger />
+        </div>
+      </section>
 
       <section className="mt-6">
         <H2>Queue depth</H2>

--- a/app/api/admin/jobs/extract-image-metadata/route.ts
+++ b/app/api/admin/jobs/extract-image-metadata/route.ts
@@ -1,0 +1,55 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { logger } from "@/lib/logger";
+import {
+  getExtractionProgress,
+  runExtractionBatch,
+} from "@/lib/image-metadata-extract";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+// GET — progress snapshot for the admin UI poller.
+export async function GET() {
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  try {
+    const progress = await getExtractionProgress();
+    return NextResponse.json(progress);
+  } catch (err) {
+    logger.error("extract.admin_get_error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}
+
+// POST — trigger one synchronous batch from the admin UI.
+export async function POST() {
+  const gate = await requireAdminForApi({ roles: ["super_admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_IMAGES_API_TOKEN;
+  if (!accountId || !apiToken) {
+    logger.error("extract.admin_missing_cf_creds", {});
+    return NextResponse.json(
+      { error: "Cloudflare credentials not configured on this deployment" },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const result = await runExtractionBatch({ accountId, apiToken, batchSize: 10 });
+    return NextResponse.json(result);
+  } catch (err) {
+    logger.error("extract.admin_post_error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/app/api/cron/backfill-image-captions/route.ts
+++ b/app/api/cron/backfill-image-captions/route.ts
@@ -64,6 +64,12 @@ async function fetchOriginalBytes(
 // EXIF extraction
 // ---------------------------------------------------------------------------
 
+// Only accept plain strings — IPTC record objects stringify to "[object Object]".
+function str(v: unknown, max: number): string | null {
+  if (typeof v === "string" && v.trim()) return v.trim().slice(0, max) || null;
+  return null;
+}
+
 type ExifResult = {
   caption: string | null;
   altText: string | null;
@@ -75,27 +81,23 @@ async function extractExif(bytes: Uint8Array): Promise<ExifResult> {
     const meta = await exifr.parse(Buffer.from(bytes), { iptc: true, exif: true, xmp: true });
     if (!meta) return { caption: null, altText: null, tags: [] };
 
-    const rawCaption =
-      (meta["Caption-Abstract"] as string | undefined) ??
-      (meta.description as string | undefined) ??
-      (meta.Headline as string | undefined) ??
-      null;
+    const caption =
+      str(meta["Caption-Abstract"], 150) ??
+      str(meta.description, 150) ??
+      str(meta.Headline, 150);
 
-    const rawAlt =
-      (meta.Headline as string | undefined) ??
-      (meta.ObjectName as string | undefined) ??
-      (meta.Title as string | undefined) ??
-      null;
+    const altText =
+      str(meta.Headline, 100) ??
+      str(meta.ObjectName, 100) ??
+      str(meta.Title, 100);
 
     const rawTags: unknown = (meta.Keywords as unknown) ?? (meta.Subject as unknown) ?? [];
     const tagsArr = Array.isArray(rawTags) ? rawTags : rawTags ? [rawTags] : [];
     const tags = tagsArr
-      .map((t: unknown) => String(t).trim().toLowerCase())
+      .filter((t): t is string => typeof t === "string")
+      .map((t) => t.trim().toLowerCase())
       .filter(Boolean)
       .slice(0, 12);
-
-    const caption = rawCaption ? String(rawCaption).trim().slice(0, 150) || null : null;
-    const altText = rawAlt ? String(rawAlt).trim().slice(0, 100) || null : null;
 
     return { caption, altText, tags };
   } catch {
@@ -126,7 +128,7 @@ export async function GET(req: NextRequest) {
     .from("image_library")
     .select("id, cloudflare_id, filename, tags")
     .is("deleted_at", null)
-    .or("caption.is.null,caption.eq.")
+    .or("caption.is.null,caption.eq.,caption.eq.[object Object]")
     .order("created_at", { ascending: true })
     .limit(BATCH_SIZE);
 
@@ -192,7 +194,7 @@ export async function GET(req: NextRequest) {
     .from("image_library")
     .select("id", { count: "exact", head: true })
     .is("deleted_at", null)
-    .or("caption.is.null,caption.eq.");
+    .or("caption.is.null,caption.eq.,caption.eq.[object Object]");
 
   logger.info("backfill.tick_complete", {
     processed: total,

--- a/app/api/cron/extract-image-metadata/route.ts
+++ b/app/api/cron/extract-image-metadata/route.ts
@@ -1,0 +1,41 @@
+import "server-only";
+
+import { type NextRequest, NextResponse } from "next/server";
+
+import { constantTimeEqual } from "@/lib/crypto-compare";
+import { logger } from "@/lib/logger";
+import { runExtractionBatch } from "@/lib/image-metadata-extract";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+function authorised(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || secret.length < 16) return false;
+  const header = req.headers.get("authorization") ?? "";
+  if (!header.toLowerCase().startsWith("bearer ")) return false;
+  return constantTimeEqual(header.slice(7).trim(), secret);
+}
+
+export async function GET(req: NextRequest) {
+  if (!authorised(req)) {
+    return NextResponse.json({ error: "Unauthorised" }, { status: 401 });
+  }
+
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_IMAGES_API_TOKEN;
+  if (!accountId || !apiToken) {
+    logger.error("extract.missing_cf_credentials", {});
+    return NextResponse.json({ error: "Missing Cloudflare credentials" }, { status: 500 });
+  }
+
+  try {
+    const result = await runExtractionBatch({ accountId, apiToken, batchSize: 10 });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    logger.error("extract.cron_handler_error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/components/admin/ImageMetadataJobTrigger.tsx
+++ b/components/admin/ImageMetadataJobTrigger.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type Progress = {
+  total: number;
+  done: number;
+  remaining: number;
+  pct: number;
+  cfCredsPresent: boolean;
+};
+
+type BatchResult = {
+  processed: number;
+  saved: number;
+  noData: number;
+  errors: number;
+  remaining: number | null;
+  done: boolean;
+};
+
+const POLL_MS = 4000;
+
+export function ImageMetadataJobTrigger() {
+  const [progress, setProgress] = useState<Progress | null>(null);
+  const [running, setRunning] = useState(false);
+  const [lastResult, setLastResult] = useState<BatchResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchProgress = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/jobs/extract-image-metadata");
+      if (!res.ok) return;
+      const data = (await res.json()) as Progress;
+      setProgress(data);
+    } catch {
+      // silent — polling is best-effort
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchProgress();
+    function schedule() {
+      timerRef.current = setTimeout(async () => {
+        await fetchProgress();
+        // Stop polling when everything is done.
+        if (progress?.remaining !== 0) schedule();
+      }, POLL_MS);
+    }
+    schedule();
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [fetchProgress, progress?.remaining]);
+
+  async function runBatch() {
+    setRunning(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/jobs/extract-image-metadata", {
+        method: "POST",
+      });
+      const data = (await res.json()) as BatchResult & { error?: string };
+      if (!res.ok) {
+        setError(data.error ?? "Batch failed");
+      } else {
+        setLastResult(data);
+        await fetchProgress();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  const isDone = progress?.remaining === 0;
+  const noCredsMsg =
+    progress && !progress.cfCredsPresent
+      ? "Cloudflare credentials are not set on this deployment."
+      : null;
+
+  return (
+    <div className="rounded-md border p-4 space-y-3">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium">Image metadata extraction</p>
+          <p className="text-xs text-muted-foreground">
+            Fetches original CF blobs and writes dimensions, dominant colour, and
+            EXIF to <code>image_library</code> + <code>image_metadata</code>.
+            Idempotent — skips images already extracted.
+          </p>
+        </div>
+        <button
+          onClick={() => void runBatch()}
+          disabled={running || isDone || !!noCredsMsg}
+          className="shrink-0 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {running ? "Running…" : isDone ? "All done" : "Run batch"}
+        </button>
+      </div>
+
+      {noCredsMsg && (
+        <p className="text-xs text-destructive">{noCredsMsg}</p>
+      )}
+
+      {progress && (
+        <div className="space-y-1">
+          <div className="flex justify-between text-xs text-muted-foreground">
+            <span>
+              {progress.done.toLocaleString()} / {progress.total.toLocaleString()} extracted
+            </span>
+            <span>{progress.pct}%</span>
+          </div>
+          <div className="h-2 rounded-full bg-muted overflow-hidden">
+            <div
+              className="h-full bg-primary transition-all"
+              style={{ width: `${progress.pct}%` }}
+            />
+          </div>
+          {isDone && (
+            <p className="text-xs text-green-600 dark:text-green-400">
+              All images extracted.
+            </p>
+          )}
+        </div>
+      )}
+
+      {lastResult && (
+        <p className="text-xs text-muted-foreground">
+          Last batch: processed {lastResult.processed}, saved {lastResult.saved},
+          no-data {lastResult.noData}, errors {lastResult.errors}
+          {lastResult.remaining !== null
+            ? `, ${lastResult.remaining} remaining`
+            : ""}
+          .
+        </p>
+      )}
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/lib/image-metadata-extract.ts
+++ b/lib/image-metadata-extract.ts
@@ -1,0 +1,375 @@
+import "server-only";
+
+import sharp from "sharp";
+import exifr from "exifr";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ExtractionBatchResult = {
+  processed: number;
+  saved: number;
+  noData: number;
+  errors: number;
+  remaining: number | null;
+  done: boolean;
+};
+
+export type ExtractionProgress = {
+  total: number;
+  done: number;
+  remaining: number;
+  pct: number;
+  cfCredsPresent: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CF_BLOB_BASE =
+  "https://api.cloudflare.com/client/v4/accounts";
+
+function blobUrl(accountId: string, cfId: string): string {
+  return `${CF_BLOB_BASE}/${accountId}/images/v1/${encodeURIComponent(cfId)}/blob`;
+}
+
+// Only accept plain strings — IPTC record objects stringify to "[object Object]".
+function safeStr(v: unknown, maxLen: number): string | null {
+  if (typeof v === "string" && v.trim()) return v.trim().slice(0, maxLen) || null;
+  return null;
+}
+
+async function fetchImageBytes(
+  accountId: string,
+  apiToken: string,
+  cfId: string,
+): Promise<Uint8Array | null> {
+  const MAX = 20 * 1024 * 1024;
+  try {
+    const res = await fetch(blobUrl(accountId, cfId), {
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        Range: `bytes=0-${MAX - 1}`,
+      },
+    });
+    if (!res.ok && res.status !== 206) {
+      logger.warn("extract.blob_fetch_failed", { cf_id: cfId, status: res.status });
+      return null;
+    }
+    return new Uint8Array(await res.arrayBuffer());
+  } catch (err) {
+    logger.warn("extract.blob_fetch_error", {
+      cf_id: cfId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+type ImageMeta = {
+  width: number | null;
+  height: number | null;
+  dominantR: number | null;
+  dominantG: number | null;
+  dominantB: number | null;
+  caption: string | null;
+  altText: string | null;
+  tags: string[];
+  exifRaw: Record<string, unknown> | null;
+};
+
+async function extractMetadata(bytes: Uint8Array): Promise<ImageMeta> {
+  const buf = Buffer.from(bytes);
+
+  // Sharp: dimensions + dominant colour
+  let width: number | null = null;
+  let height: number | null = null;
+  let dominantR: number | null = null;
+  let dominantG: number | null = null;
+  let dominantB: number | null = null;
+
+  try {
+    const img = sharp(buf);
+    const [meta, stats] = await Promise.all([img.metadata(), img.stats()]);
+    width = meta.width ?? null;
+    height = meta.height ?? null;
+    dominantR = Math.round(stats.dominant.r);
+    dominantG = Math.round(stats.dominant.g);
+    dominantB = Math.round(stats.dominant.b);
+  } catch {
+    // non-fatal — carry on to EXIF
+  }
+
+  // exifr: IPTC/XMP/EXIF
+  let caption: string | null = null;
+  let altText: string | null = null;
+  let tags: string[] = [];
+  let exifRaw: Record<string, unknown> | null = null;
+
+  try {
+    const parsed = await exifr.parse(buf, {
+      iptc: true,
+      exif: true,
+      xmp: true,
+      reviveValues: true,
+    });
+
+    if (parsed) {
+      exifRaw = parsed as Record<string, unknown>;
+
+      caption =
+        safeStr(parsed["Caption-Abstract"], 150) ??
+        safeStr(parsed.description, 150) ??
+        safeStr(parsed.Headline, 150);
+
+      altText =
+        safeStr(parsed.Headline, 100) ??
+        safeStr(parsed.ObjectName, 100) ??
+        safeStr(parsed.Title, 100);
+
+      const rawKw: unknown =
+        (parsed.Keywords as unknown) ?? (parsed.Subject as unknown) ?? [];
+      const kwArr = Array.isArray(rawKw) ? rawKw : rawKw ? [rawKw] : [];
+      tags = kwArr
+        .filter((t): t is string => typeof t === "string")
+        .map((t) => t.trim().toLowerCase())
+        .filter(Boolean)
+        .slice(0, 20);
+    }
+  } catch {
+    // non-fatal
+  }
+
+  return { width, height, dominantR, dominantG, dominantB, caption, altText, tags, exifRaw };
+}
+
+// ---------------------------------------------------------------------------
+// Core batch runner
+// ---------------------------------------------------------------------------
+
+export async function runExtractionBatch(opts: {
+  accountId: string;
+  apiToken: string;
+  batchSize?: number;
+}): Promise<ExtractionBatchResult> {
+  const { accountId, apiToken, batchSize = 10 } = opts;
+  const svc = getServiceRoleClient();
+  const now = new Date().toISOString();
+
+  // Primary idempotency: only rows that don't have dimensions yet.
+  const { data: rows, error: fetchErr } = await svc
+    .from("image_library")
+    .select("id, cloudflare_id, filename, tags")
+    .is("deleted_at", null)
+    .is("width_px", null)
+    .order("created_at", { ascending: true })
+    .limit(batchSize);
+
+  if (fetchErr) {
+    logger.error("extract.db_query_failed", { error: fetchErr.message });
+    throw new Error(fetchErr.message);
+  }
+
+  const batch = rows ?? [];
+  const batchIds = batch.map((r) => r.id as string);
+
+  // Secondary idempotency: skip rows already processed this batch cycle
+  // (covers images where Sharp couldn't extract dimensions).
+  let doneIds = new Set<string>();
+  if (batchIds.length > 0) {
+    const { data: sentinels } = await svc
+      .from("image_metadata")
+      .select("image_id")
+      .in("image_id", batchIds)
+      .eq("key", "metadata_extracted_at");
+    doneIds = new Set((sentinels ?? []).map((s) => s.image_id as string));
+  }
+
+  let saved = 0;
+  let noData = 0;
+  let errors = 0;
+
+  for (const row of batch) {
+    const imageId = row.id as string;
+    if (doneIds.has(imageId)) {
+      noData++;
+      continue;
+    }
+
+    const cfId = row.cloudflare_id as string | null;
+    if (!cfId) {
+      noData++;
+      continue;
+    }
+
+    const bytes = await fetchImageBytes(accountId, apiToken, cfId);
+    if (!bytes) {
+      errors++;
+      continue;
+    }
+
+    const meta = await extractMetadata(bytes);
+
+    // Write dimensions + text fields to image_library.
+    const patch: Record<string, unknown> = { updated_at: now };
+    if (meta.width !== null) patch.width_px = meta.width;
+    if (meta.height !== null) patch.height_px = meta.height;
+    if (meta.caption) patch.caption = meta.caption;
+    if (meta.altText) patch.alt_text = meta.altText;
+    if (meta.tags.length > 0) {
+      const existing = Array.isArray(row.tags) ? (row.tags as string[]) : [];
+      patch.tags = Array.from(new Set([...existing, ...meta.tags]));
+    }
+
+    const { error: libErr } = await svc
+      .from("image_library")
+      .update(patch)
+      .eq("id", imageId);
+
+    if (libErr) {
+      logger.error("extract.library_update_failed", {
+        image_id: imageId,
+        error: libErr.message,
+      });
+      errors++;
+      continue;
+    }
+
+    // Write sidecar metadata rows.
+    type MetaRow = {
+      image_id: string;
+      key: string;
+      value_jsonb: unknown;
+      updated_at: string;
+    };
+    const sidecar: MetaRow[] = [
+      {
+        image_id: imageId,
+        key: "metadata_extracted_at",
+        value_jsonb: now,
+        updated_at: now,
+      },
+    ];
+
+    if (meta.dominantR !== null) {
+      sidecar.push({
+        image_id: imageId,
+        key: "dominant_color",
+        value_jsonb: { r: meta.dominantR, g: meta.dominantG, b: meta.dominantB },
+        updated_at: now,
+      });
+    }
+
+    if (meta.exifRaw) {
+      // Store only a safe subset — skip binary blobs, unknown objects.
+      const safeKeys = [
+        "Make",
+        "Model",
+        "DateTimeOriginal",
+        "latitude",
+        "longitude",
+        "Copyright",
+        "Credit",
+        "Source",
+        "Country",
+        "City",
+      ];
+      const subset: Record<string, unknown> = {};
+      for (const k of safeKeys) {
+        if (k in meta.exifRaw) subset[k] = meta.exifRaw[k];
+      }
+      if (Object.keys(subset).length > 0) {
+        sidecar.push({
+          image_id: imageId,
+          key: "exif_summary",
+          value_jsonb: subset,
+          updated_at: now,
+        });
+      }
+    }
+
+    const { error: sidecarErr } = await svc
+      .from("image_metadata")
+      .upsert(sidecar, { onConflict: "image_id,key" });
+
+    if (sidecarErr) {
+      logger.warn("extract.sidecar_upsert_failed", {
+        image_id: imageId,
+        error: sidecarErr.message,
+      });
+    }
+
+    logger.info("extract.image_saved", {
+      image_id: imageId,
+      filename: row.filename,
+      width: meta.width,
+      height: meta.height,
+      caption: meta.caption?.slice(0, 60) ?? null,
+    });
+    saved++;
+  }
+
+  // Count remaining images still needing extraction.
+  const { count: remaining } = await svc
+    .from("image_library")
+    .select("id", { count: "exact", head: true })
+    .is("deleted_at", null)
+    .is("width_px", null);
+
+  logger.info("extract.batch_complete", {
+    processed: batch.length,
+    saved,
+    no_data: noData,
+    errors,
+    remaining: remaining ?? "?",
+  });
+
+  return {
+    processed: batch.length,
+    saved,
+    noData,
+    errors,
+    remaining: remaining ?? null,
+    done: (remaining ?? 1) === 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Progress query (for the admin UI)
+// ---------------------------------------------------------------------------
+
+export async function getExtractionProgress(): Promise<ExtractionProgress> {
+  const svc = getServiceRoleClient();
+
+  const [totalRes, remainingRes] = await Promise.all([
+    svc
+      .from("image_library")
+      .select("id", { count: "exact", head: true })
+      .is("deleted_at", null),
+    svc
+      .from("image_library")
+      .select("id", { count: "exact", head: true })
+      .is("deleted_at", null)
+      .is("width_px", null),
+  ]);
+
+  const total = totalRes.count ?? 0;
+  const remaining = remainingRes.count ?? 0;
+  const done = total - remaining;
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+
+  return {
+    total,
+    done,
+    remaining,
+    pct,
+    cfCredsPresent: !!(
+      process.env.CLOUDFLARE_ACCOUNT_ID && process.env.CLOUDFLARE_IMAGES_API_TOKEN
+    ),
+  };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -103,6 +103,10 @@
     {
       "path": "/api/cron/backfill-image-captions",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/cron/extract-image-metadata",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **lib/image-metadata-extract.ts** — shared extraction core (Sharp + exifr). Fetches original Cloudflare blob (EXIF intact; delivery CDN strips it), writes `width_px`/`height_px`/`caption`/`alt_text`/`tags` to `image_library`, and stores `dominant_color`, `exif_summary`, and `metadata_extracted_at` sentinel in `image_metadata` via UPSERT. Primary idempotency: `width_px IS NULL`. Secondary: per-batch sentinel check prevents re-processing images Sharp couldn't dimension.

- **app/api/cron/extract-image-metadata/route.ts** — Vercel cron worker (CRON_SECRET bearer auth, `maxDuration=299`). Calls `runExtractionBatch` with `batchSize=10` per tick.

- **app/api/admin/jobs/extract-image-metadata/route.ts** — session-authed admin route. GET returns progress snapshot; POST triggers one synchronous batch (super_admin only). Calls `runExtractionBatch` directly — no inter-service HTTP.

- **components/admin/ImageMetadataJobTrigger.tsx** — "use client" progress bar + "Run batch" button. Polls GET every 4 s; stops when `remaining === 0`. Disables button when CF creds absent.

- **app/admin/system/jobs/page.tsx** — "Library maintenance" section with `ImageMetadataJobTrigger`; CRON_DESCRIPTIONS entries for both image crons.

- **vercel.json** — adds `/api/cron/extract-image-metadata` at `* * * * *` (27 crons total).

- **app/api/cron/backfill-image-captions/route.ts** — fixes `[object Object]` caption bug in the existing cron. Replaces `String(rawCaption)` with `str()` that only accepts `typeof v === "string"`; updates OR filters to also match the 50 corrupted prod rows (`caption.eq.[object Object]`).

## Cloudflare credentials
`CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_IMAGES_API_TOKEN`, and `CLOUDFLARE_IMAGES_HASH` are confirmed present in Vercel (encrypted, Preview + Production). The admin POST route returns a 500 with a clear message if they're missing on the deployment.

## Risks identified and mitigated
- **Idempotency:** `width_px IS NULL` is the fast primary gate (indexed). Secondary sentinel prevents double-processing on Sharp failures. `image_metadata` UPSERT uses `onConflict: "image_id,key"`.
- **[object Object] bug:** Fixed in both the cron and the new lib. Query filters updated to treat `[object Object]` as absent so the cron picks up the 50 corrupted prod rows.
- **No Anthropic API credits used:** Sharp + exifr only.
- **CF creds not in local .env.local:** Handled gracefully — 500 with descriptive error; prod uses Vercel env vars.

## Test plan
- [ ] Push → CI lint/typecheck/build
- [ ] Navigate to `/admin/system/jobs` — "Library maintenance" section renders with progress bar
- [ ] POST to `/api/admin/jobs/extract-image-metadata` with session cookie — processes first 10 images, returns `processed`/`saved`/`remaining`
- [ ] Re-run — already-extracted images are skipped (idempotent)
- [ ] Cron endpoint responds 401 without correct `Authorization: Bearer <CRON_SECRET>` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)