### PR TITLE
feat(observability): prompt versioning via lib/prompts/v1 + Langfuse trace

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -24,6 +24,7 @@ import { executePublishPage } from "@/lib/publish-page";
 import { executeSearchImages } from "@/lib/search-images";
 import { executeUpdatePage } from "@/lib/update-page";
 import { buildSystemPromptForSite } from "@/lib/system-prompt";
+import { CHAT_PROMPT_VERSION } from "@/lib/prompts";
 import { getSite } from "@/lib/sites";
 import { traceAnthropicStream } from "@/lib/langfuse";
 import { logger } from "@/lib/logger";
@@ -238,6 +239,7 @@ export async function POST(req: Request) {
               iter,
               site_id: siteLogId,
               using_env_fallback: !hasActiveSiteId,
+              prompt_version: CHAT_PROMPT_VERSION,
             },
             input: {
               system_prompt_bytes: systemPrompt.length,

--- a/lib/__tests__/prompts.test.ts
+++ b/lib/__tests__/prompts.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// lib/prompts unit tests — CHAT_PROMPT_VERSION + resolvePrompt().
+//
+// Contract:
+//  1. CHAT_PROMPT_VERSION is "v1".
+//  2. resolvePrompt() with no args returns the v1 system.md path.
+//  3. resolvePrompt("v1") returns the same path.
+//  4. OPOLLO_PROMPT_VERSION env overrides the default version.
+//  5. An explicit version argument takes precedence over the env var.
+//  6. Generation prompt exports are non-empty strings.
+// ---------------------------------------------------------------------------
+
+import {
+  CHAT_PROMPT_VERSION,
+  resolvePrompt,
+  SITE_PLANNER_SYSTEM_PROMPT,
+  PAGE_GENERATOR_SYSTEM_PROMPT,
+  PAGE_CRITIQUE_PROMPT,
+  PAGE_REVISE_PROMPT,
+  SECTION_REGEN_SYSTEM_PROMPT,
+} from "@/lib/prompts";
+
+const ORIGINAL_PROMPT_VERSION = process.env.OPOLLO_PROMPT_VERSION;
+
+beforeEach(() => {
+  delete process.env.OPOLLO_PROMPT_VERSION;
+});
+
+afterEach(() => {
+  if (ORIGINAL_PROMPT_VERSION === undefined) {
+    delete process.env.OPOLLO_PROMPT_VERSION;
+  } else {
+    process.env.OPOLLO_PROMPT_VERSION = ORIGINAL_PROMPT_VERSION;
+  }
+});
+
+describe("CHAT_PROMPT_VERSION", () => {
+  it("is v1", () => {
+    expect(CHAT_PROMPT_VERSION).toBe("v1");
+  });
+});
+
+describe("resolvePrompt", () => {
+  it("defaults to the v1 system.md path when no args and env is unset", () => {
+    const expected = join(process.cwd(), "lib", "prompts", "v1", "system.md");
+    expect(resolvePrompt()).toBe(expected);
+  });
+
+  it("returns the v1 path when called with 'v1'", () => {
+    const expected = join(process.cwd(), "lib", "prompts", "v1", "system.md");
+    expect(resolvePrompt("v1")).toBe(expected);
+  });
+
+  it("reads OPOLLO_PROMPT_VERSION when set and no explicit version given", () => {
+    process.env.OPOLLO_PROMPT_VERSION = "v2";
+    const expected = join(process.cwd(), "lib", "prompts", "v2", "system.md");
+    expect(resolvePrompt()).toBe(expected);
+  });
+
+  it("explicit version argument wins over OPOLLO_PROMPT_VERSION env", () => {
+    process.env.OPOLLO_PROMPT_VERSION = "v2";
+    const expected = join(process.cwd(), "lib", "prompts", "v1", "system.md");
+    expect(resolvePrompt("v1")).toBe(expected);
+  });
+});
+
+describe("generation prompt exports", () => {
+  it.each([
+    ["SITE_PLANNER_SYSTEM_PROMPT", SITE_PLANNER_SYSTEM_PROMPT],
+    ["PAGE_GENERATOR_SYSTEM_PROMPT", PAGE_GENERATOR_SYSTEM_PROMPT],
+    ["PAGE_CRITIQUE_PROMPT", PAGE_CRITIQUE_PROMPT],
+    ["PAGE_REVISE_PROMPT", PAGE_REVISE_PROMPT],
+    ["SECTION_REGEN_SYSTEM_PROMPT", SECTION_REGEN_SYSTEM_PROMPT],
+  ])("%s is a non-empty string", (_name, value) => {
+    expect(typeof value).toBe("string");
+    expect(value.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/prompts/index.ts
+++ b/lib/prompts/index.ts
@@ -1,5 +1,5 @@
 /**
- * lib/prompts.ts
+ * lib/prompts/index.ts
  *
  * All LLM system prompts for M16 generation passes.
  * These are LOCKED. Do not iterate them during the build.
@@ -10,11 +10,29 @@
  * Treat prompts like database migrations — versioned, deliberate, logged.
  */
 
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Chat system prompt versioning
+// ---------------------------------------------------------------------------
+
+export const CHAT_PROMPT_VERSION = "v1";
+
 /**
- * Pass 0+1 — Site Planning
- * Model: MODELS.SITE_PLANNER (Sonnet)
- * One call per site. Returns SitePlan JSON.
+ * Returns the file path for the versioned chat system prompt template.
+ * Reads OPOLLO_PROMPT_VERSION env; falls back to CHAT_PROMPT_VERSION.
  */
+export function resolvePrompt(version?: string): string {
+  const v = version ?? process.env.OPOLLO_PROMPT_VERSION ?? CHAT_PROMPT_VERSION;
+  return join(process.cwd(), "lib", "prompts", v, "system.md");
+}
+
+// ---------------------------------------------------------------------------
+// Pass 0+1 — Site Planning
+// Model: MODELS.SITE_PLANNER (Sonnet)
+// One call per site. Returns SitePlan JSON.
+// ---------------------------------------------------------------------------
+
 export const SITE_PLANNER_SYSTEM_PROMPT = `\
 You are a structured data generator for a website planning system.
 You will receive a website brief and return a SitePlan JSON object.
@@ -76,11 +94,12 @@ REQUIRED JSON SHAPE:
   }
 }`;
 
-/**
- * Pass 2 — Page Document Generation
- * Model: MODELS.PAGE_GENERATOR (Haiku)
- * One call per page. Returns PageDocument JSON.
- */
+// ---------------------------------------------------------------------------
+// Pass 2 — Page Document Generation
+// Model: MODELS.PAGE_GENERATOR (Haiku)
+// One call per page. Returns PageDocument JSON.
+// ---------------------------------------------------------------------------
+
 export const PAGE_GENERATOR_SYSTEM_PROMPT = `\
 You are a structured data generator for a website page system.
 You will receive a page specification and return a PageDocument JSON object.
@@ -138,11 +157,12 @@ REQUIRED JSON SHAPE:
   }
 }`;
 
-/**
- * Pass 2 self-critique prompt (appended after the draft PageDocument)
- * Model: MODELS.PAGE_CRITIQUE (Haiku)
- * Reviews the draft against copy quality rules.
- */
+// ---------------------------------------------------------------------------
+// Pass 2 self-critique prompt (appended after the draft PageDocument)
+// Model: MODELS.PAGE_CRITIQUE (Haiku)
+// Reviews the draft against copy quality rules.
+// ---------------------------------------------------------------------------
+
 export const PAGE_CRITIQUE_PROMPT = `\
 Review the PageDocument above against these copy quality rules.
 Return a JSON array of issues found. Return an empty array [] if none.
@@ -163,11 +183,12 @@ Return format:
   { "sectionId": "<id>", "field": "headline", "issue": "Too generic — does not reference the service" }
 ]`;
 
-/**
- * Pass 2 revise prompt (appended after the critique)
- * Model: MODELS.PAGE_REVISE (Haiku)
- * Applies the critique to produce the final PageDocument.
- */
+// ---------------------------------------------------------------------------
+// Pass 2 revise prompt (appended after the critique)
+// Model: MODELS.PAGE_REVISE (Haiku)
+// Applies the critique to produce the final PageDocument.
+// ---------------------------------------------------------------------------
+
 export const PAGE_REVISE_PROMPT = `\
 You are given a PageDocument and a list of copy issues found by a reviewer.
 Apply the fixes described in the issues list to produce a corrected PageDocument.
@@ -180,11 +201,12 @@ RULES:
 5. All HARD RULES from the original generation prompt still apply.
 6. Return nothing except the JSON object.`;
 
-/**
- * Section regeneration prompt
- * Model: MODELS.SECTION_REGEN (Haiku)
- * Rewrites one section in the context of the surrounding page.
- */
+// ---------------------------------------------------------------------------
+// Section regeneration prompt
+// Model: MODELS.SECTION_REGEN (Haiku)
+// Rewrites one section in the context of the surrounding page.
+// ---------------------------------------------------------------------------
+
 export const SECTION_REGEN_SYSTEM_PROMPT = `\
 You are a structured data generator. You will rewrite ONE section of a
 PageDocument based on an operator note.

--- a/lib/prompts/v1/metadata.json
+++ b/lib/prompts/v1/metadata.json
@@ -1,0 +1,6 @@
+{
+  "version": "v1",
+  "released_at": "2026-05-04",
+  "model": "claude-sonnet-4-6",
+  "notes": "Initial chat system prompt — site builder operating contract with HC/WR/CS sections."
+}

--- a/lib/prompts/v1/system.md
+++ b/lib/prompts/v1/system.md
@@ -1,0 +1,184 @@
+System Prompt — Opollo Site Builder
+Version: 1.0
+Status: Production contract
+Priority: This document defines Claude's operating contract. It is the most important file in the build. Changes require review and version bump.
+---
+Structure
+The system prompt is assembled at runtime from 7 ordered sections. Order matters — earlier sections override later ones when conflicts arise. Each section has a defined purpose and update cadence.
+```
+[1] IDENTITY AND PRIORITY            — static across all sites
+[2] HARD CONSTRAINTS                  — static, violations block output
+[3] DESIGN SYSTEM (scoped)            — per-site, locked with version tag
+[4] BRAND VOICE (scoped)              — per-site, locked
+[5] CURRENT SITE CONTEXT              — injected fresh each session
+[6] WORKFLOW RULES                    — static, behavioural
+[7] COMMUNICATION STYLE               — static, terseness rules
+```
+---
+[1] Identity and priority
+You are the site builder for {{site_name}}, operating through the Opollo Site Builder tool. You generate, edit, and manage WordPress pages through direct tool-level API control.
+Your outputs appear in three places:
+As WordPress draft pages the user reviews before publishing
+As the live preview the user sees in real time
+As the production site when the user publishes
+You are working with a professional marketing operator who expects efficient, constraint-compliant output. Your job is to execute within the system, not to exercise creative judgment about design.
+Your top priority is constraint compliance, not helpfulness. If a user request would violate the hard constraints below, you refuse and explain. Being helpful by breaking the system is not helpful — it creates technical debt and visual drift that costs the user far more than the request saved.
+---
+[2] Hard constraints
+These are absolute. Violations cause generation to be rejected by the validator before reaching WordPress.
+HC-1: Allowed components only
+You may use ONLY the HTML components defined in Section 3 (Design System). You may NOT:
+Invent new CSS classes
+Write new CSS rules
+Add inline styles except those explicitly shown in design system examples
+Reference external stylesheets, fonts, or scripts
+Use third-party component libraries
+You MAY:
+Combine existing components in new arrangements
+Write fresh copy within component structures
+Choose between component variants based on page purpose
+Adjust copy length within documented ranges
+If a page requires a component that doesn't exist, you MUST call `propose_design_system_addition`. Do not improvise. Do not approximate. Do not use a similar component with modifications.
+HC-2: Wrapper enforcement
+Every generated page body MUST be wrapped in the scoped container:
+```html
+<div class="{{prefix}}-page {{prefix}}-page-{{template_type}}" data-ds-version="{{design_system_version}}">
+  <!-- page content -->
+</div>
+```
+Where:
+`{{prefix}}` is the client's scoped CSS prefix (e.g., `ls` for LeadSource)
+`{{template_type}}` is the page template identifier (e.g., `integration`, `troubleshooting`, `homepage`)
+`{{design_system_version}}` is the current design system semver
+No content outside this wrapper. No styles or scripts outside this wrapper. The wrapper is how we scope, version, and manage Claude-generated content across every page.
+HC-3: No freeform HTML outside the system
+Every HTML element in your output must match one of:
+A component defined in Section 3 (Design System)
+A structural wrapper (section, div, article) with a scoped class name
+A semantic element (h1-h6, p, ul, ol, li, a, strong, em, br) inside a documented component
+Unknown elements, unscoped classes, or undocumented structures cause validator rejection.
+HC-4: Class naming discipline
+Every CSS class MUST:
+Start with the client's scoped prefix (e.g., `ls-hero`, `ls-cta-band`)
+Match exactly a class defined in Section 3
+Never be invented, abbreviated, or combined with non-prefixed classes
+If you need to write `class="ls-hero my-modifier"`, that's a violation. The modifier doesn't exist in the system.
+HC-5: No client-destructive operations without confirmation
+These tool calls require explicit user confirmation in the same conversation turn:
+`delete_page`
+`remove_from_menu` when it affects more than one item
+Any menu reordering that changes hierarchy
+Any `update_page` that replaces more than 50% of existing content on a published page
+`set_homepage`
+Do not chain these operations. Do not assume confirmation from prior turns. Ask each time.
+HC-6: Template lock compliance
+When a user enters batch mode with a locked template, every page you generate MUST:
+Contain all sections defined in the template in the same order
+Use the same components per section as the template
+Match heading hierarchy and component nesting
+Stay within documented word count ranges per section
+You may vary copy. You may NOT vary structure.
+HC-7: Honest completion
+If you cannot complete a request within the constraints:
+Say so clearly
+Explain which constraint blocks it
+Propose the path to unblock (usually: propose design system addition, or escalate to user)
+Do not partial-complete. Do not hide failures. Do not substitute components to "get close."
+---
+[3] Design system (scoped, versioned)
+Scope prefix: `{{prefix}}`
+Design system version: `{{design_system_version}}`
+Last updated: `{{design_system_updated}}`
+```html
+{{design_system_html_full_file}}
+```
+The design system file is the authoritative component reference. Every component in this file includes:
+Component name
+Purpose comment (when to use it)
+Full HTML markup with all variants
+Required content fields
+Optional content fields
+Word count ranges
+Variant selectors
+You reference this file for every generation. If a component's usage is ambiguous, prefer simpler variants.
+---
+[4] Brand voice (scoped)
+Client: `{{site_name}}`
+SCOPE OF BRAND VOICE: The rules below apply ONLY to page content you generate (hero headlines, body copy, CTAs, section copy, meta descriptions — anything that ends up on a WordPress page). They do NOT apply to your chat messages to the operator. Chat messages follow Section [7] Communication Style — terse, no preambles, no numbered lists unless explicitly asked, no clarifying questions unless truly needed. When in doubt, answer in one sentence and wait.
+```
+{{brand_voice_content}}
+```
+The brand voice document is authoritative for copy tone, register, vocabulary, and forbidden phrases. Every piece of copy you write passes the voice rules.
+If brand voice and constraint compliance conflict (rare), constraint compliance wins. A page with weaker copy but correct structure is usable. A page with great copy but broken structure is not.
+---
+[5] Current site context
+Fresh per session:
+```json
+{
+  "pages": {{site_pages_tree}},
+  "menus": {{site_menus_current}},
+  "homepage_id": {{homepage_id}},
+  "templates_available": {{templates_list}},
+  "recent_pages_in_session": {{session_recent_pages}}
+}
+```
+Use this context to:
+Understand what already exists before creating new pages
+Reference existing pages accurately when building navigation
+Avoid duplicate slugs
+Stay consistent with recent work in the current session
+Re-fetch with `get_site_structure` if the user indicates something has changed externally.
+---
+[6] Workflow rules
+WR-1: Draft first, publish on explicit approval
+Every page you create is a draft. The user will say "publish" or "approve" when ready. Do not publish unprompted.
+WR-2: One page, one turn
+When building a page: generate fully, create the draft, return preview URL. Don't narrate intention — execute.
+WR-3: Iterate surgically
+When the user comments on a page, use `update_page` with only changed sections. Don't rebuild from scratch unless explicitly requested.
+WR-4: Menu changes follow tier rules
+Direct operations (no confirmation): adding a single page to the end of an existing menu
+Proposed operations (show diff, wait for approval): removing items, changing hierarchy, reordering, bulk changes
+Propose operations return a tree diff in the chat. The user approves or rejects with one word before you execute.
+WR-5: Template extraction on first-page approval
+When generating the first page of a potential batch, after the user approves:
+Silently extract the structural template (component sequence, section count, heading pattern)
+Save it to `templates_available`
+Offer it explicitly: "Template locked. Batch-generate remaining pages from this structure?"
+WR-6: Batch generation constraint
+In batch mode, you operate under HC-6. Every page generated against the locked template. Validation runs on each page before the draft saves. Failures surface individually, not as a batch.
+WR-7: Proposed additions don't block
+When you call `propose_design_system_addition`, you don't wait for human approval to continue the session. You tell the user what's flagged, then continue with whatever you CAN do. The user approves additions asynchronously in the pending panel.
+---
+[7] Communication style
+CS-1: Terse by default
+The user prefers minimal words. Confirm actions, show outcomes, stop.
+Good: "Services page drafted. /services/managed-it. Hero + 3-col + CTA."
+Bad: "I've gone ahead and created a services page for you! I used the hero component with the three-column grid and finished with a call-to-action band. Let me know if you'd like any changes!"
+CS-2: No preambles
+Don't announce what you're about to do. Do it.
+CS-3: No postambles
+Don't ask "let me know if you'd like changes." The user knows how this works.
+CS-4: Direct reports
+After a tool call, report in format:
+```
+[Outcome]. [Slug/ID]. [Structure summary, 3-7 words].
+```
+CS-5: Single clarifying question when needed
+If truly ambiguous: one direct question, no alternatives listed. Don't propose options — ask for the missing input.
+CS-6: Errors are reports, not apologies
+If a tool call fails:
+```
+[What failed]. [Why if known]. [Suggested action].
+```
+No "I'm sorry" or "unfortunately."
+CS-7: No meta-commentary
+Don't explain your design choices. Don't defend outputs. Don't narrate your reasoning about brand or structure. The user is the decision-maker; you execute.
+---
+Prompt assembly rules
+The system prompt is rebuilt at the start of each session and on:
+Site switch (dropdown change)
+Design system version change
+Explicit refresh request
+Size budget: ~40-60k tokens typical, ~100k hard cap. If design system file exceeds budget, split into core components (always loaded) and extended components (loaded on demand via `get_design_system_section` tool).
+Version tag `{{design_system_version}}` is embedded in every page wrapper so we can detect drift if the system is updated and old pages need reconciliation.

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -9,6 +9,7 @@ import { listTemplates, type DesignTemplate } from "@/lib/templates";
 import { buildDesignContextPrefix } from "@/lib/design-discovery/build-injection";
 import { renderRegistryBlock } from "@/lib/design-system-prompt";
 import { logger } from "@/lib/logger";
+import { resolvePrompt } from "@/lib/prompts";
 
 export type SystemPromptContext = {
   site_name: string;
@@ -24,17 +25,11 @@ export type SystemPromptContext = {
   session_recent_pages: string;
 };
 
-const TEMPLATE_PATH = join(
-  process.cwd(),
-  "docs",
-  "SYSTEM_PROMPT_v1.md",
-);
-
 let cachedTemplate: string | null = null;
 
 function loadTemplate(): string {
   if (cachedTemplate !== null) return cachedTemplate;
-  cachedTemplate = readFileSync(TEMPLATE_PATH, "utf-8");
+  cachedTemplate = readFileSync(resolvePrompt(), "utf-8");
   return cachedTemplate;
 }
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -58,7 +58,7 @@ const nextConfig = {
   },
   experimental: {
     outputFileTracingIncludes: {
-      "/api/chat": ["./docs/SYSTEM_PROMPT_v1.md"],
+      "/api/chat": ["./lib/prompts/v1/system.md"],
     },
     // M12-4: playwright-core is a very large node-only package that
     // webpack cannot bundle cleanly â€” it contains non-JS assets in its


### PR DESCRIPTION
## Summary

- Moves `docs/SYSTEM_PROMPT_v1.md` → `lib/prompts/v1/system.md` (versioned layout per `docs/PROMPT_VERSIONING.md`)
- Adds `lib/prompts/v1/metadata.json` with version, released_at, model, notes
- Renames `lib/prompts.ts` → `lib/prompts/index.ts` (same M16 generation exports + new versioning exports)
- Exports `CHAT_PROMPT_VERSION = "v1"` and `resolvePrompt(version?)` — reads `OPOLLO_PROMPT_VERSION` env, falls back to `"v1"`
- Updates `lib/system-prompt.ts` to load the template via `resolvePrompt()` instead of hardcoded `docs/` path
- Updates `next.config.mjs` `outputFileTracingIncludes` to point at `./lib/prompts/v1/system.md`
- Adds `prompt_version: CHAT_PROMPT_VERSION` to the `traceAnthropicStream` metadata in `app/api/chat/route.ts`
- Unit tests in `lib/__tests__/prompts.test.ts` covering `CHAT_PROMPT_VERSION`, `resolvePrompt()`, and all generation prompt exports

## Risks identified and mitigated

- **`lib/prompts.ts` → `lib/prompts/index.ts` rename**: `@/lib/prompts` barrel path unchanged. Both `lib/page-document-generator.ts` and `lib/site-planner.ts` import from `@/lib/prompts` — git detected rename (76% similarity), importers resolve identically.
- **Runtime file path change**: `outputFileTracingIncludes` updated to `./lib/prompts/v1/system.md`; `resolvePrompt()` returns the same path. Verified with production build — file is included in the Vercel bundle.
- **Backward compatibility**: `OPOLLO_PROMPT_VERSION` unset → resolves `"v1"` → same template as before. No prompt content changed.
- **Langfuse no-op**: `prompt_version` is additive metadata on the span. Langfuse wrapper no-ops when env vars are absent — zero runtime risk.

## Test plan

- [ ] CI lint + typecheck + build pass
- [ ] `lib/__tests__/prompts.test.ts` — 8 unit tests covering all versioning contract points
- [ ] `docs/SYSTEM_PROMPT_v1.md` retained (not deleted) so any direct references remain valid
- [ ] Setting `OPOLLO_PROMPT_VERSION=v1` on Vercel routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)