### PR TITLE
fix(blog): featured image amber warning + hide duplicate save-draft button

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -584,8 +584,9 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
   const canPublish =
     canSaveDraft &&
     metaTitleIsValid &&
-    metaDescriptionIsValid &&
-    featuredImage !== null;
+    metaDescriptionIsValid;
+
+  const publishMissingImage = canPublish && featuredImage === null;
 
   // BL-8 — ⌘S / Ctrl+S triggers Save draft (draft, always safe).
   useEffect(() => {
@@ -942,7 +943,13 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
 
           {publishMode === "publish" && !canPublish && canSaveDraft && (
             <p className="text-sm text-muted-foreground">
-              Add SEO title, meta description, and featured image to publish.
+              Add SEO title and meta description to enable publishing.
+            </p>
+          )}
+
+          {publishMode === "publish" && publishMissingImage && (
+            <p className="rounded-md bg-warning/10 px-3 py-2 text-sm text-warning">
+              No featured image set. Posts without a featured image may not display correctly in WordPress.
             </p>
           )}
 
@@ -953,22 +960,24 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
               disabled={primaryDisabled || submitting}
               title={
                 publishMode === "publish" && !canPublish
-                  ? "Fill in SEO title, meta description, and featured image to publish."
+                  ? "Fill in SEO title and meta description to publish."
                   : undefined
               }
             >
               {submitting ? "Saving…" : primaryLabel}
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              className="w-full"
-              disabled={!canSaveDraft || submitting}
-              onClick={handleSaveToOpollo}
-              title="Save as draft in Opollo. Does not publish to WordPress."
-            >
-              {submitting ? "Saving…" : "Save draft"}
-            </Button>
+            {publishMode !== "draft" && (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                disabled={!canSaveDraft || submitting}
+                onClick={handleSaveToOpollo}
+                title="Save as draft in Opollo. Does not publish to WordPress."
+              >
+                {submitting ? "Saving…" : "Save draft"}
+              </Button>
+            )}
           </div>
 
           <p


### PR DESCRIPTION
## What

Two composer publish UX fixes.

## Changes

**Issue 10 — Featured image downgraded from hard blocker to advisory warning:**
- `canPublish` no longer requires `featuredImage !== null`
- When about to publish without a featured image, shows an amber `bg-warning/10 text-warning` notice: "No featured image set. Posts without a featured image may not display correctly in WordPress."
- Operators can still publish; they just see the warning

**Issue 11 — Duplicate "Save draft" button hidden in draft mode:**
- Secondary outline "Save draft" button is now only rendered when `publishMode !== "draft"`
- In draft mode the primary button already says "Save as Draft" — the second button was redundant

## Test plan
- [ ] In publish mode, no featured image → amber warning shown, Publish button still enabled
- [ ] In publish mode, featured image set → no warning shown
- [ ] In draft mode → only one "Save as Draft" button visible
- [ ] In publish/schedule mode → secondary "Save draft" button still visible

Closes dogfood issues 10, 11.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)