### PR TITLE
feat(ui-consistency): canonical control primitives (slice 4)

### DIFF
--- a/components/ui/icon-button.tsx
+++ b/components/ui/icon-button.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// IconButton — 32×32 circular icon-only control.
+//
+// Spec: fully rounded pill (9999px), transparent background, hover
+// bg-[#F3F4F6]. Must always carry an accessible label (aria-label or
+// aria-labelledby). Always pair with a visible text label where space
+// allows; this component is for space-constrained controls only (‹ ›,
+// close, overflow).
+// ---------------------------------------------------------------------------
+
+export interface IconButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+}
+
+export const IconButton = React.forwardRef<
+  HTMLButtonElement,
+  IconButtonProps
+>(({ label, className, children, ...props }, ref) => {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      aria-label={label}
+      className={cn(
+        "inline-flex h-8 w-8 items-center justify-center rounded-full",
+        "bg-transparent text-[#374151] transition-colors",
+        "hover:bg-[#F3F4F6]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "disabled:pointer-events-none disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+});
+IconButton.displayName = "IconButton";

--- a/components/ui/pill-select.tsx
+++ b/components/ui/pill-select.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+import { cn } from "@/lib/utils";
+import { NavIcon } from "@/components/ui/nav-icon";
+
+// ---------------------------------------------------------------------------
+// PillSelect — pill-shaped dropdown selector.
+//
+// Spec: pill-shaped, secondary variant styling (white bg, #1F2937 border),
+// trailing chevron-down icon. Used for workspace selectors, profile filters,
+// and any other single-choice dropdown control.
+//
+// Built on Radix Popover (available) rather than native <select> to allow
+// fully custom pill styling across all browsers.
+// ---------------------------------------------------------------------------
+
+export interface PillSelectOption {
+  value: string;
+  label: string;
+}
+
+export interface PillSelectProps {
+  options: readonly PillSelectOption[];
+  value: string;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+  /** Size maps to canonical Button sizes. Default "sm". */
+  size?: "sm" | "default";
+}
+
+const TRIGGER_BASE =
+  "inline-flex items-center justify-between gap-1.5 rounded-full border border-[#1F2937] bg-white font-medium text-[#1F2937] transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50";
+
+const SIZE_CLASSES = {
+  sm: "px-[14px] py-[6px] text-[13px]",
+  default: "px-5 py-[10px] text-[14px]",
+} as const;
+
+export function PillSelect({
+  options,
+  value,
+  onValueChange,
+  placeholder = "Select…",
+  className,
+  size = "sm",
+}: PillSelectProps) {
+  const [open, setOpen] = React.useState(false);
+  const selected = options.find((o) => o.value === value);
+  const label = selected?.label ?? placeholder;
+
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <PopoverPrimitive.Trigger asChild>
+        <button
+          type="button"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          className={cn(TRIGGER_BASE, SIZE_CLASSES[size], className)}
+        >
+          <span>{label}</span>
+          <NavIcon
+            name="chevron-down"
+            size={14}
+            className={cn("shrink-0 transition-transform", open && "rotate-180")}
+          />
+        </button>
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          align="start"
+          sideOffset={4}
+          className="z-50 min-w-[8rem] overflow-hidden rounded-xl border border-[#E5E7EB] bg-white p-1 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+        >
+          <ul role="listbox" aria-label={placeholder} className="outline-none">
+            {options.map((option) => (
+              <li
+                key={option.value}
+                role="option"
+                aria-selected={option.value === value}
+                className={cn(
+                  "relative flex cursor-pointer select-none items-center rounded-lg px-3 py-1.5 text-[14px] outline-none transition-colors",
+                  option.value === value
+                    ? "bg-[#00e5a0]/10 font-medium text-[#111827]"
+                    : "text-[#374151] hover:bg-[#F3F4F6]",
+                )}
+                onClick={() => {
+                  onValueChange(option.value);
+                  setOpen(false);
+                }}
+              >
+                {option.value === value && (
+                  <NavIcon name="check" size={14} className="mr-2 shrink-0 text-[#00e5a0]" />
+                )}
+                {option.value !== value && (
+                  <span className="mr-[22px]" />
+                )}
+                {option.label}
+              </li>
+            ))}
+          </ul>
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}

--- a/components/ui/pill-tabs.tsx
+++ b/components/ui/pill-tabs.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// PillTabs — pill-shaped tab group.
+//
+// Spec:
+//   Active:   bg-[#00e5a0], white text, rounded-full
+//   Inactive: transparent bg, text-[#4B5563], rounded-full, hover bg-[#F3F4F6]
+//   No borders on individual tabs.
+//
+// Each tab renders as a <Link> when `href` is supplied (navigation tabs)
+// or as a <button> otherwise (state-driven tabs). Disabled tabs render
+// as a non-interactive span.
+// ---------------------------------------------------------------------------
+
+export interface PillTab {
+  label: string;
+  value: string;
+  /** When set, the tab renders as a Next.js <Link> instead of a <button>. */
+  href?: string;
+  disabled?: boolean;
+}
+
+export interface PillTabsProps {
+  tabs: readonly PillTab[];
+  activeValue: string;
+  /** Called when a button-mode tab is selected. Not needed for href-based tabs. */
+  onSelect?: (value: string) => void;
+  className?: string;
+}
+
+const TAB_BASE =
+  "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[14px] font-medium transition-colors whitespace-nowrap";
+
+const TAB_ACTIVE = "bg-[#00e5a0] text-white";
+
+const TAB_INACTIVE =
+  "bg-transparent text-[#4B5563] hover:bg-[#F3F4F6] hover:text-[#111827]";
+
+const TAB_DISABLED = "bg-transparent text-[#9CA3AF] cursor-not-allowed";
+
+export function PillTabs({ tabs, activeValue, onSelect, className }: PillTabsProps) {
+  return (
+    <div
+      role="tablist"
+      className={cn("inline-flex items-center gap-0.5", className)}
+    >
+      {tabs.map((tab) => {
+        const isActive = tab.value === activeValue;
+        const tabClass = cn(
+          TAB_BASE,
+          isActive ? TAB_ACTIVE : tab.disabled ? TAB_DISABLED : TAB_INACTIVE,
+        );
+
+        if (tab.disabled) {
+          return (
+            <span
+              key={tab.value}
+              role="tab"
+              aria-selected={false}
+              aria-disabled
+              className={tabClass}
+            >
+              {tab.label}
+            </span>
+          );
+        }
+
+        if (tab.href) {
+          return (
+            <Link
+              key={tab.value}
+              href={tab.href}
+              role="tab"
+              aria-selected={isActive}
+              aria-current={isActive ? "page" : undefined}
+              className={tabClass}
+            >
+              {tab.label}
+            </Link>
+          );
+        }
+
+        return (
+          <button
+            key={tab.value}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onSelect?.(tab.value)}
+            className={tabClass}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/ui/search-input.tsx
+++ b/components/ui/search-input.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { NavIcon } from "@/components/ui/nav-icon";
+
+// ---------------------------------------------------------------------------
+// SearchInput — pill-shaped search field.
+//
+// Spec: rounded-full, 1px border #E5E7EB (gray-200), 12px horizontal padding
+// (px-3), leading search icon. The submit control (if any) must be a
+// canonical <Button variant="default" size="sm"> — never a bare text link.
+// ---------------------------------------------------------------------------
+
+export interface SearchInputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  /** Accessible wrapper label; defaults to "Search". */
+  label?: string;
+}
+
+export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
+  ({ label = "Search", className, ...props }, ref) => {
+    return (
+      <div className="relative flex items-center">
+        <NavIcon
+          name="magnifier"
+          size={16}
+          className="pointer-events-none absolute left-3 text-[#9CA3AF]"
+        />
+        <input
+          ref={ref}
+          type="search"
+          aria-label={props["aria-label"] ?? label}
+          className={cn(
+            "h-9 w-full rounded-full border border-[#E5E7EB] bg-white pl-9 pr-3",
+            "text-[14px] text-[#111827] placeholder:text-[#9CA3AF]",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+            "disabled:pointer-events-none disabled:opacity-50",
+            className,
+          )}
+          {...props}
+        />
+      </div>
+    );
+  },
+);
+SearchInput.displayName = "SearchInput";


### PR DESCRIPTION
## Summary

Adds four new primitive components that slice 5 (SocialModuleShell) and the social module migration (slices 6–8) build on. All purely additive — no existing code modified.

**Risks identified and mitigated**
- All four components are new files; no existing code changed.
- `PillSelect` uses `@radix-ui/react-popover` (already a project dependency). No new packages.
- `SearchInput` uses `NavIcon` with `name="magnifier"` — confirmed available in Linearicons font.
- `PillTabs` renders as `<Link>` (navigation) or `<button>` (state) depending on whether `href` is supplied, preventing the common mistake of using `<a>` elements that submit forms.

## Components

| Component | Spec match |
|-----------|-----------|
| `IconButton` | 32×32 circular, transparent bg, hover #F3F4F6 |
| `PillTabs` | Pill active (#00e5a0 bg, white text), inactive (transparent, #4B5563) |
| `SearchInput` | Pill (rounded-full), 1px border #E5E7EB, leading icon |
| `PillSelect` | Pill, secondary variant styling, trailing chevron-down |

## Test plan

- [x] Lint: clean
- [x] Typecheck: clean
- [x] Build: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)