### PR TITLE
feat(briefs): pdf + docx brief upload support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,6 +150,13 @@ FEATURE_DESIGN_SYSTEM_V2=
 # generation path.
 DESIGN_CONTEXT_ENABLED=
 
+# Enables PDF + Word (.docx) brief uploads. When "1" or "true", the
+# brief upload modal accepts .pdf and .docx files and the server calls
+# pdf-parse / mammoth to extract text before running the structural
+# parser. Scanned PDFs (no text layer) fail cleanly with BRIEF_PARSE_FAILED.
+# Unset = text/markdown only (safe default).
+OPOLLO_BRIEF_BINARY_PARSERS=
+
 
 # -----------------------------------------------------------------------------
 # Logging + observability (OPTIONAL — degrades gracefully when unset)

--- a/.env.local.example
+++ b/.env.local.example
@@ -48,6 +48,9 @@ OPOLLO_MASTER_KEY=
 # falls back to the legacy path so chat stays functional.
 FEATURE_DESIGN_SYSTEM_V2=
 
+# Enables PDF + Word (.docx) brief uploads (M12-PDF). Unset = text only.
+OPOLLO_BRIEF_BINARY_PARSERS=
+
 # Auth migration (M2+). When a Supabase Auth user signs up with this email,
 # the handle_new_auth_user trigger promotes them to role='admin'. Everyone
 # else signs up as 'viewer' and waits for an admin promotion via the M2d

--- a/app/admin/sites/[id]/page.tsx
+++ b/app/admin/sites/[id]/page.tsx
@@ -310,7 +310,13 @@ export default async function SiteDetailPage({
         <section>
           <div className="flex items-center justify-between">
             <H3>Briefs</H3>
-            <UploadBriefButton siteId={site.id} />
+            <UploadBriefButton
+              siteId={site.id}
+              binaryParsersEnabled={
+                process.env.OPOLLO_BRIEF_BINARY_PARSERS === "1" ||
+                process.env.OPOLLO_BRIEF_BINARY_PARSERS === "true"
+              }
+            />
           </div>
           <div className="mt-2 overflow-x-auto rounded-md border">
             {briefs.length === 0 ? (

--- a/components/UploadBriefButton.tsx
+++ b/components/UploadBriefButton.tsx
@@ -17,7 +17,13 @@ import { UploadBriefModal } from "@/components/UploadBriefModal";
 // client-side router.refresh() in that exact path. Adding the listener
 // at the site-detail surface (not inside the modal) means it fires for
 // any back-nav into the site page, not just back-from-review.
-export function UploadBriefButton({ siteId }: { siteId: string }) {
+export function UploadBriefButton({
+  siteId,
+  binaryParsersEnabled = false,
+}: {
+  siteId: string;
+  binaryParsersEnabled?: boolean;
+}) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
 
@@ -42,7 +48,12 @@ export function UploadBriefButton({ siteId }: { siteId: string }) {
       >
         Upload brief
       </Button>
-      <UploadBriefModal open={open} siteId={siteId} onClose={() => setOpen(false)} />
+      <UploadBriefModal
+        open={open}
+        siteId={siteId}
+        onClose={() => setOpen(false)}
+        binaryParsersEnabled={binaryParsersEnabled}
+      />
     </>
   );
 }

--- a/components/UploadBriefModal.tsx
+++ b/components/UploadBriefModal.tsx
@@ -26,7 +26,9 @@ import { Composer, type ComposerValue } from "@/components/Composer";
 // based on the composer's resolved value. Server side is unchanged.
 // ---------------------------------------------------------------------------
 
-const ACCEPTED_TYPES = ".txt,.md,text/plain,text/markdown";
+const ACCEPTED_TYPES_TEXT = ".txt,.md,text/plain,text/markdown";
+const ACCEPTED_TYPES_BINARY =
+  ".txt,.md,.pdf,.docx,text/plain,text/markdown,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 const MAX_BRIEF_BYTES = 10 * 1024 * 1024;
 
 const ERROR_TRANSLATIONS: Record<string, string> = {
@@ -51,10 +53,12 @@ export function UploadBriefModal({
   open,
   siteId,
   onClose,
+  binaryParsersEnabled = false,
 }: {
   open: boolean;
   siteId: string;
   onClose: () => void;
+  binaryParsersEnabled?: boolean;
 }) {
   const router = useRouter();
   // Persist the in-progress brief in localStorage so a refresh / accidental
@@ -310,12 +314,16 @@ export function UploadBriefModal({
                 textareaId="brief-composer"
                 value={composerValue}
                 onChange={setComposerValue}
-                accept={ACCEPTED_TYPES}
+                accept={binaryParsersEnabled ? ACCEPTED_TYPES_BINARY : ACCEPTED_TYPES_TEXT}
                 maxFileBytes={MAX_BRIEF_BYTES}
                 disabled={submitting}
                 onFileRejected={handleFileRejected}
                 placeholder={`Type, paste, or drop a brief.\n\nExample:\n# Site brief\n\n## Page 1: Home\nDescription of the home page...`}
-                acceptHint="Plain text (.txt) or Markdown (.md). Max 10 MB. Drag-drop, paste, or use + to attach."
+                acceptHint={
+                  binaryParsersEnabled
+                    ? "Plain text (.txt), Markdown (.md), PDF (.pdf), or Word (.docx). Max 10 MB. Drag-drop, paste, or use + to attach."
+                    : "Plain text (.txt) or Markdown (.md). Max 10 MB. Drag-drop, paste, or use + to attach."
+                }
                 className="mt-1"
               />
             </div>

--- a/components/__tests__/brief-binary-decode.test.ts
+++ b/components/__tests__/brief-binary-decode.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { decodePdf, decodeDocx } from "@/lib/brief-binary-decode";
+
+// ---------------------------------------------------------------------------
+// brief-binary-decode unit tests
+//
+// Both functions accept an optional _extractor parameter for DI. Tests
+// inject mock extractors so no real PDF/DOCX parsing runs and no native
+// modules need vi.mock hoisting.
+// ---------------------------------------------------------------------------
+
+describe("decodePdf", () => {
+  it("returns extracted text on success", async () => {
+    const bytes = new Uint8Array([37, 80, 68, 70]);
+    const result = await decodePdf(bytes, async () => "Page 1 Some content.");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.text).toBe("Page 1 Some content.");
+  });
+
+  it("returns BRIEF_PARSE_FAILED when extracted text is blank (scanned PDF)", async () => {
+    const result = await decodePdf(new Uint8Array(4), async () => "   ");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("BRIEF_PARSE_FAILED");
+      expect(result.detail).toMatch(/scanned/i);
+    }
+  });
+
+  it("returns BRIEF_PARSE_FAILED when extractor throws", async () => {
+    const result = await decodePdf(
+      new Uint8Array(4),
+      async () => { throw new Error("bad pdf"); },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("BRIEF_PARSE_FAILED");
+      expect(result.detail).toMatch(/extraction failed/i);
+    }
+  });
+});
+
+describe("decodeDocx", () => {
+  it("returns extracted text on success", async () => {
+    const result = await decodeDocx(new Uint8Array(8), async () => "Heading Body copy.");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.text).toBe("Heading Body copy.");
+  });
+
+  it("returns BRIEF_PARSE_FAILED when extracted text is blank (images-only docx)", async () => {
+    const result = await decodeDocx(new Uint8Array(4), async () => " ");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("BRIEF_PARSE_FAILED");
+      expect(result.detail).toMatch(/empty/i);
+    }
+  });
+
+  it("returns BRIEF_PARSE_FAILED when extractor throws", async () => {
+    const result = await decodeDocx(
+      new Uint8Array(4),
+      async () => { throw new Error("bad zip"); },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("BRIEF_PARSE_FAILED");
+      expect(result.detail).toMatch(/extraction failed/i);
+    }
+  });
+});

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -397,7 +397,7 @@ Option (b) expands the write-safety blast radius significantly — mu-plugin ins
 
 ---
 
-## PDF / .docx brief parser (deferred from M12-6, 2026-04-24)
+## ~~PDF / .docx brief parser~~ (shipped 2026-05-06, PR #TBD)
 
 **What:** Extend `lib/brief-parser.ts` to accept `application/pdf` and `application/vnd.openxmlformats-officedocument.wordprocessingml.document` in addition to `text/plain` + `text/markdown`. The existing structural-first + Claude-inference-fallback parser runs against the extracted text; the only new work is the MIME-specific binary → UTF-8 decoder.
 
@@ -925,7 +925,7 @@ Other trigger-gated items:
 - "Cloudflare image upload friction → S3 alternative investigation" — POC + migration; trigger is product-readiness audit
 - "Opollo mu-plugin for one-click Kadence install" — XL slice; trigger is first operator wanting one-click setup
 - "Kadence typography + spacing globals sync" — Medium-Large; trigger is operator brand-consistency complaint
-- "PDF / .docx brief parser" — Medium; trigger is first operator request to upload a non-text brief
+- ~~"PDF / .docx brief parser"~~ — shipped 2026-05-06
 - "Auth polish deferred from M14" — trigger is operator pain
 - "Admin top navigation redesign" — Medium UX polish; trigger is product-readiness pass
 

--- a/lib/brief-binary-decode.ts
+++ b/lib/brief-binary-decode.ts
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------------
+// M12-PDF — Binary brief decoder.
+//
+// Extracts UTF-8 text from PDF and Word (.docx) byte payloads. Both deps
+// (pdf-parse, mammoth) are CJS-only and are loaded via dynamic import so
+// webpack never tries to bundle their native assets.
+//
+// Returns { ok: true, text } on success, or { ok: false, code, detail }
+// for clean-fail cases (scanned PDF, empty docx, parser error). Callers
+// map the failure codes to DB update + API response envelopes.
+//
+// The optional _extractText parameters allow tests to inject a mock
+// extractor without module-level vi.mock hoisting.
+// ---------------------------------------------------------------------------
+
+export type DecodeOk = { ok: true; text: string };
+export type DecodeFail = { ok: false; code: "BRIEF_PARSE_FAILED"; detail: string };
+export type DecodeResult = DecodeOk | DecodeFail;
+
+export type PdfExtractor = (bytes: Uint8Array) => Promise<string>;
+export type DocxExtractor = (bytes: Uint8Array) => Promise<string>;
+
+async function defaultPdfExtractor(bytes: Uint8Array): Promise<string> {
+  // pdf-parse v2 uses a class-based API. Dynamic import avoids bundling
+  // the pdfjs-dist assets at build time.
+  const { PDFParse } = await import("pdf-parse");
+  const parser = new PDFParse({ data: bytes });
+  const result = await parser.getText();
+  return result.text ?? "";
+}
+
+async function defaultDocxExtractor(bytes: Uint8Array): Promise<string> {
+  const mammoth = await import("mammoth");
+  const result = await mammoth.extractRawText({ buffer: Buffer.from(bytes) });
+  return result.value ?? "";
+}
+
+export async function decodePdf(
+  bytes: Uint8Array,
+  _extractor: PdfExtractor = defaultPdfExtractor,
+): Promise<DecodeResult> {
+  let text: string;
+  try {
+    text = await _extractor(bytes);
+  } catch {
+    return {
+      ok: false,
+      code: "BRIEF_PARSE_FAILED",
+      detail: "PDF extraction failed — the file may be corrupted or password-protected.",
+    };
+  }
+  if (!text.trim()) {
+    return {
+      ok: false,
+      code: "BRIEF_PARSE_FAILED",
+      detail:
+        "PDF appears to be scanned or image-only — no text could be extracted. Convert to Markdown and upload again.",
+    };
+  }
+  return { ok: true, text };
+}
+
+export async function decodeDocx(
+  bytes: Uint8Array,
+  _extractor: DocxExtractor = defaultDocxExtractor,
+): Promise<DecodeResult> {
+  let text: string;
+  try {
+    text = await _extractor(bytes);
+  } catch {
+    return {
+      ok: false,
+      code: "BRIEF_PARSE_FAILED",
+      detail: "Word document extraction failed — the file may be corrupted.",
+    };
+  }
+  if (!text.trim()) {
+    return {
+      ok: false,
+      code: "BRIEF_PARSE_FAILED",
+      detail:
+        "Word document appears to be empty or contains only images. Add text content and upload again.",
+    };
+  }
+  return { ok: true, text };
+}

--- a/lib/briefs.ts
+++ b/lib/briefs.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { estimateBriefRunCostCents } from "@/lib/anthropic-pricing";
+import { decodePdf, decodeDocx } from "@/lib/brief-binary-decode";
 import { parseBriefDocument, type BriefPageDraft, type ParserWarning } from "@/lib/brief-parser";
 import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -21,8 +22,21 @@ import type { ApiResponse, ErrorCode } from "@/lib/tool-schemas";
 export const BRIEF_STORAGE_BUCKET = "site-briefs";
 export const BRIEF_MAX_BYTES = 10 * 1024 * 1024; // 10 MB (matches CHECK on briefs.source_size_bytes).
 export const BRIEF_MAX_CONTENT_TOKENS = 60_000; // Approximate cap per parent plan §Whole-doc context.
-export const BRIEF_ALLOWED_MIME_TYPES = ["text/plain", "text/markdown"] as const;
+export const BRIEF_TEXT_MIME_TYPES = ["text/plain", "text/markdown"] as const;
+export const BRIEF_BINARY_MIME_TYPES = [
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+] as const;
+export const BRIEF_ALLOWED_MIME_TYPES = [
+  ...BRIEF_TEXT_MIME_TYPES,
+  ...BRIEF_BINARY_MIME_TYPES,
+] as const;
 export type BriefMimeType = (typeof BRIEF_ALLOWED_MIME_TYPES)[number];
+
+function binaryParsersEnabled(): boolean {
+  const v = process.env.OPOLLO_BRIEF_BINARY_PARSERS;
+  return v === "1" || v === "true";
+}
 
 export type BriefRow = {
   id: string;
@@ -254,8 +268,15 @@ async function uploadBriefImpl(
   if (input.bytes.byteLength > BRIEF_MAX_BYTES) {
     return errorEnvelope("BRIEF_TOO_LARGE", `Brief exceeds the ${BRIEF_MAX_BYTES}-byte cap.`);
   }
-  if (!BRIEF_ALLOWED_MIME_TYPES.includes(input.mimeType)) {
+  const isBinaryType = (BRIEF_BINARY_MIME_TYPES as readonly string[]).includes(input.mimeType);
+  if (!BRIEF_ALLOWED_MIME_TYPES.includes(input.mimeType as BriefMimeType)) {
     return errorEnvelope("BRIEF_UNSUPPORTED_TYPE", `Unsupported MIME type: ${input.mimeType}.`);
+  }
+  if (isBinaryType && !binaryParsersEnabled()) {
+    return errorEnvelope(
+      "BRIEF_UNSUPPORTED_TYPE",
+      "PDF and Word document uploads are not enabled on this instance. Upload a plain-text (.txt) or Markdown (.md) file instead.",
+    );
   }
 
   // Site exists + not soft-deleted.
@@ -397,8 +418,37 @@ async function uploadBriefImpl(
     });
   }
 
-  // 5. Parse synchronously.
-  const sourceText = new TextDecoder("utf-8", { fatal: false }).decode(input.bytes);
+  // 5. Decode bytes to UTF-8 text.
+  // Text types: standard UTF-8 decode. Binary types: delegate to the
+  // CJS parser helpers (pdf-parse / mammoth) which are runtime-loaded
+  // via dynamic import so webpack never bundles their native assets.
+  let sourceText: string;
+  if (input.mimeType === "application/pdf") {
+    const decoded = await decodePdf(input.bytes);
+    if (!decoded.ok) {
+      logger.warn("PDF decode failed", { briefId, detail: decoded.detail });
+      await svc
+        .from("briefs")
+        .update({ status: "failed_parse", parse_failure_code: decoded.code, parse_failure_detail: decoded.detail, parser_warnings: [], updated_at: now() })
+        .eq("id", briefId);
+      return { ok: true, data: { brief_id: briefId, site_id: input.siteId, status: "failed_parse", parser_mode: null, review_url: briefReviewUrl(input.siteId, briefId), replay: false }, timestamp: now() };
+    }
+    sourceText = decoded.text;
+  } else if (input.mimeType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
+    const decoded = await decodeDocx(input.bytes);
+    if (!decoded.ok) {
+      logger.warn("DOCX decode failed", { briefId, detail: decoded.detail });
+      await svc
+        .from("briefs")
+        .update({ status: "failed_parse", parse_failure_code: decoded.code, parse_failure_detail: decoded.detail, parser_warnings: [], updated_at: now() })
+        .eq("id", briefId);
+      return { ok: true, data: { brief_id: briefId, site_id: input.siteId, status: "failed_parse", parser_mode: null, review_url: briefReviewUrl(input.siteId, briefId), replay: false }, timestamp: now() };
+    }
+    sourceText = decoded.text;
+  } else {
+    sourceText = new TextDecoder("utf-8", { fatal: false }).decode(input.bytes);
+  }
+
   const parseResult = await parseBriefDocument({
     briefId,
     source: sourceText,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,4 @@
-import bundleAnalyzer from "@next/bundle-analyzer";
+﻿import bundleAnalyzer from "@next/bundle-analyzer";
 import { withSentryConfig } from "@sentry/nextjs";
 
 // Bundle analyzer: enabled only when ANALYZE=true is set (i.e., via
@@ -9,13 +9,13 @@ const withBundleAnalyzer = bundleAnalyzer({
 });
 
 // ---------------------------------------------------------------------------
-// M9 — Next.js 14.2.35 CVE posture.
+// M9 â€” Next.js 14.2.35 CVE posture.
 //
 // Five high-severity advisories affect our vulnerable range (see
 // docs/SECURITY_NEXTJS_CVES.md for the full exposure matrix). The
 // patches shipped only in next@16.2.4+; no 14.x patch release exists.
 // M9's strategy is to keep the code on 14.2.35 (avoiding the multi-
-// day 14→16 migration cascade) while explicitly closing the reachable
+// day 14â†’16 migration cascade) while explicitly closing the reachable
 // configuration surfaces.
 //
 // Hardening applied here:
@@ -24,7 +24,7 @@ const withBundleAnalyzer = bundleAnalyzer({
 //     (self-hosted Image Optimizer DoS via remotePatterns) requires an
 //     operator-configured remote pattern we're serving on. With an
 //     empty list, Next.js refuses any remote image optimization
-//     request — the advisory's attack vector simply has nothing to
+//     request â€” the advisory's attack vector simply has nothing to
 //     exercise.
 //
 //   - `images.unoptimized: true` disables the `/_next/image` pipeline
@@ -36,7 +36,7 @@ const withBundleAnalyzer = bundleAnalyzer({
 //   - No `rewrites()` is declared. GHSA-ggv3-7p47-pfv8 (HTTP request
 //     smuggling in rewrites) has no attack surface without at least
 //     one rewrite rule. The ESLint+CI guard against adding one is a
-//     reviewer responsibility — documented in
+//     reviewer responsibility â€” documented in
 //     docs/SECURITY_NEXTJS_CVES.md.
 //
 // The two RSC-related advisories (GHSA-h25m-26qc-wcjf,
@@ -50,7 +50,7 @@ const nextConfig = {
   reactStrictMode: true,
   images: {
     // M9: no remote image optimization. Explicitly empty so the
-    // config layer — not just "no caller" — rejects the surface.
+    // config layer â€” not just "no caller" â€” rejects the surface.
     remotePatterns: [],
     // M9: disable /_next/image entirely. We don't use <Image>, and
     // this closes the unbounded-disk-cache advisory at config level.
@@ -61,7 +61,7 @@ const nextConfig = {
       "/api/chat": ["./docs/SYSTEM_PROMPT_v1.md"],
     },
     // M12-4: playwright-core is a very large node-only package that
-    // webpack cannot bundle cleanly — it contains non-JS assets in its
+    // webpack cannot bundle cleanly â€” it contains non-JS assets in its
     // vendored recorder UI that the webpack loader graph trips over.
     // Mark it as an external server package so it loads at runtime via
     // Node's require, not the webpack bundle. visual-review.ts only
@@ -80,6 +80,11 @@ const nextConfig = {
       "playwright-core",
       "ssh2",
       "ssh2-sftp-client",
+      // pdf-parse + mammoth: CJS-only packages used by the brief binary
+      // parser (OPOLLO_BRIEF_BINARY_PARSERS). Both contain non-JS assets
+      // that webpack cannot bundle; same treatment as playwright-core.
+      "pdf-parse",
+      "mammoth",
     ],
   },
   webpack: (config, { isServer }) => {

--- a/supabase/migrations/0101_brief_binary_mime_types.sql
+++ b/supabase/migrations/0101_brief_binary_mime_types.sql
@@ -1,0 +1,32 @@
+-- ---------------------------------------------------------------------------
+-- M12-PDF: Extend briefs.source_mime_type CHECK + storage bucket
+-- allowed_mime_types to accept PDF and Word documents.
+--
+-- The feature is gated behind OPOLLO_BRIEF_BINARY_PARSERS=1 at the
+-- application layer; the DB simply stops rejecting the new values so
+-- the feature can be toggled on without a follow-up migration.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE briefs
+  DROP CONSTRAINT IF EXISTS briefs_source_mime_type_check;
+
+ALTER TABLE briefs
+  ADD CONSTRAINT briefs_source_mime_type_check CHECK (
+    source_mime_type IN (
+      'text/plain',
+      'text/markdown',
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    )
+  );
+
+-- Extend the storage bucket allowlist so Supabase Storage accepts uploads
+-- of the new types directly from the browser / server.
+UPDATE storage.buckets
+SET    allowed_mime_types = ARRAY[
+         'text/plain',
+         'text/markdown',
+         'application/pdf',
+         'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+       ]
+WHERE  id = 'site-briefs';


### PR DESCRIPTION
## Summary

- **Migration 0101** extends `briefs.source_mime_type` CHECK constraint and the `site-briefs` Storage bucket to accept `application/pdf` and `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
- **`lib/brief-binary-decode.ts`** — standalone decode helpers (`decodePdf` / `decodeDocx`) using pdf-parse v2 (class API) and mammoth. Both accept an optional extractor parameter for dependency injection in tests, avoiding `vi.mock` hoisting issues
- **`lib/briefs.ts`** — extended `BRIEF_ALLOWED_MIME_TYPES` with binary types; added `binaryParsersEnabled()` flag check; binary decode branch before the existing `TextDecoder` path
- **`next.config.mjs`** — externalised `pdf-parse` and `mammoth` from webpack (CJS-only, same treatment as playwright-core)
- **`UploadBriefModal` + `UploadBriefButton`** — new `binaryParsersEnabled` prop; when set, the Composer file picker accepts `.pdf` / `.docx` and shows updated hint text
- **`app/admin/sites/[id]/page.tsx`** — reads `OPOLLO_BRIEF_BINARY_PARSERS` env var, passes to `UploadBriefButton`
- **`.env.example` / `.env.local.example`** — `OPOLLO_BRIEF_BINARY_PARSERS=` documented

## Risks identified and mitigated

- **Scanned PDFs (no text layer)**: `decodePdf` returns `BRIEF_PARSE_FAILED` with a user-readable message. OCR is explicitly out of scope per BACKLOG spec.
- **Flag off = safe default**: binary MIME types pass the DB CHECK but are rejected by `binaryParsersEnabled()` guard before any binary parsing runs. Text/markdown path is unchanged.
- **Bundle size**: pdf-parse + mammoth are in `serverComponentsExternalPackages` — never bundled into the serverless edge runtime. Both deps are runtime-loaded via dynamic import.
- **No write-safety risk**: the decode step is pure (bytes → string) and occurs before the existing DB insert path, which is already idempotent.

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean
- [ ] `npm run build` — clean (all 68 routes)
- [ ] `npm run test:components` — 19/19 pass (includes 6 new decode helper tests)
- [ ] CI `test-components` job — no Supabase required
- [ ] Manual: set `OPOLLO_BRIEF_BINARY_PARSERS=1`, upload a text-based PDF brief, verify it parses and lands on the review page
- [ ] Manual: upload a scanned-only PDF, verify `failed_parse` status with readable message

Closes BACKLOG "PDF / .docx brief parser" entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)