### PR TITLE
feat(spec07-a): content-preview fix — empty-state detection + scoped styles

### DIFF
--- a/components/PostDetailClient.tsx
+++ b/components/PostDetailClient.tsx
@@ -33,6 +33,46 @@ import type { PreflightResult } from "@/lib/site-preflight";
 
 type ActionState = "idle" | "publishing" | "unpublishing";
 
+// Spec 07 PR A — Tiptap saves blank documents as "<p></p>" / "<p><br></p>",
+// which the previous truthy check rendered as a blank iframe. Strip tags +
+// nbsp + zero-width chars before deciding.
+function isHtmlEffectivelyEmpty(html: string | null | undefined): boolean {
+  if (!html) return true;
+  const stripped = html
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;|&#160;| |​|‌|‍|﻿/g, "")
+    .trim();
+  return stripped.length === 0;
+}
+
+// Spec 07 PR A — wrap generated_html in a minimal styled document so the
+// iframe preview renders with sensible typography even before any
+// site-level CSS is loaded.
+//
+// Sanitisation note: rendering happens in <iframe sandbox=""> with NO
+// allow-scripts / allow-same-origin / allow-forms — the browser blocks
+// every active content type. This is stricter than DOMPurify-plus-
+// dangerouslySetInnerHTML because nothing inside the frame can execute
+// or reach the parent. Provenance: relying on browser-native sandbox
+// per https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#sandbox.
+function wrapPreviewDocument(rawHtml: string): string {
+  const styles = [
+    "body{margin:16px;font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;font-size:15px;line-height:1.6;color:#111827}",
+    "h1{font-size:24px;line-height:1.25;margin:0 0 12px;font-weight:700}",
+    "h2{font-size:20px;line-height:1.3;margin:20px 0 10px;font-weight:700}",
+    "h3{font-size:18px;line-height:1.35;margin:16px 0 8px;font-weight:600}",
+    "p{margin:0 0 12px}",
+    "ul,ol{margin:0 0 12px 20px;padding:0}",
+    "li{margin:4px 0}",
+    "blockquote{margin:0 0 12px;padding:8px 12px;border-left:3px solid #e5e7eb;color:#374151}",
+    "code{background:#f3f4f6;padding:1px 4px;border-radius:3px;font-size:14px;font-family:ui-monospace,monospace}",
+    "pre{background:#f3f4f6;padding:12px;border-radius:6px;overflow:auto;font-size:13px}",
+    "img{max-width:100%;height:auto}",
+    "a{color:#2563eb;text-decoration:underline}",
+  ].join("");
+  return `<!doctype html><html><head><meta charset="utf-8"><style>${styles}</style></head><body>${rawHtml}</body></html>`;
+}
+
 export function PostDetailClient({
   siteId,
   siteWpUrl,
@@ -237,16 +277,16 @@ export function PostDetailClient({
             className="mt-3 h-96 w-full rounded border"
             title={`Live preview of ${post.title}`}
           />
-        ) : post.generated_html ? (
+        ) : !isHtmlEffectivelyEmpty(post.generated_html) ? (
           <iframe
             sandbox=""
-            srcDoc={post.generated_html}
-            className="mt-3 h-96 w-full rounded border"
+            srcDoc={wrapPreviewDocument(post.generated_html ?? "")}
+            className="mt-3 h-[32rem] w-full rounded border"
             title={`Draft preview of ${post.title}`}
           />
         ) : (
           <p className="mt-3 text-sm text-muted-foreground">
-            No content yet. Save a draft from the composer to see a preview here.
+            No content yet — add content via the post editor.
           </p>
         )}
       </section>


### PR DESCRIPTION
## Summary

Implements **Spec 07 PR A** from the 2026-05-08 master brief — fixes the post-detail Content Preview block that operators reported as "broken" while the excerpt right below it rendered fine.

## Root cause

`post.generated_html ?` is a truthy check: Tiptap saves blank documents as `"<p></p>"` or `"<p><br></p>"`, which is truthy, so the iframe rendered with empty content → operators saw a blank pane and concluded "preview is broken." Excerpt below worked because it doesn't get the empty-marker treatment.

## Fix

- **`isHtmlEffectivelyEmpty(html)`** — strips tags + nbsp + zero-width chars before deciding empty vs not. Handles the four common zero-width variants and `&nbsp;` / `&#160;`.
- **`wrapPreviewDocument(rawHtml)`** — wraps the body in a minimal styled HTML doc so iframe rendering has sensible typography even before any site-level CSS loads. Solves the secondary "unstyled text feels blank" symptom.
- Empty-state copy → spec wording: **"No content yet — add content via the post editor."**
- Iframe height bumped from `h-96` to `h-[32rem]` for better long-content affordance.

## Sanitisation provenance

Content originates from **Tiptap** (HTML on `posts.generated_html`) and is rendered via `<iframe sandbox="">`. The empty `sandbox` attribute disables scripts, same-origin, forms, popups, and every other active content type. **Stricter than DOMPurify + `dangerouslySetInnerHTML`** because nothing inside the frame can execute or reach the parent.

Reference: [MDN — iframe.sandbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#sandbox).

## Risks identified and mitigated

- **Markup injection via post.title in the wrapper document** — title is NOT inlined into the wrapper; only `generated_html` is, and that sits inside `sandbox=""` where active content is blocked.
- **Unicode whitespace / zero-width chars masking emptiness** → regex covers `nbsp` + four common zero-width variants.
- **Backwards-compat** — `wrapPreviewDocument` is a pure function over the raw HTML; existing valid markup renders identically (just with the additional base styles).

## Verification

- `npm run typecheck` / `lint` / `build` — green
- `npm run audit:static` — 0 HIGH, 0 MEDIUM

PR is **independently revertible** (single-file change, no schema, env vars, or migration).

## Test plan

- [ ] Open a post detail page with empty Tiptap content (`<p></p>`) → shows "No content yet — add content via the post editor." instead of a blank iframe
- [ ] Open a post detail page with real content → preview renders WITH typography (not raw unstyled text)
- [ ] Open a published post → live iframe (unchanged behaviour)
- [ ] Tiptap editor empty → save draft → return → empty-state shows
- [ ] Long content → 32rem-tall iframe renders with scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)