### PR TITLE
feat(spec11): yoast-style SEO panel — preview first, length bars, slug inline

### DIFF
--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -39,6 +39,11 @@ import {
   type BlogPostMetadata,
   type ParseSource,
 } from "@/lib/blog-post-parser";
+import { SeoLengthFeedback } from "@/components/seo/seo-length-feedback";
+import {
+  getMetaDescriptionFeedback,
+  getSeoTitleFeedback,
+} from "@/lib/seo/length-feedback";
 import { generateSlug } from "@/lib/slug";
 import { cn, formatRelativeTime } from "@/lib/utils";
 
@@ -71,9 +76,9 @@ const AUTOSAVE_STATUS_FRESH_MS = 1500;
 // BL-3 — SEO recommendation envelopes. Advisory only; neither field is
 // hard-capped. Matches Google / Bing SERPs as of mid-2025.
 const TITLE_SEO_CAP = 60;
-const META_TITLE_SEO_CAP = 60;
-const META_DESCRIPTION_SEO_MIN = 120;
-const META_DESCRIPTION_SEO_MAX = 160;
+// Spec 11 — META_TITLE_SEO_CAP / META_DESCRIPTION_SEO_MIN / META_DESCRIPTION_SEO_MAX
+// removed; thresholds now live in lib/seo/length-feedback.ts via the
+// getSeoTitleFeedback / getMetaDescriptionFeedback bucket maps.
 
 const SOURCE_HINTS: Record<ParseSource, string> = {
   yaml: "Auto-filled from YAML front-matter",
@@ -115,28 +120,100 @@ function extractFirstParagraph(html: string): string {
 }
 
 // Google SERP snippet preview — purely visual, no interaction.
+// Spec 11 — extract domain for the favicon. Returns null on parse error;
+// caller falls back to a globe glyph.
+function extractDomain(url: string | null | undefined): string | null {
+  if (!url) return null;
+  try {
+    const u = new URL(url);
+    return u.hostname || null;
+  } catch {
+    return null;
+  }
+}
+
 function GoogleSnippetPreview({
   title,
   url,
   description,
+  siteName,
+  featuredImageUrl,
 }: {
   title: string;
   url: string;
   description: string;
+  siteName?: string | null;
+  featuredImageUrl?: string | null;
 }) {
   const displayTitle = title || "Post title";
   const displayDesc = description || "Meta description will appear here.";
+  const domain = extractDomain(url);
+  const faviconUrl = domain
+    ? `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=64`
+    : null;
+  // SERP shows today's date alongside the description in many layouts.
+  const today = new Date().toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
   return (
-    <div className="rounded border border-border bg-background p-3 font-sans text-sm">
-      <div
-        className="truncate text-base font-medium leading-snug text-serp-title"
-        title={displayTitle}
-      >
-        {displayTitle.length > 60 ? displayTitle.slice(0, 60) + "…" : displayTitle}
-      </div>
-      <div className="mt-0.5 truncate text-xs text-serp-url">{url}</div>
-      <div className="mt-1 line-clamp-2 text-xs text-serp-desc">
-        {displayDesc.length > 160 ? displayDesc.slice(0, 160) + "…" : displayDesc}
+    <div className="rounded-lg border border-border bg-background p-3 font-sans text-sm shadow-sm">
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          {/* Site identity row */}
+          <div className="flex items-center gap-2">
+            {faviconUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={faviconUrl}
+                alt=""
+                width={24}
+                height={24}
+                className="h-6 w-6 rounded-full bg-muted"
+              />
+            ) : (
+              <div className="h-6 w-6 rounded-full bg-muted" aria-hidden />
+            )}
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium text-foreground">
+                {siteName ?? domain ?? "Your site"}
+              </div>
+              <div className="truncate text-xs text-muted-foreground">
+                {domain ?? url}
+              </div>
+            </div>
+          </div>
+          {/* Title in faithful SERP blue */}
+          <div
+            className="mt-2 truncate text-lg font-medium leading-snug"
+            style={{ color: "#1a0dab" }}
+            title={displayTitle}
+          >
+            {displayTitle.length > 60 ? displayTitle.slice(0, 60) + "…" : displayTitle}
+          </div>
+          {/* Date · description (muted grey) */}
+          <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+            <span>{today}</span>
+            <span> — </span>
+            <span>
+              {displayDesc.length > 160
+                ? displayDesc.slice(0, 160) + "…"
+                : displayDesc}
+            </span>
+          </div>
+        </div>
+        {/* Featured image thumbnail — 80×80 right-aligned, when set */}
+        {featuredImageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={featuredImageUrl}
+            alt=""
+            width={80}
+            height={80}
+            className="h-20 w-20 shrink-0 rounded-md object-cover"
+          />
+        ) : null}
       </div>
     </div>
   );
@@ -262,7 +339,6 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
   const [lastParse, setLastParse] = useState<BlogPostMetadata | null>(null);
   const [featuredImage, setFeaturedImage] = useState<ImagePickerEntry | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
-  const [seoPanelOpen, setSeoPanelOpen] = useState(true);
   const [autosave, setAutosave] = useState<AutosaveState>({ kind: "idle" });
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [pendingDraft, setPendingDraft] = useState<DraftSnapshot | null>(null);
@@ -947,96 +1023,154 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
             )}
           </div>
 
-          {/* SEO section — inside left column below editor */}
+          {/* SEO section — Spec 11: no collapsible header, Google preview
+              at top, then SEO title → Slug → Meta description with live
+              progress bars below each input. */}
           <section
             className="mt-8 border-t pt-6"
             data-testid="seo-section"
             aria-label="SEO settings"
           >
-            <button
-              type="button"
-              onClick={() => setSeoPanelOpen((v) => !v)}
-              aria-expanded={seoPanelOpen}
-              className="flex w-full items-center justify-between text-left text-sm font-semibold transition-colors hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              SEO
-              <NavIcon
-                name="chevron-down"
-                size={16}
-                className={cn(
-                  "text-muted-foreground transition-transform",
-                  seoPanelOpen && "rotate-180",
-                )}
+            <h2 className="text-sm font-semibold">SEO</h2>
+            <div className="mt-4 space-y-4">
+              {/* 1. Google search preview */}
+              <GoogleSnippetPreview
+                title={metaTitle.value || title.value}
+                url={
+                  siteWpUrl && slug.value
+                    ? `${siteWpUrl.replace(/\/$/, "")}/${slug.value}/`
+                    : siteWpUrl ?? "https://example.com/"
+                }
+                description={metaDescription.value}
+                siteName={siteName}
+                featuredImageUrl={featuredImage?.delivery_url ?? null}
               />
-            </button>
-            {seoPanelOpen && <div className="mt-4 space-y-4">
-              <div className="space-y-3">
-                <div>
-                  <label htmlFor="post-meta-title" className="block text-sm font-medium">
-                    SEO title
-                  </label>
-                  <Input
-                    id="post-meta-title"
-                    className="mt-1"
-                    value={metaTitle.value}
-                    onChange={(e) =>
-                      setFieldValue(
-                        setMetaTitle,
-                        e.target.value,
-                        lastParse?.meta_title ?? null,
-                        lastParse?.source_map.meta_title ?? "derived",
-                      )
-                    }
-                    disabled={submitting}
-                    maxLength={200}
-                  />
-                  <div className="mt-1 flex items-center justify-between gap-2">
-                    <SourceHint source={metaTitle.source} />
-                    <MetaTitleLengthHint length={metaTitle.value.length} />
-                  </div>
-                </div>
-                <div>
-                  <label htmlFor="post-meta-description" className="block text-sm font-medium">
-                    Meta description
-                  </label>
-                  <Textarea
-                    id="post-meta-description"
-                    className="mt-1"
-                    rows={3}
-                    value={metaDescription.value}
-                    onChange={(e) =>
-                      setFieldValue(
-                        setMetaDescription,
-                        e.target.value,
-                        lastParse?.meta_description ?? null,
-                        lastParse?.source_map.meta_description ?? "derived",
-                      )
-                    }
-                    disabled={submitting}
-                    maxLength={400}
-                    aria-invalid={metaDescription.value.length > 0 && !metaDescriptionIsValid}
-                  />
-                  <div className="mt-1 flex items-center justify-between gap-2 text-sm">
-                    <SourceHint source={metaDescription.source} />
-                    <MetaDescriptionLengthHint length={metaDescription.value.length} />
-                  </div>
-                </div>
-              </div>
+
+              {/* 2. SEO title */}
               <div>
-                <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  Search preview
-                </p>
-                <GoogleSnippetPreview
-                  title={metaTitle.value || title.value}
-                  url={
-                    siteWpUrl && slug.value
-                      ? `${siteWpUrl.replace(/\/$/, "")}/${slug.value}/`
-                      : siteWpUrl ?? "https://example.com/"
+                <label htmlFor="post-meta-title" className="block text-sm font-medium">
+                  SEO title
+                </label>
+                <Input
+                  id="post-meta-title"
+                  className="mt-1"
+                  value={metaTitle.value}
+                  onChange={(e) =>
+                    setFieldValue(
+                      setMetaTitle,
+                      e.target.value,
+                      lastParse?.meta_title ?? null,
+                      lastParse?.source_map.meta_title ?? "derived",
+                    )
                   }
-                  description={metaDescription.value}
+                  disabled={submitting}
+                  maxLength={200}
                 />
+                <SeoLengthFeedback
+                  feedback={getSeoTitleFeedback(metaTitle.value.length)}
+                  length={metaTitle.value.length}
+                />
+                <div className="mt-1">
+                  <SourceHint source={metaTitle.source} />
+                </div>
               </div>
-            </div>}
+
+              {/* 3. Slug — moved into the SEO panel per Spec 11 field order */}
+              <div>
+                <div className="flex items-baseline justify-between gap-2">
+                  <label htmlFor="post-slug" className="block text-sm font-medium">
+                    URL slug
+                  </label>
+                  {title.value.trim().length > 0 && (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setSlug({
+                          value: generateSlug(title.value),
+                          source: "derived",
+                          touched: true,
+                        })
+                      }
+                      disabled={submitting}
+                      className="rounded-sm text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      Regenerate
+                    </button>
+                  )}
+                </div>
+                <Input
+                  id="post-slug"
+                  className="mt-1"
+                  value={slug.value}
+                  onChange={(e) =>
+                    setFieldValue(
+                      setSlug,
+                      e.target.value.toLowerCase(),
+                      lastParse?.slug ?? null,
+                      lastParse?.source_map.slug ?? "derived",
+                    )
+                  }
+                  onBlur={() => {
+                    if (slug.value && !slugIsValid) {
+                      setSlug({
+                        value: generateSlug(slug.value),
+                        source: "derived",
+                        touched: true,
+                      });
+                    }
+                  }}
+                  disabled={submitting}
+                  maxLength={100}
+                  aria-invalid={!slugIsValid}
+                />
+                <div className="mt-1 space-y-0.5">
+                  <div className="flex items-center justify-between gap-2">
+                    <SourceHint source={slug.source} />
+                    {!slugIsValid && slug.value.length > 0 && (
+                      <span className="text-xs text-destructive">
+                        Lowercase, numbers, dashes only.
+                      </span>
+                    )}
+                  </div>
+                  <PermalinkPreview
+                    structure={permalinkStructure}
+                    wpUrl={siteWpUrl}
+                    slug={slug.value}
+                  />
+                </div>
+              </div>
+
+              {/* 4. Meta description */}
+              <div>
+                <label htmlFor="post-meta-description" className="block text-sm font-medium">
+                  Meta description
+                </label>
+                <Textarea
+                  id="post-meta-description"
+                  className="mt-1"
+                  rows={3}
+                  value={metaDescription.value}
+                  onChange={(e) =>
+                    setFieldValue(
+                      setMetaDescription,
+                      e.target.value,
+                      lastParse?.meta_description ?? null,
+                      lastParse?.source_map.meta_description ?? "derived",
+                    )
+                  }
+                  disabled={submitting}
+                  maxLength={400}
+                  aria-invalid={metaDescription.value.length > 0 && !metaDescriptionIsValid}
+                />
+                <SeoLengthFeedback
+                  feedback={getMetaDescriptionFeedback(metaDescription.value.length)}
+                  length={metaDescription.value.length}
+                />
+                <div className="mt-1">
+                  <SourceHint source={metaDescription.source} />
+                </div>
+              </div>
+            </div>
           </section>
         </div>
 
@@ -1176,65 +1310,9 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
           </p>
         </SidebarPanel>
 
-        {/* Permalink panel */}
-        <SidebarPanel title="Permalink" defaultOpen testId="sidebar-permalink">
-          <div className="flex items-baseline justify-between gap-2">
-            <label htmlFor="post-slug" className="block text-sm font-medium">
-              URL slug
-            </label>
-            {title.value.trim().length > 0 && (
-              <button
-                type="button"
-                onClick={() =>
-                  setSlug({
-                    value: generateSlug(title.value),
-                    source: "derived",
-                    touched: true,
-                  })
-                }
-                disabled={submitting}
-                className="rounded-sm text-sm text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                Regenerate
-              </button>
-            )}
-          </div>
-          <Input
-            id="post-slug"
-            value={slug.value}
-            onChange={(e) =>
-              setFieldValue(
-                setSlug,
-                e.target.value.toLowerCase(),
-                lastParse?.slug ?? null,
-                lastParse?.source_map.slug ?? "derived",
-              )
-            }
-            onBlur={() => {
-              if (slug.value && !slugIsValid) {
-                setSlug({ value: generateSlug(slug.value), source: "derived", touched: true });
-              }
-            }}
-            disabled={submitting}
-            maxLength={100}
-            aria-invalid={!slugIsValid}
-          />
-          <div className="space-y-0.5">
-            <div className="flex items-center justify-between gap-2">
-              <SourceHint source={slug.source} />
-              {!slugIsValid && slug.value.length > 0 && (
-                <span className="text-sm text-destructive">
-                  Lowercase, numbers, dashes only.
-                </span>
-              )}
-            </div>
-            <PermalinkPreview
-              structure={permalinkStructure}
-              wpUrl={siteWpUrl}
-              slug={slug.value}
-            />
-          </div>
-        </SidebarPanel>
+        {/* Spec 11 — Permalink sidebar panel removed; URL slug now lives
+            inside the SEO section in the main column (Google preview →
+            SEO title → Slug → Meta description). */}
 
         {/* Categories panel */}
         <SidebarPanel title="Categories" defaultOpen testId="sidebar-categories">
@@ -1492,51 +1570,10 @@ function TitleLengthHint({
   );
 }
 
-function MetaTitleLengthHint({ length }: { length: number }) {
-  if (length === 0) return null;
-  const overSeoCap = length > META_TITLE_SEO_CAP;
-  return (
-    <span
-      data-testid="post-meta-title-length-hint"
-      className={cn(
-        "text-sm",
-        overSeoCap ? "text-warning" : "text-muted-foreground",
-      )}
-    >
-      {length}/{META_TITLE_SEO_CAP}
-      {overSeoCap && " · search will truncate"}
-    </span>
-  );
-}
-
-function MetaDescriptionLengthHint({ length }: { length: number }) {
-  if (length === 0) {
-    return (
-      <span className="text-muted-foreground">
-        Aim for {META_DESCRIPTION_SEO_MIN}–{META_DESCRIPTION_SEO_MAX} chars.
-      </span>
-    );
-  }
-  if (length > META_DESCRIPTION_SEO_MAX) {
-    return (
-      <span data-testid="post-meta-description-length-hint" className="text-destructive">
-        {length}/{META_DESCRIPTION_SEO_MAX} · search will truncate
-      </span>
-    );
-  }
-  if (length < META_DESCRIPTION_SEO_MIN) {
-    return (
-      <span data-testid="post-meta-description-length-hint" className="text-muted-foreground">
-        {length}/{META_DESCRIPTION_SEO_MAX} · aim for {META_DESCRIPTION_SEO_MIN}+
-      </span>
-    );
-  }
-  return (
-    <span data-testid="post-meta-description-length-hint" className="text-success">
-      {length}/{META_DESCRIPTION_SEO_MAX} · good length
-    </span>
-  );
-}
+// Spec 11 — MetaTitleLengthHint / MetaDescriptionLengthHint replaced by
+// <SeoLengthFeedback> in components/seo/seo-length-feedback.tsx, which
+// renders the live progress bar + heuristic label per the brief's
+// qualifying-language requirement ("typically good", not "ideal").
 
 // ---------------------------------------------------------------------------
 // WordPress-style collapsible sidebar panel.

--- a/components/seo/seo-length-feedback.tsx
+++ b/components/seo/seo-length-feedback.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { LengthFeedback } from "@/lib/seo/length-feedback";
+import { cn } from "@/lib/utils";
+
+// Spec 11 — visual progress bar + qualifying-language hint pair.
+//
+// Renders directly under the SEO title or meta description input. The
+// brief asks for a 4px bar plus the heuristic label; this component
+// owns that layout. Colour map:
+//   • red    → bg-red-500
+//   • orange → bg-amber-500
+//   • green  → bg-emerald-500
+// (Tailwind tokens; kept inline rather than wired through brand vars
+// because Yoast/serp readability conventions are colour-specific.)
+
+interface Props {
+  feedback: LengthFeedback;
+  /** Current character count — shown after the qualifying label as e.g. "55 chars · typically good". */
+  length: number;
+}
+
+const COLOR_BAR: Record<LengthFeedback["color"], string> = {
+  red: "bg-red-500",
+  orange: "bg-amber-500",
+  green: "bg-emerald-500",
+};
+
+const COLOR_TEXT: Record<LengthFeedback["color"], string> = {
+  red: "text-red-600 dark:text-red-400",
+  orange: "text-amber-700 dark:text-amber-400",
+  green: "text-emerald-700 dark:text-emerald-400",
+};
+
+export function SeoLengthFeedback({ feedback, length }: Props) {
+  return (
+    <div className="mt-1.5">
+      <div
+        className="h-1 w-full overflow-hidden rounded-full bg-muted"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={feedback.percentage}
+        aria-label={`SEO length: ${feedback.label}`}
+      >
+        <div
+          className={cn(
+            "h-full rounded-full transition-[width] duration-150",
+            COLOR_BAR[feedback.color],
+          )}
+          style={{ width: `${feedback.percentage}%` }}
+        />
+      </div>
+      <p className={cn("mt-1 text-xs", COLOR_TEXT[feedback.color])}>
+        {length} char{length === 1 ? "" : "s"} · {feedback.label}
+      </p>
+    </div>
+  );
+}

--- a/e2e/posts-new.spec.ts
+++ b/e2e/posts-new.spec.ts
@@ -112,9 +112,12 @@ test.describe("/admin/posts/new — top-level entry", () => {
     await firstOption.click();
 
     // Sidebar document panels are visible from the start.
+    // Spec 11: slug + permalink moved into the SEO section in the main
+    // column; the right-rail Permalink panel was removed.
     await expect(page.getByTestId("post-sidebar")).toBeVisible();
     await expect(page.getByTestId("sidebar-publish")).toBeVisible();
-    await expect(page.getByTestId("sidebar-permalink")).toBeVisible();
+    await expect(page.getByTestId("seo-section")).toBeVisible();
+    await expect(page.locator("#post-slug")).toBeVisible();
 
     // Type into the composer (TipTap ProseMirror). Use pressSequentially so
     // TipTap's key-event handlers fire and update the React state that the
@@ -213,14 +216,17 @@ test.describe("/admin/posts/new — top-level entry", () => {
       .click();
 
     // All default-open panels are visible.
+    // Spec 11: Permalink panel removed from the sidebar — slug now lives
+    // inside the SEO section in the main column.
     const publishPanel = page.getByTestId("sidebar-publish");
-    const permalinkPanel = page.getByTestId("sidebar-permalink");
+    const seoSection = page.getByTestId("seo-section");
     const categoriesPanel = page.getByTestId("sidebar-categories");
     const tagsPanel = page.getByTestId("sidebar-tags");
     const featuredImagePanel = page.getByTestId("sidebar-featured-image");
 
     await expect(publishPanel).toBeVisible();
-    await expect(permalinkPanel).toBeVisible();
+    await expect(seoSection).toBeVisible();
+    await expect(seoSection.locator("#post-slug")).toBeVisible();
     await expect(categoriesPanel).toBeVisible();
     await expect(tagsPanel).toBeVisible();
     await expect(featuredImagePanel).toBeVisible();
@@ -246,8 +252,6 @@ test.describe("/admin/posts/new — top-level entry", () => {
     await expect(publishPanel.getByRole("button", { name: /save as draft/i })).toBeVisible();
 
     // SEO section is now full-width below the editor grid (not a collapsible sidebar panel).
-    const seoSection = page.getByTestId("seo-section");
-    await expect(seoSection).toBeVisible();
     await expect(seoSection.locator("#post-meta-title")).toBeVisible();
     await expect(seoSection.locator("#post-meta-description")).toBeVisible();
 

--- a/lib/__tests__/length-feedback.test.ts
+++ b/lib/__tests__/length-feedback.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getMetaDescriptionFeedback,
+  getSeoTitleFeedback,
+} from "@/lib/seo/length-feedback";
+
+describe("getSeoTitleFeedback", () => {
+  it("flags 0 chars as too short / red", () => {
+    const f = getSeoTitleFeedback(0);
+    expect(f.color).toBe("red");
+    expect(f.label).toBe("too short");
+    expect(f.percentage).toBe(0);
+  });
+
+  it("flags 19 chars as too short / red (boundary)", () => {
+    const f = getSeoTitleFeedback(19);
+    expect(f.color).toBe("red");
+    expect(f.label).toBe("too short");
+  });
+
+  it("flags 20 chars as getting there / orange", () => {
+    const f = getSeoTitleFeedback(20);
+    expect(f.color).toBe("orange");
+    expect(f.label).toBe("getting there");
+  });
+
+  it("flags 30 chars as getting there / orange (per brief example)", () => {
+    const f = getSeoTitleFeedback(30);
+    expect(f.color).toBe("orange");
+    expect(f.label).toBe("getting there");
+  });
+
+  it("flags 50 chars as typically good / green (lower good boundary)", () => {
+    const f = getSeoTitleFeedback(50);
+    expect(f.color).toBe("green");
+    expect(f.label).toBe("typically good");
+  });
+
+  it("flags 55 chars as typically good / green (per brief example)", () => {
+    const f = getSeoTitleFeedback(55);
+    expect(f.color).toBe("green");
+    expect(f.label).toBe("typically good");
+  });
+
+  it("flags 60 chars as typically good / green (upper good boundary)", () => {
+    const f = getSeoTitleFeedback(60);
+    expect(f.color).toBe("green");
+    expect(f.label).toBe("typically good");
+    expect(f.percentage).toBe(100);
+  });
+
+  it("flags 61 chars as may truncate / orange", () => {
+    const f = getSeoTitleFeedback(61);
+    expect(f.color).toBe("orange");
+    expect(f.label).toBe("may truncate");
+  });
+
+  it("flags 70 chars as may truncate / orange (boundary)", () => {
+    const f = getSeoTitleFeedback(70);
+    expect(f.color).toBe("orange");
+    expect(f.label).toBe("may truncate");
+  });
+
+  it("flags 71 chars as likely truncates / red", () => {
+    const f = getSeoTitleFeedback(71);
+    expect(f.color).toBe("red");
+    expect(f.label).toBe("likely truncates");
+  });
+
+  it("flags 75 chars as likely truncates / red (per brief example)", () => {
+    const f = getSeoTitleFeedback(75);
+    expect(f.color).toBe("red");
+    expect(f.label).toBe("likely truncates");
+  });
+
+  it("never uses definitive wording — no 'ideal' or 'perfect'", () => {
+    for (let len = 0; len <= 200; len++) {
+      const label = getSeoTitleFeedback(len).label;
+      expect(label).not.toMatch(/\b(ideal|perfect|exact|guaranteed)\b/i);
+    }
+  });
+
+  it("caps percentage at 100", () => {
+    expect(getSeoTitleFeedback(200).percentage).toBe(100);
+  });
+});
+
+describe("getMetaDescriptionFeedback", () => {
+  it("flags 0 chars as too short / red", () => {
+    expect(getMetaDescriptionFeedback(0).color).toBe("red");
+    expect(getMetaDescriptionFeedback(0).label).toBe("too short");
+  });
+
+  it("flags 49 chars as too short (lower bound boundary)", () => {
+    expect(getMetaDescriptionFeedback(49).color).toBe("red");
+    expect(getMetaDescriptionFeedback(49).label).toBe("too short");
+  });
+
+  it("flags 50 chars as getting there", () => {
+    expect(getMetaDescriptionFeedback(50).color).toBe("orange");
+    expect(getMetaDescriptionFeedback(50).label).toBe("getting there");
+  });
+
+  it("flags 119 chars as getting there (upper boundary)", () => {
+    expect(getMetaDescriptionFeedback(119).color).toBe("orange");
+    expect(getMetaDescriptionFeedback(119).label).toBe("getting there");
+  });
+
+  it("flags 120 chars as typically good (lower good)", () => {
+    expect(getMetaDescriptionFeedback(120).color).toBe("green");
+    expect(getMetaDescriptionFeedback(120).label).toBe("typically good");
+  });
+
+  it("flags 156 chars as typically good (upper good)", () => {
+    expect(getMetaDescriptionFeedback(156).color).toBe("green");
+    expect(getMetaDescriptionFeedback(156).label).toBe("typically good");
+    expect(getMetaDescriptionFeedback(156).percentage).toBe(100);
+  });
+
+  it("flags 157 chars as may truncate", () => {
+    expect(getMetaDescriptionFeedback(157).color).toBe("orange");
+    expect(getMetaDescriptionFeedback(157).label).toBe("may truncate");
+  });
+
+  it("flags 170 chars as may truncate (upper)", () => {
+    expect(getMetaDescriptionFeedback(170).color).toBe("orange");
+    expect(getMetaDescriptionFeedback(170).label).toBe("may truncate");
+  });
+
+  it("flags 171 chars as likely truncates", () => {
+    expect(getMetaDescriptionFeedback(171).color).toBe("red");
+    expect(getMetaDescriptionFeedback(171).label).toBe("likely truncates");
+  });
+
+  it("never uses definitive wording", () => {
+    for (let len = 0; len <= 300; len++) {
+      const label = getMetaDescriptionFeedback(len).label;
+      expect(label).not.toMatch(/\b(ideal|perfect|exact|guaranteed)\b/i);
+    }
+  });
+});

--- a/lib/seo/length-feedback.ts
+++ b/lib/seo/length-feedback.ts
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------------
+// Spec 11 — heuristic length feedback for SEO title + meta description.
+//
+// Modern Google truncation depends on pixel width, query bolding, and
+// viewport — these thresholds are UX guidance, not exact predictions.
+// Helper text uses qualifying language ("typically good" / "may truncate"
+// / "likely truncates"), never definitive wording.
+// ---------------------------------------------------------------------------
+
+export type LengthState =
+  | "critical-low"
+  | "low"
+  | "ok"
+  | "good"
+  | "high"
+  | "critical-high";
+
+export type LengthColor = "red" | "orange" | "green";
+
+export interface LengthFeedback {
+  state: LengthState;
+  color: LengthColor;
+  /**
+   * Qualifying label: "too short" / "getting there" / "typically good" /
+   * "may truncate" / "likely truncates". Empty input → "too short" still.
+   */
+  label: string;
+  /**
+   * Progress percentage clamped to 0–100. Drives the visual bar width.
+   * Anchored to the upper end of the "good" range so the bar fills as
+   * the operator types into the green zone.
+   */
+  percentage: number;
+}
+
+interface Bucket {
+  state: LengthState;
+  color: LengthColor;
+  label: string;
+  /** inclusive lower bound */
+  min: number;
+}
+
+// Buckets defined per the brief — last bucket has no upper cap.
+const SEO_TITLE_BUCKETS: Bucket[] = [
+  { state: "critical-low", color: "red", label: "too short", min: 0 },
+  { state: "low", color: "orange", label: "getting there", min: 20 },
+  { state: "good", color: "green", label: "typically good", min: 50 },
+  { state: "high", color: "orange", label: "may truncate", min: 61 },
+  { state: "critical-high", color: "red", label: "likely truncates", min: 71 },
+];
+
+const META_DESCRIPTION_BUCKETS: Bucket[] = [
+  { state: "critical-low", color: "red", label: "too short", min: 0 },
+  { state: "low", color: "orange", label: "getting there", min: 50 },
+  { state: "good", color: "green", label: "typically good", min: 120 },
+  { state: "high", color: "orange", label: "may truncate", min: 157 },
+  { state: "critical-high", color: "red", label: "likely truncates", min: 171 },
+];
+
+// Anchor for the progress bar: the upper bound of the "good" range. We cap
+// length / anchor at 1 so titles past the green zone still show a full bar
+// (consistent with most UX progress-bar conventions — operators read past-
+// full as "too long" via the colour change, not the bar width).
+const SEO_TITLE_ANCHOR = 60;
+const META_DESCRIPTION_ANCHOR = 156;
+
+function pickBucket(buckets: Bucket[], length: number): Bucket {
+  // Iterate descending so the first bucket whose min ≤ length wins.
+  for (let i = buckets.length - 1; i >= 0; i--) {
+    if (length >= buckets[i].min) return buckets[i];
+  }
+  return buckets[0];
+}
+
+function percentageOf(length: number, anchor: number): number {
+  if (length <= 0) return 0;
+  return Math.min(100, Math.round((length / anchor) * 100));
+}
+
+export function getSeoTitleFeedback(length: number): LengthFeedback {
+  const bucket = pickBucket(SEO_TITLE_BUCKETS, length);
+  return {
+    state: bucket.state,
+    color: bucket.color,
+    label: bucket.label,
+    percentage: percentageOf(length, SEO_TITLE_ANCHOR),
+  };
+}
+
+export function getMetaDescriptionFeedback(length: number): LengthFeedback {
+  const bucket = pickBucket(META_DESCRIPTION_BUCKETS, length);
+  return {
+    state: bucket.state,
+    color: bucket.color,
+    label: bucket.label,
+    percentage: percentageOf(length, META_DESCRIPTION_ANCHOR),
+  };
+}


### PR DESCRIPTION
## Summary

Implements **Spec 11** from the 2026-05-08 master brief. The composer's SEO section is rebuilt from "collapsible disclosure with two fields and a hidden preview" into a Yoast-style always-visible panel where the Google search preview leads, length feedback is live and qualifying, and the slug field moves inline so the operator sees the URL alongside title and description.

## What this PR ships

### 1. `lib/seo/length-feedback.ts`

Heuristic bucket maps per the brief's qualifying-language requirement. Returns `{state, color, label, percentage}` per length. Anchor-based percentage targets the upper "good" bound so the bar fills as the operator types into the green zone.

| Field | red (low) | orange | **green** | orange | red (high) |
|---|---|---|---|---|---|
| **SEO title** | 0–19 "too short" | 20–49 "getting there" | **50–60 "typically good"** | 61–70 "may truncate" | 71+ "likely truncates" |
| **Meta description** | 0–49 "too short" | 50–119 "getting there" | **120–156 "typically good"** | 157–170 "may truncate" | 171+ "likely truncates" |

`lib/__tests__/length-feedback.test.ts` — 23 cases including a "no definitive wording ever" probe that scans every length 0–300.

### 2. `components/seo/seo-length-feedback.tsx`

4px progress bar + label pair. Tailwind colour map (`red-500` / `amber-500` / `emerald-500`), accessible via `role="progressbar" + aria-valuenow`.

### 3. SEO section rebuild — `components/BlogPostComposer.tsx`

- **Collapsible disclosure header DROPPED.** Section is always visible.
- **Mobile/Desktop toggle DROPPED** — desktop preview only.
- **Field order locked:** Google preview → SEO title → Slug → Meta description.
- **`<GoogleSnippetPreview>` enhanced:**
  - Site identity row: favicon (via `google.com/s2/favicons` fallback) + site name + domain
  - Title in SERP-faithful `#1a0dab`
  - Date · description in muted grey
  - **Featured image as 80×80 right-aligned thumbnail when set**
- **SEO title** input + `<SeoLengthFeedback>` below
- **URL slug** input MOVED from the right-rail Permalink panel into the SEO section (Permalink panel removed)
- **Meta description** textarea + `<SeoLengthFeedback>` below

### 4. Sidebar-permalink panel removed

URL slug now lives inside the SEO section per the spec's field order. Permalink preview still renders (under the slug input). `seoPanelOpen` state and the now-unused `MetaTitleLengthHint` / `MetaDescriptionLengthHint` helpers are deleted.

### 5. E2E test updates

`e2e/posts-new.spec.ts` updated to assert the new structure: SEO section visible, slug inside it, no `sidebar-permalink` panel reference.

## Risks identified and mitigated

- **Existing E2E tests referencing `sidebar-permalink`** → updated in this PR to look for the slug inside `seo-section`.
- **Favicon network call exposing the operator's domain** → `google.com/s2/favicons` is public; the request comes from the browser (no server-side fetch). Domain comes from `siteWpUrl` which the operator configured.
- **Title id collision** between sidebar-permalink and SEO section → Permalink panel fully removed, no duplicate `post-slug` id.
- **Heuristic thresholds drifting from real SERP behaviour over time** → buckets centralised in `lib/seo/length-feedback.ts`; test probes every length boundary; future tweaks land in one place.

## Verification

- `npm run typecheck` / `lint` / `build` — green
- `npm run audit:static` — 0 HIGH, 0 MEDIUM

PR is **independently revertible** — no schema, env vars, or migrations.

## Test plan

- [ ] Open the composer → SEO section visible at the bottom of the main column (no disclosure)
- [ ] Google preview at top with site favicon + site name + domain
- [ ] Set a featured image → 80×80 thumbnail appears on the right of the preview
- [ ] Type a 30-char SEO title → orange bar, "getting there" label
- [ ] Type a 55-char SEO title → green bar, "typically good"
- [ ] Type a 75-char SEO title → red bar, "likely truncates"
- [ ] Type a 100-char meta description → orange bar, "getting there"
- [ ] Slug field renders below SEO title; permalink preview shows the live URL
- [ ] No `sidebar-permalink` panel in the right-rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)