### PR TITLE
feat(ui-consistency): design token layer (slice 2)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -17,9 +17,9 @@
   :root {
     /* ---- Opollo raw hex tokens — ds.css v5 palette -------------------- */
     /* Brand accent: green replaces pink as the primary action color */
-    --pk: #00E89A;                          /* brand green — Opollo accent */
+    --pk: #00e5a0;                          /* brand green — Opollo accent (spec: #00e5a0) */
     --pk2: #00A86B;                         /* green-deep — hover, gradient end */
-    --pk-soft: rgba(0, 232, 154, 0.10);
+    --pk-soft: rgba(0, 229, 160, 0.10);
     --gr: #00B07C;                          /* mint — secondary green accent */
     --gr2: #00875a;
     --gr-soft: rgba(0, 176, 124, 0.12);
@@ -27,9 +27,9 @@
     --bl-soft: rgba(30, 111, 255, 0.10);
     --am: #FFB547;                          /* warning */
     --rd: #FF5F5A;                          /* danger */
-    --bg: #F4F5F7;                          /* page canvas */
+    --bg: #F9FAFB;                          /* page canvas — soft-light theme */
     --d1: #FFFFFF;                          /* card / sidebar surface */
-    --d2: #F4F5F7;                          /* off-white */
+    --d2: #F9FAFB;                          /* off-white */
     --d3: #EEF0F3;                          /* deeper inset */
     --d4: #E6E8EC;                          /* dividers */
     --white: #FFFFFF;
@@ -43,10 +43,39 @@
     /* Dim alpha for inactive icons */
     --icon-dim: rgba(75, 83, 96, 0.80);
     /* Nav chrome — semantic aliases so components don't hard-code rgba */
-    --nav-active: rgba(0, 232, 154, 0.10);  /* green at 10%: active nav item bg */
-    --nav-hover:  rgba(0, 232, 154, 0.06);  /* green at 6%: nav item hover bg   */
+    --nav-active: rgba(0, 229, 160, 0.10);  /* green at 10%: active nav item bg */
+    --nav-hover:  rgba(0, 229, 160, 0.06);  /* green at 6%: nav item hover bg   */
     --topbar-bg:  rgba(255, 255, 255, 0.92);/* white at 92%: mobile topbar      */
-    --pk-glow:    rgba(0, 232, 154, 0.20);  /* green glow — button hover shadow */
+    --pk-glow:    rgba(0, 229, 160, 0.20);  /* green glow — button hover shadow */
+
+    /* ---- UI consistency token layer (2026-05-08) ----------------------- */
+    /* Button system — used by components/ui/button.tsx */
+    --btn-primary-bg:       #00e5a0;        /* = var(--pk); explicit for clarity */
+    --btn-primary-text:     #FFFFFF;
+    --btn-secondary-bg:     #FFFFFF;
+    --btn-secondary-border: #1F2937;        /* gray-800 */
+    --btn-secondary-text:   #1F2937;
+    --btn-tertiary-text:    #1F2937;
+    --btn-tertiary-hover:   #F3F4F6;        /* gray-100 */
+    --btn-destructive-bg:   #DC2626;        /* red-600 — WCAG AA on white */
+    --btn-destructive-text: #FFFFFF;
+
+    /* Icon-only controls — 32×32 circular hit area */
+    --icon-control-hover:   #F3F4F6;        /* gray-100 */
+
+    /* Tab states */
+    --tab-active-bg:        #00e5a0;        /* = var(--pk) */
+    --tab-active-text:      #FFFFFF;
+    --tab-inactive-text:    #4B5563;        /* gray-600 */
+
+    /* Search inputs */
+    --search-input-border:  #E5E7EB;        /* gray-200 */
+
+    /* Text semantic tokens — WCAG AA on #F9FAFB / white canvas */
+    --tx-primary:   #111827;                /* gray-900 — headings, active labels */
+    --tx-secondary: #374151;                /* gray-700 — body, inactive tabs */
+    --tx-muted:     #6B7280;                /* gray-500 — dates, disabled, helpers */
+    --tx-inverse:   #FFFFFF;                /* white on dark backgrounds only */
 
     /* ---- Font stack — defined here so Tailwind fontFamily vars resolve ---- */
     --font-display: "Sora", "Helvetica Neue", "Arial", sans-serif;
@@ -59,7 +88,7 @@
     --card-foreground: 218 27% 6%;
     --popover: 0 0% 100%;
     --popover-foreground: 218 27% 6%;
-    --primary: 156 100% 46%;               /* --pk  #00E89A brand green       */
+    --primary: 162 100% 45%;               /* --pk  #00e5a0 brand green       */
     --primary-foreground: 0 0% 100%;
     --secondary: 220 14% 93%;              /* --d3  #EEF0F3                   */
     --secondary-foreground: 218 27% 6%;
@@ -75,10 +104,10 @@
     --radius: 0.375rem;                    /* op-r-md                         */
 
     /* canvas = page base */
-    --canvas: 220 16% 96%;                 /* --bg  #F4F5F7                   */
+    --canvas: 210 20% 98%;                 /* --bg  #F9FAFB soft-light        */
 
     /* status tokens — ds.css v5 */
-    --success: 156 100% 46%;               /* --pk  #00E89A                   */
+    --success: 162 100% 45%;               /* --pk  #00e5a0                   */
     --success-foreground: 0 0% 100%;
     --warning: 36 100% 64%;                /* --am  #FFB547                   */
     --warning-foreground: 0 0% 100%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -116,6 +116,23 @@ const config: Config = {
           url: "#006621",
           desc: "#545454",
         },
+        /* UI consistency semantic text tokens (2026-05-08).
+         * Use as: text-tx-primary, text-tx-secondary, text-tx-muted, text-tx-inverse.
+         * bg-tx-* and border-tx-* also available via Tailwind's utilities. */
+        "tx-primary":   "var(--tx-primary)",    /* #111827 gray-900 */
+        "tx-secondary": "var(--tx-secondary)",  /* #374151 gray-700 */
+        "tx-muted":     "var(--tx-muted)",      /* #6B7280 gray-500 */
+        "tx-inverse":   "var(--tx-inverse)",    /* #FFFFFF */
+        /* Button token passthrough — consumed by components/ui/button.tsx */
+        "btn-primary":          "var(--btn-primary-bg)",
+        "btn-secondary-border": "var(--btn-secondary-border)",
+        "btn-tertiary-hover":   "var(--btn-tertiary-hover)",
+        "btn-destructive":      "var(--btn-destructive-bg)",
+        /* Tab + control tokens */
+        "tab-active":           "var(--tab-active-bg)",
+        "tab-inactive-text":    "var(--tab-inactive-text)",
+        "icon-hover":           "var(--icon-control-hover)",
+        "search-border":        "var(--search-input-border)",
       },
       boxShadow: {
         'pk-glow': '0 4px 24px var(--pk-glow)',


### PR DESCRIPTION
## Summary

Adds the CSS custom property + Tailwind alias foundations for the UI consistency pass. All subsequent slices (3–11) consume these tokens. No existing component logic changes — tokens only.

**Risks identified and mitigated**
- Palette update (`--pk #00E89A → #00e5a0`): same hue family, ~1% lightness shift. Affects nav-active tint, button glows, success states. All visually equivalent; no WCAG impact.
- Canvas update (`#F4F5F7 → #F9FAFB`): lighter off-white. Pre-existing nav and card components on white already pass WCAG AA; the lighter canvas only improves contrast.
- No component code changed in this slice — pure CSS variable additions and minor value corrections.

## Token additions

| Token | Value | Usage |
|-------|-------|-------|
| `--tx-primary` | `#111827` | Headings, active labels |
| `--tx-secondary` | `#374151` | Body, inactive tabs |
| `--tx-muted` | `#6B7280` | Dates, disabled, helpers |
| `--tx-inverse` | `#FFFFFF` | Text on dark backgrounds |
| `--btn-primary-bg` | `#00e5a0` | Primary button fill |
| `--btn-secondary-border` | `#1F2937` | Secondary button border |
| `--btn-tertiary-hover` | `#F3F4F6` | Tertiary hover bg |
| `--btn-destructive-bg` | `#DC2626` | Destructive button fill |
| `--tab-active-bg` | `#00e5a0` | Active tab fill |
| `--tab-inactive-text` | `#4B5563` | Inactive tab text |
| `--icon-control-hover` | `#F3F4F6` | Icon control hover |
| `--search-input-border` | `#E5E7EB` | Search input border |

Tailwind aliases: `text-tx-primary`, `bg-btn-primary`, `bg-btn-destructive`, `bg-tab-active`, etc.

## Test plan

- [x] Lint: clean
- [x] Typecheck: clean
- [x] Build: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)