### PR TITLE
fix(infra): remove false-positive @generated match from supabase types placeholder

### DIFF
--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -3,10 +3,10 @@
 // PLACEHOLDER — schema types not yet bootstrapped.
 //
 // Until this file is replaced with the real generated output, the Supabase
-// client is typed as `any` (same behaviour as before M15-8).  The CI drift
-// gate is inactive while this placeholder is in place — it only activates
-// once the file contains the `@generated` marker that `supabase gen types`
-// emits on the first line.
+// client is typed as `any` (same behaviour as before M15-8). The CI drift
+// gate is inactive while this placeholder is in place — it activates once
+// `supabase gen types` has run and replaced this file (the generated output
+// starts with a marker on the first line that CI scans for).
 //
 // Bootstrap (one-time, requires Docker + local stack running):
 //


### PR DESCRIPTION
## Problem

The `types/supabase.ts` placeholder comment contained the literal string `@generated` to explain the CI gate mechanism:

```
// once the file contains the `@generated` marker that `supabase gen types`
```

The CI drift-gate step does `grep -q '@generated' types/supabase.ts` to decide whether the file has been bootstrapped. This matched the comment, so CI treated the placeholder as a bootstrapped file, ran the diff against freshly generated types, and failed every PR with "types/supabase.ts is out of date with the current schema."

## Fix

Reword the placeholder comment to remove the literal trigger string while keeping the explanation intact. The gate is now correctly inactive until the file is replaced with real generated output.

## Test plan

- [ ] CI `test` job passes — schema drift check prints "⚠ types/supabase.ts not yet bootstrapped — schema drift gate inactive." instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)