### PR TITLE
feat(infra): supabase schema type drift gate + typed client (m15-8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,25 @@ jobs:
           supabase status | tee /tmp/supabase-status.txt
           echo "---- JSON ----" | tee -a /tmp/supabase-status.txt
           supabase status --output json | tee -a /tmp/supabase-status.txt || true
+      - name: Check Supabase schema type drift
+        run: |
+          # Only active once types/supabase.ts has been bootstrapped with the
+          # real generated output (identified by the "@generated" marker that
+          # `supabase gen types` emits on the first line).  Until bootstrap,
+          # this step is a no-op and prints a reminder.
+          if grep -q '@generated' types/supabase.ts 2>/dev/null; then
+            supabase gen types typescript --local > /tmp/supabase.ts.generated
+            if ! diff -q types/supabase.ts /tmp/supabase.ts.generated > /dev/null; then
+              echo "::error::types/supabase.ts is out of date with the current schema."
+              echo "Run 'supabase start && npm run gen:types' locally, commit types/supabase.ts, and push."
+              diff types/supabase.ts /tmp/supabase.ts.generated || true
+              exit 1
+            fi
+            echo "✓ types/supabase.ts matches the live schema"
+          else
+            echo "⚠ types/supabase.ts not yet bootstrapped — schema drift gate inactive."
+            echo "  See docs/RUNBOOK.md § 'Supabase schema types bootstrap' to activate."
+          fi
       - name: Run Vitest suite
         id: vitest
         run: |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -736,3 +736,52 @@ Keep the Quick-reference table in sync.
 - Check Vercel deployment logs for seed data — if the E2E admin user or fixture site didn't backfill, specs fail with "user not found" or "site not found."
 - Rerun the failing PR in GitHub Actions if logs are clean (transient Playwright timing issue).
 - If the same test fails twice, open an issue on the spec itself before escalating — likely a race condition or a recent code change broke the locator.
+
+---
+
+## Supabase schema types bootstrap
+
+**Context:** `types/supabase.ts` is a generated file that maps every table/view/function in the live schema to TypeScript types. Once bootstrapped, `lib/supabase.ts`'s `getServiceRoleClient()` returns a `SupabaseClient<Database>` typed client — column drift that would previously surface as a silent `INTERNAL_ERROR` 500 becomes a compile-time error instead. The CI `test` job includes a drift gate that fails when the committed types file diverges from the live schema.
+
+**Why the gate is inactive by default:** The gate only runs when `types/supabase.ts` contains the `@generated` marker that `supabase gen types` emits. The placeholder file shipped with M15-8 does not have this marker, so CI won't fail until the real types file is committed.
+
+**One-time bootstrap (run locally with Docker):**
+
+```bash
+supabase start           # start local stack with all migrations applied
+npm run gen:types        # writes types/supabase.ts (adds @generated marker)
+npm run typecheck        # confirm no new type errors from the generated types
+git add types/supabase.ts
+git commit -m "chore(infra): bootstrap supabase schema types"
+git push
+```
+
+After this commit, the CI gate activates. Every future migration must regenerate the file.
+
+**After every migration:**
+
+```bash
+supabase start           # if not already running
+npm run gen:types        # regenerate
+git add types/supabase.ts
+# commit alongside the migration file in the same PR
+```
+
+**If CI fails with "types/supabase.ts is out of date":**
+
+A migration was pushed without regenerating the types file.
+
+```bash
+supabase start
+npm run gen:types
+git add types/supabase.ts
+git commit -m "chore(infra): regenerate supabase types after migration NNNN"
+git push
+```
+
+**Checking the diff without failing:**
+
+```bash
+supabase gen types typescript --local > /tmp/supabase-check.ts
+diff types/supabase.ts /tmp/supabase-check.ts
+```

--- a/docs/patterns/new-migration.md
+++ b/docs/patterns/new-migration.md
@@ -15,7 +15,16 @@ Don't use for: data migrations (row rewrites in bulk) — those go under `supaba
 | `lib/__tests__/<slug>.test.ts` | Applied-migration assertions: constraints reject invalid inserts, cascades fire as expected, RLS policies honour the role matrix. |
 | `supabase/rollbacks/README.md` | Add a line if the new migration has subtlety worth warning future operators about. |
 
-If the migration extends a type, schema, or enum that TypeScript reflects, regenerate types after apply.
+After apply, regenerate `types/supabase.ts` so the typed client stays in sync and the CI drift gate passes:
+
+```bash
+supabase start          # if not already running
+npm run gen:types       # overwrites types/supabase.ts
+git add types/supabase.ts
+# commit in the same PR as the migration
+```
+
+If `types/supabase.ts` hasn't been bootstrapped yet (placeholder in place), skip this step — see `docs/RUNBOOK.md` § "Supabase schema types bootstrap".
 
 ## Scaffolding
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { type Database } from "@/types/supabase";
 
 function requireEnv(key: string): string {
   const value = process.env[key];
@@ -9,17 +10,21 @@ function requireEnv(key: string): string {
   return value;
 }
 
-let serviceRoleClient: SupabaseClient | null = null;
+let serviceRoleClient: SupabaseClient<Database> | null = null;
 
 /**
  * Service-role client. Bypasses RLS. Use only in trusted server-side code
  * (API routes, background jobs). Never expose the service role key to clients.
+ *
+ * Typed as `SupabaseClient<Database>` so TypeScript will catch column-name drift
+ * once `types/supabase.ts` is bootstrapped (see RUNBOOK § "Supabase schema types
+ * bootstrap"). Until bootstrap, `Database = any` and behaviour is unchanged.
  */
-export function getServiceRoleClient(): SupabaseClient {
+export function getServiceRoleClient(): SupabaseClient<Database> {
   if (serviceRoleClient) return serviceRoleClient;
   const url = requireEnv("SUPABASE_URL");
   const key = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
-  serviceRoleClient = createClient(url, key, {
+  serviceRoleClient = createClient<Database>(url, key, {
     auth: {
       autoRefreshToken: false,
       persistSession: false,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:e2e:update-snapshots": "playwright test --update-snapshots",
     "screenshots": "RUN_SCREENSHOTS=1 playwright test screenshots.spec.ts",
     "audit:static": "tsx scripts/audit.ts",
+    "gen:types": "supabase gen types typescript --local > types/supabase.ts",
     "analyze": "ANALYZE=true next build",
     "prepare": "husky"
   },

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,0 +1,34 @@
+// types/supabase.ts
+//
+// PLACEHOLDER — schema types not yet bootstrapped.
+//
+// Until this file is replaced with the real generated output, the Supabase
+// client is typed as `any` (same behaviour as before M15-8).  The CI drift
+// gate is inactive while this placeholder is in place — it only activates
+// once the file contains the `@generated` marker that `supabase gen types`
+// emits on the first line.
+//
+// Bootstrap (one-time, requires Docker + local stack running):
+//
+//   supabase start
+//   npm run gen:types
+//   git add types/supabase.ts
+//   git commit -m "chore(infra): bootstrap supabase schema types"
+//
+// After that commit, every future migration must be followed by
+// `npm run gen:types` + `git add types/supabase.ts` or CI will fail.
+// See docs/RUNBOOK.md "Supabase schema types bootstrap" for the full
+// procedure, and docs/patterns/new-migration.md for the per-migration reminder.
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+// Placeholder: typed as `any` until bootstrap runs.
+// Replacing this with the real generated type activates TypeScript column-drift
+// checking and the CI gate simultaneously.
+export type Database = any; // nolint: will be replaced by real generated types


### PR DESCRIPTION
## M15-8 — Supabase schema type drift gate + typed client

### What

Adds infrastructure to catch column-drift bugs (like the `version_lock` incident where the app referred to a column that a migration had renamed).

**Files changed:**

| File | Change |
|---|---|
| `types/supabase.ts` | Placeholder. `Database = any` until bootstrap runs. |
| `lib/supabase.ts` | Service-role client typed as `SupabaseClient<Database>`. Once bootstrapped, TypeScript catches column drift at build time. |
| `package.json` | Added `gen:types` script (`supabase gen types typescript --local > types/supabase.ts`). |
| `.github/workflows/ci.yml` | New "Check Supabase schema type drift" step. No-ops while placeholder is in place (`@generated` marker absent). Activates automatically after bootstrap. |
| `docs/RUNBOOK.md` | "Supabase schema types bootstrap" section — one-time setup + per-migration regeneration procedure. |
| `docs/patterns/new-migration.md` | Updated post-apply checklist to include `npm run gen:types`. |

### How the gate works

The CI step checks for the `@generated` marker that `supabase gen types` emits on line 1. If absent (placeholder), it prints a warning and exits 0 — no disruption to current CI. Once Steven runs `supabase start && npm run gen:types` and commits the result, the marker appears and the gate activates: CI compares the committed file against a fresh generation and fails the build if they differ.

### Bootstrap (one-time, after this PR merges)

```bash
supabase start            # local stack
npm run gen:types         # overwrites types/supabase.ts with real generated output
git add types/supabase.ts
git commit -m "chore(infra): bootstrap supabase schema types"
git push
```

Requires Docker + Supabase CLI. See `docs/RUNBOOK.md` § "Supabase schema types bootstrap".

### Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Bootstrap not run → gate never activates | Documented in RUNBOOK + new-migration pattern. CI prints a visible advisory on every run until bootstrap happens. |
| Placeholder `Database = any` doesn't provide type safety | Intentional — typed client is a no-op today. Safety activates automatically after bootstrap without any code change. |
| `gen:types` requires Docker (not available in CI without stack) | CI gate only runs when Supabase stack is running (same job that starts `supabase start`). The step runs after the "Start Supabase local stack" step. |
| New migration lands without regenerating types → CI fails | That's the desired behaviour post-bootstrap. The new-migration pattern now includes the regen step. |

### No breaking changes

`Database = any` is identical in behaviour to the pre-PR state (untyped client). Nothing regresses. CI passes as-is; the gate is advisory until bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)