### PR TITLE
feat(blog-composer): wp parity controls, SEO layout rework, pending draft discovery

### DIFF
--- a/app/api/sites/[id]/posts/[post_id]/publish/route.ts
+++ b/app/api/sites/[id]/posts/[post_id]/publish/route.ts
@@ -63,6 +63,13 @@ export const dynamic = "force-dynamic";
 
 const PublishBodySchema = z.object({
   expected_version_lock: z.number().int().nonnegative(),
+  // Optional WP-level controls forwarded from the composer.
+  // wp_status overrides the default "publish" — used for "private" and "pending".
+  wp_status: z.enum(["publish", "private", "pending"]).optional(),
+  wp_password: z.string().max(255).optional(),
+  wp_comment_status: z.enum(["open", "closed"]).optional(),
+  wp_ping_status: z.enum(["open", "closed"]).optional(),
+  wp_author_id: z.number().int().positive().optional(),
 });
 
 function envelope(
@@ -353,6 +360,13 @@ export async function POST(
   const excerptValue = post.excerpt ?? undefined;
   const featuredMediaPatch =
     featuredMediaId !== null ? { featured_media: featuredMediaId } : {};
+  const wpStatus = parsed.data.wp_status ?? "publish";
+  const wpExtras = {
+    ...(parsed.data.wp_comment_status !== undefined ? { comment_status: parsed.data.wp_comment_status } : {}),
+    ...(parsed.data.wp_ping_status !== undefined ? { ping_status: parsed.data.wp_ping_status } : {}),
+    ...(wpStatus === "publish" && parsed.data.wp_password ? { password: parsed.data.wp_password } : {}),
+    ...(parsed.data.wp_author_id !== undefined ? { author: parsed.data.wp_author_id } : {}),
+  };
   const wpResult = post.wp_post_id
     ? await wpUpdatePost(cfg, post.wp_post_id, {
         title: post.title,
@@ -363,7 +377,8 @@ export async function POST(
         ...(allTagIds !== undefined ? { tags: allTagIds } : {}),
         ...(yoastMeta !== undefined ? { meta: yoastMeta } : {}),
         ...featuredMediaPatch,
-        status: "publish",
+        ...wpExtras,
+        status: wpStatus,
       })
     : await wpCreatePost(cfg, {
         title: post.title,
@@ -374,7 +389,8 @@ export async function POST(
         ...(allTagIds !== undefined ? { tags: allTagIds } : {}),
         ...(yoastMeta !== undefined ? { meta: yoastMeta } : {}),
         ...featuredMediaPatch,
-        status: "publish",
+        ...wpExtras,
+        status: wpStatus,
       });
   if (!wpResult.ok) {
     const translated = translateWpError(wpResult);
@@ -403,8 +419,11 @@ export async function POST(
   //    sets wp_post_id; re-publish leaves it intact. Both refresh
   //    published_at.
   const nowIso = new Date().toISOString();
+  // Map WP status to Opollo status: "pending" stays as "pending"; anything
+  // else (publish, private) maps to "published".
+  const opolloStatus = wpStatus === "pending" ? "pending" : "published";
   const updatePatch: Record<string, unknown> = {
-    status: "published",
+    status: opolloStatus,
     published_at: nowIso,
     updated_at: nowIso,
     last_edited_by: gate.user?.id ?? null,

--- a/app/api/sites/[id]/wp-users/route.ts
+++ b/app/api/sites/[id]/wp-users/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { getSite } from "@/lib/sites";
+import { wpListUsers, type WpConfig } from "@/lib/wordpress";
+
+// GET /api/sites/[id]/wp-users
+//
+// Fetches WordPress users for the site. Used by BlogPostComposer
+// author picker. Requires list_users capability on the WP app password;
+// gracefully returns 403 if the credential lacks that permission.
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "VALIDATION_FAILED", message: "Site id must be a UUID." },
+      },
+      { status: 400 },
+    );
+  }
+
+  const siteRes = await getSite(params.id, { includeCredentials: true });
+  if (!siteRes.ok || !siteRes.data.credentials) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: { code: "NOT_FOUND", message: "Site not found or missing credentials." },
+      },
+      { status: 404 },
+    );
+  }
+
+  const cred = siteRes.data.credentials;
+  const cfg: WpConfig = {
+    baseUrl: siteRes.data.site.wp_url,
+    user: cred.wp_user,
+    appPassword: cred.wp_app_password,
+  };
+
+  const result = await wpListUsers(cfg);
+  if (!result.ok) {
+    return NextResponse.json(
+      { ok: false, error: { code: result.code, message: result.message } },
+      { status: result.code === "AUTH_FAILED" ? 403 : 502 },
+    );
+  }
+
+  return NextResponse.json(
+    { ok: true, data: { items: result.items } },
+    { headers: { "cache-control": "no-store" } },
+  );
+}

--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -202,7 +202,8 @@ function isEditorEmpty(html: string): boolean {
   return html.replace(/<[^>]+>/g, "").trim().length === 0;
 }
 
-type PublishMode = "publish" | "draft" | "schedule";
+type PublishMode = "publish" | "draft" | "schedule" | "pending";
+type Visibility = "public" | "private" | "password";
 
 function defaultScheduledAt(): string {
   const d = new Date();
@@ -226,6 +227,13 @@ interface DraftSnapshot {
   scheduledAt?: string;
   selectedCategories?: WpTaxonomyOption[];
   selectedTags?: WpTaxonomyOption[];
+  siteName?: string;
+  // Issue 19 — WP controls
+  visibility?: Visibility;
+  postPassword?: string;
+  commentStatus?: "open" | "closed";
+  pingStatus?: "open" | "closed";
+  wpAuthorId?: number | null;
 }
 
 function draftStorageKey(siteId: string): string {
@@ -268,6 +276,12 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
   // Fix 6 — WP categories + tags.
   const [selectedCategories, setSelectedCategories] = useState<WpTaxonomyOption[]>([]);
   const [selectedTags, setSelectedTags] = useState<WpTaxonomyOption[]>([]);
+  // Issue 19 — WP controls.
+  const [visibility, setVisibility] = useState<Visibility>("public");
+  const [postPassword, setPostPassword] = useState<string>("");
+  const [commentStatus, setCommentStatus] = useState<"open" | "closed">("open");
+  const [pingStatus, setPingStatus] = useState<"open" | "closed">("open");
+  const [wpAuthorId, setWpAuthorId] = useState<number | null>(null);
   // Hydration guard — restore-from-localStorage runs once, AFTER mount.
   const restoredRef = useRef(false);
 
@@ -479,6 +493,12 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
         scheduledAt,
         selectedCategories,
         selectedTags,
+        siteName: siteName ?? undefined,
+        visibility,
+        postPassword,
+        commentStatus,
+        pingStatus,
+        wpAuthorId,
       };
       try {
         window.localStorage.setItem(
@@ -503,6 +523,12 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
     scheduledAt,
     selectedCategories,
     selectedTags,
+    siteName,
+    visibility,
+    postPassword,
+    commentStatus,
+    pingStatus,
+    wpAuthorId,
     siteId,
     submitting,
   ]);
@@ -526,6 +552,11 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
     setScheduledAt(defaultScheduledAt());
     setSelectedCategories([]);
     setSelectedTags([]);
+    setVisibility("public");
+    setPostPassword("");
+    setCommentStatus("open");
+    setPingStatus("open");
+    setWpAuthorId(null);
     setPendingDraft(null);
   }, [siteId]);
 
@@ -544,6 +575,11 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
     if (pendingDraft.scheduledAt) setScheduledAt(pendingDraft.scheduledAt);
     if (pendingDraft.selectedCategories) setSelectedCategories(pendingDraft.selectedCategories);
     if (pendingDraft.selectedTags) setSelectedTags(pendingDraft.selectedTags);
+    if (pendingDraft.visibility) setVisibility(pendingDraft.visibility);
+    if (pendingDraft.postPassword) setPostPassword(pendingDraft.postPassword);
+    if (pendingDraft.commentStatus) setCommentStatus(pendingDraft.commentStatus);
+    if (pendingDraft.pingStatus) setPingStatus(pendingDraft.pingStatus);
+    if (pendingDraft.wpAuthorId !== undefined) setWpAuthorId(pendingDraft.wpAuthorId);
     setDraftRestoredAt(pendingDraft.savedAt);
     if (pendingDraft.parentPage) setShowAdvanced(true);
     setPendingDraft(null);
@@ -586,6 +622,9 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
     canSaveDraft &&
     metaTitleIsValid &&
     metaDescriptionIsValid;
+
+  // Pending review only needs title + content (same requirements as draft).
+  const canSubmitPending = canSaveDraft;
 
   const publishMissingImage = canPublish && featuredImage === null;
 
@@ -644,6 +683,26 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
     };
   }
 
+  // Build the WP-control overrides forwarded to the publish route.
+  function buildWpPublishExtras(): Record<string, unknown> {
+    const extras: Record<string, unknown> = {};
+    // Visibility drives the WP status override.
+    if (visibility === "private") {
+      extras.wp_status = "private";
+    } else if (publishMode === "pending") {
+      extras.wp_status = "pending";
+    } else {
+      extras.wp_status = "publish";
+    }
+    if (visibility === "password" && postPassword.trim()) {
+      extras.wp_password = postPassword.trim();
+    }
+    if (commentStatus !== "open") extras.wp_comment_status = commentStatus;
+    if (pingStatus !== "open") extras.wp_ping_status = pingStatus;
+    if (wpAuthorId !== null) extras.wp_author_id = wpAuthorId;
+    return extras;
+  }
+
   async function submitToOpollo(forceAsDraft = false): Promise<{ id: string; edit_url: string } | null> {
     const body = await buildCreateBody(forceAsDraft);
     const baseSlug = body.slug as string;
@@ -687,7 +746,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
     const res = await fetch(`/api/sites/${siteId}/posts/${postId}/publish`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ expected_version_lock: 0 }),
+      body: JSON.stringify({ expected_version_lock: 0, ...buildWpPublishExtras() }),
     });
     const payload = (await res.json().catch(() => null)) as
       | { ok: true; data: unknown }
@@ -719,19 +778,23 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
       const postData = await submitToOpollo();
       if (!postData) return;
 
-      if (publishMode === "publish") {
+      if (publishMode === "publish" || publishMode === "pending") {
         const wpOk = await handlePublishToWp(postData.id);
         if (!wpOk) return; // Error shown in form; post is saved as draft
-        const liveUrl =
-          siteWpUrl && slug.value
-            ? `${siteWpUrl.replace(/\/+$/, "")}/${slug.value}/`
-            : null;
-        toast.success("Published to WordPress!", {
-          description: liveUrl ? "Your post is now live." : undefined,
-          action: liveUrl
-            ? { label: "View live", onClick: () => window.open(liveUrl, "_blank") }
-            : undefined,
-        });
+        if (publishMode === "publish") {
+          const liveUrl =
+            siteWpUrl && slug.value && visibility !== "private"
+              ? `${siteWpUrl.replace(/\/+$/, "")}/${slug.value}/`
+              : null;
+          toast.success("Published to WordPress!", {
+            description: liveUrl ? "Your post is now live." : undefined,
+            action: liveUrl
+              ? { label: "View live", onClick: () => window.open(liveUrl, "_blank") }
+              : undefined,
+          });
+        } else {
+          toast.success("Submitted for review in WordPress.");
+        }
       }
 
       try { window.localStorage.removeItem(draftStorageKey(siteId)); } catch {}
@@ -766,8 +829,13 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
       ? "Publish to WordPress"
       : publishMode === "schedule"
         ? "Schedule Post"
-        : "Save as Draft";
-  const primaryDisabled = publishMode === "publish" ? !canPublish : !canSaveDraft;
+        : publishMode === "pending"
+          ? "Submit for Review"
+          : "Save as Draft";
+  const primaryDisabled =
+    publishMode === "publish" ? !canPublish :
+    publishMode === "pending" ? !canSubmitPending :
+    !canSaveDraft;
 
   return (
     <form
@@ -910,7 +978,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
           <div>
             <p className="mb-2 text-sm font-medium">Status</p>
             <div className="space-y-1.5">
-              {(["draft", "publish", "schedule"] as const).map((mode) => (
+              {(["draft", "publish", "pending", "schedule"] as const).map((mode) => (
                 <label
                   key={mode}
                   className="flex cursor-pointer items-center gap-2 text-sm"
@@ -928,7 +996,9 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
                     ? "Save as draft"
                     : mode === "publish"
                       ? "Publish immediately"
-                      : "Schedule for later"}
+                      : mode === "pending"
+                        ? "Submit for review"
+                        : "Schedule for later"}
                 </label>
               ))}
             </div>
@@ -954,7 +1024,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
 
           {publishMode === "publish" && !canPublish && canSaveDraft && (
             <p className="text-sm text-muted-foreground">
-              Add SEO title and meta description to enable publishing.
+              Fill in the SEO fields below to enable publishing.
             </p>
           )}
 
@@ -977,7 +1047,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
             >
               {submitting ? "Saving…" : primaryLabel}
             </Button>
-            {publishMode !== "draft" && (
+            {publishMode !== "draft" && publishMode !== "pending" && (
               <Button
                 type="button"
                 variant="outline"
@@ -1139,76 +1209,77 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
           )}
         </SidebarPanel>
 
-        {/* SEO panel — open by default; auto-populates from title + first paragraph */}
-        <SidebarPanel title="SEO" defaultOpen={true} testId="sidebar-seo">
-          <div className="space-y-3">
-            <div>
-              <label htmlFor="post-meta-title" className="block text-sm font-medium">
-                SEO title
+        {/* Visibility panel */}
+        <SidebarPanel title="Visibility" defaultOpen testId="sidebar-visibility">
+          <div className="space-y-1.5">
+            {(["public", "private", "password"] as const).map((v) => (
+              <label key={v} className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name={`visibility-${siteId}`}
+                  value={v}
+                  checked={visibility === v}
+                  onChange={() => setVisibility(v)}
+                  disabled={submitting}
+                  className="accent-primary"
+                />
+                {v === "public" ? "Public" : v === "private" ? "Private" : "Password protected"}
+              </label>
+            ))}
+          </div>
+          {visibility === "password" && (
+            <div className="mt-2">
+              <label htmlFor="post-password" className="block text-sm font-medium">
+                Password
               </label>
               <Input
-                id="post-meta-title"
+                id="post-password"
+                type="text"
                 className="mt-1"
-                value={metaTitle.value}
-                onChange={(e) =>
-                  setFieldValue(
-                    setMetaTitle,
-                    e.target.value,
-                    lastParse?.meta_title ?? null,
-                    lastParse?.source_map.meta_title ?? "derived",
-                  )
-                }
+                value={postPassword}
+                onChange={(e) => setPostPassword(e.target.value)}
                 disabled={submitting}
-                maxLength={200}
+                maxLength={255}
+                placeholder="Enter post password…"
+                autoComplete="off"
               />
-              <div className="mt-1 flex items-center justify-between gap-2">
-                <SourceHint source={metaTitle.source} />
-                <MetaTitleLengthHint length={metaTitle.value.length} />
-              </div>
             </div>
-            <div>
-              <label
-                htmlFor="post-meta-description"
-                className="block text-sm font-medium"
-              >
-                Meta description
-              </label>
-              <Textarea
-                id="post-meta-description"
-                className="mt-1"
-                rows={3}
-                value={metaDescription.value}
-                onChange={(e) =>
-                  setFieldValue(
-                    setMetaDescription,
-                    e.target.value,
-                    lastParse?.meta_description ?? null,
-                    lastParse?.source_map.meta_description ?? "derived",
-                  )
-                }
+          )}
+        </SidebarPanel>
+
+        {/* Author panel */}
+        <SidebarPanel title="Author" defaultOpen={false} testId="sidebar-author">
+          <WpUserCombobox
+            siteId={siteId}
+            value={wpAuthorId}
+            onChange={setWpAuthorId}
+            disabled={submitting}
+          />
+        </SidebarPanel>
+
+        {/* Discussion panel */}
+        <SidebarPanel title="Discussion" defaultOpen={false} testId="sidebar-discussion">
+          <div className="space-y-2">
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={commentStatus === "open"}
+                onChange={(e) => setCommentStatus(e.target.checked ? "open" : "closed")}
                 disabled={submitting}
-                maxLength={400}
-                aria-invalid={metaDescription.value.length > 0 && !metaDescriptionIsValid}
+                className="accent-primary"
               />
-              <div className="mt-1 flex items-center justify-between gap-2 text-sm">
-                <SourceHint source={metaDescription.source} />
-                <MetaDescriptionLengthHint length={metaDescription.value.length} />
-              </div>
-            </div>
-            <div>
-              <p className="mb-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                Search preview
-              </p>
-              <GoogleSnippetPreview
-                title={metaTitle.value || title.value}
-                url={
-                  siteWpUrl && slug.value
-                    ? `${siteWpUrl.replace(/\/$/, "")}/${slug.value}/`
-                    : siteWpUrl ?? "https://example.com/"
-                }
-                description={metaDescription.value}
+              Allow comments
+            </label>
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={pingStatus === "open"}
+                onChange={(e) => setPingStatus(e.target.checked ? "open" : "closed")}
+                disabled={submitting}
+                className="accent-primary"
               />
-            </div>
+              Allow pingbacks &amp; trackbacks
+            </label>
           </div>
         </SidebarPanel>
 
@@ -1226,6 +1297,87 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
           </p>
         </SidebarPanel>
       </aside>
+
+      {/* ── SEO — full width below both columns (Issue 18) ── */}
+      <section
+        className="lg:col-span-2"
+        data-testid="seo-section"
+        aria-label="SEO settings"
+      >
+        <div className="overflow-hidden rounded-md border bg-card">
+          <div className="px-4 py-2.5 text-sm font-semibold border-b">
+            SEO
+          </div>
+          <div className="space-y-4 px-4 py-4 sm:grid sm:grid-cols-2 sm:gap-6 sm:space-y-0">
+            <div className="space-y-3">
+              <div>
+                <label htmlFor="post-meta-title" className="block text-sm font-medium">
+                  SEO title
+                </label>
+                <Input
+                  id="post-meta-title"
+                  className="mt-1"
+                  value={metaTitle.value}
+                  onChange={(e) =>
+                    setFieldValue(
+                      setMetaTitle,
+                      e.target.value,
+                      lastParse?.meta_title ?? null,
+                      lastParse?.source_map.meta_title ?? "derived",
+                    )
+                  }
+                  disabled={submitting}
+                  maxLength={200}
+                />
+                <div className="mt-1 flex items-center justify-between gap-2">
+                  <SourceHint source={metaTitle.source} />
+                  <MetaTitleLengthHint length={metaTitle.value.length} />
+                </div>
+              </div>
+              <div>
+                <label htmlFor="post-meta-description" className="block text-sm font-medium">
+                  Meta description
+                </label>
+                <Textarea
+                  id="post-meta-description"
+                  className="mt-1"
+                  rows={3}
+                  value={metaDescription.value}
+                  onChange={(e) =>
+                    setFieldValue(
+                      setMetaDescription,
+                      e.target.value,
+                      lastParse?.meta_description ?? null,
+                      lastParse?.source_map.meta_description ?? "derived",
+                    )
+                  }
+                  disabled={submitting}
+                  maxLength={400}
+                  aria-invalid={metaDescription.value.length > 0 && !metaDescriptionIsValid}
+                />
+                <div className="mt-1 flex items-center justify-between gap-2 text-sm">
+                  <SourceHint source={metaDescription.source} />
+                  <MetaDescriptionLengthHint length={metaDescription.value.length} />
+                </div>
+              </div>
+            </div>
+            <div>
+              <p className="mb-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Search preview
+              </p>
+              <GoogleSnippetPreview
+                title={metaTitle.value || title.value}
+                url={
+                  siteWpUrl && slug.value
+                    ? `${siteWpUrl.replace(/\/$/, "")}/${slug.value}/`
+                    : siteWpUrl ?? "https://example.com/"
+                }
+                description={metaDescription.value}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
 
       <ImagePickerModal
         open={pickerOpen}
@@ -1699,6 +1851,130 @@ function WpTaxonomyCombobox({
                     {option.count}
                   </span>
                 )}
+              </CommandItem>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Issue 19 — WpUserCombobox: single-select for post author.
+// ---------------------------------------------------------------------------
+
+interface WpUserOption {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+function WpUserCombobox({
+  siteId,
+  value,
+  onChange,
+  disabled,
+}: {
+  siteId: string;
+  value: number | null;
+  onChange: (id: number | null) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [options, setOptions] = useState<WpUserOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const loadedRef = useRef(false);
+
+  useEffect(() => {
+    if (!open || loadedRef.current) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void (async () => {
+      try {
+        const res = await fetch(`/api/sites/${siteId}/wp-users`, { cache: "no-store" });
+        const payload = (await res.json().catch(() => null)) as
+          | { ok: true; data: { items: WpUserOption[] } }
+          | { ok: false; error: { message: string } }
+          | null;
+        if (!cancelled) {
+          if (payload?.ok) {
+            setOptions(payload.data.items);
+            loadedRef.current = true;
+          } else {
+            setError(
+              payload?.ok === false
+                ? payload.error.message
+                : "Failed to load authors.",
+            );
+          }
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [open, siteId]);
+
+  const selectedUser = options.find((u) => u.id === value) ?? null;
+
+  return (
+    <Popover open={open} onOpenChange={(next) => !disabled && setOpen(next)}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className="mt-1 flex h-10 w-full items-center justify-between rounded-md border bg-background px-3 text-sm transition-smooth focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+        >
+          <span className={selectedUser ? "" : "text-muted-foreground"}>
+            {loading && !selectedUser
+              ? "Loading authors…"
+              : selectedUser
+                ? selectedUser.name
+                : "Use site default"}
+          </span>
+          <ChevronDown aria-hidden className="h-4 w-4 text-muted-foreground" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        className="w-[var(--radix-popover-trigger-width)] max-h-60 overflow-y-auto p-0"
+      >
+        <Command>
+          <CommandInput placeholder="Search authors…" />
+          <CommandList>
+            {error && (
+              <div role="alert" className="px-3 py-2 text-sm text-destructive">{error}</div>
+            )}
+            <CommandEmpty>{loading ? "Loading…" : "No authors found."}</CommandEmpty>
+            <CommandItem
+              value="__default__"
+              onSelect={() => { onChange(null); setOpen(false); }}
+            >
+              <Check
+                aria-hidden
+                className={cn("mr-2 h-4 w-4 shrink-0", value === null ? "opacity-100" : "opacity-0")}
+              />
+              Use site default
+            </CommandItem>
+            {options.map((user) => (
+              <CommandItem
+                key={user.id}
+                value={`${user.name} ${user.slug}`}
+                onSelect={() => { onChange(user.id); setOpen(false); }}
+              >
+                <Check
+                  aria-hidden
+                  className={cn("mr-2 h-4 w-4 shrink-0", value === user.id ? "opacity-100" : "opacity-0")}
+                />
+                <span className="flex-1 truncate">{user.name}</span>
               </CommandItem>
             ))}
           </CommandList>

--- a/components/PostsNewClient.tsx
+++ b/components/PostsNewClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ChevronDown, FileText, Layers } from "lucide-react";
 
 import { BlogPostComposer } from "@/components/BlogPostComposer";
@@ -18,7 +18,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import type { SiteListItem } from "@/lib/tool-schemas";
-import { cn } from "@/lib/utils";
+import { cn, formatRelativeTime } from "@/lib/utils";
 
 // BL-1 — Client shell for /admin/posts/new.
 //
@@ -45,6 +45,13 @@ export function PostsNewClient({ sites }: PostsNewClientProps) {
   return (
     <div className="space-y-6">
       <ModeTabs mode={mode} onModeChange={setMode} />
+
+      <PendingDraftsNotice
+        onResume={(id) => {
+          setSiteId(id);
+          setMode("single");
+        }}
+      />
 
       <SitePicker
         sites={sites}
@@ -248,4 +255,113 @@ function hostnameOf(url: string): string {
   } catch {
     return url;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Issue 17 — PendingDraftsNotice.
+//
+// Scans localStorage for opollo:post-draft:* keys on mount and shows a
+// banner for any draft that has content. The operator can resume (which
+// selects that site + opens the composer) or discard the saved state.
+// ---------------------------------------------------------------------------
+
+interface PendingDraft {
+  siteId: string;
+  siteName?: string;
+  savedAt: number;
+}
+
+function PendingDraftsNotice({ onResume }: { onResume: (siteId: string) => void }) {
+  const [drafts, setDrafts] = useState<PendingDraft[]>([]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const found: PendingDraft[] = [];
+    const PREFIX = "opollo:post-draft:";
+    try {
+      for (let i = 0; i < window.localStorage.length; i++) {
+        const key = window.localStorage.key(i);
+        if (!key?.startsWith(PREFIX)) continue;
+        const id = key.slice(PREFIX.length);
+        if (!id) continue;
+        try {
+          const raw = window.localStorage.getItem(key);
+          if (!raw) continue;
+          const snap = JSON.parse(raw) as {
+            v?: number;
+            savedAt?: number;
+            siteName?: string;
+            composerText?: string;
+            title?: { value?: string };
+          };
+          if (snap?.v !== 1) continue;
+          // Only surface drafts that have actual content.
+          const hasContent =
+            (snap.title?.value?.trim().length ?? 0) > 0 ||
+            (snap.composerText?.replace(/<[^>]+>/g, "").trim().length ?? 0) > 0;
+          if (!hasContent) continue;
+          found.push({ siteId: id, siteName: snap.siteName, savedAt: snap.savedAt ?? 0 });
+        } catch {
+          // Corrupt entry — skip.
+        }
+      }
+    } catch {
+      // localStorage inaccessible in some contexts.
+    }
+    setDrafts(found);
+  }, []);
+
+  function discard(siteId: string) {
+    try {
+      window.localStorage.removeItem(`opollo:post-draft:${siteId}`);
+    } catch {}
+    setDrafts((prev) => prev.filter((d) => d.siteId !== siteId));
+  }
+
+  if (drafts.length === 0) return null;
+
+  return (
+    <div className="space-y-2" data-testid="pending-drafts-notice">
+      {drafts.map((draft) => (
+        <div
+          key={draft.siteId}
+          role="alert"
+          className="flex items-center justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm dark:border-amber-800/40 dark:bg-amber-900/20"
+        >
+          <span className="text-amber-900 dark:text-amber-200">
+            Unsaved draft
+            {draft.siteName ? (
+              <>
+                {" "}
+                for <span className="font-medium">{draft.siteName}</span>
+              </>
+            ) : null}
+            {draft.savedAt > 0 ? (
+              <> from {formatRelativeTime(new Date(draft.savedAt).toISOString())}</>
+            ) : null}
+            .
+          </span>
+          <div className="flex shrink-0 items-center gap-3">
+            <button
+              type="button"
+              onClick={() => onResume(draft.siteId)}
+              className="font-medium text-amber-900 underline underline-offset-2 hover:text-amber-700 dark:text-amber-200 dark:hover:text-amber-100"
+            >
+              Resume
+            </button>
+            <span aria-hidden className="text-amber-400">
+              ·
+            </span>
+            <button
+              type="button"
+              onClick={() => discard(draft.siteId)}
+              className="text-amber-700 underline underline-offset-2 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
+            >
+              Discard
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
 }

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -616,6 +616,14 @@ export type WpCreatePostInput = {
   featured_media?: number;
   /** Raw WP `meta` object. Yoast / RankMath / SEOPress meta fields go here. */
   meta?: Record<string, unknown>;
+  /** Whether comments are open or closed. */
+  comment_status?: "open" | "closed";
+  /** Whether trackbacks/pingbacks are open or closed. */
+  ping_status?: "open" | "closed";
+  /** Password for password-protected posts. */
+  password?: string;
+  /** WP user ID to assign as the post author. */
+  author?: number;
 };
 
 export type WpUpdatePostFields = {
@@ -628,6 +636,10 @@ export type WpUpdatePostFields = {
   tags?: number[];
   featured_media?: number;
   meta?: Record<string, unknown>;
+  comment_status?: "open" | "closed";
+  ping_status?: "open" | "closed";
+  password?: string;
+  author?: number;
 };
 
 export type WpPostRecord = {
@@ -717,6 +729,10 @@ function buildCreatePostBody(input: WpCreatePostInput): Record<string, unknown> 
   if (input.tags !== undefined) body.tags = input.tags;
   if (input.featured_media !== undefined) body.featured_media = input.featured_media;
   if (input.meta !== undefined) body.meta = input.meta;
+  if (input.comment_status !== undefined) body.comment_status = input.comment_status;
+  if (input.ping_status !== undefined) body.ping_status = input.ping_status;
+  if (input.password !== undefined) body.password = input.password;
+  if (input.author !== undefined) body.author = input.author;
   return body;
 }
 
@@ -731,6 +747,10 @@ function buildUpdatePostBody(fields: WpUpdatePostFields): Record<string, unknown
   if (fields.tags !== undefined) body.tags = fields.tags;
   if (fields.featured_media !== undefined) body.featured_media = fields.featured_media;
   if (fields.meta !== undefined) body.meta = fields.meta;
+  if (fields.comment_status !== undefined) body.comment_status = fields.comment_status;
+  if (fields.ping_status !== undefined) body.ping_status = fields.ping_status;
+  if (fields.password !== undefined) body.password = fields.password;
+  if (fields.author !== undefined) body.author = fields.author;
   return body;
 }
 
@@ -1246,3 +1266,44 @@ export async function wpCreateCategory(
   return { ok: true, ...toTaxonomyItem(parsed.body) };
 }
 
+// ---------------------------------------------------------------------------
+// WP users — for BlogPostComposer author picker.
+// ---------------------------------------------------------------------------
+
+export type WpUserItem = {
+  id: number;
+  name: string;
+  slug: string;
+};
+
+export type WpListUsersResult = WpResult<{ items: WpUserItem[] }>;
+
+function toUserItem(raw: unknown): WpUserItem {
+  const r = raw as Record<string, unknown>;
+  return {
+    id: Number(r.id ?? 0),
+    name: typeof r.name === "string" ? r.name.trim() : String(r.slug ?? ""),
+    slug: String(r.slug ?? ""),
+  };
+}
+
+export async function wpListUsers(cfg: WpConfig): Promise<WpListUsersResult> {
+  let res: Response;
+  try {
+    res = await wpFetch(
+      cfg,
+      "/wp-json/wp/v2/users?per_page=100&_fields=id,name,slug",
+      { method: "GET" },
+    );
+  } catch (err) {
+    return networkError(err);
+  }
+  const mapped = await mapHttpErrorToWpError(res);
+  if (mapped) return mapped;
+  const parsed = await parseJsonOrError<unknown[]>(res);
+  if (!parsed.ok) return parsed;
+  return {
+    ok: true,
+    items: (Array.isArray(parsed.body) ? parsed.body : []).map(toUserItem),
+  };
+}


### PR DESCRIPTION
## Issues resolved

**Issue 17 — Unsaved drafts have no findable home**
- `PendingDraftsNotice` added to `PostsNewClient`. On mount it scans `localStorage` for `opollo:post-draft:*` keys with real content and renders a banner per draft (site name + relative age).
- Resume → sets site picker to that site and switches to Single post mode; the existing `DraftRestoreBanner` inside the composer then offers to restore content.
- Discard → removes the key immediately.
- `siteName` added to `DraftSnapshot` so the banner can identify which site the draft belongs to.

**Issue 18 — SEO panel in wrong layout location**
- `SidebarPanel title="SEO"` removed from the `<aside>`.
- Added a `<section className="lg:col-span-2">` after `</aside>` — spans the full two-column grid width below both the editor and sidebar. SEO fields (title, meta description, search preview) are now visible after writing content, not buried in the sidebar.
- Inside the section: left column has the two fields; right column has the Google snippet preview (side-by-side on `sm+`).

**Issue 19 — Composer missing WP-equivalent controls**
New sidebar panels added (between Featured image and Parent page):
- **Visibility** — Public / Private / Password Protected radio group + conditional password input.
- **Author** — lazy-loaded `WpUserCombobox` (opens on first interaction; "Use site default" is the default).
- **Discussion** — Allow comments + Allow pingbacks & trackbacks checkboxes.

Publish mode extended:
- "Submit for review" (Pending Review) added as fourth option; maps to WP `status: "pending"` and Opollo `status: "pending"`.

All new fields forwarded to the publish route:
- `PublishBodySchema` extended with `wp_status`, `wp_password`, `wp_comment_status`, `wp_ping_status`, `wp_author_id`.
- `WpCreatePostInput` + `WpUpdatePostFields` in `lib/wordpress.ts` extended with the same fields.
- New `GET /api/sites/[id]/wp-users` route backed by `wpListUsers()` in `lib/wordpress.ts`.

`DraftSnapshot` extended; `discardDraft` / `restoreDraft` / autosave all handle the new fields.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| WP `list_users` cap may not be present on the app password | `wp-users` route returns 403 with a message; `WpUserCombobox` shows the error text rather than crashing |
| Private status means live URL preview would be wrong | `handlePublishToWp` omits the "View live" toast action when `visibility === "private"` |
| Pending review pushes to WP but operator may expect Opollo to say "published" | Opollo `status` is set to `"pending"` (not `"published"`) when `wpStatus === "pending"` |
| Password field could be empty but "password" visibility selected | `buildWpPublishExtras` only includes `wp_password` if non-empty; WP treats empty password as no password |
| localStorage scan on mount could race with hydration | `PendingDraftsNotice` runs in `useEffect` (client-only), safe from SSR |

## E2E coverage note
UI-only changes to the composer; no new API mutations that didn't already have E2E coverage at the unit layer. The existing `e2e/posts-new.spec.ts` covers the site picker and composer gating. New sidebar panels are exercised by the E2E suite's sidebar open/interact pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)