### PR TITLE
fix(e2e): restore DraftRestoreBanner mount dropped by PR #703 layout refactor

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -860,6 +860,13 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
             </span>
           </Alert>
         )}
+        {pendingDraft && (
+          <DraftRestoreBanner
+            savedAt={pendingDraft.savedAt}
+            onRestore={restoreDraft}
+            onDiscard={discardDraft}
+          />
+        )}
 
         {/* Unified editor card: title + content editor + SEO */}
         <div className="rounded-lg border bg-card p-6">


### PR DESCRIPTION
## What

The `DraftRestoreBanner` JSX block (autosave draft restore/discard prompt) was accidentally removed during the WordPress-style layout refactor in PR #703. This caused the E2E test `posts-new.spec.ts › autosave persists across reload; draft-restore banner lets operator restore or discard` to fail on every subsequent CI run.

## Fix

Re-adds the 7-line `{pendingDraft && <DraftRestoreBanner ... />}` block in `BlogPostComposer.tsx` immediately above the unified editor card, which is where it was before the refactor moved things around.

## Risks identified and mitigated

| Risk | Mitigation |
|------|-----------|
| Regression to the PR #703 layout | Change is additive — adds back a component mount that was previously present; no layout logic altered. |

## Testing

lint ✅ typecheck ✅ — E2E `posts-new.spec.ts:100` is the single failing test this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)