### PR TITLE
fix(images): extract EXIF correctly on upload and unblock backfill crons

### DIFF
--- a/app/api/admin/images/upload/route.ts
+++ b/app/api/admin/images/upload/route.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import Anthropic from "@anthropic-ai/sdk";
 import { NextResponse, type NextRequest } from "next/server";
+import sharp from "sharp";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
 import {
@@ -149,7 +150,16 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const cloudflareId = `opollo/upload/${randomUUID()}`;
   const filename = file.name || `${cloudflareId}.bin`;
   const bytes = new Uint8Array(await file.arrayBuffer());
-  const dims = readImageDimensions(bytes);
+
+  // Sharp is more reliable across all JPEG encodings; fall back to the pure
+  // header parser only when Sharp itself throws (e.g. unsupported variant).
+  let dims: { width: number; height: number } | null = null;
+  try {
+    const meta = await sharp(Buffer.from(bytes)).metadata();
+    if (meta.width && meta.height) dims = { width: meta.width, height: meta.height };
+  } catch {
+    dims = readImageDimensions(bytes);
+  }
 
   // Extract EXIF/IPTC/XMP metadata. NEVER block the upload on failure.
   let exifCaption: string | null = null;

--- a/app/api/cron/backfill-image-captions/route.ts
+++ b/app/api/cron/backfill-image-captions/route.ts
@@ -174,7 +174,8 @@ export async function GET(req: NextRequest) {
       .from("image_library")
       .update(patch)
       .eq("id", row.id)
-      .is("caption", null); // idempotency guard
+      // Match the same set the SELECT picked: null, empty, or "[object Object]"
+      .or("caption.is.null,caption.eq.,caption.eq.[object Object]");
 
     if (updateErr) {
       logger.error("backfill.update_failed", { image_id: row.id, error: updateErr.message });

--- a/lib/exif-extract.ts
+++ b/lib/exif-extract.ts
@@ -26,6 +26,8 @@ export async function extractExifFields(
 ): Promise<ExifFields | null> {
   const raw = (await parseExif(buffer, {
     tiff: true,
+    exif: true,
+    gps: true,
     xmp: true,
     iptc: true,
     icc: false,

--- a/lib/image-metadata-extract.ts
+++ b/lib/image-metadata-extract.ts
@@ -256,20 +256,33 @@ export async function runExtractionBatch(opts: {
     }
 
     // Write sidecar metadata rows.
+    // Only write the sentinel when something was actually extracted — writing
+    // it unconditionally would permanently skip images where Sharp / exifr
+    // both yield nothing (sentinel found next run → skipped forever despite
+    // width_px still being null).
+    const didExtractData =
+      meta.width !== null ||
+      meta.caption !== null ||
+      meta.title !== null ||
+      meta.altText !== null ||
+      meta.tags.length > 0;
+
     type MetaRow = {
       image_id: string;
       key: string;
       value_jsonb: unknown;
       updated_at: string;
     };
-    const sidecar: MetaRow[] = [
-      {
-        image_id: imageId,
-        key: "metadata_extracted_at",
-        value_jsonb: now,
-        updated_at: now,
-      },
-    ];
+    const sidecar: MetaRow[] = didExtractData
+      ? [
+          {
+            image_id: imageId,
+            key: "metadata_extracted_at",
+            value_jsonb: now,
+            updated_at: now,
+          },
+        ]
+      : [];
 
     if (meta.dominantR !== null) {
       sidecar.push({
@@ -327,6 +340,35 @@ export async function runExtractionBatch(opts: {
       caption: meta.caption?.slice(0, 60) ?? null,
     });
     saved++;
+  }
+
+  // Title-only backfill: images that have dimensions but no title.
+  // These exist when the image was processed before migration 0099 added the
+  // title column, or when the first extraction run pre-dated EXIF support.
+  // Derive from filename alone — no Cloudflare API call needed.
+  const { data: titleRows } = await svc
+    .from("image_library")
+    .select("id, filename")
+    .is("deleted_at", null)
+    .is("title", null)
+    .not("width_px", "is", null)
+    .order("created_at", { ascending: true })
+    .limit(batchSize);
+
+  for (const row of titleRows ?? []) {
+    const filename = row.filename as string | null;
+    if (!filename) continue;
+    const base = filename.replace(/\.[^.]+$/, "");
+    const m = /^istock[-_](\d+)/i.exec(base);
+    const derived = m
+      ? `iStock Image ${m[1]}`
+      : base.replace(/[-_]+/g, " ").replace(/\s+/g, " ").trim() || null;
+    if (!derived) continue;
+    await svc
+      .from("image_library")
+      .update({ title: derived, updated_at: now })
+      .eq("id", row.id as string)
+      .is("title", null);
   }
 
   // Count remaining images still needing extraction.


### PR DESCRIPTION
## Root cause

Five separate bugs prevented EXIF metadata from reaching the database. The infrastructure (exifr, Sharp, cron jobs, reextract endpoint) was all there — the extraction was silently failing or getting stuck.

## Bugs fixed

### 1 — `lib/exif-extract.ts` missing `exif: true` / `gps: true`
exifr's `tiff: true` parses IFD0 basic tags but does NOT follow the EXIF sub-IFD pointer. Without `exif: true`, DateTimeOriginal, FNumber, ISO, ExposureTime, and GPS coordinates were never extracted.

### 2 — Upload handler used a fragile pure-header JPEG parser for dimensions
`readImageDimensions` walks JPEG segment markers and returns null immediately on any unexpected byte — some JPEG encodings could silently produce null. Replaced primary dimension extraction with Sharp; pure parser kept as fallback.

### 3 — `runExtractionBatch` sentinel bug (images permanently skipped)
When the batch cron processed an image and extraction yielded nothing, it still wrote a `metadata_extracted_at` sentinel. The secondary idempotency check then skipped that image on every subsequent run even though `width_px` was still null. Fix: only write the sentinel when at least one field was actually saved.

### 4 — No title backfill for images with dimensions but null title
`backfill-image-captions` never sets `title`. `runExtractionBatch` only queried `width_px IS NULL`, missing images with dimensions but null title (e.g. uploaded before migration 0099 added the column). Added a second pass that derives title from filename with no Cloudflare API call.

### 5 — `backfill-image-captions` idempotency guard mismatch
SELECT picked up `caption IS NULL OR caption = '' OR caption = '[object Object]'` but UPDATE guard was `.is("caption", null)`. Images with an empty-string or object-stringified caption were selected but update never matched → permanently stuck. Guard now mirrors the SELECT filter exactly.

## Risks identified and mitigated

| Risk | Mitigation |
|------|-----------|
| Sentinel removal causes infinite-retry for corrupted images | Only affects images where blob fetch succeeds but both Sharp and exifr return nothing — rare for valid JPEGs. Bounded by cron batch size. |
| Title-backfill overwrites intentionally-blank title | Update guard is `.is("title", null)` — blank/empty titles already set are left alone. |
| Sharp in upload route increases cold-start | Sharp is already bundled via `lib/image-reextract.ts` — no new native module load. |

## Testing

lint ✅ typecheck ✅ build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)