### PR TITLE
fix(e2e): exact:true for getByLabel to avoid partial match on Apply search button

### DIFF
--- a/e2e/images.spec.ts
+++ b/e2e/images.spec.ts
@@ -108,8 +108,9 @@ test.describe("images admin surface", () => {
     }
 
     // The filter bar exposes a search box + source selector + apply button.
-    await expect(page.getByLabel("Search")).toBeVisible();
-    await expect(page.getByLabel("Source")).toBeVisible();
+    // exact: true avoids matching "Apply search" button whose aria-label contains "search".
+    await expect(page.getByLabel("Search", { exact: true })).toBeVisible();
+    await expect(page.getByLabel("Source", { exact: true })).toBeVisible();
     await expect(page.getByRole("button", { name: /apply/i })).toBeVisible();
   });
 
@@ -144,7 +145,7 @@ test.describe("images admin surface", () => {
     );
     await page.goto("/admin/images");
     await page.waitForSelector('[data-testid="images-table"]');
-    await page.getByLabel("Source").selectOption("upload");
+    await page.getByLabel("Source", { exact: true }).selectOption("upload");
     await page.getByRole("button", { name: /apply/i }).click();
     await page.waitForSelector('[data-testid="images-table"]');
 


### PR DESCRIPTION
## Summary

- `getByLabel("Search")` matched 2 elements: the search input AND the
  submit button (whose `aria-label="Apply search"` contains "search" as
  substring — Playwright uses partial matching by default)
- Applied `{ exact: true }` to both `getByLabel("Search")` and
  `getByLabel("Source")` in the images e2e first test

## Working analog

Standard Playwright fix — exact matching documented in Playwright locator guide.

## Risks

None — single test-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)