### PR TITLE
feat(spec08): tier-1 surfaces — first site, first customer, optimiser apply

### DIFF
--- a/app/admin/companies/page.tsx
+++ b/app/admin/companies/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { FirstCustomerOnboardedMoment } from "@/components/onboarding/first-customer-onboarded-moment";
 import { PlatformCompaniesListClient } from "@/components/PlatformCompaniesListClient";
 import { Button } from "@/components/ui/button";
 import { NavIcon } from "@/components/ui/nav-icon";
@@ -16,7 +17,11 @@ import { listPlatformCompanies } from "@/lib/platform/companies";
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
-export default async function AdminCompaniesPage() {
+export default async function AdminCompaniesPage({
+  searchParams,
+}: {
+  searchParams?: { created?: string; name?: string };
+}) {
   const result = await listPlatformCompanies();
   if (!result.ok) {
     return (
@@ -66,6 +71,14 @@ export default async function AdminCompaniesPage() {
           </Button>
         </PageHeader.Actions>
       </PageHeader>
+      {searchParams?.created && (
+        <div className="mb-6">
+          <FirstCustomerOnboardedMoment
+            companyId={searchParams.created}
+            companyName={searchParams.name ?? "New customer"}
+          />
+        </div>
+      )}
       <PlatformCompaniesListClient companies={companies} />
     </PageShell>
   );

--- a/app/admin/sites/[id]/onboarding/page.tsx
+++ b/app/admin/sites/[id]/onboarding/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
+import { FirstSiteConnectedMoment } from "@/components/onboarding/first-site-connected-moment";
 import { SiteOnboardingForm } from "@/components/SiteOnboardingForm";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
@@ -26,8 +27,10 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 export default async function SiteOnboardingPage({
   params,
+  searchParams,
 }: {
   params: { id: string };
+  searchParams?: { fresh?: string };
 }) {
   const access = await checkAdminAccess({
     requiredRoles: ["super_admin", "admin"],
@@ -83,6 +86,11 @@ export default async function SiteOnboardingPage({
         </PageHeader.Subtitle>
       </PageHeader>
       <div className="max-w-3xl">
+        {searchParams?.fresh === "1" && (
+          <div className="mb-6">
+            <FirstSiteConnectedMoment siteName={site.name} />
+          </div>
+        )}
         <SiteOnboardingForm siteId={site.id} />
 
         <section className="mt-10 border-t pt-6">

--- a/app/optimiser/proposals/[id]/page.tsx
+++ b/app/optimiser/proposals/[id]/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { CreateVariantButton } from "@/components/optimiser/CreateVariantButton";
 import { PastCausalDeltasPanel } from "@/components/optimiser/PastCausalDeltasPanel";
 import { PatternPriorsPanel } from "@/components/optimiser/PatternPriorsPanel";
+import { ProposalAppliedMoment } from "@/components/optimiser/ProposalAppliedMoment";
 import { ProposalReview } from "@/components/optimiser/ProposalReview";
 import { ProposalRolloutLink } from "@/components/optimiser/ProposalRolloutLink";
 import { getClient } from "@/lib/optimiser/clients";
@@ -76,6 +77,16 @@ export default async function OptimiserProposalReviewPage({
           Status: <code>{proposal.status}</code>
         </span>
       </div>
+      {proposal.status === "applied" && (
+        <ProposalAppliedMoment
+          proposalId={proposal.id}
+          rolloutHref={
+            rollout
+              ? `/optimiser/pages/${proposal.landing_page_id}`
+              : null
+          }
+        />
+      )}
       <ProposalRolloutLink
         rollout={rollout}
         landingPageId={proposal.landing_page_id}

--- a/components/PlatformCompanyCreateForm.tsx
+++ b/components/PlatformCompanyCreateForm.tsx
@@ -62,6 +62,7 @@ export function PlatformCompanyCreateForm() {
     });
     const json = (await response.json().catch(() => null)) as {
       ok: boolean;
+      data?: { company: { id: string; name: string } };
       error?: { code: string; message: string };
     } | null;
 
@@ -74,7 +75,13 @@ export function PlatformCompanyCreateForm() {
       return;
     }
 
-    router.push("/admin/companies");
+    // Spec 08 — pass the new company id + name through so the list
+    // page can render the FirstCustomerOnboardedMoment celebration once.
+    const created = json.data?.company;
+    const query = created
+      ? `?created=${encodeURIComponent(created.id)}&name=${encodeURIComponent(created.name)}`
+      : "";
+    router.push(`/admin/companies${query}`);
     router.refresh();
   }
 

--- a/components/SiteCreateForm.tsx
+++ b/components/SiteCreateForm.tsx
@@ -165,7 +165,9 @@ export function SiteCreateForm() {
         // mode-selection screen first; the existing copy / new-design
         // branches diverge from there. The post-onboarding redirect
         // sends the operator to the right wizard or extraction flow.
-        router.push(`/admin/sites/${payload.data.id}/onboarding`);
+        // Spec 08 — pass ?fresh=1 so the onboarding page can render
+        // the first-site-connected SuccessMoment when applicable.
+        router.push(`/admin/sites/${payload.data.id}/onboarding?fresh=1`);
         return;
       }
       const message =

--- a/components/onboarding/first-customer-onboarded-moment.tsx
+++ b/components/onboarding/first-customer-onboarded-moment.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { SuccessMoment } from "@/components/ui/success-moment";
+
+// Spec 08 surface — first customer/company created.
+//
+// Renders at the top of /admin/companies when arriving from the create
+// form with ?created=<id>. Per-customer firstTimeKey so the celebration
+// fires exactly once per company and never re-fires on subsequent visits.
+
+interface Props {
+  companyId: string;
+  companyName: string;
+}
+
+export function FirstCustomerOnboardedMoment({
+  companyId,
+  companyName,
+}: Props) {
+  return (
+    <SuccessMoment
+      firstTimeKey={`customer-onboarded:${companyId}`}
+      title={`${companyName} is set up.`}
+      firstTimeTitle={`${companyName} is set up. Nice — your first customer.`}
+      subtitle="You can invite users, configure social platforms, and start creating content from the new company's surfaces."
+    />
+  );
+}

--- a/components/onboarding/first-site-connected-moment.tsx
+++ b/components/onboarding/first-site-connected-moment.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { SuccessMoment } from "@/components/ui/success-moment";
+
+// Spec 08 surface — first WordPress site ever connected.
+//
+// Renders at the top of /admin/sites/[id]/onboarding when arriving from
+// SiteCreateForm with ?fresh=1. The page is the natural celebration
+// moment: operator just connected WP credentials, they're seeing their
+// site for the first time, and they're about to pick onboarding mode.
+//
+// firstTimeKey is device-scoped ('first-site-connected'), so the
+// celebration fires once per device — subsequent sites get the
+// existing toast.success("Site connected") on SiteCreateForm.
+
+interface Props {
+  siteName: string;
+}
+
+export function FirstSiteConnectedMoment({ siteName }: Props) {
+  return (
+    <SuccessMoment
+      firstTimeKey="first-site-connected"
+      title={`${siteName} is connected.`}
+      firstTimeTitle={`${siteName} is connected. Nice — your first site.`}
+      subtitle="Pick how you want to set it up below. You can change your mind later."
+    />
+  );
+}

--- a/components/optimiser/ProposalAppliedMoment.tsx
+++ b/components/optimiser/ProposalAppliedMoment.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { SuccessMoment } from "@/components/ui/success-moment";
+
+// Spec 08 surface — optimiser proposal applied (Tier 1).
+//
+// Renders at the top of /optimiser/proposals/[id] when the proposal's
+// status is "applied". Per-proposal firstTimeKey so the celebration
+// fires once when the operator first lands on the applied state and
+// stays quiet on subsequent revisits.
+//
+// Lives under components/optimiser/ per the module-private rule
+// (CLAUDE.md → "Module-private code under components/optimiser/").
+
+interface Props {
+  proposalId: string;
+  rolloutHref?: string | null;
+}
+
+export function ProposalAppliedMoment({
+  proposalId,
+  rolloutHref,
+}: Props) {
+  return (
+    <SuccessMoment
+      firstTimeKey={`optimiser-applied:${proposalId}`}
+      title="Proposal applied to the live page."
+      firstTimeTitle="Proposal applied. The live page is updated."
+      subtitle="The change is live now. Track its measured impact in the rollout panel below."
+      primaryAction={
+        rolloutHref
+          ? { label: "View rollout", href: rolloutHref }
+          : undefined
+      }
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Closes the remaining **Spec 08 Tier-1 surface gaps** from the 2026-05-08 master brief. PR #774 shipped post-publish hero + batch-completion; this PR adds the three surfaces noted as deferred there.

## What this PR ships

### 1. First site connected — `components/onboarding/first-site-connected-moment.tsx`

Mounts at the top of `/admin/sites/[id]/onboarding` when arriving from `SiteCreateForm` with `?fresh=1`. **device-scoped `firstTimeKey: 'first-site-connected'`** so the celebration fires once per device; subsequent sites get the existing `toast.success("Site connected")` on the create form. `SiteCreateForm` now redirects with `?fresh=1`.

### 2. First customer onboarded — `components/onboarding/first-customer-onboarded-moment.tsx`

Mounts at the top of `/admin/companies` when arriving from `PlatformCompanyCreateForm` with `?created=<id>&name=<name>`. **per-company `firstTimeKey: \`customer-onboarded:${companyId}\`** so each new company gets one celebration on first viewing. Form now passes both the new company id and name through the redirect (the API already returns `data.company`; no API change needed).

### 3. Optimiser proposal applied — `components/optimiser/ProposalAppliedMoment.tsx`

Mounts at the top of `/optimiser/proposals/[id]` when `proposal.status === 'applied'`. **per-proposal `firstTimeKey: \`optimiser-applied:${proposalId}\`** so the celebration fires once when the operator first lands on the applied state. Lives under `components/optimiser/` per the module-private rule (CLAUDE.md). Optional "View rollout" CTA when a rollout is present.

## Implementation notes

All three surfaces use `SuccessMoment` from #762 — subtle confetti only, respects `prefers-reduced-motion`, no emojis in copy. Storage is `useFirstTime`'s localStorage-keyed first-time detection (private-mode safe via try/catch).

## Risks identified and mitigated

- **Re-celebration on page reload** — gated by `?fresh=1` / `?created=` query params + `firstTimeKey` `markSeen()`. After first paint the moment records "seen" in localStorage so even a refresh won't replay.
- **`?fresh=1` reachable via direct URL** — anyone hand-crafting `/onboarding?fresh=1` sees the SuccessMoment **exactly once per device** (the same one-shot constraint applies). Harmless on misuse.
- **`?created=<id>` name interpolation** — `name` flows into `SuccessMoment` as React text content (escaped), not a URL or HTML attribute.
- **Optimiser namespacing** — `ProposalAppliedMoment` lives under `components/optimiser/` as required by CLAUDE.md's strict-list rule.

## Verification

- `npm run typecheck` / `lint` / `build` — green
- `npm run audit:static` — 0 HIGH, 0 MEDIUM

PR is **independently revertible** — surfaces are additive; `?fresh` and `?created` have no effect outside the new conditional renders.

## Test plan

- [ ] Create a fresh site → land on `/admin/sites/[id]/onboarding?fresh=1` → green SuccessMoment with "first site" copy + subtle confetti (once per device)
- [ ] Reload the same URL → no confetti (markSeen)
- [ ] Create a second site on the same device → no SuccessMoment, just `toast.success`
- [ ] Create a new company → land on `/admin/companies?created=<id>&name=<name>` → green SuccessMoment with first-customer copy + subtle confetti
- [ ] Apply an optimiser proposal → land on `/optimiser/proposals/[id]` with `status=applied` → green SuccessMoment + optional "View rollout" CTA
- [ ] `prefers-reduced-motion: reduce` → no confetti on any of the three

🤖 Generated with [Claude Code](https://claude.com/claude-code)