### PR TITLE
fix(e2e): restore DraftRestoreBanner accidentally dropped in PR #703

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -860,6 +860,13 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
             </span>
           </Alert>
         )}
+        {pendingDraft && (
+          <DraftRestoreBanner
+            savedAt={pendingDraft.savedAt}
+            onRestore={restoreDraft}
+            onDiscard={discardDraft}
+          />
+        )}
 
         {/* Unified editor card: title + content editor + SEO */}
         <div className="rounded-lg border bg-card p-6">


### PR DESCRIPTION
## Summary

- PR #703 refactored BlogPostComposer into a WP-style card layout but accidentally removed the `{pendingDraft && <DraftRestoreBanner />}` render.
- The `DraftRestoreBanner` component definition remained (line 1574) but was never mounted, so `data-testid="draft-restore-banner"` never appeared in the DOM.
- This caused two E2E tests to fail: *autosave persists across reload* and *draft-restore banner discard clears the stored draft* (`posts-new.spec.ts:100` and `:163`).

The banner is restored to the same position it occupied before: after the "no WP site" Alert, before the editor card.

## Risks identified and mitigated

None — single-line JSX restoration. No state, logic, or prop changes. Component behaviour is identical to pre-#703.

## Test plan
- [ ] E2E: `posts-new.spec.ts` lines 100 and 163 pass (draft-restore-banner visible)
- [ ] No regressions on other posts-new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)