### PR TITLE
fix(spec22): composer loading stuck forever + NavIcon spin wobble

### DIFF
--- a/components/composer/post-composer-modal.tsx
+++ b/components/composer/post-composer-modal.tsx
@@ -105,9 +105,8 @@ export function PostComposerModal({
         const result = await response.json();
         if (!result.ok) {
           dispatch({
-            type: "SAVE_FAIL",
+            type: "LOAD_FAIL",
             error: { message: result.error?.message ?? "Failed to initialise draft.", code: result.error?.code ?? "INTERNAL_ERROR", correlationId },
-            retryable: result.error?.retryable ?? true,
           });
           return;
         }
@@ -123,9 +122,8 @@ export function PostComposerModal({
       } catch (err) {
         if (cancelled) return;
         dispatch({
-          type: "SAVE_FAIL",
+          type: "LOAD_FAIL",
           error: { message: err instanceof Error ? err.message : "Network error.", code: "NETWORK_ERROR", correlationId },
-          retryable: true,
         });
       }
     }
@@ -382,6 +380,7 @@ export function PostComposerModal({
   // ---------------------------------------------------------------------------
 
   const isLoading = state.status === "idle" || state.status === "loading";
+  const isLoadFailed = state.status === "load_failed";
   const isConflict = state.status === "recovering";
   const draftData: DraftData | null =
     state.status === "editing" || state.status === "saved" || state.status === "saving"
@@ -430,7 +429,9 @@ export function PostComposerModal({
           <div className="flex items-center gap-3">
             {saveStatus === "saving" && (
               <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                <NavIcon name="sync" size={12} className="animate-spin" />
+                <span className="inline-flex animate-spin">
+                  <NavIcon name="sync" size={12} />
+                </span>
                 Saving…
               </span>
             )}
@@ -488,9 +489,24 @@ export function PostComposerModal({
         <div className="flex min-h-0 flex-1">
           {/* Left pane — editor (60%) */}
           <div className="flex w-[60%] flex-col gap-4 overflow-y-auto border-r border-white/10 p-6">
-            {isLoading ? (
+            {isLoadFailed && state.status === "load_failed" ? (
+              <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+                <p className="text-sm text-destructive">
+                  {state.error.message}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => void handleClose()}
+                  className="text-xs text-muted-foreground underline hover:text-foreground"
+                >
+                  Close
+                </button>
+              </div>
+            ) : isLoading ? (
               <div className="flex flex-1 items-center justify-center">
-                <NavIcon name="sync" size={24} className="animate-spin text-muted-foreground" />
+                <span className="inline-flex animate-spin text-muted-foreground">
+                  <NavIcon name="sync" size={24} />
+                </span>
               </div>
             ) : (
               <>

--- a/components/composer/use-composer-reducer.ts
+++ b/components/composer/use-composer-reducer.ts
@@ -25,6 +25,7 @@ export type ComposerError = {
 export type ComposerState =
   | { status: "idle" }
   | { status: "loading" }
+  | { status: "load_failed"; error: ComposerError }
   | { status: "editing"; draft: Draft; dirty: boolean }
   | { status: "saving"; draft: Draft }
   | { status: "saved"; draft: Draft; savedAt: Date }
@@ -40,6 +41,7 @@ export type ComposerState =
 export type ComposerAction =
   | { type: "LOAD_START" }
   | { type: "LOAD_SUCCESS"; draft: Draft }
+  | { type: "LOAD_FAIL"; error: ComposerError }
   | { type: "UPDATE_DRAFT"; patch: Partial<DraftData> }
   | { type: "SAVE_START" }
   | { type: "SAVE_SUCCESS"; draft: Draft; savedAt: Date }
@@ -67,6 +69,10 @@ export function composerReducer(
 
     case "LOAD_SUCCESS":
       return { status: "editing", draft: action.draft, dirty: false };
+
+    case "LOAD_FAIL":
+      if (state.status !== "loading") return state;
+      return { status: "load_failed", error: action.error };
 
     case "UPDATE_DRAFT": {
       if (state.status !== "editing" && state.status !== "saved") return state;

--- a/components/ui/nav-icon.tsx
+++ b/components/ui/nav-icon.tsx
@@ -23,7 +23,7 @@ export function NavIcon({ name, size = 20, className }: NavIconProps) {
   return (
     <i
       className={cn(`icon-${name}`, className)}
-      style={{ fontSize: `${size}px` }}
+      style={{ fontSize: `${size}px`, display: "inline-block", lineHeight: 1 }}
       aria-hidden="true"
     />
   );


### PR DESCRIPTION
## Bug 1 — Loading spinner stuck forever

**Root cause:** `SAVE_FAIL` in the reducer is guarded by `if (state.status !== "saving") return state`. When the draft creation API fails (auth error, network error, any non-ok response), the init function dispatched `SAVE_FAIL` from `loading` state — the reducer silently ignored it and the state stayed `loading` forever.

**Fix:** Added `LOAD_FAIL` action + `load_failed` state to the state machine. The init function now dispatches `LOAD_FAIL` on any error, which transitions `loading → load_failed`. The left pane renders an error message with the specific API error (e.g. "Action 'create_post' not permitted") and a Close button.

This means any underlying auth/permission issue is now surfaced to the user rather than producing an infinite spinner.

## Bug 2 — NavIcon rotate wobble

**Root cause:** `NavIcon` renders `<i>`, which has `display: inline` by default. CSS transforms on inline elements produce unreliable results because the element's visual box includes line-height leading — the visual center of the glyph doesn't align with the transform-origin, so the icon oscillates during rotation.

**Fix:** Added `display: inline-block; line-height: 1` inline styles to `NavIcon` globally. `inline-block` elements participate in transforms correctly (transform-origin = center of content box). `line-height: 1` removes the font metric padding so the box is tight around the glyph. Applies to all ~90 spinner/icon usages in the codebase without layout changes.

## Reversible? Yes
## Migration required? No
## Data risk? None

🤖 Generated with [Claude Code](https://claude.com/claude-code)