### PR TITLE
fix(images): compute preview URLs server-side; detect iStock source on upload

### DIFF
--- a/app/admin/images/page.tsx
+++ b/app/admin/images/page.tsx
@@ -7,6 +7,7 @@ import { ImageMetadataJobTrigger } from "@/components/admin/ImageMetadataJobTrig
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
 import { checkAdminAccess } from "@/lib/admin-gate";
+import { deliveryUrl } from "@/lib/cloudflare-images";
 import {
   LIST_IMAGES_DEFAULT_LIMIT,
   LIST_IMAGES_MAX_LIMIT,
@@ -146,7 +147,11 @@ export default async function AdminImagesPage({
     );
   }
 
-  const { items, total } = result.data;
+  const { items: rawItems, total } = result.data;
+  const items = rawItems.map((item) => ({
+    ...item,
+    previewUrl: item.cloudflare_id ? deliveryUrl(item.cloudflare_id, "public") : null,
+  }));
   const totalPages = Math.max(1, Math.ceil(total / limit));
   const currentPage = Math.min(parsed.page, totalPages);
   const rangeStart = total === 0 ? 0 : offset + 1;

--- a/app/api/admin/images/upload/route.ts
+++ b/app/api/admin/images/upload/route.ts
@@ -14,6 +14,7 @@ import { extractExifFields } from "@/lib/exif-extract";
 import { internalError, routeError, validationError } from "@/lib/http";
 import { readImageDimensions } from "@/lib/image-dimensions";
 import { embedAndStoreImage, refreshImageEmbedding } from "@/lib/images/embed";
+import { detectImageSource } from "@/lib/images/source-detection";
 import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -251,8 +252,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     cloudflare_id: cfRecord.id,
     filename,
     title: deriveTitle(exifRaw, filename),
-    source: "upload" as const,
-    source_ref: filename,
+    ...detectImageSource(filename),
     bytes: file.size,
     width_px: dims?.width ?? null,
     height_px: dims?.height ?? null,

--- a/components/ImagesTable.tsx
+++ b/components/ImagesTable.tsx
@@ -10,7 +10,6 @@ import { DataTable, type ColumnDef } from "@/components/ui/data-table";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { Pill, type PillVariant } from "@/components/ui/pill";
 import { TableCell } from "@/components/ui/table-cell";
-import { deliveryUrl } from "@/lib/cloudflare-images";
 import type { ImageListItem } from "@/lib/image-library";
 import { formatRelativeTime } from "@/lib/utils";
 
@@ -57,8 +56,10 @@ type LightboxState = {
   height_px: number | null;
 };
 
+type ImageListItemWithUrl = ImageListItem & { previewUrl: string | null };
+
 type ImagesTableProps = {
-  items: ImageListItem[];
+  items: ImageListItemWithUrl[];
   backHref?: string;
 };
 
@@ -72,10 +73,10 @@ function Thumbnail({
   item,
   onClick,
 }: {
-  item: ImageListItem;
+  item: ImageListItemWithUrl;
   onClick?: () => void;
 }) {
-  const url = item.cloudflare_id ? deliveryUrl(item.cloudflare_id) : null;
+  const url = item.previewUrl;
   const alt = item.alt_text ?? item.filename ?? "Library image";
   if (!url) {
     return (
@@ -131,8 +132,8 @@ export function ImagesTable({ items, backHref }: ImagesTableProps) {
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkError, setBulkError] = useState<string | null>(null);
 
-  function openLightbox(item: ImageListItem) {
-    const url = item.cloudflare_id ? deliveryUrl(item.cloudflare_id) : null;
+  function openLightbox(item: ImageListItemWithUrl) {
+    const url = item.previewUrl;
     if (!url) return;
     setLightbox({
       src: url,
@@ -145,7 +146,7 @@ export function ImagesTable({ items, backHref }: ImagesTableProps) {
     });
   }
 
-  const columns: ColumnDef<ImageListItem>[] = [
+  const columns: ColumnDef<ImageListItemWithUrl>[] = [
     {
       key: "preview",
       header: "Preview",
@@ -154,7 +155,7 @@ export function ImagesTable({ items, backHref }: ImagesTableProps) {
         <Thumbnail
           item={item}
           onClick={
-            item.cloudflare_id ? () => openLightbox(item) : undefined
+            item.previewUrl ? () => openLightbox(item) : undefined
           }
         />
       ),
@@ -249,7 +250,7 @@ export function ImagesTable({ items, backHref }: ImagesTableProps) {
         selectable
         selectedKeys={selectedKeys}
         onSelectionChange={setSelectedKeys}
-        onRowClick={(item) => router.push(buildDetailHref(item.id, backHref))}
+        onRowClick={(item: ImageListItemWithUrl) => router.push(buildDetailHref(item.id, backHref))}
         testId="images-table"
         emptyState={{
           icon: <NavIcon name="picture" size={20} />,

--- a/lib/__tests__/image-source-detection.unit.test.ts
+++ b/lib/__tests__/image-source-detection.unit.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { detectImageSource } from "@/lib/images/source-detection";
+
+describe("detectImageSource", () => {
+  it("detects istock-<id>.jpg as istock with numeric source_ref", () => {
+    expect(detectImageSource("istock-1234567890.jpg")).toEqual({
+      source: "istock",
+      source_ref: "1234567890",
+    });
+  });
+
+  it("detects istock_<id>.jpeg with underscore separator", () => {
+    expect(detectImageSource("istock_9876543.jpeg")).toEqual({
+      source: "istock",
+      source_ref: "9876543",
+    });
+  });
+
+  it("is case-insensitive (iStock-...)", () => {
+    expect(detectImageSource("iStock-2216481617.png")).toEqual({
+      source: "istock",
+      source_ref: "2216481617",
+    });
+  });
+
+  it("strips extension before matching", () => {
+    expect(detectImageSource("istock-123456.webp")).toEqual({
+      source: "istock",
+      source_ref: "123456",
+    });
+  });
+
+  it("returns upload for a generic photo filename", () => {
+    expect(detectImageSource("hero-banner.jpg")).toEqual({
+      source: "upload",
+      source_ref: "hero-banner.jpg",
+    });
+  });
+
+  it("returns upload when istock prefix has fewer than 6 digits", () => {
+    expect(detectImageSource("istock-123.jpg")).toEqual({
+      source: "upload",
+      source_ref: "istock-123.jpg",
+    });
+  });
+
+  it("returns upload when istock is not adjacent to digits", () => {
+    expect(detectImageSource("istock-photo.jpg")).toEqual({
+      source: "upload",
+      source_ref: "istock-photo.jpg",
+    });
+  });
+
+  it("preserves full filename as source_ref for upload rows", () => {
+    const result = detectImageSource("portrait.png");
+    expect(result.source_ref).toBe("portrait.png");
+  });
+});

--- a/lib/images/source-detection.ts
+++ b/lib/images/source-detection.ts
@@ -1,0 +1,15 @@
+import { parseIstockIdFromFilename } from "@/lib/image-dimensions";
+import type { ImageLibrarySource } from "@/lib/image-library";
+
+export type DetectedImageSource = {
+  source: ImageLibrarySource;
+  source_ref: string;
+};
+
+export function detectImageSource(filename: string): DetectedImageSource {
+  const istockId = parseIstockIdFromFilename(filename);
+  if (istockId) {
+    return { source: "istock", source_ref: istockId };
+  }
+  return { source: "upload", source_ref: filename };
+}

--- a/supabase/migrations/0114_fix_istock_source.sql
+++ b/supabase/migrations/0114_fix_istock_source.sql
@@ -1,0 +1,29 @@
+-- Fix source classification for iStock images that were bulk-uploaded via the
+-- admin UI before the upload route learned to detect iStock filenames.
+-- Before: all uploads got source='upload', source_ref=filename.
+-- After:  istock[-_]<6+digits> filenames get source='istock', source_ref=<digits>.
+--
+-- Uses the same pattern as lib/image-dimensions.ts ISTOCK_FILENAME_RE:
+-- iStock[-_](\d{6,})  (case-insensitive, anywhere in the filename)
+-- so both the SQL migration and the TypeScript upload path agree on what
+-- constitutes an iStock filename.
+--
+-- The NOT EXISTS guard prevents the UPDATE from running when an 'istock' row
+-- already exists with the same numeric ID (e.g. if the iStock CSV seed was
+-- also used for these images), which would otherwise violate the
+-- UNIQUE (source, source_ref) constraint.
+
+UPDATE image_library
+SET
+  source     = 'istock',
+  source_ref = (regexp_match(filename, 'istock[-_](\d{6,})', 'i'))[1],
+  updated_at = now()
+WHERE source   = 'upload'
+  AND filename ~* 'istock[-_]\d{6,}'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM image_library AS dup
+    WHERE dup.source     = 'istock'
+      AND dup.source_ref = (regexp_match(image_library.filename, 'istock[-_](\d{6,})', 'i'))[1]
+      AND dup.id         != image_library.id
+  );


### PR DESCRIPTION
## Summary

- **Bug 1 — thumbnails blank on /admin/images**: `ImagesTable` is a client component; calling `deliveryUrl()` there reads `CLOUDFLARE_IMAGES_HASH` client-side where it is `undefined`. Fix: server component (`app/admin/images/page.tsx`) now calls `deliveryUrl(item.cloudflare_id, "public")` per item — identical to the working detail page pattern — and passes the pre-computed `previewUrl: string | null` down to `ImagesTable`. Client component never touches `process.env`.
- **Bug 2 — source badge always "Upload"**: upload route hardcoded `source: "upload"`. New `detectImageSource()` helper detects iStock filenames using the existing `parseIstockIdFromFilename` regex and returns the correct `source`/`source_ref`. Migration 0114 back-fills existing rows.

## Test plan

- [ ] `npm run test:unit` — 82 tests pass (includes 8 new `detectImageSource` unit tests)
- [ ] `npm run typecheck` — clean
- [ ] Navigate to `/admin/images` in production — thumbnails render
- [ ] Source badge shows "iStock" for istock-*.jpg images

## Risks identified and mitigated

- Migration 0114 uses `NOT EXISTS` guard against UNIQUE `(source, source_ref)` constraint violation
- `previewUrl` is computed once server-side per page load; no client env var access

🤖 Generated with [Claude Code](https://claude.com/claude-code)