### PR TITLE
fix(images): remove invalid Cloudflare URL suffix from thumbnails

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -983,7 +983,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
             <div className="space-y-2">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src={`${featuredImage.delivery_url}/w=300,h=200,fit=cover`}
+                src={featuredImage.delivery_url}
                 alt={featuredImage.alt_text ?? featuredImage.caption ?? ""}
                 className="aspect-video w-full rounded-md border object-cover"
               />

--- a/components/ImagePickerModal.tsx
+++ b/components/ImagePickerModal.tsx
@@ -723,10 +723,9 @@ function ImageGrid({
           >
             <div className="aspect-square w-full overflow-hidden">
               {img.delivery_url ? (
-                // Cloudflare delivery URL with explicit w=/h=/fit= sizing.
                 // eslint-disable-next-line @next/next/no-img-element
                 <img
-                  src={`${img.delivery_url}/w=200,h=200,fit=cover`}
+                  src={img.delivery_url}
                   alt={img.alt_text ?? img.caption ?? ""}
                   loading="lazy"
                   className="h-full w-full object-cover transition-smooth group-hover:scale-105"


### PR DESCRIPTION
## Issues closed
Fixes Issues 5 and 6 from the 2026-05-05 dogfood pass.

## Root cause
`deliveryUrl()` in `lib/cloudflare-images.ts` already returns a URL ending with `/public` (the named variant). Both image pickers were appending `/w=200,h=200,fit=cover` — a flexible variants path segment. Cloudflare rejects requests where a named variant is followed by flexible-variant parameters, returning a 404, so all image thumbnails appeared broken.

## Fix
Remove the URL parameters from both callers:
- `components/ImagePickerModal.tsx:729` — grid thumbnails
- `components/BlogPostComposer.tsx:993` — featured image preview

Both already use `className="... object-cover"` so the CSS handles crop without any URL-side transformation.

## Risks identified and mitigated
- No change to Cloudflare Images configuration needed; the named `public` variant is already configured to serve at the correct dimensions
- Two-file change, no DB or API impact