### PR TITLE
fix(blog): inline category creation + combobox UX (Issues 3+4)

### DIFF
--- a/app/api/sites/[id]/posts/[post_id]/publish/route.ts
+++ b/app/api/sites/[id]/posts/[post_id]/publish/route.ts
@@ -14,6 +14,7 @@ import { preflightSitePublish } from "@/lib/site-preflight";
 import { getServiceRoleClient } from "@/lib/supabase";
 import { getSite } from "@/lib/sites";
 import {
+  wpCreateCategory,
   wpCreatePost,
   wpCreateTag,
   wpUpdatePost,
@@ -254,9 +255,32 @@ export async function POST(
       ? (post.metadata as Record<string, unknown>)
       : {};
 
-  const wpCategoryIds = Array.isArray(metaObj.wp_category_ids)
+  const existingCategoryIds = Array.isArray(metaObj.wp_category_ids)
     ? (metaObj.wp_category_ids as number[])
-    : undefined;
+    : [];
+
+  const newCategoryNames = Array.isArray(metaObj.wp_new_category_names)
+    ? (metaObj.wp_new_category_names as string[])
+    : [];
+
+  const createdCategoryIds: number[] = [];
+  for (const catName of newCategoryNames) {
+    const catResult = await wpCreateCategory(cfg, catName);
+    if (catResult.ok) {
+      createdCategoryIds.push(catResult.id);
+    } else {
+      logger.warn("posts.publish.wp_category_create_failed", {
+        post_id: postIdCheck.value,
+        category_name: catName,
+        wp_code: catResult.code,
+      });
+    }
+  }
+
+  const allCategoryIds =
+    existingCategoryIds.length > 0 || createdCategoryIds.length > 0
+      ? [...existingCategoryIds, ...createdCategoryIds]
+      : undefined;
 
   const existingTagIds = Array.isArray(metaObj.wp_tag_ids)
     ? (metaObj.wp_tag_ids as number[])
@@ -312,7 +336,7 @@ export async function POST(
         slug: post.slug,
         content: post.generated_html,
         ...(excerptValue !== undefined ? { excerpt: excerptValue } : {}),
-        ...(wpCategoryIds !== undefined ? { categories: wpCategoryIds } : {}),
+        ...(allCategoryIds !== undefined ? { categories: allCategoryIds } : {}),
         ...(allTagIds !== undefined ? { tags: allTagIds } : {}),
         ...(yoastMeta !== undefined ? { meta: yoastMeta } : {}),
         ...featuredMediaPatch,
@@ -323,7 +347,7 @@ export async function POST(
         slug: post.slug,
         content: post.generated_html,
         ...(excerptValue !== undefined ? { excerpt: excerptValue } : {}),
-        ...(wpCategoryIds !== undefined ? { categories: wpCategoryIds } : {}),
+        ...(allCategoryIds !== undefined ? { categories: allCategoryIds } : {}),
         ...(allTagIds !== undefined ? { tags: allTagIds } : {}),
         ...(yoastMeta !== undefined ? { meta: yoastMeta } : {}),
         ...featuredMediaPatch,

--- a/app/api/sites/[id]/posts/route.ts
+++ b/app/api/sites/[id]/posts/route.ts
@@ -48,6 +48,8 @@ const BodySchema = z
     wp_tag_ids: z.array(z.number().int().nonnegative()).max(20).optional(),
     // New tag names (not yet created in WP); created on publish.
     wp_new_tag_names: z.array(z.string().min(1).max(200)).max(20).optional(),
+    // New category names (not yet created in WP); created on publish.
+    wp_new_category_names: z.array(z.string().min(1).max(200)).max(20).optional(),
     // Pre-composed HTML for "Publish immediately" mode.
     generated_html: z.string().max(500_000).nullable().optional(),
   })
@@ -133,6 +135,9 @@ export async function POST(
       : {}),
     ...(parsed.data.wp_new_tag_names !== undefined
       ? { wp_new_tag_names: parsed.data.wp_new_tag_names }
+      : {}),
+    ...(parsed.data.wp_new_category_names !== undefined
+      ? { wp_new_category_names: parsed.data.wp_new_category_names }
       : {}),
   };
 

--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -532,6 +532,12 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
     const existingTagIds = selectedTags
       .filter((t) => !t.isNew)
       .map((t) => t.id);
+    const newCategoryNames = selectedCategories
+      .filter((c) => c.isNew)
+      .map((c) => c.name);
+    const existingCategoryIds = selectedCategories
+      .filter((c) => !c.isNew)
+      .map((c) => c.id);
     const mode = forceAsDraft ? "draft" : publishMode;
     return {
       title: title.value.trim(),
@@ -543,8 +549,9 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
       meta_title: metaTitle.value.trim() || null,
       status: mode === "schedule" ? "scheduled" : "draft",
       scheduled_at: mode === "schedule" ? scheduledAt : null,
-      wp_category_ids: selectedCategories.map((c) => c.id),
+      wp_category_ids: existingCategoryIds,
       wp_tag_ids: existingTagIds,
+      ...(newCategoryNames.length > 0 ? { wp_new_category_names: newCategoryNames } : {}),
       ...(newTagNames.length > 0 ? { wp_new_tag_names: newTagNames } : {}),
       metadata: lastParse ?? null,
       featured_image_id: featuredImage?.id ?? null,
@@ -1454,7 +1461,6 @@ function WpTaxonomyCombobox({
   const placeholder = loading ? `Loading ${type}…` : `Pick ${type}…`;
 
   const canCreateNew =
-    type === "tags" &&
     inputValue.trim().length > 0 &&
     !options.some(
       (o) => o.name.toLowerCase() === inputValue.trim().toLowerCase(),
@@ -1463,17 +1469,17 @@ function WpTaxonomyCombobox({
       (v) => v.name.toLowerCase() === inputValue.trim().toLowerCase(),
     );
 
-  function addNewTag() {
+  function addNew() {
     const name = inputValue.trim();
     if (!name) return;
-    const newTag: WpTaxonomyOption = {
+    const newItem: WpTaxonomyOption = {
       id: -Date.now(),
       name,
       slug: name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, ""),
       count: 0,
       isNew: true,
     };
-    onChange([...value, newTag]);
+    onChange([...value, newItem]);
     setInputValue("");
   }
 
@@ -1521,13 +1527,13 @@ function WpTaxonomyCombobox({
       >
         <Command shouldFilter={true}>
           <CommandInput
-            placeholder={type === "tags" ? `Search or create ${label}…` : `Search ${type}…`}
+            placeholder={`Search or create ${label}…`}
             value={inputValue}
             onValueChange={setInputValue}
             onKeyDown={(e) => {
               if (e.key === "Enter" && canCreateNew) {
                 e.preventDefault();
-                addNewTag();
+                addNew();
               }
             }}
           />
@@ -1540,19 +1546,17 @@ function WpTaxonomyCombobox({
             {canCreateNew && (
               <CommandItem
                 value={`__new__${inputValue}`}
-                onSelect={addNewTag}
+                onSelect={addNew}
                 className="text-primary"
               >
                 <span className="mr-2 text-primary">+</span>
-                Add tag &ldquo;{inputValue.trim()}&rdquo;
+                Add {label} &ldquo;{inputValue.trim()}&rdquo;
               </CommandItem>
             )}
             <CommandEmpty>
               {loading
                 ? "Loading…"
-                : type === "tags"
-                  ? "Type a name to search or create a tag."
-                  : `No ${label}s found.`}
+                : `Type a name to search or create a ${label}.`}
             </CommandEmpty>
             {options.map((option) => (
               <CommandItem

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -1222,3 +1222,27 @@ export async function wpCreateTag(
   return { ok: true, ...toTaxonomyItem(parsed.body) };
 }
 
+// ---------- wpCreateCategory ----------
+
+export type WpCreateCategoryResult = WpResult<WpTaxonomyItem>;
+
+export async function wpCreateCategory(
+  cfg: WpConfig,
+  name: string,
+): Promise<WpCreateCategoryResult> {
+  let res: Response;
+  try {
+    res = await wpFetch(cfg, "/wp-json/wp/v2/categories", {
+      method: "POST",
+      body: JSON.stringify({ name, slug: name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "") }),
+    });
+  } catch (err) {
+    return networkError(err);
+  }
+  const mapped = await mapHttpErrorToWpError(res);
+  if (mapped) return mapped;
+  const parsed = await parseJsonOrError<unknown>(res);
+  if (!parsed.ok) return parsed;
+  return { ok: true, ...toTaxonomyItem(parsed.body) };
+}
+


### PR DESCRIPTION
## Issues closed
Fixes Issues 3 and 4 from the 2026-05-05 dogfood pass.

## Changes

**Issue 3 — Typo + inline category creation**
- Fixed "No categorys found." → "Type a name to search or create a category." (uniform empty state for both category and tag comboboxes)
- Enabled inline category creation: same UX as tags — type a name, hit Enter or click "Add category", get a `+` badge; new categories are stored as `wp_new_category_names` in the post's metadata and created via `wpCreateCategory()` at publish time
- `buildCreateBody()` now separates `existingCategoryIds` (existing WP terms) from `newCategoryNames` (to-be-created)
- Publish route creates new categories before pushing to WordPress, using `allCategoryIds = existingCategoryIds + createdCategoryIds`

**Issue 4 — Tag create flow**
- `canCreateNew` now works for both categories and tags (was tags-only); the "Add tag/category" button is shown whenever the typed name doesn't match any existing option

**New function:** `wpCreateCategory()` in `lib/wordpress.ts` — mirrors `wpCreateTag` against `/wp-json/wp/v2/categories`.

## Risks identified and mitigated
- Category creation is best-effort (same pattern as tags): failures log `wp_category_create_failed` but do not block the post publish
- No migration needed — `wp_new_category_names` is stored in the existing `metadata` JSONB column

## Test plan
- [ ] Type a new category name → "Add category …" item appears
- [ ] Select it → `+` badge shown in picker
- [ ] Publish → category created in WP and post assigned to it
- [ ] Category that already exists → only "Add category" for genuinely new names