### PR TITLE
fix(bsp-10): profile_id ownership check on customer connect route

### DIFF
--- a/app/api/platform/social/connections/connect/route.ts
+++ b/app/api/platform/social/connections/connect/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
-import { dbUuid, readJsonBody, validationError, invalidState, internalError } from "@/lib/http";
+import { dbUuid, readJsonBody, validationError, invalidState, internalError, notFound } from "@/lib/http";
+import { logger } from "@/lib/logger";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getProfileById } from "@/lib/platform/social/profiles";
 import {
   initiateProfileConnect,
   type ProfileSocialPlatform,
@@ -77,6 +79,23 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     "manage_connections",
   );
   if (gate.kind === "deny") return gate.response;
+
+  // BSP-10: cross-tenant profile_id smuggling guard.
+  // An admin authenticated against company A must not be able to pass a
+  // profile_id belonging to company B — that would initiate OAuth against
+  // B's bundle.social team. The gate above only checks company_id; we must
+  // also verify the profile belongs to the same company.
+  const profile = await getProfileById(parsed.data.profile_id);
+  if (!profile) return notFound("Profile not found.");
+  if (profile.company_id !== parsed.data.company_id) {
+    logger.warn("social.connections.connect.profile_smuggling_attempt", {
+      companyId: parsed.data.company_id,
+      profileId: parsed.data.profile_id,
+      profileCompanyId: profile.company_id,
+      userId: gate.userId,
+    });
+    return notFound("Profile not found in this company.");
+  }
 
   const origin =
     process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ||

--- a/tests/regressions/bsp10-connect-rejects-cross-tenant-profile.test.ts
+++ b/tests/regressions/bsp10-connect-rejects-cross-tenant-profile.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// SECURITY — BSP-10: cross-tenant profile_id smuggling guard
+//
+// Invariant: POST /api/platform/social/connections/connect must reject
+// requests where `profile_id` belongs to a different company than
+// `company_id`, even when the caller is an authenticated admin of
+// `company_id`.
+//
+// Without this check, an admin of company A could pass a profile_id from
+// company B and initiate OAuth against B's bundle.social team, attributing
+// the resulting connection to a company they don't control.
+//
+// Layer 1 / Layer 6 — unit, mocked dependencies. No real Supabase needed.
+// ---------------------------------------------------------------------------
+
+const COMPANY_A = "aaaaaaaa-0000-0000-0000-000000000001";
+const COMPANY_B = "bbbbbbbb-0000-0000-0000-000000000001";
+const PROFILE_A = "aaaaaaaa-0000-0000-0000-000000000002";
+const PROFILE_B = "bbbbbbbb-0000-0000-0000-000000000002";
+
+const warnCalls: Array<{ event: string; payload: Record<string, unknown> }> = [];
+const initiateCalls: Array<{ profileId: string }> = [];
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: (event: string, payload: Record<string, unknown>) => {
+      warnCalls.push({ event, payload });
+    },
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: async () => ({ kind: "allow" as const, userId: "user-a" }),
+}));
+
+const profileStore: Record<string, { id: string; company_id: string }> = {
+  [PROFILE_A]: { id: PROFILE_A, company_id: COMPANY_A },
+  [PROFILE_B]: { id: PROFILE_B, company_id: COMPANY_B },
+};
+
+vi.mock("@/lib/platform/social/profiles", () => ({
+  getProfileById: async (id: string) => profileStore[id] ?? null,
+}));
+
+vi.mock("@/lib/platform/social/profiles/connect", () => ({
+  initiateProfileConnect: async (input: { profileId: string }) => {
+    initiateCalls.push({ profileId: input.profileId });
+    return { ok: true, data: { url: "https://oauth.example.com/go", teamId: "team-x" } };
+  },
+}));
+
+import { POST } from "@/app/api/platform/social/connections/connect/route";
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/api/platform/social/connections/connect", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  warnCalls.length = 0;
+  initiateCalls.length = 0;
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("BSP-10 SECURITY: connect route rejects cross-tenant profile_id", () => {
+  it("allows when profile_id belongs to the same company", async () => {
+    const res = await POST(makeRequest({
+      company_id: COMPANY_A,
+      profile_id: PROFILE_A,
+      platform: "LINKEDIN",
+    }) as never);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(true);
+    expect(initiateCalls).toHaveLength(1);
+  });
+
+  it("returns 404 when profile_id belongs to a different company", async () => {
+    const res = await POST(makeRequest({
+      company_id: COMPANY_A,
+      profile_id: PROFILE_B,
+      platform: "LINKEDIN",
+    }) as never);
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as { ok: boolean; error?: { code: string } };
+    expect(json.ok).toBe(false);
+  });
+
+  it("does not call initiateProfileConnect on a smuggling attempt", async () => {
+    await POST(makeRequest({
+      company_id: COMPANY_A,
+      profile_id: PROFILE_B,
+      platform: "FACEBOOK",
+    }) as never);
+    expect(initiateCalls).toHaveLength(0);
+  });
+
+  it("emits a warning log on a smuggling attempt", async () => {
+    await POST(makeRequest({
+      company_id: COMPANY_A,
+      profile_id: PROFILE_B,
+      platform: "LINKEDIN",
+    }) as never);
+    const hit = warnCalls.find(
+      (c) => c.event === "social.connections.connect.profile_smuggling_attempt",
+    );
+    expect(hit).toBeDefined();
+    expect(hit?.payload.companyId).toBe(COMPANY_A);
+    expect(hit?.payload.profileId).toBe(PROFILE_B);
+    expect(hit?.payload.profileCompanyId).toBe(COMPANY_B);
+  });
+
+  it("returns 404 when profile_id is unknown", async () => {
+    const res = await POST(makeRequest({
+      company_id: COMPANY_A,
+      profile_id: "00000000-0000-0000-0000-000000000099",
+      platform: "LINKEDIN",
+    }) as never);
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(false);
+    expect(initiateCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a cross-tenant smuggling guard to `POST /api/platform/social/connections/connect`
- After the `manage_connections` auth gate, `getProfileById` is called and `profile.company_id` is asserted to equal `company_id` from the request body
- A mismatched company returns 404 (indistinguishable from "not found") and emits a `social.connections.connect.profile_smuggling_attempt` warn log with the actor's user ID
- Adds a permanent regression test (Layer 1 + Layer 6): `tests/regressions/bsp10-connect-rejects-cross-tenant-profile.test.ts`

## Working analog

**Working analog**: `app/api/admin/companies/[id]/social-profiles/[profileId]/connect/route.ts:75-79` — admin connect route already does `getProfileById` + `profile.company_id !== idCheck.value → notFound()`

**Diff**: the customer connect route (BSP-6-CUSTOMER, #862) accepted any UUID that parses as `profile_id` without verifying it belongs to the company in `company_id`

**Fix**: copy the exact same ownership check from the admin analog

## Risks identified and mitigated

- **Extra DB read per connect call**: one `getProfileById` query (indexed PK lookup, sub-ms). Negligible vs the OAuth round-trip that follows.
- **404 vs 403**: returning 404 (not 403) for a smuggling attempt is intentional — it avoids confirming to an attacker that the profile_id exists in any company.
- **Warn log carries user ID**: `gate.userId` is set when `requireCanDoForApi` returns `allow`, so the smuggling actor is always attributable in logs.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:regressions` (5 new BSP-10 tests, all pass)
- [x] Contract snapshots reviewed (none touched)
- [x] Cross-tenant test added ✓ (the point of this PR)
- [x] Regression test added ✓
- [x] Working-analog block above
- [x] Risks identified and mitigated above
- [x] PR is under 500 net lines (152 net)