### PR TITLE
feat(path-b): kadence palette sync gate before post publish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,6 +157,11 @@ DESIGN_CONTEXT_ENABLED=
 # Unset = text/markdown only (safe default).
 OPOLLO_BRIEF_BINARY_PARSERS=
 
+# Path-B publish gate — blocks post publish on new_design sites that have
+# never synced their Kadence palette (kadence_globals_synced_at IS NULL).
+# Returns 409 KADENCE_SYNC_DRIFT_BLOCKED. Unset = gate inactive (safe default).
+FEATURE_PATH_B_PUBLISH_GATE=
+
 
 # -----------------------------------------------------------------------------
 # Logging + observability (OPTIONAL — degrades gracefully when unset)

--- a/.env.local.example
+++ b/.env.local.example
@@ -51,6 +51,11 @@ FEATURE_DESIGN_SYSTEM_V2=
 # Enables PDF + Word (.docx) brief uploads (M12-PDF). Unset = text only.
 OPOLLO_BRIEF_BINARY_PARSERS=
 
+# Path-B publish gate — blocks post publish on new_design sites with no
+# Kadence palette sync (kadence_globals_synced_at IS NULL). 409
+# KADENCE_SYNC_DRIFT_BLOCKED. Unset = inactive.
+FEATURE_PATH_B_PUBLISH_GATE=
+
 # Auth migration (M2+). When a Supabase Auth user signs up with this email,
 # the handle_new_auth_user trigger promotes them to role='admin'. Everyone
 # else signs up as 'viewer' and waits for an admin promotion via the M2d

--- a/app/admin/sites/[id]/appearance/page.tsx
+++ b/app/admin/sites/[id]/appearance/page.tsx
@@ -129,6 +129,9 @@ export default async function SiteAppearancePage({
 
   // new_design — preserve the existing Kadence-aware panel verbatim.
   const events = await listAppearanceEventsForSite(params.id, 20);
+  const publishGateEnabled =
+    process.env.FEATURE_PATH_B_PUBLISH_GATE === "true" ||
+    process.env.FEATURE_PATH_B_PUBLISH_GATE === "1";
 
   return (
     <main className="mx-auto max-w-5xl p-6">
@@ -141,6 +144,7 @@ export default async function SiteAppearancePage({
         initialKadenceGlobalsSyncedAt={modeRow.kadence_globals_synced_at}
         initialSiteVersionLock={modeRow.version_lock}
         initialEvents={events}
+        publishGateEnabled={publishGateEnabled}
       />
     </main>
   );

--- a/app/api/sites/[id]/posts/[post_id]/publish/route.ts
+++ b/app/api/sites/[id]/posts/[post_id]/publish/route.ts
@@ -10,7 +10,10 @@ import {
   validateUuidParam,
 } from "@/lib/http";
 import { logger } from "@/lib/logger";
-import { preflightSitePublish } from "@/lib/site-preflight";
+import {
+  checkKadenceSyncFresh,
+  preflightSitePublish,
+} from "@/lib/site-preflight";
 import { getServiceRoleClient } from "@/lib/supabase";
 import { getSite } from "@/lib/sites";
 import {
@@ -161,6 +164,26 @@ export async function POST(
       preflight.blocker.detail,
       403,
       { blocker: preflight.blocker },
+    );
+  }
+
+  // 2.5. Path-B publish gate — Kadence palette sync check.
+  //
+  // Gated by FEATURE_PATH_B_PUBLISH_GATE (default off). When on, a
+  // new_design site that has never synced its palette is refused publish
+  // with 409 KADENCE_SYNC_DRIFT_BLOCKED so the operator is directed to
+  // the Appearance panel first.
+  const syncCheck = await checkKadenceSyncFresh(siteIdCheck.value);
+  if (syncCheck.blocked) {
+    logger.info("posts.publish.kadence_sync_drift_blocked", {
+      site_id: siteIdCheck.value,
+      post_id: postIdCheck.value,
+    });
+    return envelope(
+      "KADENCE_SYNC_DRIFT_BLOCKED",
+      syncCheck.message,
+      409,
+      { appearance_url: syncCheck.appearanceUrl },
     );
   }
 

--- a/components/AppearancePanelClient.tsx
+++ b/components/AppearancePanelClient.tsx
@@ -76,6 +76,7 @@ export function AppearancePanelClient({
   initialKadenceGlobalsSyncedAt,
   initialSiteVersionLock,
   initialEvents,
+  publishGateEnabled = false,
 }: {
   siteId: string;
   siteName: string;
@@ -84,6 +85,7 @@ export function AppearancePanelClient({
   initialKadenceGlobalsSyncedAt: string | null;
   initialSiteVersionLock: number;
   initialEvents: AppearanceEventRow[];
+  publishGateEnabled?: boolean;
 }) {
   const router = useRouter();
   const [phase, setPhase] = useState<Phase>("loading");
@@ -394,6 +396,7 @@ export function AppearancePanelClient({
           ctx={ctx}
           kadenceInstalledAt={initialKadenceInstalledAt}
           kadenceGlobalsSyncedAt={kadenceGlobalsSyncedAt}
+          publishGateEnabled={publishGateEnabled}
           actionState={actionState}
           lastSyncEventId={lastSyncEventId}
           onSyncClick={() => setConfirmOpen("sync")}
@@ -561,6 +564,7 @@ function ReadyState({
   ctx,
   kadenceInstalledAt,
   kadenceGlobalsSyncedAt,
+  publishGateEnabled,
   actionState,
   lastSyncEventId,
   onSyncClick,
@@ -570,6 +574,7 @@ function ReadyState({
   ctx: PreflightContext;
   kadenceInstalledAt: string | null;
   kadenceGlobalsSyncedAt: string | null;
+  publishGateEnabled: boolean;
   actionState: ActionState;
   lastSyncEventId: string | null;
   onSyncClick: () => void;
@@ -626,6 +631,20 @@ function ReadyState({
           </Button>
         </div>
       </div>
+
+      {publishGateEnabled && kadenceGlobalsSyncedAt === null && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        >
+          <p className="font-medium">Palette sync required before publishing</p>
+          <p className="mt-1">
+            Publishing is blocked until the Kadence palette has been synced at
+            least once. Sync the palette below — this only needs to happen once
+            per design-system version.
+          </p>
+        </div>
+      )}
 
       {insufficientProposal && (
         <div

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -109,7 +109,7 @@ When path-A rows become stale enough or visually disruptive enough, retire by ru
 
 ---
 
-## Path-B publish gate on Kadence sync drift (path B, opened 2026-04-29 by PB-8)
+## ~~Path-B publish gate on Kadence sync drift~~ (shipped 2026-05-06, PR #TBD)
 
 **Tags:** `path-b`, `m13`, `publish`, `feature-flag`
 
@@ -161,7 +161,7 @@ For high-fidelity preview, fetch the customer's actual theme CSS bundle and inli
 
 ---
 
-## Post meta description via WP excerpt (path B, opened 2026-04-29 by PB-1)
+## ~~Post meta description via WP excerpt~~ (shipped 2026-05-06, PR #635)
 
 **Tags:** `path-b`, `m13`, `posts`, `seo`
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -529,6 +529,39 @@ Log the provisioning date + vendor account IDs somewhere persistent; each rotati
 
 ---
 
+## publish-blocked-no-palette-sync — 409 KADENCE_SYNC_DRIFT_BLOCKED on post publish
+
+**Severity:** BLOCKED PUBLISH — operator cannot publish until resolved.
+
+**Symptom:** Operator clicks Publish on a post for a `new_design` site and gets
+a 409 response. JSON body: `{ "error": { "code": "KADENCE_SYNC_DRIFT_BLOCKED",
+"message": "Palette not yet synced. Run palette sync in the Appearance panel before publishing." } }`.
+The Appearance panel also shows a red "Palette sync required before publishing"
+alert.
+
+**Trigger:** `FEATURE_PATH_B_PUBLISH_GATE=true` + `sites.site_mode = 'new_design'`
++ `sites.kadence_globals_synced_at IS NULL`.  
+Gate is **off** when the env var is unset. `copy_existing` sites are never gated.
+
+**Source:** `lib/site-preflight.ts::checkKadenceSyncFresh` + step 2.5 in
+`app/api/sites/[id]/posts/[post_id]/publish/route.ts`.
+
+**Resolution:**
+1. Navigate to **Admin → Sites → [site] → Appearance**.
+2. Run **Palette Sync** (confirm the diff and click Sync). Once successful,
+   `kadence_globals_synced_at` will be non-null.
+3. Re-attempt publish — the gate will clear.
+
+**If palette sync itself is failing:** see the `kadence-customizer-drift` entry
+below for the `WP_STATE_DRIFTED` / `KADENCE_NOT_ACTIVE` troubleshooting paths.
+
+**To disable the gate temporarily** (e.g. during an incident): set
+`FEATURE_PATH_B_PUBLISH_GATE=` (empty/unset) in the Vercel project env and
+redeploy. The gate is fail-open on DB errors by design — a transient DB
+read failure does NOT block publishing.
+
+---
+
 ## kadence-customizer-drift — palette sync hits WP_STATE_DRIFTED
 
 **Severity (path B, post-2026-04-29):** **CONTENT BUG**, not polish. Under path B (decision PR #192), Opollo emits content fragments and the host theme owns visual tokens (palette, fonts, spacing). Kadence palette sync IS the visual contract — drift between the design-system tokens and the WP-side palette means published Opollo content renders with the wrong colours. Treat sync-drift incidents at the same urgency as a runner regression. Prior framing of "polish" is obsolete.

--- a/lib/__tests__/posts-publish-routes.test.ts
+++ b/lib/__tests__/posts-publish-routes.test.ts
@@ -450,3 +450,134 @@ describe("POST /api/sites/[id]/posts/[post_id]/unpublish", () => {
     expect(body.error.code).toBe("INVALID_STATE");
   });
 });
+
+describe("POST /api/sites/[id]/posts/[post_id]/publish — path-B Kadence sync gate", () => {
+  const GATE_KEY = "FEATURE_PATH_B_PUBLISH_GATE";
+  let origGate: string | undefined;
+  beforeEach(() => { origGate = process.env[GATE_KEY]; });
+  afterEach(() => {
+    if (origGate === undefined) delete process.env[GATE_KEY];
+    else process.env[GATE_KEY] = origGate;
+  });
+
+  async function setSiteMode(
+    siteId: string,
+    opts: { site_mode: string | null; kadence_globals_synced_at: string | null },
+  ) {
+    const svc = getServiceRoleClient();
+    await svc.from("sites").update(opts).eq("id", siteId);
+  }
+
+  it("blocks with 409 KADENCE_SYNC_DRIFT_BLOCKED when flag on + new_design + never synced", async () => {
+    process.env[GATE_KEY] = "true";
+    const site = await seedSiteWithCreds();
+    await setSiteMode(site.id, { site_mode: "new_design", kadence_globals_synced_at: null });
+    const { postId, versionLock } = await seedDraftPost({ siteId: site.id, slug: "gate-block" });
+
+    mockFetch({
+      "/wp-json/wp/v2/users/me": {
+        status: 200,
+        body: { id: 7, username: "u", capabilities: { edit_posts: true, upload_files: true } },
+      },
+    });
+
+    const res = await publishPOST(
+      new Request(`http://localhost/api/sites/${site.id}/posts/${postId}/publish`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ expected_version_lock: versionLock }),
+      }),
+      { params: { id: site.id, post_id: postId } },
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("KADENCE_SYNC_DRIFT_BLOCKED");
+  });
+
+  it("allows publish when flag on + new_design + kadence_globals_synced_at set", async () => {
+    process.env[GATE_KEY] = "true";
+    const site = await seedSiteWithCreds();
+    await setSiteMode(site.id, {
+      site_mode: "new_design",
+      kadence_globals_synced_at: new Date().toISOString(),
+    });
+    const { postId, versionLock } = await seedDraftPost({ siteId: site.id, slug: "gate-synced" });
+
+    mockFetch({
+      "/wp-json/wp/v2/users/me": {
+        status: 200,
+        body: { id: 7, username: "u", capabilities: { edit_posts: true, upload_files: true } },
+      },
+      "/wp-json/wp/v2/posts": {
+        status: 201,
+        body: { id: 99, slug: "gate-synced", status: "publish", link: "https://example.com/?p=99" },
+      },
+    });
+
+    const res = await publishPOST(
+      new Request(`http://localhost/api/sites/${site.id}/posts/${postId}/publish`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ expected_version_lock: versionLock }),
+      }),
+      { params: { id: site.id, post_id: postId } },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("allows publish for copy_existing site even with flag on + no sync", async () => {
+    process.env[GATE_KEY] = "true";
+    const site = await seedSiteWithCreds();
+    await setSiteMode(site.id, { site_mode: "copy_existing", kadence_globals_synced_at: null });
+    const { postId, versionLock } = await seedDraftPost({ siteId: site.id, slug: "gate-copy" });
+
+    mockFetch({
+      "/wp-json/wp/v2/users/me": {
+        status: 200,
+        body: { id: 7, username: "u", capabilities: { edit_posts: true, upload_files: true } },
+      },
+      "/wp-json/wp/v2/posts": {
+        status: 201,
+        body: { id: 88, slug: "gate-copy", status: "publish", link: "https://example.com/?p=88" },
+      },
+    });
+
+    const res = await publishPOST(
+      new Request(`http://localhost/api/sites/${site.id}/posts/${postId}/publish`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ expected_version_lock: versionLock }),
+      }),
+      { params: { id: site.id, post_id: postId } },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("allows publish when flag off even for new_design + no sync", async () => {
+    delete process.env[GATE_KEY];
+    const site = await seedSiteWithCreds();
+    await setSiteMode(site.id, { site_mode: "new_design", kadence_globals_synced_at: null });
+    const { postId, versionLock } = await seedDraftPost({ siteId: site.id, slug: "gate-off" });
+
+    mockFetch({
+      "/wp-json/wp/v2/users/me": {
+        status: 200,
+        body: { id: 7, username: "u", capabilities: { edit_posts: true, upload_files: true } },
+      },
+      "/wp-json/wp/v2/posts": {
+        status: 201,
+        body: { id: 77, slug: "gate-off", status: "publish", link: "https://example.com/?p=77" },
+      },
+    });
+
+    const res = await publishPOST(
+      new Request(`http://localhost/api/sites/${site.id}/posts/${postId}/publish`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ expected_version_lock: versionLock }),
+      }),
+      { params: { id: site.id, post_id: postId } },
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/lib/site-preflight.ts
+++ b/lib/site-preflight.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { logger } from "@/lib/logger";
 import { getSite } from "@/lib/sites";
+import { getServiceRoleClient } from "@/lib/supabase";
 import { translateWpError } from "@/lib/error-translations";
 import {
   wpGetMe,
@@ -196,5 +197,70 @@ function translateWpErrorToBlocker(
       detail: translated.detail,
       nextAction: translated.nextAction,
     },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Path-B publish gate — Kadence sync freshness check.
+//
+// Gated by FEATURE_PATH_B_PUBLISH_GATE env var (default off).
+// Only applies to new_design sites — copy_existing sites don't use
+// Kadence palette sync so the check is a no-op for them.
+//
+// Blocks publish when:
+//   - flag is on
+//   - site_mode === 'new_design'
+//   - kadence_globals_synced_at IS NULL (never synced)
+//
+// Callers receive a typed result; the 409 KADENCE_SYNC_DRIFT_BLOCKED
+// response code is defined here so all publish-path routes use the
+// same wire format.
+// ---------------------------------------------------------------------------
+
+export type KadenceSyncCheckResult =
+  | { blocked: false }
+  | {
+      blocked: true;
+      code: "KADENCE_SYNC_DRIFT_BLOCKED";
+      message: string;
+      appearanceUrl: string;
+    };
+
+export async function checkKadenceSyncFresh(
+  site_id: string,
+): Promise<KadenceSyncCheckResult> {
+  const flag = process.env.FEATURE_PATH_B_PUBLISH_GATE;
+  if (flag !== "true" && flag !== "1") return { blocked: false };
+
+  const svc = getServiceRoleClient();
+  const res = await svc
+    .from("sites")
+    .select("site_mode, kadence_globals_synced_at")
+    .eq("id", site_id)
+    .maybeSingle();
+
+  if (res.error) {
+    logger.error("site_preflight.kadence_sync_check_failed", {
+      site_id,
+      error: res.error,
+    });
+    // Fail open — don't block publish on a DB read error.
+    return { blocked: false };
+  }
+
+  const row = res.data as {
+    site_mode: string | null;
+    kadence_globals_synced_at: string | null;
+  } | null;
+
+  if (!row || row.site_mode !== "new_design") return { blocked: false };
+  if (row.kadence_globals_synced_at !== null) return { blocked: false };
+
+  return {
+    blocked: true,
+    code: "KADENCE_SYNC_DRIFT_BLOCKED",
+    message:
+      "Palette not yet synced. Run palette sync in the Appearance panel before publishing.",
+    appearanceUrl: `/admin/sites/${site_id}/appearance`,
   };
 }


### PR DESCRIPTION
## Summary

- Adds `FEATURE_PATH_B_PUBLISH_GATE` env flag (off by default).
- When on, `POST .../posts/:id/publish` calls `checkKadenceSyncFresh(siteId)` (step 2.5 in the publish route) and returns **409 `KADENCE_SYNC_DRIFT_BLOCKED`** for `new_design` sites whose `kadence_globals_synced_at IS NULL`.
- `copy_existing` sites are never gated (Kadence sync is irrelevant for them). DB read errors fail open so a transient DB blip can't block all publishes.
- The Appearance panel (`AppearancePanelClient` / `ReadyState`) surfaces a red alert when the gate is active and sync hasn't run, so operators see the blocker before clicking Publish.
- RUNBOOK entry added for `KADENCE_SYNC_DRIFT_BLOCKED` resolution path.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Gate fires when DB is flaky | `checkKadenceSyncFresh` catches `res.error` and returns `{ blocked: false }` — fail-open |
| Gate accidentally blocks `copy_existing` sites | Explicitly check `site_mode !== 'new_design'` → return unblocked |
| Flag forgotten unset on prod deploy | Default unset = inactive; no breaking change to existing deploys |
| Parallel test env variable mutation | Gate tests use `beforeEach`/`afterEach` to save/restore `FEATURE_PATH_B_PUBLISH_GATE` |

## Test plan

- [x] `feat(path-b) — path-B Kadence sync gate` describe block: 4 new unit tests in `lib/__tests__/posts-publish-routes.test.ts` covering all four branches (blocked / synced / copy_existing / flag-off)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Closes backlog item PB-8

Closes #fix/issue6-font-size-violations (n/a — this is a standalone feature slice, not issue-linked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)