### PR TITLE
chore(typography): phase 2 body-copy sweep — text-sm → text-base on section descriptions

### DIFF
--- a/app/admin/batches/[id]/page.tsx
+++ b/app/admin/batches/[id]/page.tsx
@@ -91,7 +91,7 @@ export default async function BatchDetailPage({
   ) {
     return (
       <div className="rounded-md border p-8 text-center">
-        <p className="text-sm text-muted-foreground">
+        <p className="text-base text-muted-foreground">
           This batch belongs to another operator.
         </p>
       </div>

--- a/app/admin/images/[id]/page.tsx
+++ b/app/admin/images/[id]/page.tsx
@@ -298,7 +298,7 @@ export default async function AdminImageDetailPage({
             ({usage.length})
           </span>
         </H3>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-base text-muted-foreground">
           Every WP site this image has been mirrored to via the publish pipeline.
         </p>
         <div className="mt-3" data-testid="image-usage-list">
@@ -377,7 +377,7 @@ export default async function AdminImageDetailPage({
             ({metadata.length})
           </span>
         </H3>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-base text-muted-foreground">
           EXIF, licensing notes, model info, and any other per-image attributes
           tracked outside the main row.
         </p>

--- a/app/admin/sites/[id]/blueprints/review/page.tsx
+++ b/app/admin/sites/[id]/blueprints/review/page.tsx
@@ -171,7 +171,7 @@ export default function BlueprintReviewPage({
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold">Site Plan Review</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
+          <p className="mt-1 text-base text-muted-foreground">
             Review the plan before approving page generation.
           </p>
         </div>

--- a/app/admin/sites/[id]/content/page.tsx
+++ b/app/admin/sites/[id]/content/page.tsx
@@ -143,7 +143,7 @@ export default function SharedContentPage({
     <main className="mx-auto max-w-4xl space-y-6 p-6">
       <div>
         <h1 className="text-2xl font-semibold">Shared Content</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-1 text-base text-muted-foreground">
           Reusable content objects referenced from generated pages.
         </p>
       </div>

--- a/app/admin/sites/[id]/design-system/page.tsx
+++ b/app/admin/sites/[id]/design-system/page.tsx
@@ -76,7 +76,7 @@ export default function DesignSystemIndexPage() {
         <div className="flex items-center justify-between">
           <div>
             <H1>Versions (advanced)</H1>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-base text-muted-foreground">
               One version is active at a time. Edit drafts before activating —
               activation is atomic and archives the previous active version.
             </p>
@@ -212,7 +212,7 @@ function ModeSummaryCard({
         data-testid="design-system-copy-existing"
       >
         <H3>Copy existing site</H3>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-1 text-base text-muted-foreground">
           Generated content uses the existing theme&apos;s class names and
           colours.{" "}
           {hasProfile
@@ -243,7 +243,7 @@ function ModeSummaryCard({
       data-testid="design-system-new-design"
     >
       <H3>New design</H3>
-      <p className="mt-1 text-sm text-muted-foreground">
+      <p className="mt-1 text-base text-muted-foreground">
         {approved
           ? "Design direction approved. Tokens, concepts, and tone of voice are wired into generation."
           : "Design setup hasn't finished yet — open the wizard to pick a direction and tone of voice."}

--- a/app/admin/sites/[id]/page.tsx
+++ b/app/admin/sites/[id]/page.tsx
@@ -526,7 +526,7 @@ export default async function SiteDetailPage({
               <Layers aria-hidden className="mt-0.5 h-4 w-4 text-muted-foreground" />
               <div className="min-w-0 flex-1">
                 <H3>Appearance</H3>
-                <p className="mt-1 text-sm text-muted-foreground">
+                <p className="mt-1 text-base text-muted-foreground">
                   Sync the active DS palette to Kadence on this site&apos;s
                   WordPress install.
                 </p>
@@ -546,7 +546,7 @@ export default async function SiteDetailPage({
               <LayoutTemplate aria-hidden className="mt-0.5 h-4 w-4 text-muted-foreground" />
               <div className="min-w-0 flex-1">
                 <H3>Site Plan</H3>
-                <p className="mt-1 text-sm text-muted-foreground">
+                <p className="mt-1 text-base text-muted-foreground">
                   Review and approve the AI-generated page blueprint before
                   running batch generation.
                 </p>
@@ -566,7 +566,7 @@ export default async function SiteDetailPage({
               <FileText aria-hidden className="mt-0.5 h-4 w-4 text-muted-foreground" />
               <div className="min-w-0 flex-1">
                 <H3>Shared Content</H3>
-                <p className="mt-1 text-sm text-muted-foreground">
+                <p className="mt-1 text-base text-muted-foreground">
                   Reusable content objects — CTAs, testimonials, and FAQ items
                   shared across generated pages.
                 </p>
@@ -593,7 +593,7 @@ export default async function SiteDetailPage({
                     <StatusPill kind="brief_parsing" label="Not set" />
                   )}
                 </div>
-                <p className="mt-1 text-sm text-muted-foreground">
+                <p className="mt-1 text-base text-muted-foreground">
                   Brand voice &amp; design direction defaults that every new
                   brief inherits.
                 </p>

--- a/app/admin/sites/[id]/pages/[pageId]/page.tsx
+++ b/app/admin/sites/[id]/pages/[pageId]/page.tsx
@@ -228,7 +228,7 @@ export default async function PageDetail({
             ({regenJobs.length})
           </span>
         </H3>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-base text-muted-foreground">
           Each row is one operator-triggered re-run against the current design
           system. Cost + tokens come from Anthropic; failures carry their
           terminal code. In-flight jobs auto-refresh while the Re-generate

--- a/app/admin/sites/[id]/settings/page.tsx
+++ b/app/admin/sites/[id]/settings/page.tsx
@@ -88,7 +88,7 @@ export default async function SiteSettingsPage({
         className="mt-6 rounded-lg border p-4"
       >
         <H2 id="voice-heading">Brand voice &amp; design direction</H2>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-1 text-base text-muted-foreground">
           Set once for the site; the brief commit form inherits these as
           defaults.
         </p>
@@ -107,7 +107,7 @@ export default async function SiteSettingsPage({
         className="mt-6 rounded-lg border p-4"
       >
         <H2 id="image-library-heading">Image library</H2>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-1 text-base text-muted-foreground">
           When enabled, brief generation can suggest images from the shared
           library where the page topic matches.
         </p>

--- a/app/admin/system/jobs/page.tsx
+++ b/app/admin/system/jobs/page.tsx
@@ -283,7 +283,7 @@ export default async function SystemJobsPage() {
 
       <section className="mt-6">
         <H2>Library maintenance</H2>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-1 text-base text-muted-foreground">
           One-off and on-demand jobs for the image library. Each batch processes
           up to 10 images; run repeatedly until all images are done.
         </p>
@@ -294,7 +294,7 @@ export default async function SystemJobsPage() {
 
       <section className="mt-6">
         <H2>Queue depth</H2>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-1 text-base text-muted-foreground">
           Pending = waiting for a worker. Running = leased and in flight. Failed
           = terminal failure (no further retries).
         </p>
@@ -374,7 +374,7 @@ export default async function SystemJobsPage() {
 
       <section className="mt-8">
         <H2>Cron schedule</H2>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-1 text-base text-muted-foreground">
           Sourced from <code>vercel.json</code>. Last-run timestamps are not
           mirrored locally — check Vercel Dashboard → Cron Jobs for invocation
           history.

--- a/components/AddSiteModal.tsx
+++ b/components/AddSiteModal.tsx
@@ -174,7 +174,7 @@ export function AddSiteModal({
         <h2 id="add-site-title" className="text-lg font-semibold">
           Add new site
         </h2>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-1 text-base text-muted-foreground">
           Register a WordPress site. The app password is encrypted before
           storage.
         </p>

--- a/components/BriefReviewClient.tsx
+++ b/components/BriefReviewClient.tsx
@@ -354,7 +354,7 @@ export function BriefReviewClient({
               <h2 id="voice-direction-heading" className="text-base font-semibold">
                 Brand voice &amp; design direction
               </h2>
-              <p className="mt-1 text-sm text-muted-foreground">
+              <p className="mt-1 text-base text-muted-foreground">
                 {hasSiteDefault && !voiceOverrideOpen
                   ? "Inheriting from site defaults. Expand to customize for this brief."
                   : hasSiteDefault
@@ -477,7 +477,7 @@ export function BriefReviewClient({
             <h2 id="model-tier-heading" className="text-base font-semibold">
               Model tier
             </h2>
-            <p className="mt-1 text-sm text-muted-foreground">
+            <p className="mt-1 text-base text-muted-foreground">
               Pick the Claude model for text generation and for the visual
               review critique. Sonnet is the default for both — Opus is
               reserved for complex-judgment briefs. See the cost estimate on

--- a/components/ConfirmActionModal.tsx
+++ b/components/ConfirmActionModal.tsx
@@ -151,7 +151,7 @@ export function ConfirmActionModal({
         <h2 id="confirm-title" className="text-lg font-semibold">
           {title}
         </h2>
-        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        <p className="mt-1 text-base text-muted-foreground">{description}</p>
 
         {extraContent && <div className="mt-4">{extraContent}</div>}
 

--- a/components/CopyExistingExtractionWizard.tsx
+++ b/components/CopyExistingExtractionWizard.tsx
@@ -222,7 +222,7 @@ export function CopyExistingExtractionWizard({
           data-testid="copy-existing-design-profile"
         >
           <h2 className="text-sm font-semibold">2 · Review the design profile</h2>
-          <p className="mt-1 text-sm text-muted-foreground">
+          <p className="mt-1 text-base text-muted-foreground">
             Tweak any extracted value that looks wrong. Empty fields land as
             null and the generation prompt falls back to the site theme.
           </p>

--- a/components/CreateDesignSystemModal.tsx
+++ b/components/CreateDesignSystemModal.tsx
@@ -159,7 +159,7 @@ export function CreateDesignSystemModal({
         <h2 id="new-ds-title" className="text-lg font-semibold">
           New design system draft
         </h2>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-1 text-base text-muted-foreground">
           Version number is auto-assigned to the next integer. The draft is
           not activated — you can edit components and templates, then activate
           from the list when ready.

--- a/components/CustomerBrandProfileEditor.tsx
+++ b/components/CustomerBrandProfileEditor.tsx
@@ -133,7 +133,7 @@ export function CustomerBrandProfileEditor({ company, brand }: Props) {
       >
         <Eyebrow id="tier-summary">Setup</Eyebrow>
         <h2 className="mt-1 text-base font-semibold">{brandTierLabel(tier)}</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-1 text-base text-muted-foreground">
           {brandTierDescription(tier)}
         </p>
         {brand ? (
@@ -157,7 +157,7 @@ export function CustomerBrandProfileEditor({ company, brand }: Props) {
             <h2 id="visual-identity-heading" className="text-base font-semibold">
               Visual identity
             </h2>
-            <p className="mt-1 text-sm text-muted-foreground">
+            <p className="mt-1 text-base text-muted-foreground">
               Colours and fonts. Image generation and compositing read these
               for every output.
             </p>
@@ -219,7 +219,7 @@ export function CustomerBrandProfileEditor({ company, brand }: Props) {
             <h2 id="tone-heading" className="text-base font-semibold">
               Tone of voice
             </h2>
-            <p className="mt-1 text-sm text-muted-foreground">
+            <p className="mt-1 text-base text-muted-foreground">
               The basics. Personality traits, voice examples, and platform
               overrides land in a follow-up.
             </p>


### PR DESCRIPTION
## Summary

- Picks up the Typography Phase 2 deferred item from `docs/BACKLOG.md` (top-priority entry; Phase 1 stabilised in PR #492 on 2026-05-03)
- Rule applied: body copy floor = 1rem (`text-base`); small text floor = 0.875rem (`text-sm`) per `docs/RULES.md` rule #7
- 27 callsites across 15 files uplifted — all are multi-sentence section descriptions or modal body text under headings

**Changed:** section description `<p>` elements following H1/H2/H3 headings, modal body text, multi-sentence wizard instructions

**Left at `text-sm`:** form labels, badge text, table cells, nav items, timestamps, compact metadata labels, form hints, empty-state brief messages. Dense tabular data stays compact per the world-class-polish density target.

Surfaces covered: `/admin/system/jobs`, `/admin/sites/[id]`, `/admin/sites/[id]/settings`, `/admin/sites/[id]/content`, `/admin/sites/[id]/blueprints/review`, `/admin/sites/[id]/pages/[pageId]`, `/admin/sites/[id]/design-system`, `/admin/images/[id]`, `/admin/batches/[id]`, `BriefReviewClient`, `AddSiteModal`, `ConfirmActionModal`, `CreateDesignSystemModal`, `CustomerBrandProfileEditor`, `CopyExistingExtractionWizard`

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings/errors
- [ ] Visual smoke: open `/admin/system/jobs`, `/admin/sites/[id]`, `/admin/images/[id]` — section descriptions render at 16px, surrounding compact elements unchanged

## Risks identified and mitigated

Pure Tailwind classname change (`text-sm` → `text-base` on `<p>` elements). No layout reflow risk: description paragraphs sit in flex-flow containers without fixed height constraints; 2px size increase per line does not cause truncation or overflow. Tables, form labels, nav items untouched.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)