### PR TITLE
feat(bsp-4): orphan-team reconciliation script + safety filters

### DIFF
--- a/lib/__tests__/bundle-social-reconcile.unit.test.ts
+++ b/lib/__tests__/bundle-social-reconcile.unit.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// LAYER 1 — Unit. Pure functions, no Supabase, no SDK.
+//
+// BSP-4: tests the reconciliation diff and delete-safety filters that
+// drive scripts/bundlesocial-reconcile-orphans.ts. These functions are
+// the only ones a misconfigured operator could use to delete real teams,
+// so they MUST have hard-floor tests independent of the script wrapper.
+// ---------------------------------------------------------------------------
+
+import {
+  computeReconcileDiff,
+  filterDeleteSafeOrphans,
+  type ReconcileTeam,
+} from "@/lib/platform/social/bundle-social/reconcile";
+
+const T0 = new Date("2026-05-10T12:00:00Z");
+
+function team(id: string, createdAt: string | null = null): ReconcileTeam {
+  return { id, name: `team-${id}`, createdAt };
+}
+
+describe("BSP-4 — computeReconcileDiff", () => {
+  it("identifies remote teams not present in tracked set as orphans", () => {
+    const remote: ReconcileTeam[] = [
+      team("a"),
+      team("b"),
+      team("c"),
+    ];
+    const tracked = new Set(["a", "c"]);
+
+    const r = computeReconcileDiff(remote, tracked);
+    expect(r.totalRemote).toBe(3);
+    expect(r.totalTracked).toBe(2);
+    expect(r.orphans.map((t) => t.id)).toEqual(["b"]);
+    expect(r.danglingRefs).toEqual([]);
+  });
+
+  it("identifies tracked ids missing from remote as dangling refs", () => {
+    const remote: ReconcileTeam[] = [team("a")];
+    const tracked = new Set(["a", "ghost-1", "ghost-2"]);
+
+    const r = computeReconcileDiff(remote, tracked);
+    expect(r.orphans).toEqual([]);
+    expect(r.danglingRefs.sort()).toEqual(["ghost-1", "ghost-2"]);
+  });
+
+  it("returns zero of each when sets match exactly", () => {
+    const remote: ReconcileTeam[] = [team("a"), team("b")];
+    const tracked = new Set(["a", "b"]);
+
+    const r = computeReconcileDiff(remote, tracked);
+    expect(r.orphans).toEqual([]);
+    expect(r.danglingRefs).toEqual([]);
+  });
+
+  it("handles empty inputs without throwing", () => {
+    const r = computeReconcileDiff([], new Set());
+    expect(r.totalRemote).toBe(0);
+    expect(r.totalTracked).toBe(0);
+    expect(r.orphans).toEqual([]);
+    expect(r.danglingRefs).toEqual([]);
+  });
+
+  it("preserves orphan team metadata (name, createdAt) for the report", () => {
+    const remote: ReconcileTeam[] = [
+      { id: "x", name: "Race Loser", createdAt: "2026-05-09T10:00:00Z" },
+    ];
+    const r = computeReconcileDiff(remote, new Set());
+    expect(r.orphans).toHaveLength(1);
+    expect(r.orphans[0]?.name).toBe("Race Loser");
+    expect(r.orphans[0]?.createdAt).toBe("2026-05-09T10:00:00Z");
+  });
+});
+
+describe("BSP-4 — filterDeleteSafeOrphans", () => {
+  it("REGRESSION: never deletes teams created within minAgeMs of now", () => {
+    // Orphan created 30s ago; minAge = 60s → must NOT be returned as
+    // delete-safe. This is the protection against deleting a team that
+    // a concurrent provisioner just created but hasn't yet committed
+    // to the DB.
+    const orphans: ReconcileTeam[] = [
+      team("recent", "2026-05-10T11:59:30Z"), // 30s before T0
+      team("old", "2026-05-09T10:00:00Z"),
+    ];
+    const safe = filterDeleteSafeOrphans(orphans, T0, 60_000);
+    expect(safe.map((t) => t.id)).toEqual(["old"]);
+  });
+
+  it("REGRESSION: refuses to mark teams with null createdAt as delete-safe", () => {
+    // A team with unknown age is never delete-safe. Better to leak an
+    // orphan than to nuke a team that might be in flight.
+    const orphans: ReconcileTeam[] = [team("unknown-age", null)];
+    const safe = filterDeleteSafeOrphans(orphans, T0, 60_000);
+    expect(safe).toEqual([]);
+  });
+
+  it("REGRESSION: refuses to mark teams with malformed createdAt as delete-safe", () => {
+    const orphans: ReconcileTeam[] = [team("bad-date", "not-a-date")];
+    const safe = filterDeleteSafeOrphans(orphans, T0, 60_000);
+    expect(safe).toEqual([]);
+  });
+
+  it("returns delete-safe orphans when minAge is satisfied", () => {
+    const orphans: ReconcileTeam[] = [
+      team("a", "2026-05-09T10:00:00Z"),
+      team("b", "2026-05-08T10:00:00Z"),
+    ];
+    const safe = filterDeleteSafeOrphans(orphans, T0, 60_000);
+    expect(safe.map((t) => t.id).sort()).toEqual(["a", "b"]);
+  });
+});

--- a/lib/platform/social/bundle-social/reconcile.ts
+++ b/lib/platform/social/bundle-social/reconcile.ts
@@ -1,0 +1,123 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// BSP-4 — orphan-team reconciliation.
+//
+// "Orphan" = a bundle.social team that exists on bundle.social's side but
+// is not referenced by any of:
+//   * platform_companies.bundle_social_team_id
+//   * platform_social_profiles.bundle_social_team_id
+//
+// Orphans are created by:
+//   1. The cross-process race in provisionImpl — two concurrent provisioners
+//      both call teamCreateTeam; one wins the UPDATE WHERE IS NULL race;
+//      the loser's team is orphaned. BSP-2 reduces this risk via in-process
+//      dedup (Layer 1) but does not eliminate it across separate Vercel
+//      function invocations.
+//   2. Manual experimentation in the bundle.social dashboard.
+//   3. Failed provisioning where teamCreate succeeded but the DB write
+//      threw before the optimistic UPDATE landed.
+//
+// Reconciliation is offline tooling — no application code path calls into
+// it. Run it from a developer machine against production credentials when
+// orphan accounting drifts.
+// ---------------------------------------------------------------------------
+
+export type ReconcileTeam = {
+  id: string;
+  name: string;
+  createdAt: string | null;
+};
+
+export type ReconcileReport = {
+  totalRemote: number;
+  totalTracked: number;
+  orphans: ReconcileTeam[];
+  // Teams referenced in our DB but missing from bundle.social — should be
+  // empty in healthy state. Indicates manual deletion or DB drift.
+  danglingRefs: string[];
+};
+
+// Pure function: given the list of bundle.social teams and the set of
+// team ids tracked in our DB, returns the diff. Testable without DB or
+// API access.
+export function computeReconcileDiff(
+  remoteTeams: ReadonlyArray<ReconcileTeam>,
+  trackedTeamIds: ReadonlySet<string>,
+): ReconcileReport {
+  const orphans: ReconcileTeam[] = [];
+  const remoteIds = new Set<string>();
+  for (const t of remoteTeams) {
+    remoteIds.add(t.id);
+    if (!trackedTeamIds.has(t.id)) {
+      orphans.push(t);
+    }
+  }
+  const danglingRefs: string[] = [];
+  for (const id of trackedTeamIds) {
+    if (!remoteIds.has(id)) {
+      danglingRefs.push(id);
+    }
+  }
+  return {
+    totalRemote: remoteTeams.length,
+    totalTracked: trackedTeamIds.size,
+    orphans,
+    danglingRefs,
+  };
+}
+
+// Reads every bundle_social_team_id we currently track from both
+// platform_companies and platform_social_profiles. Returns a Set so
+// the diff can run in O(1) per remote team.
+export async function readTrackedTeamIds(): Promise<Set<string>> {
+  const svc = getServiceRoleClient();
+
+  const tracked = new Set<string>();
+
+  const { data: companies, error: companiesErr } = await svc
+    .from("platform_companies")
+    .select("bundle_social_team_id")
+    .not("bundle_social_team_id", "is", null);
+  if (companiesErr) {
+    throw new Error(`readTrackedTeamIds.companies: ${companiesErr.message}`);
+  }
+  for (const row of companies ?? []) {
+    const id = row.bundle_social_team_id as string | null;
+    if (id) tracked.add(id);
+  }
+
+  const { data: profiles, error: profilesErr } = await svc
+    .from("platform_social_profiles")
+    .select("bundle_social_team_id")
+    .not("bundle_social_team_id", "is", null);
+  if (profilesErr) {
+    throw new Error(`readTrackedTeamIds.profiles: ${profilesErr.message}`);
+  }
+  for (const row of profiles ?? []) {
+    const id = row.bundle_social_team_id as string | null;
+    if (id) tracked.add(id);
+  }
+
+  return tracked;
+}
+
+// Filter helper for delete safety: never delete teams created within
+// the last `minAgeMs` milliseconds. Protects against races where a
+// concurrent provisioner just created a team that hasn't been written
+// to the DB yet.
+export function filterDeleteSafeOrphans(
+  orphans: ReadonlyArray<ReconcileTeam>,
+  now: Date,
+  minAgeMs: number,
+): ReconcileTeam[] {
+  const threshold = now.getTime() - minAgeMs;
+  return orphans.filter((t) => {
+    if (!t.createdAt) return false; // unknown age → unsafe.
+    const created = new Date(t.createdAt).getTime();
+    if (Number.isNaN(created)) return false;
+    return created < threshold;
+  });
+}

--- a/scripts/bundlesocial-reconcile-orphans.ts
+++ b/scripts/bundlesocial-reconcile-orphans.ts
@@ -1,0 +1,229 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * scripts/bundlesocial-reconcile-orphans.ts
+ *
+ * BSP-4 — orphan-team reconciliation.
+ *
+ * Compares the bundle.social organisation's team list against the team
+ * ids tracked in our DB (platform_companies.bundle_social_team_id +
+ * platform_social_profiles.bundle_social_team_id). Reports orphans
+ * (remote teams we don't track) and dangling refs (DB rows pointing at
+ * remote teams that no longer exist).
+ *
+ * Modes:
+ *   (default — report only)
+ *     Lists orphans + dangling refs. Does not call any mutating API.
+ *
+ *   --delete-dry-run
+ *     Lists orphans that WOULD be deleted under the safety filter
+ *     (older than --min-age-min, default 60 minutes). Does not call
+ *     the delete API.
+ *
+ *   --delete --confirm-delete
+ *     Actually deletes orphans that pass the safety filter. Requires
+ *     BOTH flags to prevent accidental nuke-from-orbit.
+ *
+ * Usage:
+ *   npx tsx scripts/bundlesocial-reconcile-orphans.ts
+ *   npx tsx scripts/bundlesocial-reconcile-orphans.ts --delete-dry-run
+ *   npx tsx scripts/bundlesocial-reconcile-orphans.ts --delete-dry-run --min-age-min=120
+ *   npx tsx scripts/bundlesocial-reconcile-orphans.ts --delete --confirm-delete
+ *
+ * Required env:
+ *   BUNDLE_SOCIAL_API
+ *   NEXT_PUBLIC_SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { Bundlesocial } from "bundlesocial";
+import { config } from "dotenv";
+
+import {
+  computeReconcileDiff,
+  filterDeleteSafeOrphans,
+  type ReconcileTeam,
+} from "../lib/platform/social/bundle-social/reconcile";
+
+config({ path: ".env.local" });
+
+type Args = {
+  delete: boolean;
+  confirmDelete: boolean;
+  deleteDryRun: boolean;
+  minAgeMin: number;
+};
+
+function parseArgs(argv: ReadonlyArray<string>): Args {
+  const args: Args = {
+    delete: false,
+    confirmDelete: false,
+    deleteDryRun: false,
+    minAgeMin: 60,
+  };
+  for (const a of argv) {
+    if (a === "--delete") args.delete = true;
+    else if (a === "--confirm-delete") args.confirmDelete = true;
+    else if (a === "--delete-dry-run") args.deleteDryRun = true;
+    else if (a.startsWith("--min-age-min=")) {
+      const n = Number(a.split("=")[1]);
+      if (Number.isFinite(n) && n >= 0) args.minAgeMin = n;
+    }
+  }
+  return args;
+}
+
+async function listAllTeams(client: Bundlesocial): Promise<ReconcileTeam[]> {
+  // bundle.social pagination via limit + offset.
+  const PAGE = 100;
+  const out: ReconcileTeam[] = [];
+  let offset = 0;
+  // Hard cap to prevent infinite loops on a misbehaving SDK.
+  for (let page = 0; page < 50; page++) {
+    const resp = (await client.team.teamGetList({
+      limit: PAGE,
+      offset,
+    })) as { items?: Array<{ id: string; name: string; createdAt?: string | null }> };
+    const items = resp.items ?? [];
+    for (const t of items) {
+      out.push({
+        id: t.id,
+        name: t.name,
+        createdAt: t.createdAt ?? null,
+      });
+    }
+    if (items.length < PAGE) break;
+    offset += PAGE;
+  }
+  return out;
+}
+
+async function readTrackedIds(supabaseUrl: string, serviceRoleKey: string): Promise<Set<string>> {
+  const svc = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+  const tracked = new Set<string>();
+
+  const { data: companies, error: cErr } = await svc
+    .from("platform_companies")
+    .select("bundle_social_team_id")
+    .not("bundle_social_team_id", "is", null);
+  if (cErr) throw new Error(`read companies: ${cErr.message}`);
+  for (const row of companies ?? []) {
+    const id = (row as { bundle_social_team_id: string | null }).bundle_social_team_id;
+    if (id) tracked.add(id);
+  }
+
+  const { data: profiles, error: pErr } = await svc
+    .from("platform_social_profiles")
+    .select("bundle_social_team_id")
+    .not("bundle_social_team_id", "is", null);
+  if (pErr) throw new Error(`read profiles: ${pErr.message}`);
+  for (const row of profiles ?? []) {
+    const id = (row as { bundle_social_team_id: string | null }).bundle_social_team_id;
+    if (id) tracked.add(id);
+  }
+
+  return tracked;
+}
+
+async function main(): Promise<void> {
+  const apiKey = process.env.BUNDLE_SOCIAL_API;
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!apiKey || !supabaseUrl || !serviceRoleKey) {
+    console.error(
+      "Missing required env: BUNDLE_SOCIAL_API, NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY",
+    );
+    process.exit(1);
+  }
+
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.delete && !args.confirmDelete) {
+    console.error("Refusing to delete without --confirm-delete (safety guard).");
+    process.exit(1);
+  }
+
+  const client = new Bundlesocial(apiKey);
+
+  console.log("Listing bundle.social teams...");
+  const remoteTeams = await listAllTeams(client);
+  console.log(`  ${remoteTeams.length} teams visible.`);
+
+  console.log("Reading tracked team ids from Supabase...");
+  const tracked = await readTrackedIds(supabaseUrl, serviceRoleKey);
+  console.log(`  ${tracked.size} tracked.`);
+
+  const report = computeReconcileDiff(remoteTeams, tracked);
+  console.log("");
+  console.log(`Remote total:  ${report.totalRemote}`);
+  console.log(`Tracked total: ${report.totalTracked}`);
+  console.log(`Orphans:       ${report.orphans.length}`);
+  console.log(`Dangling refs: ${report.danglingRefs.length}`);
+
+  if (report.orphans.length > 0) {
+    console.log("");
+    console.log("ORPHANS (remote teams not tracked in DB):");
+    for (const t of report.orphans) {
+      console.log(
+        `  ${t.id}  ${t.createdAt ?? "no-createdAt"}  ${t.name}`,
+      );
+    }
+  }
+
+  if (report.danglingRefs.length > 0) {
+    console.log("");
+    console.log("DANGLING REFS (DB rows pointing at non-existent remote teams):");
+    for (const id of report.danglingRefs) {
+      console.log(`  ${id}`);
+    }
+  }
+
+  if (!args.delete && !args.deleteDryRun) {
+    console.log("");
+    console.log("(report only — pass --delete-dry-run to preview deletes)");
+    return;
+  }
+
+  const minAgeMs = args.minAgeMin * 60 * 1000;
+  const deleteSafe = filterDeleteSafeOrphans(report.orphans, new Date(), minAgeMs);
+
+  console.log("");
+  console.log(
+    `Delete-safe orphans (createdAt > ${args.minAgeMin}m old, with valid createdAt): ${deleteSafe.length}`,
+  );
+  for (const t of deleteSafe) {
+    console.log(`  ${t.id}  ${t.createdAt}  ${t.name}`);
+  }
+
+  if (args.deleteDryRun) {
+    console.log("");
+    console.log("(dry-run only — no deletes issued)");
+    return;
+  }
+
+  // --delete --confirm-delete path.
+  console.log("");
+  console.log("DELETING delete-safe orphans...");
+  let ok = 0;
+  let failed = 0;
+  for (const t of deleteSafe) {
+    try {
+      await client.team.teamDeleteTeam({ id: t.id });
+      console.log(`  deleted ${t.id}`);
+      ok++;
+    } catch (err) {
+      console.error(`  FAILED ${t.id}: ${err instanceof Error ? err.message : String(err)}`);
+      failed++;
+    }
+  }
+  console.log("");
+  console.log(`Done. Deleted ${ok}, failed ${failed}.`);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds offline tooling to detect (and, with explicit double-confirm, clean up) bundle.social teams that exist on bundle.social's side but are not referenced by any `platform_companies.bundle_social_team_id` or `platform_social_profiles.bundle_social_team_id` row.

**No application code path calls into this — it's developer/operator tooling only.** Run from a developer machine against production credentials when orphan accounting drifts.

## Why we'll have orphans even with BSP-2

- BSP-2's in-process Promise dedup eliminates the **in-process** race but not the **cross-process** race (two Vercel function instances both calling `teamCreateTeam` before either commits the DB write).
- Manual experiments in the bundle.social dashboard.
- Provisioning failures where `teamCreateTeam` succeeded but the DB UPDATE threw before landing.

## Three layers of safety on the destructive path

1. **Default mode is REPORT-ONLY.** Running with no args lists orphans but cannot mutate anything. Operators who fat-finger the command get a diff, not a delete.
2. **`--delete-dry-run`** shows which orphans WOULD be deleted under the safety filter, without calling the delete API.
3. **Real delete requires BOTH `--delete` AND `--confirm-delete`.** Single-flag `--delete` refuses to run.

Plus a content-aware safety filter:

- `filterDeleteSafeOrphans` rejects any team whose `createdAt` is within `--min-age-min` (default **60 minutes**) of now. Protects against deleting a team that a concurrent provisioner just created but hasn't yet committed to the DB.
- Teams with null or malformed `createdAt` are NEVER delete-safe — better to leak an orphan than to nuke a team of unknown age.

## Working analog

`scripts/backfill-bundle-social-teams.ts` is the established BSP operational-tooling pattern (dotenv, `createClient` with service-role, direct SDK calls). This script follows the same shape and adds the report → dry-run → delete progression as a deliberate extension because backfill is **additive** (cannot lose data) but reconciliation is **destructive** (can permanently delete a team carrying real social-account connections).

**Diff vs prior shape**: backfill has no analogue for destructive ops. This is the first BSP operational script that can call a mutating bundle.social API, so the multi-flag confirmation gate is a new pattern. Justified because no analog exists for safely performing destructive operational tasks in this codebase yet.

## Risks identified and mitigated

- **Accidental delete of in-flight team** — `filterDeleteSafeOrphans` rejects recently-created teams. Default min-age 60 minutes covers a Vercel function execution window with margin. Regression test pins this.
- **Accidental delete of all teams** — `--delete` without `--confirm-delete` refuses to run.
- **Operator doesn't realise destructive mode exists** — default mode is report-only, so the script Just Works as a diagnostic without surprising the operator with side effects.
- **Pagination overrun on bundle.social side** — `listAllTeams` paginates with limit=100 and breaks on short page; hard cap of 50 pages (5000 teams) prevents infinite loop on a misbehaving SDK.
- **Team with unknown age treated as delete-safe** — filter rejects null AND NaN `createdAt`; tested.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 1204 passed (added 9 unit tests for `computeReconcileDiff` + `filterDeleteSafeOrphans`)
- Three regression tests pin the safety filter behaviour:
  - "never deletes teams created within minAgeMs of now"
  - "refuses to mark teams with null createdAt as delete-safe"
  - "refuses to mark teams with malformed createdAt as delete-safe"

These are LAYER 1 unit tests on pure functions — independent of the script wrapper, the Supabase client, the bundle.social SDK. Anything the operator could do to bypass them would have to first compromise the test gate.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (9 new tests)
- [ ] Contract snapshots reviewed — N/A (no SDK shape change)
- [ ] Cross-tenant test added — N/A (operator tooling only; no per-tenant code path)
- [ ] XSS payload coverage added — N/A
- [ ] Probe script updated — N/A
- [ ] Regression test added — N/A (new operational tool, not a fix; safety regressions are pinned by the LAYER 1 tests)
- [x] Working-analog block in PR body
- [x] Risks identified and mitigated section in PR body
- [x] PR is under 500 net lines (465 insertions, 0 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)