### PR TITLE
feat(page-header): migrate Spec 04 final batch (Spec 04 PR E)

### DIFF
--- a/app/account/devices/page.tsx
+++ b/app/account/devices/page.tsx
@@ -3,7 +3,8 @@ import { redirect } from "next/navigation";
 
 import { TrustedDevicesList } from "@/components/TrustedDevicesList";
 import { Alert } from "@/components/ui/alert";
-import { H1, Lead } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
 import {
   DEVICE_ID_COOKIE,
   decodeDeviceCookie,
@@ -48,16 +49,24 @@ export default async function AccountDevicesPage() {
     : [];
 
   return (
-    <div className="mx-auto max-w-3xl">
-      <H1>Trusted devices</H1>
-      <Lead className="mt-1">
-        Devices that skip the email-approval step on sign-in. Trust
-        lasts 30 days from last sign-in; sign out any device you
-        don&apos;t recognise.
-      </Lead>
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Account", href: "/account/security" },
+            { label: "Trusted devices" },
+          ]}
+        />
+        <PageHeader.Title>Trusted devices</PageHeader.Title>
+        <PageHeader.Subtitle>
+          Devices that skip the email-approval step on sign-in. Trust
+          lasts 30 days from last sign-in; sign out any device you
+          don&apos;t recognise.
+        </PageHeader.Subtitle>
+      </PageHeader>
 
       {!flagOn && (
-        <Alert className="mt-6">
+        <Alert>
           Email-2FA is not currently enabled on this environment.
           Trusted-device tracking starts when{" "}
           <code className="font-mono text-sm">AUTH_2FA_ENABLED</code>{" "}
@@ -66,7 +75,7 @@ export default async function AccountDevicesPage() {
       )}
 
       {flagOn && devices.length === 0 && (
-        <Alert className="mt-6">
+        <Alert>
           No trusted devices yet. The next time you sign in and tick
           &quot;Trust this device for 30 days&quot;, it will appear
           here.
@@ -74,13 +83,11 @@ export default async function AccountDevicesPage() {
       )}
 
       {flagOn && devices.length > 0 && (
-        <div className="mt-6">
-          <TrustedDevicesList
-            devices={devices}
-            hasCurrentDevice={currentDeviceId !== null}
-          />
-        </div>
+        <TrustedDevicesList
+          devices={devices}
+          hasCurrentDevice={currentDeviceId !== null}
+        />
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/app/account/security/page.tsx
+++ b/app/account/security/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 
 import { AccountSecurityForm } from "@/components/AccountSecurityForm";
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
 import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
 
 // ---------------------------------------------------------------------------
@@ -28,17 +30,21 @@ export default async function AccountSecurityPage() {
     redirect("/login");
   }
 
-  // Nested <main> would be invalid HTML — the /account layout already
-  // owns the outer <main>. Use a section wrapper here instead.
   return (
-    <section className="mx-auto flex max-w-md flex-col gap-6">
-      <div>
-        <h1 className="text-xl font-semibold">Account security</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Account", href: "/account/security" },
+            { label: "Security" },
+          ]}
+        />
+        <PageHeader.Title>Account security</PageHeader.Title>
+        <PageHeader.Subtitle>
           Change your password. Minimum 12 characters.
-        </p>
-      </div>
+        </PageHeader.Subtitle>
+      </PageHeader>
       <AccountSecurityForm userEmail={user.email} />
-    </section>
+    </PageShell>
   );
 }

--- a/app/admin/sites/[id]/posts/[post_id]/page.tsx
+++ b/app/admin/sites/[id]/posts/[post_id]/page.tsx
@@ -1,7 +1,8 @@
 import { notFound, redirect } from "next/navigation";
 
-import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { PostDetailClient } from "@/components/PostDetailClient";
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getPost } from "@/lib/posts";
 import { preflightSitePublish } from "@/lib/site-preflight";
@@ -75,21 +76,25 @@ export default async function PostDetailPage({
   const preflight = await preflightSitePublish(params.id);
 
   return (
-    <main className="mx-auto max-w-5xl p-6">
-      <Breadcrumbs
-        crumbs={[
-          { label: "Sites", href: "/admin/sites" },
-          { label: site.name, href: `/admin/sites/${site.id}` },
-          { label: "Posts", href: `/admin/sites/${site.id}/posts` },
-          { label: post.title },
-        ]}
-      />
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Admin", href: "/admin/sites" },
+            { label: "Sites", href: "/admin/sites" },
+            { label: site.name, href: `/admin/sites/${site.id}` },
+            { label: "Posts", href: `/admin/sites/${site.id}/posts` },
+            { label: post.title },
+          ]}
+        />
+        <PageHeader.Title>{post.title}</PageHeader.Title>
+      </PageHeader>
       <PostDetailClient
         siteId={site.id}
         siteWpUrl={site.wp_url}
         post={post}
         preflight={preflight}
       />
-    </main>
+    </PageShell>
   );
 }

--- a/app/admin/sites/[id]/posts/new/page.tsx
+++ b/app/admin/sites/[id]/posts/new/page.tsx
@@ -1,9 +1,9 @@
 import { notFound, redirect } from "next/navigation";
 
-import { Breadcrumbs } from "@/components/Breadcrumbs";
 import { BlogPostComposer } from "@/components/BlogPostComposer";
 import { Alert } from "@/components/ui/alert";
-import { H1, Lead } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getSite } from "@/lib/sites";
 
@@ -39,25 +39,25 @@ export default async function BlogPostEntryPage({
   const site = result.data.site;
 
   return (
-    <div className="mx-auto max-w-4xl">
-      <Breadcrumbs
-        crumbs={[
-          { label: "Sites", href: "/admin/sites" },
-          { label: site.name, href: `/admin/sites/${site.id}` },
-          { label: "Posts", href: `/admin/sites/${site.id}/posts` },
-          { label: "New post" },
-        ]}
-      />
-      <H1 className="mt-2">New blog post</H1>
-      <Lead className="mt-1">
-        Paste a markdown / HTML / YAML-fronted post. We&apos;ll parse the
-        metadata into the fields below — every value is editable before you
-        save the draft.
-      </Lead>
-
-      <div className="mt-6">
-        <BlogPostComposer siteId={site.id} />
-      </div>
-    </div>
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Admin", href: "/admin/sites" },
+            { label: "Sites", href: "/admin/sites" },
+            { label: site.name, href: `/admin/sites/${site.id}` },
+            { label: "Posts", href: `/admin/sites/${site.id}/posts` },
+            { label: "New post" },
+          ]}
+        />
+        <PageHeader.Title>New blog post</PageHeader.Title>
+        <PageHeader.Subtitle>
+          Paste a markdown / HTML / YAML-fronted post. We&apos;ll parse the
+          metadata into the fields below — every value is editable before you
+          save the draft.
+        </PageHeader.Subtitle>
+      </PageHeader>
+      <BlogPostComposer siteId={site.id} />
+    </PageShell>
   );
 }

--- a/app/admin/system/jobs/page.tsx
+++ b/app/admin/system/jobs/page.tsx
@@ -2,8 +2,9 @@ import { redirect } from "next/navigation";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
-import { Breadcrumbs } from "@/components/Breadcrumbs";
-import { H1, H2, Lead } from "@/components/ui/typography";
+import { H2 } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
 import { StatusPill } from "@/components/ui/status-pill";
 import { ImageMetadataJobTrigger } from "@/components/admin/ImageMetadataJobTrigger";
 import { checkAdminAccess } from "@/lib/admin-gate";
@@ -255,19 +256,21 @@ export default async function SystemJobsPage() {
   );
 
   return (
-    <div className="mx-auto max-w-5xl">
-      <Breadcrumbs
-        crumbs={[
-          { label: "Admin", href: "/admin/sites" },
-          { label: "System", href: "/admin/system/jobs" },
-          { label: "Jobs" },
-        ]}
-      />
-      <H1 className="mt-2">System jobs</H1>
-      <Lead className="mt-1">
-        Cron schedule + queue depth across the worker pipelines. Refresh the
-        page to re-read; counts come straight from the queue tables.
-      </Lead>
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Admin", href: "/admin/sites" },
+            { label: "System", href: "/admin/system/jobs" },
+            { label: "Jobs" },
+          ]}
+        />
+        <PageHeader.Title>System jobs</PageHeader.Title>
+        <PageHeader.Subtitle>
+          Cron schedule + queue depth across the worker pipelines. Refresh the
+          page to re-read; counts come straight from the queue tables.
+        </PageHeader.Subtitle>
+      </PageHeader>
 
       {stuckQueues.length > 0 && (
         <div
@@ -422,6 +425,6 @@ export default async function SystemJobsPage() {
           </table>
         </div>
       </section>
-    </div>
+    </PageShell>
   );
 }

--- a/app/admin/users/audit/page.tsx
+++ b/app/admin/users/audit/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { Alert } from "@/components/ui/alert";
-import { H1, Lead } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 import { formatRelativeTime } from "@/lib/utils";
@@ -45,22 +46,20 @@ export default async function UserAuditPage({ searchParams }: PageProps) {
   const totalPages = count ? Math.max(1, Math.ceil(count / PAGE_SIZE)) : 1;
 
   return (
-    <>
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <H1>User audit log</H1>
-          <Lead className="mt-0.5">
-            Append-only record of every user-management action.
-            super_admin only.
-          </Lead>
-        </div>
-        <Link
-          href="/admin/users"
-          className="rounded-md border px-3 py-2 text-sm transition-smooth hover:bg-muted"
-        >
-          ← Back to users
-        </Link>
-      </div>
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Admin", href: "/admin/sites" },
+            { label: "Users", href: "/admin/users" },
+            { label: "Audit log" },
+          ]}
+        />
+        <PageHeader.Title>User audit log</PageHeader.Title>
+        <PageHeader.Subtitle>
+          Append-only record of every user-management action. super_admin only.
+        </PageHeader.Subtitle>
+      </PageHeader>
 
       {error ? (
         <Alert variant="destructive" className="mt-6" title="Failed to load audit log">
@@ -153,6 +152,6 @@ export default async function UserAuditPage({ searchParams }: PageProps) {
           )}
         </>
       )}
-    </>
+    </PageShell>
   );
 }

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -4,7 +4,8 @@ import { redirect } from "next/navigation";
 import { InviteUserButton } from "@/components/InviteUserButton";
 import { PendingInvitesTable } from "@/components/PendingInvitesTable";
 import { Alert } from "@/components/ui/alert";
-import { H1, Lead } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
 import { UsersTable } from "@/components/UsersTable";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -75,18 +76,24 @@ export default async function AdminUsersPage() {
     },
   );
 
+  const userCount = (usersRes.data ?? []).length;
+  const subtitle =
+    userCount === 0
+      ? "No users yet."
+      : `${userCount} ${userCount === 1 ? "user" : "users"} with access. Change a role inline; the server blocks self-modification, last-admin demotions, and any change to the super_admin row.`;
+
   return (
-    <>
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <H1>Users</H1>
-          <Lead className="mt-0.5">
-            {(usersRes.data ?? []).length === 0
-              ? "No users yet."
-              : `${(usersRes.data ?? []).length} ${(usersRes.data ?? []).length === 1 ? "user" : "users"} with access. Change a role inline; the server blocks self-modification, last-admin demotions, and any change to the super_admin row.`}
-          </Lead>
-        </div>
-        <div className="flex items-center gap-2">
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Admin", href: "/admin/sites" },
+            { label: "Users" },
+          ]}
+        />
+        <PageHeader.Title>Users</PageHeader.Title>
+        <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>
+        <PageHeader.Actions>
           {isSuperAdmin && (
             <Link
               href="/admin/users/audit"
@@ -97,8 +104,8 @@ export default async function AdminUsersPage() {
             </Link>
           )}
           <InviteUserButton actorRole={actorRole} />
-        </div>
-      </div>
+        </PageHeader.Actions>
+      </PageHeader>
 
       {pendingInvites.length > 0 && (
         <div className="mt-6">
@@ -126,6 +133,6 @@ export default async function AdminUsersPage() {
           </>
         )}
       </div>
-    </>
+    </PageShell>
   );
 }

--- a/docs/specs/_blockers.md
+++ b/docs/specs/_blockers.md
@@ -1,5 +1,20 @@
 # Spec run blockers
 
+## Spec 04 — Optimiser PageHeader sweep (TODO, do after `feat/optimiser` merges to main)
+
+**Date:** 2026-05-08
+
+**Spec section in tension:** Spec 04 PR E aimed to drain `PAGE_HEADER_DEFERRED_ROUTES` to `[]` for every admin-tier route. The optimiser module lives on the long-running `feat/optimiser` branch and is **out of scope** for this workstream by explicit instruction.
+
+**What this leaves open:**
+
+- Routes under `app/optimiser/**/page.tsx` will need the same Title → Breadcrumb → Subtitle → Meta → Actions migration once `feat/optimiser` merges into main.
+- The audit script's `headings-use-page-header` rule scopes to `app/admin/` and `app/account/` only; it does NOT walk `app/optimiser/`. So nothing fires today, but the moment Steven adds the optimiser to the audit roots, every optimiser page.tsx will surface as HIGH.
+
+**To execute:** after `feat/optimiser` lands, walk every `app/optimiser/**/page.tsx`, migrate header chrome to PageHeader (matching the patterns used in PRs B–E), then extend the `roots` array in `check11_headingsUsePageHeader`, `check12_breadcrumbRequiredWithPageHeader`, and `check13_noRawH1InPages` from `["app/admin", "app/account"]` to `["app/admin", "app/account", "app/optimiser"]`. PR 4 of the optimiser cleanup is the natural place.
+
+---
+
 ## Spec 02 PR 2 — partial admin-route adoption sweep (8 of 37 routes)
 
 **Date:** 2026-05-07

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -1157,25 +1157,11 @@ function printResults(issues: Issue[]): boolean {
 // sweep migrates them.
 //
 // PAGE_HEADER_DEFERRED_ROUTES: routes pending migration. Remove entries
-// as each route adopts PageHeader. This list should reach [] when
-// migration completes (Spec 04). New routes added here = regression —
-// don't.
-const PAGE_HEADER_DEFERRED_ROUTES: readonly string[] = [
-  // /admin/* deferred routes — drains as Spec 04 PRs B–E migrate.
-  // PR B (batch 1): admin index, batches/*, companies/*, email-test, images.
-  // PR C (batch 2): images/[id], posts/new, settings/design-system,
-  //                  sites/[id], sites/[id]/appearance, blueprints/review,
-  //                  briefs/[brief_id]/review. /admin/settings → EXEMPT.
-  "app/admin/sites/[id]/posts/new/page.tsx",
-  "app/admin/sites/[id]/posts/[post_id]/page.tsx",
-  "app/admin/system/jobs/page.tsx",
-  "app/admin/users/page.tsx",
-  "app/admin/users/audit/page.tsx",
-  // /account/* deferred (the operator account-management surface; same
-  // mechanical migration as /admin/* but kept out of PR 2's scope).
-  "app/account/devices/page.tsx",
-  "app/account/security/page.tsx",
-];
+// as each route adopts PageHeader. This list reached [] when Spec 04
+// PR E landed — every /admin/* and /account/* route now uses PageHeader
+// (or sits in PAGE_HEADER_EXEMPT_ROUTES below). New routes added here =
+// regression — don't.
+const PAGE_HEADER_DEFERRED_ROUTES: readonly string[] = [];
 
 // PAGE_HEADER_EXEMPT_ROUTES: routes that intentionally don't use
 // PageHeader because they have a different chrome contract (e.g.


### PR DESCRIPTION
## Summary

PR E of Spec 04 — the final batch of admin/account routes migrate to PageHeader, and `PAGE_HEADER_DEFERRED_ROUTES` drains to `[]`.

Stacked on PR D (#749), which is stacked on PR C (#748), which is stacked on PR B (#747), which is stacked on PR A (#744).

## Routes migrated (7)

- `/admin/sites/[id]/posts/new`
- `/admin/sites/[id]/posts/[post_id]`
- `/admin/system/jobs`
- `/admin/users`
- `/admin/users/audit`
- `/account/devices`
- `/account/security`

Each: replaced `<H1>+<Lead>` (or raw `<h1>+<p>`) + standalone `<Breadcrumbs>` + outer `<div className="mx-auto max-w-…">` wrapper with `<PageShell><PageHeader><PageHeader.Breadcrumb segments={…} /><PageHeader.Title>…</PageHeader.Title><PageHeader.Subtitle>…</PageHeader.Subtitle></PageHeader>…</PageShell>`.

Subtitle copy is ported verbatim from each page's existing Lead copy — no copy invented.

## Audit script changes

- `PAGE_HEADER_DEFERRED_ROUTES` drained to `[]` with a comment marking Spec 04 complete. New routes added here = regression.
- `PAGE_HEADER_EXEMPT_ROUTES` unchanged (still the two redirect-only `/admin/page.tsx` and `/admin/settings/page.tsx`).

## Docs

- `docs/specs/_blockers.md` — added an entry for the optimiser PageHeader sweep, scheduled for after `feat/optimiser` merges to main.

## Risks identified and mitigated

- **Breadcrumb segments invented from thin air** → All segments use the canonical `Admin → <Section> → <Current>` shape that already exists in sibling routes; for `/account/*`, segments anchor on `Account → <Page>` consistent with the layout's user-tier scope.
- **Server vs client component drift** → All migrated pages are server components; PageHeader renders fine in either, and the imports are pure structural (no client hooks).
- **Subtitle copy hallucination** → Every Subtitle ported verbatim from the page's prior Lead/p copy. No new copy.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run audit:static` — 0 HIGH, 0 MEDIUM (LOWs are pre-existing dead-routes / env-vars noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)