### PR TITLE
fix(routing): /admin 404 — redirect to /admin/sites

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdminRootPage() {
+  redirect("/admin/sites");
+}


### PR DESCRIPTION
## Issue closed
Fixes Issue 1 from the 2026-05-05 dogfood pass: navigating to `/admin` with no sub-route returned a 404.

## Change
Add `app/admin/page.tsx` — a server component that calls `redirect("/admin/sites")` so the root admin URL resolves immediately.

## Risks identified and mitigated
- Server-only `redirect()` — correct for a server component; no client-side JS involved
- Single file, no DB or API changes