### PR TITLE
fix(observability): logger.error on approveProposal/rejectProposal failures in lib/optimiser/proposals.ts

### DIFF
--- a/lib/optimiser/proposals.ts
+++ b/lib/optimiser/proposals.ts
@@ -214,6 +214,7 @@ export async function approveProposal(args: {
     .eq("id", args.proposalId)
     .eq("status", "pending");
   if (updErr) {
+    logger.error("optimiser.proposals.approveProposal.update_failed", { proposal_id: args.proposalId, supabase_error: updErr.message });
     return {
       ok: false,
       code: "INTERNAL_ERROR",
@@ -324,6 +325,7 @@ export async function rejectProposal(args: {
     .eq("id", args.proposalId)
     .eq("status", "pending");
   if (updErr) {
+    logger.error("optimiser.proposals.rejectProposal.update_failed", { proposal_id: args.proposalId, supabase_error: updErr.message });
     return {
       ok: false,
       code: "INTERNAL_ERROR",


### PR DESCRIPTION
## Summary

Adds `logger.error` before two silent `INTERNAL_ERROR` returns in `lib/optimiser/proposals.ts`:
- `approveProposal` — update query failure
- `rejectProposal` — update query failure

Continuation of the observability sweep from PRs #634/#631. These two paths were returning `{ ok: false, code: "INTERNAL_ERROR" }` silently with no structured log, making DB failures invisible in production logs.

## Risks identified and mitigated

- Logger calls are fire-and-forget structured logs; no change to return value or error handling path.
- No schema changes, no migration needed.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)