### PR TITLE
fix(image-picker): reset browse offset atomically on query change

### DIFF
--- a/components/ImagePickerModal.tsx
+++ b/components/ImagePickerModal.tsx
@@ -220,10 +220,6 @@ export function ImagePickerModal({
     };
   }, [open, tab, browseQuery, browseOffset]);
 
-  useEffect(() => {
-    setBrowseOffset(0);
-  }, [browseQuery]);
-
   function handleSelect(image: ImagePickerEntry) {
     onSelect(image);
     onClose();
@@ -296,7 +292,7 @@ export function ImagePickerModal({
               type="search"
               placeholder="Search by caption, alt, or filename"
               value={browseQuery}
-              onChange={(e) => setBrowseQuery(e.target.value)}
+              onChange={(e) => { setBrowseQuery(e.target.value); setBrowseOffset(0); }}
               aria-label="Search images"
             />
             {browseError && (


### PR DESCRIPTION
## Issue 15 — ImagePickerModal thumbnails break after filter + paginate

### What was wrong

When the user typed a new search term after paginating (`browseOffset > 0`), the
browse effect fired **twice**:

1. First render after query change: effect ran with the **stale `browseOffset`**
   (still > 0), so it appended results from the new query onto the old page's
   results — corrupted list.
2. A separate `useEffect(() => { setBrowseOffset(0) }, [browseQuery])` caused a
   second render, then the fetch ran again correctly with `offset=0`.

### Fix

Merge `setBrowseOffset(0)` into the `onChange` handler for the search input. React
batches both `setBrowseQuery` and `setBrowseOffset(0)` into a single render, so the
effect always sees a consistent `(newQuery, 0)` pair. The now-redundant separate
effect is removed.

### Risks identified and mitigated

- **Double-fetch on query change** — eliminated; single fetch per query change.
- **Load more pagination** — unaffected; `setBrowseOffset(browseItems.length)` in the
  "Load more" button is a deliberate page-forward action, not a query reset.
- **Open/tab reset** — the existing `useEffect([open, hasSuggestionSource])` already
  calls `setBrowseOffset(0)` on modal open; no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)