### PR TITLE
fix(blog): use DOMParser.textContent for first-paragraph extraction

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -85,10 +85,11 @@ const SOURCE_HINTS: Record<ParseSource, string> = {
 };
 
 // Extract first plain-text paragraph from HTML for meta-description seeding.
+// Uses DOMParser so only textContent is returned, never raw HTML (CodeQL safe).
 function extractFirstParagraph(html: string): string {
-  const match = /<p[^>]*>([\s\S]*?)<\/p>/i.exec(html);
-  if (!match) return "";
-  return match[1].replace(/<[^>]+>/g, "").trim();
+  if (typeof window === "undefined") return "";
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  return doc.querySelector("p")?.textContent?.trim() ?? "";
 }
 
 // Google SERP snippet preview — purely visual, no interaction.


### PR DESCRIPTION
## What

Closes the CodeQL high alert introduced in #640.

`extractFirstParagraph` in `BlogPostComposer.tsx` used `/<[^>]+>/g` to strip
HTML tags before returning plain text. CodeQL flagged this as "incomplete
multi-character sanitization" (high severity) because the regex can be
bypassed by attribute values containing `>`.

**Fix:** Replace the regex with `DOMParser.parseFromString + textContent`.
- `textContent` returns only the rendered text, with no HTML whatsoever.
- The function is only ever called inside a `useEffect` hook (client-side),
  so `window` / `DOMParser` are always available when it executes.
- No behaviour change for valid Tiptap HTML output.

## Risks identified and mitigated

- **SSR guard**: `if (typeof window === "undefined") return ""` added so the
  function is safe even if a future refactor moves the call outside a `useEffect`.
- **Behavioural parity**: `DOMParser` + `querySelector("p")?.textContent`
  handles nested inline elements correctly; the old regex would have kept tag bytes.

## Test plan

- [ ] Paste content with a `<p>` into the composer → meta description auto-populates with plain text (no HTML tags)
- [ ] CodeQL check passes on this PR

🤖 Generated with [Claude Code](https://claude.ai/claude-code)