### PR TITLE
fix(social): bundle.social 4xx returns 409 INVALID_STATE not 500

### DIFF
--- a/app/api/admin/companies/[id]/social-profiles/[profileId]/connect/route.ts
+++ b/app/api/admin/companies/[id]/social-profiles/[profileId]/connect/route.ts
@@ -109,6 +109,7 @@ export async function POST(
       code,
       message,
     });
+    if (code === "UPSTREAM_REJECTED") return invalidState(message);
     return internalError(message);
   }
 

--- a/app/api/platform/social/connections/connect/route.ts
+++ b/app/api/platform/social/connections/connect/route.ts
@@ -116,6 +116,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const { code, message } = result.error;
     if (code === "VALIDATION_FAILED") return validationError(message);
     if (code === "RECEIVER_NOT_CONFIGURED") return invalidState(message);
+    // bundle.social returned a 4xx (e.g. "this platform is already connected
+    // to this team", or a flag the platform doesn't support). 500 was
+    // misleading and made the surface look broken to the operator. 409
+    // with bundle.social's own message is more actionable.
+    if (code === "UPSTREAM_REJECTED") return invalidState(message);
     return internalError(message);
   }
 

--- a/lib/platform/social/profiles/connect.ts
+++ b/lib/platform/social/profiles/connect.ts
@@ -58,7 +58,48 @@ export type InitiateProfileConnectInput = {
 export type InitiateProfileConnectError =
   | { code: "VALIDATION_FAILED"; message: string }
   | { code: "RECEIVER_NOT_CONFIGURED"; message: string }
+  // bundle.social rejected the connect request with a 4xx status. Typical
+  // causes: a connection of this (team, platform) already exists, a
+  // platform-specific flag is unsupported, or the team has been suspended.
+  // Carries the bundle.social-supplied detail so the route can surface a
+  // useful message instead of a generic 500.
+  | { code: "UPSTREAM_REJECTED"; message: string; upstreamStatus: number }
   | { code: "INTERNAL_ERROR"; message: string };
+
+// Narrow check for the bundlesocial SDK's ApiError shape. Avoids importing
+// the SDK's class symbol (not exported in a stable place) — we duck-type
+// on the four fields the SDK populates: status, statusText, body, url.
+function isBundleSocialApiError(err: unknown): err is {
+  name: string;
+  status: number;
+  statusText?: string;
+  body?: unknown;
+  url?: string;
+} {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { name?: string }).name === "ApiError" &&
+    typeof (err as { status?: unknown }).status === "number"
+  );
+}
+
+// bundle.social returns error bodies as JSON. Extract whichever message
+// shape arrives — flat `{ message }`, nested `{ error: { message } }`, or
+// raw string — so the operator-visible string is meaningful instead of
+// the literal status code string ("400") that Error.message defaults to.
+function extractUpstreamMessage(body: unknown, statusText?: string): string {
+  if (body && typeof body === "object") {
+    const o = body as Record<string, unknown>;
+    if (typeof o.message === "string" && o.message.length > 0) return o.message;
+    if (o.error && typeof o.error === "object") {
+      const e = o.error as Record<string, unknown>;
+      if (typeof e.message === "string" && e.message.length > 0) return e.message;
+    }
+  }
+  if (typeof body === "string" && body.length > 0) return body;
+  return statusText && statusText.length > 0 ? statusText : "bundle.social rejected the request.";
+}
 
 export type InitiateProfileConnectResult =
   | { ok: true; data: { url: string; teamId: string } }
@@ -125,6 +166,43 @@ export async function initiateProfileConnect(
     });
     url = resp.url;
   } catch (err) {
+    // Two failure shapes worth distinguishing:
+    //   1. bundle.social ApiError (4xx / 5xx with structured body) — extract
+    //      the upstream message so the operator sees what bundle.social
+    //      actually said, not the literal status code echoed as message.
+    //   2. Anything else (network failure, SDK bug, etc.) — fall through
+    //      to INTERNAL_ERROR with the message as-is.
+    if (isBundleSocialApiError(err)) {
+      const upstreamMessage = extractUpstreamMessage(err.body, err.statusText);
+      logger.error("bundlesocial.profile.connect.sdk_failed", {
+        profile_id: input.profileId,
+        team_id: teamId,
+        platform: input.platform,
+        upstream_status: err.status,
+        upstream_status_text: err.statusText ?? null,
+        upstream_body: err.body ?? null,
+        upstream_url: err.url ?? null,
+        err: upstreamMessage,
+      });
+      // 4xx is a client/state issue (duplicate connection, flag not
+      // supported on this platform, team suspended). Map to
+      // UPSTREAM_REJECTED so the caller can return 409 INVALID_STATE
+      // with a useful message instead of a misleading 500.
+      if (err.status >= 400 && err.status < 500) {
+        return {
+          ok: false,
+          error: {
+            code: "UPSTREAM_REJECTED",
+            message: upstreamMessage,
+            upstreamStatus: err.status,
+          },
+        };
+      }
+      return {
+        ok: false,
+        error: { code: "INTERNAL_ERROR", message: upstreamMessage },
+      };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     logger.error("bundlesocial.profile.connect.sdk_failed", {
       profile_id: input.profileId,


### PR DESCRIPTION
## Summary

Production /company/social/connections was returning a 500 for any platform tile click on tenants that already had a connection. Root cause: bundle.social SDK throws an ApiError with a 4xx status (e.g. \"this team already has a LINKEDIN connection\"), but the SDK's Error.message defaults to just the literal status code string (`\"400\"`). Our handler logged that as the err message and translated everything to INTERNAL_ERROR → 500.

This wasn't a regression from PR #864 — it shipped in PR #862 (BSP-6-CUSTOMER) and just hadn't been observed until Steven's reproduction hit the \"platform already connected\" branch.

## Diagnosis

Vercel production log for the failing requests:
```
{\"msg\":\"bundlesocial.profile.connect.sdk_failed\",
 \"profile_id\":\"a1c0fb5e-...\",\"team_id\":\"5313a67d-...\",
 \"platform\":\"LINKEDIN\",\"err\":\"400\"}
```

The pattern is clear: first LinkedIn connect for a profile succeeds (returns OAuth URL), every subsequent attempt for the SAME profile returns 400 from bundle.social. bundle.social enforces 1 account per (team, platform); the SDK throws ApiError(400) with the real reason in `.body`, but `Error.message = String(status) = \"400\"` is the only thing we were logging.

## Fix

Split SDK exception handling in `initiateProfileConnect`:

- ApiError with 4xx → `UPSTREAM_REJECTED { message, upstreamStatus }` (extracts body.message or body.error.message)
- ApiError with 5xx → INTERNAL_ERROR with the extracted upstream message
- Non-ApiError exceptions (network, SDK bug) → INTERNAL_ERROR with err.message as before
- Log now carries `upstream_status`, `upstream_status_text`, `upstream_body`, `upstream_url` so next time the actual bundle.social complaint is visible in Vercel logs

Both connect routes (customer + admin) gain the UPSTREAM_REJECTED → invalidState (409) translation.

## Working analog

`lib/platform/social/profiles/connect.ts:disconnectProfileAccount` uses the same SDK shape but catches less informatively. Same fix would apply, but it's out of scope here — only the connect path matters for the production bug.

## Risks identified and mitigated

- **Duck-typed ApiError check**: tests `name === \"ApiError\"` + `typeof status === \"number\"`. SDK upgrade could break the shape, in which case we fall through to the existing INTERNAL_ERROR path — same behaviour as before this PR. Not a regression.
- **409 vs 400**: bundle.social itself returned 400, but the request was syntactically valid from our route's perspective — the rejection is a conflict with the team's existing state (duplicate platform). 409 INVALID_STATE matches that semantic better than 400 BAD_REQUEST.
- **Body extraction**: nested `{ error: { message } }` and flat `{ message }` both handled; falls back to statusText, then to a generic string.
- **No client-side UX change**: tiles still show for already-connected platforms. Out of scope for this PR; the Report-to-admin button (PR #864) plus the better 409 message now make the broken-feeling \"500 with no info\" path actionable.

## Pre-PR checklist

- [x] Lint, typecheck, build all green (1337 unit tests pass)
- [x] Working-analog block in PR body
- [x] Risks identified and mitigated section in PR body
- [x] PR is under 500 net lines (~85 lines)

## Test plan

- [ ] After deploy, sign in as platform admin → switch to Skyview → /company/social/connections
- [ ] Click LinkedIn tile (Skyview already has LinkedIn connected)
- [ ] Expected: red error box with the actual bundle.social message (e.g. \"This team already has a LINKEDIN account.\") + the Report-to-admin button from PR #864
- [ ] Click a platform tile that's NOT yet connected (e.g. Twitter) — popup opens normally
- [ ] Check Vercel logs: the new failure entries should now carry upstream_status/upstream_body fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)