### PR TITLE
feat(ui-consistency): create timeline view stub with SocialModuleShell (slice 8)

### DIFF
--- a/app/company/social/timeline/page.tsx
+++ b/app/company/social/timeline/page.tsx
@@ -1,0 +1,64 @@
+import { redirect } from "next/navigation";
+
+import { SocialModuleShell } from "@/components/social/social-module-shell";
+import { getCurrentPlatformSession } from "@/lib/platform/auth";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// /company/social/timeline — placeholder for the chronological timeline view.
+//
+// The Timeline tab in SocialModuleShell is disabled (coming soon). This page
+// is reachable via direct URL navigation. The view will be fleshed out in a
+// future slice once the data model for chronological post history is defined.
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+export default async function CompanySocialTimelinePage() {
+  const session = await getCurrentPlatformSession();
+  if (!session) {
+    redirect(`/login?next=${encodeURIComponent("/company/social/timeline")}`);
+  }
+  if (!session.company) {
+    return (
+      <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+        <p className="font-medium">No company context.</p>
+      </div>
+    );
+  }
+
+  const companyId = session.company.companyId;
+
+  const companyRow = await getServiceRoleClient()
+    .from("platform_companies")
+    .select("name")
+    .eq("id", companyId)
+    .maybeSingle();
+
+  const companyName: string =
+    (companyRow.data as { name: string } | null)?.name ?? "My company";
+
+  const composerEnabled = process.env.FEATURE_COMPOSER_V2 === "true";
+
+  return (
+    <main className="mx-auto max-w-5xl p-6">
+      <SocialModuleShell
+        activeView="timeline"
+        companyName={companyName}
+        composerEnabled={composerEnabled}
+      >
+        <div
+          className="flex min-h-[24rem] flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-[#E5E7EB] text-center"
+          data-testid="timeline-coming-soon"
+        >
+          <p className="text-sm font-medium text-tx-primary">
+            Timeline coming soon
+          </p>
+          <p className="max-w-xs text-sm text-tx-muted">
+            A chronological view of your social post history will appear here.
+          </p>
+        </div>
+      </SocialModuleShell>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- Creates `app/company/social/timeline/page.tsx` — a coming-soon placeholder page for the chronological timeline view
- Uses `SocialModuleShell activeView="timeline"` so the shell correctly highlights the Timeline tab as active when on this route
- The Timeline tab in the shell remains `disabled: true` (no nav-level link); the route is reachable via direct URL
- Renders a dashed-border empty state with light-theme `text-tx-primary` / `text-tx-muted` tokens

## Part of platform-wide UI consistency workstream
- Slices 1–7 ✅
- **Slice 8: Timeline view stub ← this PR**
- Slice 9: Calendar grid contrast fixes (upcoming)
- Slices 10–12: platform button/text migration + cleanup

## Risks identified and mitigated
- No DB writes; `companyName` query is a read-only `.maybeSingle()` — same pattern as calendar and posts pages
- New route under `/company/social/*` is covered by the social layout auth guard

## Test plan
- `npm run lint` — clean ✅
- `npm run typecheck` — clean ✅
- `npm run build` — succeeded ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)