### PR TITLE
feat(social): auto-open ChannelPickerModal for pending_identity connections

### DIFF
--- a/components/AdminProfileConnectionsList.tsx
+++ b/components/AdminProfileConnectionsList.tsx
@@ -153,6 +153,9 @@ export function AdminProfileConnectionsList({
   const popupRef = useRef<Window | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const popupOpenedAtRef = useRef<number | null>(null);
+  // Shown-set for the auto-open effect. useRef resets on unmount (page
+  // refresh) so a new mount always re-evaluates pending rows.
+  const pickerShownRef = useRef<Set<string>>(new Set());
 
   function clearPopupState() {
     if (pollRef.current) clearInterval(pollRef.current);
@@ -253,6 +256,46 @@ export function AdminProfileConnectionsList({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [busy]);
+
+  // On mount and after any accounts change, fetch DB connections and
+  // auto-open the picker for any pending_identity row not shown yet
+  // this component lifetime.
+  useEffect(() => {
+    if (pickerTarget) return;
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/platform/social/connections?company_id=${encodeURIComponent(companyId)}`,
+        );
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          data?: {
+            connections: Array<{
+              id: string;
+              platform: string;
+              status: string;
+              connected_at: string;
+            }>;
+          };
+        };
+        const pending = (data?.data?.connections ?? []).find(
+          (c) =>
+            c.status === "pending_identity" &&
+            DB_PLATFORM_TO_PICKER[c.platform] !== null &&
+            DB_PLATFORM_TO_PICKER[c.platform] !== undefined &&
+            !pickerShownRef.current.has(c.id),
+        );
+        if (!pending) return;
+        const picker = DB_PLATFORM_TO_PICKER[pending.platform]!;
+        pickerShownRef.current.add(pending.id);
+        setPickerTarget({
+          connectionId: pending.id,
+          platform: picker.platform,
+          label: picker.label,
+        });
+      } catch {}
+    })();
+  }, [accounts, pickerTarget, companyId]);
 
   async function handleDisconnect(account: Account) {
     if (

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -184,6 +184,9 @@ export function SocialConnectionsList({
   // Timestamp set when the popup opens so we can identify connections
   // created AFTER the popup (needed for auto-picker after sync).
   const popupOpenedAtRef = useRef<number | null>(null);
+  // Shown-set for the auto-open effect. useRef resets on unmount (page
+  // refresh) so a new mount always re-evaluates pending rows.
+  const pickerShownRef = useRef<Set<string>>(new Set());
   // Set to Date.now() when a post-popup sync inserted > 0 rows.
   // Drives the auto-open picker effect below.
   const [postPopupSyncAt, setPostPopupSyncAt] = useState<number | null>(null);
@@ -269,6 +272,23 @@ export function SocialConnectionsList({
     // pending_identity — TWITTER goes straight to healthy).
     if (Date.now() - postPopupSyncAt > 10_000) setPostPopupSyncAt(null);
   }, [connections, pickerForConnectionId, postPopupSyncAt]);
+
+  // Auto-open the channel picker for any pending_identity row that hasn't
+  // been shown this component lifetime. Runs on mount and whenever the
+  // connections array or open-picker state changes.
+  useEffect(() => {
+    if (pickerForConnectionId) return;
+    const pending = connections.find(
+      (c) =>
+        c.status === "pending_identity" &&
+        PLATFORM_TO_BUNDLE_LABEL[c.platform] !== null &&
+        PLATFORM_TO_BUNDLE_LABEL[c.platform] !== undefined &&
+        !pickerShownRef.current.has(c.id),
+    );
+    if (!pending) return;
+    pickerShownRef.current.add(pending.id);
+    setPickerForConnectionId(pending.id);
+  }, [connections, pickerForConnectionId]);
 
   useEffect(() => {
     const expectedOrigin = window.location.origin;

--- a/docs/incidents/2026-05-13-split-brain-recurrence.md
+++ b/docs/incidents/2026-05-13-split-brain-recurrence.md
@@ -1,0 +1,194 @@
+# Split-brain recurrence — "already connected" on empty table (2026-05-13)
+
+## Section 1: Verdict
+
+**Failure mode (a): PR #881 was never merged. Every one of the four defenses is undeployed.**
+
+The incident re-occurred for the same structural reason as the original: a
+bundle.social OAuth completed, the popup landed on bundle.social's dashboard
+(bundle.social's redirect behaviour, the bug PR #884 targeted), our callback
+was never called, and no DB row was created for the new account. With no L1
+pre-connect ghost check live, the next connect attempt hit `socialAccountConnect`
+directly — bundle.social rejected it with "This team already has a LinkedIn
+account connected. Please disconnect it first."
+
+PR #884 (sync-on-close) does NOT help here because it fires *after* the popup
+opens. The ghost blocks `socialAccountConnect` before a popup is ever opened.
+L1 (PR #881) is the only defense that runs before that call.
+
+---
+
+## Section 2: Findings from I1–I10
+
+### I1 — PR #881 state
+
+```
+gh pr view 881 --json state,mergedAt,mergeCommit
+→ { "state": "OPEN", "mergedAt": null, "mergeCommit": null }
+```
+
+PR #881 (`hotfix/bundlesocial-reconcile-and-failsafe`) is open and unmerged.
+The four-layer failsafe described in its description — L1 pre-connect ghost
+check, L2 reconciliation API, L3 maintenance UI, L4 verify-loop disconnect —
+has never been deployed to production.
+
+### I2 — Deployed SHA vs PR #881
+
+Production deployed SHA: `621ce960` (PR #884 — sync-on-close fix, merged
+this session). PR #881's merge commit: null (open). PR #881's code is not in
+the deployed bundle.
+
+### I3 — L1 in connect route
+
+`app/api/platform/social/connections/connect/route.ts` (line 107–113):
+`initiateProfileConnect` is called directly with no pre-flight ghost check.
+No reference to `checkBundleSocialGhost`, `preConnectGhostCheck`, or `L1`.
+Confirmed: L1 is not wired.
+
+### I4 — social_connections table
+
+```
+GET /rest/v1/social_connections → []
+```
+
+Zero rows. The UI's "No social connections yet" is accurate.
+
+### I5/I6 — Ghost account on bundle.social
+
+`socialAccountGetByType(teamId='2960f6ea', type='LINKEDIN')`:
+
+| Field | Value |
+|---|---|
+| Account ID | `4b3b1448-5fc9-42a6-9d9b-c748f1d816ea` |
+| Team | `2960f6ea` (Opollo) |
+| User | Steven Morey (`urn:li:person:cn_0IGowb1`, userUsername: `stevenmorey`) |
+| externalId | `null` |
+| Channels | 15 (personal profile + 14 organisations) |
+| `createdAt` on bundle.social | `2026-05-12T21:58:23.254Z` |
+| `deletedAt` | `null` |
+| DB row matching this account | **none** |
+
+All other teams (Vincovi, ASCII Group, Planet6, Skyview) returned
+`"Team does not have a Linkedin account"` → clean.
+
+### I7 — platform_events (last 48 h)
+
+Six `connection_disconnected` events, all LINKEDIN, all `disconnect_ok: true`,
+all `deleted: true`. No `connection_created`, no `bundlesocial_ghost_cleared`,
+no `disconnect_split_brain_detected`, no `disconnect_failed`.
+
+```
+2026-05-12T21:57:58  bundle_social_account_id: 21a1e828  deleted: true
+2026-05-12T21:36:00  bundle_social_account_id: 787f0479  deleted: true
+2026-05-12T20:23:00  bundle_social_account_id: 93d57333  deleted: true
+2026-05-12T20:03:52  bundle_social_account_id: 0055f158  deleted: true
+2026-05-12T11:08:13  bundle_social_account_id: 02109aeb  deleted: true
+2026-05-12T06:23:22  bundle_social_account_id: f6eb9f32  deleted: true  (unset_ok: null)
+```
+
+Note: `sync.ts` does not emit `connection_created` events when it inserts rows,
+so there is no positive-side audit trail for when connections were created.
+
+### I8 — Vercel function logs
+
+`vercel logs --environment production` enters streaming mode and does not
+return historical log lines via the CLI. Logs for the 21:57–22:05 UTC window
+were not accessible through the available tooling.
+
+**Inference from I7**: the ghost account's `createdAt` is `21:58:23` — 25
+seconds after the last disconnect event at `21:57:58`. The most likely
+explanation is that Steven completed a new OAuth within that window. Without
+callback logs, it cannot be confirmed whether the callback URL was hit and
+failed, or was never called (bundle.social dashboard redirect).
+
+### I9 — Reconstructed sequence
+
+```
+~06:23 → connect → OAuth → bundle.social creates account f6eb9f32
+           → callback? (unknown, but DB row existed at time of disconnect)
+  11:08 → disconnect f6eb9f32 → deleted: true
+  11:08 → connect → OAuth → bundle.social creates account 02109aeb
+           → callback hit (DB row created — confirmed by later deleted:true)
+  20:03 → disconnect 02109aeb → deleted: true
+  20:03 → connect → bundle.social creates 0055f158
+  20:23 → disconnect 0055f158 → deleted: true
+  20:23 → connect → bundle.social creates 93d57333
+  21:36 → disconnect 93d57333 → deleted: true
+  21:36 → connect → bundle.social creates 787f0479
+  21:57 → disconnect 787f0479 → deleted: true
+
+  21:57:58 → disconnect 21a1e828 → deleted: true  ← last clean state
+  21:58:23 → bundle.social receives new OAuth → creates 4b3b1448
+             → callback NOT called (dashboard redirect, PR #884 not yet live)
+             → no DB row created for 4b3b1448
+             → social_connections: 0 rows
+             → bundle.social Opollo team: has 4b3b1448
+
+  23:56:32 → PR #884 deployed (sync-on-close)
+
+  [now]    → Steven attempts connect
+           → POST /connections/connect → socialAccountConnect
+           → bundle.social: "This team already has a LinkedIn account connected"
+           → route returns 409 INVALID_STATE
+           → popup never opens → sync-on-close never fires
+```
+
+### I10 — L1 direct test
+
+POST `/api/platform/social/connections/connect` without auth → 401 UNAUTHORIZED
+(correct). With valid auth, the route calls `socialAccountConnect` which returns
+bundle.social's "already connected" error. The route wraps it as 409
+INVALID_STATE (line 122–123 of the route). No pre-flight check exists.
+
+**PR #884's sync-on-close does not help**: it runs after popup close, but the
+popup never opens because `socialAccountConnect` fails before the popup URL is
+returned. The error is surfaced to the user before any OAuth flow begins.
+
+---
+
+## Section 3: Concrete fix recommendation
+
+### Immediate (do not skip)
+
+**Merge PR #881.** The branch is current (`hotfix/bundlesocial-reconcile-and-failsafe`),
+CI was green at the time the PR was opened (test count: 1475/1475), and the
+design is correct:
+
+- L1 detects the ghost via `socialAccountGetByType` before calling
+  `socialAccountConnect`, auto-disconnects it, proceeds to OAuth. This
+  eliminates the "already connected" surface permanently as long as the DB is
+  up.
+- L4 prevent new ghosts by refusing to delete the DB row until bundle.social
+  confirms the disconnect — closing the 25-second race window observed in I9.
+- L2/L3 provide operational tooling to scan and repair divergences.
+
+Before merging, re-run CI to confirm the branch hasn't drifted against main
+(PR #884 and PR #881 both touch `components/SocialConnectionsList.tsx` and
+the connect/disconnect routes — a rebase or merge may be needed).
+
+### Complementary (do in the same PR or follow-up)
+
+1. **Add a `connection_created` event in `syncBundlesocialConnections`** (sync.ts
+   line ~440, inside the insert block). Currently there is no positive-side audit
+   trail: we can see when connections are deleted but not when they are created.
+   This made I9's sequence reconstruction incomplete.
+
+2. **PR #884 sync-on-close + ghost already present**: if `syncBundlesocialConnections`
+   returns `inserted: 0` after popup close, surface a user-visible warning
+   ("Connection may not have completed — try again"). The current behaviour
+   silently succeeds with no visible row. This is a UX gap that will recur for
+   any user who already has a ghost when they open the popup.
+
+3. **Do not rely solely on L1 for future safety**: L1 fixes the pre-connect path,
+   but the underlying root cause is that `syncBundlesocialConnections` is never
+   called unless triggered by a callback or sync-on-close. A lightweight
+   background job that periodically calls `reconcileBundlesocialAccounts` (L2)
+   and auto-clears confirmed ghosts would catch any that slip through during
+   outage windows.
+
+### What NOT to do
+
+- Do not write a new one-shot unstick script. PR #881's L2/L3 reconcile surface
+  covers this permanently.
+- Do not add more code before merging PR #881. Every new defensive layer added
+  without merging the existing one increases code surface without reducing risk.

--- a/tests/regressions/auto-open-pending-picker.test.tsx
+++ b/tests/regressions/auto-open-pending-picker.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// REGRESSION — auto-open ChannelPickerModal for pending_identity connections.
+//
+// After OAuth completes with a channel-selection platform (LinkedIn, Facebook,
+// GBP), the DB row lands in status='pending_identity'. On the next mount of
+// SocialConnectionsList the modal MUST auto-open without user action.
+//
+// Critical pins:
+//   - useRef<Set<string>> (not sessionStorage) so the shown-set resets on
+//     page refresh (component remount), allowing the modal to reopen.
+//   - Non-channel-selection platforms (x) must NOT trigger the modal even
+//     if status is pending_identity.
+//   - Dismissing the modal without picking must not reopen it during the
+//     same component lifetime.
+// ---------------------------------------------------------------------------
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/toast-success", () => ({ toastSuccess: vi.fn() }));
+
+vi.mock("@/components/ChannelPickerModal", () => ({
+  ChannelPickerModal: ({
+    isOpen,
+    onClose,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="channel-picker-modal">
+        <button data-testid="picker-close" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+import { SocialConnectionsList } from "@/components/SocialConnectionsList";
+import type { SocialConnection } from "@/lib/platform/social/connections/types";
+
+const fetchMock = vi.fn();
+const ORIGINAL_FETCH = global.fetch;
+
+const BASE_PROPS = {
+  companyId: "company-1",
+  profileId: "profile-1",
+  connections: [] as SocialConnection[],
+  canManage: true,
+  canReconnect: true,
+};
+
+function makeConn(overrides: Partial<SocialConnection> = {}): SocialConnection {
+  return {
+    id: "conn-1",
+    company_id: "company-1",
+    profile_id: "profile-1",
+    platform: "linkedin_personal",
+    bundle_social_account_id: "bs-1",
+    display_name: "Test LinkedIn",
+    avatar_url: null,
+    status: "pending_identity",
+    last_error: null,
+    connected_at: new Date().toISOString(),
+    disconnected_at: null,
+    last_health_check_at: new Date().toISOString(),
+    external_account_id: null,
+    external_user_id: null,
+    external_identity_hash: null,
+    is_personal_mode: false,
+    has_emitted_overdue_event: false,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  global.fetch = ORIGINAL_FETCH;
+  vi.clearAllMocks();
+});
+
+describe("R-AUTO-OPEN-PICKER: pending_identity rows auto-open ChannelPickerModal", () => {
+  it("mount with pending_identity LinkedIn row → picker modal opens automatically", async () => {
+    const conn = makeConn({ id: "conn-linkedin", platform: "linkedin_personal" });
+    render(<SocialConnectionsList {...BASE_PROPS} connections={[conn]} />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("channel-picker-modal")).toBeInTheDocument();
+    });
+  });
+
+  it("pending_identity X (Twitter) row → picker stays closed (not a channel-selection platform)", async () => {
+    const conn = makeConn({ id: "conn-x", platform: "x", status: "pending_identity" });
+    render(<SocialConnectionsList {...BASE_PROPS} connections={[conn]} />);
+
+    await act(async () => {});
+    expect(screen.queryByTestId("channel-picker-modal")).toBeNull();
+  });
+
+  it("dismiss modal without picking → does NOT reopen during the same mount", async () => {
+    const conn = makeConn({ id: "conn-linkedin", platform: "linkedin_personal" });
+    render(<SocialConnectionsList {...BASE_PROPS} connections={[conn]} />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("channel-picker-modal")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("picker-close"));
+
+    await act(async () => {});
+    expect(screen.queryByTestId("channel-picker-modal")).toBeNull();
+  });
+
+  it("remount (page refresh) → modal reopens because useRef resets on unmount", async () => {
+    const conn = makeConn({ id: "conn-linkedin", platform: "linkedin_personal" });
+    const { unmount } = render(
+      <SocialConnectionsList {...BASE_PROPS} connections={[conn]} />,
+    );
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("channel-picker-modal")).toBeInTheDocument();
+    });
+
+    unmount();
+
+    render(<SocialConnectionsList {...BASE_PROPS} connections={[conn]} />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("channel-picker-modal")).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/regressions/popup-close-triggers-sync.test.tsx
+++ b/tests/regressions/popup-close-triggers-sync.test.tsx
@@ -1,5 +1,21 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
 
 import { SocialConnectionsList } from "@/components/SocialConnectionsList";
 
@@ -38,6 +54,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  cleanup();
   global.fetch = originalFetch;
   Object.defineProperty(window, "open", { configurable: true, writable: true, value: originalOpen });
   vi.clearAllMocks();
@@ -89,24 +106,26 @@ describe("R-POPUP-SYNC: sync fires when popup closes without postMessage", () =>
     fireEvent.click(screen.getByTestId("connections-connect-button"));
     fireEvent.click(screen.getByTestId("connect-platform-LINKEDIN"));
 
-    // Wait for the popup to be opened
-    await waitFor(() => expect(openMock).toHaveBeenCalledTimes(1));
+    // Flush async handlers (preflight + connect fetch chain) so window.open fires.
+    await act(async () => {});
+    expect(openMock).toHaveBeenCalledTimes(1);
 
     // Simulate popup closing (user closes bundle.social dashboard manually)
     fakePopup.closed = true;
 
-    // Advance timer by 600ms to trigger the popup-close poll
-    await vi.advanceTimersByTimeAsync(600);
+    // Advance timer by 600ms to trigger the popup-close poll, then flush
+    // the resulting async fetch chain.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
 
     // Sync endpoint must be called
-    await waitFor(() => {
-      const syncCalls = fetchMock.mock.calls.filter(
-        (c) =>
-          typeof c[0] === "string" &&
-          (c[0] as string).includes("/connections/sync"),
-      );
-      expect(syncCalls.length).toBeGreaterThan(0);
-    });
+    const syncCalls = fetchMock.mock.calls.filter(
+      (c) =>
+        typeof c[0] === "string" &&
+        (c[0] as string).includes("/connections/sync"),
+    );
+    expect(syncCalls.length).toBeGreaterThan(0);
 
     // Verify the sync call used POST with the right company_id
     const syncCall = fetchMock.mock.calls.find(
@@ -142,7 +161,9 @@ describe("R-POPUP-SYNC: sync fires when popup closes without postMessage", () =>
     fireEvent.click(screen.getByTestId("connections-connect-button"));
     fireEvent.click(screen.getByTestId("connect-platform-FACEBOOK"));
 
-    await waitFor(() => expect(openMock).toHaveBeenCalledTimes(1));
+    // Flush the async fetch chain so window.open fires.
+    await act(async () => {});
+    expect(openMock).toHaveBeenCalledTimes(1);
 
     // Simulate our callback firing a postMessage (happy path).
     window.dispatchEvent(
@@ -157,7 +178,9 @@ describe("R-POPUP-SYNC: sync fires when popup closes without postMessage", () =>
 
     // The postMessage handler clears the poll immediately. Advancing
     // the timer should NOT trigger a sync call.
-    await vi.advanceTimersByTimeAsync(600);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
 
     const syncCalls = fetchMock.mock.calls.filter(
       (c) =>

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
     include: [
       "lib/__tests__/**/*.contract.test.ts",
       "lib/__tests__/**/*.unit.test.ts",
-      "tests/regressions/**/*.test.ts",
+      "tests/regressions/**/*.test.{ts,tsx}",
       "tests/security/**/*.security.test.ts",
     ],
     testTimeout: 10_000,


### PR DESCRIPTION
## Summary

- `SocialConnectionsList` and `AdminProfileConnectionsList` now auto-open `ChannelPickerModal` on mount (and on every connections refresh) for any `pending_identity` row that hasn't been shown this component lifetime
- Uses `useRef<Set<string>>(new Set())` (not `sessionStorage`) so the shown-set resets on page refresh/remount, allowing the modal to reopen if the user navigates away and comes back
- `AdminProfileConnectionsList` fetches `/api/platform/social/connections?company_id=...` on mount since its `accounts` prop is bundle.social objects without a `status` field

## What was broken

After OAuth completes with a channel-selection platform (LinkedIn, Facebook, GBP), the DB row lands in `status=pending_identity`. Previously, the user had to manually click "Select channel" to open the picker. If they closed the popup without selecting, the pending row just sat there silently.

## Working analog

`**Working analog**`: `SocialConnectionsList.tsx:253–271` — the `postPopupSyncAt` effect finds new `pending_identity` rows and calls `setPickerForConnectionId`. The new auto-open effect is the same pattern, operating on the full connections array at mount rather than just post-popup rows.  
`**Diff**`: The old effect was guarded by `postPopupSyncAt !== null` so only ran after a popup close. The new effect runs on every mount.  
`**Fix**`: Added a second effect with `[connections, pickerForConnectionId]` deps; uses `pickerShownRef` to prevent reopen within the same mount.

## Also in this PR

- `tests/regressions/auto-open-pending-picker.test.tsx` — 4 regression tests (mount auto-opens, X skipped, dismiss-no-reopen, remount-reopens)
- `tests/regressions/popup-close-triggers-sync.test.tsx` — fixed pre-existing test that was never being run (needed `// @vitest-environment jsdom` + `vi.useFakeTimers` + `waitFor` deadlock fix)
- `vitest.unit.config.ts` — extended `tests/regressions/**/*.test.{ts,tsx}` to pick up component regression tests
- `docs/incidents/2026-05-13-split-brain-recurrence.md` — incident report for the split-brain recurrence

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Extra API fetch on every mount in `AdminProfileConnectionsList` | Request is a GET with auth (lightweight), admin-only UI, only fetches when `pickerTarget` is null |
| Double-open if both the existing `postPopupSyncAt` effect and the new auto-open effect fire simultaneously | `pickerForConnectionId` guard in the new effect: returns early if picker is already open |
| Re-open loop on dismiss | `pickerShownRef.current.has(id)` check; ID is added to ref BEFORE calling `setPickerForConnectionId` |
| sessionStorage persistence across tabs | Not using sessionStorage; `useRef` is per-instance and resets on unmount |

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (1493/1493), `test:components` (84/84)
- [x] Regression test added: `tests/regressions/auto-open-pending-picker.test.tsx` (4 cases)
- [x] Working-analog block in PR body ✓
- [x] Risks identified and mitigated section ✓
- [x] PR is under 500 net lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)