### PR TITLE
fix(api): restore correct UPDATE_FAILED/TEMPLATE_NOT_FOUND contracts (M15-4 follow-up)

### DIFF
--- a/app/api/admin/batch/route.ts
+++ b/app/api/admin/batch/route.ts
@@ -5,8 +5,8 @@ import { createBatchJob } from "@/lib/batch-jobs";
 import {
   conflict,
   internalError,
-  notFound,
   readJsonBody,
+  routeError,
   validationError,
 } from "@/lib/http";
 import { logger } from "@/lib/logger";
@@ -74,7 +74,7 @@ export async function POST(req: Request): Promise<NextResponse> {
       case "VALIDATION_FAILED":
         return validationError(message, details);
       case "TEMPLATE_NOT_FOUND":
-        return notFound(message);
+        return routeError("TEMPLATE_NOT_FOUND", message);
       case "TEMPLATE_NOT_ACTIVE":
       case "IDEMPOTENCY_KEY_CONFLICT":
         return conflict(code, message, details);

--- a/app/api/ops/reset-admin-password/route.ts
+++ b/app/api/ops/reset-admin-password/route.ts
@@ -112,7 +112,7 @@ export async function POST(req: Request): Promise<NextResponse> {
         email: normalizedEmail,
         error: opolloErr.message,
       });
-      return internalError("Admin lookup failed. See server logs.");
+      return internalError("Admin lookup failed. See server logs.", true);
     }
 
     if (!opolloUser) {

--- a/lib/__tests__/admin-batch-route.test.ts
+++ b/lib/__tests__/admin-batch-route.test.ts
@@ -221,7 +221,7 @@ describe("POST /api/admin/batch — createBatchJob error mapping", () => {
     const res = await POST(makeRequest(VALID_BODY));
     expect(res.status).toBe(404);
     const body = await res.json();
-    expect(body.error.code).toBe("NOT_FOUND"); // route uses notFound() helper which emits NOT_FOUND code
+    expect(body.error.code).toBe("TEMPLATE_NOT_FOUND");
   });
 
   it("returns 409 on TEMPLATE_NOT_ACTIVE", async () => {

--- a/lib/__tests__/change-password-route.test.ts
+++ b/lib/__tests__/change-password-route.test.ts
@@ -266,7 +266,7 @@ describe("POST /api/account/change-password: update errors", () => {
     expect(body.error.code).toBe("SAME_PASSWORD");
   });
 
-  it("returns 500 UPDATE_FAILED on a generic supabase error", async () => {
+  it("returns 422 UPDATE_FAILED on a generic supabase error", async () => {
     mockState.updateResult = { error: { message: "service unavailable" } };
     const res = await changePasswordPOST(
       makeRequest({
@@ -274,7 +274,7 @@ describe("POST /api/account/change-password: update errors", () => {
         new_password: NEW_PASSWORD,
       }) as never,
     );
-    expect(res.status).toBe(500); // UPDATE_FAILED maps to 500 via errorCodeToStatus
+    expect(res.status).toBe(422);
     const body = await res.json();
     expect(body.error.code).toBe("UPDATE_FAILED");
   });

--- a/lib/__tests__/reset-password-route.test.ts
+++ b/lib/__tests__/reset-password-route.test.ts
@@ -135,12 +135,12 @@ describe("POST /api/auth/reset-password: supabase errors", () => {
     expect(body.error.code).toBe("SAME_PASSWORD");
   });
 
-  it("returns 500 UPDATE_FAILED on a generic supabase error", async () => {
+  it("returns 422 UPDATE_FAILED on a generic supabase error", async () => {
     mockState.updateResult = { error: { message: "random failure" } };
     const res = await resetPasswordPOST(
       makeRequest({ new_password: VALID_PASSWORD }) as never,
     );
-    expect(res.status).toBe(500); // UPDATE_FAILED maps to 500 via errorCodeToStatus
+    expect(res.status).toBe(422);
     const body = await res.json();
     expect(body.error.code).toBe("UPDATE_FAILED");
   });

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -65,13 +65,13 @@ export function notFound(message: string): NextResponse {
 }
 
 // 500 Internal Error (for catch blocks and unrecoverable DB errors)
-export function internalError(message: string): NextResponse {
+export function internalError(message: string, retryable = false): NextResponse {
   const body: ToolError = {
     ok: false,
     error: {
       code: "INTERNAL_ERROR",
       message,
-      retryable: false,
+      retryable,
       suggested_action: "An unexpected error occurred. Try again later.",
     },
     timestamp: now(),

--- a/lib/tool-schemas.ts
+++ b/lib/tool-schemas.ts
@@ -176,8 +176,9 @@ export function errorCodeToStatus(code: ErrorCode): number {
     case "EMERGENCY_NOT_CONFIGURED":
       return 503;
     case "INTERNAL_ERROR":
-    case "UPDATE_FAILED":
       return 500;
+    case "UPDATE_FAILED":
+      return 422;
     case "WP_CREDENTIALS_MISSING":
     case "BLUEPRINT_MISMATCH":
       return 400;


### PR DESCRIPTION
## Summary

PR #701 fixed test assertions to match what the routes were emitting, but the routes were emitting the wrong thing. This PR fixes the routes (and restores the test assertions to reflect the correct contract):

- **`lib/tool-schemas.ts`**: `UPDATE_FAILED` maps to **422** (Unprocessable Entity), not 500. Password-update failures from Supabase are client-resolvable (wrong password, policy rejection) — 422 is the correct semantic.
- **`app/api/admin/batch/route.ts`**: `TEMPLATE_NOT_FOUND` case now uses `routeError("TEMPLATE_NOT_FOUND", message)` instead of `notFound(message)`, so the specific code reaches the caller rather than being coerced to `NOT_FOUND`.
- **`lib/http.ts`**: `internalError()` gains an optional `retryable` parameter (default `false`). Used by…
- **`app/api/ops/reset-admin-password/route.ts`**: DB lookup error passes `retryable: true` since a transient connection reset is indeed retryable.
- Test assertions in `admin-batch-route`, `change-password-route`, `reset-password-route` updated to match the now-correct behavior.

## Risks identified and mitigated

- **Status code change (422 vs 500 for UPDATE_FAILED)**: no UI currently branches on this status; the error code `UPDATE_FAILED` was already preserved. Any future consumer that conditionally handles 5xx vs 4xx gets a more accurate signal.
- **`internalError` signature change**: backward-compatible (default `false`); existing callers unaffected.

## Test plan
- [ ] Vitest: `admin-batch-route`, `change-password-route`, `reset-password-route`, `reset-admin-password-route` all pass
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)