### PR TITLE
fix(social): channel-picker endpoint uses GetByType; personal-mode subtext

### DIFF
--- a/app/api/platform/social/connections/[id]/channels/route.ts
+++ b/app/api/platform/social/connections/[id]/channels/route.ts
@@ -8,7 +8,7 @@ import {
 } from "@/lib/http";
 import { logger } from "@/lib/logger";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
-import { refreshChannels } from "@/lib/platform/social/connections/channels";
+import { getChannels } from "@/lib/platform/social/connections/channels";
 import {
   CHANNEL_SELECTION_PLATFORMS,
 } from "@/lib/platform/social/connections/identity";
@@ -50,7 +50,12 @@ export async function GET(
     );
   }
 
-  const result = await refreshChannels({
+  // Use getChannels (socialAccountGetByType — reads cached channels) rather
+  // than refreshChannels (socialAccountRefreshChannels — forces a platform
+  // re-fetch). Refresh 500s on LinkedIn at bundle.social's end; the cached
+  // list is populated immediately after OAuth so it's all the picker needs.
+  // Incident: docs/incidents/2026-05-12-channel-picker-second-pass.md §B.
+  const result = await getChannels({
     teamId: conn.teamId,
     platform: conn.bundlePlatform,
   });

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -669,6 +669,14 @@ export function SocialConnectionsList({
                         </span>
                       )}
                     </div>
+                    {c.status === "healthy" && c.is_personal_mode ? (
+                      <div
+                        className="mt-0.5 text-xs italic text-muted-foreground"
+                        data-testid={`connection-personal-mode-${c.id}`}
+                      >
+                        Personal profile
+                      </div>
+                    ) : null}
                     {c.last_error ? (
                       <div
                         className="mt-1 text-sm text-rose-700"

--- a/docs/incidents/2026-05-12-channel-picker-second-pass.md
+++ b/docs/incidents/2026-05-12-channel-picker-second-pass.md
@@ -1,0 +1,116 @@
+# Incident: Channel picker UI — second pass (post PR #878)
+
+**Date:** 2026-05-12
+**Reporter:** Steven Morey
+**Symptoms:**
+1. Row Steven set to `healthy` via ops script (PR #878 step 5) renders as "Pending channel selection" in the UI.
+2. Clicking "Select channel" opens the picker modal, which immediately surfaces "Something went wrong, please try again later" from `GET /api/platform/social/connections/[id]/channels`.
+
+---
+
+## Section A — Bug A (row shows "Pending channel selection")
+
+### A.1 — Actual row state
+
+The original row `3f29ab79-ddc1-49fd-a598-926d412db47d` no longer exists. It was deleted (the disconnect flow does `unset → disconnect → DELETE`, per `tests/regressions/disconnect-ordering.test.ts`).
+
+A new row was created at 06:23 UTC, ~10 minutes after the PR #878 deploy verification:
+
+```json
+{
+  "id": "65beb232-4334-4a67-bb16-bd3de05d0920",
+  "platform": "linkedin_personal",
+  "status": "pending_identity",
+  "external_account_id": null,
+  "external_user_id": "urn:li:person:cn_0IGowb1",
+  "is_personal_mode": false,
+  "display_name": "Steven Morey",
+  "bundle_social_account_id": "02109aeb-5a39-4aff-aa27-376cc613523a",
+  "created_at": "2026-05-12T06:23:39.168237+00:00"
+}
+```
+
+`bundle_social_account_id` is different from the prior `f6eb9f32-…` — Steven re-OAuthed. The new account `02109aeb-…` exists in bundle.social with `externalId=null` (no channel selected yet) and 16 channel candidates.
+
+**Verdict on Bug A symptom**: the row is **genuinely** `status=pending_identity` because of the re-OAuth. The post-#884 sync logic correctly refused to mark it `healthy` without a channel binding. The UI rendering is internally consistent with the row state.
+
+### A.2 — Where the pill text comes from
+
+`components/SocialConnectionsList.tsx:683-687` renders `STATUS_LABEL[c.status]`. `STATUS_LABEL` is defined in `lib/platform/social/connections/types.ts:61-67`:
+
+```ts
+pending_identity: "Pending channel selection",
+```
+
+So the pill text comes from branch **(a) `status === 'pending_identity'`**. There is no separate branch for `external_account_id === null` or `is_personal_mode === false` — the UI is purely driven by `status`.
+
+### A.3 — The actual UI gap
+
+The current code already does the right thing for the Select Channel button: it only shows when `status === 'pending_identity'` (line 698-700). But the UI does **not** distinguish, in the rendered row, whether a healthy connection is bound via:
+- **Personal mode** (`is_personal_mode = true`, `external_account_id = null`)
+- **Channel mode** (`is_personal_mode = false`, `external_account_id` populated)
+
+Both render the same way (display_name + Healthy pill). For LinkedIn especially, where the same user can pick personal vs org channel, this is ambiguous: "Steven Morey" could mean "personal LinkedIn" or "Steven happens to be the OAuth-er for some org page". Steven wants a visible discriminator.
+
+**Fix scope for Bug A**: add an italic "Personal profile" subtext under the display_name when `is_personal_mode === true`. Keep the rest of the rendering as-is — the existing Select Channel button visibility (only on `pending_identity`) and pill rendering already match the spec.
+
+### A.4 — AdminProfileConnectionsList
+
+`components/AdminProfileConnectionsList.tsx` renders raw `Account` rows from bundle.social (not `SocialConnection` rows from our DB), without a Status column or `is_personal_mode` awareness. Bug A does not apply to it. No change needed there.
+
+---
+
+## Section B — Bug B (channels endpoint 500s)
+
+### B.1 — Direct SDK probe results
+
+Hit against `teamId=2960f6ea-1c15-4baf-8812-00f681c05dd6` (Opollo), `type=LINKEDIN`:
+
+| SDK method | Request body | Status | Channels returned |
+|---|---|---|---|
+| `socialAccountGetByType` | `{ teamId, type: 'LINKEDIN' }` | **200** | 16 |
+| `socialAccountRefreshChannels` | `{ requestBody: { teamId, type: 'LINKEDIN' } }` | **500** | — body: `{"statusCode":500,"message":"Something went wrong, please try again later."}` |
+
+`socialAccountGetByType` returns the cached channels list with `externalId: null` (channel not yet selected) and `channels: [16 items]`. `socialAccountRefreshChannels` 500s — bundle.social's server-side failure on the refresh endpoint, repeatable across calls.
+
+### B.2 — Endpoint wiring
+
+`app/api/platform/social/connections/[id]/channels/route.ts:53-56`:
+
+```ts
+const result = await refreshChannels({
+  teamId: conn.teamId,
+  platform: conn.bundlePlatform,
+});
+```
+
+`refreshChannels` (in `lib/platform/social/connections/channels.ts:210-228`) calls `socialAccountRefreshChannels`. This is the 500-ing endpoint.
+
+There's already a `getChannels` wrapper in the same file (lines 245-279) that calls `socialAccountGetByType` — the method that works. It returns the same shape (`{ channels: Channel[] }`).
+
+### B.3 — Root cause
+
+The picker GET endpoint calls `refreshChannels` (force-refresh from the platform), which 500s on bundle.social's side. The cheaper `getChannels` (read cached) works fine. The picker only needs to render what bundle.social already has; a force refresh is not required for the picker's job.
+
+**Fix scope for Bug B**: switch the route from `refreshChannels` → `getChannels`. The wrapper already exists. The contract test (`lib/__tests__/social-channels.contract.test.ts:234-246`) already pins the `getChannels` calling convention.
+
+### B.4 — A "Refresh from platform" affordance later?
+
+Out of scope. The cached channels list is sufficient. If a future scenario needs force-refresh, it can be a separate button in the modal backed by a separate endpoint — but until bundle.social fixes their 500, force-refresh is a known dead end.
+
+---
+
+## Section C — Fix plan per bug
+
+**Bug A**: In `components/SocialConnectionsList.tsx`, add a small italic "Personal profile" subtext under the display_name in the Account column when `is_personal_mode === true` AND `status === 'healthy'`. No change to the Select Channel button logic (which already gates on `pending_identity` only). No change to AdminProfileConnectionsList.tsx (different data shape, no status column).
+
+**Bug B**: In `app/api/platform/social/connections/[id]/channels/route.ts`, replace the `refreshChannels` import with `getChannels` and update the call site. The error mapping branches (`RECEIVER_NOT_CONFIGURED`, `UPSTREAM_REJECTED`) stay — `getChannels` returns the same `ChannelOpsResult` shape. Add a regression test in `tests/regressions/channels-endpoint-uses-getbytype.test.ts` that mocks the SDK and asserts the route calls `socialAccountGetByType`, not `socialAccountRefreshChannels`.
+
+---
+
+## Section D — Files changing
+
+- `components/SocialConnectionsList.tsx` — add `is_personal_mode` subtext in the Account column.
+- `app/api/platform/social/connections/[id]/channels/route.ts` — switch import + call from `refreshChannels` to `getChannels`.
+- `tests/regressions/channels-endpoint-uses-getbytype.test.ts` — new regression pinning the SDK method via mocks.
+- `docs/incidents/2026-05-12-channel-picker-second-pass.md` — this doc.

--- a/tests/regressions/channels-endpoint-uses-getbytype.test.ts
+++ b/tests/regressions/channels-endpoint-uses-getbytype.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// REGRESSION — channels picker endpoint must use socialAccountGetByType
+// (cached read), NOT socialAccountRefreshChannels (forces upstream
+// refresh, which 500s on bundle.social for LinkedIn).
+//
+// Incident: docs/incidents/2026-05-12-channel-picker-second-pass.md §B.
+//
+// Pinned invariant: GET /api/platform/social/connections/[id]/channels
+// reads the cached channels list via socialAccountGetByType. The
+// upstream refresh endpoint is broken (500 from bundle.social). The
+// picker only needs the channels that OAuth populated immediately;
+// force-refresh adds nothing.
+// ---------------------------------------------------------------------------
+
+const getByTypeMock = vi.fn();
+const refreshChannelsMock = vi.fn();
+
+vi.mock("@/lib/bundlesocial", () => ({
+  getBundlesocialClient: () => ({
+    socialAccount: {
+      socialAccountGetByType: getByTypeMock,
+      socialAccountRefreshChannels: refreshChannelsMock,
+    },
+  }),
+}));
+
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: async () => ({
+    kind: "allow" as const,
+    userId: "user-test",
+    supabase: {} as never,
+  }),
+}));
+
+const connRow = {
+  id: "abcdef00-0000-0000-0000-aaaaaaaa0001",
+  company_id: "11111111-1111-1111-1111-111111111111",
+  profile_id: "22222222-2222-2222-2222-222222222222",
+  platform: "linkedin_personal",
+  bundle_social_account_id: "bs-acct-1",
+  status: "pending_identity",
+  is_personal_mode: false,
+};
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({
+    from: (table: string) => {
+      if (table === "social_connections") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: connRow, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === "platform_social_profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: { bundle_social_team_id: "team-fixture" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  }),
+}));
+
+import { GET } from "@/app/api/platform/social/connections/[id]/channels/route";
+
+beforeEach(() => {
+  getByTypeMock.mockReset();
+  refreshChannelsMock.mockReset();
+  getByTypeMock.mockResolvedValue({
+    externalId: null,
+    userId: "urn:li:person:cn_test",
+    channels: [
+      { id: "urn:li:person:cn_test", name: "Test User", username: "testuser" },
+      { id: "urn:li:organization:1234", name: "Test Org", username: "test-org" },
+    ],
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+async function callGet(): Promise<Response> {
+  return GET(
+    new Request("http://localhost/x", { method: "GET" }) as never,
+    { params: { id: connRow.id } },
+  );
+}
+
+describe("R-CHANNELS-ENDPOINT: picker must use socialAccountGetByType (not RefreshChannels)", () => {
+  it("invokes socialAccountGetByType, NOT socialAccountRefreshChannels", async () => {
+    const res = await callGet();
+    expect(res.status).toBe(200);
+    expect(getByTypeMock).toHaveBeenCalledTimes(1);
+    expect(refreshChannelsMock).not.toHaveBeenCalled();
+  });
+
+  it("passes teamId and platform type to socialAccountGetByType", async () => {
+    await callGet();
+    expect(getByTypeMock).toHaveBeenCalledWith({
+      teamId: "team-fixture",
+      type: "LINKEDIN",
+    });
+  });
+
+  it("returns the channels in the picker payload shape", async () => {
+    const res = await callGet();
+    const json = (await res.json()) as {
+      ok: boolean;
+      data?: { channels: Array<{ id: string; name: string }> };
+    };
+    expect(json.ok).toBe(true);
+    expect(json.data?.channels).toHaveLength(2);
+    expect(json.data?.channels[0]?.id).toBe("urn:li:person:cn_test");
+    expect(json.data?.channels[1]?.id).toBe("urn:li:organization:1234");
+  });
+
+  it("does not call RefreshChannels even when bundle.social would normally 500 on it", async () => {
+    // Sanity check: if anyone wires the route back to refreshChannels and
+    // that endpoint 500s, this test still fires correctly because the
+    // refreshChannels mock is configured to throw.
+    refreshChannelsMock.mockRejectedValueOnce(
+      Object.assign(new Error("Something went wrong, please try again later."), {
+        name: "ApiError",
+        status: 500,
+      }),
+    );
+    const res = await callGet();
+    expect(res.status).toBe(200);
+    expect(refreshChannelsMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Two stacked UI/endpoint bugs found on the connections page after PR #878 shipped. Investigation + fix in this single PR.

Full write-up: `docs/incidents/2026-05-12-channel-picker-second-pass.md`.

## Bug A — Row rendering for personal-mode rows

**Symptom**: Row Steven set to `healthy` via the PR #878 ops script appeared as "Pending channel selection".

**What actually happened**: The original row (`3f29ab79-…`) was disconnected (the disconnect flow does `unset → disconnect → DELETE`). A new row (`65beb232-…`) was created from a re-OAuth, correctly landing as `pending_identity` per the post-#884 logic. The UI was right for that state.

**Underlying UI gap**: the connections table doesn't distinguish, in healthy rows, whether the binding is via personal mode (no org channel) or via a picked channel. The Select Channel button visibility already correctly gates on `status='pending_identity'`; the missing piece is a visual indicator on healthy personal-mode rows.

**Fix**: in `components/SocialConnectionsList.tsx`, add a small italic "Personal profile" subtext under `display_name` when `status='healthy' && is_personal_mode=true`. `AdminProfileConnectionsList.tsx` does not need a change — it renders raw bundle.social `Account` rows without our status / is_personal_mode columns.

## Bug B — `/channels` endpoint 500

**Symptom**: Clicking Select Channel opens the picker which immediately surfaces "Something went wrong, please try again later" from `GET /api/platform/social/connections/[id]/channels`.

**Direct SDK probe results** (against `teamId=2960f6ea-…`, `type=LINKEDIN`):

| Method | Result |
|---|---|
| `socialAccountGetByType({ teamId, type })` | ✅ **200**, returns 16 channels |
| `socialAccountRefreshChannels({ requestBody: { teamId, type } })` | ❌ **500** — `Something went wrong, please try again later.` |

The route was calling `refreshChannels` (forces a platform-side refresh — broken on bundle.social's end). The `getChannels` wrapper using `socialAccountGetByType` (cached read) already exists in `channels.ts` and works.

**Fix**: switch `app/api/platform/social/connections/[id]/channels/route.ts` from `refreshChannels` → `getChannels`. The bundle.social cached list is populated immediately after OAuth, which is all the picker needs.

## Working analog

**Working analog**: `lib/platform/social/connections/channels.ts:245-279` — `getChannels` already wraps `socialAccountGetByType` and returns the same `ChannelOpsResult<{ channels: Channel[] }>` shape.
**Diff**: broken route called `refreshChannels` (5xx on bundle.social side); cached-read variant works.
**Fix**: route imports/uses `getChannels` instead of `refreshChannels`. No new wrapper needed.

## Risks identified and mitigated

- **Stale channels list**: `getChannels` reads bundle.social's cached list rather than forcing an upstream refresh. The cache is populated at OAuth time, which is when the user actually needs to pick. If bundle.social ever fixes their refresh endpoint, a future Refresh affordance can be added as a separate button — out of scope here.
- **Other callers of `refreshChannels`**: kept untouched. They're not on the hot path of the picker; if they later hit the same 500, they can be migrated case-by-case.
- **Personal-mode subtext on non-LinkedIn platforms**: `is_personal_mode` is currently only flipped true for LinkedIn (via `/connect-as-personal`). Other platforms will never see the subtext, which is correct behaviour.
- **AdminProfileConnectionsList rendering**: confirmed it operates on a different data shape (raw bundle.social accounts, no status column). No matching bug to fix there.

## Tests

- `tests/regressions/channels-endpoint-uses-getbytype.test.ts` — new R-CHANNELS-ENDPOINT pin: mocks the bundle.social client, drives a request through the route handler, asserts `socialAccountGetByType` is called and `socialAccountRefreshChannels` is **not**. 4 cases including a "would-500" scenario that's still gated by the regression.
- `npm run test:unit`: 1456/1456 (4 new).
- `npm run test:components`: 76/76.
- `npm run typecheck`: clean.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit`, `test:components`, `typecheck`
- [x] Regression test added (`tests/regressions/channels-endpoint-uses-getbytype.test.ts`)
- [x] Working-analog block in PR body
- [x] Risks identified and mitigated section
- [x] PR is under 500 net lines

Ref: `docs/incidents/2026-05-12-channel-picker-second-pass.md`