### PR TITLE
fix(layout): Phase 3 rebuild — breadcrumb, PageShell, H1 (rebuilt from scratch)

### DIFF
--- a/app/(platform)/account/devices/page.tsx
+++ b/app/(platform)/account/devices/page.tsx
@@ -4,7 +4,6 @@ import { redirect } from "next/navigation";
 import { TrustedDevicesList } from "@/components/TrustedDevicesList";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import {
   DEVICE_ID_COOKIE,
   decodeDeviceCookie,
@@ -49,7 +48,7 @@ export default async function AccountDevicesPage() {
     : [];
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -88,6 +87,6 @@ export default async function AccountDevicesPage() {
           hasCurrentDevice={currentDeviceId !== null}
         />
       )}
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/account/security/page.tsx
+++ b/app/(platform)/account/security/page.tsx
@@ -2,7 +2,6 @@ import { redirect } from "next/navigation";
 
 import { AccountSecurityForm } from "@/components/AccountSecurityForm";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
 
 // ---------------------------------------------------------------------------
@@ -31,7 +30,7 @@ export default async function AccountSecurityPage() {
   }
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -45,6 +44,6 @@ export default async function AccountSecurityPage() {
         </PageHeader.Subtitle>
       </PageHeader>
       <AccountSecurityForm userEmail={user.email} />
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/_internal/table-examples/page.tsx
+++ b/app/(platform)/admin/_internal/table-examples/page.tsx
@@ -2,7 +2,6 @@ import { redirect } from "next/navigation";
 
 import { ExampleTablesClient } from "@/components/admin/internal/ExampleTablesClient";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 
 // ---------------------------------------------------------------------------
@@ -30,7 +29,7 @@ export default async function TableExamplesPage() {
   if (access.kind === "redirect") redirect(access.to);
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -46,6 +45,6 @@ export default async function TableExamplesPage() {
         </PageHeader.Subtitle>
       </PageHeader>
       <ExampleTablesClient />
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/batches/[siteId]/[batchId]/page.tsx
+++ b/app/(platform)/admin/batches/[siteId]/[batchId]/page.tsx
@@ -5,7 +5,6 @@ import { BatchDetailClient } from "@/components/BatchDetailClient";
 import { BatchSuccessMoment } from "@/components/BatchSuccessMoment";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import {
   StatusPill,
   jobStatusKind,
@@ -61,7 +60,7 @@ export default async function BatchDetailPage({
 
   if (jobErr) {
     return (
-      <PageShell>
+      <>
         <PageHeader>
           <PageHeader.Breadcrumb
             segments={[
@@ -73,7 +72,7 @@ export default async function BatchDetailPage({
           <PageHeader.Title>Failed to load batch</PageHeader.Title>
         </PageHeader>
         <Alert variant="destructive">{jobErr.message}</Alert>
-      </PageShell>
+      </>
     );
   }
   if (!job) {
@@ -120,7 +119,7 @@ export default async function BatchDetailPage({
   const tmpl = job.template as unknown as { name: string; page_type: string };
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -241,6 +240,6 @@ export default async function BatchDetailPage({
           </div>
         </div>
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/batches/[siteId]/page.tsx
+++ b/app/(platform)/admin/batches/[siteId]/page.tsx
@@ -5,7 +5,6 @@ import { NewBatchButton } from "@/components/NewBatchButton";
 import type { BatchTemplateOption } from "@/components/NewBatchModal";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -65,7 +64,7 @@ export default async function AdminBatchesSitePage({
 
   if (error) {
     return (
-      <PageShell>
+      <>
         <PageHeader>
           <PageHeader.Breadcrumb
             segments={[
@@ -79,7 +78,7 @@ export default async function AdminBatchesSitePage({
         <Alert variant="destructive" title="Failed to load batches">
           {error.message}
         </Alert>
-      </PageShell>
+      </>
     );
   }
 
@@ -142,7 +141,7 @@ export default async function AdminBatchesSitePage({
   const subtitle = `${rows.length} ${rows.length === 1 ? "batch" : "batches"} for ${site.name}.`;
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -161,6 +160,6 @@ export default async function AdminBatchesSitePage({
       <div>
         <BatchesTable rows={rows} siteId={params.siteId} />
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/batches/page.tsx
+++ b/app/(platform)/admin/batches/page.tsx
@@ -2,7 +2,6 @@ import { redirect, permanentRedirect } from "next/navigation";
 
 import { NavIcon } from "@/components/ui/nav-icon";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 
 // Batches section entry point.
@@ -35,7 +34,7 @@ export default async function BatchesEntryPage({
   }
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -53,6 +52,6 @@ export default async function BatchesEntryPage({
           site, then navigate here again.
         </p>
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/companies/[id]/page.tsx
+++ b/app/(platform)/admin/companies/[id]/page.tsx
@@ -2,7 +2,6 @@ import { notFound } from "next/navigation";
 
 import { PlatformCompanyDetail } from "@/components/PlatformCompanyDetail";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { getCurrentPlatformSession } from "@/lib/platform/auth";
 import { getPlatformCompany } from "@/lib/platform/companies";
 import { joinCompanyAsAdmin } from "../_actions";
@@ -27,7 +26,7 @@ export default async function CompanyDetailPage({
   if (!result.ok) {
     if (result.error.code === "NOT_FOUND") notFound();
     return (
-      <PageShell>
+      <>
         <PageHeader>
           <PageHeader.Breadcrumb
             segments={[
@@ -44,7 +43,7 @@ export default async function CompanyDetailPage({
         >
           {result.error.message}
         </div>
-      </PageShell>
+      </>
     );
   }
 
@@ -59,7 +58,7 @@ export default async function CompanyDetailPage({
   const { company } = result.data;
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -92,6 +91,6 @@ export default async function CompanyDetailPage({
         isCurrentUserMember={isCurrentUserMember}
         joinAction={boundJoinAction}
       />
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/companies/new/page.tsx
+++ b/app/(platform)/admin/companies/new/page.tsx
@@ -1,6 +1,5 @@
 import { PlatformCompanyCreateForm } from "@/components/PlatformCompanyCreateForm";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 
 // P3-2 — Opollo admin "create company" page. Server-rendered shell;
 // the form posts to POST /api/admin/companies. Gated by
@@ -10,7 +9,7 @@ export const dynamic = "force-dynamic";
 
 export default function NewCompanyPage() {
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -26,6 +25,6 @@ export default function NewCompanyPage() {
         </PageHeader.Subtitle>
       </PageHeader>
       <PlatformCompanyCreateForm />
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/companies/page.tsx
+++ b/app/(platform)/admin/companies/page.tsx
@@ -5,7 +5,6 @@ import { PlatformCompaniesListClient } from "@/components/PlatformCompaniesListC
 import { Button } from "@/components/ui/button";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { listPlatformCompanies } from "@/lib/platform/companies";
 
 // P3-1 — Opollo admin companies list. Gated by app/admin/layout.tsx's
@@ -25,7 +24,7 @@ export default async function AdminCompaniesPage({
   const result = await listPlatformCompanies();
   if (!result.ok) {
     return (
-      <PageShell>
+      <>
         <PageHeader>
           <PageHeader.Breadcrumb
             segments={[
@@ -41,7 +40,7 @@ export default async function AdminCompaniesPage({
         >
           Failed to load companies: {result.error.message}
         </div>
-      </PageShell>
+      </>
     );
   }
 
@@ -52,7 +51,7 @@ export default async function AdminCompaniesPage({
       : `${companies.length} ${companies.length === 1 ? "company" : "companies"} on the platform.`;
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -80,6 +79,6 @@ export default async function AdminCompaniesPage({
         </div>
       )}
       <PlatformCompaniesListClient companies={companies} />
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/email-test/page.tsx
+++ b/app/(platform)/admin/email-test/page.tsx
@@ -3,7 +3,6 @@ import { redirect } from "next/navigation";
 import { EmailTestForm } from "@/components/EmailTestForm";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 
 // AUTH-FOUNDATION P3.4 — /admin/email-test now gated on super_admin.
@@ -23,7 +22,7 @@ export default async function EmailTestPage() {
   if (access.kind === "redirect") redirect(access.to);
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -51,6 +50,6 @@ export default async function EmailTestPage() {
           <EmailTestForm />
         </div>
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/images/[id]/page.tsx
+++ b/app/(platform)/admin/images/[id]/page.tsx
@@ -10,7 +10,6 @@ import { Alert } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { H3 } from "@/components/ui/typography";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { EditImageMetadataButton } from "@/components/EditImageMetadataButton";
 import { ImageArchiveButton } from "@/components/ImageArchiveButton";
 import { checkAdminAccess } from "@/lib/admin-gate";
@@ -134,7 +133,7 @@ export default async function AdminImageDetailPage({
 
   const titleLabel = image.title ?? image.filename ?? "Untitled image";
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -393,6 +392,6 @@ export default async function AdminImageDetailPage({
           )}
         </div>
       </section>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/settings/design-system/page.tsx
+++ b/app/(platform)/admin/settings/design-system/page.tsx
@@ -2,7 +2,6 @@ import { redirect } from "next/navigation";
 
 import { DesignSystemSettingsClient } from "@/components/DesignSystemSettingsClient";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -23,7 +22,7 @@ export default async function DesignSystemSettingsPage() {
     .maybeSingle();
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -40,6 +39,6 @@ export default async function DesignSystemSettingsPage() {
         </PageHeader.Subtitle>
       </PageHeader>
       <DesignSystemSettingsClient initialSettings={data ?? null} />
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/appearance/page.tsx
+++ b/app/(platform)/admin/sites/[id]/appearance/page.tsx
@@ -6,7 +6,6 @@ import { ExtractedProfilePanel } from "@/components/ExtractedProfilePanel";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { listAppearanceEventsForSite } from "@/lib/appearance-events";
 import { getSite } from "@/lib/sites";
@@ -89,7 +88,7 @@ export default async function SiteAppearancePage({
 
   if (modeRow.site_mode === null) {
     return (
-      <PageShell>
+      <>
         <PageHeader>
           <PageHeader.Breadcrumb segments={headerSegments} />
           <PageHeader.Title>{site.name}</PageHeader.Title>
@@ -107,13 +106,13 @@ export default async function SiteAppearancePage({
             </Link>
           </Button>
         </div>
-      </PageShell>
+      </>
     );
   }
 
   if (modeRow.site_mode === "copy_existing") {
     return (
-      <PageShell>
+      <>
         <PageHeader>
           <PageHeader.Breadcrumb segments={headerSegments} />
           <PageHeader.Title>Appearance · {site.name}</PageHeader.Title>
@@ -125,7 +124,7 @@ export default async function SiteAppearancePage({
           extractedDesign={modeRow.extracted_design}
           extractedClasses={modeRow.extracted_css_classes}
         />
-      </PageShell>
+      </>
     );
   }
 
@@ -136,7 +135,7 @@ export default async function SiteAppearancePage({
     process.env.FEATURE_PATH_B_PUBLISH_GATE === "1";
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb segments={headerSegments} />
         <PageHeader.Title>Appearance · {site.name}</PageHeader.Title>
@@ -151,6 +150,6 @@ export default async function SiteAppearancePage({
         initialEvents={events}
         publishGateEnabled={publishGateEnabled}
       />
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/blueprints/review/page.tsx
+++ b/app/(platform)/admin/sites/[id]/blueprints/review/page.tsx
@@ -9,7 +9,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { Skeleton } from "@/components/ui/skeleton";
 
 // /admin/sites/[id]/blueprints/review — M16-7.
@@ -150,7 +149,7 @@ export default function BlueprintReviewPage({
 
   if (loading) {
     return (
-      <PageShell>
+      <>
         <PageHeader>
           <PageHeader.Breadcrumb segments={breadcrumbSegments} />
           <PageHeader.Title>Site Plan Review</PageHeader.Title>
@@ -161,13 +160,13 @@ export default function BlueprintReviewPage({
           <Skeleton className="h-32 w-full" />
           <Skeleton className="h-32 w-full" />
         </div>
-      </PageShell>
+      </>
     );
   }
 
   if (!blueprint) {
     return (
-      <PageShell>
+      <>
         <PageHeader>
           <PageHeader.Breadcrumb segments={breadcrumbSegments} />
           <PageHeader.Title>Site Plan Review</PageHeader.Title>
@@ -178,14 +177,14 @@ export default function BlueprintReviewPage({
           title="No site plan yet"
           body="Run the site planner from the brief run page to generate a plan before approving page generation."
         />
-      </PageShell>
+      </>
     );
   }
 
   const isApproved = blueprint.status === "approved";
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb segments={breadcrumbSegments} />
         <PageHeader.Title>Site Plan Review</PageHeader.Title>
@@ -291,6 +290,6 @@ export default function BlueprintReviewPage({
         </pre>
       </details>
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/briefs/[brief_id]/review/page.tsx
+++ b/app/(platform)/admin/sites/[id]/briefs/[brief_id]/review/page.tsx
@@ -2,7 +2,6 @@ import { notFound, redirect } from "next/navigation";
 
 import { BriefReviewClient } from "@/components/BriefReviewClient";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { getBriefWithPages } from "@/lib/briefs";
 import { getSite } from "@/lib/sites";
 
@@ -58,7 +57,7 @@ export default async function BriefReviewPage({
   const { brief, pages } = briefResult.data;
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -82,6 +81,6 @@ export default async function BriefReviewPage({
         brief={brief}
         initialPages={pages}
       />
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/briefs/[brief_id]/run/page.tsx
+++ b/app/(platform)/admin/sites/[id]/briefs/[brief_id]/run/page.tsx
@@ -4,7 +4,6 @@ import { BlogStyleCalibrationBanner } from "@/components/BlogStyleCalibrationBan
 import { BriefCommitWaiter } from "@/components/BriefCommitWaiter";
 import { BriefRunClient } from "@/components/BriefRunClient";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import {
   estimateBriefRunCost,
   getBriefWithPages,
@@ -101,7 +100,7 @@ export default async function BriefRunPage({
     // commit" message + back-to-review link, replacing the prior
     // panel's role.
     return (
-      <PageShell>
+      <>
         <PageHeader>
           <PageHeader.Breadcrumb
             segments={[
@@ -118,7 +117,7 @@ export default async function BriefRunPage({
           briefId={brief.id}
           reviewUrl={`/admin/sites/${site.id}/briefs/${brief.id}/review`}
         />
-      </PageShell>
+      </>
     );
   }
 
@@ -155,7 +154,7 @@ export default async function BriefRunPage({
       : null;
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -185,6 +184,6 @@ export default async function BriefRunPage({
         remainingBudgetCents={remainingBudgetCents}
         blogStyleBlocked={blogStyleBlocker !== null}
       />
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/content/page.tsx
+++ b/app/(platform)/admin/sites/[id]/content/page.tsx
@@ -8,7 +8,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Dialog,
@@ -141,7 +140,7 @@ export default function SharedContentPage({
   }, {});
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -268,6 +267,6 @@ export default function SharedContentPage({
         </Dialog>
       )}
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/edit/page.tsx
+++ b/app/(platform)/admin/sites/[id]/edit/page.tsx
@@ -3,7 +3,6 @@ import { notFound, redirect } from "next/navigation";
 import { SiteEditForm } from "@/components/SiteEditForm";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getSite } from "@/lib/sites";
 
@@ -31,7 +30,7 @@ export default async function EditSitePage({
   if (!result.ok) {
     if (result.error.code === "NOT_FOUND") notFound();
     return (
-      <PageShell>
+      <>
         <PageHeader>
           <PageHeader.Breadcrumb
             segments={[
@@ -45,7 +44,7 @@ export default async function EditSitePage({
         <div className="mx-auto max-w-2xl">
           <Alert variant="destructive">{result.error.message}</Alert>
         </div>
-      </PageShell>
+      </>
     );
   }
 
@@ -53,7 +52,7 @@ export default async function EditSitePage({
   const creds = result.data.credentials;
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -80,6 +79,6 @@ export default async function EditSitePage({
           hasStoredCredentials={creds !== null}
         />
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/onboarding/page.tsx
+++ b/app/(platform)/admin/sites/[id]/onboarding/page.tsx
@@ -5,7 +5,6 @@ import { FirstSiteConnectedMoment } from "@/components/onboarding/first-site-con
 import { SiteOnboardingForm } from "@/components/SiteOnboardingForm";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { H3 } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -66,7 +65,7 @@ export default async function SiteOnboardingPage({
   }
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -117,6 +116,6 @@ export default async function SiteOnboardingPage({
           </Link>
         </section>
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/page.tsx
+++ b/app/(platform)/admin/sites/[id]/page.tsx
@@ -18,7 +18,6 @@ import {
 import { H3 } from "@/components/ui/typography";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { UploadBriefButton } from "@/components/UploadBriefButton";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { listSiteBriefs } from "@/lib/briefs";
@@ -196,7 +195,7 @@ export default async function SiteDetailPage({
     : null;
 
   return (
-    <PageShell>
+    <>
       {needsOnboarding && <OnboardingReminderBanner siteId={site.id} />}
       {needsSetupReminder && <SetupReminderBanner siteId={site.id} />}
       {blogStyleBlocker && <BlogStyleCalibrationBanner siteId={site.id} />}
@@ -625,6 +624,6 @@ export default async function SiteDetailPage({
           </div>
         </aside>
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/pages/[pageId]/page.tsx
+++ b/app/(platform)/admin/sites/[id]/pages/[pageId]/page.tsx
@@ -4,7 +4,6 @@ import { notFound, redirect } from "next/navigation";
 import { EditPageMetadataButton } from "@/components/EditPageMetadataButton";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { StatusPill, postStatusKind } from "@/components/ui/status-pill";
 import { H3 } from "@/components/ui/typography";
 import { PageHtmlPreview } from "@/components/PageHtmlPreview";
@@ -113,7 +112,7 @@ export default async function PageDetail({
   );
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -232,6 +231,6 @@ export default async function PageDetail({
           <RegenHistoryPanel jobs={regenJobs} />
         </div>
       </section>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/pages/page.tsx
+++ b/app/(platform)/admin/sites/[id]/pages/page.tsx
@@ -4,7 +4,6 @@ import { notFound, redirect } from "next/navigation";
 import { PagesTable } from "@/components/PagesTable";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import {
   LIST_PAGES_DEFAULT_LIMIT,
@@ -130,7 +129,7 @@ export default async function SitePagesList({
   const rangeEnd = Math.min(offset + limit, total);
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -262,6 +261,6 @@ export default async function SitePagesList({
           backHref={buildHref(params.id, parsed, {})}
         />
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/posts/[post_id]/page.tsx
+++ b/app/(platform)/admin/sites/[id]/posts/[post_id]/page.tsx
@@ -2,7 +2,6 @@ import { notFound, redirect } from "next/navigation";
 
 import { PostDetailClient } from "@/components/PostDetailClient";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getPost } from "@/lib/posts";
 import { preflightSitePublish } from "@/lib/site-preflight";
@@ -76,7 +75,7 @@ export default async function PostDetailPage({
   const preflight = await preflightSitePublish(params.id);
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -95,6 +94,6 @@ export default async function PostDetailPage({
         post={post}
         preflight={preflight}
       />
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/posts/new/page.tsx
+++ b/app/(platform)/admin/sites/[id]/posts/new/page.tsx
@@ -3,7 +3,6 @@ import { notFound, redirect } from "next/navigation";
 import { BlogPostComposer } from "@/components/BlogPostComposer";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getSite } from "@/lib/sites";
 
@@ -39,7 +38,7 @@ export default async function BlogPostEntryPage({
   const site = result.data.site;
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -58,6 +57,6 @@ export default async function BlogPostEntryPage({
         </PageHeader.Subtitle>
       </PageHeader>
       <BlogPostComposer siteId={site.id} />
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/posts/page.tsx
+++ b/app/(platform)/admin/sites/[id]/posts/page.tsx
@@ -6,7 +6,6 @@ import { checkAdminAccess } from "@/lib/admin-gate";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { StatusPill, postStatusKind } from "@/components/ui/status-pill";
 import { NavIcon } from "@/components/ui/nav-icon";
 import {
@@ -141,7 +140,7 @@ export default async function SitePostsList({
       : `${total} ${total === 1 ? "post" : "posts"}${total > 0 && items.length < total ? ` · showing ${rangeStart}–${rangeEnd}` : ""}`;
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -382,6 +381,6 @@ export default async function SitePostsList({
         </nav>
       )}
       </>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/settings/page.tsx
+++ b/app/(platform)/admin/sites/[id]/settings/page.tsx
@@ -4,7 +4,6 @@ import { SiteVoiceSettingsForm } from "@/components/SiteVoiceSettingsForm";
 import { UseImageLibraryToggle } from "@/components/UseImageLibraryToggle";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { H2 } from "@/components/ui/typography";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getSite } from "@/lib/sites";
@@ -69,7 +68,7 @@ export default async function SiteSettingsPage({
   const imagesWithMetadata = metadataCountRow.count ?? 0;
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -125,6 +124,6 @@ export default async function SiteSettingsPage({
         </div>
       </section>
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/setup/extract/page.tsx
+++ b/app/(platform)/admin/sites/[id]/setup/extract/page.tsx
@@ -3,7 +3,6 @@ import { notFound, redirect } from "next/navigation";
 import { CopyExistingExtractionWizard } from "@/components/CopyExistingExtractionWizard";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -69,7 +68,7 @@ export default async function CopyExistingExtractPage({
   }
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -94,6 +93,6 @@ export default async function CopyExistingExtractPage({
           existingClasses={site.extracted_css_classes}
         />
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/[id]/setup/page.tsx
+++ b/app/(platform)/admin/sites/[id]/setup/page.tsx
@@ -2,7 +2,6 @@ import { notFound, redirect } from "next/navigation";
 
 import { SetupWizard } from "@/components/SetupWizard";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import {
   computeResumeStep,
@@ -89,7 +88,7 @@ export default async function SiteSetupPage({
   const step: SetupStep = requested;
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -114,6 +113,6 @@ export default async function SiteSetupPage({
           status={status}
         />
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/new/page.tsx
+++ b/app/(platform)/admin/sites/new/page.tsx
@@ -2,7 +2,6 @@ import { redirect } from "next/navigation";
 
 import { SiteCreateForm } from "@/components/SiteCreateForm";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 
 // AUTH-FOUNDATION P2.2 — /admin/sites/new.
@@ -21,7 +20,7 @@ export default async function NewSitePage() {
   if (access.kind === "redirect") redirect(access.to);
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -40,6 +39,6 @@ export default async function NewSitePage() {
       <div className="mx-auto max-w-2xl">
         <SiteCreateForm />
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/sites/page.tsx
+++ b/app/(platform)/admin/sites/page.tsx
@@ -4,7 +4,6 @@ import { SitesListClient } from "@/components/SitesListClient";
 import { Button } from "@/components/ui/button";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import {
   SITE_SORTABLE_COLUMNS,
@@ -86,7 +85,7 @@ export default async function ManageSitesPage({
   const result = await listSites({ status, sort, dir });
   if (!result.ok) {
     return (
-      <PageShell>
+      <>
         <PageHeader>
           <PageHeader.Breadcrumb
             segments={[
@@ -102,7 +101,7 @@ export default async function ManageSitesPage({
         >
           Failed to load sites: {result.error.message}
         </div>
-      </PageShell>
+      </>
     );
   }
   const sites: SiteListItem[] = result.data.sites;
@@ -111,7 +110,7 @@ export default async function ManageSitesPage({
       ? "No WordPress sites connected yet."
       : `${sites.length} WordPress ${sites.length === 1 ? "site" : "sites"} connected to this builder.`;
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -137,6 +136,6 @@ export default async function ManageSitesPage({
         dir={dir}
         isSuperAdmin={isSuperAdmin}
       />
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/system/jobs/page.tsx
+++ b/app/(platform)/admin/system/jobs/page.tsx
@@ -4,7 +4,6 @@ import path from "node:path";
 
 import { H2 } from "@/components/ui/typography";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { StatusPill } from "@/components/ui/status-pill";
 import { ImageMetadataJobTrigger } from "@/components/admin/ImageMetadataJobTrigger";
 import { checkAdminAccess } from "@/lib/admin-gate";
@@ -256,7 +255,7 @@ export default async function SystemJobsPage() {
   );
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -425,6 +424,6 @@ export default async function SystemJobsPage() {
           </table>
         </div>
       </section>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/users/audit/page.tsx
+++ b/app/(platform)/admin/users/audit/page.tsx
@@ -3,7 +3,6 @@ import { redirect } from "next/navigation";
 
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 import { formatRelativeTime } from "@/lib/utils";
@@ -46,7 +45,7 @@ export default async function UserAuditPage({ searchParams }: PageProps) {
   const totalPages = count ? Math.max(1, Math.ceil(count / PAGE_SIZE)) : 1;
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -152,6 +151,6 @@ export default async function UserAuditPage({ searchParams }: PageProps) {
           )}
         </>
       )}
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/admin/users/page.tsx
+++ b/app/(platform)/admin/users/page.tsx
@@ -5,7 +5,6 @@ import { InviteUserButton } from "@/components/InviteUserButton";
 import { PendingInvitesTable } from "@/components/PendingInvitesTable";
 import { Alert } from "@/components/ui/alert";
 import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { UsersTable } from "@/components/UsersTable";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -83,7 +82,7 @@ export default async function AdminUsersPage() {
       : `${userCount} ${userCount === 1 ? "user" : "users"} with access. Change a role inline; the server blocks self-modification, last-admin demotions, and any change to the super_admin row.`;
 
   return (
-    <PageShell>
+    <>
       <PageHeader>
         <PageHeader.Breadcrumb
           segments={[
@@ -133,6 +132,6 @@ export default async function AdminUsersPage() {
           </>
         )}
       </div>
-    </PageShell>
+    </>
   );
 }

--- a/app/(platform)/company/social/connections/page.tsx
+++ b/app/(platform)/company/social/connections/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { SocialConnectionsList } from "@/components/SocialConnectionsList";
-import { H1, Lead } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
 import { listConnections } from "@/lib/platform/social/connections";
 
@@ -123,13 +123,13 @@ export default async function CompanySocialConnectionsPage({
 
   return (
     <>
-      <header>
-        <H1>Social connections</H1>
-        <Lead className="mt-0.5">
+      <PageHeader>
+        <PageHeader.Title>Social connections</PageHeader.Title>
+        <PageHeader.Subtitle>
           Each platform you publish to has one connection. Reconnect
           flows when a credential expires.
-        </Lead>
-      </header>
+        </PageHeader.Subtitle>
+      </PageHeader>
 
       <div className="mt-6">
         <ConnectBanner params={searchParams ?? {}} />

--- a/app/(platform)/company/social/media/page.tsx
+++ b/app/(platform)/company/social/media/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { MediaLibraryClient } from "@/components/MediaLibraryClient";
-import { H1, Lead } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
 import { listMediaAssets } from "@/lib/platform/social/media";
 
@@ -43,13 +43,13 @@ export default async function CompanySocialMediaPage() {
 
   return (
     <>
-      <header>
-        <H1>Media library</H1>
-        <Lead className="mt-0.5">
+      <PageHeader>
+        <PageHeader.Title>Media library</PageHeader.Title>
+        <PageHeader.Subtitle>
           Reusable images and video for your social posts. Add an asset
           here, then attach by id when scheduling.
-        </Lead>
-      </header>
+        </PageHeader.Subtitle>
+      </PageHeader>
       <div className="mt-6">
         {listResult.ok ? (
           <MediaLibraryClient

--- a/app/globals.css
+++ b/app/globals.css
@@ -258,7 +258,7 @@
 /* ---------------------------------------------------------------------------
  * A-1 — Typography scale.
  *
- *   <H1>      page heading          text-xl  font-display  ~20px
+ *   <H1>      page heading          text-2xl font-display  ~24px
  *   <H2>      section heading       text-base font-display ~16px
  *   <H3>      sub-section / card    text-sm  font-display  ~14px
  *   <Eyebrow> .lbl                  0.75rem  font-body 700 uppercase (12px design exception)

--- a/components/AppearancePanelClient.tsx
+++ b/components/AppearancePanelClient.tsx
@@ -9,7 +9,7 @@ import { KadencePaletteDiffTable } from "@/components/KadencePaletteDiffTable";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { CardSkeleton } from "@/components/ui/skeleton";
-import { H1, Lead } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
 import type { AppearanceEventRow } from "@/lib/appearance-events";
 import type {
   KadencePaletteProposal,
@@ -313,14 +313,14 @@ export function AppearancePanelClient({
 
   return (
     <div className="mt-4 space-y-5">
-      <div>
-        <H1>Appearance</H1>
-        <Lead className="mt-0.5">
+      <PageHeader>
+        <PageHeader.Title>Appearance</PageHeader.Title>
+        <PageHeader.Subtitle>
           Sync this site&apos;s design-system palette to Kadence on{" "}
           <span className="font-medium text-foreground">{siteName}</span>{" "}
           ({wpDisplayUrl}).
-        </Lead>
-      </div>
+        </PageHeader.Subtitle>
+      </PageHeader>
 
       {/* Scope clarifier — what Opollo owns vs what the operator owns. */}
       <div

--- a/components/BriefRunClient.tsx
+++ b/components/BriefRunClient.tsx
@@ -356,7 +356,7 @@ export function BriefRunClient({
   }
 
   return (
-    <div className="mt-6 space-y-6">
+    <div className="mt-6 space-y-6 pb-24">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
           <span>

--- a/components/CustomerBrandProfileEditor.tsx
+++ b/components/CustomerBrandProfileEditor.tsx
@@ -5,7 +5,8 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Eyebrow, H1, Lead } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
+import { Eyebrow } from "@/components/ui/typography";
 // Value imports come directly from the sub-path. Importing them from
 // the `@/lib/platform/brand` barrel would pull `./get` and `./update`
 // (both `import "server-only"`) into the client bundle via the
@@ -119,13 +120,13 @@ export function CustomerBrandProfileEditor({ company, brand }: Props) {
 
   return (
     <div className="space-y-8">
-      <header>
-        <H1>Brand profile</H1>
-        <Lead className="mt-1">
+      <PageHeader>
+        <PageHeader.Title>Brand profile</PageHeader.Title>
+        <PageHeader.Subtitle>
           How <strong>{company.name}</strong> looks, sounds, and behaves
           across every Opollo product.
-        </Lead>
-      </header>
+        </PageHeader.Subtitle>
+      </PageHeader>
 
       <section
         className="rounded-lg border bg-card p-4"

--- a/components/CustomerCompanyUsersView.tsx
+++ b/components/CustomerCompanyUsersView.tsx
@@ -6,7 +6,7 @@ import { DataTable, type ColumnDef } from "@/components/ui/data-table";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { Pill, type PillVariant } from "@/components/ui/pill";
 import { TableCell } from "@/components/ui/table-cell";
-import { H1, Lead } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
 import type {
   CompanyDetail,
   CompanyMember,
@@ -121,12 +121,12 @@ export function CustomerCompanyUsersView({
 
   return (
     <div className="space-y-8">
-      <header>
-        <H1>Users</H1>
-        <Lead className="mt-1">
+      <PageHeader>
+        <PageHeader.Title>Users</PageHeader.Title>
+        <PageHeader.Subtitle>
           Manage users for <strong>{company.name}</strong>.
-        </Lead>
-      </header>
+        </PageHeader.Subtitle>
+      </PageHeader>
 
       <section
         className="space-y-3"

--- a/components/ExtractedProfilePanel.tsx
+++ b/components/ExtractedProfilePanel.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
-import { H1, H3, Lead } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
+import { H3 } from "@/components/ui/typography";
 
 // DESIGN-SYSTEM-OVERHAUL PR 8 — Appearance panel for copy_existing
 // sites. Pure read-only summary of sites.extracted_design +
@@ -58,9 +59,9 @@ export function ExtractedProfilePanel({
 
   return (
     <div data-testid="extracted-profile-panel" className="mt-6 space-y-6">
-      <header>
-        <H1>{siteName}</H1>
-        <Lead className="mt-1">
+      <PageHeader>
+        <PageHeader.Title>{siteName}</PageHeader.Title>
+        <PageHeader.Subtitle>
           Appearance — design extracted from{" "}
           <a
             href={siteUrl}
@@ -70,8 +71,8 @@ export function ExtractedProfilePanel({
           >
             {siteUrl}
           </a>
-        </Lead>
-      </header>
+        </PageHeader.Subtitle>
+      </PageHeader>
 
       {!hasProfile ? (
         <section

--- a/components/SocialAnalyticsClient.tsx
+++ b/components/SocialAnalyticsClient.tsx
@@ -17,7 +17,8 @@ import {
 } from "recharts";
 
 import { Button } from "@/components/ui/button";
-import { H1, H3, Lead } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
+import { H3 } from "@/components/ui/typography";
 import type { SocialAnalytics } from "@/lib/platform/social/analytics";
 
 // ---------------------------------------------------------------------------
@@ -134,12 +135,12 @@ export function SocialAnalyticsClient({
 
   return (
     <main className="mx-auto max-w-6xl space-y-10 p-6">
-      <header>
-        <H1>Analytics</H1>
-        <Lead className="mt-0.5">
+      <PageHeader>
+        <PageHeader.Title>Analytics</PageHeader.Title>
+        <PageHeader.Subtitle>
           Your social media performance at a glance.
-        </Lead>
-      </header>
+        </PageHeader.Subtitle>
+      </PageHeader>
 
       {!hasAnyPosts && (
         <div

--- a/components/SocialPostsListClient.tsx
+++ b/components/SocialPostsListClient.tsx
@@ -7,7 +7,7 @@ import { BulkUploadButton } from "@/components/BulkUploadButton";
 import { CAPGenerateModal } from "@/components/CAPGenerateModal";
 import { ProfileSelector } from "@/components/social/ProfileSelector";
 import { Button } from "@/components/ui/button";
-import { H1, Lead } from "@/components/ui/typography";
+import { PageHeader } from "@/components/ui/page-header";
 import { cn } from "@/lib/utils";
 import type {
   PostMasterListItem,
@@ -312,13 +312,11 @@ export function SocialPostsListClient({
     <SocialModuleShell
       activeView="posts"
     >
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <H1>Social posts</H1>
-          <Lead className="mt-0.5">{countLabel}</Lead>
-        </div>
+      <PageHeader>
+        <PageHeader.Title>Social posts</PageHeader.Title>
+        <PageHeader.Subtitle>{countLabel}</PageHeader.Subtitle>
         {canCreate ? (
-          <div className="flex items-center gap-2">
+          <PageHeader.Actions>
             <BulkUploadButton
               companyId={companyId}
               onSuccess={(newPosts) =>
@@ -347,9 +345,9 @@ export function SocialPostsListClient({
                 {showCreate ? "Cancel" : "New post"}
               </Button>
             )}
-          </div>
+          </PageHeader.Actions>
         ) : null}
-      </div>
+      </PageHeader>
 
       {/* Search bar */}
       <form

--- a/components/ui/page-header.tsx
+++ b/components/ui/page-header.tsx
@@ -11,15 +11,15 @@ import { cn } from "@/lib/utils";
 // Compound layout (visual order is enforced regardless of JSX order):
 //
 //   ┌──────────────────────────────────────────────────────────┐
-//   │ Test Site 2                              [Run Batch]     │  Title row · Actions right-aligned, vertically centered
-//   │   ↑ 20px gap                                              │
 //   │ Admin › Sites › Test Site 2                              │  Breadcrumb (text-sm muted)
-//   │   ↑ 8px gap (or 20px from title if breadcrumb absent)    │
+//   │   ↑ 8px gap (only when breadcrumb is present)            │
+//   │ Test Site 2                              [Run Batch]     │  Title row · Actions right-aligned, vertically centered
+//   │   ↑ 8px gap                                              │
 //   │ Optional one-line description.                            │  Subtitle (text-base muted)
-//   │   ↑ 12px gap                                              │
+//   │   ↑ 12px gap                                             │
 //   │ ● Active · https://test2... · Tested 2h ago             │  Meta row (text-sm muted, inline)
 //   └──────────────────────────────────────────────────────────┘
-//                       [32px gap to PageShell.Content]
+//                       [32px gap to page content]
 //
 // Slot order is enforced by render order in this component, not by JSX
 // child position. Detection is via `displayName`, NOT reference equality:
@@ -30,11 +30,10 @@ import { cn } from "@/lib/utils";
 // only (console.error, never throws). The `headings-use-page-header`
 // audit rule (Spec 02 PR 3) enforces presence at the build layer.
 //
-// Spec 04 amendment (2026-05-08): slot order reversed from
-// Breadcrumb→Title→… to Title→Breadcrumb→…, and the rhythm spec
-// (20/8/12/32 gaps) added. Title weight bumped 600→700 in
-// app/globals.css. Consumer JSX is unchanged — slot identity
-// (displayName) drives the order, not the JSX order.
+// Spec 04 amendment (2026-05-08) originally reversed to Title→Breadcrumb.
+// Reverted 2026-05-09: Breadcrumb renders above Title so the nav context
+// appears before the page label — standard Linear/Vercel/Stripe pattern.
+// Consumer JSX is unchanged — slot identity (displayName) drives order.
 
 const SLOT_NAMES = {
   Breadcrumb: "PageHeaderBreadcrumb",
@@ -127,27 +126,21 @@ export function PageHeader({ children, className }: PageHeaderProps) {
     }
   }
 
-  // Rhythm gaps below the title row, conditional on which slots are
-  // present so the rhythm collapses cleanly when slots are missing:
-  //   first-rendered-slot-after-title → mt-5  (20px)
-  //   subtitle when breadcrumb shown   → mt-2  (8px)
-  //   meta when subtitle shown         → mt-3  (12px)
-  //   meta when only breadcrumb shown  → mt-2  (8px)
-  //   meta with neither breadcrumb nor subtitle → mt-5 (20px)
-  const subtitleGap = slots.Breadcrumb ? "mt-2" : "mt-5";
-  const metaGap = slots.Subtitle
-    ? "mt-3"
-    : slots.Breadcrumb
-      ? "mt-2"
-      : "mt-5";
+  // Rhythm gaps — breadcrumb is first, title row follows with mt-2 when
+  // breadcrumb is present, then subtitle and meta step down from there.
+  const titleGap = slots.Breadcrumb ? "mt-2" : undefined;
+  const subtitleGap = "mt-2";
+  const metaGap = slots.Subtitle ? "mt-3" : "mt-2";
 
   return (
     <header className={cn("mb-8", className)}>
+      {slots.Breadcrumb && <div>{slots.Breadcrumb}</div>}
+
       {/* Title row — Actions sit on the same horizontal axis, right-aligned,
           vertically centered with the title. flex-wrap so very long titles
           can push Actions onto a second row at narrow widths instead of
           clipping. */}
-      <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className={cn("flex flex-wrap items-center justify-between gap-3", titleGap)}>
         <div className="min-w-0 flex-1">{slots.Title}</div>
         {slots.Actions && (
           <div className="flex shrink-0 items-center gap-2">
@@ -156,7 +149,6 @@ export function PageHeader({ children, className }: PageHeaderProps) {
         )}
       </div>
 
-      {slots.Breadcrumb && <div className="mt-5">{slots.Breadcrumb}</div>}
       {slots.Subtitle && (
         <div className={subtitleGap}>{slots.Subtitle}</div>
       )}
@@ -183,7 +175,7 @@ function PageHeaderTitle({
   className?: string;
 }) {
   return (
-    <h1 className={cn("text-xl text-page-title text-foreground", className)}>
+    <h1 className={cn("text-2xl text-page-title text-foreground", className)}>
       {children}
     </h1>
   );

--- a/components/ui/typography.tsx
+++ b/components/ui/typography.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 //
 // Five components cover every text role on an admin surface:
 //
-//   <H1>      page heading             text-xl font-semibold     ~20px
+//   <H1>      page heading             text-2xl font-semibold    ~24px
 //   <H2>      section heading          text-base font-semibold   ~16px
 //   <H3>      sub-section / card title text-sm font-semibold     ~14px
 //   <Eyebrow> small uppercase label    text-sm font-medium       ~14px
@@ -57,7 +57,7 @@ export const H1 = React.forwardRef<HTMLHeadingElement, HeadingProps>(
       <h1
         ref={ref}
         className={cn(
-          "text-xl font-semibold tracking-tight text-foreground",
+          "text-2xl font-semibold tracking-tight text-foreground",
           className,
         )}
         {...props}

--- a/scripts/layout-audit.sh
+++ b/scripts/layout-audit.sh
@@ -66,6 +66,10 @@ audit_section "Bug D: hex colours in JSX" '(bg|text|border|fill|stroke)-\[#[0-9a
 audit_section "Bug E: rounded-full inline buttons (likely raw <button>)" '<button[^>]*className="[^"]*rounded-' 'app/'
 audit_section "Bug F: per-page header.mb-8 blocks" '<header className="mb-8"' 'app/'
 audit_section "Bug G: NavShellClient prop usage" 'contentMaxWidth|contentPadding' 'app/ components/'
+# Bug H: <H1> typography component used as page heading instead of PageHeader.Title
+audit_section "Bug H: typography H1 component used instead of PageHeader.Title" '<H1[\s>]' 'app/ components/'
+# Bug I: <PageShell> inside NavShell creates double max-w-7xl container
+audit_section "Bug I: PageShell double container (PageShell inside NavShell)" '<PageShell' 'app/'
 
 echo "## Summary" >> "$OUTPUT_FILE"
 echo "" >> "$OUTPUT_FILE"


### PR DESCRIPTION
## What

Phase 3 of the platform layout refactor — three staged commits, rebuilt against current main.

## Commits

**1. `30890271` — breadcrumb above title, H1 24px, extend audit script**
- Reverses Spec 04 slot order: Breadcrumb now renders above the Title row in `PageHeader`. The Title→Breadcrumb arrangement put the nav-context trail below the page heading — inverted from the Linear/Vercel/Stripe pattern.
- Rhythm gaps: breadcrumb first with no top margin; title row gets `mt-2` when breadcrumb present; subtitle `mt-2`; meta `mt-3` (with subtitle) or `mt-2` (without).
- `PageHeader.Title` and `H1` typography primitive bumped `text-xl` (20px) → `text-2xl` (24px). The 20px floor was visually too small in production.
- Adds Bug H + Bug I patterns to `layout-audit.sh` to catch `<H1>` typography component misuse and `<PageShell>` double container.

**2. `d4102051` — strip PageShell from all 33 admin/account pages**
- NavShell already provides `mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8`. PageShell was creating a second identical container inside it on every page (the double-container bug).
- Pages now return their content directly with `<>` Fragment where multiple top-level elements are needed.
- `app/auth/approve/page.tsx` is unchanged — it defines a local PageShell helper for centered auth layout (different component).

**3. `7e41a7d8` — migrate 8 in-shell H1 typography usages to PageHeader.Title**
- Pages and client components rendered inside NavShell were using `<H1>` from `components/ui/typography` instead of `PageHeader.Title`. Converts all 8 in-shell usages to the PageHeader compound (Title + Subtitle + Actions slots).
- Files: `app/(platform)/company/social/connections/page.tsx`, `app/(platform)/company/social/media/page.tsx`, `components/AppearancePanelClient.tsx`, `components/CustomerBrandProfileEditor.tsx`, `components/CustomerCompanyUsersView.tsx`, `components/ExtractedProfilePanel.tsx`, `components/SocialAnalyticsClient.tsx`, `components/SocialPostsListClient.tsx`.

## Final audit (after all 3 commits)

| Bug | Count | Status |
|-----|-------|--------|
| A: per-page max-w containers | 0 | ✓ |
| B: bare `<h1>` with text-size class | 0 | ✓ |
| C: `"mt-5"` breadcrumb wrapper | 0 | ✓ |
| D: hex colours in JSX | 0 | ✓ |
| E: rounded-full raw buttons | 0 | ✓ |
| F: `<header className="mb-8">` | 0 | ✓ |
| G: NavShellClient props | 0 | ✓ |
| H: `<H1>` typography in NavShell | **14** | 11 auth/login/invite (intentionally preserved) + 3 comment lines |
| I: `<PageShell>` double container | **4** | 4 = local `PageShell` in `auth/approve` (different component, intentionally preserved) |

## Pre-merge validation

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run test:unit` — 1195 tests pass

## Risks identified and mitigated

- `PageHeader` is a shared component; breadcrumb-order swap is a pure render-order change with no prop or data change. All 33 PageShell-using pages benefit automatically.
- `text-2xl` swap is a visual-only size bump; no semantic or structural change.
- All 33 PageShell strips were validated by audit script (Bug I dropped 48 → 4 expected residual).
- All 8 H1 migrations preserve subtitle/breadcrumb/actions — no UI affordances lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)