### PR TITLE
feat(pb1): extract ### Excerpt from brief → posts.excerpt → WP SEO meta

### DIFF
--- a/e2e/posts-new.spec.ts
+++ b/e2e/posts-new.spec.ts
@@ -227,7 +227,7 @@ test.describe("/admin/posts/new — top-level entry", () => {
 
     // Publish panel contains action buttons.
     await expect(publishPanel.getByRole("button", { name: /save as draft/i })).toBeVisible();
-    await expect(publishPanel.getByRole("button", { name: /save to opollo/i })).toBeVisible();
+    await expect(publishPanel.getByRole("button", { name: /save draft/i })).toBeVisible();
 
     // Clicking the Publish panel header collapses it.
     await publishPanel.getByRole("button", { name: /^publish$/i }).click();

--- a/e2e/posts.spec.ts
+++ b/e2e/posts.spec.ts
@@ -127,7 +127,7 @@ test.describe("M13-4 posts — admin surface", () => {
       page.getByRole("heading", { level: 1, name: /E2E post/ }),
     ).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: /generated html/i }),
+      page.getByRole("heading", { name: /content preview/i }),
     ).toBeVisible();
 
     // The preview iframe exists with sandbox="" (security invariant).

--- a/lib/__tests__/brief-parser.test.ts
+++ b/lib/__tests__/brief-parser.test.ts
@@ -325,7 +325,62 @@ describe("brief-parser", () => {
   });
 
   // -----------------------------------------------------------------------
-  // 12. Inference idempotency key — same brief_id + sha256 → same key.
+  // 12. Excerpt extraction from `### Excerpt` H3.
+  // -----------------------------------------------------------------------
+  it("excerpt: ### Excerpt section extracted and stripped from source_text", async () => {
+    const src = [
+      "## Home",
+      "",
+      "Long body content about the home page.",
+      "",
+      "### Excerpt",
+      "Friendly homepage for a modern consultancy.",
+      "",
+      "## Contact",
+      "",
+      "Short contact page.",
+    ].join("\n");
+    const result = await parseBriefDocument({
+      briefId: "test-excerpt",
+      source: src,
+      sourceSha256: sha256Hex(src),
+      anthropicCall: stubAnthropic("[]"),
+    });
+    const ok = expectOk(result);
+    expect(ok.pages).toHaveLength(2);
+    const home = ok.pages[0];
+    expect(home.excerpt).toBe("Friendly homepage for a modern consultancy.");
+    expect(home.source_text).not.toContain("### Excerpt");
+    expect(home.source_text).not.toContain("Friendly homepage");
+    expect(ok.pages[1].excerpt).toBeNull();
+  });
+
+  it("excerpt: case-insensitive matching (### EXCERPT)", async () => {
+    const src = "## Home\n\nBody text.\n\n### EXCERPT\nSEO description here.\n";
+    const result = await parseBriefDocument({
+      briefId: "test-excerpt-case",
+      source: src,
+      sourceSha256: sha256Hex(src),
+      anthropicCall: stubAnthropic("[]"),
+    });
+    const ok = expectOk(result);
+    expect(ok.pages[0].excerpt).toBe("SEO description here.");
+  });
+
+  it("excerpt: no ### Excerpt section → null", async () => {
+    const src = "## Home\n\nBody text without an excerpt section.\n";
+    const result = await parseBriefDocument({
+      briefId: "test-no-excerpt",
+      source: src,
+      sourceSha256: sha256Hex(src),
+      anthropicCall: stubAnthropic("[]"),
+    });
+    const ok = expectOk(result);
+    expect(ok.pages[0].excerpt).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // 13. Inference idempotency key — same brief_id + sha256 → same key.
   //     The key is passed to anthropicCall; tests observe it there.
   // -----------------------------------------------------------------------
   it("inference idempotency: same (brief_id, source_sha256) produces the same Anthropic key", async () => {

--- a/lib/brief-parser.ts
+++ b/lib/brief-parser.ts
@@ -55,6 +55,7 @@ export type BriefPageDraft = {
   word_count: number;
   source_span_start: number | null;
   source_span_end: number | null;
+  excerpt: string | null;
 };
 
 export type BriefParseResult =
@@ -180,6 +181,47 @@ function dedentSource(source: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Excerpt extraction — looks for `### Excerpt` (H3, case-insensitive) within
+// a page's body text. If found, returns the text under that heading as the
+// excerpt and removes the heading + its body from source_text so it does not
+// pollute AI generation context.
+// ---------------------------------------------------------------------------
+
+function extractExcerptFromSection(sectionText: string): {
+  excerpt: string | null;
+  cleanedText: string;
+} {
+  const headingRegex = /^[ \t]{0,3}###[ \t]+excerpt[ \t]*$/im;
+  const match = headingRegex.exec(sectionText);
+  if (!match) return { excerpt: null, cleanedText: sectionText };
+
+  const headingLineEnd = sectionText.indexOf("\n", match.index);
+  const afterHeading =
+    headingLineEnd === -1 ? "" : sectionText.slice(headingLineEnd + 1);
+
+  const nextSubsectionRegex = /^[ \t]{0,3}###[ \t]/m;
+  const nextSubsection = nextSubsectionRegex.exec(afterHeading);
+  const excerptBlock = nextSubsection
+    ? afterHeading.slice(0, nextSubsection.index)
+    : afterHeading;
+  const excerptText = excerptBlock.trim();
+
+  const beforeExcerpt = sectionText.slice(0, match.index).trimEnd();
+  const afterExcerptBlock = nextSubsection
+    ? afterHeading.slice(nextSubsection.index)
+    : "";
+  const cleanedParts = [beforeExcerpt, afterExcerptBlock.trim()].filter(
+    Boolean,
+  );
+  const cleanedText = cleanedParts.join("\n\n").trim() || excerptText;
+
+  return {
+    excerpt: excerptText || null,
+    cleanedText: cleanedText || sectionText,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Structural path #1 — markdown H2 delimiters (primary).
 // Every `## <title>` line starts a new page.
 // ---------------------------------------------------------------------------
@@ -261,16 +303,18 @@ function parseByHrule(body: string, offset: number): BriefPageDraft[] {
     const firstLineEnd = text.indexOf("\n");
     const title = (firstLineEnd === -1 ? text : text.slice(0, firstLineEnd)).trim();
     const rest = firstLineEnd === -1 ? "" : text.slice(firstLineEnd + 1).trim();
-    const sourceText = rest.length > 0 ? rest : text;
-    const wordCount = countWords(sourceText);
+    const raw = rest.length > 0 ? rest : text;
+    const { excerpt, cleanedText } = extractExcerptFromSection(raw);
+    const wordCount = countWords(cleanedText);
     pages.push({
       ordinal: ordinal++,
       title: title.replace(/^#+\s*/, "") || `Section ${ordinal}`,
       mode: inferMode(wordCount),
-      source_text: sourceText,
+      source_text: cleanedText,
       word_count: wordCount,
       source_span_start: offset + seg.start,
       source_span_end: offset + seg.end,
+      excerpt,
     });
   }
   return pages;
@@ -307,16 +351,18 @@ function materialisePages(
   for (let i = 0; i < matches.length; i++) {
     const cur = matches[i];
     const nextStart = i + 1 < matches.length ? matches[i + 1].index : body.length;
-    const sectionText = body.slice(cur.lineEnd, nextStart).trim();
-    const wordCount = countWords(sectionText);
+    const raw = body.slice(cur.lineEnd, nextStart).trim();
+    const { excerpt, cleanedText } = extractExcerptFromSection(raw);
+    const wordCount = countWords(cleanedText);
     pages.push({
       ordinal: i,
       title: cur.title,
       mode: inferMode(wordCount),
-      source_text: sectionText,
+      source_text: cleanedText,
       word_count: wordCount,
       source_span_start: offset + cur.index,
       source_span_end: offset + nextStart,
+      excerpt,
     });
   }
   return pages;
@@ -474,6 +520,7 @@ async function runInferenceFallback(opts: {
       word_count: wordCount,
       source_span_start: start,
       source_span_end: nextStart,
+      excerpt: null,
     });
   }
 
@@ -619,6 +666,7 @@ export async function parseBriefDocument(opts: {
           word_count: wordCount,
           source_span_start: 0,
           source_span_end: trimmed.length,
+          excerpt: null,
         },
       ],
       warnings,

--- a/lib/brief-runner.ts
+++ b/lib/brief-runner.ts
@@ -2825,7 +2825,7 @@ export async function approveBriefPage(
   const pageRes = await svc
     .from("brief_pages")
     .select(
-      "id, brief_id, ordinal, page_status, draft_html, title, slug_hint, source_text, version_lock",
+      "id, brief_id, ordinal, page_status, draft_html, title, slug_hint, source_text, excerpt, version_lock",
     )
     .eq("id", input.pageId)
     .is("deleted_at", null)
@@ -2857,6 +2857,7 @@ export async function approveBriefPage(
     title: string;
     slug_hint: string | null;
     source_text: string;
+    excerpt: string | null;
     version_lock: number;
   };
 
@@ -3089,6 +3090,7 @@ async function bridgeApprovedPageToPostIfNeeded(
     slug_hint: string | null;
     draft_html: string | null;
     source_text: string;
+    excerpt: string | null;
   },
   _nowIso: string,
 ): Promise<{ post_id: string | null; failed_bridge_reason: string | null }> {
@@ -3163,6 +3165,11 @@ async function bridgeApprovedPageToPostIfNeeded(
   // 5. Insert the posts row. A 23505 here means another operator raced
   //    us to the same slug — treat as soft failure so approval stays
   //    successful.
+  const rawExcerpt = page.excerpt?.trim() ?? null;
+  const excerptValue =
+    rawExcerpt && rawExcerpt.length > POST_META_DESCRIPTION_MAX
+      ? rawExcerpt.slice(0, POST_META_DESCRIPTION_MAX)
+      : rawExcerpt;
   const insertRes = await svc
     .from("posts")
     .insert({
@@ -3174,6 +3181,7 @@ async function bridgeApprovedPageToPostIfNeeded(
       status: "draft",
       generated_html: page.draft_html,
       content_brief: { source_text: page.source_text, brief_id: page.brief_id },
+      excerpt: excerptValue,
     })
     .select("id")
     .maybeSingle();

--- a/lib/briefs.ts
+++ b/lib/briefs.ts
@@ -150,6 +150,7 @@ export type BriefPageRow = {
   source_span_start: number | null;
   source_span_end: number | null;
   source_text: string;
+  excerpt: string | null;
   word_count: number;
   operator_notes: string | null;
   version_lock: number;
@@ -511,6 +512,7 @@ async function uploadBriefImpl(
     word_count: p.word_count,
     source_span_start: p.source_span_start,
     source_span_end: p.source_span_end,
+    excerpt: p.excerpt ?? null,
     created_by: input.uploadedBy,
     updated_by: input.uploadedBy,
   }));

--- a/supabase/migrations/0102_brief_pages_excerpt.sql
+++ b/supabase/migrations/0102_brief_pages_excerpt.sql
@@ -1,0 +1,13 @@
+-- 0102 — Add excerpt column to brief_pages.
+--
+-- PB-1: operators can include a `### Excerpt` H3 section in a brief page's
+-- body. The parser extracts it into BriefPageDraft.excerpt; this column
+-- stores it so the approve-page bridge can write it to posts.excerpt, which
+-- the publish route forwards to the WP REST API and Yoast SEO meta.
+--
+-- The 300-char cap mirrors POST_META_DESCRIPTION_MAX in lib/brief-runner.ts
+-- and matches the WP REST excerpt outer bound.
+
+ALTER TABLE brief_pages
+  ADD COLUMN excerpt text
+    CHECK (excerpt IS NULL OR char_length(excerpt) <= 300);


### PR DESCRIPTION
## Summary

Implements the Post Meta Description backlog item (PB-1). Operators can now embed an SEO excerpt directly in their brief markdown using a `### Excerpt` H3 sub-section. The text flows end-to-end to WP REST and Yoast SEO on publish.

### How it works

Brief format (within a `## Page Title` section):

\`\`\`markdown
## Blog Post Title

Full post content here...

### Excerpt
Friendly 1–2 sentence description for search engines and social previews.
\`\`\`

The `### Excerpt` block is **stripped from `source_text`** before it reaches the AI, so it does not pollute generation context.

### Changes

- **`lib/brief-parser.ts`** — `BriefPageDraft` gains `excerpt: string | null`; `extractExcerptFromSection` helper parses and strips H3 Excerpt blocks; all structural paths + inference fallback populate `excerpt`
- **`supabase/migrations/0102_brief_pages_excerpt.sql`** — `ALTER TABLE brief_pages ADD COLUMN excerpt text CHECK (char_length <= 300)`
- **`lib/briefs.ts`** — `BriefPageRow` type + `pageRows` insert include `excerpt`
- **`lib/brief-runner.ts`** — `approveBriefPage` SELECT + type cast + `bridgeApprovedPageToPostIfNeeded` parameter all include `excerpt`; truncates to `POST_META_DESCRIPTION_MAX` before writing to `posts.excerpt`
- **`lib/__tests__/brief-parser.test.ts`** — 3 new excerpt extraction tests

### Already wired (no changes needed)

The publish route already reads `posts.excerpt`, passes it to `wpCreatePost`/`wpUpdatePost`, and sets `_yoast_wpseo_metadesc`.

### Risks identified and mitigated

| Hotspot | Mitigation |
|---|---|
| New nullable column on `brief_pages` | Migration adds `excerpt text` (nullable); existing rows default to NULL |
| excerpt length | Truncated to `POST_META_DESCRIPTION_MAX = 300` before insert |
| Inference + single-page fallback paths | Explicitly set `excerpt: null` |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)