### PR TITLE
feat(spec03): activate blog_content_classes injection in brief runner

### DIFF
--- a/lib/brief-runner.ts
+++ b/lib/brief-runner.ts
@@ -2001,7 +2001,10 @@ async function processPagePassLoop(
   // DESIGN-DISCOVERY (PR 10) — load the design + voice context once
   // per page-tick. Empty string when DESIGN_CONTEXT_ENABLED is off
   // or neither step is approved; existing behaviour preserved.
-  const designContextPrefix = await buildDesignContextPrefix(brief.site_id);
+  const designContextPrefix = await buildDesignContextPrefix(
+    brief.site_id,
+    brief.content_type,
+  );
 
   // DESIGN-SYSTEM-OVERHAUL PR 13 — load sites.site_mode so the
   // systemPromptFor branch for content_type='post' can drop the


### PR DESCRIPTION
## Summary

One-line activation of the `<blog_content_classes>` injection that shipped in Spec 03 PR 3 (#739) but was left inert pending explicit approval of a brief-runner.ts change (ARCH §18).

**The change:** thread `brief.content_type` into `buildDesignContextPrefix` so the helper's `contentType` parameter is populated:

```ts
// before
const designContextPrefix = await buildDesignContextPrefix(brief.site_id);

// after
const designContextPrefix = await buildDesignContextPrefix(
  brief.site_id,
  brief.content_type,
);
```

With this wired, `copy_existing` sites whose operators have calibrated blog styling will now receive a `<blog_content_classes>` block in the generation prompt when running a `content_type='post'` brief — using the extracted container / heading / list / media CSS class names from the live WordPress theme instead of generating new ones.

## Risks identified and mitigated

- **Regression on page briefs**: `buildDesignContextPrefix` only emits `<blog_content_classes>` when `contentType === 'post'` AND `extracted_design.blog_styling` has usable data. Pages get identical output to before — no regression.
- **NULL / new_design sites**: the helper's dispatch returns early for both cases regardless of `contentType`. No change in behaviour.
- **Flag-off (`DESIGN_CONTEXT_ENABLED` unset) new_design sites**: still guarded inside `renderInjection`. No change.
- **brief.content_type type safety**: `"page" | "post"` — matches the helper's `contentType?: "post" | "page"` param exactly. TypeScript confirms no widening.

Closes the blocker documented in `docs/specs/_blockers.md` under "Spec 03 PR 3 — content_type gating without modifying brief-runner.ts."

🤖 Generated with [Claude Code](https://claude.com/claude-code)