### PR TITLE
feat(setup-wizard): numbered stepped progress indicator with gating

### DIFF
--- a/components/SetupWizard.tsx
+++ b/components/SetupWizard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { Fragment, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { Check, ChevronRight, Loader2, Palette, Volume2 } from "lucide-react";
+import { Check, Loader2, Palette, Volume2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { ApprovedDesignReadout } from "@/components/ConceptRefinementView";
@@ -14,6 +14,7 @@ import {
 } from "@/components/DesignDirectionInputs";
 import { ToneOfVoiceInputs } from "@/components/ToneOfVoiceInputs";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import type { Industry } from "@/lib/design-discovery/industry-defaults";
 import type { SetupStatus, SetupStep, SetupStepStatus } from "@/lib/site-setup";
 
@@ -59,8 +60,8 @@ function statusLabel(s: SetupStepStatus): string {
 
 export function SetupWizard({ siteId, step, status }: Props) {
   return (
-    <div className="space-y-6" data-testid="setup-wizard">
-      <ProgressStrip step={step} status={status} siteId={siteId} />
+    <div className="space-y-8" data-testid="setup-wizard">
+      <WizardStepper step={step} status={status} siteId={siteId} />
       {step === 1 && <Step1 siteId={siteId} status={status} />}
       {step === 2 && <Step2 siteId={siteId} status={status} />}
       {step === 3 && <Step3 siteId={siteId} status={status} />}
@@ -68,7 +69,12 @@ export function SetupWizard({ siteId, step, status }: Props) {
   );
 }
 
-function ProgressStrip({
+// ---------------------------------------------------------------------------
+// Numbered step indicator with connecting lines and gating.
+// A step is accessible only when all preceding steps are complete.
+// ---------------------------------------------------------------------------
+
+function WizardStepper({
   step,
   status,
   siteId,
@@ -77,63 +83,109 @@ function ProgressStrip({
   status: SetupStatus;
   siteId: string;
 }) {
-  // A step is "complete" if its status column is approved or skipped.
-  // Step 3 is "complete" when both prior steps are complete.
   const stepComplete = (n: SetupStep): boolean => {
-    if (n === 1) {
+    if (n === 1)
       return (
         status.design_direction_status === "approved" ||
         status.design_direction_status === "skipped"
       );
-    }
-    if (n === 2) {
+    if (n === 2)
       return (
         status.tone_of_voice_status === "approved" ||
         status.tone_of_voice_status === "skipped"
       );
-    }
+    return stepComplete(1) && stepComplete(2);
+  };
+
+  // Step N is navigable only when all steps before it are done.
+  const stepAccessible = (n: SetupStep): boolean => {
+    if (n === 1) return true;
+    if (n === 2) return stepComplete(1);
     return stepComplete(1) && stepComplete(2);
   };
 
   return (
-    <ol className="flex items-center gap-1 text-sm" aria-label="Setup progress">
-      {STEPS.map((s, i) => {
-        const active = s.n === step;
-        const done = stepComplete(s.n);
-        const Icon = done ? Check : s.icon;
-        return (
-          <li
-            key={s.n}
-            className="flex items-center gap-1"
-            data-testid={`setup-progress-step-${s.n}`}
-            data-active={active ? "true" : "false"}
-            data-complete={done ? "true" : "false"}
-          >
-            <Link
-              href={`/admin/sites/${siteId}/setup?step=${s.n}`}
-              className={[
-                "flex items-center gap-1.5 rounded-md border px-2.5 py-1 transition-smooth",
+    <nav aria-label="Setup progress" data-testid="setup-wizard-stepper">
+      <ol className="flex w-full items-start">
+        {STEPS.map((s, i) => {
+          const active = s.n === step;
+          const done = stepComplete(s.n);
+          const accessible = stepAccessible(s.n);
+          const isLast = i === STEPS.length - 1;
+
+          const circle = (
+            <span
+              className={cn(
+                "flex h-9 w-9 items-center justify-center rounded-full border-2 text-sm font-bold transition-colors",
                 active
-                  ? "border-foreground bg-foreground text-background"
+                  ? "border-primary bg-primary text-primary-foreground"
                   : done
-                    ? "border-success/40 bg-success/10 text-success"
-                    : "border-muted bg-muted/30 text-muted-foreground",
-                "hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-              ].join(" ")}
+                    ? "border-success bg-success/10 text-success"
+                    : "border-border bg-background text-muted-foreground/50",
+              )}
+              aria-current={active ? "step" : undefined}
             >
-              <Icon aria-hidden className="h-3.5 w-3.5" />
-              <span className="font-medium">{s.label}</span>
-            </Link>
-            {i < STEPS.length - 1 && (
-              <ChevronRight
-                aria-hidden
-                className="h-4 w-4 shrink-0 text-muted-foreground"
-              />
-            )}
-          </li>
-        );
-      })}
-    </ol>
+              {done && !active ? (
+                <Check aria-hidden className="h-4 w-4" />
+              ) : (
+                s.n
+              )}
+            </span>
+          );
+
+          return (
+            <Fragment key={s.n}>
+              <li
+                className="flex flex-none flex-col items-center gap-1"
+                data-testid={`setup-progress-step-${s.n}`}
+                data-active={active ? "true" : "false"}
+                data-complete={done ? "true" : "false"}
+              >
+                {accessible ? (
+                  <Link
+                    href={`/admin/sites/${siteId}/setup?step=${s.n}`}
+                    className="rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  >
+                    {circle}
+                  </Link>
+                ) : (
+                  <span
+                    className="cursor-not-allowed opacity-60"
+                    aria-disabled="true"
+                  >
+                    {circle}
+                  </span>
+                )}
+                <span
+                  className={cn(
+                    "text-xs font-medium",
+                    active
+                      ? "text-foreground"
+                      : done
+                        ? "text-success"
+                        : "text-muted-foreground/60",
+                  )}
+                >
+                  {s.label}
+                </span>
+              </li>
+
+              {/* Connecting line between step circles */}
+              {!isLast && (
+                <li
+                  role="presentation"
+                  aria-hidden
+                  className={cn(
+                    "mt-[1.125rem] h-px flex-1",
+                    done ? "bg-success/40" : "bg-border",
+                  )}
+                />
+              )}
+            </Fragment>
+          );
+        })}
+      </ol>
+    </nav>
   );
 }
 
@@ -621,7 +673,7 @@ function DesignDirectionDetails({
                 style={{ background: s.v }}
                 aria-hidden
               />
-              <span className="font-mono text-[10px] uppercase">{s.k}</span>
+              <span className="font-mono text-xs uppercase">{s.k}</span>
             </span>
           ))}
         </div>

--- a/e2e/site-setup.spec.ts
+++ b/e2e/site-setup.spec.ts
@@ -106,6 +106,48 @@ test.describe("setup wizard shell", () => {
     await expect(page.getByRole("heading", { name })).toBeVisible();
   });
 
+  test("wizard stepper shows numbered circles; step 2 is gated until step 1 is done", async ({
+    page,
+  }, testInfo) => {
+    const name = `Stepper Gate ${Date.now()}`;
+    const id = await createSiteAndOpenSetup(page, name);
+    await page.waitForURL(new RegExp(`/admin/sites/${id}/setup\\?step=1`));
+
+    // Stepper is visible with step 1 active.
+    const stepper = page.getByTestId("setup-wizard-stepper");
+    await expect(stepper).toBeVisible();
+
+    const step1Item = page.getByTestId("setup-progress-step-1");
+    const step2Item = page.getByTestId("setup-progress-step-2");
+    const step3Item = page.getByTestId("setup-progress-step-3");
+
+    await expect(step1Item).toHaveAttribute("data-active", "true");
+    await expect(step2Item).toHaveAttribute("data-active", "false");
+    await expect(step3Item).toHaveAttribute("data-active", "false");
+
+    // Step 2 is not yet accessible — circle is wrapped in a span[aria-disabled].
+    await expect(step2Item.locator('[aria-disabled="true"]')).toBeVisible();
+    // Step 1 circle is a link (accessible).
+    await expect(step1Item.locator("a")).toBeVisible();
+
+    await auditA11y(page, testInfo);
+
+    // Skip step 1 — step 2 should become accessible.
+    await page.getByTestId("setup-step-1-skip").click();
+    await page.waitForURL(new RegExp(`/admin/sites/${id}/setup\\?step=2`));
+
+    await expect(step1Item).toHaveAttribute("data-complete", "true");
+    await expect(step2Item).toHaveAttribute("data-active", "true");
+    // Step 1 circle now shows a checkmark state (data-complete=true).
+    await expect(step1Item).toHaveAttribute("data-complete", "true");
+    // Step 2 circle is now a link.
+    await expect(step2Item.locator("a")).toBeVisible();
+    // Step 3 still gated.
+    await expect(step3Item.locator('[aria-disabled="true"]')).toBeVisible();
+
+    await auditA11y(page, testInfo);
+  });
+
   test("returning to setup with both steps skipped resumes at step 3", async ({
     page,
   }) => {


### PR DESCRIPTION
## What

Replaces the horizontal pill-based `ProgressStrip` in the design discovery wizard with a proper `WizardStepper`: numbered circles connected by lines, with step gating so operators can only navigate to a step when all prior steps are complete.

## Before / After

**Before:** Three text pills with icons (`Palette`, `Volume2`, `Check`) separated by `ChevronRight` arrows. All steps freely clickable. No visual hierarchy.

**After:**
```
①●────────────②○────────────③○
Design direction    Tone of voice    Done
```
- ① Active step: filled primary circle with number
- ●  Completed step: success-tinted circle with ✓ icon, green label
- ○  Locked step: muted circle, `aria-disabled="true"` span (not a link)
- `── ` Connector: `h-px` line, success-tinted when preceding step is done

## Step Gating

| Step | Accessible when |
|------|----------------|
| 1 | Always |
| 2 | Step 1 approved or skipped |
| 3 | Steps 1 and 2 both approved or skipped |

When a step is locked, the circle renders as `<span aria-disabled="true">` rather than `<Link>`, so keyboard/screen-reader users can't navigate to it.

## Other Changes

- `text-[10px]` → `text-xs` on swatch key labels in `DesignDirectionDetails` (font-size floor compliance)
- `space-y-6` → `space-y-8` on wizard container for better visual breathing room
- `Fragment` import added (needed for key-bearing map)
- `cn` utility imported (was missing)

## Tests

`e2e/site-setup.spec.ts` — new test "wizard stepper shows numbered circles; step 2 is gated until step 1 is done":
- Verifies `setup-wizard-stepper` is visible
- Checks `data-active` attributes on each step item
- Confirms step 2 circle renders as `aria-disabled` span (not link) on fresh site
- Skips step 1, verifies step 2 becomes a link and step 3 remains locked

## Risks identified and mitigated

- **E2E testid continuity**: kept all existing `data-testid="setup-progress-step-N"`, `data-active`, `data-complete` attributes; existing skip/resume tests unaffected
- **Pure UI change**: no API calls, no DB mutations, no schema changes
- **Mobile layout**: `flex w-full items-start` + `flex-1` connector lines scale gracefully to any width