### PR TITLE
feat(spec14): partial-state autosave endpoint for posts

### DIFF
--- a/app/api/sites/[id]/posts/[post_id]/autosave/route.ts
+++ b/app/api/sites/[id]/posts/[post_id]/autosave/route.ts
@@ -1,0 +1,194 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { readJsonBody, validationError } from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/sites/[id]/posts/[post_id]/autosave — Spec 14 PR B follow-up.
+//
+// Partial-state autosave endpoint. Accepts any subset of the editable
+// post fields (title, slug, generated_html, excerpt, metadata,
+// meta_title) and writes them with last-write-wins semantics. Designed
+// to pair with `lib/hooks/use-auto-save.ts` so long-form surfaces can
+// flush dirty state during the session warning + grace windows.
+//
+// Why no version_lock CAS:
+//
+// The operator's local state is the canonical source of truth between
+// keystrokes — they don't want a CAS conflict to discard their typing
+// just because a second tab raced a stale snapshot. Mutations that
+// matter for transactional integrity (publish, unpublish, status flips)
+// continue to flow through the dedicated routes, which DO use CAS.
+// Autosave is best-effort + idempotent in a way CAS would interfere
+// with.
+//
+// Why a separate sub-route instead of extending /api/sites/[id]/posts:
+//
+// /api/sites/[id]/posts is the create endpoint and treating PATCH
+// semantics as a side-channel there muddies the contract. Sub-route
+// keeps autosave's "last-write-wins, no CAS, partial body" shape
+// distinct from "create" and from "publish/unpublish".
+//
+// Auth: super_admin or admin (admin tier — same gate as the sibling
+// publish/unpublish routes).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const BodySchema = z
+  .object({
+    title: z.string().min(1).max(200).optional(),
+    slug: z
+      .string()
+      .min(1)
+      .max(100)
+      .regex(/^[a-z0-9-]+$/)
+      .optional(),
+    excerpt: z.string().max(2000).nullable().optional(),
+    meta_title: z.string().max(200).nullable().optional(),
+    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+    generated_html: z.string().max(500_000).nullable().optional(),
+  })
+  .strict()
+  .refine(
+    (v) =>
+      v.title !== undefined ||
+      v.slug !== undefined ||
+      v.excerpt !== undefined ||
+      v.meta_title !== undefined ||
+      v.metadata !== undefined ||
+      v.generated_html !== undefined,
+    { message: "Body must include at least one autosaveable field." },
+  );
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string; post_id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  if (!UUID_RE.test(params.id)) {
+    return validationError("Site id must be a UUID.");
+  }
+  if (!UUID_RE.test(params.post_id)) {
+    return validationError("Post id must be a UUID.");
+  }
+
+  const body = await readJsonBody(req);
+  if (body === undefined) {
+    return validationError("Request body must be valid JSON.");
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError("Body failed validation.", {
+      issues: parsed.error.issues,
+    });
+  }
+
+  const supabase = getServiceRoleClient();
+
+  // Build the update row from the parsed patch. The schema's strict()
+  // means unknown keys are already rejected; we only forward the
+  // explicit autosaveable fields.
+  const updateRow: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  };
+  if (gate.user?.id) {
+    updateRow.last_edited_by = gate.user.id;
+    updateRow.updated_by = gate.user.id;
+  }
+  if ("title" in parsed.data) updateRow.title = parsed.data.title;
+  if ("slug" in parsed.data) updateRow.slug = parsed.data.slug;
+  if ("excerpt" in parsed.data) updateRow.excerpt = parsed.data.excerpt;
+  if ("meta_title" in parsed.data) updateRow.meta_title = parsed.data.meta_title;
+  if ("metadata" in parsed.data) updateRow.metadata = parsed.data.metadata;
+  if ("generated_html" in parsed.data) {
+    updateRow.generated_html = parsed.data.generated_html;
+  }
+
+  const res = await supabase
+    .from("posts")
+    .update(updateRow)
+    .eq("id", params.post_id)
+    .eq("site_id", params.id)
+    .is("deleted_at", null)
+    // Block autosave on already-published posts. They still go through
+    // the publish/unpublish routes with proper CAS — autosave bypassing
+    // version_lock would mask concurrent publish state.
+    .neq("status", "published")
+    .select("id, version_lock, updated_at")
+    .maybeSingle();
+
+  if (res.error) {
+    // Slug uniqueness collisions (23505) are the only reasonable
+    // operator-visible failure here — surface as 409 so the UI can
+    // hint the operator to pick a different slug.
+    if (res.error.code === "23505") {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: "UNIQUE_VIOLATION",
+            message: `Slug "${parsed.data.slug}" is already used by another live post on this site.`,
+            details: {
+              site_id: params.id,
+              attempted_slug: parsed.data.slug ?? null,
+            },
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 409 },
+      );
+    }
+    logger.error("posts.autosave.update_failed", {
+      site_id: params.id,
+      post_id: params.post_id,
+      supabase_error: res.error.message,
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Failed to autosave post.",
+          details: { supabase_error: res.error.message },
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 },
+    );
+  }
+  if (!res.data) {
+    // Either the post doesn't exist, doesn't belong to the site, has
+    // been soft-deleted, or has already been published (the .neq filter
+    // excluded published rows).
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "NOT_FOUND",
+          message:
+            "Post does not exist, belongs to a different site, has been deleted, or is already published.",
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: res.data,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/lib/__tests__/posts-autosave-route.test.ts
+++ b/lib/__tests__/posts-autosave-route.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Route handler unit tests for POST /api/sites/[id]/posts/[post_id]/autosave
+// (Spec 14 PR B follow-up — partial-state autosave endpoint).
+//
+// Mocks admin-api-gate + supabase service-role client. Asserts UUID
+// validation, body validation (must include at least one field), auth
+// gate, slug-collision 409 mapping, and happy path.
+// ---------------------------------------------------------------------------
+
+const mockRequireAdminForApi = vi.hoisted(() => vi.fn());
+const mockGetServiceRoleClient = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/admin-api-gate", () => ({
+  requireAdminForApi: mockRequireAdminForApi,
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: mockGetServiceRoleClient,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({ getAll: () => [], set: () => {} }),
+  headers: () => new Headers(),
+}));
+
+import { POST } from "@/app/api/sites/[id]/posts/[post_id]/autosave/route";
+
+const GATE_ALLOW = {
+  kind: "allow" as const,
+  user: { id: "admin-1", email: "admin@test.com", role: "super_admin" as const },
+};
+const GATE_DENY = {
+  kind: "deny" as const,
+  response: new Response(
+    JSON.stringify({ ok: false, error: { code: "UNAUTHORIZED" } }),
+    { status: 401 },
+  ),
+};
+
+const SITE_ID = "11111111-1111-1111-1111-111111111111";
+const POST_ID = "22222222-2222-2222-2222-222222222222";
+const INVALID_ID = "not-a-uuid";
+
+function makeRequest(body: unknown): Request {
+  return new Request(
+    `http://localhost/api/sites/${SITE_ID}/posts/${POST_ID}/autosave`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function makeCtx(siteId = SITE_ID, postId = POST_ID) {
+  return { params: { id: siteId, post_id: postId } };
+}
+
+interface MockSupabaseUpdateResult {
+  data: { id: string; version_lock: number; updated_at: string } | null;
+  error: { code?: string; message: string } | null;
+}
+
+function mockSupabaseUpdate(result: MockSupabaseUpdateResult): void {
+  const chain = {
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  };
+  mockGetServiceRoleClient.mockReturnValue({
+    from: vi.fn().mockReturnValue(chain),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/sites/[id]/posts/[post_id]/autosave", () => {
+  it("401 when auth gate denies", async () => {
+    mockRequireAdminForApi.mockResolvedValue(GATE_DENY);
+    const res = await POST(makeRequest({ title: "x" }), makeCtx());
+    expect(res.status).toBe(401);
+  });
+
+  it("400 VALIDATION_FAILED when site id is not a UUID", async () => {
+    mockRequireAdminForApi.mockResolvedValue(GATE_ALLOW);
+    const res = await POST(
+      makeRequest({ title: "x" }),
+      makeCtx(INVALID_ID, POST_ID),
+    );
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("400 VALIDATION_FAILED when post id is not a UUID", async () => {
+    mockRequireAdminForApi.mockResolvedValue(GATE_ALLOW);
+    const res = await POST(
+      makeRequest({ title: "x" }),
+      makeCtx(SITE_ID, INVALID_ID),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("400 VALIDATION_FAILED when body is empty", async () => {
+    mockRequireAdminForApi.mockResolvedValue(GATE_ALLOW);
+    const res = await POST(makeRequest({}), makeCtx());
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("400 VALIDATION_FAILED when body includes unknown keys", async () => {
+    mockRequireAdminForApi.mockResolvedValue(GATE_ALLOW);
+    const res = await POST(
+      makeRequest({ title: "x", unknown_field: "y" }),
+      makeCtx(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("400 VALIDATION_FAILED when slug fails the regex", async () => {
+    mockRequireAdminForApi.mockResolvedValue(GATE_ALLOW);
+    const res = await POST(
+      makeRequest({ slug: "Bad Slug With Spaces" }),
+      makeCtx(),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when supabase returns no row (post missing / wrong site / published)", async () => {
+    mockRequireAdminForApi.mockResolvedValue(GATE_ALLOW);
+    mockSupabaseUpdate({ data: null, error: null });
+    const res = await POST(makeRequest({ title: "x" }), makeCtx());
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("NOT_FOUND");
+  });
+
+  it("409 UNIQUE_VIOLATION when slug collides on the site", async () => {
+    mockRequireAdminForApi.mockResolvedValue(GATE_ALLOW);
+    mockSupabaseUpdate({
+      data: null,
+      error: { code: "23505", message: "duplicate key value" },
+    });
+    const res = await POST(
+      makeRequest({ slug: "taken-slug" }),
+      makeCtx(),
+    );
+    expect(res.status).toBe(409);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("UNIQUE_VIOLATION");
+  });
+
+  it("500 INTERNAL_ERROR on other supabase failures", async () => {
+    mockRequireAdminForApi.mockResolvedValue(GATE_ALLOW);
+    mockSupabaseUpdate({
+      data: null,
+      error: { code: "42P01", message: "relation does not exist" },
+    });
+    const res = await POST(makeRequest({ title: "x" }), makeCtx());
+    expect(res.status).toBe(500);
+  });
+
+  it("200 OK on happy path; returns id + version_lock + updated_at", async () => {
+    mockRequireAdminForApi.mockResolvedValue(GATE_ALLOW);
+    mockSupabaseUpdate({
+      data: {
+        id: POST_ID,
+        version_lock: 7,
+        updated_at: "2026-05-08T00:00:00Z",
+      },
+      error: null,
+    });
+    const res = await POST(
+      makeRequest({
+        title: "Autosaved",
+        slug: "autosaved",
+        excerpt: "Snip",
+        meta_title: null,
+        metadata: { foo: "bar" },
+        generated_html: "<p>hello</p>",
+      }),
+      makeCtx(),
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      data: { id: string; version_lock: number };
+    };
+    expect(json.ok).toBe(true);
+    expect(json.data.id).toBe(POST_ID);
+    expect(json.data.version_lock).toBe(7);
+  });
+
+  it("accepts a single-field patch (just generated_html)", async () => {
+    mockRequireAdminForApi.mockResolvedValue(GATE_ALLOW);
+    mockSupabaseUpdate({
+      data: {
+        id: POST_ID,
+        version_lock: 1,
+        updated_at: "2026-05-08T00:00:00Z",
+      },
+      error: null,
+    });
+    const res = await POST(
+      makeRequest({ generated_html: "<p>hi</p>" }),
+      makeCtx(),
+    );
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the auto-save infrastructure gap from Spec 14 PR B. Ships the server-side endpoint that long-form post-editor surfaces will flush to via the `useAutoSave` hook shipped in #772.

## What this PR ships

### `app/api/sites/[id]/posts/[post_id]/autosave/route.ts`

POST handler accepting any subset of `{title, slug, generated_html, excerpt, meta_title, metadata}`. Last-write-wins update (no `version_lock` CAS — autosave's role is to capture the operator's local state, not mediate concurrent transactional writes; CAS is preserved for publish/unpublish where it matters).

- **Auth**: `super_admin` or `admin`
- **Rejects published posts** (`.neq status published`) so autosave can't bypass the publish/unpublish CAS routes
- **Slug-collision (23505)** surfaces as 409 `UNIQUE_VIOLATION` so the UI can hint a different slug
- **Returns** the post's current `version_lock` + `updated_at` on success so the client can use CAS on subsequent transactional ops

### `lib/__tests__/posts-autosave-route.test.ts`

11 mock-based unit tests covering:
- Auth-gate denial (401)
- UUID validation on both site and post id (400 each)
- Empty-body rejection (400)
- Unknown-key rejection (400)
- Slug regex enforcement (400)
- 404 on missing / wrong-site / published posts
- 409 mapping for slug uniqueness violations
- 500 on other DB errors
- Happy path returning `{id, version_lock, updated_at}`
- Single-field patch acceptance

## Why a separate sub-route instead of extending `/api/sites/[id]/posts`

Create + autosave are different contracts (POST creates a new post; autosave PATCHes an existing draft). A sub-route keeps autosave's "last-write-wins, no CAS, partial body" shape distinct from the create + publish/unpublish routes that DO use CAS.

## Why no consumer wired in this PR

- `BlogPostComposer` is a one-shot create flow (POST then `router.push`), not an in-place editor. Wiring `useAutoSave` to it would require restructuring the surface to keep the composer mounted with a `postId` after first save.
- `PostDetailClient` is read-only today (publish + unpublish controls only; no editor).

Surface adoption is a separate slice with its own UX considerations. This PR ships the missing infrastructure so the future surface work has a working endpoint to flush to.

## Risks identified and mitigated

- **Last-write-wins overwriting concurrent-tab edits** → `useAutoSave`'s leader election (`lib/hooks/use-tab-leader.ts`) ensures only one tab fires saves; concurrent flushes from sibling tabs of the same operator are eliminated client-side.
- **Bypassing publish-state CAS** → `.neq("status", "published")` filter blocks autosave on already-published rows; the route returns 404.
- **Schema drift on `metadata` (JSONB)** → `z.record(z.string(), z.unknown())` accepts any flat-object shape; deeper validation belongs in the caller (composer schemas).
- **Slug uniqueness collisions** → mapped to 409 `UNIQUE_VIOLATION` with the attempted slug in details, parallel to the create route's shape.

## Verification

- `npm run typecheck` / `lint` / `build` — green
- `npm run audit:static` — 0 HIGH, 0 MEDIUM

PR is **independently revertible** — additive route + test; no schema, env vars, migration, or surface adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)