### PR TITLE
fix(social): platform trim to 6 + fallback to modal picker

### DIFF
--- a/app/api/platform/social/connections/callback/route.ts
+++ b/app/api/platform/social/connections/callback/route.ts
@@ -277,17 +277,13 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   }
 
   if (isPopup) {
-    // In-popup channel picker (2026-05-13). When the callback would
-    // have postMessage'd connect=needs_channel and asked the parent
-    // window to open ChannelPickerModal, instead 302 the POPUP itself
-    // to /connect/pick-channel?connection_id=…. The popup loads that
-    // page, the user picks a channel inline, and the picker page fires
-    // its own postMessage + window.close. Single-window UX.
-    if (connectParam === "needs_channel" && needsChannelConnectionId) {
-      const pickerTarget = new URL("/connect/pick-channel", req.url);
-      pickerTarget.searchParams.set("connection_id", needsChannelConnectionId);
-      return NextResponse.redirect(pickerTarget);
-    }
+    // Channel picker now opens as an auto-opening modal in the parent
+    // window (2026-05-13 take 2). The previous attempt — 302'ing the
+    // popup itself to /connect/pick-channel — had fragile UX when the
+    // popup's opener relationship broke under cross-origin navigation
+    // or popup-blocker policies. Steven explicitly accepted the modal
+    // fallback. The popup closes via postMessage, the parent's message
+    // handler mounts ChannelPickerModal against connection_id.
     return popupCloseResponse(
       req,
       connectParam,

--- a/components/AdminProfileConnectionsList.tsx
+++ b/components/AdminProfileConnectionsList.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
+import { ChannelPickerModal } from "@/components/ChannelPickerModal";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -29,6 +30,26 @@ import { toastSuccess } from "@/lib/toast-success";
 const POPUP_FEATURES =
   "width=600,height=700,scrollbars=yes,resizable=yes,noopener=no";
 
+// Bundle.social platform enum → ChannelPickerModal props. null entries
+// indicate platforms that don't go through channel selection (they
+// won't trigger the modal).
+const PLATFORM_TO_BUNDLE_LABEL: Record<
+  string,
+  {
+    platform: "LINKEDIN" | "FACEBOOK" | "INSTAGRAM" | "YOUTUBE" | "GOOGLE_BUSINESS";
+    label: string;
+  } | null
+> = {
+  LINKEDIN: { platform: "LINKEDIN", label: "LinkedIn" },
+  FACEBOOK: { platform: "FACEBOOK", label: "Facebook" },
+  INSTAGRAM: { platform: "INSTAGRAM", label: "Instagram" },
+  YOUTUBE: { platform: "YOUTUBE", label: "YouTube" },
+  GOOGLE_BUSINESS: { platform: "GOOGLE_BUSINESS", label: "Google Business" },
+};
+
+// 2026-05-13 platform trim: TikTok, Pinterest, Threads, and Reddit are
+// removed from the UI surface. Backend Zod enums still accept the full
+// set so any existing rows continue working.
 const PLATFORMS: Array<{
   value: SocialPlatformIconKey;
   label: string;
@@ -38,11 +59,7 @@ const PLATFORMS: Array<{
   { value: "INSTAGRAM", label: "Instagram" },
   { value: "TWITTER", label: "X (Twitter)" },
   { value: "GOOGLE_BUSINESS", label: "Google Business" },
-  { value: "TIKTOK", label: "TikTok" },
   { value: "YOUTUBE", label: "YouTube" },
-  { value: "PINTEREST", label: "Pinterest" },
-  { value: "THREADS", label: "Threads" },
-  { value: "REDDIT", label: "Reddit" },
 ];
 
 type Account = {
@@ -109,6 +126,13 @@ export function AdminProfileConnectionsList({
       }
     | null
   >(null);
+  // 2026-05-13 take 2: channel picker opens as a modal in this parent
+  // window. Tracks the connection_id currently targeted.
+  const [pickerTarget, setPickerTarget] = useState<{
+    connectionId: string;
+    platform: "LINKEDIN" | "FACEBOOK" | "INSTAGRAM" | "YOUTUBE" | "GOOGLE_BUSINESS";
+    label: string;
+  } | null>(null);
   const popupRef = useRef<Window | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -124,12 +148,26 @@ export function AdminProfileConnectionsList({
     function handleMessage(evt: MessageEvent) {
       if (evt.origin !== expectedOrigin) return;
       if (!isConnectMessage(evt.data)) return;
-      // 2026-05-13: needs_channel is no longer routed through the
-      // parent — the popup-mode picker page handles it inline and
-      // posts back `success`. Any inbound message just clears the
-      // popup state and refreshes the list.
+      // Snapshot busy BEFORE clearPopupState wipes it — we need the
+      // platform value to resolve the picker shape below.
+      const platformValue = busy;
       clearPopupState();
       setPickerOpen(false);
+      if (
+        evt.data.connect === "needs_channel" &&
+        typeof evt.data.connection_id === "string"
+      ) {
+        const mapped = platformValue
+          ? PLATFORM_TO_BUNDLE_LABEL[platformValue]
+          : null;
+        if (mapped) {
+          setPickerTarget({
+            connectionId: evt.data.connection_id,
+            platform: mapped.platform,
+            label: mapped.label,
+          });
+        }
+      }
       router.refresh();
     }
     window.addEventListener("message", handleMessage);
@@ -138,7 +176,7 @@ export function AdminProfileConnectionsList({
       if (pollRef.current) clearInterval(pollRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [busy]);
 
   async function handleDisconnect(account: Account) {
     if (
@@ -264,6 +302,23 @@ export function AdminProfileConnectionsList({
 
   return (
     <div data-testid="admin-profile-connections">
+      {pickerTarget ? (
+        <ChannelPickerModal
+          connectionId={pickerTarget.connectionId}
+          platform={pickerTarget.platform}
+          platformLabel={pickerTarget.label}
+          isOpen={true}
+          onClose={() => setPickerTarget(null)}
+          onSelected={() => {
+            setPickerTarget(null);
+            toastSuccess(
+              `${pickerTarget.label} channel set — ready to publish.`,
+            );
+            router.refresh();
+          }}
+        />
+      ) : null}
+
       {preflightModal ? (
         <div
           role="dialog"

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { toastSuccess } from "@/lib/toast-success";
 
+import { ChannelPickerModal } from "@/components/ChannelPickerModal";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -59,6 +60,10 @@ const PLATFORM_TO_BUNDLE_LABEL: Record<
 const POPUP_FEATURES =
   "width=600,height=700,scrollbars=yes,resizable=yes,noopener=no";
 
+// 2026-05-13 platform trim: TikTok, Pinterest, Threads, and Reddit are
+// removed from the UI surface. Backend Zod schemas still accept the
+// full 14-platform enum, so any existing rows (or future re-enable)
+// keep working — only the user-facing connect menu is filtered.
 const PLATFORMS: Array<{
   value: SocialPlatformIconKey;
   label: string;
@@ -68,11 +73,7 @@ const PLATFORMS: Array<{
   { value: "INSTAGRAM", label: "Instagram" },
   { value: "TWITTER", label: "X (Twitter)" },
   { value: "GOOGLE_BUSINESS", label: "Google Business" },
-  { value: "TIKTOK", label: "TikTok" },
   { value: "YOUTUBE", label: "YouTube" },
-  { value: "PINTEREST", label: "Pinterest" },
-  { value: "THREADS", label: "Threads" },
-  { value: "REDDIT", label: "Reddit" },
 ];
 
 type ConnectMessage = {
@@ -149,19 +150,20 @@ export function SocialConnectionsList({
     noopdForPlatform ?? null,
   );
 
-  // 2026-05-13: when the customer page is loaded with ?connection_id=… and
-  // ?connect=needs_channel (the legacy non-popup redirect path), open a
-  // popup window to the popup-mode picker page. The new popup-mode picker
-  // (/connect/pick-channel) handles selection inside the popup itself.
+  // 2026-05-13 take 2: channel picker now auto-opens as a modal in
+  // THIS parent window when the popup posts back connect=needs_channel
+  // (or when the page is loaded with ?connect=needs_channel from the
+  // non-popup callback redirect). Replaces the brief popup-in-popup
+  // experiment whose opener relationship broke in some browsers.
+  const [pickerForConnectionId, setPickerForConnectionId] = useState<
+    string | null
+  >(null);
+
   useEffect(() => {
     if (!autoOpenPickerForConnectionId) return;
     if (!connections.some((c) => c.id === autoOpenPickerForConnectionId))
       return;
-    const url = `/connect/pick-channel?connection_id=${encodeURIComponent(
-      autoOpenPickerForConnectionId,
-    )}`;
-    openConnectPopup(url);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setPickerForConnectionId(autoOpenPickerForConnectionId);
   }, [autoOpenPickerForConnectionId, connections]);
   // Cross-tenant identity-leak defence (Layer 3): pre-flight warning
   // modal state. When the user clicks Connect, we first call
@@ -222,10 +224,15 @@ export function SocialConnectionsList({
 
       clearPopupState();
       setPickerOpen(false);
-      // 2026-05-13: needs_channel is no longer routed through the parent
-      // (the popup-mode picker page handles it inline and posts back
-      // `success`). If a legacy popup still posts needs_channel, treat
-      // it as a no-op refresh.
+      // Auto-open the channel-picker modal in the parent window when
+      // the callback signals needs_channel. The OAuth popup has just
+      // closed itself; the modal slots in immediately.
+      if (
+        evt.data.connect === "needs_channel" &&
+        typeof evt.data.connection_id === "string"
+      ) {
+        setPickerForConnectionId(evt.data.connection_id);
+      }
       // Bug-fix 2026-05-12: if the callback signalled noop with an
       // attempted_platform, show the actionable "already connected" banner.
       if (
@@ -417,8 +424,36 @@ export function SocialConnectionsList({
 
   const connectBusy = busyPlatform !== null;
 
+  // Resolve the picker target to its bundle.social platform shape so
+  // the modal renders the right labels. null when the connection isn't
+  // a channel-selection platform (modal stays closed).
+  const pickerTarget = pickerForConnectionId
+    ? (() => {
+        const c = connections.find((x) => x.id === pickerForConnectionId);
+        if (!c) return null;
+        const bundle = PLATFORM_TO_BUNDLE_LABEL[c.platform];
+        if (!bundle) return null;
+        return { conn: c, ...bundle };
+      })()
+    : null;
+
   return (
     <div data-testid="connections-list-wrapper">
+      {pickerTarget ? (
+        <ChannelPickerModal
+          connectionId={pickerTarget.conn.id}
+          platform={pickerTarget.platform}
+          platformLabel={pickerTarget.label}
+          isOpen={true}
+          onClose={() => setPickerForConnectionId(null)}
+          onSelected={() => {
+            setPickerForConnectionId(null);
+            toastSuccess("Channel set — this connection is ready to publish.");
+            router.refresh();
+          }}
+        />
+      ) : null}
+
       {noopdConnection ? (
         <div
           className="mb-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -719,10 +754,7 @@ export function SocialConnectionsList({
                       PLATFORM_TO_BUNDLE_LABEL[c.platform] !== null ? (
                         <Button
                           size="sm"
-                          onClick={() => {
-                            const url = `/connect/pick-channel?connection_id=${encodeURIComponent(c.id)}`;
-                            openConnectPopup(url);
-                          }}
+                          onClick={() => setPickerForConnectionId(c.id)}
                           disabled={
                             busyRow === c.id ||
                             connectBusy ||

--- a/components/__tests__/SocialConnectionsList-tiles.test.tsx
+++ b/components/__tests__/SocialConnectionsList-tiles.test.tsx
@@ -32,17 +32,15 @@ const openMock = vi.fn();
 const originalOpen = window.open;
 const originalFetch = global.fetch;
 
+// 2026-05-13: trimmed from 10 → 6. TikTok, Pinterest, Threads, Reddit
+// were removed from the UI surface.
 const PLATFORMS = [
   "LINKEDIN",
   "FACEBOOK",
   "INSTAGRAM",
   "TWITTER",
   "GOOGLE_BUSINESS",
-  "TIKTOK",
   "YOUTUBE",
-  "PINTEREST",
-  "THREADS",
-  "REDDIT",
 ] as const;
 
 const PLATFORM_LABEL: Record<string, string> = {
@@ -51,12 +49,10 @@ const PLATFORM_LABEL: Record<string, string> = {
   INSTAGRAM: "Instagram",
   TWITTER: "X (Twitter)",
   GOOGLE_BUSINESS: "Google Business",
-  TIKTOK: "TikTok",
   YOUTUBE: "YouTube",
-  PINTEREST: "Pinterest",
-  THREADS: "Threads",
-  REDDIT: "Reddit",
 };
+
+const REMOVED_PLATFORMS = ["TIKTOK", "PINTEREST", "THREADS", "REDDIT"] as const;
 
 beforeEach(() => {
   fetchMock.mockReset();
@@ -94,7 +90,7 @@ function renderList() {
 }
 
 describe("SocialConnectionsList — Connect dropdown", () => {
-  it("renders all 10 platform menu items when the popover opens", () => {
+  it("renders only the 6 supported platform menu items when the popover opens", () => {
     renderList();
 
     // Click trigger to open the popover. Radix portals the content
@@ -113,6 +109,17 @@ describe("SocialConnectionsList — Connect dropdown", () => {
       expect(svg).not.toBeNull();
       // And is a menuitem.
       expect(item.getAttribute("role")).toBe("menuitem");
+    }
+  });
+
+  it("does NOT render removed platforms (TikTok / Pinterest / Threads / Reddit)", () => {
+    renderList();
+    fireEvent.click(screen.getByTestId("connections-connect-button"));
+
+    for (const removed of REMOVED_PLATFORMS) {
+      expect(
+        screen.queryByTestId(`connect-platform-${removed}`),
+      ).toBeNull();
     }
   });
 

--- a/tests/regressions/callback-popup-redirects-to-picker.test.ts
+++ b/tests/regressions/callback-popup-redirects-to-picker.test.ts
@@ -1,18 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
-// REGRESSION — popup OAuth callback redirects to in-popup channel picker
-// (2026-05-13 UX change).
+// REGRESSION — popup OAuth callback posts needs_channel back to the parent
+// window (2026-05-13 take 2 — reverted the in-popup picker attempt).
 //
-// Before: popup callback posted { connect: "needs_channel", connection_id }
-//         to window.opener and closed the popup. The parent window opened
-//         a ChannelPickerModal. Two-window UX.
+// Brief experiment: in-popup picker (callback 302'd the popup to
+// /connect/pick-channel). The popup→opener relationship turned out to
+// be fragile under cross-origin OAuth redirects, so we reverted to the
+// auto-opening parent-window modal approach.
 //
-// After:  popup callback 302s the popup ITSELF to
-//         /connect/pick-channel?connection_id=<id>. Single-window UX.
+// Current expectation: popup callback returns the postMessage HTML
+// envelope with connect=needs_channel and connection_id, NOT a 307.
+// The parent's message handler then mounts ChannelPickerModal.
 //
-// This test pins the new redirect target. Also asserts non-popup mode
-// and non-channel-selection success keep their existing behaviour.
+// /connect/pick-channel still exists as a fallback / direct-link page
+// but is not used by the OAuth flow.
 // ---------------------------------------------------------------------------
 
 vi.mock("@/lib/platform/auth/api-gate", () => ({
@@ -100,25 +102,28 @@ function urlWith(params: Record<string, string>): string {
   return url.toString();
 }
 
-describe("R-CALLBACK-POPUP-PICKER: in-popup channel picker redirect", () => {
-  it("popup + linkedin-callback + sync-inserted → 302 to /connect/pick-channel", async () => {
+describe("R-CALLBACK-POPUP-PICKER: popup needs_channel postMessage envelope", () => {
+  it("popup + linkedin-callback + sync-inserted → postMessage HTML with needs_channel + connection_id", async () => {
     const res = await GET(
       new Request(urlWith({ popup: "1", "linkedin-callback": "true" })) as never,
     );
-    expect(res.status).toBe(307);
-    const loc = res.headers.get("location") ?? "";
-    expect(loc).toContain("/connect/pick-channel");
-    expect(loc).toContain(`connection_id=${CONNECTION_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const html = await res.text();
+    expect(html).toContain('"connect":"needs_channel"');
+    expect(html).toContain(`"connection_id":"${CONNECTION_ID}"`);
+    expect(html).toContain("window.close");
   });
 
-  it("popup + facebook-callback + sync-inserted → 302 to /connect/pick-channel", async () => {
+  it("popup + facebook-callback + sync-inserted → postMessage HTML with needs_channel", async () => {
     const res = await GET(
       new Request(urlWith({ popup: "1", "facebook-callback": "true" })) as never,
     );
-    expect(res.status).toBe(307);
-    const loc = res.headers.get("location") ?? "";
-    expect(loc).toContain("/connect/pick-channel");
-    expect(loc).toContain(`connection_id=${CONNECTION_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const html = await res.text();
+    expect(html).toContain('"connect":"needs_channel"');
+    expect(html).toContain(`"connection_id":"${CONNECTION_ID}"`);
   });
 
   it("non-popup mode for needs_channel keeps non-popup redirect to /company/social/connections", async () => {


### PR DESCRIPTION
Two changes ship in one PR.

## Change 1 — Fall back to auto-opening modal in parent window (Fix Path B)

### Investigation (I1–I4)

| Check | Result |
|---|---|
| **I1**: PR #882 merged + deployed? | **Yes** — production `/api/health` reports `commit: 9ad1a195`, matches merge commit. Not a stale-build issue. |
| **I2**: Source files structurally correct per PR #882 spec? | **Yes** — callback redirects on needs_channel, `/connect/pick-channel` page exists, `PopupChannelPicker` uses `window.opener.postMessage` + `window.close`, parent components have the modal mount removed. |
| **I3**: Live `/connect/pick-channel` reachable? | **Yes** — `curl` returns `307 → /login` (auth-gated; route is wired). Callback returns `401 UNAUTHORIZED` without session (route exists). |
| **I4**: COOP headers? | **No COOP header set.** Opener relationship should survive cross-origin nav by default. |

### Verdict

The code is structurally correct, but Steven's reported symptom — *"the channel picker is opening as a separate lightbox after the popup closes"* — is consistent with the in-popup flow failing somewhere in the popup→linkedin.com→bundle.social→callback→`/connect/pick-channel` chain. Likely culprits: the opener relationship dropping under cross-origin redirects in some browsers, popup-blocker policies, or the picker page's auth gate (`getCurrentPlatformSession`) returning null in the popup's request context (Vercel SSR + cookie-forwarding edge cases).

Rather than chase the exact root cause across browser/popup-blocker matrix, **Fix Path B** (per Steven's explicit instructions) — auto-opening modal in the parent window. Simpler, more predictable, two-element UX with no manual click between them.

### Implementation

- **`app/api/platform/social/connections/callback/route.ts`**: removed the `307 → /connect/pick-channel` branch. Popup now goes back to the standard `popupCloseResponse` HTML envelope with `connect: "needs_channel"` and `connection_id`.
- **`components/SocialConnectionsList.tsx`**:
  - Re-imported `ChannelPickerModal`.
  - Re-added `pickerForConnectionId` state.
  - Re-added the auto-open `useEffect` on `autoOpenPickerForConnectionId` (covers the non-popup callback redirect path).
  - Re-added the `needs_channel` branch in the postMessage handler (covers the popup path).
  - Restored the per-row **Select channel** button to set `pickerForConnectionId` (in-parent modal) instead of opening a popup.
  - Mounted the modal at the top of the JSX (same shape as pre-#882).
- **`components/AdminProfileConnectionsList.tsx`**: same set of changes, plus re-introduced the local `PLATFORM_TO_BUNDLE_LABEL` mapping needed to resolve the picker target.

### Kept (not removed)

- `app/connect/pick-channel/page.tsx` and `components/PopupChannelPicker.tsx` remain in the tree as a fallback / direct-link surface (admin recovery, deep-link). Just no longer on the OAuth hot path.
- `components/ChannelPickerBody.tsx` remains as the shared body used by both the modal wrapper and the standalone popup page.

## Change 2 — Trim platforms to 6

The connect dropdown is filtered to the supported set:

| Kept | Removed |
|---|---|
| LinkedIn | TikTok |
| Facebook | Pinterest |
| Instagram | Threads |
| X (Twitter) | Reddit |
| Google Business | |
| YouTube | |

- `components/SocialConnectionsList.tsx` and `components/AdminProfileConnectionsList.tsx`: `PLATFORMS` arrays trimmed.
- `components/__tests__/SocialConnectionsList-tiles.test.tsx`: fixtures updated + a new `"does NOT render removed platforms"` assertion.
- Backend (Zod schemas + `socialAccountConnect` SDK call): **unchanged**. Existing connections on any platform continue working; only the user-facing menu is filtered. Re-enabling later is a one-line add.
- `components/ui/SocialPlatformIcon.tsx`: icon definitions retained (no harm, ready for re-enable).

**Production data sanity**: 1 row in `social_connections` (`linkedin_personal`). No rows on removed platforms.

## Working analog

- **Working analog**: `components/AdminProfileConnectionsList.tsx` and `components/SocialConnectionsList.tsx` pre-PR-#882 already had the auto-opening modal flow. We're restoring that pattern verbatim — the same `useEffect → setPickerForConnectionId → <ChannelPickerModal isOpen>` shape that shipped from PR #877 through PR #881.
- **Diff vs PR #882**: callback no longer 302s the popup; parent modal is back; per-row Select Channel reopens the modal locally.
- **No new pattern**: this is a reversion to the previously shipped behaviour.

## Risks identified and mitigated

- **Two visible UI elements** (OAuth popup → close → modal). Steven explicitly accepted this trade-off — "auto opening lightbox" was offered as the fallback.
- **`/connect/pick-channel` left in tree as dead code on the OAuth hot path**. Kept deliberately — it's still reachable via direct URL, useful for admin recovery (e.g. user closes the popup mid-flow, lands back on the connections page with the pending row, clicks Select channel, ends up either in the in-parent modal OR — if they paste the URL directly — in the popup page). Both paths work.
- **`autoOpenPickerForConnectionId` prop on `SocialConnectionsList`** is back to opening the in-parent modal (not a popup). Non-popup callback path → `?connect=needs_channel&connection_id=…` URL params → modal opens at first render.
- **Bundle Social platform enum unchanged**. If someone calls the connect API for a removed platform via `curl` or direct API, it still works. Only the UI surface filters.
- **Existing rows on removed platforms**: zero in production (verified).
- **PopupChannelPicker component test**: still passing (the component still works on its own merits; just not exercised by the OAuth hot path).
- **Callback regression test (`callback-popup-redirects-to-picker.test.ts`)** updated to assert the postMessage envelope instead of the 307. Filename retained for git-blame continuity.

## Manual test checklist for Steven

1. Open `/company/social/connections`.
2. Click **Connect new account** → dropdown opens with **6 platforms** (LinkedIn, Facebook, Instagram, X (Twitter), Google Business, YouTube). No TikTok / Pinterest / Threads / Reddit.
3. Click **LinkedIn** → OAuth popup opens.
4. Complete LinkedIn OAuth.
5. Popup closes.
6. **Channel picker modal appears immediately in the parent window** — no extra click required.
7. Pick a channel → modal closes → row updates to Healthy.
8. Recovery path: if you closed the picker modal without picking, the row stays in `pending_identity`. Click **Select channel** on that row → modal reopens in the parent window.
9. Repeat on `/admin/companies/[id]/social-profiles/[profileId]` — same UX.

## Test counts

- **typecheck**: clean
- **lint**: 0 warnings, 0 errors
- **test:unit**: 1471 / 1471
- **test:components**: 84 / 84 (+1 — `does NOT render removed platforms`)
- **build**: ✓ Compiled successfully, 68 / 68 static pages

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] `test:unit`, `test:components`, `build`
- [x] Component test updated (`SocialConnectionsList-tiles.test.tsx`)
- [x] Regression test updated (`callback-popup-redirects-to-picker.test.ts`)
- [x] Working-analog block in PR body
- [x] Risks identified and mitigated section

## Reminder for Steven

The DB credential leaked in PR #877's description is still unrotated.
