### PR TITLE
fix(migration): pick one winner per istock_id to avoid UNIQUE violation in 0114

### DIFF
--- a/supabase/migrations/0114_fix_istock_source.sql
+++ b/supabase/migrations/0114_fix_istock_source.sql
@@ -8,22 +8,36 @@
 -- so both the SQL migration and the TypeScript upload path agree on what
 -- constitutes an iStock filename.
 --
--- The NOT EXISTS guard prevents the UPDATE from running when an 'istock' row
--- already exists with the same numeric ID (e.g. if the iStock CSV seed was
--- also used for these images), which would otherwise violate the
--- UNIQUE (source, source_ref) constraint.
+-- When multiple 'upload' rows share the same extracted istock ID (e.g.
+-- istock-1234567.jpg and istock-1234567-v2.jpg), updating all of them would
+-- violate UNIQUE (source, source_ref). DISTINCT ON picks exactly one winner
+-- per istock_id (lowest UUID wins for determinism). Any 'upload' rows that
+-- already have a corresponding 'istock' row are skipped by the NOT EXISTS
+-- guard. Losers keep source='upload'.
 
+WITH candidates AS (
+  SELECT
+    id,
+    (regexp_match(filename, 'istock[-_](\d{6,})', 'i'))[1] AS istock_id
+  FROM image_library
+  WHERE source   = 'upload'
+    AND filename ~* 'istock[-_]\d{6,}'
+),
+winners AS (
+  SELECT DISTINCT ON (istock_id) id, istock_id
+  FROM candidates
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM image_library ex
+    WHERE ex.source     = 'istock'
+      AND ex.source_ref = candidates.istock_id
+  )
+  ORDER BY istock_id, id
+)
 UPDATE image_library
 SET
   source     = 'istock',
-  source_ref = (regexp_match(filename, 'istock[-_](\d{6,})', 'i'))[1],
+  source_ref = winners.istock_id,
   updated_at = now()
-WHERE source   = 'upload'
-  AND filename ~* 'istock[-_]\d{6,}'
-  AND NOT EXISTS (
-    SELECT 1
-    FROM image_library AS dup
-    WHERE dup.source     = 'istock'
-      AND dup.source_ref = (regexp_match(image_library.filename, 'istock[-_](\d{6,})', 'i'))[1]
-      AND dup.id         != image_library.id
-  );
+FROM winners
+WHERE image_library.id = winners.id;


### PR DESCRIPTION
## Summary

- Migration `0114_fix_istock_source.sql` failed on production with `ERROR: duplicate key value violates unique constraint "image_library_source_ref_unique"`.
- Root cause: multiple `upload` rows with different filenames (e.g. `istock-1234567.jpg` and `istock-1234567-v2.jpg`) extract the same istock ID. Updating all of them to `(source='istock', source_ref='1234567')` violates `UNIQUE (source, source_ref)`.
- Fix: replace the plain `UPDATE` with a CTE that uses `DISTINCT ON (istock_id)` to select exactly one winner per ID (ties broken by lowest UUID). Non-winner duplicates keep `source='upload'`. Pre-existing `istock` rows still guarded by `NOT EXISTS`.

## Risks identified and mitigated

- **UNIQUE violation on re-run**: fixed — `DISTINCT ON` guarantees at most one row per istock_id will be updated; the `NOT EXISTS` guard skips any istock_id that already has an `istock` row.
- **Non-deterministic winner selection**: mitigated — `ORDER BY istock_id, id` is deterministic (UUID sort); same row wins on every run.
- **Failed migration not recorded in `supabase_migrations`**: Supabase fully rolls back a failed migration, so 0114 will retry cleanly on next deploy.
- **Data loss for duplicate filenames**: by design — only one row per istock_id can carry the istock source; losers keep `source='upload'` and remain accessible.

## Test plan

- [x] `test:unit` — 83 tests pass (no schema change, no new code path to test)
- [x] SQL reviewed for `DISTINCT ON` correctness
- [ ] `deploy-migrations.yml` applies 0114 cleanly on production after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)