### PR TITLE
feat(spec18): migrate Images/Pages/Batches tables to DataTable — PR C

### DIFF
--- a/app/admin/batches/page.tsx
+++ b/app/admin/batches/page.tsx
@@ -1,17 +1,12 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { BatchesTable, type BatchRow } from "@/components/BatchesTable";
 import { NewBatchButton } from "@/components/NewBatchButton";
 import type { BatchTemplateOption } from "@/components/NewBatchModal";
 import { Alert } from "@/components/ui/alert";
-import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
 import { PageShell } from "@/components/ui/page-shell";
-import {
-  StatusPill,
-  jobStatusKind,
-} from "@/components/ui/status-pill";
-import { NavIcon } from "@/components/ui/nav-icon";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -26,37 +21,8 @@ import { getServiceRoleClient } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
 
-type BatchRow = {
-  id: string;
-  site_name: string;
-  template_name: string;
-  status: string;
-  requested_count: number;
-  succeeded_count: number;
-  failed_count: number;
-  created_at: string;
-  created_by_email: string | null;
-  total_cost_usd_cents: number;
-};
-
-// StatusBadge folded to A-4's StatusPill primitive. See call site below.
-
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "numeric",
-    });
-  } catch {
-    return iso;
-  }
-}
-
-function formatCostCents(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
-}
+// BatchRow + status mapping live in components/BatchesTable.tsx — the
+// presentation moved client-side as part of Spec 18 PR C.
 
 export default async function AdminBatchesPage({
   searchParams,
@@ -231,68 +197,9 @@ export default async function AdminBatchesPage({
       )}
 
       <div>
-        {rows.length === 0 ? (
-          <EmptyState
-            icon={<NavIcon name="tree" size={20} />}
-            iconLabel="No batches"
-            title="No batches yet"
-            body={
-              <>
-                Run a batch to generate multiple pages from a template
-                against the active design system.
-              </>
-            }
-          />
-        ) : (
-          <div className="overflow-x-auto rounded-md border">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b bg-muted/40 text-left text-sm text-muted-foreground">
-                  <th className="px-3 py-2 font-medium">Site / Template</th>
-                  <th className="px-3 py-2 font-medium">Status</th>
-                  <th className="px-3 py-2 font-medium">Progress</th>
-                  <th className="px-3 py-2 font-medium">Cost</th>
-                  <th className="px-3 py-2 font-medium">Created</th>
-                  <th className="px-3 py-2 font-medium">By</th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((r) => (
-                  <tr key={r.id} className="border-b last:border-b-0">
-                    <td className="px-3 py-2">
-                      <Link
-                        href={`/admin/batches/${r.id}`}
-                        className="font-medium hover:underline"
-                      >
-                        {r.site_name}
-                      </Link>
-                      <div className="text-sm text-muted-foreground">
-                        {r.template_name}
-                      </div>
-                    </td>
-                    <td className="px-3 py-2">
-                      <StatusPill kind={jobStatusKind(r.status as Parameters<typeof jobStatusKind>[0])} />
-                    </td>
-                    <td className="px-3 py-2 text-sm text-muted-foreground">
-                      {r.succeeded_count} ok · {r.failed_count} fail ·{" "}
-                      {r.requested_count} total
-                    </td>
-                    <td className="px-3 py-2 text-sm text-muted-foreground">
-                      {formatCostCents(r.total_cost_usd_cents)}
-                    </td>
-                    <td className="px-3 py-2 text-sm text-muted-foreground">
-                      {formatDate(r.created_at)}
-                    </td>
-                    <td className="px-3 py-2 text-sm text-muted-foreground">
-                      {r.created_by_email ?? "—"}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
+        <BatchesTable rows={rows} />
       </div>
     </PageShell>
   );
 }
+

--- a/components/BatchesTable.tsx
+++ b/components/BatchesTable.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
+import { NavIcon } from "@/components/ui/nav-icon";
+import { Pill, type PillVariant } from "@/components/ui/pill";
+import { TableCell } from "@/components/ui/table-cell";
+
+// ---------------------------------------------------------------------------
+// Spec 18 PR C — BatchesTable client component.
+//
+// Pulled out of `app/admin/batches/page.tsx` as a "use client" island so
+// the canonical DataTable (which relies on `useRouter` for row click +
+// React state for hover/selection) can drive presentation. The server
+// component continues to fetch + project the rows; this component only
+// handles the table chrome.
+//
+// Visual contract:
+//   - Site / Template → TableCell.Stack (site_name + template_name).
+//   - Status          → Pill keyed off the job_status taxonomy.
+//   - Progress        → tabular-nums, secondary muted text.
+//   - Cost            → TableCell.Mono ($0.42 etc.).
+//   - Created         → TableCell.Secondary.
+//   - By              → TableCell.Secondary OR TableCell.Empty.
+// ---------------------------------------------------------------------------
+
+export type BatchRow = {
+  id: string;
+  site_name: string;
+  template_name: string;
+  status: string;
+  requested_count: number;
+  succeeded_count: number;
+  failed_count: number;
+  created_at: string;
+  created_by_email: string | null;
+  total_cost_usd_cents: number;
+};
+
+const STATUS_VARIANT: Record<string, PillVariant> = {
+  queued: "neutral",
+  running: "info",
+  partial: "warning",
+  succeeded: "success",
+  failed: "danger",
+  cancelled: "neutral",
+};
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatCost(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+interface BatchesTableProps {
+  rows: BatchRow[];
+}
+
+export function BatchesTable({ rows }: BatchesTableProps) {
+  const router = useRouter();
+
+  const columns: ColumnDef<BatchRow>[] = [
+    {
+      key: "site_template",
+      header: "Site / Template",
+      cell: (r) => (
+        <TableCell.Stack primary={r.site_name} secondary={r.template_name} />
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (r) => (
+        <Pill variant={STATUS_VARIANT[r.status] ?? "neutral"}>{r.status}</Pill>
+      ),
+    },
+    {
+      key: "progress",
+      header: "Progress",
+      cell: (r) => (
+        <span className="text-sm tabular-nums text-muted-foreground">
+          {r.succeeded_count} ok · {r.failed_count} fail · {r.requested_count}{" "}
+          total
+        </span>
+      ),
+    },
+    {
+      key: "cost",
+      header: "Cost",
+      align: "right",
+      cell: (r) => (
+        <TableCell.Mono>{formatCost(r.total_cost_usd_cents)}</TableCell.Mono>
+      ),
+    },
+    {
+      key: "created",
+      header: "Created",
+      cell: (r) => <TableCell.Secondary>{formatDate(r.created_at)}</TableCell.Secondary>,
+    },
+    {
+      key: "by",
+      header: "By",
+      cell: (r) =>
+        r.created_by_email ? (
+          <TableCell.Secondary>{r.created_by_email}</TableCell.Secondary>
+        ) : (
+          <TableCell.Empty />
+        ),
+    },
+  ];
+
+  return (
+    <DataTable
+      data={rows}
+      columns={columns}
+      rowKey={(r) => r.id}
+      onRowClick={(r) => router.push(`/admin/batches/${r.id}`)}
+      testId="batches-table"
+      emptyState={{
+        icon: <NavIcon name="tree" size={20} />,
+        iconLabel: "No batches",
+        title: "No batches yet",
+        body: (
+          <>
+            Run a batch to generate multiple pages from a template against the
+            active design system.
+          </>
+        ),
+      }}
+    />
+  );
+}

--- a/components/ImagesTable.tsx
+++ b/components/ImagesTable.tsx
@@ -1,24 +1,51 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
 import { ImageLightbox } from "@/components/ImageLightbox";
-import { StatusPill, imageSourceKind } from "@/components/ui/status-pill";
+import { Button } from "@/components/ui/button";
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
+import { NavIcon } from "@/components/ui/nav-icon";
+import { Pill, type PillVariant } from "@/components/ui/pill";
+import { TableCell } from "@/components/ui/table-cell";
 import { deliveryUrl } from "@/lib/cloudflare-images";
 import type { ImageListItem } from "@/lib/image-library";
 import { formatRelativeTime } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
-// M5-1 (updated) — images table with bulk hard-delete + lightbox.
+// Spec 18 PR C — ImagesTable migration.
+//
+// Replaced bespoke <table> + inline StatusPill with the canonical
+// DataTable. The bulk-delete surface (selection chip + Delete CTA +
+// ConfirmActionModal) is preserved above the table; DataTable's
+// `selectable` prop drives the per-row checkboxes.
+//
+// Visual contract:
+//   - Preview                 → 48×48 thumbnail with optional lightbox.
+//   - Title / Caption / File  → TableCell.Stack (title + filename
+//                               as secondary). Caption renders as a
+//                               second secondary line via flex.
+//   - Tags                    → up to 6 Pill (neutral) chips inline,
+//                               "+N" affordance for overflow.
+//   - Source                  → Pill (info iStock, warning Upload,
+//                               accent Generated).
+//   - Dimensions              → TableCell.Mono (or Empty when null).
+//   - Imported                → TableCell.Secondary (relative time).
 // ---------------------------------------------------------------------------
 
-function formatDimensions(width: number | null, height: number | null): string {
-  if (!width || !height) return "—";
-  return `${width}×${height}`;
-}
+const SOURCE_VARIANT: Record<ImageListItem["source"], PillVariant> = {
+  istock: "info",
+  upload: "warning",
+  generated: "accent",
+};
+
+const SOURCE_LABEL: Record<ImageListItem["source"], string> = {
+  istock: "iStock",
+  upload: "Upload",
+  generated: "Generated",
+};
 
 type LightboxState = {
   src: string;
@@ -30,12 +57,24 @@ type LightboxState = {
   height_px: number | null;
 };
 
-type ThumbnailProps = {
-  item: ImageListItem;
-  onClick?: () => void;
+type ImagesTableProps = {
+  items: ImageListItem[];
+  backHref?: string;
 };
 
-function Thumbnail({ item, onClick }: ThumbnailProps) {
+function buildDetailHref(id: string, backHref: string | undefined): string {
+  if (!backHref || backHref === "/admin/images") return `/admin/images/${id}`;
+  const params = new URLSearchParams({ from: backHref });
+  return `/admin/images/${id}?${params.toString()}`;
+}
+
+function Thumbnail({
+  item,
+  onClick,
+}: {
+  item: ImageListItem;
+  onClick?: () => void;
+}) {
   const url = item.cloudflare_id ? deliveryUrl(item.cloudflare_id) : null;
   const alt = item.alt_text ?? item.filename ?? "Library image";
   if (!url) {
@@ -56,29 +95,39 @@ function Thumbnail({ item, onClick }: ThumbnailProps) {
       width={48}
       height={48}
       loading="lazy"
-      onClick={onClick}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick?.();
+      }}
       className={`h-12 w-12 rounded object-cover${onClick ? " cursor-pointer" : ""}`}
       data-testid="image-thumbnail"
     />
   );
 }
 
-type ImagesTableProps = {
-  items: ImageListItem[];
-  backHref?: string;
-};
-
-function buildDetailHref(id: string, backHref: string | undefined): string {
-  if (!backHref || backHref === "/admin/images") return `/admin/images/${id}`;
-  const params = new URLSearchParams({ from: backHref });
-  return `/admin/images/${id}?${params.toString()}`;
+function TagsCell({ tags }: { tags: string[] }) {
+  if (tags.length === 0) return <TableCell.Empty />;
+  const visible = tags.slice(0, 6);
+  const overflow = tags.length - visible.length;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {visible.map((tag) => (
+        <Pill key={tag} variant="neutral">
+          {tag}
+        </Pill>
+      ))}
+      {overflow > 0 && (
+        <span className="text-sm text-muted-foreground">+{overflow}</span>
+      )}
+    </div>
+  );
 }
 
 export function ImagesTable({ items, backHref }: ImagesTableProps) {
   const router = useRouter();
   const [, startTransition] = useTransition();
   const [lightbox, setLightbox] = useState<LightboxState | null>(null);
-  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkError, setBulkError] = useState<string | null>(null);
 
@@ -96,185 +145,119 @@ export function ImagesTable({ items, backHref }: ImagesTableProps) {
     });
   }
 
-  function toggleAll(checked: boolean) {
-    if (checked) {
-      setSelected(new Set(items.map((i) => i.id)));
-    } else {
-      setSelected(new Set());
-    }
-  }
-
-  function toggleOne(id: string) {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-  }
-
-  async function executeBulkDelete() {
-    setBulkError(null);
-    const ids = Array.from(selected);
-    const res = await fetch("/api/admin/images/bulk-hard-delete", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ ids }),
-    });
-    const payload = await res.json().catch(() => null) as { ok: boolean; data?: { deleted: string[]; errors: Array<{ id: string; message: string }> } } | null;
-    if (!res.ok || !payload?.ok) {
-      setBulkError("Bulk delete failed. Please try again.");
-      return;
-    }
-    if (payload.data && payload.data.errors.length > 0) {
-      setBulkError(`${payload.data.errors.length} item(s) failed to delete.`);
-    }
-    setSelected(new Set());
-    setBulkDeleteOpen(false);
-    startTransition(() => router.refresh());
-  }
-
-  if (items.length === 0) {
-    return (
-      <div className="rounded-md border border-dashed p-8 text-center">
-        <p className="text-sm text-muted-foreground">
-          No images match these filters.
-        </p>
-      </div>
-    );
-  }
-
-  const allSelected = selected.size === items.length;
-  const someSelected = selected.size > 0;
+  const columns: ColumnDef<ImageListItem>[] = [
+    {
+      key: "preview",
+      header: "Preview",
+      width: "64px",
+      cell: (item) => (
+        <Thumbnail
+          item={item}
+          onClick={
+            item.cloudflare_id ? () => openLightbox(item) : undefined
+          }
+        />
+      ),
+    },
+    {
+      key: "title",
+      header: "Title / Caption",
+      cell: (item) => (
+        <TableCell.Stack
+          primary={
+            item.title ?? item.caption ?? (
+              <span className="text-muted-foreground">(no title yet)</span>
+            )
+          }
+          secondary={
+            item.title && item.caption
+              ? item.caption
+              : item.filename ?? undefined
+          }
+        />
+      ),
+    },
+    {
+      key: "tags",
+      header: "Tags",
+      cell: (item) => <TagsCell tags={item.tags} />,
+    },
+    {
+      key: "source",
+      header: "Source",
+      cell: (item) => (
+        <Pill variant={SOURCE_VARIANT[item.source]}>
+          {SOURCE_LABEL[item.source]}
+        </Pill>
+      ),
+    },
+    {
+      key: "dimensions",
+      header: "Dimensions",
+      cell: (item) =>
+        item.width_px && item.height_px ? (
+          <TableCell.Mono>
+            {item.width_px}×{item.height_px}
+          </TableCell.Mono>
+        ) : (
+          <TableCell.Empty />
+        ),
+    },
+    {
+      key: "imported",
+      header: "Imported",
+      cell: (item) => (
+        <TableCell.Secondary>
+          {formatRelativeTime(item.created_at)}
+        </TableCell.Secondary>
+      ),
+    },
+  ];
 
   return (
     <>
-      {someSelected && (
+      {selectedKeys.length > 0 && (
         <div className="mb-2 flex items-center gap-3">
           <span className="text-sm text-muted-foreground">
-            {selected.size} selected
+            {selectedKeys.length} selected
           </span>
-          <button
+          <Button
             type="button"
-            className="rounded border border-destructive px-3 py-1 text-sm text-destructive hover:bg-destructive/10"
-            onClick={() => { setBulkError(null); setBulkDeleteOpen(true); }}
+            variant="outline"
+            size="sm"
+            className="text-destructive hover:bg-destructive/10"
+            onClick={() => {
+              setBulkError(null);
+              setBulkDeleteOpen(true);
+            }}
             data-testid="bulk-delete-button"
           >
             Delete permanently
-          </button>
+          </Button>
           {bulkError && (
-            <p className="text-sm text-destructive" role="alert">{bulkError}</p>
+            <p className="text-sm text-destructive" role="alert">
+              {bulkError}
+            </p>
           )}
         </div>
       )}
 
-      <div className="overflow-hidden rounded-md border">
-        <table className="w-full text-sm">
-          <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
-            <tr>
-              <th className="w-10 px-3 py-2">
-                <input
-                  type="checkbox"
-                  aria-label="Select all"
-                  checked={allSelected}
-                  onChange={(e) => toggleAll(e.target.checked)}
-                  className="h-4 w-4 rounded border"
-                  data-testid="select-all-checkbox"
-                />
-              </th>
-              <th className="w-16 px-4 py-2 font-medium">Preview</th>
-              <th className="px-4 py-2 font-medium">Title / Caption</th>
-              <th className="px-4 py-2 font-medium">Tags</th>
-              <th className="px-4 py-2 font-medium">Source</th>
-              <th className="px-4 py-2 font-medium">Dimensions</th>
-              <th className="px-4 py-2 font-medium">Imported</th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map((item) => (
-              <tr
-                key={item.id}
-                className="border-b last:border-b-0 hover:bg-muted/40"
-                data-testid="image-row"
-                data-image-id={item.id}
-              >
-                <td className="px-3 py-3">
-                  <input
-                    type="checkbox"
-                    aria-label={`Select ${item.title ?? item.filename ?? item.id}`}
-                    checked={selected.has(item.id)}
-                    onChange={() => toggleOne(item.id)}
-                    className="h-4 w-4 rounded border"
-                    data-testid="image-row-checkbox"
-                  />
-                </td>
-                <td className="px-4 py-3">
-                  <Thumbnail
-                    item={item}
-                    onClick={item.cloudflare_id ? () => openLightbox(item) : undefined}
-                  />
-                </td>
-                <td className="px-4 py-3 align-top">
-                  <Link
-                    href={buildDetailHref(item.id, backHref)}
-                    className="line-clamp-2 block max-w-md text-sm hover:underline"
-                    data-testid="image-row-link"
-                  >
-                    {item.title ?? item.caption ?? (
-                      <span className="text-muted-foreground">
-                        (no title yet)
-                      </span>
-                    )}
-                  </Link>
-                  {item.caption && item.title && (
-                    <div className="mt-0.5 line-clamp-1 text-sm text-muted-foreground">
-                      {item.caption}
-                    </div>
-                  )}
-                  {item.filename && (
-                    <div className="mt-1 text-sm text-muted-foreground">
-                      {item.filename}
-                    </div>
-                  )}
-                </td>
-                <td className="px-4 py-3 align-top">
-                  <div className="flex flex-wrap gap-1">
-                    {item.tags.length === 0 ? (
-                      <span className="text-sm text-muted-foreground">—</span>
-                    ) : (
-                      item.tags.slice(0, 6).map((tag) => (
-                        <span
-                          key={tag}
-                          className="rounded bg-muted px-2 py-0.5 text-sm"
-                        >
-                          {tag}
-                        </span>
-                      ))
-                    )}
-                    {item.tags.length > 6 && (
-                      <span className="text-sm text-muted-foreground">
-                        +{item.tags.length - 6}
-                      </span>
-                    )}
-                  </div>
-                </td>
-                <td className="px-4 py-3 align-top">
-                  <StatusPill kind={imageSourceKind(item.source)} />
-                </td>
-                <td className="px-4 py-3 align-top text-sm text-muted-foreground">
-                  {formatDimensions(item.width_px, item.height_px)}
-                </td>
-                <td className="px-4 py-3 align-top text-sm text-muted-foreground">
-                  {formatRelativeTime(item.created_at)}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <DataTable
+        data={items}
+        columns={columns}
+        rowKey={(i) => i.id}
+        selectable
+        selectedKeys={selectedKeys}
+        onSelectionChange={setSelectedKeys}
+        onRowClick={(item) => router.push(buildDetailHref(item.id, backHref))}
+        testId="images-table"
+        emptyState={{
+          icon: <NavIcon name="picture" size={20} />,
+          iconLabel: "No images",
+          title: "No images match these filters",
+          body: <>Adjust the filters above or upload an image to start.</>,
+        }}
+      />
 
       {lightbox && (
         <ImageLightbox
@@ -291,15 +274,15 @@ export function ImagesTable({ items, backHref }: ImagesTableProps) {
 
       <ConfirmActionModal
         open={bulkDeleteOpen}
-        title={`Permanently delete ${selected.size} image${selected.size === 1 ? "" : "s"}?`}
+        title={`Permanently delete ${selectedKeys.length} image${selectedKeys.length === 1 ? "" : "s"}?`}
         description="This removes the selected images from Cloudflare and Supabase. It cannot be undone."
         confirmLabel="Delete permanently"
         confirmVariant="destructive"
         endpoint="/api/admin/images/bulk-hard-delete"
-        request={{ method: "POST", body: { ids: Array.from(selected) } }}
+        request={{ method: "POST", body: { ids: selectedKeys } }}
         onClose={() => setBulkDeleteOpen(false)}
         onSuccess={() => {
-          setSelected(new Set());
+          setSelectedKeys([]);
           setBulkDeleteOpen(false);
           startTransition(() => router.refresh());
         }}

--- a/components/PagesTable.tsx
+++ b/components/PagesTable.tsx
@@ -1,22 +1,43 @@
-import Link from "next/link";
+"use client";
 
-import { StatusPill, postStatusKind } from "@/components/ui/status-pill";
+import { useRouter } from "next/navigation";
+
+import { DataTable, type ColumnDef } from "@/components/ui/data-table";
+import { NavIcon } from "@/components/ui/nav-icon";
+import { Pill, type PillVariant } from "@/components/ui/pill";
+import { TableCell } from "@/components/ui/table-cell";
 import type { PageListItem } from "@/lib/pages";
 import { formatRelativeTime } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
-// M6-1 — pure presentation of the pages list.
+// Spec 18 PR C — PagesTable migration.
 //
-// Each row links to the detail page (M6-2 wires the target route);
-// until that ships, the link points at the placeholder route. Actions
-// column is reserved for M6-3 (edit) and a future "Open in WP admin"
-// shortcut.
+// Replaced bespoke <table> + StatusPill with the canonical DataTable.
+//
+// Visual contract:
+//   - Title / Slug → TableCell.Stack (title + /slug as secondary).
+//   - Type         → Pill (info) — page_type is taxonomic, treat as
+//                    `info` (blue) since neutral is reserved for "no
+//                    semantic value" and these all carry meaning.
+//   - Status       → Pill (success Published, neutral Draft, warning
+//                    Scheduled). Status comes from the M6-1 page-status
+//                    enum which mirrors post-status.
+//   - DS version   → TableCell.Mono.
+//   - Updated      → TableCell.Secondary (relative time).
+//
+// Row click navigates to the page detail surface.
 // ---------------------------------------------------------------------------
 
 type PagesTableProps = {
   items: PageListItem[];
   siteId: string;
   backHref?: string;
+};
+
+const STATUS_VARIANT: Record<string, PillVariant> = {
+  published: "success",
+  draft: "neutral",
+  scheduled: "warning",
 };
 
 function buildDetailHref(
@@ -31,65 +52,57 @@ function buildDetailHref(
 }
 
 export function PagesTable({ items, siteId, backHref }: PagesTableProps) {
-  if (items.length === 0) {
-    return (
-      <div className="rounded-md border border-dashed p-8 text-center">
-        <p className="text-sm text-muted-foreground">
-          No pages match these filters.
-        </p>
-      </div>
-    );
-  }
+  const router = useRouter();
+
+  const columns: ColumnDef<PageListItem>[] = [
+    {
+      key: "title",
+      header: "Title",
+      cell: (p) => (
+        <TableCell.Stack primary={p.title} secondary={`/${p.slug}`} />
+      ),
+    },
+    {
+      key: "type",
+      header: "Type",
+      cell: (p) => <Pill variant="info">{p.page_type.replace(/_/g, " ")}</Pill>,
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (p) => (
+        <Pill variant={STATUS_VARIANT[p.status] ?? "neutral"}>{p.status}</Pill>
+      ),
+    },
+    {
+      key: "ds_version",
+      header: "DS version",
+      cell: (p) => <TableCell.Mono>v{p.design_system_version}</TableCell.Mono>,
+    },
+    {
+      key: "updated",
+      header: "Updated",
+      cell: (p) => (
+        <TableCell.Secondary>{formatRelativeTime(p.updated_at)}</TableCell.Secondary>
+      ),
+    },
+  ];
 
   return (
-    <div className="overflow-hidden rounded-md border">
-      <table className="w-full text-sm">
-        <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
-          <tr>
-            <th className="px-4 py-2 font-medium">Title</th>
-            <th className="px-4 py-2 font-medium">Type</th>
-            <th className="px-4 py-2 font-medium">Status</th>
-            <th className="px-4 py-2 font-medium">DS version</th>
-            <th className="px-4 py-2 font-medium">Updated</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((p) => (
-            <tr
-              key={p.id}
-              className="border-b last:border-b-0 hover:bg-muted/40"
-              data-testid="page-row"
-              data-page-id={p.id}
-            >
-              <td className="px-4 py-3 align-top">
-                <Link
-                  href={buildDetailHref(siteId, p.id, backHref)}
-                  className="font-medium hover:underline"
-                  data-testid="page-row-link"
-                >
-                  {p.title}
-                </Link>
-                <div className="mt-1 text-sm text-muted-foreground">
-                  /{p.slug}
-                </div>
-              </td>
-              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
-                {p.page_type.replace(/_/g, " ")}
-              </td>
-              <td className="px-4 py-3 align-top">
-                {/* page status taxonomy is identical to post (draft / published) */}
-                <StatusPill kind={postStatusKind(p.status as Parameters<typeof postStatusKind>[0])} className="capitalize" />
-              </td>
-              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
-                v{p.design_system_version}
-              </td>
-              <td className="px-4 py-3 align-top text-sm text-muted-foreground">
-                {formatRelativeTime(p.updated_at)}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <DataTable
+      data={items}
+      columns={columns}
+      rowKey={(p) => p.id}
+      onRowClick={(p) =>
+        router.push(buildDetailHref(siteId, p.id, backHref))
+      }
+      testId="pages-table"
+      emptyState={{
+        icon: <NavIcon name="file-empty" size={20} />,
+        iconLabel: "No pages",
+        title: "No pages match these filters",
+        body: <>Adjust the filters above or run a batch to generate pages.</>,
+      }}
+    />
   );
 }


### PR DESCRIPTION
## Summary

Spec 18 PR C — three high-traffic admin lists migrated to the canonical `DataTable` from PR A. No data-fetching or business logic changed.

### Pages (`components/PagesTable.tsx`)
Title+slug → `TableCell.Stack`, Type/Status → `Pill`, DS version → `TableCell.Mono`, Updated → `TableCell.Secondary`. Row click → page detail.

### Images (`components/ImagesTable.tsx`)
- Bulk-delete affordance preserved above the table; selection state migrated from `Set<string>` to `string[]` to match `DataTable`'s `selectedKeys` prop.
- Title + filename → `TableCell.Stack` (caption renders as secondary when title is present; falls back to filename).
- Tags → up to 6 `Pill` (neutral) chips with `+N` overflow.
- Source → `Pill` (info iStock, warning Upload, accent Generated).
- Dimensions → `TableCell.Mono` or `TableCell.Empty`.
- Lightbox state preserved.

### Batches (`app/admin/batches/page.tsx` + `components/BatchesTable.tsx`)
- Inline server-rendered `<table>` extracted into a `BatchesTable` client island so `DataTable` can drive presentation. The server component continues to fetch + project rows.
- Site/Template → `TableCell.Stack`, Status → `Pill` (job taxonomy), Cost → `TableCell.Mono`, Progress → tabular-nums secondary text.

## Note: Posts vs Pages

Spec 18 said "Posts" but the codebase has `PagesTable` (`components/PagesTable.tsx`) which renders the page list under the M6 routing. There's also `app/admin/posts` (blog posts) — that surface uses `BlogPostComposer` and post-detail views, not a table list, so there's no table to migrate there. Migrated the page list as the spec's analogue. Flag if this is wrong and you want me to look at a different surface.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Image thumbnail click bubbling to row click | Explicit `stopPropagation` on the `<img>`. |
| Bulk-delete checkbox propagating to `onRowClick` | DataTable wraps the `<td>` with `stopPropagation` when `selectable`. |
| Server→client boundary in `batches/page.tsx` | `BatchesTable` is a thin client wrapper; page still server-renders the data fetch + RLS shape. |

## Test plan

- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [x] `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)