### PR TITLE
fix(social): block tokenless bundle.social portal redirect + diagnostics

### DIFF
--- a/lib/platform/social/connections/initiate-connect.ts
+++ b/lib/platform/social/connections/initiate-connect.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { ApiError } from "bundlesocial";
+
 import {
   getBundlesocialClient,
   getBundlesocialTeamId,
@@ -95,29 +97,97 @@ export async function initiateBundlesocialConnect(
   // duplicate before Set collapses it).
   const bundlePlatforms = Array.from(new Set(rawPlatforms));
 
+  const requestPayload = {
+    teamId,
+    redirectUrl: input.redirectUrl,
+    socialAccountTypes: bundlePlatforms,
+    userName: input.userName ?? undefined,
+    userLogoUrl: input.userLogoUrl ?? undefined,
+  };
+
+  logger.info("bundlesocial.initiate_connect.request", {
+    company_id: input.companyId,
+    team_id_prefix: teamId.slice(0, 8),
+    redirect_url: input.redirectUrl,
+    social_account_types: bundlePlatforms,
+  });
+
   try {
     const response = await client.socialAccount.socialAccountCreatePortalLink({
-      requestBody: {
-        teamId,
-        redirectUrl: input.redirectUrl,
-        socialAccountTypes: bundlePlatforms,
-        userName: input.userName ?? undefined,
-        userLogoUrl: input.userLogoUrl ?? undefined,
-      },
+      requestBody: requestPayload,
     });
+
+    logger.info("bundlesocial.initiate_connect.response", {
+      company_id: input.companyId,
+      response_url: response?.url ?? null,
+      response_keys: response ? Object.keys(response) : [],
+      has_url: Boolean(response?.url),
+    });
+
     if (!response?.url) {
       return internal("bundle.social returned no portal URL.");
     }
+
+    // Validate the returned URL. A bare https://bundle.social/connect with no
+    // query params means bundle.social did not embed a session token — the user
+    // would see "There was an error" on that page. Hard-fail here rather than
+    // redirecting to a broken page, and log the full URL so we can diagnose.
+    let parsedUrl: URL | null = null;
+    try { parsedUrl = new URL(response.url); } catch { /* logged below */ }
+
+    if (!parsedUrl || parsedUrl.protocol !== "https:") {
+      logger.error("bundlesocial.initiate_connect.invalid_url", {
+        company_id: input.companyId,
+        url: response.url,
+        reason: "not a valid https URL",
+      });
+      return internal(`bundle.social returned an invalid portal URL: ${response.url}`);
+    }
+
+    if (!parsedUrl.search) {
+      // No query params means no token. Most likely causes:
+      //   1. redirectUrl domain is not whitelisted in bundle.social's team settings.
+      //   2. teamId does not match the API key's team.
+      // Check: bundle.social dashboard → Team → Settings → Allowed redirect domains.
+      logger.error("bundlesocial.initiate_connect.url_missing_token", {
+        company_id: input.companyId,
+        url: response.url,
+        redirect_url_sent: input.redirectUrl,
+        team_id_prefix: teamId.slice(0, 8),
+        reason: "portal URL has no query params — token not embedded by bundle.social",
+      });
+      return internal(
+        "bundle.social returned a portal URL without a session token. " +
+        "The redirect URL is probably not whitelisted in the bundle.social team settings. " +
+        `Redirect URL sent: ${input.redirectUrl}`,
+      );
+    }
+
     return {
       ok: true,
       data: { url: response.url },
       timestamp: new Date().toISOString(),
     };
   } catch (err) {
+    if (err instanceof ApiError) {
+      logger.error("bundlesocial.initiate_connect.api_error", {
+        company_id: input.companyId,
+        status: err.status,
+        status_text: err.statusText,
+        body: err.body,
+        request_url: err.request?.url,
+        message: err.message,
+      });
+      return internal(
+        `bundle.social create-portal-link failed: HTTP ${err.status} ${err.statusText} — ${JSON.stringify(err.body)}`,
+      );
+    }
     const message = err instanceof Error ? err.message : String(err);
+    const cause = err instanceof Error && err.cause ? String(err.cause) : undefined;
     logger.error("bundlesocial.initiate_connect.failed", {
-      err: message,
       company_id: input.companyId,
+      err: message,
+      cause,
     });
     return internal(`bundle.social create-portal-link failed: ${message}`);
   }


### PR DESCRIPTION
## Problem

The "Connect new account" button redirects to `https://bundle.social/connect` with no query string, which shows "There was an error". The root cause: bundle.social is returning a portal URL with no session token embedded. Previously our code redirected to that broken URL silently.

## Root cause hypothesis

When bundle.social returns `https://bundle.social/connect` with no `?token=...`, the two most likely causes are:

1. **Redirect URL not whitelisted** — bundle.social requires the `redirectUrl` sent in the portal-link request to be pre-registered in the team's allowed domains. If `https://opollo-site-builder.vercel.app` is not in that list, they return the base portal page without a token.
2. **Team ID / API key mismatch** — `BUNDLE_SOCIAL_TEAMID` doesn't match the team owned by `BUNDLE_SOCIAL_API`.

## Changes

- **Hard-fail on tokenless URL**: when `response.url` has no query params, return `INTERNAL_ERROR` with an explicit message instead of redirecting to the broken page. The UI renders `json.error.message` via `setError()`, so the operator sees the message directly.
- **Full request logging**: logs `team_id_prefix`, `redirect_url`, and `social_account_types` before every SDK call.
- **Full response logging**: logs `response_url` and `response_keys` after every SDK call so the next test attempt shows exactly what bundle.social returned.
- **Structured `ApiError` handling**: logs `status`, `statusText`, and `body` from bundle.social's HTTP error response instead of just `err.message`.

## What to do next

After this deploys, click "Connect new account" once. You will either:

**A) See an error message on the page** (instead of the broken redirect) — look at Vercel logs for `bundlesocial.initiate_connect.url_missing_token`. It will show the exact `redirect_url_sent`. Then go to **bundle.social dashboard → Team → Settings → Allowed redirect domains** and add `https://opollo-site-builder.vercel.app`.

**B) See a different error message** (HTTP 4xx) — look for `bundlesocial.initiate_connect.api_error` in logs. The `status` + `body` fields will tell us the exact rejection reason from bundle.social.

**C) Connect flow works** — the previous duplicate-LINKEDIN fix was the actual root cause after all, and this was a red herring test after an old production build.

## Risks identified and mitigated

Read-only diagnostics + guard on the happy path. No DB writes, no schema changes, no billed external calls added.

Generated with [Claude Code](https://claude.com/claude-code)
