### PR TITLE
Spec 03 PR 3: blog_content_classes injection block (helper ready)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -142,7 +142,7 @@ Operators get **Approve** / **Revise with note** / **Cancel run**. Approve write
 - What the appearance panel shows (`AppearancePanelClient` for new_design with Kadence preflight; `ExtractedProfilePanel` for copy_existing).
 - Which design context gets injected into the brief-runner prompt:
   - **`new_design`** — `design_tokens` + `homepage_concept_html` + `tone_of_voice` (gated on `DESIGN_CONTEXT_ENABLED`).
-  - **`copy_existing`** — `extracted_design` + `extracted_css_classes` (always on; mode is the gate).
+  - **`copy_existing`** — `extracted_design` + `extracted_css_classes` (always on; mode is the gate). When `extracted_design.blog_styling` is calibrated (Spec 03) AND the runner passes `content_type='post'` to `buildDesignContextPrefix()`, an additional `<blog_content_classes>` block is emitted alongside `<existing_theme_context>`. Pages and uncalibrated sites do not get the block.
   - **NULL** — pre-PR-10 fallback, no design context unless `DESIGN_CONTEXT_ENABLED` is on.
 
 `lib/design-discovery/build-injection.ts` orchestrates the dispatch. Don't centralise design-context construction back into a single path — the mode-aware split is intentional.

--- a/docs/audit/admin-route-audit-2026-05-07.md
+++ b/docs/audit/admin-route-audit-2026-05-07.md
@@ -1,0 +1,114 @@
+# Admin route audit — 2026-05-07
+
+Static-analysis audit prompted by the admin-shell brief. Walks every
+`/admin/*` page route and the `/api/admin/*` endpoints, checks the data
+dependency, and flags anything broken in production.
+
+## Methodology
+
+Source-only audit. Could not hit the live env (no prod admin credentials
+in this environment). Each row is verified by reading the route file and
+its server-side data calls, then cross-referencing the column names
+against migrations on disk.
+
+## Root cause that drives most of the breakage
+
+Migrations `0106_sites_last_connection_test_at.sql` and
+`0107_user_audit_log_site_actions.sql` (both from PR #732 / Spec 01)
+were not applied to production. The `.github/workflows/deploy-migrations.yml`
+last successful run was on commit `42dd9c2f` (PR #730); the squash-merges
+of PR #731, PR #732, PR #734, PR #735, and PR #736 did not trigger it.
+
+`lib/sites.ts:29 LIGHT_SITE_FIELDS` includes `last_connection_test_at`,
+which doesn't exist in prod yet. PostgREST returns
+`column "last_connection_test_at" does not exist` → `listSites()` returns
+`{ ok:false, error:{code:"INTERNAL_ERROR", message:"Failed to list sites"} }`.
+
+## Page routes
+
+| Route | Data dep | Status | Notes |
+|-------|----------|--------|-------|
+| `/admin` | redirect → `/admin/sites` | OK | trivial redirect |
+| `/admin/sites` | `listSites()` | **BROKEN** | LIGHT_SITE_FIELDS selects `last_connection_test_at` (Issue #2) |
+| `/admin/sites/new` | none server-side | OK | client form |
+| `/admin/sites/[id]` | `getSite()` (`select *`) + ad-hoc selects on listed columns | OK | `select *` is robust to missing columns; the ad-hoc select at line 164 lists pre-0106 columns only |
+| `/admin/sites/[id]/edit` | `getSite()` | OK | |
+| `/admin/sites/[id]/settings` | `getSite()` | OK | |
+| `/admin/sites/[id]/onboarding` | `getSite()` | OK | |
+| `/admin/sites/[id]/setup` | `getSite()` | OK | |
+| `/admin/sites/[id]/setup/extract` | `getSite()` | OK | |
+| `/admin/sites/[id]/appearance` | `getSite()` | OK | |
+| `/admin/sites/[id]/pages` | `getSite()` | OK | |
+| `/admin/sites/[id]/pages/[pageId]` | per-page select | OK | `pages` table not affected |
+| `/admin/sites/[id]/posts` | `getSite()` + `listPostsForSite()` | OK | `posts` table not affected |
+| `/admin/sites/[id]/posts/new` | `getSite()` | OK | |
+| `/admin/sites/[id]/posts/[post_id]` | per-post select | OK | |
+| `/admin/sites/[id]/briefs/[brief_id]/run` | `getSite()` + briefs select | OK | |
+| `/admin/sites/[id]/briefs/[brief_id]/review` | `getSite()` + briefs select | OK | |
+| `/admin/sites/[id]/blueprints/review` | client fetch | OK | hits `/api/sites/[id]/blueprints` |
+| `/admin/sites/[id]/content` | client fetch | OK | hits `/api/sites/[id]/shared-content` |
+| `/admin/sites/[id]/design-system` | `design_systems` select | OK | |
+| `/admin/sites/[id]/design-system/components` | `design_templates` select | OK | |
+| `/admin/sites/[id]/design-system/templates` | `design_templates` select | OK | |
+| `/admin/sites/[id]/design-system/preview` | renders only | OK | |
+| `/admin/posts/new` | `listSites()` | **BROKEN** | same root cause as `/admin/sites` (Issue #3) |
+| `/admin/batches` | `generation_jobs` select | OK | not affected |
+| `/admin/batches/[id]` | per-job select | OK | |
+| `/admin/images` | `image_library` select via `/api/admin/images/list` | OK | |
+| `/admin/images/[id]` | per-image select | OK | |
+| `/admin/users` | `opollo_users` select | OK | |
+| `/admin/users/audit` | `user_audit_log` select | OK at read-time | `0107` only loosens the action CHECK + drops NOT NULL on `target_email`; existing reads keep working pre-migration |
+| `/admin/companies` | `platform_companies` select | OK | |
+| `/admin/companies/new` | client form | OK | |
+| `/admin/companies/[id]` | `platform_companies` + `opollo_users` | OK | |
+| `/admin/system/jobs` | `generation_jobs` select | OK | |
+| `/admin/email-test` | none server-side | OK | client form |
+| `/admin/settings` | `design_system_settings` select | OK | |
+| `/admin/settings/design-system` | `design_system_settings` select | OK | |
+
+## API endpoints (admin-only or admin-callable)
+
+| Endpoint | Status | Notes |
+|----------|--------|-------|
+| `GET /api/sites/list` | **BROKEN (write-side dep)** | calls `listSites()` underneath |
+| `POST /api/sites/[id]/test-connection` | **PARTIALLY BROKEN** | tries to UPDATE `last_connection_test_at = now()` (lib/sites.ts:966). UPDATE on a missing column fails. |
+| `DELETE /api/sites/[id]/purge` | **BROKEN if invoked** | inserts `action='site_purged'` into `user_audit_log` — CHECK constraint blocks pre-0107. Super-admin only, so unlikely surfaced. |
+| `GET /api/admin/users/list` | OK | unaffected schema |
+| `GET /api/admin/images/list` | OK | unaffected schema |
+| `POST /api/platform/invitations` | OK | unaffected schema |
+| `GET /api/platform/companies/list` | OK | unaffected schema |
+| Other `/api/sites/[id]/*` (settings, blueprints, content, etc.) | OK | use getSite or per-id selects, all robust |
+
+## Summary
+
+- **Blocking failures in prod**: `/admin/sites`, `/admin/posts/new`,
+  `POST /api/sites/[id]/test-connection`, and (latent)
+  `DELETE /api/sites/[id]/purge`. All four are the same root cause —
+  missing migrations 0106 + 0107 in production.
+- **Single fix**: apply the two pending migrations via
+  `.github/workflows/deploy-migrations.yml` (workflow_dispatch on the
+  GitHub Actions UI, or a `gh workflow run deploy-migrations.yml --ref main`
+  from a local with credentials).
+- **Code is already correct on `main`** — no code change needed in PR A.
+- **No other admin routes are broken** in static analysis. If the user
+  surfaces additional issues from the live env, those go in a follow-up.
+
+## Why deploy-migrations didn't auto-trigger
+
+Confirmed gap: `gh run list --workflow deploy-migrations.yml --limit 20`
+shows the last successful run was on commit `42dd9c2f` (PR #730).
+PR #731 (commit `1d07ecfa`), PR #732 (`a6819e42`), PR #734 (`022a3ea1`),
+PR #735 (`9fcf1336`), PR #736 (`9c955cde`) all merged on `main` AFTER
+that. PR #732 modified `supabase/migrations/0106*.sql` and `0107*.sql`,
+which match the workflow's `paths` filter, but no run fired.
+
+Most likely cause: the workflow's `environment: production` gate has a
+required-reviewer rule that's silently dropping the auto-trigger queue
+without surfacing a "waiting for approval" run in the UI. (No
+`status=waiting` runs were found via `gh run list --status waiting`.)
+
+A separate follow-up should investigate why the queue isn't surfacing.
+For now, the recovery procedure documented in `docs/RUNBOOK.md`
+§"Apply pending migrations to production" is the right path:
+`workflow_dispatch` the deploy job (or run `supabase db push --linked
+--include-all` against the prod DB URL).

--- a/docs/specs/_blockers.md
+++ b/docs/specs/_blockers.md
@@ -1,0 +1,47 @@
+# Spec run blockers
+
+Surfaced by the autonomous spec runner. Each entry: which spec/PR, the
+contradiction encountered, and the chosen interim behaviour.
+
+## Spec 03 PR 3 — content_type gating without modifying brief-runner.ts
+
+**Date:** 2026-05-07
+
+**Spec section in tension:** Spec 03 §3.1 + §3.2.
+
+- §3.1 requires `<blog_content_classes>` to emit only when `content_type='post'`.
+- §3.2 says "This PR does not modify the runner" (per ARCH §18, `lib/brief-runner.ts` is on the cannot-refactor list).
+
+**Reality on disk:**
+
+- The runner calls `buildDesignContextPrefix(brief.site_id)` at `lib/brief-runner.ts:2004` — siteId only, no content_type, no `ctx` parameter.
+- The spec's diagnostic ("`ctx.brief.content_type` mirrors the pattern at brief-runner.ts:656-661") didn't match the actual signature. The spec author wrote "If different, use the actual path and adjust this spec's wording" but also wrote "this PR does not modify the runner" — these instructions disagree when the only non-runner-touching path requires adding a DB read inside the helper.
+
+**What this PR did:**
+
+- Added optional `contentType?: 'post' | 'page'` parameter to `buildDesignContextPrefix()` and `renderInjection()`.
+- Added the `<blog_content_classes>` block emission gated on `contentType === 'post'` AND `extracted_design.blog_styling` having usable data.
+- **Did NOT modify `lib/brief-runner.ts:2004`.** The call site still passes only `siteId`. Result: with current main, the new block never emits — the helper extension is ready-to-activate but inert.
+
+**To activate:** change `lib/brief-runner.ts:2004` from
+
+```ts
+const designContextPrefix = await buildDesignContextPrefix(brief.site_id);
+```
+
+to
+
+```ts
+const designContextPrefix = await buildDesignContextPrefix(
+  brief.site_id,
+  brief.content_type,
+);
+```
+
+That single-line change is gated on Steven's explicit approval per ARCH §18.
+
+**Why this is acceptable interim state:**
+
+- All vitest tests for the helper still pass (they exercise both the gated and ungated paths via the optional parameter).
+- No runtime regression: existing callers' behaviour is unchanged.
+- PR 1 (extraction) + PR 2 (preflight gate) of Spec 03 still deliver value: operators can calibrate, gate fires at publish time. The third leg (model receives the calibrated classes) waits on Steven's approval to thread the parameter.

--- a/lib/__tests__/build-injection.test.ts
+++ b/lib/__tests__/build-injection.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import { renderInjection } from "@/lib/design-discovery/build-injection";
+
+// Spec 03 §3.3 — <blog_content_classes> emission rules.
+//
+// The renderInjection() helper is exercised here directly with stub
+// SiteContextRow inputs so we don't depend on the Supabase stack for
+// pure-function behaviour. The DB-loading path is exercised via the
+// existing brief-runner-dummy integration test footprint (locate +
+// extend in a follow-up if/when the runner-side activation lands;
+// see docs/specs/_blockers.md).
+
+const BLOG_STYLING_FULL = {
+  source_blog_urls: ["https://example.com/blog/p1"],
+  article_container: "entry",
+  paragraph: "entry-content",
+  link_in_body: "entry-link",
+  blockquote: null,
+  unordered_list: null,
+  ordered_list: null,
+  list_item: null,
+  figure: null,
+  figcaption: null,
+  code_inline: null,
+  code_block: null,
+  hr: null,
+  article_h2: "wp-block-heading",
+  article_h3: null,
+  article_h4: null,
+  notes: [],
+  extracted_at: new Date().toISOString(),
+};
+
+function copyExistingRow(opts: {
+  blog_styling?: unknown;
+}): Parameters<typeof renderInjection>[0] {
+  return {
+    site_mode: "copy_existing",
+    design_direction_status: null,
+    tone_of_voice_status: null,
+    design_tokens: null,
+    homepage_concept_html: null,
+    tone_applied_homepage_html: null,
+    tone_of_voice: null,
+    extracted_design: {
+      colors: { primary: "#000" },
+      fonts: { heading: "Inter" },
+      layout_density: "medium",
+      visual_tone: "Neutral",
+      blog_styling: opts.blog_styling ?? null,
+    } as unknown as Record<string, unknown>,
+    extracted_css_classes: {
+      container: "container",
+      headings: { h1: "h1", h2: "h2", h3: "h3" },
+      button: "btn",
+      card: "card",
+    } as unknown as Record<string, unknown>,
+  };
+}
+
+describe("renderInjection — Spec 03 PR 3 blog_content_classes block", () => {
+  it("emits the block when blog_styling is present + content_type='post'", () => {
+    const out = renderInjection(
+      copyExistingRow({ blog_styling: BLOG_STYLING_FULL }),
+      "post",
+    );
+    expect(out).toContain("<blog_content_classes>");
+    expect(out).toContain("paragraph: .entry-content");
+    expect(out).toContain("article_h2: .wp-block-heading");
+    expect(out).toContain("</blog_content_classes>");
+  });
+
+  it("does NOT emit when blog_styling is present + content_type='page'", () => {
+    const out = renderInjection(
+      copyExistingRow({ blog_styling: BLOG_STYLING_FULL }),
+      "page",
+    );
+    expect(out).not.toContain("<blog_content_classes>");
+    // The landing-page block always emits for copy_existing.
+    expect(out).toContain("<existing_theme_context>");
+  });
+
+  it("does NOT emit when blog_styling is null + content_type='post'", () => {
+    const out = renderInjection(
+      copyExistingRow({ blog_styling: null }),
+      "post",
+    );
+    expect(out).not.toContain("<blog_content_classes>");
+  });
+
+  it("does NOT emit when blog_styling is null + content_type='page'", () => {
+    const out = renderInjection(
+      copyExistingRow({ blog_styling: null }),
+      "page",
+    );
+    expect(out).not.toContain("<blog_content_classes>");
+  });
+
+  it("renders the placeholder text for null buckets", () => {
+    const out = renderInjection(
+      copyExistingRow({
+        blog_styling: { ...BLOG_STYLING_FULL, blockquote: null, code_block: null },
+      }),
+      "post",
+    );
+    // Placeholder format per spec: '(none — use plain <X>)'
+    expect(out).toContain("blockquote: (none — use plain <blockquote>)");
+    expect(out).toContain("code_block: (none — use plain <pre><code>)");
+  });
+
+  it("does NOT emit when blog_styling has zero source URLs and zero non-null buckets", () => {
+    const out = renderInjection(
+      copyExistingRow({
+        blog_styling: {
+          ...BLOG_STYLING_FULL,
+          source_blog_urls: [],
+          article_container: null,
+          paragraph: null,
+          link_in_body: null,
+          article_h2: null,
+        },
+      }),
+      "post",
+    );
+    expect(out).not.toContain("<blog_content_classes>");
+  });
+
+  it("does NOT emit when content_type is undefined (default)", () => {
+    const out = renderInjection(
+      copyExistingRow({ blog_styling: BLOG_STYLING_FULL }),
+    );
+    expect(out).not.toContain("<blog_content_classes>");
+  });
+
+  it("emits the landing-page block alongside, not instead of", () => {
+    const out = renderInjection(
+      copyExistingRow({ blog_styling: BLOG_STYLING_FULL }),
+      "post",
+    );
+    // Both blocks present; <existing_theme_context> appears first.
+    const idxTheme = out.indexOf("<existing_theme_context>");
+    const idxBlog = out.indexOf("<blog_content_classes>");
+    expect(idxTheme).toBeGreaterThan(-1);
+    expect(idxBlog).toBeGreaterThan(idxTheme);
+  });
+});

--- a/lib/design-discovery/build-injection.ts
+++ b/lib/design-discovery/build-injection.ts
@@ -55,6 +55,157 @@ interface SiteContextRow {
   extracted_css_classes: Record<string, unknown> | null;
 }
 
+// Spec 03 PR 3 — operator-calibrated blog content classes injected
+// alongside <existing_theme_context> for content_type='post' runs on
+// copy_existing sites. Stored on extracted_design.blog_styling.
+interface BlogStylingRow {
+  source_blog_urls?: string[];
+  article_container?: string | null;
+  paragraph?: string | null;
+  link_in_body?: string | null;
+  blockquote?: string | null;
+  unordered_list?: string | null;
+  ordered_list?: string | null;
+  list_item?: string | null;
+  figure?: string | null;
+  figcaption?: string | null;
+  code_inline?: string | null;
+  code_block?: string | null;
+  hr?: string | null;
+  article_h2?: string | null;
+  article_h3?: string | null;
+  article_h4?: string | null;
+}
+
+const BLOG_BUCKET_FALLBACK_TAGS: Record<keyof BlogStylingRow, string> = {
+  source_blog_urls: "",
+  article_container: "<article>",
+  paragraph: "<p>",
+  link_in_body: "",
+  blockquote: "<blockquote>",
+  unordered_list: "<ul>",
+  ordered_list: "<ol>",
+  list_item: "<li>",
+  figure: "<figure>",
+  figcaption: "<figcaption>",
+  code_inline: "<code>",
+  code_block: "<pre><code>",
+  hr: "<hr>",
+  article_h2: "<h2>",
+  article_h3: "<h3>",
+  article_h4: "<h4>",
+};
+
+function renderBlogClassLine(
+  key: keyof BlogStylingRow,
+  value: string | null | undefined,
+): string {
+  if (key === "source_blog_urls") return "";
+  if (typeof value === "string" && value.length > 0) {
+    return `${key}: .${value}`;
+  }
+  if (key === "link_in_body") {
+    return `${key}: (none)`;
+  }
+  const fallbackTag = BLOG_BUCKET_FALLBACK_TAGS[key];
+  return `${key}: (none — use plain ${fallbackTag})`;
+}
+
+function renderBlogContentClassesBlock(blog: BlogStylingRow): string {
+  const orderedKeys: Array<keyof BlogStylingRow> = [
+    "article_container",
+    "paragraph",
+    "link_in_body",
+    "blockquote",
+    "unordered_list",
+    "ordered_list",
+    "list_item",
+    "figure",
+    "figcaption",
+    "code_inline",
+    "code_block",
+    "hr",
+    "article_h2",
+    "article_h3",
+    "article_h4",
+  ];
+  const lines: string[] = [
+    "<blog_content_classes>",
+    "When generating blog post content (long-form articles), use these existing CSS classes",
+    "on the matching elements. Drop the `.` prefix when applying as className. If a bucket",
+    "is null, fall back to plain semantic tags without a class.",
+    "",
+  ];
+  for (const key of orderedKeys) {
+    const value = blog[key];
+    lines.push(renderBlogClassLine(key, value as string | null | undefined));
+  }
+  lines.push("");
+  lines.push(
+    "These classes were extracted from your existing blog posts. Use them verbatim — do",
+  );
+  lines.push(
+    "not invent variants. Do not introduce inline CSS for elements that have a class above.",
+  );
+  lines.push("</blog_content_classes>");
+  return lines.join("\n");
+}
+
+function blogStylingHasUsableData(
+  blog: BlogStylingRow | null | undefined,
+): blog is BlogStylingRow {
+  if (!blog || typeof blog !== "object") return false;
+  if (
+    Array.isArray(blog.source_blog_urls) &&
+    blog.source_blog_urls.length === 0
+  ) {
+    // Operator submitted but extraction produced nothing — bucket
+    // values still count if any were filled in manually.
+    const bucketKeys: Array<keyof BlogStylingRow> = [
+      "article_container",
+      "paragraph",
+      "link_in_body",
+      "blockquote",
+      "unordered_list",
+      "ordered_list",
+      "list_item",
+      "figure",
+      "figcaption",
+      "code_inline",
+      "code_block",
+      "hr",
+      "article_h2",
+      "article_h3",
+      "article_h4",
+    ];
+    return bucketKeys.some(
+      (k) => typeof blog[k] === "string" && (blog[k] as string).length > 0,
+    );
+  }
+  if (!Array.isArray(blog.source_blog_urls)) return false;
+  // At least one bucket must have a non-null value to be useful.
+  const bucketKeys: Array<keyof BlogStylingRow> = [
+    "article_container",
+    "paragraph",
+    "link_in_body",
+    "blockquote",
+    "unordered_list",
+    "ordered_list",
+    "list_item",
+    "figure",
+    "figcaption",
+    "code_inline",
+    "code_block",
+    "hr",
+    "article_h2",
+    "article_h3",
+    "article_h4",
+  ];
+  return bucketKeys.some(
+    (k) => typeof blog[k] === "string" && (blog[k] as string).length > 0,
+  );
+}
+
 export async function loadSiteDesignContext(
   siteId: string,
 ): Promise<SiteContextRow | null> {
@@ -115,13 +266,17 @@ function samplesBlock(tone: Record<string, unknown>): string {
   return out.join("\n");
 }
 
-function renderCopyExistingInjection(row: SiteContextRow): string {
+function renderCopyExistingInjection(
+  row: SiteContextRow,
+  contentType?: "post" | "page",
+): string {
   const design = (row.extracted_design ?? null) as
     | {
         colors?: Record<string, string | null>;
         fonts?: Record<string, string | null>;
         layout_density?: string | null;
         visual_tone?: string | null;
+        blog_styling?: BlogStylingRow | null;
       }
     | null;
   const classes = (row.extracted_css_classes ?? null) as
@@ -192,17 +347,33 @@ function renderCopyExistingInjection(row: SiteContextRow): string {
     "If a bucket above is missing, fall back to plain semantic tags without a class.",
   );
   lines.push("</existing_theme_context>");
+
+  // Spec 03 PR 3 — append <blog_content_classes> for content_type='post'
+  // runs only, alongside (not instead of) the landing-page block.
+  // Pages still need landing-page class context; posts need both.
+  if (
+    contentType === "post" &&
+    design?.blog_styling &&
+    blogStylingHasUsableData(design.blog_styling)
+  ) {
+    const blogBlock = renderBlogContentClassesBlock(design.blog_styling);
+    return `${lines.join("\n")}\n${blogBlock}`;
+  }
+
   return lines.join("\n");
 }
 
-export function renderInjection(row: SiteContextRow | null): string {
+export function renderInjection(
+  row: SiteContextRow | null,
+  contentType?: "post" | "page",
+): string {
   if (!row) return "";
 
   // copy_existing pathway runs regardless of DESIGN_CONTEXT_ENABLED —
   // it's gated by site_mode itself, which is only set after the
   // operator opts in via /onboarding.
   if (row.site_mode === "copy_existing") {
-    return renderCopyExistingInjection(row) + "\n\n";
+    return renderCopyExistingInjection(row, contentType) + "\n\n";
   }
 
   // new_design pathway — preserve the original DESIGN-DISCOVERY
@@ -271,17 +442,20 @@ export function renderInjection(row: SiteContextRow | null): string {
 // Returns "" on early exit so callers don't have to pre-check.
 export async function buildDesignContextPrefix(
   siteId: string,
+  contentType?: "post" | "page",
 ): Promise<string> {
   const row = await loadSiteDesignContext(siteId);
   if (!row) return "";
-  if (row.site_mode === "copy_existing") return renderInjection(row);
+  if (row.site_mode === "copy_existing") {
+    return renderInjection(row, contentType);
+  }
   if (row.site_mode === "new_design") {
     if (!isDesignContextEnabled()) return "";
-    return renderInjection(row);
+    return renderInjection(row, contentType);
   }
   // site_mode IS NULL — preserve the pre-PR-10 fallback exactly so a
   // half-onboarded site doesn't suddenly start pulling discovery
   // context.
   if (!isDesignContextEnabled()) return "";
-  return renderInjection(row);
+  return renderInjection(row, contentType);
 }


### PR DESCRIPTION
Third and final PR for `docs/specs/03-blog-styling-calibration.md`.

## What this PR does

Extends `lib/design-discovery/build-injection.ts` to emit a `<blog_content_classes>` block alongside `<existing_theme_context>` when `extracted_design.blog_styling` is calibrated AND the runner indicates `content_type='post'`. The block lists every bucket — `article_container`, `paragraph`, `link_in_body`, `blockquote`, `unordered_list`, `ordered_list`, `list_item`, `figure`, `figcaption`, `code_inline`, `code_block`, `hr`, `article_h2`, `article_h3`, `article_h4` — with the spec-mandated placeholder text for null buckets ("(none — use plain `<X>`)").

Block is **additive**: pages still get `<existing_theme_context>` alone; only post-mode runs on calibrated copy_existing sites get both blocks concatenated.

## API change

`buildDesignContextPrefix()` and `renderInjection()` now accept an optional `contentType?: 'post' | 'page'` parameter. Without it, the helper preserves pre-existing behaviour exactly — the new block does NOT emit. All current callers (`lib/brief-runner.ts:2004`, `lib/system-prompt.ts:225`) remain unmodified by this PR.

## ⚠ Activation requires one runner-line change — gated on Steven's approval

Per **ARCH §18**, `lib/brief-runner.ts` is on the cannot-refactor-without-approval list. Per **Spec 03 §3.2**, "this PR does not modify the runner". These instructions are mutually exclusive when the runner is the only caller that has `brief.content_type` in scope at the call site.

**This PR does NOT touch `lib/brief-runner.ts`.** The helper extension ships ready to activate. To turn on the block emission for production runs, the one-line change at `lib/brief-runner.ts:2004` is:

```ts
const designContextPrefix = await buildDesignContextPrefix(
  brief.site_id,
  brief.content_type,   // ← add this
);
```

Full contradiction note + rationale lives in `docs/specs/_blockers.md`.

## Files

- `lib/design-discovery/build-injection.ts` — new `BlogStylingRow` type, `renderBlogContentClassesBlock()`, `blogStylingHasUsableData()` guard, optional `contentType` plumbing on `renderInjection` + `buildDesignContextPrefix`.
- `lib/__tests__/build-injection.test.ts` — 8 vitest cases:
  1. blog_styling present + content_type='post' → block emitted.
  2. blog_styling present + content_type='page' → block NOT emitted.
  3. blog_styling null + content_type='post' → block NOT emitted.
  4. blog_styling null + content_type='page' → block NOT emitted.
  5. Null buckets render with the spec placeholder text.
  6. Empty `source_blog_urls` + zero non-null buckets → block NOT emitted.
  7. content_type undefined (default) → block NOT emitted.
  8. Block ordering — `<existing_theme_context>` precedes `<blog_content_classes>`.
- `docs/ARCHITECTURE.md` §5 — documents the new block.
- `docs/specs/_blockers.md` — spec-vs-ARCH contradiction surfaced for Steven.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Runner activation requires a one-line change Steven controls | `_blockers.md` surfaces it explicitly; helper ships ready-to-activate |
| Block over-emits when `contentType` undefined | Fail-safe: returns no block when `contentType` is undefined |
| `blog_styling` rows with empty `source_blog_urls` AND no manual edits emit phantom block | `blogStylingHasUsableData()` rejects this case (vitest covers it) |
| Block order across `<existing_theme_context>` and `<blog_content_classes>` matters for the model | Vitest pins ordering |
| Helper used by both brief-runner + system-prompt LeadSource path | Optional parameter is backward-compatible; system-prompt.ts passes nothing → no block emission, preserves LeadSource behaviour |

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — clean
- `npm run audit:static` — 0 HIGH, 0 MEDIUM (LOWs pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
