### PR TITLE
test(m12-1): fix source_mime_type rejection test for PDF-allowed constraint

### DIFF
--- a/lib/__tests__/m12-1-schema.test.ts
+++ b/lib/__tests__/m12-1-schema.test.ts
@@ -286,12 +286,12 @@ describe("M12-1: briefs / brief_pages / brief_runs / site_conventions", () => {
     const { id: siteId } = await seedSite({ prefix: "m12j" });
     const svc = getServiceRoleClient();
     const res = await svc.from("briefs").insert({
-      site_id: siteId, title: "PDF",
-      source_storage_path: makeStoragePath("pdf"),
-      source_mime_type: "application/pdf",
+      site_id: siteId, title: "Zip",
+      source_storage_path: makeStoragePath("zip"),
+      source_mime_type: "application/zip",
       source_size_bytes: 100,
       source_sha256: "0".repeat(64),
-      upload_idempotency_key: makeIdempKey("pdf"),
+      upload_idempotency_key: makeIdempKey("zip"),
     });
     expect(res.error?.code).toBe("23514");
   });


### PR DESCRIPTION
## Summary

- Migration 0101 added `application/pdf` and DOCX to the allowed `source_mime_type` values in the `briefs` table constraint.
- Test 10 in `m12-1-schema.test.ts` was still testing `application/pdf` as an *unsupported* type, so it now returns `undefined` instead of the expected `23514` code.
- Fix: switch the test to `application/zip`, which remains unsupported.

## Risks identified and mitigated

- No schema changes, no runtime changes — test-only fix.
- The test now asserts the constraint still rejects anything outside the four allowed types.

## Test plan

- [ ] CI `test` job passes with the updated assertion