### PR TITLE
feat(spec12): composer typography — 40px title, 18px body, 800px column

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -430,3 +430,67 @@
     font-size: 24px;
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Spec 12 — composer typography overrides.
+ *
+ * Scoped to .composer-editor-content so prose styles inside the published-
+ * post renderer stay untouched. The published renderer keeps its existing
+ * Tailwind prose tokens; this block only applies inside the composer's
+ * Tiptap editor surface.
+ * ------------------------------------------------------------------------- */
+
+.composer-editor-content,
+.composer-editor-content p,
+.composer-editor-content li {
+  font-size: 18px;
+  line-height: 1.7;
+}
+
+.composer-editor-content h1 {
+  font-size: 32px;
+  line-height: 1.25;
+  font-weight: 700;
+}
+
+.composer-editor-content h2 {
+  font-size: 26px;
+  line-height: 1.3;
+  font-weight: 700;
+}
+
+.composer-editor-content h3 {
+  font-size: 22px;
+  line-height: 1.35;
+  font-weight: 600;
+}
+
+.composer-editor-content blockquote {
+  font-size: 18px;
+}
+
+.composer-editor-content code {
+  font-size: 16px;
+}
+
+.composer-editor-content pre {
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+/* Composer title input — Spec 12 specifies 40px desktop / 32px mobile,
+ * weight 700, line-height 1.2. Bare input (no border, no focus ring),
+ * matching the WordPress block editor's title affordance. */
+
+.composer-title-input {
+  font-size: 32px;
+  line-height: 1.2;
+  font-weight: 700;
+}
+
+@media (min-width: 1024px) {
+  .composer-title-input {
+    font-size: 40px;
+  }
+}
+

--- a/components/BlogPostComposer.tsx
+++ b/components/BlogPostComposer.tsx
@@ -923,7 +923,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
     <form
       id={`blog-post-composer-form-${siteId}`}
       onSubmit={handlePrimarySubmit}
-      className="lg:grid lg:grid-cols-[minmax(0,1fr)_260px] lg:items-start lg:gap-6"
+      className="lg:grid lg:grid-cols-[minmax(0,800px)_300px] lg:items-start lg:gap-10"
     >
       {/* ── LEFT: title + editor + SEO ── */}
       <div className="space-y-4">
@@ -963,7 +963,7 @@ export function BlogPostComposer({ siteId }: { siteId: string }) {
             </label>
             <Input
               id="post-title"
-              className="rounded-none border-0 border-b px-0 text-2xl font-bold shadow-none focus-visible:ring-0 placeholder:text-muted-foreground/50"
+              className="composer-title-input rounded-none border-0 border-b-0 bg-transparent px-0 shadow-none focus-visible:ring-0 placeholder:text-muted-foreground/50 h-auto"
               placeholder="Post title"
               value={title.value}
               onChange={(e) =>

--- a/components/RichTextEditor.tsx
+++ b/components/RichTextEditor.tsx
@@ -80,8 +80,12 @@ export function RichTextEditor({
           .replace(/<o:[^/]+\/>/gi, "");
       },
       attributes: {
+        // Spec 12 — composer-editor-content is the hook for the
+        // typography overrides in app/globals.css (18px body, 32px h1,
+        // etc.). Keep `prose` for baseline tag resets but drop
+        // `prose-sm` so our explicit sizes win without specificity wars.
         class:
-          "prose prose-sm max-w-none min-h-[400px] px-3 py-2 focus:outline-none",
+          "composer-editor-content prose max-w-none min-h-[400px] px-3 py-2 focus:outline-none",
       },
     },
   });


### PR DESCRIPTION
## Summary

Implements **Spec 12** from the 2026-05-08 master brief. The composer gains a WordPress-block-editor-style title (40px desktop / 32px mobile, 700 weight), an 18px body editor with explicit prose overrides, and a clamped 800px main column with a 300px sidebar at 40px gap.

## What this PR ships

### 1. `app/globals.css` — composer typography block

Scoped to a new `.composer-editor-content` class:

| Element | Size | Line-height | Weight |
|---|---|---|---|
| body `p` / `li` | 18px | 1.7 | — |
| `h1` | 32px | 1.25 | 700 |
| `h2` | 26px | 1.3 | 700 |
| `h3` | 22px | 1.35 | 600 |
| `blockquote` | 18px | — | — |
| `code` | 16px (Spec 02 helper exemption) | — | — |
| `pre` | 15px | 1.5 | — |

Plus `.composer-title-input` for the title field — 32px mobile, **40px ≥ 1024px**, 700 weight, 1.2 line-height.

### 2. `components/RichTextEditor.tsx`

Adds `composer-editor-content` to `editorProps.attributes.class`. Drops `prose-sm` (which fought our explicit sizes) but keeps `prose` for baseline tag resets and `max-w-none` so the column-width clamp comes from the layout grid rather than the prose plugin.

### 3. `components/BlogPostComposer.tsx`

- **Form grid** → `lg:grid-cols-[minmax(0,800px)_300px] lg:gap-10`. Below 1024px: stacked layout (existing `lg:` prefix already handled this; gap goes back to 0).
- **Title input** → `composer-title-input rounded-none border-0 bg-transparent px-0`. Bare input per the brief ("no border, no background, no focus ring") — operator visual cue is the caret + placeholder.

## Scope-out

**Composer-only — the published-post renderer is untouched.** Spec 02 type-floor preserved: 18px > 16px floor; 15px pre + 16px code are the helper exemptions Spec 02 already documents.

## Risks identified and mitigated

- **`prose-sm` removal causing other prose surfaces to shift** — `RichTextEditor` is only used by `BlogPostComposer` (verified via grep). No other surface depends on `prose-sm` here.
- **`composer-editor-content` class colliding with existing CSS** — name unique to this spec; greps return no other usage.
- **Title input losing its border on focus** — bare input is intentional per the brief.
- **Form grid clamp making the sidebar feel cramped on 1280px viewports** — 800 + 40 + 300 = 1140px, leaving 140px breathing room inside PageShell's 1280px max-width.
- **`prose` defaults overriding Spec 02 floor** — `prose` has no size declarations at the element level beyond what `composer-editor-content` now sets. Heading + body sizes are explicit; `prose` handles spacing/lists/quotes only.

## Verification

- `npm run typecheck` / `lint` / `build` — green
- `npm run audit:static` — 0 HIGH, 0 MEDIUM (LOWs unchanged at 27)

PR is **independently revertible** (CSS additions + class-name swaps; no schema, env vars, or migrations).

## Test plan

- [ ] Composer at ≥ 1024px — title renders 40px / 700 / line-height 1.2
- [ ] Composer at < 1024px — title renders 32px / 700
- [ ] Body editor — paragraphs at 18px / 1.7
- [ ] Body editor — h1 at 32px / 700, h2 at 26px / 700, h3 at 22px / 600
- [ ] Form grid clamps the main column at 800px on a 1440px viewport
- [ ] Sidebar is 300px, 40px gap from main column
- [ ] Below 1024px, sidebar collapses to drawer / stacks (per existing layout)
- [ ] Published post renderer (`/posts/[slug]`) renders identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)