### PR TITLE
feat(ui-consistency): wire posts view to SocialModuleShell (slice 7)

### DIFF
--- a/app/company/social/posts/page.tsx
+++ b/app/company/social/posts/page.tsx
@@ -4,6 +4,7 @@ import { SocialPostsListClient } from "@/components/SocialPostsListClient";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
 import { listPostMasters } from "@/lib/platform/social/posts";
 import type { SocialPostState } from "@/lib/platform/social/posts";
+import { getServiceRoleClient } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
 // S1-2 — customer-facing social posts list at /company/social/posts.
@@ -76,7 +77,7 @@ export default async function CompanySocialPostsPage({ searchParams }: Props) {
       ? (dirParam as "asc" | "desc")
       : "desc";
 
-  const [postsResult, canCreate, canApprove] = await Promise.all([
+  const [postsResult, canCreate, canApprove, companyRow] = await Promise.all([
     listPostMasters({
       companyId,
       q: searchTerm || undefined,
@@ -89,7 +90,14 @@ export default async function CompanySocialPostsPage({ searchParams }: Props) {
     }),
     canDo(companyId, "create_post"),
     canDo(companyId, "approve_post"),
+    getServiceRoleClient()
+      .from("platform_companies")
+      .select("name")
+      .eq("id", companyId)
+      .maybeSingle(),
   ]);
+
+  const companyName: string = (companyRow.data as { name: string } | null)?.name ?? "My company";
 
   if (!postsResult.ok) {
     return (
@@ -107,6 +115,7 @@ export default async function CompanySocialPostsPage({ searchParams }: Props) {
   return (
     <SocialPostsListClient
       companyId={companyId}
+      companyName={companyName}
       initialPosts={postsResult.data.posts}
       canCreate={canCreate}
       canApprove={canApprove}

--- a/components/SocialPostsListClient.tsx
+++ b/components/SocialPostsListClient.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useRef, useState } from "react";
 import { BulkUploadButton } from "@/components/BulkUploadButton";
-import { NavIcon } from "@/components/ui/nav-icon";
 import { CAPGenerateModal } from "@/components/CAPGenerateModal";
 import { ProfileSelector } from "@/components/social/ProfileSelector";
 import { Button } from "@/components/ui/button";
@@ -15,6 +14,7 @@ import type {
   SocialPostSource,
   SocialPostState,
 } from "@/lib/platform/social/posts";
+import { SocialModuleShell } from "@/components/social/social-module-shell";
 
 // ---------------------------------------------------------------------------
 // S1-2 — client shell for /company/social/posts.
@@ -45,6 +45,7 @@ type RowActionKind = "approving" | "rejecting" | "requesting";
 
 type Props = {
   companyId: string;
+  companyName: string;
   initialPosts: PostMasterListItem[];
   canCreate: boolean;
   canApprove?: boolean;
@@ -132,6 +133,7 @@ function buildUrl({
 
 export function SocialPostsListClient({
   companyId,
+  companyName,
   initialPosts,
   canCreate,
   canApprove = false,
@@ -309,53 +311,11 @@ export function SocialPostsListClient({
         : `${total} ${total === 1 ? "post" : "posts"}`;
 
   return (
-    <>
-      {/* Breadcrumbs */}
-      <nav aria-label="Breadcrumb" className="mb-4">
-        <ol className="flex items-center gap-1.5 text-sm text-m3">
-          <li>
-            <Link href="/company/social" className="transition-colors hover:text-white">
-              Social
-            </Link>
-          </li>
-          <li aria-hidden>/</li>
-          <li className="font-medium text-white">Posts</li>
-        </ol>
-      </nav>
-
-      {/* View toggle */}
-      <div className="mb-5 flex items-center gap-2">
-        <div
-          className="flex items-center overflow-hidden rounded-lg border border-white/[0.1]"
-          role="group"
-          aria-label="View mode"
-        >
-          <Link
-            href="/company/social/calendar"
-            className="flex items-center gap-1.5 border-r border-white/[0.1] px-3 py-1.5 text-sm text-m2 transition-colors hover:bg-white/[0.05] hover:text-white"
-          >
-            <NavIcon name="calendar-full" size={14} />
-            Calendar
-          </Link>
-          <span
-            aria-current="page"
-            className="flex items-center gap-1.5 border-r border-white/[0.1] bg-pk px-3 py-1.5 text-sm text-white"
-          >
-            <NavIcon name="list" size={14} />
-            Posts
-          </span>
-          <button
-            disabled
-            aria-disabled="true"
-            title="Coming soon"
-            className="flex cursor-not-allowed items-center gap-1.5 px-3 py-1.5 text-sm text-m3 opacity-40"
-          >
-            <NavIcon name="clock" size={14} />
-            Timeline
-          </button>
-        </div>
-      </div>
-
+    <SocialModuleShell
+      activeView="posts"
+      companyName={companyName}
+      composerEnabled={composerEnabled}
+    >
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <H1>Social posts</H1>
@@ -708,6 +668,6 @@ export function SocialPostsListClient({
         onClose={() => setShowCAPGenerate(false)}
         onSuccess={(newPosts) => setPosts((prev) => [...newPosts, ...prev])}
       />
-    </>
+    </SocialModuleShell>
   );
 }

--- a/components/social/social-module-shell.tsx
+++ b/components/social/social-module-shell.tsx
@@ -47,7 +47,7 @@ export function SocialModuleShell({
 }: SocialModuleShellProps) {
   const newPostHref = composerEnabled
     ? "?compose=new"
-    : "/company/social/posts/new";
+    : "/company/social/posts";
 
   return (
     <div data-testid="social-module-shell">


### PR DESCRIPTION
## Summary

- Removes inline breadcrumb and view-toggle from `SocialPostsListClient`; wraps with `SocialModuleShell activeView="posts"`
- Fixes `SocialModuleShell` CTA fallback href: `/company/social/posts/new` → `/company/social/posts` (the `/new` route doesn't exist yet)
- Adds `companyName` prop to `SocialPostsListClient`; posts page fetches it alongside existing data in `Promise.all`
- Existing action buttons (BulkUpload, Generate with AI, New post inline form) kept in place below the toolbar

## Part of platform-wide UI consistency workstream
- Slices 1–6 ✅
- **Slice 7: Posts view migration ← this PR**
- Slice 8: Timeline view migration (upcoming)
- Slices 9–12: grid contrast + platform button/text migration + cleanup

## Risks identified and mitigated
- No DB writes; `companyName` query is a read-only `.maybeSingle()` — same pattern as the calendar page
- `SocialModuleShell` imports safely from client component (no server-only APIs)
- All `data-testid` attributes preserved

## Test plan
- `npm run lint` — clean ✅
- `npm run typecheck` — clean ✅
- `npm run build` — succeeded ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)