### PR TITLE
fix(blog): store generated_html on draft save; halt on WP publish error

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -548,8 +548,9 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
       ...(newTagNames.length > 0 ? { wp_new_tag_names: newTagNames } : {}),
       metadata: lastParse ?? null,
       featured_image_id: featuredImage?.id ?? null,
-      // For "Publish immediately": send composed content as generated_html.
-      ...(mode === "publish" && composerValue.text.trim().length > 0
+      // Always persist composer content as generated_html so the detail
+      // page's Publish button is enabled regardless of save mode.
+      ...(!isEditorEmpty(composerValue.text)
         ? { generated_html: composerValue.text }
         : {}),
     };
@@ -594,7 +595,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
     return null;
   }
 
-  async function handlePublishToWp(postId: string) {
+  async function handlePublishToWp(postId: string): Promise<boolean> {
     const res = await fetch(`/api/sites/${siteId}/posts/${postId}/publish`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -609,9 +610,11 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
       const fallback =
         payload?.ok === false
           ? payload.error.message
-          : `Publish failed (HTTP ${res.status}). Post saved to Opollo.`;
+          : `Publish failed (HTTP ${res.status}). Post saved to Opollo — open the post to retry.`;
       setFormError(ERROR_TRANSLATIONS[code] ?? fallback);
+      return false;
     }
+    return true;
   }
 
   async function handlePrimarySubmit(e: FormEvent<HTMLFormElement>) {
@@ -629,7 +632,8 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
       if (!postData) return;
 
       if (publishMode === "publish") {
-        await handlePublishToWp(postData.id);
+        const wpOk = await handlePublishToWp(postData.id);
+        if (!wpOk) return; // Error shown in form; post is saved as draft
       }
 
       try { window.localStorage.removeItem(draftStorageKey(siteId)); } catch {}

--- a/docs/QA-ISSUES.md
+++ b/docs/QA-ISSUES.md
@@ -361,3 +361,30 @@ All items from the original work list confirmed implemented and passing typechec
 
 `npm run typecheck` — ✅ 0 errors
 `npm run lint` — ✅ 0 warnings / errors
+
+---
+
+## Phase 10 — Blog publishing dogfood sweep (2026-05-06)
+
+Issues surfaced during production dogfood on Test Site 2 / test2.leftleads.co.
+
+### Fixed in this sweep
+
+| Issue | Severity | Fix | PR |
+|---|---|---|---|
+| I-12: Published posts not reaching WordPress | CRITICAL | `buildCreateBody()` now always stores composer content as `generated_html` regardless of publish mode. `handlePublishToWp` returns `boolean`; `handlePrimarySubmit` stops navigation when WP publish fails, so the error is visible. | fix/blog-publish-end-to-end |
+| I-1: /admin and /admin/ return 404 | HIGH | Added `app/admin/page.tsx` redirect to `/admin/sites`. | fix/admin-routing-404 |
+| I-8: "Save to Opollo" button ambiguous | MEDIUM | Renamed to "Save draft" with tooltip clarifying Opollo-only (no WP push). | fix/blog-composer-ux |
+| I-9: Post detail page uses internal jargon | MEDIUM | Replaced "brief runner / operator approves" copy with plain-English status. Entry-point posts (metadata IS NOT NULL) get action-oriented copy; legacy brief-runner posts keep existing language. | fix/blog-composer-ux |
+| I-10: Final URL not surfaced after save | MEDIUM | Post detail shows full live URL (or expected URL for drafts) with "View live" button when published. | fix/blog-composer-ux |
+| I-3: "No categorys found." typo + no category creation | MEDIUM | Fixed typo → "No categories found."; added inline category creation (same UX as tags, stored as `wp_new_category_names` in metadata, created at publish time). | fix/blog-composer-taxonomy |
+| I-4: Tags slow / create flow | MEDIUM | Tags pre-load on composer mount (unchanged); `canCreateNew` logic was correct. | Not a bug — working as designed |
+| I-5/I-6: Image picker thumbnails broken | HIGH | `delivery_url` from API already includes `/public` variant; callers were appending `/w=200,h=200,fit=cover` creating an invalid double-segment URL. Changed pickers to use `delivery_url` directly (CSS `object-cover` handles crop). | fix/image-thumbnail-url |
+
+### Not fixed / deferred
+
+| Issue | Reason |
+|---|---|
+| I-2: UI contrast | Requires design-token audit; no WCAG failure found in a quick check — deferred to dedicated polish slice |
+| I-7: SEO panel | Fields exist (SEO title + meta description in collapsed panel, Yoast meta pushed to WP). Auto-populate + AI generation are new features; deferred |
+| I-11: Bulk export | New feature; deferred |


### PR DESCRIPTION
## Issue 12 (P0) — Published posts not reaching WordPress

### Root cause

The two-step flow (save draft → publish later from detail page) was completely broken:

1. `buildCreateBody()` only included `generated_html` when `publishMode === 'publish'`. Draft saves stored `NULL`.
2. `PostDetailClient.canPublish` requires `post.generated_html !== null`. With null, the Publish button was **always disabled** after a draft save.
3. Even on the direct "Publish to WordPress" path, if the WP API call failed, `handlePublishToWp` set a form error then **still called `router.push()`**, navigating away before the error was visible.

### Fix

- `buildCreateBody()`: always store `composerValue.text` as `generated_html` when editor is non-empty, regardless of publish mode.
- `handlePublishToWp()`: returns `boolean`; `false` = error already shown in form state.
- `handlePrimarySubmit()`: bails on `wpOk === false` so the operator sees the error and stays on the composer.

### Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Storing Tiptap HTML as `generated_html` | Entry-point posts (`metadata IS NOT NULL`) always hold composer HTML — intended path (Phase 8 FIX 5). No brief-runner regression. |
| `version_lock` on first publish | `handlePublishToWp` sends `expected_version_lock: 0` — correct for freshly created posts. |
| Re-publish from detail page | `canPublish` gate now works; detail route re-reads `generated_html` from DB. |

### Testing

1. Create post (title + content only, no SEO/image) → "Save draft" → lands on detail page.
2. Detail page shows "Publish to WP" button **enabled** (was always disabled before).
3. Click it → post appears in WordPress admin.

WP-error path: bad credentials → composer shows error inline and stays; draft survives intact.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>