### PR TITLE
fix(spec22): center loading spinner in composer left pane

### DIFF
--- a/components/composer/post-composer-modal.tsx
+++ b/components/composer/post-composer-modal.tsx
@@ -488,9 +488,9 @@ export function PostComposerModal({
         {/* Body — split panes */}
         <div className="flex min-h-0 flex-1">
           {/* Left pane — editor (60%) */}
-          <div className="flex w-[60%] flex-col gap-4 overflow-y-auto border-r border-white/10 p-6">
+          <div className="flex w-[60%] flex-col border-r border-white/10">
             {isLoadFailed && state.status === "load_failed" ? (
-              <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+              <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
                 <p className="text-sm text-destructive">
                   {state.error.message}
                 </p>
@@ -509,7 +509,7 @@ export function PostComposerModal({
                 </span>
               </div>
             ) : (
-              <>
+              <div className="flex flex-col gap-4 overflow-y-auto p-6">
                 {/* Profile selector */}
                 <ProfileSelector
                   companyId={companyId}
@@ -549,7 +549,7 @@ export function PostComposerModal({
                   onChange={updateApproval}
                   disabled={submitting}
                 />
-              </>
+              </div>
             )}
           </div>
 


### PR DESCRIPTION
## Summary

- Restructure left pane in `PostComposerModal` so `overflow-y-auto`, `gap-4`, and `p-6` live only on the content branch, not on the outer `flex-col` wrapper
- Loading and error states now use `flex-1` against a clean flex container, making the spinner genuinely vertically/horizontally centered
- No logic changes; purely a layout fix for the visual regression reported after PR 790 merged

## Root cause

`overflow-y: auto` on a flex container creates a new block formatting context that can prevent `flex-1` children from expanding to fill the container height. The spinner div's `flex-1` was silently collapsed, leaving the spinner near the top of the pane instead of centred.

## Test plan
- [ ] Open the composer modal — spinner should appear dead-centre in the left pane while the draft initialises
- [ ] Error state (kill network or return 500 from drafts API) — error message should appear centred too
- [ ] Once loaded, pane scrolls normally (scroll wrapper still present on content branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)