### PR TITLE
fix(social): de-dupe socialAccountTypes in bundle.social portal link

### DIFF
--- a/lib/__tests__/social-connections-bundlesocial.test.ts
+++ b/lib/__tests__/social-connections-bundlesocial.test.ts
@@ -143,14 +143,28 @@ describe("initiateBundlesocialConnect", () => {
 
     const callArg =
       mockClient.socialAccount.socialAccountCreatePortalLink.mock.calls[0]?.[0];
-    expect(callArg?.requestBody?.socialAccountTypes).toEqual(
-      expect.arrayContaining([
-        "LINKEDIN",
-        "FACEBOOK",
-        "TWITTER",
-        "GOOGLE_BUSINESS",
-      ]),
+    const types: string[] = callArg?.requestBody?.socialAccountTypes ?? [];
+    expect(types).toHaveLength(4);
+    expect(types).toEqual(
+      expect.arrayContaining(["LINKEDIN", "FACEBOOK", "TWITTER", "GOOGLE_BUSINESS"]),
     );
+  });
+
+  it("de-dupes LINKEDIN when only linkedin variants are supplied (non-empty path)", async () => {
+    mockClient.socialAccount.socialAccountCreatePortalLink.mockResolvedValueOnce({
+      url: "https://bundle.social/portal/li-only",
+    });
+
+    const result = await initiateBundlesocialConnect({
+      companyId: COMPANY_A_ID,
+      platforms: ["linkedin_personal", "linkedin_company"],
+      redirectUrl: "https://opollo.test/cb",
+    });
+
+    expect(result.ok).toBe(true);
+    const callArg =
+      mockClient.socialAccount.socialAccountCreatePortalLink.mock.calls[0]?.[0];
+    expect(callArg?.requestBody?.socialAccountTypes).toStrictEqual(["LINKEDIN"]);
   });
 
   it("returns INTERNAL_ERROR when SDK throws", async () => {

--- a/lib/platform/social/connections/initiate-connect.ts
+++ b/lib/platform/social/connections/initiate-connect.ts
@@ -82,24 +82,25 @@ export async function initiateBundlesocialConnect(
   const teamId = getBundlesocialTeamId();
   if (!teamId) return notConfigured("BUNDLE_SOCIAL_TEAMID");
 
-  // De-dupe the bundle.social platform set; LINKEDIN appears once
-  // even if the operator picked both linkedin_personal and
-  // linkedin_company (bundle.social's "channel selection" step
-  // covers the per-account choice).
-  const bundlePlatforms = Array.from(
-    new Set(input.platforms.map((p) => PLATFORM_TO_BUNDLE[p])),
-  );
+  const rawPlatforms: Array<
+    "LINKEDIN" | "FACEBOOK" | "TWITTER" | "GOOGLE_BUSINESS"
+  > =
+    input.platforms.length > 0
+      ? input.platforms.map((p) => PLATFORM_TO_BUNDLE[p])
+      : (Object.values(PLATFORM_TO_BUNDLE) as Array<
+          "LINKEDIN" | "FACEBOOK" | "TWITTER" | "GOOGLE_BUSINESS"
+        >);
+  // De-dupe once; covers both paths (linkedin_personal + linkedin_company
+  // both map to LINKEDIN; the fallback Object.values produces the same
+  // duplicate before Set collapses it).
+  const bundlePlatforms = Array.from(new Set(rawPlatforms));
 
   try {
     const response = await client.socialAccount.socialAccountCreatePortalLink({
       requestBody: {
         teamId,
         redirectUrl: input.redirectUrl,
-        socialAccountTypes: bundlePlatforms.length > 0
-          ? bundlePlatforms
-          : (Object.values(PLATFORM_TO_BUNDLE) as Array<
-              "LINKEDIN" | "FACEBOOK" | "TWITTER" | "GOOGLE_BUSINESS"
-            >),
+        socialAccountTypes: bundlePlatforms,
         userName: input.userName ?? undefined,
         userLogoUrl: input.userLogoUrl ?? undefined,
       },


### PR DESCRIPTION
## Problem

The "Connect new account" button on `/company/social/connections` was failing with "There was an error" on bundle.social's hosted portal. The root cause: `socialAccountTypes` in the portal-link request contained a duplicate `LINKEDIN` entry — `["LINKEDIN", "LINKEDIN", "FACEBOOK", "TWITTER", "GOOGLE_BUSINESS"]` — because both `linkedin_personal` and `linkedin_company` map to `LINKEDIN` in `PLATFORM_TO_BUNDLE`, and the empty-platforms fallback path bypassed the `Array.from(new Set(...))` guard that the non-empty path already had.

## Fix

Refactored `initiate-connect.ts` so the dedup runs once after the source array is picked, not on each branch independently. The ternary now selects either the mapped input or `Object.values(PLATFORM_TO_BUNDLE)`, then a single `Array.from(new Set(rawPlatforms))` collapses duplicates in both cases.

## Tests

- **Tightened** the existing empty-array fallback test: added `toHaveLength(4)` to assert no duplicates slip through (this test would have caught the bug if the length assertion had been present).
- **Added** `de-dupes LINKEDIN when only linkedin variants are supplied (non-empty path)`: passes `["linkedin_personal", "linkedin_company"]`, asserts `socialAccountTypes` is strictly `["LINKEDIN"]`.

## Risks identified and mitigated

No write-safety hotspots — this is a pure input-transformation fix with no DB writes, no billed external calls beyond the existing bundle.social SDK call, and no schema changes. The dedup is idempotent.

Generated with [Claude Code](https://claude.com/claude-code)
