### PR TITLE
fix(test): redis mock uses regular function so new Redis() constructs correctly

### DIFF
--- a/lib/__tests__/redis.test.ts
+++ b/lib/__tests__/redis.test.ts
@@ -20,7 +20,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // destructuring vi.hoisted() into a const puts the binding in TDZ when the
 // factory runs. Capture the whole object and access the property instead.
 const redisMocks = vi.hoisted(() => ({
-  mockRedisConstructor: vi.fn().mockImplementation((opts: object) => opts),
+  mockRedisConstructor: vi.fn().mockImplementation(function(opts: object) { return opts; }),
 }));
 
 vi.mock("@upstash/redis", () => ({


### PR DESCRIPTION
## What

`vi.fn().mockImplementation((opts: object) => opts)` — arrow function can't be called with `new`. When `lib/redis.ts` does `new Redis({ url, token })`, vitest throws:

> TypeError: (opts) => opts is not a constructor

> [vitest] The vi.fn() mock did not use 'function' or 'class' in its implementation

## Fix

Single-character change: arrow → regular function.

```diff
- mockRedisConstructor: vi.fn().mockImplementation((opts: object) => opts),
+ mockRedisConstructor: vi.fn().mockImplementation(function(opts: object) { return opts; }),
```

Regular functions return the opts object when called with `new` (since it's a non-null object return), which satisfies:
- `not.toBeNull()` — returned value is the opts object
- `toBe(second)` — module caches the result, both calls return same instance
- `toHaveBeenCalledWith({ url, token })` — args still recorded correctly

## Context

The TDZ crash was fixed in PR #705 (switched to object-capture via `vi.hoisted`). This PR fixes the remaining failure: 4 tests in the "when env vars are present" + `__resetRedisClientForTests` groups were still failing because the arrow mock can't be a constructor.

Closes #6 (font-size violations branch is separate — this is purely the redis test fix).

## Test plan
- [ ] CI passes (all redis unit tests green)
- [ ] No other test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)