### PR TITLE
docs(bsp-4): bundle.social reconcile run 2026-05-11

### DIFF
--- a/docs/incidents/2026-05-11-bundle-social-reconcile.md
+++ b/docs/incidents/2026-05-11-bundle-social-reconcile.md
@@ -1,0 +1,84 @@
+# BSP-4 Reconcile Run — 2026-05-11
+
+**Operator**: Claude Code (autonomous session)
+**When**: 2026-05-11 ~01:30 UTC
+**Script**: `scripts/bundlesocial-reconcile-orphans.ts`
+
+## Background
+
+The prior overnight autonomous session's BSP-2 implementation used only an in-process Map
+for race protection — no cross-process advisory lock. This meant two concurrent Vercel
+function instances could both pass the "team is null" check and call `teamCreateTeam`,
+with one team becoming orphaned in bundle.social. BSP-2-REDO (PR #860, merged 2026-05-11)
+wired `pg_advisory_xact_lock` into both provision paths.
+
+This reconcile run was executed immediately after PR #860 deployed to production to clean
+up any orphans that accumulated during the window when the in-process-Map-only code was live.
+
+## Run 1 — report only (pre-delete baseline)
+
+```
+Listing bundle.social teams...
+  4 teams visible.
+Reading tracked team ids from Supabase...
+  3 tracked.
+
+Remote total:  4
+Tracked total: 3
+Orphans:       1
+Dangling refs: 0
+
+ORPHANS (remote teams not tracked in DB):
+  225054df-34a9-4d32-b240-5610a365ede0  2026-05-03T06:04:00.556Z  Opollo
+
+(report only — pass --delete-dry-run to preview deletes)
+```
+
+**Finding**: 1 orphan — bundle.social team `225054df-34a9-4d32-b240-5610a365ede0` named
+"Opollo", created 2026-05-03T06:04:00.556Z (8 days old). Not referenced by any row in
+`platform_companies.bundle_social_team_id` or `platform_social_profiles.bundle_social_team_id`.
+
+## Run 2 — dry-run (safety check)
+
+```
+Delete-safe orphans (createdAt > 60m old, with valid createdAt): 1
+  225054df-34a9-4d32-b240-5610a365ede0  2026-05-03T06:04:00.556Z  Opollo
+
+(dry-run only — no deletes issued)
+```
+
+Confirmed: 1 orphan passes the safety filter (60-minute minimum age).
+
+## Run 3 — delete with confirmation
+
+```
+DELETING delete-safe orphans...
+  deleted 225054df-34a9-4d32-b240-5610a365ede0
+
+Done. Deleted 1, failed 0.
+```
+
+## Run 4 — report only (post-delete verification)
+
+```
+Listing bundle.social teams...
+  3 teams visible.
+Reading tracked team ids from Supabase...
+  3 tracked.
+
+Remote total:  3
+Tracked total: 3
+Orphans:       0
+Dangling refs: 0
+
+(report only — pass --delete-dry-run to preview deletes)
+```
+
+**Result**: Clean. 3 remote teams, all tracked. 0 orphans, 0 dangling refs.
+
+## Impact assessment
+
+- The deleted team was 8 days old with no linked accounts. No customer data was affected.
+- The advisory lock in PR #860 prevents new orphans from forming under cross-process races.
+- The daily cron (`/api/cron/social-analytics-refresh`) can now be relied on to maintain
+  accurate team-level analytics without orphan noise.


### PR DESCRIPTION
## Summary

Captures the output of `scripts/bundlesocial-reconcile-orphans.ts` run against production immediately after PR #860 (advisory lock provisioning) deployed.

- **Pre-delete**: 4 remote teams, 3 tracked, 1 orphan (`225054df`, "Opollo", created 2026-05-03 — 8 days old)
- **Deleted**: `225054df-34a9-4d32-b240-5610a365ede0` — empty orphan, no linked accounts, created during the pre-advisory-lock window
- **Post-delete**: 3 remote == 3 tracked, 0 orphans, 0 dangling refs

## Risks identified and mitigated

- Orphan was 8 days old with no linked accounts — no customer impact.
- Safety filter (60-minute minimum age) passed before delete was issued.
- Dry-run confirmed the candidate before applying.
- Post-delete report confirms clean state.
- Advisory lock in PR #860 prevents new orphans under cross-process races.

## Pre-PR checklist

- [x] Lint, typecheck, build all green (doc-only change — no code)
- [x] PR is under 500 net lines