### PR TITLE
feat(spec05): image caption embeddings — PR A (schema + ingest + backfill)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,18 @@ ANTHROPIC_API_KEY=
 
 
 # -----------------------------------------------------------------------------
+# OpenAI API (OPTIONAL — embeddings degrade gracefully when unset)
+# -----------------------------------------------------------------------------
+# Used by lib/images/embed.ts to compute caption embeddings for the
+# featured-image suggestion ranking (Spec 05). Unset = the caption
+# embedding hook no-ops on upload / PATCH / reextract; the suggest
+# endpoint falls back to keyword-only ranking. Set this to enable
+# semantic ranking (and run `npm run backfill:image-embeddings` to
+# populate the existing library).
+OPENAI_API_KEY=
+
+
+# -----------------------------------------------------------------------------
 # Cron + ops (HARD)
 # -----------------------------------------------------------------------------
 # Bearer token for /api/cron/* routes. Vercel cron must send this. Min

--- a/app/api/admin/images/[id]/reextract/route.ts
+++ b/app/api/admin/images/[id]/reextract/route.ts
@@ -3,6 +3,8 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import { requireAdminForApi } from "@/lib/admin-api-gate";
 import { reextractImageMetadata } from "@/lib/image-reextract";
+import { refreshImageEmbedding } from "@/lib/images/embed";
+import { getServiceRoleClient } from "@/lib/supabase";
 import { errorCodeToStatus } from "@/lib/tool-schemas";
 
 // POST /api/admin/images/[id]/reextract
@@ -51,6 +53,10 @@ export async function POST(
 
   revalidatePath(`/admin/images/${params.id}`);
   revalidatePath("/admin/images");
+
+  // Spec 05 — title / caption may have changed; refresh embedding.
+  // Fire-and-forget; no-op when OPENAI_API_KEY isn't set.
+  void refreshImageEmbedding(params.id, getServiceRoleClient());
 
   return NextResponse.json(result, { status: 200 });
 }

--- a/app/api/admin/images/[id]/route.ts
+++ b/app/api/admin/images/[id]/route.ts
@@ -12,7 +12,9 @@ import {
   softDeleteImage,
   updateImageMetadata,
 } from "@/lib/image-library";
+import { refreshImageEmbedding } from "@/lib/images/embed";
 import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
 // PATCH /api/admin/images/[id] — M5-3.
@@ -115,6 +117,10 @@ export async function PATCH(
   // reflect the edit on the next render.
   revalidatePath("/admin/images");
   revalidatePath(`/admin/images/${params.id}`);
+
+  // Spec 05 — caption / alt / tags changed, so the embedding is stale.
+  // Fire-and-forget; no-op when OPENAI_API_KEY isn't set.
+  void refreshImageEmbedding(params.id, getServiceRoleClient());
 
   return respond(result);
 }

--- a/app/api/admin/images/upload/route.ts
+++ b/app/api/admin/images/upload/route.ts
@@ -13,6 +13,7 @@ import {
 import { extractExifFields } from "@/lib/exif-extract";
 import { internalError, routeError, validationError } from "@/lib/http";
 import { readImageDimensions } from "@/lib/image-dimensions";
+import { embedAndStoreImage, refreshImageEmbedding } from "@/lib/images/embed";
 import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -94,6 +95,10 @@ async function generateAiCaption(
       })
       .eq("id", imageId)
       .is("caption", null);
+
+    // Spec 05 — refresh the caption embedding now that the AI caption
+    // has landed. Best-effort; no-op when OPENAI_API_KEY isn't set.
+    void refreshImageEmbedding(imageId, svc);
   } catch (err) {
     logger.warn("image.upload.ai_caption_failed", {
       image_id: imageId,
@@ -316,6 +321,21 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // one asynchronously via Anthropic vision (fire-and-forget).
   if (!exifCaption && ins.data?.id && file.type.startsWith("image/")) {
     void generateAiCaption(ins.data.id, bytes, file.type);
+  } else if (ins.data?.id) {
+    // Spec 05 — when we already have a caption (EXIF path) the AI caption
+    // hook never runs, so embed here. Fire-and-forget; no-op when
+    // OPENAI_API_KEY isn't set.
+    void embedAndStoreImage(
+      ins.data.id,
+      {
+        caption: exifCaption,
+        alt: exifAltText,
+        tags: exifTags,
+        title: insertRow.title,
+        filename,
+      },
+      supabase,
+    );
   }
 
   return NextResponse.json(

--- a/audit/spec-05-blockers.md
+++ b/audit/spec-05-blockers.md
@@ -1,0 +1,32 @@
+# Spec 05 — featured-image hybrid ranking — blockers
+
+## OPENAI_API_KEY not provisioned in this checkout (2026-05-08)
+
+PR A (schema + embed lib + ingest hook + backfill script) ships without
+needing the key — the embed module no-ops gracefully when `OPENAI_API_KEY`
+is unset. PR B's `/api/images/suggest` falls back to keyword-only ranking
+when the key is unset OR when no rows have an embedding yet.
+
+To activate semantic ranking end-to-end:
+
+1. Add `OPENAI_API_KEY` to Vercel project env (`production`, `preview`,
+   `development` scopes as needed).
+2. Add the same key to local `.env.local` if working from this checkout.
+3. Run `npm run backfill:image-embeddings` once against the production
+   database. ~9k rows, ~$0.10 cost, ~5–10 minutes wall-clock at the
+   default batch=100, delay=200ms.
+4. After the run, the script reports the populated %. If >5% of the
+   library still lacks an embedding (because they have no caption /
+   alt / tags / title / filename), open Spec 05 PR C scope: a follow-up
+   that uses iStock metadata or AI batch captioning to fill the gaps.
+
+The ingest hooks (upload / PATCH / reextract) start populating embeddings
+for any new caption changes immediately once the env var is set — no
+backfill is needed for new uploads, only the historical library.
+
+## Tracking
+
+- Spec 05 PR A: schema + ingest pipeline + backfill script (this PR).
+- Spec 05 PR B: search endpoint + UI wiring (follows PR A).
+- Spec 05 PR C: caption-quality follow-up — only if PR A's backfill
+  reports >5% missing.

--- a/lib/__tests__/images-embed.test.ts
+++ b/lib/__tests__/images-embed.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  composeImageEmbeddingInput,
+  vectorToLiteral,
+} from "@/lib/images/embed";
+
+// ---------------------------------------------------------------------------
+// Spec 05 — pure-function tests for the embed module.
+//
+// Network-side helpers (`embedText`, `embedImageCaption`,
+// `embedAndStoreImage`, `refreshImageEmbedding`) are exercised at the
+// integration layer in PR B's tests. This file covers the deterministic
+// shape-only helpers.
+// ---------------------------------------------------------------------------
+
+describe("composeImageEmbeddingInput", () => {
+  it("concatenates title, caption, alt, tags, filename in priority order", () => {
+    const input = composeImageEmbeddingInput({
+      title: "Sunset over Sydney",
+      caption: "A wide shot of Sydney Harbour at sunset.",
+      alt: "Sydney harbour, golden hour",
+      tags: ["sunset", "sydney", "harbour"],
+      filename: "istock-12345.jpg",
+    });
+    expect(input).not.toBeNull();
+    expect(input).toContain("Sunset over Sydney");
+    expect(input).toContain("Sydney Harbour at sunset");
+    expect(input).toContain("sunset, sydney, harbour");
+    expect(input).toContain("istock-12345.jpg");
+    // Title should appear before filename in the composed string.
+    expect(input!.indexOf("Sunset over Sydney")).toBeLessThan(
+      input!.indexOf("istock-12345.jpg"),
+    );
+  });
+
+  it("returns null when every field is empty / null", () => {
+    expect(
+      composeImageEmbeddingInput({
+        title: null,
+        caption: null,
+        alt: null,
+        tags: null,
+        filename: null,
+      }),
+    ).toBeNull();
+    expect(
+      composeImageEmbeddingInput({
+        title: "",
+        caption: "  ",
+        alt: "\t",
+        tags: [],
+        filename: "",
+      }),
+    ).toBeNull();
+  });
+
+  it("trims whitespace and collapses runs of whitespace", () => {
+    const input = composeImageEmbeddingInput({
+      caption: "   spaced    out   caption   ",
+      filename: "  file.jpg  ",
+    });
+    expect(input).toBe("spaced out caption. file.jpg");
+  });
+
+  it("drops empty tags before joining", () => {
+    const input = composeImageEmbeddingInput({
+      caption: "x",
+      tags: ["one", "", "  ", "two"],
+    });
+    expect(input).toContain("Tags: one, two");
+  });
+
+  it("caps very long inputs at the documented MAX_INPUT_CHARS", () => {
+    const huge = "a".repeat(50_000);
+    const input = composeImageEmbeddingInput({ caption: huge });
+    expect(input).not.toBeNull();
+    expect(input!.length).toBeLessThanOrEqual(24_000);
+  });
+});
+
+describe("vectorToLiteral", () => {
+  it("formats a float array as a pgvector literal", () => {
+    expect(vectorToLiteral([0.1, 0.2, 0.3])).toBe("[0.1,0.2,0.3]");
+  });
+
+  it("handles negatives + zeros", () => {
+    expect(vectorToLiteral([-1, 0, 1])).toBe("[-1,0,1]");
+  });
+
+  it("formats an empty vector as []", () => {
+    expect(vectorToLiteral([])).toBe("[]");
+  });
+});

--- a/lib/images/embed.ts
+++ b/lib/images/embed.ts
@@ -1,0 +1,267 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { logger } from "@/lib/logger";
+import type { Database } from "@/types/supabase";
+
+// ---------------------------------------------------------------------------
+// Spec 05 — image caption embedding helper.
+//
+// Calls OpenAI's text-embedding-3-small model directly via fetch. Returns a
+// 1536-dim vector ready to be written to image_library.caption_embedding
+// (pgvector column from migration 0108).
+//
+// Why bare fetch and not the openai SDK:
+//   - One endpoint, no streaming, no tool use → SDK overhead isn't earned.
+//   - Avoids adding a new top-level npm dep + bundle bytes for a single call.
+//
+// Why text-embedding-3-small:
+//   - 1536 dimensions, $0.02 per 1M tokens — backfilling the 9k iStock
+//     library costs roughly $0.10 total.
+//   - OpenAI documents it as production-grade and competitive on retrieval
+//     benchmarks against larger models for this kind of short-doc use.
+//
+// Cost is tracked at the call-site via logger payloads; no central cost
+// ledger like Anthropic transfers because this isn't a billed-per-page
+// operation in the M3/M4 sense — it runs once per image at ingest, and
+// once per suggestion query (sub-cent, drowned by Cloudflare egress).
+// ---------------------------------------------------------------------------
+
+const OPENAI_EMBED_ENDPOINT = "https://api.openai.com/v1/embeddings";
+const OPENAI_EMBED_MODEL = "text-embedding-3-small";
+export const EMBEDDING_DIMENSIONS = 1536;
+
+// OpenAI rejects inputs > 8192 tokens. Tokens ≈ chars / 4 for English; cap
+// at 24000 chars defensively (~6k tokens) so we never round-trip a 400.
+const MAX_INPUT_CHARS = 24000;
+
+export class EmbeddingNotConfiguredError extends Error {
+  readonly code = "EMBEDDING_NOT_CONFIGURED";
+  constructor(message = "OPENAI_API_KEY is not set; embeddings disabled.") {
+    super(message);
+    this.name = "EmbeddingNotConfiguredError";
+  }
+}
+
+export class EmbeddingCallError extends Error {
+  readonly code: string;
+  readonly status?: number;
+  constructor(code: string, message: string, status?: number) {
+    super(message);
+    this.name = "EmbeddingCallError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export interface ImageEmbedInput {
+  caption?: string | null;
+  alt?: string | null;
+  tags?: readonly string[] | null;
+  filename?: string | null;
+  title?: string | null;
+}
+
+/**
+ * Build the deterministic input string for embedding an image. Title gets
+ * a leading position because operators describe the subject there; alt + tags
+ * round out the keyword surface; filename is last because it's frequently
+ * just a hash for stock photography.
+ *
+ * Returns null when there's nothing meaningful to embed (all fields empty).
+ */
+export function composeImageEmbeddingInput(input: ImageEmbedInput): string | null {
+  const parts: string[] = [];
+  const push = (s: string | null | undefined) => {
+    if (typeof s === "string") {
+      const t = s.trim();
+      if (t) parts.push(t);
+    }
+  };
+  push(input.title);
+  push(input.caption);
+  push(input.alt);
+  if (input.tags && input.tags.length > 0) {
+    const joined = input.tags
+      .map((t) => (typeof t === "string" ? t.trim() : ""))
+      .filter(Boolean)
+      .join(", ");
+    if (joined) parts.push(`Tags: ${joined}`);
+  }
+  push(input.filename);
+  if (parts.length === 0) return null;
+  return parts.join(". ").replace(/\s+/g, " ").slice(0, MAX_INPUT_CHARS);
+}
+
+/**
+ * Generate an embedding for a single text input. Returns a 1536-element
+ * number array. Throws `EmbeddingNotConfiguredError` when OPENAI_API_KEY
+ * isn't set so callers can degrade gracefully.
+ */
+export async function embedText(text: string): Promise<number[]> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new EmbeddingNotConfiguredError();
+
+  const trimmed = text.trim().slice(0, MAX_INPUT_CHARS);
+  if (!trimmed) throw new EmbeddingCallError("EMPTY_INPUT", "Cannot embed an empty string.");
+
+  const res = await fetch(OPENAI_EMBED_ENDPOINT, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: OPENAI_EMBED_MODEL,
+      input: trimmed,
+    }),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    const code =
+      res.status === 401
+        ? "UNAUTHORIZED"
+        : res.status === 429
+          ? "RATE_LIMITED"
+          : res.status >= 500
+            ? "UPSTREAM_5XX"
+            : "UPSTREAM_REJECTED";
+    throw new EmbeddingCallError(
+      code,
+      `OpenAI embeddings call failed (${res.status}): ${detail.slice(0, 200)}`,
+      res.status,
+    );
+  }
+
+  const json = (await res.json().catch(() => null)) as
+    | { data?: Array<{ embedding?: unknown }> }
+    | null;
+  const vec = json?.data?.[0]?.embedding;
+  if (!Array.isArray(vec) || vec.length !== EMBEDDING_DIMENSIONS) {
+    throw new EmbeddingCallError(
+      "MALFORMED_RESPONSE",
+      `OpenAI returned an unexpected embedding shape (length=${
+        Array.isArray(vec) ? vec.length : "n/a"
+      }).`,
+    );
+  }
+  return vec as number[];
+}
+
+/**
+ * Generate an embedding for an image's caption-side metadata. Convenience
+ * wrapper around `embedText` + `composeImageEmbeddingInput`. Returns null
+ * when there's nothing to embed (empty caption / alt / tags / filename).
+ */
+export async function embedImageCaption(
+  input: ImageEmbedInput,
+): Promise<number[] | null> {
+  const text = composeImageEmbeddingInput(input);
+  if (!text) return null;
+  return embedText(text);
+}
+
+/**
+ * Format a JS number array as a pgvector literal string ("[0.1,0.2,...]").
+ * Supabase's PostgREST client doesn't natively serialise the vector type;
+ * passing the literal works in `update()` payloads and as a `?` parameter
+ * to raw SQL.
+ */
+export function vectorToLiteral(vec: readonly number[]): string {
+  return `[${vec.join(",")}]`;
+}
+
+// Service-role client surface — same type as `getServiceRoleClient()`.
+type SupabaseLike = SupabaseClient<Database>;
+
+/**
+ * Best-effort: generate the embedding and write it to image_library.
+ * Logs warnings on failure rather than throwing — caller is the upload
+ * happy path and we never block on an embedding round-trip.
+ *
+ * No-op (with debug log) when OPENAI_API_KEY isn't set, so the upload
+ * happy path stays green in environments without embedding configured.
+ */
+export async function embedAndStoreImage(
+  imageId: string,
+  input: ImageEmbedInput,
+  supabase: SupabaseLike,
+): Promise<void> {
+  try {
+    const vec = await embedImageCaption(input);
+    if (!vec) {
+      logger.debug("image.embed.skipped_empty_input", { image_id: imageId });
+      return;
+    }
+    const { error } = await supabase
+      .from("image_library")
+      .update({
+        caption_embedding: vectorToLiteral(vec),
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", imageId);
+    if (error) {
+      logger.warn("image.embed.persist_failed", {
+        image_id: imageId,
+        error: error.message ?? String(error),
+      });
+      return;
+    }
+    logger.debug("image.embed.stored", { image_id: imageId });
+  } catch (err) {
+    if (err instanceof EmbeddingNotConfiguredError) {
+      logger.debug("image.embed.disabled", { image_id: imageId });
+      return;
+    }
+    logger.warn("image.embed.failed", {
+      image_id: imageId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Read the current caption / alt / tags / title / filename for an image
+ * from the database, then embed + persist. Useful from PATCH / reextract
+ * paths where the caller doesn't want to thread the latest fields through.
+ *
+ * Best-effort. Logs warnings on failure rather than throwing.
+ */
+export async function refreshImageEmbedding(
+  imageId: string,
+  supabase: SupabaseLike,
+): Promise<void> {
+  try {
+    const { data, error } = await supabase
+      .from("image_library")
+      .select("caption, alt_text, tags, title, filename")
+      .eq("id", imageId)
+      .maybeSingle();
+    if (error) {
+      logger.warn("image.embed.read_failed", {
+        image_id: imageId,
+        error: error.message ?? String(error),
+      });
+      return;
+    }
+    if (!data) return;
+    await embedAndStoreImage(
+      imageId,
+      {
+        caption: (data.caption as string | null) ?? null,
+        alt: (data.alt_text as string | null) ?? null,
+        tags: (data.tags as string[] | null) ?? null,
+        title: (data.title as string | null) ?? null,
+        filename: (data.filename as string | null) ?? null,
+      },
+      supabase,
+    );
+  } catch (err) {
+    logger.warn("image.embed.refresh_failed", {
+      image_id: imageId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:e2e:update-snapshots": "playwright test --update-snapshots",
     "screenshots": "RUN_SCREENSHOTS=1 playwright test screenshots.spec.ts",
     "audit:static": "tsx scripts/audit.ts",
+    "backfill:image-embeddings": "tsx scripts/backfill-image-embeddings.ts",
     "gen:types": "supabase gen types typescript --local > types/supabase.ts",
     "analyze": "ANALYZE=true next build",
     "prepare": "husky"

--- a/scripts/backfill-image-embeddings.ts
+++ b/scripts/backfill-image-embeddings.ts
@@ -1,0 +1,250 @@
+/**
+ * Backfill caption embeddings for image_library rows that have a caption
+ * but no caption_embedding.
+ *
+ * Spec 05 — companion to migration 0108. Idempotent: safe to re-run; skips
+ * rows that already have an embedding. Skips rows with no caption /
+ * alt_text / tags / title / filename to embed.
+ *
+ * Required env vars (add to .env.local):
+ *   SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY
+ *   OPENAI_API_KEY
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a
+ *   npx tsx scripts/backfill-image-embeddings.ts
+ *
+ * Or, on PowerShell:
+ *   Get-Content .env.local | ForEach-Object { if ($_ -match '^([^=]+)=(.*)$') { Set-Item "Env:$($Matches[1])" $Matches[2] } }
+ *   npm run backfill:image-embeddings
+ *
+ * Cost: text-embedding-3-small is $0.02 per 1M tokens. The 9k iStock
+ * library should backfill for roughly $0.10 total.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const BATCH_SIZE = parseInt(process.env.BATCH_SIZE ?? "", 10) || 100;
+const BATCH_DELAY_MS = parseInt(process.env.BATCH_DELAY_MS ?? "", 10) || 200;
+const OPENAI_EMBED_ENDPOINT = "https://api.openai.com/v1/embeddings";
+const OPENAI_EMBED_MODEL = "text-embedding-3-small";
+const EMBEDDING_DIMENSIONS = 1536;
+const MAX_INPUT_CHARS = 24000;
+
+// ---------------------------------------------------------------------------
+// Clients
+// ---------------------------------------------------------------------------
+
+const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const openaiKey = process.env.OPENAI_API_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error("Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in env.");
+  process.exit(1);
+}
+if (!openaiKey) {
+  console.error("Missing OPENAI_API_KEY in env.");
+  process.exit(1);
+}
+
+const svc = createClient(supabaseUrl, supabaseKey, {
+  auth: { persistSession: false },
+});
+
+// ---------------------------------------------------------------------------
+// Compose / embed helpers (mirrors lib/images/embed.ts; intentionally
+// duplicated so the script is self-contained for a one-shot backfill).
+// ---------------------------------------------------------------------------
+
+interface ImageRow {
+  id: string;
+  caption: string | null;
+  alt_text: string | null;
+  tags: string[] | null;
+  title: string | null;
+  filename: string | null;
+}
+
+function composeInput(row: ImageRow): string | null {
+  const parts: string[] = [];
+  const push = (s: string | null | undefined) => {
+    if (typeof s === "string" && s.trim()) parts.push(s.trim());
+  };
+  push(row.title);
+  push(row.caption);
+  push(row.alt_text);
+  if (row.tags && row.tags.length > 0) {
+    const joined = row.tags.map((t) => (t ?? "").trim()).filter(Boolean).join(", ");
+    if (joined) parts.push(`Tags: ${joined}`);
+  }
+  push(row.filename);
+  if (parts.length === 0) return null;
+  return parts.join(". ").replace(/\s+/g, " ").slice(0, MAX_INPUT_CHARS);
+}
+
+async function embedText(text: string): Promise<number[]> {
+  const res = await fetch(OPENAI_EMBED_ENDPOINT, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${openaiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ model: OPENAI_EMBED_MODEL, input: text }),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`OpenAI ${res.status}: ${detail.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as { data?: Array<{ embedding?: unknown }> };
+  const vec = json.data?.[0]?.embedding;
+  if (!Array.isArray(vec) || vec.length !== EMBEDDING_DIMENSIONS) {
+    throw new Error(`Malformed embedding (length=${Array.isArray(vec) ? vec.length : "n/a"})`);
+  }
+  return vec as number[];
+}
+
+function vectorToLiteral(vec: readonly number[]): string {
+  return `[${vec.join(",")}]`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+interface Stats {
+  scanned: number;
+  embedded: number;
+  skippedNoInput: number;
+  errors: number;
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `Backfilling caption embeddings (batch=${BATCH_SIZE}, delay=${BATCH_DELAY_MS}ms)…`,
+  );
+  const stats: Stats = { scanned: 0, embedded: 0, skippedNoInput: 0, errors: 0 };
+  const errorSamples: Array<{ id: string; error: string }> = [];
+  const skippedSamples: string[] = [];
+
+  let cursorCreatedAt: string | null = null;
+
+  while (true) {
+    let q = svc
+      .from("image_library")
+      .select("id, caption, alt_text, tags, title, filename, created_at")
+      .is("deleted_at", null)
+      .is("caption_embedding", null)
+      .order("created_at", { ascending: true })
+      .order("id", { ascending: true })
+      .limit(BATCH_SIZE);
+    if (cursorCreatedAt) {
+      q = q.gt("created_at", cursorCreatedAt);
+    }
+
+    const { data, error } = await q;
+    if (error) {
+      console.error(`Query failed: ${error.message}`);
+      process.exit(1);
+    }
+    if (!data || data.length === 0) break;
+
+    for (const row of data) {
+      stats.scanned++;
+      const r = row as ImageRow & { created_at: string };
+      cursorCreatedAt = r.created_at;
+      const input = composeInput(r);
+      if (!input) {
+        stats.skippedNoInput++;
+        if (skippedSamples.length < 20) skippedSamples.push(r.id);
+        continue;
+      }
+      try {
+        const vec = await embedText(input);
+        const { error: upErr } = await svc
+          .from("image_library")
+          .update({
+            caption_embedding: vectorToLiteral(vec),
+            updated_at: new Date().toISOString(),
+          })
+          .eq("id", r.id);
+        if (upErr) {
+          stats.errors++;
+          if (errorSamples.length < 10) {
+            errorSamples.push({ id: r.id, error: upErr.message });
+          }
+          continue;
+        }
+        stats.embedded++;
+        if (stats.embedded % 100 === 0) {
+          console.log(
+            `  …${stats.embedded} embedded, ${stats.skippedNoInput} skipped, ${stats.errors} errors`,
+          );
+        }
+      } catch (err) {
+        stats.errors++;
+        if (errorSamples.length < 10) {
+          errorSamples.push({
+            id: r.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
+
+    await sleep(BATCH_DELAY_MS);
+  }
+
+  // Report.
+  const totalRes = await svc
+    .from("image_library")
+    .select("id", { count: "exact", head: true })
+    .is("deleted_at", null);
+  const totalActive = totalRes.count ?? 0;
+  const populatedRes = await svc
+    .from("image_library")
+    .select("id", { count: "exact", head: true })
+    .is("deleted_at", null)
+    .not("caption_embedding", "is", null);
+  const populated = populatedRes.count ?? 0;
+
+  console.log("");
+  console.log("Backfill complete.");
+  console.log(`  Library size (active):       ${totalActive}`);
+  console.log(`  Rows scanned this run:       ${stats.scanned}`);
+  console.log(`  Embeddings generated:        ${stats.embedded}`);
+  console.log(`  Skipped (no caption/etc):    ${stats.skippedNoInput}`);
+  console.log(`  Errors:                      ${stats.errors}`);
+  console.log(`  Embeddings populated total:  ${populated}/${totalActive}`);
+  if (skippedSamples.length > 0) {
+    console.log(`  First skipped ids:           ${skippedSamples.slice(0, 5).join(", ")}…`);
+  }
+  if (errorSamples.length > 0) {
+    console.log("  First errors:");
+    for (const s of errorSamples.slice(0, 5)) {
+      console.log(`    ${s.id}: ${s.error}`);
+    }
+  }
+  const missingPct =
+    totalActive > 0 ? ((totalActive - populated) / totalActive) * 100 : 0;
+  if (missingPct > 5) {
+    console.log("");
+    console.log(
+      `WARNING: ${missingPct.toFixed(1)}% of the library still lacks an embedding (>5% threshold).`,
+    );
+    console.log("Per Spec 05 PR C scope, file a follow-up to caption images that have no metadata.");
+  }
+}
+
+void main().catch((err) => {
+  console.error("Backfill aborted:", err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/supabase/migrations/0108_image_caption_embedding.sql
+++ b/supabase/migrations/0108_image_caption_embedding.sql
@@ -1,0 +1,47 @@
+-- 0108 — image_library.caption_embedding (pgvector).
+-- Reference: Spec 05 (featured-image suggestions hybrid ranking).
+--
+-- Adds a 1536-dim vector column storing the OpenAI text-embedding-3-small
+-- representation of each image's caption + alt + tags + filename concatenation.
+-- Hybrid ranking against this column blends with the existing GIN/tsvector
+-- BM25-style search via Reciprocal Rank Fusion (RRF) at query time.
+--
+-- Design decisions encoded here:
+--
+-- 1. Column nullable. Existing 9k iStock rows + every new upload starts with
+--    NULL until either the upload-time hook or the backfill script runs.
+--    The query path treats NULL embeddings as semantic-rank-absent and
+--    falls back to keyword-only ranking for those rows.
+--
+-- 2. HNSW index over `vector_cosine_ops`. Cosine matches the angular
+--    similarity OpenAI's normalised vectors are designed for. HNSW is
+--    Postgres pgvector's only ANN index that supports cosine; ivfflat
+--    requires building from a populated set, which would force a
+--    backfill-then-index two-step. HNSW indexes inserts incrementally so
+--    we can add it now and let the backfill populate behind it.
+--
+-- 3. Dimension 1536 hard-coded. text-embedding-3-small produces 1536-dim
+--    vectors; pgvector requires the column dimension at DDL time. Changing
+--    the embedding model later requires a separate migration with a new
+--    column or a column type change — that's a deliberate explicit step
+--    rather than implicit truncation.
+--
+-- 4. Extension created in `extensions` schema (Supabase convention). The
+--    `vector` TYPE is qualified to that schema in the column definition.
+--
+-- Write-safety hotspots addressed:
+--   - No constraint on populated vs NULL — search degrades gracefully
+--     instead of failing a row that hasn't been embedded yet.
+--   - HNSW index is incremental; no offline rebuild step.
+-- ---------------------------------------------------------------------------
+
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA extensions;
+
+ALTER TABLE image_library
+  ADD COLUMN IF NOT EXISTS caption_embedding extensions.vector(1536);
+
+-- HNSW index for ANN cosine search. m=16 / ef_construction=64 are pgvector
+-- defaults documented for production workloads; tune later only with data.
+CREATE INDEX IF NOT EXISTS idx_image_library_caption_embedding_hnsw
+  ON image_library
+  USING hnsw (caption_embedding extensions.vector_cosine_ops);

--- a/supabase/rollbacks/0108_image_caption_embedding.down.sql
+++ b/supabase/rollbacks/0108_image_caption_embedding.down.sql
@@ -1,0 +1,7 @@
+-- Rollback for 0108_image_caption_embedding.sql
+-- Drops the embedding column + HNSW index. Does NOT drop the vector
+-- extension itself (other tables may eventually use it; dropping the
+-- extension is reserved for an operator-driven step).
+
+DROP INDEX IF EXISTS idx_image_library_caption_embedding_hnsw;
+ALTER TABLE image_library DROP COLUMN IF EXISTS caption_embedding;


### PR DESCRIPTION
## Summary

PR A of Spec 05 — featured-image suggestions hybrid ranking. Adds the foundation: schema, embed module, ingest hooks, backfill script. PR B (search endpoint + UI wiring) follows.

- **Migration 0108** — `pgvector` extension + `image_library.caption_embedding vector(1536)` + HNSW cosine index. Column is nullable; rows without embeddings degrade gracefully to keyword-only ranking.
- **`lib/images/embed.ts`** — OpenAI `text-embedding-3-small` via bare `fetch` (no SDK dep). Helpers: `composeImageEmbeddingInput`, `embedText`, `embedImageCaption`, `embedAndStoreImage`, `refreshImageEmbedding`. All no-op when `OPENAI_API_KEY` is unset.
- **Ingest hooks** — `POST /api/admin/images/upload` (after EXIF or AI caption lands), `PATCH /api/admin/images/[id]` (after a metadata edit), `POST /api/admin/images/[id]/reextract` (after re-derived metadata) all fire-and-forget refresh the embedding.
- **Backfill** — `scripts/backfill-image-embeddings.ts` exposed as `npm run backfill:image-embeddings`. Idempotent, batched 100 rows / 200 ms, skips rows without metadata, reports populated %, warns on >5% missing.
- **`audit/spec-05-blockers.md`** — documents the `OPENAI_API_KEY` env var that the operator needs to provision before activation.

## Activation steps (operator)

1. Add `OPENAI_API_KEY` to Vercel project env (production / preview / development scopes as needed).
2. Run `npm run backfill:image-embeddings` against prod once. ~9k rows, ~\$0.10 cost, 5–10 min wall-clock.
3. If the backfill report shows >5% of the library missing embeddings (no caption / alt / tags / title / filename), open Spec 05 PR C scope.

Until step 1 is done, the embedding path is dormant — **no behaviour regression**: every existing route still works, the suggest endpoint (PR B) falls back to keyword-only.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| `pgvector` not enabled on Supabase plan tier | `CREATE EXTENSION IF NOT EXISTS vector` in `extensions` schema. pgvector has shipped on Supabase free tier for years; no contractual blocker expected. |
| HNSW index build cost on a 9k-row table | HNSW supports incremental inserts; the index is created empty and populated row-by-row as the backfill writes. No offline rebuild step. |
| OpenAI cost overrun | `text-embedding-3-small` at \$0.02 / 1M tokens. 9k iStock captions ≈ \$0.10 total. No per-suggestion cost (query-time embed is \~1 token of cost). Backfill script is rate-limited (100 / 200 ms = 30k items/min ceiling). |
| Embedding write races with concurrent caption edits | Each caption mutation fires its own embed-refresh after the row write. If write A lands first then write B, B's embed refresh runs after B's caption update is committed → final embedding matches final caption. No write-loss hazard. |
| Hard-fail on cold start when `OPENAI_API_KEY` is unset | `embedText` throws `EmbeddingNotConfiguredError`; every caller catches and logs a `image.embed.disabled` debug line, then returns. Upload / PATCH / reextract happy paths unaffected. |
| Embedding generation in upload happy path adds 100–500 ms latency | All hooks are `void`-fired (fire-and-forget) — the operator's upload response returns immediately; the embed network call resolves in the background. |

## Assumptions documented

- `text-embedding-3-small` (1536 dim) is the right model: it's the cheapest production-grade OpenAI embedding, well-attested on retrieval benchmarks for short docs.
- `OPENAI_API_KEY` is a new env var the operator will provision — there's no project-wide rule against bringing OpenAI in (Anthropic is for completions; embeddings are a different surface). If the rule should be "no OpenAI", redirect to a self-hosted embedding model in a follow-up.
- HNSW with default `m=16 / ef_construction=64` is good enough for 9k–100k images. Will revisit if telemetry from PR B suggests otherwise.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [x] `npm run build` — clean (Next.js + ESLint pass).
- [x] `npm run audit:static` — 0 HIGH, 0 MEDIUM. `OPENAI_API_KEY` registered in `.env.example`.
- [x] `lib/__tests__/images-embed.test.ts` — pure-function tests for `composeImageEmbeddingInput` + `vectorToLiteral`. (Local vitest needs Docker for Supabase stack; trusting CI here.)
- [ ] Backfill run on prod — deferred to operator activation (env var not yet provisioned in this checkout — see `audit/spec-05-blockers.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)