### PR TITLE
feat(spec18): canonical DataTable primitive + Pill/RowActions/TableCell — PR A

### DIFF
--- a/app/admin/_internal/table-examples/page.tsx
+++ b/app/admin/_internal/table-examples/page.tsx
@@ -1,0 +1,51 @@
+import { redirect } from "next/navigation";
+
+import { ExampleTablesClient } from "@/components/admin/internal/ExampleTablesClient";
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
+import { checkAdminAccess } from "@/lib/admin-gate";
+
+// ---------------------------------------------------------------------------
+// Spec 18 — DataTable visual reference page.
+//
+// Admin-only page rendering every state of the DataTable primitive:
+// populated, empty, loading, with row actions, with row click, with
+// selection, plus all six Pill variants.
+//
+// Not linked from main nav. Intended for:
+//   1. Visual reference when migrating tables in PRs B/C/D.
+//   2. Manual visual regression check after Spec 18-shaped changes.
+//
+// `_internal` segment makes the URL self-documenting as developer-only.
+// Admin gate is the authorisation; the segment name is a hint to
+// future contributors.
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+export default async function TableExamplesPage() {
+  const access = await checkAdminAccess({
+    requiredRoles: ["super_admin", "admin"],
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  return (
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Admin", href: "/admin/sites" },
+            { label: "Internal", href: "/admin/_internal/table-examples" },
+            { label: "Table examples" },
+          ]}
+        />
+        <PageHeader.Title>DataTable examples</PageHeader.Title>
+        <PageHeader.Subtitle>
+          Visual reference for the canonical DataTable primitive (Spec 18).
+          Admin-only.
+        </PageHeader.Subtitle>
+      </PageHeader>
+      <ExampleTablesClient />
+    </PageShell>
+  );
+}

--- a/components/__tests__/data-table.test.tsx
+++ b/components/__tests__/data-table.test.tsx
@@ -1,0 +1,207 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
+import { Pill } from "@/components/ui/pill";
+import { TableCell } from "@/components/ui/table-cell";
+
+// ---------------------------------------------------------------------------
+// Spec 18 — DataTable + Pill + TableCell component tests.
+// ---------------------------------------------------------------------------
+
+interface Row {
+  id: string;
+  name: string;
+  status: "Connected" | "Not Connected";
+}
+
+const SAMPLE: Row[] = [
+  { id: "a", name: "Alpha", status: "Connected" },
+  { id: "b", name: "Beta", status: "Not Connected" },
+];
+
+const COLS: ColumnDef<Row>[] = [
+  {
+    key: "name",
+    header: "Name",
+    cell: (r) => <TableCell.Primary>{r.name}</TableCell.Primary>,
+  },
+  {
+    key: "status",
+    header: "Status",
+    cell: (r) => (
+      <Pill variant={r.status === "Connected" ? "success" : "neutral"}>
+        {r.status}
+      </Pill>
+    ),
+  },
+];
+
+describe("DataTable", () => {
+  it("renders headers + rows", () => {
+    render(<DataTable data={SAMPLE} columns={COLS} rowKey={(r) => r.id} />);
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when data is empty and emptyState is provided", () => {
+    render(
+      <DataTable<Row>
+        data={[]}
+        columns={COLS}
+        rowKey={(r) => r.id}
+        emptyState={{
+          icon: <span>icon</span>,
+          title: "Nothing yet",
+          body: "Try adding one.",
+        }}
+      />,
+    );
+    expect(screen.getByText("Nothing yet")).toBeInTheDocument();
+    expect(screen.getByText("Try adding one.")).toBeInTheDocument();
+  });
+
+  it("renders skeleton rows when loading", () => {
+    const { container } = render(
+      <DataTable<Row>
+        data={[]}
+        columns={COLS}
+        rowKey={(r) => r.id}
+        loading
+        loadingRowCount={3}
+      />,
+    );
+    // 3 skeleton rows × 2 columns = 6 skeleton cells.
+    const rows = container.querySelectorAll("tbody tr");
+    expect(rows.length).toBe(3);
+  });
+
+  it("fires onRowClick when a row is clicked", async () => {
+    const onRowClick = vi.fn();
+    render(
+      <DataTable
+        data={SAMPLE}
+        columns={COLS}
+        rowKey={(r) => r.id}
+        onRowClick={onRowClick}
+      />,
+    );
+    const row = screen.getByText("Alpha").closest("tr");
+    expect(row).not.toBeNull();
+    fireEvent.click(row!);
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick).toHaveBeenCalledWith(SAMPLE[0]);
+  });
+
+  it("renders the row actions menu and fires action callbacks", async () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    render(
+      <DataTable
+        data={SAMPLE}
+        columns={COLS}
+        rowKey={(r) => r.id}
+        rowActions={(r) => [
+          { label: `Edit ${r.name}`, onClick: onEdit },
+          {
+            label: `Delete ${r.name}`,
+            variant: "destructive" as const,
+            onClick: onDelete,
+          },
+        ]}
+      />,
+    );
+    const triggers = screen.getAllByRole("button", { name: "Row actions" });
+    expect(triggers.length).toBe(2);
+    await userEvent.click(triggers[0]);
+    const editItem = await screen.findByRole("menuitem", { name: "Edit Alpha" });
+    await userEvent.click(editItem);
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onRowClick when the row actions trigger is clicked", async () => {
+    const onRowClick = vi.fn();
+    render(
+      <DataTable
+        data={SAMPLE}
+        columns={COLS}
+        rowKey={(r) => r.id}
+        onRowClick={onRowClick}
+        rowActions={() => [{ label: "Noop", onClick: vi.fn() }]}
+      />,
+    );
+    const triggers = screen.getAllByRole("button", { name: "Row actions" });
+    await userEvent.click(triggers[0]);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it("toggles selection when checkbox column is enabled", async () => {
+    const onSelectionChange = vi.fn();
+    const { rerender } = render(
+      <DataTable
+        data={SAMPLE}
+        columns={COLS}
+        rowKey={(r) => r.id}
+        selectable
+        selectedKeys={[]}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+    // 1 header + 2 rows = 3 checkboxes.
+    expect(checkboxes.length).toBe(3);
+    await userEvent.click(checkboxes[1]);
+    expect(onSelectionChange).toHaveBeenCalledWith(["a"]);
+
+    // Render with one selected; clicking the header should select all.
+    rerender(
+      <DataTable
+        data={SAMPLE}
+        columns={COLS}
+        rowKey={(r) => r.id}
+        selectable
+        selectedKeys={["a"]}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+    await userEvent.click(screen.getAllByRole("checkbox")[0]);
+    expect(onSelectionChange).toHaveBeenLastCalledWith(["a", "b"]);
+  });
+});
+
+describe("Pill", () => {
+  it("renders all six variants with the children verbatim", () => {
+    const variants = ["success", "neutral", "warning", "danger", "info", "accent"] as const;
+    for (const v of variants) {
+      const { unmount } = render(<Pill variant={v}>{v}-label</Pill>);
+      expect(screen.getByText(`${v}-label`)).toBeInTheDocument();
+      unmount();
+    }
+  });
+});
+
+describe("TableCell helpers", () => {
+  it("Stack renders both primary and secondary lines", () => {
+    render(<TableCell.Stack primary="Site name" secondary="never tested" />);
+    expect(screen.getByText("Site name")).toBeInTheDocument();
+    expect(screen.getByText("never tested")).toBeInTheDocument();
+  });
+
+  it("Stack omits secondary when not provided", () => {
+    render(<TableCell.Stack primary="Site name" />);
+    expect(screen.getByText("Site name")).toBeInTheDocument();
+  });
+
+  it("Empty renders an em-dash", () => {
+    render(<TableCell.Empty />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("Mono wraps content in a <code>", () => {
+    const { container } = render(<TableCell.Mono>foo-bar</TableCell.Mono>);
+    expect(container.querySelector("code")).not.toBeNull();
+  });
+});

--- a/components/admin/internal/ExampleTablesClient.tsx
+++ b/components/admin/internal/ExampleTablesClient.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useState } from "react";
+
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
+import { NavIcon } from "@/components/ui/nav-icon";
+import { Pill, type PillVariant } from "@/components/ui/pill";
+import { TableCell } from "@/components/ui/table-cell";
+import { toast } from "sonner";
+
+// ---------------------------------------------------------------------------
+// Spec 18 — DataTable + Pill visual reference page (client island).
+//
+// Each section below illustrates one canonical state. When migrating a
+// real table, find the closest example here, copy the column config
+// shape, and adapt.
+// ---------------------------------------------------------------------------
+
+interface SiteSample {
+  id: string;
+  name: string;
+  company: string;
+  wpUrl: string;
+  status: "Connected" | "Not Connected";
+  lastTested: string | null;
+}
+
+const SITE_SAMPLES: SiteSample[] = [
+  {
+    id: "1",
+    name: "Test Site 2",
+    company: "Acme Corp",
+    wpUrl: "https://test2.acme.test",
+    status: "Connected",
+    lastTested: "2 hours ago",
+  },
+  {
+    id: "2",
+    name: "Acme Marketing",
+    company: "Acme Corp",
+    wpUrl: "https://marketing.acme.test",
+    status: "Not Connected",
+    lastTested: null,
+  },
+  {
+    id: "3",
+    name: "Planet6 Blog",
+    company: "Planet6",
+    wpUrl: "https://blog.planet6.test",
+    status: "Connected",
+    lastTested: "5 days ago",
+  },
+];
+
+const PILL_VARIANTS: Array<{ variant: PillVariant; label: string; example: string }> = [
+  { variant: "success", label: "success", example: "Connected" },
+  { variant: "neutral", label: "neutral", example: "Customer" },
+  { variant: "warning", label: "warning", example: "Scheduled" },
+  { variant: "danger", label: "danger", example: "Removed" },
+  { variant: "info", label: "info", example: "iStock" },
+  { variant: "accent", label: "accent", example: "Opollo internal" },
+];
+
+export function ExampleTablesClient() {
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+
+  const siteCols: ColumnDef<SiteSample>[] = [
+    {
+      key: "name",
+      header: "Name",
+      cell: (r) => <TableCell.Primary>{r.name}</TableCell.Primary>,
+    },
+    {
+      key: "company",
+      header: "Company",
+      cell: (r) => <TableCell.Secondary>{r.company}</TableCell.Secondary>,
+    },
+    {
+      key: "wpUrl",
+      header: "WP URL",
+      cell: (r) => <TableCell.Mono>{r.wpUrl}</TableCell.Mono>,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (r) => (
+        <Pill variant={r.status === "Connected" ? "success" : "neutral"}>
+          {r.status}
+        </Pill>
+      ),
+    },
+    {
+      key: "lastTested",
+      header: "Last tested",
+      cell: (r) =>
+        r.lastTested ? (
+          <TableCell.Secondary>Tested {r.lastTested}</TableCell.Secondary>
+        ) : (
+          <TableCell.Secondary>Never tested</TableCell.Secondary>
+        ),
+    },
+  ];
+
+  return (
+    <div className="mt-6 space-y-12">
+      <Section
+        title="Pill variants"
+        description="The six canonical variants. Use Pill for every status / type / role indicator inside table cells."
+      >
+        <div className="flex flex-wrap items-center gap-3">
+          {PILL_VARIANTS.map((p) => (
+            <div key={p.variant} className="flex items-center gap-2 text-sm">
+              <Pill variant={p.variant}>{p.example}</Pill>
+              <span className="text-muted-foreground">{p.label}</span>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        title="Populated table with row click + row actions"
+        description="Default pattern: rows are clickable and the trailing column is a `...` overflow menu."
+      >
+        <DataTable
+          data={SITE_SAMPLES}
+          columns={siteCols}
+          rowKey={(r) => r.id}
+          onRowClick={(r) => {
+            toast.info(`Row clicked: ${r.name}`);
+          }}
+          rowActions={(r) => [
+            {
+              label: "Test connection",
+              icon: <NavIcon name="cloud-lightning" size={14} />,
+              onClick: () => {
+                toast.success(`Tested: ${r.name}`);
+              },
+            },
+            {
+              label: "Edit",
+              icon: <NavIcon name="pencil" size={14} />,
+              onClick: () => {
+                toast.info(`Edit: ${r.name}`);
+              },
+            },
+            {
+              label: "Delete",
+              icon: <NavIcon name="trash2" size={14} />,
+              variant: "destructive",
+              onClick: () => {
+                toast.error(`Delete: ${r.name}`);
+              },
+            },
+          ]}
+        />
+      </Section>
+
+      <Section
+        title="Selectable rows"
+        description="Pass `selectable` and `onSelectionChange` to surface a checkbox column."
+      >
+        <DataTable
+          data={SITE_SAMPLES}
+          columns={siteCols}
+          rowKey={(r) => r.id}
+          selectable
+          selectedKeys={selectedKeys}
+          onSelectionChange={setSelectedKeys}
+        />
+        <p className="mt-2 text-sm text-muted-foreground">
+          Selected: {selectedKeys.length === 0 ? "none" : selectedKeys.join(", ")}
+        </p>
+      </Section>
+
+      <Section
+        title="Empty state"
+        description="When `data.length === 0`, render an EmptyState block in place of the table body."
+      >
+        <DataTable<SiteSample>
+          data={[]}
+          columns={siteCols}
+          rowKey={(r) => r.id}
+          emptyState={{
+            icon: <NavIcon name="earth" size={20} />,
+            title: "No sites yet",
+            body: "Connect your first WordPress site to start publishing.",
+          }}
+        />
+      </Section>
+
+      <Section
+        title="Loading skeletons"
+        description="Pass `loading` to render placeholder rows while data is in flight."
+      >
+        <DataTable<SiteSample>
+          data={[]}
+          columns={siteCols}
+          rowKey={(r) => r.id}
+          loading
+          loadingRowCount={4}
+        />
+      </Section>
+
+      <Section
+        title="Stack cell (title + secondary line)"
+        description="Use TableCell.Stack for the 'Test Site 2 / never tested' pattern — primary headline + muted secondary line."
+      >
+        <DataTable
+          data={SITE_SAMPLES}
+          columns={[
+            {
+              key: "stack",
+              header: "Site",
+              cell: (r) => (
+                <TableCell.Stack
+                  primary={r.name}
+                  secondary={r.lastTested ? `Tested ${r.lastTested}` : "Never tested"}
+                />
+              ),
+            },
+            {
+              key: "status",
+              header: "Status",
+              cell: (r) => (
+                <Pill variant={r.status === "Connected" ? "success" : "neutral"}>
+                  {r.status}
+                </Pill>
+              ),
+            },
+          ]}
+          rowKey={(r) => r.id}
+        />
+      </Section>
+
+      <Section
+        title="Empty cell sentinel"
+        description="Use TableCell.Empty (em-dash) for null / missing values. Never blank."
+      >
+        <DataTable
+          data={[
+            { id: "1", name: "Site with domain", domain: "example.com" },
+            { id: "2", name: "Site without domain", domain: null },
+          ]}
+          columns={[
+            {
+              key: "name",
+              header: "Name",
+              cell: (r) => <TableCell.Primary>{r.name}</TableCell.Primary>,
+            },
+            {
+              key: "domain",
+              header: "Domain",
+              cell: (r) =>
+                r.domain ? (
+                  <TableCell.Mono>{r.domain}</TableCell.Mono>
+                ) : (
+                  <TableCell.Empty />
+                ),
+            },
+          ]}
+          rowKey={(r) => r.id}
+        />
+      </Section>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <header>
+        <h2 className="text-base font-semibold text-foreground">{title}</h2>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </header>
+      {children}
+    </section>
+  );
+}

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import * as React from "react";
+
+import { EmptyState, type EmptyStateProps } from "@/components/ui/empty-state";
+import { RowActions, type RowAction } from "@/components/ui/row-actions";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Spec 18 — DataTable canonical primitive.
+//
+// One table to rule them all. Headers all-caps tracked, cells 14px,
+// hover row, empty + loading states, optional row click + row actions
+// menu, optional checkbox selection. Migration target for every
+// bespoke `<table>` in the admin app.
+//
+// API summary:
+//
+//   const cols: ColumnDef<Site>[] = [
+//     { key: 'name', header: 'Name', cell: row => <TableCell.Primary>{row.name}</TableCell.Primary> },
+//     ...
+//   ];
+//   <DataTable
+//     data={sites}
+//     columns={cols}
+//     rowKey={r => r.id}
+//     onRowClick={r => navigate(`/admin/sites/${r.id}`)}
+//     rowActions={r => [{ label: 'Edit', onClick: () => ... }]}
+//     emptyState={{ icon, title, body, cta }}
+//   />
+//
+// Headers / cells / row hover / actions menu are handled internally so
+// every consumer table renders identically by default.
+// ---------------------------------------------------------------------------
+
+export interface ColumnDef<T> {
+  key: string;
+  header: React.ReactNode;
+  /** CSS width — e.g. "200px", "20%", "minmax(0, 1fr)". */
+  width?: string;
+  align?: "left" | "right" | "center";
+  cell: (row: T) => React.ReactNode;
+}
+
+export interface DataTableProps<T> {
+  data: readonly T[];
+  columns: ReadonlyArray<ColumnDef<T>>;
+  rowKey: (row: T) => string;
+  onRowClick?: (row: T) => void;
+  rowActions?: (row: T) => RowAction[];
+  /**
+   * `EmptyState` props (icon / title / body / cta) rendered when
+   * `data.length === 0` and `loading === false`. Pass `null` to skip
+   * rendering anything when empty (rare — most tables should opt in).
+   */
+  emptyState?: EmptyStateProps | null;
+  loading?: boolean;
+  /** Number of skeleton rows to render while `loading` is true. */
+  loadingRowCount?: number;
+  selectable?: boolean;
+  selectedKeys?: ReadonlyArray<string>;
+  onSelectionChange?: (selectedKeys: string[]) => void;
+  /** Test-id on the root `<table>`. */
+  testId?: string;
+  /** Extra class on the wrapping `<div>`. */
+  className?: string;
+}
+
+const HEADER_CLASS = cn(
+  // Spec 18 canonical: all-caps, 12px, +0.05em tracking, weight 600,
+  // muted color. Background: bg-muted/30. Bottom border 1px.
+  "px-3 py-3 text-left text-[12px] font-semibold uppercase tracking-wider text-muted-foreground",
+);
+
+const CELL_CLASS = cn(
+  // Spec 18 canonical: 14px text, py-3.5 (14px) / px-3 (12px). Bottom
+  // border 1px on every row except the last (handled via last:border-0).
+  "px-3 py-3.5 text-sm text-foreground",
+);
+
+export function DataTable<T>({
+  data,
+  columns,
+  rowKey,
+  onRowClick,
+  rowActions,
+  emptyState,
+  loading = false,
+  loadingRowCount = 5,
+  selectable = false,
+  selectedKeys,
+  onSelectionChange,
+  testId,
+  className,
+}: DataTableProps<T>) {
+  // The root layout always renders `border` + rounded corners so empty +
+  // populated states sit in the same chrome.
+  const wrapperClass = cn("rounded-md border bg-background", className);
+
+  if (!loading && data.length === 0 && emptyState !== null && emptyState !== undefined) {
+    return (
+      <div className={wrapperClass}>
+        <div className="px-4 py-12">
+          <EmptyState {...emptyState} />
+        </div>
+      </div>
+    );
+  }
+
+  const showActionsCol = Boolean(rowActions);
+  const showSelectCol = selectable;
+  const allSelected =
+    selectable &&
+    selectedKeys !== undefined &&
+    data.length > 0 &&
+    selectedKeys.length === data.length;
+  const someSelected =
+    selectable &&
+    selectedKeys !== undefined &&
+    selectedKeys.length > 0 &&
+    selectedKeys.length < data.length;
+
+  function handleHeaderToggle() {
+    if (!onSelectionChange) return;
+    if (allSelected) {
+      onSelectionChange([]);
+    } else {
+      onSelectionChange(data.map(rowKey));
+    }
+  }
+
+  function handleRowToggle(key: string) {
+    if (!onSelectionChange || selectedKeys === undefined) return;
+    if (selectedKeys.includes(key)) {
+      onSelectionChange(selectedKeys.filter((k) => k !== key));
+    } else {
+      onSelectionChange([...selectedKeys, key]);
+    }
+  }
+
+  return (
+    <div className={wrapperClass}>
+      <div className="w-full overflow-x-auto">
+        <table
+          className="w-full table-auto border-collapse"
+          data-testid={testId}
+        >
+          <thead className="border-b bg-muted/30">
+            <tr>
+              {showSelectCol && (
+                <th className={cn(HEADER_CLASS, "w-10")}>
+                  <input
+                    type="checkbox"
+                    checked={Boolean(allSelected)}
+                    ref={(el) => {
+                      if (el) el.indeterminate = Boolean(someSelected);
+                    }}
+                    onChange={handleHeaderToggle}
+                    aria-label="Select all rows"
+                    className="h-4 w-4 cursor-pointer rounded border-input"
+                  />
+                </th>
+              )}
+              {columns.map((col) => (
+                <th
+                  key={col.key}
+                  className={cn(
+                    HEADER_CLASS,
+                    col.align === "right" && "text-right",
+                    col.align === "center" && "text-center",
+                  )}
+                  style={col.width ? { width: col.width } : undefined}
+                >
+                  {col.header}
+                </th>
+              ))}
+              {showActionsCol && (
+                // No header label; fixed narrow width for the `...` menu.
+                <th className={cn(HEADER_CLASS, "w-10")}>
+                  <span className="sr-only">Actions</span>
+                </th>
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {loading
+              ? renderSkeletonRows(
+                  loadingRowCount,
+                  columns.length +
+                    (showSelectCol ? 1 : 0) +
+                    (showActionsCol ? 1 : 0),
+                )
+              : data.map((row) => {
+                  const key = rowKey(row);
+                  const isSelected =
+                    selectable && selectedKeys?.includes(key);
+                  const clickable = Boolean(onRowClick);
+                  return (
+                    <tr
+                      key={key}
+                      data-row-key={key}
+                      className={cn(
+                        "border-b transition-smooth last:border-b-0",
+                        "hover:bg-muted/30",
+                        clickable && "cursor-pointer",
+                        isSelected && "bg-primary/5",
+                      )}
+                      onClick={
+                        clickable
+                          ? () => onRowClick!(row)
+                          : undefined
+                      }
+                    >
+                      {showSelectCol && (
+                        <td
+                          className={cn(CELL_CLASS, "w-10")}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={Boolean(isSelected)}
+                            onChange={() => handleRowToggle(key)}
+                            aria-label={`Select row`}
+                            className="h-4 w-4 cursor-pointer rounded border-input"
+                          />
+                        </td>
+                      )}
+                      {columns.map((col) => (
+                        <td
+                          key={col.key}
+                          className={cn(
+                            CELL_CLASS,
+                            col.align === "right" && "text-right",
+                            col.align === "center" && "text-center",
+                          )}
+                          style={col.width ? { width: col.width } : undefined}
+                        >
+                          {col.cell(row)}
+                        </td>
+                      ))}
+                      {showActionsCol && (
+                        <td
+                          className={cn(CELL_CLASS, "w-10 text-right")}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <RowActions
+                            actions={rowActions!(row)}
+                            testId={`row-actions-${key}`}
+                          />
+                        </td>
+                      )}
+                    </tr>
+                  );
+                })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function renderSkeletonRows(count: number, totalCols: number): React.ReactNode {
+  return Array.from({ length: count }).map((_, i) => (
+    <tr key={`skel-${i}`} className="border-b last:border-b-0">
+      {Array.from({ length: totalCols }).map((__, j) => (
+        <td key={j} className={CELL_CLASS}>
+          <Skeleton className="h-4 w-full max-w-[200px]" />
+        </td>
+      ))}
+    </tr>
+  ));
+}

--- a/components/ui/pill.tsx
+++ b/components/ui/pill.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+
+import { Badge, type BadgeProps } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Spec 18 — Pill primitive.
+//
+// The canonical inline status / type / role indicator used by DataTable
+// cells. Six variants documented in the spec:
+//
+//   success   — green   (e.g. Connected, Published, Active)
+//   neutral   — grey    (e.g. Not Connected, Draft, Customer)
+//   warning   — amber   (e.g. Scheduled, Pending review)
+//   danger    — red     (e.g. Failed, Removed)
+//   info      — blue    (e.g. iStock, Operator)
+//   accent    — Opollo  (e.g. "Opollo internal", "super_admin")
+//
+// Maps to the existing Badge primitive's tones — Pill is a stable public
+// API so consumers don't reach into Badge's `tone` enum directly. Keeps
+// the variant vocabulary aligned with the spec rather than the legacy
+// design-system mapping (success/error/primary/...).
+//
+// Width: padding-x 1.5 / padding-y 0.5 + text-xs = ~22px tall. Matches
+// the spec's `font-size: 12px`, `padding: 4px 2px`, `border-radius: 4px`
+// canonical pill geometry once the rounded-md class lands.
+// ---------------------------------------------------------------------------
+
+export type PillVariant =
+  | "success"
+  | "neutral"
+  | "warning"
+  | "danger"
+  | "info"
+  | "accent";
+
+const VARIANT_TO_TONE: Record<PillVariant, NonNullable<BadgeProps["tone"]>> = {
+  success: "success",
+  neutral: "neutral",
+  warning: "warning",
+  danger: "error",
+  info: "info",
+  // The accent variant uses the Opollo brand accent. Map to the
+  // primary tone in the existing badge palette — that's what
+  // resolves to the brand green (or the active theme's primary).
+  accent: "primary",
+};
+
+export interface PillProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, "color"> {
+  variant?: PillVariant;
+}
+
+export const Pill = React.forwardRef<HTMLSpanElement, PillProps>(
+  function Pill({ variant = "neutral", className, children, ...props }, ref) {
+    const tone = VARIANT_TO_TONE[variant];
+    return (
+      <Badge
+        ref={ref}
+        tone={tone}
+        density="default"
+        className={cn("rounded text-xs", className)}
+        {...props}
+      >
+        {children}
+      </Badge>
+    );
+  },
+);

--- a/components/ui/row-actions.tsx
+++ b/components/ui/row-actions.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import * as React from "react";
+
+import { NavIcon } from "@/components/ui/nav-icon";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Spec 18 — RowActions overflow menu.
+//
+// The canonical `...` button + popover used in the rightmost column of
+// every DataTable row. Consumers pass an array of `RowAction` objects;
+// each renders as a menu item with optional icon + variant + disabled.
+//
+// Used internally by DataTable; also exported for non-table surfaces
+// that need the same overflow-menu pattern.
+// ---------------------------------------------------------------------------
+
+export interface RowAction {
+  label: string;
+  icon?: React.ReactNode;
+  /** `destructive` swaps the item to a red danger treatment. */
+  variant?: "default" | "destructive";
+  onClick: () => void | Promise<void>;
+  disabled?: boolean;
+  /** When set, renders an external link instead of a button. */
+  href?: string;
+}
+
+export interface RowActionsProps {
+  actions: RowAction[];
+  /** Accessible label for the trigger button. */
+  label?: string;
+  /** Test-id for the trigger button. */
+  testId?: string;
+  align?: "start" | "center" | "end";
+}
+
+export function RowActions({
+  actions,
+  label = "Row actions",
+  testId,
+  align = "end",
+}: RowActionsProps) {
+  const [open, setOpen] = React.useState(false);
+
+  if (actions.length === 0) return null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        type="button"
+        aria-label={label}
+        data-testid={testId}
+        // Stop click propagation so a row's onRowClick handler doesn't
+        // fire when the operator opens the menu.
+        onClick={(e) => e.stopPropagation()}
+        className={cn(
+          "inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground",
+          "transition-smooth hover:bg-muted hover:text-foreground",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          open && "bg-muted text-foreground",
+        )}
+      >
+        <NavIcon name="ellipsis" size={16} />
+      </PopoverTrigger>
+      <PopoverContent
+        align={align}
+        sideOffset={4}
+        className="w-56 p-1"
+        // Stop click propagation here too so menu-item clicks don't
+        // bubble to a row's onRowClick handler.
+        onClick={(e) => e.stopPropagation()}
+      >
+        <ul role="menu" className="flex flex-col">
+          {actions.map((action, idx) => {
+            const isDestructive = action.variant === "destructive";
+            const itemClassName = cn(
+              "flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
+              "transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              isDestructive
+                ? "text-destructive hover:bg-destructive/10 focus:bg-destructive/10"
+                : "text-foreground hover:bg-muted focus:bg-muted",
+              action.disabled &&
+                "cursor-not-allowed opacity-50 hover:bg-transparent focus:bg-transparent",
+            );
+            const content = (
+              <>
+                {action.icon && (
+                  <span className="text-muted-foreground" aria-hidden>
+                    {action.icon}
+                  </span>
+                )}
+                <span>{action.label}</span>
+              </>
+            );
+            return (
+              <li key={idx} role="none">
+                {action.href ? (
+                  <a
+                    role="menuitem"
+                    href={action.href}
+                    aria-disabled={action.disabled || undefined}
+                    onClick={(e) => {
+                      if (action.disabled) {
+                        e.preventDefault();
+                        return;
+                      }
+                      setOpen(false);
+                    }}
+                    className={itemClassName}
+                  >
+                    {content}
+                  </a>
+                ) : (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    disabled={action.disabled}
+                    onClick={() => {
+                      if (action.disabled) return;
+                      setOpen(false);
+                      void action.onClick();
+                    }}
+                    className={cn(itemClassName, "w-full text-left")}
+                  >
+                    {content}
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/ui/table-cell.tsx
+++ b/components/ui/table-cell.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Spec 18 — TableCell typographic helpers.
+//
+// Drop-in cell content components that enforce the spec's text rules:
+//
+//   Primary    — body color, weight 500 (the headline cell — site name,
+//                user email, image title)
+//   Secondary  — muted color, 13px (timestamps, secondary metadata)
+//   Mono       — monospace 13px (slugs, IDs, URLs, dimensions)
+//   Stack      — Primary line + Secondary line stacked vertically
+//                (the "Test Site 2 / never tested" pattern)
+//
+// Composable inside a `cell: (row) => ...` callback; consumers don't
+// need to know the exact Tailwind classes.
+// ---------------------------------------------------------------------------
+
+export interface TextCellProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+function Primary({ className, children }: TextCellProps) {
+  return (
+    <span className={cn("text-sm font-medium text-foreground", className)}>
+      {children}
+    </span>
+  );
+}
+
+function Secondary({ className, children }: TextCellProps) {
+  return (
+    <span
+      className={cn(
+        "text-[13px] leading-tight text-muted-foreground",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function Mono({ className, children }: TextCellProps) {
+  return (
+    <code
+      className={cn(
+        "font-mono text-[13px] text-foreground",
+        // Reset code's default browser background so it sits flush in a
+        // cell. Consumers who want a chip-shaped mono cell apply
+        // bg-muted themselves.
+        "bg-transparent p-0",
+        className,
+      )}
+    >
+      {children}
+    </code>
+  );
+}
+
+interface StackProps {
+  /** Primary (top) line. Always rendered. */
+  primary: React.ReactNode;
+  /** Secondary (bottom) line. When falsy, only the primary renders. */
+  secondary?: React.ReactNode;
+  className?: string;
+}
+
+function Stack({ primary, secondary, className }: StackProps) {
+  return (
+    <span className={cn("flex flex-col gap-0.5", className)}>
+      <Primary>{primary}</Primary>
+      {secondary && <Secondary>{secondary}</Secondary>}
+    </span>
+  );
+}
+
+/**
+ * Em-dash placeholder for empty cells. Spec 18: "Empty cells: em-dash —
+ * in muted color. Never blank."
+ */
+function Empty() {
+  return <span className="text-sm text-muted-foreground">—</span>;
+}
+
+export const TableCell = {
+  Primary,
+  Secondary,
+  Mono,
+  Stack,
+  Empty,
+};


### PR DESCRIPTION
## Summary

Spec 18 PR A — the foundation for the central table system. One canonical `DataTable` primitive plus four supporting components, ready for migration sweeps in PRs B/C/D.

### What lands

- **`components/ui/data-table.tsx`** — `DataTable<T>` with a `ColumnDef` API. Handles header rendering (all-caps tracked), cell rendering (14px), hover/click/select states, empty + loading states, and the integrated `...` row-actions menu.
- **`components/ui/pill.tsx`** — six-variant Pill (`success | neutral | warning | danger | info | accent`) wrapping the existing `Badge` primitive. Stable public API for status / type / role indicators in cells.
- **`components/ui/row-actions.tsx`** — the `...` overflow menu via Radix Popover. Stops click propagation so it doesn't accidentally fire `onRowClick`.
- **`components/ui/table-cell.tsx`** — `Primary` / `Secondary` / `Mono` / `Stack` / `Empty` typographic helpers for cell content.
- **`/admin/_internal/table-examples`** — admin-only visual reference page rendering every DataTable state + every Pill variant. Use this when migrating real tables in PRs B/C/D — copy the closest example, adapt.
- **`components/__tests__/data-table.test.tsx`** — 12 component tests covering empty/loading/click/actions/selection behaviours.

### Inventory

Tables found across the codebase that PRs B/C/D will sweep:

| File | Spec PR |
|---|---|
| `components/SitesTable.tsx` | B |
| `components/PlatformCompaniesListClient.tsx` | B |
| `components/UsersTable.tsx` | B |
| `components/ImagesTable.tsx` | C |
| `components/PagesTable.tsx` (posts) | C |
| `app/admin/batches/page.tsx` | C |
| `components/CustomerCompanyUsersView.tsx` (Members) | D |
| `components/PendingInvitesTable.tsx` | D |
| `components/TrustedDevicesList.tsx` | D |
| `components/TemplatesTable.tsx`, `DesignSystemsTable.tsx`, `KadencePaletteDiffTable.tsx`, `RegenHistoryPanel.tsx`, `SocialPostsListClient.tsx`, `SocialConnectionsList.tsx`, `optimiser/*` | D |
| `app/admin/users/audit/page.tsx`, `app/admin/system/jobs/page.tsx`, `app/admin/sites/[id]/content/page.tsx`, `app/admin/sites/[id]/page.tsx`, `app/admin/sites/[id]/blueprints/review/page.tsx`, `app/admin/images/[id]/page.tsx`, `app/admin/batches/[id]/page.tsx`, `app/optimiser/proposals/page.tsx`, `app/optimiser/change-log/page.tsx` | D |

### Existing primitives reused

- `Badge` (CVA) — Pill maps to its tone enum so we don't duplicate the colour resolution.
- `StatusPill` — domain-status mapper layered above Badge; will continue to work alongside Pill (StatusPill renders a Badge internally; Pill is the new direct API for cell-level usage).
- `EmptyState` — already provides the icon/title/body/cta shape DataTable expects.
- `Skeleton` — used to render loading rows.

### Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Action menu click bubbles to `onRowClick` | Both the trigger button and the popover content stop click propagation. |
| Header checkbox indeterminate state can't be passed via prop | Set imperatively via ref callback. |
| Selection state desync if parent passes stale `selectedKeys` | DataTable treats `selectedKeys` as source of truth and only calls `onSelectionChange`; never stores internal state. |
| Loading row width mismatch with populated rows | Skeleton renders inside the same `<table>` layout so column widths stay consistent across loading→loaded. |

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [x] `npm run build` — clean.
- [x] `npm run audit:static` — 0 HIGH, 0 MEDIUM.
- [x] 12 component tests pass via `npx vitest run --config vitest.components.config.ts components/__tests__/data-table.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)