### PR TITLE
fix(ux): sidebar button overflow + toast position

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -1058,6 +1058,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
           <div className="flex flex-col gap-2">
             <Button
               type="submit"
+              size="sm"
               className="w-full"
               disabled={primaryDisabled || submitting}
               title={
@@ -1071,6 +1072,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
             {publishMode !== "draft" && publishMode !== "pending" && (
               <Button
                 type="button"
+                size="sm"
                 variant="outline"
                 className="w-full"
                 disabled={!canSaveDraft || submitting}

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -27,7 +27,7 @@ import { Toaster as SonnerToaster } from "sonner";
 export function Toaster() {
   return (
     <SonnerToaster
-      position="bottom-right"
+      position="top-right"
       richColors
       closeButton
       duration={4000}


### PR DESCRIPTION
## Summary

Two targeted UX fixes from the platform audit follow-up:

- **Button text overflow** — The default Button variant applies `uppercase + text-base + font-bold + tracking-[0.05em]`. In the 260 px publish sidebar (w-full), "PUBLISH TO WORDPRESS" is ~238 px wide — wider than the 212 px available after `px-6` padding. Added `size="sm"` to both sidebar buttons in `BlogPostComposer` (primary and "Save draft"). `size="sm"` applies `h-8 px-4 text-sm`, giving ~228 px for text and leaving enough room for all label variants ("Publish to WordPress", "Schedule Post", "Submit for Review", "Save draft").

- **Toaster position** — Moved Sonner from `bottom-right` → `top-right`. Success confirmations ("Published to WordPress!" etc.) and any future error toasts now appear in the operator's primary scan path rather than the peripheral bottom corner.

## Context

This PR is stacked on top of `fix/platform-audit-remediation` (#726) which fixes:
- The 409 version_lock root cause (publish was silently failing)
- `formError` moved to top of form (errors now visible without scrolling)

Together these three changes fully resolve RECURRING-2 (post-publish dead-end):
1. The 409 error no longer occurs (version_lock fixed)
2. If any error does occur, it appears at the top of the form
3. Success confirmation + "View live" toast appears at top-right
4. Redirect lands on the post detail page with live WP preview iframe

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| `size="sm"` changes button height from h-10 to h-8 | Sidebar is already tight — smaller height is appropriate and matches the sidebar density. Confirm in Vercel preview. |
| Moving toaster to top-right conflicts with other UI | Admin header is top-left; sidebar is right edge. Top-right is a clean position with no known conflicts. |
| Stacked PR dependency on #726 | This PR will be rebased onto main after #726 merges. CI is expected green regardless since the changed files are independent of migrations/RLS. |

## Test plan

- [ ] Navigate to `/admin/posts/new` for a site with WP connected — confirm "Publish to WordPress" text fits without overflow in the sidebar
- [ ] Trigger a post publish — confirm toast appears top-right rather than bottom
- [ ] Confirm "Save draft" button also fits correctly at the sm size

🤖 Generated with [Claude Code](https://claude.com/claude-code)