### PR TITLE
feat(spec22): inline AI Assistant panel with copy generation (PR 4 of 5)

### DIFF
--- a/app/api/platform/social/cap/assist/route.ts
+++ b/app/api/platform/social/cap/assist/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { readJsonBody, validationError, internalError } from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
+import { generateAssistText } from "@/lib/platform/social/cap/assist";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/social/cap/assist — inline AI text generation for the
+// composer AI-assistant panel (Spec 22 PR 4).
+//
+// Generates a single post from a user prompt without creating any DB records.
+// Rate limit: 30 calls/company/hour ("cap_assist") keyed on "company:<uuid>".
+// Gate: create_post (editor+).
+//
+// Body: { company_id, prompt, tone, length }
+// Response: { ok: true, data: { text: string } }
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const BodySchema = z.object({
+  company_id: z.string().uuid(),
+  prompt: z.string().min(1).max(500),
+  tone: z.enum(["professional", "casual", "playful"]),
+  length: z.enum(["short", "medium", "long"]),
+});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body must be valid JSON.");
+
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError(
+      "Body must be { company_id: uuid, prompt: string, tone: professional|casual|playful, length: short|medium|long }.",
+    );
+  }
+
+  const { company_id: companyId, prompt, tone, length } = parsed.data;
+
+  const gate = await requireCanDoForApi(companyId, "create_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("cap_assist", `company:${companyId}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
+
+  logger.info("cap.assist.route.start", { companyId, tone, length, userId: gate.userId });
+
+  const result = await generateAssistText({
+    companyId,
+    prompt,
+    tone,
+    length,
+    requestedBy: gate.userId,
+  });
+
+  if (!result.ok) {
+    return internalError(result.error.message);
+  }
+
+  return NextResponse.json(
+    { ok: true, data: { text: result.text }, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/components/composer/ai-assistant-panel.tsx
+++ b/components/composer/ai-assistant-panel.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useState } from "react";
+
+import { NavIcon } from "@/components/ui/nav-icon";
+
+// ---------------------------------------------------------------------------
+// Spec 22 PR 4 — AiAssistantPanel.
+//
+// Inline expansion below the tools row. User enters a prompt, selects tone +
+// length, clicks Generate. Calls /api/platform/social/cap/assist (30/hour
+// per company, no DB records created). Generated text shown with
+// Replace / Append / Regenerate actions; ai_metadata passed in callbacks.
+// ---------------------------------------------------------------------------
+
+type Tone = "professional" | "casual" | "playful";
+type Length = "short" | "medium" | "long";
+
+const LENGTH_LABEL: Record<Length, string> = {
+  short: "Short",
+  medium: "Medium",
+  long: "Long",
+};
+
+export type AiMeta = { prompt: string; tone: string; generated_at: string };
+
+type PanelStatus = "idle" | "loading" | "done" | "error" | "rate_limited";
+
+interface AiAssistantPanelProps {
+  companyId: string;
+  correlationId: string;
+  onReplace: (text: string, meta: AiMeta) => void;
+  onAppend: (text: string, meta: AiMeta) => void;
+  onClose: () => void;
+}
+
+export function AiAssistantPanel({
+  companyId,
+  correlationId,
+  onReplace,
+  onAppend,
+  onClose,
+}: AiAssistantPanelProps) {
+  const [prompt, setPrompt] = useState("");
+  const [tone, setTone] = useState<Tone>("professional");
+  const [length, setLength] = useState<Length>("medium");
+  const [status, setStatus] = useState<PanelStatus>("idle");
+  const [generatedText, setGeneratedText] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleGenerate() {
+    if (!prompt.trim()) return;
+    setStatus("loading");
+    setGeneratedText(null);
+    setErrorMessage(null);
+
+    try {
+      const res = await fetch("/api/platform/social/cap/assist", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-correlation-id": correlationId,
+        },
+        body: JSON.stringify({
+          company_id: companyId,
+          prompt: prompt.trim(),
+          tone,
+          length,
+        }),
+      });
+
+      if (res.status === 429) {
+        setStatus("rate_limited");
+        return;
+      }
+
+      const result = (await res.json()) as {
+        ok: boolean;
+        data?: { text: string };
+        error?: { message?: string };
+      };
+
+      if (!result.ok) {
+        setStatus("error");
+        setErrorMessage(result.error?.message ?? "Generation failed. Please try again.");
+        return;
+      }
+
+      const text = result.data?.text ?? "";
+      if (!text) {
+        setStatus("error");
+        setErrorMessage("No content was generated. Please try again.");
+        return;
+      }
+
+      setGeneratedText(text);
+      setStatus("done");
+    } catch {
+      setStatus("error");
+      setErrorMessage("Network error. Please try again.");
+    }
+  }
+
+  const canGenerate = !!prompt.trim() && status !== "loading" && status !== "rate_limited";
+  const meta = (): AiMeta => ({ prompt, tone, generated_at: new Date().toISOString() });
+
+  return (
+    <div className="rounded-lg border border-pk/30 bg-pk/5 p-4">
+      {/* Header */}
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-1.5 text-sm font-medium">
+          <NavIcon name="magic-wand" size={14} className="text-pk" />
+          AI Assistant
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close AI assistant"
+          className="rounded p-1 text-muted-foreground hover:text-foreground"
+        >
+          <NavIcon name="cross" size={14} />
+        </button>
+      </div>
+
+      {/* Prompt textarea */}
+      <textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        placeholder="Write a post about…"
+        rows={2}
+        maxLength={500}
+        disabled={status === "loading"}
+        aria-label="Describe what you want the post to say"
+        className="mb-3 w-full resize-none rounded border border-white/10 bg-background px-3 py-2 text-sm placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-pk/50 disabled:opacity-60"
+      />
+
+      {/* Tone + Length + Generate button */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">Tone</span>
+          <select
+            value={tone}
+            onChange={(e) => setTone(e.target.value as Tone)}
+            disabled={status === "loading"}
+            aria-label="Tone"
+            className="rounded border border-white/10 bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-pk/50 disabled:opacity-60"
+          >
+            <option value="professional">Professional</option>
+            <option value="casual">Casual</option>
+            <option value="playful">Playful</option>
+          </select>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">Length</span>
+          <select
+            value={length}
+            onChange={(e) => setLength(e.target.value as Length)}
+            disabled={status === "loading"}
+            aria-label="Length"
+            className="rounded border border-white/10 bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-pk/50 disabled:opacity-60"
+          >
+            {(["short", "medium", "long"] as Length[]).map((l) => (
+              <option key={l} value={l}>
+                {LENGTH_LABEL[l]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="ml-auto">
+          <button
+            type="button"
+            onClick={() => void handleGenerate()}
+            disabled={!canGenerate}
+            title={status === "rate_limited" ? "Out of AI credits — resets in 1 hour" : undefined}
+            aria-label={status === "rate_limited" ? "Out of AI credits" : "Generate text"}
+            className="flex items-center gap-1.5 rounded bg-pk px-3 py-1.5 text-xs font-medium text-white hover:bg-pk/80 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {status === "loading" ? (
+              <>
+                <span className="inline-flex animate-spin">
+                  <NavIcon name="sync" size={12} />
+                </span>
+                Generating…
+              </>
+            ) : status === "rate_limited" ? (
+              <>
+                <NavIcon name="magic-wand" size={12} />
+                Out of AI credits
+              </>
+            ) : (
+              <>
+                <NavIcon name="magic-wand" size={12} />
+                Generate
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Error state */}
+      {status === "error" && errorMessage && (
+        <p className="mt-3 text-xs text-destructive">{errorMessage}</p>
+      )}
+
+      {/* Rate-limited hint */}
+      {status === "rate_limited" && (
+        <p className="mt-3 text-xs text-muted-foreground">
+          AI generation limit reached. Credits reset every hour.
+        </p>
+      )}
+
+      {/* Generated result */}
+      {status === "done" && generatedText && (
+        <div className="mt-3 space-y-2">
+          <p className="whitespace-pre-wrap rounded border border-white/10 bg-background p-3 text-sm leading-relaxed">
+            {generatedText}
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => { onReplace(generatedText, meta()); onClose(); }}
+              className="rounded border border-white/10 px-3 py-1.5 text-xs font-medium hover:bg-white/10"
+            >
+              Replace
+            </button>
+            <button
+              type="button"
+              onClick={() => { onAppend(generatedText, meta()); onClose(); }}
+              className="rounded border border-white/10 px-3 py-1.5 text-xs font-medium hover:bg-white/10"
+            >
+              Append
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleGenerate()}
+              disabled={!prompt.trim()}
+              className="ml-auto text-xs text-muted-foreground hover:text-foreground disabled:opacity-40"
+            >
+              Regenerate
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/composer/post-composer-modal.tsx
+++ b/components/composer/post-composer-modal.tsx
@@ -11,6 +11,8 @@ import type { DraftData } from "@/lib/platform/social/drafts";
 import type { SocialConnection } from "@/lib/platform/social/connections/types";
 import type { SocialPlatform } from "@/lib/platform/social/variants/types";
 
+import { AiAssistantPanel } from "./ai-assistant-panel";
+import type { AiMeta } from "./ai-assistant-panel";
 import { ApprovalToggle } from "./approval-toggle";
 import { ComposerActions } from "./composer-actions";
 import { ComposerPreview } from "./composer-preview";
@@ -68,6 +70,9 @@ export function PostComposerModal({
 
   // Connections list — loaded by ProfileSelector, also needed for publish call.
   const [connections, setConnections] = useState<SocialConnection[]>([]);
+
+  // AI assistant panel open/close.
+  const [aiPanelOpen, setAiPanelOpen] = useState(false);
 
   // ---------------------------------------------------------------------------
   // Initialise: create or load draft on mount
@@ -155,6 +160,25 @@ export function PostComposerModal({
     if (s.status !== "editing" && s.status !== "saved") return;
     const text = s.draft.draft_data.master_text ?? "";
     dispatch({ type: "UPDATE_DRAFT", patch: { master_text: text + emoji } });
+  }, []);
+
+  const aiReplace = useCallback((text: string, meta: AiMeta) => {
+    dispatch({ type: "UPDATE_DRAFT", patch: { master_text: text, ai_metadata: { prompt: meta.prompt, tone: meta.tone, generated_at: meta.generated_at } } });
+    setAiPanelOpen(false);
+  }, []);
+
+  const aiAppend = useCallback((text: string, meta: AiMeta) => {
+    const s = stateRef.current;
+    if (s.status !== "editing" && s.status !== "saved") return;
+    const current = s.draft.draft_data.master_text ?? "";
+    dispatch({
+      type: "UPDATE_DRAFT",
+      patch: {
+        master_text: current ? `${current}\n\n${text}` : text,
+        ai_metadata: { prompt: meta.prompt, tone: meta.tone, generated_at: meta.generated_at },
+      },
+    });
+    setAiPanelOpen(false);
   }, []);
 
   // Keep schedule in draft_data for autosave.
@@ -540,8 +564,20 @@ export function PostComposerModal({
                 {/* Tools row */}
                 <ToolsRow
                   onEmojiInsert={insertEmoji}
+                  onAIAssistant={() => setAiPanelOpen((v) => !v)}
                   disabled={submitting}
                 />
+
+                {/* AI assistant inline panel */}
+                {aiPanelOpen && (
+                  <AiAssistantPanel
+                    companyId={companyId}
+                    correlationId={correlationId}
+                    onReplace={aiReplace}
+                    onAppend={aiAppend}
+                    onClose={() => setAiPanelOpen(false)}
+                  />
+                )}
 
                 {/* Approval toggle */}
                 <ApprovalToggle

--- a/lib/platform/social/cap/assist.ts
+++ b/lib/platform/social/cap/assist.ts
@@ -1,0 +1,112 @@
+import "server-only";
+
+import { randomUUID } from "crypto";
+
+import { getActiveBrandProfile } from "@/lib/platform/brand/get";
+import { logger } from "@/lib/logger";
+import {
+  defaultAnthropicCall,
+  type AnthropicCallFn,
+} from "@/lib/anthropic-call";
+
+// ---------------------------------------------------------------------------
+// Spec 22 PR 4 — AI assist for the inline composer panel.
+//
+// Generates a single post from a user-supplied prompt without creating any
+// DB records — text is returned for the user to Replace or Append into
+// their draft. Lighter than CAP generate (Haiku model, plain-text output).
+// ---------------------------------------------------------------------------
+
+export type AssistTone = "professional" | "casual" | "playful";
+export type AssistLength = "short" | "medium" | "long";
+
+export interface AssistInput {
+  companyId: string;
+  prompt: string;
+  tone: AssistTone;
+  length: AssistLength;
+  requestedBy: string;
+}
+
+export type AssistResult =
+  | { ok: true; text: string }
+  | { ok: false; error: { code: string; message: string } };
+
+const TONE_GUIDE: Record<AssistTone, string> = {
+  professional:
+    "Use a professional, authoritative tone. Clear, confident, jargon-free language.",
+  casual:
+    "Use a conversational, friendly tone. Approachable and relatable — like talking to a colleague.",
+  playful:
+    "Use a light, fun, energetic tone. Emojis are welcome if they fit naturally.",
+};
+
+const LENGTH_GUIDE: Record<AssistLength, string> = {
+  short: "Keep it brief — 1–2 sentences, around 30–60 words maximum.",
+  medium: "Aim for 2–4 sentences, around 80–150 words.",
+  long: "Write a fuller post — 4–8 sentences, around 180–280 words.",
+};
+
+export async function generateAssistText(
+  input: AssistInput,
+  callFn: AnthropicCallFn = defaultAnthropicCall,
+): Promise<AssistResult> {
+  const { companyId, prompt, tone, length, requestedBy } = input;
+
+  const brand = await getActiveBrandProfile(companyId);
+
+  const systemParts: string[] = [
+    "You are a social media copywriter. Write a single social media post based on the user's instructions.",
+    "Return ONLY the post text — no quotes around it, no markdown, no preamble, no explanations.",
+  ];
+
+  if (brand) {
+    if (brand.personality_traits.length > 0) {
+      systemParts.push(`Brand personality: ${brand.personality_traits.join(", ")}.`);
+    }
+    if (brand.avoided_terms.length > 0) {
+      systemParts.push(`Never use these words or phrases: ${brand.avoided_terms.join(", ")}.`);
+    }
+    if (brand.content_restrictions.length > 0) {
+      systemParts.push(`Hard content rules (never violate): ${brand.content_restrictions.join(". ")}.`);
+    }
+  }
+
+  systemParts.push(`Tone instruction: ${TONE_GUIDE[tone]}`);
+  systemParts.push(`Length instruction: ${LENGTH_GUIDE[length]}`);
+
+  const system = systemParts.join("\n");
+
+  logger.info("cap.assist.start", { companyId, tone, length, requestedBy });
+
+  let rawText: string;
+  try {
+    const resp = await callFn({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 512,
+      system,
+      messages: [{ role: "user", content: `Write a social media post about: ${prompt}` }],
+      idempotency_key: randomUUID(),
+    });
+    rawText = resp.content.map((b) => b.text).join("").trim();
+  } catch (err) {
+    logger.error("cap.assist.claude_failed", {
+      companyId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      ok: false,
+      error: { code: "CLAUDE_ERROR", message: "Failed to generate text. Please try again." },
+    };
+  }
+
+  if (!rawText) {
+    return {
+      ok: false,
+      error: { code: "EMPTY_RESPONSE", message: "No text was generated. Please try again." },
+    };
+  }
+
+  logger.info("cap.assist.done", { companyId, chars: rawText.length });
+  return { ok: true, text: rawText };
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -44,6 +44,7 @@ export type LimiterName =
   | "admin_write"
   | "briefs_upload"
   | "cap_generate"
+  | "cap_assist"
   | "approval_decision";
 
 type LimiterConfig = {
@@ -103,6 +104,9 @@ const CONFIGS: Record<LimiterName, LimiterConfig> = {
   // 5 posts; 10/company/24 h caps runaway spend while leaving headroom
   // for daily editorial use. Keyed on "company:<uuid>".
   cap_generate: { requests: 10, window: "24 h" },
+  // Spec 22 PR 4: inline AI assist in composer. 30 calls/company/hour —
+  // lighter than CAP generate (no DB rows); covers rapid "regenerate" use.
+  cap_assist: { requests: 30, window: "1 h" },
   // B-8: public approval decision endpoint. 256-bit token keyspace makes
   // brute-force infeasible; this per-IP cap is defence-in-depth against
   // credential-stuffing / automated replay. 20/hour matches invite_accept.


### PR DESCRIPTION
## Summary

Spec 22 PR 4 — inline AI Assistant panel that expands below the composer tools row.

- **`AiAssistantPanel` component** (`components/composer/ai-assistant-panel.tsx`) — prompt textarea, tone selector (professional / casual / playful), length selector (short / medium / long), Generate button with loading / rate-limited / error states; Replace / Append / Regenerate actions on the generated result
- **`generateAssistText()` service** (`lib/platform/social/cap/assist.ts`) — Haiku model, plain-text output, no DB records created; incorporates active brand profile (personality traits, avoided terms, content restrictions)
- **`POST /api/platform/social/cap/assist`** (`app/api/platform/social/cap/assist/route.ts`) — gated on `create_post` permission, rate-limited at 30 calls/company/hour (`cap_assist`); separate from the heavyweight CAP generate endpoint
- **Composer integration** (`post-composer-modal.tsx`) — AI wand button toggles the panel; Replace writes `master_text` + `ai_metadata`; Append appends with double newline; both store `{ prompt, tone, generated_at }` in draft_data for audit trail

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Billed Claude call with no idempotency | `randomUUID()` idempotency key on every call; Haiku model minimises cost; no DB rows created so no partial-write risk |
| Rate limit bypass | `checkRateLimit("cap_assist", "company:<uuid>")` before calling Claude; 429 surfaced to UI with "Out of AI credits" state |
| Brand profile injection | `getActiveBrandProfile` called server-side; content restrictions embedded in system prompt before user prompt |
| `ai_metadata` in draft without schema | Field already exists in `DraftData` Zod schema (added in PR 1) |

## Test plan

- [ ] Open composer, click AI wand icon → panel expands below tools row
- [ ] Enter a prompt, select tone/length, click Generate → loading spinner, text appears
- [ ] Click Replace → textarea fills with generated text, panel closes, ai_metadata written to draft
- [ ] Click Append → text appended to existing draft content
- [ ] Click Regenerate → new generation with same prompt
- [ ] Hit rate limit (mock 429) → "Out of AI credits" button state + hint text
- [ ] Network error → error message shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)