### PR TITLE
feat(spec06): platform-aware keyboard shortcuts

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -14,6 +14,7 @@ import { NavIcon } from "@/components/ui/nav-icon";
 
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Kbd } from "@/components/ui/kbd";
 import { RichTextEditor } from "@/components/RichTextEditor";
 import {
   Command,
@@ -1170,8 +1171,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
             aria-hidden
             className="flex items-center justify-center gap-0.5 text-sm text-muted-foreground"
           >
-            <kbd className="rounded border bg-muted px-1 font-mono text-xs">⌘</kbd>
-            <kbd className="rounded border bg-muted px-1 font-mono text-xs">S</kbd>
+            <Kbd keys={["mod", "S"]} />
             <span className="ml-1">to save draft</span>
           </p>
         </SidebarPanel>

--- a/components/BulkUploadPanel.tsx
+++ b/components/BulkUploadPanel.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import { Button } from "@/components/ui/button";
+import { Kbd } from "@/components/ui/kbd";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -394,12 +395,7 @@ Body of second post.`}
           aria-hidden
           className="hidden items-center gap-0.5 text-sm text-muted-foreground sm:inline-flex"
         >
-          <kbd className="rounded border bg-muted px-1 font-mono text-xs">
-            ⌘
-          </kbd>
-          <kbd className="rounded border bg-muted px-1 font-mono text-xs">
-            ↵
-          </kbd>
+          <Kbd keys={["mod", "enter"]} />
         </span>
         <Button
           type="button"

--- a/components/RichTextEditor.tsx
+++ b/components/RichTextEditor.tsx
@@ -16,6 +16,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { useModKey } from "@/lib/hooks/use-platform";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -52,6 +53,9 @@ export function RichTextEditor({
 }: RichTextEditorProps) {
   const [linkDialogOpen, setLinkDialogOpen] = useState(false);
   const linkInputRef = useRef<HTMLInputElement>(null);
+  const mod = useModKey();
+  // Shift glyph kept on Mac, "Shift+" elsewhere. Joined with "+" on non-Mac.
+  const shiftZ = mod === "⌘" ? "⇧Z" : "+Shift+Z";
 
   const editor = useEditor({
     extensions: [
@@ -112,14 +116,14 @@ export function RichTextEditor({
         <ToolbarButton
           onClick={() => editor?.chain().focus().toggleBold().run()}
           active={editor?.isActive("bold")}
-          title="Bold (⌘B)"
+          title={`Bold (${mod}${mod === "⌘" ? "B" : "+B"})`}
         >
           <NavIcon name="bold" size={14} />
         </ToolbarButton>
         <ToolbarButton
           onClick={() => editor?.chain().focus().toggleItalic().run()}
           active={editor?.isActive("italic")}
-          title="Italic (⌘I)"
+          title={`Italic (${mod}${mod === "⌘" ? "I" : "+I"})`}
         >
           <NavIcon name="italic" size={14} />
         </ToolbarButton>
@@ -185,14 +189,14 @@ export function RichTextEditor({
         <ToolbarButton
           onClick={() => editor?.chain().focus().undo().run()}
           disabled={!editor?.can().undo()}
-          title="Undo (⌘Z)"
+          title={`Undo (${mod}${mod === "⌘" ? "Z" : "+Z"})`}
         >
           <NavIcon name="undo" size={14} />
         </ToolbarButton>
         <ToolbarButton
           onClick={() => editor?.chain().focus().redo().run()}
           disabled={!editor?.can().redo()}
-          title="Redo (⌘⇧Z)"
+          title={`Redo (${mod}${shiftZ})`}
         >
           <NavIcon name="redo" size={14} />
         </ToolbarButton>

--- a/components/nav/primary-nav.tsx
+++ b/components/nav/primary-nav.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 
 import { cn } from "@/lib/utils";
+import { Kbd } from "@/components/ui/kbd";
 import { NavIcon } from "@/components/ui/nav-icon";
 import {
   bottomNavItems,
@@ -187,7 +188,7 @@ export function PrimaryNav({
               return (
                 <div
                   key={item.key}
-                  title="Command palette (⌘K)"
+                  title="Command palette"
                   className={cn(
                     "flex items-center rounded-md px-1 py-2 text-m3",
                     collapsed
@@ -197,7 +198,7 @@ export function PrimaryNav({
                 >
                   <NavIcon name={item.icon} size={20} className="text-icon-dim" />
                   {!collapsed && (
-                    <span className="text-xs font-mono leading-none">⌘K</span>
+                    <Kbd keys={["mod", "K"]} className="border-0 bg-transparent px-0 py-0 text-xs leading-none" />
                   )}
                 </div>
               );

--- a/components/ui/kbd.tsx
+++ b/components/ui/kbd.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Fragment } from "react";
+import { usePlatform } from "@/lib/hooks/use-platform";
+import { cn } from "@/lib/utils";
+
+export type KbdModifier = "mod" | "shift" | "alt" | "ctrl" | "enter";
+
+const MAC_GLYPHS: Record<KbdModifier, string> = {
+  mod: "⌘",
+  shift: "⇧",
+  alt: "⌥",
+  ctrl: "⌃",
+  enter: "⏎",
+};
+
+const NON_MAC_LABELS: Record<KbdModifier, string> = {
+  mod: "Ctrl",
+  shift: "Shift",
+  alt: "Alt",
+  ctrl: "Ctrl",
+  enter: "Enter",
+};
+
+function isModifier(key: string): key is KbdModifier {
+  return key in MAC_GLYPHS;
+}
+
+export interface KbdProps {
+  keys: Array<KbdModifier | string>;
+  className?: string;
+}
+
+export function Kbd({ keys, className }: KbdProps) {
+  const { platform, hydrated } = usePlatform();
+  // Render Ctrl-style labels until hydration completes — prevents a one-frame
+  // ⌘ flash on Windows. Mac users still see ⌘ after hydration.
+  const isMac = hydrated && platform === "mac";
+
+  const ariaLabel = keys
+    .map((k) => (isModifier(k) ? NON_MAC_LABELS[k] : k))
+    .join(" ");
+
+  return (
+    <kbd
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex items-center gap-0.5 rounded border bg-muted px-1.5 py-0.5 font-mono text-xs font-medium",
+        className,
+      )}
+    >
+      {keys.map((k, i) => {
+        const display = isModifier(k)
+          ? isMac
+            ? MAC_GLYPHS[k]
+            : NON_MAC_LABELS[k]
+          : k;
+        return (
+          <Fragment key={i}>
+            <span>{display}</span>
+            {i < keys.length - 1 && !isMac ? (
+              <span className="opacity-60">+</span>
+            ) : null}
+          </Fragment>
+        );
+      })}
+    </kbd>
+  );
+}

--- a/lib/__tests__/use-platform.test.ts
+++ b/lib/__tests__/use-platform.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { detectPlatform } from "@/lib/hooks/use-platform";
+
+describe("detectPlatform", () => {
+  it("identifies macOS via navigator.platform", () => {
+    expect(detectPlatform("Mozilla/5.0 (Macintosh)", "MacIntel")).toBe("mac");
+  });
+
+  it("identifies macOS via UA fallback (modern Safari hides platform)", () => {
+    // Modern Safari may report empty navigator.platform.
+    expect(detectPlatform("Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) Safari", "")).toBe("mac");
+  });
+
+  it("identifies Windows via navigator.platform", () => {
+    expect(detectPlatform("Mozilla/5.0 (Windows NT 10.0)", "Win32")).toBe("windows");
+  });
+
+  it("identifies Windows via UA when platform is empty", () => {
+    expect(detectPlatform("Mozilla/5.0 (Windows NT 10.0)", "")).toBe("windows");
+  });
+
+  it("identifies Linux", () => {
+    expect(detectPlatform("Mozilla/5.0 (X11; Linux x86_64)", "Linux x86_64")).toBe("linux");
+  });
+
+  it("falls back to 'unknown' for empty inputs", () => {
+    expect(detectPlatform("", "")).toBe("unknown");
+  });
+
+  it("falls back to 'unknown' for unrecognised UA", () => {
+    expect(detectPlatform("Mozilla/5.0 (PlayStation 5)", "PS5")).toBe("unknown");
+  });
+
+  it("is case-insensitive", () => {
+    expect(detectPlatform("MOZILLA/5.0 (MACINTOSH)", "MACINTEL")).toBe("mac");
+  });
+});

--- a/lib/hooks/use-platform.ts
+++ b/lib/hooks/use-platform.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type Platform = "mac" | "windows" | "linux" | "unknown";
+
+export function detectPlatform(ua: string, ps: string): Platform {
+  const u = ua.toLowerCase();
+  const p = (ps || "").toLowerCase();
+  if (p.includes("mac") || u.includes("mac os")) return "mac";
+  if (p.includes("win") || u.includes("windows")) return "windows";
+  if (p.includes("linux") || u.includes("linux")) return "linux";
+  return "unknown";
+}
+
+export function usePlatform(): { platform: Platform; hydrated: boolean } {
+  const [platform, setPlatform] = useState<Platform>("unknown");
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined") {
+      setHydrated(true);
+      return;
+    }
+    setPlatform(detectPlatform(navigator.userAgent, navigator.platform || ""));
+    setHydrated(true);
+  }, []);
+
+  return { platform, hydrated };
+}
+
+// String-form modifier label, suited for HTML `title` attributes (which
+// don't accept JSX). Returns "Ctrl" until hydration completes — same
+// flash-prevention principle as <Kbd>. After hydration: "⌘" on macOS,
+// "Ctrl" everywhere else.
+export function useModKey(): string {
+  const { platform, hydrated } = usePlatform();
+  return hydrated && platform === "mac" ? "⌘" : "Ctrl";
+}


### PR DESCRIPTION
## Summary

Replaces hardcoded ⌘ glyphs with a platform-aware `<Kbd>` component that defers Mac glyphs until React hydration completes — eliminating the one-frame ⌘ flash on Windows that Steven reported. Implements **Spec 06** from the 2026-05-08 master brief.

## Changes

- **`lib/hooks/use-platform.ts`**: `usePlatform()` hook + pure `detectPlatform(ua, ps)` helper. `useModKey()` returns `"⌘"` or `"Ctrl"` for HTML `title=` attributes that can't host JSX.
- **`components/ui/kbd.tsx`**: `<Kbd keys={["mod","K"]}>` — renders Ctrl-style labels until `hydrated && platform === 'mac'` to prevent the ⌘ flash on non-Mac. `aria-label` uses Ctrl-style strings for screen readers.
- **Sweep — visible glyphs replaced** in:
  - `components/nav/primary-nav.tsx` (⌘K command-palette hint)
  - `components/BlogPostComposer.tsx` (⌘S save-draft hint)
  - `components/BulkUploadPanel.tsx` (⌘↵ run hint)
  - `components/RichTextEditor.tsx` toolbar tooltips (Bold / Italic / Undo / Redo via `useModKey()`)
- **Test**: `lib/__tests__/use-platform.test.ts` — 8 cases (Mac via platform/UA, Windows, Linux, empty, unknown, case-insensitive).

## Scope-out (per brief)

- TipTap / Monaco / CodeMirror keybindings untouched — those libraries manage cross-platform via `Mod-` already.
- Comment-only ⌘ occurrences left as-is — developer-only, not user-visible.

## Risks identified and mitigated

- One-frame Mac-glyph flash on Windows → `<Kbd>` defers ⌘ until hydration; `useModKey` does same for title strings.
- Screen-reader accessibility → `aria-label` always Ctrl-style.
- No keyboard-handler changes; existing `e.metaKey || e.ctrlKey` patterns already accept both modifiers.
- No deps, schema, env vars, or migrations. **Independently revertible.**

## Verification

- `npm run typecheck` / `lint` / `build` — green
- `npm run audit:static` — 0 HIGH, 0 MEDIUM
- vitest unit test added (CI runs it; local Supabase stack down per ARCH §14.1)

## Test plan

- [ ] Windows: hover any shortcut → `Ctrl + K` (no ⌘ flash)
- [ ] macOS / UA-spoofed: ⌘ glyphs after hydration
- [ ] Ctrl+K and Cmd+K both open command palette
- [ ] RichTextEditor toolbar tooltips show platform-correct text
- [ ] `aria-label` on `<Kbd>` always reads "Ctrl K" / "Ctrl S" for screen readers

🤖 Generated with [Claude Code](https://claude.com/claude-code)