### PR TITLE
docs(claude): replace narrow no-auto rule with verified-green merge gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,9 +71,11 @@ Walk top to bottom.
    ├─ Yes → STOP. Wait for review.
    └─ No  → continue.
 
-7. Auto-merge: poll `gh pr checks` until all green, then `gh pr merge --squash`.
-   Do NOT use `--auto` — branch protection has no required checks here, so
-   `--auto` fires immediately without CI. Project memory documents this.
+7. Merge gate: poll `gh pr checks <PR> --watch` until terminal. Verify
+   every required check shows `pass`. Only then `gh pr merge <PR> --squash`.
+   Auto-merge flags (`--auto`, `enable_pr_auto_merge`, UI button) are
+   forbidden until issue #822 closes — they bypass CI on permissive branch
+   protection. See §"Merge gate — no merge without CI-verified green".
 ```
 
 Full background and edge cases: `docs/governance/MERGE_RULES.md`.
@@ -274,13 +276,42 @@ Still on <slice>; current state: <X>; next: <Y>.
 Heartbeat is the only allowed deviation from §"Communication". It
 exists so Steven knows whether to interrupt without him having to ask.
 
-## Auto-merge — operational notes
+## Merge gate — no merge without CI-verified green
 
-The §"Merge decision tree" is the truth. These are operational mechanics:
+The §"Merge decision tree" is the truth. This section is the **gate
+that prevents premature merges** — the failure mode where a PR
+auto-merges before CI runs.
 
-- Every PR must arm GitHub auto-merge at creation time via `mcp__github__enable_pr_auto_merge` (`mergeMethod: "SQUASH"`) immediately after `create_pull_request`. Without this, the PR sits mergeable and the loop breaks.
-- Never call `gh pr merge --auto`: branch protection is permissive here so `--auto` fires before CI. Poll `gh pr checks` until green, then `--squash`.
-- "Out-of-date with base" handling: if a polled PR shows OPEN + BEHIND, run `gh pr update-branch <PR>` automatically. Update-branch failure due to merge conflict → stop and report; do not force.
+**No merge — CLI, MCP, or UI button — fires until CI is verified green
+by polling.** The mechanism that prevents premature merge is
+required-status-checks at the branch protection level. Until those are
+configured (tracked in #822), all merges are gated by an explicit
+polling loop:
+
+1. `gh pr checks <PR> --watch` — wait until every check is terminal.
+2. Read the conclusion of each check. Every required check must show `pass`.
+3. Only then: `gh pr merge <PR> --squash`.
+
+**Auto-merge flags are forbidden on this repo** until #822 closes:
+
+- ❌ `gh pr merge --auto` — fires immediately on permissive branch protection.
+- ❌ `mcp__github__enable_pr_auto_merge` — same failure mode at the API layer.
+- ❌ Clicking the green merge button in the UI before checks are green.
+
+The "arm auto-merge at creation time" pattern from earlier docs is
+revoked by this rule. It only worked when branch protection required
+checks; here it does not, so arming = merging-without-CI.
+
+**"Out-of-date with base" handling**: if a polled PR shows OPEN +
+BEHIND, run `gh pr update-branch <PR>` automatically. Update-branch
+failure due to merge conflict → stop and report; do not force. After
+update-branch, CI re-runs — wait for terminal green again before
+`--squash`.
+
+Once #822 closes (branch protection requires the eight CI status
+checks), the polling loop becomes a **backup** rather than the primary
+gate, and arming auto-merge via `gh pr merge --auto` becomes safe again.
+At that point this section gets revised.
 
 ## Sub-slice autonomy
 


### PR DESCRIPTION
## Summary

Replaces the narrow "never call `--auto`" rule with the broader principle: **no merge fires until CI is verified green**, regardless of mechanism. Closes the gap surfaced when PR #821 auto-merged into `chore/test-harness` without CI gating because branch protection is permissive on this repo.

## What changed

`CLAUDE.md` §"Auto-merge — operational notes" → renamed to §"Merge gate — no merge without CI-verified green". The rule now covers:

- ❌ `gh pr merge --auto`
- ❌ `mcp__github__enable_pr_auto_merge`
- ❌ Clicking the green merge button in the UI before checks are green

All three are forbidden until issue #822 (branch protection on main requires the eight CI status checks) closes. The polling-loop gate (`gh pr checks --watch` then `gh pr merge --squash` after terminal green) is the primary mechanism until then.

`CLAUDE.md` §"Merge decision tree" node 7 also tightened to reflect the same principle.

## Why

Steven's correction to my rule violation (PR #821 auto-merged before CI ran):

> "Never call `--auto`" is too narrow; the real rule is "no merge without CI-verified green."

The robust fix is required-status-checks at the branch protection level (#822). Until that lands, the polling loop is the gate. Once it lands, this section will be revised to make polling the backup rather than the primary gate.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] CI green via polling, then merge

## Pre-PR checklist

- [x] Lint, typecheck, build green
- [x] Risks identified and mitigated:
  - **Risk:** rule update lands but the merge mechanism that violated the prior rule is still callable. **Mitigation:** issue #822 tracks the persistent fix (branch protection); this PR is the documentation update. Together they close the gap.
  - **Risk:** further docs drift between top-level CLAUDE.md and `docs/governance/MERGE_RULES.md`. **Mitigation:** governance/MERGE_RULES.md continues to delegate to CLAUDE.md as the truth; only CLAUDE.md changes here.
- [x] PR is under 500 net lines

## Cross-references

- Surfaced by: PR #821 (CLAUDE.md restructure, auto-merged without CI)
- Persistent fix: issue #822 (branch protection)
- Test harness: PR #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)
