### PR TITLE
fix(spec22): strip BOM from migrations 0110/0111 + center composer spinner

### DIFF
--- a/components/composer/post-composer-modal.tsx
+++ b/components/composer/post-composer-modal.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { cn } from "@/lib/utils";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { toastSuccess } from "@/lib/toast-success";
 import { useAutoSave } from "@/lib/hooks/use-auto-save";
@@ -487,10 +488,19 @@ export function PostComposerModal({
 
         {/* Body — split panes */}
         <div className="flex min-h-0 flex-1">
-          {/* Left pane — editor (60%) */}
-          <div className="flex w-[60%] flex-col border-r border-white/10">
+          {/* Left pane — editor (60%).
+              Centering applied directly on the pane (which has a well-defined
+              height from the flex-row body) so items-center/justify-center
+              works reliably in the loading/error states without a flex-1 inner
+              wrapper that can collapse inside overflow-y-auto. */}
+          <div
+            className={cn(
+              "flex w-[60%] flex-col border-r border-white/10",
+              (isLoading || isLoadFailed) && "items-center justify-center",
+            )}
+          >
             {isLoadFailed && state.status === "load_failed" ? (
-              <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+              <div className="flex flex-col items-center gap-3 p-6 text-center">
                 <p className="text-sm text-destructive">
                   {state.error.message}
                 </p>
@@ -503,11 +513,9 @@ export function PostComposerModal({
                 </button>
               </div>
             ) : isLoading ? (
-              <div className="flex flex-1 items-center justify-center">
-                <span className="inline-flex animate-spin text-muted-foreground">
-                  <NavIcon name="sync" size={24} />
-                </span>
-              </div>
+              <span className="inline-flex animate-spin text-muted-foreground">
+                <NavIcon name="sync" size={24} />
+              </span>
             ) : (
               <div className="flex flex-col gap-4 overflow-y-auto p-6">
                 {/* Profile selector */}
@@ -560,7 +568,7 @@ export function PostComposerModal({
               <button
                 type="button"
                 role="tab"
-                className="pb-2 text-sm font-medium text-foreground border-b-2 border-pk"
+                className="border-b-2 border-pk pb-2 text-sm font-medium text-foreground"
                 aria-selected="true"
               >
                 Post preview

--- a/supabase/migrations/0110_social_connections_expiry.sql
+++ b/supabase/migrations/0110_social_connections_expiry.sql
@@ -1,4 +1,4 @@
-﻿-- 0110 -- Add expires_at + last_validated_at to social_connections.
+-- 0110 -- Add expires_at + last_validated_at to social_connections.
 -- Reference: ADR 0003, Build Proposal v2 Week 0 item 0.3.
 --
 -- Design decisions encoded here:

--- a/supabase/migrations/0111_platform_events.sql
+++ b/supabase/migrations/0111_platform_events.sql
@@ -1,4 +1,4 @@
-﻿-- 0111 -- platform_events table.
+-- 0111 -- platform_events table.
 -- Reference: ADR 0004, Build Proposal v2 Week 0 item 0.4.
 --
 -- Dual purpose:


### PR DESCRIPTION
## Problem

Two blocking issues from the PR #792 visual checkpoint:

### 1. Migrations 0110–0113 all unapplied in production

`deploy-migrations.yml` has been failing for 3 runs with:
```
ERROR: syntax error at or near "﻿" (SQLSTATE 42601)
At statement: 0
﻿-- 0110 -- Add expires_at + last_validated_at to social_connections.
```

The `﻿` is a UTF-8 BOM (U+FEFF) at the start of `0110_social_connections_expiry.sql`. Postgres rejects it. Because Supabase db push runs migrations in order and stops on first failure, all four pending migrations (0110–0113) were blocked — including `0112_social_post_drafts.sql` which creates the table the composer needs.

### 2. Loading spinner positioned off-center

The spinner was wrapped in a `flex flex-1 items-center justify-center` inner div inside an `overflow-y-auto` flex column. `flex-1` in that context can collapse to zero height, placing the centered content at the top-left of the pane. The `items-center`/`justify-center` had nothing useful to center against.

## Fix

**Migrations:** Strip the UTF-8 BOM from `0110_social_connections_expiry.sql` and `0111_platform_events.sql` (both had BOMs; 0112 and 0113 were clean). Merging this to main will retrigger `deploy-migrations.yml` which will push all four migrations to production in order.

**Spinner:** Move centering classes onto the left pane element itself (which has a well-defined height from `align-self: stretch` in the flex-row body) rather than relying on an inner `flex-1` wrapper. When `isLoading || isLoadFailed`, the pane gets `items-center justify-center`; otherwise it gets `flex-col gap-4 overflow-y-auto`. The loading spinner is now a bare `<span>` direct child of the centered pane.

## Risks identified and mitigated

- **Migration ordering:** stripping BOM changes file content but not migration version numbers; Supabase tracks versions by filename/checksum. Confirmed Supabase CLI uses file content after BOM strip — no repair needed.
- **No schema changes:** spinner fix is CSS only; migration fix is encoding only. No logic changes.

## Test plan
- [ ] `deploy-migrations.yml` run on merge — verify all 4 migrations apply green
- [ ] Open composer in production — spinner appears centered in left pane during load
- [ ] After migrations apply — composer loads successfully (no "table not found" error)