### PR TITLE
fix(e2e): posts-new save-draft button hidden in draft mode

### DIFF
--- a/e2e/posts-new.spec.ts
+++ b/e2e/posts-new.spec.ts
@@ -226,8 +226,16 @@ test.describe("/admin/posts/new — top-level entry", () => {
     await expect(featuredImagePanel).toBeVisible();
 
     // Publish panel contains action buttons.
+    // Default mode is "draft" — primary button reads "Save as Draft", secondary hidden.
     await expect(publishPanel.getByRole("button", { name: /save as draft/i })).toBeVisible();
-    await expect(publishPanel.getByRole("button", { name: /save draft/i })).toBeVisible();
+    await expect(publishPanel.getByRole("button", { name: /^save draft$/i })).toHaveCount(0);
+
+    // Switch to publish mode → secondary "Save draft" button appears.
+    await publishPanel.getByRole("radio", { name: /publish immediately/i }).click();
+    await expect(publishPanel.getByRole("button", { name: /^save draft$/i })).toBeVisible();
+    // Restore draft mode.
+    await publishPanel.getByRole("radio", { name: /save as draft/i }).click();
+    await expect(publishPanel.getByRole("button", { name: /^save draft$/i })).toHaveCount(0);
 
     // Clicking the Publish panel header collapses it.
     await publishPanel.getByRole("button", { name: /^publish$/i }).click();


### PR DESCRIPTION
## What

Fixes a broken e2e assertion introduced when PR #651 hid the secondary "Save draft" button in draft mode.

## Root cause

The secondary outline "Save draft" button is now only rendered when `publishMode !== 'draft'`. The default mode is `draft`, so the button is not in the DOM on page load. The old test asserted `toBeVisible()` on it without first switching modes.

## Fix

- Assert the secondary button has count 0 in default draft mode
- Switch to "Publish immediately" radio, assert the button appears
- Switch back to draft mode, assert it's gone again
- The collapse/expand assertions below are unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)