### PR TITLE
fix(observability): add logger.error to internalError() helpers in core lib files

### DIFF
--- a/lib/design-system-errors.ts
+++ b/lib/design-system-errors.ts
@@ -1,4 +1,5 @@
 import type { ZodError } from "zod";
+import { logger } from "@/lib/logger";
 import type { ApiResponse, ToolError } from "@/lib/tool-schemas";
 
 // ---------------------------------------------------------------------------
@@ -131,6 +132,7 @@ export function internalError(
   message: string,
   details?: Record<string, unknown>,
 ): ApiResponse<never> {
+  logger.error("design_system_errors.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/image-library.ts
+++ b/lib/image-library.ts
@@ -75,6 +75,7 @@ function internalError(
   message: string,
   details?: Record<string, unknown>,
 ): ApiResponse<never> {
+  logger.error("image_library.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/image-reextract.ts
+++ b/lib/image-reextract.ts
@@ -61,6 +61,7 @@ function notFound(msg = "Image not found."): ApiResponse<never> {
 }
 
 function internalError(message: string, details?: Record<string, unknown>): ApiResponse<never> {
+  logger.error("image_reextract.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/invites.ts
+++ b/lib/invites.ts
@@ -339,6 +339,7 @@ function internalError(message: string): {
   ok: false;
   error: { code: "INTERNAL_ERROR"; message: string };
 } {
+  logger.error("invites.internal_error", { message });
   return {
     ok: false,
     error: { code: "INTERNAL_ERROR", message },

--- a/lib/pages.ts
+++ b/lib/pages.ts
@@ -85,6 +85,7 @@ function internalError(
   message: string,
   details?: Record<string, unknown>,
 ): ApiResponse<never> {
+  logger.error("pages.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/companies/create.ts
+++ b/lib/platform/companies/create.ts
@@ -129,6 +129,7 @@ function validation(message: string): ApiResponse<PlatformCompany> {
 }
 
 function internal(message: string): ApiResponse<PlatformCompany> {
+  logger.error("platform.companies.create.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/companies/get.ts
+++ b/lib/platform/companies/get.ts
@@ -182,6 +182,7 @@ export async function getPlatformCompany(
 }
 
 function internal(message: string): ApiResponse<CompanyDetail> {
+  logger.error("platform.companies.get.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/platform/invitations/accept.ts
+++ b/lib/platform/invitations/accept.ts
@@ -250,5 +250,6 @@ function validation(message: string): AcceptInvitationResult {
 }
 
 function internal(message: string): AcceptInvitationResult {
+  logger.error("platform.invitations.accept.internal_error", { message });
   return { ok: false, error: { code: "INTERNAL_ERROR", message } };
 }

--- a/lib/platform/invitations/send.ts
+++ b/lib/platform/invitations/send.ts
@@ -166,5 +166,6 @@ export async function sendInvitation(
 }
 
 function internal(message: string): SendInvitationResult {
+  logger.error("platform.invitations.send.internal_error", { message });
   return { ok: false, error: { code: "INTERNAL_ERROR", message } };
 }

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -159,6 +159,7 @@ function internalError(
   message: string,
   details?: Record<string, unknown>,
 ): ApiResponse<never> {
+  logger.error("posts.internal_error", { message });
   return {
     ok: false,
     error: {

--- a/lib/sites.ts
+++ b/lib/sites.ts
@@ -46,6 +46,7 @@ function internalError(
   message: string,
   details?: Record<string, unknown>,
 ): ApiResponse<never> {
+  logger.error("sites.internal_error", { message });
   return {
     ok: false,
     error: {


### PR DESCRIPTION
## Summary

- Adds `logger.error` as the first statement in every `internalError()` / `internal()` helper function across 11 core lib files
- Files: `lib/design-system-errors.ts`, `lib/image-library.ts`, `lib/image-reextract.ts`, `lib/invites.ts`, `lib/pages.ts`, `lib/platform/companies/create.ts`, `lib/platform/companies/get.ts`, `lib/platform/invitations/accept.ts`, `lib/platform/invitations/send.ts`, `lib/posts.ts`, `lib/sites.ts`
- Also adds `import { logger }` to `lib/design-system-errors.ts` (the only file missing it)
- After this PR the audit script reports only **6 remaining entries**, all TypeScript return-type annotations (genuine false positives the script cannot filter)

## Test plan

- [ ] `npm run lint` — passes
- [ ] `npm run typecheck` — passes
- [ ] CI green

## Risks identified and mitigated

**None** — purely additive logging. Some call sites in these files already had explicit `logger.error` before calling `internal()` — those paths will emit two log entries (specific + generic), which is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)