### PR TITLE
fix(linkedin-channel-selection): two-step OAuth + channel-picker flow

### DIFF
--- a/app/(platform)/company/social/connections/page.tsx
+++ b/app/(platform)/company/social/connections/page.tsx
@@ -32,6 +32,10 @@ type SearchParams = {
   // sets this on success-with-channel-needed so the client can auto-
   // open the channel-picker modal against the freshly-inserted row.
   connection_id?: string;
+  // Bug-fix 2026-05-12: set on noop+updated to identify which platform
+  // the user tried to connect (already had one). Drives the actionable
+  // "already connected" banner + row highlight in SocialConnectionsList.
+  attempted_platform?: string;
 };
 
 const REASON_LABEL: Record<string, string> = {
@@ -233,6 +237,11 @@ export default async function CompanySocialConnectionsPage({
                 autoOpenPickerForConnectionId={
                   (searchParams ?? {}).connect === "needs_channel"
                     ? ((searchParams ?? {}).connection_id ?? null)
+                    : null
+                }
+                noopdForPlatform={
+                  (searchParams ?? {}).connect === "noop"
+                    ? ((searchParams ?? {}).attempted_platform ?? null)
                     : null
                 }
               />

--- a/app/(platform)/company/social/connections/page.tsx
+++ b/app/(platform)/company/social/connections/page.tsx
@@ -5,6 +5,7 @@ import { Alert } from "@/components/ui/alert";
 import { H1, Lead } from "@/components/ui/typography";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
 import { listConnections } from "@/lib/platform/social/connections";
+import { emitOverdueEventsIfNeeded } from "@/lib/platform/social/connections/overdue-events";
 import { listProfilesForCompany } from "@/lib/platform/social/profiles";
 
 // ---------------------------------------------------------------------------
@@ -27,6 +28,10 @@ type SearchParams = {
   connect?: string;
   reason?: string;
   count?: string;
+  // Channel-selection flow (incident 2026-05-12): the callback route
+  // sets this on success-with-channel-needed so the client can auto-
+  // open the channel-picker modal against the freshly-inserted row.
+  connection_id?: string;
 };
 
 const REASON_LABEL: Record<string, string> = {
@@ -35,6 +40,20 @@ const REASON_LABEL: Record<string, string> = {
   "not-enough-pages": "No eligible pages were attached to that account.",
   "auth-failed": "The platform rejected the sign-in.",
   "user-cancelled": "You cancelled the connection flow.",
+  // Channel-selection flow (incident 2026-05-12). Platform-specific
+  // error codes surfaced when the user's OAuth grant is valid but the
+  // account lacks the resource needed to publish — no admin orgs on
+  // LinkedIn, no business pages on Facebook, etc.
+  "not-enough-channels":
+    "Your account doesn't admin any pages or channels for this platform. " +
+    "Connect a different account or, for LinkedIn, choose personal-mode.",
+  "not-enough-accounts":
+    "Your Instagram account isn't linked to a Facebook Page. " +
+    "Link them via Meta Business Suite, then reconnect here.",
+  "not-enough-servers":
+    "Your Discord account doesn't admin any servers Opollo can post to.",
+  "not-enough-workspaces":
+    "Your Slack account isn't a member of any workspace Opollo can post to.",
   // Cross-tenant identity-leak defence (migration 0122). Set by the
   // sync layer when checkCrossTenantConflict refuses an INSERT because
   // the same platform identity is already owned by another company.
@@ -46,6 +65,10 @@ const REASON_LABEL: Record<string, string> = {
 
 function ConnectBanner({ params }: { params: SearchParams }) {
   if (!params.connect) return null;
+  // Channel-selection flow: the channel-picker modal handles its own
+  // UX state. The banner stays silent so the modal isn't competing
+  // for attention.
+  if (params.connect === "needs_channel") return null;
   if (params.connect === "success") {
     const n = Number(params.count ?? "1");
     return (
@@ -145,10 +168,17 @@ export default async function CompanySocialConnectionsPage({
     import("@/lib/platform/social/connections/types").SocialConnection[]
   > = {};
   if (listResult.ok) {
+    // Channel-selection flow: emit connection_channel_overdue events
+    // for any pending_identity rows > 24h that haven't emitted yet.
+    // The helper flips has_emitted_overdue_event in the DB and returns
+    // a patched list so the banner stays in sync with DB state.
+    const connections = await emitOverdueEventsIfNeeded(
+      listResult.data.connections,
+    );
     for (const p of profiles) buckets[p.id] = [];
     const defaultProfileId =
       profiles.find((p) => p.is_default)?.id ?? profiles[0]?.id;
-    for (const c of listResult.data.connections) {
+    for (const c of connections) {
       const targetId = c.profile_id ?? defaultProfileId;
       if (targetId && buckets[targetId]) buckets[targetId].push(c);
     }
@@ -200,6 +230,11 @@ export default async function CompanySocialConnectionsPage({
                 connections={buckets[p.id] ?? []}
                 canManage={canManage}
                 canReconnect={canReconnect}
+                autoOpenPickerForConnectionId={
+                  (searchParams ?? {}).connect === "needs_channel"
+                    ? ((searchParams ?? {}).connection_id ?? null)
+                    : null
+                }
               />
             </section>
           ))

--- a/app/api/platform/social/connections/[id]/channels/route.ts
+++ b/app/api/platform/social/connections/[id]/channels/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import {
+  internalError,
+  invalidState,
+  notFound,
+  validateUuidParam,
+} from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { refreshChannels } from "@/lib/platform/social/connections/channels";
+import {
+  CHANNEL_SELECTION_PLATFORMS,
+} from "@/lib/platform/social/connections/identity";
+import { loadConnectionWithTeam } from "@/lib/platform/social/connections/route-helpers";
+
+// ---------------------------------------------------------------------------
+// GET /api/platform/social/connections/[id]/channels
+//
+// Re-fetches the channel list from the platform side (LinkedIn / FB /
+// IG / YT / GBP) for a specific social_connections row, and returns
+// the normalised picker payload.
+//
+// Gate: canDo("manage_connections", company_id of the connection).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const idCheck = validateUuidParam(params.id, "id");
+  if (!idCheck.ok) return idCheck.response;
+
+  const loaded = await loadConnectionWithTeam(idCheck.value);
+  if (!loaded.ok) {
+    if (loaded.error.code === "NOT_FOUND") return notFound(loaded.error.message);
+    return invalidState(loaded.error.message);
+  }
+  const conn = loaded.data;
+
+  const gate = await requireCanDoForApi(conn.company_id, "manage_connections");
+  if (gate.kind === "deny") return gate.response;
+
+  if (!CHANNEL_SELECTION_PLATFORMS.has(conn.bundlePlatform)) {
+    return invalidState(
+      `Platform '${conn.bundlePlatform}' is not a channel-selection platform.`,
+    );
+  }
+
+  const result = await refreshChannels({
+    teamId: conn.teamId,
+    platform: conn.bundlePlatform,
+  });
+  if (!result.ok) {
+    logger.error("social.channels.list_failed", {
+      connection_id: conn.id,
+      platform: conn.bundlePlatform,
+      code: result.error.code,
+      message: result.error.message,
+    });
+    if (result.error.code === "RECEIVER_NOT_CONFIGURED")
+      return invalidState(result.error.message);
+    if (result.error.code === "UPSTREAM_REJECTED")
+      return invalidState(result.error.message);
+    return internalError(result.error.message);
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { channels: result.data.channels },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/platform/social/connections/[id]/connect-as-personal/route.ts
+++ b/app/api/platform/social/connections/[id]/connect-as-personal/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import {
+  internalError,
+  invalidState,
+  notFound,
+  validateUuidParam,
+} from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { loadConnectionWithTeam } from "@/lib/platform/social/connections/route-helpers";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/social/connections/[id]/connect-as-personal
+//
+// Marks a connection as personal-mode: the user explicitly chose to
+// publish under their own profile (LinkedIn personal urn) instead of
+// picking a company page. is_personal_mode=true, status='healthy', and
+// no set-channel call is made on bundle.social — they accept publishing
+// against the user's own profile by default when no channel is bound.
+//
+// LinkedIn-only today; extensible. Refuses if the platform doesn't
+// support personal-mode (everything but LINKEDIN).
+//
+// Gate: canDo("manage_connections", company_id of the connection).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const idCheck = validateUuidParam(params.id, "id");
+  if (!idCheck.ok) return idCheck.response;
+
+  const loaded = await loadConnectionWithTeam(idCheck.value);
+  if (!loaded.ok) {
+    if (loaded.error.code === "NOT_FOUND") return notFound(loaded.error.message);
+    return invalidState(loaded.error.message);
+  }
+  const conn = loaded.data;
+
+  const gate = await requireCanDoForApi(conn.company_id, "manage_connections");
+  if (gate.kind === "deny") return gate.response;
+
+  if (conn.bundlePlatform !== "LINKEDIN") {
+    return invalidState(
+      "Personal-mode is only supported for LinkedIn today. " +
+        "Other platforms require a channel selection.",
+    );
+  }
+
+  const svc = getServiceRoleClient();
+  const now = new Date().toISOString();
+  const update = await svc
+    .from("social_connections")
+    .update({
+      status: "healthy",
+      is_personal_mode: true,
+      last_health_check_at: now,
+      last_error: null,
+    })
+    .eq("id", conn.id);
+  if (update.error) {
+    logger.error("social.channels.personal_mode_update_failed", {
+      connection_id: conn.id,
+      err: update.error.message,
+    });
+    return internalError(
+      `Failed to record personal-mode selection: ${update.error.message}`,
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { connection_id: conn.id, is_personal_mode: true },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/platform/social/connections/[id]/disconnect/route.ts
+++ b/app/api/platform/social/connections/[id]/disconnect/route.ts
@@ -1,0 +1,194 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { getBundlesocialClient } from "@/lib/bundlesocial";
+import {
+  internalError,
+  invalidState,
+  notFound,
+  validateUuidParam,
+} from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { unsetChannel } from "@/lib/platform/social/connections/channels";
+import {
+  CHANNEL_SELECTION_PLATFORMS,
+} from "@/lib/platform/social/connections/identity";
+import { loadConnectionWithTeam } from "@/lib/platform/social/connections/route-helpers";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/social/connections/[id]/disconnect
+//
+// Layer 6 disconnect ordering: unset channel → settle (200ms) →
+// socialAccountDisconnect → DELETE row → emit audit. The order
+// matters because drafts referencing the old channel must be released
+// before bundle.social tears down the account, otherwise they ghost-
+// point at a dead connection (per bundle.social docs).
+//
+// Each upstream step tolerates failure independently and logs — the
+// row-delete is the customer-visible "this is gone" moment, so it
+// happens at the end of the chain even when the SDK calls error.
+//
+// Gate: canDo("manage_connections", company_id of the connection).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Bundle.social's "Team does not have a <platform> account" 400 is the
+// idempotent-success case — disconnecting an already-disconnected
+// (team, type) returns 400 with this message. Tolerate it.
+function isAlreadyDisconnected400(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { name?: string; status?: number; body?: unknown };
+  if (e.name !== "ApiError" || e.status !== 400) return false;
+  const body = e.body;
+  const message =
+    body && typeof body === "object" && body !== null
+      ? ((body as { message?: string }).message ?? "")
+      : typeof body === "string"
+        ? body
+        : "";
+  return /does not have/i.test(message);
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const idCheck = validateUuidParam(params.id, "id");
+  if (!idCheck.ok) return idCheck.response;
+
+  const loaded = await loadConnectionWithTeam(idCheck.value);
+  if (!loaded.ok) {
+    if (loaded.error.code === "NOT_FOUND") return notFound(loaded.error.message);
+    return invalidState(loaded.error.message);
+  }
+  const conn = loaded.data;
+
+  const gate = await requireCanDoForApi(conn.company_id, "manage_connections");
+  if (gate.kind === "deny") return gate.response;
+
+  const client = getBundlesocialClient();
+  if (!client) return invalidState("BUNDLE_SOCIAL_API is not configured.");
+
+  const audit: {
+    unset_ok: boolean | null;
+    unset_error: string | null;
+    disconnect_ok: boolean;
+    disconnect_error: string | null;
+    deleted: boolean;
+    delete_error: string | null;
+  } = {
+    unset_ok: null,
+    unset_error: null,
+    disconnect_ok: false,
+    disconnect_error: null,
+    deleted: false,
+    delete_error: null,
+  };
+
+  // Step 1: unset channel (only for channel-selection platforms with an
+  // attached channel). Tolerates failure — proceeding to disconnect is
+  // safe even when unset errors; bundle.social tears down the channel
+  // binding alongside the account.
+  if (
+    CHANNEL_SELECTION_PLATFORMS.has(conn.bundlePlatform) &&
+    !conn.is_personal_mode
+  ) {
+    const unset = await unsetChannel({
+      teamId: conn.teamId,
+      platform: conn.bundlePlatform,
+    });
+    audit.unset_ok = unset.ok;
+    if (!unset.ok) audit.unset_error = unset.error.message;
+  }
+
+  // Step 2: 200ms settle. bundle.social's set-channel / unset-channel
+  // ops cascade through the platform-side SDK; rapid unset → disconnect
+  // can race with the unset's downstream sync and leave a partial
+  // state. 200ms is empirically clean in the support-ticket history
+  // we've seen.
+  await new Promise((r) => setTimeout(r, 200));
+
+  // Step 3: socialAccountDisconnect. The 400 "does not have" branch is
+  // idempotent-success.
+  try {
+    await client.socialAccount.socialAccountDisconnect({
+      requestBody: { type: conn.bundlePlatform, teamId: conn.teamId },
+    });
+    audit.disconnect_ok = true;
+  } catch (err) {
+    if (isAlreadyDisconnected400(err)) {
+      audit.disconnect_ok = true;
+      audit.disconnect_error = "Already disconnected at bundle.social (idempotent).";
+    } else {
+      audit.disconnect_error = err instanceof Error ? err.message : String(err);
+      logger.warn("social.connections.disconnect.sdk_failed", {
+        connection_id: conn.id,
+        team_id: conn.teamId,
+        platform: conn.bundlePlatform,
+        err: audit.disconnect_error,
+      });
+    }
+  }
+
+  // Step 4: DELETE the row regardless of upstream outcome. The customer
+  // pressed disconnect; the row must go away.
+  const svc = getServiceRoleClient();
+  const del = await svc.from("social_connections").delete().eq("id", conn.id);
+  if (del.error) {
+    audit.delete_error = del.error.message;
+    logger.error("social.connections.disconnect.delete_failed", {
+      connection_id: conn.id,
+      err: del.error.message,
+    });
+  } else {
+    audit.deleted = true;
+  }
+
+  // Step 5: audit event. Fire-and-forget; the disconnect succeeded from
+  // the customer's perspective regardless of audit insertion.
+  void (async () => {
+    try {
+      await svc.from("platform_events").insert({
+        event_type: "connection_disconnected",
+        company_id: conn.company_id,
+        actor_id: gate.userId,
+        entity_type: "social_connection",
+        entity_id: conn.id,
+        payload: {
+          platform: conn.platform,
+          bundle_social_account_id: conn.bundle_social_account_id,
+          bundle_platform: conn.bundlePlatform,
+          ...audit,
+        },
+      });
+    } catch (err) {
+      logger.warn("social.connections.disconnect.audit_failed", {
+        connection_id: conn.id,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  })();
+
+  if (!audit.deleted) {
+    return internalError(
+      `Connection row delete failed: ${audit.delete_error ?? "unknown"}`,
+      false,
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        connection_id: conn.id,
+        upstream_disconnect_ok: audit.disconnect_ok,
+        upstream_unset_ok: audit.unset_ok,
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/platform/social/connections/[id]/set-channel/route.ts
+++ b/app/api/platform/social/connections/[id]/set-channel/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import {
+  internalError,
+  invalidState,
+  notFound,
+  parseBodyWith,
+  readJsonBody,
+  validateUuidParam,
+  validationError,
+} from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { setChannel } from "@/lib/platform/social/connections/channels";
+import {
+  checkCrossTenantConflict,
+  computeIdentityHash,
+  emitCrossTenantBlocked,
+  resolveIdentityFingerprint,
+} from "@/lib/platform/social/connections/identity";
+import { loadConnectionWithTeam } from "@/lib/platform/social/connections/route-helpers";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/social/connections/[id]/set-channel
+//
+// Body: { channel_id: string }
+//
+// Commits a channel selection on bundle.social, then refreshes our
+// row's identity columns (set-channel changes externalId for LinkedIn
+// org / FB Page / IG / YT / GBP), runs the cross-tenant conflict check
+// against the freshly-resolved identity, and flips status to 'healthy'
+// (or refuses on cross-tenant conflict).
+//
+// Gate: canDo("manage_connections", company_id of the connection).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const SetChannelSchema = z.object({
+  channel_id: z.string().min(1).max(512),
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const idCheck = validateUuidParam(params.id, "id");
+  if (!idCheck.ok) return idCheck.response;
+
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body must be valid JSON.");
+  const parsed = parseBodyWith(SetChannelSchema, body);
+  if (!parsed.ok) return parsed.response;
+
+  const loaded = await loadConnectionWithTeam(idCheck.value);
+  if (!loaded.ok) {
+    if (loaded.error.code === "NOT_FOUND") return notFound(loaded.error.message);
+    return invalidState(loaded.error.message);
+  }
+  const conn = loaded.data;
+
+  const gate = await requireCanDoForApi(conn.company_id, "manage_connections");
+  if (gate.kind === "deny") return gate.response;
+
+  const setResult = await setChannel({
+    teamId: conn.teamId,
+    platform: conn.bundlePlatform,
+    channelId: parsed.data.channel_id,
+  });
+  if (!setResult.ok) {
+    logger.error("social.channels.set_failed", {
+      connection_id: conn.id,
+      platform: conn.bundlePlatform,
+      code: setResult.error.code,
+      message: setResult.error.message,
+    });
+    if (setResult.error.code === "RECEIVER_NOT_CONFIGURED")
+      return invalidState(setResult.error.message);
+    if (setResult.error.code === "PLATFORM_NOT_SUPPORTED")
+      return invalidState(setResult.error.message);
+    if (setResult.error.code === "UPSTREAM_REJECTED")
+      return invalidState(setResult.error.message);
+    return internalError(setResult.error.message);
+  }
+
+  // Re-resolve identity now that channel is bound — externalId can
+  // change (LinkedIn org urn ≠ LinkedIn person urn, FB page id ≠ user
+  // id, etc.). Then run the cross-tenant detector against the freshly-
+  // resolved identity before flipping to 'healthy'. The identity layer
+  // PR #868 introduced runs at every write point; this is the new write.
+  const fingerprint = await resolveIdentityFingerprint({
+    platform: conn.bundlePlatform,
+    teamId: conn.teamId,
+  });
+  const externalIdentityHash = computeIdentityHash(
+    conn.platform,
+    fingerprint.external_account_id,
+    fingerprint.external_user_id,
+  );
+
+  const conflict = await checkCrossTenantConflict({
+    platform: conn.platform,
+    identity_hash: externalIdentityHash,
+    external_account_id: fingerprint.external_account_id,
+    external_user_id: fingerprint.external_user_id,
+    target_company_id: conn.company_id,
+    target_profile_id: conn.profile_id,
+    excludeConnectionId: conn.id,
+  });
+  if (!conflict.ok && !conflict.override_allowed) {
+    logger.warn("social.channels.set_cross_tenant_blocked", {
+      connection_id: conn.id,
+      platform: conn.platform,
+      target_company_id: conn.company_id,
+      conflict_code: conflict.code,
+    });
+    void emitCrossTenantBlocked({
+      platform: conn.platform,
+      identity_hash: externalIdentityHash,
+      external_account_id: fingerprint.external_account_id,
+      external_user_id: fingerprint.external_user_id,
+      target_company_id: conn.company_id,
+      target_profile_id: conn.profile_id,
+      actor_user_id: gate.userId,
+      conflicting_rows: conflict.conflicting_rows,
+    });
+    return invalidState(
+      "This channel is already attached to another company on Opollo. " +
+        "Contact support to set up multi-company sharing.",
+    );
+  }
+
+  const svc = getServiceRoleClient();
+  const now = new Date().toISOString();
+  const update = await svc
+    .from("social_connections")
+    .update({
+      status: "healthy",
+      external_account_id: fingerprint.external_account_id,
+      external_user_id: fingerprint.external_user_id,
+      external_identity_hash: externalIdentityHash,
+      is_personal_mode: false,
+      last_health_check_at: now,
+      last_error: null,
+    })
+    .eq("id", conn.id);
+  if (update.error) {
+    logger.error("social.channels.set_update_failed", {
+      connection_id: conn.id,
+      err: update.error.message,
+    });
+    return internalError(`Failed to record channel selection: ${update.error.message}`);
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        connection_id: conn.id,
+        channel_id: parsed.data.channel_id,
+        external_account_id: fingerprint.external_account_id,
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/platform/social/connections/[id]/unset-channel/route.ts
+++ b/app/api/platform/social/connections/[id]/unset-channel/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import {
+  internalError,
+  invalidState,
+  notFound,
+  validateUuidParam,
+} from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { unsetChannel } from "@/lib/platform/social/connections/channels";
+import { loadConnectionWithTeam } from "@/lib/platform/social/connections/route-helpers";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/social/connections/[id]/unset-channel
+//
+// Clears the channel binding on bundle.social and flips the row back
+// to 'pending_identity'. Used to let a user re-pick without re-running
+// OAuth, and as step 1 of the Layer 6 disconnect ordering.
+//
+// Gate: canDo("manage_connections", company_id of the connection).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const idCheck = validateUuidParam(params.id, "id");
+  if (!idCheck.ok) return idCheck.response;
+
+  const loaded = await loadConnectionWithTeam(idCheck.value);
+  if (!loaded.ok) {
+    if (loaded.error.code === "NOT_FOUND") return notFound(loaded.error.message);
+    return invalidState(loaded.error.message);
+  }
+  const conn = loaded.data;
+
+  const gate = await requireCanDoForApi(conn.company_id, "manage_connections");
+  if (gate.kind === "deny") return gate.response;
+
+  const result = await unsetChannel({
+    teamId: conn.teamId,
+    platform: conn.bundlePlatform,
+  });
+  if (!result.ok) {
+    logger.error("social.channels.unset_failed", {
+      connection_id: conn.id,
+      platform: conn.bundlePlatform,
+      code: result.error.code,
+      message: result.error.message,
+    });
+    if (result.error.code === "RECEIVER_NOT_CONFIGURED")
+      return invalidState(result.error.message);
+    if (result.error.code === "PLATFORM_NOT_SUPPORTED")
+      return invalidState(result.error.message);
+    if (result.error.code === "UPSTREAM_REJECTED")
+      return invalidState(result.error.message);
+    return internalError(result.error.message);
+  }
+
+  const svc = getServiceRoleClient();
+  const now = new Date().toISOString();
+  // Channel-cleared rows revert to 'pending_identity' so the publishing
+  // gate refuses them and the customer page renders the picker prompt.
+  // Identity columns stay populated — the user OAuth-grant hasn't been
+  // revoked, only the channel binding has been cleared.
+  const update = await svc
+    .from("social_connections")
+    .update({
+      status: "pending_identity",
+      is_personal_mode: false,
+      last_health_check_at: now,
+    })
+    .eq("id", conn.id);
+  if (update.error) {
+    logger.error("social.channels.unset_update_failed", {
+      connection_id: conn.id,
+      err: update.error.message,
+    });
+    return internalError(`Failed to record channel unset: ${update.error.message}`);
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: { connection_id: conn.id },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/platform/social/connections/callback/route.ts
+++ b/app/api/platform/social/connections/callback/route.ts
@@ -133,6 +133,7 @@ function popupCloseResponse(
   connectParam: string,
   reason?: string,
   connectionId?: string,
+  attemptedPlatform?: string,
 ): NextResponse {
   const origin =
     process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ||
@@ -143,6 +144,7 @@ function popupCloseResponse(
     connect: connectParam,
     ...(reason ? { reason } : {}),
     ...(connectionId ? { connection_id: connectionId } : {}),
+    ...(attemptedPlatform ? { attempted_platform: attemptedPlatform } : {}),
   });
 
   // Strict target origin — only our own origin accepts this message.
@@ -241,6 +243,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   let connectParam: string;
   let reasonParam: string | undefined;
+  // Bug-fix 2026-05-12: when the user re-connected a platform they already
+  // have (sync found existing row → updated=1, inserted=0), surface the
+  // platform name so the customer page can render an actionable
+  // "already connected" banner and highlight the blocking row.
+  let attemptedPlatform: string | undefined;
   if (!sync.ok) {
     connectParam = "sync-failed";
     reasonParam = sync.error.code;
@@ -261,6 +268,12 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     reasonParam = "cross-tenant-blocked";
   } else {
     connectParam = "noop";
+    // If the user deliberately went through OAuth but landed back with
+    // nothing inserted (updated=1 means the account already exists),
+    // pass the platform so the UI can show which connection is blocking.
+    if (classified?.kind === "success" && sync.data.updated > 0) {
+      attemptedPlatform = classified.platform;
+    }
   }
 
   if (isPopup) {
@@ -269,6 +282,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       connectParam,
       reasonParam,
       needsChannelConnectionId ?? undefined,
+      attemptedPlatform,
     );
   }
 
@@ -280,6 +294,9 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   }
   if (needsChannelConnectionId) {
     target.searchParams.set("connection_id", needsChannelConnectionId);
+  }
+  if (attemptedPlatform) {
+    target.searchParams.set("attempted_platform", attemptedPlatform);
   }
   return NextResponse.redirect(target);
 }

--- a/app/api/platform/social/connections/callback/route.ts
+++ b/app/api/platform/social/connections/callback/route.ts
@@ -4,8 +4,97 @@ import { enqueuePostHistoryImport } from "@/lib/platform/social/analytics-ingest
 import { logger } from "@/lib/logger";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
 import { syncBundlesocialConnections } from "@/lib/platform/social/connections";
+import { CHANNEL_SELECTION_PLATFORMS } from "@/lib/platform/social/connections/identity";
 import { getServiceRoleClient } from "@/lib/supabase";
 import type { SocialPlatform } from "@/lib/platform/social/variants/types";
+
+// Per the bundle.social docs at
+// https://info.bundle.social/api-reference/connect-social-accounts,
+// every per-platform OAuth redirect lands with a `<platform>-callback=`
+// query param (either `true` for success or `error` for generic OAuth
+// failure), plus optional platform-specific error params.
+//
+// The set below is normalised to lowercase bundle.social platform
+// names; `find` against this set rather than the hand-rolled four-
+// generic-string list that used to live here. New platforms only need
+// adding to the PLATFORM_KEYS list below — error-handling stays generic.
+const PLATFORM_KEYS = [
+  "linkedin",
+  "facebook",
+  "instagram",
+  "twitter",
+  "threads",
+  "tiktok",
+  "youtube",
+  "google_business",
+  "pinterest",
+  "reddit",
+  "bluesky",
+  "mastodon",
+  "discord",
+  "slack",
+] as const;
+
+type PlatformKey = (typeof PLATFORM_KEYS)[number];
+
+// Error-suffix → reason code mapping. Reason codes are the values
+// surfaced via ?reason= to /company/social/connections, where
+// REASON_LABEL maps them to copy.
+const ERROR_SUFFIXES: Array<{ suffix: string; reason: string }> = [
+  { suffix: "-not-enough-channels", reason: "not-enough-channels" },
+  { suffix: "-not-enough-permissions", reason: "not-enough-permissions" },
+  { suffix: "-not-enough-pages", reason: "not-enough-pages" },
+  { suffix: "-not-enough-accounts", reason: "not-enough-accounts" },
+  { suffix: "-not-enough-servers", reason: "not-enough-servers" },
+  { suffix: "-not-enough-workspaces", reason: "not-enough-workspaces" },
+];
+
+// Scan the URL for the first platform-prefixed signal and classify.
+// Returns `null` when nothing matches — the caller falls through to
+// the sync-driven outcome.
+function classifyPlatformParams(
+  url: URL,
+):
+  | { kind: "success"; platform: PlatformKey }
+  | { kind: "error"; platform: PlatformKey; reason: string }
+  | null {
+  // Pre-existing generic keys (legacy bundle.social paths and our own
+  // ad-hoc signals from PR #868). Treated as error with the suffix as
+  // the reason code.
+  for (const key of [
+    "not-enough-permissions",
+    "not-enough-pages",
+    "auth-failed",
+    "user-cancelled",
+  ]) {
+    if (url.searchParams.has(key)) {
+      // Use 'unknown' as a synthetic platform — the customer-facing
+      // banner only renders the reason copy, not the platform.
+      return { kind: "error", platform: "linkedin", reason: key };
+    }
+  }
+  // Platform-prefixed signals.
+  for (const platform of PLATFORM_KEYS) {
+    // <platform>-callback=true|error
+    const cb = url.searchParams.get(`${platform}-callback`);
+    if (cb !== null) {
+      if (cb === "error") {
+        return { kind: "error", platform, reason: "auth-failed" };
+      }
+      // 'true' or anything else non-error → success signal. Note: we
+      // still rely on the sync to do the actual DB insert; this branch
+      // only suppresses the noop fall-through.
+      return { kind: "success", platform };
+    }
+    // Platform-specific error suffixes.
+    for (const { suffix, reason } of ERROR_SUFFIXES) {
+      if (url.searchParams.has(`${platform}${suffix}`)) {
+        return { kind: "error", platform, reason };
+      }
+    }
+  }
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // S1-16 — GET /api/platform/social/connections/callback
@@ -43,6 +132,7 @@ function popupCloseResponse(
   req: NextRequest,
   connectParam: string,
   reason?: string,
+  connectionId?: string,
 ): NextResponse {
   const origin =
     process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ||
@@ -52,6 +142,7 @@ function popupCloseResponse(
     type: "bundle-connect-complete",
     connect: connectParam,
     ...(reason ? { reason } : {}),
+    ...(connectionId ? { connection_id: connectionId } : {}),
   });
 
   // Strict target origin — only our own origin accepts this message.
@@ -101,6 +192,21 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     return gate.response;
   }
 
+  // Classify URL params BEFORE running the sync — bundle.social's
+  // error signals like <platform>-not-enough-channels mean OAuth never
+  // completed (no account created), so the sync would just no-op and
+  // produce a misleading "noop" banner. Surface the error directly.
+  const classified = classifyPlatformParams(url);
+  if (classified && classified.kind === "error") {
+    if (isPopup) {
+      return popupCloseResponse(req, "error", classified.reason);
+    }
+    const target = new URL("/company/social/connections", req.url);
+    target.searchParams.set("connect", "error");
+    target.searchParams.set("reason", classified.reason);
+    return NextResponse.redirect(target);
+  }
+
   const sync = await syncBundlesocialConnections({
     companyId,
     attributeNewToCompanyId: companyId,
@@ -114,21 +220,32 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     void triggerImportsForRecentConnections(req, companyId);
   }
 
-  const errorParam = [
-    "not-enough-permissions",
-    "not-enough-pages",
-    "auth-failed",
-    "user-cancelled",
-  ].find((k) => url.searchParams.has(k));
+  // If the user just connected a channel-selection platform (LINKEDIN /
+  // FACEBOOK / INSTAGRAM / YOUTUBE / GOOGLE_BUSINESS), the sync inserted
+  // the row in 'pending_identity' state and the customer page needs to
+  // open the channel-picker modal. We carry the freshly-inserted row's
+  // id so the page can target the picker without a separate lookup.
+  let needsChannelConnectionId: string | null = null;
+  if (
+    sync.ok &&
+    sync.data.inserted > 0 &&
+    classified?.kind === "success" &&
+    CHANNEL_SELECTION_PLATFORMS.has(
+      classified.platform.toUpperCase() as "LINKEDIN",
+    )
+  ) {
+    needsChannelConnectionId = await findMostRecentlyInsertedConnectionId(
+      companyId,
+    );
+  }
 
   let connectParam: string;
   let reasonParam: string | undefined;
-  if (errorParam) {
-    connectParam = "error";
-    reasonParam = errorParam;
-  } else if (!sync.ok) {
+  if (!sync.ok) {
     connectParam = "sync-failed";
     reasonParam = sync.error.code;
+  } else if (needsChannelConnectionId) {
+    connectParam = "needs_channel";
   } else if (sync.data.inserted > 0) {
     connectParam = "success";
   } else if (
@@ -147,7 +264,12 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   }
 
   if (isPopup) {
-    return popupCloseResponse(req, connectParam, reasonParam);
+    return popupCloseResponse(
+      req,
+      connectParam,
+      reasonParam,
+      needsChannelConnectionId ?? undefined,
+    );
   }
 
   const target = new URL("/company/social/connections", req.url);
@@ -156,7 +278,37 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   if (connectParam === "success" && sync.ok) {
     target.searchParams.set("count", String(sync.data.inserted));
   }
+  if (needsChannelConnectionId) {
+    target.searchParams.set("connection_id", needsChannelConnectionId);
+  }
   return NextResponse.redirect(target);
+}
+
+// After a sync inserts a channel-selection-platform row, the customer
+// page needs to know WHICH row to open the channel-picker against.
+// Look up the most-recently-inserted row for the company; the sync
+// just created it seconds ago, so age-sort is unambiguous.
+async function findMostRecentlyInsertedConnectionId(
+  companyId: string,
+): Promise<string | null> {
+  const svc = getServiceRoleClient();
+  const since = new Date(Date.now() - 60_000).toISOString();
+  const { data, error } = await svc
+    .from("social_connections")
+    .select("id")
+    .eq("company_id", companyId)
+    .eq("status", "pending_identity")
+    .gte("created_at", since)
+    .order("created_at", { ascending: false })
+    .limit(1);
+  if (error) {
+    logger.warn("social.callback.needs_channel_lookup_failed", {
+      err: error.message,
+      company_id: companyId,
+    });
+    return null;
+  }
+  return (data?.[0]?.id as string | undefined) ?? null;
 }
 
 // Scans for connections that were just inserted by sync and enqueues a

--- a/components/AdminProfileConnectionsList.tsx
+++ b/components/AdminProfileConnectionsList.tsx
@@ -3,8 +3,23 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
+import { ChannelPickerModal } from "@/components/ChannelPickerModal";
 import { Button } from "@/components/ui/button";
 import { toastSuccess } from "@/lib/toast-success";
+
+const PLATFORM_TO_BUNDLE_LABEL: Record<
+  string,
+  {
+    platform: "LINKEDIN" | "FACEBOOK" | "INSTAGRAM" | "YOUTUBE" | "GOOGLE_BUSINESS";
+    label: string;
+  } | null
+> = {
+  LINKEDIN: { platform: "LINKEDIN", label: "LinkedIn" },
+  FACEBOOK: { platform: "FACEBOOK", label: "Facebook" },
+  INSTAGRAM: { platform: "INSTAGRAM", label: "Instagram" },
+  YOUTUBE: { platform: "YOUTUBE", label: "YouTube" },
+  GOOGLE_BUSINESS: { platform: "GOOGLE_BUSINESS", label: "Google Business" },
+};
 
 // BSP-6 — per-profile connections list with connect lightbox.
 //
@@ -59,7 +74,13 @@ type ApiResponse<T> =
       timestamp: string;
     };
 
-function isConnectMessage(v: unknown): boolean {
+type ConnectMessage = {
+  type: "bundle-connect-complete";
+  connect?: string;
+  connection_id?: string;
+};
+
+function isConnectMessage(v: unknown): v is ConnectMessage {
   return (
     typeof v === "object" &&
     v !== null &&
@@ -90,6 +111,13 @@ export function AdminProfileConnectionsList({
       }
     | null
   >(null);
+  // Channel-selection flow (incident 2026-05-12): the connection_id
+  // currently targeted by the picker modal.
+  const [pickerTarget, setPickerTarget] = useState<{
+    connectionId: string;
+    platform: "LINKEDIN" | "FACEBOOK" | "INSTAGRAM" | "YOUTUBE" | "GOOGLE_BUSINESS";
+    label: string;
+  } | null>(null);
   const popupRef = useRef<Window | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -105,8 +133,26 @@ export function AdminProfileConnectionsList({
     function handleMessage(evt: MessageEvent) {
       if (evt.origin !== expectedOrigin) return;
       if (!isConnectMessage(evt.data)) return;
+      // Snapshot busy BEFORE clearPopupState wipes it — we need the
+      // platform value to resolve the picker shape below.
+      const platformValue = busy;
       clearPopupState();
       setShowLightbox(false);
+      if (
+        evt.data.connect === "needs_channel" &&
+        typeof evt.data.connection_id === "string"
+      ) {
+        const mapped = platformValue
+          ? PLATFORM_TO_BUNDLE_LABEL[platformValue]
+          : null;
+        if (mapped) {
+          setPickerTarget({
+            connectionId: evt.data.connection_id,
+            platform: mapped.platform,
+            label: mapped.label,
+          });
+        }
+      }
       router.refresh();
     }
     window.addEventListener("message", handleMessage);
@@ -115,7 +161,7 @@ export function AdminProfileConnectionsList({
       if (pollRef.current) clearInterval(pollRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [busy]);
 
   async function handleDisconnect(account: Account) {
     if (
@@ -241,6 +287,23 @@ export function AdminProfileConnectionsList({
 
   return (
     <div data-testid="admin-profile-connections">
+      {pickerTarget ? (
+        <ChannelPickerModal
+          connectionId={pickerTarget.connectionId}
+          platform={pickerTarget.platform}
+          platformLabel={pickerTarget.label}
+          isOpen={true}
+          onClose={() => setPickerTarget(null)}
+          onSelected={() => {
+            setPickerTarget(null);
+            toastSuccess(
+              `${pickerTarget.label} channel set — ready to publish.`,
+            );
+            router.refresh();
+          }}
+        />
+      ) : null}
+
       {preflightModal ? (
         <div
           role="dialog"

--- a/components/ChannelPickerModal.tsx
+++ b/components/ChannelPickerModal.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+// ---------------------------------------------------------------------------
+// ChannelPickerModal — channel-selection flow (incident 2026-05-12).
+//
+// Used after a customer connects a channel-selection platform
+// (LinkedIn / FB / IG / YT / GBP) and bundle.social returns the
+// account in pending_identity. The modal:
+//   1. Fetches the channel list from
+//      GET /api/platform/social/connections/[id]/channels.
+//   2. Renders rows with platform-specific subtext.
+//   3. On select → POST .../set-channel → onSelected().
+//   4. LinkedIn empty-channels branch → "Connect as personal profile"
+//      → POST .../connect-as-personal → onSelected().
+//
+// Platform-agnostic by design: the API normalises every channel into
+// the `Channel` shape exposed by lib/platform/social/connections/
+// channels.ts, so this component does no per-platform branching aside
+// from the LinkedIn personal-mode affordance.
+// ---------------------------------------------------------------------------
+
+type Channel = {
+  id: string;
+  name: string;
+  subtext: string | null;
+  avatarUrl: string | null;
+  kind:
+    | "LINKEDIN_ORG"
+    | "FACEBOOK_PAGE"
+    | "INSTAGRAM_ACCOUNT"
+    | "YOUTUBE_CHANNEL"
+    | "GBP_LOCATION"
+    | "OTHER";
+};
+
+type Props = {
+  connectionId: string;
+  platform: "LINKEDIN" | "FACEBOOK" | "INSTAGRAM" | "YOUTUBE" | "GOOGLE_BUSINESS";
+  platformLabel: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onSelected: () => void;
+};
+
+type FetchState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "loaded"; channels: Channel[] }
+  | { kind: "error"; message: string };
+
+export function ChannelPickerModal({
+  connectionId,
+  platform,
+  platformLabel,
+  isOpen,
+  onClose,
+  onSelected,
+}: Props) {
+  const [state, setState] = useState<FetchState>({ kind: "idle" });
+  const [busyChannelId, setBusyChannelId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [busyPersonal, setBusyPersonal] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setState({ kind: "loading" });
+    setActionError(null);
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/platform/social/connections/${connectionId}/channels`,
+          { method: "GET" },
+        );
+        const json = (await res.json()) as
+          | { ok: true; data: { channels: Channel[] } }
+          | { ok: false; error: { message: string } };
+        if (cancelled) return;
+        if (!res.ok || !json.ok) {
+          setState({
+            kind: "error",
+            message: !json.ok ? json.error.message : "Failed to load channels.",
+          });
+          return;
+        }
+        setState({ kind: "loaded", channels: json.data.channels });
+      } catch (err) {
+        if (cancelled) return;
+        setState({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, connectionId]);
+
+  async function handleSelect(channel: Channel) {
+    setBusyChannelId(channel.id);
+    setActionError(null);
+    const res = await fetch(
+      `/api/platform/social/connections/${connectionId}/set-channel`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ channel_id: channel.id }),
+      },
+    );
+    const json = (await res.json()) as
+      | { ok: true }
+      | { ok: false; error: { message: string } };
+    setBusyChannelId(null);
+    if (!res.ok || !json.ok) {
+      setActionError(!json.ok ? json.error.message : "Failed to set channel.");
+      return;
+    }
+    onSelected();
+  }
+
+  async function handlePersonalMode() {
+    setBusyPersonal(true);
+    setActionError(null);
+    const res = await fetch(
+      `/api/platform/social/connections/${connectionId}/connect-as-personal`,
+      { method: "POST" },
+    );
+    const json = (await res.json()) as
+      | { ok: true }
+      | { ok: false; error: { message: string } };
+    setBusyPersonal(false);
+    if (!res.ok || !json.ok) {
+      setActionError(
+        !json.ok ? json.error.message : "Failed to enable personal-mode.",
+      );
+      return;
+    }
+    onSelected();
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="channel-picker-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      data-testid="channel-picker-modal"
+    >
+      <div className="max-h-[80vh] w-full max-w-md overflow-hidden rounded-lg bg-background shadow-xl">
+        <header className="border-b p-4">
+          <h2
+            id="channel-picker-title"
+            className="text-base font-semibold"
+            data-testid="channel-picker-title"
+          >
+            Pick a {platformLabel} channel
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Posts to this connection will be published to the channel you
+            pick. You can change it later.
+          </p>
+        </header>
+
+        <div
+          className="max-h-[55vh] overflow-y-auto p-4"
+          data-testid="channel-picker-body"
+        >
+          {state.kind === "loading" || state.kind === "idle" ? (
+            <p
+              className="text-sm text-muted-foreground"
+              data-testid="channel-picker-loading"
+            >
+              Loading channels…
+            </p>
+          ) : state.kind === "error" ? (
+            <p
+              className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              role="alert"
+              data-testid="channel-picker-fetch-error"
+            >
+              {state.message}
+            </p>
+          ) : state.channels.length === 0 ? (
+            <div data-testid="channel-picker-empty">
+              <p className="mb-3 text-sm text-muted-foreground">
+                You don&apos;t admin any {platformLabel} channels.
+              </p>
+              {platform === "LINKEDIN" ? (
+                <>
+                  <p className="mb-3 text-sm text-muted-foreground">
+                    Connect as your personal LinkedIn profile instead?
+                    Posts will be published under your own name.
+                  </p>
+                  <Button
+                    onClick={handlePersonalMode}
+                    disabled={busyPersonal}
+                    data-testid="channel-picker-personal-mode"
+                  >
+                    {busyPersonal ? "Connecting…" : "Connect as personal profile"}
+                  </Button>
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Disconnect this account and try again with one that
+                  admins at least one {platformLabel} resource.
+                </p>
+              )}
+            </div>
+          ) : (
+            <ul className="space-y-2" data-testid="channel-picker-list">
+              {state.channels.map((c) => (
+                <li key={c.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelect(c)}
+                    disabled={busyChannelId !== null}
+                    className="flex w-full items-center gap-3 rounded-md border bg-card p-3 text-left hover:bg-muted/30 disabled:opacity-50"
+                    data-testid={`channel-picker-row-${c.id}`}
+                  >
+                    {c.avatarUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={c.avatarUrl}
+                        alt=""
+                        className="h-10 w-10 flex-shrink-0 rounded-full bg-muted"
+                      />
+                    ) : (
+                      <div className="h-10 w-10 flex-shrink-0 rounded-full bg-muted" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium">
+                        {c.name}
+                      </div>
+                      {c.subtext ? (
+                        <div className="truncate text-sm text-muted-foreground">
+                          {c.subtext}
+                        </div>
+                      ) : null}
+                    </div>
+                    {busyChannelId === c.id ? (
+                      <span className="text-sm text-muted-foreground">
+                        Selecting…
+                      </span>
+                    ) : null}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {actionError ? (
+            <p
+              className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              role="alert"
+              data-testid="channel-picker-action-error"
+            >
+              {actionError}
+            </p>
+          ) : null}
+        </div>
+
+        <footer className="flex justify-end gap-2 border-t p-4">
+          <Button
+            variant="ghost"
+            onClick={onClose}
+            disabled={busyChannelId !== null || busyPersonal}
+            data-testid="channel-picker-close"
+          >
+            Close
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -69,6 +69,10 @@ type ConnectMessage = {
   connect: "success" | "noop" | "error" | "sync-failed" | "needs_channel";
   reason?: string;
   connection_id?: string;
+  // Bug-fix 2026-05-12: set on noop when the user re-connected a platform
+  // they already have (sync updated=1, inserted=0). Drives the actionable
+  // "already connected" banner and row highlight.
+  attempted_platform?: string;
 };
 
 function isConnectMessage(v: unknown): v is ConnectMessage {
@@ -97,6 +101,10 @@ type Props = {
   // the page passes the id here so we auto-open the picker against
   // that row on first render.
   autoOpenPickerForConnectionId?: string | null;
+  // Bug-fix 2026-05-12: when the callback route signals noop+updated,
+  // the page passes the attempted platform (lowercase, e.g. "linkedin")
+  // so we show an actionable banner and highlight the blocking row.
+  noopdForPlatform?: string | null;
 };
 
 export function SocialConnectionsList({
@@ -106,6 +114,7 @@ export function SocialConnectionsList({
   canManage,
   canReconnect,
   autoOpenPickerForConnectionId,
+  noopdForPlatform,
 }: Props) {
   const router = useRouter();
   const [busyRow, setBusyRow] = useState<string | null>(null);
@@ -121,6 +130,12 @@ export function SocialConnectionsList({
   >(null);
   // Track per-row disconnect spinner state.
   const [disconnectBusy, setDisconnectBusy] = useState<string | null>(null);
+  // Bug-fix 2026-05-12: "already connected" banner — set from prop (non-
+  // popup redirect) or from the popup postMessage when noop+updated fires.
+  // Lowercase bundle.social platform string, e.g. "linkedin".
+  const [noopdPlatform, setNoopdPlatform] = useState<string | null>(
+    noopdForPlatform ?? null,
+  );
 
   // Auto-open the picker when the page hands us a connection_id (after
   // a fresh OAuth that needs channel selection). The effect only fires
@@ -201,6 +216,14 @@ export function SocialConnectionsList({
         typeof evt.data.connection_id === "string"
       ) {
         setPickerForConnectionId(evt.data.connection_id);
+      }
+      // Bug-fix 2026-05-12: if the callback signalled noop with an
+      // attempted_platform, show the actionable "already connected" banner.
+      if (
+        evt.data.connect === "noop" &&
+        typeof evt.data.attempted_platform === "string"
+      ) {
+        setNoopdPlatform(evt.data.attempted_platform);
       }
       router.refresh();
     }
@@ -354,6 +377,19 @@ export function SocialConnectionsList({
       })()
     : null;
 
+  // Bug-fix 2026-05-12: the "already connected" blocking row — find the
+  // first healthy (or pending_identity) connection whose bundle.social
+  // platform matches the attempted_platform signal. Used for the
+  // actionable banner and yellow row highlight.
+  const noopdConnection = noopdPlatform
+    ? connections.find(
+        (c) =>
+          (PLATFORM_TO_BUNDLE_LABEL[c.platform]?.platform ?? "").toLowerCase() ===
+            noopdPlatform.toLowerCase() &&
+          (c.status === "healthy" || c.status === "pending_identity"),
+      ) ?? null
+    : null;
+
   async function handleSync() {
     setBusySync(true);
     setError(null);
@@ -401,6 +437,31 @@ export function SocialConnectionsList({
             router.refresh();
           }}
         />
+      ) : null}
+
+      {noopdConnection ? (
+        <div
+          className="mb-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
+          role="alert"
+          data-testid="connections-already-connected-banner"
+        >
+          <p className="font-medium">
+            This profile already has a{" "}
+            {PLATFORM_LABEL[noopdConnection.platform] ?? noopdConnection.platform}{" "}
+            connection
+            {noopdConnection.display_name ? ` (${noopdConnection.display_name})` : ""},
+            connected{" "}
+            {new Date(noopdConnection.connected_at).toLocaleDateString("en-AU", {
+              day: "numeric",
+              month: "short",
+              year: "numeric",
+            })}.
+          </p>
+          <p className="mt-1 text-amber-900/80">
+            Disconnect the existing connection below to connect a different
+            account, or ask an admin to create a new profile.
+          </p>
+        </div>
       ) : null}
 
       {overdueConnections.length > 0 ? (
@@ -590,7 +651,11 @@ export function SocialConnectionsList({
               {connections.map((c) => (
                 <tr
                   key={c.id}
-                  className="border-b last:border-b-0 hover:bg-muted/20"
+                  className={`border-b last:border-b-0 ${
+                    noopdConnection?.id === c.id
+                      ? "bg-amber-50"
+                      : "hover:bg-muted/20"
+                  }`}
                   data-testid={`connection-row-${c.id}`}
                 >
                   <td className="px-4 py-3 font-medium">

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { toastSuccess } from "@/lib/toast-success";
 
+import { ChannelPickerModal } from "@/components/ChannelPickerModal";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,6 +13,25 @@ import {
   STATUS_PILL,
   type SocialConnection,
 } from "@/lib/platform/social/connections/types";
+
+// Map our DB SocialPlatform enum to the bundle.social platform type
+// the picker modal expects. Identical mapping to
+// lib/platform/social/connections/route-helpers.ts's PLATFORM_TO_BUNDLE.
+const PLATFORM_TO_BUNDLE_LABEL: Record<
+  string,
+  {
+    platform: "LINKEDIN" | "FACEBOOK" | "INSTAGRAM" | "YOUTUBE" | "GOOGLE_BUSINESS";
+    label: string;
+  } | null
+> = {
+  linkedin_personal: { platform: "LINKEDIN", label: "LinkedIn" },
+  linkedin_company: { platform: "LINKEDIN", label: "LinkedIn" },
+  facebook_page: { platform: "FACEBOOK", label: "Facebook" },
+  gbp: { platform: "GOOGLE_BUSINESS", label: "Google Business" },
+  // Twitter / X is NOT a channel-selection platform; render undefined
+  // so the banner / modal don't try to pick a channel for it.
+  x: null,
+};
 
 // ---------------------------------------------------------------------------
 // S1-12 / S1-16 / BSP-6-CUSTOMER — connections roster for
@@ -46,8 +66,9 @@ const PLATFORMS: Array<{ value: string; label: string }> = [
 
 type ConnectMessage = {
   type: "bundle-connect-complete";
-  connect: "success" | "noop" | "error" | "sync-failed";
+  connect: "success" | "noop" | "error" | "sync-failed" | "needs_channel";
   reason?: string;
+  connection_id?: string;
 };
 
 function isConnectMessage(v: unknown): v is ConnectMessage {
@@ -71,6 +92,11 @@ type Props = {
   // connections. Admins already have this via canManage; editors can
   // reconnect but not create new connections (S8).
   canReconnect: boolean;
+  // Channel-selection flow (incident 2026-05-12): when the callback
+  // route redirects with ?connect=needs_channel&connection_id=<id>,
+  // the page passes the id here so we auto-open the picker against
+  // that row on first render.
+  autoOpenPickerForConnectionId?: string | null;
 };
 
 export function SocialConnectionsList({
@@ -79,6 +105,7 @@ export function SocialConnectionsList({
   connections,
   canManage,
   canReconnect,
+  autoOpenPickerForConnectionId,
 }: Props) {
   const router = useRouter();
   const [busyRow, setBusyRow] = useState<string | null>(null);
@@ -87,6 +114,25 @@ export function SocialConnectionsList({
   const [busyPlatform, setBusyPlatform] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [popupBlockedUrl, setPopupBlockedUrl] = useState<string | null>(null);
+  // Channel-selection flow (incident 2026-05-12): which connection
+  // (if any) should the picker modal be open against?
+  const [pickerForConnectionId, setPickerForConnectionId] = useState<
+    string | null
+  >(null);
+  // Track per-row disconnect spinner state.
+  const [disconnectBusy, setDisconnectBusy] = useState<string | null>(null);
+
+  // Auto-open the picker when the page hands us a connection_id (after
+  // a fresh OAuth that needs channel selection). The effect only fires
+  // when the prop is non-null and the connection is actually in this
+  // list's bucket — guards against the parent passing us another
+  // profile's connection.
+  useEffect(() => {
+    if (!autoOpenPickerForConnectionId) return;
+    if (!connections.some((c) => c.id === autoOpenPickerForConnectionId))
+      return;
+    setPickerForConnectionId(autoOpenPickerForConnectionId);
+  }, [autoOpenPickerForConnectionId, connections]);
   // Cross-tenant identity-leak defence (Layer 3): pre-flight warning
   // modal state. When the user clicks Connect, we first call
   // /identity-preflight; if it returns warn=true, we render a
@@ -146,6 +192,16 @@ export function SocialConnectionsList({
 
       clearPopupState();
       setShowLightbox(false);
+      // Channel-selection flow: if the callback signalled needs_channel,
+      // open the picker directly without waiting for a router.refresh
+      // round-trip. router.refresh still fires so the row appears in
+      // the list (status='pending_identity') in the same tick.
+      if (
+        evt.data.connect === "needs_channel" &&
+        typeof evt.data.connection_id === "string"
+      ) {
+        setPickerForConnectionId(evt.data.connection_id);
+      }
       router.refresh();
     }
 
@@ -247,6 +303,57 @@ export function SocialConnectionsList({
     openConnectPopup(json.data.url, rowId);
   }
 
+  async function handleDisconnect(connectionId: string) {
+    if (
+      !window.confirm(
+        "Disconnect this account? Drafts that reference it will be released back to drafts.",
+      )
+    ) {
+      return;
+    }
+    setDisconnectBusy(connectionId);
+    setError(null);
+    const res = await fetch(
+      `/api/platform/social/connections/${connectionId}/disconnect`,
+      { method: "POST" },
+    );
+    const json = (await res.json()) as
+      | { ok: true }
+      | { ok: false; error: { message: string } };
+    setDisconnectBusy(null);
+    if (!res.ok || !json.ok) {
+      setError(!json.ok ? json.error.message : "Failed to disconnect.");
+      return;
+    }
+    toastSuccess("Connection disconnected.");
+    router.refresh();
+  }
+
+  // Connections that have been sitting in pending_identity for >24h.
+  // The server emits the connection_channel_overdue audit on first
+  // render via emitOverdueEventsIfNeeded; the client renders the banner
+  // here.
+  const OVERDUE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+  const overdueConnections = connections.filter((c) => {
+    if (c.status !== "pending_identity") return false;
+    const age = Date.now() - new Date(c.connected_at).getTime();
+    return age > OVERDUE_THRESHOLD_MS;
+  });
+
+  // Resolve the currently-targeted picker connection to its platform
+  // shape so the modal renders the right labels. Returns null when
+  // the connection is missing or the platform isn't a channel-selection
+  // platform.
+  const pickerTarget = pickerForConnectionId
+    ? (() => {
+        const c = connections.find((x) => x.id === pickerForConnectionId);
+        if (!c) return null;
+        const bundle = PLATFORM_TO_BUNDLE_LABEL[c.platform];
+        if (!bundle) return null;
+        return { conn: c, ...bundle };
+      })()
+    : null;
+
   async function handleSync() {
     setBusySync(true);
     setError(null);
@@ -281,6 +388,39 @@ export function SocialConnectionsList({
 
   return (
     <div data-testid="connections-list-wrapper">
+      {pickerTarget ? (
+        <ChannelPickerModal
+          connectionId={pickerTarget.conn.id}
+          platform={pickerTarget.platform}
+          platformLabel={pickerTarget.label}
+          isOpen={true}
+          onClose={() => setPickerForConnectionId(null)}
+          onSelected={() => {
+            setPickerForConnectionId(null);
+            toastSuccess("Channel set — this connection is ready to publish.");
+            router.refresh();
+          }}
+        />
+      ) : null}
+
+      {overdueConnections.length > 0 ? (
+        <div
+          className="mb-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
+          role="alert"
+          data-testid="connections-overdue-banner"
+        >
+          <p className="font-medium">
+            {overdueConnections.length}{" "}
+            {overdueConnections.length === 1 ? "connection needs" : "connections need"}{" "}
+            a channel.
+          </p>
+          <p className="mt-1 text-amber-900/80">
+            Pick a channel below to start publishing. Connections without a
+            channel can&apos;t post.
+          </p>
+        </div>
+      ) : null}
+
       {preflightModal ? (
         <div
           role="dialog"
@@ -489,19 +629,56 @@ export function SocialConnectionsList({
                     })}
                   </td>
                   <td className="px-4 py-3 text-right">
-                    {(canManage || canReconnect) &&
-                    (c.status === "auth_required" ||
-                      c.status === "disconnected") ? (
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => handleReconnect(c.id)}
-                        disabled={busyRow === c.id || connectBusy || busySync}
-                        data-testid={`connection-reconnect-${c.id}`}
-                      >
-                        {busyRow === c.id ? "Opening…" : "Reconnect"}
-                      </Button>
-                    ) : null}
+                    <div className="flex justify-end gap-1">
+                      {canManage &&
+                      c.status === "pending_identity" &&
+                      PLATFORM_TO_BUNDLE_LABEL[c.platform] !== null ? (
+                        <Button
+                          size="sm"
+                          onClick={() => setPickerForConnectionId(c.id)}
+                          disabled={
+                            busyRow === c.id ||
+                            connectBusy ||
+                            busySync ||
+                            disconnectBusy !== null
+                          }
+                          data-testid={`connection-select-channel-${c.id}`}
+                        >
+                          Select channel
+                        </Button>
+                      ) : null}
+                      {(canManage || canReconnect) &&
+                      (c.status === "auth_required" ||
+                        c.status === "disconnected") ? (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => handleReconnect(c.id)}
+                          disabled={busyRow === c.id || connectBusy || busySync}
+                          data-testid={`connection-reconnect-${c.id}`}
+                        >
+                          {busyRow === c.id ? "Opening…" : "Reconnect"}
+                        </Button>
+                      ) : null}
+                      {canManage ? (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => handleDisconnect(c.id)}
+                          disabled={
+                            disconnectBusy === c.id ||
+                            busySync ||
+                            connectBusy ||
+                            busyRow !== null
+                          }
+                          data-testid={`connection-disconnect-${c.id}`}
+                        >
+                          {disconnectBusy === c.id
+                            ? "Disconnecting…"
+                            : "Disconnect"}
+                        </Button>
+                      ) : null}
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/lib/__tests__/__snapshots__/social-channels.contract.test.ts.snap
+++ b/lib/__tests__/__snapshots__/social-channels.contract.test.ts.snap
@@ -1,0 +1,150 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CONTRACT: socialAccountRefreshChannels — per platform > [snapshot] DISCORD — request body (refresh-only platform) 1`] = `
+{
+  "requestBody": {
+    "teamId": "team-channels-contract",
+    "type": "DISCORD",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountRefreshChannels — per platform > [snapshot] FACEBOOK — request body 1`] = `
+{
+  "requestBody": {
+    "teamId": "team-channels-contract",
+    "type": "FACEBOOK",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountRefreshChannels — per platform > [snapshot] GOOGLE_BUSINESS — request body 1`] = `
+{
+  "requestBody": {
+    "teamId": "team-channels-contract",
+    "type": "GOOGLE_BUSINESS",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountRefreshChannels — per platform > [snapshot] INSTAGRAM — request body 1`] = `
+{
+  "requestBody": {
+    "teamId": "team-channels-contract",
+    "type": "INSTAGRAM",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountRefreshChannels — per platform > [snapshot] LINKEDIN — request body 1`] = `
+{
+  "requestBody": {
+    "teamId": "team-channels-contract",
+    "type": "LINKEDIN",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountRefreshChannels — per platform > [snapshot] YOUTUBE — request body 1`] = `
+{
+  "requestBody": {
+    "teamId": "team-channels-contract",
+    "type": "YOUTUBE",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountSetChannel — per platform > [snapshot] FACEBOOK — request body 1`] = `
+{
+  "requestBody": {
+    "channelId": "channel-fixture-1",
+    "teamId": "team-channels-contract",
+    "type": "FACEBOOK",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountSetChannel — per platform > [snapshot] GOOGLE_BUSINESS — request body 1`] = `
+{
+  "requestBody": {
+    "channelId": "channel-fixture-1",
+    "teamId": "team-channels-contract",
+    "type": "GOOGLE_BUSINESS",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountSetChannel — per platform > [snapshot] INSTAGRAM — request body 1`] = `
+{
+  "requestBody": {
+    "channelId": "channel-fixture-1",
+    "teamId": "team-channels-contract",
+    "type": "INSTAGRAM",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountSetChannel — per platform > [snapshot] LINKEDIN — request body 1`] = `
+{
+  "requestBody": {
+    "channelId": "channel-fixture-1",
+    "teamId": "team-channels-contract",
+    "type": "LINKEDIN",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountSetChannel — per platform > [snapshot] YOUTUBE — request body 1`] = `
+{
+  "requestBody": {
+    "channelId": "channel-fixture-1",
+    "teamId": "team-channels-contract",
+    "type": "YOUTUBE",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountUnsetChannel — per platform > [snapshot] FACEBOOK — request body 1`] = `
+{
+  "requestBody": {
+    "teamId": "team-channels-contract",
+    "type": "FACEBOOK",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountUnsetChannel — per platform > [snapshot] GOOGLE_BUSINESS — request body 1`] = `
+{
+  "requestBody": {
+    "teamId": "team-channels-contract",
+    "type": "GOOGLE_BUSINESS",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountUnsetChannel — per platform > [snapshot] INSTAGRAM — request body 1`] = `
+{
+  "requestBody": {
+    "teamId": "team-channels-contract",
+    "type": "INSTAGRAM",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountUnsetChannel — per platform > [snapshot] LINKEDIN — request body 1`] = `
+{
+  "requestBody": {
+    "teamId": "team-channels-contract",
+    "type": "LINKEDIN",
+  },
+}
+`;
+
+exports[`CONTRACT: socialAccountUnsetChannel — per platform > [snapshot] YOUTUBE — request body 1`] = `
+{
+  "requestBody": {
+    "teamId": "team-channels-contract",
+    "type": "YOUTUBE",
+  },
+}
+`;

--- a/lib/__tests__/social-channels.contract.test.ts
+++ b/lib/__tests__/social-channels.contract.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// LAYER 2 — Contract. Channel-selection SDK shape.
+//
+// Pins the exact request body the channels.ts wrappers send to
+// bundle.social's socialAccountRefreshChannels / socialAccountSetChannel
+// / socialAccountUnsetChannel endpoints, per platform. Snapshot drift
+// gets reviewed as a Zod-schema diff at the boundary.
+//
+// Coverage: 5 channel-selection platforms × 3 ops = 15 snapshots.
+// refreshChannels additionally supports DISCORD/SLACK/REDDIT/PINTEREST,
+// but those aren't channel-selection-required so only one extra-platform
+// smoke is included (DISCORD).
+// ---------------------------------------------------------------------------
+
+const setChannelMock = vi.fn();
+const unsetChannelMock = vi.fn();
+const refreshChannelsMock = vi.fn();
+const getByTypeMock = vi.fn();
+
+vi.mock("@/lib/bundlesocial", () => ({
+  getBundlesocialClient: () => ({
+    socialAccount: {
+      socialAccountSetChannel: setChannelMock,
+      socialAccountUnsetChannel: unsetChannelMock,
+      socialAccountRefreshChannels: refreshChannelsMock,
+      socialAccountGetByType: getByTypeMock,
+    },
+  }),
+  getBundlesocialTeamId: () => "ignored-in-this-test",
+}));
+
+import {
+  getChannels,
+  normalizeChannel,
+  refreshChannels,
+  setChannel,
+  unsetChannel,
+} from "@/lib/platform/social/connections/channels";
+
+const TEAM_ID = "team-channels-contract";
+
+const CHANNEL_PLATFORMS = [
+  "LINKEDIN",
+  "FACEBOOK",
+  "INSTAGRAM",
+  "YOUTUBE",
+  "GOOGLE_BUSINESS",
+] as const;
+
+beforeEach(() => {
+  setChannelMock.mockReset();
+  unsetChannelMock.mockReset();
+  refreshChannelsMock.mockReset();
+  getByTypeMock.mockReset();
+  refreshChannelsMock.mockResolvedValue({ channels: [] });
+  setChannelMock.mockResolvedValue({ externalId: "urn:x", userId: "urn:u" });
+  unsetChannelMock.mockResolvedValue({});
+  getByTypeMock.mockResolvedValue({ channels: [] });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CONTRACT: socialAccountRefreshChannels — per platform", () => {
+  for (const platform of CHANNEL_PLATFORMS) {
+    it(`[snapshot] ${platform} — request body`, async () => {
+      await refreshChannels({ teamId: TEAM_ID, platform });
+      const arg = refreshChannelsMock.mock.calls[0]?.[0];
+      expect(arg).toMatchSnapshot();
+    });
+  }
+
+  // Extra-platform smoke: refreshChannels supports DISCORD/SLACK/REDDIT/
+  // PINTEREST in addition to the channel-selection set. setChannel /
+  // unsetChannel do NOT — covered by the supported-platform error tests
+  // below.
+  it("[snapshot] DISCORD — request body (refresh-only platform)", async () => {
+    await refreshChannels({ teamId: TEAM_ID, platform: "DISCORD" });
+    const arg = refreshChannelsMock.mock.calls[0]?.[0];
+    expect(arg).toMatchSnapshot();
+  });
+});
+
+describe("CONTRACT: socialAccountSetChannel — per platform", () => {
+  for (const platform of CHANNEL_PLATFORMS) {
+    it(`[snapshot] ${platform} — request body`, async () => {
+      await setChannel({
+        teamId: TEAM_ID,
+        platform,
+        channelId: "channel-fixture-1",
+      });
+      const arg = setChannelMock.mock.calls[0]?.[0];
+      expect(arg).toMatchSnapshot();
+    });
+  }
+});
+
+describe("CONTRACT: socialAccountUnsetChannel — per platform", () => {
+  for (const platform of CHANNEL_PLATFORMS) {
+    it(`[snapshot] ${platform} — request body`, async () => {
+      await unsetChannel({ teamId: TEAM_ID, platform });
+      const arg = unsetChannelMock.mock.calls[0]?.[0];
+      expect(arg).toMatchSnapshot();
+    });
+  }
+});
+
+describe("setChannel / unsetChannel — platform support", () => {
+  it("setChannel refuses TWITTER (not a channel-selection platform)", async () => {
+    const r = await setChannel({
+      teamId: TEAM_ID,
+      // @ts-expect-error — intentionally widening to test the runtime guard
+      platform: "TWITTER",
+      channelId: "x",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe("PLATFORM_NOT_SUPPORTED");
+    expect(setChannelMock).not.toHaveBeenCalled();
+  });
+
+  it("unsetChannel refuses DISCORD (not a channel-selection platform)", async () => {
+    const r = await unsetChannel({
+      teamId: TEAM_ID,
+      // @ts-expect-error — intentionally widening to test the runtime guard
+      platform: "DISCORD",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe("PLATFORM_NOT_SUPPORTED");
+    expect(unsetChannelMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("normalizeChannel — per-platform subtext", () => {
+  it("LINKEDIN — uses username for the subtext", () => {
+    const c = normalizeChannel("LINKEDIN", {
+      id: "urn:li:organization:42",
+      name: "ACME Co",
+      username: "acme-co",
+      avatarUrl: "https://cdn/acme.png",
+    });
+    expect(c.kind).toBe("LINKEDIN_ORG");
+    expect(c.name).toBe("ACME Co");
+    expect(c.subtext).toBe("acme-co");
+    expect(c.avatarUrl).toBe("https://cdn/acme.png");
+  });
+
+  it("FACEBOOK_PAGE — uses username for the subtext", () => {
+    const c = normalizeChannel("FACEBOOK", {
+      id: "fb-page-42",
+      name: "Pizza Inc",
+      username: "pizza.inc",
+    });
+    expect(c.kind).toBe("FACEBOOK_PAGE");
+    expect(c.subtext).toBe("pizza.inc");
+  });
+
+  it("INSTAGRAM — prefixes the username with @", () => {
+    const c = normalizeChannel("INSTAGRAM", {
+      id: "ig-acc-42",
+      name: "Pizza Inc",
+      username: "pizza_inc",
+    });
+    expect(c.subtext).toBe("@pizza_inc");
+  });
+
+  it("INSTAGRAM — does NOT double-prefix when username already starts with @", () => {
+    const c = normalizeChannel("INSTAGRAM", {
+      id: "ig-acc-42",
+      name: "Pizza Inc",
+      username: "@pizza_inc",
+    });
+    expect(c.subtext).toBe("@pizza_inc");
+  });
+
+  it("YOUTUBE — uses username for the subtext", () => {
+    const c = normalizeChannel("YOUTUBE", {
+      id: "yt-ch-42",
+      name: "Pizza Tube",
+      username: "pizzatube",
+    });
+    expect(c.kind).toBe("YOUTUBE_CHANNEL");
+    expect(c.subtext).toBe("pizzatube");
+  });
+
+  it("GOOGLE_BUSINESS — uses address for the subtext", () => {
+    const c = normalizeChannel("GOOGLE_BUSINESS", {
+      id: "gbp-loc-42",
+      name: "Pizza Inc — Surry Hills",
+      address: "12 Crown St, Surry Hills NSW 2010",
+    });
+    expect(c.kind).toBe("GBP_LOCATION");
+    expect(c.subtext).toBe("12 Crown St, Surry Hills NSW 2010");
+  });
+
+  it("falls back to username, then id, when name is missing", () => {
+    expect(
+      normalizeChannel("LINKEDIN", { id: "urn:li:42", username: "fallback" }).name,
+    ).toBe("fallback");
+    expect(normalizeChannel("FACEBOOK", { id: "id-only" }).name).toBe(
+      "id-only",
+    );
+  });
+});
+
+describe("refreshChannels / getChannels — response shaping", () => {
+  it("returns the normalised Channel[] from the SDK response", async () => {
+    refreshChannelsMock.mockResolvedValueOnce({
+      channels: [
+        { id: "urn:1", name: "Org One", username: "one" },
+        { id: "urn:2", name: "Org Two", username: "two" },
+      ],
+    });
+    const r = await refreshChannels({ teamId: TEAM_ID, platform: "LINKEDIN" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.data.channels).toHaveLength(2);
+      expect(r.data.channels[0]).toMatchObject({
+        id: "urn:1",
+        name: "Org One",
+        subtext: "one",
+        kind: "LINKEDIN_ORG",
+      });
+    }
+  });
+
+  it("returns [] when the SDK returns null channels", async () => {
+    refreshChannelsMock.mockResolvedValueOnce({ channels: null });
+    const r = await refreshChannels({ teamId: TEAM_ID, platform: "LINKEDIN" });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data.channels).toEqual([]);
+  });
+
+  it("getChannels uses socialAccountGetByType (cached read, no refresh)", async () => {
+    getByTypeMock.mockResolvedValueOnce({
+      channels: [{ id: "urn:cached", name: "Cached" }],
+    });
+    const r = await getChannels({ teamId: TEAM_ID, platform: "FACEBOOK" });
+    expect(getByTypeMock).toHaveBeenCalledWith({
+      teamId: TEAM_ID,
+      type: "FACEBOOK",
+    });
+    expect(refreshChannelsMock).not.toHaveBeenCalled();
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data.channels[0]?.id).toBe("urn:cached");
+  });
+});
+
+describe("SDK error mapping — UPSTREAM_REJECTED for 4xx", () => {
+  it("setChannel surfaces UPSTREAM_REJECTED on 400", async () => {
+    setChannelMock.mockRejectedValueOnce({
+      name: "ApiError",
+      status: 400,
+      body: { message: "channel not found" },
+    });
+    const r = await setChannel({
+      teamId: TEAM_ID,
+      platform: "LINKEDIN",
+      channelId: "missing",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.code).toBe("UPSTREAM_REJECTED");
+      expect(r.error.message).toBe("channel not found");
+    }
+  });
+
+  it("setChannel surfaces INTERNAL_ERROR on 500", async () => {
+    setChannelMock.mockRejectedValueOnce({
+      name: "ApiError",
+      status: 503,
+      body: { message: "downstream out" },
+    });
+    const r = await setChannel({
+      teamId: TEAM_ID,
+      platform: "LINKEDIN",
+      channelId: "ok",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe("INTERNAL_ERROR");
+  });
+});

--- a/lib/__tests__/social-channels.contract.test.ts
+++ b/lib/__tests__/social-channels.contract.test.ts
@@ -112,7 +112,6 @@ describe("setChannel / unsetChannel — platform support", () => {
   it("setChannel refuses TWITTER (not a channel-selection platform)", async () => {
     const r = await setChannel({
       teamId: TEAM_ID,
-      // @ts-expect-error — intentionally widening to test the runtime guard
       platform: "TWITTER",
       channelId: "x",
     });
@@ -124,7 +123,6 @@ describe("setChannel / unsetChannel — platform support", () => {
   it("unsetChannel refuses DISCORD (not a channel-selection platform)", async () => {
     const r = await unsetChannel({
       teamId: TEAM_ID,
-      // @ts-expect-error — intentionally widening to test the runtime guard
       platform: "DISCORD",
     });
     expect(r.ok).toBe(false);

--- a/lib/__tests__/social-connections-bundlesocial.test.ts
+++ b/lib/__tests__/social-connections-bundlesocial.test.ts
@@ -129,7 +129,10 @@ describe("syncBundlesocialConnections", () => {
     expect(rows.data?.length).toBe(2);
     expect(rows.data?.[0]?.platform).toBe("linkedin_personal");
     expect(rows.data?.[0]?.display_name).toBe("Acme LI");
-    expect(rows.data?.[0]?.status).toBe("healthy");
+    // Post-877: LINKEDIN requires channel selection before becoming healthy;
+    // a brand-new INSERT lands as pending_identity until the user picks a
+    // channel or opts into personal mode via /connect-as-personal.
+    expect(rows.data?.[0]?.status).toBe("pending_identity");
     expect(rows.data?.[1]?.platform).toBe("x");
     expect(rows.data?.[1]?.display_name).toBe("acme");
   });
@@ -146,6 +149,9 @@ describe("syncBundlesocialConnections", () => {
         display_name: "Old Name",
         status: "auth_required",
         last_error: "old token expired",
+        // Simulate a personal-mode account whose auth expired; is_personal_mode
+        // lets sync restore healthy without requiring a channel pick.
+        is_personal_mode: true,
       })
       .select("id")
       .single();

--- a/lib/__tests__/social-identity-fingerprint.contract.test.ts
+++ b/lib/__tests__/social-identity-fingerprint.contract.test.ts
@@ -111,5 +111,46 @@ describe("resolveIdentityFingerprint — response mapping", () => {
     expect(result.external_account_id).toBeNull();
     expect(result.external_user_id).toBeNull();
     expect(result.external_identity_hash).toBeNull();
+    expect(result.displayName).toBeNull();
+  });
+
+  it("displayName uses userDisplayName from the SDK response", async () => {
+    socialAccountGetByTypeMock.mockResolvedValueOnce({
+      externalId: "ext-1",
+      userId: "user-1",
+      userDisplayName: "Steven Morey",
+      userUsername: "stevenm",
+    });
+    const result = await resolveIdentityFingerprint({
+      platform: "LINKEDIN",
+      teamId: TEAM_ID,
+    });
+    expect(result.displayName).toBe("Steven Morey");
+  });
+
+  it("displayName falls back to userUsername when userDisplayName is null", async () => {
+    socialAccountGetByTypeMock.mockResolvedValueOnce({
+      externalId: "ext-1",
+      userId: "user-1",
+      userDisplayName: null,
+      userUsername: "stevenm",
+    });
+    const result = await resolveIdentityFingerprint({
+      platform: "LINKEDIN",
+      teamId: TEAM_ID,
+    });
+    expect(result.displayName).toBe("stevenm");
+  });
+
+  it("displayName is null when both userDisplayName and userUsername are absent", async () => {
+    socialAccountGetByTypeMock.mockResolvedValueOnce({
+      externalId: "ext-1",
+      userId: "user-1",
+    });
+    const result = await resolveIdentityFingerprint({
+      platform: "LINKEDIN",
+      teamId: TEAM_ID,
+    });
+    expect(result.displayName).toBeNull();
   });
 });

--- a/lib/platform/social/connections/channels.ts
+++ b/lib/platform/social/connections/channels.ts
@@ -1,0 +1,451 @@
+import "server-only";
+
+import { getBundlesocialClient } from "@/lib/bundlesocial";
+import { logger } from "@/lib/logger";
+
+import {
+  CHANNEL_SELECTION_PLATFORMS,
+  requiresChannelSelection,
+  type BundlesocialPlatformType,
+} from "./identity";
+
+// ---------------------------------------------------------------------------
+// Channel-selection flow — SDK wrappers around bundle.social's
+// set-channel / unset-channel / refresh-channels endpoints.
+//
+// Context: bundle.social's docs at
+// https://info.bundle.social/api-reference/connect-social-accounts
+// describe a two-step flow for LINKEDIN / FACEBOOK / INSTAGRAM /
+// YOUTUBE / GOOGLE_BUSINESS:
+//   1. OAuth via socialAccountConnect creates a socialAccount with
+//      channels:[].
+//   2. The user picks a specific channel (org page, FB page, IG page,
+//      YT channel, GBP location). The app calls
+//      socialAccountSetChannel to bind it.
+//
+// Until step 2 lands, the account exists but cannot publish. Customers
+// see a generic "OAuth error" on the bundle.social dashboard.
+//
+// The wrappers below are platform-agnostic by design. They normalise
+// the SDK's loose Channel shape into a `Channel` we render directly
+// in the picker UI; the per-platform subtext is computed here, not in
+// the React layer (so /channels GET is what the modal renders, no
+// platform branching client-side).
+//
+// SDK types pinned from node_modules/bundlesocial/dist/index.d.ts:
+//   socialAccountRefreshChannels — type 'DISCORD' | 'SLACK' | 'REDDIT'
+//     | 'PINTEREST' | 'FACEBOOK' | 'INSTAGRAM' | 'LINKEDIN' | 'YOUTUBE'
+//     | 'GOOGLE_BUSINESS' (9 platforms — superset of channel-selection
+//     because Discord/Slack/Reddit/Pinterest fan-out to channels too,
+//     but those use a different UX).
+//   socialAccountSetChannel    — 5 platforms (the channel-selection set)
+//   socialAccountUnsetChannel  — 5 platforms (the channel-selection set)
+//
+// No separate `getChannels` method exists. Cached channels[] is read
+// via socialAccountGetByType (already wrapped in identity.ts's
+// resolveIdentityFingerprint).
+// ---------------------------------------------------------------------------
+
+// Platforms refreshChannels accepts. Wider than CHANNEL_SELECTION_PLATFORMS
+// — see SDK docs.
+const REFRESH_CHANNELS_PLATFORMS: ReadonlySet<BundlesocialPlatformType> =
+  new Set([
+    "LINKEDIN",
+    "FACEBOOK",
+    "INSTAGRAM",
+    "YOUTUBE",
+    "GOOGLE_BUSINESS",
+    "DISCORD",
+    "SLACK",
+    "REDDIT",
+    "PINTEREST",
+  ]);
+
+export type Channel = {
+  id: string;
+  name: string;
+  // Sub-line under the channel name in the picker. Per platform:
+  //   LINKEDIN_ORG       → username (org urn slug)
+  //   FACEBOOK_PAGE      → username (page handle)
+  //   INSTAGRAM_ACCOUNT  → @username
+  //   YOUTUBE_CHANNEL    → username / handle
+  //   GBP_LOCATION       → physical address
+  // Bundle.social's SDK doesn't return follower / subscriber counts on
+  // this endpoint, so the subtext is identifying info only — not metrics.
+  subtext: string | null;
+  avatarUrl: string | null;
+  // Tag indicating the rendered channel shape. Useful for tests and
+  // for any picker logic that wants to render platform-specific icons.
+  kind:
+    | "LINKEDIN_ORG"
+    | "FACEBOOK_PAGE"
+    | "INSTAGRAM_ACCOUNT"
+    | "YOUTUBE_CHANNEL"
+    | "GBP_LOCATION"
+    | "OTHER";
+};
+
+export type ChannelOpsError =
+  | { code: "VALIDATION_FAILED"; message: string }
+  | { code: "RECEIVER_NOT_CONFIGURED"; message: string }
+  | { code: "PLATFORM_NOT_SUPPORTED"; message: string }
+  | { code: "UPSTREAM_REJECTED"; message: string; upstreamStatus: number }
+  | { code: "INTERNAL_ERROR"; message: string };
+
+export type ChannelOpsResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: ChannelOpsError };
+
+// Narrow check for the bundlesocial SDK's ApiError shape. Mirrors the
+// helper in lib/platform/social/profiles/connect.ts — we duck-type
+// rather than import the class symbol.
+function isBundleSocialApiError(err: unknown): err is {
+  name: string;
+  status: number;
+  statusText?: string;
+  body?: unknown;
+  url?: string;
+} {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { name?: string }).name === "ApiError" &&
+    typeof (err as { status?: unknown }).status === "number"
+  );
+}
+
+function extractUpstreamMessage(body: unknown, statusText?: string): string {
+  if (body && typeof body === "object") {
+    const o = body as Record<string, unknown>;
+    if (typeof o.message === "string" && o.message.length > 0) return o.message;
+    if (o.error && typeof o.error === "object") {
+      const e = o.error as Record<string, unknown>;
+      if (typeof e.message === "string" && e.message.length > 0) return e.message;
+    }
+  }
+  if (typeof body === "string" && body.length > 0) return body;
+  return statusText && statusText.length > 0
+    ? statusText
+    : "bundle.social rejected the request.";
+}
+
+type RawChannel = {
+  id: string;
+  name?: string | null;
+  username?: string | null;
+  address?: string | null;
+  avatarUrl?: string | null;
+};
+
+export function normalizeChannel(
+  platform: BundlesocialPlatformType,
+  raw: RawChannel,
+): Channel {
+  const kind: Channel["kind"] = (
+    {
+      LINKEDIN: "LINKEDIN_ORG",
+      FACEBOOK: "FACEBOOK_PAGE",
+      INSTAGRAM: "INSTAGRAM_ACCOUNT",
+      YOUTUBE: "YOUTUBE_CHANNEL",
+      GOOGLE_BUSINESS: "GBP_LOCATION",
+    } as const
+  )[platform as "LINKEDIN" | "FACEBOOK" | "INSTAGRAM" | "YOUTUBE" | "GOOGLE_BUSINESS"] ??
+    "OTHER";
+
+  // Per-platform subtext picks the most-identifying field. Most
+  // platforms surface a username; GBP uses physical address.
+  const subtext =
+    platform === "GOOGLE_BUSINESS"
+      ? raw.address ?? null
+      : platform === "INSTAGRAM" && raw.username
+        ? `@${raw.username.replace(/^@/, "")}`
+        : raw.username ?? null;
+
+  return {
+    id: raw.id,
+    name: raw.name ?? raw.username ?? raw.id,
+    subtext,
+    avatarUrl: raw.avatarUrl ?? null,
+    kind,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// refreshChannels — re-fetches the channel list from the platform side.
+// Use after OAuth completes (the freshly-connected account hasn't seen
+// its channels listed yet) and when the user clicks "refresh channels".
+// ---------------------------------------------------------------------------
+
+export async function refreshChannels(args: {
+  teamId: string;
+  platform: BundlesocialPlatformType;
+}): Promise<ChannelOpsResult<{ channels: Channel[] }>> {
+  if (!args.teamId) {
+    return {
+      ok: false,
+      error: { code: "VALIDATION_FAILED", message: "teamId is required." },
+    };
+  }
+  if (!REFRESH_CHANNELS_PLATFORMS.has(args.platform)) {
+    return {
+      ok: false,
+      error: {
+        code: "PLATFORM_NOT_SUPPORTED",
+        message: `refreshChannels does not support platform '${args.platform}'.`,
+      },
+    };
+  }
+
+  const client = getBundlesocialClient();
+  if (!client) {
+    return {
+      ok: false,
+      error: {
+        code: "RECEIVER_NOT_CONFIGURED",
+        message: "BUNDLE_SOCIAL_API is not configured.",
+      },
+    };
+  }
+
+  try {
+    // SDK narrows the type union to refresh-supported platforms; we've
+    // already gated on REFRESH_CHANNELS_PLATFORMS above so the cast is
+    // safe (TS can't infer the narrowing through Set.has).
+    const resp = (await client.socialAccount.socialAccountRefreshChannels({
+      requestBody: {
+        type: args.platform as
+          | "DISCORD"
+          | "SLACK"
+          | "REDDIT"
+          | "PINTEREST"
+          | "FACEBOOK"
+          | "INSTAGRAM"
+          | "LINKEDIN"
+          | "YOUTUBE"
+          | "GOOGLE_BUSINESS",
+        teamId: args.teamId,
+      },
+    })) as { channels?: RawChannel[] | null };
+    const channels = (resp.channels ?? []).map((c) =>
+      normalizeChannel(args.platform, c),
+    );
+    return { ok: true, data: { channels } };
+  } catch (err) {
+    return mapSdkError(err, "refresh_channels", args);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getChannels — reads cached channels without re-fetching from the
+// platform side. Cheaper than refreshChannels (no upstream LinkedIn /
+// FB call). Use to populate the picker quickly on initial load; the
+// modal can offer a "Refresh" affordance backed by refreshChannels.
+// ---------------------------------------------------------------------------
+
+export async function getChannels(args: {
+  teamId: string;
+  platform: BundlesocialPlatformType;
+}): Promise<ChannelOpsResult<{ channels: Channel[] }>> {
+  if (!args.teamId) {
+    return {
+      ok: false,
+      error: { code: "VALIDATION_FAILED", message: "teamId is required." },
+    };
+  }
+
+  const client = getBundlesocialClient();
+  if (!client) {
+    return {
+      ok: false,
+      error: {
+        code: "RECEIVER_NOT_CONFIGURED",
+        message: "BUNDLE_SOCIAL_API is not configured.",
+      },
+    };
+  }
+
+  try {
+    const resp = (await client.socialAccount.socialAccountGetByType({
+      teamId: args.teamId,
+      type: args.platform,
+    })) as { channels?: RawChannel[] | null };
+    const channels = (resp.channels ?? []).map((c) =>
+      normalizeChannel(args.platform, c),
+    );
+    return { ok: true, data: { channels } };
+  } catch (err) {
+    return mapSdkError(err, "get_channels", args);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// setChannel — commits the user's pick. After success, callers should
+// re-resolve identity (setChannel changes externalId for LinkedIn / GBP
+// / YT) and flip the social_connections row from pending_identity →
+// healthy. The route handler does that — this module is a thin wrapper.
+// ---------------------------------------------------------------------------
+
+export async function setChannel(args: {
+  teamId: string;
+  platform: BundlesocialPlatformType;
+  channelId: string;
+}): Promise<ChannelOpsResult<{ externalId: string | null; userId: string | null }>> {
+  if (!args.teamId || !args.channelId) {
+    return {
+      ok: false,
+      error: {
+        code: "VALIDATION_FAILED",
+        message: "teamId and channelId are required.",
+      },
+    };
+  }
+  if (!requiresChannelSelection(args.platform)) {
+    return {
+      ok: false,
+      error: {
+        code: "PLATFORM_NOT_SUPPORTED",
+        message: `setChannel does not support platform '${args.platform}'.`,
+      },
+    };
+  }
+
+  const client = getBundlesocialClient();
+  if (!client) {
+    return {
+      ok: false,
+      error: {
+        code: "RECEIVER_NOT_CONFIGURED",
+        message: "BUNDLE_SOCIAL_API is not configured.",
+      },
+    };
+  }
+
+  try {
+    const resp = (await client.socialAccount.socialAccountSetChannel({
+      requestBody: {
+        type: args.platform as
+          | "FACEBOOK"
+          | "INSTAGRAM"
+          | "LINKEDIN"
+          | "YOUTUBE"
+          | "GOOGLE_BUSINESS",
+        teamId: args.teamId,
+        channelId: args.channelId,
+      },
+    })) as { externalId?: string | null; userId?: string | null };
+    return {
+      ok: true,
+      data: {
+        externalId: resp.externalId ?? null,
+        userId: resp.userId ?? null,
+      },
+    };
+  } catch (err) {
+    return mapSdkError(err, "set_channel", args);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// unsetChannel — clears the binding without disconnecting. Per the
+// bundle.social docs: drafts that referenced the old channel become
+// genuine drafts (recoverable), rather than ghost-pointing at a dead
+// connection. Use this:
+//   * Before a full disconnect (Layer 6 ordering).
+//   * To let the user re-pick without re-running OAuth.
+// ---------------------------------------------------------------------------
+
+export async function unsetChannel(args: {
+  teamId: string;
+  platform: BundlesocialPlatformType;
+}): Promise<ChannelOpsResult<{ unset: true }>> {
+  if (!args.teamId) {
+    return {
+      ok: false,
+      error: { code: "VALIDATION_FAILED", message: "teamId is required." },
+    };
+  }
+  if (!requiresChannelSelection(args.platform)) {
+    return {
+      ok: false,
+      error: {
+        code: "PLATFORM_NOT_SUPPORTED",
+        message: `unsetChannel does not support platform '${args.platform}'.`,
+      },
+    };
+  }
+
+  const client = getBundlesocialClient();
+  if (!client) {
+    return {
+      ok: false,
+      error: {
+        code: "RECEIVER_NOT_CONFIGURED",
+        message: "BUNDLE_SOCIAL_API is not configured.",
+      },
+    };
+  }
+
+  try {
+    await client.socialAccount.socialAccountUnsetChannel({
+      requestBody: {
+        type: args.platform as
+          | "FACEBOOK"
+          | "INSTAGRAM"
+          | "LINKEDIN"
+          | "YOUTUBE"
+          | "GOOGLE_BUSINESS",
+        teamId: args.teamId,
+      },
+    });
+    return { ok: true, data: { unset: true } };
+  } catch (err) {
+    return mapSdkError(err, "unset_channel", args);
+  }
+}
+
+function mapSdkError<T>(
+  err: unknown,
+  op: string,
+  args: { teamId: string; platform: BundlesocialPlatformType },
+): ChannelOpsResult<T> {
+  if (isBundleSocialApiError(err)) {
+    const upstreamMessage = extractUpstreamMessage(err.body, err.statusText);
+    logger.error("social.channels.sdk_failed", {
+      op,
+      team_id: args.teamId,
+      platform: args.platform,
+      upstream_status: err.status,
+      upstream_status_text: err.statusText ?? null,
+      upstream_body: err.body ?? null,
+      upstream_url: err.url ?? null,
+      err: upstreamMessage,
+    });
+    if (err.status >= 400 && err.status < 500) {
+      return {
+        ok: false,
+        error: {
+          code: "UPSTREAM_REJECTED",
+          message: upstreamMessage,
+          upstreamStatus: err.status,
+        },
+      };
+    }
+    return {
+      ok: false,
+      error: { code: "INTERNAL_ERROR", message: upstreamMessage },
+    };
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  logger.error("social.channels.sdk_failed", {
+    op,
+    team_id: args.teamId,
+    platform: args.platform,
+    err: msg,
+  });
+  return {
+    ok: false,
+    error: { code: "INTERNAL_ERROR", message: msg },
+  };
+}
+
+export { CHANNEL_SELECTION_PLATFORMS, requiresChannelSelection };

--- a/lib/platform/social/connections/identity.ts
+++ b/lib/platform/social/connections/identity.ts
@@ -89,10 +89,15 @@ export type BundlesocialPlatformType =
 // FACEBOOK, INSTAGRAM, YOUTUBE, GOOGLE_BUSINESS) require a non-empty
 // channels[] OR an explicit personal-mode opt-in before publishing is
 // allowed — see lib/platform/social/connections/channels.ts.
+//
+// `displayName` is resolved from socialAccountGetByType's userDisplayName
+// (or userUsername as fallback) — more reliable than teamGetTeam's
+// displayName which is often null for freshly-connected accounts.
 export type IdentityFingerprint = {
   external_account_id: string | null;
   external_user_id: string | null;
   external_identity_hash: string | null;
+  displayName: string | null;
   channels: Array<{
     id: string;
     name: string | null;
@@ -155,6 +160,7 @@ export async function resolveIdentityFingerprint(input: {
       external_account_id: null,
       external_user_id: null,
       external_identity_hash: null,
+      displayName: null,
       channels: [],
       raw: {},
     };
@@ -186,6 +192,7 @@ export async function resolveIdentityFingerprint(input: {
         accountId,
         userId,
       ),
+      displayName: resp.userDisplayName ?? resp.userUsername ?? null,
       channels: (resp.channels ?? []).map((c) => ({
         id: c.id,
         name: c.name ?? null,
@@ -205,6 +212,7 @@ export async function resolveIdentityFingerprint(input: {
       external_account_id: null,
       external_user_id: null,
       external_identity_hash: null,
+      displayName: null,
       channels: [],
       raw: {},
     };

--- a/lib/platform/social/connections/identity.ts
+++ b/lib/platform/social/connections/identity.ts
@@ -80,15 +80,52 @@ export type BundlesocialPlatformType =
   | "GOOGLE_BUSINESS";
 
 // Identity fingerprint resolved from bundle.social for a (team, type)
-// pair. external_identity_hash is null when EITHER identity field is
+// pair. external_identity_hash is null when BOTH identity fields are
 // null — the connection is in "pending_identity" state until the user
 // completes channel selection on the platform side.
+//
+// `channels` is the raw channels[] array bundle.social currently has
+// cached for this (team, type). Channel-selection platforms (LINKEDIN,
+// FACEBOOK, INSTAGRAM, YOUTUBE, GOOGLE_BUSINESS) require a non-empty
+// channels[] OR an explicit personal-mode opt-in before publishing is
+// allowed — see lib/platform/social/connections/channels.ts.
 export type IdentityFingerprint = {
   external_account_id: string | null;
   external_user_id: string | null;
   external_identity_hash: string | null;
+  channels: Array<{
+    id: string;
+    name: string | null;
+    username: string | null;
+    address: string | null;
+    avatarUrl: string | null;
+  }>;
   raw: Record<string, unknown>;
 };
+
+// Platforms whose OAuth grants are necessary-but-not-sufficient — the
+// user must additionally pick a channel (org page / FB page / IG page /
+// YT channel / GBP location) before publishing can succeed. See
+// https://info.bundle.social/api-reference/connect-social-accounts.
+//
+// Bundle.social's SDK exposes set-channel / unset-channel for exactly
+// these five platforms; refresh-channels covers a wider superset
+// (DISCORD/SLACK/REDDIT/PINTEREST also) but those are post-OAuth
+// fan-out subscriptions, not the same blocking-channel-pick UX.
+export const CHANNEL_SELECTION_PLATFORMS: ReadonlySet<BundlesocialPlatformType> =
+  new Set([
+    "LINKEDIN",
+    "FACEBOOK",
+    "INSTAGRAM",
+    "YOUTUBE",
+    "GOOGLE_BUSINESS",
+  ]);
+
+export function requiresChannelSelection(
+  platform: BundlesocialPlatformType | string,
+): boolean {
+  return CHANNEL_SELECTION_PLATFORMS.has(platform as BundlesocialPlatformType);
+}
 
 // Deterministic identity hash. Returns null when both ids are null
 // (no platform identity to fingerprint yet). When only one is null,
@@ -118,6 +155,7 @@ export async function resolveIdentityFingerprint(input: {
       external_account_id: null,
       external_user_id: null,
       external_identity_hash: null,
+      channels: [],
       raw: {},
     };
   }
@@ -130,6 +168,13 @@ export async function resolveIdentityFingerprint(input: {
       userId?: string | null;
       userUsername?: string | null;
       userDisplayName?: string | null;
+      channels?: Array<{
+        id: string;
+        name?: string | null;
+        username?: string | null;
+        address?: string | null;
+        avatarUrl?: string | null;
+      }> | null;
     };
     const accountId = resp.externalId ?? null;
     const userId = resp.userId ?? null;
@@ -141,6 +186,13 @@ export async function resolveIdentityFingerprint(input: {
         accountId,
         userId,
       ),
+      channels: (resp.channels ?? []).map((c) => ({
+        id: c.id,
+        name: c.name ?? null,
+        username: c.username ?? null,
+        address: c.address ?? null,
+        avatarUrl: c.avatarUrl ?? null,
+      })),
       raw: resp as Record<string, unknown>,
     };
   } catch (err) {
@@ -153,6 +205,7 @@ export async function resolveIdentityFingerprint(input: {
       external_account_id: null,
       external_user_id: null,
       external_identity_hash: null,
+      channels: [],
       raw: {},
     };
   }

--- a/lib/platform/social/connections/list.ts
+++ b/lib/platform/social/connections/list.ts
@@ -26,7 +26,7 @@ export async function listConnections(
   let query = svc
     .from("social_connections")
     .select(
-      "id, company_id, profile_id, platform, bundle_social_account_id, display_name, avatar_url, status, last_error, connected_at, disconnected_at, last_health_check_at, external_account_id, external_user_id, external_identity_hash, created_at, updated_at",
+      "id, company_id, profile_id, platform, bundle_social_account_id, display_name, avatar_url, status, last_error, connected_at, disconnected_at, last_health_check_at, external_account_id, external_user_id, external_identity_hash, is_personal_mode, has_emitted_overdue_event, created_at, updated_at",
     )
     .eq("company_id", input.companyId);
   // BSP-8: optional per-profile filter for the customer-facing UI.

--- a/lib/platform/social/connections/overdue-events.ts
+++ b/lib/platform/social/connections/overdue-events.ts
@@ -1,0 +1,77 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import type { SocialConnection } from "./types";
+
+// ---------------------------------------------------------------------------
+// connection_channel_overdue audit event emitter.
+//
+// Channel-selection flow (incident 2026-05-12): when a connection sits
+// in 'pending_identity' for more than 24 hours, the customer-facing
+// page renders a yellow callout asking the user to pick a channel.
+// First render per connection emits a `connection_channel_overdue`
+// platform_events row so operators can spot stuck connections.
+//
+// Idempotency is row-level via the `has_emitted_overdue_event` boolean
+// column (migration 0123). This helper walks a list of connections,
+// emits for ones that qualify, and flips the flag in the same write.
+// Callers receive the patched list back so the rendered UI matches DB
+// state without a re-fetch.
+// ---------------------------------------------------------------------------
+
+const OVERDUE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+export function isChannelOverdue(conn: SocialConnection): boolean {
+  if (conn.status !== "pending_identity") return false;
+  // The clock starts when the row was inserted (connected_at). Pending
+  // rows older than 24h are considered overdue.
+  const age = Date.now() - new Date(conn.connected_at).getTime();
+  return age > OVERDUE_THRESHOLD_MS;
+}
+
+export async function emitOverdueEventsIfNeeded(
+  connections: SocialConnection[],
+): Promise<SocialConnection[]> {
+  const targets = connections.filter(
+    (c) => isChannelOverdue(c) && !c.has_emitted_overdue_event,
+  );
+  if (targets.length === 0) return connections;
+
+  const svc = getServiceRoleClient();
+  // Best-effort per-row; failures don't surface to the user — the
+  // banner still renders, the next page load retries.
+  for (const c of targets) {
+    try {
+      await svc.from("platform_events").insert({
+        event_type: "connection_channel_overdue",
+        company_id: c.company_id,
+        actor_id: null,
+        entity_type: "social_connection",
+        entity_id: c.id,
+        payload: {
+          platform: c.platform,
+          bundle_social_account_id: c.bundle_social_account_id,
+          connected_at: c.connected_at,
+          overdue_for_ms: Date.now() - new Date(c.connected_at).getTime(),
+        },
+      });
+      await svc
+        .from("social_connections")
+        .update({ has_emitted_overdue_event: true })
+        .eq("id", c.id);
+    } catch (err) {
+      logger.warn("social.connections.overdue_emit_failed", {
+        connection_id: c.id,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // Return a patched copy so callers don't render the flag as stale.
+  const updatedIds = new Set(targets.map((t) => t.id));
+  return connections.map((c) =>
+    updatedIds.has(c.id) ? { ...c, has_emitted_overdue_event: true } : c,
+  );
+}

--- a/lib/platform/social/connections/route-helpers.ts
+++ b/lib/platform/social/connections/route-helpers.ts
@@ -1,0 +1,131 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import type { BundlesocialPlatformType } from "./identity";
+import type { SocialPlatform } from "./types";
+
+// ---------------------------------------------------------------------------
+// Shared loaders for the channel-selection API routes.
+//
+// Every per-connection route (channels GET, set-channel POST,
+// unset-channel POST, connect-as-personal POST, disconnect POST) needs
+// the same prep: load the row, resolve the bundle.social team_id from
+// the row's profile_id, and map our SocialPlatform back to a
+// BundlesocialPlatformType the SDK wrappers expect.
+// ---------------------------------------------------------------------------
+
+// Inverse of BUNDLE_TO_PLATFORM in sync.ts. Both linkedin_personal and
+// linkedin_company funnel back to bundle.social's single LINKEDIN type
+// — the personal-mode distinction lives in our DB only.
+const PLATFORM_TO_BUNDLE: Record<SocialPlatform, BundlesocialPlatformType> = {
+  linkedin_personal: "LINKEDIN",
+  linkedin_company: "LINKEDIN",
+  facebook_page: "FACEBOOK",
+  x: "TWITTER",
+  gbp: "GOOGLE_BUSINESS",
+};
+
+export function dbPlatformToBundleType(
+  platform: SocialPlatform,
+): BundlesocialPlatformType {
+  return PLATFORM_TO_BUNDLE[platform];
+}
+
+export type LoadedConnection = {
+  id: string;
+  company_id: string;
+  profile_id: string | null;
+  platform: SocialPlatform;
+  bundlePlatform: BundlesocialPlatformType;
+  bundle_social_account_id: string;
+  status: string;
+  is_personal_mode: boolean;
+  teamId: string;
+};
+
+export type LoadConnectionError =
+  | { code: "NOT_FOUND"; message: string }
+  | { code: "INVALID_STATE"; message: string };
+
+// Load a social_connections row by id, resolve its bundle.social team
+// via the profile_id → platform_social_profiles join, and map the
+// platform enum back to the bundle.social type for SDK calls. Returns
+// NOT_FOUND if the row or its team is missing.
+export async function loadConnectionWithTeam(
+  connectionId: string,
+): Promise<
+  { ok: true; data: LoadedConnection } | { ok: false; error: LoadConnectionError }
+> {
+  const svc = getServiceRoleClient();
+
+  const connRead = await svc
+    .from("social_connections")
+    .select(
+      "id, company_id, profile_id, platform, bundle_social_account_id, status, is_personal_mode",
+    )
+    .eq("id", connectionId)
+    .maybeSingle();
+
+  if (connRead.error || !connRead.data) {
+    return {
+      ok: false,
+      error: { code: "NOT_FOUND", message: "Connection not found." },
+    };
+  }
+
+  const row = connRead.data as {
+    id: string;
+    company_id: string;
+    profile_id: string | null;
+    platform: SocialPlatform;
+    bundle_social_account_id: string;
+    status: string;
+    is_personal_mode: boolean | null;
+  };
+
+  if (!row.profile_id) {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_STATE",
+        message:
+          "Connection has no profile_id — channel ops require a profile-scoped bundle.social team.",
+      },
+    };
+  }
+
+  const profileRead = await svc
+    .from("platform_social_profiles")
+    .select("bundle_social_team_id")
+    .eq("id", row.profile_id)
+    .maybeSingle();
+
+  const teamId = (
+    profileRead.data as { bundle_social_team_id?: string | null } | null
+  )?.bundle_social_team_id;
+  if (!teamId) {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_STATE",
+        message: "Profile has no provisioned bundle.social team.",
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      id: row.id,
+      company_id: row.company_id,
+      profile_id: row.profile_id,
+      platform: row.platform,
+      bundlePlatform: dbPlatformToBundleType(row.platform),
+      bundle_social_account_id: row.bundle_social_account_id,
+      status: row.status,
+      is_personal_mode: Boolean(row.is_personal_mode),
+      teamId,
+    },
+  };
+}

--- a/lib/platform/social/connections/sync.ts
+++ b/lib/platform/social/connections/sync.ts
@@ -11,6 +11,7 @@ import {
   computeIdentityHash,
   emitCrossTenantBlocked,
   emitCrossTenantOverride,
+  requiresChannelSelection,
   resolveIdentityFingerprint,
   type BundlesocialPlatformType,
 } from "./identity";
@@ -215,7 +216,7 @@ export async function syncBundlesocialConnections(
   const existing = await svc
     .from("social_connections")
     .select(
-      "id, company_id, platform, bundle_social_account_id, display_name, avatar_url, status, profile_id",
+      "id, company_id, platform, bundle_social_account_id, display_name, avatar_url, status, profile_id, is_personal_mode",
     )
     .eq("company_id", input.companyId);
   if (existing.error) {
@@ -235,6 +236,7 @@ export async function syncBundlesocialConnections(
       avatar_url: string | null;
       status: string;
       profile_id: string | null;
+      is_personal_mode: boolean;
     }
   >();
   for (const row of existing.data ?? []) {
@@ -246,6 +248,9 @@ export async function syncBundlesocialConnections(
       avatar_url: (row.avatar_url as string | null) ?? null,
       status: row.status as string,
       profile_id: (row.profile_id as string | null) ?? null,
+      is_personal_mode: Boolean(
+        (row as { is_personal_mode?: boolean }).is_personal_mode,
+      ),
     });
   }
 
@@ -292,10 +297,24 @@ export async function syncBundlesocialConnections(
         rawIdentity.external_user_id,
       ),
     };
-    const status: "healthy" | "pending_identity" =
-      identity.external_account_id || identity.external_user_id
-        ? "healthy"
-        : "pending_identity";
+    // Channel-selection flow (migration 0123): the channel-selection
+    // platforms (LINKEDIN/FACEBOOK/INSTAGRAM/YOUTUBE/GOOGLE_BUSINESS)
+    // need a channel bound before publishing can succeed. bundle.social
+    // returns populated externalId+userId even when channels[] is empty,
+    // so the identity-only check below would wrongly mark them
+    // 'healthy'. Refuse 'healthy' until the user has either picked a
+    // channel OR explicitly opted into personal-mode (LinkedIn).
+    const hasIdentity =
+      identity.external_account_id !== null ||
+      identity.external_user_id !== null;
+    const isChannelPlatform = requiresChannelSelection(remote.type);
+    const hasChannel = identity.channels.length > 0;
+    const isPersonal = existingById.get(bundleAccountId)?.is_personal_mode ?? false;
+    const status: "healthy" | "pending_identity" = !hasIdentity
+      ? "pending_identity"
+      : isChannelPlatform && !hasChannel && !isPersonal
+        ? "pending_identity"
+        : "healthy";
 
     const localRow = existingById.get(bundleAccountId);
     if (localRow) {

--- a/lib/platform/social/connections/sync.ts
+++ b/lib/platform/social/connections/sync.ts
@@ -270,7 +270,7 @@ export async function syncBundlesocialConnections(
       result.unmapped_skipped += 1;
       continue;
     }
-    const displayName = (remote.displayName ?? remote.username ?? null) as
+    const remoteDisplayName = (remote.displayName ?? remote.username ?? null) as
       | string
       | null;
     const avatarUrl = (remote.avatarUrl ?? null) as string | null;
@@ -279,7 +279,8 @@ export async function syncBundlesocialConnections(
     // platform-side identity for this account; the result feeds both
     // the conflict check (Layer 2) and the row's status flag (Layer 5).
     // socialAccountGetByType is the source-of-truth read — teamGetTeam
-    // sometimes omits externalId/userId for newly-connected accounts.
+    // sometimes omits externalId/userId and displayName for newly-
+    // connected accounts; prefer the identity fingerprint's displayName.
     const rawIdentity = await resolveIdentityFingerprint({
       platform: remote.type as BundlesocialPlatformType,
       teamId,
@@ -315,6 +316,11 @@ export async function syncBundlesocialConnections(
       : isChannelPlatform && !hasChannel && !isPersonal
         ? "pending_identity"
         : "healthy";
+
+    // Prefer the display name from socialAccountGetByType (identity) over
+    // teamGetTeam (remote) — the former populates userDisplayName even for
+    // freshly-connected accounts where teamGetTeam returns null.
+    const displayName = rawIdentity.displayName ?? remoteDisplayName;
 
     const localRow = existingById.get(bundleAccountId);
     if (localRow) {

--- a/lib/platform/social/connections/types.ts
+++ b/lib/platform/social/connections/types.ts
@@ -40,6 +40,12 @@ export type SocialConnection = {
   external_account_id: string | null;
   external_user_id: string | null;
   external_identity_hash: string | null;
+  // Channel-selection flow (migration 0123). is_personal_mode flips
+  // true when the user explicitly chose to connect their personal
+  // profile on LinkedIn (no org-page picker). has_emitted_overdue_event
+  // is the idempotency flag for the >24h pending_identity banner.
+  is_personal_mode: boolean;
+  has_emitted_overdue_event: boolean;
   created_at: string;
   updated_at: string;
 };

--- a/lib/platform/social/webhooks/process.ts
+++ b/lib/platform/social/webhooks/process.ts
@@ -351,7 +351,9 @@ async function handleAccountEvent(
 
   const conn = await svc
     .from("social_connections")
-    .select("id, company_id, status, platform, profile_id")
+    .select(
+      "id, company_id, status, platform, profile_id, is_personal_mode",
+    )
     .eq("bundle_social_account_id", accountId)
     .maybeSingle();
   if (conn.error) {
@@ -409,13 +411,16 @@ async function handleAccountEvent(
       const teamId = (profileTeam.data as { bundle_social_team_id?: string } | null)
         ?.bundle_social_team_id;
       if (teamId) {
-        const { resolveIdentityFingerprint, computeIdentityHash } = await import(
-          "@/lib/platform/social/connections/identity"
-        );
+        const {
+          resolveIdentityFingerprint,
+          computeIdentityHash,
+          requiresChannelSelection,
+        } = await import("@/lib/platform/social/connections/identity");
+        const bsType = (
+          envelope.data as { type?: string } | undefined
+        )?.type as Parameters<typeof resolveIdentityFingerprint>[0]["platform"];
         const rawIdentity = await resolveIdentityFingerprint({
-          platform: (
-            envelope.data as { type?: string } | undefined
-          )?.type as Parameters<typeof resolveIdentityFingerprint>[0]["platform"],
+          platform: bsType,
           teamId,
         });
         const platformDb = conn.data.platform as string;
@@ -427,14 +432,27 @@ async function handleAccountEvent(
             rawIdentity.external_user_id,
           ),
         };
+        // Channel-selection flow (migration 0123): mirror sync.ts. The
+        // row's is_personal_mode may already be true (user previously
+        // opted into LinkedIn personal-mode); preserve it if so.
+        const hasIdentity =
+          identity.external_account_id !== null ||
+          identity.external_user_id !== null;
+        const isChannelPlatform = requiresChannelSelection(bsType);
+        const hasChannel = identity.channels.length > 0;
+        const isPersonal = Boolean(
+          (conn.data as { is_personal_mode?: boolean }).is_personal_mode,
+        );
+        const status: "healthy" | "pending_identity" = !hasIdentity
+          ? "pending_identity"
+          : isChannelPlatform && !hasChannel && !isPersonal
+            ? "pending_identity"
+            : "healthy";
         identityUpdate = {
           external_account_id: identity.external_account_id,
           external_user_id: identity.external_user_id,
           external_identity_hash: identity.external_identity_hash,
-          status:
-            identity.external_account_id || identity.external_user_id
-              ? "healthy"
-              : "pending_identity",
+          status,
         };
       }
     }

--- a/lib/platform/social/webhooks/process.ts
+++ b/lib/platform/social/webhooks/process.ts
@@ -399,6 +399,7 @@ async function handleAccountEvent(
       external_account_id: string | null;
       external_user_id: string | null;
       external_identity_hash: string | null;
+      display_name: string | null;
       status: "healthy" | "pending_identity";
     } | null = null;
 
@@ -452,6 +453,7 @@ async function handleAccountEvent(
           external_account_id: identity.external_account_id,
           external_user_id: identity.external_user_id,
           external_identity_hash: identity.external_identity_hash,
+          display_name: identity.displayName,
           status,
         };
       }
@@ -475,6 +477,9 @@ async function handleAccountEvent(
               external_account_id: identityUpdate.external_account_id,
               external_user_id: identityUpdate.external_user_id,
               external_identity_hash: identityUpdate.external_identity_hash,
+              ...(identityUpdate.display_name !== null
+                ? { display_name: identityUpdate.display_name }
+                : {}),
             }
           : {}),
       })

--- a/supabase/migrations/0123_social_connections_channel_selection.sql
+++ b/supabase/migrations/0123_social_connections_channel_selection.sql
@@ -1,0 +1,57 @@
+-- LinkedIn channel-selection flow — incident
+-- docs/incidents/2026-05-12-linkedin-connect-flow-broken.md.
+--
+-- The reported gap: bundle.social's channel-selection platforms
+-- (LINKEDIN, FACEBOOK, INSTAGRAM, YOUTUBE, GOOGLE_BUSINESS) require a
+-- second SDK call after OAuth completes — POST set-channel — to bind
+-- the freshly-created socialAccount to a specific org / page / channel
+-- / location. Until that call lands, channels[] is empty on the
+-- bundle.social side and publishing fails. We never made that call;
+-- our DB wrongly marked these connections 'healthy' because the SDK's
+-- externalId+userId are populated even with empty channels[].
+--
+-- This migration adds the two flags the new flow needs and extends
+-- the platform_events CHECK to admit the new audit event types.
+--
+-- See also lib/platform/social/connections/channels.ts.
+
+ALTER TABLE social_connections
+  ADD COLUMN IF NOT EXISTS is_personal_mode BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS has_emitted_overdue_event BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN social_connections.is_personal_mode IS
+  'LinkedIn and future personal-profile platforms: user explicitly chose '
+  'to connect their personal profile rather than picking a company page. '
+  'Status is ''healthy'' but bundle.social channels[] is empty. Set by '
+  '/api/platform/social/connections/:id/connect-as-personal.';
+
+COMMENT ON COLUMN social_connections.has_emitted_overdue_event IS
+  'Idempotency flag for the connection_channel_overdue audit event. '
+  'Flips to true the first time the customer-facing connections page '
+  'renders the >24h overdue banner for this connection, so the event '
+  'is emitted exactly once.';
+
+-- Extend the platform_events event_type CHECK constraint to admit the
+-- two new audit event types the channel-selection flow emits.
+ALTER TABLE platform_events
+  DROP CONSTRAINT IF EXISTS platform_events_event_type_check;
+
+ALTER TABLE platform_events
+  ADD CONSTRAINT platform_events_event_type_check
+  CHECK (event_type IN (
+    'compose_opened', 'compose_closed',
+    'draft_saved', 'draft_save_failed', 'draft_recovered', 'draft_conflict',
+    'publish_started', 'publish_succeeded', 'publish_failed',
+    'ai_generated', 'ai_failed',
+    'reconnect_started', 'reconnect_completed',
+    'connection_broken', 'connection_expired', 'connection_pre_expiry',
+    'notification_emitted',
+    'approval_requested', 'approval_granted', 'approval_rejected',
+    -- Cross-tenant identity-leak defence (migration 0122).
+    'cross_tenant_blocked',
+    'cross_tenant_override',
+    'connection_reattributed',
+    -- Channel-selection flow (this migration).
+    'connection_channel_overdue',
+    'connection_disconnected'
+  ));

--- a/supabase/rollbacks/0123_social_connections_channel_selection.down.sql
+++ b/supabase/rollbacks/0123_social_connections_channel_selection.down.sql
@@ -1,0 +1,27 @@
+-- Rollback for 0123_social_connections_channel_selection.sql.
+--
+-- Removes the two boolean columns and reverts the platform_events
+-- event_type CHECK to its post-0122 shape.
+
+ALTER TABLE social_connections
+  DROP COLUMN IF EXISTS is_personal_mode,
+  DROP COLUMN IF EXISTS has_emitted_overdue_event;
+
+ALTER TABLE platform_events
+  DROP CONSTRAINT IF EXISTS platform_events_event_type_check;
+
+ALTER TABLE platform_events
+  ADD CONSTRAINT platform_events_event_type_check
+  CHECK (event_type IN (
+    'compose_opened', 'compose_closed',
+    'draft_saved', 'draft_save_failed', 'draft_recovered', 'draft_conflict',
+    'publish_started', 'publish_succeeded', 'publish_failed',
+    'ai_generated', 'ai_failed',
+    'reconnect_started', 'reconnect_completed',
+    'connection_broken', 'connection_expired', 'connection_pre_expiry',
+    'notification_emitted',
+    'approval_requested', 'approval_granted', 'approval_rejected',
+    'cross_tenant_blocked',
+    'cross_tenant_override',
+    'connection_reattributed'
+  ));

--- a/tests/regressions/callback-platform-prefixed-params.test.ts
+++ b/tests/regressions/callback-platform-prefixed-params.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
 
 // ---------------------------------------------------------------------------
 // REGRESSION — callback platform-prefixed param recognition.
@@ -37,6 +37,8 @@ vi.mock("@/lib/platform/social/connections", () => ({
     timestamp: new Date().toISOString(),
   }),
 }));
+
+import { syncBundlesocialConnections } from "@/lib/platform/social/connections";
 
 vi.mock("@/lib/platform/social/analytics-ingest", () => ({
   enqueuePostHistoryImport: vi.fn(),
@@ -185,5 +187,37 @@ describe("R-CALLBACK: success path is unaffected by absent error params", () => 
   it("no platform params + sync.inserted=0 → connect=noop", async () => {
     const out = await reasonFor({});
     expect(out.connect).toBe("noop");
+  });
+});
+
+describe("R-CALLBACK: noop+already-connected surfaces attempted_platform", () => {
+  it("linkedin-callback=true + sync.updated=1 → noop with attempted_platform=linkedin", async () => {
+    // Bug-fix 2026-05-12: when the user re-connects a platform they already
+    // have, the callback surfaces the platform so the UI can show an
+    // actionable "already connected" banner and highlight the blocking row.
+    vi.mocked(syncBundlesocialConnections as unknown as MockInstance).mockResolvedValueOnce({
+      ok: true,
+      data: {
+        inserted: 0,
+        updated: 1,
+        marked_disconnected: 0,
+        unmapped_skipped: 0,
+        cross_tenant_blocked: 0,
+      },
+      timestamp: new Date().toISOString(),
+    });
+    const out = await reasonFor({ "linkedin-callback": "true" });
+    expect(out.connect).toBe("noop");
+    const loc = new URL(out.location, "http://localhost");
+    expect(loc.searchParams.get("attempted_platform")).toBe("linkedin");
+  });
+
+  it("linkedin-callback=true + sync.updated=0 → plain noop (no attempted_platform)", async () => {
+    // When there was no update either, don't add the platform hint — the
+    // user may just have a delay on the bundle.social side.
+    const out = await reasonFor({ "linkedin-callback": "true" });
+    expect(out.connect).toBe("noop");
+    const loc = new URL(out.location, "http://localhost");
+    expect(loc.searchParams.get("attempted_platform")).toBeNull();
   });
 });

--- a/tests/regressions/callback-platform-prefixed-params.test.ts
+++ b/tests/regressions/callback-platform-prefixed-params.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// REGRESSION — callback platform-prefixed param recognition.
+//
+// Bug from docs/incidents/2026-05-12-linkedin-connect-flow-broken.md:
+// the callback used to find() against only four generic strings
+// (not-enough-permissions, not-enough-pages, auth-failed, user-cancelled).
+// bundle.social actually sends platform-prefixed params:
+//   <platform>-callback={true|error}
+//   <platform>-not-enough-channels|permissions|pages|accounts|servers|workspaces
+// All platform-prefixed params dropped through to the noop branch.
+//
+// This test pins: every platform-prefixed error param now maps to a
+// matching ?reason= redirect. New platforms only need adding to the
+// PLATFORM_KEYS list — error handling stays generic.
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: async () => ({
+    kind: "allow" as const,
+    userId: "user-test",
+    supabase: {} as never,
+  }),
+}));
+
+vi.mock("@/lib/platform/social/connections", () => ({
+  syncBundlesocialConnections: vi.fn().mockResolvedValue({
+    ok: true,
+    data: {
+      inserted: 0,
+      updated: 0,
+      marked_disconnected: 0,
+      unmapped_skipped: 0,
+      cross_tenant_blocked: 0,
+    },
+    timestamp: new Date().toISOString(),
+  }),
+}));
+
+vi.mock("@/lib/platform/social/analytics-ingest", () => ({
+  enqueuePostHistoryImport: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          gte: () => ({
+            order: () => ({
+              limit: async () => ({ data: [], error: null }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+import { GET } from "@/app/api/platform/social/connections/callback/route";
+
+const COMPANY = "11111111-1111-1111-1111-111111111111";
+
+function urlWith(params: Record<string, string>): string {
+  const url = new URL("http://localhost/api/platform/social/connections/callback");
+  url.searchParams.set("company_id", COMPANY);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return url.toString();
+}
+
+async function reasonFor(params: Record<string, string>): Promise<{
+  connect: string | null;
+  reason: string | null;
+  location: string;
+}> {
+  const res = await GET(new Request(urlWith(params)) as never);
+  const location = res.headers.get("location") ?? "";
+  const loc = new URL(location, "http://localhost");
+  return {
+    connect: loc.searchParams.get("connect"),
+    reason: loc.searchParams.get("reason"),
+    location,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("R-CALLBACK: platform-prefixed callback=error params surface as error", () => {
+  for (const platform of [
+    "linkedin",
+    "facebook",
+    "instagram",
+    "twitter",
+    "youtube",
+    "google_business",
+    "tiktok",
+    "pinterest",
+    "threads",
+    "reddit",
+    "bluesky",
+    "mastodon",
+    "discord",
+    "slack",
+  ]) {
+    it(`${platform}-callback=error → connect=error&reason=auth-failed`, async () => {
+      const out = await reasonFor({ [`${platform}-callback`]: "error" });
+      expect(out.connect).toBe("error");
+      expect(out.reason).toBe("auth-failed");
+    });
+  }
+});
+
+describe("R-CALLBACK: platform-prefixed error-suffix params surface their reason", () => {
+  it("linkedin-not-enough-channels → reason=not-enough-channels", async () => {
+    const out = await reasonFor({ "linkedin-not-enough-channels": "true" });
+    expect(out.connect).toBe("error");
+    expect(out.reason).toBe("not-enough-channels");
+  });
+
+  it("linkedin-not-enough-permissions → reason=not-enough-permissions", async () => {
+    const out = await reasonFor({ "linkedin-not-enough-permissions": "true" });
+    expect(out.connect).toBe("error");
+    expect(out.reason).toBe("not-enough-permissions");
+  });
+
+  it("facebook-not-enough-pages → reason=not-enough-pages", async () => {
+    const out = await reasonFor({ "facebook-not-enough-pages": "true" });
+    expect(out.connect).toBe("error");
+    expect(out.reason).toBe("not-enough-pages");
+  });
+
+  it("instagram-not-enough-accounts → reason=not-enough-accounts", async () => {
+    const out = await reasonFor({ "instagram-not-enough-accounts": "true" });
+    expect(out.connect).toBe("error");
+    expect(out.reason).toBe("not-enough-accounts");
+  });
+
+  it("discord-not-enough-servers → reason=not-enough-servers", async () => {
+    const out = await reasonFor({ "discord-not-enough-servers": "true" });
+    expect(out.connect).toBe("error");
+    expect(out.reason).toBe("not-enough-servers");
+  });
+
+  it("slack-not-enough-workspaces → reason=not-enough-workspaces", async () => {
+    const out = await reasonFor({ "slack-not-enough-workspaces": "true" });
+    expect(out.connect).toBe("error");
+    expect(out.reason).toBe("not-enough-workspaces");
+  });
+
+  it("youtube-not-enough-channels → reason=not-enough-channels", async () => {
+    const out = await reasonFor({ "youtube-not-enough-channels": "true" });
+    expect(out.connect).toBe("error");
+    expect(out.reason).toBe("not-enough-channels");
+  });
+});
+
+describe("R-CALLBACK: legacy generic keys still recognised", () => {
+  it("not-enough-permissions (no platform prefix) still maps", async () => {
+    const out = await reasonFor({ "not-enough-permissions": "true" });
+    expect(out.connect).toBe("error");
+    expect(out.reason).toBe("not-enough-permissions");
+  });
+
+  it("auth-failed (no platform prefix) still maps", async () => {
+    const out = await reasonFor({ "auth-failed": "true" });
+    expect(out.connect).toBe("error");
+    expect(out.reason).toBe("auth-failed");
+  });
+
+  it("user-cancelled (no platform prefix) still maps", async () => {
+    const out = await reasonFor({ "user-cancelled": "true" });
+    expect(out.connect).toBe("error");
+    expect(out.reason).toBe("user-cancelled");
+  });
+});
+
+describe("R-CALLBACK: success path is unaffected by absent error params", () => {
+  it("no platform params + sync.inserted=0 → connect=noop", async () => {
+    const out = await reasonFor({});
+    expect(out.connect).toBe("noop");
+  });
+});

--- a/tests/regressions/disconnect-ordering.test.ts
+++ b/tests/regressions/disconnect-ordering.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// REGRESSION — Layer 6 disconnect ordering.
+//
+// Channel-selection flow (incident 2026-05-12): when a connection
+// with a bound channel is disconnected, the order is:
+//   1. unsetChannel (so drafts release back to drafts)
+//   2. 200ms settle
+//   3. socialAccountDisconnect
+//   4. DELETE social_connections row
+//
+// Critical pin: DELETE happens regardless of upstream failures (the
+// customer pressed disconnect — the row must go away from their UI),
+// and unsetChannel runs BEFORE socialAccountDisconnect so bundle.social
+// has a chance to release drafts cleanly.
+// ---------------------------------------------------------------------------
+
+const callOrder: string[] = [];
+
+const unsetChannelSdkMock = vi.fn(async () => {
+  callOrder.push("unsetChannel");
+});
+const disconnectSdkMock = vi.fn(async () => {
+  callOrder.push("disconnect");
+});
+const deleteMock = vi.fn(async () => {
+  callOrder.push("delete");
+  return { error: null };
+});
+const insertEventMock = vi.fn(async () => ({ error: null }));
+
+vi.mock("@/lib/bundlesocial", () => ({
+  getBundlesocialClient: () => ({
+    socialAccount: {
+      socialAccountUnsetChannel: unsetChannelSdkMock,
+      socialAccountDisconnect: disconnectSdkMock,
+    },
+  }),
+}));
+
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: async () => ({
+    kind: "allow" as const,
+    userId: "user-test",
+    supabase: {} as never,
+  }),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({
+    from: (table: string) => {
+      if (table === "social_connections") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: connRow,
+                error: null,
+              }),
+            }),
+          }),
+          delete: () => ({
+            eq: deleteMock,
+          }),
+        };
+      }
+      if (table === "platform_social_profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: { bundle_social_team_id: "team-fixture" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "platform_events") {
+        return {
+          insert: insertEventMock,
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  }),
+}));
+
+import { POST } from "@/app/api/platform/social/connections/[id]/disconnect/route";
+
+const CONNECTION_ID = "abcdef00-0000-0000-0000-aaaaaaaa0001";
+
+let connRow: {
+  id: string;
+  company_id: string;
+  profile_id: string;
+  platform: string;
+  bundle_social_account_id: string;
+  status: string;
+  is_personal_mode: boolean;
+};
+
+beforeEach(() => {
+  callOrder.length = 0;
+  unsetChannelSdkMock.mockClear();
+  disconnectSdkMock.mockClear();
+  deleteMock.mockClear();
+  insertEventMock.mockClear();
+  connRow = {
+    id: CONNECTION_ID,
+    company_id: "11111111-1111-1111-1111-111111111111",
+    profile_id: "22222222-2222-2222-2222-222222222222",
+    platform: "linkedin_personal",
+    bundle_social_account_id: "bs-acct-1",
+    status: "healthy",
+    is_personal_mode: false,
+  };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+async function callDisconnect(): Promise<Response> {
+  return POST(new Request("http://localhost/x", { method: "POST" }) as never, {
+    params: { id: CONNECTION_ID },
+  });
+}
+
+describe("R-DISCONNECT: order is unset → disconnect → DELETE", () => {
+  it("channel-selection platform with bound channel: unset runs first", async () => {
+    const res = await callDisconnect();
+    expect(res.status).toBe(200);
+    expect(callOrder).toEqual(["unsetChannel", "disconnect", "delete"]);
+  });
+
+  it("personal-mode LinkedIn skips unsetChannel (no channel bound)", async () => {
+    connRow.is_personal_mode = true;
+    const res = await callDisconnect();
+    expect(res.status).toBe(200);
+    expect(callOrder).toEqual(["disconnect", "delete"]);
+  });
+
+  it("non-channel-selection platform (X) skips unsetChannel", async () => {
+    connRow.platform = "x";
+    const res = await callDisconnect();
+    expect(res.status).toBe(200);
+    expect(callOrder).toEqual(["disconnect", "delete"]);
+  });
+
+  it("DELETE still runs when unsetChannel errors", async () => {
+    unsetChannelSdkMock.mockImplementationOnce(async () => {
+      callOrder.push("unsetChannel");
+      throw new Error("upstream fail");
+    });
+    const res = await callDisconnect();
+    expect(res.status).toBe(200);
+    expect(callOrder).toEqual(["unsetChannel", "disconnect", "delete"]);
+  });
+
+  it("DELETE still runs when socialAccountDisconnect errors", async () => {
+    disconnectSdkMock.mockImplementationOnce(async () => {
+      callOrder.push("disconnect");
+      throw new Error("upstream fail");
+    });
+    const res = await callDisconnect();
+    expect(res.status).toBe(200);
+    expect(callOrder).toEqual(["unsetChannel", "disconnect", "delete"]);
+  });
+
+  it("400 'Team does not have' is idempotent-success, not a failure", async () => {
+    disconnectSdkMock.mockImplementationOnce(async () => {
+      callOrder.push("disconnect");
+      throw {
+        name: "ApiError",
+        status: 400,
+        body: { message: "Team does not have a LINKEDIN account" },
+      };
+    });
+    const res = await callDisconnect();
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      data?: { upstream_disconnect_ok: boolean };
+    };
+    expect(json.ok).toBe(true);
+    expect(json.data?.upstream_disconnect_ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## ⚠️ Pre-requisite: Apply migration 0123 BEFORE merging



Migration `0123_social_connections_channel_selection.sql` adds `is_personal_mode` and `has_emitted_overdue_event` to `social_connections`. Both `sync.ts` and `process.ts` SELECT `is_personal_mode`; all syncs and webhook handlers error with `42703 column does not exist` until applied.



**Steven: run this once before merging:**

```

npx supabase db push --db-url "[DB-URL-REDACTED — credential rotated]"

```

(Port 5432 = session mode. Port 6543 = transaction mode; `db push` fails there with prepared-statement errors.)



---



## Post-merge follow-up fixes (commit `e5904030`)



Three bugs reported on first connect at `/company/social/connections` after the original commits were live:



**Bug 1 — No Disconnect button** ✅ Already fixed. `handleDisconnect` and the Disconnect button exist in `SocialConnectionsList.tsx`. No new code needed.



**Bug 2 — "Already connected" banner has no escape hatch**

- Root cause: noop callback path didn't forward which platform the user tried to connect → client couldn't identify or highlight the blocking row.

- Fix: `callback/route.ts` extracts `classified.platform` when `sync.data.updated > 0` and appends `attempted_platform=<platform>` to both the redirect URL and popup postMessage. `SocialConnectionsList.tsx` renders an actionable amber banner + yellow row highlight for the matching connection.



**Bug 3 — Production row showed UUID as display name; display_name=null**

- Root cause: `teamGetTeam` returns `displayName=null` for fresh accounts. `socialAccountGetByType` (already fetched via `resolveIdentityFingerprint`) reliably returns `userDisplayName`/`userUsername`. `IdentityFingerprint` type lacked a `displayName` field.

- Fix: added `displayName: string | null` to `IdentityFingerprint`, populated from `userDisplayName ?? userUsername ?? null`; `sync.ts` and `webhooks/process.ts` use this as the primary display name source.

- Note: the existing row (`display_name=null`) will populate on next "Refresh" via the sync UPDATE path, after migration 0123 is applied.

- Note: LinkedIn personal NOT opening the picker is **correct** — bundle.social returns the person as their own channel → `hasChannel=true` → `status='healthy'` immediately.



**Additional test coverage (commit `e5904030`):**

- `tests/regressions/callback-platform-prefixed-params.test.ts` — 2 new tests: noop+updated=1 surfaces `attempted_platform`; noop+updated=0 doesn't

- `lib/__tests__/social-identity-fingerprint.contract.test.ts` — 3 new unit tests for `IdentityFingerprint.displayName`

- `lib/__tests__/social-channels.contract.test.ts` — removed 2 stale `@ts-expect-error` directives



---



## Summary (original PR #877)



Implements the LinkedIn channel-selection flow gap documented in the incident doc. Built platform-agnostic — LINKEDIN drives the immediate fix but the picker / SDK wrappers / publishing gate also cover FACEBOOK / INSTAGRAM / YOUTUBE / GOOGLE_BUSINESS.



**Do not auto-merge.** Steven reviews + merges manually (write-safety: changes the social_connections schema, touches the live customer connect flow).



## What changed (per layer)



| Layer | Files |

|---|---|

| **1** Callback param recognition | `app/api/platform/social/connections/callback/route.ts` + page.tsx REASON_LABEL |

| **2** SDK wrappers | `lib/platform/social/connections/channels.ts` (new) + `identity.ts` extensions |

| **3** API routes | 5 new routes: `channels`, `set-channel`, `unset-channel`, `connect-as-personal`, `disconnect` + `route-helpers.ts` |

| **4** Picker UI | `components/ChannelPickerModal.tsx` (new) |

| **5** Overdue banner + auto-open | `lib/platform/social/connections/overdue-events.ts` (new) + page.tsx wiring |

| **6** Disconnect ordering | New `/disconnect` route: `unsetChannel → 200ms → socialAccountDisconnect → DELETE → audit` |

| **7** Schema | `supabase/migrations/0123_social_connections_channel_selection.sql` + rollback |

| **8** Tests | 16 contract snapshots + regression suites + follow-up displayName + callback tests (1447 total) |



## Schema (Migration 0123)



```sql

ALTER TABLE social_connections

  ADD COLUMN is_personal_mode BOOLEAN NOT NULL DEFAULT false,

  ADD COLUMN has_emitted_overdue_event BOOLEAN NOT NULL DEFAULT false;

```

Plus CHECK extension on `platform_events.event_type`. Additive only. Rollback at `supabase/rollbacks/0123_*.down.sql`.



## Risks identified and mitigated



- Cross-tenant identity-leak defence (PR #868) preserved: `set-channel/route.ts` re-runs `checkCrossTenantConflict` after setChannel returns.

- Personal-mode race: `webhooks/process.ts` reads `is_personal_mode` and preserves healthy status.

- Disconnect partial-failure: unsetChannel error no longer blocks DELETE. Pinned by regression test.

- 24h overdue emit idempotency: row-level `has_emitted_overdue_event` boolean; one event per connection.

- `attempted_platform` in URL/postMessage: platform string only (e.g., `"linkedin"`) — not a secret. Falls back to null if no match.

- `display_name=null` for existing row: populates on next Refresh via sync UPDATE after migration applied.



## Test plan



- [ ] Apply migration 0123 to production DB (command in section above).

- [ ] Steven connects LinkedIn at `/company/social/connections`.

- [ ] Verify popup → OAuth → popup closes → picker opens (org account) or status=healthy immediately (personal).

- [ ] Verify re-connecting an already-connected platform shows amber banner + yellow row highlight.

- [ ] Verify channel-less LinkedIn connection >24h shows overdue banner.

- [ ] Verify disconnect drops the row even with bundle.social returning 400.



## Pre-PR checklist



- [x] Lint, typecheck, build all green

- [x] `test:unit` — 1447/1447 passing

- [x] Contract snapshots reviewed (16 new + 3 updated for displayName)

- [x] Cross-tenant test — `set-channel/route.ts` re-runs existing `checkCrossTenantConflict`

- [x] Regression tests added (4 total across 2 test files)

- [x] Risks identified and mitigated (above)

- [x] PR size exception stated — ~3000+ net lines, 8 distinct layers + follow-up fixes, one cohesive incident resolution



🤖 Generated with [Claude Code](https://claude.com/claude-code)