### PR TITLE
fix(audit): replace hardcoded Google SERP hex colors with named Tailwind aliases

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -128,13 +128,13 @@ function GoogleSnippetPreview({
   return (
     <div className="rounded border border-border bg-background p-3 font-sans text-sm">
       <div
-        className="truncate text-base font-medium leading-snug text-[#1a0dab]"
+        className="truncate text-base font-medium leading-snug text-serp-title"
         title={displayTitle}
       >
         {displayTitle.length > 60 ? displayTitle.slice(0, 60) + "…" : displayTitle}
       </div>
-      <div className="mt-0.5 truncate text-xs text-[#006621]">{url}</div>
-      <div className="mt-1 line-clamp-2 text-xs text-[#545454]">
+      <div className="mt-0.5 truncate text-xs text-serp-url">{url}</div>
+      <div className="mt-1 line-clamp-2 text-xs text-serp-desc">
         {displayDesc.length > 160 ? displayDesc.slice(0, 160) + "…" : displayDesc}
       </div>
     </div>

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -399,7 +399,7 @@ Option (b) expands the write-safety blast radius significantly — mu-plugin ins
 
 ---
 
-## ~~PDF / .docx brief parser~~ (shipped 2026-05-06, PR #TBD)
+## ~~PDF / .docx brief parser~~ (shipped 2026-05-06, PR #626)
 
 **What:** Extend `lib/brief-parser.ts` to accept `application/pdf` and `application/vnd.openxmlformats-officedocument.wordprocessingml.document` in addition to `text/plain` + `text/markdown`. The existing structural-first + Claude-inference-fallback parser runs against the extracted text; the only new work is the MIME-specific binary → UTF-8 decoder.
 
@@ -509,7 +509,7 @@ Reports live at:
 - ~~**[M15-2 #4] Missing index on regen daily-budget query.**~~ Fixed 2026-05-03 — migration 0080 adds `idx_regen_jobs_created_at` index on `regeneration_jobs(created_at DESC)` supporting the `.gte("created_at", startOfDay)` range predicate in `lib/regeneration-publisher.ts#checkDailyBudget`.
 - ~~**[M15-2 #5] No cancel endpoint for `transfer_jobs`.**~~ Resolved 2026-05-04 — PR #527 migrated away the `cancel_requested_at` column (transfer cron deleted, M15-5 #1 took the "drop" path).
 - ~~**[M15-2 #8] Event-table PK type inconsistency.**~~ Documented 2026-05-04 — PR #533 migration 0086 adds `COMMENT ON TABLE` to all three event tables noting the bigserial/uuid mismatch and normalisation path.
-- **[M15-2 #10] Lease-coherent CHECK asymmetry.** `transfer_job_items_lease_coherent` requires `worker_id IS NOT NULL` in leased states; `generation_job_pages_lease_coherent` + `regeneration_jobs_lease_coherent` don't. Scope: tighten M3/M7 CHECKs after verifying no orphan-leased rows in production.
+- ~~**[M15-2 #10] Lease-coherent CHECK asymmetry.**~~ Migration 0087 (PR #541) dropped and re-added all three CHECKs with `NOT VALID` (generation_job_pages, regeneration_jobs, brief_runs now enforce worker_id IS NOT NULL in active states). VALIDATE step deferred until prod confirms no orphan-leased rows — see migration 0087 inline comment for the exact VALIDATE commands.
 - ~~**[M15-2 #12] `image_usage` RLS excludes viewer.**~~ See M15-5 #12 above — documented in PR #529.
 - ~~**[M15-2 #13, #14] Service-role-only write tables + `opollo_config` read — undocumented at the migration level.**~~ Documented 2026-05-04 — PR #529 migration 0085 adds `COMMENT ON TABLE` for all service-role-only write tables and `opollo_config` anon-read pattern.
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -110,6 +110,12 @@ const config: Config = {
         "nav-active": "var(--nav-active)",
         "nav-hover": "var(--nav-hover)",
         topbar: "var(--topbar-bg)",
+        /* Google SERP preview mimicry — used only in the SEO panel snippet */
+        serp: {
+          title: "#1a0dab",
+          url: "#006621",
+          desc: "#545454",
+        },
       },
       boxShadow: {
         'pk-glow': '0 4px 24px var(--pk-glow)',


### PR DESCRIPTION
## Summary

- Adds `serp.{title,url,desc}` to `tailwind.config.ts` `extend.colors` with the exact Google SERP mimicry values (`#1a0dab` / `#006621` / `#545454`)
- Replaces the three `text-[#hex]` arbitrary values in the SEO-preview snippet in `components/BlogPostComposer.tsx` with `text-serp-title` / `text-serp-url` / `text-serp-desc`
- Drops `audit:static` LOW count 17 → 14 (0 HIGH / 0 MEDIUM unchanged)

## Test plan
- [ ] `npm run lint` — ✅ clean
- [ ] `npm run typecheck` — ✅ clean
- [ ] `npx tsx scripts/audit.ts` — ✅ 0 HIGH, 0 MEDIUM, 14 LOW (was 17 LOW)
- [ ] SEO preview snippet in BlogPostComposer still renders Google-blue title / green URL / grey description (visual parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)