### PR TITLE
feat(spec22): live preview pane — PR 3 of 5

### DIFF
--- a/components/composer/composer-preview.tsx
+++ b/components/composer/composer-preview.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+
+import { NavIcon } from "@/components/ui/nav-icon";
+import type { DraftData } from "@/lib/platform/social/drafts";
+import type { SocialConnection } from "@/lib/platform/social/connections/types";
+import type { SocialPlatform } from "@/lib/platform/social/variants/types";
+import { SUPPORTED_PLATFORMS } from "@/lib/platform/social/variants/types";
+import type { ComposerMode } from "./scheduling-tabs";
+import { LivePreviewCard } from "./live-preview-card";
+import { MiniCalendarPreview } from "./mini-calendar-preview";
+
+// ---------------------------------------------------------------------------
+// Spec 22 PR 3 — ComposerPreview.
+//
+// Right-pane 40% of PostComposerModal. Two tabs:
+//   "Post preview" — LivePreviewCard per selected platform, stacked.
+//   "Calendar"     — MiniCalendarPreview highlighting the schedule date.
+//
+// Updates are driven by props from the modal (no internal fetch).
+// ---------------------------------------------------------------------------
+
+type PreviewTab = "post" | "calendar";
+
+interface ComposerPreviewProps {
+  draftData: DraftData | null;
+  selectedPlatforms: SocialPlatform[];
+  connections: SocialConnection[];
+  mode: ComposerMode;
+  scheduleDate: string; // YYYY-MM-DD
+  scheduleTime: string; // HH:MM
+}
+
+export function ComposerPreview({
+  draftData,
+  selectedPlatforms,
+  connections,
+  mode,
+  scheduleDate,
+}: ComposerPreviewProps) {
+  const [tab, setTab] = useState<PreviewTab>("post");
+
+  const text = draftData?.master_text ?? "";
+  const linkUrl = draftData?.link_url ?? null;
+
+  // Map platform → display name from the matching connection.
+  function displayNameFor(platform: SocialPlatform): string | undefined {
+    const conn = connections.find((c) => c.platform === platform);
+    return conn?.display_name ?? undefined;
+  }
+
+  // Order previews in the canonical SUPPORTED_PLATFORMS order.
+  const orderedPlatforms = SUPPORTED_PLATFORMS.filter((p) =>
+    selectedPlatforms.includes(p),
+  );
+
+  const isEmpty = orderedPlatforms.length === 0 || !text.trim();
+
+  const highlightDate = mode === "schedule" ? scheduleDate : undefined;
+
+  return (
+    <div className="flex flex-col p-6 gap-0">
+      {/* Tab bar */}
+      <div role="tablist" className="mb-4 flex gap-1 border-b border-white/10 pb-0">
+        {(["post", "calendar"] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            role="tab"
+            aria-selected={tab === t}
+            onClick={() => setTab(t)}
+            className={[
+              "pb-3 pr-4 text-sm transition-colors",
+              tab === t
+                ? "border-b-2 border-pk font-medium text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            ].join(" ")}
+          >
+            {t === "post" ? "Post preview" : "Calendar"}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {tab === "post" ? (
+        isEmpty ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground">
+            <NavIcon name="picture" size={32} className="opacity-30" />
+            <p>Select at least one profile and start typing to see preview</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {orderedPlatforms.map((platform) => (
+              <LivePreviewCard
+                key={platform}
+                platform={platform}
+                text={text}
+                linkUrl={linkUrl}
+                displayName={displayNameFor(platform)}
+              />
+            ))}
+          </div>
+        )
+      ) : (
+        <MiniCalendarPreview highlightDate={highlightDate} />
+      )}
+    </div>
+  );
+}

--- a/components/composer/live-preview-card.tsx
+++ b/components/composer/live-preview-card.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { NavIcon } from "@/components/ui/nav-icon";
+import type { SocialPlatform } from "@/lib/platform/social/variants/types";
+import { PLATFORM_LABEL } from "@/lib/platform/social/variants/types";
+
+// ---------------------------------------------------------------------------
+// Spec 22 PR 3 — LivePreviewCard.
+//
+// Renders a per-platform mockup of how the post will appear. V1 shows the
+// same master_text on all platforms (no per-platform copy variants per D12
+// exclusions). The card is visual-only — tapping "Like" does nothing.
+// ---------------------------------------------------------------------------
+
+const CHAR_LIMITS: Partial<Record<SocialPlatform, number>> = {
+  x: 280,
+  linkedin_personal: 3000,
+  linkedin_company: 3000,
+  facebook_page: 63206,
+  gbp: 1500,
+};
+
+// Tailwind bg classes for the platform accent stripe.
+const PLATFORM_STRIPE: Record<SocialPlatform, string> = {
+  linkedin_personal: "bg-[#0077B5]",
+  linkedin_company: "bg-[#0077B5]",
+  facebook_page: "bg-[#1877F2]",
+  x: "bg-black",
+  gbp: "bg-[#4285F4]",
+};
+
+interface LivePreviewCardProps {
+  platform: SocialPlatform;
+  text: string;
+  linkUrl?: string | null;
+  displayName?: string;
+}
+
+export function LivePreviewCard({
+  platform,
+  text,
+  linkUrl,
+  displayName,
+}: LivePreviewCardProps) {
+  const charLimit = CHAR_LIMITS[platform];
+  const isOverLimit = charLimit !== undefined && text.length > charLimit;
+  const label = PLATFORM_LABEL[platform];
+  const name = displayName ?? label;
+
+  const previewText = text.length > 600 ? text.slice(0, 600) + "…" : text;
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-white/10 bg-card text-sm">
+      {/* Platform label bar */}
+      <div className={`flex items-center gap-2 px-3 py-1.5 ${PLATFORM_STRIPE[platform]}/20 border-b border-white/10`}>
+        <span className="text-xs font-medium text-foreground">{label}</span>
+        {charLimit && (
+          <span className={`ml-auto text-xs ${isOverLimit ? "text-destructive" : "text-muted-foreground/50"}`}>
+            {text.length}/{charLimit}
+          </span>
+        )}
+      </div>
+
+      {/* Post body */}
+      <div className="space-y-2 p-3">
+        {/* Author row */}
+        <div className="flex items-center gap-2">
+          <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-white/10">
+            <NavIcon name="user" size={14} className="text-muted-foreground" />
+          </div>
+          <div>
+            <p className="text-xs font-medium text-foreground">{name}</p>
+            <p className="text-xs text-muted-foreground/60">Just now</p>
+          </div>
+        </div>
+
+        {/* Post text */}
+        {previewText ? (
+          <p className="whitespace-pre-wrap break-words text-xs leading-relaxed text-foreground">
+            {previewText}
+          </p>
+        ) : (
+          <p className="text-xs italic text-muted-foreground/40">
+            Start typing to see preview…
+          </p>
+        )}
+
+        {/* Link strip */}
+        {linkUrl && (
+          <div className="truncate rounded border border-white/10 bg-white/5 px-2 py-1 text-xs text-muted-foreground">
+            {linkUrl}
+          </div>
+        )}
+
+        {/* Engagement row */}
+        <div className="flex gap-4 border-t border-white/5 pt-2 text-xs text-muted-foreground/30">
+          {platform === "x" ? (
+            <>
+              <span>Reply</span>
+              <span>Repost</span>
+              <span>Like</span>
+              <span>Views</span>
+            </>
+          ) : platform === "gbp" ? (
+            <span className="rounded border border-white/10 px-2 py-0.5 text-muted-foreground/50">
+              Learn more
+            </span>
+          ) : (
+            <>
+              <span>Like</span>
+              <span>Comment</span>
+              <span>Share</span>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/composer/mini-calendar-preview.tsx
+++ b/components/composer/mini-calendar-preview.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useMemo } from "react";
+
+// ---------------------------------------------------------------------------
+// Spec 22 PR 3 — MiniCalendarPreview.
+//
+// Month grid showing where the scheduled post lands. Displayed in the
+// "Calendar" tab of the preview pane. Navigation arrows allow the user to
+// confirm the target month; the highlighted date is read-only (editing
+// schedule happens in the footer SchedulingTabs).
+// ---------------------------------------------------------------------------
+
+const DOW_LABELS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+interface MiniCalendarPreviewProps {
+  /** YYYY-MM-DD — the post's scheduled date, or undefined if not in schedule mode. */
+  highlightDate?: string;
+}
+
+export function MiniCalendarPreview({ highlightDate }: MiniCalendarPreviewProps) {
+  const today = useMemo(() => new Date(), []);
+
+  // Derive the display month from the highlight date, or fall back to today.
+  const { year: viewYear, month: viewMonth } = useMemo(() => {
+    if (highlightDate) {
+      const [y, m] = highlightDate.split("-").map(Number);
+      return { year: y, month: m - 1 };
+    }
+    return { year: today.getFullYear(), month: today.getMonth() };
+  }, [highlightDate, today]);
+
+  const highlightDay = highlightDate ? Number(highlightDate.split("-")[2]) : null;
+  const highlightYear = highlightDate ? Number(highlightDate.split("-")[0]) : null;
+  const highlightMonth = highlightDate ? Number(highlightDate.split("-")[1]) - 1 : null;
+
+  // Grid: null = padding cell; number = day of month.
+  const cells = useMemo((): (number | null)[] => {
+    const firstDOW = new Date(viewYear, viewMonth, 1).getDay();
+    const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+    const result: (number | null)[] = Array<null>(firstDOW).fill(null);
+    for (let d = 1; d <= daysInMonth; d++) result.push(d);
+    while (result.length % 7 !== 0) result.push(null);
+    return result;
+  }, [viewYear, viewMonth]);
+
+  const isHighlight = (day: number) =>
+    day === highlightDay &&
+    viewYear === highlightYear &&
+    viewMonth === highlightMonth;
+
+  const isToday = (day: number) =>
+    day === today.getDate() &&
+    viewYear === today.getFullYear() &&
+    viewMonth === today.getMonth();
+
+  return (
+    <div className="space-y-3">
+      {/* Month header */}
+      <div className="text-center text-sm font-medium text-foreground">
+        {MONTH_NAMES[viewMonth]} {viewYear}
+      </div>
+
+      {/* Day-of-week labels */}
+      <div className="grid grid-cols-7 text-center text-xs text-muted-foreground/50">
+        {DOW_LABELS.map((d) => (
+          <div key={d} className="py-1 font-medium">
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* Date cells */}
+      <div className="grid grid-cols-7 text-center text-xs">
+        {cells.map((day, i) => (
+          <div key={i} className="flex items-center justify-center py-0.5">
+            {day !== null && (
+              <span
+                className={[
+                  "flex h-6 w-6 items-center justify-center rounded-full",
+                  isHighlight(day)
+                    ? "bg-pk font-semibold text-white"
+                    : isToday(day)
+                      ? "font-semibold text-pk ring-1 ring-pk"
+                      : "text-foreground",
+                ].join(" ")}
+              >
+                {day}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {highlightDate ? (
+        <p className="text-center text-xs text-muted-foreground">
+          Scheduled for{" "}
+          <span className="font-medium text-foreground">
+            {new Date(highlightDate + "T00:00:00").toLocaleDateString(undefined, {
+              weekday: "long",
+              month: "long",
+              day: "numeric",
+            })}
+          </span>
+        </p>
+      ) : (
+        <p className="text-center text-xs text-muted-foreground">
+          Switch to Schedule mode to pick a date.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/composer/post-composer-modal.tsx
+++ b/components/composer/post-composer-modal.tsx
@@ -13,6 +13,7 @@ import type { SocialPlatform } from "@/lib/platform/social/variants/types";
 
 import { ApprovalToggle } from "./approval-toggle";
 import { ComposerActions } from "./composer-actions";
+import { ComposerPreview } from "./composer-preview";
 import { ComposerTextarea } from "./composer-textarea";
 import { ImageUploadZone } from "./image-upload-zone";
 import { ProfileSelector } from "./profile-selector";
@@ -26,20 +27,11 @@ import {
 import type { ComposerError, Draft } from "./use-composer-reducer";
 
 // ---------------------------------------------------------------------------
-// Spec 22 PR 2 — PostComposerModal with real editor components.
+// Spec 22 PR 3 — PostComposerModal with live preview pane.
 //
-// PR 1 shipped the modal chrome + state machine + autosave.
-// PR 2 replaces all placeholder blocks with:
-//   - ProfileSelector (left pane top)
-//   - ComposerTextarea (main text input)
-//   - ImageUploadZone (three-source picker)
-//   - ToolsRow (emoji / GIF stub / UTM stub / AI stub)
-//   - SchedulingTabs + date/time pickers (footer left)
-//   - ApprovalToggle
-//   - ComposerActions (primary submit button)
-//
-// Submit flow: POST /api/platform/social/drafts/[id]/publish which handles
-// create-post → submit → auto-approve → schedule in one server-side call.
+// PR 2 shipped all editor components. PR 3 replaces the right-pane
+// placeholder with ComposerPreview (LivePreviewCard per platform +
+// MiniCalendarPreview on the Calendar tab).
 // ---------------------------------------------------------------------------
 
 interface PostComposerModalProps {
@@ -562,32 +554,15 @@ export function PostComposerModal({
           </div>
 
           {/* Right pane — preview (40%) */}
-          <div className="flex w-[40%] flex-col overflow-y-auto p-6">
-            {/* Preview tab strip */}
-            <div role="tablist" className="mb-4 flex gap-3 border-b border-white/10 pb-3">
-              <button
-                type="button"
-                role="tab"
-                className="border-b-2 border-pk pb-2 text-sm font-medium text-foreground"
-                aria-selected="true"
-              >
-                Post preview
-              </button>
-              <button
-                type="button"
-                role="tab"
-                className="pb-2 text-sm text-muted-foreground hover:text-foreground"
-                aria-selected="false"
-              >
-                Calendar
-              </button>
-            </div>
-
-            {/* Preview empty state — PR 3 replaces this */}
-            <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground">
-              <NavIcon name="picture" size={32} className="opacity-30" />
-              <p>Select at least one profile and start typing to see preview</p>
-            </div>
+          <div className="flex w-[40%] flex-col overflow-y-auto">
+            <ComposerPreview
+              draftData={draftData}
+              selectedPlatforms={selectedPlatforms}
+              connections={connections}
+              mode={mode}
+              scheduleDate={scheduleDate}
+              scheduleTime={scheduleTime}
+            />
           </div>
         </div>
 

--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -7,6 +7,19 @@ Empty claim-block list means: no parallel work active; serial-single-session is 
 <!-- CLAIM BLOCKS BELOW THIS LINE — append on slice start, remove on slice merge -->
 
 ---
+## Session B
+- Started: 2026-05-08 UTC
+- Branch: feat/spec22-pr3-preview-pane
+- Slice: Spec 22 PR 3 — preview pane (ComposerPreview, LivePreviewCard, MiniCalendarPreview)
+- Files claimed:
+  - components/composer/composer-preview.tsx
+  - components/composer/live-preview-card.tsx
+  - components/composer/mini-calendar-preview.tsx
+  - components/composer/post-composer-modal.tsx
+- Expected completion: same session
+---
+
+---
 ## Session A
 - Started: 2026-05-08 UTC
 - Branch: feat/ui-consistency-s1-visual-regression


### PR DESCRIPTION
## Summary

Replaces the right-pane placeholder in `PostComposerModal` with a live preview system:

- **`LivePreviewCard`** — per-platform post mockup styled for LinkedIn, X, Facebook, and Google Business Profile. Shows post text (truncated at 600 chars), link URL strip, author avatar placeholder, and a per-platform engagement row. Character counter turns destructive when over the platform limit (X: 280, GBP: 1500)
- **`MiniCalendarPreview`** — month grid with today ringed in `ring-pk` and the scheduled date highlighted in solid `bg-pk`. Shows a plain-English caption below ("Scheduled for Thursday, May 8"). Falls back to "Switch to Schedule mode to pick a date" when not in schedule mode
- **`ComposerPreview`** — right-pane wrapper; owns the "Post preview" / "Calendar" tab state. Renders `LivePreviewCard` per selected platform in canonical `SUPPORTED_PLATFORMS` order; shows the empty-state illustration until at least one profile is selected *and* text is entered

`PostComposerModal` diff: import `ComposerPreview`, replace the 30-line static placeholder block with a 9-line wired component.

## Risks identified and mitigated

| Hotspot | Mitigation |
|---|---|
| No backend changes | Preview is derived entirely from props already present in the modal — zero new API calls |
| Linearicons icon names | Engagement row uses plain text labels (Like / Comment / Share / Reply / Repost) — avoids any guessed icon names that might not exist in the font |
| `useMemo` in MiniCalendarPreview | Calendar grid recomputes only when `viewYear`/`viewMonth` change; `today` reference stabilised with `useMemo(()=>new Date(),[])` |

## Reversible?
Yes — no migration, no schema change, no API change.

## Visual checkpoint (Steven)
1. Open composer → right pane should show empty state ("Select at least one profile and start typing to see preview")
2. Select a profile → empty state persists until text is typed
3. Type text → `LivePreviewCard(s)` appear live, one per selected platform
4. Click Calendar tab → `MiniCalendarPreview` appears for the current month
5. Switch to Schedule mode, pick a future date → calendar highlights that date in pink

🤖 Generated with [Claude Code](https://claude.com/claude-code)