### PR TITLE
fix: clean up test debt — fix 5 failing unit test groups

### DIFF
--- a/components/SitesFilterChips.tsx
+++ b/components/SitesFilterChips.tsx
@@ -74,7 +74,7 @@ export function SitesFilterChips({
             className={cn(
               "inline-flex items-center rounded-full px-3 py-1 text-sm transition-smooth focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
               isActive
-                ? "bg-[var(--brand-pink,#FF03A5)] text-white shadow-sm"
+                ? "bg-[var(--brand-pink)] text-white shadow-sm"
                 : "border border-border text-muted-foreground hover:bg-muted",
             )}
           >

--- a/lib/__tests__/images-suggest.test.ts
+++ b/lib/__tests__/images-suggest.test.ts
@@ -207,10 +207,12 @@ describe("POST /api/images/suggest", () => {
     const spy = vi
       .spyOn(embedMod, "embedText")
       .mockRejectedValueOnce(new embedMod.EmbeddingNotConfiguredError());
+    // Use terms that exist in the seeded phishing image ("phishing", "fraud")
+    // so plainto_tsquery returns at least one row on the keyword side.
     const res = await suggestPOST(
       makePost({
-        postTitle: "Phishing email basics",
-        postBody: "fraud",
+        postTitle: "Phishing fraud",
+        postBody: "phishing email fraud cybersecurity",
         limit: 3,
       }) as never,
     );

--- a/lib/__tests__/sites-purge-permissions.test.ts
+++ b/lib/__tests__/sites-purge-permissions.test.ts
@@ -8,6 +8,9 @@ import {
 } from "vitest";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
+// revalidatePath throws outside Next.js App Router — suppress in tests.
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
 import { __resetAuthKillSwitchCacheForTests } from "@/lib/auth-kill-switch";
 import { getServiceRoleClient } from "@/lib/supabase";
 

--- a/lib/__tests__/sites-purge.test.ts
+++ b/lib/__tests__/sites-purge.test.ts
@@ -46,8 +46,12 @@ describe("purgeSite recursive cascade", () => {
         site_id: siteId,
         title: "Purge test brief",
         status: "parsed",
-        original_text: "Some content",
         text_model: "claude-sonnet-4-6",
+        source_storage_path: "purge-test/brief.txt",
+        source_mime_type: "text/plain",
+        source_size_bytes: 12,
+        source_sha256: "aabbccdd",
+        upload_idempotency_key: "purge-test-idem-key",
       })
       .select("id")
       .single();

--- a/lib/seo/alt-text.ts
+++ b/lib/seo/alt-text.ts
@@ -17,19 +17,21 @@ export interface DeriveAltTextInput {
 }
 
 export function deriveAltText(input: DeriveAltTextInput): string {
-  const seo = (input.seoTitle ?? "").trim();
+  const raw = input.seoTitle ?? "";
+  const seo = raw.trim();
   if (!seo) return input.postTitleFallback;
 
   const site = (input.siteName ?? "").trim();
   if (!site) return seo;
 
   // Strip trailing " {sep}{siteName}" — first matching separator wins,
-  // mirroring the order in the spec.
+  // mirroring the order in the spec. Match against the raw (untrimmed)
+  // value so leading whitespace in the title is preserved as-is.
   for (const sep of SEPARATORS) {
     const pattern = `${sep}${site}`;
-    if (seo.endsWith(pattern)) {
-      const stripped = seo.slice(0, seo.length - pattern.length).trim();
-      return stripped || seo;
+    if (raw.endsWith(pattern)) {
+      const stripped = raw.slice(0, raw.length - pattern.length).trim();
+      return stripped || raw;
     }
   }
   return seo;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 import path from "node:path";
 
 export default defineConfig({
+  // tsconfig.json uses jsx: "preserve" for Next.js, but vitest's Vite
+  // bundler needs JSX transformed so .tsx imports work in server tests.
+  esbuild: { jsx: "automatic" },
   resolve: {
     // Array form so `server-only` can match a regex pattern. Next.js's
     // bundler resolves `server-only` via its `react-server` export


### PR DESCRIPTION
## Summary

Fixes all failing unit test groups so future CI runs are clean.

- **alt-text.ts**: `deriveAltText` trimmed `seoTitle` before matching the separator pattern, so a title like `" - Acme"` had its leading space stripped and the pattern never matched. Fixed by matching against `raw` (untrimmed) and returning `raw` when stripping would produce an empty string.
- **design-tokens**: `SitesFilterChips.tsx` had `bg-[var(--brand-pink,#FF03A5)]` — the hex fallback was caught by the design-tokens scan. Removed fallback; the CSS variable is guaranteed by the theme.
- **breadcrumb / page-header / spec08-success-moment**: `vitest.config.ts` had no JSX transform. `tsconfig.json` uses `jsx:preserve` (required for Next.js), but Vite's `vite:import-analysis` plugin can't parse raw JSX. Added `esbuild:{jsx:'automatic'}` to `vitest.config.ts`; the components config already uses `@vitejs/plugin-react` for this.
- **sites-purge.test.ts**: Brief insert referenced a non-existent `original_text` column. Replaced with the real NOT NULL schema fields (`source_storage_path`, `source_mime_type`, `source_size_bytes`, `source_sha256`, `upload_idempotency_key`).
- **sites-purge-permissions.test.ts**: `DELETE /api/sites/[id]/purge` calls `revalidatePath("/admin/sites")` which throws the Next.js App Router invariant in vitest. Added `vi.mock("next/cache", ...)` to no-op it.
- **images-suggest.test.ts**: Keyword-only fallback test used `postTitle: "Phishing email basics"`. `plainto_tsquery` ANDs all stemmed terms — "basic" (from "basics") is absent from all seeded images, so 0 rows were returned. Changed to `"Phishing fraud"` whose stems both appear in the seeded phishing image.

## Test plan

- [ ] `test` CI job passes (Supabase stack required — requires CI)
- [ ] `test-components` CI job passes
- [ ] `build`, `lint`, `typecheck`, `static-audit` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)