### PR TITLE
fix(observability): add logger.error to all internal() helpers in lib/platform/social

### DIFF
--- a/lib/platform/social/approvals/decisions/record.ts
+++ b/lib/platform/social/approvals/decisions/record.ts
@@ -277,6 +277,7 @@ function notFound<T>(message: string): ApiResponse<T> {
 }
 
 function internal<T>(message: string): ApiResponse<T> {
+  logger.error("social.approvals.decisions.record.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/approvals/events/list.ts
+++ b/lib/platform/social/approvals/events/list.ts
@@ -106,6 +106,7 @@ function notFound(): ApiResponse<{ events: ApprovalEvent[] }> {
 }
 
 function internal(message: string): ApiResponse<{ events: ApprovalEvent[] }> {
+  logger.error("social.approvals.events.list.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/approvals/recipients/add.ts
+++ b/lib/platform/social/approvals/recipients/add.ts
@@ -176,6 +176,7 @@ function invalidState(message: string): ApiResponse<AddRecipientResult> {
 }
 
 function internal(message: string): ApiResponse<AddRecipientResult> {
+  logger.error("social.approvals.recipients.add.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/approvals/recipients/list.ts
+++ b/lib/platform/social/approvals/recipients/list.ts
@@ -98,6 +98,7 @@ function notFound(): ApiResponse<{ recipients: ApprovalRecipient[] }> {
 function internal(
   message: string,
 ): ApiResponse<{ recipients: ApprovalRecipient[] }> {
+  logger.error("social.approvals.recipients.list.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/approvals/recipients/revoke.ts
+++ b/lib/platform/social/approvals/recipients/revoke.ts
@@ -137,6 +137,7 @@ function alreadyRevoked(): ApiResponse<ApprovalRecipient> {
 }
 
 function internal(message: string): ApiResponse<ApprovalRecipient> {
+  logger.error("social.approvals.recipients.revoke.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/connections/initiate-connect.ts
+++ b/lib/platform/social/connections/initiate-connect.ts
@@ -136,6 +136,7 @@ function validation(message: string): ApiResponse<InitiateConnectResult> {
 }
 
 function notConfigured(envVar: string): ApiResponse<InitiateConnectResult> {
+  logger.error("social.connections.initiate_connect.not_configured", { env_var: envVar });
   return {
     ok: false,
     error: {
@@ -150,6 +151,7 @@ function notConfigured(envVar: string): ApiResponse<InitiateConnectResult> {
 }
 
 function internal(message: string): ApiResponse<InitiateConnectResult> {
+  logger.error("social.connections.initiate_connect.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/connections/list.ts
+++ b/lib/platform/social/connections/list.ts
@@ -64,6 +64,7 @@ function validation(
 function internal(
   message: string,
 ): ApiResponse<{ connections: SocialConnection[] }> {
+  logger.error("social.connections.list.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/connections/sync.ts
+++ b/lib/platform/social/connections/sync.ts
@@ -231,6 +231,7 @@ export async function syncBundlesocialConnections(
 }
 
 function notConfigured(envVar: string): ApiResponse<SyncConnectionsResult> {
+  logger.error("social.connections.sync.not_configured", { env_var: envVar });
   return {
     ok: false,
     error: {
@@ -244,6 +245,7 @@ function notConfigured(envVar: string): ApiResponse<SyncConnectionsResult> {
 }
 
 function internal(message: string): ApiResponse<SyncConnectionsResult> {
+  logger.error("social.connections.sync.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/media/create.ts
+++ b/lib/platform/social/media/create.ts
@@ -121,6 +121,7 @@ function validation(message: string): ApiResponse<CreateMediaAssetResult> {
 }
 
 function internal(message: string): ApiResponse<CreateMediaAssetResult> {
+  logger.error("social.media.create.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/media/list.ts
+++ b/lib/platform/social/media/list.ts
@@ -88,6 +88,7 @@ function validation(message: string): ApiResponse<{ assets: MediaAsset[]; nextCu
 }
 
 function internal(message: string): ApiResponse<{ assets: MediaAsset[]; nextCursor: string | null }> {
+  logger.error("social.media.list.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/media/upload-to-bundle.ts
+++ b/lib/platform/social/media/upload-to-bundle.ts
@@ -189,6 +189,7 @@ function notFound<T>(): ApiResponse<T> {
 }
 
 function notConfigured<T>(envVar: string): ApiResponse<T> {
+  logger.error("social.media.upload_to_bundle.not_configured", { env_var: envVar });
   return {
     ok: false,
     error: {
@@ -202,6 +203,7 @@ function notConfigured<T>(envVar: string): ApiResponse<T> {
 }
 
 function internal<T>(message: string): ApiResponse<T> {
+  logger.error("social.media.upload_to_bundle.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/posts/create.ts
+++ b/lib/platform/social/posts/create.ts
@@ -136,6 +136,7 @@ function validation(message: string): ApiResponse<PostMaster> {
 }
 
 function internal(message: string): ApiResponse<PostMaster> {
+  logger.error("social.posts.create.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/posts/dashboard.ts
+++ b/lib/platform/social/posts/dashboard.ts
@@ -136,6 +136,7 @@ function validation(message: string): ApiResponse<SocialPostsStats> {
 }
 
 function internal(message: string): ApiResponse<SocialPostsStats> {
+  logger.error("social.posts.dashboard.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/posts/delete.ts
+++ b/lib/platform/social/posts/delete.ts
@@ -126,6 +126,7 @@ function notFound(): ApiResponse<{ deleted: true }> {
 }
 
 function internal(message: string): ApiResponse<{ deleted: true }> {
+  logger.error("social.posts.delete.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/posts/duplicate.ts
+++ b/lib/platform/social/posts/duplicate.ts
@@ -116,6 +116,7 @@ export async function duplicatePost(input: {
 }
 
 function internal(message: string): ApiResponse<{ newPostId: string }> {
+  logger.error("social.posts.duplicate.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/posts/get.ts
+++ b/lib/platform/social/posts/get.ts
@@ -79,6 +79,7 @@ function validation(message: string): ApiResponse<PostMaster> {
 }
 
 function internal(message: string): ApiResponse<PostMaster> {
+  logger.error("social.posts.get.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/posts/list.ts
+++ b/lib/platform/social/posts/list.ts
@@ -100,6 +100,7 @@ function validation(
 function internal(
   message: string,
 ): ApiResponse<{ posts: PostMasterListItem[]; totalCount: number }> {
+  logger.error("social.posts.list.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/posts/transitions.ts
+++ b/lib/platform/social/posts/transitions.ts
@@ -214,6 +214,7 @@ function notFoundWith(
 }
 
 function internal(message: string): ApiResponse<SubmitForApprovalResult> {
+  logger.error("social.posts.transitions.submit_for_approval.internal_error", { message });
   return {
     ok: false,
     error: {
@@ -359,6 +360,7 @@ function reopenInvalidState(
 function reopenInternal(
   message: string,
 ): ApiResponse<ReopenForEditingResult> {
+  logger.error("social.posts.transitions.reopen.internal_error", { message });
   return {
     ok: false,
     error: {
@@ -513,6 +515,7 @@ function cancelNotFound(
 function cancelInternal(
   message: string,
 ): ApiResponse<CancelApprovalResult> {
+  logger.error("social.posts.transitions.cancel.internal_error", { message });
   return {
     ok: false,
     error: {
@@ -605,6 +608,7 @@ function approveNotFound(): ApiResponse<ApprovePostResult> {
   return { ok: false, error: { code: "NOT_FOUND", message: "No post with that id in this company.", retryable: false, suggested_action: "Check the post id." }, timestamp: new Date().toISOString() };
 }
 function approveInternal(message: string): ApiResponse<ApprovePostResult> {
+  logger.error("social.posts.transitions.approve.internal_error", { message });
   return { ok: false, error: { code: "INTERNAL_ERROR", message, retryable: false, suggested_action: "Retry. If the error persists, contact support." }, timestamp: new Date().toISOString() };
 }
 
@@ -682,6 +686,7 @@ function rejectNotFound(): ApiResponse<RejectPostResult> {
   return { ok: false, error: { code: "NOT_FOUND", message: "No post with that id in this company.", retryable: false, suggested_action: "Check the post id." }, timestamp: new Date().toISOString() };
 }
 function rejectInternal(message: string): ApiResponse<RejectPostResult> {
+  logger.error("social.posts.transitions.reject.internal_error", { message });
   return { ok: false, error: { code: "INTERNAL_ERROR", message, retryable: false, suggested_action: "Retry. If the error persists, contact support." }, timestamp: new Date().toISOString() };
 }
 
@@ -759,6 +764,7 @@ function requestChangesNotFound(): ApiResponse<RequestChangesResult> {
   return { ok: false, error: { code: "NOT_FOUND", message: "No post with that id in this company.", retryable: false, suggested_action: "Check the post id." }, timestamp: new Date().toISOString() };
 }
 function requestChangesInternal(message: string): ApiResponse<RequestChangesResult> {
+  logger.error("social.posts.transitions.request_changes.internal_error", { message });
   return { ok: false, error: { code: "INTERNAL_ERROR", message, retryable: false, suggested_action: "Retry. If the error persists, contact support." }, timestamp: new Date().toISOString() };
 }
 

--- a/lib/platform/social/posts/update.ts
+++ b/lib/platform/social/posts/update.ts
@@ -207,6 +207,7 @@ function notFound(): ApiResponse<PostMaster> {
 }
 
 function internal(message: string): ApiResponse<PostMaster> {
+  logger.error("social.posts.update.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/publishing/backfill.ts
+++ b/lib/platform/social/publishing/backfill.ts
@@ -129,6 +129,7 @@ function validation(message: string): ApiResponse<BackfillResult> {
 }
 
 function internal(message: string): ApiResponse<BackfillResult> {
+  logger.error("social.publishing.backfill.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/publishing/enqueue.ts
+++ b/lib/platform/social/publishing/enqueue.ts
@@ -182,6 +182,7 @@ function validation<T>(message: string): ApiResponse<T> {
 }
 
 function internal<T>(message: string): ApiResponse<T> {
+  logger.error("social.publishing.enqueue.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/publishing/fire.ts
+++ b/lib/platform/social/publishing/fire.ts
@@ -441,6 +441,7 @@ function validation(message: string): ApiResponse<FirePublishResult> {
 }
 
 function internal(message: string): ApiResponse<FirePublishResult> {
+  logger.error("social.publishing.fire.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/publishing/list-attempts.ts
+++ b/lib/platform/social/publishing/list-attempts.ts
@@ -168,6 +168,7 @@ function validation<T>(message: string): ApiResponse<T> {
 }
 
 function internal<T>(message: string): ApiResponse<T> {
+  logger.error("social.publishing.list_attempts.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/publishing/retry.ts
+++ b/lib/platform/social/publishing/retry.ts
@@ -325,6 +325,7 @@ function validation(message: string): ApiResponse<RetryPublishResult> {
 }
 
 function internal(message: string): ApiResponse<RetryPublishResult> {
+  logger.error("social.publishing.retry.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/scheduling/cancel.ts
+++ b/lib/platform/social/scheduling/cancel.ts
@@ -159,6 +159,7 @@ function invalidState(message: string): ApiResponse<ScheduleEntry> {
 }
 
 function internal(message: string): ApiResponse<ScheduleEntry> {
+  logger.error("social.scheduling.cancel.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/scheduling/create.ts
+++ b/lib/platform/social/scheduling/create.ts
@@ -239,6 +239,7 @@ function invalidState(message: string): ApiResponse<ScheduleEntryWithPlatform> {
 }
 
 function internal(message: string): ApiResponse<ScheduleEntryWithPlatform> {
+  logger.error("social.scheduling.create.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/scheduling/list-company.ts
+++ b/lib/platform/social/scheduling/list-company.ts
@@ -189,6 +189,7 @@ function validation(
 function internal(
   message: string,
 ): ApiResponse<{ entries: CompanyScheduleEntry[] }> {
+  logger.error("social.scheduling.list_company.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/scheduling/list.ts
+++ b/lib/platform/social/scheduling/list.ts
@@ -140,6 +140,7 @@ function notFound(): ApiResponse<{ entries: ScheduleEntryWithPlatform[] }> {
 function internal(
   message: string,
 ): ApiResponse<{ entries: ScheduleEntryWithPlatform[] }> {
+  logger.error("social.scheduling.list.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/variants/list.ts
+++ b/lib/platform/social/variants/list.ts
@@ -119,6 +119,7 @@ function notFound(): ApiResponse<ListVariantsResult> {
 }
 
 function internal(message: string): ApiResponse<ListVariantsResult> {
+  logger.error("social.variants.list.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/variants/upsert.ts
+++ b/lib/platform/social/variants/upsert.ts
@@ -173,6 +173,7 @@ function notFound(): ApiResponse<PostVariant> {
 }
 
 function internal(message: string): ApiResponse<PostVariant> {
+  logger.error("social.variants.upsert.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/viewer-links/create.ts
+++ b/lib/platform/social/viewer-links/create.ts
@@ -97,6 +97,7 @@ function validation(message: string): ApiResponse<CreateViewerLinkResult> {
 }
 
 function internal(message: string): ApiResponse<CreateViewerLinkResult> {
+  logger.error("social.viewer_links.create.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/viewer-links/list.ts
+++ b/lib/platform/social/viewer-links/list.ts
@@ -65,6 +65,7 @@ function validation(message: string): ApiResponse<{ links: ViewerLink[] }> {
 }
 
 function internal(message: string): ApiResponse<{ links: ViewerLink[] }> {
+  logger.error("social.viewer_links.list.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/viewer-links/resolve.ts
+++ b/lib/platform/social/viewer-links/resolve.ts
@@ -112,6 +112,7 @@ function internal(message: string): ApiResponse<{
   link: ViewerLink;
   company: { id: string; name: string; timezone: string };
 }> {
+  logger.error("social.viewer_links.resolve.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/social/viewer-links/revoke.ts
+++ b/lib/platform/social/viewer-links/revoke.ts
@@ -108,6 +108,7 @@ function invalidState(message: string): ApiResponse<ViewerLink> {
 }
 
 function internal(message: string): ApiResponse<ViewerLink> {
+  logger.error("social.viewer_links.revoke.internal_error", { message });
   return {
     ok: false,
     error: {


### PR DESCRIPTION
## Summary

- Adds `logger.error` as the first statement inside every `internal()` and `notConfigured()` helper function across **34 files** in `lib/platform/social/`
- Clusters covered: `approvals/`, `connections/`, `media/`, `posts/`, `publishing/`, `scheduling/`, `variants/`, `viewer-links/`
- Each helper emits a module-specific event name (e.g. `"social.posts.transitions.approve.internal_error"`) plus the `message` string, making every `INTERNAL_ERROR` envelope traceable in structured logs
- No behavior changes; no schema changes; no new imports needed (all files already import `logger`)

## Test plan

- [ ] `npm run lint` — passes
- [ ] `npm run typecheck` — passes
- [ ] CI green

## Risks identified and mitigated

**None** — purely additive logging. Files that already had explicit `logger.error` calls at individual call sites will see two log entries for those paths (specific call-site event + generic helper event), but no data loss and no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)