### PR TITLE
chore(spec08): tier-2 toast.success → toastSuccess sweep (18 files)

### DIFF
--- a/components/BulkUploadButton.tsx
+++ b/components/BulkUploadButton.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { toastSuccess } from "@/lib/toast-success";
 import type { PostMasterListItem } from "@/lib/platform/social/posts";
 
 // ---------------------------------------------------------------------------
@@ -73,7 +74,7 @@ export function BulkUploadButton({ companyId, onSuccess }: Props) {
       setResult(data);
 
       if (data.created > 0) {
-        toast.success(
+        toastSuccess(
           `${data.created} post${data.created !== 1 ? "s" : ""} imported.`,
         );
         onSuccess(data.posts);

--- a/components/CAPGenerateModal.tsx
+++ b/components/CAPGenerateModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { toast } from "sonner";
+import { toastSuccess } from "@/lib/toast-success";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -93,7 +93,7 @@ export function CAPGenerateModal({ open, companyId, onClose, onSuccess }: Props)
         setError(msg);
         return;
       }
-      toast.success(`${json.data.count} draft ${json.data.count === 1 ? "post" : "posts"} generated.`);
+      toastSuccess(`${json.data.count} draft ${json.data.count === 1 ? "post" : "posts"} generated.`);
       onSuccess(json.data.posts);
       reset();
       onClose();

--- a/components/ConceptRefinementView.tsx
+++ b/components/ConceptRefinementView.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
+import { toastSuccess } from "@/lib/toast-success";
 import { Button } from "@/components/ui/button";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { Textarea } from "@/components/ui/textarea";
@@ -160,7 +161,7 @@ export function ConceptRefinementView({
         setApproving(false);
         return;
       }
-      toast.success("Design direction approved.");
+      toastSuccess("Design direction approved.");
       router.refresh();
       onApproved();
     } catch (err) {
@@ -364,7 +365,7 @@ export function ApprovedDesignReadout({
         setResetting(false);
         return;
       }
-      toast.success("Approved concept cleared. Generate or refine again.");
+      toastSuccess("Approved concept cleared. Generate or refine again.");
       router.refresh();
       onReset?.();
     } catch (err) {

--- a/components/DesignSystemSettingsClient.tsx
+++ b/components/DesignSystemSettingsClient.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 
+import { toastSuccess } from "@/lib/toast-success";
 import { Button } from "@/components/ui/button";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { cn } from "@/lib/utils";
@@ -164,7 +165,7 @@ export function DesignSystemSettingsClient({ initialSettings }: Props) {
         const json: { ok: boolean; error?: { message: string } } = await res.json();
         if (!json.ok) throw new Error(json.error?.message ?? "Save failed");
         isDirty.current = false;
-        toast.success("Design system settings saved.");
+        toastSuccess("Design system settings saved.");
       } catch (err) {
         toast.error("Save failed", {
           description: err instanceof Error ? err.message : "Unknown error",

--- a/components/MoodBoardClient.tsx
+++ b/components/MoodBoardClient.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { toastSuccess } from "@/lib/toast-success";
 import type { AspectRatio, CompositionType, StyleId } from "@/lib/image/types";
 
 // ---------------------------------------------------------------------------
@@ -130,7 +131,7 @@ export function MoodBoardClient({
     setSelectedIdx(idx);
     try {
       await navigator.clipboard.writeText(img.signedUrl);
-      toast.success("Image URL copied to clipboard.");
+      toastSuccess("Image URL copied to clipboard.");
     } catch {
       toast.error(
         "Could not copy to clipboard — check browser permissions.",

--- a/components/PendingInvitesTable.tsx
+++ b/components/PendingInvitesTable.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { toastSuccess } from "@/lib/toast-success";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { DataTable, type ColumnDef } from "@/components/ui/data-table";
 import { NavIcon } from "@/components/ui/nav-icon";
@@ -57,7 +58,7 @@ export function PendingInvitesTable({
         });
         return;
       }
-      toast.success(`Invite for ${email} revoked.`);
+      toastSuccess(`Invite for ${email} revoked.`);
       router.refresh();
     } catch (err) {
       toast.error("Network error revoking invite", {

--- a/components/SiteActionsMenu.tsx
+++ b/components/SiteActionsMenu.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { toast } from "sonner";
 
+import { toastSuccess } from "@/lib/toast-success";
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { translateTestConnectionErrorCode } from "@/lib/error-translations";
@@ -116,7 +117,7 @@ export function SiteActionsMenu({
         | { ok: false; errorCode?: string }
         | null;
       if (payload && payload.ok === true) {
-        toast.success("Connection healthy");
+        toastSuccess("Connection healthy");
         // Refresh the row so the "Last tested" cell updates from the
         // freshly written timestamp.
         router.refresh();
@@ -250,7 +251,7 @@ export function SiteActionsMenu({
           onClose={() => setDeleteOpen(false)}
           onSuccess={() => {
             setDeleteOpen(false);
-            toast.success("Site deleted permanently");
+            toastSuccess("Site deleted permanently");
             router.refresh();
           }}
         />

--- a/components/SiteCreateForm.tsx
+++ b/components/SiteCreateForm.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
-import { toast } from "sonner";
+import { toastSuccess } from "@/lib/toast-success";
 
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -158,7 +158,7 @@ export function SiteCreateForm() {
         | { ok: false; error: { code: string; message: string } }
         | null;
       if (payload?.ok) {
-        toast.success("Site connected", {
+        toastSuccess("Site connected", {
           description: `${form.name} — choose how you want to use this site next.`,
         });
         // DESIGN-SYSTEM-OVERHAUL (PR 6) — fresh sites land on the

--- a/components/SiteEditForm.tsx
+++ b/components/SiteEditForm.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState, type FormEvent } from "react";
-import { toast } from "sonner";
+import { toastSuccess } from "@/lib/toast-success";
 
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -234,7 +234,7 @@ export function SiteEditForm({
         | { ok: false; error: { code: string; message: string } }
         | null;
       if (payload?.ok) {
-        toast.success("Site updated", {
+        toastSuccess("Site updated", {
           description: form.passwordTouched
             ? "Credentials rotated."
             : "Changes saved.",

--- a/components/SiteVoiceSettingsForm.tsx
+++ b/components/SiteVoiceSettingsForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import { toast } from "sonner";
+import { toastSuccess } from "@/lib/toast-success";
 
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -66,7 +66,7 @@ export function SiteVoiceSettingsForm({
         | { ok: true; data: { brand_voice: string | null } }
         | { ok: false; error: { code: string; message: string } };
       if (payload.ok) {
-        toast.success("Voice settings saved", {
+        toastSuccess("Voice settings saved", {
           description:
             "New briefs on this site will inherit the updated defaults.",
         });

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { toast } from "sonner";
+import { toastSuccess } from "@/lib/toast-success";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -127,7 +127,7 @@ export function SocialConnectionsList({
         setError(msg);
         return;
       }
-      toast.success("Connections refreshed.");
+      toastSuccess("Connections refreshed.");
       router.refresh();
     } finally {
       setBusyTop(null);

--- a/components/SocialPostDetailClient.tsx
+++ b/components/SocialPostDetailClient.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { toast } from "sonner";
+import { toastSuccess } from "@/lib/toast-success";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -194,7 +194,7 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
         setSubmitting(false);
         return;
       }
-      toast.success("Submitted for approval.");
+      toastSuccess("Submitted for approval.");
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -239,7 +239,7 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
         setCancelling(false);
         return;
       }
-      toast.success("Approval cancelled — post returned to draft.");
+      toastSuccess("Approval cancelled — post returned to draft.");
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -279,7 +279,7 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
         setReopening(false);
         return;
       }
-      toast.success("Post reopened for editing.");
+      toastSuccess("Post reopened for editing.");
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -314,7 +314,7 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
         setApproving(false);
         return;
       }
-      toast.success("Post approved.");
+      toastSuccess("Post approved.");
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -351,7 +351,7 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
         setRejecting(false);
         return;
       }
-      toast.success("Post rejected.");
+      toastSuccess("Post rejected.");
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -387,7 +387,7 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
         setRequestingChanges(false);
         return;
       }
-      toast.success("Changes requested.");
+      toastSuccess("Changes requested.");
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -415,7 +415,7 @@ export function SocialPostDetailClient({ post, canEdit, canSubmit, canCreate, ca
         setDuplicating(false);
         return;
       }
-      toast.success("Post duplicated.");
+      toastSuccess("Post duplicated.");
       router.push(`/company/social/posts/${json.data.newPostId}`);
       router.refresh();
     } catch (err) {

--- a/components/ToneOfVoiceInputs.tsx
+++ b/components/ToneOfVoiceInputs.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { toastSuccess } from "@/lib/toast-success";
 import { Button } from "@/components/ui/button";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { Input } from "@/components/ui/input";
@@ -241,7 +242,7 @@ export function ToneOfVoiceInputs({
       void fetch(`/api/admin/sites/${siteId}/setup/apply-tone`, {
         method: "POST",
       }).catch(() => {});
-      toast.success("Tone of voice approved.");
+      toastSuccess("Tone of voice approved.");
       router.push(`/admin/sites/${siteId}/setup?step=3`);
       router.refresh();
     } catch (err) {

--- a/components/TrustedDevicesList.tsx
+++ b/components/TrustedDevicesList.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { toastSuccess } from "@/lib/toast-success";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { formatRelativeTime } from "@/lib/utils";
@@ -52,7 +53,7 @@ export function TrustedDevicesList({
         });
         return;
       }
-      toast.success(`${label} signed out.`);
+      toastSuccess(`${label} signed out.`);
       router.refresh();
     } finally {
       setRevokingId(null);
@@ -75,7 +76,7 @@ export function TrustedDevicesList({
         });
         return;
       }
-      toast.success(
+      toastSuccess(
         `${payload.data.revoked_count} other ${payload.data.revoked_count === 1 ? "device" : "devices"} signed out.`,
       );
       router.refresh();

--- a/components/UserActionsMenu.tsx
+++ b/components/UserActionsMenu.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { toastSuccess } from "@/lib/toast-success";
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
 import { ChangeUserRoleModal } from "@/components/ChangeUserRoleModal";
 import { NavIcon } from "@/components/ui/nav-icon";
@@ -68,7 +69,7 @@ export function UserActionsMenu({
         });
         return;
       }
-      toast.success("User reinstated");
+      toastSuccess("User reinstated");
       router.refresh();
     } catch (err) {
       toast.error("Network error reinstating user", {
@@ -120,7 +121,7 @@ export function UserActionsMenu({
           onClose={() => setRoleModalOpen(false)}
           onSuccess={() => {
             setRoleModalOpen(false);
-            toast.success(`Role updated for ${email}`);
+            toastSuccess(`Role updated for ${email}`);
             router.refresh();
           }}
         />
@@ -137,7 +138,7 @@ export function UserActionsMenu({
           onClose={() => setRevokeOpen(false)}
           onSuccess={() => {
             setRevokeOpen(false);
-            toast.success("User revoked");
+            toastSuccess("User revoked");
             router.refresh();
           }}
         />

--- a/components/UserRoleActionCell.tsx
+++ b/components/UserRoleActionCell.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation";
 import { useState, type ChangeEvent } from "react";
 import { toast } from "sonner";
 
+import { toastSuccess } from "@/lib/toast-success";
+
 // AUTH-FOUNDATION P3 — role enum migrated from
 // (admin, operator, viewer) to (super_admin, admin, user).
 // super_admin is the locked top tier; this dropdown only offers
@@ -73,7 +75,7 @@ export function UserRoleActionCell({
         });
         return;
       }
-      toast.success(`Role updated to ${newRole}`);
+      toastSuccess(`Role updated to ${newRole}`);
       // Server-rendered list still reflects the old role until refresh;
       // re-fetch so the rest of the table catches up.
       router.refresh();

--- a/components/UserStatusActionCell.tsx
+++ b/components/UserStatusActionCell.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { toastSuccess } from "@/lib/toast-success";
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
 
 // ---------------------------------------------------------------------------
@@ -48,7 +49,7 @@ export function UserStatusActionCell({
         });
         return;
       }
-      toast.success("User reinstated");
+      toastSuccess("User reinstated");
       router.refresh();
     } catch (err) {
       setOptimisticRevoked(true);
@@ -103,7 +104,7 @@ export function UserStatusActionCell({
           onSuccess={() => {
             setRevokeOpen(false);
             setOptimisticRevoked(true);
-            toast.success("User revoked");
+            toastSuccess("User revoked");
             router.refresh();
           }}
         />

--- a/components/admin/internal/ExampleTablesClient.tsx
+++ b/components/admin/internal/ExampleTablesClient.tsx
@@ -8,6 +8,8 @@ import { Pill, type PillVariant } from "@/components/ui/pill";
 import { TableCell } from "@/components/ui/table-cell";
 import { toast } from "sonner";
 
+import { toastSuccess } from "@/lib/toast-success";
+
 // ---------------------------------------------------------------------------
 // Spec 18 — DataTable + Pill visual reference page (client island).
 //
@@ -133,7 +135,7 @@ export function ExampleTablesClient() {
               label: "Test connection",
               icon: <NavIcon name="cloud-lightning" size={14} />,
               onClick: () => {
-                toast.success(`Tested: ${r.name}`);
+                toastSuccess(`Tested: ${r.name}`);
               },
             },
             {


### PR DESCRIPTION
## Summary

Completes the **Spec 08 Tier-2 toast standardisation sweep** that was deferred from the 2026-05-08 master-brief run. Mechanical refactor: every `toast.success(...)` call site in `components/` is now `toastSuccess(...)`. Zero behaviour change — `lib/toast-success.ts` forwards every option (description, action, duration, id) to sonner unchanged.

## Files swept (18 total)

**Pure-success (sonner import dropped):**
- `BlogPostComposer.tsx` (already merged via #780)
- `CAPGenerateModal.tsx`
- `SiteCreateForm.tsx`
- `SiteEditForm.tsx`
- `SiteVoiceSettingsForm.tsx`
- `SocialConnectionsList.tsx`
- `SocialPostDetailClient.tsx`
- `PostDetailClient.tsx` (already merged via #774)

**Mixed (kept sonner for `toast.error` etc.; added `toastSuccess` alongside):**
- `admin/internal/ExampleTablesClient.tsx`
- `BulkUploadButton.tsx`
- `ConceptRefinementView.tsx`
- `DesignSystemSettingsClient.tsx`
- `MoodBoardClient.tsx`
- `PendingInvitesTable.tsx`
- `SiteActionsMenu.tsx`
- `ToneOfVoiceInputs.tsx`
- `TrustedDevicesList.tsx`
- `UserActionsMenu.tsx`
- `UserRoleActionCell.tsx`
- `UserStatusActionCell.tsx`

## Verification

Final grep — `grep "toast.success" components/ app/` (excluding `lib/toast-success.ts` itself + comments) returns **zero** results.

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 warnings/errors
- `npm run audit:static` — 0 HIGH, 0 MEDIUM

## Risks identified and mitigated

- **Behaviour change** — none. `toastSuccess` is a thin wrapper that forwards `description`, `action`, `duration`, `id` to sonner's `toast.success` with the same shape. The brief's "don't change firing behaviour" requirement is preserved.
- **Mixed-import collisions** — files that still call `toast.error` keep both imports (`toast` from sonner + `toastSuccess` from the helper). No name shadowing.
- **Stale call sites slipping through** — verified via final grep across `components/` and `app/`.

PR is **independently revertible** (pure rename + import swap; no schema, env vars, migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)