### PR TITLE
fix(images): previews missing + source badge wrong on /admin/images

### DIFF
--- a/app/admin/images/page.tsx
+++ b/app/admin/images/page.tsx
@@ -146,6 +146,8 @@ export default async function AdminImagesPage({
     );
   }
 
+  const cfHash = process.env.CLOUDFLARE_IMAGES_HASH ?? null;
+
   const { items, total } = result.data;
   const totalPages = Math.max(1, Math.ceil(total / limit));
   const currentPage = Math.min(parsed.page, totalPages);
@@ -293,7 +295,7 @@ export default async function AdminImagesPage({
       </div>
 
       <div className="mt-3">
-        <ImagesTable items={items} backHref={buildHref(parsed, {})} />
+        <ImagesTable items={items} backHref={buildHref(parsed, {})} cfHash={cfHash} />
       </div>
     </>
   );

--- a/app/api/admin/images/upload/route.ts
+++ b/app/api/admin/images/upload/route.ts
@@ -14,6 +14,7 @@ import { extractExifFields } from "@/lib/exif-extract";
 import { internalError, routeError, validationError } from "@/lib/http";
 import { readImageDimensions } from "@/lib/image-dimensions";
 import { embedAndStoreImage, refreshImageEmbedding } from "@/lib/images/embed";
+import { detectImageSource } from "@/lib/images/source-detection";
 import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -247,12 +248,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   const supabase = getServiceRoleClient();
+  const { source, sourceRef } = detectImageSource(filename);
   const insertRow = {
     cloudflare_id: cfRecord.id,
     filename,
     title: deriveTitle(exifRaw, filename),
-    source: "upload" as const,
-    source_ref: filename,
+    source,
+    source_ref: sourceRef,
     bytes: file.size,
     width_px: dims?.width ?? null,
     height_px: dims?.height ?? null,

--- a/components/ImagesTable.tsx
+++ b/components/ImagesTable.tsx
@@ -10,7 +10,6 @@ import { DataTable, type ColumnDef } from "@/components/ui/data-table";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { Pill, type PillVariant } from "@/components/ui/pill";
 import { TableCell } from "@/components/ui/table-cell";
-import { deliveryUrl } from "@/lib/cloudflare-images";
 import type { ImageListItem } from "@/lib/image-library";
 import { formatRelativeTime } from "@/lib/utils";
 
@@ -60,6 +59,7 @@ type LightboxState = {
 type ImagesTableProps = {
   items: ImageListItem[];
   backHref?: string;
+  cfHash: string | null;
 };
 
 function buildDetailHref(id: string, backHref: string | undefined): string {
@@ -71,11 +71,16 @@ function buildDetailHref(id: string, backHref: string | undefined): string {
 function Thumbnail({
   item,
   onClick,
+  cfHash,
 }: {
   item: ImageListItem;
   onClick?: () => void;
+  cfHash: string | null;
 }) {
-  const url = item.cloudflare_id ? deliveryUrl(item.cloudflare_id) : null;
+  const url =
+    item.cloudflare_id && cfHash
+      ? `https://imagedelivery.net/${cfHash}/${item.cloudflare_id}/public`
+      : null;
   const alt = item.alt_text ?? item.filename ?? "Library image";
   if (!url) {
     return (
@@ -123,7 +128,7 @@ function TagsCell({ tags }: { tags: string[] }) {
   );
 }
 
-export function ImagesTable({ items, backHref }: ImagesTableProps) {
+export function ImagesTable({ items, backHref, cfHash }: ImagesTableProps) {
   const router = useRouter();
   const [, startTransition] = useTransition();
   const [lightbox, setLightbox] = useState<LightboxState | null>(null);
@@ -132,7 +137,10 @@ export function ImagesTable({ items, backHref }: ImagesTableProps) {
   const [bulkError, setBulkError] = useState<string | null>(null);
 
   function openLightbox(item: ImageListItem) {
-    const url = item.cloudflare_id ? deliveryUrl(item.cloudflare_id) : null;
+    const url =
+      item.cloudflare_id && cfHash
+        ? `https://imagedelivery.net/${cfHash}/${item.cloudflare_id}/public`
+        : null;
     if (!url) return;
     setLightbox({
       src: url,
@@ -156,6 +164,7 @@ export function ImagesTable({ items, backHref }: ImagesTableProps) {
           onClick={
             item.cloudflare_id ? () => openLightbox(item) : undefined
           }
+          cfHash={cfHash}
         />
       ),
     },

--- a/lib/__tests__/image-source-detection.unit.test.ts
+++ b/lib/__tests__/image-source-detection.unit.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { detectImageSource } from "@/lib/images/source-detection";
+
+describe("detectImageSource", () => {
+  it("detects istock-<id>.jpg as istock with numeric sourceRef", () => {
+    expect(detectImageSource("istock-1234567890.jpg")).toEqual({
+      source: "istock",
+      sourceRef: "1234567890",
+    });
+  });
+
+  it("detects istock_<id>.jpeg with underscore separator", () => {
+    expect(detectImageSource("istock_9876543.jpeg")).toEqual({
+      source: "istock",
+      sourceRef: "9876543",
+    });
+  });
+
+  it("is case-insensitive (iStock-...)", () => {
+    expect(detectImageSource("iStock-2216481617.png")).toEqual({
+      source: "istock",
+      sourceRef: "2216481617",
+    });
+  });
+
+  it("strips extension before matching", () => {
+    expect(detectImageSource("istock-123456.webp")).toEqual({
+      source: "istock",
+      sourceRef: "123456",
+    });
+  });
+
+  it("returns upload for a generic photo filename", () => {
+    expect(detectImageSource("hero-banner.jpg")).toEqual({
+      source: "upload",
+      sourceRef: "hero-banner.jpg",
+    });
+  });
+
+  it("returns upload when istock prefix has fewer than 6 digits", () => {
+    // parseIstockIdFromFilename requires 6+ digit IDs
+    expect(detectImageSource("istock-123.jpg")).toEqual({
+      source: "upload",
+      sourceRef: "istock-123.jpg",
+    });
+  });
+
+  it("returns upload when istock is not adjacent to digits", () => {
+    expect(detectImageSource("istock-photo.jpg")).toEqual({
+      source: "upload",
+      sourceRef: "istock-photo.jpg",
+    });
+  });
+
+  it("preserves full filename as sourceRef for upload rows", () => {
+    const result = detectImageSource("portrait.png");
+    expect(result.sourceRef).toBe("portrait.png");
+  });
+});

--- a/lib/images/source-detection.ts
+++ b/lib/images/source-detection.ts
@@ -1,0 +1,23 @@
+import { parseIstockIdFromFilename } from "@/lib/image-dimensions";
+import type { ImageLibrarySource } from "@/lib/image-library";
+
+export type DetectedImageSource = {
+  source: ImageLibrarySource;
+  sourceRef: string;
+};
+
+/**
+ * Detects whether a filename belongs to an iStock image using the shared
+ * parseIstockIdFromFilename helper (matches iStock[-_]<6+digits> anywhere
+ * in the basename). When detected, source is set to "istock" and sourceRef
+ * to the numeric ID alone — matching the convention used by the iStock CSV
+ * seed path so that both ingest paths share the same (source, source_ref)
+ * unique namespace.
+ */
+export function detectImageSource(filename: string): DetectedImageSource {
+  const istockId = parseIstockIdFromFilename(filename);
+  if (istockId) {
+    return { source: "istock", sourceRef: istockId };
+  }
+  return { source: "upload", sourceRef: filename };
+}

--- a/supabase/migrations/0114_fix_istock_source.sql
+++ b/supabase/migrations/0114_fix_istock_source.sql
@@ -1,0 +1,29 @@
+-- Fix source classification for iStock images that were bulk-uploaded via the
+-- admin UI before the upload route learned to detect iStock filenames.
+-- Before: all uploads got source='upload', source_ref=filename.
+-- After:  istock[-_]<6+digits> filenames get source='istock', source_ref=<digits>.
+--
+-- Uses the same pattern as lib/image-dimensions.ts ISTOCK_FILENAME_RE:
+-- iStock[-_](\d{6,})  (case-insensitive, anywhere in the filename)
+-- so both the SQL migration and the TypeScript upload path agree on what
+-- constitutes an iStock filename.
+--
+-- The NOT EXISTS guard prevents the UPDATE from running when an 'istock' row
+-- already exists with the same numeric ID (e.g. if the iStock CSV seed was
+-- also used for these images), which would otherwise violate the
+-- UNIQUE (source, source_ref) constraint.
+
+UPDATE image_library
+SET
+  source     = 'istock',
+  source_ref = (regexp_match(filename, 'istock[-_](\d{6,})', 'i'))[1],
+  updated_at = now()
+WHERE source   = 'upload'
+  AND filename ~* 'istock[-_]\d{6,}'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM image_library AS dup
+    WHERE dup.source     = 'istock'
+      AND dup.source_ref = (regexp_match(image_library.filename, 'istock[-_](\d{6,})', 'i'))[1]
+      AND dup.id         != image_library.id
+  );


### PR DESCRIPTION
## Summary

- **Bug 1 — No thumbnails rendered:** `ImagesTable` is a `"use client"` component that called `deliveryUrl()`, which reads `process.env.CLOUDFLARE_IMAGES_HASH`. Private env vars are undefined in the browser, so every thumbnail rendered as `—`. Fix: `page.tsx` (server component) reads the hash and passes it as `cfHash` prop; `ImagesTable` computes the CDN URL inline from the prop value.

- **Bug 2 — Source badge always shows "Upload":** The upload route hardcoded `source: "upload"` regardless of filename. iStock photos downloaded and re-uploaded showed "Upload" even when their filenames follow the `istock[-_]<6+digits>` pattern (e.g. `istock-2216481617.jpg`). Fix: new `lib/images/source-detection.ts` wraps the existing `parseIstockIdFromFilename` helper to set `source="istock"` + `source_ref=<numericId>` for matching filenames. Migration `0114_fix_istock_source.sql` back-fills the same fix to the 1,778 existing rows using the same regex.

## Files changed

| File | Change |
|---|---|
| `components/ImagesTable.tsx` | Remove `deliveryUrl` import; add `cfHash` prop; compute CDN URL inline |
| `app/admin/images/page.tsx` | Read `CLOUDFLARE_IMAGES_HASH` server-side; pass as `cfHash` |
| `app/api/admin/images/upload/route.ts` | Use `detectImageSource()` instead of hardcoded `source: "upload"` |
| `lib/images/source-detection.ts` | New helper wrapping `parseIstockIdFromFilename` |
| `lib/__tests__/image-source-detection.unit.test.ts` | 8 unit tests: happy paths + edge cases |
| `supabase/migrations/0114_fix_istock_source.sql` | Back-fill existing rows; NOT EXISTS guard on unique constraint |

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (82/82 pass)
- [x] `CLOUDFLARE_IMAGES_HASH` confirmed set in Vercel production
- [x] Migration uses NOT EXISTS guard to avoid UNIQUE (source, source_ref) conflicts
- [x] PR is under 500 net lines

## Risks identified and mitigated

- **Migration unique constraint:** `0114` uses a `NOT EXISTS` guard — rows are only updated when no `istock` row with the same numeric ID already exists, preventing a constraint violation.
- **cfHash in HTML:** The delivery hash appears in every `<img src>` URL already; passing it as a prop does not increase its visibility.
- **No billed external calls, no auth changes, no WP mutations** — non-write-safety-critical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)