### PR TITLE
fix(composer): new post always starts blank — explicit draft restore prompt

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -210,47 +210,59 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
   // Fix 6 — WP categories + tags.
   const [selectedCategories, setSelectedCategories] = useState<WpTaxonomyOption[]>([]);
   const [selectedTags, setSelectedTags] = useState<WpTaxonomyOption[]>([]);
-  // Hydration guard — restore-from-localStorage runs once, AFTER mount.
+  // BL-2 — pending draft found in localStorage; shown as a restore prompt,
+  // NOT applied silently. Operator must explicitly click "Restore" to load it.
+  const [pendingDraft, setPendingDraft] = useState<DraftSnapshot | null>(null);
+  // Hydration guard — draft-check runs once, AFTER mount.
   const restoredRef = useRef(false);
 
-  // BL-2 — restore from localStorage on mount.
+  // BL-2 — check localStorage on mount. Do NOT silently restore. Instead,
+  // surface a banner so the operator can choose to restore or start fresh.
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined") {
+      restoredRef.current = true;
+      return;
+    }
     try {
       const raw = window.localStorage.getItem(draftStorageKey(siteId));
-      if (!raw) {
-        restoredRef.current = true;
-        return;
-      }
-      const parsed = JSON.parse(raw) as DraftSnapshot;
-      if (parsed?.v !== 1) {
-        restoredRef.current = true;
-        return;
-      }
-      if (typeof parsed.composerText === "string") {
-        setComposerValue({ text: parsed.composerText, file: null });
-      }
-      if (parsed.title) setTitle(parsed.title);
-      if (parsed.slug) setSlug(parsed.slug);
-      if (parsed.metaTitle) setMetaTitle(parsed.metaTitle);
-      if (parsed.metaDescription) setMetaDescription(parsed.metaDescription);
-      if (parsed.parentPage !== undefined) setParentPage(parsed.parentPage);
-      if (parsed.featuredImage !== undefined) setFeaturedImage(parsed.featuredImage);
-      if (parsed.publishMode) setPublishMode(parsed.publishMode);
-      if (parsed.scheduledAt) setScheduledAt(parsed.scheduledAt);
-      if (parsed.selectedCategories) setSelectedCategories(parsed.selectedCategories);
-      if (parsed.selectedTags) setSelectedTags(parsed.selectedTags);
-      setDraftRestoredAt(parsed.savedAt);
-      if (parsed.parentPage) {
-        setShowAdvanced(true);
+      if (raw) {
+        const parsed = JSON.parse(raw) as DraftSnapshot;
+        if (parsed?.v === 1) {
+          setPendingDraft(parsed);
+        }
       }
     } catch {
-      try {
-        window.localStorage.removeItem(draftStorageKey(siteId));
-      } catch {}
+      try { window.localStorage.removeItem(draftStorageKey(siteId)); } catch {}
     } finally {
       restoredRef.current = true;
     }
+  }, [siteId]);
+
+  const applyPendingDraft = useCallback(() => {
+    if (!pendingDraft) return;
+    if (typeof pendingDraft.composerText === "string") {
+      setComposerValue({ text: pendingDraft.composerText, file: null });
+    }
+    if (pendingDraft.title) setTitle(pendingDraft.title);
+    if (pendingDraft.slug) setSlug(pendingDraft.slug);
+    if (pendingDraft.metaTitle) setMetaTitle(pendingDraft.metaTitle);
+    if (pendingDraft.metaDescription) setMetaDescription(pendingDraft.metaDescription);
+    if (pendingDraft.parentPage !== undefined) setParentPage(pendingDraft.parentPage);
+    if (pendingDraft.featuredImage !== undefined) setFeaturedImage(pendingDraft.featuredImage);
+    if (pendingDraft.publishMode) setPublishMode(pendingDraft.publishMode);
+    if (pendingDraft.scheduledAt) setScheduledAt(pendingDraft.scheduledAt);
+    if (pendingDraft.selectedCategories) setSelectedCategories(pendingDraft.selectedCategories);
+    if (pendingDraft.selectedTags) setSelectedTags(pendingDraft.selectedTags);
+    setDraftRestoredAt(pendingDraft.savedAt);
+    if (pendingDraft.parentPage) setShowAdvanced(true);
+    setPendingDraft(null);
+  }, [pendingDraft]);
+
+  const dismissPendingDraft = useCallback(() => {
+    if (typeof window !== "undefined") {
+      try { window.localStorage.removeItem(draftStorageKey(siteId)); } catch {}
+    }
+    setPendingDraft(null);
   }, [siteId]);
 
   // Read attached file content into composerValue.text.
@@ -671,6 +683,15 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
       onSubmit={handlePrimarySubmit}
       className="space-y-6"
     >
+      {/* BL-2 — explicit draft restore prompt. Never silently restore. */}
+      {pendingDraft && (
+        <DraftRestoreBanner
+          savedAt={pendingDraft.savedAt}
+          onRestore={applyPendingDraft}
+          onDiscard={dismissPendingDraft}
+        />
+      )}
+
       {/* Fix 5 — site indicator: shows WP hostname + Change link, or a warning if not connected. */}
       {!siteLoading && !siteWpUrl && (
         <Alert variant="destructive" className="flex items-start gap-2">
@@ -1763,5 +1784,58 @@ function WpPageCombobox({
         </Command>
       </PopoverContent>
     </Popover>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BL-2 — Explicit draft restore prompt.
+//
+// Shown when a localStorage draft is found on mount. The editor always
+// starts blank; the operator must consciously click Restore to load the
+// draft. This prevents stale content from previous sessions appearing
+// unexpectedly when navigating to /admin/posts/new.
+// ---------------------------------------------------------------------------
+
+function DraftRestoreBanner({
+  savedAt,
+  onRestore,
+  onDiscard,
+}: {
+  savedAt: number;
+  onRestore: () => void;
+  onDiscard: () => void;
+}) {
+  return (
+    <div
+      data-testid="draft-restore-banner"
+      className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-sm"
+      role="alert"
+    >
+      <span className="text-foreground">
+        You have an unsaved draft from{" "}
+        <span className="font-medium">
+          {formatRelativeTime(new Date(savedAt).toISOString())}
+        </span>
+        .
+      </span>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onDiscard}
+          data-testid="draft-discard-btn"
+          className="text-sm text-muted-foreground underline underline-offset-2 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
+        >
+          Start fresh
+        </button>
+        <button
+          type="button"
+          onClick={onRestore}
+          data-testid="draft-restore-btn"
+          className="rounded-md border bg-background px-3 py-1 text-sm font-medium transition-smooth hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Restore draft
+        </button>
+      </div>
+    </div>
   );
 }

--- a/e2e/posts-new.spec.ts
+++ b/e2e/posts-new.spec.ts
@@ -96,68 +96,155 @@ test.describe("/admin/posts/new — top-level entry", () => {
     await auditA11y(page, testInfo);
   });
 
-  // BL-2 — autosave + progressive disclosure round-trip.
-  test("autosave persists across reload and disclosure toggles", async ({
+  // BL-2 — new post route always starts blank; saved draft is offered
+  // via an explicit restore banner, never silently applied.
+  test("navigating to new post always starts with empty editor", async ({
     page,
   }, testInfo) => {
     await signInAsAdmin(page);
     await page.goto("/admin/posts/new");
 
-    // Pick the seeded site so the composer mounts with a stable
-    // localStorage key.
     await page.getByTestId("posts-new-site-picker").click();
     const firstOption = page
       .locator('[data-testid^="posts-new-site-option-"]')
       .first();
     await firstOption.click();
 
-    // Advanced fields are collapsed by default for a fresh draft.
-    const panel = page.getByTestId("post-advanced-panel");
-    await expect(panel).toHaveCount(0);
+    // Seed a draft in localStorage so the next navigation would previously
+    // have silently restored it.
+    await page.evaluate(() => {
+      const key = Object.keys(localStorage).find((k) =>
+        k.startsWith("opollo:post-draft:"),
+      );
+      if (!key) {
+        // Write a synthetic stale draft so the test is deterministic even
+        // when no prior autosave exists.
+        const siteId = window.location.search; // fallback — not ideal but robust
+        void siteId;
+        // Write to any matching key; the composerValue is what we care about.
+        const entries = Object.entries(localStorage);
+        const draftKey =
+          entries.find(([k]) => k.startsWith("opollo:post-draft:"))?.[0] ??
+          "opollo:post-draft:synthetic";
+        localStorage.setItem(
+          draftKey,
+          JSON.stringify({
+            v: 1,
+            composerText: "<p>Stale content from previous session</p>",
+            title: { value: "Stale title", source: "h1", touched: true },
+            slug: { value: "url1", source: "derived", touched: true },
+            savedAt: Date.now() - 1000 * 60 * 60, // 1 hour ago
+          }),
+        );
+      }
+    });
 
-    // Type into the composer (TipTap ProseMirror). Use pressSequentially so
-    // TipTap's key-event handlers fire and update the React state that the
-    // autosave debounce watches.
-    const composer = page.locator(".ProseMirror");
-    await composer.click();
-    await composer.pressSequentially("Hello world body for autosave probe.");
-    await page.locator("#post-title").fill("Autosave probe");
-
-    // Wait for the autosave to COMPLETE (localStorage written), not just
-    // started. "Saving…" fires immediately; "Saved ·" fires after the 800ms
-    // debounce callback runs.
-    await expect(page.getByTestId("post-save-status")).toContainText(
-      /saved ·/i,
-      { timeout: 8000 },
-    );
-
-    // Open the disclosure manually.
-    await page.getByTestId("post-advanced-toggle").click();
-    await expect(page.getByTestId("post-advanced-panel")).toBeVisible();
-
-    // Reload — the snapshot should rehydrate the title + body.
     await page.reload();
-
-    // The site picker resets to "Pick a site…" because the page
-    // tracks selection client-side, but the composer's localStorage
-    // is keyed by siteId. Re-pick the site to remount the composer.
     await page.getByTestId("posts-new-site-picker").click();
     await page
       .locator('[data-testid^="posts-new-site-option-"]')
       .first()
       .click();
 
-    await expect(page.locator("#post-title")).toHaveValue(
-      /autosave probe/i,
+    // The editor must be blank — no stale content.
+    await expect(page.locator(".ProseMirror")).toBeEmpty();
+    // Title field must be blank.
+    await expect(page.locator("#post-title")).toHaveValue("");
+
+    // A restore banner must be visible, offering to bring the draft back.
+    await expect(page.getByTestId("draft-restore-banner")).toBeVisible();
+    await expect(page.getByTestId("draft-restore-btn")).toBeVisible();
+    await expect(page.getByTestId("draft-discard-btn")).toBeVisible();
+
+    await auditA11y(page, testInfo);
+  });
+
+  // BL-2 — autosave + explicit restore round-trip.
+  test("clicking Restore draft applies saved content", async ({
+    page,
+  }, testInfo) => {
+    await signInAsAdmin(page);
+    await page.goto("/admin/posts/new");
+
+    await page.getByTestId("posts-new-site-picker").click();
+    const firstOption = page
+      .locator('[data-testid^="posts-new-site-option-"]')
+      .first();
+    await firstOption.click();
+
+    const composer = page.locator(".ProseMirror");
+    await composer.click();
+    await composer.pressSequentially("Hello world body for autosave probe.");
+    await page.locator("#post-title").fill("Autosave probe");
+
+    await expect(page.getByTestId("post-save-status")).toContainText(
+      /saved ·/i,
+      { timeout: 8000 },
     );
+
+    await page.reload();
+
+    await page.getByTestId("posts-new-site-picker").click();
+    await page
+      .locator('[data-testid^="posts-new-site-option-"]')
+      .first()
+      .click();
+
+    // Restore banner visible; editor still blank.
+    await expect(page.getByTestId("draft-restore-banner")).toBeVisible();
+    await expect(page.locator("#post-title")).toHaveValue("");
+
+    // Click Restore — draft content loads.
+    await page.getByTestId("draft-restore-btn").click();
+    await expect(page.locator("#post-title")).toHaveValue(/autosave probe/i);
     await expect(page.locator(".ProseMirror")).toContainText(
       /hello world body for autosave probe/i,
     );
 
-    // "Draft restored" status surfaces with a Discard control.
+    // Banner disappears after restoring.
+    await expect(page.getByTestId("draft-restore-banner")).toHaveCount(0);
+
+    await auditA11y(page, testInfo);
+  });
+
+  // BL-2 — dismissing the banner clears the saved draft.
+  test("clicking Start fresh clears the saved draft and hides banner", async ({
+    page,
+  }, testInfo) => {
+    await signInAsAdmin(page);
+    await page.goto("/admin/posts/new");
+
+    await page.getByTestId("posts-new-site-picker").click();
+    const firstOption = page
+      .locator('[data-testid^="posts-new-site-option-"]')
+      .first();
+    await firstOption.click();
+
+    const composer = page.locator(".ProseMirror");
+    await composer.click();
+    await composer.pressSequentially("Some content to be discarded.");
+    await page.locator("#post-title").fill("Draft to discard");
+
     await expect(page.getByTestId("post-save-status")).toContainText(
-      /draft restored|saved/i,
+      /saved ·/i,
+      { timeout: 8000 },
     );
+
+    await page.reload();
+
+    await page.getByTestId("posts-new-site-picker").click();
+    await page
+      .locator('[data-testid^="posts-new-site-option-"]')
+      .first()
+      .click();
+
+    await expect(page.getByTestId("draft-restore-banner")).toBeVisible();
+
+    // Click Start fresh — banner disappears, editor stays blank.
+    await page.getByTestId("draft-discard-btn").click();
+    await expect(page.getByTestId("draft-restore-banner")).toHaveCount(0);
+    await expect(page.locator("#post-title")).toHaveValue("");
+    await expect(page.locator(".ProseMirror")).toBeEmpty();
 
     await auditA11y(page, testInfo);
   });


### PR DESCRIPTION
## Problem

`/admin/posts/new` silently applied the most recent autosaved draft on mount. Navigating back to create a new post loaded stale content — title, body, slug — from the previous session without any operator action.

Root cause: the mount `useEffect` in `BlogPostComposer` read localStorage and directly set all form state (title, composerText, slug, etc.), then set `restoredRef.current = true`. This meant every fresh navigation looked like a restore.

## Solution

Replace the silent restore with an **explicit opt-in banner**:

1. Mount reads localStorage → stores draft as `pendingDraft` state (never touches the form).
2. Editor, title, slug, and all other fields always initialise **empty**.
3. If a draft exists, `DraftRestoreBanner` appears at the top of the form:
   - **Restore draft** → applies all saved fields, sets the "restored from X" status, clears the banner.
   - **Start fresh** → removes the localStorage entry, clears the banner. Next navigation starts clean.

## Files changed

- `components/BlogPostComposer.tsx` — pendingDraft state + useEffect + applyPendingDraft/dismissPendingDraft callbacks + DraftRestoreBanner component (data-testids: `draft-restore-banner`, `draft-restore-btn`, `draft-discard-btn`)
- `e2e/posts-new.spec.ts` — three new E2E tests: blank start + banner visible, explicit restore round-trip, discard clears draft and hides banner

## Risks identified and mitigated

- **Existing autosave tests:** the previous "autosave persists across reload" test asserted that content was auto-restored after reload; that is now the wrong behaviour. The existing test has been updated to the new explicit-restore flow. Three new tests replace the prior implicit coverage.
- **No schema / API changes:** this is entirely a localStorage + React state change. No backend risk.
- **Draft key collision:** not changed — still keyed by `siteId` so drafts for different sites are independent.

## Note (does not need action)

Duplicate site names ("testme" × 3) visible in the site picker are a **seed data issue**, not a code issue. `listSites` returns distinct rows by ID; the names themselves are duplicated in the test database. No code fix needed.