### PR TITLE
feat(spec14): draft editor consumer wires useAutoSave to autosave endpoint

### DIFF
--- a/components/PostDetailClient.tsx
+++ b/components/PostDetailClient.tsx
@@ -9,6 +9,7 @@ import { toastSuccess } from "@/lib/toast-success";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { LoadingButton } from "@/components/ui/loading-button";
+import { PostDraftEditor } from "@/components/PostDraftEditor";
 import { StatusPill, postStatusKind } from "@/components/ui/status-pill";
 import { SuccessMoment } from "@/components/ui/success-moment";
 import { H1 } from "@/components/ui/typography";
@@ -281,6 +282,15 @@ export function PostDetailClient({
       )}
 
       {errorMessage && <Alert variant="destructive">{errorMessage}</Alert>}
+
+      {post.status === "draft" && (
+        <PostDraftEditor
+          siteId={siteId}
+          postId={post.id}
+          initialTitle={post.title}
+          initialHtml={post.generated_html ?? ""}
+        />
+      )}
 
       <section
         aria-labelledby="preview-heading"

--- a/components/PostDraftEditor.tsx
+++ b/components/PostDraftEditor.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { RichTextEditor } from "@/components/RichTextEditor";
+import { useAutoSave } from "@/lib/hooks/use-auto-save";
+
+// ---------------------------------------------------------------------------
+// PostDraftEditor — Spec 14 PR B follow-up.
+//
+// Inline draft-edit surface mounted by PostDetailClient when the post
+// has status === 'draft'. First real consumer of:
+//   • lib/hooks/use-auto-save.ts (PR B / #772)
+//   • lib/hooks/use-tab-leader.ts (PR B / #772)
+//   • lib/hooks/use-session-grace.ts (PR B / #772)
+//   • POST /api/sites/[id]/posts/[post_id]/autosave (#783)
+//
+// What this surface does:
+//   - Operator edits title + body inline on the post detail page.
+//   - useAutoSave fires server-side flushes on the standard cadence
+//     (60s normal / 30s during warning / 15s during grace; doubled
+//     when document.hidden). Dirty-state guard skips ticks when
+//     nothing has changed; leader election ensures only one tab
+//     flushes per cadence tick.
+//   - Save status is rendered via a tiny "Saved Ns ago" indicator
+//     below the editor.
+//
+// What this surface deliberately does NOT do:
+//   - SEO panel, slug editing, taxonomy, scheduling, featured image —
+//     those live in BlogPostComposer for new posts; surfacing them on
+//     the inline edit flow is a separate UX slice.
+//   - Optimistic concurrency (version_lock CAS) — the autosave route
+//     is last-write-wins by design (Spec 14 PR B). Operators
+//     coordinating across tabs are protected by the leader-election
+//     gate in useAutoSave; the server route refuses autosave on
+//     already-published posts so autosave cannot bypass the
+//     publish/unpublish CAS routes.
+//
+// Failure modes:
+//   - Server returns 404 (post deleted, or someone else published it
+//     while we were editing) → status flips to 'error'; the operator's
+//     local state remains intact and can be copied out manually.
+//   - Server returns 409 UNIQUE_VIOLATION (slug collision) — only
+//     possible if a future revision adds slug editing to this surface.
+//     Today this surface does NOT touch slug.
+// ---------------------------------------------------------------------------
+
+interface Props {
+  siteId: string;
+  postId: string;
+  initialTitle: string;
+  initialHtml: string;
+}
+
+export function PostDraftEditor({
+  siteId,
+  postId,
+  initialTitle,
+  initialHtml,
+}: Props) {
+  const [title, setTitle] = useState(initialTitle);
+  const [html, setHtml] = useState(initialHtml);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  // useAutoSave's getValue runs on every cadence tick, so keep it cheap.
+  const getValue = useCallback(
+    () => ({ title, generated_html: html }),
+    [title, html],
+  );
+
+  const save = useCallback(
+    async (value: { title: string; generated_html: string }) => {
+      const res = await fetch(
+        `/api/sites/${siteId}/posts/${postId}/autosave`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(value),
+        },
+      );
+      if (!res.ok) {
+        const payload = await res.json().catch(() => null);
+        const code =
+          payload && typeof payload === "object" && "error" in payload
+            ? (payload as { error?: { code?: string } }).error?.code
+            : undefined;
+        throw new Error(
+          code ? `Autosave failed: ${code} (HTTP ${res.status})` : `Autosave failed (HTTP ${res.status})`,
+        );
+      }
+    },
+    [siteId, postId],
+  );
+
+  const onError = useCallback((err: Error) => {
+    setServerError(err.message);
+  }, []);
+
+  const onSuccess = useCallback(() => {
+    setServerError(null);
+  }, []);
+
+  const { status, lastSavedAt } = useAutoSave({
+    key: `post-draft:${postId}`,
+    getValue,
+    save,
+    onSuccess,
+    onError,
+  });
+
+  return (
+    <section
+      aria-label="Draft editor"
+      className="space-y-4 rounded-lg border bg-background p-4"
+    >
+      <div>
+        <label htmlFor="draft-title" className="block text-sm font-medium">
+          Title
+        </label>
+        <Input
+          id="draft-title"
+          className="mt-1 text-xl font-semibold"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          maxLength={200}
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium">Body</label>
+        <RichTextEditor
+          value={html}
+          onChange={setHtml}
+          placeholder="Write your post body…"
+          className="mt-1"
+        />
+      </div>
+
+      <SaveStatus
+        status={status}
+        lastSavedAt={lastSavedAt}
+        serverError={serverError}
+      />
+    </section>
+  );
+}
+
+function SaveStatus({
+  status,
+  lastSavedAt,
+  serverError,
+}: {
+  status: ReturnType<typeof useAutoSave>["status"];
+  lastSavedAt: number | null;
+  serverError: string | null;
+}) {
+  if (serverError) {
+    return (
+      <p className="text-xs text-destructive" data-testid="post-autosave-status">
+        {serverError}
+      </p>
+    );
+  }
+  if (status === "saving") {
+    return (
+      <p className="text-xs text-muted-foreground" data-testid="post-autosave-status">
+        Saving…
+      </p>
+    );
+  }
+  if (status === "follower") {
+    return (
+      <p className="text-xs text-muted-foreground" data-testid="post-autosave-status">
+        Another tab is the autosave leader.
+      </p>
+    );
+  }
+  if (status === "saved" && lastSavedAt !== null) {
+    const seconds = Math.max(0, Math.floor((Date.now() - lastSavedAt) / 1000));
+    return (
+      <p className="text-xs text-muted-foreground" data-testid="post-autosave-status">
+        Saved {seconds === 0 ? "just now" : `${seconds}s ago`}
+      </p>
+    );
+  }
+  if (status === "dirty") {
+    return (
+      <p className="text-xs text-muted-foreground" data-testid="post-autosave-status">
+        Unsaved changes…
+      </p>
+    );
+  }
+  return null;
+}


### PR DESCRIPTION
## ⚠️ Spec 14 — please merge by hand

Per the master brief's standing rule, Spec 14 PRs are excluded from auto-merge unless you authorise per-PR. Not arming auto-merge on this one.

## Summary

Closes the auto-save adoption loop. PR #783 shipped the autosave endpoint as infrastructure with no consumer; this PR ships the first real consumer — an inline draft-edit surface on the post detail page that pairs `useAutoSave` (#772) with the autosave endpoint (#783).

## What this PR ships

### `components/PostDraftEditor.tsx` (new)

Client component mounted on the post detail page when `post.status === 'draft'`. Title input + `RichTextEditor` for body.

- `useAutoSave` key: `post-draft:${postId}`
- Cadence escalation per the existing rules: 60s normal → 30s during warning (≤ 120m) → 15s during grace, **doubled when `document.hidden`**
- Status pill below the editor renders one of:
  - `Saving…`
  - `Saved Ns ago`
  - `Unsaved changes…`
  - `Another tab is the autosave leader.`
  - typed error from the route (e.g. 404, slug collision)

### `components/PostDetailClient.tsx` (modified)

Imports + mounts `PostDraftEditor` above the content-preview section, gated on `post.status === 'draft'`. No change to publish / unpublish controls. The preview pane stays for non-draft statuses (iframe surface still serves Path B fragments + Spec 07 PR A wrapping).

## What this PR deliberately does NOT do

- **SEO panel, slug editing, taxonomy, scheduling, featured image** — those live on `BlogPostComposer` (new-post surface). Surfacing them on the inline edit flow is a separate UX slice.
- **Optimistic concurrency (version_lock CAS)** — autosave is last-write-wins by design (PR B). Multi-tab sibling protection comes from `useTabLeader`'s leader gate. The route itself rejects autosave on already-published posts.

## Risks identified and mitigated

- **Multi-tab API hammering** — `useTabLeader` (localStorage heartbeat) guarantees only one tab per origin hits the endpoint per cadence tick; followers report `status: 'follower'`.
- **Failed autosave silently dropped** — server errors flip status to `'error'` and the failure message renders below the editor. Local state is preserved; on next tick `useAutoSave` re-tries.
- **Already-published post mid-edit** — autosave route returns 404 (the `.neq("status", "published")` filter excludes published rows). Caller surfaces the 404 as a typed error; operator's local edits remain in component state for manual recovery.
- **Editor mounting on non-draft posts** — guarded by `post.status === 'draft'`. Published / scheduled / archived posts continue to render the preview pane only.

## Verification

- `npm run typecheck` / `lint` / `build` — green
- `npm run audit:static` — 0 HIGH, 0 MEDIUM (LOWs unchanged at 28)

PR is **independently revertible** (additive surface; gated on `post.status === 'draft'` so existing workflows for published / scheduled posts are untouched).

## Test plan

- [ ] Open a draft post → editor mounts above the preview pane
- [ ] Type into the title → status pill shows "Unsaved changes…" then "Saving…" then "Saved Xs ago"
- [ ] Reload → typed value persists (round-tripped through the autosave route + DB)
- [ ] Two tabs open on the same draft → only one tab fires saves; the other shows "Another tab is the autosave leader."
- [ ] Background a tab → saves continue at half rate (verify via network tab)
- [ ] Published post → editor does NOT mount; preview pane behaves as before
- [ ] Set Supabase JWT expiry to 5m, wait → grace banner appears, autosave cadence drops to 15s, saves still fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)