### PR TITLE
fix(spec22): spinner centering + platform-wide Button migration (slice 10)

### DIFF
--- a/app/admin/sites/[id]/posts/page.tsx
+++ b/app/admin/sites/[id]/posts/page.tsx
@@ -237,12 +237,9 @@ export default async function SitePostsList({
             className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm"
           />
         </div>
-        <button
-          type="submit"
-          className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90"
-        >
+        <Button type="submit" size="sm">
           Apply
-        </button>
+        </Button>
         {(parsed.status || parsed.query) && (
           <Link
             href={`/admin/sites/${site.id}/posts`}

--- a/app/auth/expired/page.tsx
+++ b/app/auth/expired/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { Button } from "@/components/ui/button";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { H1, Lead } from "@/components/ui/typography";
 
@@ -105,12 +106,9 @@ export default function SessionExpiredPage({
 
         {/* CTA */}
         <div className="flex flex-col items-center gap-3">
-          <Link
-            href={loginHref}
-            className="inline-flex w-full items-center justify-center rounded-md bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground shadow-sm transition-smooth hover:bg-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          >
-            Sign in again
-          </Link>
+          <Button asChild className="w-full">
+            <Link href={loginHref}>Sign in again</Link>
+          </Button>
           <p className="text-xs text-muted-foreground">
             Your work was auto-saved before sign-out.
           </p>

--- a/app/company/internal/autosave-lab/AutosaveLabClient.tsx
+++ b/app/company/internal/autosave-lab/AutosaveLabClient.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { Button } from "@/components/ui/button";
 import { useAutoSave } from "@/lib/hooks/use-auto-save";
 import { useTabLeader } from "@/lib/hooks/use-tab-leader";
 
@@ -336,14 +337,13 @@ export function AutosaveLabClient() {
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-3">
-        <button
+        <Button
           type="button"
           onClick={runAll}
           disabled={isRunningAll && !allDone}
-          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
         >
           Run all 12 scenarios
-        </button>
+        </Button>
         {allDone && (
           <span className={`text-sm font-medium ${failCount === 0 ? "text-green-600" : "text-destructive"}`}>
             {passCount}/{scenarios.length} passed{failCount > 0 && ` -- ${failCount} failed`}
@@ -380,14 +380,16 @@ export function AutosaveLabClient() {
                 </p>
               )}
             </div>
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={() => runScenario(s.id)}
               disabled={s.status === "running"}
-              className="shrink-0 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40"
+              className="shrink-0"
             >
               Run
-            </button>
+            </Button>
           </div>
         ))}
       </div>

--- a/app/company/page.tsx
+++ b/app/company/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
+import { Button } from "@/components/ui/button";
+
 import { SocialPostsDashboardCard } from "@/components/SocialPostsDashboardCard";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
 import { getActiveBrandProfile, getBrandTier } from "@/lib/platform/brand";
@@ -214,13 +216,11 @@ function BrandCompletionBanner({ tier }: { tier: "none" | "minimal" }) {
           <p className="text-base font-semibold">{heading}</p>
           <p className="mt-1 text-base text-muted-foreground">{body}</p>
         </div>
-        <Link
-          href="/company/settings/brand"
-          className="inline-flex items-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          data-testid="brand-completion-cta"
-        >
-          {tier === "none" ? "Get started" : "Continue setup"}
-        </Link>
+        <Button asChild data-testid="brand-completion-cta">
+          <Link href="/company/settings/brand">
+            {tier === "none" ? "Get started" : "Continue setup"}
+          </Link>
+        </Button>
       </div>
     </div>
   );

--- a/components/BulkUploadButton.tsx
+++ b/components/BulkUploadButton.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { Button } from "@/components/ui/button";
 import { toastSuccess } from "@/lib/toast-success";
 import type { PostMasterListItem } from "@/lib/platform/social/posts";
 
@@ -119,23 +120,26 @@ export function BulkUploadButton({ companyId, onSuccess }: Props) {
         onChange={handleFile}
       />
       <div className="flex items-center gap-2">
-        <button
+        <Button
           type="button"
+          variant="secondary"
+          size="sm"
           onClick={openPicker}
           disabled={uploading}
           data-testid="bulk-upload-button"
-          className="inline-flex items-center rounded-md border border-border bg-background px-3 py-1.5 text-sm transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
         >
           {uploading ? "Uploading…" : "Upload CSV"}
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
+          variant="link"
+          size="sm"
           onClick={downloadTemplate}
-          className="text-sm text-muted-foreground underline-offset-2 hover:underline"
+          className="text-muted-foreground"
           data-testid="bulk-template-download"
         >
           Download template
-        </button>
+        </Button>
       </div>
 
       {/* Upload error */}

--- a/components/MoodBoardClient.tsx
+++ b/components/MoodBoardClient.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { Button } from "@/components/ui/button";
 import { toastSuccess } from "@/lib/toast-success";
 import type { AspectRatio, CompositionType, StyleId } from "@/lib/image/types";
 
@@ -147,18 +148,16 @@ export function MoodBoardClient({
           <p className="mb-1.5 text-sm font-medium">Style</p>
           <div className="flex flex-wrap gap-1.5">
             {allowedStyles.map((s) => (
-              <button
+              <Button
                 key={s}
                 type="button"
+                variant={style === s ? "default" : "secondary"}
+                size="sm"
+                className="h-auto px-3 py-1 text-xs"
                 onClick={() => setStyle(s)}
-                className={`rounded-full border px-3 py-1 text-xs transition-colors ${
-                  style === s
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-border bg-background hover:border-primary/50"
-                }`}
               >
                 {STYLE_LABELS[s]}
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -168,18 +167,16 @@ export function MoodBoardClient({
           <p className="mb-1.5 text-sm font-medium">Composition</p>
           <div className="flex flex-wrap gap-1.5">
             {ALL_COMPOSITIONS.map((c) => (
-              <button
+              <Button
                 key={c}
                 type="button"
+                variant={composition === c ? "default" : "secondary"}
+                size="sm"
+                className="h-auto px-3 py-1 text-xs"
                 onClick={() => setComposition(c)}
-                className={`rounded-full border px-3 py-1 text-xs transition-colors ${
-                  composition === c
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-border bg-background hover:border-primary/50"
-                }`}
               >
                 {COMPOSITION_LABELS[c]}
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -189,18 +186,16 @@ export function MoodBoardClient({
           <p className="mb-1.5 text-sm font-medium">Aspect ratio</p>
           <div className="flex flex-wrap gap-1.5">
             {ALL_ASPECT_RATIOS.map((ar) => (
-              <button
+              <Button
                 key={ar}
                 type="button"
+                variant={aspectRatio === ar ? "default" : "secondary"}
+                size="sm"
+                className="h-auto px-3 py-1 text-xs"
                 onClick={() => setAspectRatio(ar)}
-                className={`rounded-full border px-3 py-1 text-xs transition-colors ${
-                  aspectRatio === ar
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-border bg-background hover:border-primary/50"
-                }`}
               >
                 {ASPECT_RATIO_LABELS[ar]}
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -210,18 +205,16 @@ export function MoodBoardClient({
           <p className="mb-1.5 text-sm font-medium">Count</p>
           <div className="flex gap-1.5">
             {COUNT_OPTIONS.map((n) => (
-              <button
+              <Button
                 key={n}
                 type="button"
+                variant={count === n ? "default" : "secondary"}
+                size="sm"
+                className="h-auto px-3 py-1 text-xs"
                 onClick={() => setCount(n)}
-                className={`rounded-full border px-3 py-1 text-xs transition-colors ${
-                  count === n
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-border bg-background hover:border-primary/50"
-                }`}
               >
                 {n}
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -229,14 +222,14 @@ export function MoodBoardClient({
 
       {/* Generate button */}
       <div>
-        <button
+        <Button
           type="button"
+          className="min-w-[160px]"
           onClick={generate}
           disabled={isLoading || allowedStyles.length === 0}
-          className="inline-flex min-w-[160px] items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
         >
           {isLoading ? "Generating…" : "Generate images"}
-        </button>
+        </Button>
         {isLoading ? (
           <p className="mt-2 text-xs text-muted-foreground">
             This can take up to 60 seconds for {count} images — please wait.

--- a/components/PlatformCompanyDetail.tsx
+++ b/components/PlatformCompanyDetail.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { PlatformInviteUserModal } from "@/components/PlatformInviteUserModal";
 import { PlatformRevokeInvitationButton } from "@/components/PlatformRevokeInvitationButton";
+import { Button } from "@/components/ui/button";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { cn } from "@/lib/utils";
 import type { CompanyDetail, CompanyStats } from "@/lib/platform/companies";
@@ -49,22 +50,14 @@ export function PlatformCompanyDetail({
               </p>
             </div>
             {isCurrentUserMember ? (
-              <Link
-                href="/company"
-                className="inline-flex items-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-                data-testid="staff-go-to-platform-link"
-              >
-                Go to platform →
-              </Link>
+              <Button asChild data-testid="staff-go-to-platform-link">
+                <Link href="/company">Go to platform →</Link>
+              </Button>
             ) : joinAction ? (
               <form action={joinAction}>
-                <button
-                  type="submit"
-                  className="inline-flex items-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-                  data-testid="staff-join-button"
-                >
+                <Button type="submit" data-testid="staff-join-button">
                   Join as admin
-                </button>
+                </Button>
               </form>
             ) : null}
           </div>
@@ -203,12 +196,9 @@ function OverviewTab({
               Manage posts, connections, and scheduling for this company.
             </p>
           </div>
-          <Link
-            href="/company"
-            className="inline-flex items-center rounded-md border px-3 py-2 text-sm font-medium transition-colors hover:bg-muted"
-          >
-            Open platform →
-          </Link>
+          <Button asChild variant="secondary">
+            <Link href="/company">Open platform →</Link>
+          </Button>
         </div>
       </section>
     </div>

--- a/components/SocialAnalyticsClient.tsx
+++ b/components/SocialAnalyticsClient.tsx
@@ -16,6 +16,7 @@ import {
   YAxis,
 } from "recharts";
 
+import { Button } from "@/components/ui/button";
 import { H1, H3, Lead } from "@/components/ui/typography";
 import type { SocialAnalytics } from "@/lib/platform/social/analytics";
 
@@ -149,12 +150,9 @@ export function SocialAnalyticsClient({
           <p className="mt-1 text-sm text-muted-foreground">
             Create your first post to see analytics here.
           </p>
-          <Link
-            href="/company/social/posts"
-            className="mt-4 inline-block rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          >
-            Go to Posts
-          </Link>
+          <Button asChild className="mt-4">
+            <Link href="/company/social/posts">Go to Posts</Link>
+          </Button>
         </div>
       )}
 

--- a/components/admin/ImageMetadataJobTrigger.tsx
+++ b/components/admin/ImageMetadataJobTrigger.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { Button } from "@/components/ui/button";
+
 type Progress = {
   total: number;
   done: number;
@@ -156,28 +158,27 @@ export function ImageMetadataJobTrigger() {
 
         <div className="flex shrink-0 gap-2">
           {autoRunning ? (
-            <button
-              onClick={stopAll}
-              className="rounded-md border border-destructive px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10"
-            >
+            <Button variant="destructive" size="sm" onClick={stopAll}>
               Stop
-            </button>
+            </Button>
           ) : (
             <>
-              <button
+              <Button
+                variant="secondary"
+                size="sm"
                 onClick={() => void runBatch()}
                 disabled={running || isDone || !!noCreds || autoRunning}
-                className="rounded-md border px-3 py-1.5 text-xs font-medium disabled:opacity-50 hover:bg-muted"
               >
                 {running ? "Running…" : "Run one batch"}
-              </button>
-              <button
+              </Button>
+              <Button
+                variant="default"
+                size="sm"
                 onClick={() => void runAll()}
                 disabled={running || isDone || !!noCreds || autoRunning}
-                className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground disabled:opacity-50 hover:bg-primary/90"
               >
                 {isDone ? "All done ✓" : "Extract all"}
-              </button>
+              </Button>
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary

- **fix(spec22):** center loading spinner in the composer left pane (regression from PR 2)
- **feat(spec22) slice 10:** migrate all non-canonical `<button>` / inline-styled link patterns across the platform to the canonical `<Button>` component

### Files migrated (slice 10)

| File | Changes |
|---|---|
| `components/admin/ImageMetadataJobTrigger.tsx` | 3 buttons → `Button` destructive/secondary/default sm |
| `components/MoodBoardClient.tsx` | 4 option-selector groups + generate button → `Button` |
| `components/PlatformCompanyDetail.tsx` | 2 Link/button → `Button asChild` / `Button` |
| `app/company/internal/autosave-lab/AutosaveLabClient.tsx` | 2 buttons → `Button` default / ghost sm |
| `components/BulkUploadButton.tsx` | 2 buttons → `Button` secondary sm / link sm |
| `components/SocialAnalyticsClient.tsx` | empty-state Link → `Button asChild` |
| `app/admin/sites/[id]/posts/page.tsx` | Apply submit → `Button` default sm |
| `app/company/page.tsx` | Brand CTA Link → `Button asChild` |
| `app/auth/expired/page.tsx` | Sign-in Link → `Button asChild w-full` |

Tab-navigation buttons with `role="tab"` in `PlatformCompanyDetail` and image-tile toggle buttons in `MoodBoardClient` (thumbnail selectors with aria-pressed) are intentionally left as plain `<button>` elements — they use bespoke active-state styling that falls outside the canonical hierarchy.

### Risks identified and mitigated

- No schema changes, no external calls, no new deps — style-only migration.
- `asChild` pattern delegates all styles to `Button` wrapper; data-testid attributes are preserved on the correct element via Radix `Slot`.
- Lint + typecheck: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)