### PR TITLE
fix(spec22): fix super_admin enum + idempotency in migrations 0112/0113

### DIFF
--- a/supabase/migrations/0112_social_post_drafts.sql
+++ b/supabase/migrations/0112_social_post_drafts.sql
@@ -14,8 +14,12 @@
 --   4. RLS gates on platform_company_users so only editors/approvers/admins
 --      of the owning company can read or write their own drafts.
 --   5. service_role bypasses RLS for the create/save API routes.
+--
+-- Idempotency note: IF NOT EXISTS guards and DROP POLICY IF EXISTS make this
+-- safe to re-run after a partial failure (e.g. the policy creation failed on
+-- first attempt but the table+indexes were already created).
 
-CREATE TABLE social_post_drafts (
+CREATE TABLE IF NOT EXISTS social_post_drafts (
   id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
   company_id        UUID        NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
   created_by        UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -28,36 +32,37 @@ CREATE TABLE social_post_drafts (
 );
 
 -- Fast lookup of active drafts for a company (list + conflict-check on open).
-CREATE INDEX idx_social_post_drafts_company
+CREATE INDEX IF NOT EXISTS idx_social_post_drafts_company
   ON social_post_drafts (company_id, archived_at)
   WHERE archived_at IS NULL;
 
 -- Feed for "my drafts" view scoped by author.
-CREATE INDEX idx_social_post_drafts_created_by
+CREATE INDEX IF NOT EXISTS idx_social_post_drafts_created_by
   ON social_post_drafts (created_by, updated_at DESC)
   WHERE archived_at IS NULL;
 
 -- General-purpose recency ordering used by admin list + draft-recovery.
-CREATE INDEX idx_social_post_drafts_updated
+CREATE INDEX IF NOT EXISTS idx_social_post_drafts_updated
   ON social_post_drafts (updated_at DESC);
 
 -- RLS: allow all platform company editors/approvers/admins to read and
 -- write their own company's drafts. Service-role callers bypass this.
 ALTER TABLE social_post_drafts ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS social_post_drafts_company_editors ON social_post_drafts;
 CREATE POLICY social_post_drafts_company_editors
   ON social_post_drafts FOR ALL
   USING (
     company_id IN (
       SELECT company_id FROM platform_company_users
       WHERE user_id = auth.uid()
-        AND role IN ('editor', 'approver', 'admin', 'super_admin')
+        AND role IN ('editor', 'approver', 'admin')
     )
   )
   WITH CHECK (
     company_id IN (
       SELECT company_id FROM platform_company_users
       WHERE user_id = auth.uid()
-        AND role IN ('editor', 'approver', 'admin', 'super_admin')
+        AND role IN ('editor', 'approver', 'admin')
     )
   );

--- a/supabase/migrations/0113_social_media_uploads_bucket.sql
+++ b/supabase/migrations/0113_social_media_uploads_bucket.sql
@@ -17,6 +17,7 @@ ON CONFLICT (id) DO NOTHING;
 
 -- Editors+ in a company may read/write their own company folder.
 -- Path convention: {company_id}/{uuid}.{ext}
+DROP POLICY IF EXISTS social_media_company_editor ON storage.objects;
 CREATE POLICY social_media_company_editor
   ON storage.objects FOR ALL
   TO authenticated
@@ -27,7 +28,7 @@ CREATE POLICY social_media_company_editor
       FROM platform_company_users pcu
       WHERE pcu.user_id = auth.uid()
         AND pcu.company_id = (storage.foldername(name))[1]::uuid
-        AND pcu.role IN ('editor', 'approver', 'admin', 'super_admin')
+        AND pcu.role IN ('editor', 'approver', 'admin')
     )
   )
   WITH CHECK (
@@ -37,6 +38,6 @@ CREATE POLICY social_media_company_editor
       FROM platform_company_users pcu
       WHERE pcu.user_id = auth.uid()
         AND pcu.company_id = (storage.foldername(name))[1]::uuid
-        AND pcu.role IN ('editor', 'approver', 'admin', 'super_admin')
+        AND pcu.role IN ('editor', 'approver', 'admin')
     )
   );


### PR DESCRIPTION
## Problem

`deploy-migrations.yml` ran after PR #804 applied 0110/0111, then failed on 0112:
```
ERROR: invalid input value for enum platform_company_role: "super_admin" (SQLSTATE 22P02)
At statement: 5
```

The `platform_company_role` enum (defined in migration 0070) has only `admin`, `approver`, `editor`, `viewer`. The RLS policies in 0112 and 0113 both referenced `'super_admin'` which does not exist.

Additionally, 0112 is now partially applied in production — the table and indexes were created (statements 0–4 succeeded) but the policy was never created. A naive re-run would fail again at statement 0 (`CREATE TABLE` → "already exists").

## Fix

- **0112:** `'super_admin'` → removed. `CREATE TABLE` → `CREATE TABLE IF NOT EXISTS`. `CREATE INDEX` → `CREATE INDEX IF NOT EXISTS`. Added `DROP POLICY IF EXISTS` before `CREATE POLICY` so re-running after partial application is safe.
- **0113:** Same `'super_admin'` → removed. Added `DROP POLICY IF EXISTS` for consistency.

## After merge

`deploy-migrations.yml` will fire. Expected result:
- 0112: table/indexes no-ops (already exist), policy created (was missing)
- 0113: bucket INSERT (ON CONFLICT DO NOTHING), policy created

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>