### PR TITLE
chore(data-conventions): wire created_by/updated_by into sites.createSite

### DIFF
--- a/app/api/sites/register/route.ts
+++ b/app/api/sites/register/route.ts
@@ -47,7 +47,7 @@ export async function POST(req: Request) {
     return NextResponse.json(response, { status: 400 });
   }
 
-  const result = await createSite(parsed.data);
+  const result = await createSite(parsed.data, { createdBy: gate.user?.id ?? null });
   if (!result.ok) logger.error("createSite failed", { code: result.error.code });
   if (result.ok) {
     // Bust the cached server-component render of /admin/sites so the

--- a/lib/sites.ts
+++ b/lib/sites.ts
@@ -62,9 +62,10 @@ function internalError(
 
 export async function createSite(
   input: RegisterSiteInput,
+  opts?: { createdBy?: string | null },
 ): Promise<ApiResponse<SiteRecord>> {
   try {
-    return await createSiteImpl(input);
+    return await createSiteImpl(input, opts);
   } catch (err) {
     logger.error("sites.createSite.uncaught", { err: err instanceof Error ? err.message : String(err) });
     return internalError(
@@ -75,6 +76,7 @@ export async function createSite(
 
 async function createSiteImpl(
   input: RegisterSiteInput,
+  opts?: { createdBy?: string | null },
 ): Promise<ApiResponse<SiteRecord>> {
   const supabase = getServiceRoleClient();
 
@@ -98,6 +100,8 @@ async function createSiteImpl(
       wp_url: input.wp_url,
       prefix,
       status: "active",
+      created_by: opts?.createdBy ?? null,
+      updated_by: opts?.createdBy ?? null,
     })
     .select()
     .single();

--- a/lib/tool-schemas.ts
+++ b/lib/tool-schemas.ts
@@ -93,7 +93,7 @@ export const ERROR_CODES = [
   // Webhook receiver codes.
   "INVALID_SIGNATURE",
   "RECEIVER_NOT_CONFIGURED",
-  // S8 reconnect — healthy-connection guard.
+  // S8 reconnect ï¿½ healthy-connection guard.
   "CONFLICT",
 ] as const;
 
@@ -282,6 +282,8 @@ export type SiteRecord = {
   version_lock: number;
   // DESIGN-SYSTEM-OVERHAUL â€” null when onboarding hasn't picked a mode yet.
   site_mode: "copy_existing" | "new_design" | null;
+  created_by: string | null;
+  updated_by: string | null;
 };
 
 export type SiteListItem = {


### PR DESCRIPTION
## Summary

Migration `0079_sites_audit_columns.sql` added `created_by` and `updated_by` to the `sites` table but `lib/sites.createSite()` and the `POST /api/sites/register` route never populated them. All new site rows have been landing with NULL audit columns since PR #491.

- Adds `opts?: { createdBy? }` to `createSite()` — backwards-compatible, existing callers unaffected
- Register route threads `gate.user?.id` through as `createdBy`
- Sets both `created_by` and `updated_by` on insert (both point to the registering admin)
- Adds `created_by` / `updated_by` to `SiteRecord` so TypeScript callers can read them without casting

No new migration needed — columns exist since 0079.

## Risks identified and mitigated

- **New columns already nullable** — no NOT NULL constraint added, so existing NULL rows are fine; no backfill required
- **opts is optional** — zero breaking changes to `createSite` call sites (tests, lib callers)
- **No concurrency surface** — single insert, no CAS

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)