### PR TITLE
feat(nav): widen primary rail + add desktop collapse toggle

### DIFF
--- a/components/nav/nav-shell-client.tsx
+++ b/components/nav/nav-shell-client.tsx
@@ -7,7 +7,11 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { PrimaryNav } from "./primary-nav";
-import { SectionNav, SECTION_NAV_COLLAPSED_COOKIE } from "./section-nav";
+import { SectionNav } from "./section-nav";
+import {
+  PRIMARY_NAV_COLLAPSED_COOKIE,
+  SECTION_NAV_COLLAPSED_COOKIE,
+} from "./nav-shell-cookies";
 import {
   filterPrimaryItems,
   filterSectionItems,
@@ -17,22 +21,28 @@ import {
 } from "./nav-config";
 
 // ---------------------------------------------------------------------------
-// NavShellClient — manages mobile drawer + section-nav collapse state.
-// Rendered by the server NavShell; receives children as a prop (RSC pattern).
+// NavShellClient — manages mobile drawer + the two desktop collapse states
+// (primary rail, section panel). Rendered by the server NavShell; receives
+// children + initial collapse states (read from cookies) as props so SSR
+// matches first paint.
 // ---------------------------------------------------------------------------
 
 const SECTION_NAV_LS_KEY = "opollo:section-nav:collapsed";
+const PRIMARY_NAV_LS_KEY = "opollo:nav:collapsed";
 
-function persistSectionNavCollapsed(next: boolean) {
+function persistCookie(name: string, next: boolean) {
   try {
-    window.localStorage.setItem(SECTION_NAV_LS_KEY, next ? "1" : "0");
-  } catch {
-    /* localStorage disabled */
-  }
-  try {
-    document.cookie = `${SECTION_NAV_COLLAPSED_COOKIE}=${next ? "1" : "0"}; path=/; max-age=${60 * 60 * 24 * 365}; samesite=lax`;
+    document.cookie = `${name}=${next ? "1" : "0"}; path=/; max-age=${60 * 60 * 24 * 365}; samesite=lax`;
   } catch {
     /* cookieless context */
+  }
+}
+
+function persistLocalStorage(key: string, next: boolean) {
+  try {
+    window.localStorage.setItem(key, next ? "1" : "0");
+  } catch {
+    /* localStorage disabled */
   }
 }
 
@@ -40,6 +50,7 @@ interface NavShellClientProps {
   children: React.ReactNode;
   navContext: NavUserContext;
   initialSectionNavCollapsed: boolean;
+  initialPrimaryNavCollapsed: boolean;
   skipToId: string;
   contentMaxWidth: string;
   contentPadding: string;
@@ -49,6 +60,7 @@ export function NavShellClient({
   children,
   navContext,
   initialSectionNavCollapsed,
+  initialPrimaryNavCollapsed,
   skipToId,
   contentMaxWidth,
   contentPadding,
@@ -58,6 +70,9 @@ export function NavShellClient({
   const [mobileOpen, setMobileOpen] = useState(false);
   const [sectionNavCollapsed, setSectionNavCollapsed] = useState(
     initialSectionNavCollapsed,
+  );
+  const [primaryNavCollapsed, setPrimaryNavCollapsed] = useState(
+    initialPrimaryNavCollapsed,
   );
 
   useEffect(() => {
@@ -90,15 +105,26 @@ export function NavShellClient({
 
     setSectionNavCollapsed((prev) => {
       const next = !prev;
-      persistSectionNavCollapsed(next);
+      persistLocalStorage(SECTION_NAV_LS_KEY, next);
+      persistCookie(SECTION_NAV_COLLAPSED_COOKIE, next);
       return next;
     });
   }
 
-  function handleCollapseToggle() {
+  function handleSectionCollapseToggle() {
     setSectionNavCollapsed((prev) => {
       const next = !prev;
-      persistSectionNavCollapsed(next);
+      persistLocalStorage(SECTION_NAV_LS_KEY, next);
+      persistCookie(SECTION_NAV_COLLAPSED_COOKIE, next);
+      return next;
+    });
+  }
+
+  function handlePrimaryCollapseToggle() {
+    setPrimaryNavCollapsed((prev) => {
+      const next = !prev;
+      persistLocalStorage(PRIMARY_NAV_LS_KEY, next);
+      persistCookie(PRIMARY_NAV_COLLAPSED_COOKIE, next);
       return next;
     });
   }
@@ -192,13 +218,15 @@ export function NavShellClient({
           activeSectionKey={activeSectionKey}
           onSectionNavToggle={handleSectionNavToggle}
           isSectionNavVisible={hasSectionNav && !sectionNavCollapsed}
+          collapsed={primaryNavCollapsed}
+          onCollapseToggle={handlePrimaryCollapseToggle}
         />
 
         {hasSectionNav && (
           <SectionNav
             navContext={navContext}
             collapsed={sectionNavCollapsed}
-            onToggle={handleCollapseToggle}
+            onToggle={handleSectionCollapseToggle}
           />
         )}
       </div>

--- a/components/nav/nav-shell-cookies.ts
+++ b/components/nav/nav-shell-cookies.ts
@@ -1,0 +1,5 @@
+// Shared cookie names for the nav shell. Kept in their own file so server
+// components can import them without dragging in client-only modules.
+
+export const SECTION_NAV_COLLAPSED_COOKIE = "opollo_section_nav_collapsed";
+export const PRIMARY_NAV_COLLAPSED_COOKIE = "opollo_primary_nav_collapsed";

--- a/components/nav/nav-shell.tsx
+++ b/components/nav/nav-shell.tsx
@@ -3,12 +3,13 @@ import type { ReactNode } from "react";
 
 import { NavShellClient } from "./nav-shell-client";
 import { SECTION_NAV_COLLAPSED_COOKIE } from "./section-nav";
+import { PRIMARY_NAV_COLLAPSED_COOKIE } from "./nav-shell-cookies";
 import type { NavUserContext } from "./nav-config";
 
 // ---------------------------------------------------------------------------
-// NavShell — server component. Reads collapse-state cookie so SSR +
-// first paint match (no hydration flash). Delegates all interactive
-// behaviour to NavShellClient.
+// NavShell — server component. Reads collapse-state cookies for both the
+// primary rail and the section panel so SSR + first paint match (no
+// hydration flash). Delegates all interactive behaviour to NavShellClient.
 // ---------------------------------------------------------------------------
 
 export type { NavUserContext };
@@ -28,8 +29,11 @@ export async function NavShell({
   contentMaxWidth = "7xl",
   contentPadding = "px-4 py-6 sm:px-8 sm:py-8",
 }: NavShellProps) {
+  const cookieJar = cookies();
   const initialSectionNavCollapsed =
-    cookies().get(SECTION_NAV_COLLAPSED_COOKIE)?.value === "1";
+    cookieJar.get(SECTION_NAV_COLLAPSED_COOKIE)?.value === "1";
+  const initialPrimaryNavCollapsed =
+    cookieJar.get(PRIMARY_NAV_COLLAPSED_COOKIE)?.value === "1";
 
   return (
     <>
@@ -42,6 +46,7 @@ export async function NavShell({
       <NavShellClient
         navContext={navContext}
         initialSectionNavCollapsed={initialSectionNavCollapsed}
+        initialPrimaryNavCollapsed={initialPrimaryNavCollapsed}
         skipToId={skipToId}
         contentMaxWidth={contentMaxWidth}
         contentPadding={contentPadding}

--- a/components/nav/primary-nav.tsx
+++ b/components/nav/primary-nav.tsx
@@ -13,10 +13,12 @@ import {
 } from "./nav-config";
 
 // ---------------------------------------------------------------------------
-// Primary Nav — left rail, always visible at 70px on desktop.
-// Icon stacked above label. Active item uses a single subtle background
-// tint (bg-nav-active) — no border, no text-color shift, no other signal.
-// Mobile: shown as part of the off-canvas drawer managed by NavShellClient.
+// Primary Nav — left rail. Two-state desktop:
+//   • Expanded: 112px, icon stacked over full-text label.
+//   • Collapsed: 64px, icon only; full label appears as a native title
+//     tooltip on hover.
+// Active item uses bg-nav-active only (no border, text-color shift, etc.).
+// Mobile: rendered through the off-canvas drawer in NavShellClient.
 // ---------------------------------------------------------------------------
 
 interface PrimaryNavProps {
@@ -26,6 +28,10 @@ interface PrimaryNavProps {
   isSectionNavVisible: boolean;
   mobile?: boolean;
   onMobileNavItemClick?: () => void;
+  /** Desktop collapse state. Hides labels, renders icons only. */
+  collapsed?: boolean;
+  /** Toggle handler — renders the chevron button when provided. */
+  onCollapseToggle?: () => void;
 }
 
 export function PrimaryNav({
@@ -34,6 +40,8 @@ export function PrimaryNav({
   onSectionNavToggle,
   mobile = false,
   onMobileNavItemClick,
+  collapsed = false,
+  onCollapseToggle,
 }: PrimaryNavProps) {
   const visibleItems = filterPrimaryItems(primaryNavItems, navContext);
   const hasUser = !!navContext.email;
@@ -43,7 +51,10 @@ export function PrimaryNav({
     const hasSectionNav = item.sectionNav !== null;
 
     const itemClass = cn(
-      "group flex w-full flex-col items-center gap-1 rounded-md px-1 py-3 transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-gr",
+      "group flex w-full items-center rounded-md transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-gr",
+      collapsed
+        ? "justify-center px-1 py-2.5"
+        : "flex-col gap-1 px-1 py-3",
       isActive
         ? "bg-nav-active text-foreground"
         : "text-m2 hover:bg-nav-hover hover:text-gr",
@@ -69,7 +80,7 @@ export function PrimaryNav({
             className={itemClass}
           >
             <NavIcon name={item.icon} size={20} className={iconClass} />
-            <span className={labelClass}>{item.label}</span>
+            {!collapsed && <span className={labelClass}>{item.label}</span>}
           </button>
         </li>
       );
@@ -86,26 +97,38 @@ export function PrimaryNav({
           className={itemClass}
         >
           <NavIcon name={item.icon} size={20} className={iconClass} />
-          <span className={labelClass}>{item.label}</span>
+          {!collapsed && <span className={labelClass}>{item.label}</span>}
         </Link>
       </li>
     );
   }
 
+  // Desktop width: 112px expanded, 64px collapsed. Mobile drawer is full-width.
+  // Width transitions are intentional — section nav + content shift in lockstep.
+  const railWidthClass = mobile
+    ? "w-full"
+    : collapsed
+      ? "w-[64px] shrink-0"
+      : "w-[112px] shrink-0";
+
   return (
     <nav
       data-testid="primary-nav"
       aria-label="Primary navigation"
+      data-collapsed={!mobile && collapsed ? "true" : "false"}
       className={cn(
         "flex flex-col border-r border-border bg-[linear-gradient(180deg,var(--d1)_0%,var(--bg)_100%)]",
-        mobile ? "w-full" : "w-[70px] shrink-0",
+        !mobile && "transition-[width] duration-150 ease-out",
+        railWidthClass,
       )}
     >
-      {/* Round Opollo logo — fixed 36×36 in the rail header */}
+      {/* Round Opollo logo + (desktop) collapse toggle */}
       <div
         className={cn(
-          "flex items-center justify-center border-b border-border",
-          mobile ? "h-14 px-4 justify-start" : "h-14",
+          "flex items-center border-b border-border",
+          mobile
+            ? "h-14 px-4 justify-start"
+            : "h-14 justify-center",
         )}
       >
         <Link
@@ -123,6 +146,24 @@ export function PrimaryNav({
           />
         </Link>
       </div>
+
+      {/* Desktop-only collapse toggle, sits just below the logo bar so it's
+          equally reachable in both rail widths. */}
+      {!mobile && onCollapseToggle && (
+        <div className="flex items-center justify-end border-b border-border px-1.5 py-1">
+          <button
+            type="button"
+            onClick={onCollapseToggle}
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? "Expand navigation" : "Collapse navigation"}
+            title={collapsed ? "Expand navigation" : "Collapse navigation"}
+            data-testid="nav-collapse-toggle"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-m3 transition-smooth hover:bg-nav-hover hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-gr"
+          >
+            <NavIcon name={collapsed ? "chevron-right" : "chevron-left"} size={14} />
+          </button>
+        </div>
+      )}
 
       {/* Primary items */}
       <ul
@@ -147,10 +188,17 @@ export function PrimaryNav({
                 <div
                   key={item.key}
                   title="Command palette (⌘K)"
-                  className="flex flex-col items-center gap-1 rounded-md px-1 py-2 text-m3"
+                  className={cn(
+                    "flex items-center rounded-md px-1 py-2 text-m3",
+                    collapsed
+                      ? "justify-center"
+                      : "flex-col gap-1",
+                  )}
                 >
                   <NavIcon name={item.icon} size={20} className="text-icon-dim" />
-                  <span className="text-xs font-mono leading-none">⌘K</span>
+                  {!collapsed && (
+                    <span className="text-xs font-mono leading-none">⌘K</span>
+                  )}
                 </div>
               );
             }
@@ -160,14 +208,21 @@ export function PrimaryNav({
                 <form key={item.key} action="/logout" method="POST">
                   <button
                     type="submit"
-                    title="Sign out"
+                    title={item.label}
                     data-testid={item.testId}
-                    className="group flex w-full flex-col items-center gap-1 rounded-md px-1 py-2 transition-smooth text-destructive hover:bg-destructive/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-gr"
+                    className={cn(
+                      "group flex w-full items-center rounded-md px-1 py-2 transition-smooth text-destructive hover:bg-destructive/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-gr",
+                      collapsed
+                        ? "justify-center"
+                        : "flex-col gap-1",
+                    )}
                   >
                     <NavIcon name={item.icon} size={20} className="shrink-0" />
-                    <span className="text-xs font-medium leading-none truncate w-full text-center">
-                      {item.label}
-                    </span>
+                    {!collapsed && (
+                      <span className="text-xs font-medium leading-none truncate w-full text-center">
+                        {item.label}
+                      </span>
+                    )}
                   </button>
                 </form>
               );
@@ -176,8 +231,8 @@ export function PrimaryNav({
             return null;
           })}
 
-          {/* Email truncated at very bottom */}
-          {navContext.email && (
+          {/* Email truncated at very bottom — hidden when collapsed (no room) */}
+          {!collapsed && navContext.email && (
             <p
               className="mt-1 truncate border-t border-border pt-1.5 px-1 text-xs text-m3 text-center"
               title={navContext.email}

--- a/components/nav/section-nav.tsx
+++ b/components/nav/section-nav.tsx
@@ -22,7 +22,10 @@ import { CompanySelector } from "./company-selector";
 // text-color shift, per the two-level-nav spec.
 // ---------------------------------------------------------------------------
 
-export const SECTION_NAV_COLLAPSED_COOKIE = "opollo_section_nav_collapsed";
+// Re-export so existing callers (NavShellClient) keep working. Source of
+// truth for both nav cookies is `nav-shell-cookies.ts` so server components
+// can import them without crossing the "use client" boundary.
+export { SECTION_NAV_COLLAPSED_COOKIE } from "./nav-shell-cookies";
 
 interface SectionNavProps {
   navContext: NavUserContext;


### PR DESCRIPTION
## Summary

Closes Issues #1 and #4 from the admin-shell brief.

- **Width:** primary rail goes from `w-[70px]` → `w-[112px]` so labels render in full ("Optimiser", "Companies", "Batches", "Images" no longer truncate). Project-remapped `text-xs` is 16px in `app/globals.css`, so 9-char labels need ~110px to clear per-item padding.
- **Collapse toggle:** new chevron button below the logo bar. `aria-expanded` on the button, `aria-label` describes the action, focus-visible ring, Enter/Space operable. State persisted to BOTH localStorage (`opollo:nav:collapsed`) AND a cookie (`opollo_primary_nav_collapsed`) — same dual pattern the section nav already uses; cookie powers SSR first paint, localStorage carries across tabs.
- **Collapsed width:** 64px (icons only). Full label appears via the existing `title` attribute on hover. No new tooltip dependency.
- **Transitions:** 150ms ease-out on the rail width; section nav + content shift in lockstep.

## Files

- `components/nav/primary-nav.tsx` — accepts `collapsed` + `onCollapseToggle` props; renders the toggle row; dual-state classNames.
- `components/nav/nav-shell.tsx` — reads the new cookie server-side and passes the initial state to the client.
- `components/nav/nav-shell-client.tsx` — manages `primaryNavCollapsed` state alongside the existing section-nav collapse; toggle persists to both stores.
- `components/nav/nav-shell-cookies.ts` — new shared module so the server shell can import cookie names without crossing the "use client" boundary. `section-nav.tsx` re-exports `SECTION_NAV_COLLAPSED_COOKIE` from here so existing callers don't break.

## Applies to

`/admin/*`, `/company/*`, `/optimiser/*`, `/account/*` — all of which mount the same `NavShell`. One change covers everything per the brief.

## Spec divergence

The brief specified `lucide-react` `PanelLeftClose` / `PanelLeftOpen` icons for the toggle. **`lucide-react` was uninstalled in PR #734.** I'm using Linearicons `chevron-left` (when expanded — points to where the panel will collapse) / `chevron-right` (when collapsed — points to where it will expand). Functionally identical, directionally readable.

## Test plan

- [x] `npm run lint` — green
- [x] `npm run typecheck` — green
- [x] `npm run build` — green
- [ ] Visual smoke at 1280 / 1440 / 1920: every label rendered in full when expanded, none clipped
- [ ] Click the toggle, confirm rail collapses to 64px with icons only, hover reveals tooltip with full label
- [ ] Reload — collapsed state persists (cookie + localStorage)
- [ ] Tab to the toggle, confirm focus ring; Enter/Space operate it
- [ ] Verify same behaviour on `/company/social/calendar`, `/optimiser`, `/account/security`

🤖 Generated with [Claude Code](https://claude.com/claude-code)