### PR TITLE
fix(social): YouTube trim, wider popup, Instagram copy, sync display_name fix

### DIFF
--- a/app/api/platform/social/connections/[id]/set-channel/route.ts
+++ b/app/api/platform/social/connections/[id]/set-channel/route.ts
@@ -133,12 +133,18 @@ export async function POST(
     );
   }
 
+  const selectedChannel = fingerprint.channels.find(
+    (c) => c.id === parsed.data.channel_id,
+  );
+  const channelDisplayName = selectedChannel?.name ?? null;
+
   const svc = getServiceRoleClient();
   const now = new Date().toISOString();
   const update = await svc
     .from("social_connections")
     .update({
       status: "healthy",
+      display_name: channelDisplayName,
       external_account_id: fingerprint.external_account_id,
       external_user_id: fingerprint.external_user_id,
       external_identity_hash: externalIdentityHash,
@@ -154,6 +160,21 @@ export async function POST(
     });
     return internalError(`Failed to record channel selection: ${update.error.message}`);
   }
+
+  void svc.from("platform_events").insert({
+    company_id: conn.company_id,
+    actor_id: gate.userId,
+    event_type: "connection_channel_selected",
+    entity_type: "social_connection",
+    entity_id: conn.id,
+    payload: {
+      connection_id: conn.id,
+      channel_id: parsed.data.channel_id,
+      channel_name: channelDisplayName,
+      previous_external_account_id: conn.external_account_id,
+      previous_display_name: conn.display_name,
+    },
+  });
 
   return NextResponse.json(
     {

--- a/components/AdminProfileConnectionsList.tsx
+++ b/components/AdminProfileConnectionsList.tsx
@@ -27,8 +27,13 @@ import { toastSuccess } from "@/lib/toast-success";
 // Same handshake as the existing SocialConnectionsList (reuse the
 // origin-validated message listener pattern).
 
-const POPUP_FEATURES =
-  "width=600,height=700,scrollbars=yes,resizable=yes,noopener=no";
+function getPopupFeatures(): string {
+  const w = 900;
+  const h = 820;
+  const left = Math.floor(window.screen.width / 2 - w / 2);
+  const top = Math.floor(window.screen.height / 2 - h / 2);
+  return `width=${w},height=${h},left=${left},top=${top},scrollbars=yes,resizable=yes`;
+}
 
 // Bundle.social platform enum → ChannelPickerModal props. null entries
 // indicate platforms that don't go through channel selection (they
@@ -76,7 +81,6 @@ const PLATFORMS: Array<{
   { value: "INSTAGRAM", label: "Instagram" },
   { value: "TWITTER", label: "X (Twitter)" },
   { value: "GOOGLE_BUSINESS", label: "Google Business" },
-  { value: "YOUTUBE", label: "YouTube" },
 ];
 
 type Account = {
@@ -402,7 +406,7 @@ export function AdminProfileConnectionsList({
       setBusy(null);
       return;
     }
-    const popup = window.open(json.data.url, "bundle-connect", POPUP_FEATURES);
+    const popup = window.open(json.data.url, "bundle-connect", getPopupFeatures());
     if (!popup || popup.closed) {
       setPopupBlockedUrl(json.data.url);
       setBusy(null);

--- a/components/AdminProfileConnectionsList.tsx
+++ b/components/AdminProfileConnectionsList.tsx
@@ -153,6 +153,9 @@ export function AdminProfileConnectionsList({
   const popupRef = useRef<Window | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const popupOpenedAtRef = useRef<number | null>(null);
+  // Shown-set for the auto-open effect. useRef resets on unmount (page
+  // refresh) so a new mount always re-evaluates pending rows.
+  const pickerShownRef = useRef<Set<string>>(new Set());
 
   function clearPopupState() {
     if (pollRef.current) clearInterval(pollRef.current);
@@ -253,6 +256,46 @@ export function AdminProfileConnectionsList({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [busy]);
+
+  // On mount and after any accounts change, fetch DB connections and
+  // auto-open the picker for any pending_identity row not shown yet
+  // this component lifetime.
+  useEffect(() => {
+    if (pickerTarget) return;
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/platform/social/connections?company_id=${encodeURIComponent(companyId)}`,
+        );
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          data?: {
+            connections: Array<{
+              id: string;
+              platform: string;
+              status: string;
+              connected_at: string;
+            }>;
+          };
+        };
+        const pending = (data?.data?.connections ?? []).find(
+          (c) =>
+            c.status === "pending_identity" &&
+            DB_PLATFORM_TO_PICKER[c.platform] !== null &&
+            DB_PLATFORM_TO_PICKER[c.platform] !== undefined &&
+            !pickerShownRef.current.has(c.id),
+        );
+        if (!pending) return;
+        const picker = DB_PLATFORM_TO_PICKER[pending.platform]!;
+        pickerShownRef.current.add(pending.id);
+        setPickerTarget({
+          connectionId: pending.id,
+          platform: picker.platform,
+          label: picker.label,
+        });
+      } catch {}
+    })();
+  }, [accounts, pickerTarget, companyId]);
 
   async function handleDisconnect(account: Account) {
     if (

--- a/components/ChannelPickerModal.tsx
+++ b/components/ChannelPickerModal.tsx
@@ -45,11 +45,14 @@ export function ChannelPickerModal({
             className="text-base font-semibold"
             data-testid="channel-picker-title"
           >
-            Pick a {platformLabel} channel
+            {platform === "INSTAGRAM"
+              ? "Pick a Facebook Page connected to your Instagram account"
+              : `Pick a ${platformLabel} channel`}
           </h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            Posts to this connection will be published to the channel you
-            pick. You can change it later.
+            {platform === "INSTAGRAM"
+              ? "Instagram Business publishing goes through the Facebook Page your Instagram account is linked to."
+              : "Posts to this connection will be published to the channel you pick. You can change it later."}
           </p>
         </header>
 

--- a/components/PopupChannelPicker.tsx
+++ b/components/PopupChannelPicker.tsx
@@ -80,12 +80,15 @@ export function PopupChannelPicker({
             className="text-foreground"
           />
           <h1 className="text-base font-semibold">
-            Pick a {platformLabel} channel
+            {platform === "INSTAGRAM"
+              ? "Pick a Facebook Page connected to your Instagram account"
+              : `Pick a ${platformLabel} channel`}
           </h1>
         </div>
         <p className="mt-1 text-sm text-muted-foreground">
-          Posts to this connection will be published to the channel you pick.
-          You can change it later from the connections page.
+          {platform === "INSTAGRAM"
+            ? "Instagram Business publishing goes through the Facebook Page your Instagram account is linked to."
+            : "Posts to this connection will be published to the channel you pick. You can change it later from the connections page."}
         </p>
       </header>
 

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -184,6 +184,9 @@ export function SocialConnectionsList({
   // Timestamp set when the popup opens so we can identify connections
   // created AFTER the popup (needed for auto-picker after sync).
   const popupOpenedAtRef = useRef<number | null>(null);
+  // Shown-set for the auto-open effect. useRef resets on unmount (page
+  // refresh) so a new mount always re-evaluates pending rows.
+  const pickerShownRef = useRef<Set<string>>(new Set());
   // Set to Date.now() when a post-popup sync inserted > 0 rows.
   // Drives the auto-open picker effect below.
   const [postPopupSyncAt, setPostPopupSyncAt] = useState<number | null>(null);
@@ -269,6 +272,23 @@ export function SocialConnectionsList({
     // pending_identity — TWITTER goes straight to healthy).
     if (Date.now() - postPopupSyncAt > 10_000) setPostPopupSyncAt(null);
   }, [connections, pickerForConnectionId, postPopupSyncAt]);
+
+  // Auto-open the channel picker for any pending_identity row that hasn't
+  // been shown this component lifetime. Runs on mount and whenever the
+  // connections array or open-picker state changes.
+  useEffect(() => {
+    if (pickerForConnectionId) return;
+    const pending = connections.find(
+      (c) =>
+        c.status === "pending_identity" &&
+        PLATFORM_TO_BUNDLE_LABEL[c.platform] !== null &&
+        PLATFORM_TO_BUNDLE_LABEL[c.platform] !== undefined &&
+        !pickerShownRef.current.has(c.id),
+    );
+    if (!pending) return;
+    pickerShownRef.current.add(pending.id);
+    setPickerForConnectionId(pending.id);
+  }, [connections, pickerForConnectionId]);
 
   useEffect(() => {
     const expectedOrigin = window.location.origin;

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -57,8 +57,13 @@ const PLATFORM_TO_BUNDLE_LABEL: Record<
 //   6. Fallback: setInterval polling popup.closed for abandoned popups
 // ---------------------------------------------------------------------------
 
-const POPUP_FEATURES =
-  "width=600,height=700,scrollbars=yes,resizable=yes,noopener=no";
+function getPopupFeatures(): string {
+  const w = 900;
+  const h = 820;
+  const left = Math.floor(window.screen.width / 2 - w / 2);
+  const top = Math.floor(window.screen.height / 2 - h / 2);
+  return `width=${w},height=${h},left=${left},top=${top},scrollbars=yes,resizable=yes`;
+}
 
 // 2026-05-13 platform trim: TikTok, Pinterest, Threads, and Reddit are
 // removed from the UI surface. Backend Zod schemas still accept the
@@ -73,7 +78,6 @@ const PLATFORMS: Array<{
   { value: "INSTAGRAM", label: "Instagram" },
   { value: "TWITTER", label: "X (Twitter)" },
   { value: "GOOGLE_BUSINESS", label: "Google Business" },
-  { value: "YOUTUBE", label: "YouTube" },
 ];
 
 type ConnectMessage = {
@@ -179,6 +183,16 @@ export function SocialConnectionsList({
     | null
   >(null);
 
+  // Mirrors busyPlatform in a ref so the stale-closed handleMessage
+  // effect can read the platform the user originally clicked (needed to
+  // distinguish Instagram from Facebook — both land as facebook_page rows).
+  const busyPlatformRef = useRef<string | null>(null);
+  // When needs_channel fires after an Instagram connect, override the
+  // picker modal's platform so it shows Instagram-specific copy.
+  const [pickerPlatformOverride, setPickerPlatformOverride] = useState<
+    string | null
+  >(null);
+
   const popupRef = useRef<Window | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   // Timestamp set when the popup opens so we can identify connections
@@ -230,7 +244,7 @@ export function SocialConnectionsList({
       return;
     }
 
-    const popup = window.open(url, "bundle-connect", POPUP_FEATURES);
+    const popup = window.open(url, "bundle-connect", getPopupFeatures());
 
     if (!popup || popup.closed) {
       setPopupBlockedUrl(url);
@@ -297,6 +311,7 @@ export function SocialConnectionsList({
       if (evt.origin !== expectedOrigin) return;
       if (!isConnectMessage(evt.data)) return;
 
+      const clickedPlatform = busyPlatformRef.current;
       clearPopupState();
       setPickerOpen(false);
       // Auto-open the channel-picker modal in the parent window when
@@ -306,6 +321,11 @@ export function SocialConnectionsList({
         evt.data.connect === "needs_channel" &&
         typeof evt.data.connection_id === "string"
       ) {
+        // Instagram Business creates a facebook_page DB row — preserve
+        // the original click intent so the modal shows Instagram copy.
+        if (clickedPlatform === "INSTAGRAM") {
+          setPickerPlatformOverride("INSTAGRAM");
+        }
         setPickerForConnectionId(evt.data.connection_id);
       }
       // Bug-fix 2026-05-12: if the callback signalled noop with an
@@ -347,6 +367,7 @@ export function SocialConnectionsList({
     }
 
     setBusyPlatform(platform);
+    busyPlatformRef.current = platform;
     setPopupBlockedUrl(null);
 
     const res = await fetch("/api/platform/social/connections/connect", {
@@ -506,6 +527,12 @@ export function SocialConnectionsList({
     ? (() => {
         const c = connections.find((x) => x.id === pickerForConnectionId);
         if (!c) return null;
+        // Instagram Business connects via Facebook OAuth and creates a
+        // facebook_page row. If the user originally clicked Instagram,
+        // override the platform label so the modal shows Instagram copy.
+        if (pickerPlatformOverride === "INSTAGRAM" && c.platform === "facebook_page") {
+          return { conn: c, platform: "INSTAGRAM" as const, label: "Instagram" };
+        }
         const bundle = PLATFORM_TO_BUNDLE_LABEL[c.platform];
         if (!bundle) return null;
         return { conn: c, ...bundle };
@@ -520,9 +547,13 @@ export function SocialConnectionsList({
           platform={pickerTarget.platform}
           platformLabel={pickerTarget.label}
           isOpen={true}
-          onClose={() => setPickerForConnectionId(null)}
+          onClose={() => {
+            setPickerForConnectionId(null);
+            setPickerPlatformOverride(null);
+          }}
           onSelected={() => {
             setPickerForConnectionId(null);
+            setPickerPlatformOverride(null);
             toastSuccess("Channel set — this connection is ready to publish.");
             router.refresh();
           }}

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -780,7 +780,9 @@ export function SocialConnectionsList({
                   data-testid={`connection-row-${c.id}`}
                 >
                   <td className="px-4 py-3 font-medium">
-                    {PLATFORM_LABEL[c.platform] ?? c.platform}
+                    {c.platform.startsWith("linkedin") && !c.is_personal_mode
+                      ? "LinkedIn"
+                      : (PLATFORM_LABEL[c.platform] ?? c.platform)}
                   </td>
                   <td className="px-4 py-3">
                     <div>

--- a/components/__tests__/SocialConnectionsList-tiles.test.tsx
+++ b/components/__tests__/SocialConnectionsList-tiles.test.tsx
@@ -32,15 +32,14 @@ const openMock = vi.fn();
 const originalOpen = window.open;
 const originalFetch = global.fetch;
 
-// 2026-05-13: trimmed from 10 → 6. TikTok, Pinterest, Threads, Reddit
-// were removed from the UI surface.
+// 2026-05-13: trimmed from 10 → 5. TikTok, Pinterest, Threads, Reddit,
+// and YouTube were removed from the UI surface.
 const PLATFORMS = [
   "LINKEDIN",
   "FACEBOOK",
   "INSTAGRAM",
   "TWITTER",
   "GOOGLE_BUSINESS",
-  "YOUTUBE",
 ] as const;
 
 const PLATFORM_LABEL: Record<string, string> = {
@@ -49,7 +48,6 @@ const PLATFORM_LABEL: Record<string, string> = {
   INSTAGRAM: "Instagram",
   TWITTER: "X (Twitter)",
   GOOGLE_BUSINESS: "Google Business",
-  YOUTUBE: "YouTube",
 };
 
 const REMOVED_PLATFORMS = ["TIKTOK", "PINTEREST", "THREADS", "REDDIT"] as const;
@@ -90,7 +88,7 @@ function renderList() {
 }
 
 describe("SocialConnectionsList — Connect dropdown", () => {
-  it("renders only the 6 supported platform menu items when the popover opens", () => {
+  it("renders only the 5 supported platform menu items when the popover opens", () => {
     renderList();
 
     // Click trigger to open the popover. Radix portals the content

--- a/docs/incidents/2026-05-13-split-brain-recurrence.md
+++ b/docs/incidents/2026-05-13-split-brain-recurrence.md
@@ -1,0 +1,194 @@
+# Split-brain recurrence — "already connected" on empty table (2026-05-13)
+
+## Section 1: Verdict
+
+**Failure mode (a): PR #881 was never merged. Every one of the four defenses is undeployed.**
+
+The incident re-occurred for the same structural reason as the original: a
+bundle.social OAuth completed, the popup landed on bundle.social's dashboard
+(bundle.social's redirect behaviour, the bug PR #884 targeted), our callback
+was never called, and no DB row was created for the new account. With no L1
+pre-connect ghost check live, the next connect attempt hit `socialAccountConnect`
+directly — bundle.social rejected it with "This team already has a LinkedIn
+account connected. Please disconnect it first."
+
+PR #884 (sync-on-close) does NOT help here because it fires *after* the popup
+opens. The ghost blocks `socialAccountConnect` before a popup is ever opened.
+L1 (PR #881) is the only defense that runs before that call.
+
+---
+
+## Section 2: Findings from I1–I10
+
+### I1 — PR #881 state
+
+```
+gh pr view 881 --json state,mergedAt,mergeCommit
+→ { "state": "OPEN", "mergedAt": null, "mergeCommit": null }
+```
+
+PR #881 (`hotfix/bundlesocial-reconcile-and-failsafe`) is open and unmerged.
+The four-layer failsafe described in its description — L1 pre-connect ghost
+check, L2 reconciliation API, L3 maintenance UI, L4 verify-loop disconnect —
+has never been deployed to production.
+
+### I2 — Deployed SHA vs PR #881
+
+Production deployed SHA: `621ce960` (PR #884 — sync-on-close fix, merged
+this session). PR #881's merge commit: null (open). PR #881's code is not in
+the deployed bundle.
+
+### I3 — L1 in connect route
+
+`app/api/platform/social/connections/connect/route.ts` (line 107–113):
+`initiateProfileConnect` is called directly with no pre-flight ghost check.
+No reference to `checkBundleSocialGhost`, `preConnectGhostCheck`, or `L1`.
+Confirmed: L1 is not wired.
+
+### I4 — social_connections table
+
+```
+GET /rest/v1/social_connections → []
+```
+
+Zero rows. The UI's "No social connections yet" is accurate.
+
+### I5/I6 — Ghost account on bundle.social
+
+`socialAccountGetByType(teamId='2960f6ea', type='LINKEDIN')`:
+
+| Field | Value |
+|---|---|
+| Account ID | `4b3b1448-5fc9-42a6-9d9b-c748f1d816ea` |
+| Team | `2960f6ea` (Opollo) |
+| User | Steven Morey (`urn:li:person:cn_0IGowb1`, userUsername: `stevenmorey`) |
+| externalId | `null` |
+| Channels | 15 (personal profile + 14 organisations) |
+| `createdAt` on bundle.social | `2026-05-12T21:58:23.254Z` |
+| `deletedAt` | `null` |
+| DB row matching this account | **none** |
+
+All other teams (Vincovi, ASCII Group, Planet6, Skyview) returned
+`"Team does not have a Linkedin account"` → clean.
+
+### I7 — platform_events (last 48 h)
+
+Six `connection_disconnected` events, all LINKEDIN, all `disconnect_ok: true`,
+all `deleted: true`. No `connection_created`, no `bundlesocial_ghost_cleared`,
+no `disconnect_split_brain_detected`, no `disconnect_failed`.
+
+```
+2026-05-12T21:57:58  bundle_social_account_id: 21a1e828  deleted: true
+2026-05-12T21:36:00  bundle_social_account_id: 787f0479  deleted: true
+2026-05-12T20:23:00  bundle_social_account_id: 93d57333  deleted: true
+2026-05-12T20:03:52  bundle_social_account_id: 0055f158  deleted: true
+2026-05-12T11:08:13  bundle_social_account_id: 02109aeb  deleted: true
+2026-05-12T06:23:22  bundle_social_account_id: f6eb9f32  deleted: true  (unset_ok: null)
+```
+
+Note: `sync.ts` does not emit `connection_created` events when it inserts rows,
+so there is no positive-side audit trail for when connections were created.
+
+### I8 — Vercel function logs
+
+`vercel logs --environment production` enters streaming mode and does not
+return historical log lines via the CLI. Logs for the 21:57–22:05 UTC window
+were not accessible through the available tooling.
+
+**Inference from I7**: the ghost account's `createdAt` is `21:58:23` — 25
+seconds after the last disconnect event at `21:57:58`. The most likely
+explanation is that Steven completed a new OAuth within that window. Without
+callback logs, it cannot be confirmed whether the callback URL was hit and
+failed, or was never called (bundle.social dashboard redirect).
+
+### I9 — Reconstructed sequence
+
+```
+~06:23 → connect → OAuth → bundle.social creates account f6eb9f32
+           → callback? (unknown, but DB row existed at time of disconnect)
+  11:08 → disconnect f6eb9f32 → deleted: true
+  11:08 → connect → OAuth → bundle.social creates account 02109aeb
+           → callback hit (DB row created — confirmed by later deleted:true)
+  20:03 → disconnect 02109aeb → deleted: true
+  20:03 → connect → bundle.social creates 0055f158
+  20:23 → disconnect 0055f158 → deleted: true
+  20:23 → connect → bundle.social creates 93d57333
+  21:36 → disconnect 93d57333 → deleted: true
+  21:36 → connect → bundle.social creates 787f0479
+  21:57 → disconnect 787f0479 → deleted: true
+
+  21:57:58 → disconnect 21a1e828 → deleted: true  ← last clean state
+  21:58:23 → bundle.social receives new OAuth → creates 4b3b1448
+             → callback NOT called (dashboard redirect, PR #884 not yet live)
+             → no DB row created for 4b3b1448
+             → social_connections: 0 rows
+             → bundle.social Opollo team: has 4b3b1448
+
+  23:56:32 → PR #884 deployed (sync-on-close)
+
+  [now]    → Steven attempts connect
+           → POST /connections/connect → socialAccountConnect
+           → bundle.social: "This team already has a LinkedIn account connected"
+           → route returns 409 INVALID_STATE
+           → popup never opens → sync-on-close never fires
+```
+
+### I10 — L1 direct test
+
+POST `/api/platform/social/connections/connect` without auth → 401 UNAUTHORIZED
+(correct). With valid auth, the route calls `socialAccountConnect` which returns
+bundle.social's "already connected" error. The route wraps it as 409
+INVALID_STATE (line 122–123 of the route). No pre-flight check exists.
+
+**PR #884's sync-on-close does not help**: it runs after popup close, but the
+popup never opens because `socialAccountConnect` fails before the popup URL is
+returned. The error is surfaced to the user before any OAuth flow begins.
+
+---
+
+## Section 3: Concrete fix recommendation
+
+### Immediate (do not skip)
+
+**Merge PR #881.** The branch is current (`hotfix/bundlesocial-reconcile-and-failsafe`),
+CI was green at the time the PR was opened (test count: 1475/1475), and the
+design is correct:
+
+- L1 detects the ghost via `socialAccountGetByType` before calling
+  `socialAccountConnect`, auto-disconnects it, proceeds to OAuth. This
+  eliminates the "already connected" surface permanently as long as the DB is
+  up.
+- L4 prevent new ghosts by refusing to delete the DB row until bundle.social
+  confirms the disconnect — closing the 25-second race window observed in I9.
+- L2/L3 provide operational tooling to scan and repair divergences.
+
+Before merging, re-run CI to confirm the branch hasn't drifted against main
+(PR #884 and PR #881 both touch `components/SocialConnectionsList.tsx` and
+the connect/disconnect routes — a rebase or merge may be needed).
+
+### Complementary (do in the same PR or follow-up)
+
+1. **Add a `connection_created` event in `syncBundlesocialConnections`** (sync.ts
+   line ~440, inside the insert block). Currently there is no positive-side audit
+   trail: we can see when connections are deleted but not when they are created.
+   This made I9's sequence reconstruction incomplete.
+
+2. **PR #884 sync-on-close + ghost already present**: if `syncBundlesocialConnections`
+   returns `inserted: 0` after popup close, surface a user-visible warning
+   ("Connection may not have completed — try again"). The current behaviour
+   silently succeeds with no visible row. This is a UX gap that will recur for
+   any user who already has a ghost when they open the popup.
+
+3. **Do not rely solely on L1 for future safety**: L1 fixes the pre-connect path,
+   but the underlying root cause is that `syncBundlesocialConnections` is never
+   called unless triggered by a callback or sync-on-close. A lightweight
+   background job that periodically calls `reconcileBundlesocialAccounts` (L2)
+   and auto-clears confirmed ghosts would catch any that slip through during
+   outage windows.
+
+### What NOT to do
+
+- Do not write a new one-shot unstick script. PR #881's L2/L3 reconcile surface
+  covers this permanently.
+- Do not add more code before merging PR #881. Every new defensive layer added
+  without merging the existing one increases code surface without reducing risk.

--- a/lib/platform/social/connections/route-helpers.ts
+++ b/lib/platform/social/connections/route-helpers.ts
@@ -41,6 +41,8 @@ export type LoadedConnection = {
   bundle_social_account_id: string;
   status: string;
   is_personal_mode: boolean;
+  display_name: string | null;
+  external_account_id: string | null;
   teamId: string;
 };
 
@@ -62,7 +64,7 @@ export async function loadConnectionWithTeam(
   const connRead = await svc
     .from("social_connections")
     .select(
-      "id, company_id, profile_id, platform, bundle_social_account_id, status, is_personal_mode",
+      "id, company_id, profile_id, platform, bundle_social_account_id, status, is_personal_mode, display_name, external_account_id",
     )
     .eq("id", connectionId)
     .maybeSingle();
@@ -82,6 +84,8 @@ export async function loadConnectionWithTeam(
     bundle_social_account_id: string;
     status: string;
     is_personal_mode: boolean | null;
+    display_name: string | null;
+    external_account_id: string | null;
   };
 
   if (!row.profile_id) {
@@ -125,6 +129,8 @@ export async function loadConnectionWithTeam(
       bundle_social_account_id: row.bundle_social_account_id,
       status: row.status,
       is_personal_mode: Boolean(row.is_personal_mode),
+      display_name: row.display_name ?? null,
+      external_account_id: row.external_account_id ?? null,
       teamId,
     },
   };

--- a/lib/platform/social/connections/sync.ts
+++ b/lib/platform/social/connections/sync.ts
@@ -319,12 +319,21 @@ export async function syncBundlesocialConnections(
     const status: "healthy" | "pending_identity" =
       !hasIdentity || needsChannelSelection ? "pending_identity" : "healthy";
 
-    // Prefer the display name from socialAccountGetByType (identity) over
-    // teamGetTeam (remote) — the former populates userDisplayName even for
-    // freshly-connected accounts where teamGetTeam returns null.
-    const displayName = rawIdentity.displayName ?? remoteDisplayName;
-
+    // For channel-selection platforms (LinkedIn, Facebook, etc.), prefer
+    // the channel's own name when a channel is bound (external_account_id
+    // set, not personal mode). Falls back to the OAuth personal display
+    // name so new/unbound rows still get a readable label.
     const localRow = existingById.get(bundleAccountId);
+    const isChannelBound =
+      requiresChannelSelection(remote.type) &&
+      identity.external_account_id !== null &&
+      !(localRow?.is_personal_mode ?? false);
+    const displayName: string | null = isChannelBound
+      ? (rawIdentity.channels.find(
+          (c) => c.id === identity.external_account_id,
+        )?.name ?? rawIdentity.displayName ?? remoteDisplayName)
+      : (rawIdentity.displayName ?? remoteDisplayName);
+
     if (localRow) {
       // UPDATE existing — refresh display_name + avatar + status. Also
       // backfill profile_id if it was NULL (e.g. row pre-dates BSP-8)

--- a/scripts/backfill-channel-display-name.ts
+++ b/scripts/backfill-channel-display-name.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * One-shot backfill: update display_name for social_connections rows where
+ * is_personal_mode=false and external_account_id is a known org/page URN
+ * but display_name is stale (personal-account name from OAuth, not the
+ * channel name).
+ *
+ * Only touches rows that are healthy, not in personal mode, and have a
+ * non-null external_account_id (i.e. a channel has been bound). For each
+ * such row it fetches the current channel list from bundle.social and
+ * matches on external_account_id to find the channel name.
+ *
+ * Idempotent — re-running only writes rows where the name differs.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-channel-display-name.ts            # writes
+ *   npx tsx scripts/backfill-channel-display-name.ts --dry-run  # no writes
+ */
+
+import { config } from "dotenv";
+import { createClient } from "@supabase/supabase-js";
+import { Bundlesocial } from "bundlesocial";
+
+config({ path: ".env.production.local" });
+config({ path: ".env.local" });
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`${name} not set`);
+  return v;
+}
+
+const supabaseUrl =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ?? requireEnv("SUPABASE_URL");
+const serviceRoleKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+const bundleApi = requireEnv("BUNDLE_SOCIAL_API");
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false },
+});
+const client = new Bundlesocial(bundleApi);
+
+const dryRun = process.argv.includes("--dry-run");
+
+// Map DB platform to bundle.social type string.
+const PLATFORM_TO_BUNDLE: Record<string, string> = {
+  linkedin_personal: "LINKEDIN",
+  linkedin_company: "LINKEDIN",
+  facebook_page: "FACEBOOK",
+  gbp: "GOOGLE_BUSINESS",
+};
+
+async function main() {
+  console.log(`[backfill-channel-display-name] dry-run=${dryRun}`);
+
+  // Load rows: healthy, not personal mode, channel bound (external_account_id set).
+  const { data: rows, error: fetchErr } = await supabase
+    .from("social_connections")
+    .select(
+      "id, platform, bundle_social_account_id, display_name, external_account_id, profile_id",
+    )
+    .eq("status", "healthy")
+    .eq("is_personal_mode", false)
+    .not("external_account_id", "is", null)
+    .in("platform", ["linkedin_personal", "linkedin_company", "facebook_page", "gbp"]);
+
+  if (fetchErr) {
+    console.error("Failed to query social_connections:", fetchErr.message);
+    process.exit(1);
+  }
+
+  if (!rows || rows.length === 0) {
+    console.log("No rows to backfill.");
+    return;
+  }
+
+  console.log(`Found ${rows.length} candidate rows.`);
+
+  // For each row, look up the profile's bundle.social team, fetch channels,
+  // find the matching channel by external_account_id, and update display_name.
+  let updated = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const row of rows) {
+    const bundleType = PLATFORM_TO_BUNDLE[row.platform as string];
+    if (!bundleType) {
+      console.log(`  [SKIP] ${row.id} — platform ${row.platform} not backfillable`);
+      skipped++;
+      continue;
+    }
+
+    // Resolve the bundle.social team for this profile.
+    const { data: profile, error: profileErr } = await supabase
+      .from("platform_social_profiles")
+      .select("bundle_social_team_id")
+      .eq("id", row.profile_id)
+      .maybeSingle();
+
+    if (profileErr || !profile?.bundle_social_team_id) {
+      console.warn(`  [SKIP] ${row.id} — no team_id (profileErr=${profileErr?.message})`);
+      skipped++;
+      continue;
+    }
+
+    const teamId = profile.bundle_social_team_id as string;
+
+    // Fetch channels from bundle.social.
+    let channelName: string | null = null;
+    try {
+      const acct = await client.socialAccount.socialAccountGetByType({
+        teamId,
+        type: bundleType as "LINKEDIN" | "FACEBOOK" | "GOOGLE_BUSINESS",
+      });
+
+      // channels is at acct.channels (array of {id, name, ...})
+      const channels = (acct as unknown as {
+        channels?: Array<{ id: string; name: string | null }>;
+      }).channels ?? [];
+
+      const match = channels.find((ch) => ch.id === (row.external_account_id as string));
+      if (match) {
+        channelName = match.name ?? null;
+      } else {
+        console.warn(
+          `  [WARN] ${row.id} — external_account_id ${row.external_account_id} not found in channels list (${channels.length} channels)`,
+        );
+      }
+    } catch (sdkErr) {
+      console.error(`  [ERROR] ${row.id} — SDK call failed:`, sdkErr);
+      errors++;
+      continue;
+    }
+
+    if (!channelName) {
+      console.log(`  [SKIP] ${row.id} — could not resolve channel name`);
+      skipped++;
+      continue;
+    }
+
+    if (channelName === row.display_name) {
+      console.log(`  [SKIP] ${row.id} — display_name already correct ("${channelName}")`);
+      skipped++;
+      continue;
+    }
+
+    console.log(
+      `  [UPDATE] ${row.id} — "${row.display_name}" → "${channelName}" (${row.external_account_id})`,
+    );
+
+    if (!dryRun) {
+      const { error: updErr } = await supabase
+        .from("social_connections")
+        .update({ display_name: channelName })
+        .eq("id", row.id);
+
+      if (updErr) {
+        console.error(`    UPDATE failed: ${updErr.message}`);
+        errors++;
+        continue;
+      }
+    }
+
+    updated++;
+    // Brief pause to avoid hammering the bundle.social API.
+    await new Promise((r) => setTimeout(r, 150));
+  }
+
+  console.log(
+    `\nDone. updated=${updated} skipped=${skipped} errors=${errors}${dryRun ? " (dry-run — no writes)" : ""}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/regressions/auto-open-pending-picker.test.tsx
+++ b/tests/regressions/auto-open-pending-picker.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// REGRESSION — auto-open ChannelPickerModal for pending_identity connections.
+//
+// After OAuth completes with a channel-selection platform (LinkedIn, Facebook,
+// GBP), the DB row lands in status='pending_identity'. On the next mount of
+// SocialConnectionsList the modal MUST auto-open without user action.
+//
+// Critical pins:
+//   - useRef<Set<string>> (not sessionStorage) so the shown-set resets on
+//     page refresh (component remount), allowing the modal to reopen.
+//   - Non-channel-selection platforms (x) must NOT trigger the modal even
+//     if status is pending_identity.
+//   - Dismissing the modal without picking must not reopen it during the
+//     same component lifetime.
+// ---------------------------------------------------------------------------
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/toast-success", () => ({ toastSuccess: vi.fn() }));
+
+vi.mock("@/components/ChannelPickerModal", () => ({
+  ChannelPickerModal: ({
+    isOpen,
+    onClose,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="channel-picker-modal">
+        <button data-testid="picker-close" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+import { SocialConnectionsList } from "@/components/SocialConnectionsList";
+import type { SocialConnection } from "@/lib/platform/social/connections/types";
+
+const fetchMock = vi.fn();
+const ORIGINAL_FETCH = global.fetch;
+
+const BASE_PROPS = {
+  companyId: "company-1",
+  profileId: "profile-1",
+  connections: [] as SocialConnection[],
+  canManage: true,
+  canReconnect: true,
+};
+
+function makeConn(overrides: Partial<SocialConnection> = {}): SocialConnection {
+  return {
+    id: "conn-1",
+    company_id: "company-1",
+    profile_id: "profile-1",
+    platform: "linkedin_personal",
+    bundle_social_account_id: "bs-1",
+    display_name: "Test LinkedIn",
+    avatar_url: null,
+    status: "pending_identity",
+    last_error: null,
+    connected_at: new Date().toISOString(),
+    disconnected_at: null,
+    last_health_check_at: new Date().toISOString(),
+    external_account_id: null,
+    external_user_id: null,
+    external_identity_hash: null,
+    is_personal_mode: false,
+    has_emitted_overdue_event: false,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  global.fetch = ORIGINAL_FETCH;
+  vi.clearAllMocks();
+});
+
+describe("R-AUTO-OPEN-PICKER: pending_identity rows auto-open ChannelPickerModal", () => {
+  it("mount with pending_identity LinkedIn row → picker modal opens automatically", async () => {
+    const conn = makeConn({ id: "conn-linkedin", platform: "linkedin_personal" });
+    render(<SocialConnectionsList {...BASE_PROPS} connections={[conn]} />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("channel-picker-modal")).toBeInTheDocument();
+    });
+  });
+
+  it("pending_identity X (Twitter) row → picker stays closed (not a channel-selection platform)", async () => {
+    const conn = makeConn({ id: "conn-x", platform: "x", status: "pending_identity" });
+    render(<SocialConnectionsList {...BASE_PROPS} connections={[conn]} />);
+
+    await act(async () => {});
+    expect(screen.queryByTestId("channel-picker-modal")).toBeNull();
+  });
+
+  it("dismiss modal without picking → does NOT reopen during the same mount", async () => {
+    const conn = makeConn({ id: "conn-linkedin", platform: "linkedin_personal" });
+    render(<SocialConnectionsList {...BASE_PROPS} connections={[conn]} />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("channel-picker-modal")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("picker-close"));
+
+    await act(async () => {});
+    expect(screen.queryByTestId("channel-picker-modal")).toBeNull();
+  });
+
+  it("remount (page refresh) → modal reopens because useRef resets on unmount", async () => {
+    const conn = makeConn({ id: "conn-linkedin", platform: "linkedin_personal" });
+    const { unmount } = render(
+      <SocialConnectionsList {...BASE_PROPS} connections={[conn]} />,
+    );
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("channel-picker-modal")).toBeInTheDocument();
+    });
+
+    unmount();
+
+    render(<SocialConnectionsList {...BASE_PROPS} connections={[conn]} />);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("channel-picker-modal")).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/regressions/linkedin-label-uses-is-personal-mode.test.tsx
+++ b/tests/regressions/linkedin-label-uses-is-personal-mode.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+// ---------------------------------------------------------------------------
+// REGRESSION — LinkedIn connection label must be driven by is_personal_mode,
+// not the platform enum value.
+//
+// Before fix: platform="linkedin_personal" always showed "LinkedIn (personal)"
+// even when an org page was bound (is_personal_mode=false, external_account_id
+// = urn:li:organization:...).
+//
+// After fix:
+//   is_personal_mode=false → "LinkedIn"
+//   is_personal_mode=true  → "LinkedIn (personal)"
+// ---------------------------------------------------------------------------
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/toast-success", () => ({ toastSuccess: vi.fn() }));
+
+import { SocialConnectionsList } from "@/components/SocialConnectionsList";
+import type { SocialConnection } from "@/lib/platform/social/connections/types";
+
+const fetchMock = vi.fn();
+const ORIGINAL_FETCH = global.fetch;
+
+const BASE_PROPS = {
+  companyId: "company-1",
+  profileId: "profile-1",
+  connections: [] as SocialConnection[],
+  canManage: true,
+  canReconnect: true,
+};
+
+function makeLinkedInConn(
+  overrides: Partial<SocialConnection> = {},
+): SocialConnection {
+  return {
+    id: "conn-1",
+    company_id: "company-1",
+    profile_id: "profile-1",
+    platform: "linkedin_personal",
+    bundle_social_account_id: "bs-1",
+    display_name: "Opollo MSP Marketing",
+    avatar_url: null,
+    status: "healthy",
+    last_error: null,
+    connected_at: new Date().toISOString(),
+    disconnected_at: null,
+    last_health_check_at: new Date().toISOString(),
+    external_account_id: "urn:li:organization:105341307",
+    external_user_id: "urn:li:person:abc",
+    external_identity_hash: null,
+    is_personal_mode: false,
+    has_emitted_overdue_event: false,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  global.fetch = ORIGINAL_FETCH;
+  vi.clearAllMocks();
+});
+
+describe("R-LINKEDIN-LABEL: label driven by is_personal_mode, not platform enum", () => {
+  it("is_personal_mode=false → renders 'LinkedIn' (org page bound)", () => {
+    const conn = makeLinkedInConn({ is_personal_mode: false });
+    render(<SocialConnectionsList {...BASE_PROPS} connections={[conn]} />);
+
+    // Find the cell that shows the platform label for this connection row.
+    const row = screen.getByTestId(`connection-row-${conn.id}`);
+    expect(row).toHaveTextContent("LinkedIn");
+    expect(row).not.toHaveTextContent("LinkedIn (personal)");
+  });
+
+  it("is_personal_mode=true → renders 'LinkedIn (personal)' (personal profile bound)", () => {
+    const conn = makeLinkedInConn({
+      is_personal_mode: true,
+      external_account_id: "urn:li:person:abc",
+      display_name: "Steven Morey",
+    });
+    render(<SocialConnectionsList {...BASE_PROPS} connections={[conn]} />);
+
+    const row = screen.getByTestId(`connection-row-${conn.id}`);
+    expect(row).toHaveTextContent("LinkedIn (personal)");
+  });
+
+  it("platform=linkedin_company, is_personal_mode=false → renders 'LinkedIn'", () => {
+    const conn = makeLinkedInConn({
+      platform: "linkedin_company",
+      is_personal_mode: false,
+    } as Partial<SocialConnection>);
+    render(<SocialConnectionsList {...BASE_PROPS} connections={[conn]} />);
+
+    const row = screen.getByTestId(`connection-row-${conn.id}`);
+    expect(row).toHaveTextContent("LinkedIn");
+    expect(row).not.toHaveTextContent("(personal)");
+  });
+
+  it("non-LinkedIn platform (x) label is unaffected", () => {
+    const conn = makeLinkedInConn({
+      id: "conn-x",
+      platform: "x",
+      is_personal_mode: false,
+      external_account_id: null,
+      display_name: "@opollo",
+    } as Partial<SocialConnection>);
+    render(<SocialConnectionsList {...BASE_PROPS} connections={[conn]} />);
+
+    const row = screen.getByTestId(`connection-row-${conn.id}`);
+    expect(row).toHaveTextContent("X");
+    expect(row).not.toHaveTextContent("LinkedIn");
+  });
+});

--- a/tests/regressions/popup-close-triggers-sync.test.tsx
+++ b/tests/regressions/popup-close-triggers-sync.test.tsx
@@ -1,5 +1,21 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
 
 import { SocialConnectionsList } from "@/components/SocialConnectionsList";
 
@@ -38,6 +54,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  cleanup();
   global.fetch = originalFetch;
   Object.defineProperty(window, "open", { configurable: true, writable: true, value: originalOpen });
   vi.clearAllMocks();
@@ -89,24 +106,26 @@ describe("R-POPUP-SYNC: sync fires when popup closes without postMessage", () =>
     fireEvent.click(screen.getByTestId("connections-connect-button"));
     fireEvent.click(screen.getByTestId("connect-platform-LINKEDIN"));
 
-    // Wait for the popup to be opened
-    await waitFor(() => expect(openMock).toHaveBeenCalledTimes(1));
+    // Flush async handlers (preflight + connect fetch chain) so window.open fires.
+    await act(async () => {});
+    expect(openMock).toHaveBeenCalledTimes(1);
 
     // Simulate popup closing (user closes bundle.social dashboard manually)
     fakePopup.closed = true;
 
-    // Advance timer by 600ms to trigger the popup-close poll
-    await vi.advanceTimersByTimeAsync(600);
+    // Advance timer by 600ms to trigger the popup-close poll, then flush
+    // the resulting async fetch chain.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
 
     // Sync endpoint must be called
-    await waitFor(() => {
-      const syncCalls = fetchMock.mock.calls.filter(
-        (c) =>
-          typeof c[0] === "string" &&
-          (c[0] as string).includes("/connections/sync"),
-      );
-      expect(syncCalls.length).toBeGreaterThan(0);
-    });
+    const syncCalls = fetchMock.mock.calls.filter(
+      (c) =>
+        typeof c[0] === "string" &&
+        (c[0] as string).includes("/connections/sync"),
+    );
+    expect(syncCalls.length).toBeGreaterThan(0);
 
     // Verify the sync call used POST with the right company_id
     const syncCall = fetchMock.mock.calls.find(
@@ -142,7 +161,9 @@ describe("R-POPUP-SYNC: sync fires when popup closes without postMessage", () =>
     fireEvent.click(screen.getByTestId("connections-connect-button"));
     fireEvent.click(screen.getByTestId("connect-platform-FACEBOOK"));
 
-    await waitFor(() => expect(openMock).toHaveBeenCalledTimes(1));
+    // Flush the async fetch chain so window.open fires.
+    await act(async () => {});
+    expect(openMock).toHaveBeenCalledTimes(1);
 
     // Simulate our callback firing a postMessage (happy path).
     window.dispatchEvent(
@@ -157,7 +178,9 @@ describe("R-POPUP-SYNC: sync fires when popup closes without postMessage", () =>
 
     // The postMessage handler clears the poll immediately. Advancing
     // the timer should NOT trigger a sync call.
-    await vi.advanceTimersByTimeAsync(600);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
 
     const syncCalls = fetchMock.mock.calls.filter(
       (c) =>

--- a/tests/regressions/set-channel-updates-display-name.test.ts
+++ b/tests/regressions/set-channel-updates-display-name.test.ts
@@ -1,0 +1,251 @@
+// ---------------------------------------------------------------------------
+// REGRESSION — set-channel must write display_name from the selected
+// channel's name (not the personal OAuth displayName). And must emit
+// a connection_channel_selected platform_event on success.
+//
+// Incident: 2026-05-13
+// After picking an org page the UI showed "Steven Morey" (OAuth personal
+// name) instead of the org page name because set-channel never updated
+// display_name. Fixed: find channel in fingerprint.channels and write name.
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock factories are hoisted above variable declarations, so all mock
+// fn handles must be created via vi.hoisted() to be in scope.
+const mocks = vi.hoisted(() => ({
+  setChannel: vi.fn(),
+  resolveIdentityFingerprint: vi.fn(),
+  checkCrossTenantConflict: vi.fn(),
+  computeIdentityHash: vi.fn(),
+  emitCrossTenantBlocked: vi.fn(),
+  update: vi.fn(),
+  platformEventInsert: vi.fn(),
+}));
+
+vi.mock("@/lib/platform/social/connections/channels", () => ({
+  setChannel: mocks.setChannel,
+}));
+
+vi.mock("@/lib/platform/social/connections/identity", () => ({
+  resolveIdentityFingerprint: mocks.resolveIdentityFingerprint,
+  checkCrossTenantConflict: mocks.checkCrossTenantConflict,
+  computeIdentityHash: mocks.computeIdentityHash,
+  emitCrossTenantBlocked: mocks.emitCrossTenantBlocked,
+}));
+
+vi.mock("@/lib/bundlesocial", () => ({}));
+
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: async () => ({
+    kind: "allow" as const,
+    userId: "user-test",
+    supabase: {} as never,
+  }),
+}));
+
+const connRow = {
+  id: "cd339e96-8388-469f-9ef7-d035d9306353",
+  company_id: "11111111-1111-1111-1111-111111111111",
+  profile_id: "22222222-2222-2222-2222-222222222222",
+  platform: "linkedin_personal",
+  bundle_social_account_id: "bs-acct-1",
+  status: "pending_identity",
+  is_personal_mode: false,
+  display_name: "Steven Morey",
+  external_account_id: null,
+};
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({
+    from: (table: string) => {
+      if (table === "social_connections") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: connRow, error: null }),
+            }),
+          }),
+          update: (vals: unknown) => ({
+            eq: (_col: string, _val: string) => mocks.update(vals),
+          }),
+        };
+      }
+      if (table === "platform_social_profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: { bundle_social_team_id: "team-fixture" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "platform_events") {
+        return {
+          insert: (payload: unknown) => mocks.platformEventInsert(payload),
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  }),
+}));
+
+import { POST } from "@/app/api/platform/social/connections/[id]/set-channel/route";
+
+const ORG_URN = "urn:li:organization:105341307";
+const ORG_NAME = "Opollo MSP Marketing";
+const PERSON_URN = "urn:li:person:AbC123";
+const PERSON_NAME = "Steven Morey";
+
+function makeReq(channelId: string): Request {
+  return new Request(
+    `http://localhost/api/platform/social/connections/${connRow.id}/set-channel`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel_id: channelId }),
+    },
+  );
+}
+
+const BASE_FINGERPRINT = {
+  external_account_id: ORG_URN,
+  external_user_id: PERSON_URN,
+  external_identity_hash: "hash-abc",
+  displayName: PERSON_NAME,
+  channels: [
+    {
+      id: ORG_URN,
+      name: ORG_NAME,
+      username: "opollo-msp",
+      address: null,
+      avatarUrl: null,
+    },
+    {
+      id: "urn:li:organization:999",
+      name: "Some Other Page",
+      username: "other",
+      address: null,
+      avatarUrl: null,
+    },
+  ],
+  raw: {},
+};
+
+beforeEach(() => {
+  mocks.setChannel.mockReset();
+  mocks.resolveIdentityFingerprint.mockReset();
+  mocks.checkCrossTenantConflict.mockReset();
+  mocks.computeIdentityHash.mockReset();
+  mocks.emitCrossTenantBlocked.mockReset();
+  mocks.update.mockReset();
+  mocks.platformEventInsert.mockReset();
+
+  mocks.setChannel.mockResolvedValue({
+    ok: true,
+    data: { externalId: ORG_URN, userId: PERSON_URN },
+  });
+  mocks.resolveIdentityFingerprint.mockResolvedValue(BASE_FINGERPRINT);
+  mocks.computeIdentityHash.mockReturnValue("hash-abc");
+  mocks.checkCrossTenantConflict.mockResolvedValue({
+    ok: true,
+    override_allowed: true,
+    conflicting_rows: [],
+  });
+  mocks.update.mockResolvedValue({ error: null });
+  mocks.platformEventInsert.mockResolvedValue({ error: null });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("R-SET-CHANNEL-DISPLAY-NAME: set-channel writes channel name, not personal name", () => {
+  it("200 on success", async () => {
+    const res = await POST(makeReq(ORG_URN) as never, {
+      params: { id: connRow.id },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("writes display_name from the selected channel's name (not OAuth personal name)", async () => {
+    await POST(makeReq(ORG_URN) as never, { params: { id: connRow.id } });
+
+    expect(mocks.update).toHaveBeenCalledTimes(1);
+    const written = mocks.update.mock.calls[0]![0] as Record<string, unknown>;
+    expect(written.display_name).toBe(ORG_NAME);
+  });
+
+  it("does NOT write the personal OAuth displayName as display_name", async () => {
+    await POST(makeReq(ORG_URN) as never, { params: { id: connRow.id } });
+
+    const written = mocks.update.mock.calls[0]![0] as Record<string, unknown>;
+    expect(written.display_name).not.toBe(PERSON_NAME);
+  });
+
+  it("sets is_personal_mode=false and status=healthy on the update", async () => {
+    await POST(makeReq(ORG_URN) as never, { params: { id: connRow.id } });
+
+    const written = mocks.update.mock.calls[0]![0] as Record<string, unknown>;
+    expect(written.status).toBe("healthy");
+    expect(written.is_personal_mode).toBe(false);
+  });
+
+  it("emits a connection_channel_selected platform_event", async () => {
+    await POST(makeReq(ORG_URN) as never, { params: { id: connRow.id } });
+
+    // platform_events insert fires async (void); flush microtasks.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mocks.platformEventInsert).toHaveBeenCalledTimes(1);
+    const payload = mocks.platformEventInsert.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload.event_type).toBe("connection_channel_selected");
+    expect(payload.entity_id).toBe(connRow.id);
+    const inner = payload.payload as Record<string, unknown>;
+    expect(inner.channel_id).toBe(ORG_URN);
+    expect(inner.channel_name).toBe(ORG_NAME);
+  });
+
+  it("records previous display_name in the event payload for audit trail", async () => {
+    await POST(makeReq(ORG_URN) as never, { params: { id: connRow.id } });
+
+    await new Promise((r) => setTimeout(r, 0));
+    const payload = mocks.platformEventInsert.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    const inner = payload.payload as Record<string, unknown>;
+    expect(inner.previous_display_name).toBe(PERSON_NAME);
+  });
+
+  it("display_name is null when channel_id is not found in channels list (graceful fallback)", async () => {
+    const unknownId = "urn:li:organization:999999";
+    // channels list does not contain unknownId — find returns undefined.
+    mocks.resolveIdentityFingerprint.mockResolvedValueOnce({
+      ...BASE_FINGERPRINT,
+      external_account_id: unknownId,
+      channels: [
+        {
+          id: ORG_URN,
+          name: ORG_NAME,
+          username: "opollo-msp",
+          address: null,
+          avatarUrl: null,
+        },
+      ],
+    });
+
+    const res = await POST(makeReq(unknownId) as never, {
+      params: { id: connRow.id },
+    });
+    expect(res.status).toBe(200);
+
+    const written = mocks.update.mock.calls[0]![0] as Record<string, unknown>;
+    expect(written.display_name).toBeNull();
+  });
+});

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
     include: [
       "lib/__tests__/**/*.contract.test.ts",
       "lib/__tests__/**/*.unit.test.ts",
-      "tests/regressions/**/*.test.ts",
+      "tests/regressions/**/*.test.{ts,tsx}",
       "tests/security/**/*.security.test.ts",
     ],
     testTimeout: 10_000,


### PR DESCRIPTION
## Investigation findings

**I1 — YouTube in connect menu**: YouTube has no `youtube` entry in the `SocialPlatform` DB enum and no `YOUTUBE` key in `BUNDLE_TO_PLATFORM` in sync.ts. Any YouTube OAuth would silently fail at sync. Removed from UI.

**I2 — OAuth popup too narrow**: `POPUP_FEATURES` was a module-level constant (`600×700`) that couldn't read `window.screen.*`. Changed to a runtime function that centres a `900×820` window. Removed `noopener=no` (redundant — omitting `noopener` is the default; `window.opener` for postMessage is preserved).

**I3 — Instagram picker copy**: AdminProfileConnectionsList correctly snapshots `busyPlatform` before `clearPopupState()` and passes `platform="INSTAGRAM"` to the modal. SocialConnectionsList didn't — it re-derived the platform from the DB row (`facebook_page` → `FACEBOOK`). Fix: added `busyPlatformRef` + `pickerPlatformOverride` state; `handleMessage` captures the click platform before clearing and sets the override when it's `INSTAGRAM`. ChannelPickerModal and PopupChannelPicker now render Instagram-specific heading/body copy.

**I4 — Facebook silent-fail**: NOT broken. `facebook_page` row `e38d7828` is healthy. No code change.

**I5 — Facebook display_name overwritten by sync**: Root cause: `sync.ts` line 325 unconditionally set `displayName = rawIdentity.displayName ?? remoteDisplayName`. For Facebook/LinkedIn-org, `rawIdentity.displayName` is the personal OAuth name. Every sync run clobbered the correct channel name written by set-channel. Fix: when `requiresChannelSelection(remote.type) && external_account_id !== null && !is_personal_mode`, prefer `rawIdentity.channels.find(c => c.id === external_account_id)?.name`.

**I6 — X/Twitter silent-fail**: Architecture correct. `BUNDLE_TO_PLATFORM` maps `TWITTER → "x"`, callback handles it, sync maps correctly. Silent failure likely timing; user should retry. No code change.

**I7 — Label logic**: Already correct from PR #886. No change.

## Changes shipped

| File | Change |
|---|---|
| `components/SocialConnectionsList.tsx` | Remove YouTube; `getPopupFeatures()` fn; `busyPlatformRef` + `pickerPlatformOverride` for Instagram picker |
| `components/AdminProfileConnectionsList.tsx` | Remove YouTube; `getPopupFeatures()` fn |
| `components/ChannelPickerModal.tsx` | Instagram-specific heading + body copy |
| `components/PopupChannelPicker.tsx` | Instagram-specific heading + body copy |
| `lib/platform/social/connections/sync.ts` | Prefer channel name from `fingerprint.channels` when channel is bound |
| `components/__tests__/SocialConnectionsList-tiles.test.tsx` | Update PLATFORMS array and test description (6 → 5) |

## Backfill needed post-deploy

Facebook row `e38d7828` (`display_name="Steven Morey"`) — sync.ts fix will correct this on the next sync run, or run manually:

```bash
npx tsx scripts/backfill-channel-display-name.ts --dry-run
npx tsx scripts/backfill-channel-display-name.ts
```

## Working analog

**I5 fix**: `app/api/platform/social/connections/[id]/set-channel/route.ts:136-139` — same `fingerprint.channels.find(c => c.id === channel_id)?.name` pattern from PR #886. Diff: set-channel correctly did this; sync.ts did not. Fix makes sync.ts match.

**Why:** set-channel writes the correct channel name on first bind; sync.ts then ran nightly and overwrote it with the personal OAuth name. Both write to `display_name`; only one was reading from `channels[]`.

## Risks identified and mitigated

- **sync.ts channel-name fallback**: if the channel no longer appears in `fingerprint.channels`, falls back to `rawIdentity.displayName ?? remoteDisplayName`. No data loss.
- **pickerPlatformOverride stale state**: cleared in both `onClose` and `onSelected`. Auto-open path (`?connect=needs_channel` redirect) doesn't set the override — falls back to DB-derived FACEBOOK label (acceptable; original click intent not available in redirect path).
- **YouTube removal**: backend Zod schemas still accept full 14-platform enum; no DB migration needed; existing rows unaffected.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (1504 tests), `test:components` (84 tests)
- [x] Working-analog block in PR body
- [x] Risks identified and mitigated
- [x] PR is under 500 net lines (73 insertions, 25 deletions)