### PR TITLE
feat(health): add Upstash Redis reachability probe to /api/health

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import {
   checkBudgetResetBacklog,
+  checkRedis,
   checkSupabase,
 } from "@/lib/health-checks";
 import { logger } from "@/lib/logger";
@@ -57,12 +58,16 @@ export async function GET(): Promise<NextResponse> {
   // an error-shaped result), we still return a structured 503 instead
   // of an unhandled-rejection 500 with no body shape.
   try {
-    const [supabase, backlog] = await Promise.all([
+    const [supabase, backlog, redis] = await Promise.all([
       checkSupabase(),
       checkBudgetResetBacklog(),
+      checkRedis(),
     ]);
 
-    const allOk = supabase.result === "ok" && backlog.result === "ok";
+    const allOk =
+      supabase.result === "ok" &&
+      backlog.result === "ok" &&
+      redis.result === "ok";
     const body = {
       status: allOk ? "ok" : "degraded",
       checks: {
@@ -74,6 +79,10 @@ export async function GET(): Promise<NextResponse> {
         budget_reset_backlog_sample: backlog.sample,
         budget_reset_backlog_latency_ms: backlog.latency_ms,
         ...(backlog.error ? { budget_reset_backlog_error: backlog.error } : {}),
+        redis: redis.result,
+        redis_configured: redis.configured,
+        redis_latency_ms: redis.latency_ms,
+        ...(redis.error ? { redis_error: redis.error } : {}),
       },
       build: {
         commit: process.env.VERCEL_GIT_COMMIT_SHA ?? "local",

--- a/lib/__tests__/health-route-degraded.test.ts
+++ b/lib/__tests__/health-route-degraded.test.ts
@@ -3,16 +3,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // ---------------------------------------------------------------------------
 // Degraded-branch tests for GET /api/health (M15-6 #17).
 //
-// The happy path (both probes ok → 200) is covered in health-route.test.ts.
+// The happy path (all probes ok → 200) is covered in health-route.test.ts.
 // This file covers:
 //   - supabase probe fails → 503 degraded
 //   - budget_reset_backlog probe fails → 503 degraded
-//   - both probes fail → 503 degraded
+//   - redis probe fails (configured) → 503 degraded
+//   - redis not configured → still 200 ok
+//   - all probes fail → 503 degraded
 //   - a probe throws → outer catch returns structured 503
 // ---------------------------------------------------------------------------
 
 const mockCheckSupabase = vi.hoisted(() => vi.fn());
 const mockCheckBudgetResetBacklog = vi.hoisted(() => vi.fn());
+const mockCheckRedis = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/health-checks", async () => {
   const actual = await vi.importActual<typeof import("@/lib/health-checks")>(
@@ -22,6 +25,7 @@ vi.mock("@/lib/health-checks", async () => {
     ...actual,
     checkSupabase: mockCheckSupabase,
     checkBudgetResetBacklog: mockCheckBudgetResetBacklog,
+    checkRedis: mockCheckRedis,
   };
 });
 
@@ -29,10 +33,13 @@ import { GET } from "@/app/api/health/route";
 
 const SUPABASE_OK = { result: "ok" as const, latency_ms: 5 };
 const BACKLOG_OK = { result: "ok" as const, count: 0, sample: [], latency_ms: 8 };
+const REDIS_OK = { result: "ok" as const, latency_ms: 2, configured: true };
+const REDIS_UNCONFIGURED = { result: "ok" as const, latency_ms: 0, configured: false };
 
 beforeEach(() => {
   mockCheckSupabase.mockReset().mockResolvedValue(SUPABASE_OK);
   mockCheckBudgetResetBacklog.mockReset().mockResolvedValue(BACKLOG_OK);
+  mockCheckRedis.mockReset().mockResolvedValue(REDIS_OK);
 });
 
 describe("GET /api/health — degraded branches", () => {
@@ -51,6 +58,7 @@ describe("GET /api/health — degraded branches", () => {
     expect(body.checks.supabase).toBe("fail");
     expect(body.checks.supabase_error).toBe("connection refused");
     expect(body.checks.budget_reset_backlog).toBe("ok");
+    expect(body.checks.redis).toBe("ok");
   });
 
   it("503 when budget_reset_backlog probe returns fail", async () => {
@@ -70,13 +78,52 @@ describe("GET /api/health — degraded branches", () => {
     expect(body.checks.budget_reset_backlog).toBe("fail");
     expect(body.checks.budget_reset_backlog_count).toBe(2);
     expect(body.checks.budget_reset_backlog_sample).toEqual(["site-a", "site-b"]);
+    expect(body.checks.redis).toBe("ok");
   });
 
-  it("503 when both probes fail", async () => {
+  it("503 when redis probe returns fail (configured but unreachable)", async () => {
+    mockCheckRedis.mockResolvedValue({
+      result: "fail",
+      latency_ms: 3,
+      configured: true,
+      error: "ECONNREFUSED",
+    });
+
+    const res = await GET();
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.status).toBe("degraded");
+    expect(body.checks.supabase).toBe("ok");
+    expect(body.checks.budget_reset_backlog).toBe("ok");
+    expect(body.checks.redis).toBe("fail");
+    expect(body.checks.redis_configured).toBe(true);
+    expect(body.checks.redis_error).toBe("ECONNREFUSED");
+  });
+
+  it("200 when redis is not configured (unconfigured = not expected = ok)", async () => {
+    mockCheckRedis.mockResolvedValue(REDIS_UNCONFIGURED);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(body.checks.redis).toBe("ok");
+    expect(body.checks.redis_configured).toBe(false);
+  });
+
+  it("503 when both supabase and redis fail", async () => {
     mockCheckSupabase.mockResolvedValue({
       result: "fail",
       latency_ms: 5,
       error: "db unreachable",
+    });
+    mockCheckRedis.mockResolvedValue({
+      result: "fail",
+      latency_ms: 3,
+      configured: true,
+      error: "redis unreachable",
     });
     mockCheckBudgetResetBacklog.mockResolvedValue({
       result: "fail",
@@ -94,6 +141,8 @@ describe("GET /api/health — degraded branches", () => {
     expect(body.checks.supabase).toBe("fail");
     expect(body.checks.budget_reset_backlog).toBe("fail");
     expect(body.checks.budget_reset_backlog_error).toBe("query timeout");
+    expect(body.checks.redis).toBe("fail");
+    expect(body.checks.redis_error).toBe("redis unreachable");
   });
 
   it("503 when a probe throws — outer catch returns structured degraded body", async () => {
@@ -110,7 +159,7 @@ describe("GET /api/health — degraded branches", () => {
     expect(typeof body.timestamp).toBe("string");
   });
 
-  it("200 when both probes return ok (sanity — mocked happy path)", async () => {
+  it("200 when all probes return ok (sanity — mocked happy path)", async () => {
     const res = await GET();
 
     expect(res.status).toBe(200);
@@ -118,5 +167,6 @@ describe("GET /api/health — degraded branches", () => {
     expect(body.status).toBe("ok");
     expect(body.checks.supabase).toBe("ok");
     expect(body.checks.budget_reset_backlog).toBe("ok");
+    expect(body.checks.redis).toBe("ok");
   });
 });

--- a/lib/health-checks.ts
+++ b/lib/health-checks.ts
@@ -1,4 +1,5 @@
 import { getServiceRoleClient } from "@/lib/supabase";
+import { getRedisClient } from "@/lib/redis";
 
 // ---------------------------------------------------------------------------
 // Health-probe helpers. Each function returns a bounded, typed envelope the
@@ -33,6 +34,35 @@ export async function checkSupabase(): Promise<{
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { result: "fail", latency_ms: Date.now() - start, error: message };
+  }
+}
+
+// Redis (Upstash) reachability probe.
+// Returns ok immediately when UPSTASH env vars are absent — the rate limiter
+// already fails open in that case, so unconfigured is not a degraded state.
+// When vars are present but PING fails, the caller should surface "degraded".
+export async function checkRedis(): Promise<{
+  result: CheckResult;
+  latency_ms: number;
+  configured: boolean;
+  error?: string;
+}> {
+  const start = Date.now();
+  const client = getRedisClient();
+  if (!client) {
+    return { result: "ok", latency_ms: 0, configured: false };
+  }
+  try {
+    await client.ping();
+    return { result: "ok", latency_ms: Date.now() - start, configured: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      result: "fail",
+      latency_ms: Date.now() - start,
+      configured: true,
+      error: message,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `checkRedis()` to `lib/health-checks.ts` — PINGs Upstash when env vars are present; returns `ok` immediately when unconfigured (rate limiter already fails open, so unconfigured = expected, not degraded)
- Wires the probe into `app/api/health/route.ts` alongside the existing Supabase and budget-backlog probes — Redis failure flips `allOk` to false → 503 degraded
- Response body gains `redis`, `redis_configured`, `redis_latency_ms`, and optional `redis_error` fields
- Updates `lib/__tests__/health-route-degraded.test.ts` with `mockCheckRedis` + 3 new test cases: configured-fail, unconfigured-ok, all-fail

## Risks identified and mitigated

- **Fail-open preserved**: `getRedisClient()` returns null when env vars absent → probe short-circuits to `{ result: "ok", configured: false }`. No regression on prod deployments without Upstash provisioned.
- **No new env vars required**: probe reads `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` already documented in `.env.local.example`.
- **Degraded-only on configured failure**: operators who have Upstash provisioned but hit a transient outage will see 503 — matches the intent of the health contract (readiness = dependencies reachable).

## Test plan

- [ ] CI lint + typecheck + build pass
- [ ] Updated `health-route-degraded.test.ts` — 7 test cases covering all probe combinations

Closes the "(b) `/api/health` probe for Upstash reachability" follow-up from the rate-limiting BACKLOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)