### PR TITLE
fix(taxonomy-combobox): lazy-load WP terms on first open

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -1530,8 +1530,10 @@ function WpTaxonomyCombobox({
   const [options, setOptions] = useState<WpTaxonomyOption[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const loadedRef = useRef(false);
 
   useEffect(() => {
+    if (!open || loadedRef.current) return;
     let cancelled = false;
     setLoading(true);
     setError(null);
@@ -1548,6 +1550,7 @@ function WpTaxonomyCombobox({
         if (!cancelled) {
           if (payload?.ok) {
             setOptions(payload.data.items);
+            loadedRef.current = true;
           } else {
             setError(
               payload?.ok === false
@@ -1567,7 +1570,7 @@ function WpTaxonomyCombobox({
     return () => {
       cancelled = true;
     };
-  }, [siteId, type]);
+  }, [open, siteId, type]);
 
   const selectedIds = useMemo(() => new Set(value.map((v) => v.id)), [value]);
   const label = type === "categories" ? "category" : "tag";


### PR DESCRIPTION
## Issue 13 — WP categories/tags load slowly and fire duplicate requests on mount

### What was wrong

`WpTaxonomyCombobox` fetched WP taxonomy terms in `useEffect([siteId, type])` — i.e.,
immediately on mount. The sidebar renders **two** instances simultaneously (one for
categories, one for tags), causing two concurrent WP REST API calls the moment the
composer page loads, even before the operator has touched either field.

On slow WP sites this made the page feel heavy; on sites with WP auth failures it
surfaced errors in panels the operator hadn't opened yet.

### Fix

- Add `open` to the effect deps and guard with `if (!open || loadedRef.current) return`.
- `loadedRef` prevents redundant re-fetches on subsequent opens.
- A failed fetch leaves `loadedRef.current = false` so the next open retries.
- No change to cmdk filtering, Enter-key inline creation, or the selection/badge UI.

### Risks identified and mitigated

- **Stale data** — WP taxonomy lists are stable in practice (rarely change mid-session).
  Lazy-once is appropriate. If freshness is needed, a future slice can add a manual
  refresh button.
- **siteId change** — the component unmounts and remounts when siteId changes, resetting
  `loadedRef` automatically. No stale-data risk.
- **Fetch on failed attempt** — `loadedRef.current` is only set to `true` on success,
  so errors auto-retry on the next open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)