### PR TITLE
fix(blog): rename Save button, plain-English post detail, live URL

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -508,7 +508,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
     metaDescriptionIsValid &&
     featuredImage !== null;
 
-  // BL-8 — ⌘S / Ctrl+S triggers Save to Opollo (draft, always safe).
+  // BL-8 — ⌘S / Ctrl+S triggers Save draft (draft, always safe).
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       const isCmdS =
@@ -879,9 +879,9 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
               className="w-full"
               disabled={!canSaveDraft || submitting}
               onClick={handleSaveToOpollo}
-              title="Save to Opollo as a draft without publishing to WordPress."
+              title="Save as draft in Opollo. Does not publish to WordPress."
             >
-              {submitting ? "Saving…" : "Save to Opollo"}
+              {submitting ? "Saving…" : "Save draft"}
             </Button>
           </div>
 

--- a/components/PostDetailClient.tsx
+++ b/components/PostDetailClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -60,9 +61,11 @@ export function PostDetailClient({
 
   const canUnpublish = post.status === "published" && post.wp_post_id !== null;
 
+  const wpBase = siteWpUrl.replace(/\/+$/, "");
   const wpFrontendUrl = post.wp_post_id
-    ? `${siteWpUrl.replace(/\/+$/, "")}/?p=${post.wp_post_id}`
+    ? `${wpBase}/?p=${post.wp_post_id}`
     : null;
+  const expectedUrl = `${wpBase}/${post.slug}`;
 
   async function handlePublish() {
     setActionState("publishing");
@@ -86,6 +89,7 @@ export function PostDetailClient({
       };
       if (res.ok && payload.ok) {
         setPublishOpen(false);
+        toast.success("Post published to WordPress.");
         router.refresh();
         return;
       }
@@ -122,6 +126,7 @@ export function PostDetailClient({
       };
       if (res.ok && payload.ok) {
         setUnpublishOpen(false);
+        toast.success("Post moved to WordPress trash. You can re-publish any time.");
         router.refresh();
         return;
       }
@@ -205,7 +210,7 @@ export function PostDetailClient({
         className="rounded-lg border p-4"
       >
         <h2 id="preview-heading" className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
-          Generated HTML
+          Content preview
         </h2>
         {post.generated_html ? (
           <iframe
@@ -216,8 +221,7 @@ export function PostDetailClient({
           />
         ) : (
           <p className="mt-3 text-sm text-muted-foreground">
-            No generated HTML yet. The post will populate when the brief runner
-            lands a draft for this page and the operator approves it.
+            No content yet. Save a draft from the composer to see a preview here.
           </p>
         )}
       </section>
@@ -225,25 +229,35 @@ export function PostDetailClient({
       {post.excerpt && (
         <section className="rounded-lg border p-4">
           <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
-            Excerpt
+            Excerpt / Meta description
           </h2>
           <p className="mt-2 text-sm">{post.excerpt}</p>
         </section>
       )}
 
-      {wpFrontendUrl && post.status === "published" && (
-        <p className="text-sm text-muted-foreground">
-          Live on WordPress:{" "}
-          <a
-            href={wpFrontendUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="underline hover:no-underline"
-          >
-            {wpFrontendUrl}
-          </a>
-        </p>
-      )}
+      <section className="rounded-lg border p-4">
+        <h2 className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          WordPress URL
+        </h2>
+        {post.status === "published" && wpFrontendUrl ? (
+          <p className="mt-2 text-sm">
+            <a
+              href={wpFrontendUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="underline hover:no-underline"
+            >
+              {wpFrontendUrl}
+            </a>
+            <span className="ml-2 text-muted-foreground">(live)</span>
+          </p>
+        ) : (
+          <p className="mt-2 text-sm text-muted-foreground">
+            Expected URL after publish:{" "}
+            <span className="font-mono">{expectedUrl}</span>
+          </p>
+        )}
+      </section>
 
       {publishOpen && (
         <ConfirmModal


### PR DESCRIPTION
## Issues closed
Fixes Issues 8, 9, 10 from the 2026-05-05 dogfood pass.

## Changes

**Issue 8 — Rename "Save to Opollo"**
- `BlogPostComposer.tsx`: button label `Save to Opollo` → `Save draft`; tooltip updated to "Save as draft in Opollo. Does not publish to WordPress."

**Issue 9 — Success feedback after publish/unpublish**
- `PostDetailClient.tsx`: `sonner` toast on publish success ("Post published to WordPress.") and unpublish success ("Post moved to WordPress trash. You can re-publish any time.")

**Issue 10 — URL transparency + jargon cleanup**
- Post detail now shows a "WordPress URL" section: draft posts display the expected URL (slug-based), published posts display the live link with a "(live)" badge
- "Generated HTML" → "Content preview"
- Empty-state copy: removed "brief runner / operator approves" jargon → "Save a draft from the composer to see a preview here."
- "Excerpt" → "Excerpt / Meta description"

## Risks identified and mitigated
- `sonner` is already a project dependency (used elsewhere); no new dep
- URL display is read-only; the expected URL may differ if WP applies its own slug rules, but it's clearly labelled "Expected URL after publish" so no false promise
- No DB changes, no API changes

## Test plan
- [ ] Open a draft blog post → URL section shows expected URL
- [ ] Publish → toast fires, URL section flips to live link
- [ ] Unpublish → toast fires, URL section reverts to expected URL
- [ ] Composer: "Save draft" button label visible