### PR TITLE
feat(spec22): timeline view + composer polish — PR 5 of 5

### DIFF
--- a/app/company/social/calendar/page.tsx
+++ b/app/company/social/calendar/page.tsx
@@ -86,7 +86,7 @@ export default async function CompanySocialCalendarPage({ searchParams }: Props)
         }))
       : [];
 
-  const composerEnabled = process.env.FEATURE_COMPOSER_V2 === "true";
+  const composerEnabled = process.env.FEATURE_COMPOSER_V2 !== "false";
 
   return (
     <main className="mx-auto max-w-5xl p-6">

--- a/app/company/social/posts/page.tsx
+++ b/app/company/social/posts/page.tsx
@@ -110,7 +110,7 @@ export default async function CompanySocialPostsPage({ searchParams }: Props) {
     );
   }
 
-  const composerEnabled = process.env.FEATURE_COMPOSER_V2 === "true";
+  const composerEnabled = process.env.FEATURE_COMPOSER_V2 !== "false";
 
   return (
     <SocialPostsListClient

--- a/app/company/social/timeline/page.tsx
+++ b/app/company/social/timeline/page.tsx
@@ -1,20 +1,26 @@
 import { redirect } from "next/navigation";
 
 import { SocialModuleShell } from "@/components/social/social-module-shell";
-import { getCurrentPlatformSession } from "@/lib/platform/auth";
+import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
+import { listPostMasters } from "@/lib/platform/social/posts";
 import { getServiceRoleClient } from "@/lib/supabase";
 
+import { TimelineFeed } from "./timeline-feed";
+
 // ---------------------------------------------------------------------------
-// /company/social/timeline — placeholder for the chronological timeline view.
+// Spec 22 PR 5 — /company/social/timeline
 //
-// The Timeline tab in SocialModuleShell is disabled (coming soon). This page
-// is reachable via direct URL navigation. The view will be fleshed out in a
-// future slice once the data model for chronological post history is defined.
+// Chronological feed of all posts (all states) sorted newest first.
+// Viewer+ gate. Editor+ also sees "New post" CTA via composerEnabled.
 // ---------------------------------------------------------------------------
 
 export const dynamic = "force-dynamic";
 
-export default async function CompanySocialTimelinePage() {
+const PAGE_SIZE = 50;
+
+type Props = { searchParams: Promise<{ page?: string }> };
+
+export default async function CompanySocialTimelinePage({ searchParams }: Props) {
   const session = await getCurrentPlatformSession();
   if (!session) {
     redirect(`/login?next=${encodeURIComponent("/company/social/timeline")}`);
@@ -28,36 +34,56 @@ export default async function CompanySocialTimelinePage() {
   }
 
   const companyId = session.company.companyId;
+  const { page: pageParam } = await searchParams;
+  const page = Math.max(1, parseInt(pageParam ?? "1", 10) || 1);
+  const offset = (page - 1) * PAGE_SIZE;
 
-  const companyRow = await getServiceRoleClient()
-    .from("platform_companies")
-    .select("name")
-    .eq("id", companyId)
-    .maybeSingle();
+  const [postsResult, canCreate, companyRow] = await Promise.all([
+    listPostMasters({
+      companyId,
+      limit: PAGE_SIZE,
+      offset,
+      withCount: true,
+      sortBy: "created_at",
+      sortDir: "desc",
+    }),
+    canDo(companyId, "create_post"),
+    getServiceRoleClient()
+      .from("platform_companies")
+      .select("name")
+      .eq("id", companyId)
+      .maybeSingle(),
+  ]);
 
   const companyName: string =
     (companyRow.data as { name: string } | null)?.name ?? "My company";
 
-  const composerEnabled = process.env.FEATURE_COMPOSER_V2 === "true";
+  const composerEnabled = process.env.FEATURE_COMPOSER_V2 !== "false";
+
+  if (!postsResult.ok) {
+    return (
+      <div
+        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        role="alert"
+      >
+        Failed to load timeline: {postsResult.error.message}
+      </div>
+    );
+  }
 
   return (
     <main className="mx-auto max-w-5xl p-6">
       <SocialModuleShell
         activeView="timeline"
         companyName={companyName}
-        composerEnabled={composerEnabled}
+        composerEnabled={composerEnabled && canCreate}
       >
-        <div
-          className="flex min-h-[24rem] flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-gray-200 text-center"
-          data-testid="timeline-coming-soon"
-        >
-          <p className="text-sm font-medium text-tx-primary">
-            Timeline coming soon
-          </p>
-          <p className="max-w-xs text-sm text-tx-muted">
-            A chronological view of your social post history will appear here.
-          </p>
-        </div>
+        <TimelineFeed
+          posts={postsResult.data.posts}
+          totalCount={postsResult.data.totalCount}
+          page={page}
+          pageSize={PAGE_SIZE}
+        />
       </SocialModuleShell>
     </main>
   );

--- a/app/company/social/timeline/timeline-feed.tsx
+++ b/app/company/social/timeline/timeline-feed.tsx
@@ -1,0 +1,139 @@
+import Link from "next/link";
+
+import type { PostMasterListItem, SocialPostState } from "@/lib/platform/social/posts";
+
+// ---------------------------------------------------------------------------
+// Spec 22 PR 5 — TimelineFeed.
+//
+// Chronological list of social posts (newest first). Server component;
+// data is fetched by the page RSC and passed in as props.
+// ---------------------------------------------------------------------------
+
+interface TimelineFeedProps {
+  posts: PostMasterListItem[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+const STATE_PILL: Record<SocialPostState, string> = {
+  draft: "bg-muted text-muted-foreground",
+  pending_client_approval: "bg-amber-100 text-amber-900",
+  approved: "bg-emerald-100 text-emerald-900",
+  rejected: "bg-rose-100 text-rose-900",
+  changes_requested: "bg-amber-100 text-amber-900",
+  scheduled: "bg-sky-100 text-sky-900",
+  publishing: "bg-sky-200 text-sky-900",
+  published: "bg-primary/10 text-primary",
+  failed: "bg-rose-100 text-rose-900",
+};
+
+const STATE_LABEL: Record<SocialPostState, string> = {
+  draft: "Draft",
+  pending_client_approval: "Awaiting approval",
+  approved: "Approved",
+  rejected: "Rejected",
+  changes_requested: "Changes requested",
+  scheduled: "Scheduled",
+  publishing: "Publishing",
+  published: "Published",
+  failed: "Failed",
+};
+
+export function TimelineFeed({ posts, totalCount, page, pageSize }: TimelineFeedProps) {
+  const totalPages = Math.ceil(totalCount / pageSize);
+  const hasPrev = page > 1;
+  const hasNext = page < totalPages;
+
+  if (posts.length === 0 && page === 1) {
+    return (
+      <div
+        data-testid="timeline-empty"
+        className="flex min-h-[24rem] flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-gray-200 text-center"
+      >
+        <p className="text-sm font-medium text-tx-primary">No posts yet</p>
+        <p className="max-w-xs text-sm text-tx-muted">
+          Posts you create will appear here in chronological order.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="timeline-feed">
+      <ol className="space-y-3">
+        {posts.map((post) => (
+          <li
+            key={post.id}
+            className="flex items-start gap-4 rounded-lg border border-white/10 bg-card p-4"
+          >
+            {/* Timestamp column */}
+            <time
+              dateTime={post.created_at}
+              className="w-28 shrink-0 text-xs text-muted-foreground tabular-nums"
+            >
+              {new Date(post.created_at).toLocaleString("en-AU", {
+                day: "numeric",
+                month: "short",
+                year: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </time>
+
+            {/* Content */}
+            <div className="min-w-0 flex-1">
+              <p className="line-clamp-3 text-sm text-foreground">
+                {post.master_text ?? (
+                  <span className="italic text-muted-foreground">No text</span>
+                )}
+              </p>
+              {post.link_url && (
+                <p className="mt-1 truncate text-xs text-muted-foreground">
+                  {post.link_url}
+                </p>
+              )}
+            </div>
+
+            {/* State pill */}
+            <span
+              className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${STATE_PILL[post.state]}`}
+            >
+              {STATE_LABEL[post.state]}
+            </span>
+          </li>
+        ))}
+      </ol>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <nav
+          aria-label="Timeline pagination"
+          className="mt-6 flex items-center justify-between text-sm"
+        >
+          <span className="text-muted-foreground">
+            {(page - 1) * pageSize + 1}–{Math.min(page * pageSize, totalCount)} of {totalCount}
+          </span>
+          <div className="flex gap-2">
+            {hasPrev && (
+              <Link
+                href={`?page=${page - 1}`}
+                className="rounded border border-white/10 px-3 py-1.5 hover:bg-white/5"
+              >
+                Previous
+              </Link>
+            )}
+            {hasNext && (
+              <Link
+                href={`?page=${page + 1}`}
+                className="rounded border border-white/10 px-3 py-1.5 hover:bg-white/5"
+              >
+                Next
+              </Link>
+            )}
+          </div>
+        </nav>
+      )}
+    </div>
+  );
+}

--- a/components/composer/composer-actions.tsx
+++ b/components/composer/composer-actions.tsx
@@ -3,10 +3,10 @@
 import type { ComposerMode } from "./scheduling-tabs";
 
 // ---------------------------------------------------------------------------
-// Spec 22 PR 2 — ComposerActions.
+// Spec 22 PR 5 — ComposerActions.
 //
 // Primary action button (label changes per mode) + "Schedule & create another"
-// stub (PR 5 wires the "create another" behaviour).
+// (wired in PR 5: submits current draft then resets composer for a new draft).
 // ---------------------------------------------------------------------------
 
 const MODE_LABEL: Record<ComposerMode, string> = {
@@ -20,6 +20,7 @@ interface ComposerActionsProps {
   submitting: boolean;
   disabled: boolean;
   onSubmit: () => void;
+  onSubmitAndCreateAnother?: () => void;
 }
 
 export function ComposerActions({
@@ -27,16 +28,17 @@ export function ComposerActions({
   submitting,
   disabled,
   onSubmit,
+  onSubmitAndCreateAnother,
 }: ComposerActionsProps) {
   return (
     <div className="flex items-center gap-3">
-      {/* "Schedule & create another" — stub, PR 5 */}
-      {mode === "schedule" && (
+      {/* "Schedule & create another" — only in schedule mode */}
+      {mode === "schedule" && onSubmitAndCreateAnother && (
         <button
           type="button"
-          disabled
-          title="Coming in a future update"
-          className="rounded-md border border-white/10 px-4 py-2 text-sm text-muted-foreground/40"
+          onClick={onSubmitAndCreateAnother}
+          disabled={disabled || submitting}
+          className="rounded-md border border-white/10 px-4 py-2 text-sm text-muted-foreground hover:bg-white/5 hover:text-foreground disabled:opacity-40"
         >
           Schedule &amp; create another
         </button>

--- a/components/composer/post-composer-modal.tsx
+++ b/components/composer/post-composer-modal.tsx
@@ -272,10 +272,10 @@ export function PostComposerModal({
   });
 
   // ---------------------------------------------------------------------------
-  // Submit
+  // Submit (shared logic; createAnother = true resets for next draft)
   // ---------------------------------------------------------------------------
 
-  const handleSubmit = useCallback(async () => {
+  const handleSubmit = useCallback(async (createAnother = false) => {
     const s = stateRef.current;
     if (s.status !== "editing" && s.status !== "saved") return;
 
@@ -329,12 +329,21 @@ export function PostComposerModal({
         toastSuccess("Post queued for publishing");
       }
 
-      // Close modal.
-      const url = new URL(window.location.href);
-      url.searchParams.delete("compose");
-      url.searchParams.delete("date");
-      router.replace(url.pathname + (url.search || ""), { scroll: false });
-      dispatch({ type: "RESET" });
+      if (createAnother) {
+        // Keep modal open with a fresh composer (triggers new draft creation).
+        const url = new URL(window.location.href);
+        url.searchParams.set("compose", "new");
+        url.searchParams.delete("date");
+        router.replace(url.pathname + url.search, { scroll: false });
+        dispatch({ type: "RESET" });
+      } else {
+        // Close modal.
+        const url = new URL(window.location.href);
+        url.searchParams.delete("compose");
+        url.searchParams.delete("date");
+        router.replace(url.pathname + (url.search || ""), { scroll: false });
+        dispatch({ type: "RESET" });
+      }
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : "Submit failed.");
       dispatch({
@@ -621,6 +630,7 @@ export function PostComposerModal({
             submitting={submitting}
             disabled={!canSubmit}
             onSubmit={() => void handleSubmit()}
+            onSubmitAndCreateAnother={() => void handleSubmit(true)}
           />
         </div>
       </div>

--- a/components/social/social-module-shell.tsx
+++ b/components/social/social-module-shell.tsx
@@ -28,7 +28,7 @@ export interface SocialModuleShellProps {
 const TABS: readonly PillTab[] = [
   { value: "calendar", label: "Calendar", href: "/company/social/calendar" },
   { value: "posts", label: "Posts", href: "/company/social/posts" },
-  { value: "timeline", label: "Timeline", disabled: true },
+  { value: "timeline", label: "Timeline", href: "/company/social/timeline" },
 ];
 
 const VIEW_LABEL: Record<SocialView, string> = {

--- a/e2e/social.spec.ts
+++ b/e2e/social.spec.ts
@@ -96,4 +96,28 @@ test.describe("social platform", () => {
 
     await auditA11y(page, testInfo);
   });
+
+  test("timeline page loads with feed or empty state", async ({ page }, testInfo) => {
+    await page.goto("/company/social/timeline");
+    await expect(page).toHaveURL(/\/company\/social\/timeline/);
+
+    // Either a feed or an empty state must render.
+    const feed = page.getByTestId("timeline-feed");
+    const empty = page.getByTestId("timeline-empty");
+    await expect(feed.or(empty)).toBeVisible({ timeout: 15_000 });
+
+    // Shell toolbar must be present.
+    await expect(page.getByTestId("social-module-shell")).toBeVisible();
+
+    await auditA11y(page, testInfo);
+  });
+
+  test("timeline tab in shell navigation links to timeline", async ({ page }) => {
+    await page.goto("/company/social/posts");
+    await expect(page).toHaveURL(/\/company\/social\/posts/);
+
+    // Click the Timeline pill tab.
+    await page.getByRole("link", { name: /timeline/i }).click();
+    await expect(page).toHaveURL(/\/company\/social\/timeline/, { timeout: 10_000 });
+  });
 });


### PR DESCRIPTION
## Spec 22 — PR 5 of 5: Timeline View + Final Polish

### What this ships

**Timeline view (`/company/social/timeline`):**
- RSC page fetching `listPostMasters` (sorted `created_at` DESC), auth gate, `composerEnabled` wired to SocialModuleShell
- `TimelineFeed` component: chronological ordered list with state pills, timestamps, text preview, link URL, pagination, empty state

**Navigation:**
- Timeline tab enabled in `SocialModuleShell` (`disabled: true` removed, `href: "/company/social/timeline"` added). Spec 22 D19 satisfied.

**Composer polish:**
- `ComposerActions`: `onSubmitAndCreateAnother` prop wired — Schedule & create another is now active in schedule mode
- `PostComposerModal`: `handleSubmit(createAnother?: boolean)` — when true, navigates to `?compose=new` after submit (keeps modal open with fresh draft)

**Feature flag flip:**
- `FEATURE_COMPOSER_V2 !== "false"` in calendar, posts, timeline pages — default-on. Kill switch: set `FEATURE_COMPOSER_V2=false` in Vercel to revert.

**E2E tests:**
- Added to `e2e/social.spec.ts`: timeline page load (feed or empty state), shell present, auditA11y; tab navigation test

### Risks identified and mitigated
- **Feature flag flip**: `!== "false"` so env-unset deployments get composer by default. Kill switch documented.
- **"Schedule & create another"**: resets after publish then navigates to `?compose=new`. No double-submit risk.
- **Timeline query**: simple range scan on `social_post_master` by `created_at`, no JOIN/LIKE, no new migrations.

### Pre-existing CI failures
- `e2e` — Supabase stack doesn't start in CI (pre-existing across all PRs 802–809)
- `test` — 50+ min timeout (pre-existing)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)