### PR TITLE
feat(spec18): migrate Sites/Companies/Users tables to DataTable — PR B

### DIFF
--- a/components/ChangeUserRoleModal.tsx
+++ b/components/ChangeUserRoleModal.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+// ---------------------------------------------------------------------------
+// Spec 18 PR B — Change user role modal.
+//
+// Replaces the inline <select> in the Users table cell. Editing a
+// user's role now happens through this modal opened from the row's
+// `...` menu — same pattern as the rest of the admin UI's destructive
+// / structured-write actions.
+//
+// Calls PATCH /api/admin/users/[id]/role with { role: "admin" | "user" }.
+// The route's existing guards (no self-modification, no super_admin
+// demotion) still apply server-side.
+// ---------------------------------------------------------------------------
+
+type Role = "super_admin" | "admin" | "user";
+type AssignableRole = Exclude<Role, "super_admin">;
+
+const ROLE_OPTIONS: Array<{ value: AssignableRole; label: string; description: string }> = [
+  {
+    value: "admin",
+    label: "Admin",
+    description: "Full read/write across all admin surfaces.",
+  },
+  {
+    value: "user",
+    label: "User",
+    description: "Standard access, no admin surfaces.",
+  },
+];
+
+export interface ChangeUserRoleModalProps {
+  open: boolean;
+  userId: string;
+  email: string;
+  currentRole: Role;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function ChangeUserRoleModal({
+  open,
+  userId,
+  email,
+  currentRole,
+  onClose,
+  onSuccess,
+}: ChangeUserRoleModalProps) {
+  const initial: AssignableRole =
+    currentRole === "super_admin" ? "admin" : currentRole;
+  const [selected, setSelected] = useState<AssignableRole>(initial);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) setSelected(initial);
+    // initial only matters at open time — currentRole from props
+    // determines it; we want the modal to reset each open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, currentRole]);
+
+  async function handleConfirm() {
+    if (selected === currentRole) {
+      onClose();
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(
+        `/api/admin/users/${encodeURIComponent(userId)}/role`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ role: selected }),
+        },
+      );
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        toast.error("Couldn't change role", {
+          description:
+            payload?.error?.message ??
+            `Role change failed (HTTP ${res.status}).`,
+        });
+        return;
+      }
+      onSuccess();
+    } catch (err) {
+      toast.error("Network error changing role", {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!next) onClose(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Change role</DialogTitle>
+          <DialogDescription>
+            Pick a new role for <span className="font-medium text-foreground">{email}</span>.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="mt-2 flex flex-col gap-2" role="radiogroup" aria-label="Role">
+          {ROLE_OPTIONS.map((opt) => (
+            <label
+              key={opt.value}
+              className="flex cursor-pointer items-start gap-3 rounded-md border bg-card p-3 transition-smooth hover:border-ring has-[:checked]:border-primary has-[:checked]:bg-primary/5"
+            >
+              <input
+                type="radio"
+                name="role"
+                value={opt.value}
+                checked={selected === opt.value}
+                onChange={() => setSelected(opt.value)}
+                disabled={submitting}
+                className="mt-1"
+              />
+              <span className="flex flex-col">
+                <span className="text-sm font-medium text-foreground">
+                  {opt.label}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  {opt.description}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <Button variant="ghost" onClick={onClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={submitting || selected === currentRole}>
+            {submitting ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/PlatformCompaniesListClient.tsx
+++ b/components/PlatformCompaniesListClient.tsx
@@ -1,79 +1,94 @@
 "use client";
 
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
+import { NavIcon } from "@/components/ui/nav-icon";
+import { Pill } from "@/components/ui/pill";
+import { TableCell } from "@/components/ui/table-cell";
 import type { PlatformCompanyListItem } from "@/lib/platform/companies";
 
-// P3-1 — client shell for /admin/companies. Renders the table only;
-// the page header (H1 + subtitle + "New company" CTA) lives in
-// app/admin/companies/page.tsx via PageHeader (Spec 04 migration).
+// ---------------------------------------------------------------------------
+// Spec 18 PR B — Companies table migration.
+//
+// Replaced the bespoke <table> markup with the canonical DataTable
+// primitive. Visual contract:
+//
+//   - Slug    → TableCell.Mono.
+//   - Domain  → TableCell.Mono OR TableCell.Empty (never blank).
+//   - Members → right-aligned tabular-nums, primary cell text.
+//   - Type    → Pill (`accent` for "Opollo internal", `neutral` otherwise).
+//
+// Row actions intentionally omitted: edit / manage-members / delete are
+// not yet exposed via individual API routes for companies, so the
+// canonical pattern (`...` menu) has nothing to call. Action lives on
+// the company detail page reached via row click. Documented in the
+// Spec 18 PR B description.
+// ---------------------------------------------------------------------------
+
+const COLUMNS: ColumnDef<PlatformCompanyListItem>[] = [
+  {
+    key: "name",
+    header: "Name",
+    cell: (c) => <TableCell.Primary>{c.name}</TableCell.Primary>,
+  },
+  {
+    key: "slug",
+    header: "Slug",
+    cell: (c) => <TableCell.Mono>{c.slug}</TableCell.Mono>,
+  },
+  {
+    key: "domain",
+    header: "Domain",
+    cell: (c) =>
+      c.domain ? <TableCell.Mono>{c.domain}</TableCell.Mono> : <TableCell.Empty />,
+  },
+  {
+    key: "members",
+    header: "Members",
+    align: "right",
+    cell: (c) => (
+      <span className="text-sm tabular-nums text-foreground">
+        {c.member_count}
+      </span>
+    ),
+  },
+  {
+    key: "type",
+    header: "Type",
+    cell: (c) => (
+      <Pill variant={c.is_opollo_internal ? "accent" : "neutral"}>
+        {c.is_opollo_internal ? "Opollo internal" : "Customer"}
+      </Pill>
+    ),
+  },
+];
 
 export function PlatformCompaniesListClient({
   companies,
 }: {
   companies: PlatformCompanyListItem[];
 }) {
+  const router = useRouter();
+
   return (
-    <>
-      <div
-        className="overflow-hidden rounded-lg border bg-card"
-        data-testid="platform-companies-table"
-      >
-        {companies.length === 0 ? (
-          <div className="p-8 text-center text-sm text-muted-foreground">
-            No companies yet — click <strong>New company</strong> to add one.
-          </div>
-        ) : (
-          <table className="w-full text-sm">
-            <thead className="border-b bg-muted/30 text-left text-sm uppercase tracking-wide text-muted-foreground">
-              <tr>
-                <th className="px-4 py-2 font-medium">Name</th>
-                <th className="px-4 py-2 font-medium">Slug</th>
-                <th className="px-4 py-2 font-medium">Domain</th>
-                <th className="px-4 py-2 font-medium">Members</th>
-                <th className="px-4 py-2 font-medium">Type</th>
-              </tr>
-            </thead>
-            <tbody>
-              {companies.map((c) => (
-                <tr
-                  key={c.id}
-                  className="border-b last:border-b-0 hover:bg-muted/20"
-                  data-testid={`platform-company-row-${c.slug}`}
-                >
-                  <td className="px-4 py-3 font-medium">
-                    <Link
-                      href={`/admin/companies/${c.id}`}
-                      className="hover:underline"
-                      data-testid={`platform-company-link-${c.slug}`}
-                    >
-                      {c.name}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 font-mono text-sm text-muted-foreground">
-                    {c.slug}
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground">
-                    {c.domain ?? "—"}
-                  </td>
-                  <td className="px-4 py-3 text-right tabular-nums">
-                    {c.member_count}
-                  </td>
-                  <td className="px-4 py-3 text-sm">
-                    {c.is_opollo_internal ? (
-                      <span className="rounded-full bg-primary/10 px-2 py-0.5 font-medium text-primary">
-                        Opollo internal
-                      </span>
-                    ) : (
-                      <span className="text-muted-foreground">Customer</span>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
-    </>
+    <DataTable
+      data={companies}
+      columns={COLUMNS}
+      rowKey={(c) => c.id}
+      onRowClick={(c) => router.push(`/admin/companies/${c.id}`)}
+      testId="platform-companies-table"
+      emptyState={{
+        icon: <NavIcon name="apartment" size={20} />,
+        iconLabel: "No companies",
+        title: "No companies yet",
+        body: (
+          <>
+            Companies group sites and members under a single billing /
+            access tenant. Click <strong>New company</strong> to add one.
+          </>
+        ),
+      }}
+    />
   );
 }

--- a/components/SitesTable.tsx
+++ b/components/SitesTable.tsx
@@ -1,37 +1,38 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 import { SiteActionsMenu } from "@/components/SiteActionsMenu";
 import { Button } from "@/components/ui/button";
-import { EmptyState } from "@/components/ui/empty-state";
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
 import { NavIcon } from "@/components/ui/nav-icon";
-import {
-  StatusPill,
-  siteStatusKind,
-} from "@/components/ui/status-pill";
+import { Pill } from "@/components/ui/pill";
+import { TableCell } from "@/components/ui/table-cell";
 import type {
   ListSitesOptions,
   SiteSortColumn,
   SiteSortDir,
 } from "@/lib/sites";
 import type { SiteListItem } from "@/lib/tool-schemas";
-import { cn, formatRelativeTime } from "@/lib/utils";
+import { formatRelativeTime } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
-// Spec 01 — Sites admin cleanup.
+// Spec 18 PR B — Sites table migration.
 //
-// - StatusCell now defers to StatusPill (the centralised pill primitive)
-//   so the operator-visible label respects STATUS_MAP. No more inline
-//   `status.replace(/_/g, " ")` leaking the enum value as English.
-// - Pending-pairing rows render an inline `Connect →` link in the
-//   Status cell, deep-linking to the edit page with ?focus=credentials
-//   so the credentials section auto-scrolls + focuses on mount.
-// - Headers are clickable: ?sort=<col>&dir=<asc|desc>. Three-state
-//   toggle: idle → asc → desc → cleared (revert to default order).
-//   Filter params are preserved when changing sort.
-// - "Updated" column dropped; replaced by "Last tested" backed by
-//   sites.last_connection_test_at (migration 0106).
+// Migrated from bespoke <table> + StatusPill to the canonical
+// DataTable. The status column keeps the dual treatment from Spec 01:
+//
+//   - When status === "active":           Pill (success) "Connected"
+//                                         + actions in the `...` menu.
+//   - When status === "pending_pairing":  Pill (neutral) "Not Connected"
+//                                         + inline "Connect →" link
+//                                         (the documented single-primary-
+//                                         action exception).
+//
+// Sortable headers preserved via SortHeader rendered inside ColumnDef
+// `header` slots; clicking a header navigates with the new sort param
+// without mutating row state.
 // ---------------------------------------------------------------------------
 
 interface SitesTableProps {
@@ -43,12 +44,12 @@ interface SitesTableProps {
   onCreateClick?: () => void;
 }
 
-type Column = {
+type SortColumn = {
   key: SiteSortColumn;
   label: string;
 };
 
-const SORTABLE_HEADERS: Column[] = [
+const SORTABLE_HEADERS: SortColumn[] = [
   { key: "name", label: "Name" },
   { key: "company_name", label: "Company" },
   { key: "wp_url", label: "WP URL" },
@@ -62,7 +63,7 @@ function buildHeaderHref(
   currentDir: SiteSortDir | null,
   filter: ListSitesOptions["status"],
 ): string {
-  // Three-state toggle:
+  // Three-state toggle (Spec 01):
   //   no sort on this column      → ?sort=col&dir=asc
   //   sort=col & dir=asc          → ?sort=col&dir=desc
   //   sort=col & dir=desc         → clear sort (revert to default)
@@ -75,50 +76,10 @@ function buildHeaderHref(
   } else if (currentDir === "asc") {
     params.set("sort", column);
     params.set("dir", "desc");
-  } // else: leave sort/dir off → default order
+  }
 
   const qs = params.toString();
   return qs.length > 0 ? `/admin/sites?${qs}` : "/admin/sites";
-}
-
-function StatusCell({ status, siteId }: { status: string; siteId: string }) {
-  return (
-    <span className="inline-flex items-center gap-2 text-sm">
-      <StatusPill
-        kind={siteStatusKind(status as Parameters<typeof siteStatusKind>[0])}
-      />
-      {status === "pending_pairing" && (
-        <Link
-          href={`/admin/sites/${encodeURIComponent(siteId)}/edit?focus=credentials`}
-          data-testid={`site-connect-link-${siteId}`}
-          className="text-sm text-primary underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
-        >
-          Connect →
-        </Link>
-      )}
-    </span>
-  );
-}
-
-function LastTestedCell({ value }: { value: string | null }) {
-  if (!value) {
-    return <span className="text-sm text-muted-foreground">Never tested</span>;
-  }
-  let iso: string;
-  try {
-    iso = new Date(value).toISOString();
-  } catch {
-    iso = value;
-  }
-  return (
-    <span
-      className="text-sm text-muted-foreground"
-      title={iso}
-      data-screenshot-mask
-    >
-      Tested {formatRelativeTime(value)}
-    </span>
-  );
 }
 
 function SortHeader({
@@ -141,19 +102,59 @@ function SortHeader({
       href={href}
       scroll={false}
       data-testid={`sites-sort-${column}`}
-      aria-sort={
-        active ? (dir === "desc" ? "descending" : "ascending") : "none"
-      }
+      aria-sort={active ? (dir === "desc" ? "descending" : "ascending") : "none"}
       className="inline-flex items-center gap-1 transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
     >
       {label}
-      {active && dir === "desc" && (
-        <NavIcon name="arrow-down" size={20} />
-      )}
-      {active && dir !== "desc" && (
-        <NavIcon name="arrow-up" size={20} />
-      )}
+      {active && dir === "desc" && <NavIcon name="arrow-down" size={14} />}
+      {active && dir !== "desc" && <NavIcon name="arrow-up" size={14} />}
     </Link>
+  );
+}
+
+function StatusCell({ status, siteId }: { status: string; siteId: string }) {
+  if (status === "pending_pairing") {
+    return (
+      <span className="inline-flex items-center gap-2 text-sm">
+        <Pill variant="neutral">Not Connected</Pill>
+        <Link
+          href={`/admin/sites/${encodeURIComponent(siteId)}/edit?focus=credentials`}
+          data-testid={`site-connect-link-${siteId}`}
+          // Stop the row click from intercepting the connect link.
+          onClick={(e) => e.stopPropagation()}
+          className="text-sm text-primary underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+        >
+          Connect →
+        </Link>
+      </span>
+    );
+  }
+  if (status === "active") {
+    return <Pill variant="success">Connected</Pill>;
+  }
+  if (status === "paused") {
+    return <Pill variant="warning">Paused</Pill>;
+  }
+  if (status === "removed") {
+    return <Pill variant="danger">Removed</Pill>;
+  }
+  return <Pill variant="neutral">{status}</Pill>;
+}
+
+function LastTestedCell({ value }: { value: string | null }) {
+  if (!value) return <TableCell.Secondary>Never tested</TableCell.Secondary>;
+  let iso: string;
+  try {
+    iso = new Date(value).toISOString();
+  } catch {
+    iso = value;
+  }
+  return (
+    <TableCell.Secondary>
+      <span title={iso} data-screenshot-mask>
+        Tested {formatRelativeTime(value)}
+      </span>
+    </TableCell.Secondary>
   );
 }
 
@@ -165,111 +166,142 @@ export function SitesTable({
   isSuperAdmin,
   onCreateClick,
 }: SitesTableProps) {
-  if (sites.length === 0) {
-    return (
-      <EmptyState
-        icon={<NavIcon name="earth" size={20} />}
-        iconLabel="No sites"
-        title="No sites connected yet"
-        body={
-          <>
-            Sites become available after you connect a WordPress install
-            with the Opollo plugin. Add your first site to start
-            generating pages.
-          </>
-        }
-        cta={
-          onCreateClick && (
-            <Button onClick={onCreateClick}>
-              <NavIcon name="plus" size={16} />
-              Add a site
-            </Button>
-          )
-        }
-      />
-    );
-  }
+  const router = useRouter();
 
-  // BACKLOG fix (2026-04-29): the wrapper used `overflow-hidden` to
-  // mask the table's corners against the rounded border, but it also
-  // created a clipping context that hid the SiteActionsMenu pop-out
-  // on rows near the bottom of the list. Drop overflow-hidden so the
-  // menu can extend past the table.
+  const columns: ColumnDef<SiteListItem>[] = [
+    {
+      key: "name",
+      header: (
+        <SortHeader column="name" label="Name" sort={sort} dir={dir} filter={filter} />
+      ),
+      cell: (s) => (
+        <Link
+          href={`/admin/sites/${s.id}`}
+          onClick={(e) => e.stopPropagation()}
+          className="block transition-smooth hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+          data-testid={`site-row-link-${s.id}`}
+        >
+          <TableCell.Primary>{s.name}</TableCell.Primary>
+        </Link>
+      ),
+    },
+    {
+      key: "company_name",
+      header: (
+        <SortHeader
+          column="company_name"
+          label="Company"
+          sort={sort}
+          dir={dir}
+          filter={filter}
+        />
+      ),
+      cell: (s) =>
+        s.company_name ? (
+          <TableCell.Secondary>{s.company_name}</TableCell.Secondary>
+        ) : (
+          <span className="text-sm italic text-destructive/70">Unassigned</span>
+        ),
+    },
+    {
+      key: "wp_url",
+      header: (
+        <SortHeader
+          column="wp_url"
+          label="WP URL"
+          sort={sort}
+          dir={dir}
+          filter={filter}
+        />
+      ),
+      cell: (s) => (
+        <a
+          href={s.wp_url}
+          target="_blank"
+          rel="noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className="text-sm text-muted-foreground transition-smooth hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+        >
+          {s.wp_url}
+        </a>
+      ),
+    },
+    {
+      key: "status",
+      header: (
+        <SortHeader
+          column="status"
+          label="Status"
+          sort={sort}
+          dir={dir}
+          filter={filter}
+        />
+      ),
+      cell: (s) => <StatusCell status={s.status} siteId={s.id} />,
+    },
+    {
+      key: "last_connection_test_at",
+      header: (
+        <SortHeader
+          column="last_connection_test_at"
+          label="Last tested"
+          sort={sort}
+          dir={dir}
+          filter={filter}
+        />
+      ),
+      cell: (s) => <LastTestedCell value={s.last_connection_test_at} />,
+    },
+    // Custom actions column rendered as a regular cell so we can keep
+    // SiteActionsMenu's `...` portal — DataTable's built-in rowActions
+    // expects RowAction[], and SiteActionsMenu carries its own modal
+    // state. Keep the existing component as-is.
+    {
+      key: "actions",
+      header: <span className="sr-only">Actions</span>,
+      width: "40px",
+      align: "right",
+      cell: (s) => (
+        <span onClick={(e) => e.stopPropagation()}>
+          <SiteActionsMenu
+            siteId={s.id}
+            name={s.name}
+            wpUrl={s.wp_url}
+            canDelete={isSuperAdmin}
+          />
+        </span>
+      ),
+    },
+  ];
+
   return (
-    <div className="rounded-md border">
-      <table className="w-full text-sm">
-        <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
-          <tr>
-            {SORTABLE_HEADERS.map((col) => (
-              <th key={col.key} className="px-3 py-2 font-medium">
-                <SortHeader
-                  column={col.key}
-                  label={col.label}
-                  sort={sort}
-                  dir={dir}
-                  filter={filter}
-                />
-              </th>
-            ))}
-            <th className="w-10 px-2 py-2"></th>
-          </tr>
-        </thead>
-        <tbody>
-          {sites.map((s) => (
-            <tr
-              key={s.id}
-              className={cn(
-                "group border-b transition-smooth last:border-b-0 hover:bg-muted/40",
-              )}
-              data-status={s.status}
-              data-testid={`sites-row-${s.id}`}
-            >
-              <td className="px-3 py-2 font-medium">
-                <Link
-                  href={`/admin/sites/${s.id}`}
-                  className="block transition-smooth hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
-                  data-testid={`site-row-link-${s.id}`}
-                >
-                  {s.name}
-                </Link>
-              </td>
-              <td className="px-3 py-2 text-sm text-muted-foreground">
-                {s.company_name ?? (
-                  <span className="italic text-destructive/70">Unassigned</span>
-                )}
-              </td>
-              <td className="px-3 py-2 text-muted-foreground">
-                <a
-                  href={s.wp_url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="transition-smooth hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  {s.wp_url}
-                </a>
-              </td>
-              <td className="px-3 py-2">
-                <StatusCell status={s.status} siteId={s.id} />
-              </td>
-              <td className="px-3 py-2">
-                <LastTestedCell value={s.last_connection_test_at} />
-              </td>
-              <td
-                className="px-2 py-2 text-right"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <SiteActionsMenu
-                  siteId={s.id}
-                  name={s.name}
-                  wpUrl={s.wp_url}
-                  canDelete={isSuperAdmin}
-                />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <DataTable
+      data={sites}
+      columns={columns}
+      rowKey={(s) => s.id}
+      onRowClick={(s) => router.push(`/admin/sites/${s.id}`)}
+      testId="sites-table"
+      emptyState={{
+        icon: <NavIcon name="earth" size={20} />,
+        iconLabel: "No sites",
+        title: "No sites connected yet",
+        body: (
+          <>
+            Sites become available after you connect a WordPress install with
+            the Opollo plugin. Add your first site to start generating pages.
+          </>
+        ),
+        cta: onCreateClick ? (
+          <Button onClick={onCreateClick}>
+            <NavIcon name="plus" size={16} />
+            Add a site
+          </Button>
+        ) : undefined,
+      }}
+    />
   );
 }
+
+// Suppress unused-import lint of SORTABLE_HEADERS — kept as documentation
+// for the column→header mapping but rendered via inline ColumnDef config.
+void SORTABLE_HEADERS;

--- a/components/UserActionsMenu.tsx
+++ b/components/UserActionsMenu.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { ConfirmActionModal } from "@/components/ConfirmActionModal";
+import { ChangeUserRoleModal } from "@/components/ChangeUserRoleModal";
+import { NavIcon } from "@/components/ui/nav-icon";
+import { RowActions, type RowAction } from "@/components/ui/row-actions";
+
+// ---------------------------------------------------------------------------
+// Spec 18 PR B — Users `...` overflow menu.
+//
+// Replaces the inline role dropdown + inline Revoke button (which mixed
+// per-row interactivity into the cell content). Edits flow through a
+// modal opened from this menu — same pattern as Sites' SiteActionsMenu.
+//
+// Items:
+//   - Change role        → opens ChangeUserRoleModal
+//   - Reinstate          → POST /api/admin/users/[id]/reinstate (only when revoked)
+//   - Revoke access      → opens ConfirmActionModal calling
+//                          POST /api/admin/users/[id]/revoke (only when active)
+//
+// `super_admin` rows have role-change disabled — DB-level guard
+// blocks demotion regardless. Self rows have both items disabled per
+// the role/revoke route guards.
+// ---------------------------------------------------------------------------
+
+type Role = "super_admin" | "admin" | "user";
+
+export interface UserActionsMenuProps {
+  userId: string;
+  email: string;
+  currentRole: Role;
+  revoked: boolean;
+  selfUserId: string | null;
+}
+
+export function UserActionsMenu({
+  userId,
+  email,
+  currentRole,
+  revoked,
+  selfUserId,
+}: UserActionsMenuProps) {
+  const router = useRouter();
+  const [roleModalOpen, setRoleModalOpen] = useState(false);
+  const [revokeOpen, setRevokeOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const isSelf = selfUserId !== null && selfUserId === userId;
+  const isSuperAdmin = currentRole === "super_admin";
+
+  async function reinstate() {
+    setSubmitting(true);
+    try {
+      const res = await fetch(
+        `/api/admin/users/${encodeURIComponent(userId)}/reinstate`,
+        { method: "POST" },
+      );
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload?.ok) {
+        toast.error("Couldn't reinstate user", {
+          description:
+            payload?.error?.message ??
+            `Reinstate failed (HTTP ${res.status}).`,
+        });
+        return;
+      }
+      toast.success("User reinstated");
+      router.refresh();
+    } catch (err) {
+      toast.error("Network error reinstating user", {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const actions: RowAction[] = [
+    {
+      label: "Change role",
+      icon: <NavIcon name="users" size={14} />,
+      onClick: () => setRoleModalOpen(true),
+      disabled: isSelf || isSuperAdmin || submitting,
+    },
+    revoked
+      ? {
+          label: "Reinstate access",
+          icon: <NavIcon name="checkmark-circle" size={14} />,
+          onClick: () => {
+            void reinstate();
+          },
+          disabled: isSelf || submitting,
+        }
+      : {
+          label: "Revoke access",
+          icon: <NavIcon name="cross-circle" size={14} />,
+          variant: "destructive" as const,
+          onClick: () => setRevokeOpen(true),
+          disabled: isSelf || submitting,
+        },
+  ];
+
+  return (
+    <>
+      <RowActions
+        actions={actions}
+        label={`Actions for ${email}`}
+        testId={`user-actions-${userId}`}
+      />
+      {roleModalOpen && (
+        <ChangeUserRoleModal
+          open
+          userId={userId}
+          email={email}
+          currentRole={currentRole}
+          onClose={() => setRoleModalOpen(false)}
+          onSuccess={() => {
+            setRoleModalOpen(false);
+            toast.success(`Role updated for ${email}`);
+            router.refresh();
+          }}
+        />
+      )}
+      {revokeOpen && (
+        <ConfirmActionModal
+          open
+          title="Revoke access?"
+          description={`${email} will be signed out and blocked from signing back in until reinstated.`}
+          confirmLabel="Revoke"
+          confirmVariant="destructive"
+          endpoint={`/api/admin/users/${encodeURIComponent(userId)}/revoke`}
+          request={{ method: "POST", body: {} }}
+          onClose={() => setRevokeOpen(false)}
+          onSuccess={() => {
+            setRevokeOpen(false);
+            toast.success("User revoked");
+            router.refresh();
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/components/UsersTable.tsx
+++ b/components/UsersTable.tsx
@@ -1,12 +1,39 @@
-import type { AdminUserRow } from "@/app/api/admin/users/list/route";
-import { EmptyState } from "@/components/ui/empty-state";
-import { NavIcon } from "@/components/ui/nav-icon";
-import { UserRoleActionCell } from "@/components/UserRoleActionCell";
-import { UserStatusActionCell } from "@/components/UserStatusActionCell";
+"use client";
 
-// Users table for /admin/users. Server component for the shell + static
-// cells; the role <select> is a client island so the action stays
-// interactive without forcing the whole table client-side.
+import type { AdminUserRow } from "@/app/api/admin/users/list/route";
+import { UserActionsMenu } from "@/components/UserActionsMenu";
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
+import { NavIcon } from "@/components/ui/nav-icon";
+import { Pill, type PillVariant } from "@/components/ui/pill";
+import { TableCell } from "@/components/ui/table-cell";
+
+// ---------------------------------------------------------------------------
+// Spec 18 PR B — Users table migration.
+//
+// Replaces the bespoke <table> + inline role <select> + inline Revoke
+// button with the canonical DataTable. Edit operations now live in the
+// trailing `...` menu (UserActionsMenu) — same shape as Sites.
+//
+// Visual contract:
+//
+//   - Email     → TableCell.Stack (email + display_name).
+//   - Role      → Pill (`accent` for super_admin, `info` for admin,
+//                 `neutral` for user).
+//   - Created   → TableCell.Secondary (formatted date).
+//   - Status    → Pill (`success` for active, `neutral` for revoked).
+//
+// Removed: UserRoleActionCell (inline dropdown), UserStatusActionCell
+// (inline button). Both are kept as exports in case any non-table
+// surface still wants them — but the Users table no longer uses them.
+// ---------------------------------------------------------------------------
+
+type Role = "super_admin" | "admin" | "user";
+
+const ROLE_VARIANT: Record<Role, PillVariant> = {
+  super_admin: "accent",
+  admin: "info",
+  user: "neutral",
+};
 
 function formatDate(iso: string): string {
   try {
@@ -26,75 +53,83 @@ export function UsersTable({
 }: {
   users: AdminUserRow[];
   /**
-   * ID of the currently-signed-in admin, when known. Used by the role
-   * action cell to disable self-modification. `null` under flag-off /
-   * kill-switch (no Supabase identity); the server-side guard still
+   * ID of the currently-signed-in admin, when known. Used by
+   * UserActionsMenu to disable self-modification. `null` under flag-off
+   * / kill-switch (no Supabase identity); the server-side guard still
    * enforces the rest.
    */
   currentUserId: string | null;
 }) {
-  if (users.length === 0) {
-    return (
-      <EmptyState
-        icon={<NavIcon name="users" size={20} />}
-        iconLabel="No users"
-        title="No users yet"
-        body={
+  const columns: ColumnDef<AdminUserRow>[] = [
+    {
+      key: "email",
+      header: "Email",
+      cell: (u) => (
+        <TableCell.Stack
+          primary={u.email}
+          secondary={u.display_name ?? undefined}
+        />
+      ),
+    },
+    {
+      key: "role",
+      header: "Role",
+      cell: (u) => (
+        <Pill variant={ROLE_VARIANT[u.role as Role] ?? "neutral"}>{u.role}</Pill>
+      ),
+    },
+    {
+      key: "created",
+      header: "Created",
+      cell: (u) => <TableCell.Secondary>{formatDate(u.created_at)}</TableCell.Secondary>,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (u) =>
+        u.revoked_at !== null ? (
+          <Pill variant="neutral">revoked</Pill>
+        ) : (
+          <Pill variant="success">active</Pill>
+        ),
+    },
+    {
+      key: "actions",
+      header: <span className="sr-only">Actions</span>,
+      width: "40px",
+      align: "right",
+      cell: (u) => (
+        <span onClick={(e) => e.stopPropagation()}>
+          <UserActionsMenu
+            userId={u.id}
+            email={u.email}
+            currentRole={u.role as Role}
+            revoked={u.revoked_at !== null}
+            selfUserId={currentUserId}
+          />
+        </span>
+      ),
+    },
+  ];
+
+  return (
+    <DataTable
+      data={users}
+      columns={columns}
+      rowKey={(u) => u.id}
+      testId="users-table"
+      emptyState={{
+        icon: <NavIcon name="users" size={20} />,
+        iconLabel: "No users",
+        title: "No users yet",
+        body: (
           <>
             The <code className="font-mono text-sm">first_admin_email</code>{" "}
             bootstrap promotes the first Supabase signup to admin; everyone
-            else starts as viewer.
+            else starts as user.
           </>
-        }
-      />
-    );
-  }
-
-  return (
-    <div className="overflow-x-auto rounded-md border">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b bg-muted/40 text-left text-sm text-muted-foreground">
-            <th className="px-3 py-2 font-medium">Email</th>
-            <th className="px-3 py-2 font-medium">Role</th>
-            <th className="px-3 py-2 font-medium">Created</th>
-            <th className="px-3 py-2 font-medium">Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          {users.map((u) => (
-            <tr key={u.id} className="border-b last:border-b-0 align-top">
-              <td className="px-3 py-2">
-                <div className="flex flex-col">
-                  <span>{u.email}</span>
-                  {u.display_name && (
-                    <span className="text-sm text-muted-foreground">
-                      {u.display_name}
-                    </span>
-                  )}
-                </div>
-              </td>
-              <td className="px-3 py-2">
-                <UserRoleActionCell
-                  userId={u.id}
-                  currentRole={u.role}
-                  selfUserId={currentUserId}
-                />
-              </td>
-              <td className="px-3 py-2 text-muted-foreground">
-                {formatDate(u.created_at)}
-              </td>
-              <td className="px-3 py-2">
-                <UserStatusActionCell
-                  userId={u.id}
-                  revoked={u.revoked_at !== null}
-                  selfUserId={currentUserId}
-                />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+        ),
+      }}
+    />
   );
 }


### PR DESCRIPTION
## Summary

Spec 18 PR B — the three most-visible admin lists migrated to the canonical `DataTable` primitive from PR A (#767). No data-fetching or business logic changed; only presentation.

### Sites (`components/SitesTable.tsx`)

- `<table>` + `StatusPill` → `DataTable` + `Pill`.
- Sortable headers preserved (`SortHeader` rendered as `ColumnDef.header` ReactNode).
- Status: `Pill` (`success` Connected, `neutral` Not Connected, `warning` Paused, `danger` Removed).
- `pending_pairing` rows keep the inline **Connect →** link — this is the documented single-primary-action exception.
- Row click → site detail page. `SiteActionsMenu` (the `...` overflow) preserved as the trailing action column.

### Companies (`components/PlatformCompaniesListClient.tsx`)

- Bespoke `<table>` with the rounded-full "Opollo internal" chip → `DataTable` + `Pill` (`accent` for Opollo internal, `neutral` for Customer).
- Slug + domain via `TableCell.Mono`. Empty domain renders `TableCell.Empty` (em-dash).
- **No row actions yet:** edit / manage-members / delete don't have per-company API routes — those operations all live on the company detail page reached via row click. When a future PR adds those endpoints, the `...` menu plugs in directly.

### Users (`components/UsersTable.tsx`) — biggest behavioural change

- `<table>` + `UserRoleActionCell` (inline `<select>`) + `UserStatusActionCell` (inline Revoke/Reinstate buttons) → `DataTable` + `Pill` + `UserActionsMenu`.
- Email column: `TableCell.Stack` (email + display_name).
- Role: `Pill` (`accent` super_admin, `info` admin, `neutral` user).
- Status: `Pill` (`success` active, `neutral` revoked).
- **Change role** moves to the `...` menu → opens `ChangeUserRoleModal` (Dialog with radio-group). PATCH route unchanged.
- **Revoke / Reinstate** moves to the `...` menu (Revoke is destructive, Reinstate fires immediately).
- `UserRoleActionCell` + `UserStatusActionCell` kept as exports for any non-table caller; the Users table no longer imports them.

## Assumptions documented

- Companies table has no per-row API endpoints, so the `...` menu is omitted in favour of row-click→detail. If you want me to scaffold the missing endpoints + add the actions, that's a separate PR.
- Users table doesn't add a "View audit" action even though the route exists at `/admin/users/audit`. Reasoning: audit is system-wide, not per-user. If you want a per-user filter linked from this menu, follow-up.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Sortable header click bubbles into row click | Headers render in `<thead>`; DataTable only fires `onRowClick` from `<tbody>` rows. |
| WP URL inline link bubbling into row click | Explicit `stopPropagation` on the anchor's `onClick`. |
| "Connect →" link bubbling into row click | Same `stopPropagation` guard. |
| Self-modification on Users | `UserActionsMenu` disables both Change role and Revoke when `selfUserId === userId`; route guards still enforce server-side. |

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [x] `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)