### PR TITLE
test(tokens): add hex-in-className/style scan to design-tokens guard

### DIFF
--- a/lib/__tests__/design-tokens.test.ts
+++ b/lib/__tests__/design-tokens.test.ts
@@ -63,7 +63,27 @@ describe("No sub-16px arbitrary font sizes in source", () => {
     it(`${path.relative(ROOT, file)} has no text-[<16px]`, () => {
       const content = fs.readFileSync(file, "utf-8");
       const match = content.match(subMinFontRe);
-      if (match) throw new Error(`sub-16px font "${match[0]}" in ${path.relative(ROOT, file)}`);
+      if (match) {
+        throw new Error(
+          `Found sub-16px arbitrary text size "${match[0]}" in ${path.relative(ROOT, file)}`,
+        );
+      }
+    });
+  }
+});
+
+const hexInClassRe = /(?:className|style)=[^>]*#[0-9a-fA-F]{3,8}(?!\s*;)/;
+
+describe("No hardcoded hex colours in className/style", () => {
+  for (const file of SRC_FILES) {
+    it(`${path.relative(ROOT, file)} has no hex in className/style`, () => {
+      const content = fs.readFileSync(file, "utf-8");
+      const match = content.match(hexInClassRe);
+      if (match) {
+        throw new Error(
+          `Found hex colour in className/style in ${path.relative(ROOT, file)}: ${match[0].slice(0, 80)}`,
+        );
+      }
     });
   }
 });


### PR DESCRIPTION
## What

Extends `lib/__tests__/design-tokens.test.ts` to scan every `app/` and `components/` source file for hardcoded hex colour literals in `className` or `style` props.

## Why

The fix/issue6-font-size-violations branch included this test in `db2ab6d` but it was lost when the cherry-pick resolved to HEAD. Main already has the sub-16px font-size scanner; the hex scan is the natural companion rule.

## Verified

Ran `grep -rn "className.*#[0-9a-fA-F]\|style.*#[0-9a-fA-F]"` across `app/` and `components/` — zero matches. The existing hex literals (e.g. in `DesignSystemSettingsClient.tsx`'s default-values object) are in plain JS data, not in JSX attribute positions, so the regex does not match them.

## Test plan
- [ ] CI `test` passes (all per-file describe blocks green)
- [ ] No false positives from legitimate hex in data objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)