### PR TITLE
chore(audit3): close remaining low findings — env docs, lighthouse thresholds, prompt versioning

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,8 @@
+# --- Required (all environments) -------------------------------------------
+# These must be set before the app will start. Local dev: copy this file to
+# .env.local and fill in all vars in this block. Vercel: set in the dashboard
+# under Environment Variables → Production + Preview. Everything below the
+# "optional" section headers is safe to leave unset during early development.
 ANTHROPIC_API_KEY=
 LEADSOURCE_WP_URL=
 # WP Application Password (NOT the regular WP login password). Generate

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,8 +5,9 @@ name: Lighthouse
 # surface is session-gated and testing it would require the full
 # Supabase-in-CI flow that e2e.yml already runs.
 #
-# Assertions are `warn`-only for now. Once we have a few runs of
-# baseline history we'll flip categories:performance to `error`.
+# Assertions: accessibility + best-practices are `error` (structural, stable
+# over many runs). Performance and Core Web Vitals remain `warn` — they vary
+# with render budget and image load on CI infra.
 #
 # Reports upload to Google's temporary public storage (no API keys).
 # Links land as a PR comment via the LHCI GitHub App when installed,

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -527,7 +527,7 @@ Reports live at:
 
 #### Tech-debt (bundled cleanup, no urgency)
 
-- **[M15-4 #14] 12 local `errorJson()` helpers across route files.** Migration to `lib/http.respond()` / `lib/http.validationError()` incomplete. Large mechanical diff.
+- **[M15-4 #14] Remaining local `errorJson()` helpers across route files.** 11 setup routes migrated to shared helpers in PR #679. ~17 routes remain (admin/batch, admin/batch/[id]/cancel, admin/companies, admin/images/*, admin/sites/[id]/budget, admin/sites/[id]/voice, admin/users/*, approve/*, sites/[id]/*, platform/brand, platform/invitations/*, platform/social/*). Note: `respond()` is only safe when the lib function returns a full `ApiResponse<T>` — routes calling lib functions that return `{ ok:false, error:{ code, message } }` (without timestamp/retryable) need explicit `notFound`/`internalError` routing instead. See PR #679 for the pattern.
 - ~~**[M15-4 #15] 7 copies of `constantTimeEqual` across cron + ops routes.**~~ Extracted to `lib/crypto-compare.ts` 2026-05-03 — PR #510. 9 files deduplicated: cron/budget-reset, cron/optimiser-monitor-rollouts, cron/process-batch, cron/process-brief-runner, cron/process-regenerations, emergency, ops/reset-admin-password, ops/self-probe, and cron/process-transfer (since deleted by PR #527).
 - ~~**[M15-4 #16] `"INVALID_STATE"` error code in `admin/batch/[id]/cancel` not in `ERROR_CODES` enum**.~~ Added to `lib/tool-schemas.ts` ERROR_CODES + errorCodeToStatus 409 mapping (2026-04-29).
 - ~~**[M15-4 #17] `admin/sites/[id]/budget` admin-only while siblings allow admin+operator.**~~ Comment added in route handler explaining the financial-control rationale (2026-04-29).
@@ -590,14 +590,14 @@ Medium / Low findings from Audit 3 (UI + cross-milestone integration) that are d
 - ~~`#7` — `EditPageMetadataModal` no-op submit UX + client-side slug regex~~ (shipped this PR)
 - ~~`#8` — `ComponentFormModal` selector-violations list~~ (shipped this PR)
 - ~~`#9` — Empty-state CTAs in `DesignSystemsTable` / `ComponentsGrid` / `TemplatesTable`~~ (shipped this PR)
-- `#10` — `.env.local.example` optional-vars block (Medium)
-- `#11` — `<Image>` vs `<img>` decision if admin surfaces ever render images (Medium)
+- ~~`#10` — `.env.local.example` optional-vars block~~ (shipped 2026-05-06 — added `# --- Required ---` section header PR #681)
+- ~~`#11` — `<Image>` vs `<img>` decision if admin surfaces ever render images~~ (decision: keep bare `<img>` for external Cloudflare URLs with `eslint-disable-next-line`; `images.unoptimized: true` is set for CVE mitigation so Next.js `<Image>` provides no benefit — PR #681)
 - ~~`#12` — Unify inline validation pattern across modals~~ (shipped this PR)
 - `#13` — Brand tokens in Tailwind (Low — only if admin scope changes)
-- `#14` — `force-dynamic` vs `revalidate: 0` audit (Low)
-- `#15` — Lighthouse thresholds ratchet + `/` route coverage (Low)
+- ~~`#14` — `force-dynamic` vs `revalidate: 0` audit~~ (confirmed 2026-05-06: all API routes use `force-dynamic`; no page route mixes `revalidate = 0`; decision is correct — PR #681)
+- ~~`#15` — Lighthouse thresholds ratchet~~ (ratcheted 2026-05-06: accessibility + best-practices flipped from `warn` to `error` in `lighthouserc.json`; performance/CWV remain `warn`; `/` route is session-gated and can't be added to Lighthouse CI without Supabase-in-CI — PR #681)
 - ~~`#16` — Four `: any` annotations in WP + chat boundary~~ (shipped this PR)
-- `#17` — `docs/PROMPT_VERSIONING.md` vs `lib/prompts/vN/` reconciliation (Low)
+- ~~`#17` — `docs/PROMPT_VERSIONING.md` vs `lib/prompts/vN/` reconciliation~~ (updated 2026-05-06: status note now reflects `lib/prompts.ts` as the current flat module; versioned directory layout remains future work — PR #681)
 - ~~`#18` — Two stale `TODO(M3)` / `TODO(M7)` comments → BACKLOG~~ (shipped this PR)
 - ~~`#20` — Smart-quote / HTML-entity standardisation in empty states~~ (shipped this PR — CTAs replace text references)
 

--- a/docs/PROMPT_VERSIONING.md
+++ b/docs/PROMPT_VERSIONING.md
@@ -1,6 +1,17 @@
 # Prompt Versioning
 
-> **Status: not yet shipped.** This file describes the target layout for a future cutover, not the current runtime. As of 2026-04-24, chat still loads `docs/SYSTEM_PROMPT_v1.md` + `docs/TOOL_SCHEMAS_v1.md` directly. The `lib/prompts/` directory, the `resolvePrompt()` helper, and the `OPOLLO_PROMPT_VERSION` env var described below do **not** exist in the codebase yet — setting `OPOLLO_PROMPT_VERSION` on Vercel today has no effect. The cutover is its own sub-slice, pending the `LANGFUSE_*` env provisioning called out later in this doc.
+> **Status: partially shipped; versioned directory layout is future work.**
+>
+> As of 2026-05-06, generation prompts live in `lib/prompts.ts` — a flat module
+> exporting named constants (`SITE_PLANNER_SYSTEM_PROMPT`, etc.). The versioned
+> `lib/prompts/vN/` directory layout, the `resolvePrompt()` helper, and the
+> `OPOLLO_PROMPT_VERSION` env var described below do **not** exist yet — setting
+> `OPOLLO_PROMPT_VERSION` on Vercel has no effect. The file described below is
+> the migration target; the cutover is its own sub-slice pending the
+> `LANGFUSE_*` env provisioning noted later in this doc.
+>
+> The chat path still loads `docs/SYSTEM_PROMPT_v1.md` + `docs/TOOL_SCHEMAS_v1.md`
+> directly (M16 generation uses `lib/prompts.ts`; the two paths are independent).
 
 Spec for how system prompts, tool schemas, and evaluation suites are organised in `lib/prompts/`. Target layout once we start routing chat traffic through versioned prompts and measuring with Langfuse.
 

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -19,8 +19,8 @@
     "assert": {
       "assertions": {
         "categories:performance": ["warn", { "minScore": 0.85 }],
-        "categories:accessibility": ["warn", { "minScore": 0.95 }],
-        "categories:best-practices": ["warn", { "minScore": 0.9 }],
+        "categories:accessibility": ["error", { "minScore": 0.95 }],
+        "categories:best-practices": ["error", { "minScore": 0.9 }],
         "first-contentful-paint": ["warn", { "maxNumericValue": 2000 }],
         "largest-contentful-paint": ["warn", { "maxNumericValue": 2500 }],
         "cumulative-layout-shift": ["warn", { "maxNumericValue": 0.1 }],


### PR DESCRIPTION
## Summary

Closes audit-3 Low findings #10, #11, #14, #15, #17. All are doc/config only — no runtime code changed.

- **#10 `.env.local.example`** — added `# --- Required (all environments) ---` section header before the must-have vars block so new devs don't overlook required keys.
- **#11 `<Image>` vs `<img>` decision** — BACKLOG note: keep bare `<img>` for external Cloudflare URLs; `images.unoptimized` is set for CVE mitigation so Next.js `<Image>` provides no benefit on these surfaces.
- **#14 `force-dynamic` vs `revalidate: 0` audit** — confirmed all API routes use `force-dynamic`; decision is correct. BACKLOG closed.
- **#15 Lighthouse thresholds ratcheted** — `accessibility` + `best-practices` flipped from `warn` to `error` (structurally stable over many runs). Performance / CWV remain `warn` (CI variance).
- **#17 `docs/PROMPT_VERSIONING.md` status note** — updated to reflect `lib/prompts.ts` as the current flat module; versioned `lib/prompts/vN/` directory layout + `OPOLLO_PROMPT_VERSION` env var are future work.

## Risks identified and mitigated

None — doc and CI config changes only. Ratcheting Lighthouse thresholds to `error` could surface pre-existing regressions on the `/login` page; the `continue-on-error: true` flag is retained so it never blocks merge.

## Test plan
- [ ] `npm run typecheck` — clean (no code changes)
- [ ] `npm run lint` — clean (no code changes)
- [ ] `npm run build` — clean (no code changes)
- [ ] Lighthouse CI will run on PR and report against the new thresholds