### PR TITLE
feat(ui-consistency): visual regression infrastructure (slice 1)

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,23 +1,24 @@
 name: Screenshots
 
-# Polish workstream visual-regression harness. Captures every admin
-# surface at desktop 1440×900 + mobile 380×844 against an ephemeral
-# local Supabase, uploads the playwright-screenshots/ folder as a
-# downloadable artifact.
+# Visual-regression harness — baseline capture + diff gating.
 #
-# Per the world-class polish brief (PR #229) the per-screen Phase B
-# PRs and the R-0 operator-review report each need before/after PNGs.
-# This workflow makes them downloadable from every PR's CI run.
+# Two modes:
+#   compare  — PR branches. Compares against committed baselines in
+#              e2e/__screenshots__/. Fails the job if any baseline
+#              diverges beyond the maxDiffPixelRatio threshold, blocking
+#              merge of unintended visual regressions.
+#   baseline — First run (no committed baselines) OR manual trigger with
+#              UPDATE_SNAPSHOTS=true. Generates fresh baselines and
+#              uploads them as a downloadable artifact. Commit the
+#              artifact contents to e2e/__screenshots__/ to activate
+#              the comparison gate on future PRs.
 #
 # Triggered:
-#   • pull_request — every Phase B / Phase C PR gets fresh screenshots
-#     for visual review.
-#   • workflow_dispatch — Steven can fire it manually against any
-#     branch (e.g. for the R-0 report PR).
-#   • push to main — captures the post-merge baseline; the artifact on
-#     the latest main run is the reference state.
+#   • pull_request — comparison mode on every PR.
+#   • push to main — baseline mode; refreshes post-merge reference.
+#   • workflow_dispatch — set UPDATE_SNAPSHOTS=true for manual regen.
 #
-# Skipped on forked-repo PRs (same as e2e.yml — secrets would leak).
+# Skipped on forked-repo PRs (secrets would leak).
 
 on:
   pull_request:
@@ -25,6 +26,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      update_snapshots:
+        description: "Regenerate baselines (UPDATE_SNAPSHOTS=true)"
+        required: false
+        default: "false"
 
 concurrency:
   group: screenshots-${{ github.ref }}
@@ -34,10 +40,8 @@ jobs:
   screenshots:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
-      # Same setup as e2e.yml — admin gate ON exercises the real auth
-      # flow; deterministic master key for ephemeral encryption.
       FEATURE_SUPABASE_AUTH: "true"
       OPOLLO_MASTER_KEY: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
     steps:
@@ -84,20 +88,63 @@ jobs:
           echo "SUPABASE_ANON_KEY=$ANON" >> "$GITHUB_ENV"
           echo "SUPABASE_DB_URL=$DB" >> "$GITHUB_ENV"
 
-      - name: Capture screenshots
-        run: npm run screenshots
+      # Detect run mode:
+      #   baseline — no committed snapshots OR explicit override.
+      #   compare  — committed snapshots present; gate on regressions.
+      - name: Detect run mode
+        id: mode
+        run: |
+          SNAP_DIR="e2e/__screenshots__"
+          FORCE_UPDATE="${{ github.event_name == 'push' && 'true' || github.event.inputs.update_snapshots || 'false' }}"
+          if [ "$FORCE_UPDATE" = "true" ] || [ ! -d "$SNAP_DIR" ] || [ -z "$(ls -A "$SNAP_DIR" 2>/dev/null)" ]; then
+            echo "mode=baseline" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=compare" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Detected mode: $(cat $GITHUB_OUTPUT | grep mode | cut -d= -f2)"
 
-      - name: Upload screenshot artifact
+      # Comparison mode — gates on visual regressions.
+      - name: Capture + compare screenshots
+        if: steps.mode.outputs.mode == 'compare'
+        run: npm run screenshots
+        env:
+          RUN_SCREENSHOTS: "1"
+
+      # Baseline mode — generates fresh snapshots for commit.
+      - name: Generate baseline screenshots
+        if: steps.mode.outputs.mode == 'baseline'
+        run: npm run screenshots:baseline
+        env:
+          RUN_SCREENSHOTS: "1"
+
+      - name: Upload screenshot artifacts (PR review)
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: playwright-screenshots-${{ github.event.pull_request.number || github.sha }}
           path: playwright-screenshots
           retention-days: 30
-          # if-no-files-found: warn rather than error — a partially
-          # broken capture run still gives reviewers something to look
-          # at while we triage the failure.
           if-no-files-found: warn
+
+      # Upload new baselines when generated — download, commit to
+      # e2e/__screenshots__/ to activate the comparison gate on PRs.
+      - name: Upload baseline snapshots
+        if: steps.mode.outputs.mode == 'baseline'
+        uses: actions/upload-artifact@v7
+        with:
+          name: visual-regression-baselines-${{ github.sha }}
+          path: e2e/__screenshots__
+          retention-days: 90
+          if-no-files-found: warn
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-screenshots-${{ github.event.pull_request.number || github.sha }}
+          path: playwright-report
+          retention-days: 14
+          if-no-files-found: ignore
 
       - name: Stop Supabase
         if: always()

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -8,25 +8,14 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 
 ---
 ## Session A
-- Started: 2026-05-08 07:30 UTC
-- Branch: feat/spec22-pr2-core-editor
-- Slice: Spec 22 PR 2 — core editor (ProfileSelector, ComposerTextarea, ImageUploadZone, ToolsRow, SchedulingTabs, submit wiring)
+- Started: 2026-05-08 UTC
+- Branch: feat/ui-consistency-s1-visual-regression
+- Slice: UI Consistency S1 — Playwright visual regression infrastructure (screenshots.spec.ts, playwright.config.ts, screenshots.yml, package.json)
 - Files claimed:
-  - components/composer/profile-selector.tsx
-  - components/composer/composer-textarea.tsx
-  - components/composer/image-upload-zone.tsx
-  - components/composer/tools-row.tsx
-  - components/composer/scheduling-tabs.tsx
-  - components/composer/approval-toggle.tsx
-  - components/composer/composer-actions.tsx
-  - components/composer/post-composer-modal.tsx (left-pane wiring only)
-  - app/api/platform/social/drafts/[id]/publish/route.ts
-  - app/api/platform/social/media/upload/route.ts
-  - app/api/platform/social/cap/generate-image/route.ts
-  - supabase/migrations/0113_social_media_uploads_bucket.sql
-- Migration number reserved: 0113
-- Expected completion: same session
-- Migration number reserved: 0112
+  - e2e/screenshots.spec.ts
+  - playwright.config.ts
+  - .github/workflows/screenshots.yml
+  - package.json
 - Expected completion: same session
 ---
 
@@ -68,7 +57,7 @@ When a session starts a migration, reserve the number here before writing the fi
 - ~~0072 — S1-7 record_approval_decision transactional function.~~ Shipped in #415.
 - ~~0073 — S1-10 cancel_post_approval transactional function.~~ Shipped (0073_cancel_post_approval_fn.sql in main).
 - ~~0112 — Session A — Spec 22 PR 1 social_post_drafts table (branch: feat/spec22-pr1-composer-shell).~~ Shipped in #789.
-- 0113 — Session A — Spec 22 PR 2 social-media-uploads storage bucket (branch: feat/spec22-pr2-core-editor)
+- ~~0113 — Session A — Spec 22 PR 2 social-media-uploads storage bucket (branch: feat/spec22-pr2-core-editor).~~ Shipped.
 
 ## Claim block template
 

--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -1,41 +1,43 @@
+import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 
+import type { Browser, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
-import { auditA11y, signInAsAdmin } from "./helpers";
+import { auditA11y, signInAsAdmin, signInAsCompanyAdmin } from "./helpers";
 import { E2E_TEST_SITE_PREFIX } from "./fixtures";
 import { createClient } from "@supabase/supabase-js";
 
 // ---------------------------------------------------------------------------
-// A-0 — Visual regression screenshot harness for the polish workstream.
+// A-0 — Visual regression screenshot harness.
 //
-// Captures every admin surface at two viewports:
+// Captures every admin + social surface at two viewports:
 //   - Desktop  1440×900 (Linear / Vercel reference)
 //   - Mobile    380×844 (iPhone-class width floor)
 //
-// Output: `playwright-screenshots/<viewport>/<route-slug>.png`
+// Two outputs per route:
+//   1. playwright-screenshots/<viewport>/<route-slug>.png
+//      → uploaded as a CI artifact; reviewers download for visual diff.
+//   2. expect(page).toHaveScreenshot() baseline in e2e/__screenshots__/
+//      → automated regression gate. CI fails on mismatch once baselines
+//      are committed. Baselines are skipped on first run (no file present)
+//      to avoid bootstrap failures; generate them with:
 //
-// Each Phase B per-screen PR overwrites the screenshots for the surfaces
-// it touches. GitHub renders the PNG diff in the PR's Files Changed view
-// — that's the canonical "before / after" for review (no manual paste).
-// PR description references the affected files by path.
+//        npm run screenshots:baseline
 //
-// Determinism notes:
-//   - Time-rendered surfaces ("updated 2 minutes ago") are masked at
-//     screenshot time so a clock tick doesn't churn the diff.
-//   - Per-route, we wait for `networkidle` so SSR + client-side
-//     hydration both settle before the snapshot.
-//   - Animations are disabled via `reducedMotion: "reduce"` page
-//     context option — every PR's screenshots represent the
-//     reduced-motion "static" view of the surface, which is the
-//     stable-by-design end state.
+//      then commit e2e/__screenshots__/ to lock the baseline.
 //
-// Skip semantics:
-//   - Routes that require seeded data we don't have (specific brief in
-//     `awaiting_review`, specific WP post id) capture the empty/redirect
-//     state instead. That's still useful — empty states are part of
-//     the polish surface area.
+// Viewport taxonomy:
+//   ADMIN_ROUTES   — signed in as Opollo super_admin (all /admin/* routes)
+//   COMPANY_ROUTES — signed in as company admin (all /company/social/* routes)
+//
+// Determinism:
+//   - reducedMotion: "reduce" disables CSS animations.
+//   - Locale en-US + timezone UTC stabilise date-formatted strings.
+//   - networkidle wait ensures SSR + hydration settle.
+//   - [data-screenshot-mask] elements are masked (muted gray) so
+//     relative timestamps ("updated 2 min ago") don't churn the diff.
 // ---------------------------------------------------------------------------
 
 const DESKTOP = { width: 1440, height: 900 } as const;
@@ -43,22 +45,25 @@ const MOBILE = { width: 380, height: 844 } as const;
 
 const SCREENSHOTS_DIR = path.join(process.cwd(), "playwright-screenshots");
 
+// Snapshots are stored at:
+// e2e/__screenshots__/screenshots.spec.ts/<slug>-<viewport>-linux.png
+// Matches snapshotPathTemplate in playwright.config.ts.
+const SNAPSHOT_DIR = path.join(
+  process.cwd(),
+  "e2e/__screenshots__/screenshots.spec.ts",
+);
+
 interface RouteEntry {
-  /** Slug used for the filename (alphanumerics + hyphens only). */
   slug: string;
-  /** Route to navigate to. `{siteId}` is replaced with the seeded test site's id. */
   url: string;
-  /** Optional wait condition: a selector to wait for before the snapshot. */
   waitForSelector?: string;
-  /** Optional ms wait after navigation for any client-side hydration. */
   hydrationDelayMs?: number;
 }
 
-const ROUTES: readonly RouteEntry[] = [
-  // Auth surfaces (no sign-in required — the harness signs out for these).
+// Admin routes — sign in as Opollo super_admin.
+const ADMIN_ROUTES: readonly RouteEntry[] = [
   { slug: "login", url: "/login" },
   { slug: "auth-forgot-password", url: "/auth/forgot-password" },
-  // Admin surfaces (sign-in required).
   { slug: "admin-sites-list", url: "/admin/sites" },
   { slug: "admin-site-detail", url: "/admin/sites/{siteId}" },
   { slug: "admin-site-settings", url: "/admin/sites/{siteId}/settings" },
@@ -84,6 +89,31 @@ const ROUTES: readonly RouteEntry[] = [
   { slug: "admin-batches-list", url: "/admin/batches" },
   { slug: "admin-images-list", url: "/admin/images" },
   { slug: "admin-users-list", url: "/admin/users" },
+  { slug: "admin-companies-list", url: "/admin/companies" },
+];
+
+// Company routes — sign in as the seeded company admin (e2e-customer-co).
+// These render the actual social UI (calendar grid, posts list, etc.).
+const COMPANY_ROUTES: readonly RouteEntry[] = [
+  // Social module — primary targets of the UI consistency pass.
+  {
+    slug: "social-calendar",
+    url: "/company/social/calendar",
+    hydrationDelayMs: 300,
+  },
+  {
+    slug: "social-posts",
+    url: "/company/social/posts",
+    hydrationDelayMs: 300,
+  },
+  { slug: "social-connections", url: "/company/social/connections" },
+  { slug: "social-media", url: "/company/social/media" },
+  { slug: "social-analytics", url: "/company/social/analytics" },
+  { slug: "social-sharing", url: "/company/social/sharing" },
+  // Company account surfaces (also get button + nav migrations).
+  { slug: "company-users", url: "/company/users" },
+  { slug: "company-settings", url: "/company/settings" },
+  { slug: "company-brand", url: "/company/brand" },
 ];
 
 async function getSeededSiteId(): Promise<string> {
@@ -91,7 +121,7 @@ async function getSeededSiteId(): Promise<string> {
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) {
     throw new Error(
-      "SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required for the screenshot harness — run via `npm run screenshots`.",
+      "SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required — run via `npm run screenshots`.",
     );
   }
   const supabase = createClient(url, key, {
@@ -111,106 +141,148 @@ async function getSeededSiteId(): Promise<string> {
   return data.id as string;
 }
 
-// Skipped by default so the regular `npm run test:e2e` pipeline doesn't
-// pay the ~2-minute screenshot pass on every CI run. `npm run screenshots`
-// flips RUN_SCREENSHOTS=1 to enable.
+/** True when the committed baseline file exists for this slug + viewport. */
+function baselineExists(slug: string, viewportName: string): boolean {
+  return existsSync(
+    path.join(SNAPSHOT_DIR, `${slug}-${viewportName}-linux.png`),
+  );
+}
+
+type ViewportSpec = { name: "desktop" | "mobile"; size: typeof DESKTOP | typeof MOBILE };
+
+/**
+ * Capture screenshots for a route list using the given sign-in helper.
+ * Per route:
+ *   1. Save full-page PNG to playwright-screenshots/ (artifact upload).
+ *   2. If a baseline exists, assert via toHaveScreenshot() (CI gate).
+ *
+ * Navigation failures are logged and skipped — a broken single route
+ * doesn't abort the rest of the run.
+ */
+async function captureRoutes(
+  browser: Browser,
+  viewport: ViewportSpec,
+  routes: readonly RouteEntry[],
+  signIn: (page: Page) => Promise<void>,
+  siteId: string,
+  testInfo: import("@playwright/test").TestInfo,
+): Promise<void> {
+  const context = await browser.newContext({
+    viewport: viewport.size,
+    reducedMotion: "reduce",
+    locale: "en-US",
+    timezoneId: "UTC",
+  });
+  const page = await context.newPage();
+  await signIn(page);
+
+  for (const route of routes) {
+    const targetUrl = route.url.replace("{siteId}", siteId);
+    const filePath = path.join(
+      SCREENSHOTS_DIR,
+      viewport.name,
+      `${route.slug}.png`,
+    );
+
+    let screenshotTaken = false;
+    try {
+      await page.goto(targetUrl, { waitUntil: "networkidle" });
+      if (route.waitForSelector) {
+        await page
+          .locator(route.waitForSelector)
+          .first()
+          .waitFor({ timeout: 5_000 });
+      }
+      if (route.hydrationDelayMs) {
+        await page.waitForTimeout(route.hydrationDelayMs);
+      }
+      const masks = await page.locator("[data-screenshot-mask]").all();
+      await page.screenshot({
+        path: filePath,
+        fullPage: true,
+        mask: masks,
+        maskColor: "#e5e7eb",
+        animations: "disabled",
+      });
+      screenshotTaken = true;
+
+      if (viewport.name === "desktop") {
+        await auditA11y(page, testInfo);
+      }
+      // eslint-disable-next-line no-console
+      console.log(
+        `  [${viewport.name}] ${route.slug} → ${path.relative(process.cwd(), filePath)}`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await testInfo.attach(
+        `screenshot-failed-${route.slug}-${viewport.name}`,
+        { body: `${targetUrl}\n${msg}`, contentType: "text/plain" },
+      );
+      // eslint-disable-next-line no-console
+      console.warn(`  [${viewport.name}] ${route.slug} FAILED: ${msg}`);
+    }
+
+    // Visual regression gate — only runs when a committed baseline exists.
+    // First-time baseline capture: run `npm run screenshots:baseline`.
+    if (screenshotTaken && baselineExists(route.slug, viewport.name)) {
+      const masks = await page.locator("[data-screenshot-mask]").all();
+      await expect(page).toHaveScreenshot(
+        `${route.slug}-${viewport.name}.png`,
+        {
+          fullPage: true,
+          mask: masks,
+          animations: "disabled",
+        },
+      );
+    }
+  }
+
+  await context.close();
+}
+
+// Skipped by default so `npm run test:e2e` doesn't pay the screenshot pass.
+// Enable with: RUN_SCREENSHOTS=1 (set by `npm run screenshots`).
 const SHOULD_RUN = process.env.RUN_SCREENSHOTS === "1";
 
 test.describe("A-0 visual regression screenshot harness", () => {
   test.skip(!SHOULD_RUN, "RUN_SCREENSHOTS=1 not set");
 
-  test("captures every admin surface at desktop + mobile", async ({
-    browser,
-  }, testInfo) => {
-    test.setTimeout(180_000);
+  test("captures every admin + social surface at desktop + mobile", async (
+    { browser },
+    testInfo,
+  ) => {
+    test.setTimeout(300_000);
+
     await mkdir(path.join(SCREENSHOTS_DIR, "desktop"), { recursive: true });
     await mkdir(path.join(SCREENSHOTS_DIR, "mobile"), { recursive: true });
 
     const siteId = await getSeededSiteId();
 
     for (const viewport of [
-      { name: "desktop", size: DESKTOP },
-      { name: "mobile", size: MOBILE },
-    ] as const) {
-      // Fresh context per viewport — reduced-motion + viewport are
-      // browser-context level, can't be flipped per-page.
-      const context = await browser.newContext({
-        viewport: viewport.size,
-        reducedMotion: "reduce",
-        // Pin the locale + timezone so any date-formatted text is stable.
-        locale: "en-US",
-        timezoneId: "UTC",
-      });
-      const page = await context.newPage();
-
-      // Sign in once per viewport (cookie sticks for subsequent
-      // navigations within this context).
-      await signInAsAdmin(page);
-
-      for (const route of ROUTES) {
-        const targetUrl = route.url.replace("{siteId}", siteId);
-        const filePath = path.join(
-          SCREENSHOTS_DIR,
-          viewport.name,
-          `${route.slug}.png`,
-        );
-
-        try {
-          await page.goto(targetUrl, { waitUntil: "networkidle" });
-          if (route.waitForSelector) {
-            await page
-              .locator(route.waitForSelector)
-              .first()
-              .waitFor({ timeout: 5_000 });
-          }
-          if (route.hydrationDelayMs) {
-            await page.waitForTimeout(route.hydrationDelayMs);
-          }
-          // Mask "updated N minutes ago" style relative timestamps so a
-          // clock tick between PRs doesn't reorder the diff.
-          // R1-9 — override Playwright's default magenta maskColor (which
-          // appeared on the Sites list UPDATED column as bright pink
-          // blocks in operator review). Use a subtle muted gray that
-          // blends with the canvas tint so the screenshot reads as
-          // "this column has dynamic text" rather than "broken styling."
-          const masks = await page.locator("[data-screenshot-mask]").all();
-          await page.screenshot({
-            path: filePath,
-            fullPage: true,
-            mask: masks,
-            maskColor: "#e5e7eb",
-            animations: "disabled",
-          });
-          // C-3 — run axe-core on every captured route. Findings
-          // attach to the test result; non-blocking by design (the
-          // harness still produces screenshots even if axe surfaces
-          // violations) but visible in the CI run output for triage.
-          // Desktop-viewport pass only — running on both viewports
-          // doubles audit time and rarely finds viewport-specific
-          // a11y issues.
-          if (viewport.name === "desktop") {
-            await auditA11y(page, testInfo);
-          }
-          // eslint-disable-next-line no-console
-          console.log(
-            `  [${viewport.name}] ${route.slug} → ${path.relative(process.cwd(), filePath)}`,
-          );
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          await testInfo.attach(`screenshot-failed-${route.slug}-${viewport.name}`, {
-            body: `${targetUrl}\n${msg}`,
-            contentType: "text/plain",
-          });
-          // eslint-disable-next-line no-console
-          console.warn(
-            `  [${viewport.name}] ${route.slug} FAILED: ${msg}`,
-          );
-        }
-      }
-
-      await context.close();
+      { name: "desktop" as const, size: DESKTOP },
+      { name: "mobile" as const, size: MOBILE },
+    ]) {
+      await captureRoutes(
+        browser,
+        viewport,
+        ADMIN_ROUTES,
+        signInAsAdmin,
+        siteId,
+        testInfo,
+      );
+      await captureRoutes(
+        browser,
+        viewport,
+        COMPANY_ROUTES,
+        signInAsCompanyAdmin,
+        siteId,
+        testInfo,
+      );
     }
 
+    // Sentinel — always passes; individual toHaveScreenshot assertions
+    // above are the real gate.
     expect(true).toBe(true);
   });
 });

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:e2e": "playwright test",
     "test:e2e:update-snapshots": "playwright test --update-snapshots",
     "screenshots": "RUN_SCREENSHOTS=1 playwright test screenshots.spec.ts",
+    "screenshots:baseline": "RUN_SCREENSHOTS=1 playwright test screenshots.spec.ts --update-snapshots",
     "audit:static": "tsx scripts/audit.ts",
     "backfill:image-embeddings": "tsx scripts/backfill-image-embeddings.ts",
     "gen:types": "supabase gen types typescript --local > types/supabase.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,7 +41,17 @@ export default defineConfig({
     ["html", { outputFolder: "playwright-report", open: "never" }],
   ],
   timeout: 30_000,
-  expect: { timeout: 10_000 },
+  expect: {
+    timeout: 10_000,
+    toHaveScreenshot: {
+      // 2% pixel ratio tolerance — accommodates sub-pixel antialiasing
+      // differences between CI Linux and local macOS/Windows renders.
+      // Tighten to 0.01 once baselines stabilise across a few green runs.
+      maxDiffPixelRatio: 0.02,
+      // Per-pixel colour threshold (0 = exact, 1 = ignore all colour diffs).
+      threshold: 0.2,
+    },
+  },
   use: {
     baseURL: BASE_URL,
     trace: "on-first-retry",


### PR DESCRIPTION
## Summary

Slice 1 of the platform-wide UI consistency pass. Establishes the Playwright screenshot diffing harness **before** any visual migration begins, so all subsequent slices can be gated against regressions on routes they don't touch.

**Risks identified and mitigated**
- No production writes; pure test infrastructure.
- `toHaveScreenshot()` calls are guarded by `baselineExists()` — if no baseline file is committed, the gate silently skips (no bootstrap failure). This prevents the chicken-and-egg problem where CI fails before baselines are ever generated.
- Social routes require company admin session; second context loop uses `signInAsCompanyAdmin` to access real calendar/posts UI rather than the "no company selected" staff placeholder.

## What changed

| File | Change |
|------|--------|
| `e2e/screenshots.spec.ts` | Add `COMPANY_ROUTES` (9 social/company routes); refactor into `captureRoutes()` helper; integrate `toHaveScreenshot()` regression gate |
| `playwright.config.ts` | Add `toHaveScreenshot` defaults (`maxDiffPixelRatio: 0.02`, `threshold: 0.2`) |
| `.github/workflows/screenshots.yml` | Two-mode detection: baseline (push to main / first run) vs comparison (PRs). Baseline mode uploads `e2e/__screenshots__/` artifact for downstream commit |
| `package.json` | Add `screenshots:baseline` script |

## Baseline bootstrap (one-time, after merge)

```bash
supabase start
npm run screenshots:baseline   # generates e2e/__screenshots__/
git add e2e/__screenshots__/
git commit -m "chore: capture visual regression baselines"
git push
```

Once baselines are committed, every subsequent PR that touches a route in `ROUTES` or `COMPANY_ROUTES` will automatically gate on visual diffs.

## Test plan

- [ ] Lint: clean
- [ ] Typecheck: clean
- [ ] Build: clean
- [ ] CI passes on this PR (screenshots workflow runs in baseline mode — no existing snapshots, so generates and uploads artifact)
- [ ] screenshots.yml baseline artifact visible in CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)