### PR TITLE
feat(spec22): composer shell + URL wiring + draft persistence layer (PR 1 of 5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,6 +174,11 @@ OPOLLO_BRIEF_BINARY_PARSERS=
 # Returns 409 KADENCE_SYNC_DRIFT_BLOCKED. Unset = gate inactive (safe default).
 FEATURE_PATH_B_PUBLISH_GATE=
 
+# Spec 22 — Universal social post composer (default off; set to "true" to enable).
+# When on: "New post" opens the full-screen PostComposerModal instead of the
+# inline form. Rollout: super_admin → 10% → 50% → 100% per spec §10.
+FEATURE_COMPOSER_V2=
+
 
 # -----------------------------------------------------------------------------
 # Logging + observability (OPTIONAL — degrades gracefully when unset)

--- a/app/api/platform/social/drafts/[id]/route.ts
+++ b/app/api/platform/social/drafts/[id]/route.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getDraft, saveDraft, DraftDataSchema } from "@/lib/platform/social/drafts";
+import { logger } from "@/lib/logger";
+import {
+  forbidden,
+  internalError,
+  notFound,
+  readJsonBody,
+  parseBodyWith,
+  validationError,
+  validateUuidParam,
+  conflict,
+} from "@/lib/http";
+
+// ---------------------------------------------------------------------------
+// GET /api/platform/social/drafts/[id]
+//
+// Loads a draft. Requires "edit_post" permission in the draft's company.
+// Returns the full draft row.
+// ---------------------------------------------------------------------------
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const idCheck = validateUuidParam(id, "id");
+  if (!idCheck.ok) return idCheck.response;
+
+  // Load draft first to get company_id for the gate.
+  // We use service-role here for the load; the gate enforces auth after.
+  const { getServiceRoleClient } = await import("@/lib/supabase");
+  const client = getServiceRoleClient();
+  const { data: row } = await client
+    .from("social_post_drafts")
+    .select("company_id")
+    .eq("id", idCheck.value)
+    .is("archived_at", null)
+    .maybeSingle();
+
+  if (!row) return notFound(`Draft ${id} not found.`);
+
+  const gate = await requireCanDoForApi(row.company_id as string, "edit_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await getDraft({ draftId: idCheck.value, companyId: row.company_id as string });
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") return notFound(result.error.message);
+    return internalError(result.error.message);
+  }
+
+  return NextResponse.json(result);
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/platform/social/drafts/[id]
+//
+// Saves draft content with optimistic CAS check per ADR-0002.
+// Body: { draft_version: number, draft_data: DraftData }
+//
+// Returns:
+//   200  — saved draft with new draft_version
+//   409  — VERSION_CONFLICT — includes current_draft in error.details
+// ---------------------------------------------------------------------------
+
+const SaveBodySchema = z.object({
+  draft_version: z.number().int().positive(),
+  draft_data: DraftDataSchema,
+});
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const idCheck = validateUuidParam(id, "id");
+  if (!idCheck.ok) return idCheck.response;
+
+  const body = await readJsonBody(req);
+  const parsed = parseBodyWith(SaveBodySchema, body);
+  if (!parsed.ok) return parsed.response;
+
+  const { draft_version, draft_data } = parsed.data;
+
+  // Resolve company_id from draft row (service-role peek).
+  const { getServiceRoleClient } = await import("@/lib/supabase");
+  const client = getServiceRoleClient();
+  const { data: row } = await client
+    .from("social_post_drafts")
+    .select("company_id")
+    .eq("id", idCheck.value)
+    .is("archived_at", null)
+    .maybeSingle();
+
+  if (!row) return notFound(`Draft ${id} not found.`);
+
+  const gate = await requireCanDoForApi(row.company_id as string, "edit_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await saveDraft({
+    draftId: idCheck.value,
+    companyId: row.company_id as string,
+    userId: gate.userId,
+    expectedVersion: draft_version,
+    draftData: draft_data,
+  });
+
+  if (!result.ok) {
+    if (result.error.code === "VERSION_CONFLICT") {
+      return conflict("VERSION_CONFLICT", result.error.message, result.error.details);
+    }
+    logger.error("draft_save_failed", {
+      draft_id: id,
+      error_code: result.error.code,
+    });
+    return internalError(result.error.message, result.error.retryable);
+  }
+
+  return NextResponse.json(result);
+}

--- a/app/api/platform/social/drafts/route.ts
+++ b/app/api/platform/social/drafts/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { createDraft } from "@/lib/platform/social/drafts";
+import { logger } from "@/lib/logger";
+import { forbidden, internalError, readJsonBody, validationError } from "@/lib/http";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/social/drafts
+//
+// Creates a new blank social post draft. Requires "create_post" permission.
+// Returns the new draft row with id + draft_version=1.
+//
+// Body: { company_id: string }
+// ---------------------------------------------------------------------------
+
+export async function POST(req: Request): Promise<NextResponse> {
+  const body = await readJsonBody(req);
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    typeof (body as Record<string, unknown>).company_id !== "string"
+  ) {
+    return validationError("company_id is required.");
+  }
+
+  const companyId = (body as Record<string, unknown>).company_id as string;
+
+  const gate = await requireCanDoForApi(companyId, "create_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await createDraft({ companyId, userId: gate.userId });
+  if (!result.ok) {
+    logger.error("draft_create_failed", { company_id: companyId, error: result.error });
+    return internalError(result.error.message, result.error.retryable);
+  }
+
+  return NextResponse.json(result, { status: 201 });
+}

--- a/app/company/social/calendar/page.tsx
+++ b/app/company/social/calendar/page.tsx
@@ -86,6 +86,8 @@ export default async function CompanySocialCalendarPage({ searchParams }: Props)
         }))
       : [];
 
+  const composerEnabled = process.env.FEATURE_COMPOSER_V2 === "true";
+
   return (
     <main className="mx-auto max-w-5xl p-6">
       {entriesResult.ok ? (
@@ -100,6 +102,7 @@ export default async function CompanySocialCalendarPage({ searchParams }: Props)
           monthIso={monthIso}
           connections={connections}
           companyName={companyName}
+          composerEnabled={composerEnabled}
         />
       ) : (
         <div

--- a/app/company/social/layout.tsx
+++ b/app/company/social/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 
 import { NavIcon } from "@/components/ui/nav-icon";
+import { ComposerMount } from "@/components/composer/composer-mount";
 import { getCurrentPlatformSession } from "@/lib/platform/auth";
 
 // /company/social/* — session + company guard.
@@ -10,6 +11,9 @@ import { getCurrentPlatformSession } from "@/lib/platform/auth";
 // This layout enforces that the visitor has a company context. For Opollo
 // staff who haven't yet selected a company via the Social section nav
 // selector, we render an inline prompt rather than redirecting.
+//
+// FEATURE_COMPOSER_V2: when enabled, mounts PostComposerModal here so it
+// is available on every social sub-route via ?compose=new or ?compose=<id>.
 
 export default async function CompanySocialLayout({
   children,
@@ -36,5 +40,17 @@ export default async function CompanySocialLayout({
     redirect("/company");
   }
 
-  return <>{children}</>;
+  const composerEnabled = process.env.FEATURE_COMPOSER_V2 === "true";
+
+  return (
+    <>
+      {children}
+      {composerEnabled && (
+        <ComposerMount
+          companyId={session.company.companyId}
+          userId={session.userId}
+        />
+      )}
+    </>
+  );
 }

--- a/app/company/social/posts/page.tsx
+++ b/app/company/social/posts/page.tsx
@@ -102,6 +102,8 @@ export default async function CompanySocialPostsPage({ searchParams }: Props) {
     );
   }
 
+  const composerEnabled = process.env.FEATURE_COMPOSER_V2 === "true";
+
   return (
     <SocialPostsListClient
       companyId={companyId}
@@ -115,6 +117,7 @@ export default async function CompanySocialPostsPage({ searchParams }: Props) {
       totalCount={postsResult.data.totalCount}
       sortBy={sortBy}
       sortDir={sortDir}
+      composerEnabled={composerEnabled}
     />
   );
 }

--- a/components/SocialCalendarClient.tsx
+++ b/components/SocialCalendarClient.tsx
@@ -42,6 +42,8 @@ type Props = {
   monthIso: string; // "YYYY-MM"
   connections: Connection[];
   companyName: string;
+  /** Spec 22: when true, "New post" opens ?compose=new instead of navigating to /posts */
+  composerEnabled?: boolean;
 };
 
 const MAX_CHIPS = 3;
@@ -255,6 +257,7 @@ export function SocialCalendarClient({
   monthIso,
   connections,
   companyName,
+  composerEnabled = false,
 }: Props) {
   const [hiddenPlatforms, setHiddenPlatforms] = useState<Set<SocialPlatform>>(
     new Set(),
@@ -413,7 +416,7 @@ export function SocialCalendarClient({
 
           {/* New post */}
           <Link
-            href="/company/social/posts"
+            href={composerEnabled ? "?compose=new" : "/company/social/posts"}
             className="inline-flex items-center gap-1.5 rounded-md bg-pk px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-pk/80"
             data-testid="calendar-new-post"
           >

--- a/components/SocialPostsListClient.tsx
+++ b/components/SocialPostsListClient.tsx
@@ -55,6 +55,8 @@ type Props = {
   totalCount?: number;
   sortBy?: SortCol;
   sortDir?: SortDir;
+  /** Spec 22: when true, "New post" opens ?compose=new instead of inline form */
+  composerEnabled?: boolean;
 };
 
 const STATE_PILL: Record<SocialPostState, string> = {
@@ -140,6 +142,7 @@ export function SocialPostsListClient({
   totalCount,
   sortBy: initialSortBy = "state_changed_at",
   sortDir: initialSortDir = "desc",
+  composerEnabled = false,
 }: Props) {
   const router = useRouter();
   const [posts, setPosts] = useState(initialPosts);
@@ -373,12 +376,21 @@ export function SocialPostsListClient({
             >
               Generate with AI
             </Button>
-            <Button
-              data-testid="new-post-button"
-              onClick={() => setShowCreate((v) => !v)}
-            >
-              {showCreate ? "Cancel" : "New post"}
-            </Button>
+            {composerEnabled ? (
+              <Button
+                data-testid="new-post-button"
+                onClick={() => router.push("?compose=new")}
+              >
+                New post
+              </Button>
+            ) : (
+              <Button
+                data-testid="new-post-button"
+                onClick={() => setShowCreate((v) => !v)}
+              >
+                {showCreate ? "Cancel" : "New post"}
+              </Button>
+            )}
           </div>
         ) : null}
       </div>

--- a/components/composer/composer-mount.tsx
+++ b/components/composer/composer-mount.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Suspense, useId } from "react";
+import { useSearchParams } from "next/navigation";
+
+import { PostComposerModal } from "./post-composer-modal";
+
+// ---------------------------------------------------------------------------
+// Spec 22 PR 1 — ComposerMount.
+//
+// Client component mounted in app/company/social/layout.tsx. Reads
+// ?compose= from the URL and renders PostComposerModal when present.
+//
+// FEATURE_COMPOSER_V2 gate is checked server-side in the layout;
+// ComposerMount only renders when the flag is on.
+//
+// Wrapped in Suspense per Next.js App Router requirement for
+// useSearchParams() in non-page client components.
+// ---------------------------------------------------------------------------
+
+interface ComposerMountProps {
+  companyId: string;
+  userId: string;
+}
+
+function ComposerMountInner({ companyId, userId }: ComposerMountProps) {
+  const searchParams = useSearchParams();
+  const compose = searchParams.get("compose");
+  const correlationId = useId().replace(/:/g, "");
+
+  if (!compose) return null;
+
+  const initialDraftId = compose === "new" ? null : compose;
+
+  return (
+    <PostComposerModal
+      companyId={companyId}
+      userId={userId}
+      initialDraftId={initialDraftId}
+      correlationId={correlationId}
+    />
+  );
+}
+
+export function ComposerMount({ companyId, userId }: ComposerMountProps) {
+  return (
+    <Suspense fallback={null}>
+      <ComposerMountInner companyId={companyId} userId={userId} />
+    </Suspense>
+  );
+}

--- a/components/composer/post-composer-modal.tsx
+++ b/components/composer/post-composer-modal.tsx
@@ -1,0 +1,426 @@
+"use client";
+
+import { useCallback, useEffect, useReducer, useRef } from "react";
+import { useRouter } from "next/navigation";
+
+import { NavIcon } from "@/components/ui/nav-icon";
+import { useAutoSave } from "@/lib/hooks/use-auto-save";
+import type { DraftData } from "@/lib/platform/social/drafts";
+import {
+  composerReducer,
+  INITIAL_STATE,
+} from "./use-composer-reducer";
+import type { ComposerError, Draft } from "./use-composer-reducer";
+
+// ---------------------------------------------------------------------------
+// Spec 22 PR 1 — PostComposerModal shell.
+//
+// Full-screen modal overlay. Opens when ?compose=new (creates draft) or
+// ?compose=<uuid> (loads existing draft). Closing removes the search param.
+//
+// PR 1 ships: modal chrome, state machine wiring, autosave. The editor
+// content pane is a placeholder; PR 2 replaces it with real editor
+// components (ProfileSelector, ComposerTextarea, ImageUploadZone, etc.).
+// ---------------------------------------------------------------------------
+
+interface PostComposerModalProps {
+  companyId: string;
+  userId: string;
+  /** null = new draft; string = load existing draft by ID */
+  initialDraftId: string | null;
+  correlationId: string;
+}
+
+const AUTOSAVE_KEY_PREFIX = "composer-draft";
+
+export function PostComposerModal({
+  companyId,
+  userId,
+  initialDraftId,
+  correlationId,
+}: PostComposerModalProps) {
+  const router = useRouter();
+  const [state, dispatch] = useReducer(composerReducer, INITIAL_STATE);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const firstFocusRef = useRef<HTMLButtonElement>(null);
+
+  // Derive current draft for autosave getValue; stable ref so the callback
+  // doesn't trigger hook re-subscriptions on every render.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  // ---------------------------------------------------------------------------
+  // Initialise: create or load draft on mount
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    let cancelled = false;
+    dispatch({ type: "LOAD_START" });
+
+    async function init() {
+      try {
+        const url = initialDraftId
+          ? `/api/platform/social/drafts/${initialDraftId}`
+          : "/api/platform/social/drafts";
+        const response = await fetch(url, {
+          method: initialDraftId ? "GET" : "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-correlation-id": correlationId,
+          },
+          body: initialDraftId
+            ? undefined
+            : JSON.stringify({ company_id: companyId }),
+        });
+
+        if (cancelled) return;
+
+        const result = await response.json();
+        if (!result.ok) {
+          dispatch({
+            type: "SAVE_FAIL",
+            error: { message: result.error?.message ?? "Failed to initialise draft.", code: result.error?.code ?? "INTERNAL_ERROR", correlationId },
+            retryable: result.error?.retryable ?? true,
+          });
+          return;
+        }
+
+        dispatch({
+          type: "LOAD_SUCCESS",
+          draft: {
+            id: result.data.id,
+            draft_version: result.data.draft_version,
+            draft_data: result.data.draft_data,
+          },
+        });
+      } catch (err) {
+        if (cancelled) return;
+        dispatch({
+          type: "SAVE_FAIL",
+          error: { message: err instanceof Error ? err.message : "Network error.", code: "NETWORK_ERROR", correlationId },
+          retryable: true,
+        });
+      }
+    }
+
+    void init();
+    return () => { cancelled = true; };
+    // Intentionally only run on mount — initialDraftId is stable per modal open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Autosave — wired through Spec 14 useAutoSave hook
+  // ---------------------------------------------------------------------------
+
+  const getDraftId = (): string | null => {
+    const s = stateRef.current;
+    if (s.status === "editing" || s.status === "saved") return s.draft.id;
+    if (s.status === "saving") return s.draft.id;
+    return null;
+  };
+
+  const getValue = useCallback((): { version: number; data: DraftData } | null => {
+    const s = stateRef.current;
+    if (s.status === "editing" || s.status === "saved" || s.status === "saving") {
+      return { version: s.draft.draft_version, data: s.draft.draft_data };
+    }
+    return null;
+  }, []);
+
+  const saveDraftToServer = useCallback(
+    async (snapshot: { version: number; data: DraftData } | null) => {
+      if (!snapshot) return;
+      const draftId = getDraftId();
+      if (!draftId) return;
+
+      dispatch({ type: "SAVE_START" });
+
+      const res = await fetch(`/api/platform/social/drafts/${draftId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "x-correlation-id": correlationId,
+        },
+        body: JSON.stringify({
+          draft_version: snapshot.version,
+          draft_data: snapshot.data,
+        }),
+      });
+
+      const result = await res.json();
+
+      if (!result.ok) {
+        if (result.error?.code === "VERSION_CONFLICT") {
+          const current = result.error?.details?.current_draft as Draft | null;
+          if (current) {
+            const stale: Draft = { id: draftId, draft_version: snapshot.version, draft_data: snapshot.data };
+            dispatch({ type: "CONFLICT_DETECTED", staleDraft: stale, freshDraft: current });
+          }
+        }
+        throw new Error(result.error?.message ?? "Save failed.");
+      }
+
+      dispatch({
+        type: "SAVE_SUCCESS",
+        draft: {
+          id: result.data.id,
+          draft_version: result.data.draft_version,
+          draft_data: result.data.draft_data,
+        },
+        savedAt: new Date(),
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [correlationId],
+  );
+
+  const draftId = getDraftId();
+  const { status: saveStatus, flush } = useAutoSave({
+    key: draftId ? `${AUTOSAVE_KEY_PREFIX}:${draftId}` : `${AUTOSAVE_KEY_PREFIX}:init`,
+    getValue,
+    save: saveDraftToServer,
+    enabled: state.status === "editing" && !!draftId,
+  });
+
+  // ---------------------------------------------------------------------------
+  // Close handler — flush pending save, remove search param
+  // ---------------------------------------------------------------------------
+
+  const handleClose = useCallback(async () => {
+    const s = stateRef.current;
+    const dirty = s.status === "editing" && s.draft !== undefined;
+
+    // Best-effort final flush before closing.
+    if (dirty) {
+      try { await flush(); } catch { /* ignore — user chose to close */ }
+    }
+
+    // Remove compose search param without pushing a new history entry.
+    const url = new URL(window.location.href);
+    url.searchParams.delete("compose");
+    url.searchParams.delete("date");
+    router.replace(url.pathname + (url.search || ""), { scroll: false });
+    dispatch({ type: "RESET" });
+  }, [flush, router]);
+
+  // ---------------------------------------------------------------------------
+  // Keyboard: Esc closes, focus trap
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        void handleClose();
+      }
+      // Focus trap: Tab / Shift+Tab cycles within the modal.
+      if (e.key === "Tab" && modalRef.current) {
+        const focusable = Array.from(
+          modalRef.current.querySelectorAll<HTMLElement>(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+          ),
+        ).filter((el) => !el.hasAttribute("disabled"));
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    // Auto-focus the close button on open so screen readers announce the dialog.
+    firstFocusRef.current?.focus();
+
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [handleClose]);
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  const isLoading = state.status === "idle" || state.status === "loading";
+  const isConflict = state.status === "recovering";
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="New post"
+      className="fixed inset-0 z-50 flex items-stretch"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60"
+        aria-hidden="true"
+        onClick={() => void handleClose()}
+      />
+
+      {/* Modal panel */}
+      <div
+        ref={modalRef}
+        className="relative z-10 m-auto flex h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-xl border border-white/10 bg-background shadow-2xl"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
+          <h2 className="text-base font-semibold">
+            {initialDraftId ? "Edit post" : "New post"}
+          </h2>
+          <div className="flex items-center gap-3">
+            {saveStatus === "saving" && (
+              <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                <NavIcon name="sync" size={12} className="animate-spin" />
+                Saving…
+              </span>
+            )}
+            {saveStatus === "saved" && (
+              <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                <NavIcon name="checkmark-circle" size={12} />
+                Saved
+              </span>
+            )}
+            {saveStatus === "error" && (
+              <span className="text-xs text-destructive">Save failed — retrying</span>
+            )}
+            <button
+              ref={firstFocusRef}
+              type="button"
+              onClick={() => void handleClose()}
+              aria-label="Close composer"
+              className="rounded p-1 text-muted-foreground hover:bg-white/10 hover:text-foreground"
+            >
+              <NavIcon name="cross" size={18} />
+            </button>
+          </div>
+        </div>
+
+        {/* Conflict banner */}
+        {isConflict && (
+          <div className="border-b border-amber-500/30 bg-amber-500/10 px-6 py-3 text-sm text-amber-200">
+            <span className="font-medium">Draft updated elsewhere.</span>{" "}
+            <button
+              type="button"
+              onClick={() => dispatch({ type: "CONFLICT_RESOLVED_RELOAD" })}
+              className="underline hover:no-underline"
+            >
+              Reload latest
+            </button>{" "}
+            or continue editing (your changes will overwrite on next save).
+          </div>
+        )}
+
+        {/* Body — split panes */}
+        <div className="flex min-h-0 flex-1">
+          {/* Left pane — editor (60%) */}
+          <div className="flex w-[60%] flex-col overflow-y-auto border-r border-white/10 p-6">
+            {isLoading ? (
+              <div className="flex flex-1 items-center justify-center">
+                <NavIcon name="sync" size={24} className="animate-spin text-muted-foreground" />
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {/* Profile selector placeholder — PR 2 replaces this */}
+                <div
+                  className="flex min-h-[40px] items-center gap-2 rounded-md border border-dashed border-white/20 px-3 py-2 text-sm text-muted-foreground"
+                  aria-label="Profile selector (coming in PR 2)"
+                >
+                  <NavIcon name="users" size={16} />
+                  Select accounts…
+                </div>
+
+                {/* Composer textarea placeholder — PR 2 replaces this */}
+                <div
+                  className="min-h-[120px] rounded-md border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-muted-foreground"
+                  aria-label="Post content (coming in PR 2)"
+                >
+                  Paste a link or type something…
+                </div>
+
+                {/* Image upload zone placeholder */}
+                <div
+                  className="flex items-center justify-center gap-2 rounded-md border border-dashed border-white/20 py-8 text-sm text-muted-foreground"
+                  aria-label="Image upload (coming in PR 2)"
+                >
+                  <NavIcon name="picture" size={20} />
+                  Add an image
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Right pane — preview (40%) */}
+          <div className="flex w-[40%] flex-col overflow-y-auto p-6">
+            {/* Preview tab strip */}
+            <div role="tablist" className="mb-4 flex gap-3 border-b border-white/10 pb-3">
+              <button
+                type="button"
+                role="tab"
+                className="pb-2 text-sm font-medium text-foreground border-b-2 border-pk"
+                aria-selected="true"
+              >
+                Post preview
+              </button>
+              <button
+                type="button"
+                role="tab"
+                className="pb-2 text-sm text-muted-foreground hover:text-foreground"
+                aria-selected="false"
+              >
+                Calendar
+              </button>
+            </div>
+
+            {/* Preview empty state — PR 3 replaces this */}
+            <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground">
+              <NavIcon name="picture" size={32} className="opacity-30" />
+              <p>Select at least one profile and start typing to see preview</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between border-t border-white/10 px-6 py-4">
+          {/* Mode tabs */}
+          <div className="flex gap-1 rounded-md border border-white/10 p-0.5 text-xs">
+            {(["Post now", "Schedule", "Save as draft"] as const).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                className="rounded px-3 py-1.5 text-muted-foreground hover:bg-white/10 hover:text-foreground first:bg-white/10 first:text-foreground"
+                disabled={isLoading}
+              >
+                {mode}
+              </button>
+            ))}
+            <button
+              type="button"
+              className="rounded px-3 py-1.5 text-muted-foreground/40"
+              disabled
+              title="Coming soon"
+            >
+              Publish regularly
+            </button>
+          </div>
+
+          {/* Primary action */}
+          <button
+            type="button"
+            disabled={isLoading || state.status === "saving"}
+            className="rounded-md bg-pk px-4 py-2 text-sm font-medium text-white hover:bg-pk/80 disabled:opacity-50"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/composer/use-composer-reducer.ts
+++ b/components/composer/use-composer-reducer.ts
@@ -1,0 +1,141 @@
+// Spec 22 PR 1 — composer state machine per ADR-0001.
+//
+// Named state machine via useReducer. No scattered booleans.
+// PR 1 activates: idle → loading → editing → saving → saved.
+// PR 2+ activates: publishing, published, failed, recovering.
+
+import type { DraftData } from "@/lib/platform/social/drafts";
+
+// ---------------------------------------------------------------------------
+// State types
+// ---------------------------------------------------------------------------
+
+export type Draft = {
+  id: string;
+  draft_version: number;
+  draft_data: DraftData;
+};
+
+export type ComposerError = {
+  message: string;
+  code: string;
+  correlationId?: string;
+};
+
+export type ComposerState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "editing"; draft: Draft; dirty: boolean }
+  | { status: "saving"; draft: Draft }
+  | { status: "saved"; draft: Draft; savedAt: Date }
+  | { status: "publishing"; draft: Draft }
+  | { status: "published"; postId: string }
+  | { status: "failed"; draft: Draft; error: ComposerError; retryable: boolean }
+  | { status: "recovering"; staleDraft: Draft; freshDraft: Draft };
+
+// ---------------------------------------------------------------------------
+// Action types
+// ---------------------------------------------------------------------------
+
+export type ComposerAction =
+  | { type: "LOAD_START" }
+  | { type: "LOAD_SUCCESS"; draft: Draft }
+  | { type: "UPDATE_DRAFT"; patch: Partial<DraftData> }
+  | { type: "SAVE_START" }
+  | { type: "SAVE_SUCCESS"; draft: Draft; savedAt: Date }
+  | { type: "SAVE_FAIL"; error: ComposerError; retryable: boolean }
+  | { type: "PUBLISH_START" }
+  | { type: "PUBLISH_SUCCESS"; postId: string }
+  | { type: "PUBLISH_FAIL"; error: ComposerError; retryable: boolean }
+  | { type: "CONFLICT_DETECTED"; staleDraft: Draft; freshDraft: Draft }
+  | { type: "CONFLICT_RESOLVED_RELOAD" }
+  | { type: "RESET" };
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+export const INITIAL_STATE: ComposerState = { status: "idle" };
+
+export function composerReducer(
+  state: ComposerState,
+  action: ComposerAction,
+): ComposerState {
+  switch (action.type) {
+    case "LOAD_START":
+      return { status: "loading" };
+
+    case "LOAD_SUCCESS":
+      return { status: "editing", draft: action.draft, dirty: false };
+
+    case "UPDATE_DRAFT": {
+      if (state.status !== "editing" && state.status !== "saved") return state;
+      const draft: Draft =
+        state.status === "saved"
+          ? state.draft
+          : state.draft;
+      return {
+        status: "editing",
+        draft: {
+          ...draft,
+          draft_data: { ...draft.draft_data, ...action.patch },
+        },
+        dirty: true,
+      };
+    }
+
+    case "SAVE_START": {
+      if (state.status !== "editing" && state.status !== "saved") return state;
+      return { status: "saving", draft: state.draft };
+    }
+
+    case "SAVE_SUCCESS":
+      return { status: "saved", draft: action.draft, savedAt: action.savedAt };
+
+    case "SAVE_FAIL": {
+      if (state.status !== "saving") return state;
+      return {
+        status: "failed",
+        draft: state.draft,
+        error: action.error,
+        retryable: action.retryable,
+      };
+    }
+
+    case "PUBLISH_START": {
+      if (state.status !== "editing" && state.status !== "saved") return state;
+      return { status: "publishing", draft: state.draft };
+    }
+
+    case "PUBLISH_SUCCESS":
+      return { status: "published", postId: action.postId };
+
+    case "PUBLISH_FAIL": {
+      if (state.status !== "publishing") return state;
+      return {
+        status: "failed",
+        draft: state.draft,
+        error: action.error,
+        retryable: action.retryable,
+      };
+    }
+
+    case "CONFLICT_DETECTED":
+      return {
+        status: "recovering",
+        staleDraft: action.staleDraft,
+        freshDraft: action.freshDraft,
+      };
+
+    case "CONFLICT_RESOLVED_RELOAD": {
+      if (state.status !== "recovering") return state;
+      return { status: "editing", draft: state.freshDraft, dirty: false };
+    }
+
+    case "RESET":
+      return { status: "idle" };
+
+    default:
+      return state;
+  }
+}

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -6,6 +6,27 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 
 <!-- CLAIM BLOCKS BELOW THIS LINE — append on slice start, remove on slice merge -->
 
+---
+## Session A
+- Started: 2026-05-08 06:00 UTC
+- Branch: feat/spec22-pr1-composer-shell
+- Slice: Spec 22 PR 1 — composer shell + URL wiring + draft persistence layer
+- Files claimed:
+  - supabase/migrations/0112_social_post_drafts.sql
+  - lib/platform/social/drafts.ts
+  - components/composer/use-composer-reducer.ts
+  - components/composer/post-composer-modal.tsx
+  - components/composer/composer-mount.tsx
+  - app/api/platform/social/drafts/route.ts
+  - app/api/platform/social/drafts/[id]/route.ts
+  - app/company/social/layout.tsx
+  - components/SocialCalendarClient.tsx (New post button only)
+  - components/SocialPostsListClient.tsx (New post button only)
+  - lib/tool-schemas.ts (DRAFT_CONFLICT code addition)
+- Migration number reserved: 0112
+- Expected completion: same session
+---
+
 ## Hot-shared files (always check before claiming)
 
 Even with no other session active, assume these files are "hot" and coordinate explicitly if touching them while another session is in flight:
@@ -43,6 +64,7 @@ When a session starts a migration, reserve the number here before writing the fi
 - ~~0071 — S1-5 submit_post_for_approval transactional function.~~ Shipped in #412.
 - ~~0072 — S1-7 record_approval_decision transactional function.~~ Shipped in #415.
 - ~~0073 — S1-10 cancel_post_approval transactional function.~~ Shipped (0073_cancel_post_approval_fn.sql in main).
+- 0112 — Session A — Spec 22 PR 1 social_post_drafts table (branch: feat/spec22-pr1-composer-shell)
 
 ## Claim block template
 

--- a/lib/platform/social/drafts.ts
+++ b/lib/platform/social/drafts.ts
@@ -1,0 +1,221 @@
+import { z } from "zod";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// Spec 22 PR 1 — draft types + DB helpers for social_post_drafts.
+//
+// DraftData is the content layer stored in draft_data JSONB. The top-level
+// Draft type adds identity + concurrency metadata (id, company_id, version).
+// ---------------------------------------------------------------------------
+
+export const MediaRefSchema = z.object({
+  type: z.enum(["upload", "ai_generated", "istock"]),
+  url: z.string().url(),
+  cloudflare_id: z.string().optional(),
+  alt_text: z.string().optional(),
+  width: z.number().int().positive().optional(),
+  height: z.number().int().positive().optional(),
+  source_metadata: z.record(z.string(), z.unknown()).optional(),
+});
+export type MediaRef = z.infer<typeof MediaRefSchema>;
+
+export const DraftDataSchema = z.object({
+  master_text: z.string().default(""),
+  link_url: z.string().url().optional().nullable(),
+  media_refs: z.array(MediaRefSchema).default([]),
+  target_connection_ids: z.array(z.string().uuid()).default([]),
+  schedule: z
+    .object({
+      date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      times: z.array(z.string().regex(/^\d{2}:\d{2}$/)),
+    })
+    .optional()
+    .nullable(),
+  approval_required: z.boolean().default(false),
+  ai_metadata: z
+    .object({
+      prompt: z.string(),
+      tone: z.string(),
+      generated_at: z.string(),
+    })
+    .optional()
+    .nullable(),
+});
+export type DraftData = z.infer<typeof DraftDataSchema>;
+
+export type Draft = {
+  id: string;
+  company_id: string;
+  created_by: string;
+  updated_by: string;
+  draft_version: number;
+  draft_data: DraftData;
+  created_at: string;
+  updated_at: string;
+  archived_at: string | null;
+};
+
+// ---------------------------------------------------------------------------
+// createDraft — inserts a new row and returns the full draft.
+// ---------------------------------------------------------------------------
+
+export async function createDraft(params: {
+  companyId: string;
+  userId: string;
+}): Promise<ApiResponse<Draft>> {
+  const client = getServiceRoleClient();
+
+  const { data, error } = await client
+    .from("social_post_drafts")
+    .insert({
+      company_id: params.companyId,
+      created_by: params.userId,
+      updated_by: params.userId,
+      draft_version: 1,
+      draft_data: DraftDataSchema.parse({}),
+    })
+    .select()
+    .single();
+
+  if (error || !data) {
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: error?.message ?? "Failed to create draft.",
+        retryable: true,
+        suggested_action: "Try again.",
+      },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  return {
+    ok: true,
+    data: data as unknown as Draft,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getDraft — loads a draft by ID. Returns NOT_FOUND if no row.
+// ---------------------------------------------------------------------------
+
+export async function getDraft(params: {
+  draftId: string;
+  companyId: string;
+}): Promise<ApiResponse<Draft>> {
+  const client = getServiceRoleClient();
+
+  const { data, error } = await client
+    .from("social_post_drafts")
+    .select()
+    .eq("id", params.draftId)
+    .eq("company_id", params.companyId)
+    .is("archived_at", null)
+    .maybeSingle();
+
+  if (error) {
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: error.message,
+        retryable: true,
+        suggested_action: "Try again.",
+      },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  if (!data) {
+    return {
+      ok: false,
+      error: {
+        code: "NOT_FOUND",
+        message: `Draft ${params.draftId} not found.`,
+        retryable: false,
+        suggested_action: "The draft may have been published or deleted.",
+      },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  return {
+    ok: true,
+    data: data as unknown as Draft,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// saveDraft — optimistic CAS UPDATE per ADR-0002.
+//
+// Returns VERSION_CONFLICT (409) with `currentDraft` details when the
+// expected_version doesn't match the server row. The client shows a
+// "Reload latest?" prompt instead of silently overwriting.
+// ---------------------------------------------------------------------------
+
+export async function saveDraft(params: {
+  draftId: string;
+  companyId: string;
+  userId: string;
+  expectedVersion: number;
+  draftData: DraftData;
+}): Promise<ApiResponse<Draft>> {
+  const client = getServiceRoleClient();
+
+  const { data, error } = await client
+    .from("social_post_drafts")
+    .update({
+      updated_by: params.userId,
+      draft_version: params.expectedVersion + 1,
+      draft_data: params.draftData,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", params.draftId)
+    .eq("company_id", params.companyId)
+    .eq("draft_version", params.expectedVersion)
+    .is("archived_at", null)
+    .select()
+    .maybeSingle();
+
+  if (error) {
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: error.message,
+        retryable: true,
+        suggested_action: "Try again.",
+      },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  if (!data) {
+    // CAS miss — fetch current row for the conflict prompt.
+    const current = await getDraft({ draftId: params.draftId, companyId: params.companyId });
+    return {
+      ok: false,
+      error: {
+        code: "VERSION_CONFLICT",
+        message: "Draft was modified by another tab or user.",
+        details: {
+          current_draft: current.ok ? current.data : null,
+        },
+        retryable: false,
+        suggested_action: "Reload the latest draft and re-apply your changes.",
+      },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  return {
+    ok: true,
+    data: data as unknown as Draft,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/supabase/migrations/0112_social_post_drafts.sql
+++ b/supabase/migrations/0112_social_post_drafts.sql
@@ -1,0 +1,63 @@
+-- Spec 22 PR 1 — universal social composer draft persistence layer.
+--
+-- Design decisions:
+--   1. draft_version INT enables optimistic concurrency per ADR-0002: the
+--      save endpoint does a CAS UPDATE (WHERE id=$id AND draft_version=$v)
+--      and returns 409 VERSION_CONFLICT when 0 rows affected so the UI can
+--      show "Reload latest?" rather than silently losing a concurrent save.
+--   2. draft_data JSONB stores the full Draft payload (master_text, media_refs,
+--      target_connection_ids, schedule, approval_required, ai_metadata).
+--      Keeping it as JSONB defers schema evolution to app logic; individual
+--      fields don't need columns until query/index pressure demands it.
+--   3. archived_at enables soft-delete. Hard deletes occur on publish (draft
+--      row removed) and on company cascade-delete (ON DELETE CASCADE).
+--   4. RLS gates on platform_company_users so only editors/approvers/admins
+--      of the owning company can read or write their own drafts.
+--   5. service_role bypasses RLS for the create/save API routes.
+
+CREATE TABLE social_post_drafts (
+  id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id        UUID        NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  created_by        UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  updated_by        UUID        NOT NULL REFERENCES auth.users(id),
+  draft_version     INT         NOT NULL DEFAULT 1,
+  draft_data        JSONB       NOT NULL DEFAULT '{}',
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  archived_at       TIMESTAMPTZ NULL
+);
+
+-- Fast lookup of active drafts for a company (list + conflict-check on open).
+CREATE INDEX idx_social_post_drafts_company
+  ON social_post_drafts (company_id, archived_at)
+  WHERE archived_at IS NULL;
+
+-- Feed for "my drafts" view scoped by author.
+CREATE INDEX idx_social_post_drafts_created_by
+  ON social_post_drafts (created_by, updated_at DESC)
+  WHERE archived_at IS NULL;
+
+-- General-purpose recency ordering used by admin list + draft-recovery.
+CREATE INDEX idx_social_post_drafts_updated
+  ON social_post_drafts (updated_at DESC);
+
+-- RLS: allow all platform company editors/approvers/admins to read and
+-- write their own company's drafts. Service-role callers bypass this.
+ALTER TABLE social_post_drafts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY social_post_drafts_company_editors
+  ON social_post_drafts FOR ALL
+  USING (
+    company_id IN (
+      SELECT company_id FROM platform_company_users
+      WHERE user_id = auth.uid()
+        AND role IN ('editor', 'approver', 'admin', 'super_admin')
+    )
+  )
+  WITH CHECK (
+    company_id IN (
+      SELECT company_id FROM platform_company_users
+      WHERE user_id = auth.uid()
+        AND role IN ('editor', 'approver', 'admin', 'super_admin')
+    )
+  );


### PR DESCRIPTION
## Spec 22 PR 1 — Composer shell + URL wiring + draft persistence

Delivers the load-bearing infrastructure for the universal social post composer.
PRs 2–5 stack on top of this. Feature is fully gated behind `FEATURE_COMPOSER_V2`
(default off); the old inline form is unchanged until the flag is on.

## What ships

### Migration 0112 — `social_post_drafts` table
- `draft_version INT` for optimistic CAS per ADR-0002: saves do `WHERE draft_version=$v`, return `409 VERSION_CONFLICT` on miss
- `draft_data JSONB` stores `master_text`, `media_refs`, `target_connection_ids`, `schedule`, `approval_required`, `ai_metadata`
- RLS: platform_company_users with `editor | approver | admin` can read/write their company's drafts
- Indexes: company+archived_at (active draft list), created_by+updated_at (my drafts), updated_at DESC (recency)

### State machine (`components/composer/use-composer-reducer.ts`)
- `useReducer` with discriminated union per ADR-0001 — no scattered booleans
- States: `idle | loading | editing | saving | saved | publishing | published | failed | recovering`
- PR 1 wires: `idle → loading → editing → saving → saved` transitions

### `PostComposerModal` (`components/composer/`)
- Full-screen overlay (90vh, max-w-5xl, 60/40 left/right panes)
- Opens on `?compose=new` (creates draft) or `?compose=<uuid>` (loads existing)
- Esc + × close with best-effort final flush; focus trap (Tab/Shift+Tab)
- `ComposerMount` client component in social layout reads `useSearchParams` (Suspense-wrapped)
- Autosave via Spec 14 `useAutoSave` — dirty guard + tab leader election + visibility-aware cadence
- `VERSION_CONFLICT` 409 shows amber "Reload latest" banner (state: `recovering`)
- Left pane: placeholder profile selector, textarea, image zone (PR 2 wires real components)
- Right pane: placeholder preview (PR 3 wires per-platform cards)
- Footer: mode tabs (Post now / Schedule / Save as draft / Publish regularly [disabled])

### API routes
| Route | Method | Purpose |
|---|---|---|
| `/api/platform/social/drafts` | POST | Create blank draft; returns `id + draft_version=1` |
| `/api/platform/social/drafts/[id]` | GET | Load draft; gates on `edit_post` permission |
| `/api/platform/social/drafts/[id]` | PATCH | CAS save; 409 `VERSION_CONFLICT` includes `current_draft` in `error.details` |

### Trigger surface wiring
- `SocialCalendarClient`: `New post` → `?compose=new` when `composerEnabled`, else `/posts`
- `SocialPostsListClient`: `New post` → `router.push("?compose=new")` when `composerEnabled`, else existing inline form toggle
- Both server pages pass `composerEnabled = process.env.FEATURE_COMPOSER_V2 === "true"`
- `app/company/social/layout.tsx` mounts `<ComposerMount>` when `FEATURE_COMPOSER_V2=true`

### Feature flag
- `FEATURE_COMPOSER_V2` (default off). Added to `.env.example`.
- Kill switch: set to false → old SocialPostsListClient inline form, zero data loss.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Draft version conflict (concurrent tabs) | CAS `WHERE draft_version=$v` → 409 with current row; UI shows "Reload latest?" per ADR-0002 |
| Multi-tab double-save | `useTabLeader` from Spec 14 ensures only leader saves |
| `node:async_hooks` leak into client bundle | `lib/logger` removed from client component; server-side logging lives in API routes |
| `FEATURE_COMPOSER_V2` off: regression risk | Old form path is untouched; `composerEnabled=false` preserves existing behavior exactly |
| Migration 0112 on empty table | Additive; no constraint on existing tables beyond the FK to `platform_companies` |

## Visual checkpoint (Steven)
Enable `FEATURE_COMPOSER_V2=true` in Vercel env.
1. Go to `/company/social/calendar` → click **New post**
2. Modal opens (60/40 split, spinner then placeholder panes)
3. URL shows `?compose=new`
4. Wait ~60s → "Saved" indicator appears in modal header
5. Press Esc → URL param clears, modal closes
6. Verify row in `social_post_drafts` with `draft_version=1`

**Do not auto-merge — waiting for visual checkpoint per spec §13.**

## Reversible?
Yes. Set `FEATURE_COMPOSER_V2=false` → old form. Migration 0112 is additive (new table).

## Next: PR 2 (`feat/spec22-pr2-core-editor`)
ProfileSelector, ComposerTextarea, ImageUploadZone (AI / iStock / upload), ToolsRow, SchedulingTabs, post submit wiring.