### PR TITLE
feat(social): popup connect flow + bundle.social portal branding

### DIFF
--- a/app/api/platform/social/connections/callback/route.ts
+++ b/app/api/platform/social/connections/callback/route.ts
@@ -9,16 +9,21 @@ import { syncBundlesocialConnections } from "@/lib/platform/social/connections";
 // bundle.social redirects here after the OAuth dance completes (or
 // errors). Query params:
 //   company_id           — set by /connect when minting the portal URL
+//   popup=1              — present when the flow ran in a popup window;
+//                          triggers postMessage + window.close() instead
+//                          of a full-page redirect.
 //   <platform>-callback  — bundle.social's success signal (e.g.
 //                          twitter-callback=true). We don't act on it
 //                          beyond logging; the sync below is the source
 //                          of truth.
 //   not-enough-permissions / not-enough-pages / etc — error signals.
 //
-// Behaviour: regardless of success/error params, sync from bundle.social
-// to find any newly-attached account and attribute it to company_id.
-// Then 302 redirect the admin's browser back to /company/social/
-// connections with a success or error toast.
+// Non-popup behaviour: 302 redirect back to /company/social/connections
+// with ?connect=success|error|noop.
+//
+// Popup behaviour (?popup=1): return an HTML page that sends a
+// postMessage to window.opener then calls window.close(). The parent
+// connections page listens for the message and calls router.refresh().
 //
 // Gate: canDo("manage_connections", company_id). The browser carrying
 // the bundle.social redirect IS the admin who started the flow, so the
@@ -30,13 +35,57 @@ export const dynamic = "force-dynamic";
 
 const UUID_RE = /^[0-9a-f-]{36}$/i;
 
+function popupCloseResponse(
+  req: NextRequest,
+  connectParam: string,
+  reason?: string,
+): NextResponse {
+  const origin =
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ||
+    new URL(req.url).origin;
+
+  const payload = JSON.stringify({
+    type: "bundle-connect-complete",
+    connect: connectParam,
+    ...(reason ? { reason } : {}),
+  });
+
+  // Strict target origin — only our own origin accepts this message.
+  // No user-controlled data is embedded in the script.
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Connecting…</title></head>
+<body>
+<script>
+(function () {
+  var targetOrigin = ${JSON.stringify(origin)};
+  var payload = ${payload};
+  try {
+    if (window.opener && !window.opener.closed) {
+      window.opener.postMessage(payload, targetOrigin);
+    }
+  } catch (e) {
+    // opener may be cross-origin in error paths; silently discard
+  }
+  window.close();
+})();
+</script>
+</body>
+</html>`;
+
+  return new NextResponse(html, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const url = new URL(req.url);
   const companyId = url.searchParams.get("company_id");
+  const isPopup = url.searchParams.get("popup") === "1";
+
   if (!companyId || !UUID_RE.test(companyId)) {
-    // Send the admin somewhere sensible; the company id was lost in
-    // the redirect chain. /company/social/connections requires a
-    // session anyway, so they'll land at /login if needed.
+    if (isPopup) return popupCloseResponse(req, "error", "invalid-company");
     return NextResponse.redirect(
       new URL("/company/social/connections?connect=error", req.url),
     );
@@ -44,20 +93,14 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   const gate = await requireCanDoForApi(companyId, "manage_connections");
   if (gate.kind === "deny") {
-    // 401/403 doesn't make sense as a redirect target for a browser
-    // mid-OAuth — surface the gate response directly.
+    if (isPopup) return popupCloseResponse(req, "error", "unauthorized");
     return gate.response;
   }
 
-  // Sync — attribute any new accounts to this company. The result
-  // tells us whether anything changed, but the redirect is the same
-  // either way; the admin sees the connections page repaint.
   const sync = await syncBundlesocialConnections({
     attributeNewToCompanyId: companyId,
   });
 
-  // Detect explicit error params from bundle.social and pass them
-  // through so the destination page can render a toast.
   const errorParam = [
     "not-enough-permissions",
     "not-enough-pages",
@@ -65,21 +108,29 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     "user-cancelled",
   ].find((k) => url.searchParams.has(k));
 
-  const target = new URL("/company/social/connections", req.url);
+  let connectParam: string;
+  let reasonParam: string | undefined;
   if (errorParam) {
-    target.searchParams.set("connect", "error");
-    target.searchParams.set("reason", errorParam);
+    connectParam = "error";
+    reasonParam = errorParam;
   } else if (!sync.ok) {
-    target.searchParams.set("connect", "sync-failed");
-    target.searchParams.set("reason", sync.error.code);
+    connectParam = "sync-failed";
+    reasonParam = sync.error.code;
   } else if (sync.data.inserted > 0) {
-    target.searchParams.set("connect", "success");
-    target.searchParams.set("count", String(sync.data.inserted));
+    connectParam = "success";
   } else {
-    // No new accounts attached. Common when the operator backed out
-    // or only refreshed an existing account.
-    target.searchParams.set("connect", "noop");
+    connectParam = "noop";
   }
 
+  if (isPopup) {
+    return popupCloseResponse(req, connectParam, reasonParam);
+  }
+
+  const target = new URL("/company/social/connections", req.url);
+  target.searchParams.set("connect", connectParam);
+  if (reasonParam) target.searchParams.set("reason", reasonParam);
+  if (connectParam === "success" && sync.ok) {
+    target.searchParams.set("count", String(sync.data.inserted));
+  }
   return NextResponse.redirect(target);
 }

--- a/app/api/platform/social/connections/connect/route.ts
+++ b/app/api/platform/social/connections/connect/route.ts
@@ -2,7 +2,9 @@ import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { readJsonBody, validationError, internalError } from "@/lib/http";
+import { getActiveBrandProfile } from "@/lib/platform/brand/get";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
 import {
   initiateBundlesocialConnect,
   type SocialPlatform,
@@ -11,10 +13,10 @@ import {
 // ---------------------------------------------------------------------------
 // S1-16 — POST /api/platform/social/connections/connect
 //
-// Returns a bundle.social hosted-portal URL the admin's browser is
-// redirected to for OAuth. After the dance completes, bundle.social
-// redirects to our /callback handler with success/error params; the
-// callback syncs newly-connected accounts back into social_connections.
+// Returns a bundle.social hosted-portal URL the admin's browser opens
+// in a popup for OAuth. After the dance completes, bundle.social
+// redirects to our /callback handler (?popup=1 flags the callback to
+// send a postMessage + window.close() instead of a full-page redirect).
 //
 // Body:
 //   { company_id: uuid, platforms?: SocialPlatform[] }
@@ -64,12 +66,31 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const origin =
     process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ||
     new URL(req.url).origin;
-  const redirectUrl = `${origin}/api/platform/social/connections/callback?company_id=${encodeURIComponent(parsed.data.company_id)}`;
+  // ?popup=1 tells the callback to send a postMessage + window.close()
+  // instead of a full-page redirect back to /connections.
+  const redirectUrl =
+    `${origin}/api/platform/social/connections/callback` +
+    `?company_id=${encodeURIComponent(parsed.data.company_id)}&popup=1`;
+
+  // Fetch branding in parallel — both are graceful-null on miss.
+  const [brand, companyRow] = await Promise.all([
+    getActiveBrandProfile(parsed.data.company_id),
+    getServiceRoleClient()
+      .from("platform_companies")
+      .select("name")
+      .eq("id", parsed.data.company_id)
+      .maybeSingle()
+      .then((r) => r.data),
+  ]);
 
   const result = await initiateBundlesocialConnect({
     companyId: parsed.data.company_id,
     platforms: (parsed.data.platforms ?? []) as SocialPlatform[],
     redirectUrl,
+    logoUrl: brand?.logo_primary_url ?? brand?.logo_icon_url ?? undefined,
+    userName: companyRow?.name ?? undefined,
+    // TODO: set hidePoweredBy: true once companies have a paid-plan flag.
+    language: "en",
   });
   if (!result.ok) {
     if (result.error.code === "VALIDATION_FAILED") return validationError(result.error.message);

--- a/app/api/platform/social/connections/reconnect/route.ts
+++ b/app/api/platform/social/connections/reconnect/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { readJsonBody, validationError, notFound, invalidState, internalError } from "@/lib/http";
 import { logger } from "@/lib/logger";
+import { getActiveBrandProfile } from "@/lib/platform/brand/get";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
 import { initiateBundlesocialConnect } from "@/lib/platform/social/connections";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -77,9 +78,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   }
 
   const origin =
-    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ??
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ||
     new URL(req.url).origin;
-  const redirectUrl = `${origin}/api/platform/social/connections/callback?company_id=${encodeURIComponent(companyId)}`;
+  const redirectUrl =
+    `${origin}/api/platform/social/connections/callback` +
+    `?company_id=${encodeURIComponent(companyId)}&popup=1`;
 
   logger.info("social.connections.reconnect.start", {
     companyId,
@@ -88,10 +91,24 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     userId: gate.userId,
   });
 
+  const [brand, companyRow] = await Promise.all([
+    getActiveBrandProfile(companyId),
+    svc
+      .from("platform_companies")
+      .select("name")
+      .eq("id", companyId)
+      .maybeSingle()
+      .then((r) => r.data),
+  ]);
+
   const result = await initiateBundlesocialConnect({
     companyId,
     platforms: [conn.platform],
     redirectUrl,
+    logoUrl: brand?.logo_primary_url ?? brand?.logo_icon_url ?? undefined,
+    userName: companyRow?.name ?? undefined,
+    // TODO: set hidePoweredBy: true once companies have a paid-plan flag.
+    language: "en",
   });
 
   if (!result.ok) {

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toastSuccess } from "@/lib/toast-success";
 
 import { Button } from "@/components/ui/button";
@@ -16,17 +16,34 @@ import {
 // ---------------------------------------------------------------------------
 // S1-12 / S1-16 — connections roster for /company/social/connections.
 //
-// V1 (S1-12) was read-only with a stubbed Reconnect button. S1-16 wires
-// the real bundle.social hosted-portal flow:
-//   - Top: "Connect new account" button (admin-only) → POST /connect →
-//     redirect browser to bundle.social portal → bundle.social redirects
-//     back to /callback → callback syncs new accounts → admin lands
-//     back here with ?connect=success|error|noop.
-//   - Top: "Refresh" button (admin-only) → POST /sync → re-reads bundle.
-//     social's account list, refreshes display_name + status.
-//   - Per-row: Reconnect button (admin-only, when status='auth_required'
-//     or 'disconnected') → POST /connect with the row's platform.
+// Connect flow (popup):
+//   1. "Connect new account" → POST /connect → receives bundle.social URL
+//   2. window.open() opens the URL in a 600×700 popup
+//   3. bundle.social OAuth runs inside the popup
+//   4. bundle.social redirects to /callback?popup=1 → callback syncs accounts
+//      and returns HTML that posts { type:"bundle-connect-complete" } to
+//      window.opener, then closes itself
+//   5. Parent receives postMessage → router.refresh() shows new connections
+//   6. Fallback: setInterval polling popup.closed covers user-abandons-popup
+//      and popup-blocked-then-manually-opened cases
 // ---------------------------------------------------------------------------
+
+const POPUP_FEATURES =
+  "width=600,height=700,scrollbars=yes,resizable=yes,noopener=no";
+
+type ConnectMessage = {
+  type: "bundle-connect-complete";
+  connect: "success" | "noop" | "error" | "sync-failed";
+  reason?: string;
+};
+
+function isConnectMessage(v: unknown): v is ConnectMessage {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    (v as Record<string, unknown>)["type"] === "bundle-connect-complete"
+  );
+}
 
 type Props = {
   companyId: string;
@@ -49,6 +66,71 @@ export function SocialConnectionsList({
   const [busyRow, setBusyRow] = useState<string | null>(null);
   const [busyTop, setBusyTop] = useState<"connect" | "sync" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Set when the browser blocks window.open(); shows a fallback link.
+  const [popupBlockedUrl, setPopupBlockedUrl] = useState<string | null>(null);
+
+  // Active popup reference — used by polling and to avoid stacking popups.
+  const popupRef = useRef<Window | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  function clearPopupState(activeRowId?: string) {
+    if (pollRef.current) clearInterval(pollRef.current);
+    pollRef.current = null;
+    popupRef.current = null;
+    setBusyTop(null);
+    if (activeRowId) setBusyRow(null);
+  }
+
+  function openConnectPopup(url: string, rowId?: string) {
+    // Reuse existing popup if still open, otherwise open a new one.
+    if (popupRef.current && !popupRef.current.closed) {
+      popupRef.current.focus();
+      return;
+    }
+
+    const popup = window.open(url, "bundle-connect", POPUP_FEATURES);
+
+    if (!popup || popup.closed) {
+      // Browser blocked the popup. Show a fallback link so the admin can
+      // still complete the flow.
+      setPopupBlockedUrl(url);
+      clearPopupState(rowId);
+      return;
+    }
+
+    setPopupBlockedUrl(null);
+    popupRef.current = popup;
+
+    // Polling fallback: detects user closing the popup before completing
+    // OAuth and cases where postMessage does not fire (e.g. network error).
+    pollRef.current = setInterval(() => {
+      if (popup.closed) {
+        clearPopupState(rowId);
+        router.refresh();
+      }
+    }, 500);
+  }
+
+  // postMessage listener — primary success path.
+  useEffect(() => {
+    const expectedOrigin = window.location.origin;
+
+    function handleMessage(evt: MessageEvent) {
+      if (evt.origin !== expectedOrigin) return;
+      if (!isConnectMessage(evt.data)) return;
+
+      clearPopupState();
+      // The popup closes itself after sending; no need to close it here.
+      router.refresh();
+    }
+
+    window.addEventListener("message", handleMessage);
+    return () => {
+      window.removeEventListener("message", handleMessage);
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   async function initiateConnect(platforms?: SocialPlatform[]) {
     setError(null);
@@ -66,41 +148,36 @@ export function SocialConnectionsList({
     if (!res.ok || !json.ok) {
       const msg = !json.ok ? json.error.message : "Failed to start connect.";
       setError(msg);
+      setBusyTop(null);
       return;
     }
-    window.location.href = json.data.url;
+    openConnectPopup(json.data.url);
   }
 
   async function handleConnectAll() {
     setBusyTop("connect");
-    try {
-      await initiateConnect();
-    } finally {
-      setBusyTop(null);
-    }
+    await initiateConnect();
+    // busyTop cleared by popup close (poll or postMessage).
   }
 
   async function handleReconnect(rowId: string) {
     setBusyRow(rowId);
     setError(null);
-    try {
-      const res = await fetch("/api/platform/social/connections/reconnect", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ company_id: companyId, connection_id: rowId }),
-      });
-      const json = (await res.json()) as
-        | { ok: true; data: { url: string } }
-        | { ok: false; error: { message: string } };
-      if (!res.ok || !json.ok) {
-        setError(!json.ok ? json.error.message : "Failed to start reconnect.");
-        return;
-      }
-      window.location.href = json.data.url;
-    } finally {
-      // busyRow stays set until the redirect fires; clear on error path.
+    const res = await fetch("/api/platform/social/connections/reconnect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ company_id: companyId, connection_id: rowId }),
+    });
+    const json = (await res.json()) as
+      | { ok: true; data: { url: string } }
+      | { ok: false; error: { message: string } };
+    if (!res.ok || !json.ok) {
+      setError(!json.ok ? json.error.message : "Failed to start reconnect.");
       setBusyRow(null);
+      return;
     }
+    openConnectPopup(json.data.url, rowId);
+    // busyRow cleared by popup close (poll or postMessage) via rowId arg.
   }
 
   async function handleSync() {
@@ -164,6 +241,25 @@ export function SocialConnectionsList({
           data-testid="connections-error"
         >
           {error}
+        </p>
+      ) : null}
+
+      {popupBlockedUrl ? (
+        <p
+          className="mb-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
+          role="alert"
+          data-testid="connections-popup-blocked"
+        >
+          Your browser blocked the popup.{" "}
+          <a
+            href={popupBlockedUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+            data-testid="connections-popup-fallback-link"
+          >
+            Open portal →
+          </a>
         </p>
       ) : null}
 

--- a/docs/incidents/2026-05-09-bundle-social-connect-flow.md
+++ b/docs/incidents/2026-05-09-bundle-social-connect-flow.md
@@ -199,6 +199,37 @@ This is low-risk and makes the runtime behaviour match the intent.
 
 ---
 
+## Platform-type matrix (2026-05-10)
+
+Run `scripts/probes/_platform-matrix-probe.ts` with `redirectUrl: "https://google.com"`.
+All 6 configurations generated a valid token AND loaded the picker successfully.
+
+| # | Label | socialAccountTypes | API token | Browser result | Page title |
+|---|---|---|---|---|---|
+| 1 | founder | TIKTOK, FACEBOOK, INSTAGRAM | ✅ | ✅ picker_loaded | Connect \| bundle.social |
+| 2 | ours (full set) | LINKEDIN, FACEBOOK, TWITTER, GOOGLE_BUSINESS | ✅ | ✅ picker_loaded | Connect \| bundle.social |
+| 3 | LINKEDIN only | LINKEDIN | ✅ | ✅ picker_loaded | Connect \| bundle.social |
+| 4 | FACEBOOK only | FACEBOOK | ✅ | ✅ picker_loaded | Connect \| bundle.social |
+| 5 | TWITTER only | TWITTER | ✅ | ✅ picker_loaded | Connect \| bundle.social |
+| 6 | GOOGLE_BUSINESS only | GOOGLE_BUSINESS | ✅ | ✅ picker_loaded | Connect \| bundle.social |
+
+**Conclusion: no platform type is poisoning the request.** All values accepted, picker renders
+correctly for all. Screenshots in `scripts/probes/_screenshots/`.
+
+Additional finding from screenshot inspection:
+- LinkedIn is **already connected** for the team (shows "Opollo MSP Marketing / opollo-marketing"
+  with a "Disconnect" button in the picker). Facebook, X, and Google Business still need connecting.
+- TIKTOK and INSTAGRAM are valid bundle.social account types (not just our four) — the founder's
+  payload works if those types are enabled in the team's bundle.social plan.
+
+**Confirmed conclusion: the "There was an error" occurs at the OAuth callback redirect step,**
+**not at portal load time.** bundle.social shows the platform picker correctly, then after
+the user authenticates, it redirects to the `redirectUrl` in the JWT. If that domain is not
+in the team's allowed-redirect-domains list, bundle.social displays "There was an error" at
+that point — which is consistent with the reported symptom.
+
+---
+
 ## PRs merged as part of this investigation
 
 | PR | Title | What it fixed |
@@ -206,11 +237,13 @@ This is low-risk and makes the runtime behaviour match the intent.
 | #814 | feat(S1-16): initiate-connect + sync Bundlesocial connections | Duplicate LINKEDIN in socialAccountTypes |
 | #816 | fix(S1-16): bundle.social diagnostics + tokenless-URL guard | Structured logging, tokenless URL guard, ApiError catch |
 | #818 | test(bundlesocial): fix tokenless-URL guard breaking unit tests | Updated mock URLs to include `?token=` query param |
+| #827 | fix(bundlesocial): `??` → `||` fallback for empty NEXT_PUBLIC_SITE_URL | Prevents relative redirectUrl when env var is empty string |
 
 ---
 
 ## Open action items
 
-- [ ] **Steven to add `opollo-site-builder.vercel.app` to bundle.social allowed redirect domains** (Fix 1 above)
-- [ ] Open PR for `??` → `||` fix in `connect/route.ts` (Fix 2 — defensive, low-risk)
-- [ ] Clean up temp probe files: `scripts/probes/_redirect-url-probe.ts`, `scripts/probes/_jwt-decode.ts`
+- [ ] **Steven to add `opollo-site-builder.vercel.app` to bundle.social allowed redirect domains**
+      → bundle.social dashboard → Team → Settings → Allowed redirect domains
+      → This is the primary blocker; "There was an error" shows after OAuth because the domain is not whitelisted
+- [x] `??` → `||` fix in `connect/route.ts` — merged as PR #827

--- a/e2e/social.spec.ts
+++ b/e2e/social.spec.ts
@@ -122,4 +122,120 @@ test.describe("social platform", () => {
     await page.getByRole("link", { name: /timeline/i }).click();
     await expect(page).toHaveURL(/\/company\/social\/timeline/, { timeout: 10_000 });
   });
+
+  test.describe("connect popup flow", () => {
+    // Tests the window.open popup mechanics without hitting external
+    // bundle.social. The connect API is mocked to return a URL on our
+    // own origin that we also intercept to serve postMessage HTML.
+
+    test("(a) postMessage: popup sends bundle-connect-complete and parent recovers", async ({
+      page,
+      context,
+    }, testInfo) => {
+      await page.goto("/company/social/connections");
+
+      // Mock connect API — return a URL on our own origin so same-origin
+      // postMessage passes the parent's origin check.
+      await context.route(
+        "**/api/platform/social/connections/connect",
+        (route) => {
+          const origin = new URL(page.url()).origin;
+          void route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              ok: true,
+              data: { url: `${origin}/_test-popup-stub` },
+            }),
+          });
+        },
+      );
+
+      // Intercept popup navigation — serve HTML that fires postMessage then closes.
+      await context.route("**/_test-popup-stub*", (route) => {
+        void route.fulfill({
+          status: 200,
+          contentType: "text/html; charset=utf-8",
+          body: `<!DOCTYPE html><html><body><script>
+(function () {
+  try {
+    if (window.opener && !window.opener.closed) {
+      window.opener.postMessage(
+        { type: "bundle-connect-complete", connect: "noop" },
+        window.location.origin
+      );
+    }
+  } catch (e) {}
+  window.close();
+})();
+</script></body></html>`,
+        });
+      });
+
+      const connectBtn = page.getByTestId("connections-connect-button");
+      await expect(connectBtn).toBeVisible({ timeout: 10_000 });
+
+      const popupPromise = page.waitForEvent("popup");
+      await connectBtn.click();
+      const popup = await popupPromise;
+
+      // Popup loads stub, fires postMessage, then calls window.close().
+      await popup.waitForEvent("close", { timeout: 10_000 });
+
+      // Parent must not show error or popup-blocked banners.
+      await expect(page.getByTestId("connections-error")).not.toBeVisible();
+      await expect(
+        page.getByTestId("connections-popup-blocked"),
+      ).not.toBeVisible();
+
+      await auditA11y(page, testInfo);
+    });
+
+    test("(b) user-closes-popup: parent handles abandonment gracefully", async ({
+      page,
+      context,
+    }) => {
+      await page.goto("/company/social/connections");
+
+      await context.route(
+        "**/api/platform/social/connections/connect",
+        (route) => {
+          const origin = new URL(page.url()).origin;
+          void route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              ok: true,
+              data: { url: `${origin}/_test-popup-stub-abandon` },
+            }),
+          });
+        },
+      );
+
+      // Stub stays open — simulating user who hasn't completed OAuth yet.
+      await context.route("**/_test-popup-stub-abandon*", (route) => {
+        void route.fulfill({
+          status: 200,
+          contentType: "text/html; charset=utf-8",
+          body: "<!DOCTYPE html><html><body>Loading…</body></html>",
+        });
+      });
+
+      const connectBtn = page.getByTestId("connections-connect-button");
+      await expect(connectBtn).toBeVisible({ timeout: 10_000 });
+
+      const popupPromise = page.waitForEvent("popup");
+      await connectBtn.click();
+      const popup = await popupPromise;
+
+      // User closes popup without completing OAuth.
+      await popup.close();
+
+      // Parent must recover: no crash, no error banner, wrapper still present.
+      await expect(page.getByTestId("connections-error")).not.toBeVisible();
+      await expect(
+        page.getByTestId("connections-list-wrapper"),
+      ).toBeVisible({ timeout: 10_000 });
+    });
+  });
 });

--- a/lib/__tests__/__snapshots__/bundle-social.contract.test.ts.snap
+++ b/lib/__tests__/__snapshots__/bundle-social.contract.test.ts.snap
@@ -3,12 +3,14 @@
 exports[`CONTRACT: bundle.social socialAccountCreatePortalLink > [snapshot] LinkedIn-only (personal+company → single LINKEDIN) 1`] = `
 {
   "requestBody": {
+    "hidePoweredBy": undefined,
+    "language": undefined,
+    "logoUrl": undefined,
     "redirectUrl": "https://opollo-site-builder.vercel.app/api/platform/social/connections/callback?company_id=abcdef00-0000-0000-0000-aaaaaaaa1616",
     "socialAccountTypes": [
       "LINKEDIN",
     ],
     "teamId": "team-contract-snapshot",
-    "userLogoUrl": undefined,
     "userName": undefined,
   },
 }
@@ -17,6 +19,9 @@ exports[`CONTRACT: bundle.social socialAccountCreatePortalLink > [snapshot] Link
 exports[`CONTRACT: bundle.social socialAccountCreatePortalLink > [snapshot] all platforms — order, dedup, shape are stable 1`] = `
 {
   "requestBody": {
+    "hidePoweredBy": undefined,
+    "language": undefined,
+    "logoUrl": undefined,
     "redirectUrl": "https://opollo-site-builder.vercel.app/api/platform/social/connections/callback?company_id=abcdef00-0000-0000-0000-aaaaaaaa1616",
     "socialAccountTypes": [
       "LINKEDIN",
@@ -25,7 +30,6 @@ exports[`CONTRACT: bundle.social socialAccountCreatePortalLink > [snapshot] all 
       "GOOGLE_BUSINESS",
     ],
     "teamId": "team-contract-snapshot",
-    "userLogoUrl": undefined,
     "userName": undefined,
   },
 }
@@ -34,6 +38,9 @@ exports[`CONTRACT: bundle.social socialAccountCreatePortalLink > [snapshot] all 
 exports[`CONTRACT: bundle.social socialAccountCreatePortalLink > [snapshot] empty platforms[] fallback 1`] = `
 {
   "requestBody": {
+    "hidePoweredBy": undefined,
+    "language": undefined,
+    "logoUrl": undefined,
     "redirectUrl": "https://opollo-site-builder.vercel.app/api/platform/social/connections/callback?company_id=abcdef00-0000-0000-0000-aaaaaaaa1616",
     "socialAccountTypes": [
       "LINKEDIN",
@@ -42,8 +49,23 @@ exports[`CONTRACT: bundle.social socialAccountCreatePortalLink > [snapshot] empt
       "GOOGLE_BUSINESS",
     ],
     "teamId": "team-contract-snapshot",
-    "userLogoUrl": undefined,
     "userName": undefined,
+  },
+}
+`;
+
+exports[`CONTRACT: bundle.social socialAccountCreatePortalLink > [snapshot] with branding: logoUrl, userName, language 1`] = `
+{
+  "requestBody": {
+    "hidePoweredBy": undefined,
+    "language": "en",
+    "logoUrl": "https://cdn.example.com/logo.png",
+    "redirectUrl": "https://opollo-site-builder.vercel.app/api/platform/social/connections/callback?company_id=abcdef00-0000-0000-0000-aaaaaaaa1616",
+    "socialAccountTypes": [
+      "TWITTER",
+    ],
+    "teamId": "team-contract-snapshot",
+    "userName": "Acme Corp",
   },
 }
 `;

--- a/lib/__tests__/bundle-social.contract.test.ts
+++ b/lib/__tests__/bundle-social.contract.test.ts
@@ -36,6 +36,8 @@ vi.mock("@/lib/bundlesocial", () => ({
 import { initiateBundlesocialConnect } from "@/lib/platform/social/connections";
 
 const COMPANY_ID = "abcdef00-0000-0000-0000-aaaaaaaa1616";
+// The popup=1 param is appended by the API route layer, not by
+// initiateBundlesocialConnect itself. Use the base callback URL here.
 const REDIRECT_URL =
   "https://opollo-site-builder.vercel.app/api/platform/social/connections/callback?company_id=abcdef00-0000-0000-0000-aaaaaaaa1616";
 
@@ -86,6 +88,21 @@ describe("CONTRACT: bundle.social socialAccountCreatePortalLink", () => {
       companyId: COMPANY_ID,
       platforms: ["linkedin_personal", "linkedin_company"],
       redirectUrl: REDIRECT_URL,
+    });
+
+    const arg =
+      mockClient.socialAccount.socialAccountCreatePortalLink.mock.calls[0]?.[0];
+    expect(arg).toMatchSnapshot();
+  });
+
+  it("[snapshot] with branding: logoUrl, userName, language", async () => {
+    await initiateBundlesocialConnect({
+      companyId: COMPANY_ID,
+      platforms: ["x"],
+      redirectUrl: REDIRECT_URL,
+      logoUrl: "https://cdn.example.com/logo.png",
+      userName: "Acme Corp",
+      language: "en",
     });
 
     const arg =

--- a/lib/platform/social/connections/initiate-connect.ts
+++ b/lib/platform/social/connections/initiate-connect.ts
@@ -56,12 +56,16 @@ export type InitiateConnectInput = {
   platforms: SocialPlatform[];
   // Absolute URL the admin's browser should be sent to AFTER bundle.
   // social finishes the OAuth dance. Typically:
-  //   `${origin}/api/platform/social/connections/callback?company_id=<id>`
+  //   `${origin}/api/platform/social/connections/callback?company_id=<id>&popup=1`
   redirectUrl: string;
-  // Branding overrides that surface in the bundle.social portal UI.
-  // Optional; defaults shown in their dashboard otherwise.
+  // Branding fields that surface in the bundle.social portal UI.
+  // All optional; bundle.social applies its own defaults when omitted.
+  // Note: userLogoUrl is intentionally excluded — the portal shows a
+  // placeholder avatar when omitted; wire user avatars as a follow-up.
+  logoUrl?: string | null;
   userName?: string | null;
-  userLogoUrl?: string | null;
+  hidePoweredBy?: boolean;
+  language?: string | null;
 };
 
 export type InitiateConnectResult = {
@@ -101,8 +105,13 @@ export async function initiateBundlesocialConnect(
     teamId,
     redirectUrl: input.redirectUrl,
     socialAccountTypes: bundlePlatforms,
+    logoUrl: input.logoUrl ?? undefined,
     userName: input.userName ?? undefined,
-    userLogoUrl: input.userLogoUrl ?? undefined,
+    hidePoweredBy: input.hidePoweredBy ?? undefined,
+    language: (input.language ?? undefined) as
+      | "en" | "pl" | "fr" | "hi" | "sv" | "de" | "es"
+      | "it" | "nl" | "pt" | "ru" | "tr" | "zh"
+      | undefined,
   };
 
   logger.info("bundlesocial.initiate_connect.request", {


### PR DESCRIPTION
## Summary

- Replaces the full-page redirect to bundle.social with `window.open` popup (600×700). Callback returns postMessage HTML when `?popup=1` is present, instead of 302-redirecting to `/connections`. Parent validates same-origin before accepting the message, clears busy state, and calls `router.refresh()`.
- Polling fallback (`setInterval popup.closed`) covers user-abandonment and popup-blocker cases. When `window.open` is blocked, an amber banner renders with a manual fallback link.
- Connect and reconnect routes now fetch company brand profile in parallel and pass `logoUrl`, `userName`, `language: "en"` to `initiateBundlesocialConnect`. `userLogoUrl` intentionally excluded — bundle.social shows a placeholder avatar; wire per-user avatars later.
- Contract snapshots updated: `userLogoUrl` field removed, `logoUrl`/`hidePoweredBy`/`language` fields added. New branding snapshot test freezes the new payload shape.

## Coverage

- `test:unit` — contract snapshots (4 snapshot tests + R1/R6 regressions), all existing unit/security layers: 75 tests, all pass
- `test:e2e` (new) — two new popup tests in `e2e/social.spec.ts`: (a) postMessage close path using `context.route` mock, (b) user-closes-popup abandonment path
- `typecheck` — clean

## Risks identified and mitigated

| Hotspot | Mitigation |
|---|---|
| `window.opener.postMessage` XSS — user-controlled data in the HTML script | Only `origin` (from env var / `req.url`) and a hard-coded `connectParam` string are embedded; both are serialised via `JSON.stringify`; no user input flows to the template |
| Cross-origin postMessage acceptance | Parent validates `evt.origin === window.location.origin` before acting |
| Popup blocked by browser | `popupRef.current.closed` immediate check → fallback link banner; polling fallback fires on poll close too |
| Stacked popups | `popupRef.current && !popupRef.current.closed` guard re-focuses existing popup |
| Brand fetch latency | `Promise.all` parallel fetch; both are graceful-null on DB miss |
| `userLogoUrl` removed from SDK call | Intentional — bundle.social shows placeholder avatar; not a regression |

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (contract + regression + security)
- [x] Contract snapshots reviewed (`userLogoUrl` removed, branding fields added, new branding test)
- [x] E2e tests added: postMessage path + user-closes-popup path
- [x] PR is under 500 net lines OR exception stated (421 insertions, within limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)