### PR TITLE
fix(ux): audit-3 polish + M15-8 supabase types gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,25 @@ jobs:
           supabase status | tee /tmp/supabase-status.txt
           echo "---- JSON ----" | tee -a /tmp/supabase-status.txt
           supabase status --output json | tee -a /tmp/supabase-status.txt || true
+      - name: Check Supabase schema type drift
+        run: |
+          # Only active once types/supabase.ts has been bootstrapped with the
+          # real generated output (identified by the "@generated" marker that
+          # `supabase gen types` emits on the first line).  Until bootstrap,
+          # this step is a no-op and prints a reminder.
+          if grep -q '@generated' types/supabase.ts 2>/dev/null; then
+            supabase gen types typescript --local > /tmp/supabase.ts.generated
+            if ! diff -q types/supabase.ts /tmp/supabase.ts.generated > /dev/null; then
+              echo "::error::types/supabase.ts is out of date with the current schema."
+              echo "Run 'supabase start && npm run gen:types' locally, commit types/supabase.ts, and push."
+              diff types/supabase.ts /tmp/supabase.ts.generated || true
+              exit 1
+            fi
+            echo "✓ types/supabase.ts matches the live schema"
+          else
+            echo "⚠ types/supabase.ts not yet bootstrapped — schema drift gate inactive."
+            echo "  See docs/RUNBOOK.md § 'Supabase schema types bootstrap' to activate."
+          fi
       - name: Run Vitest suite
         id: vitest
         run: |

--- a/app/admin/sites/[id]/design-system/components/page.tsx
+++ b/app/admin/sites/[id]/design-system/components/page.tsx
@@ -149,6 +149,7 @@ export default function DesignSystemComponentsPage() {
             components={state.components}
             onEdit={(c) => setFormMode({ kind: "edit", component: c })}
             onDelete={(c) => setDeleteTarget(c)}
+            onCreate={() => setFormMode({ kind: "create" })}
           />
         )}
       </div>

--- a/app/admin/sites/[id]/design-system/page.tsx
+++ b/app/admin/sites/[id]/design-system/page.tsx
@@ -90,6 +90,7 @@ export default function DesignSystemIndexPage() {
             siteId={site.id}
             onActivate={(ds) => setAction({ kind: "activate", ds })}
             onArchive={(ds) => setAction({ kind: "archive", ds })}
+            onCreate={() => setCreateOpen(true)}
           />
         </div>
 

--- a/app/admin/sites/[id]/design-system/templates/page.tsx
+++ b/app/admin/sites/[id]/design-system/templates/page.tsx
@@ -131,6 +131,7 @@ export default function DesignSystemTemplatesPage() {
             templates={state.templates}
             onEdit={(t) => setFormMode({ kind: "edit", template: t })}
             onDelete={(t) => setDeleteTarget(t)}
+            onCreate={() => setFormMode({ kind: "create" })}
           />
         )}
       </div>

--- a/components/ComponentFormModal.tsx
+++ b/components/ComponentFormModal.tsx
@@ -90,6 +90,9 @@ export function ComponentFormModal({
   const [fieldErrors, setFieldErrors] = useState<
     Partial<Record<keyof FormState, string>>
   >({});
+  const [cssViolations, setCssViolations] = useState<
+    Array<{ selector?: string; line?: number }>
+  >([]);
   const [formError, setFormError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -97,6 +100,7 @@ export function ComponentFormModal({
     if (open) {
       setForm(initial);
       setFieldErrors({});
+      setCssViolations([]);
       setFormError(null);
     }
   }, [open, initial]);
@@ -116,6 +120,9 @@ export function ComponentFormModal({
     setForm((prev) => ({ ...prev, [key]: value }));
     if (fieldErrors[key]) {
       setFieldErrors((prev) => ({ ...prev, [key]: undefined }));
+    }
+    if (key === "css" && cssViolations.length > 0) {
+      setCssViolations([]);
     }
   }
 
@@ -230,11 +237,9 @@ export function ComponentFormModal({
           prefix?: string;
         };
         if (Array.isArray(details.violations) && details.violations.length > 0) {
-          const pretty = details.violations
-            .map((v) => `${v.selector ?? "?"} (line ${v.line ?? "?"})`)
-            .join(", ");
+          setCssViolations(details.violations);
           setFieldErrors({
-            css: `Selectors not prefixed with ${details.prefix ?? "site prefix"}-: ${pretty}`,
+            css: `${details.violations.length} selector${details.violations.length === 1 ? "" : "s"} not prefixed with \`${details.prefix ?? "site prefix"}-\`:`,
           });
           setSubmitting(false);
           return;
@@ -362,6 +367,16 @@ export function ComponentFormModal({
               disabled={submitting}
             />
             <FieldError message={fieldErrors.css} />
+            {cssViolations.length > 0 && (
+              <ul className="mt-1 list-disc space-y-0.5 pl-5 text-sm text-destructive">
+                {cssViolations.map((v, i) => (
+                  <li key={i}>
+                    <code>{v.selector ?? "?"}</code>
+                    {v.line != null ? ` (line ${v.line})` : ""}
+                  </li>
+                ))}
+              </ul>
+            )}
             <p className="mt-1 text-sm text-muted-foreground">
               Every class selector must use the site&apos;s scope prefix (e.g.
               .ls-*). The server rejects unscoped CSS at submit time.

--- a/components/ComponentsGrid.tsx
+++ b/components/ComponentsGrid.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import type { DesignComponent } from "@/lib/components";
 
+
 function countRequiredFields(schema: unknown): number {
   if (!schema || typeof schema !== "object") return 0;
   const required = (schema as { required?: unknown }).required;
@@ -16,18 +17,24 @@ export function ComponentsGrid({
   components,
   onEdit,
   onDelete,
+  onCreate,
 }: {
   components: DesignComponent[];
   onEdit: (c: DesignComponent) => void;
   onDelete: (c: DesignComponent) => void;
+  onCreate?: () => void;
 }) {
   if (components.length === 0) {
     return (
       <div className="rounded-md border border-dashed p-8 text-center">
         <p className="text-sm text-muted-foreground">
-          No components in this design system yet. Click &ldquo;New component&rdquo; to add
-          one.
+          No components in this design system yet.
         </p>
+        {onCreate && (
+          <Button className="mt-4" onClick={onCreate}>
+            New component
+          </Button>
+        )}
       </div>
     );
   }

--- a/components/DesignSystemsTable.tsx
+++ b/components/DesignSystemsTable.tsx
@@ -36,19 +36,25 @@ export function DesignSystemsTable({
   siteId,
   onActivate,
   onArchive,
+  onCreate,
 }: {
   designSystems: DesignSystem[];
   siteId: string;
   onActivate: (ds: DesignSystem) => void;
   onArchive: (ds: DesignSystem) => void;
+  onCreate?: () => void;
 }) {
   if (designSystems.length === 0) {
     return (
       <div className="rounded-md border border-dashed p-8 text-center">
         <p className="text-sm text-muted-foreground">
-          No design system versions yet. Click &ldquo;New draft&rdquo; to create the
-          first one.
+          No design system versions yet.
         </p>
+        {onCreate && (
+          <Button className="mt-4" onClick={onCreate}>
+            New draft
+          </Button>
+        )}
       </div>
     );
   }

--- a/components/EditPageMetadataModal.tsx
+++ b/components/EditPageMetadataModal.tsx
@@ -20,6 +20,13 @@ import { Input } from "@/components/ui/input";
 // operation. WP still serves the old URL until the next publish.
 // ---------------------------------------------------------------------------
 
+const SLUG_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+function FieldError({ message }: { message?: string | null }) {
+  if (!message) return null;
+  return <p className="mt-1 text-sm text-destructive">{message}</p>;
+}
+
 export type EditPageMetadataModalProps = {
   open: boolean;
   onClose: () => void;
@@ -43,33 +50,44 @@ export function EditPageMetadataModal({
   const [slug, setSlug] = useState(page.slug);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [slugError, setSlugError] = useState<string | null>(null);
 
   useEffect(() => {
     if (open) {
       setTitle(page.title);
       setSlug(page.slug);
       setError(null);
+      setSlugError(null);
       setSubmitting(false);
     }
   }, [open, page.title, page.slug]);
 
   if (!open) return null;
 
+  const isDirty =
+    title.trim() !== page.title || slug.trim() !== page.slug;
+
+  function handleSlugChange(value: string) {
+    setSlug(value);
+    if (slugError) setSlugError(null);
+  }
+
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    setSubmitting(true);
     setError(null);
+
+    const trimmedSlug = slug.trim();
+    if (trimmedSlug !== page.slug && !SLUG_RE.test(trimmedSlug)) {
+      setSlugError("Lowercase letters, digits, and hyphens only. Must start and end with a letter or digit.");
+      return;
+    }
+
+    setSubmitting(true);
 
     const patch: { title?: string; slug?: string } = {};
     const trimmedTitle = title.trim();
-    const trimmedSlug = slug.trim();
     if (trimmedTitle !== page.title) patch.title = trimmedTitle;
     if (trimmedSlug !== page.slug) patch.slug = trimmedSlug;
-
-    if (patch.title === undefined && patch.slug === undefined) {
-      onClose();
-      return;
-    }
 
     try {
       const res = await fetch(
@@ -148,14 +166,15 @@ export function EditPageMetadataModal({
             <Input
               id="ep-slug"
               value={slug}
-              onChange={(e) => setSlug(e.target.value)}
+              onChange={(e) => handleSlugChange(e.target.value)}
               maxLength={100}
               disabled={submitting}
             />
             <p className="mt-1 text-sm text-muted-foreground">
               Lowercase letters, digits, and hyphens only.
             </p>
-            {slugChanged && (
+            <FieldError message={slugError} />
+            {slugChanged && !slugError && (
               <p
                 className="mt-1 text-sm text-yellow-700"
                 data-testid="slug-change-warning"
@@ -166,13 +185,13 @@ export function EditPageMetadataModal({
             )}
           </div>
           {error && (
-            <p
+            <div
               role="alert"
-              className="text-sm text-destructive"
+              className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
               data-testid="edit-page-error"
             >
               {error}
-            </p>
+            </div>
           )}
           <div className="flex justify-end gap-2 pt-2">
             <Button
@@ -183,7 +202,7 @@ export function EditPageMetadataModal({
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={submitting}>
+            <Button type="submit" disabled={submitting || !isDirty}>
               {submitting ? "Saving…" : "Save changes"}
             </Button>
           </div>

--- a/components/TemplatesTable.tsx
+++ b/components/TemplatesTable.tsx
@@ -17,18 +17,24 @@ export function TemplatesTable({
   templates,
   onEdit,
   onDelete,
+  onCreate,
 }: {
   templates: DesignTemplate[];
   onEdit: (t: DesignTemplate) => void;
   onDelete: (t: DesignTemplate) => void;
+  onCreate?: () => void;
 }) {
   if (templates.length === 0) {
     return (
       <div className="rounded-md border border-dashed p-8 text-center">
         <p className="text-sm text-muted-foreground">
-          No templates in this design system yet. Click &ldquo;New template&rdquo; to add
-          one.
+          No templates in this design system yet.
         </p>
+        {onCreate && (
+          <Button className="mt-4" onClick={onCreate}>
+            New template
+          </Button>
+        )}
       </div>
     );
   }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -587,19 +587,19 @@ No new env vars.
 
 Medium / Low findings from Audit 3 (UI + cross-milestone integration) that are deferred — pick up on the next UI polish pass, or earlier if a related slice naturally touches the same surface. Each item is in the `docs/AUDIT_2026-04-22.md` follow-on audit:
 
-- `#7` — `EditPageMetadataModal` no-op submit UX + client-side slug regex (Medium)
-- `#8` — `ComponentFormModal` selector-violations list (Medium)
-- `#9` — Empty-state CTAs in `DesignSystemsTable` / `ComponentsGrid` (Medium)
+- ~~`#7` — `EditPageMetadataModal` no-op submit UX + client-side slug regex~~ (shipped this PR)
+- ~~`#8` — `ComponentFormModal` selector-violations list~~ (shipped this PR)
+- ~~`#9` — Empty-state CTAs in `DesignSystemsTable` / `ComponentsGrid` / `TemplatesTable`~~ (shipped this PR)
 - `#10` — `.env.local.example` optional-vars block (Medium)
 - `#11` — `<Image>` vs `<img>` decision if admin surfaces ever render images (Medium)
-- `#12` — Unify inline validation pattern across modals (Medium)
+- ~~`#12` — Unify inline validation pattern across modals~~ (shipped this PR)
 - `#13` — Brand tokens in Tailwind (Low — only if admin scope changes)
 - `#14` — `force-dynamic` vs `revalidate: 0` audit (Low)
 - `#15` — Lighthouse thresholds ratchet + `/` route coverage (Low)
 - `#16` — Four `: any` annotations in WP + chat boundary (Low)
 - `#17` — `docs/PROMPT_VERSIONING.md` vs `lib/prompts/vN/` reconciliation (Low)
 - `#18` — Two stale `TODO(M3)` / `TODO(M7)` comments → BACKLOG (Low)
-- `#20` — Smart-quote / HTML-entity standardisation in empty states (Low)
+- ~~`#20` — Smart-quote / HTML-entity standardisation in empty states~~ (shipped this PR — CTAs replace text references)
 
 Trigger to pick up: next UI polish pass, OR before any admin UI brand-scope change.
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -736,3 +736,52 @@ Keep the Quick-reference table in sync.
 - Check Vercel deployment logs for seed data — if the E2E admin user or fixture site didn't backfill, specs fail with "user not found" or "site not found."
 - Rerun the failing PR in GitHub Actions if logs are clean (transient Playwright timing issue).
 - If the same test fails twice, open an issue on the spec itself before escalating — likely a race condition or a recent code change broke the locator.
+
+---
+
+## Supabase schema types bootstrap
+
+**Context:** `types/supabase.ts` is a generated file that maps every table/view/function in the live schema to TypeScript types. Once bootstrapped, `lib/supabase.ts`'s `getServiceRoleClient()` returns a `SupabaseClient<Database>` typed client — column drift that would previously surface as a silent `INTERNAL_ERROR` 500 becomes a compile-time error instead. The CI `test` job includes a drift gate that fails when the committed types file diverges from the live schema.
+
+**Why the gate is inactive by default:** The gate only runs when `types/supabase.ts` contains the `@generated` marker that `supabase gen types` emits. The placeholder file shipped with M15-8 does not have this marker, so CI won't fail until the real types file is committed.
+
+**One-time bootstrap (run locally with Docker):**
+
+```bash
+supabase start           # start local stack with all migrations applied
+npm run gen:types        # writes types/supabase.ts (adds @generated marker)
+npm run typecheck        # confirm no new type errors from the generated types
+git add types/supabase.ts
+git commit -m "chore(infra): bootstrap supabase schema types"
+git push
+```
+
+After this commit, the CI gate activates. Every future migration must regenerate the file.
+
+**After every migration:**
+
+```bash
+supabase start           # if not already running
+npm run gen:types        # regenerate
+git add types/supabase.ts
+# commit alongside the migration file in the same PR
+```
+
+**If CI fails with "types/supabase.ts is out of date":**
+
+A migration was pushed without regenerating the types file.
+
+```bash
+supabase start
+npm run gen:types
+git add types/supabase.ts
+git commit -m "chore(infra): regenerate supabase types after migration NNNN"
+git push
+```
+
+**Checking the diff without failing:**
+
+```bash
+supabase gen types typescript --local > /tmp/supabase-check.ts
+diff types/supabase.ts /tmp/supabase-check.ts
+```

--- a/docs/patterns/new-migration.md
+++ b/docs/patterns/new-migration.md
@@ -15,7 +15,16 @@ Don't use for: data migrations (row rewrites in bulk) — those go under `supaba
 | `lib/__tests__/<slug>.test.ts` | Applied-migration assertions: constraints reject invalid inserts, cascades fire as expected, RLS policies honour the role matrix. |
 | `supabase/rollbacks/README.md` | Add a line if the new migration has subtlety worth warning future operators about. |
 
-If the migration extends a type, schema, or enum that TypeScript reflects, regenerate types after apply.
+After apply, regenerate `types/supabase.ts` so the typed client stays in sync and the CI drift gate passes:
+
+```bash
+supabase start          # if not already running
+npm run gen:types       # overwrites types/supabase.ts
+git add types/supabase.ts
+# commit in the same PR as the migration
+```
+
+If `types/supabase.ts` hasn't been bootstrapped yet (placeholder in place), skip this step — see `docs/RUNBOOK.md` § "Supabase schema types bootstrap".
 
 ## Scaffolding
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { type Database } from "@/types/supabase";
 
 function requireEnv(key: string): string {
   const value = process.env[key];
@@ -9,17 +10,21 @@ function requireEnv(key: string): string {
   return value;
 }
 
-let serviceRoleClient: SupabaseClient | null = null;
+let serviceRoleClient: SupabaseClient<Database> | null = null;
 
 /**
  * Service-role client. Bypasses RLS. Use only in trusted server-side code
  * (API routes, background jobs). Never expose the service role key to clients.
+ *
+ * Typed as `SupabaseClient<Database>` so TypeScript will catch column-name drift
+ * once `types/supabase.ts` is bootstrapped (see RUNBOOK § "Supabase schema types
+ * bootstrap"). Until bootstrap, `Database = any` and behaviour is unchanged.
  */
-export function getServiceRoleClient(): SupabaseClient {
+export function getServiceRoleClient(): SupabaseClient<Database> {
   if (serviceRoleClient) return serviceRoleClient;
   const url = requireEnv("SUPABASE_URL");
   const key = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
-  serviceRoleClient = createClient(url, key, {
+  serviceRoleClient = createClient<Database>(url, key, {
     auth: {
       autoRefreshToken: false,
       persistSession: false,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:e2e:update-snapshots": "playwright test --update-snapshots",
     "screenshots": "RUN_SCREENSHOTS=1 playwright test screenshots.spec.ts",
     "audit:static": "tsx scripts/audit.ts",
+    "gen:types": "supabase gen types typescript --local > types/supabase.ts",
     "analyze": "ANALYZE=true next build",
     "prepare": "husky"
   },

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,0 +1,34 @@
+// types/supabase.ts
+//
+// PLACEHOLDER — schema types not yet bootstrapped.
+//
+// Until this file is replaced with the real generated output, the Supabase
+// client is typed as `any` (same behaviour as before M15-8).  The CI drift
+// gate is inactive while this placeholder is in place — it only activates
+// once the file contains the `@generated` marker that `supabase gen types`
+// emits on the first line.
+//
+// Bootstrap (one-time, requires Docker + local stack running):
+//
+//   supabase start
+//   npm run gen:types
+//   git add types/supabase.ts
+//   git commit -m "chore(infra): bootstrap supabase schema types"
+//
+// After that commit, every future migration must be followed by
+// `npm run gen:types` + `git add types/supabase.ts` or CI will fail.
+// See docs/RUNBOOK.md "Supabase schema types bootstrap" for the full
+// procedure, and docs/patterns/new-migration.md for the per-migration reminder.
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+// Placeholder: typed as `any` until bootstrap runs.
+// Replacing this with the real generated type activates TypeScript column-drift
+// checking and the CI gate simultaneously.
+export type Database = any; // nolint: will be replaced by real generated types


### PR DESCRIPTION
## Summary

Two independent slices bundled into one PR.

### Slice 1 — M15-8: Supabase schema type drift gate (infra)

- `types/supabase.ts` — typed `Database` placeholder; marks the \`@generated\` gate
- `lib/supabase.ts` — typed `SupabaseClient<Database>` instead of bare client
- `package.json` — `gen:types` script (`supabase gen types typescript --local > types/supabase.ts`)
- `.github/workflows/ci.yml` — drift-check CI step (advisory until generated marker is populated)
- `docs/RUNBOOK.md` — bootstrap procedure for running `gen:types`
- `docs/patterns/new-migration.md` — reminder to re-run `gen:types` after migrations

### Slice 2 — Audit-3 UX polish (items #7, #8, #9, #12, #20)

**#7 + #12 — `EditPageMetadataModal`**
- Save button disabled when title + slug are unchanged (no-op submit prevention)
- Client-side slug regex validates before PATCH: `/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/`
- Field-level errors use local `FieldError` component (unified with `ComponentFormModal` pattern — item #12)
- Form-level error upgraded to box style matching `ComponentFormModal`

**#8 — `ComponentFormModal` CSS selector-violations list**
- Violations from the server's CSS-scope check now render as a `<ul>` with selector + line per item instead of a comma-joined inline string
- `cssViolations` state cleared when the CSS field is edited

**#9 + #20 — Empty-state CTAs**
- `DesignSystemsTable`, `ComponentsGrid`, and `TemplatesTable` all accept an optional `onCreate` prop
- When provided, the empty state renders a labelled CTA button ("New draft" / "New component" / "New template")
- Parent pages wired: `design-system/page.tsx`, `components/page.tsx`, `templates/page.tsx`
- Empty-state copy no longer quotes button names in text (resolves #20 smart-quote standardisation)

## Risks identified and mitigated

- **No schema changes, no API changes** — pure client-side/UI.
- **M15-8 `SupabaseClient<Database>` typing is additive** — the `Database` placeholder compiles but has no runtime effect until `gen:types` is run. Advisory CI gate; no hard fail.
- **Slug regex is additive validation** — the server already validates slug on PATCH; the client-side check is defence-in-depth. Existing saved slugs (like `home-page`) all satisfy the regex.

## Test plan

- [ ] Lint + typecheck + build pass (CI)
- [ ] Vitest unit suite passes (CI)
- [ ] E2E suite passes (CI) — no new E2E needed; changes are shallow UI state (disable button, add list, add button in empty state)
- [ ] Audit-3 polish items #7, #8, #9, #12, #20 struck through in `docs/BACKLOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)