### PR TITLE
fix(error-reporting): use NEXT_PUBLIC_ flag so client bundle sees it

### DIFF
--- a/app/(platform)/company/social/connections/page.tsx
+++ b/app/(platform)/company/social/connections/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { SocialConnectionsList } from "@/components/SocialConnectionsList";
+import { Alert } from "@/components/ui/alert";
 import { H1, Lead } from "@/components/ui/typography";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
 import { listConnections } from "@/lib/platform/social/connections";
@@ -159,13 +160,13 @@ export default async function CompanySocialConnectionsPage({
       <div className="mt-6 space-y-8">
         <ConnectBanner params={searchParams ?? {}} />
         {!listResult.ok ? (
-          <div
-            className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-            role="alert"
+          <Alert
+            variant="destructive"
             data-testid="connections-error"
+            reportContext={{ message: `Failed to load connections: ${listResult.error.message}` }}
           >
             Failed to load connections: {listResult.error.message}
-          </div>
+          </Alert>
         ) : (
           profiles.map((p) => (
             <section

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { toastSuccess } from "@/lib/toast-success";
 
+import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
   PLATFORM_LABEL,
@@ -270,13 +271,14 @@ export function SocialConnectionsList({
       ) : null}
 
       {error ? (
-        <p
-          className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
-          role="alert"
+        <Alert
+          variant="destructive"
+          className="mb-3"
           data-testid="connections-error"
+          reportContext={{ message: error }}
         >
           {error}
-        </p>
+        </Alert>
       ) : null}
 
       {popupBlockedUrl ? (

--- a/lib/error-reporting/flag.ts
+++ b/lib/error-reporting/flag.ts
@@ -1,4 +1,36 @@
+// Feature gate for the error-reporting subsystem.
+//
+// Next.js only inlines NEXT_PUBLIC_* env vars into the client bundle, so the
+// PREFIXED name is what gates the UI (Alert "Report to admin" button,
+// reportableToast action, BreadcrumbProvider instrumentation). The
+// non-prefixed legacy name is kept as a server-side fallback during the
+// transition — set both in Vercel to flip the feature on cleanly.
 export function isErrorReportingEnabled(): boolean {
-  const v = process.env.OPOLLO_ERROR_REPORTING_ENABLED;
+  const v =
+    process.env.NEXT_PUBLIC_OPOLLO_ERROR_REPORTING_ENABLED ??
+    process.env.OPOLLO_ERROR_REPORTING_ENABLED;
+
+  // Dev-only diagnostic: catches the misconfiguration where someone sets
+  // OPOLLO_ERROR_REPORTING_ENABLED in Vercel but forgets the NEXT_PUBLIC_
+  // twin. Server-side the legacy var still works, but client-side the
+  // Report-to-admin button stays invisible — silently.
+  if (
+    typeof window !== "undefined" &&
+    process.env.NODE_ENV !== "production" &&
+    !process.env.NEXT_PUBLIC_OPOLLO_ERROR_REPORTING_ENABLED
+  ) {
+    const w = window as Window & { __opolloErrorReportingMisconfigWarned?: boolean };
+    if (!w.__opolloErrorReportingMisconfigWarned) {
+      w.__opolloErrorReportingMisconfigWarned = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[error-reporting] NEXT_PUBLIC_OPOLLO_ERROR_REPORTING_ENABLED is not set " +
+          "in the client bundle. If OPOLLO_ERROR_REPORTING_ENABLED is set in " +
+          "Vercel, add the NEXT_PUBLIC_ twin and rebuild — otherwise the " +
+          "Report-to-admin button never renders in the browser.",
+      );
+    }
+  }
+
   return v === "true" || v === "1";
 }


### PR DESCRIPTION
## Summary

PR #853 wired Report-to-admin into every error surface, but the button never appeared in production. Three causes Steven flagged:

**Cause #1 — env var visibility** (the actual bug). `isErrorReportingEnabled()` reads `process.env.OPOLLO_ERROR_REPORTING_ENABLED` directly. Next.js does NOT inline non-`NEXT_PUBLIC_` env vars into the browser bundle, so the flag was always `undefined` client-side, every gate returned `false`, and the button stayed invisible everywhere.

**Cause #2 — raw error renderers on /company/social/connections**. The 400 Steven saw came from `SocialConnectionsList.tsx:272-280`, a raw `<p>` styled to look like a destructive Alert. Even with the flag fix, this surface wouldn't show the button until it goes through the wired `<Alert>` component. Same on the server-rendered `listConnections` failure path in `page.tsx`.

**Cause #3 — admin role gating**. Not applicable. `ErrorReportButton` has no role gate — it shows for anyone with the flag on.

## Fix

- `lib/error-reporting/flag.ts`: read `NEXT_PUBLIC_OPOLLO_ERROR_REPORTING_ENABLED` first, fall back to the legacy non-prefixed name server-side. Dev-only `console.warn` fires when legacy is set but prefixed isn't (catches future misconfigurations).
- `components/SocialConnectionsList.tsx`: replace raw `<p>` with `<Alert variant=\"destructive\" reportContext={{ message: error }}>`.
- `app/(platform)/company/social/connections/page.tsx`: replace the server-rendered raw `<div>` error path with `<Alert>` likewise.
- Vercel env: added `NEXT_PUBLIC_OPOLLO_ERROR_REPORTING_ENABLED=true` to **production**. **Preview not yet added** (Claude Code auto-mode denied the second `vercel env add` call) — add manually if you want PR-preview deploys to surface the button.

## Working analog

This is the first flag in this codebase that needs to gate client-side rendering, so no existing analog. The fix uses the standard Next.js `NEXT_PUBLIC_*` pattern; the flag is a no-secret UX toggle so leaking it into the bundle is fine.

## Risks identified and mitigated

- **`NEXT_PUBLIC_` is visible to any browser**: acceptable for a UX toggle. Means we must never reuse this pattern for security/billing gates.
- **Inlining happens at build time**: any env flip requires a redeploy. Acceptable for a feature gate.
- **Legacy non-prefixed var kept active**: server-side reads find either name during the transition. Remove the legacy var post-merge once production has been on the new code for a deploy cycle.
- **Preview env not yet set**: preview deploys will not show the button. Production unaffected.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] `npm run test:precommit` (1327 tests pass)
- [x] `npm run test:components` (76 tests pass)
- [x] Working-analog block in PR body
- [x] Risks identified and mitigated section in PR body
- [x] PR is under 500 net lines (~50 lines)

## Test plan

- [ ] After deploy: visit `/company/social/connections` on production as a platform admin
- [ ] Trigger a connection error (e.g. click Connect → cancel popup, or Sync with a stale connection)
- [ ] Confirm the red error box now renders via `<Alert>` AND shows a \"Report to admin\" button
- [ ] Click it — confirms the modal opens and the report flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)