### PR TITLE
Spec 02 PR 3: page-header HIGH audit rules + RULES.md + ARCH

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -304,6 +304,7 @@ Pages under `app/admin/*` are server components by default. Promote to client on
 - shadcn/ui primitives in `components/ui/*`. Don't create a custom Button when `Button` exists.
 - Status pills go through `components/ui/status-pill.tsx` — adding a new status means adding to the kind union + STATUS_MAP.
 - Typography minimum: `text-base` (16px) for body, `text-sm` (15px after the 2026-05-03 floor bump) for helper. `text-xs` is forbidden and overridden to 15px sitewide via `app/globals.css`. Lucide icons floor at 20px (`svg.lucide`) — same source.
+- **Page chrome** (Spec 02): admin and account pages compose `components/ui/page-header.tsx` (compound component with `Breadcrumb` / `Title` / `Subtitle` / `Meta` / `Actions` slots) inside `components/ui/page-shell.tsx` (1280px max-width frame). `components/ui/breadcrumb.tsx` is the standalone breadcrumb primitive. The page-heading type scale (`.text-page-title` 28px, `.text-section-title` 20px, `.text-subsection` 16px) lives in `app/globals.css` alongside the body / helper floors. Audit rules `headings-use-page-header`, `breadcrumb-required-when-page-header`, and `no-raw-h1-in-pages` (HIGH severity, all in `scripts/audit.ts`) enforce the contract on every PR.
 
 ### 13.4 Toast pattern
 
@@ -376,8 +377,8 @@ These traps will catch a "dead code" sweep. Don't delete:
 - **Path B** (PB-1+) — fragments-only generation, inline CSS budget capped at 200 chars, mandatory `data-opollo` wrapper, site-prefixed classes. See `docs/plans/path-b-migration-parent.md`. The model's system prompt enforces this in `lib/brief-runner.ts:574-609`. Don't reintroduce full-document generation paths.
 - **DESIGN-SYSTEM-OVERHAUL** — see § 5. Site mode dispatch is the load-bearing piece.
 - **AUTH-FOUNDATION (P1–P4)** — the role rename, invites table, login_challenges + trusted_devices, audit log, are all current state. The full picture is in `CLAUDE.md` AUTH-FOUNDATION section + UAT-CHECKLIST § 1.
-- **PLATFORM-AUDIT** — `npm run audit:static` runs `scripts/audit.ts` which ships a static-analysis suite (middleware coverage, auth gates, db references, migration sanity, typography, env vars, error handling, dead routes). HIGH severity gates CI. Adding a new check is a small PR; loosening an existing one needs `docs/RULES.md` justification.
-- **Optimiser** — see § 2. Currently on `feat/optimiser` branch, not main.
+- **PLATFORM-AUDIT** — `npm run audit:static` runs `scripts/audit.ts` which ships a static-analysis suite (middleware coverage, auth gates, db references, migration sanity, typography, env vars, error handling, dead routes). HIGH severity gates CI. Adding a new check is a small PR; loosening an existing one needs `docs/RULES.md` justification. Spec 02 added three more HIGH rules: `headings-use-page-header`, `breadcrumb-required-when-page-header`, `no-raw-h1-in-pages`. Allowlist for the routes still pending PageHeader migration lives in `scripts/audit.ts:PAGE_HEADER_DEFERRED_ROUTES`.
+- **Optimiser** — see § 2. Currently on `feat/optimiser` branch, not main. **TODO** (Spec 02 PR 2 §2.1): once the optimiser branch merges to main, sweep its routes to adopt PageHeader / PageShell — they were intentionally skipped from PR 2's adoption sweep because they live on a separate feature branch.
 
 ---
 
@@ -466,6 +467,7 @@ Today operators see everything. The "viewer" role is a legacy tier with no opera
 | Data conventions | `docs/DATA_CONVENTIONS.md` |
 | Prompt versioning | `docs/PROMPT_VERSIONING.md`, `lib/prompts/v*` |
 | UAT checklist | `docs/UAT-CHECKLIST.md` (round-by-round procedure) |
+| Page chrome / breadcrumbs | `components/ui/{page-header,breadcrumb,page-shell}.tsx`, `app/globals.css` (`.text-page-title` / `.text-section-title` / `.text-subsection`) |
 
 ---
 

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -78,6 +78,30 @@ Sort: strongest "if you skip this, production breaks" signal at the top.
 
 ---
 
+## 10. Admin pages use the shared PageHeader primitive
+
+**Rule.** All authenticated admin pages must use the shared PageHeader component to ensure consistent typographic hierarchy and breadcrumb structure across the platform. Concretely: every `app/admin/**/page.tsx` and `app/account/**/page.tsx` file MUST `import { PageHeader } from "@/components/ui/page-header"` and render its compound slots (`<PageHeader.Breadcrumb>`, `<PageHeader.Title>`, optional Subtitle / Meta / Actions) in the component tree. Audit script `headings-use-page-header` (HIGH) enforces presence at PR time. New admin / account pages join the rule by default; the deferred-routes allowlist in `scripts/audit.ts` (`PAGE_HEADER_DEFERRED_ROUTES`) carries the legacy routes from PR 2's partial sweep — entries get removed as each route is migrated.
+
+**Incident (Spec 02, 2026-05-07).** PageHeader / PageShell / Breadcrumb landed in PR 1 of Spec 02. PR 2 swept the top 8 operator-traffic routes (sites list, site detail edit, onboarding, setup, setup/extract, posts, settings); the remaining 29 admin routes plus 2 account routes are deferred to a follow-up sweep (see `docs/specs/_blockers.md`). Audit rule lands in PR 3 with the deferred allowlist so the rule starts firing as soon as the follow-up migrates each route.
+
+---
+
+## 11. Breadcrumbs are required when a page imports PageHeader
+
+**Rule.** Breadcrumbs are required because the platform's nested navigation depth (`Admin > Sites > Site > Setup > Step`) cannot be inferred from the URL alone. If a `page.tsx` imports `PageHeader`, it MUST render `<PageHeader.Breadcrumb>` in its JSX. Audit script `breadcrumb-required-when-page-header` (HIGH) enforces. Pages outside admin / account (public marketing, login chrome) don't import PageHeader and are unaffected.
+
+**Incident (Spec 02, 2026-05-07).** Same workstream as Rule #10. Operators on the run page have lost track of which site they were on more than once — no breadcrumb on that surface meant 5-deep navigation depth without trail. The rule prevents that class of UX failure from regressing on any PageHeader-adopting page.
+
+---
+
+## 12. Raw h1 tags are forbidden in page.tsx
+
+**Rule.** Raw `<h1>` JSX tags appearing directly in `app/admin/**/page.tsx` or `app/account/**/page.tsx` outside of `<PageHeader.Title>` are forbidden — they bypass the type scale defined in `app/globals.css` (`.text-page-title` 28px / 24px mobile) and create accessibility issues with multiple page-level h1s. Audit script `no-raw-h1-in-pages` (HIGH) enforces JSX-tag-positionally. Excluded from rule scope: `app/api/**`, `app/**/_components/**`, polymorphic `<Component as="h1" />` patterns, and pages that already render an `<h1>` inside a `<PageHeader.Title>` window. Variable-assigned `<h1>` then passed into PageHeader does not fire — see Spec 02 §3.3 rule scope.
+
+**Incident (Spec 02, 2026-05-07).** Same workstream as Rules #10 and #11. The pre-PageHeader admin surfaces had 30+ `<H1>` instances scattered across page files with inconsistent custom class soup. Rule #12 prevents new instances; PR 2's sweep removed them on the migrated routes; the deferred-routes allowlist in the audit script keeps legacy h1s tolerated until each is migrated.
+
+---
+
 ## Adding a new rule
 
 - If a recurring shape with scaffolding emerges, that's a pattern — put it in `docs/patterns/`, not here.

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -2,7 +2,7 @@
 /**
  * scripts/audit.ts — Static analysis: catch logic errors before UAT.
  *
- * Ten checks (HIGH | MEDIUM | LOW severity):
+ * Thirteen checks (HIGH | MEDIUM | LOW severity):
  *   1. Middleware public paths              HIGH
  *   2. Admin API gate coverage              MEDIUM
  *   3. DB column references                 MEDIUM
@@ -13,6 +13,9 @@
  *   8. Missing error handling on writes     MEDIUM
  *   9. Dead routes                          LOW
  *  10. Hardcoded design token values        LOW
+ *  11. Headings use PageHeader              HIGH (Spec 02 §3.1)
+ *  12. Breadcrumb required when PageHeader  HIGH (Spec 02 §3.2)
+ *  13. No raw <h1> in pages                 HIGH (Spec 02 §3.3)
  *
  * Output:
  *   - Per-issue lines: FILE:LINE — CATEGORY — message
@@ -1145,11 +1148,182 @@ function printResults(issues: Issue[]): boolean {
 }
 
 // ============================================================================
+// Spec 02 §3 — PageHeader audit rules.
+// ============================================================================
+
+// Routes deferred from Spec 02 PR 2's adoption sweep. Tracked in
+// docs/specs/_blockers.md. Allowlist runs at HIGH severity for the
+// migrated routes; deferred routes are scoped out until the follow-up
+// sweep migrates them. Once a route here adopts PageHeader, REMOVE it
+// from this list — that's how the rule progressively widens.
+const PAGE_HEADER_DEFERRED_ROUTES: readonly string[] = [
+  // /admin/* deferred routes (29 of 37)
+  "app/admin/page.tsx",
+  "app/admin/batches/page.tsx",
+  "app/admin/batches/[id]/page.tsx",
+  "app/admin/companies/page.tsx",
+  "app/admin/companies/new/page.tsx",
+  "app/admin/companies/[id]/page.tsx",
+  "app/admin/email-test/page.tsx",
+  "app/admin/images/page.tsx",
+  "app/admin/images/[id]/page.tsx",
+  "app/admin/posts/new/page.tsx",
+  "app/admin/settings/page.tsx",
+  "app/admin/settings/design-system/page.tsx",
+  "app/admin/sites/[id]/page.tsx",
+  "app/admin/sites/[id]/appearance/page.tsx",
+  "app/admin/sites/[id]/blueprints/review/page.tsx",
+  "app/admin/sites/[id]/briefs/[brief_id]/review/page.tsx",
+  "app/admin/sites/[id]/briefs/[brief_id]/run/page.tsx",
+  "app/admin/sites/[id]/content/page.tsx",
+  "app/admin/sites/[id]/design-system/page.tsx",
+  "app/admin/sites/[id]/design-system/components/page.tsx",
+  "app/admin/sites/[id]/design-system/preview/page.tsx",
+  "app/admin/sites/[id]/design-system/templates/page.tsx",
+  "app/admin/sites/[id]/pages/page.tsx",
+  "app/admin/sites/[id]/pages/[pageId]/page.tsx",
+  "app/admin/sites/[id]/posts/new/page.tsx",
+  "app/admin/sites/[id]/posts/[post_id]/page.tsx",
+  "app/admin/system/jobs/page.tsx",
+  "app/admin/users/page.tsx",
+  "app/admin/users/audit/page.tsx",
+  // /account/* deferred (the operator account-management surface; same
+  // mechanical migration as /admin/* but kept out of PR 2's scope).
+  "app/account/devices/page.tsx",
+  "app/account/security/page.tsx",
+];
+
+function isPageHeaderDeferred(rel: string): boolean {
+  return PAGE_HEADER_DEFERRED_ROUTES.includes(rel.replace(/\\/g, "/"));
+}
+
+function isPageHeaderEnforcedRoute(rel: string): boolean {
+  // Normalise Windows separators (the audit walker uses node:path which
+  // can produce "\" on Windows) so the allowlist match is OS-agnostic.
+  const norm = rel.replace(/\\/g, "/");
+  if (!norm.startsWith("app/admin/") && !norm.startsWith("app/account/")) {
+    return false;
+  }
+  if (!norm.endsWith("/page.tsx")) return false;
+  return !PAGE_HEADER_DEFERRED_ROUTES.includes(norm);
+}
+
+function check11_headingsUsePageHeader(): Issue[] {
+  const issues: Issue[] = [];
+  const roots = ["app/admin", "app/account"];
+  for (const root of roots) {
+    const dir = join(REPO_ROOT, root);
+    if (!existsSync(dir)) continue;
+    for (const file of walkFiles(dir, [".tsx"])) {
+      const rel = relPath(file);
+      if (!isPageHeaderEnforcedRoute(rel)) continue;
+      const src = readSafe(file);
+      // Match either an `import { PageHeader } …` named import or a
+      // typed `import …, { PageHeader …}` form. The path is fixed.
+      const hasImport =
+        /import\s*(?:type\s+)?\{[^}]*\bPageHeader\b[^}]*\}\s*from\s*["']@\/components\/ui\/page-header["']/.test(
+          src,
+        );
+      if (!hasImport) {
+        issues.push({
+          category: "headings-use-page-header",
+          severity: "HIGH",
+          file: rel,
+          line: 1,
+          message:
+            "Admin/account page must import PageHeader from @/components/ui/page-header (Spec 02 §3.1).",
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+function check12_breadcrumbRequiredWithPageHeader(): Issue[] {
+  const issues: Issue[] = [];
+  const roots = ["app/admin", "app/account"];
+  for (const root of roots) {
+    const dir = join(REPO_ROOT, root);
+    if (!existsSync(dir)) continue;
+    for (const file of walkFiles(dir, [".tsx"])) {
+      const rel = relPath(file);
+      if (!rel.replace(/\\/g, "/").endsWith("/page.tsx")) continue;
+      const src = readSafe(file);
+      const importsPageHeader =
+        /import\s*(?:type\s+)?\{[^}]*\bPageHeader\b[^}]*\}\s*from\s*["']@\/components\/ui\/page-header["']/.test(
+          src,
+        );
+      if (!importsPageHeader) continue;
+      const usesBreadcrumb = /<PageHeader\.Breadcrumb\b/.test(src);
+      if (!usesBreadcrumb) {
+        issues.push({
+          category: "breadcrumb-required-when-page-header",
+          severity: "HIGH",
+          file: rel,
+          line: 1,
+          message:
+            "page.tsx imports PageHeader but is missing <PageHeader.Breadcrumb> (Spec 02 §3.2).",
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+function check13_noRawH1InPages(): Issue[] {
+  const issues: Issue[] = [];
+  const roots = ["app/admin", "app/account"];
+  // Match a literal JSX `<h1>` opening tag (with attrs allowed). Skip
+  // closing tags. Self-closing not relevant for h1. The rule is JSX-tag
+  // positional; flow-analysis-style cases (assigning <h1>… to a
+  // variable then passing into PageHeader.Title) do not fire — see
+  // Spec 02 §3.3 rule scope.
+  const h1OpenRe = /<h1\b[^>]*>/;
+  for (const root of roots) {
+    const dir = join(REPO_ROOT, root);
+    if (!existsSync(dir)) continue;
+    for (const file of walkFiles(dir, [".tsx"])) {
+      const rel = relPath(file);
+      const norm = rel.replace(/\\/g, "/");
+      if (!norm.endsWith("/page.tsx")) continue;
+      // Excluded scope per Spec 02 §3.3: app/api, _components private dirs.
+      if (norm.includes("/_components/")) continue;
+      // Allowlist deferred routes from PR 2's partial sweep — see the
+      // PAGE_HEADER_DEFERRED_ROUTES list above. Once a deferred route
+      // adopts PageHeader, remove it from that list and this check
+      // starts firing on it.
+      if (isPageHeaderDeferred(rel)) continue;
+      const lines = readSafe(file).split(/\r?\n/);
+      lines.forEach((ln, i) => {
+        if (h1OpenRe.test(ln)) {
+          // Allow when the surrounding source nests the h1 inside a
+          // PageHeader.Title element on the same or adjacent line. Cheap
+          // heuristic: peek 2 lines back.
+          const window = lines
+            .slice(Math.max(0, i - 2), i + 1)
+            .join("\n");
+          if (/<PageHeader\.Title\b/.test(window)) return;
+          issues.push({
+            category: "no-raw-h1-in-pages",
+            severity: "HIGH",
+            file: rel,
+            line: i + 1,
+            message:
+              "Raw <h1> in page.tsx — wrap inside <PageHeader.Title> instead (Spec 02 §3.3).",
+          });
+        }
+      });
+    }
+  }
+  return issues;
+}
+
+// ============================================================================
 // Main
 // ============================================================================
 
 function main(): void {
-  console.log("scripts/audit.ts — running 10 static checks...\n");
+  console.log("scripts/audit.ts — running 13 static checks...\n");
 
   const all: Issue[] = [
     ...check1_middlewarePublicPaths(),
@@ -1162,6 +1336,9 @@ function main(): void {
     ...check8_errorHandling(),
     ...check9_deadRoutes(),
     ...check10_hardcodedDesignValues(),
+    ...check11_headingsUsePageHeader(),
+    ...check12_breadcrumbRequiredWithPageHeader(),
+    ...check13_noRawH1InPages(),
   ];
 
   const failed = printResults(all);


### PR DESCRIPTION
Third and final PR for `docs/specs/02-page-header-typography.md`.

## What this PR does

Three new HIGH-severity audit:static rules to enforce the PageHeader / Breadcrumb / type-scale contract from PRs 1 + 2. The rules use a deferred-routes allowlist so they pass on the 29 admin + 2 account routes that PR 2 didn't migrate, and they fire as soon as those routes adopt PageHeader (just remove from the allowlist).

## New audit rules

| Rule | Severity | Description |
|---|---|---|
| `headings-use-page-header` | HIGH | Every `app/admin/**/page.tsx` and `app/account/**/page.tsx` must `import { PageHeader } from "@/components/ui/page-header"`. |
| `breadcrumb-required-when-page-header` | HIGH | If `page.tsx` imports `PageHeader`, it must render `<PageHeader.Breadcrumb>` in JSX. |
| `no-raw-h1-in-pages` | HIGH | Raw `<h1>` JSX in `page.tsx` outside `<PageHeader.Title>` is forbidden. |

Rule scope (per Spec 02 §3.3):
- Excludes `app/api/**`
- Excludes `app/**/_components/**`
- Excludes polymorphic `<Component as="h1" />` patterns
- Excludes h1s already nested inside a `<PageHeader.Title>` 3-line window
- Variable-assigned `<h1>` then passed into `PageHeader.Title` does not fire — the rule is JSX-tag positional, not flow-analysis

## Allowlist mechanism

`PAGE_HEADER_DEFERRED_ROUTES` in `scripts/audit.ts` carries the 31 routes deferred from PR 2's partial sweep. Each route stays in the list until a follow-up PR migrates it; removing it from the list is how the rule progressively widens.

## Doc updates

### `docs/RULES.md`

Added rules #10 (admin pages use PageHeader), #11 (breadcrumb required when PageHeader), #12 (raw h1 forbidden in page.tsx) — each with the locked justification copy from Spec 02 §3.4 and the 2026-05-07 incident note.

### `docs/ARCHITECTURE.md`

- §13.3 documents PageHeader / PageShell / Breadcrumb as canonical primitives plus the `.text-page-title` / `.text-section-title` / `.text-subsection` scale.
- §17 adds the three new audit rules to the in-flight workstream list and the optimiser-branch TODO from Spec 02 §2.1.
- §20 quick-reference table gains a Page-chrome row.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Rule fires HIGH on unmigrated routes and breaks CI | `PAGE_HEADER_DEFERRED_ROUTES` allowlist explicitly enumerates them; rule passes today, fires as routes are migrated. |
| Allowlist drift: routes adopt PageHeader but stay in the list | Once a route adopts PageHeader, removing the entry is the natural cleanup pass. The allowlist stays compact because each entry is a one-liner. |
| Rule's `no-raw-h1` heuristic false-positives on edge JSX patterns | Rule scope locked per spec §3.3 — we explicitly exclude `_components/`, polymorphic `as="h1"`, and PageHeader.Title-windowed h1s. |
| Allowlist hides genuine regressions on already-migrated routes | The 8 migrated routes from PR 2 are NOT in the allowlist — any regression there fires immediately. |

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — clean
- `npm run audit:static` — 0 HIGH, 0 MEDIUM (LOWs pre-existing). The new rules pass via the deferred-routes allowlist on unmigrated pages and confirm presence on the 8 migrated pages from PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
