### PR TITLE
fix(blog): replace HTML-strip regex with quote-aware state machine

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -85,11 +85,31 @@ const SOURCE_HINTS: Record<ParseSource, string> = {
 };
 
 // Extract first plain-text paragraph from HTML for meta-description seeding.
-// Uses DOMParser so only textContent is returned, never raw HTML (CodeQL safe).
+// Pure string walk — no DOM API, no regex replace — avoids both CodeQL rules
+// (js/incomplete-multi-char-sanitization and js/xss).
 function extractFirstParagraph(html: string): string {
-  if (typeof window === "undefined") return "";
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  return doc.querySelector("p")?.textContent?.trim() ?? "";
+  const pMatch = /<p[\s>]/.exec(html);
+  if (!pMatch) return "";
+  const tagEnd = html.indexOf(">", pMatch.index);
+  if (tagEnd === -1) return "";
+  const contentEnd = html.indexOf("</p>", tagEnd);
+  if (contentEnd === -1) return "";
+  let text = "";
+  let inTag = false;
+  let quote = "";
+  for (let i = tagEnd + 1; i < contentEnd; i++) {
+    const ch = html[i];
+    if (inTag) {
+      if (quote) { if (ch === quote) quote = ""; }
+      else if (ch === '"' || ch === "'") { quote = ch; }
+      else if (ch === ">") { inTag = false; }
+    } else if (ch === "<") {
+      inTag = true;
+    } else {
+      text += ch;
+    }
+  }
+  return text.trim();
 }
 
 // Google SERP snippet preview — purely visual, no interaction.


### PR DESCRIPTION
## What

Fixes CodeQL HIGH finding `js/incomplete-multi-char-sanitization` in `extractFirstParagraph` (`components/BlogPostComposer.tsx`).

The fix history:
1. Original: `/<[^>]+>/g` regex → triggered `js/incomplete-multi-char-sanitization` (CodeQL HIGH)
2. Intermediate attempt: `DOMParser.parseFromString` → triggered `js/xss` (DOM text reinterpreted as HTML)
3. **Final fix (this PR):** Pure-string state machine walking the first `<p>` block character by character, tracking quote state so `>` inside attribute values is handled correctly. No DOM APIs, no regex replace — neither CodeQL rule can fire.

## Changes

- `components/BlogPostComposer.tsx`: Replace `DOMParser` with a quote-aware character-walk that reads `textContent` directly from the string without parsing HTML.

## Test plan

- [ ] TypeScript typecheck clean
- [ ] ESLint clean
- [ ] Build passes
- [ ] CodeQL scan — no `js/incomplete-multi-char-sanitization` or `js/xss` findings on this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)