### PR TITLE
fix(spec05): pass query vector as JS array to RPC, not text literal

### DIFF
--- a/app/api/images/suggest/route.ts
+++ b/app/api/images/suggest/route.ts
@@ -7,7 +7,6 @@ import { readJsonBody, validationError } from "@/lib/http";
 import {
   EmbeddingNotConfiguredError,
   embedText,
-  vectorToLiteral,
 } from "@/lib/images/embed";
 import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -151,12 +150,16 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const embedInput = composeEmbedInput(postTitle, postBody);
 
   // Try to embed the query. Failures degrade to keyword-only.
-  let queryVectorLiteral: string | null = null;
+  // Pass as a JS number[] (Supabase pgvector idiomatic — see
+  // https://supabase.com/docs/guides/ai/vector-columns). PostgREST
+  // binds it to the `vector(1536)` parameter via pgvector's implicit
+  // float[] → vector cast, which avoids the text→vector path that
+  // pgvector doesn't ship a cast for.
+  let queryVector: number[] | null = null;
   let embedFailureReason: string | null = null;
   if (embedInput) {
     try {
-      const vec = await embedText(embedInput);
-      queryVectorLiteral = vectorToLiteral(vec);
+      queryVector = await embedText(embedInput);
     } catch (err) {
       if (err instanceof EmbeddingNotConfiguredError) {
         embedFailureReason = "not_configured";
@@ -170,7 +173,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     }
   }
 
-  if (!keywordQuery && !queryVectorLiteral) {
+  if (!keywordQuery && !queryVector) {
     // Both sides empty → no DB call. Defensive: shouldn't happen given the
     // earlier "both empty" early-return.
     return NextResponse.json(
@@ -187,7 +190,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const svc = getServiceRoleClient();
   const { data, error } = await svc.rpc("hybrid_search_images", {
     p_keyword_query: keywordQuery || null,
-    p_query_vector: queryVectorLiteral,
+    p_query_vector: queryVector,
     p_limit: limit,
     p_exclude_ids: excludeIds,
   });
@@ -249,8 +252,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     has_title: postTitle.trim().length > 0,
     body_chars: postBody.length,
     keyword_query_chars: keywordQuery.length,
-    query_embedded: queryVectorLiteral !== null,
-    keyword_only: queryVectorLiteral === null,
+    query_embedded: queryVector !== null,
+    keyword_only: queryVector === null,
     embed_failure: embedFailureReason,
     elapsed_ms: elapsedMs,
     result_count: images.length,
@@ -267,8 +270,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       ok: true,
       data: {
         images,
-        queryEmbedded: queryVectorLiteral !== null,
-        keywordOnly: queryVectorLiteral === null,
+        queryEmbedded: queryVector !== null,
+        keywordOnly: queryVector === null,
         elapsedMs,
       },
       timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary

Code-review pass on Spec 05 PR B (#746) found a latent bug in `/api/images/suggest`. The query embedding was being passed to the `hybrid_search_images` RPC as a pgvector text literal (`"[0.1,0.2,...]"`). That requires PG to do an implicit `text → vector` cast, which **pgvector does not ship**. The function call would fail with a cast error the moment `OPENAI_API_KEY` is provisioned and the route starts actually generating embeddings.

Until activation the route ran in keyword-only mode (no embedding, no RPC vector parameter), so the bug was latent — green CI didn't catch it because no test exercised the embedded path against a real PG.

## Fix

Pass the JS `number[]` directly to `.rpc()`. Supabase JS serialises it as a JSON array; PostgREST binds it to the `vector(1536)` parameter via pgvector's implicit `float[] → vector` cast (this one **does** exist). Matches the Supabase docs example for vector columns: https://supabase.com/docs/guides/ai/vector-columns

`vectorToLiteral` is still exported from `lib/images/embed.ts` because the embed-and-store path uses it for `UPDATE image_library SET caption_embedding = '[...]'` — column writes go through pgvector's `vector_in()` text input function, where text-form is the canonical input. Only the RPC parameter binding changed.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)