### PR TITLE
feat(spec14-c): wire watcher to /auth/expired + harden returnTo handling

### DIFF
--- a/app/auth/expired/page.tsx
+++ b/app/auth/expired/page.tsx
@@ -7,16 +7,24 @@ import { H1, Lead } from "@/components/ui/typography";
 // /auth/expired — Spec 14 PR C.
 //
 // Cybersecurity-explainer page for cap-driven logouts. Shown when:
-//   • The 15-minute grace period after session expiry elapses (hardLogout
-//     in use-session-expiry.ts redirects here).
+//   • The 15-minute non-renewable activity grace elapses, OR
+//   • The operator was inactive at T-0 and was hard-logged-out immediately.
+//
+// Both code paths route through SessionExpiryWatcher's hard-logout effect
+// (PR B, components/session/session-expiry-watcher.tsx), which calls
+// supabase.auth.signOut() and redirects here with returnTo preserved.
 //
 // NOT shown for:
-//   • User-initiated sign-out → /login
-//   • Suspension / password change → /login (admin-forced revocation)
+//   • User-initiated sign-out → /login (no policy explainer needed)
+//   • Suspension / password change → /login (admin-forced revocation;
+//     different copy, separate UX)
 //
 // The three-bullet rationale is required copy per the Spec 14 brief.
 // It explains WHY the 48-hour cap exists so operators understand this is
-// a deliberate security policy, not a bug or server error.
+// a deliberate security policy, not a bug or server error. Force-static
+// because the page has no per-user content — it can be cached at the
+// edge and served without hitting the auth layer (which the operator
+// has just been kicked out of).
 // ---------------------------------------------------------------------------
 
 export const dynamic = "force-static";
@@ -39,7 +47,27 @@ const WHY_BULLETS = [
   },
 ] as const;
 
-export default function SessionExpiredPage() {
+interface SearchParams {
+  returnTo?: string;
+}
+
+export default function SessionExpiredPage({
+  searchParams,
+}: {
+  searchParams?: SearchParams;
+}) {
+  // returnTo is preserved through the cap-driven logout flow so the
+  // operator lands back on the same page after re-auth. Defensive
+  // validation: only accept paths that start with "/" and not "//"
+  // (which would resolve as a protocol-relative external URL). Anything
+  // else falls back to /admin.
+  const returnToRaw = searchParams?.returnTo ?? "/admin";
+  const returnToSafe =
+    returnToRaw.startsWith("/") && !returnToRaw.startsWith("//")
+      ? returnToRaw
+      : "/admin";
+  const loginHref = `/login?returnTo=${encodeURIComponent(returnToSafe)}`;
+
   return (
     <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
       <div className="w-full max-w-lg space-y-8">
@@ -78,7 +106,7 @@ export default function SessionExpiredPage() {
         {/* CTA */}
         <div className="flex flex-col items-center gap-3">
           <Link
-            href="/login"
+            href={loginHref}
             className="inline-flex w-full items-center justify-center rounded-md bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground shadow-sm transition-smooth hover:bg-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
             Sign in again

--- a/components/session/session-expiry-watcher.tsx
+++ b/components/session/session-expiry-watcher.tsx
@@ -60,8 +60,11 @@ export function SessionExpiryWatcher() {
       }
       const returnTo = pathname ?? "/admin";
       // Use replace() so back-button doesn't return to the expired session.
+      // PR C — cap-driven logouts land on /auth/expired (the cybersecurity
+      // explainer). User-initiated sign-out continues to land on /login
+      // directly; the explainer is only for "we kicked you out" flows.
       window.location.replace(
-        `/login?returnTo=${encodeURIComponent(returnTo)}&reason=session_expired`,
+        `/auth/expired?returnTo=${encodeURIComponent(returnTo)}`,
       );
     })();
   }, [grace.mustLogout, pathname]);


### PR DESCRIPTION
## Summary

Completes **Spec 14 PR C** integration. The page itself shipped in #773 (parallel session) but didn't include the watcher integration; this PR:

1. Retargets the watcher's hard-logout redirect from `/login?returnTo=...&reason=session_expired` to `/auth/expired?returnTo=...`
2. Hardens the explainer page with `returnTo` support and defensive validation against open-redirect

## Changes

### `components/session/session-expiry-watcher.tsx` (one-line redirect change)

Cap-driven logouts now route to the explainer; user-initiated sign-outs continue routing to `/login` directly.

### `app/auth/expired/page.tsx` (additive — adds `returnTo` support)

The page from #773 had a hard-coded `<Link href="/login">`. This update reads `searchParams.returnTo`, validates the path (must start with `/` and not `//` to block protocol-relative URLs), and embeds the validated value in the login link href so the operator lands back on their pre-expiry page after re-auth.

Comment block + bullet copy lightly tightened to reflect the actual hard-logout path (in the watcher, not in `use-session-expiry.ts` as the original draft suggested).

## Risks identified and mitigated

- **Open-redirect via `returnTo`** — page validates the path; falls back to `/admin` for `https://...`, `//evil.com`, etc.
- **`force-static` page caching** — page reads `searchParams` (Next.js streams these on every request even on static pages), so the `returnTo`-aware link href is correct per request.
- **Watcher not retargeting** — change is one-line; the previous redirect target (`/login?reason=session_expired`) was reachable but missed the explainer surface entirely.

## Verification

- `npm run typecheck` / `lint` — green

## Test plan

- [ ] Force session to expire while user is mid-task → grace banner → 15 min later → land on `/auth/expired?returnTo=/admin/sites/[id]` (NOT `/login`)
- [ ] User-initiated sign-out → `/login` (unchanged)
- [ ] Explainer "Sign in again" CTA preserves `returnTo` → re-auth → land on the original page
- [ ] Open-redirect probe: `?returnTo=https://evil.com` → falls back to `/admin`
- [ ] `?returnTo=//evil.com` → falls back to `/admin`

🤖 Updated by Claude Code