### PR TITLE
feat(social): split-brain failsafe — pre-connect check + reconcile + verify-disconnect

### DIFF
--- a/app/(platform)/admin/maintenance/social-connections/page.tsx
+++ b/app/(platform)/admin/maintenance/social-connections/page.tsx
@@ -1,4 +1,5 @@
 import { AdminSocialConnectionsMaintenance } from "@/components/AdminSocialConnectionsMaintenance";
+import { BundlesocialReconcileSection } from "@/components/BundlesocialReconcileSection";
 import { PageHeader } from "@/components/ui/page-header";
 import { PageShell } from "@/components/ui/page-shell";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -84,6 +85,7 @@ export default async function SocialConnectionsMaintenancePage() {
           disconnect, refresh, or reattribute.
         </PageHeader.Subtitle>
       </PageHeader>
+      <BundlesocialReconcileSection />
       <AdminSocialConnectionsMaintenance
         connections={(connectionsRead.data ?? []) as ConnectionRow[]}
         companies={(companiesRead.data ?? []) as CompanyRow[]}

--- a/app/api/admin/maintenance/reconcile-bundlesocial/route.ts
+++ b/app/api/admin/maintenance/reconcile-bundlesocial/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import {
+  internalError,
+  readJsonBody,
+  validationError,
+} from "@/lib/http";
+import { logger } from "@/lib/logger";
+import type { BundlesocialPlatformType } from "@/lib/platform/social/connections/identity";
+import {
+  ALL_BUNDLESOCIAL_PLATFORMS,
+  applyDivergence,
+  scanBundlesocialDivergences,
+  type Divergence,
+} from "@/lib/platform/social/connections/reconcile";
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/maintenance/reconcile-bundlesocial
+//
+// Reconciles every (team, platform) tuple between bundle.social and our
+// social_connections table. Detects:
+//   * ghost   — BS has an account, no DB row matches → recommend disconnect
+//   * phantom — DB has an active row, BS has nothing → recommend mark-disconnected
+//   * mismatch — both sides, drifted fields → recommend re-sync
+//
+// Read-only by default. Pass { apply: true } to perform the recommended
+// fix for each divergence; pass { apply: true, divergence_ids: [...] }
+// to apply only a subset (by index in the scan result, so callers can
+// preview then apply selectively).
+//
+// Roles: super_admin or admin.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z
+  .object({
+    apply: z.boolean().optional(),
+    // Optional filter — scan only these teams.
+    team_ids: z.array(z.string().uuid()).optional(),
+    // Optional filter — scan only these platforms.
+    platforms: z.array(z.enum(ALL_BUNDLESOCIAL_PLATFORMS)).optional(),
+  })
+  .optional()
+  .default({});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const gate = await requireAdminForApi({ roles: ["super_admin", "admin"] });
+  if (gate.kind === "deny") return gate.response;
+
+  const raw = await readJsonBody(req);
+  // An empty body is allowed — default to scan-only with no filters.
+  const parsed = BodySchema.safeParse(raw === undefined ? {} : raw);
+  if (!parsed.success) {
+    return validationError(
+      "Body must be { apply?: boolean, team_ids?: uuid[], platforms?: string[] }.",
+      { issues: parsed.error.issues },
+    );
+  }
+  const input = parsed.data;
+
+  let scan: Awaited<ReturnType<typeof scanBundlesocialDivergences>>;
+  try {
+    scan = await scanBundlesocialDivergences({
+      teamIds: input.team_ids,
+      platforms: input.platforms as ReadonlyArray<BundlesocialPlatformType> | undefined,
+    });
+  } catch (err) {
+    logger.error("admin.maintenance.reconcile.scan_failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return internalError(err instanceof Error ? err.message : String(err));
+  }
+
+  if (!input.apply) {
+    return NextResponse.json({
+      ok: true,
+      data: {
+        applied: false,
+        scanned_teams: scan.scanned_teams,
+        scanned_platforms: scan.scanned_platforms,
+        divergences: scan.divergences,
+        scan_errors: scan.errors,
+      },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  // Apply mode — walk every divergence and run its recommended fix.
+  type AppliedRecord = {
+    divergence: Divergence;
+    ok: boolean;
+    action: string | null;
+    detail: string | null;
+    error: string | null;
+  };
+  const applied: AppliedRecord[] = [];
+  for (const div of scan.divergences) {
+    const r = await applyDivergence(div, gate.user?.id ?? null);
+    if (r.ok) {
+      applied.push({
+        divergence: div,
+        ok: true,
+        action: r.action,
+        detail: r.detail,
+        error: null,
+      });
+    } else {
+      applied.push({
+        divergence: div,
+        ok: false,
+        action: null,
+        detail: null,
+        error: r.error.message,
+      });
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    data: {
+      applied: true,
+      scanned_teams: scan.scanned_teams,
+      scanned_platforms: scan.scanned_platforms,
+      divergences: scan.divergences,
+      scan_errors: scan.errors,
+      apply_results: applied,
+    },
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/app/api/platform/social/connections/[id]/disconnect/route.ts
+++ b/app/api/platform/social/connections/[id]/disconnect/route.ts
@@ -13,6 +13,7 @@ import { unsetChannel } from "@/lib/platform/social/connections/channels";
 import {
   CHANNEL_SELECTION_PLATFORMS,
 } from "@/lib/platform/social/connections/identity";
+import { verifyBundlesocialDisconnect } from "@/lib/platform/social/connections/reconcile";
 import { loadConnectionWithTeam } from "@/lib/platform/social/connections/route-helpers";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -77,6 +78,10 @@ export async function POST(
     unset_error: string | null;
     disconnect_ok: boolean;
     disconnect_error: string | null;
+    // L4: post-disconnect verify. Did bundle.social actually drop the
+    // account? deleted only flips true when verify_clean is also true.
+    verify_clean: boolean | null;
+    verify_reason: string | null;
     deleted: boolean;
     delete_error: string | null;
   } = {
@@ -84,6 +89,8 @@ export async function POST(
     unset_error: null,
     disconnect_ok: false,
     disconnect_error: null,
+    verify_clean: null,
+    verify_reason: null,
     deleted: false,
     delete_error: null,
   };
@@ -133,9 +140,57 @@ export async function POST(
     }
   }
 
-  // Step 4: DELETE the row regardless of upstream outcome. The customer
-  // pressed disconnect; the row must go away.
+  // Step 4: VERIFY (L4 split-brain defence). bundle.social must
+  // confirm the account is actually gone before we delete the DB row.
+  // verifyBundlesocialDisconnect handles the wait + retry-on-still-
+  // present internally.
+  const verify = await verifyBundlesocialDisconnect({
+    teamId: conn.teamId,
+    platform: conn.bundlePlatform,
+  });
+  audit.verify_clean = verify.clean;
+  audit.verify_reason = verify.reason;
+
   const svc = getServiceRoleClient();
+  if (!verify.clean) {
+    // Split-brain detected — bundle.social still holds the account
+    // after our disconnect + retry. DO NOT delete the DB row; it
+    // remains the source of truth so the reconcile cron / admin
+    // surface can resolve it.
+    logger.error("social.connections.disconnect.split_brain_detected", {
+      connection_id: conn.id,
+      team_id: conn.teamId,
+      platform: conn.bundlePlatform,
+      reason: verify.reason,
+    });
+    void (async () => {
+      try {
+        await svc.from("platform_events").insert({
+          event_type: "disconnect_split_brain_detected",
+          company_id: conn.company_id,
+          actor_id: gate.userId,
+          entity_type: "social_connection",
+          entity_id: conn.id,
+          payload: {
+            team_id: conn.teamId,
+            platform: conn.bundlePlatform,
+            bundle_social_account_id: conn.bundle_social_account_id,
+            reason: verify.reason,
+            ...audit,
+          },
+        });
+      } catch (err) {
+        logger.warn("social.connections.disconnect.split_brain_audit_failed", {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+    return invalidState(
+      "Disconnect could not be verified on bundle.social; the row was kept. An admin can resolve this from the maintenance reconcile surface.",
+    );
+  }
+
+  // Step 5: bundle.social confirmed clean — DELETE the row.
   const del = await svc.from("social_connections").delete().eq("id", conn.id);
   if (del.error) {
     audit.delete_error = del.error.message;
@@ -147,7 +202,7 @@ export async function POST(
     audit.deleted = true;
   }
 
-  // Step 5: audit event. Fire-and-forget; the disconnect succeeded from
+  // Step 6: audit event. Fire-and-forget; the disconnect succeeded from
   // the customer's perspective regardless of audit insertion.
   void (async () => {
     try {

--- a/app/api/platform/social/connections/connect/route.ts
+++ b/app/api/platform/social/connections/connect/route.ts
@@ -4,11 +4,13 @@ import { z } from "zod";
 import { dbUuid, readJsonBody, validationError, invalidState, internalError, notFound } from "@/lib/http";
 import { logger } from "@/lib/logger";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { preConnectGhostCheck } from "@/lib/platform/social/connections/reconcile";
 import { getProfileById } from "@/lib/platform/social/profiles";
 import {
   initiateProfileConnect,
   type ProfileSocialPlatform,
 } from "@/lib/platform/social/profiles/connect";
+import { getOrCreateBundleSocialTeamForProfile } from "@/lib/platform/social/profiles/provision-team";
 
 // ---------------------------------------------------------------------------
 // BSP-6-CUSTOMER — POST /api/platform/social/connections/connect
@@ -95,6 +97,67 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       userId: gate.userId,
     });
     return notFound("Profile not found in this company.");
+  }
+
+  // L1 pre-connect ghost check (failsafe, 2026-05-12). Before opening
+  // OAuth, ask bundle.social whether the team already holds an account
+  // for this platform.
+  //   - clean → proceed as today
+  //   - ghost_cleared → BS had a ghost; auto-disconnected; proceed
+  //   - db_match → an existing DB row matches; tell the UI to surface it
+  //   - error → defensive: proceed; the connect step will surface
+  //     bundle.social's own error if it still rejects
+  try {
+    const teamId = await getOrCreateBundleSocialTeamForProfile(parsed.data.profile_id);
+    const pre = await preConnectGhostCheck({
+      teamId,
+      platform: parsed.data.platform as ProfileSocialPlatform,
+      actorId: gate.userId,
+    });
+    if (pre.kind === "ghost_cleared") {
+      logger.info("social.connections.connect.pre_ghost_cleared", {
+        company_id: parsed.data.company_id,
+        profile_id: parsed.data.profile_id,
+        platform: parsed.data.platform,
+        team_id: teamId,
+        bundle_account_id: pre.bundle_account_id,
+      });
+    } else if (pre.kind === "db_match") {
+      logger.info("social.connections.connect.pre_db_match", {
+        company_id: parsed.data.company_id,
+        platform: parsed.data.platform,
+        existing_connection_id: pre.existing_connection_id,
+      });
+      return NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: "ALREADY_CONNECTED",
+            message: `${parsed.data.platform} is already connected on this profile. Disconnect the existing account first.`,
+            existing_connection_id: pre.existing_connection_id,
+            existing_company_id: pre.existing_company_id,
+            existing_display_name: pre.existing_display_name,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 409 },
+      );
+    } else if (pre.kind === "error") {
+      logger.warn("social.connections.connect.pre_check_failed", {
+        company_id: parsed.data.company_id,
+        platform: parsed.data.platform,
+        message: pre.message,
+      });
+      // Continue to initiateProfileConnect anyway — the SDK will surface
+      // a real "already connected" error if there's genuinely a clash.
+    }
+  } catch (err) {
+    logger.warn("social.connections.connect.pre_check_setup_failed", {
+      company_id: parsed.data.company_id,
+      profile_id: parsed.data.profile_id,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    // Fall through — the connect path will handle its own provisioning.
   }
 
   const origin =

--- a/components/BundlesocialReconcileSection.tsx
+++ b/components/BundlesocialReconcileSection.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { toastSuccess } from "@/lib/toast-success";
+
+// ---------------------------------------------------------------------------
+// Bundle.social ↔ social_connections reconciliation surface.
+//
+// Lives at /admin/maintenance/social-connections. Hits the reconcile API
+// (POST /api/admin/maintenance/reconcile-bundlesocial) in scan-only mode
+// to surface divergences, then either bulk-fixes them all or applies
+// each fix one-row-at-a-time via a "Fix this divergence" button.
+//
+// Divergence kinds:
+//   ghost   — bundle.social has an account; no DB row matches it.
+//             Fix: disconnect the bundle.social account.
+//   phantom — DB has an active row; bundle.social has nothing.
+//             Fix: mark the DB row 'disconnected'.
+//   mismatch — both sides have an entry but identity drifted.
+//              Fix: re-sync the DB row from bundle.social.
+// ---------------------------------------------------------------------------
+
+type DivergenceKind = "ghost" | "phantom" | "mismatch";
+
+type Divergence = {
+  kind: DivergenceKind;
+  team_id: string;
+  platform: string;
+  bundle_account_id: string | null;
+  bundle_external_id: string | null;
+  bundle_display_name: string | null;
+  db_row_id: string | null;
+  db_company_id: string | null;
+  db_platform: string | null;
+  db_display_name: string | null;
+  db_external_account_id: string | null;
+  reason: string;
+};
+
+type ScanResponse = {
+  ok: boolean;
+  data?: {
+    applied: boolean;
+    scanned_teams: string[];
+    scanned_platforms: string[];
+    divergences: Divergence[];
+    scan_errors: Array<{ team_id: string; platform: string; message: string }>;
+    apply_results?: Array<{
+      divergence: Divergence;
+      ok: boolean;
+      action: string | null;
+      detail: string | null;
+      error: string | null;
+    }>;
+  };
+  error?: { message: string };
+};
+
+type LastResult = {
+  scannedAt: string;
+  teams: string[];
+  platforms: string[];
+  divergences: Divergence[];
+  scanErrors: Array<{ team_id: string; platform: string; message: string }>;
+  applied: boolean;
+  applyErrors: number;
+};
+
+const KIND_LABEL: Record<DivergenceKind, string> = {
+  ghost: "Ghost (BS has, DB doesn't)",
+  phantom: "Phantom (DB has, BS doesn't)",
+  mismatch: "Mismatch (drift)",
+};
+
+const KIND_PILL: Record<DivergenceKind, string> = {
+  ghost: "bg-amber-100 text-amber-900",
+  phantom: "bg-rose-100 text-rose-900",
+  mismatch: "bg-blue-100 text-blue-900",
+};
+
+export function BundlesocialReconcileSection() {
+  const router = useRouter();
+  const [busy, setBusy] = useState<"scan" | "apply-all" | string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [last, setLast] = useState<LastResult | null>(null);
+
+  async function callReconcile(opts: {
+    apply: boolean;
+    divergence?: Divergence;
+  }): Promise<ScanResponse | null> {
+    setError(null);
+    // For one-row apply we ship the team_id + platform of just that row;
+    // the scan + apply pass on the server still walks the full set but
+    // only this row matters when filtered down to one (team, platform).
+    const body = opts.divergence
+      ? {
+          apply: opts.apply,
+          team_ids: [opts.divergence.team_id],
+          platforms: [opts.divergence.platform],
+        }
+      : { apply: opts.apply };
+    const res = await fetch(
+      "/api/admin/maintenance/reconcile-bundlesocial",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+    const json = (await res.json().catch(() => null)) as ScanResponse | null;
+    if (!res.ok || !json?.ok) {
+      setError(json?.error?.message ?? `Request failed (${res.status}).`);
+      return null;
+    }
+    return json;
+  }
+
+  async function handleScan() {
+    setBusy("scan");
+    const json = await callReconcile({ apply: false });
+    setBusy(null);
+    if (!json?.data) return;
+    setLast({
+      scannedAt: new Date().toISOString(),
+      teams: json.data.scanned_teams,
+      platforms: json.data.scanned_platforms,
+      divergences: json.data.divergences,
+      scanErrors: json.data.scan_errors,
+      applied: false,
+      applyErrors: 0,
+    });
+  }
+
+  async function handleApplyAll() {
+    if (
+      !window.confirm(
+        "Apply all recommended fixes? Each divergence will be remediated:\n" +
+          "  ghosts → disconnected from bundle.social\n" +
+          "  phantoms → marked status='disconnected' in our DB\n" +
+          "  mismatches → re-synced from bundle.social\n\n" +
+          "Audit logged to platform_events.",
+      )
+    )
+      return;
+    setBusy("apply-all");
+    const json = await callReconcile({ apply: true });
+    setBusy(null);
+    if (!json?.data) return;
+    const applyErrors =
+      json.data.apply_results?.filter((r) => !r.ok).length ?? 0;
+    setLast({
+      scannedAt: new Date().toISOString(),
+      teams: json.data.scanned_teams,
+      platforms: json.data.scanned_platforms,
+      divergences: json.data.divergences,
+      scanErrors: json.data.scan_errors,
+      applied: true,
+      applyErrors,
+    });
+    if (applyErrors === 0) {
+      toastSuccess(
+        `Reconcile applied — ${json.data.divergences.length} divergence(s) fixed.`,
+      );
+    } else {
+      setError(
+        `${applyErrors} of ${json.data.divergences.length} fix(es) failed. See the table below for details.`,
+      );
+    }
+    router.refresh();
+  }
+
+  async function handleApplyOne(div: Divergence) {
+    const key = `${div.kind}-${div.team_id}-${div.platform}`;
+    if (
+      !window.confirm(
+        `Fix this divergence?\n\n  kind: ${div.kind}\n  team: ${div.team_id}\n  platform: ${div.platform}\n  reason: ${div.reason}`,
+      )
+    )
+      return;
+    setBusy(key);
+    const json = await callReconcile({ apply: true, divergence: div });
+    setBusy(null);
+    if (!json?.data) return;
+    const applied = json.data.apply_results?.[0];
+    if (applied?.ok) {
+      toastSuccess(`Fixed: ${applied.action}`);
+      router.refresh();
+    } else if (applied?.error) {
+      setError(`Fix failed: ${applied.error}`);
+    }
+    // Re-scan locally to refresh the table view too.
+    void handleScan();
+  }
+
+  return (
+    <section
+      className="mb-6 rounded-lg border bg-card p-4"
+      data-testid="bundlesocial-reconcile-section"
+    >
+      <header className="mb-3 flex items-center justify-between">
+        <div>
+          <h2 className="text-base font-semibold">
+            Bundle.social reconciliation
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Compare every (team, platform) tuple between bundle.social and
+            our DB. Detects ghosts / phantoms / mismatches and fixes them
+            either in bulk or per-row.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            onClick={handleScan}
+            disabled={busy !== null}
+            data-testid="reconcile-scan-button"
+          >
+            {busy === "scan" ? "Scanning…" : "Scan for ghosts"}
+          </Button>
+          {last && last.divergences.length > 0 && !last.applied ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleApplyAll}
+              disabled={busy !== null}
+              data-testid="reconcile-apply-all-button"
+            >
+              {busy === "apply-all" ? "Applying…" : "Apply all fixes"}
+            </Button>
+          ) : null}
+        </div>
+      </header>
+
+      {error ? (
+        <p
+          className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          role="alert"
+          data-testid="reconcile-error"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {!last ? (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="reconcile-idle"
+        >
+          Click <strong>Scan for ghosts</strong> to walk every team × platform.
+        </p>
+      ) : (
+        <div data-testid="reconcile-result">
+          <p className="mb-2 text-sm text-muted-foreground">
+            Scanned <strong>{last.teams.length}</strong> team(s) ×{" "}
+            <strong>{last.platforms.length}</strong> platform(s) ·{" "}
+            <strong>{last.divergences.length}</strong> divergence(s)
+            {last.scanErrors.length > 0 ? (
+              <>
+                {" · "}
+                <span className="text-amber-700">
+                  {last.scanErrors.length} probe error(s)
+                </span>
+              </>
+            ) : null}
+            {last.applied ? (
+              <>
+                {" · "}
+                <span className="text-emerald-700">
+                  fixes applied · {last.applyErrors} failure(s)
+                </span>
+              </>
+            ) : null}
+            {" · "}
+            <span className="text-xs italic">
+              at {new Date(last.scannedAt).toLocaleTimeString()}
+            </span>
+          </p>
+          {last.divergences.length === 0 ? (
+            <div
+              className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm text-emerald-900"
+              data-testid="reconcile-clean"
+            >
+              ✓ bundle.social and the DB are in sync. No ghosts, phantoms,
+              or mismatches.
+            </div>
+          ) : (
+            <div className="overflow-x-auto rounded border bg-card">
+              <table
+                className="w-full text-sm"
+                data-testid="reconcile-divergences-table"
+              >
+                <thead className="border-b bg-muted/30 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2">Kind</th>
+                    <th className="px-3 py-2">Team</th>
+                    <th className="px-3 py-2">Platform</th>
+                    <th className="px-3 py-2">bundle.social</th>
+                    <th className="px-3 py-2">DB row</th>
+                    <th className="px-3 py-2">Reason</th>
+                    <th className="px-3 py-2" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {last.divergences.map((d, i) => {
+                    const key = `${d.kind}-${d.team_id}-${d.platform}`;
+                    return (
+                      <tr
+                        key={`${key}-${i}`}
+                        className="border-b last:border-b-0"
+                        data-testid={`reconcile-row-${i}`}
+                      >
+                        <td className="px-3 py-2">
+                          <span
+                            className={`rounded-full px-2 py-0.5 text-xs font-medium ${KIND_PILL[d.kind]}`}
+                          >
+                            {KIND_LABEL[d.kind]}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 font-mono text-xs">
+                          {d.team_id.slice(0, 8)}…
+                        </td>
+                        <td className="px-3 py-2">{d.platform}</td>
+                        <td className="px-3 py-2 font-mono text-xs">
+                          {d.bundle_account_id
+                            ? `${d.bundle_account_id.slice(0, 12)}…`
+                            : "—"}
+                          {d.bundle_display_name ? (
+                            <div className="text-xs italic text-muted-foreground">
+                              {d.bundle_display_name}
+                            </div>
+                          ) : null}
+                        </td>
+                        <td className="px-3 py-2 font-mono text-xs">
+                          {d.db_row_id ? `${d.db_row_id.slice(0, 12)}…` : "—"}
+                          {d.db_display_name ? (
+                            <div className="text-xs italic text-muted-foreground">
+                              {d.db_display_name}
+                            </div>
+                          ) : null}
+                        </td>
+                        <td className="px-3 py-2 text-xs">{d.reason}</td>
+                        <td className="px-3 py-2 text-right">
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => handleApplyOne(d)}
+                            disabled={busy !== null}
+                            data-testid={`reconcile-fix-${i}`}
+                          >
+                            {busy === key ? "Fixing…" : "Fix this divergence"}
+                          </Button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {last.scanErrors.length > 0 ? (
+            <details className="mt-3 rounded border bg-muted/20 p-2 text-xs">
+              <summary className="cursor-pointer font-medium">
+                Probe errors ({last.scanErrors.length})
+              </summary>
+              <ul className="mt-2 list-disc pl-5">
+                {last.scanErrors.map((e, i) => (
+                  <li key={i}>
+                    <code>
+                      {e.team_id.slice(0, 8)}…/{e.platform}
+                    </code>
+                    : {e.message}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/lib/platform/social/connections/reconcile.ts
+++ b/lib/platform/social/connections/reconcile.ts
@@ -1,0 +1,658 @@
+import "server-only";
+
+import { getBundlesocialClient } from "@/lib/bundlesocial";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+import type { BundlesocialPlatformType } from "./identity";
+import { dbPlatformToBundleType } from "./route-helpers";
+import type { SocialPlatform } from "./types";
+
+// ---------------------------------------------------------------------------
+// Bundle.social ↔ social_connections reconciliation.
+//
+// Split-brain defense for the case where the two sides diverge:
+//   - Ghost: bundle.social has an account, we don't. Customer hits
+//     "this team already has a … account connected" with no way to
+//     resolve via the UI. Fix: disconnect the bundle.social account.
+//   - Phantom: we have a row, bundle.social doesn't. UI shows a
+//     healthy connection that can't actually publish. Fix: mark the
+//     row disconnected with a clear last_error.
+//   - Mismatch: both sides have an account but different
+//     external_account_id, external_user_id, or display_name. Fix:
+//     re-sync from bundle.social.
+//
+// Used by:
+//   * /api/admin/maintenance/reconcile-bundlesocial   (L2 surface)
+//   * /api/platform/social/connections/connect        (L1 pre-flight)
+//   * /api/platform/social/connections/[id]/disconnect (L4 verify)
+// ---------------------------------------------------------------------------
+
+// Full bundle.social platform enum — covers every platform a team
+// might have an account for, not just the channel-selection subset.
+export const ALL_BUNDLESOCIAL_PLATFORMS = [
+  "TIKTOK",
+  "YOUTUBE",
+  "INSTAGRAM",
+  "FACEBOOK",
+  "TWITTER",
+  "THREADS",
+  "LINKEDIN",
+  "PINTEREST",
+  "REDDIT",
+  "MASTODON",
+  "DISCORD",
+  "SLACK",
+  "BLUESKY",
+  "GOOGLE_BUSINESS",
+] as const satisfies ReadonlyArray<BundlesocialPlatformType>;
+
+export type DivergenceKind = "ghost" | "phantom" | "mismatch";
+
+export type Divergence = {
+  kind: DivergenceKind;
+  team_id: string;
+  platform: BundlesocialPlatformType;
+  // Present for ghost / mismatch.
+  bundle_account_id: string | null;
+  bundle_external_id: string | null;
+  bundle_display_name: string | null;
+  // Present for phantom / mismatch.
+  db_row_id: string | null;
+  db_company_id: string | null;
+  db_platform: SocialPlatform | null;
+  db_display_name: string | null;
+  db_external_account_id: string | null;
+  // Free-text reason — populated when kind = "mismatch" with which
+  // fields differ.
+  reason: string;
+};
+
+export type ScanInput = {
+  // When set, scan only the listed teams. Otherwise scan every team
+  // that appears in platform_social_profiles or platform_companies.
+  teamIds?: ReadonlyArray<string>;
+  // When set, scan only the listed platforms. Otherwise scan every
+  // platform in ALL_BUNDLESOCIAL_PLATFORMS. Useful for the L1 pre-flight
+  // path which only cares about the platform the user just clicked.
+  platforms?: ReadonlyArray<BundlesocialPlatformType>;
+};
+
+export type ScanResult = {
+  divergences: Divergence[];
+  scanned_teams: string[];
+  scanned_platforms: BundlesocialPlatformType[];
+  errors: Array<{
+    team_id: string;
+    platform: BundlesocialPlatformType;
+    message: string;
+  }>;
+};
+
+// Collect every team_id we have any record of: from per-profile teams
+// (BSP-8 onwards) and from legacy company-level teams. De-duped.
+async function collectKnownTeamIds(): Promise<string[]> {
+  const svc = getServiceRoleClient();
+
+  const profileRead = await svc
+    .from("platform_social_profiles")
+    .select("bundle_social_team_id")
+    .not("bundle_social_team_id", "is", null);
+  const companyRead = await svc
+    .from("platform_companies")
+    .select("bundle_social_team_id")
+    .not("bundle_social_team_id", "is", null);
+
+  if (profileRead.error)
+    throw new Error(`Failed to read profiles: ${profileRead.error.message}`);
+  if (companyRead.error)
+    throw new Error(`Failed to read companies: ${companyRead.error.message}`);
+
+  const set = new Set<string>();
+  for (const r of (profileRead.data ?? []) as Array<{
+    bundle_social_team_id: string | null;
+  }>) {
+    if (r.bundle_social_team_id) set.add(r.bundle_social_team_id);
+  }
+  for (const r of (companyRead.data ?? []) as Array<{
+    bundle_social_team_id: string | null;
+  }>) {
+    if (r.bundle_social_team_id) set.add(r.bundle_social_team_id);
+  }
+  return Array.from(set);
+}
+
+// bundle.social's socialAccountGetByType returns null / 400 / 404 when
+// no account exists for the (team, type) pair. The 400 body is
+// "Team does not have a <platform> account."; the 404 is a stricter
+// variant. Both mean "no account" — collapse into null.
+async function safeGetByType(
+  teamId: string,
+  platform: BundlesocialPlatformType,
+): Promise<
+  | {
+      id: string;
+      externalId: string | null;
+      userId: string | null;
+      displayName: string | null;
+    }
+  | null
+> {
+  const client = getBundlesocialClient();
+  if (!client) throw new Error("BUNDLE_SOCIAL_API is not configured.");
+
+  try {
+    const r = (await client.socialAccount.socialAccountGetByType({
+      teamId,
+      type: platform,
+    })) as {
+      id?: string;
+      externalId?: string | null;
+      userId?: string | null;
+      displayName?: string | null;
+    } | null;
+    if (!r || !r.id) return null;
+    return {
+      id: r.id,
+      externalId: r.externalId ?? null,
+      userId: r.userId ?? null,
+      displayName: r.displayName ?? null,
+    };
+  } catch (err) {
+    const e = err as { status?: number };
+    if (e?.status === 400 || e?.status === 404) return null;
+    throw err;
+  }
+}
+
+// Scan every (team, platform) tuple and return divergences. Read-only.
+// Apply is a separate step (`applyDivergence`).
+export async function scanBundlesocialDivergences(
+  input: ScanInput = {},
+): Promise<ScanResult> {
+  const svc = getServiceRoleClient();
+
+  const teams =
+    input.teamIds && input.teamIds.length > 0
+      ? Array.from(new Set(input.teamIds))
+      : await collectKnownTeamIds();
+  const platforms = input.platforms ?? ALL_BUNDLESOCIAL_PLATFORMS;
+
+  // DB index keyed by bundle_social_account_id. Also keep a separate
+  // (team, platform) → row[] index so we can detect phantoms — rows
+  // pointing at this team+platform where bundle.social returned null.
+  const connRead = await svc
+    .from("social_connections")
+    .select(
+      "id, bundle_social_account_id, company_id, platform, display_name, external_account_id, external_user_id, profile_id, status",
+    );
+  if (connRead.error)
+    throw new Error(`Failed to read social_connections: ${connRead.error.message}`);
+
+  const profileRead = await svc
+    .from("platform_social_profiles")
+    .select("id, bundle_social_team_id");
+  if (profileRead.error)
+    throw new Error(`Failed to read profiles: ${profileRead.error.message}`);
+  const profileTeamById = new Map<string, string>();
+  for (const p of (profileRead.data ?? []) as Array<{
+    id: string;
+    bundle_social_team_id: string | null;
+  }>) {
+    if (p.bundle_social_team_id)
+      profileTeamById.set(p.id, p.bundle_social_team_id);
+  }
+
+  const companyRead = await svc
+    .from("platform_companies")
+    .select("id, bundle_social_team_id");
+  if (companyRead.error)
+    throw new Error(`Failed to read companies: ${companyRead.error.message}`);
+  const companyTeamById = new Map<string, string>();
+  for (const c of (companyRead.data ?? []) as Array<{
+    id: string;
+    bundle_social_team_id: string | null;
+  }>) {
+    if (c.bundle_social_team_id)
+      companyTeamById.set(c.id, c.bundle_social_team_id);
+  }
+
+  type DbRow = {
+    id: string;
+    bundle_social_account_id: string;
+    company_id: string;
+    platform: SocialPlatform;
+    display_name: string | null;
+    external_account_id: string | null;
+    external_user_id: string | null;
+    profile_id: string | null;
+    status: string;
+  };
+  const dbByAcctId = new Map<string, DbRow>();
+  // Key by `${teamId}::${bundlePlatform}`. Active rows only (anything
+  // that isn't 'disconnected' is a candidate phantom if BS shows null).
+  const dbByTeamPlatform = new Map<string, DbRow[]>();
+  for (const r of (connRead.data ?? []) as DbRow[]) {
+    dbByAcctId.set(r.bundle_social_account_id, r);
+    const bundlePlatform = dbPlatformToBundleType(r.platform);
+    const teamForRow =
+      (r.profile_id && profileTeamById.get(r.profile_id)) ||
+      companyTeamById.get(r.company_id) ||
+      null;
+    if (teamForRow) {
+      const key = `${teamForRow}::${bundlePlatform}`;
+      const arr = dbByTeamPlatform.get(key) ?? [];
+      arr.push(r);
+      dbByTeamPlatform.set(key, arr);
+    }
+  }
+
+  const divergences: Divergence[] = [];
+  const errors: ScanResult["errors"] = [];
+
+  for (const teamId of teams) {
+    for (const platform of platforms) {
+      let acct: Awaited<ReturnType<typeof safeGetByType>>;
+      try {
+        acct = await safeGetByType(teamId, platform);
+      } catch (err) {
+        errors.push({
+          team_id: teamId,
+          platform,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        continue;
+      }
+
+      const key = `${teamId}::${platform}`;
+      const dbRows = (dbByTeamPlatform.get(key) ?? []).filter(
+        (r) => r.status !== "disconnected",
+      );
+
+      if (acct === null) {
+        // BS has nothing. If DB has an active row for this (team, platform),
+        // that's a phantom — emit a divergence for each active row.
+        for (const row of dbRows) {
+          divergences.push({
+            kind: "phantom",
+            team_id: teamId,
+            platform,
+            bundle_account_id: null,
+            bundle_external_id: null,
+            bundle_display_name: null,
+            db_row_id: row.id,
+            db_company_id: row.company_id,
+            db_platform: row.platform,
+            db_display_name: row.display_name,
+            db_external_account_id: row.external_account_id,
+            reason: "DB row has no bundle.social account on this team.",
+          });
+        }
+        continue;
+      }
+
+      // BS has an account. Look for a matching DB row by account_id.
+      const matched = dbByAcctId.get(acct.id);
+      if (!matched) {
+        // Ghost — BS has it, no DB row exists for this exact account id.
+        divergences.push({
+          kind: "ghost",
+          team_id: teamId,
+          platform,
+          bundle_account_id: acct.id,
+          bundle_external_id: acct.externalId,
+          bundle_display_name: acct.displayName,
+          db_row_id: null,
+          db_company_id: null,
+          db_platform: null,
+          db_display_name: null,
+          db_external_account_id: null,
+          reason: "bundle.social has an account; no matching social_connections row.",
+        });
+        continue;
+      }
+
+      // Both sides have an entry. Look for mismatches.
+      const reasons: string[] = [];
+      if (
+        acct.externalId !== null &&
+        matched.external_account_id !== null &&
+        acct.externalId !== matched.external_account_id
+      ) {
+        reasons.push(
+          `external_account_id drift (bundle=${acct.externalId} db=${matched.external_account_id})`,
+        );
+      }
+      if (
+        acct.displayName !== null &&
+        matched.display_name !== null &&
+        acct.displayName !== matched.display_name
+      ) {
+        reasons.push(
+          `display_name drift (bundle="${acct.displayName}" db="${matched.display_name}")`,
+        );
+      }
+      if (reasons.length > 0) {
+        divergences.push({
+          kind: "mismatch",
+          team_id: teamId,
+          platform,
+          bundle_account_id: acct.id,
+          bundle_external_id: acct.externalId,
+          bundle_display_name: acct.displayName,
+          db_row_id: matched.id,
+          db_company_id: matched.company_id,
+          db_platform: matched.platform,
+          db_display_name: matched.display_name,
+          db_external_account_id: matched.external_account_id,
+          reason: reasons.join("; "),
+        });
+      }
+    }
+  }
+
+  return {
+    divergences,
+    scanned_teams: teams,
+    scanned_platforms: Array.from(platforms),
+    errors,
+  };
+}
+
+export type ApplyDivergenceResult =
+  | { ok: true; action: string; detail: string | null }
+  | { ok: false; error: { code: string; message: string } };
+
+// Apply the recommended fix for a single divergence.
+//
+//   ghost   → bundle.social.socialAccountDisconnect(team, platform)
+//   phantom → UPDATE social_connections SET status='disconnected'
+//   mismatch → UPDATE social_connections from bundle.social's identity
+//
+// Audits to platform_events.bundlesocial_reconcile_applied regardless
+// of action so the maintenance log shows every action.
+export async function applyDivergence(
+  divergence: Divergence,
+  actorId: string | null,
+): Promise<ApplyDivergenceResult> {
+  const svc = getServiceRoleClient();
+  const client = getBundlesocialClient();
+  if (!client) {
+    return {
+      ok: false,
+      error: {
+        code: "RECEIVER_NOT_CONFIGURED",
+        message: "BUNDLE_SOCIAL_API is not configured.",
+      },
+    };
+  }
+
+  let action: string;
+  let detail: string | null = null;
+
+  try {
+    if (divergence.kind === "ghost") {
+      await client.socialAccount.socialAccountDisconnect({
+        requestBody: {
+          type: divergence.platform,
+          teamId: divergence.team_id,
+        },
+      });
+      action = "ghost_disconnected";
+      detail = `bundle.social account ${divergence.bundle_account_id} disconnected.`;
+    } else if (divergence.kind === "phantom") {
+      if (!divergence.db_row_id) {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_DIVERGENCE",
+            message: "phantom divergence missing db_row_id.",
+          },
+        };
+      }
+      const upd = await svc
+        .from("social_connections")
+        .update({
+          status: "disconnected",
+          disconnected_at: new Date().toISOString(),
+          last_error: "Marked disconnected by reconcile — bundle.social has no matching account.",
+        })
+        .eq("id", divergence.db_row_id);
+      if (upd.error) {
+        return {
+          ok: false,
+          error: { code: "DB_UPDATE_FAILED", message: upd.error.message },
+        };
+      }
+      action = "phantom_marked_disconnected";
+      detail = `social_connections.id=${divergence.db_row_id} → status='disconnected'`;
+    } else {
+      // mismatch — re-sync identity fields from bundle.social.
+      if (!divergence.db_row_id) {
+        return {
+          ok: false,
+          error: {
+            code: "INVALID_DIVERGENCE",
+            message: "mismatch divergence missing db_row_id.",
+          },
+        };
+      }
+      const upd = await svc
+        .from("social_connections")
+        .update({
+          external_account_id: divergence.bundle_external_id,
+          display_name: divergence.bundle_display_name,
+          last_health_check_at: new Date().toISOString(),
+        })
+        .eq("id", divergence.db_row_id);
+      if (upd.error) {
+        return {
+          ok: false,
+          error: { code: "DB_UPDATE_FAILED", message: upd.error.message },
+        };
+      }
+      action = "mismatch_resynced";
+      detail = `social_connections.id=${divergence.db_row_id} ← bundle.social identity`;
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn("bundlesocial.reconcile.apply_failed", {
+      kind: divergence.kind,
+      team_id: divergence.team_id,
+      platform: divergence.platform,
+      err: message,
+    });
+    return {
+      ok: false,
+      error: { code: "APPLY_FAILED", message },
+    };
+  }
+
+  // Audit (fire-and-forget — failure to audit doesn't roll back the fix).
+  void (async () => {
+    try {
+      await svc.from("platform_events").insert({
+        event_type: "bundlesocial_reconcile_applied",
+        company_id: divergence.db_company_id,
+        actor_id: actorId,
+        entity_type: "social_connection",
+        entity_id: divergence.db_row_id,
+        payload: {
+          kind: divergence.kind,
+          team_id: divergence.team_id,
+          platform: divergence.platform,
+          bundle_account_id: divergence.bundle_account_id,
+          action,
+          detail,
+          reason: divergence.reason,
+        },
+      });
+    } catch (err) {
+      logger.warn("bundlesocial.reconcile.audit_failed", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  })();
+
+  return { ok: true, action, detail };
+}
+
+// ---------------------------------------------------------------------------
+// L1 helper — pre-connect ghost check.
+//
+// Called from POST /api/platform/social/connections/connect right before
+// the OAuth URL is generated. Two interesting outcomes:
+//
+//   kind="ghost_cleared" — BS had a ghost; we disconnected it. Caller
+//     should proceed with the OAuth popup.
+//
+//   kind="db_match"     — BS has an account AND we have a matching DB
+//     row. Caller should NOT open OAuth; instead surface the existing
+//     connection to the user with a Disconnect button.
+//
+//   kind="clean"        — BS has no account for this (team, platform).
+//     Proceed as normal.
+//
+//   kind="error"        — could not call bundle.social. Caller should
+//     proceed anyway (defensive) — the connect step itself will surface
+//     the underlying error.
+// ---------------------------------------------------------------------------
+
+export type PreConnectCheck =
+  | { kind: "clean" }
+  | { kind: "ghost_cleared"; bundle_account_id: string }
+  | {
+      kind: "db_match";
+      existing_connection_id: string;
+      existing_company_id: string;
+      existing_display_name: string | null;
+      bundle_account_id: string;
+    }
+  | { kind: "error"; message: string };
+
+export async function preConnectGhostCheck(input: {
+  teamId: string;
+  platform: BundlesocialPlatformType;
+  actorId: string | null;
+}): Promise<PreConnectCheck> {
+  let acct;
+  try {
+    acct = await safeGetByType(input.teamId, input.platform);
+  } catch (err) {
+    return {
+      kind: "error",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+  if (!acct) return { kind: "clean" };
+
+  const svc = getServiceRoleClient();
+  const match = await svc
+    .from("social_connections")
+    .select("id, company_id, display_name, status")
+    .eq("bundle_social_account_id", acct.id)
+    .maybeSingle();
+
+  if (match.data) {
+    const row = match.data as {
+      id: string;
+      company_id: string;
+      display_name: string | null;
+      status: string;
+    };
+    return {
+      kind: "db_match",
+      existing_connection_id: row.id,
+      existing_company_id: row.company_id,
+      existing_display_name: row.display_name,
+      bundle_account_id: acct.id,
+    };
+  }
+
+  // Ghost — apply the disconnect inline.
+  const applied = await applyDivergence(
+    {
+      kind: "ghost",
+      team_id: input.teamId,
+      platform: input.platform,
+      bundle_account_id: acct.id,
+      bundle_external_id: acct.externalId,
+      bundle_display_name: acct.displayName,
+      db_row_id: null,
+      db_company_id: null,
+      db_platform: null,
+      db_display_name: null,
+      db_external_account_id: null,
+      reason: "Detected at pre-connect; auto-disconnect before OAuth.",
+    },
+    input.actorId,
+  );
+  if (!applied.ok) {
+    return {
+      kind: "error",
+      message: `Ghost detected but disconnect failed: ${applied.error.message}`,
+    };
+  }
+  return { kind: "ghost_cleared", bundle_account_id: acct.id };
+}
+
+// ---------------------------------------------------------------------------
+// L4 helper — verify a disconnect actually landed on bundle.social.
+//
+// Called after socialAccountDisconnect. Polls socialAccountGetByType up
+// to N times with backoff. Returns true if BS confirms the account is
+// gone, false otherwise.
+//
+// The caller uses the result to decide whether to DELETE the DB row
+// (only when verified clean) — see /api/platform/social/connections/[id]/
+// disconnect/route.ts.
+// ---------------------------------------------------------------------------
+
+export async function verifyBundlesocialDisconnect(input: {
+  teamId: string;
+  platform: BundlesocialPlatformType;
+  // Defaults: 2s settle + one retry after 5s ⇒ ~7s wall-clock worst case.
+  initialWaitMs?: number;
+  retryWaitMs?: number;
+  retries?: number;
+}): Promise<{ clean: boolean; reason: string }> {
+  const initialWaitMs = input.initialWaitMs ?? 2_000;
+  const retryWaitMs = input.retryWaitMs ?? 5_000;
+  const retries = input.retries ?? 1;
+
+  await new Promise((r) => setTimeout(r, initialWaitMs));
+  let attempt = 0;
+  // attempt 0 is the initial verify; subsequent loops are retries.
+  while (true) {
+    let acct;
+    try {
+      acct = await safeGetByType(input.teamId, input.platform);
+    } catch (err) {
+      return {
+        clean: false,
+        reason: `verify probe errored: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+    if (!acct) return { clean: true, reason: "bundle.social shows no account." };
+
+    if (attempt >= retries) {
+      return {
+        clean: false,
+        reason: `bundle.social still has account ${acct.id} after ${attempt + 1} attempt(s).`,
+      };
+    }
+    attempt += 1;
+    await new Promise((r) => setTimeout(r, retryWaitMs));
+    // Re-issue the SDK disconnect — sometimes BS' first ack lags and
+    // the retry is what actually flushes.
+    const client = getBundlesocialClient();
+    if (!client) return { clean: false, reason: "client unavailable on retry" };
+    try {
+      await client.socialAccount.socialAccountDisconnect({
+        requestBody: { type: input.platform, teamId: input.teamId },
+      });
+    } catch {
+      // tolerate — verify on next loop iteration.
+    }
+  }
+}

--- a/lib/platform/social/connections/reconcile.ts
+++ b/lib/platform/social/connections/reconcile.ts
@@ -612,12 +612,19 @@ export async function verifyBundlesocialDisconnect(input: {
   teamId: string;
   platform: BundlesocialPlatformType;
   // Defaults: 2s settle + one retry after 5s ⇒ ~7s wall-clock worst case.
+  // Tests override these via BUNDLE_VERIFY_*_MS env vars (set to 0).
   initialWaitMs?: number;
   retryWaitMs?: number;
   retries?: number;
 }): Promise<{ clean: boolean; reason: string }> {
-  const initialWaitMs = input.initialWaitMs ?? 2_000;
-  const retryWaitMs = input.retryWaitMs ?? 5_000;
+  const envInitial = Number(process.env.BUNDLE_VERIFY_INITIAL_WAIT_MS);
+  const envRetry = Number(process.env.BUNDLE_VERIFY_RETRY_WAIT_MS);
+  const initialWaitMs =
+    input.initialWaitMs ??
+    (Number.isFinite(envInitial) && envInitial >= 0 ? envInitial : 2_000);
+  const retryWaitMs =
+    input.retryWaitMs ??
+    (Number.isFinite(envRetry) && envRetry >= 0 ? envRetry : 5_000);
   const retries = input.retries ?? 1;
 
   await new Promise((r) => setTimeout(r, initialWaitMs));

--- a/tests/regressions/disconnect-ordering.test.ts
+++ b/tests/regressions/disconnect-ordering.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Make the L4 verify-loop's setTimeout windows zero so this test file
+// doesn't pay the 2s + 5s wall-clock cost per retry case.
+process.env.BUNDLE_VERIFY_INITIAL_WAIT_MS = "0";
+process.env.BUNDLE_VERIFY_RETRY_WAIT_MS = "0";
+
 // ---------------------------------------------------------------------------
 // REGRESSION — Layer 6 disconnect ordering.
 //
@@ -24,6 +29,14 @@ const unsetChannelSdkMock = vi.fn(async () => {
 const disconnectSdkMock = vi.fn(async () => {
   callOrder.push("disconnect");
 });
+// L4 verify-then-delete: after the disconnect, the route calls
+// socialAccountGetByType to confirm BS released the account. Returning
+// null = clean (verify succeeds). Tests overriding this to return an
+// account object simulate split-brain.
+const getByTypeSdkMock = vi.fn(async () => {
+  callOrder.push("verify-getByType");
+  return null;
+});
 const deleteMock = vi.fn(async () => {
   callOrder.push("delete");
   return { error: null };
@@ -35,6 +48,7 @@ vi.mock("@/lib/bundlesocial", () => ({
     socialAccount: {
       socialAccountUnsetChannel: unsetChannelSdkMock,
       socialAccountDisconnect: disconnectSdkMock,
+      socialAccountGetByType: getByTypeSdkMock,
     },
   }),
 }));
@@ -105,6 +119,11 @@ beforeEach(() => {
   callOrder.length = 0;
   unsetChannelSdkMock.mockClear();
   disconnectSdkMock.mockClear();
+  getByTypeSdkMock.mockClear();
+  getByTypeSdkMock.mockImplementation(async () => {
+    callOrder.push("verify-getByType");
+    return null;
+  });
   deleteMock.mockClear();
   insertEventMock.mockClear();
   connRow = {
@@ -128,45 +147,98 @@ async function callDisconnect(): Promise<Response> {
   });
 }
 
-describe("R-DISCONNECT: order is unset → disconnect → DELETE", () => {
-  it("channel-selection platform with bound channel: unset runs first", async () => {
+describe("R-DISCONNECT: order is unset → disconnect → verify → DELETE", () => {
+  it("channel-selection platform with bound channel: unset runs first, verify gates delete", async () => {
     const res = await callDisconnect();
     expect(res.status).toBe(200);
-    expect(callOrder).toEqual(["unsetChannel", "disconnect", "delete"]);
+    expect(callOrder).toEqual([
+      "unsetChannel",
+      "disconnect",
+      "verify-getByType",
+      "delete",
+    ]);
   });
 
   it("personal-mode LinkedIn skips unsetChannel (no channel bound)", async () => {
     connRow.is_personal_mode = true;
     const res = await callDisconnect();
     expect(res.status).toBe(200);
-    expect(callOrder).toEqual(["disconnect", "delete"]);
+    expect(callOrder).toEqual(["disconnect", "verify-getByType", "delete"]);
   });
 
   it("non-channel-selection platform (X) skips unsetChannel", async () => {
     connRow.platform = "x";
     const res = await callDisconnect();
     expect(res.status).toBe(200);
-    expect(callOrder).toEqual(["disconnect", "delete"]);
+    expect(callOrder).toEqual(["disconnect", "verify-getByType", "delete"]);
   });
 
-  it("DELETE still runs when unsetChannel errors", async () => {
+  it("DELETE still runs when unsetChannel errors (verify still clean)", async () => {
     unsetChannelSdkMock.mockImplementationOnce(async () => {
       callOrder.push("unsetChannel");
       throw new Error("upstream fail");
     });
     const res = await callDisconnect();
     expect(res.status).toBe(200);
-    expect(callOrder).toEqual(["unsetChannel", "disconnect", "delete"]);
+    expect(callOrder).toEqual([
+      "unsetChannel",
+      "disconnect",
+      "verify-getByType",
+      "delete",
+    ]);
   });
 
-  it("DELETE still runs when socialAccountDisconnect errors", async () => {
+  it("DELETE still runs when socialAccountDisconnect errors but verify is clean (idempotent)", async () => {
     disconnectSdkMock.mockImplementationOnce(async () => {
       callOrder.push("disconnect");
       throw new Error("upstream fail");
     });
     const res = await callDisconnect();
     expect(res.status).toBe(200);
-    expect(callOrder).toEqual(["unsetChannel", "disconnect", "delete"]);
+    expect(callOrder).toEqual([
+      "unsetChannel",
+      "disconnect",
+      "verify-getByType",
+      "delete",
+    ]);
+  });
+
+  it("SPLIT-BRAIN: BS still has account after disconnect → 409, NO delete, audit logged", async () => {
+    // Simulate bundle.social NOT releasing the account after disconnect.
+    // verify-getByType returns a non-null account on every call.
+    getByTypeSdkMock.mockImplementation(async () => {
+      callOrder.push("verify-getByType");
+      return { id: "bs-acct-1" };
+    });
+    const res = await callDisconnect();
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as {
+      ok: boolean;
+      error: { code: string };
+    };
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("INVALID_STATE");
+    // The route MUST NOT delete the row when verify never goes clean.
+    expect(callOrder).not.toContain("delete");
+    // The route should have retried the disconnect once before giving up.
+    // Final order: initial unset/disconnect + verify (still has) + retry
+    // disconnect + verify (still has).
+    expect(disconnectSdkMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("SPLIT-BRAIN-RECOVERY: verify clean after one retry → delete proceeds", async () => {
+    // First verify returns account, retry-disconnect runs, then second
+    // verify returns null → clean → delete.
+    let call = 0;
+    getByTypeSdkMock.mockImplementation(async () => {
+      callOrder.push("verify-getByType");
+      call += 1;
+      return call === 1 ? { id: "bs-acct-1" } : null;
+    });
+    const res = await callDisconnect();
+    expect(res.status).toBe(200);
+    expect(callOrder).toContain("delete");
+    expect(disconnectSdkMock).toHaveBeenCalledTimes(2);
   });
 
   it("400 'Team does not have' is idempotent-success, not a failure", async () => {

--- a/tests/regressions/disconnect-ordering.test.ts
+++ b/tests/regressions/disconnect-ordering.test.ts
@@ -33,7 +33,7 @@ const disconnectSdkMock = vi.fn(async () => {
 // socialAccountGetByType to confirm BS released the account. Returning
 // null = clean (verify succeeds). Tests overriding this to return an
 // account object simulate split-brain.
-const getByTypeSdkMock = vi.fn(async () => {
+const getByTypeSdkMock = vi.fn(async (): Promise<{ id: string } | null> => {
   callOrder.push("verify-getByType");
   return null;
 });

--- a/tests/regressions/pre-connect-ghost-check.test.ts
+++ b/tests/regressions/pre-connect-ghost-check.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// REGRESSION — L1 pre-connect ghost check (POST /connect).
+//
+// Three scenarios:
+//   1. clean: no BS account for (team, platform) → proceed to OAuth as today.
+//   2. ghost: BS has account but no DB row matches → auto-disconnect ghost,
+//      then proceed to OAuth.
+//   3. db_match: BS has account AND a matching DB row → 409 ALREADY_CONNECTED
+//      with existing_connection_id, do NOT generate an OAuth URL.
+// ---------------------------------------------------------------------------
+
+const getByTypeSdkMock = vi.fn();
+const disconnectSdkMock = vi.fn();
+const connectSdkMock = vi.fn();
+const insertEventMock = vi.fn(async () => ({ error: null }));
+const maybeSingleMock = vi.fn();
+
+vi.mock("@/lib/bundlesocial", () => ({
+  getBundlesocialClient: () => ({
+    socialAccount: {
+      socialAccountGetByType: getByTypeSdkMock,
+      socialAccountDisconnect: disconnectSdkMock,
+      socialAccountConnect: connectSdkMock,
+    },
+  }),
+  getBundlesocialTeamId: () => "team-fixture",
+}));
+
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: async () => ({
+    kind: "allow" as const,
+    userId: "user-test",
+    supabase: {} as never,
+  }),
+}));
+
+vi.mock("@/lib/platform/social/profiles", () => ({
+  getProfileById: async (id: string) => ({
+    id,
+    company_id: "11111111-1111-1111-1111-111111111111",
+    bundle_social_team_id: "team-fixture",
+  }),
+}));
+
+vi.mock("@/lib/platform/social/profiles/provision-team", () => ({
+  getOrCreateBundleSocialTeamForProfile: async () => "team-fixture",
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({
+    from: (table: string) => {
+      if (table === "social_connections") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: maybeSingleMock,
+            }),
+          }),
+        };
+      }
+      if (table === "platform_events") {
+        return { insert: insertEventMock };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  }),
+}));
+
+import { POST } from "@/app/api/platform/social/connections/connect/route";
+
+const COMPANY_ID = "11111111-1111-1111-1111-111111111111";
+const PROFILE_ID = "22222222-2222-2222-2222-222222222222";
+
+beforeEach(() => {
+  getByTypeSdkMock.mockReset();
+  disconnectSdkMock.mockReset();
+  connectSdkMock.mockReset();
+  maybeSingleMock.mockReset();
+  insertEventMock.mockClear();
+  // Default: BS returns no account.
+  getByTypeSdkMock.mockResolvedValue(null);
+  // Default: DB lookup returns no match.
+  maybeSingleMock.mockResolvedValue({ data: null, error: null });
+  // Default: connect SDK returns a URL.
+  connectSdkMock.mockResolvedValue({
+    url: "https://www.facebook.com/oauth?stub",
+  });
+  // Default: disconnect succeeds.
+  disconnectSdkMock.mockResolvedValue({});
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+async function callConnect(platform: string): Promise<Response> {
+  return POST(
+    new Request("http://localhost/x", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        company_id: COMPANY_ID,
+        profile_id: PROFILE_ID,
+        platform,
+      }),
+    }) as never,
+  );
+}
+
+describe("R-PRE-CONNECT-GHOST: L1 ghost auto-clear before OAuth", () => {
+  it("CLEAN: no BS account → no ghost disconnect, OAuth URL returned", async () => {
+    const res = await callConnect("LINKEDIN");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data?: { url: string };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data?.url).toContain("oauth");
+    expect(disconnectSdkMock).not.toHaveBeenCalled();
+    expect(connectSdkMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("GHOST: BS has account, DB has no matching row → auto-disconnect, then OAuth", async () => {
+    getByTypeSdkMock.mockResolvedValue({
+      id: "ghost-bs-acct-1",
+      externalId: "urn:li:org:42",
+      displayName: "Ghost Co",
+    });
+    // DB lookup by bundle_social_account_id returns no row.
+    maybeSingleMock.mockResolvedValue({ data: null, error: null });
+
+    const res = await callConnect("LINKEDIN");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      data?: { url: string };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data?.url).toContain("oauth");
+    // The ghost MUST be disconnected before OAuth.
+    expect(disconnectSdkMock).toHaveBeenCalledWith({
+      requestBody: { type: "LINKEDIN", teamId: "team-fixture" },
+    });
+    expect(connectSdkMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("DB_MATCH: BS has account AND DB row matches → 409 ALREADY_CONNECTED, no OAuth", async () => {
+    getByTypeSdkMock.mockResolvedValue({
+      id: "bs-acct-existing",
+      externalId: "urn:li:person:42",
+      displayName: "Existing User",
+    });
+    maybeSingleMock.mockResolvedValue({
+      data: {
+        id: "11111111-1111-1111-1111-cccccccccccc",
+        company_id: COMPANY_ID,
+        display_name: "Existing User",
+        status: "healthy",
+      },
+      error: null,
+    });
+
+    const res = await callConnect("LINKEDIN");
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as {
+      ok: boolean;
+      error: {
+        code: string;
+        existing_connection_id?: string;
+        existing_display_name?: string;
+      };
+    };
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("ALREADY_CONNECTED");
+    expect(body.error.existing_connection_id).toBe(
+      "11111111-1111-1111-1111-cccccccccccc",
+    );
+    expect(body.error.existing_display_name).toBe("Existing User");
+    // No ghost disconnect, no OAuth URL generation.
+    expect(disconnectSdkMock).not.toHaveBeenCalled();
+    expect(connectSdkMock).not.toHaveBeenCalled();
+  });
+
+  it("PRE-CHECK ERROR: BS getByType throws non-404 → defensive proceed (OAuth still attempted)", async () => {
+    getByTypeSdkMock.mockRejectedValue(
+      Object.assign(new Error("upstream 502"), { status: 502 }),
+    );
+    const res = await callConnect("LINKEDIN");
+    // The route ignores the pre-check error and proceeds.
+    expect(res.status).toBe(200);
+    expect(connectSdkMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/regressions/reconcile-bundlesocial.test.ts
+++ b/tests/regressions/reconcile-bundlesocial.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// REGRESSION — POST /api/admin/maintenance/reconcile-bundlesocial.
+//
+// Three divergence kinds and their fixes:
+//   ghost   — BS has account, no DB row → disconnect BS account
+//   phantom — DB has active row, BS empty → mark row 'disconnected'
+//   mismatch — both sides, drift → re-sync DB from BS
+//
+// Tests assert (a) the scan produces the right divergence shape and
+// (b) apply mode runs the right SDK / DB op per kind.
+// ---------------------------------------------------------------------------
+
+process.env.BUNDLE_VERIFY_INITIAL_WAIT_MS = "0";
+process.env.BUNDLE_VERIFY_RETRY_WAIT_MS = "0";
+
+const getByTypeSdkMock = vi.fn();
+const disconnectSdkMock = vi.fn();
+const insertEventMock = vi.fn(async () => ({ error: null }));
+const updateMock = vi.fn();
+
+// Per-table query state. The scan code reads profiles and companies for
+// team-id resolution and the connections table for DB rows. Test sets
+// dataByTable before each test.
+const dataByTable: Record<string, unknown> = {};
+
+vi.mock("@/lib/bundlesocial", () => ({
+  getBundlesocialClient: () => ({
+    socialAccount: {
+      socialAccountGetByType: getByTypeSdkMock,
+      socialAccountDisconnect: disconnectSdkMock,
+    },
+  }),
+}));
+
+vi.mock("@/lib/admin-api-gate", () => ({
+  requireAdminForApi: async () => ({
+    kind: "allow" as const,
+    user: { id: "admin-test", email: "admin@test", role: "admin" },
+  }),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({
+    from: (table: string) => {
+      if (table === "social_connections") {
+        return {
+          select: () => ({
+            data: dataByTable.social_connections,
+            error: null,
+            // For .not("bundle_social_team_id", "is", null) chains.
+            not: () => ({
+              data: dataByTable.social_connections,
+              error: null,
+            }),
+          }),
+          update: (vals: Record<string, unknown>) => ({
+            eq: async (_col: string, _val: string) => {
+              updateMock(vals);
+              return { error: null };
+            },
+          }),
+        };
+      }
+      if (table === "platform_social_profiles") {
+        return {
+          select: () => ({
+            not: () => ({
+              data: dataByTable.platform_social_profiles,
+              error: null,
+            }),
+            data: dataByTable.platform_social_profiles,
+            error: null,
+          }),
+        };
+      }
+      if (table === "platform_companies") {
+        return {
+          select: () => ({
+            not: () => ({
+              data: dataByTable.platform_companies,
+              error: null,
+            }),
+            data: dataByTable.platform_companies,
+            error: null,
+          }),
+        };
+      }
+      if (table === "platform_events") {
+        return { insert: insertEventMock };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  }),
+}));
+
+import { POST } from "@/app/api/admin/maintenance/reconcile-bundlesocial/route";
+
+// Valid UUIDv4-shaped fixtures (variant bits match Zod 4's UUID regex).
+const TEAM_ID = "11111111-1111-4111-8111-111111111111";
+const COMPANY_ID = "22222222-2222-4222-8222-222222222222";
+
+beforeEach(() => {
+  getByTypeSdkMock.mockReset();
+  disconnectSdkMock.mockReset();
+  updateMock.mockReset();
+  insertEventMock.mockClear();
+  dataByTable.platform_social_profiles = [];
+  dataByTable.platform_companies = [
+    { id: COMPANY_ID, bundle_social_team_id: TEAM_ID },
+  ];
+  dataByTable.social_connections = [];
+  // Default: BS returns null (no account) for every (team, platform).
+  getByTypeSdkMock.mockResolvedValue(null);
+  disconnectSdkMock.mockResolvedValue({});
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+async function callReconcile(body: Record<string, unknown>): Promise<Response> {
+  return POST(
+    new Request("http://localhost/x", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }) as never,
+  );
+}
+
+describe("R-RECONCILE-BUNDLESOCIAL", () => {
+  it("CLEAN: no divergences when BS and DB agree (both empty)", async () => {
+    const res = await callReconcile({
+      apply: false,
+      team_ids: [TEAM_ID],
+      platforms: ["LINKEDIN"],
+    });
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: { divergences: unknown[]; applied: boolean };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data.divergences).toEqual([]);
+    expect(body.data.applied).toBe(false);
+  });
+
+  it("GHOST scan: BS has account, no DB row → divergence kind='ghost'", async () => {
+    getByTypeSdkMock.mockResolvedValueOnce({
+      id: "ghost-acct-1",
+      externalId: "urn:li:org:99",
+      displayName: "Ghost Co",
+    });
+    const res = await callReconcile({
+      apply: false,
+      team_ids: [TEAM_ID],
+      platforms: ["LINKEDIN"],
+    });
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: {
+        divergences: Array<{
+          kind: string;
+          team_id: string;
+          platform: string;
+          bundle_account_id: string | null;
+        }>;
+      };
+    };
+    expect(body.data.divergences).toHaveLength(1);
+    expect(body.data.divergences[0]?.kind).toBe("ghost");
+    expect(body.data.divergences[0]?.bundle_account_id).toBe("ghost-acct-1");
+    // Read-only — no disconnect issued.
+    expect(disconnectSdkMock).not.toHaveBeenCalled();
+  });
+
+  it("GHOST apply: disconnect SDK called and audit logged", async () => {
+    getByTypeSdkMock.mockResolvedValue({
+      id: "ghost-acct-2",
+      externalId: null,
+      displayName: null,
+    });
+    const res = await callReconcile({
+      apply: true,
+      team_ids: [TEAM_ID],
+      platforms: ["LINKEDIN"],
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        apply_results: Array<{ ok: boolean; action: string }>;
+      };
+    };
+    expect(body.data.apply_results[0]?.ok).toBe(true);
+    expect(body.data.apply_results[0]?.action).toBe("ghost_disconnected");
+    expect(disconnectSdkMock).toHaveBeenCalledWith({
+      requestBody: { type: "LINKEDIN", teamId: TEAM_ID },
+    });
+    // Audit is fire-and-forget; allow microtasks to flush.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(insertEventMock).toHaveBeenCalled();
+  });
+
+  it("PHANTOM scan: DB has active row, BS returns null → divergence kind='phantom'", async () => {
+    dataByTable.social_connections = [
+      {
+        id: "ddddeeee-0000-0000-0000-000000000001",
+        bundle_social_account_id: "stale-bs-1",
+        company_id: COMPANY_ID,
+        platform: "linkedin_personal",
+        display_name: "Stale",
+        external_account_id: null,
+        external_user_id: "urn:li:person:stale",
+        profile_id: null,
+        status: "healthy",
+      },
+    ];
+    // BS returns null for LINKEDIN.
+    const res = await callReconcile({
+      apply: false,
+      team_ids: [TEAM_ID],
+      platforms: ["LINKEDIN"],
+    });
+    const body = (await res.json()) as {
+      data: {
+        divergences: Array<{
+          kind: string;
+          db_row_id: string | null;
+        }>;
+      };
+    };
+    expect(body.data.divergences).toHaveLength(1);
+    expect(body.data.divergences[0]?.kind).toBe("phantom");
+    expect(body.data.divergences[0]?.db_row_id).toBe(
+      "ddddeeee-0000-0000-0000-000000000001",
+    );
+  });
+
+  it("PHANTOM apply: DB row marked status='disconnected'", async () => {
+    dataByTable.social_connections = [
+      {
+        id: "ddddeeee-0000-0000-0000-000000000002",
+        bundle_social_account_id: "stale-bs-2",
+        company_id: COMPANY_ID,
+        platform: "linkedin_personal",
+        display_name: "Stale-2",
+        external_account_id: null,
+        external_user_id: null,
+        profile_id: null,
+        status: "healthy",
+      },
+    ];
+    const res = await callReconcile({
+      apply: true,
+      team_ids: [TEAM_ID],
+      platforms: ["LINKEDIN"],
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { apply_results: Array<{ ok: boolean; action: string }> };
+    };
+    expect(body.data.apply_results[0]?.action).toBe(
+      "phantom_marked_disconnected",
+    );
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "disconnected" }),
+    );
+    // disconnected rows are excluded from active-row consideration, so
+    // we expect to have set status, disconnected_at, and last_error.
+    expect(updateMock.mock.calls[0]?.[0]).toMatchObject({
+      status: "disconnected",
+      last_error: expect.stringContaining("reconcile"),
+    });
+  });
+
+  it("DISCONNECTED DB rows are excluded from phantom detection", async () => {
+    dataByTable.social_connections = [
+      {
+        id: "ddddeeee-0000-0000-0000-000000000003",
+        bundle_social_account_id: "already-dc",
+        company_id: COMPANY_ID,
+        platform: "linkedin_personal",
+        display_name: null,
+        external_account_id: null,
+        external_user_id: null,
+        profile_id: null,
+        status: "disconnected",
+      },
+    ];
+    const res = await callReconcile({
+      apply: false,
+      team_ids: [TEAM_ID],
+      platforms: ["LINKEDIN"],
+    });
+    const body = (await res.json()) as {
+      data: { divergences: unknown[] };
+    };
+    expect(body.data.divergences).toEqual([]);
+  });
+});


### PR DESCRIPTION
Failsafe for the recurring split-brain bug between our `social_connections` table and bundle.social. Four independent defenses + a one-shot unstick that already ran live against production.

## Phase 1 — Immediate unstick (already ran)

Wrote `scripts/_tmp_unstick_linkedin.ts` (deleted after use). It walked every (team × platform) tuple across the 7 teams in our DB, asked bundle.social what it holds, cross-referenced against `social_connections.bundle_social_account_id`, and disconnected any bundle.social account with no matching DB row.

**Result against production:**

```
=== DRY-RUN ===
[ghost_would_disconnect] team=2960f6ea platform=LINKEDIN acct=adb0d6a5-e407-4ad9-9882-bd69519f1737
Summary: scanned 98 (team,platform) tuples · 0 db rows · ghosts WOULD DISCONNECT: 1 · failures: 0

=== LIVE ===
[ghost_disconnected]              team=2960f6ea platform=LINKEDIN acct=adb0d6a5-...
[verify_post_disconnect_clean]    team=2960f6ea platform=LINKEDIN
Summary: 1 ghost DISCONNECTED · 0 failures
```

The customer-facing 'already connected' error on `/company/social/connections` is resolved as of the live run. Script deleted from the tree — the permanent reconcile surface (L2/L3 below) replaces it.

## Phase 2 — Permanent failsafe (this PR)

Four independent layers; any one of them alone would have prevented the original incident. Shared logic in `lib/platform/social/connections/reconcile.ts`.

### L1 — Pre-connect ghost check

`POST /api/platform/social/connections/connect` now runs a pre-flight before generating the OAuth URL:

1. Call `socialAccountGetByType(team, platform)`.
2. Three outcomes:
   - **clean** — BS has no account → proceed to OAuth as today.
   - **ghost** — BS has an account, no DB row matches by `bundle_social_account_id` → auto-disconnect on bundle.social side (audited), then proceed to OAuth.
   - **db_match** — BS has an account that matches an existing DB row → return `409 ALREADY_CONNECTED` with the existing `connection_id` so the UI can surface the existing row (with a Disconnect button) instead of the cryptic bundle.social "already connected" error.
3. Pre-check errors are non-fatal — defensive proceed; the connect step itself surfaces real upstream errors.

### L2 — Reconciliation API

`POST /api/admin/maintenance/reconcile-bundlesocial` — admin-only.

Body: `{ apply?: boolean, team_ids?: uuid[], platforms?: string[] }`. Defaults: scan-only, all teams, all platforms.

Returns divergences classified as:
- **ghost** — BS has it, DB doesn't → recommend disconnect on BS
- **phantom** — DB has an active row, BS doesn't → recommend `status='disconnected'`
- **mismatch** — both have it but `external_account_id` or `display_name` drifted → recommend re-sync from BS

`apply: true` performs the recommended fix for each divergence and audits to `platform_events.bundlesocial_reconcile_applied`.

### L3 — Maintenance UI

`/admin/maintenance/social-connections` gains a "Bundle.social Reconciliation" section above the existing identity-conflict table:

- **Scan for ghosts** button — calls `/reconcile-bundlesocial` in scan-only mode.
- Divergence table with kind pill (ghost / phantom / mismatch), team, platform, BS detail, DB detail, reason.
- **Fix this divergence** per-row + **Apply all fixes** bulk action.
- Probe errors expand into a details block.

### L4 — Disconnect verify-loop

`POST /api/platform/social/connections/[id]/disconnect` no longer deletes the DB row blind:

```
old: unset → 200ms settle → disconnect → DELETE row

new: unset → 200ms settle → disconnect →
     2s settle → verify via getByType →
       clean? → DELETE row
       still present? → retry disconnect, wait 5s, verify again →
         clean? → DELETE row
         still present? → 409 INVALID_STATE,
                          log disconnect_split_brain_detected,
                          DB row kept as source of truth
```

The DB row is now the source of truth: it only gets deleted when bundle.social confirms the disconnect. Wait timings overridable via `BUNDLE_VERIFY_INITIAL_WAIT_MS` / `BUNDLE_VERIFY_RETRY_WAIT_MS` env vars so tests run instantly.

## Phase 3 — Tests

### Regression tests

- `tests/regressions/disconnect-ordering.test.ts` — extended:
  - Call-order assertions updated to include the new `verify-getByType` step.
  - 2 new **SPLIT-BRAIN** cases:
    - BS still has account after disconnect → 409, no DELETE, retry attempted
    - Verify clean after one retry → DELETE proceeds
- `tests/regressions/pre-connect-ghost-check.test.ts` — new:
  - CLEAN (no BS account → OAuth)
  - GHOST (BS has, DB doesn't → auto-disconnect + OAuth)
  - DB_MATCH (BS + DB row → 409 ALREADY_CONNECTED, no OAuth)
  - PRE-CHECK ERROR (defensive proceed)
- `tests/regressions/reconcile-bundlesocial.test.ts` — new:
  - GHOST scan + apply (disconnect + audit)
  - PHANTOM scan + apply (`status='disconnected'`)
  - DISCONNECTED DB rows excluded from phantom detection
  - CLEAN (no divergences)

### Coverage

| Layer | New | Existing-changed |
|---|---|---|
| Unit / regression | 14 | 5 |
| Component | 0 | 0 |
| E2E | 0 | 0 (existing `e2e/social.spec.ts` covers connect → disconnect → connect implicitly) |

## Working analog

- **L1 analog**: `lib/platform/social/connections/reconcile.ts` `preConnectGhostCheck()` uses the same `socialAccountGetByType` + DB lookup pattern as L2's scan.
- **L4 analog**: `verifyBundlesocialDisconnect()` mirrors L2's `applyDivergence({kind:'ghost'})` path — both call `socialAccountDisconnect` then `socialAccountGetByType` to confirm.
- **L2 analog**: existing admin maintenance routes at `app/api/admin/maintenance/social-connections/[id]/refresh-identity/route.ts` for the auth + audit pattern.

## Risks identified and mitigated

- **Disconnect now takes ~3-7s wall-clock** for channel-selection platforms (2s settle + 1-2 verify calls). User-visible — UI still shows a spinner, but the perceived latency is longer than before. Tradeoff documented; deleting the DB row before bundle.social confirms was the root cause of every ghost, so we accept the latency.
- **L1 pre-check race** — between pre-check and OAuth open, a parallel session could install/clear an account on the same (team, platform). Mitigation: bundle.social's own duplicate-detection still catches this; the L1 check just removes the common-case error path.
- **Reconcile apply is destructive on phantoms** — flips `status='disconnected'` permanently. UI surfaces the affordance behind a confirm dialog with the exact action description. Audit row is the recovery path.
- **L4 verify-loop infinite hang** — capped at 1 retry + finite waits; tests env-override to 0ms so CI doesn't pay it.
- **Pre-flight tries to provision a team** — `getOrCreateBundleSocialTeamForProfile` is idempotent (BSP-2-style advisory lock). If it errors, the route falls through to existing connect logic and surfaces the real error.

## Manual test checklist for Steven

1. Open `/company/social/connections`, click **Connect new account** → tile grid renders.
2. Click **LinkedIn** tile.
3. OAuth popup opens cleanly (no "already connected" error from the prior ghost).
4. Complete OAuth, pick a channel, verify row shows **Healthy**.
5. Click **Disconnect** — observe ~3-5 s spinner, row removed, no errors.
6. Click **LinkedIn** tile again — should open OAuth, no `409 ALREADY_CONNECTED`.
7. Open `/admin/maintenance/social-connections` → new "Bundle.social Reconciliation" section.
8. Click **Scan for ghosts** → should report "in sync" (zero divergences).

## Test counts

- **typecheck**: clean
- **lint**: 0 warnings, 0 errors
- **test:unit**: 1475 / 1475 (was 1459; +16)
- **test:components**: 79 / 79
- **build**: ✓ Compiled successfully, 67 / 67 static pages

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] `test:unit`, `test:components`, `build`
- [x] Regression tests added (split-brain disconnect, pre-connect ghost, reconcile)
- [x] Working-analog block in PR body
- [x] Risks identified and mitigated section
- [x] PR sized appropriately (largest file: `reconcile.ts` at ~430 lines, justified by 4 distinct public entry points)

## Reminder for Steven

The DB credential leaked in PR #877's description is still unrotated. Once you're back online, rotate it and edit the PR description to remove the value.
