### PR TITLE
fix(observability): logger.error on silent INTERNAL_ERROR in lib/list-pages.ts

### DIFF
--- a/lib/list-pages.ts
+++ b/lib/list-pages.ts
@@ -3,6 +3,7 @@ import {
   type ListPagesData,
   type ToolResponse,
 } from "@/lib/tool-schemas";
+import { logger } from "@/lib/logger";
 import { readWpConfig, wpListPages } from "@/lib/wordpress";
 
 const DS_VERSION = "1.0.0";
@@ -30,6 +31,7 @@ export async function executeListPages(
 
   const cfg = readWpConfig();
   if (!cfg.ok) {
+    logger.error("list_pages.execute.missing_wp_env_vars", { missing: cfg.missing });
     return {
       ok: false,
       error: {


### PR DESCRIPTION
## Summary

`executeListPages` returned `INTERNAL_ERROR` for missing WordPress environment variables with no `logger.error` call — misconfiguration at deploy time would have been completely silent in production logs.

Added `logger.error("list_pages.execute.missing_wp_env_vars", { missing: cfg.missing })` before the return, so the missing var names appear in structured logs.

Continuation of the silent-INTERNAL_ERROR observability sweep (PRs #631, #634, #648, #654).

## Risks identified and mitigated

- Purely additive — no behavioural change, no schema change, no external calls.
- Logger calls are fire-and-forget and cannot throw.

## Test plan

- [x] Lint: clean
- [x] Typecheck: clean
- [x] `npm run audit:static`: no new HIGH violations