### PR TITLE
fix(social): Facebook auto-open race + X attribution — two post-#887 regressions

### DIFF
--- a/app/api/platform/social/connections/sync/route.ts
+++ b/app/api/platform/social/connections/sync/route.ts
@@ -28,6 +28,14 @@ export const dynamic = "force-dynamic";
 
 const PostBodySchema = z.object({
   company_id: dbUuid(),
+  // When present, new bundle.social accounts that have no local DB row are
+  // inserted and attributed to this company. The popup-close fallback path
+  // (syncOnPopupClose in SocialConnectionsList) passes this so that
+  // platforms whose OAuth redirects bundle.social's own dashboard instead
+  // of our /callback URL (e.g. X/Twitter) still get a DB row created.
+  // Omit for the manual "Refresh" UI action (should only update existing
+  // rows, not create new ones without explicit user intent).
+  attribute_new_to_company_id: dbUuid().optional(),
 });
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
@@ -46,6 +54,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   const result = await syncBundlesocialConnections({
     companyId: parsed.data.company_id,
+    ...(parsed.data.attribute_new_to_company_id
+      ? { attributeNewToCompanyId: parsed.data.attribute_new_to_company_id }
+      : {}),
   });
   if (!result.ok) {
     return internalError(result.error.message);

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -225,7 +225,13 @@ export function SocialConnectionsList({
       const r = await fetch("/api/platform/social/connections/sync", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ company_id: companyId }),
+        // For fresh connects (no rowId), attribute new accounts so
+        // platforms that don't redirect to our callback (e.g. X/Twitter
+        // going to bundle.social's dashboard) still get a DB row created.
+        body: JSON.stringify({
+          company_id: companyId,
+          ...(rowId ? {} : { attribute_new_to_company_id: companyId }),
+        }),
       });
       if (r.ok) {
         const json = (await r.json()) as { data?: { inserted: number } };
@@ -523,27 +529,51 @@ export function SocialConnectionsList({
   // Resolve the picker target to its bundle.social platform shape so
   // the modal renders the right labels. null when the connection isn't
   // a channel-selection platform (modal stays closed).
-  const pickerTarget = pickerForConnectionId
-    ? (() => {
-        const c = connections.find((x) => x.id === pickerForConnectionId);
-        if (!c) return null;
-        // Instagram Business connects via Facebook OAuth and creates a
-        // facebook_page row. If the user originally clicked Instagram,
-        // override the platform label so the modal shows Instagram copy.
-        if (pickerPlatformOverride === "INSTAGRAM" && c.platform === "facebook_page") {
-          return { conn: c, platform: "INSTAGRAM" as const, label: "Instagram" };
-        }
-        const bundle = PLATFORM_TO_BUNDLE_LABEL[c.platform];
-        if (!bundle) return null;
-        return { conn: c, ...bundle };
-      })()
-    : null;
+  //
+  // Three-tier resolution:
+  //   1. pickerPlatformOverride (Instagram-via-Facebook click intent)
+  //   2. DB row platform (connections prop, available after router.refresh)
+  //   3. busyPlatformRef (clicked platform, available immediately on
+  //      needs_channel — before the RSC re-render delivers the new row)
+  //
+  // Tier 3 fixes the race where handleMessage fires needs_channel with a
+  // connection_id but connections still contains the pre-connect snapshot
+  // and the row can't be found.
+  const pickerTarget = (() => {
+    if (!pickerForConnectionId) return null;
+
+    if (pickerPlatformOverride === "INSTAGRAM") {
+      return { platform: "INSTAGRAM" as const, label: "Instagram" };
+    }
+
+    const c = connections.find((x) => x.id === pickerForConnectionId);
+    if (c) {
+      const bundle = PLATFORM_TO_BUNDLE_LABEL[c.platform];
+      if (!bundle) return null;
+      return { platform: bundle.platform, label: bundle.label };
+    }
+
+    // Row not yet in prop (router.refresh() in flight). Derive platform
+    // from the captured click intent so the modal opens immediately.
+    const hint = busyPlatformRef.current;
+    if (!hint) return null;
+    const HINT_TO_PICKER: Record<
+      string,
+      { platform: "LINKEDIN" | "FACEBOOK" | "INSTAGRAM" | "GOOGLE_BUSINESS"; label: string } | undefined
+    > = {
+      LINKEDIN: { platform: "LINKEDIN", label: "LinkedIn" },
+      FACEBOOK: { platform: "FACEBOOK", label: "Facebook" },
+      INSTAGRAM: { platform: "INSTAGRAM", label: "Instagram" },
+      GOOGLE_BUSINESS: { platform: "GOOGLE_BUSINESS", label: "Google Business" },
+    };
+    return HINT_TO_PICKER[hint] ?? null;
+  })();
 
   return (
     <div data-testid="connections-list-wrapper">
       {pickerTarget ? (
         <ChannelPickerModal
-          connectionId={pickerTarget.conn.id}
+          connectionId={pickerForConnectionId!}
           platform={pickerTarget.platform}
           platformLabel={pickerTarget.label}
           isOpen={true}

--- a/tests/regressions/needs-channel-modal-opens-before-refresh.test.tsx
+++ b/tests/regressions/needs-channel-modal-opens-before-refresh.test.tsx
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// REGRESSION — ChannelPickerModal must open immediately when the popup
+// postMessages connect=needs_channel, even before router.refresh() delivers
+// the new connection in the `connections` prop.
+//
+// Incident: 2026-05-13
+// Facebook OAuth completed → row inserted → callback postMessaged
+// connect=needs_channel + connection_id. But pickerTarget returned null
+// because connections prop was the pre-connect snapshot (no row found).
+// Modal never opened. Steven had to manually click Refresh.
+//
+// Fix: pickerTarget falls back to busyPlatformRef.current (the platform
+// the user clicked) when the connection isn't in the prop yet.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  refresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: mocks.refresh,
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/toast-success", () => ({ toastSuccess: vi.fn() }));
+
+vi.mock("@/components/ChannelPickerModal", () => ({
+  ChannelPickerModal: ({
+    isOpen,
+    connectionId,
+    platform,
+    platformLabel,
+    onClose,
+  }: {
+    isOpen: boolean;
+    connectionId: string;
+    platform: string;
+    platformLabel: string;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div
+        data-testid="channel-picker-modal"
+        data-connection-id={connectionId}
+        data-platform={platform}
+        data-platform-label={platformLabel}
+      >
+        <button data-testid="picker-close" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+import { SocialConnectionsList } from "@/components/SocialConnectionsList";
+
+const fetchMock = vi.fn();
+const openMock = vi.fn();
+const ORIGINAL_FETCH = global.fetch;
+const ORIGINAL_OPEN = window.open;
+
+function makeFakePopup() {
+  return { closed: false, focus: vi.fn(), close() { (this as { closed: boolean }).closed = true; } };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  mocks.refresh.mockReset();
+  openMock.mockReset();
+  Object.defineProperty(window, "open", { configurable: true, writable: true, value: openMock });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  global.fetch = ORIGINAL_FETCH;
+  Object.defineProperty(window, "open", { configurable: true, writable: true, value: ORIGINAL_OPEN });
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+function renderEmpty() {
+  return render(
+    <SocialConnectionsList
+      companyId="00000000-0000-0000-0000-000000000001"
+      profileId="00000000-0000-0000-0000-000000000002"
+      connections={[]}
+      canManage={true}
+      canReconnect={true}
+    />,
+  );
+}
+
+const CONN_ID = "20acab14-d422-463e-9920-297f998bce38";
+
+describe("R-NEEDS-CHANNEL-RACE: modal opens immediately on needs_channel postMessage", () => {
+  it("Facebook connect: modal opens before router.refresh() delivers the row", async () => {
+    const fakePopup = makeFakePopup();
+    openMock.mockReturnValue(fakePopup);
+
+    fetchMock
+      // preflight
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, data: { warn: false, others: [] } }), {
+          status: 200, headers: { "content-type": "application/json" },
+        }),
+      )
+      // connect → OAuth URL
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: true, data: { url: "https://facebook.com/oauth?state=abc" } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    renderEmpty();
+
+    fireEvent.click(screen.getByTestId("connections-connect-button"));
+    fireEvent.click(screen.getByTestId("connect-platform-FACEBOOK"));
+
+    // Flush preflight + connect fetches so window.open fires.
+    await act(async () => {});
+    expect(openMock).toHaveBeenCalledTimes(1);
+
+    // Simulate callback postMessaging needs_channel. connections prop is
+    // still [] at this point (router.refresh() hasn't resolved).
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: window.location.origin,
+          data: {
+            type: "bundle-connect-complete",
+            connect: "needs_channel",
+            connection_id: CONN_ID,
+          },
+        }),
+      );
+    });
+
+    // Modal MUST be open immediately — without waiting for router.refresh()
+    // to deliver the new connection in the connections prop.
+    const modal = screen.getByTestId("channel-picker-modal");
+    expect(modal).toBeInTheDocument();
+    expect(modal.dataset.connectionId).toBe(CONN_ID);
+    expect(modal.dataset.platform).toBe("FACEBOOK");
+  });
+
+  it("LinkedIn connect: modal opens before router.refresh() delivers the row", async () => {
+    const fakePopup = makeFakePopup();
+    openMock.mockReturnValue(fakePopup);
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, data: { warn: false, others: [] } }), {
+          status: 200, headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: true, data: { url: "https://linkedin.com/oauth?state=abc" } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    renderEmpty();
+
+    fireEvent.click(screen.getByTestId("connections-connect-button"));
+    fireEvent.click(screen.getByTestId("connect-platform-LINKEDIN"));
+
+    await act(async () => {});
+    expect(openMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: window.location.origin,
+          data: {
+            type: "bundle-connect-complete",
+            connect: "needs_channel",
+            connection_id: CONN_ID,
+          },
+        }),
+      );
+    });
+
+    const modal = screen.getByTestId("channel-picker-modal");
+    expect(modal).toBeInTheDocument();
+    expect(modal.dataset.platform).toBe("LINKEDIN");
+  });
+
+  it("Instagram connect: modal opens with INSTAGRAM platform label", async () => {
+    const fakePopup = makeFakePopup();
+    openMock.mockReturnValue(fakePopup);
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, data: { warn: false, others: [] } }), {
+          status: 200, headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: true, data: { url: "https://facebook.com/oauth?state=ig" } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    renderEmpty();
+
+    fireEvent.click(screen.getByTestId("connections-connect-button"));
+    fireEvent.click(screen.getByTestId("connect-platform-INSTAGRAM"));
+
+    await act(async () => {});
+    expect(openMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: window.location.origin,
+          data: {
+            type: "bundle-connect-complete",
+            connect: "needs_channel",
+            connection_id: CONN_ID,
+          },
+        }),
+      );
+    });
+
+    const modal = screen.getByTestId("channel-picker-modal");
+    expect(modal).toBeInTheDocument();
+    // Instagram click → pickerPlatformOverride="INSTAGRAM"
+    expect(modal.dataset.platform).toBe("INSTAGRAM");
+  });
+
+  it("success (no needs_channel): modal does NOT open before connections prop updates", async () => {
+    const fakePopup = makeFakePopup();
+    openMock.mockReturnValue(fakePopup);
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, data: { warn: false, others: [] } }), {
+          status: 200, headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: true, data: { url: "https://x.com/oauth?state=abc" } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    renderEmpty();
+
+    fireEvent.click(screen.getByTestId("connections-connect-button"));
+    fireEvent.click(screen.getByTestId("connect-platform-TWITTER"));
+
+    await act(async () => {});
+    expect(openMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: window.location.origin,
+          data: {
+            type: "bundle-connect-complete",
+            connect: "success",
+          },
+        }),
+      );
+    });
+
+    // No needs_channel → picker should NOT open
+    expect(screen.queryByTestId("channel-picker-modal")).toBeNull();
+  });
+});

--- a/tests/regressions/popup-close-sync-attributes-new.test.tsx
+++ b/tests/regressions/popup-close-sync-attributes-new.test.tsx
@@ -1,0 +1,247 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// REGRESSION — popup-close sync must pass attribute_new_to_company_id so
+// that platforms whose OAuth does NOT redirect to our callback (e.g.
+// X/Twitter going to bundle.social's own dashboard) still get a DB row
+// created when the popup closes.
+//
+// Incident: 2026-05-13
+// Steven connected X: popup opened, OAuth completed, popup closed.
+// syncOnPopupClose fired but called POST /sync WITHOUT
+// attribute_new_to_company_id. The sync found the new X account in
+// bundle.social but skipped insertion (no attribution flag). No row
+// appeared. Steven had to reconnect.
+//
+// Fix: syncOnPopupClose passes attribute_new_to_company_id: companyId
+// when rowId is undefined (fresh connect, not reconnect).
+// ---------------------------------------------------------------------------
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/toast-success", () => ({ toastSuccess: vi.fn() }));
+
+import { SocialConnectionsList } from "@/components/SocialConnectionsList";
+import type { SocialConnection } from "@/lib/platform/social/connections/types";
+
+const fetchMock = vi.fn();
+const openMock = vi.fn();
+const ORIGINAL_FETCH = global.fetch;
+const ORIGINAL_OPEN = window.open;
+
+function makeFakePopup() {
+  return { closed: false, focus: vi.fn(), close() { (this as { closed: boolean }).closed = true; } };
+}
+
+const COMPANY_ID = "00000000-0000-0000-0000-000000000001";
+
+function renderList(connections: SocialConnection[] = []) {
+  return render(
+    <SocialConnectionsList
+      companyId={COMPANY_ID}
+      profileId="00000000-0000-0000-0000-000000000002"
+      connections={connections}
+      canManage={true}
+      canReconnect={true}
+    />,
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  openMock.mockReset();
+  Object.defineProperty(window, "open", { configurable: true, writable: true, value: openMock });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  global.fetch = ORIGINAL_FETCH;
+  Object.defineProperty(window, "open", { configurable: true, writable: true, value: ORIGINAL_OPEN });
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("R-POPUP-SYNC-ATTRIBUTION: popup-close sync passes attribute_new_to_company_id for fresh connects", () => {
+  it("fresh connect (no rowId): sync body includes attribute_new_to_company_id", async () => {
+    const fakePopup = makeFakePopup();
+    openMock.mockReturnValue(fakePopup);
+
+    fetchMock
+      // preflight
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, data: { warn: false, others: [] } }), {
+          status: 200, headers: { "content-type": "application/json" },
+        }),
+      )
+      // connect → URL
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: true, data: { url: "https://twitter.com/oauth?state=abc" } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+      // sync call (popup close)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: true, data: { inserted: 1, updated: 0, marked_disconnected: 0, unmapped_skipped: 0, cross_tenant_blocked: 0 } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    renderList();
+
+    fireEvent.click(screen.getByTestId("connections-connect-button"));
+    fireEvent.click(screen.getByTestId("connect-platform-TWITTER"));
+
+    await act(async () => {});
+    expect(openMock).toHaveBeenCalledTimes(1);
+
+    // Popup closes without postMessage (bundle.social dashboard redirect).
+    fakePopup.closed = true;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    const syncCall = fetchMock.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("/connections/sync"),
+    );
+    expect(syncCall).toBeDefined();
+    const body = JSON.parse((syncCall![1] as RequestInit).body as string) as Record<string, unknown>;
+
+    expect(body.company_id).toBe(COMPANY_ID);
+    // KEY assertion: attribution flag must be present for fresh connects.
+    expect(body.attribute_new_to_company_id).toBe(COMPANY_ID);
+  });
+
+  it("reconnect (rowId present): sync body does NOT include attribute_new_to_company_id", async () => {
+    const existingConn: SocialConnection = {
+      id: "conn-existing",
+      company_id: COMPANY_ID,
+      profile_id: "00000000-0000-0000-0000-000000000002",
+      platform: "x",
+      bundle_social_account_id: "bs-x",
+      display_name: "@opollo",
+      avatar_url: null,
+      status: "auth_required",
+      last_error: null,
+      connected_at: new Date().toISOString(),
+      disconnected_at: null,
+      last_health_check_at: new Date().toISOString(),
+      external_account_id: null,
+      external_user_id: null,
+      external_identity_hash: null,
+      is_personal_mode: false,
+      has_emitted_overdue_event: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    const fakePopup = makeFakePopup();
+    openMock.mockReturnValue(fakePopup);
+
+    fetchMock
+      // reconnect → URL
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: true, data: { url: "https://twitter.com/oauth?state=reconnect" } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+      // sync call (popup close — reconnect path)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: true, data: { inserted: 0, updated: 1, marked_disconnected: 0, unmapped_skipped: 0, cross_tenant_blocked: 0 } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    renderList([existingConn]);
+
+    // Click Reconnect on the existing row.
+    const reconnectBtn = screen.getByTestId(`connection-reconnect-${existingConn.id}`);
+    fireEvent.click(reconnectBtn);
+
+    await act(async () => {});
+    expect(openMock).toHaveBeenCalledTimes(1);
+
+    fakePopup.closed = true;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    const syncCall = fetchMock.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("/connections/sync"),
+    );
+    expect(syncCall).toBeDefined();
+    const body = JSON.parse((syncCall![1] as RequestInit).body as string) as Record<string, unknown>;
+
+    expect(body.company_id).toBe(COMPANY_ID);
+    // Reconnects must NOT pass attribution — row already exists.
+    expect(body.attribute_new_to_company_id).toBeUndefined();
+  });
+
+  it("postMessage success path: sync still does NOT include attribution (callback already ran)", async () => {
+    const fakePopup = makeFakePopup();
+    openMock.mockReturnValue(fakePopup);
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, data: { warn: false, others: [] } }), {
+          status: 200, headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: true, data: { url: "https://facebook.com/oauth?state=fb" } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    renderList();
+
+    fireEvent.click(screen.getByTestId("connections-connect-button"));
+    fireEvent.click(screen.getByTestId("connect-platform-FACEBOOK"));
+
+    await act(async () => {});
+    expect(openMock).toHaveBeenCalledTimes(1);
+
+    // Callback fires postMessage success → clearPopupState() stops the poll.
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: window.location.origin,
+        data: { type: "bundle-connect-complete", connect: "success" },
+      }),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    // When postMessage fires (happy path), syncOnPopupClose is NOT called
+    // at all (poll was cleared). Verify no sync call.
+    const syncCalls = fetchMock.mock.calls.filter(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("/connections/sync"),
+    );
+    expect(syncCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Two production regressions found after PR #887 merged (2026-05-13):

- **I4 — Facebook auto-open race**: `needs_channel` postMessage fired but `ChannelPickerModal` never opened. Root cause: `pickerTarget` computed `connections.find(x => x.id === pickerForConnectionId)` — but `connections` is the pre-connect server snapshot. Row not found → `pickerTarget = null` → modal not rendered. Steven had to manually click Refresh.
- **I6 — X/Twitter no row**: Popup closes, `syncOnPopupClose` fires, but POST `/sync` had no `attribute_new_to_company_id`. `syncBundlesocialConnections` skips insertion of new accounts without that flag. For X/Twitter (bundle.social redirects to their own dashboard, not our `/callback`), the poll-based sync is the only insertion path — but it was silently a no-op for fresh connects.

Issues I1, I2, I3, I5, I7 shipped in PR #887 (`4d4aaf10`).

## Root-cause analysis

### I4 — pickerTarget race

`handleMessage` fires `needs_channel` + `connection_id` and calls `router.refresh()`. But `pickerTarget` was computed as:
```ts
const c = connections.find(x => x.id === pickerForConnectionId);
// c = undefined until router.refresh() re-renders the server component
if (!c) return null; // modal not rendered
```
`router.refresh()` re-renders asynchronously — in production this can take 1–3s. The modal was not rendered during that window.

**Working analog**: `handleMessage` already stored which platform the user clicked in `busyPlatformRef.current` (set in `handleConnect` for the Instagram override path). That ref is immediately readable inside the stale-closed `handleMessage` effect. Fix: add it as tier-3 fallback when `connections.find()` returns undefined.

**Fix**: Three-tier `pickerTarget` resolution:
1. `pickerPlatformOverride === "INSTAGRAM"` → Instagram (unchanged)
2. `connections.find(x => x.id === pickerForConnectionId)` → row arrived in prop (unchanged)
3. `busyPlatformRef.current` → platform hint from click (new fallback; covers needs_channel before RSC re-render)

Also changed `connectionId={pickerTarget.conn.id}` → `connectionId={pickerForConnectionId!}` since `conn` is no longer part of `pickerTarget`.

### I6 — syncOnPopupClose attribution gap

**Working analog**: `app/api/platform/social/connections/callback/route.ts` passes `attributeNewToCompanyId: companyId` to `syncBundlesocialConnections`. That path works correctly. The poll-based `syncOnPopupClose` path was missing the same parameter.

**Fix**:
- `app/api/platform/social/connections/sync/route.ts`: Added `attribute_new_to_company_id: dbUuid().optional()` to request schema; passes it to `syncBundlesocialConnections` when present
- `syncOnPopupClose(rowId?)`: passes `attribute_new_to_company_id: companyId` when `rowId` is undefined (fresh connect); omits it for reconnects (row already exists, no new attribution needed)

## Files changed

| File | Change |
|---|---|
| `components/SocialConnectionsList.tsx` | Three-tier pickerTarget; syncOnPopupClose attribution |
| `app/api/platform/social/connections/sync/route.ts` | attribute_new_to_company_id schema field + pass-through |
| `tests/regressions/needs-channel-modal-opens-before-refresh.test.tsx` | New regression (I4): modal opens before router.refresh() delivers row |
| `tests/regressions/popup-close-sync-attributes-new.test.tsx` | New regression (I6): fresh connect passes attribution; reconnect does not |

## Regression tests

**R-NEEDS-CHANNEL-RACE** (`needs-channel-modal-opens-before-refresh.test.tsx`):
- Facebook / LinkedIn / Instagram: modal opens immediately on `needs_channel` even when `connections` prop is still `[]`
- `success` postMessage: modal does NOT open (no picker for non-channel platforms)

**R-POPUP-SYNC-ATTRIBUTION** (`popup-close-sync-attributes-new.test.tsx`):
- Fresh connect: sync body includes `attribute_new_to_company_id`
- Reconnect: sync body does NOT include `attribute_new_to_company_id`
- postMessage success path: sync not called at all (poll cleared by postMessage)

## Manual test checklist

- [ ] Facebook: click Connect → OAuth → popup closes → **ChannelPickerModal opens within 2s without manual Refresh**
- [ ] Facebook: channel picker shows correct platform label and Instagram-specific copy when connecting Instagram
- [ ] X/Twitter: click Connect → OAuth → popup closes → **row appears in social_connections immediately** (check DB or refresh page)
- [ ] X/Twitter: reconnect an existing row → row updated, no duplicate insertion

## Working-analog blocks

**I4**:
- Working analog: `busyPlatformRef.current` was already set in `handleConnect` for the Instagram path (line ~285 in pre-PR `SocialConnectionsList.tsx`)
- Diff: `pickerTarget` stopped after `connections.find()` → null; did not fall back to the ref
- Fix: added tier-3 `HINT_TO_PICKER[busyPlatformRef.current]` lookup

**I6**:
- Working analog: `app/api/platform/social/connections/callback/route.ts` — `syncBundlesocialConnections({ companyId, attributeNewToCompanyId: companyId })`
- Diff: `syncOnPopupClose` called `POST /sync` with only `{ company_id }` — no attribution flag
- Fix: `syncOnPopupClose` passes `attribute_new_to_company_id: companyId` when `rowId` is undefined

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| `busyPlatformRef.current` is null when pickerTarget tier-3 runs (e.g. user navigated away mid-flow) | Returns null — modal stays closed; same UX as before the fix |
| Attribution flag creates duplicate rows on reconnect | Reconnect passes `rowId` → attribution omitted; `syncBundlesocialConnections` upserts on `bundle_social_account_id` per existing logic |
| Sync route now accepts optional param — unintended callers could pass it | Param is a UUID gated by `requireCanDoForApi("manage_connections")` + validated with `dbUuid()` — same guards as `company_id` |

## Pre-PR checklist

- [x] Lint, typecheck, build all green (1511/1511 tests pass)
- [x] Layer scripts run: `test:unit`, `test:regressions`
- [x] Regression test added: two new files under `tests/regressions/`
- [x] Working-analog block in PR body for both I4 and I6
- [x] Risks identified and mitigated section above
- [x] PR is under 500 net lines