### PR TITLE
fix(types): replace any with unknown at WP + chat external boundaries

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -127,14 +127,15 @@ export async function POST(req: Request) {
   const rl = await checkRateLimit("chat", rlId);
   if (!rl.ok) return rateLimitExceeded(rl);
 
-  let body: any;
+  let body: unknown;
   try {
     body = await req.json();
   } catch {
     return errorResponse("VALIDATION_FAILED", "Request body must be JSON.", 400);
   }
+  const b = body as Record<string, unknown>;
 
-  const messages = body?.messages;
+  const messages = b?.messages;
   if (!Array.isArray(messages) || messages.length === 0) {
     return errorResponse(
       "VALIDATION_FAILED",
@@ -143,7 +144,7 @@ export async function POST(req: Request) {
     );
   }
 
-  const activeSiteIdRaw = body?.activeSiteId;
+  const activeSiteIdRaw = b?.activeSiteId;
   const hasActiveSiteId =
     typeof activeSiteIdRaw === "string" && activeSiteIdRaw.trim().length > 0;
 
@@ -213,10 +214,10 @@ export async function POST(req: Request) {
       };
 
       try {
-        let convo: Anthropic.MessageParam[] = messages.map((m: any) => ({
-          role: m.role,
-          content: m.content,
-        }));
+        let convo: Anthropic.MessageParam[] = messages.map((m) => {
+          const msg = m as { role: "user" | "assistant"; content: string };
+          return { role: msg.role, content: msg.content };
+        });
 
         let stopReason: string | null = null;
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -596,10 +596,15 @@ Medium / Low findings from Audit 3 (UI + cross-milestone integration) that are d
 - `#13` — Brand tokens in Tailwind (Low — only if admin scope changes)
 - `#14` — `force-dynamic` vs `revalidate: 0` audit (Low)
 - `#15` — Lighthouse thresholds ratchet + `/` route coverage (Low)
-- `#16` — Four `: any` annotations in WP + chat boundary (Low)
+- ~~`#16` — Four `: any` annotations in WP + chat boundary~~ (shipped this PR)
 - `#17` — `docs/PROMPT_VERSIONING.md` vs `lib/prompts/vN/` reconciliation (Low)
-- `#18` — Two stale `TODO(M3)` / `TODO(M7)` comments → BACKLOG (Low)
+- ~~`#18` — Two stale `TODO(M3)` / `TODO(M7)` comments → BACKLOG~~ (shipped this PR)
 - ~~`#20` — Smart-quote / HTML-entity standardisation in empty states~~ (shipped this PR — CTAs replace text references)
+
+#### Ex-TODO deferred items (moved from code, per #18)
+
+- **`loadActiveRegistry()` site-keyed LRU cache** (`lib/system-prompt.ts`) — Site-keyed LRU with 5-min TTL around `loadActiveRegistry()` would eliminate redundant DB reads during batch runs (~40 per site). Performance-only; correctness unaffected at current load. Trigger: observable latency spike in Axiom on batch ticks, or `/api/health` slow-DS-load counter.
+- **Kill-switch edge-propagation hardening** (`lib/auth-kill-switch.ts`) — Per-serverless-instance cache means the 5s TTL is the effective global propagation bound. Candidates: edge KV (immediate invalidation) or a signed cookie the emergency route issues that middleware trusts for the kill-switch window. Trigger: fleet grows to where warm-pool turnover is too slow to be operationally reliable during an active incident.
 
 Trigger to pick up: next UI polish pass, OR before any admin UI brand-scope change.
 

--- a/lib/auth-kill-switch.ts
+++ b/lib/auth-kill-switch.ts
@@ -25,9 +25,6 @@ import { getServiceRoleClient } from "@/lib/supabase";
 // state) — the effective global propagation bound is 5s + warm-pool
 // turnover.
 //
-// TODO(M7 fleet infra): revisit. Candidates: edge KV / Supabase realtime
-// broadcast for immediate invalidation; or a signed cookie the emergency
-// route issues that middleware trusts for the kill-switch window.
 // ---------------------------------------------------------------------------
 
 const TTL_MS = 5_000;

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -120,8 +120,6 @@ export function isDesignSystemV2Enabled(): boolean {
 // the known failure modes and we translate those to null + log.
 // ---------------------------------------------------------------------------
 
-// TODO(M3): consider site-keyed LRU with 5-min TTL around loadActiveRegistry().
-// Expected to matter when batch generator makes ~40 consecutive reads per site.
 export async function loadActiveRegistry(
   site_id: string,
 ): Promise<{

--- a/lib/wordpress.ts
+++ b/lib/wordpress.ts
@@ -292,19 +292,20 @@ function rawString(value: unknown): string {
   return "";
 }
 
-function toPageListItem(raw: any): PageListItem {
+function toPageListItem(raw: unknown): PageListItem {
+  const r = raw as Record<string, unknown>;
   return {
-    page_id: Number(raw.id),
-    title: renderedString(raw.title),
-    slug: typeof raw.slug === "string" ? raw.slug : "",
-    status: typeof raw.status === "string" ? raw.status : "",
+    page_id: Number(r.id),
+    title: renderedString(r.title),
+    slug: typeof r.slug === "string" ? r.slug : "",
+    status: typeof r.status === "string" ? r.status : "",
     parent_id:
-      typeof raw.parent === "number" && raw.parent > 0 ? raw.parent : null,
+      typeof r.parent === "number" && r.parent > 0 ? r.parent : null,
     modified_date:
-      typeof raw.modified_gmt === "string"
-        ? raw.modified_gmt
-        : typeof raw.modified === "string"
-          ? raw.modified
+      typeof r.modified_gmt === "string"
+        ? r.modified_gmt
+        : typeof r.modified === "string"
+          ? r.modified
           : "",
   };
 }
@@ -682,37 +683,38 @@ export type WpUpdatePostResult = WpResult<WpUpdatePostData>;
 export type WpGetPostResult = WpResult<WpPostRecord>;
 export type WpDeletePostResult = WpResult<WpDeletePostData>;
 
-function toPostRecord(raw: any): WpPostRecord {
-  const categories = Array.isArray(raw?.categories)
-    ? (raw.categories as unknown[])
+function toPostRecord(raw: unknown): WpPostRecord {
+  const r = raw as Record<string, unknown>;
+  const categories = Array.isArray(r.categories)
+    ? (r.categories as unknown[])
         .map((n) => Number(n))
         .filter((n) => Number.isFinite(n))
     : [];
-  const tags = Array.isArray(raw?.tags)
-    ? (raw.tags as unknown[])
+  const tags = Array.isArray(r.tags)
+    ? (r.tags as unknown[])
         .map((n) => Number(n))
         .filter((n) => Number.isFinite(n))
     : [];
   const featured =
-    typeof raw?.featured_media === "number" && raw.featured_media > 0
-      ? raw.featured_media
+    typeof r.featured_media === "number" && r.featured_media > 0
+      ? r.featured_media
       : null;
   return {
-    post_id: Number(raw?.id),
-    title: rawString(raw?.title),
-    slug: typeof raw?.slug === "string" ? raw.slug : "",
-    content: rawString(raw?.content),
-    excerpt: rawString(raw?.excerpt),
-    status: typeof raw?.status === "string" ? raw.status : "",
+    post_id: Number(r.id),
+    title: rawString(r.title),
+    slug: typeof r.slug === "string" ? r.slug : "",
+    content: rawString(r.content),
+    excerpt: rawString(r.excerpt),
+    status: typeof r.status === "string" ? r.status : "",
     categories,
     tags,
     featured_media: featured,
-    link: typeof raw?.link === "string" ? raw.link : "",
+    link: typeof r.link === "string" ? r.link : "",
     modified_date:
-      typeof raw?.modified_gmt === "string"
-        ? raw.modified_gmt
-        : typeof raw?.modified === "string"
-          ? raw.modified
+      typeof r.modified_gmt === "string"
+        ? r.modified_gmt
+        : typeof r.modified === "string"
+          ? r.modified
           : "",
   };
 }


### PR DESCRIPTION
## Summary

Closes Audit-3 items #16 and #18.

- **`lib/wordpress.ts`** — `toPageListItem` and `toPostRecord`: `raw: any` → `raw: unknown` with explicit `Record<string, unknown>` cast for property access. No behaviour change; all field reads were already safe.
- **`app/api/chat/route.ts`** — `body: any` → `body: unknown` with `const b = body as Record<string, unknown>` alias; `messages.map` cast narrows `role` to the literal union `"user" | "assistant"` that `Anthropic.MessageParam` requires.
- **`lib/system-prompt.ts`** — Remove stale `TODO(M3)` comment about site-keyed LRU for `loadActiveRegistry()`.
- **`lib/auth-kill-switch.ts`** — Remove stale `TODO(M7)` comment about edge-propagation hardening.
- **`docs/BACKLOG.md`** — Mark items #16 and #18 done; add proper BACKLOG entries for the two ex-TODOs so they're tracked for future slices.

## Risks identified and mitigated

- The `as { role: "user" | "assistant"; content: string }` cast in the chat route is a boundary cast on untrusted client input. The `messages` array is validated non-empty before we reach the map, but individual message shape is not checked server-side — it trusts the caller. This was already true before this change (the old `m: any` just hid the type error). Adding explicit validation is a future hardening item.
- No DB writes, no external calls modified.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean