### PR TITLE
feat(images): collapsible bulk upload in toolbar, larger grid, maintenance page

### DIFF
--- a/app/(platform)/admin/images/page.tsx
+++ b/app/(platform)/admin/images/page.tsx
@@ -1,9 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
-import { BulkImageUpload } from "@/components/BulkImageUpload";
 import { ImagesTable, type ImagesFilterState } from "@/components/ImagesTable";
-import { ImageMetadataJobTrigger } from "@/components/admin/ImageMetadataJobTrigger";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
 import { checkAdminAccess } from "@/lib/admin-gate";
@@ -181,14 +179,6 @@ export default async function AdminImagesPage({
           </Link>
         </PageHeader.Actions>
       </PageHeader>
-
-      {!parsed.deleted && <BulkImageUpload />}
-
-      {!parsed.deleted && (
-        <div className="mt-4">
-          <ImageMetadataJobTrigger />
-        </div>
-      )}
 
       <div className="mt-6">
         <ImagesTable

--- a/app/(platform)/admin/maintenance/page.tsx
+++ b/app/(platform)/admin/maintenance/page.tsx
@@ -1,0 +1,36 @@
+import { redirect } from "next/navigation";
+
+import { ImageMetadataJobTrigger } from "@/components/admin/ImageMetadataJobTrigger";
+import { PageHeader } from "@/components/ui/page-header";
+import { checkAdminAccess } from "@/lib/admin-gate";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminMaintenancePage() {
+  const access = await checkAdminAccess({
+    requiredRoles: ["super_admin", "admin"],
+    insufficientRoleRedirectTo: "/admin/sites",
+  });
+  if (access.kind === "redirect") redirect(access.to);
+
+  return (
+    <>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Admin", href: "/admin/sites" },
+            { label: "Maintenance" },
+          ]}
+        />
+        <PageHeader.Title>Maintenance</PageHeader.Title>
+        <PageHeader.Subtitle>
+          Background jobs and data maintenance tools.
+        </PageHeader.Subtitle>
+      </PageHeader>
+
+      <div className="mt-6">
+        <ImageMetadataJobTrigger />
+      </div>
+    </>
+  );
+}

--- a/components/ImagesTable.tsx
+++ b/components/ImagesTable.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
+import { BulkImageUpload } from "@/components/BulkImageUpload";
 import { ConfirmActionModal } from "@/components/ConfirmActionModal";
 import { ImageLightbox } from "@/components/ImageLightbox";
 import { Button } from "@/components/ui/button";
@@ -265,7 +266,7 @@ function ImageGrid({
       className="mt-3"
       style={{
         display: "grid",
-        gridTemplateColumns: "repeat(auto-fill, minmax(110px, 1fr))",
+        gridTemplateColumns: "repeat(auto-fill, minmax(149px, 1fr))",
         gap: "8px",
       }}
     >
@@ -296,10 +297,14 @@ function ImagesToolbar({
   view,
   onViewChange,
   filterState,
+  showBulkUpload,
+  onBulkUploadToggle,
 }: {
   view: "grid" | "list";
   onViewChange: (v: "grid" | "list") => void;
   filterState: ImagesFilterState | undefined;
+  showBulkUpload: boolean;
+  onBulkUploadToggle: () => void;
 }) {
   const toggleBtn =
     "flex h-8 w-8 items-center justify-center transition-colors hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring";
@@ -387,6 +392,18 @@ function ImagesToolbar({
           <option>Any date</option>
         </select>
 
+        {/* Bulk upload toggle — hidden in archived view */}
+        {!filterState?.deleted && (
+          <button
+            type="button"
+            onClick={onBulkUploadToggle}
+            aria-expanded={showBulkUpload}
+            className="flex h-8 items-center gap-1 rounded border bg-background px-2 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Bulk upload {showBulkUpload ? "▴" : "▾"}
+          </button>
+        )}
+
         {/* Search — pushed to far right */}
         <div className="ml-auto flex items-center gap-2">
           <input
@@ -435,6 +452,8 @@ export function ImagesTable({ items, backHref, filterState }: ImagesTableProps) 
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkError, setBulkError] = useState<string | null>(null);
+
+  const [showBulkUpload, setShowBulkUpload] = useState(false);
 
   // View toggle — grid is the default; persisted in localStorage.
   // Initialised lazily on the client to avoid SSR/hydration mismatch.
@@ -536,7 +555,15 @@ export function ImagesTable({ items, backHref, filterState }: ImagesTableProps) 
         view={view}
         onViewChange={handleViewChange}
         filterState={filterState}
+        showBulkUpload={showBulkUpload}
+        onBulkUploadToggle={() => setShowBulkUpload((v) => !v)}
       />
+
+      {showBulkUpload && !filterState?.deleted && (
+        <div className="mt-2">
+          <BulkImageUpload />
+        </div>
+      )}
 
       {selectedKeys.length > 0 && (
         <div className="mt-2 flex items-center gap-3">

--- a/components/nav/nav-config.ts
+++ b/components/nav/nav-config.ts
@@ -171,6 +171,7 @@ export const primaryNavItems: PrimaryNavItem[] = [
       "/admin/system",
       "/admin/email-test",
       "/admin/settings",
+      "/admin/maintenance",
     ],
     testId: "nav-admin-tools",
     sectionNav: {
@@ -181,6 +182,7 @@ export const primaryNavItems: PrimaryNavItem[] = [
           items: [
             { label: "Audit log", href: "/admin/users/audit", testId: "nav-audit-log" },
             { label: "System jobs", href: "/admin/system/jobs", testId: "nav-system-jobs" },
+            { label: "Maintenance", href: "/admin/maintenance", testId: "nav-maintenance" },
             { label: "Email test", href: "/admin/email-test", testId: "nav-email-test" },
             { label: "Design system", href: "/admin/settings/design-system", testId: "nav-design-system-settings" },
           ],


### PR DESCRIPTION
## Summary

- BulkImageUpload moved to collapsible toolbar panel: removed always-visible upload panel from images page. Added "Bulk upload" toggle button in ImagesTable toolbar (after the date filter); clicking expands/collapses the panel below. Hidden when viewing archived images.
- Grid thumbnails 35% larger: minmax(110px, 1fr) to minmax(149px, 1fr)
- EXIF/IPTC trigger moved to /admin/maintenance: ImageMetadataJobTrigger now lives on a dedicated maintenance page, accessible via Admin section nav (Maintenance item added between System jobs and Email test).

## Risks identified and mitigated

- BulkImageUpload is a client component — safe to render inside ImagesTable (also client). No server/client boundary issue.
- showBulkUpload state is local (not persisted in URL or localStorage) — deliberate, as upload state is ephemeral.
- /admin/maintenance uses the same checkAdminAccess guard as other admin pages.

## Test plan

- Visit /admin/images — "Bulk upload" button visible in toolbar after date filter
- Click it — upload panel expands below toolbar
- Click again — panel collapses
- Switch to archived view (?deleted=1) — Bulk upload button not shown
- Grid images visibly larger (~35%)
- Visit /admin/maintenance — page loads with EXIF/IPTC job trigger UI
- Admin nav > Admin shield icon > Maintenance link visible and routes correctly

Generated with Claude Code
