### PR TITLE
chore(docs): update spec registry + close resolved Spec 03 blocker

### DIFF
--- a/docs/registry/specs.md
+++ b/docs/registry/specs.md
@@ -16,23 +16,35 @@ the run log records what shipped.
 
 | # | Slug | Brief | Status | PRs | Notes |
 |---|---|---|---|---|---|
-| 01 | sites-admin-cleanup | `docs/specs/01-sites-admin-cleanup.md` | queued | — | Not yet started |
-| 02 | page-header-typography | `docs/specs/02-page-header-typography.md` | partial | #740 #741 #742 | Optimiser routes deferred — see `_blockers.md` |
-| 03 | blog-styling-calibration | `docs/specs/03-blog-styling-calibration.md` | partial | #735 #736 #739 | Injection inert until `brief-runner.ts:2004` change approved — see `_blockers.md` |
-| 04 | page-header-sweep | — | shipped | #744–#749 | Drained `PAGE_HEADER_DEFERRED_ROUTES` to `[]`; optimiser routes still out of scope |
-| 05 | images-suggest | — | shipped | see run-log | Spec 05 work complete |
-| 06 | platform-keyboard-shortcuts | — | shipped | #755 | |
+| 01 | sites-admin-cleanup | `docs/specs/01-sites-admin-cleanup.md` | shipped | #732 | Rename, Connect link, sort+filter, purge |
+| 02 | page-header-typography | `docs/specs/02-page-header-typography.md` | shipped | #740 #741 #742 #744–#750 | Full sweep including Spec 04 drain; optimiser routes still out of scope (blocked on feat/optimiser merge) |
+| 03 | blog-styling-calibration | `docs/specs/03-blog-styling-calibration.md` | shipped | #735 #736 #739 #785 | Injection activated in brief-runner.ts #785 (2026-05-08) |
+| 04 | page-header-sweep | — | shipped | #744–#750 | Drained `PAGE_HEADER_DEFERRED_ROUTES` to `[]`; optimiser routes deferred pending feat/optimiser merge |
+| 05 | images-suggest | — | shipped | #752 #753 #754 #756 | Picker debounce + vector array fix + bounded fetches + empty state |
+| 06 | platform-keyboard-shortcuts | — | shipped | #755 | usePlatform + Kbd primitive + sweep |
 | 07 | content-preview | — | shipped | #758 #760 | PR A: empty-state fix; PR B: loading-button sweep |
-| 08 | success-moments | `docs/specs/08-success-moments.md` | shipped | #762 | |
+| 08 | success-moments | `docs/specs/08-success-moments.md` | shipped | #762 #774 #776 #782 | Primitives + surface sweep + tier-1 adoption + toast standardisation |
 | 09 | image-filename-alt-text | — | shipped | #757 | SEO-friendly filenames + alt text on WP publish |
-| 15 | platform-status-and-docs-reorg | — | shipped | #759 #761 #763 | PR A: status report; PR B: root cleanup; PR C: this reorg |
+| 10 | composer-sidebar-panel | — | gap | — | Referenced as Spec 11 dependency; resolved in-band without a formal spec |
+| 11 | yoast-seo-panel | — | shipped | #778 | Google preview first, length bars, slug inline |
+| 12 | composer-typography | — | shipped | #779 | 40px title, 18px body, 800px column |
+| 13 | composer-right-column | — | gap | — | Referenced as Spec 12 dependency; resolved in-band without a formal spec |
+| 14 | session-expiry | — | shipped | #763 #772 #773 #775 | Warning modal + grace period + hard-logout + /auth/expired page |
+| 15 | platform-status-and-docs-reorg | — | shipped | #766 | Docs reorganisation into category subdirectories |
+| 16–17 | — | — | gap | — | Reserved |
+| 18 | data-table | — | shipped | #767 #768 #769 #770 | Canonical DataTable primitive + all admin tables migrated |
+| 19–21 | — | — | gap | — | Reserved |
+| 22 | social-composer | — | queued | — | Phase 1 social composer; ADRs 0001–0004 written (Week 0); brief not yet written |
+| 23 | pre-expiry-warnings | — | queued | — | Pre-expiry connection warning banner + notifications; FEATURE_PRE_EXPIRY_WARNINGS gates |
 
 ## Gap note
 
-Spec numbers 10–14 are not yet assigned briefs. They are reserved for future use.
-When a spec brief is written, add a row here and create `docs/specs/NN-slug.md`.
+Spec numbers 10 and 13 were absorbed into adjacent specs without formal briefs.
+Spec numbers 16–17 and 19–21 are reserved for future use.
 
 ## Related files
 
 - `docs/specs/_run-log.md` — autonomous-run session log (what shipped per run)
 - `docs/specs/_blockers.md` — spec blockers and interim deviations
+- `docs/feature-flags.md` — feature flags for social composer workstream
+- `docs/adrs/` — architectural decision records (ADR 0001–0004 for social composer)

--- a/docs/specs/_blockers.md
+++ b/docs/specs/_blockers.md
@@ -140,9 +140,9 @@ Migrated the highest-traffic operator routes:
 Surfaced by the autonomous spec runner. Each entry: which spec/PR, the
 contradiction encountered, and the chosen interim behaviour.
 
-## Spec 03 PR 3 — content_type gating without modifying brief-runner.ts
+## ~~Spec 03 PR 3 — content_type gating without modifying brief-runner.ts~~ (resolved 2026-05-08, PR #785)
 
-**Date:** 2026-05-07
+**Date:** 2026-05-07 — **Resolved:** 2026-05-08
 
 **Spec section in tension:** Spec 03 §3.1 + §3.2.
 
@@ -176,6 +176,8 @@ const designContextPrefix = await buildDesignContextPrefix(
 ```
 
 That single-line change is gated on Steven's explicit approval per ARCH §18.
+
+**Resolution (2026-05-08):** Steven approved on 2026-05-08. PR #785 made the change and merged. `<blog_content_classes>` now emits for `copy_existing` sites with calibrated blog styling when running `content_type='post'` briefs.
 
 **Why this is acceptable interim state:**
 


### PR DESCRIPTION
## Summary

Housekeeping after the 2026-05-08 overnight spec run.

**docs/registry/specs.md** — updated from stale pre-run state to reflect reality:
- Specs 01–03 updated from `queued`/`partial` → `shipped` with correct PR numbers
- Specs 10–18 added (all shipped during the overnight master-brief run)
- Specs 22–23 added as `queued` (social composer + pre-expiry warnings; ADRs written, briefs not yet written)
- Gaps 10/13 noted as resolved in-band without formal specs

**docs/specs/_blockers.md** — marks the Spec 03 PR 3 blocker as resolved: PR #785 threaded `brief.content_type` into `buildDesignContextPrefix`, activating `<blog_content_classes>` emission for `copy_existing` + `content_type='post'` briefs.

No code changes. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)