### PR TITLE
Spec 03 PR 1: blog-styling extractor + wizard section

### DIFF
--- a/app/api/admin/sites/[id]/setup/extract/route.ts
+++ b/app/api/admin/sites/[id]/setup/extract/route.ts
@@ -2,7 +2,10 @@ import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
-import { extractDesignFromUrl } from "@/lib/copy-existing-extract";
+import {
+  extractBlogStyling,
+  extractDesignFromUrl,
+} from "@/lib/copy-existing-extract";
 import { readJsonBody, validationError } from "@/lib/http";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -21,6 +24,11 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const BodySchema = z
   .object({
     extra_pages: z.array(z.string().url()).max(5).optional(),
+    // Spec 03 §1.2 — operator-supplied blog post URLs for blog-styling
+    // extraction. Up to 3; same-origin filtering happens in the
+    // extractor itself, not here, so the wizard can surface "ignored
+    // due to different domain" notes uniformly.
+    blog_urls: z.array(z.string().url()).max(3).optional(),
   })
   .optional();
 
@@ -109,6 +117,17 @@ export async function POST(
   const result = await extractDesignFromUrl(site.wp_url, {
     existingPages: parsed.data?.extra_pages,
   });
+
+  // Spec 03 — secondary pass: if the operator supplied blog URLs, run
+  // the blog-styling extractor and attach the result to the design.
+  // No blog URLs → blog_styling stays absent, the wizard renders the
+  // section as empty + collapsed.
+  const blogUrls = parsed.data?.blog_urls ?? [];
+  if (result.ok && blogUrls.length > 0) {
+    const blog = await extractBlogStyling(site.wp_url, blogUrls);
+    result.design.blog_styling = blog.blog_styling;
+    result.notes = [...result.notes, ...blog.notes];
+  }
 
   return NextResponse.json(
     { ok: true, data: result, timestamp: new Date().toISOString() },

--- a/app/api/admin/sites/[id]/setup/extract/save/route.ts
+++ b/app/api/admin/sites/[id]/setup/extract/save/route.ts
@@ -23,6 +23,43 @@ const ColorSchema = z.string().trim().min(3).max(40).nullable();
 const FontSchema = z.string().trim().min(1).max(120).nullable();
 const ClassNameSchema = z.string().trim().min(1).max(120).nullable();
 
+// Spec 03 §1.4 — single-CSS-class-per-bucket regex. Operator-edited
+// values that include spaces or multiple class tokens get rejected
+// with a clear message. Null is allowed.
+const SingleCssClassSchema = z
+  .string()
+  .trim()
+  .max(120)
+  .regex(
+    /^[a-zA-Z_][a-zA-Z0-9_-]*$/,
+    "Bucket values must be a single CSS class name. Pick the most semantic one.",
+  )
+  .nullable();
+
+const BlogStylingSchema = z
+  .object({
+    source_blog_urls: z.array(z.string().url()).max(3),
+    article_container: SingleCssClassSchema,
+    paragraph: SingleCssClassSchema,
+    link_in_body: SingleCssClassSchema,
+    blockquote: SingleCssClassSchema,
+    unordered_list: SingleCssClassSchema,
+    ordered_list: SingleCssClassSchema,
+    list_item: SingleCssClassSchema,
+    figure: SingleCssClassSchema,
+    figcaption: SingleCssClassSchema,
+    code_inline: SingleCssClassSchema,
+    code_block: SingleCssClassSchema,
+    hr: SingleCssClassSchema,
+    article_h2: SingleCssClassSchema,
+    article_h3: SingleCssClassSchema,
+    article_h4: SingleCssClassSchema,
+    notes: z.array(z.string()).max(50),
+    extracted_at: z.string().datetime(),
+  })
+  .nullable()
+  .optional();
+
 const ExtractedDesignSchema = z.object({
   colors: z.object({
     primary: ColorSchema,
@@ -39,6 +76,7 @@ const ExtractedDesignSchema = z.object({
   visual_tone: z.string().trim().min(1).max(80),
   screenshot_url: z.string().url().nullable(),
   source_pages: z.array(z.string().url()).max(10),
+  blog_styling: BlogStylingSchema,
 });
 
 const ExtractedCssClassesSchema = z.object({

--- a/components/CopyExistingExtractionWizard.tsx
+++ b/components/CopyExistingExtractionWizard.tsx
@@ -1,12 +1,34 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { formatRelativeTime } from "@/lib/utils";
 
 type LayoutDensity = "compact" | "medium" | "spacious";
+
+type BlogStyling = {
+  source_blog_urls: string[];
+  article_container: string | null;
+  paragraph: string | null;
+  link_in_body: string | null;
+  blockquote: string | null;
+  unordered_list: string | null;
+  ordered_list: string | null;
+  list_item: string | null;
+  figure: string | null;
+  figcaption: string | null;
+  code_inline: string | null;
+  code_block: string | null;
+  hr: string | null;
+  article_h2: string | null;
+  article_h3: string | null;
+  article_h4: string | null;
+  notes: string[];
+  extracted_at: string;
+};
 
 type ExtractedDesign = {
   colors: {
@@ -21,6 +43,7 @@ type ExtractedDesign = {
   visual_tone: string;
   screenshot_url: string | null;
   source_pages: string[];
+  blog_styling?: BlogStyling | null;
 };
 
 type ExtractedCssClasses = {
@@ -44,7 +67,35 @@ const EMPTY_DESIGN: ExtractedDesign = {
   visual_tone: "Neutral",
   screenshot_url: null,
   source_pages: [],
+  blog_styling: null,
 };
+
+const BLOG_STYLING_BUCKETS = [
+  { group: "Container", keys: ["article_container"] as const },
+  { group: "Text", keys: ["paragraph", "link_in_body"] as const },
+  { group: "Headings", keys: ["article_h2", "article_h3", "article_h4"] as const },
+  { group: "Lists", keys: ["unordered_list", "ordered_list", "list_item"] as const },
+  { group: "Media", keys: ["figure", "figcaption"] as const },
+  { group: "Block elements", keys: ["blockquote", "hr"] as const },
+  { group: "Code", keys: ["code_inline", "code_block"] as const },
+] as const;
+
+type BlogStylingKey =
+  | "article_container"
+  | "paragraph"
+  | "link_in_body"
+  | "blockquote"
+  | "unordered_list"
+  | "ordered_list"
+  | "list_item"
+  | "figure"
+  | "figcaption"
+  | "code_inline"
+  | "code_block"
+  | "hr"
+  | "article_h2"
+  | "article_h3"
+  | "article_h4";
 
 const EMPTY_CLASSES: ExtractedCssClasses = {
   container: null,
@@ -75,6 +126,7 @@ export function CopyExistingExtractionWizard({
   existingClasses: unknown;
 }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const seededDesign = isExtractedDesign(existingDesign) ? existingDesign : null;
   const seededClasses = isExtractedCssClasses(existingClasses) ? existingClasses : null;
   const [design, setDesign] = useState<ExtractedDesign>(seededDesign ?? EMPTY_DESIGN);
@@ -88,6 +140,79 @@ export function CopyExistingExtractionWizard({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  // Spec 03 §1.3 — blog-styling sub-flow state.
+  const [blogStylingExpanded, setBlogStylingExpanded] = useState<boolean>(
+    () => searchParams?.get("focus") === "blog-styling",
+  );
+  const [blogUrls, setBlogUrls] = useState<[string, string, string]>([
+    seededDesign?.blog_styling?.source_blog_urls?.[0] ?? "",
+    seededDesign?.blog_styling?.source_blog_urls?.[1] ?? "",
+    seededDesign?.blog_styling?.source_blog_urls?.[2] ?? "",
+  ]);
+  const [blogExtracting, setBlogExtracting] = useState(false);
+
+  // Auto-expand the section when ?focus=blog-styling lands in the URL,
+  // even after the initial render (e.g., after the operator clicks the
+  // preflight banner link from another page).
+  useEffect(() => {
+    if (searchParams?.get("focus") === "blog-styling") {
+      setBlogStylingExpanded(true);
+    }
+  }, [searchParams]);
+
+  function setBlogUrl(idx: 0 | 1 | 2, value: string) {
+    setBlogUrls((prev) => {
+      const next = [...prev] as [string, string, string];
+      next[idx] = value;
+      return next;
+    });
+  }
+
+  function setBlogStylingValue(key: BlogStylingKey, value: string) {
+    setDesign((prev) => {
+      const current: BlogStyling = prev.blog_styling ?? {
+        source_blog_urls: blogUrls.filter((u) => u.trim().length > 0),
+        article_container: null,
+        paragraph: null,
+        link_in_body: null,
+        blockquote: null,
+        unordered_list: null,
+        ordered_list: null,
+        list_item: null,
+        figure: null,
+        figcaption: null,
+        code_inline: null,
+        code_block: null,
+        hr: null,
+        article_h2: null,
+        article_h3: null,
+        article_h4: null,
+        notes: [],
+        extracted_at: new Date().toISOString(),
+      };
+      const next: BlogStyling = { ...current, [key]: value.trim() || null };
+      return { ...prev, blog_styling: next };
+    });
+  }
+
+  // Same-origin client-side check for the blog-URL inputs.
+  function blogUrlSameOrigin(value: string): boolean {
+    if (!value.trim()) return true;
+    try {
+      const candidate = new URL(value).hostname.toLowerCase();
+      const primary = new URL(siteUrl).hostname.toLowerCase();
+      // Subdomains allowed: candidate must end with primary's
+      // registrable-ish suffix. Conservative check: same hostname OR
+      // shares the trailing 2+ labels.
+      if (candidate === primary) return true;
+      const candidateSuffix = candidate.split(".").slice(-2).join(".");
+      const primarySuffix = primary.split(".").slice(-2).join(".");
+      return candidateSuffix === primarySuffix;
+    } catch {
+      return false;
+    }
+  }
 
   function parseExtraPages(text: string): string[] {
     return text
@@ -107,6 +232,7 @@ export function CopyExistingExtractionWizard({
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           extra_pages: parseExtraPages(extraPagesText),
+          blog_urls: blogUrls.filter((u) => u.trim().length > 0),
         }),
       });
       const payload = (await res.json().catch(() => null)) as
@@ -130,6 +256,59 @@ export function CopyExistingExtractionWizard({
       setError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setExtracting(false);
+    }
+  }
+
+  async function runBlogStylingExtraction() {
+    setBlogExtracting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/sites/${siteId}/setup/extract`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          extra_pages: parseExtraPages(extraPagesText),
+          blog_urls: blogUrls.filter((u) => u.trim().length > 0),
+        }),
+      });
+      const payload = (await res.json().catch(() => null)) as
+        | { ok: true; data: ExtractionResponse }
+        | { ok: false; error: { code: string; message: string } }
+        | null;
+      if (!res.ok || !payload?.ok) {
+        setError(
+          payload && payload.ok === false
+            ? payload.error.message
+            : `Blog-styling extraction failed (HTTP ${res.status}).`,
+        );
+        return;
+      }
+      const result = payload.data;
+      // Merge blog_styling into existing design without replacing the
+      // landing-page extraction. If the design itself was empty
+      // (operator hadn't run primary extraction yet), seed it from the
+      // result.
+      setDesign((prev) => ({
+        ...result.design,
+        // preserve operator-edited values on existing fields when they
+        // had results; only the blog_styling sub-tree is the new info.
+        colors: hasResults ? prev.colors : result.design.colors,
+        fonts: hasResults ? prev.fonts : result.design.fonts,
+        layout_density: hasResults ? prev.layout_density : result.design.layout_density,
+        visual_tone: hasResults ? prev.visual_tone : result.design.visual_tone,
+        screenshot_url: hasResults ? prev.screenshot_url : result.design.screenshot_url,
+        source_pages: hasResults ? prev.source_pages : result.design.source_pages,
+        blog_styling: result.design.blog_styling ?? null,
+      }));
+      if (!hasResults) {
+        setCssClasses(result.css_classes);
+        setHasResults(true);
+      }
+      setNotes(result.notes);
+    } catch (err) {
+      setError(`Network error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBlogExtracting(false);
     }
   }
 
@@ -361,6 +540,19 @@ export function CopyExistingExtractionWizard({
         </section>
       )}
 
+      <BlogStylingSection
+        siteUrl={siteUrl}
+        expanded={blogStylingExpanded}
+        setExpanded={setBlogStylingExpanded}
+        blogUrls={blogUrls}
+        setBlogUrl={setBlogUrl}
+        sameOrigin={blogUrlSameOrigin}
+        blogStyling={design.blog_styling ?? null}
+        setBlogStylingValue={setBlogStylingValue}
+        extracting={blogExtracting}
+        runExtraction={runBlogStylingExtraction}
+      />
+
       {error && (
         <Alert variant="destructive" title="Couldn't complete that step">
           {error}
@@ -407,5 +599,163 @@ function ClassInput({
         data-testid={`copy-existing-class-${label.toLowerCase()}`}
       />
     </label>
+  );
+}
+
+function BlogStylingSection({
+  siteUrl,
+  expanded,
+  setExpanded,
+  blogUrls,
+  setBlogUrl,
+  sameOrigin,
+  blogStyling,
+  setBlogStylingValue,
+  extracting,
+  runExtraction,
+}: {
+  siteUrl: string;
+  expanded: boolean;
+  setExpanded: (next: boolean) => void;
+  blogUrls: [string, string, string];
+  setBlogUrl: (idx: 0 | 1 | 2, value: string) => void;
+  sameOrigin: (value: string) => boolean;
+  blogStyling: BlogStyling | null;
+  setBlogStylingValue: (key: BlogStylingKey, value: string) => void;
+  extracting: boolean;
+  runExtraction: () => Promise<void>;
+}) {
+  const hasAnyUrl = blogUrls.some((u) => u.trim().length > 0);
+  const ageLabel =
+    blogStyling?.extracted_at
+      ? `Calibrated ${formatRelativeTime(blogStyling.extracted_at)}`
+      : null;
+  void siteUrl; // referenced via sameOrigin closure
+  return (
+    <section
+      className="rounded-md border bg-background p-4"
+      data-testid="copy-existing-blog-styling"
+    >
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <button
+            type="button"
+            onClick={() => setExpanded(!expanded)}
+            className="text-sm font-semibold hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+            data-testid="blog-styling-toggle"
+            aria-expanded={expanded}
+          >
+            Blog styling (optional) {expanded ? "▾" : "▸"}
+          </button>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Calibrate how blog posts are styled on your existing site
+          </p>
+          {ageLabel && (
+            <p className="mt-1 text-sm text-muted-foreground">{ageLabel}</p>
+          )}
+        </div>
+      </header>
+
+      {expanded && (
+        <div className="mt-4 space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Paste 1–3 example blog post URLs from this site. We&apos;ll
+            learn how your blog posts are styled and apply that to
+            generated content. Optional but recommended for sites that
+            publish blogs.
+          </p>
+
+          <div className="space-y-2">
+            {[0, 1, 2].map((i) => {
+              const idx = i as 0 | 1 | 2;
+              const value = blogUrls[idx];
+              const sameOriginOk = sameOrigin(value);
+              return (
+                <label
+                  key={i}
+                  className="flex flex-col gap-1 text-sm"
+                  htmlFor={`blog-url-${i + 1}`}
+                >
+                  <span className="text-muted-foreground">
+                    Blog URL {i + 1}
+                    {i === 0 && " (required to extract)"}
+                  </span>
+                  <input
+                    id={`blog-url-${i + 1}`}
+                    type="url"
+                    inputMode="url"
+                    value={value}
+                    onChange={(e) => setBlogUrl(idx, e.target.value)}
+                    placeholder={`https://example.com/blog/post-${i + 1}`}
+                    className="rounded border bg-background px-2 py-1 text-sm"
+                    data-testid={`blog-url-${i + 1}`}
+                  />
+                  {!sameOriginOk && (
+                    <span className="text-sm text-destructive">
+                      Must be on the same site
+                    </span>
+                  )}
+                </label>
+              );
+            })}
+          </div>
+
+          <div>
+            <Button
+              type="button"
+              onClick={() => void runExtraction()}
+              disabled={extracting || !hasAnyUrl}
+              data-testid="blog-styling-extract-run"
+            >
+              {extracting
+                ? "Extracting…"
+                : blogStyling
+                  ? "Re-extract"
+                  : "Extract blog styling"}
+            </Button>
+          </div>
+
+          {blogStyling && (
+            <div className="space-y-4">
+              {BLOG_STYLING_BUCKETS.map((group) => (
+                <div key={group.group}>
+                  <h3 className="text-base font-semibold">{group.group}</h3>
+                  <div className="mt-2 grid gap-2 md:grid-cols-2">
+                    {group.keys.map((key) => (
+                      <label
+                        key={key}
+                        className="flex items-center gap-2 text-sm"
+                      >
+                        <span className="w-32 text-muted-foreground">
+                          {key.replace(/_/g, " ")}
+                        </span>
+                        <input
+                          type="text"
+                          value={blogStyling[key] ?? ""}
+                          onChange={(e) =>
+                            setBlogStylingValue(key, e.target.value)
+                          }
+                          placeholder="(none)"
+                          className="flex-1 rounded border bg-background px-2 py-1 font-mono text-sm"
+                          data-testid={`blog-styling-${key}`}
+                        />
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              ))}
+
+              {blogStyling.notes.length > 0 && (
+                <ul className="mt-2 list-disc pl-5 text-sm text-muted-foreground">
+                  {blogStyling.notes.map((note, i) => (
+                    <li key={i}>{note}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
   );
 }

--- a/lib/__tests__/copy-existing-extract-blog.test.ts
+++ b/lib/__tests__/copy-existing-extract-blog.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  extractBlogStyling,
+  registrableDomainOf,
+} from "@/lib/copy-existing-extract";
+
+// Spec 03 §1.2 vitest — blog-styling extraction.
+//
+// The extractor uses fetch() with an 8s timeout per URL. We stub
+// global.fetch with a synchronous mock that returns canned HTML so
+// the test suite runs offline without hitting the network or the
+// vitest globalSetup Supabase stack.
+
+type FetchMock = (input: string) => Promise<Response>;
+
+function mockFetch(handler: FetchMock): void {
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return handler(url);
+  }) as unknown as typeof fetch;
+}
+
+function htmlResponse(html: string, status = 200): Response {
+  return new Response(html, {
+    status,
+    headers: { "content-type": "text/html" },
+  });
+}
+
+const PRIMARY = "https://example.com";
+
+beforeEach(() => {
+  // Reset fetch each test; tests that need it call mockFetch().
+  global.fetch = undefined as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("registrableDomainOf", () => {
+  it("treats subdomains as same registrable domain", () => {
+    expect(registrableDomainOf("https://blog.example.com/post")).toBe(
+      "example.com",
+    );
+    expect(registrableDomainOf("https://example.com/")).toBe("example.com");
+  });
+
+  it("handles multi-part TLDs (.co.uk, .com.au)", () => {
+    expect(registrableDomainOf("https://www.example.co.uk")).toBe(
+      "example.co.uk",
+    );
+    expect(registrableDomainOf("https://example.com.au")).toBe(
+      "example.com.au",
+    );
+  });
+
+  it("returns null for unparseable URLs", () => {
+    expect(registrableDomainOf("not-a-url")).toBeNull();
+  });
+});
+
+describe("extractBlogStyling — same-origin filtering", () => {
+  it("rejects URLs on a different registrable domain with a note", async () => {
+    mockFetch(async () => htmlResponse("<html><body></body></html>"));
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://other-site.com/post-1",
+    ]);
+    expect(
+      res.notes.some((n) =>
+        n.includes("Ignored blog URL on different registrable domain"),
+      ),
+    ).toBe(true);
+    expect(res.blog_styling.source_blog_urls).toEqual([]);
+  });
+
+  it("accepts a subdomain of the primary domain", async () => {
+    mockFetch(async () =>
+      htmlResponse(
+        `<html><body><article><p class="entry-content">Hi</p></article></body></html>`,
+      ),
+    );
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://blog.example.com/post-1",
+    ]);
+    expect(res.blog_styling.source_blog_urls).toEqual([
+      "https://blog.example.com/post-1",
+    ]);
+    expect(res.blog_styling.paragraph).toBe("entry-content");
+  });
+});
+
+describe("extractBlogStyling — utility-class filtering", () => {
+  it("ignores Tailwind utilities, keeps the longest semantic class", async () => {
+    mockFetch(async () =>
+      htmlResponse(
+        `<html><body>
+          <article>
+            <p class="mb-4 text-gray-700 entry-content">Hi</p>
+            <p class="mb-4 text-gray-700 entry-content">More</p>
+          </article>
+        </body></html>`,
+      ),
+    );
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://example.com/post-1",
+    ]);
+    expect(res.blog_styling.paragraph).toBe("entry-content");
+  });
+
+  it("leaves bucket null when only utilities are present", async () => {
+    mockFetch(async () =>
+      htmlResponse(
+        `<html><body>
+          <article>
+            <p class="mb-4">No semantic class.</p>
+          </article>
+        </body></html>`,
+      ),
+    );
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://example.com/post-1",
+    ]);
+    expect(res.blog_styling.paragraph).toBeNull();
+  });
+
+  it("dedupes repeated classes inside one element", async () => {
+    mockFetch(async () =>
+      htmlResponse(
+        `<html><body>
+          <article>
+            <p class="entry-content entry-content">x</p>
+          </article>
+        </body></html>`,
+      ),
+    );
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://example.com/post-1",
+    ]);
+    expect(res.blog_styling.paragraph).toBe("entry-content");
+  });
+
+  it("picks the longest semantic survivor when multiple semantic classes exist", async () => {
+    mockFetch(async () =>
+      htmlResponse(
+        `<html><body>
+          <article>
+            <p class="prose-lg article-body entry-content">x</p>
+          </article>
+        </body></html>`,
+      ),
+    );
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://example.com/post-1",
+    ]);
+    // entry-content (13) > article-body (12); prose-lg rejected by 'lg:' pattern semantics — but our regex is on full class so 'prose-lg' survives utility filter (it's >=4 and doesn't match the listed util prefixes). entry-content still wins by length.
+    expect(res.blog_styling.paragraph).toBe("entry-content");
+  });
+});
+
+describe("extractBlogStyling — cross-URL consistency", () => {
+  function articleHtml(paragraphClass: string, h2Class: string): string {
+    return `<html><body>
+      <article>
+        <h2 class="${h2Class}">Heading</h2>
+        <p class="${paragraphClass}">x</p>
+      </article>
+    </body></html>`;
+  }
+
+  it("3-URL agree case: takes the value", async () => {
+    mockFetch(async () =>
+      htmlResponse(articleHtml("entry-content", "wp-block-heading")),
+    );
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://example.com/p1",
+      "https://example.com/p2",
+      "https://example.com/p3",
+    ]);
+    expect(res.blog_styling.paragraph).toBe("entry-content");
+    expect(res.blog_styling.article_h2).toBe("wp-block-heading");
+  });
+
+  it("3-URL majority (2-of-3): uses majority and notes the minority", async () => {
+    let i = 0;
+    mockFetch(async () => {
+      i += 1;
+      const cls = i === 3 ? "post-paragraph" : "entry-content";
+      return htmlResponse(articleHtml(cls, "wp-block-heading"));
+    });
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://example.com/p1",
+      "https://example.com/p2",
+      "https://example.com/p3",
+    ]);
+    expect(res.blog_styling.paragraph).toBe("entry-content");
+    expect(
+      res.notes.some((n) => /Inconsistent paragraph class/.test(n)),
+    ).toBe(true);
+  });
+
+  it("3-URL all-differ: leaves bucket null and notes inconsistency", async () => {
+    let i = 0;
+    mockFetch(async () => {
+      i += 1;
+      const cls = `paragraph-style-${i}`;
+      return htmlResponse(articleHtml(cls, "wp-block-heading"));
+    });
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://example.com/p1",
+      "https://example.com/p2",
+      "https://example.com/p3",
+    ]);
+    expect(res.blog_styling.paragraph).toBeNull();
+    expect(
+      res.notes.some((n) =>
+        /Inconsistent paragraph classes across blogs — leaving null/.test(n),
+      ),
+    ).toBe(true);
+  });
+
+  it("2-URL agree case: takes the value", async () => {
+    mockFetch(async () =>
+      htmlResponse(articleHtml("entry-content", "wp-block-heading")),
+    );
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://example.com/p1",
+      "https://example.com/p2",
+    ]);
+    expect(res.blog_styling.paragraph).toBe("entry-content");
+  });
+
+  it("1-URL: takes the value but emits a low-confidence note", async () => {
+    mockFetch(async () =>
+      htmlResponse(articleHtml("entry-content", "wp-block-heading")),
+    );
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://example.com/p1",
+    ]);
+    expect(res.blog_styling.paragraph).toBe("entry-content");
+    expect(
+      res.notes.some((n) => /Single-URL extraction/.test(n)),
+    ).toBe(true);
+  });
+
+  it("timeout on URL 2 of 3: merges the survivors as a 2-URL case + timeout note", async () => {
+    let n = 0;
+    mockFetch(async (url) => {
+      n += 1;
+      if (url.includes("/p2")) {
+        // Fail fast — the extractor treats a non-2xx as a fetch
+        // failure; the spec wording "timeout" is one of several
+        // failure modes that all funnel into the same merge path.
+        return htmlResponse("error", 503);
+      }
+      return htmlResponse(articleHtml("entry-content", "wp-block-heading"));
+    });
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://example.com/p1",
+      "https://example.com/p2",
+      "https://example.com/p3",
+    ]);
+    void n;
+    expect(res.blog_styling.paragraph).toBe("entry-content");
+    expect(res.notes.some((nt) => /URL 2 failed to load/.test(nt))).toBe(true);
+  });
+});
+
+describe("extractBlogStyling — container detection", () => {
+  it("falls back through <main>, .post-content, .entry-content", async () => {
+    mockFetch(async () =>
+      htmlResponse(
+        `<html><body>
+          <div class="entry-content">
+            <p class="text-block">Hi</p>
+          </div>
+        </body></html>`,
+      ),
+    );
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://example.com/p1",
+    ]);
+    expect(res.blog_styling.paragraph).toBe("text-block");
+  });
+
+  it("returns nulls + skip note when no container matches", async () => {
+    mockFetch(async () =>
+      htmlResponse(
+        `<html><body>
+          <div class="navbar"><a href="#">Home</a></div>
+        </body></html>`,
+      ),
+    );
+    const res = await extractBlogStyling(PRIMARY, [
+      "https://example.com/p1",
+    ]);
+    expect(res.blog_styling.paragraph).toBeNull();
+    expect(
+      res.notes.some((n) => /no recognised article container/i.test(n)),
+    ).toBe(true);
+  });
+
+  it("survives malformed HTML without throwing", async () => {
+    mockFetch(async () =>
+      htmlResponse(
+        `<html><body><article><p class="entry-content">missing close tag`,
+      ),
+    );
+    await expect(
+      extractBlogStyling(PRIMARY, ["https://example.com/p1"]),
+    ).resolves.toBeDefined();
+  });
+});

--- a/lib/copy-existing-extract.ts
+++ b/lib/copy-existing-extract.ts
@@ -42,6 +42,39 @@ export interface ExtractedDesign {
   visual_tone: string;
   screenshot_url: string | null;
   source_pages: string[];
+  /**
+   * Spec 03 — calibrated blog post styling for copy_existing sites.
+   * Optional. Populated by extractBlogStyling() when the operator
+   * provides 1–3 blog URLs in the wizard. Consumed by the runner via
+   * lib/design-discovery/build-injection.ts when content_type='post'.
+   */
+  blog_styling?: BlogStyling | null;
+}
+
+export interface BlogStyling {
+  source_blog_urls: string[];
+  // Article container
+  article_container: string | null;
+  // Body content classes
+  paragraph: string | null;
+  link_in_body: string | null;
+  // Long-form structural elements
+  blockquote: string | null;
+  unordered_list: string | null;
+  ordered_list: string | null;
+  list_item: string | null;
+  figure: string | null;
+  figcaption: string | null;
+  code_inline: string | null;
+  code_block: string | null;
+  hr: string | null;
+  // Heading classes inside articles
+  article_h2: string | null;
+  article_h3: string | null;
+  article_h4: string | null;
+  // Diagnostics
+  notes: string[];
+  extracted_at: string;
 }
 
 export interface ExtractedCssClasses {
@@ -288,5 +321,556 @@ function emptyCssClasses(): ExtractedCssClasses {
     headings: { h1: null, h2: null, h3: null },
     button: null,
     card: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Spec 03 — blog-styling extraction.
+//
+// Extends the existing extractor with a second pass that fetches up to
+// 3 operator-supplied blog post URLs, locates the article container,
+// and pulls per-bucket class names for paragraphs, headings, lists,
+// blockquotes, etc.
+//
+// Locked design choices (per spec):
+//   - fetch() only, 8s timeout each. No headless browser.
+//   - Same-origin filter via registrable-domain check (Public Suffix
+//     List inlined as a hand-rolled multi-part TLD list — covers all
+//     conventional customer domains; documented limitation below).
+//   - Article container: first selector wins among
+//     <article>, <main>, .post-content, .entry-content, .single-post-content
+//   - Per-element regex tally with utility-class filtering to leave
+//     a single semantic class per bucket.
+//   - Cross-URL consistency rules per spec §1.2.
+// ---------------------------------------------------------------------------
+
+const BLOG_FETCH_TIMEOUT_MS = 8000;
+
+// Limitation: hand-rolled registrable-domain detection. Edge-case
+// domains (github.io, appspot.com, *.cloudfront.net, etc.) may
+// misclassify. Conventional customer registrable domains work fine.
+const MULTI_PART_TLDS = new Set<string>([
+  "co.uk",
+  "co.nz",
+  "co.za",
+  "com.au",
+  "com.br",
+  "com.mx",
+  "com.sg",
+  "com.hk",
+  "co.jp",
+  "co.kr",
+  "co.in",
+  "ac.uk",
+  "gov.uk",
+  "ac.nz",
+  "net.au",
+  "org.au",
+  "org.uk",
+]);
+
+export function registrableDomainOf(rawUrl: string): string | null {
+  let host: string;
+  try {
+    host = new URL(rawUrl).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+  if (!host) return null;
+  const labels = host.split(".").filter(Boolean);
+  if (labels.length < 2) return host;
+  const lastTwo = labels.slice(-2).join(".");
+  // Multi-part TLD: registrable = last 3 labels.
+  if (MULTI_PART_TLDS.has(lastTwo) && labels.length >= 3) {
+    return labels.slice(-3).join(".");
+  }
+  return lastTwo;
+}
+
+// Article container selectors, in priority order. First match wins.
+const ARTICLE_CONTAINER_PATTERNS: Array<{ name: string; regex: RegExp }> = [
+  { name: "article", regex: /<article\b[^>]*>([\s\S]*?)<\/article>/i },
+  { name: "main", regex: /<main\b[^>]*>([\s\S]*?)<\/main>/i },
+  {
+    name: ".post-content",
+    regex: /<(div|section)\b[^>]*\bclass="[^"]*\bpost-content\b[^"]*"[^>]*>([\s\S]*?)<\/\1>/i,
+  },
+  {
+    name: ".entry-content",
+    regex: /<(div|section)\b[^>]*\bclass="[^"]*\bentry-content\b[^"]*"[^>]*>([\s\S]*?)<\/\1>/i,
+  },
+  {
+    name: ".single-post-content",
+    regex: /<(div|section)\b[^>]*\bclass="[^"]*\bsingle-post-content\b[^"]*"[^>]*>([\s\S]*?)<\/\1>/i,
+  },
+];
+
+const UTILITY_CLASS_PATTERNS: RegExp[] = [
+  /^(m|p|mt|mb|ml|mr|mx|my|pt|pb|pl|pr|px|py)-/,
+  /^(w|h|min-w|min-h|max-w|max-h)-/,
+  /^text-(xs|sm|base|lg|xl|2xl|3xl|4xl|5xl|6xl)$/,
+  /^font-(thin|light|normal|medium|semibold|bold|extrabold|black)$/,
+  /^(bg|border|rounded|shadow)-/,
+  /^(flex|grid|gap|space|items|justify|content|self|order)-?/,
+  /^(sm|md|lg|xl|2xl):/,
+];
+
+function isUtilityClass(cls: string): boolean {
+  if (cls.length < 4) return true;
+  if (/^[a-z]$/.test(cls)) return true;
+  return UTILITY_CLASS_PATTERNS.some((p) => p.test(cls));
+}
+
+/** From a single class="…" string, return the surviving longest semantic class. */
+function pickSemanticClass(classAttr: string): string | null {
+  const classes = Array.from(
+    new Set(classAttr.split(/\s+/).map((c) => c.trim()).filter(Boolean)),
+  );
+  const survivors = classes.filter((c) => !isUtilityClass(c));
+  if (survivors.length === 0) return null;
+  // Longest by character length wins; ties broken by lexical for determinism.
+  survivors.sort((a, b) => {
+    if (b.length !== a.length) return b.length - a.length;
+    return a.localeCompare(b);
+  });
+  return survivors[0];
+}
+
+/**
+ * Tally semantic-survivor classes across every match of `pattern` in
+ * the container HTML. Returns the most frequent class, ties broken by
+ * length then lexical.
+ */
+function tallyBucketClasses(
+  containerHtml: string,
+  pattern: RegExp,
+): string | null {
+  const counts = new Map<string, number>();
+  pattern.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(containerHtml))) {
+    const classAttr = m[1];
+    if (!classAttr) continue;
+    const winner = pickSemanticClass(classAttr);
+    if (!winner) continue;
+    counts.set(winner, (counts.get(winner) ?? 0) + 1);
+  }
+  if (counts.size === 0) return null;
+  const sorted = [...counts.entries()].sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    if (b[0].length !== a[0].length) return b[0].length - a[0].length;
+    return a[0].localeCompare(b[0]);
+  });
+  return sorted[0][0];
+}
+
+interface BucketResult {
+  article_container: string | null;
+  paragraph: string | null;
+  link_in_body: string | null;
+  blockquote: string | null;
+  unordered_list: string | null;
+  ordered_list: string | null;
+  list_item: string | null;
+  figure: string | null;
+  figcaption: string | null;
+  code_inline: string | null;
+  code_block: string | null;
+  hr: string | null;
+  article_h2: string | null;
+  article_h3: string | null;
+  article_h4: string | null;
+}
+
+const EMPTY_BUCKETS: BucketResult = {
+  article_container: null,
+  paragraph: null,
+  link_in_body: null,
+  blockquote: null,
+  unordered_list: null,
+  ordered_list: null,
+  list_item: null,
+  figure: null,
+  figcaption: null,
+  code_inline: null,
+  code_block: null,
+  hr: null,
+  article_h2: null,
+  article_h3: null,
+  article_h4: null,
+};
+
+const BUCKET_KEYS = Object.keys(EMPTY_BUCKETS) as (keyof BucketResult)[];
+
+interface PerUrlBuckets {
+  ok: true;
+  url: string;
+  buckets: BucketResult;
+}
+interface PerUrlFailure {
+  ok: false;
+  url: string;
+  reason: string;
+}
+type PerUrlResult = PerUrlBuckets | PerUrlFailure;
+
+async function fetchWithTimeout(
+  url: string,
+): Promise<{ ok: true; html: string } | { ok: false; reason: string }> {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), BLOG_FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "user-agent":
+            "Opollo-Site-Builder/1.0 (+https://opollo.com) Blog-Styling-Extract",
+        },
+        signal: ctrl.signal,
+      });
+      if (!res.ok) {
+        return { ok: false, reason: `HTTP ${res.status}` };
+      }
+      const html = await res.text();
+      return { ok: true, html };
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch (err) {
+    const reason =
+      err instanceof Error ? err.message : String(err);
+    if (/abort/i.test(reason)) {
+      return { ok: false, reason: "timed out after 8s" };
+    }
+    return { ok: false, reason };
+  }
+}
+
+function extractBucketsFromHtml(html: string): {
+  buckets: BucketResult;
+  containerSelectorMatched: string | null;
+  containerByteSize: number;
+  childCount: number;
+} {
+  let containerHtml: string | null = null;
+  let matchedName: string | null = null;
+  for (const pattern of ARTICLE_CONTAINER_PATTERNS) {
+    pattern.regex.lastIndex = 0;
+    const match = pattern.regex.exec(html);
+    if (match) {
+      // Two capture groups in the .post-content / .entry-content / .single-post-content
+      // patterns; one group in <article>/<main>. The container HTML is the LAST
+      // group matched.
+      containerHtml = match[match.length - 1];
+      matchedName = pattern.name;
+      break;
+    }
+  }
+
+  if (!containerHtml) {
+    return {
+      buckets: { ...EMPTY_BUCKETS },
+      containerSelectorMatched: null,
+      containerByteSize: 0,
+      childCount: 0,
+    };
+  }
+
+  // Diagnostic counts for the structured log.
+  const childMatches = containerHtml.match(/<[a-zA-Z][^>]*>/g) ?? [];
+
+  // Outer-container class picked off the OPENING tag of the matched
+  // container. Re-find it on the original html (match[0] is the full
+  // outer tag for these regexes).
+  let outerOpening: string | null = null;
+  for (const pattern of ARTICLE_CONTAINER_PATTERNS) {
+    pattern.regex.lastIndex = 0;
+    const fullMatch = pattern.regex.exec(html);
+    if (fullMatch && pattern.name === matchedName) {
+      outerOpening = fullMatch[0].slice(
+        0,
+        fullMatch[0].indexOf(">") + 1,
+      );
+      break;
+    }
+  }
+  let articleContainer: string | null = null;
+  if (outerOpening) {
+    const classAttrMatch = /\bclass\s*=\s*"([^"]+)"/i.exec(outerOpening);
+    if (classAttrMatch) {
+      articleContainer = pickSemanticClass(classAttrMatch[1]);
+    }
+  }
+
+  // Per-bucket class regex. Match the OPENING tag's class attribute.
+  // Anchor-link inside paragraph regex requires the <a> to live inside
+  // a <p>; we approximate with a window-pattern that requires <p> to
+  // appear within the preceding 200 chars — robust enough for the
+  // structural HTML we see on real blog posts.
+  const buckets: BucketResult = {
+    ...EMPTY_BUCKETS,
+    article_container: articleContainer,
+  };
+
+  buckets.paragraph = tallyBucketClasses(
+    containerHtml,
+    /<p\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+  buckets.blockquote = tallyBucketClasses(
+    containerHtml,
+    /<blockquote\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+  buckets.unordered_list = tallyBucketClasses(
+    containerHtml,
+    /<ul\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+  buckets.ordered_list = tallyBucketClasses(
+    containerHtml,
+    /<ol\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+  buckets.list_item = tallyBucketClasses(
+    containerHtml,
+    /<li\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+  buckets.figure = tallyBucketClasses(
+    containerHtml,
+    /<figure\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+  buckets.figcaption = tallyBucketClasses(
+    containerHtml,
+    /<figcaption\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+  buckets.code_inline = tallyBucketClasses(
+    containerHtml,
+    /<code\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+  buckets.code_block = tallyBucketClasses(
+    containerHtml,
+    /<pre\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+  buckets.hr = tallyBucketClasses(
+    containerHtml,
+    /<hr\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+  buckets.article_h2 = tallyBucketClasses(
+    containerHtml,
+    /<h2\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+  buckets.article_h3 = tallyBucketClasses(
+    containerHtml,
+    /<h3\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+  buckets.article_h4 = tallyBucketClasses(
+    containerHtml,
+    /<h4\b[^>]*\bclass\s*=\s*"([^"]+)"/gi,
+  );
+
+  // Link-in-body: tally class on <a> only when preceded by <p in a
+  // small window. Cheap heuristic; avoids site-chrome <a> tags.
+  buckets.link_in_body = tallyLinkInBody(containerHtml);
+
+  return {
+    buckets,
+    containerSelectorMatched: matchedName,
+    containerByteSize: containerHtml.length,
+    childCount: childMatches.length,
+  };
+}
+
+function tallyLinkInBody(containerHtml: string): string | null {
+  const counts = new Map<string, number>();
+  // Match <a class="..."> only when inside the article container AND
+  // preceded by <p within 400 chars (so we mostly capture body links,
+  // not chrome links). The container is already the article body so
+  // most <a> tags qualify; the windowed check just filters out the
+  // rare top-of-container "Back to articles" affordance.
+  const linkRegex = /<a\b[^>]*\bclass\s*=\s*"([^"]+)"/gi;
+  let m: RegExpExecArray | null;
+  while ((m = linkRegex.exec(containerHtml))) {
+    const idx = m.index;
+    const window = containerHtml.slice(Math.max(0, idx - 400), idx);
+    if (!/<p\b/i.test(window)) continue;
+    const winner = pickSemanticClass(m[1]);
+    if (!winner) continue;
+    counts.set(winner, (counts.get(winner) ?? 0) + 1);
+  }
+  if (counts.size === 0) return null;
+  const sorted = [...counts.entries()].sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    if (b[0].length !== a[0].length) return b[0].length - a[0].length;
+    return a[0].localeCompare(b[0]);
+  });
+  return sorted[0][0];
+}
+
+/**
+ * Merge per-URL bucket results using the spec's cross-URL consistency
+ * rules: 3-of-3 take, 2-of-3 majority + note, 1 take + low-confidence
+ * note, all-differ leave null + note.
+ */
+function mergeBuckets(
+  per: PerUrlBuckets[],
+  notes: string[],
+): BucketResult {
+  const merged: BucketResult = { ...EMPTY_BUCKETS };
+  for (const key of BUCKET_KEYS) {
+    const values = per
+      .map((p) => p.buckets[key])
+      .filter((v): v is string => typeof v === "string" && v.length > 0);
+    if (values.length === 0) {
+      merged[key] = null;
+      continue;
+    }
+    const counts = new Map<string, number>();
+    for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
+    const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+    const top = sorted[0];
+    if (per.length === 1) {
+      merged[key] = top[0];
+      continue;
+    }
+    if (top[1] === per.length) {
+      merged[key] = top[0];
+      continue;
+    }
+    if (top[1] > per.length / 2) {
+      merged[key] = top[0];
+      notes.push(
+        `Inconsistent ${key} class — ${top[1]}/${per.length} agreed; using majority "${top[0]}"`,
+      );
+      continue;
+    }
+    merged[key] = null;
+    notes.push(
+      `Inconsistent ${key} classes across blogs — leaving null`,
+    );
+  }
+  return merged;
+}
+
+export interface ExtractBlogStylingResult {
+  blog_styling: BlogStyling;
+  notes: string[];
+}
+
+/**
+ * Extract blog-content class names from up to 3 operator-supplied blog
+ * URLs. Same-origin (registrable-domain) only. Returns merged bucket
+ * results plus notes describing per-URL outcomes and cross-URL merge
+ * decisions.
+ */
+export async function extractBlogStyling(
+  primaryUrl: string,
+  blogUrls: string[],
+): Promise<ExtractBlogStylingResult> {
+  const notes: string[] = [];
+  const primaryDomain = registrableDomainOf(primaryUrl);
+  if (!primaryDomain) {
+    notes.push(`Primary URL ${primaryUrl} is not a parseable URL.`);
+  }
+
+  // Filter same-origin (registrable-domain), cap at 3.
+  const accepted: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of blogUrls) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    if (accepted.length >= 3) {
+      notes.push(`Ignored extra blog URL beyond the 3-URL cap: ${trimmed}`);
+      continue;
+    }
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    const dom = registrableDomainOf(trimmed);
+    if (!dom) {
+      notes.push(`Ignored blog URL (not a valid URL): ${trimmed}`);
+      continue;
+    }
+    if (primaryDomain && dom !== primaryDomain) {
+      notes.push(
+        `Ignored blog URL on different registrable domain (${dom}): ${trimmed}`,
+      );
+      continue;
+    }
+    accepted.push(trimmed);
+  }
+
+  if (accepted.length === 0) {
+    return {
+      blog_styling: {
+        source_blog_urls: [],
+        ...EMPTY_BUCKETS,
+        notes,
+        extracted_at: new Date().toISOString(),
+      },
+      notes,
+    };
+  }
+
+  // Fetch each URL with timeout; collect results.
+  const results = await Promise.all(
+    accepted.map(async (url, idx): Promise<PerUrlResult> => {
+      const fetchRes = await fetchWithTimeout(url);
+      if (!fetchRes.ok) {
+        notes.push(`URL ${idx + 1} failed to load: ${fetchRes.reason}`);
+        return { ok: false, url, reason: fetchRes.reason };
+      }
+      const extracted = extractBucketsFromHtml(fetchRes.html);
+      logger.info("copy-existing-extract.blog_styling.url_extracted", {
+        url,
+        container_selector: extracted.containerSelectorMatched,
+        container_bytes: extracted.containerByteSize,
+        child_count: extracted.childCount,
+      });
+      if (!extracted.containerSelectorMatched) {
+        notes.push(
+          `URL ${idx + 1} (${url}): no recognised article container — skipped.`,
+        );
+        return {
+          ok: false,
+          url,
+          reason: "no article container",
+        };
+      }
+      return { ok: true, url, buckets: extracted.buckets };
+    }),
+  );
+
+  const successful = results.filter(
+    (r): r is PerUrlBuckets => r.ok,
+  );
+
+  if (successful.length === 0) {
+    return {
+      blog_styling: {
+        source_blog_urls: accepted,
+        ...EMPTY_BUCKETS,
+        notes,
+        extracted_at: new Date().toISOString(),
+      },
+      notes,
+    };
+  }
+
+  if (successful.length === 1 && accepted.length > 1) {
+    notes.push(
+      "Single-URL extraction — confidence is low; consider providing 2 more blog URLs",
+    );
+  } else if (successful.length === 1) {
+    notes.push(
+      "Single-URL extraction — confidence is low; consider providing 2 more blog URLs",
+    );
+  }
+
+  const merged = mergeBuckets(successful, notes);
+
+  return {
+    blog_styling: {
+      source_blog_urls: accepted,
+      ...merged,
+      notes: [...notes],
+      extracted_at: new Date().toISOString(),
+    },
+    notes,
   };
 }


### PR DESCRIPTION
First of three PRs implementing `docs/specs/03-blog-styling-calibration.md`.

## What this PR does

Extends the copy-existing extraction so it can learn how the customer's existing blog posts are styled. Operators paste 1–3 example blog post URLs into a new wizard section; the extractor fetches each URL, locates the article container, and pulls per-bucket class names. Result lands in `extracted_design.blog_styling`.

This PR is **store-only**: data is captured but not yet gated against (PR 2) or injected into the runner prompt (PR 3). Saved data is benign — preflight + injection wiring lands in subsequent PRs.

## Files

- `lib/copy-existing-extract.ts` — `BlogStyling` type, `extractBlogStyling()`, `registrableDomainOf()` (hand-rolled multi-part TLD support), utility-class filter (per-spec rules — Tailwind/responsive/sizing prefixes rejected, < 4 chars rejected, longest semantic survivor wins).
- `app/api/admin/sites/[id]/setup/extract/route.ts` — accepts optional `blog_urls[]`, runs the secondary extraction pass.
- `app/api/admin/sites/[id]/setup/extract/save/route.ts` — Zod schema accepts optional `blog_styling`; `SingleCssClassSchema` regex rejects multi-class operator edits with the spec-mandated copy.
- `components/CopyExistingExtractionWizard.tsx` — new collapsible "Blog styling (optional)" section with 3 URL inputs, same-origin client-side validation, grouped review fields, notes panel, "Calibrated N days ago" age label, auto-expand on `?focus=blog-styling`.
- `lib/__tests__/copy-existing-extract-blog.test.ts` — vitest for registrable-domain edge cases, same-origin filtering, utility-class filtering, cross-URL consistency (3-agree, 3-majority, 3-all-differ, 2-agree, 1-URL, fetch-failure merge), container fallback, malformed HTML.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Hand-rolled registrable-domain misclassifies edge-case domains (github.io, *.cloudfront.net) | Documented limitation; conventional customer domains work; subdomains explicitly allowed via 2-label suffix match |
| Operator pastes multi-class strings into bucket fields | `SingleCssClassSchema` regex on save: `/^[a-zA-Z_][a-zA-Z0-9_-]*$/`, rejects with clear copy |
| Cross-URL inconsistency drops bucket to null silently | `notes[]` surfaces every dropped bucket; wizard renders them inline |
| `fetch()` failure on one of N URLs | Per-URL error becomes a note; remaining URLs merge using the reduced-count rules from §1.2 |
| Runner not yet aware of `blog_styling` | This PR is store-only; PR 3 wires it; saved data is benign in the interim |
| 8s timeout per URL × 3 URLs blocks the wizard | `Promise.all` parallelises; max 8s wall time even with 3 concurrent fetches |

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — clean
- `npm run audit:static` — 0 HIGH, 0 MEDIUM (LOWs are pre-existing)
- Vitest tests written; not run locally (Docker/Supabase required per ARCH §14.1)

## Up next

- **PR 2 of Spec 03** — Preflight gate + banner: `BLOG_STYLE_NOT_CALIBRATED` blocker on `copy_existing` + `content_type='post'` + missing `blog_styling`.
- **PR 3 of Spec 03** — Runner injection: `<blog_content_classes>` block emitted from `lib/design-discovery/build-injection.ts` for post-mode generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
