### PR TITLE
feat(spec08): surface sweep — post-publish + batch-completion success moments

### DIFF
--- a/app/admin/batches/[id]/page.tsx
+++ b/app/admin/batches/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { BatchDetailClient } from "@/components/BatchDetailClient";
+import { BatchSuccessMoment } from "@/components/BatchSuccessMoment";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
 import { PageShell } from "@/components/ui/page-shell";
@@ -166,6 +167,14 @@ export default async function BatchDetailPage({
           <BatchDetailClient jobId={params.id} status={job.status as string} />
         </PageHeader.Actions>
       </PageHeader>
+
+      {job.status === "succeeded" && (
+        <BatchSuccessMoment
+          jobId={params.id}
+          succeededCount={Number(job.succeeded_count ?? 0)}
+          siteName={site.name}
+        />
+      )}
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
         <div>

--- a/components/BatchSuccessMoment.tsx
+++ b/components/BatchSuccessMoment.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { SuccessMoment } from "@/components/ui/success-moment";
+
+// Spec 08 — batch-completion success moment.
+//
+// Client component so SuccessMoment can read localStorage (firstTimeKey).
+// Rendered by the batch detail server page when job.status === "succeeded".
+
+interface Props {
+  jobId: string;
+  succeededCount: number;
+  siteName: string;
+}
+
+export function BatchSuccessMoment({ jobId, succeededCount, siteName }: Props) {
+  return (
+    <SuccessMoment
+      firstTimeKey={`batch-completed:${jobId}`}
+      title="Batch complete"
+      firstTimeTitle="Batch completed!"
+      subtitle={`${succeededCount} page${succeededCount === 1 ? "" : "s"} generated for ${siteName}.`}
+      primaryAction={{ label: "View batches", href: "/admin/batches" }}
+    />
+  );
+}

--- a/components/PostDetailClient.tsx
+++ b/components/PostDetailClient.tsx
@@ -3,12 +3,14 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { toast } from "sonner";
+
+import { toastSuccess } from "@/lib/toast-success";
 
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { StatusPill, postStatusKind } from "@/components/ui/status-pill";
+import { SuccessMoment } from "@/components/ui/success-moment";
 import { H1 } from "@/components/ui/typography";
 import type { PostDetail } from "@/lib/posts";
 import type { PreflightResult } from "@/lib/site-preflight";
@@ -126,10 +128,10 @@ export function PostDetailClient({
         };
       };
       if (res.ok && payload.ok) {
-        toast.success("Published to WordPress!", {
+        toastSuccess("Published to WordPress!", {
           description: wpFrontendUrl ? "Your post is now live." : undefined,
           action: wpFrontendUrl
-            ? { label: "View live", onClick: () => window.open(wpFrontendUrl, "_blank") }
+            ? { label: "View live →", onClick: () => window.open(wpFrontendUrl, "_blank") }
             : undefined,
         });
         router.refresh();
@@ -168,7 +170,7 @@ export function PostDetailClient({
       };
       if (res.ok && payload.ok) {
         setUnpublishOpen(false);
-        toast.success("Post moved to WordPress trash. You can re-publish any time.");
+        toastSuccess("Post moved to WordPress trash. You can re-publish any time.");
         router.refresh();
         return;
       }
@@ -238,6 +240,24 @@ export function PostDetailClient({
           )}
         </div>
       </div>
+
+      {post.status === "published" && (
+        <SuccessMoment
+          firstTimeKey={`post-published:${post.id}`}
+          title="Post published to WordPress"
+          firstTimeTitle="Your post is live!"
+          subtitle={
+            wpFrontendUrl
+              ? "The post is visible on your site. Use the link above to view it."
+              : "Published successfully to WordPress."
+          }
+          primaryAction={
+            wpFrontendUrl
+              ? { label: "View live post", href: wpFrontendUrl, external: true }
+              : undefined
+          }
+        />
+      )}
 
       {preflightBlocked && (
         <Alert

--- a/docs/specs/_blockers.md
+++ b/docs/specs/_blockers.md
@@ -18,17 +18,27 @@ Depends on Spec 13 (composer right column work that frees the layout's right edg
 
 The master brief gates this PR on >5% of `image_library` rows missing captions in production telemetry. The parallel session has already landed Spec 05 polish work (#752, #753, #754, #756 — picker debounce + suggest RPC vector array fix + bounded fetches + spec-aligned empty state). The caption-quality PR is conditional on Axiom telemetry that doesn't yet exist; defer until the data is available.
 
-### Spec 14 PRs B and C (deferred — manual review)
+### Spec 14 PR B (shipped — pending manual review merge)
 
-PR A (#763) ships the warning modal + final banner + `useSessionExpiry` hook. PRs B (activity tracking + 15-minute non-renewable grace + multi-tab leader-elected auto-save with dirty-state guard + visibility-aware cadence) and C (cybersecurity-explainer re-login page) are scope-large and benefit from sequential review. PR A on its own is a strict UX improvement over today's corner toast and reviews independently.
+PR B (#772) shipped: `lib/hooks/use-activity.ts` (60s active window; keydown / mousedown / pointerdown / touchstart — NOT mousemove), `lib/hooks/use-auto-save.ts` (dirty-state guard + localStorage leader election + visibility-aware cadence), extended `useSessionExpiry` with 15-minute non-renewable grace period, `SessionGraceBanner`, and `hardLogout()`. Awaiting Steven's manual review + merge.
 
-**To execute (PR B):** `lib/hooks/use-activity.ts` (60s active window; keydown / mousedown / pointerdown / touchstart — NOT mousemove). Extend `useSessionExpiry` with a 15-minute non-renewable grace timer that starts at T-0 and does NOT reset on activity. Add a `useAutoSave` hook with three load-bearing safeguards: (1) dirty-state guard so unchanged state doesn't fire saves, (2) BroadcastChannel-or-localStorage leader election so multi-tab doesn't hammer the API, (3) visibility-aware cadence (60s/30s/15s, half-rate when document.hidden). Auto-save sweep: post composer (verify cadence-bumping wired up), site builder (add if missing), multi-field forms > 30s of work. Surfaces lacking auto-save log a `_blockers.md` entry instead of silent skip.
+**Auto-save sweep findings (PR B):** BlogPostComposer already has localStorage-backed cadence-bumping wired up correctly. No server-side auto-save handler needed for current surfaces — existing patterns are sufficient. The `_blockers.md` note for surfaces-lacking-auto-save has no current entries.
 
-**To execute (PR C):** `app/auth/expired/page.tsx` with the cybersecurity-explainer copy (three-bullet rationale for the 48h cap). Cap-driven logouts redirect there; user-initiated sign-out / suspension / password change route to the standard login page. Inline modal challenge from the SessionExpiryWatcher's `onReauthenticate` if Supabase Auth supports it; else redirect with `returnTo`.
+### Spec 14 PR C (shipped — pending manual review merge)
 
-### Spec 08 surface sweep (deferred)
+PR C (#773) shipped: `app/auth/expired/page.tsx` with cybersecurity-explainer copy (three-bullet rationale: session-hijacking protection, compliance alignment, credential freshness). Force-static, no nav chrome. `hardLogout()` in `SessionExpiryWatcher` redirects here when grace elapses. Awaiting Steven's manual review + merge.
 
-The primitive layer shipped (#762 — `SuccessMoment`, `useFirstTime`, `celebrate`, `toastSuccess`). The Tier-1 surface integration (post-publish hero in `PostDetailClient`, first-site-connection on the sites list, first-customer-onboarded, batch-completion at the batch-runner output) is left for a follow-up. The parallel session has Spec 08 work in flight on `BriefRunClient`'s brief-run-completed surface; once that lands, sweep the remaining surfaces.
+### Spec 08 surface sweep (partially shipped)
+
+The primitive layer shipped (#762 — `SuccessMoment`, `useFirstTime`, `celebrate`, `toastSuccess`). This PR (feat/spec08-surface-sweep) ships:
+- Post-publish hero in `PostDetailClient` — SuccessMoment with `firstTimeKey="post-published:{id}"`
+- Batch-completion hero in batch detail page — new `BatchSuccessMoment` client component
+
+**Deferred Tier-1 surfaces (no existing implementation; need new work):**
+- **First-site-connection:** No trigger point exists in the current UI. The sites list (`app/admin/sites/page.tsx`) and site detail (`app/admin/sites/[id]/page.tsx`) don't track whether a WP connection is "first". Would need a `firstTimeKey="wp-connected:{siteId}"` trigger wired into the WP credential save flow. Defer to a targeted follow-up.
+- **First-customer-onboarded:** No "customer onboarded" milestone event exists on any current surface. Would require identifying where company/customer onboarding completes and adding a `firstTimeKey` there. Defer to a targeted follow-up.
+
+**toastSuccess standardization:** `PostDetailClient` migrated from `toast.success` → `toastSuccess`. Full sweep of remaining `toast.success` calls across other files is deferred to a separate cleanup PR.
 
 ### Trusted-devices feature reconsideration after 48h cap (Spec 14 follow-up)
 

--- a/docs/specs/_run-log.md
+++ b/docs/specs/_run-log.md
@@ -145,3 +145,58 @@ Run-time observation, not a new finding: per memory's "Parallel sessions, single
 ## Blockers
 
 See `_blockers.md` — Spec 11 (waits on Spec 10), Spec 12 (waits on Spec 13), Spec 05 PR C (gated on telemetry), Spec 14 PRs B+C (manual review, deferred), Spec 08 surface sweep, trusted-devices reconsideration, image-search latency baseline.
+
+---
+
+# Spec autonomous-run log — 2026-05-08 (cont.) — dispatch brief: Spec 14 PRs B+C, Spec 08 surface sweep, test debt
+
+Continuation of the 2026-05-08 master brief. Five PRs total; two require manual review.
+
+| Work item | PR # | Title | Branch | State |
+|---|---|---|---|---|
+| Test debt | #771 | fix 5 failing unit test groups | feat/fix-unit-tests | merged |
+| 14-B | #772 | activity tracking + grace period + auto-save | feat/spec14-pr-b-activity-grace-autosave | open — manual review |
+| 14-C | #773 | cybersecurity re-login page `/auth/expired` | feat/spec14-pr-c-auth-expired | open — manual review |
+| 08 (sweep) | #774 | surface sweep — post-publish + batch-completion success moments | feat/spec08-surface-sweep | CI running → auto-merge when green |
+
+## What shipped
+
+### Test debt (#771, merged)
+
+Five vitest test groups fixed in one PR:
+
+- **`breadcrumb.test.ts` / `page-header.test.ts` / `spec08-success-moment.test.ts`**: `vite:import-analysis` could not parse TSX because `tsconfig.json` sets `jsx: "preserve"` for Next.js. Fix: added `esbuild: { jsx: "automatic" }` to `vitest.config.ts`.
+- **`alt-text.test.ts`**: `deriveAltText` trimmed `seoTitle` before separator matching, stripping the leading space from `" - Acme"`. Fix: match against `raw` (untrimmed), return `raw` when stripped result is empty.
+- **`sites-purge.test.ts`**: brief insert referenced non-existent column `original_text` and omitted required NOT NULL fields. Fix: aligned insert to real schema.
+- **`sites-purge-permissions.test.ts`**: `revalidatePath` from `next/cache` throws `Invariant: static generation store missing` outside App Router context. Fix: `vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))`.
+- **`images-suggest.test.ts`**: `plainto_tsquery` ANDs all stemmed terms; `"basics"` stems to `"basic"`, absent from all seeded images → 0 rows. Fix: changed test query to `"Phishing fraud"` whose stems match the seeded phishing image.
+
+### Spec 14 PR B (#772, manual review)
+
+`lib/hooks/use-activity.ts`: tracks keydown / mousedown / pointerdown / touchstart (NOT mousemove); 60-second active window; returns `isActive: boolean`.
+
+`lib/hooks/use-auto-save.ts`: generic `useAutoSave({key, getData, onSave, intervalMs})` hook with three safeguards: (1) dirty-state guard via JSON snapshot comparison, (2) localStorage leader election (`autosave:leader:{key}`, 5s heartbeat, 12s TTL), (3) visibility-aware cadence (normal interval when visible, 2× when `document.hidden`).
+
+`lib/hooks/use-session-expiry.ts` extended: `GRACE_PERIOD_MS = 15 * 60 * 1000` starts at T-0, non-renewable. `hardLogout()` exported: Supabase sign-out + `window.location.replace("/auth/expired")`. `SessionExpiry` extended with `graceElapsed` + `graceSecondsRemaining`.
+
+`components/session/session-grace-banner.tsx`: amber undismissable countdown banner during grace period with `formatCountdown()` and "Re-authenticate now" CTA.
+
+`components/session/session-expiry-watcher.tsx` updated: imports `SessionGraceBanner`, calls `hardLogout()` via `useEffect` when `graceElapsed` becomes true.
+
+Auto-save sweep: BlogPostComposer already uses localStorage-backed cadence correctly; no additional server-side auto-save needed for current surfaces.
+
+### Spec 14 PR C (#773, manual review)
+
+`app/auth/expired/page.tsx`: `force-static` page (user already signed out), three-bullet cybersecurity rationale (session-hijacking protection / compliance alignment / credential freshness), "Sign in again" → `/login` CTA, NavIcon `lock` in amber circle header, footer note "Your work was auto-saved before sign-out."
+
+### Spec 08 surface sweep (#774, CI running)
+
+`PostDetailClient`: `SuccessMoment` block wired when `post.status === 'published'` — first-time shows "Your post is live!" confetti hero, subsequent visits show quiet "Post published to WordPress" banner. Both `toast.success()` calls migrated to `toastSuccess()`.
+
+`BatchSuccessMoment` (new client component): wraps `SuccessMoment` for `job.status === 'succeeded'` on the batch detail page, keyed `batch-completed:{jobId}`.
+
+**Deferred Tier-1 surfaces:** first-site-connection (no existing trigger point in credential-save flow) and first-company-onboarded (no onboarding milestone event) — logged in `_blockers.md` for targeted follow-up.
+
+## Blockers
+
+Spec 11 (waits on Spec 10), Spec 12 (waits on Spec 13), Spec 05 PR C (gated on telemetry), Spec 14 PRs B+C awaiting Steven's manual review. See `_blockers.md`.


### PR DESCRIPTION
## Summary

- **`PostDetailClient`**: wires `SuccessMoment` when `post.status === 'published'` — first-time shows "Your post is live!" confetti hero; subsequent visits show the quieter "Post published to WordPress" banner. Keyed by `post-published:{id}` so each post has its own first-time state.
- **`BatchSuccessMoment`** (new client component): wraps `SuccessMoment` for batch-completion state on the batch detail page. Rendered when `job.status === 'succeeded'`, keyed `batch-completed:{jobId}`.
- **`toastSuccess` adoption**: migrated both `toast.success()` calls in `PostDetailClient` to the `toastSuccess` helper (Spec 08 Tier-2 standardisation).
- **`_blockers.md` updated**: documents two deferred Tier-1 surfaces (first-site-connection, first-company-onboarded) — neither has an existing trigger point in the current UI; logged for a targeted follow-up.

## Deferred surfaces (noted in `_blockers.md`)

- **First-site-connection**: no "WP credentials saved for first time" event surface exists yet; would need a `firstTimeKey` wired into the credential-save flow.
- **First-customer-onboarded**: no company onboarding milestone event on any current page.
- **Full `toastSuccess` sweep**: only `PostDetailClient` migrated here; remaining `toast.success` calls across the app deferred to a separate cleanup PR.

## Test plan

- [ ] Navigate to a published post — SuccessMoment banner visible
- [ ] Refresh — banner remains (not first-time key, so no confetti on repeat)
- [ ] Clear localStorage key `post-published:{id}`, reload — confetti "Your post is live!" on next load
- [ ] Navigate to a succeeded batch — BatchSuccessMoment visible
- [ ] CI green (lint / typecheck / build / audit:static all pass locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)