### PR TITLE
fix(settings): image library toggle redesigned as switch control with metadata count

### DIFF
--- a/app/admin/sites/[id]/settings/page.tsx
+++ b/app/admin/sites/[id]/settings/page.tsx
@@ -43,13 +43,29 @@ export default async function SiteSettingsPage({
   const site = result.data.site;
 
   const svc = getServiceRoleClient();
-  const useImageLibraryRow = await svc
-    .from("sites")
-    .select("use_image_library")
-    .eq("id", site.id)
-    .maybeSingle();
+  const [useImageLibraryRow, imageCountRow, metadataCountRow] =
+    await Promise.all([
+      svc
+        .from("sites")
+        .select("use_image_library")
+        .eq("id", site.id)
+        .maybeSingle(),
+      svc
+        .from("image_library")
+        .select("id", { count: "exact", head: true })
+        .is("deleted_at", null),
+      svc
+        .from("image_library")
+        .select("id", { count: "exact", head: true })
+        .is("deleted_at", null)
+        .not("caption", "is", null)
+        .not("alt_text", "is", null),
+    ]);
+
   const useImageLibrary =
     (useImageLibraryRow.data?.use_image_library as boolean | undefined) ?? false;
+  const totalImages = imageCountRow.count ?? 0;
+  const imagesWithMetadata = metadataCountRow.count ?? 0;
 
   return (
     <div className="mx-auto max-w-3xl">
@@ -99,6 +115,8 @@ export default async function SiteSettingsPage({
           <UseImageLibraryToggle
             siteId={site.id}
             initialEnabled={useImageLibrary}
+            totalImages={totalImages}
+            imagesWithMetadata={imagesWithMetadata}
           />
         </div>
       </section>

--- a/components/UseImageLibraryToggle.tsx
+++ b/components/UseImageLibraryToggle.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import { useState, useTransition } from "react";
-
-import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 export function UseImageLibraryToggle({
   siteId,
   initialEnabled,
+  totalImages,
+  imagesWithMetadata,
 }: {
   siteId: string;
   initialEnabled: boolean;
+  totalImages: number;
+  imagesWithMetadata: number;
 }) {
   const [enabled, setEnabled] = useState(initialEnabled);
   const [pending, startTransition] = useTransition();
@@ -38,26 +41,78 @@ export function UseImageLibraryToggle({
     }
   }
 
+  const metadataLabel =
+    totalImages === 0
+      ? "No images in the library yet."
+      : imagesWithMetadata === totalImages
+        ? `All ${totalImages} image${totalImages === 1 ? "" : "s"} have captions and alt text.`
+        : `${imagesWithMetadata} of ${totalImages} image${totalImages === 1 ? "" : "s"} have captions and alt text.`;
+
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-background p-3">
-      <div>
+    <div
+      className="flex flex-wrap items-start justify-between gap-4 rounded-md border bg-background p-3"
+      data-testid="image-library-toggle-card"
+    >
+      <div className="min-w-0 flex-1">
         <p className="text-sm font-medium">Use images from the library</p>
         <p className="mt-1 text-sm text-muted-foreground">
-          Suggest up to 5 captioned images per page based on the page title.
-          Only images with caption + alt text are included; off by default
-          until you&apos;ve verified the metadata quality.
+          When on, brief generation can suggest up to 5 images per page based
+          on the page topic. Only images with caption and alt text are included.
         </p>
+        <p
+          className="mt-2 text-sm text-muted-foreground"
+          data-testid="image-library-metadata-count"
+        >
+          {metadataLabel}{" "}
+          {totalImages > 0 && imagesWithMetadata < totalImages && (
+            <>
+              Add captions via the{" "}
+              <a
+                href="/admin/images"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                image library
+              </a>
+              .
+            </>
+          )}
+        </p>
+        <a
+          href="/admin/images"
+          className="mt-2 inline-block text-sm underline underline-offset-2 hover:text-foreground"
+          data-testid="image-library-view-link"
+        >
+          View image library →
+        </a>
       </div>
-      <Button
+
+      {/* Switch toggle — aria-role=switch makes the control unambiguous */}
+      <button
         type="button"
-        variant={enabled ? "default" : "outline"}
-        onClick={() => startTransition(() => void commit(!enabled))}
+        role="switch"
+        aria-checked={enabled}
+        aria-label={`Use images from the library — ${enabled ? "on" : "off"}`}
         disabled={pending}
+        onClick={() => startTransition(() => void commit(!enabled))}
         data-testid="use-image-library-toggle"
-        aria-pressed={enabled}
+        className={cn(
+          "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent",
+          "transition-colors duration-200 ease-in-out",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          enabled ? "bg-primary" : "bg-muted",
+        )}
       >
-        {enabled ? "Enabled" : "Disabled"}
-      </Button>
+        <span
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm",
+            "transform transition-transform duration-200 ease-in-out",
+            enabled ? "translate-x-5" : "translate-x-0",
+          )}
+        />
+      </button>
+
       {error && (
         <p className="basis-full text-sm text-destructive" role="alert">
           {error}

--- a/e2e/sites.spec.ts
+++ b/e2e/sites.spec.ts
@@ -197,3 +197,63 @@ test.describe("sites CRUD", () => {
     await expect(row).toHaveCount(0);
   });
 });
+
+// Fix 5 — image library toggle UX
+test.describe("image library toggle on site settings", () => {
+  test("toggle is a switch control with metadata count and library link", async ({
+    page,
+  }, testInfo) => {
+    await signInAsAdmin(page);
+
+    // Navigate to the first site's settings page.
+    await page.goto("/admin/sites");
+    const firstSiteLink = page.getByRole("link", { name: /settings/i }).first();
+    // Fall back: navigate via the site list row.
+    if (!(await firstSiteLink.isVisible())) {
+      const rows = page.getByRole("row").filter({ hasText: /active|paused/i });
+      const firstRow = rows.first();
+      await firstRow.getByTestId("site-actions-summary").click();
+      const settingsLink = firstRow.getByRole("menuitem", { name: /settings/i });
+      if (await settingsLink.isVisible()) {
+        await settingsLink.click();
+      } else {
+        // Direct URL navigation — pick the first site id from the page URL.
+        const href = await firstRow
+          .getByRole("link")
+          .first()
+          .getAttribute("href");
+        const siteId = href?.match(/\/admin\/sites\/([^/]+)/)?.[1];
+        if (siteId) await page.goto(`/admin/sites/${siteId}/settings`);
+      }
+    } else {
+      await firstSiteLink.click();
+    }
+
+    await page.waitForURL(/\/admin\/sites\/[^/]+\/settings/);
+
+    // The toggle must be a switch control, not a plain button.
+    const toggle = page.getByTestId("use-image-library-toggle");
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute("role", "switch");
+    await expect(toggle).toHaveAttribute("aria-checked");
+
+    // Metadata count label is visible.
+    await expect(
+      page.getByTestId("image-library-metadata-count"),
+    ).toBeVisible();
+
+    // "View image library" link is present.
+    await expect(page.getByTestId("image-library-view-link")).toBeVisible();
+
+    // Toggle can be clicked to change state.
+    const currentChecked = await toggle.getAttribute("aria-checked");
+    await toggle.click();
+    const newChecked = await toggle.getAttribute("aria-checked");
+    expect(newChecked).not.toBe(currentChecked);
+
+    // Restore original state.
+    await toggle.click();
+
+    await auditA11y(page, testInfo);
+  });
+});


### PR DESCRIPTION
## Problem

The image library toggle on \`/admin/sites/[id]/settings\` used a \`Button\` that displayed \"Enabled\" or \"Disabled\" text. Without interacting with it, the operator couldn't tell if it was a status label or a button. Common feedback: \"I thought it was just showing me the status\".

Additionally:
- No indication of how many images in the library have caption + alt text (the metadata quality gate)
- No link to view or manage the image library from this context

## Solution

**Switch control:** Replaced the \`Button\` with a pill-shaped toggle (\`role=switch\`, \`aria-checked\`) — the standard interactive pattern for binary settings. The thumb slides left/right to communicate state unambiguously.

**Metadata count:** The card now shows \"X of Y images have captions and alt text\" so the operator can judge whether there's enough captioned content to make the feature useful before enabling it.

**In-context guidance:** When some images lack metadata, an inline \"Add captions via the image library\" link is shown. This eliminates the dead end of enabling the toggle and then wondering why no images appear.

**Library link:** A persistent \"View image library →\" link at the bottom of the card so the operator can jump directly to the image library without hunting through the nav.

## Settings page query

Two count queries added in parallel (\`Promise.all\`) — no sequential waterfall:
- Total active images (\`deleted_at IS NULL\`)
- Images with metadata (\`deleted_at IS NULL AND caption IS NOT NULL AND alt_text IS NOT NULL\`)

## E2E test

\`e2e/sites.spec.ts\` — new test:
- Navigates to a site settings page
- Asserts \`role=switch\` and \`aria-checked\` present
- Asserts the metadata count label is visible  
- Asserts the \"View image library\" link is present
- Toggles the switch and verifies \`aria-checked\` changes
- Restores original state

## Risks identified and mitigated

- **No new dependency:** Switch is implemented with Tailwind utility classes rather than \`@radix-ui/react-switch\` (not yet in project deps). Behaviour is identical; adding Radix later is a one-line swap.
- **Parallel queries on every settings page load:** Both count queries hit \`image_library\` with a simple IS NULL filter. \`image_library.deleted_at\` is indexed by the compound index on (deleted_at, id). Count queries are fast at expected library sizes (< 10k images).
- **No API changes:** Toggle still calls \`/api/admin/sites/[id]/use-image-library\` — only the UI changed.