### PR TITLE
feat(auth): session expiry pre-warning toast + ping endpoint

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -3,12 +3,14 @@ import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 
 import { checkAdminAccess } from "@/lib/admin-gate";
+import { createRouteAuthClient } from "@/lib/auth";
 import {
   AdminSidebar,
   SIDEBAR_COLLAPSED_COOKIE,
 } from "@/components/AdminSidebar";
 import { CommandPalette } from "@/components/CommandPalette";
 import { DebugFooter } from "@/components/DebugFooter";
+import { SessionExpiryWarning } from "@/components/SessionExpiryWarning";
 import { Toaster } from "@/components/ui/toaster";
 
 // Shared shell for every page under /admin.
@@ -53,6 +55,14 @@ export default async function AdminLayout({
   const initialCollapsed =
     cookies().get(SIDEBAR_COLLAPSED_COOKIE)?.value === "1";
 
+  // Pass session expiry to the client component so it can warn the operator
+  // 5 minutes before the JWT expires. getSession() is a local decode (no
+  // network); null when auth is in kill-switch / no-session mode.
+  const {
+    data: { session },
+  } = await createRouteAuthClient().auth.getSession();
+  const sessionExpiresAt = session?.expires_at ?? null;
+
   return (
     <div className="min-h-screen bg-canvas text-foreground sm:flex">
       {/* C-3 — skip-to-content link. Visually hidden until focused. */}
@@ -80,6 +90,7 @@ export default async function AdminLayout({
       </main>
       <Toaster />
       <CommandPalette />
+      <SessionExpiryWarning expiresAt={sessionExpiresAt} />
       {isSuperAdmin && (
         <DebugFooter
           buildSha={process.env.VERCEL_GIT_COMMIT_SHA ?? null}

--- a/app/api/auth/ping/route.ts
+++ b/app/api/auth/ping/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+
+import { createRouteAuthClient } from "@/lib/auth";
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/ping — lightweight session-extend endpoint.
+//
+// Middleware refreshes the Supabase session on every authenticated request.
+// Calling this endpoint from the client is sufficient to extend the session
+// without navigating away. The response carries the new `expires_at` so the
+// client can reset its expiry timer.
+//
+// No auth gate — the middleware handles auth; unauthenticated calls simply
+// return `{ ok: true, expires_at: null }`.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(): Promise<NextResponse> {
+  const supabase = createRouteAuthClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  return NextResponse.json(
+    {
+      ok: true,
+      expires_at: session?.expires_at ?? null,
+    },
+    { status: 200 },
+  );
+}

--- a/components/SessionExpiryWarning.tsx
+++ b/components/SessionExpiryWarning.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+// ---------------------------------------------------------------------------
+// SessionExpiryWarning
+//
+// Shows a dismissible sonner toast 5 minutes before the admin session JWT
+// expires. "Extend session" hits GET /api/auth/ping which lets the Supabase
+// middleware refresh the cookie; the response carries the new expires_at so
+// the timer resets without a page reload.
+//
+// Props:
+//   expiresAt — Unix epoch seconds from the Supabase session. Pass null when
+//               auth is in kill-switch / no-session mode; this component
+//               no-ops in that case.
+// ---------------------------------------------------------------------------
+
+const WARN_BEFORE_MS = 5 * 60 * 1000; // 5 minutes
+const TOAST_ID = "session-expiry-warning";
+
+export function SessionExpiryWarning({
+  expiresAt,
+}: {
+  expiresAt: number | null;
+}) {
+  const [currentExpiresAt, setCurrentExpiresAt] = useState(expiresAt);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const extend = useCallback(async () => {
+    toast.dismiss(TOAST_ID);
+    try {
+      const res = await fetch("/api/auth/ping");
+      if (res.ok) {
+        const body = (await res.json()) as { expires_at?: number | null };
+        if (body.expires_at) setCurrentExpiresAt(body.expires_at);
+      }
+    } catch {
+      // Fail silently — worst case the session expires naturally.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!currentExpiresAt) return;
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    const expiresMs = currentExpiresAt * 1000;
+    const warnAt = expiresMs - WARN_BEFORE_MS;
+    const delay = warnAt - Date.now();
+
+    if (delay <= 0) {
+      // Already inside the warning window — show immediately.
+      toast.warning("Your session is about to expire.", {
+        id: TOAST_ID,
+        duration: Infinity,
+        action: {
+          label: "Extend session",
+          onClick: extend,
+        },
+      });
+      return;
+    }
+
+    timerRef.current = setTimeout(() => {
+      toast.warning("Your session will expire in 5 minutes.", {
+        id: TOAST_ID,
+        duration: Infinity,
+        action: {
+          label: "Extend session",
+          onClick: extend,
+        },
+      });
+    }, delay);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [currentExpiresAt, extend]);
+
+  return null;
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -430,7 +430,7 @@ Option (b) expands the write-safety blast radius significantly — mu-plugin ins
 Surfaced by the M14 auth-gap audit. Deferred with Steven's explicit call: M14 stays focused on password reset; these get picked up when they actually cost someone time.
 
 - **Invite TTL + revocation.** `app/api/admin/users/invite` generates a Supabase invite link but has no expiry beyond Supabase's built-in, and no "cancel pending invite" admin action. Pick up trigger: an admin mistakenly invites the wrong email and can't revoke. Scope: new `invites` table with `expires_at` + `revoked_at`, a DELETE route, and an admin-UI "pending invites" row list.
-- **Session expiry pre-warning.** Middleware redirects to `/login` when the JWT expires; no "session about to expire" UI, no session-extend prompt. Pick up trigger: an operator loses mid-workflow state because of an expiry they didn't see coming. Scope: client-side expiry timer + pre-expiry toast + "extend session" action that refreshes the token.
+- ~~**Session expiry pre-warning.**~~ Shipped 2026-05-06. `components/SessionExpiryWarning.tsx` mounts in the admin layout and shows a sonner warning toast 5 min before JWT expiry; "Extend session" button hits `GET /api/auth/ping` which lets middleware refresh the cookie.
 
 ## UX polish deferred from M15 (2026-04-24)
 

--- a/docs/QA-ISSUES.md
+++ b/docs/QA-ISSUES.md
@@ -12,7 +12,7 @@ Severity: CRITICAL (blocks ship) | HIGH (fix before merge) | MEDIUM | LOW
 | # | Item | Status |
 |---|------|--------|
 | P1-1 | Transfer-cron dead code deletion (M15-5 #1) | ✅ Done — PR #527 |
-| P1-2 | errorJson() migration to lib/http helpers (M15-4 #14) | 🔄 Deferred — 60+ files, no urgency, tech-debt backlog |
+| P1-2 | errorJson() migration to lib/http helpers (M15-4 #14) | ✅ Done — PRs #681 #684 #685 #686. All routes now use shared `lib/http` helpers. |
 | P1-3 | Lease-coherent CHECK asymmetry M3/M7/M12 (M15-2 #10) | ✅ Done — migration 0087, PR #541 |
 
 ---


### PR DESCRIPTION
## Summary

- Adds `GET /api/auth/ping` — lightweight endpoint that lets middleware silently refresh the Supabase session cookie and returns the new `expires_at`
- Adds `components/SessionExpiryWarning.tsx` — client component mounted in the admin layout that watches session expiry and shows a sonner warning toast 5 minutes before the JWT expires
- "Extend session" action in the toast calls `/api/auth/ping`, resets the timer with the refreshed expiry
- Admin layout passes `session.expires_at` from `getSession()` (local cookie decode, no network) to the client component
- Marks M14 auth polish "Session expiry pre-warning" as shipped in BACKLOG
- Updates QA-ISSUES.md P1-2 (errorJson migration) to ✅ Done

## Risks identified and mitigated

- **`getSession()` in server layout** — local JWT decode from cookie, no GoTrue network call; negligible overhead on every admin page render
- **Client timer edge case** — if `expiresAt` is already within the 5-min window on mount, the component shows the toast immediately rather than waiting
- **Extend silently fails** — caught with an empty catch; worst case the session expires naturally and middleware redirects to `/login` as before
- No new env vars, no migration, no schema changes

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)