### PR TITLE
feat(spec14-a): session-expiry warning modal + final banner + hook

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -2,11 +2,10 @@ import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 
 import { checkAdminAccess } from "@/lib/admin-gate";
-import { createRouteAuthClient } from "@/lib/auth";
 import { NavShell, type NavUserContext } from "@/components/nav/nav-shell";
 import { CommandPalette } from "@/components/CommandPalette";
 import { DebugFooter } from "@/components/DebugFooter";
-import { SessionExpiryWarning } from "@/components/SessionExpiryWarning";
+import { SessionExpiryWatcher } from "@/components/session/session-expiry-watcher";
 import { Toaster } from "@/components/ui/toaster";
 
 export default async function AdminLayout({
@@ -22,11 +21,6 @@ export default async function AdminLayout({
   const isAdminTier =
     !user || user.role === "admin" || user.role === "super_admin";
   const isSuperAdmin = !user || user.role === "super_admin";
-
-  const {
-    data: { session },
-  } = await createRouteAuthClient().auth.getSession();
-  const sessionExpiresAt = session?.expires_at ?? null;
 
   const navContext: NavUserContext = {
     email: user?.email ?? null,
@@ -48,7 +42,7 @@ export default async function AdminLayout({
       </NavShell>
       <Toaster />
       <CommandPalette />
-      <SessionExpiryWarning expiresAt={sessionExpiresAt} />
+      <SessionExpiryWatcher />
       {isSuperAdmin && (
         <DebugFooter
           buildSha={process.env.VERCEL_GIT_COMMIT_SHA ?? null}

--- a/components/session/session-expiry-banner.tsx
+++ b/components/session/session-expiry-banner.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+// Spec 14 PR A — final session-expiry banner.
+//
+// Renders top-centre, undismissable, when minutesRemaining ≤ 5m. No close
+// button. Single CTA. Visual urgency: red border, sticky top.
+//
+// PR B will add the activity-grace overlay (extends past T-0 by up to
+// 15 minutes if the operator is mid-task). PR C plumbs the re-auth flow.
+
+const FINAL_BANNER_THRESHOLD_MIN = 5;
+
+interface Props {
+  minutesRemaining: number | null;
+  hydrated: boolean;
+  onReauthenticate: () => void;
+}
+
+export function SessionExpiryBanner({
+  minutesRemaining,
+  hydrated,
+  onReauthenticate,
+}: Props) {
+  if (!hydrated || minutesRemaining === null) return null;
+  if (minutesRemaining > FINAL_BANNER_THRESHOLD_MIN) return null;
+
+  return (
+    <div
+      role="alert"
+      className="sticky top-0 z-50 flex w-full items-center justify-center gap-3 border-b border-red-300 bg-red-50 px-4 py-2 text-sm text-red-900 shadow-sm dark:border-red-900 dark:bg-red-950/60 dark:text-red-200"
+      data-testid="session-expiry-banner"
+    >
+      <span className="font-medium">
+        Your session expires in {minutesRemaining} minute
+        {minutesRemaining === 1 ? "" : "s"}
+        {" — "}
+        save your work and re-authenticate.
+      </span>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={onReauthenticate}
+        className="border-red-400 text-red-900 hover:bg-red-100 dark:border-red-700 dark:text-red-100"
+      >
+        Re-authenticate
+      </Button>
+    </div>
+  );
+}

--- a/components/session/session-expiry-modal.tsx
+++ b/components/session/session-expiry-modal.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+// Spec 14 PR A — primary session-expiry warning modal.
+//
+// Renders centred when minutesRemaining ≤ 120m. Operator can dismiss
+// via "Remind me later" — we re-prompt 30m later (until the final
+// banner takes over at T-5m).
+//
+// Cybersecurity messaging: explains the 48h cap so operators don't
+// read the modal as a session-management bug. The 48h figure is
+// hard-coded into the copy — if Steven changes the dashboard JWT TTL,
+// update this string in the same PR.
+
+const PRIMARY_THRESHOLD_MIN = 120;
+const RE_PROMPT_AFTER_MIN = 30; // Snooze duration after "Remind me later"
+const FINAL_BANNER_THRESHOLD_MIN = 5;
+
+interface Props {
+  minutesRemaining: number | null;
+  hydrated: boolean;
+  onReauthenticate: () => void;
+}
+
+export function SessionExpiryModal({
+  minutesRemaining,
+  hydrated,
+  onReauthenticate,
+}: Props) {
+  // Ref-style snooze: when the operator clicks "Remind me later", record
+  // the minutes-remaining value AT dismissal. We re-show only when the
+  // current minutesRemaining drops below (snoozedAt - 30).
+  const [snoozedAt, setSnoozedAt] = useState<number | null>(null);
+
+  // Reset the snooze if the session was extended (re-auth). minutesRemaining
+  // jumps back above PRIMARY_THRESHOLD_MIN → forget the snooze.
+  useEffect(() => {
+    if (minutesRemaining !== null && minutesRemaining > PRIMARY_THRESHOLD_MIN) {
+      setSnoozedAt(null);
+    }
+  }, [minutesRemaining]);
+
+  if (!hydrated || minutesRemaining === null) return null;
+  if (minutesRemaining > PRIMARY_THRESHOLD_MIN) return null;
+  // Final banner takes over at T-5m — modal yields.
+  if (minutesRemaining <= FINAL_BANNER_THRESHOLD_MIN) return null;
+
+  // Honour the snooze: hide until minutesRemaining drops by at least
+  // RE_PROMPT_AFTER_MIN since dismissal.
+  if (snoozedAt !== null && snoozedAt - minutesRemaining < RE_PROMPT_AFTER_MIN) {
+    return null;
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) setSnoozedAt(minutesRemaining);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            Your session expires in about {minutesRemaining} minute
+            {minutesRemaining === 1 ? "" : "s"}
+          </DialogTitle>
+          <DialogDescription>
+            For your security, Opollo signs you out every 48 hours regardless
+            of activity. Re-authenticate now to start a fresh 48-hour session,
+            or save your work and we&apos;ll prompt you closer to the deadline.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => setSnoozedAt(minutesRemaining)}
+          >
+            Remind me later
+          </Button>
+          <Button onClick={onReauthenticate}>Re-authenticate now</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/session/session-expiry-watcher.tsx
+++ b/components/session/session-expiry-watcher.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { useCallback } from "react";
+
+import { useSessionExpiry } from "@/lib/hooks/use-session-expiry";
+
+import { SessionExpiryBanner } from "./session-expiry-banner";
+import { SessionExpiryModal } from "./session-expiry-modal";
+
+// Spec 14 PR A — single watcher that mounts both the warning modal and
+// the final banner. Drop one of these into the admin shell layout.
+//
+// "Re-authenticate" navigates to /login?returnTo=<current> so the
+// existing login flow (Supabase OAuth + magic-link callback) restores
+// the operator to their current page. PR C will replace this with a
+// dedicated cybersecurity-explainer page for cap-driven re-auths.
+
+export function SessionExpiryWatcher() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { minutesRemaining, hydrated } = useSessionExpiry();
+
+  const onReauthenticate = useCallback(() => {
+    const returnTo = pathname ?? "/admin";
+    router.push(`/login?returnTo=${encodeURIComponent(returnTo)}`);
+  }, [router, pathname]);
+
+  return (
+    <>
+      <SessionExpiryBanner
+        minutesRemaining={minutesRemaining}
+        hydrated={hydrated}
+        onReauthenticate={onReauthenticate}
+      />
+      <SessionExpiryModal
+        minutesRemaining={minutesRemaining}
+        hydrated={hydrated}
+        onReauthenticate={onReauthenticate}
+      />
+    </>
+  );
+}

--- a/lib/hooks/use-session-expiry.ts
+++ b/lib/hooks/use-session-expiry.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { createBrowserClient } from "@supabase/ssr";
+import { useEffect, useRef, useState } from "react";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "";
+
+// Spec 14 PR A — session-expiry tracker.
+//
+// Reads the active Supabase session's `expires_at` (UNIX seconds) and
+// derives `minutesRemaining`. Re-evaluates every 30 seconds (the spec's
+// resolution doesn't need second-precision; we just need to fire the
+// modal at T-120m and the banner at T-5m without keeping a tight wake-
+// up loop running).
+//
+// The hook does NOT logout — it returns `expired: true` and lets the
+// caller decide. Hard-logout enforcement happens in PR B alongside the
+// activity / grace logic.
+//
+// Caveats:
+//   • Returns `null` when no session is loaded (logged-out, or initial
+//     mount). Callers must handle that.
+//   • Mirrors the JWT_EXPIRY set in the Supabase dashboard. If the
+//     dashboard is set to <48h, the warning thresholds simply fire
+//     proportionally earlier; nothing in this hook hardcodes 48h.
+
+export interface SessionExpiry {
+  /** UNIX seconds. */
+  expiresAt: number | null;
+  /** Whole minutes remaining; clamped to >= 0. */
+  minutesRemaining: number | null;
+  /** True once expiresAt has passed. */
+  expired: boolean;
+  /** True after the first session read returns (avoids flashing modals on first paint). */
+  hydrated: boolean;
+}
+
+const POLL_INTERVAL_MS = 30_000;
+
+export function useSessionExpiry(): SessionExpiry {
+  const [expiresAt, setExpiresAt] = useState<number | null>(null);
+  const [now, setNow] = useState<number>(() => Math.floor(Date.now() / 1000));
+  const [hydrated, setHydrated] = useState(false);
+  const tickRef = useRef<number | null>(null);
+
+  // Load the session once; subsequent reads come via Supabase's onAuthStateChange.
+  useEffect(() => {
+    if (!supabaseUrl || !supabaseAnonKey) {
+      setHydrated(true);
+      return;
+    }
+    let cancelled = false;
+    const supa = createBrowserClient(supabaseUrl, supabaseAnonKey);
+    void supa.auth.getSession().then(({ data }) => {
+      if (cancelled) return;
+      const at = data.session?.expires_at ?? null;
+      setExpiresAt(at);
+      setHydrated(true);
+    });
+    const { data: sub } = supa.auth.onAuthStateChange((_event, session) => {
+      setExpiresAt(session?.expires_at ?? null);
+      setHydrated(true);
+    });
+    return () => {
+      cancelled = true;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  // Tick every POLL_INTERVAL_MS so minutesRemaining stays fresh.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    function tick() {
+      setNow(Math.floor(Date.now() / 1000));
+    }
+    tick();
+    tickRef.current = window.setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      if (tickRef.current !== null) window.clearInterval(tickRef.current);
+    };
+  }, []);
+
+  if (expiresAt === null) {
+    return { expiresAt: null, minutesRemaining: null, expired: false, hydrated };
+  }
+  const secondsRemaining = Math.max(0, expiresAt - now);
+  const minutesRemaining = Math.floor(secondsRemaining / 60);
+  return {
+    expiresAt,
+    minutesRemaining,
+    expired: secondsRemaining === 0,
+    hydrated,
+  };
+}


### PR DESCRIPTION
## ⚠️ MANUAL REVIEW REQUIRED — DO NOT --auto-merge

Per the 2026-05-08 master brief, Spec 14 PRs are excluded from the auto-merge contract. Auth changes lock people out; the cost of a wrong call is hours of operator pain. Review and merge by hand.

## Summary

Implements **Spec 14 PR A** — the 48-hour session-expiry warning surface. Replaces the existing corner-toast `SessionExpiryWarning` (which only showed a 5-minute toast) with a centred warning **modal at T-2h** + **undismissable banner at T-5m**, plus a reusable hook.

PRs B (activity tracking + grace + multi-tab leader-elected auto-save) and C (cybersecurity-explainer re-login page) are deferred to follow-ups, also manual-review.

## What this PR ships

- **`lib/hooks/use-session-expiry.ts`** — `useSessionExpiry()` reads the active Supabase session's `expires_at`, polls every 30s, returns `{expiresAt, minutesRemaining, expired, hydrated}`. Subscribes to `onAuthStateChange` so re-auth (or sign-out) updates live.
- **`components/session/session-expiry-modal.tsx`** — centred dialog when `minutesRemaining ≤ 120m`. Cybersecurity copy explains the 48h cap. "Remind me later" snoozes for 30 minutes (component state, not localStorage — survives the resolution gap, not the page reload, by design). Yields to the final banner at T-5m.
- **`components/session/session-expiry-banner.tsx`** — undismissable sticky top-of-page banner when `minutesRemaining ≤ 5m`. Red-tinted, single Re-authenticate CTA.
- **`components/session/session-expiry-watcher.tsx`** — thin wrapper that mounts both, wires `onReauthenticate` to `/login?returnTo=<current>`.
- **`app/admin/layout.tsx`** — replaces the corner-toast `SessionExpiryWarning` with the new `SessionExpiryWatcher`. Removes the server-side `expires_at` lookup (watcher reads it client-side).

## Operator-side dashboard config (load-bearing)

The 48-hour TTL itself is set in the **Supabase project dashboard** (Auth → JWT expiry → `172800` seconds). This PR's modal copy assumes the 48h figure; if you change the dashboard TTL, update the copy in `session-expiry-modal.tsx` in the same change. The client-side hook is **TTL-agnostic** — thresholds (120m / 5m) fire proportionally to whatever `expires_at` the session carries.

## Trusted-devices implication

The 48h cap applies to **all** sessions, including trusted devices. This effectively reduces what `trusted_devices` means on this codebase — skip-2FA only, no longer extended TTL. If the feature has no remaining value with this change, file a follow-up. Logged to `_blockers.md`.

## Risks identified and mitigated

- **Locking out users via deployment timing** — PR is a UI overlay only; the underlying Supabase session refresh continues to work normally. Worst case if the modal/banner has a bug: an extra popup shows; auth itself is unaffected.
- **Snooze persistence** — kept in component state, NOT localStorage. Reload after dismissal → modal re-renders. Acceptable per brief ("Remind me later → returns at T-30min").
- **Banner over fixed nav** — sticky `top-0` with `z-50`; admin shell rail is at `z-40`, banner sits above.
- **Reduced motion** — no animations on banner/modal beyond radix dialog defaults (which honour the motion preference).

## Deferred to PR B / PR C (per brief, also manual-review)

- Activity tracking + non-renewable 15-minute grace window
- Multi-tab leader-elected auto-save with dirty-state guard + visibility-aware cadence
- Cybersecurity-explainer re-login page distinguishing cap-driven vs user-initiated logouts

## Verification

- `npm run typecheck` / `lint` / `build` — green
- `npm run audit:static` — 0 HIGH, 0 MEDIUM. New file → LOW count moved 18 → 19 (no severity bump).

## Diff noise

The diff contains a number of `docs/{ => architecture}/...` renames from a parallel-session docs-reorg that was in flight on this checkout. Those are pure renames (0 line changes) and are not part of Spec 14. The substantive review is in the four `components/session/*` + `lib/hooks/use-session-expiry.ts` + `app/admin/layout.tsx` files.

## Test plan

- [ ] Set Supabase JWT expiry to 5 minutes (dashboard) — login, wait, see warning modal, then banner
- [ ] "Remind me later" → modal closes, returns 30m later
- [ ] At T-5m → undismissable banner appears top-of-page
- [ ] Re-authenticate → modal/banner disappear, fresh expiry
- [ ] No regressions on logged-out / non-admin routes (watcher only mounts in admin layout)
- [ ] Modal/banner respect `prefers-reduced-motion` (no jarring animations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)