### PR TITLE
fix(social): cross-tenant user override — preflight 'I manage both' bypasses sync block

### DIFF
--- a/app/api/platform/social/connections/callback/route.ts
+++ b/app/api/platform/social/connections/callback/route.ts
@@ -209,9 +209,16 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     return NextResponse.redirect(target);
   }
 
+  // cross_tenant_override=1 is set by /connect when the user clicked "I
+  // manage both" in the preflight warning modal. Pass it through to the
+  // sync so the cross-tenant block is bypassed for this connect.
+  const forceCrossTenantOverride =
+    url.searchParams.get("cross_tenant_override") === "1";
+
   const sync = await syncBundlesocialConnections({
     companyId,
     attributeNewToCompanyId: companyId,
+    ...(forceCrossTenantOverride ? { forceCrossTenantOverride: true } : {}),
   });
 
   // BSP analytics: after the sync attributes new connections, kick off

--- a/app/api/platform/social/connections/connect/route.ts
+++ b/app/api/platform/social/connections/connect/route.ts
@@ -58,6 +58,12 @@ const PostBodySchema = z.object({
   company_id: dbUuid(),
   profile_id: dbUuid(),
   platform: PLATFORM_ENUM,
+  // When true, the cross-tenant conflict block is bypassed for the sync
+  // that runs after this OAuth completes. Only set when the user explicitly
+  // clicked "I manage both" in the preflight warning modal. The flag is
+  // encoded in the callback redirectUrl as &cross_tenant_override=1 so the
+  // callback route can pass it through to syncBundlesocialConnections.
+  force_cross_tenant: z.boolean().optional(),
 });
 
 const WITH_BUSINESS_SCOPE_PLATFORMS: ReadonlySet<string> = new Set([
@@ -165,7 +171,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     new URL(req.url).origin;
   const redirectUrl =
     `${origin}/api/platform/social/connections/callback` +
-    `?company_id=${encodeURIComponent(parsed.data.company_id)}&popup=1`;
+    `?company_id=${encodeURIComponent(parsed.data.company_id)}&popup=1` +
+    (parsed.data.force_cross_tenant ? "&cross_tenant_override=1" : "");
 
   const result = await initiateProfileConnect({
     profileId: parsed.data.profile_id,

--- a/app/api/platform/social/connections/sync/route.ts
+++ b/app/api/platform/social/connections/sync/route.ts
@@ -36,6 +36,11 @@ const PostBodySchema = z.object({
   // Omit for the manual "Refresh" UI action (should only update existing
   // rows, not create new ones without explicit user intent).
   attribute_new_to_company_id: dbUuid().optional(),
+  // When true, bypasses the cross-tenant identity conflict block. Only set
+  // by syncOnPopupClose when the user explicitly clicked "I manage both"
+  // in the preflight warning modal. Emits a cross_tenant_override audit
+  // event regardless so the action is traceable.
+  force_cross_tenant_override: z.boolean().optional(),
 });
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
@@ -56,6 +61,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     companyId: parsed.data.company_id,
     ...(parsed.data.attribute_new_to_company_id
       ? { attributeNewToCompanyId: parsed.data.attribute_new_to_company_id }
+      : {}),
+    ...(parsed.data.force_cross_tenant_override
+      ? { forceCrossTenantOverride: true }
       : {}),
   });
   if (!result.ok) {

--- a/components/SocialConnectionsList.tsx
+++ b/components/SocialConnectionsList.tsx
@@ -188,6 +188,10 @@ export function SocialConnectionsList({
   // effect can read the platform the user originally clicked (needed to
   // distinguish Instagram from Facebook — both land as facebook_page rows).
   const busyPlatformRef = useRef<string | null>(null);
+  // Set to true when the user clicks "I manage both" in the preflight modal.
+  // Passed to /connect (encodes into callback URL) and to syncOnPopupClose
+  // (passed to /sync) so the cross-tenant block is bypassed for this flow.
+  const forceCrossTenantRef = useRef<boolean>(false);
   // When needs_channel fires after an Instagram connect, override the
   // picker modal's platform so it shows Instagram-specific copy.
   const [pickerPlatformOverride, setPickerPlatformOverride] = useState<
@@ -211,6 +215,7 @@ export function SocialConnectionsList({
     pollRef.current = null;
     popupRef.current = null;
     setBusyPlatform(null);
+    forceCrossTenantRef.current = false;
     if (activeRowId) setBusyRow(null);
   }
 
@@ -220,6 +225,7 @@ export function SocialConnectionsList({
   // only signal we get. Trigger an explicit sync so bundle.social-created
   // connections land in our DB even without a callback hit.
   async function syncOnPopupClose(rowId?: string) {
+    const forceCrossTenant = forceCrossTenantRef.current;
     clearPopupState(rowId);
     let inserted = 0;
     try {
@@ -232,6 +238,9 @@ export function SocialConnectionsList({
         body: JSON.stringify({
           company_id: companyId,
           ...(rowId ? {} : { attribute_new_to_company_id: companyId }),
+          ...(forceCrossTenant && !rowId
+            ? { force_cross_tenant_override: true }
+            : {}),
         }),
       });
       if (r.ok) {
@@ -258,6 +267,9 @@ export function SocialConnectionsList({
               body: JSON.stringify({
                 company_id: companyId,
                 attribute_new_to_company_id: companyId,
+                ...(forceCrossTenant
+                  ? { force_cross_tenant_override: true }
+                  : {}),
               }),
             });
             if (r2.ok) {
@@ -371,6 +383,19 @@ export function SocialConnectionsList({
       ) {
         setNoopdPlatform(evt.data.attempted_platform);
       }
+      // Cross-tenant block: the sync refused the account because the
+      // platform identity is already owned by another company. Surface an
+      // actionable error so the user knows they can click "I manage both"
+      // on the next attempt to override the block.
+      if (
+        evt.data.connect === "error" &&
+        evt.data.reason === "cross-tenant-blocked"
+      ) {
+        setError(
+          "This account is already connected to another client. " +
+            'To connect it here, click Connect and choose "I manage both" when prompted.',
+        );
+      }
       router.refresh();
     }
 
@@ -382,7 +407,10 @@ export function SocialConnectionsList({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  async function handleConnect(platform: string, opts?: { skipPreflight?: boolean }) {
+  async function handleConnect(
+    platform: string,
+    opts?: { skipPreflight?: boolean; forceCrossTenant?: boolean },
+  ) {
     if (!profileId) return;
     setError(null);
 
@@ -401,6 +429,10 @@ export function SocialConnectionsList({
       }
     }
 
+    // Record the cross-tenant override decision before the popup opens so
+    // syncOnPopupClose can read it if the popup bypasses the callback URL.
+    forceCrossTenantRef.current = opts?.forceCrossTenant === true;
+
     setBusyPlatform(platform);
     busyPlatformRef.current = platform;
     setPopupBlockedUrl(null);
@@ -408,7 +440,12 @@ export function SocialConnectionsList({
     const res = await fetch("/api/platform/social/connections/connect", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ company_id: companyId, profile_id: profileId, platform }),
+      body: JSON.stringify({
+        company_id: companyId,
+        profile_id: profileId,
+        platform,
+        ...(opts?.forceCrossTenant ? { force_cross_tenant: true } : {}),
+      }),
     });
     const json = (await res.json()) as
       | { ok: true; data: { url: string } }
@@ -693,12 +730,11 @@ export function SocialConnectionsList({
               ))}
             </ul>
             <p className="mb-3 text-sm text-muted-foreground">
-              If the OAuth flow auto-approves with the same{" "}
-              <strong>{preflightModal.platformLabel}</strong> account, it will
-              be <strong>rejected</strong> to prevent cross-tenant publishing.
-              You&apos;ll see an error after the popup closes. To connect a
-              different {preflightModal.platformLabel} account, log out of{" "}
-              {preflightModal.platformLabel} in another browser tab first.
+              If you personally manage{" "}
+              <strong>{preflightModal.platformLabel}</strong> for multiple
+              clients, click &ldquo;I manage both&rdquo; to proceed. The
+              connection will be audited. To connect a different account,
+              log out of {preflightModal.platformLabel} in another tab first.
             </p>
             <div className="flex justify-end gap-2">
               <Button
@@ -712,11 +748,14 @@ export function SocialConnectionsList({
                 onClick={() => {
                   const platform = preflightModal.platform;
                   setPreflightModal(null);
-                  void handleConnect(platform, { skipPreflight: true });
+                  void handleConnect(platform, {
+                    skipPreflight: true,
+                    forceCrossTenant: true,
+                  });
                 }}
                 data-testid="preflight-modal-continue"
               >
-                Continue
+                I manage both
               </Button>
             </div>
           </div>

--- a/lib/platform/social/connections/sync.ts
+++ b/lib/platform/social/connections/sync.ts
@@ -62,6 +62,12 @@ export type SyncConnectionsInput = {
   // this company on insert. Leave undefined for pure health-refresh
   // (no inserts, just updates to existing rows).
   attributeNewToCompanyId?: string | null;
+  // When true, the cross-tenant identity conflict check is bypassed for
+  // this sync call and the insert proceeds. The caller is responsible for
+  // ensuring the user explicitly confirmed the override (e.g. clicked
+  // "I manage both" in the preflight warning modal). A cross_tenant_override
+  // audit event is emitted regardless so the action is traceable.
+  forceCrossTenantOverride?: boolean;
 };
 
 export type SyncConnectionsResult = {
@@ -383,7 +389,14 @@ export async function syncBundlesocialConnections(
         target_profile_id: attributedProfileId,
       });
 
-      if (!conflict.ok && !conflict.override_allowed) {
+      // forceCrossTenantOverride: user explicitly clicked "I manage both" in
+      // the preflight warning modal. Treat as override_allowed=true so the
+      // insert proceeds. An audit event is always emitted.
+      const effectiveOverrideAllowed =
+        !conflict.ok &&
+        (conflict.override_allowed || input.forceCrossTenantOverride === true);
+
+      if (!conflict.ok && !effectiveOverrideAllowed) {
         result.cross_tenant_blocked += 1;
         logger.warn("social.cross_tenant_blocked", {
           platform,
@@ -405,13 +418,14 @@ export async function syncBundlesocialConnections(
         });
         continue;
       }
-      if (!conflict.ok && conflict.override_allowed) {
+      if (effectiveOverrideAllowed) {
         logger.warn("social.cross_tenant_override", {
           platform,
           identity_hash: identity.external_identity_hash,
           target_company_id: input.attributeNewToCompanyId,
           target_profile_id: attributedProfileId,
           bundle_account_id: bundleAccountId,
+          via: input.forceCrossTenantOverride ? "user_confirmed" : "company_flag",
         });
         void emitCrossTenantOverride({
           platform,

--- a/tests/regressions/cross-tenant-user-override.test.tsx
+++ b/tests/regressions/cross-tenant-user-override.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// REGRESSION — cross-tenant user override flow.
+//
+// Bug reported 2026-05-13: preflight warning modal "Continue" button
+// discarded the user's override decision. The sync's Layer 2 block then
+// rejected the account unconditionally (allow_cross_tenant_identity=false),
+// and the failure was silent — the popup closed with no row and no error.
+//
+// Fix:
+//   1. Preflight "I manage both" button passes forceCrossTenant:true to
+//      handleConnect, which POSTs force_cross_tenant:true to /connect.
+//      The callback URL encodes &cross_tenant_override=1 so the sync
+//      bypasses the block.
+//   2. If the block still fires (override not taken), the popup postMessage
+//      reason=cross-tenant-blocked is surfaced as a visible error with
+//      instructions to use "I manage both" next time.
+//   3. forceCrossTenantRef is reset in clearPopupState so a subsequent
+//      fresh connect doesn't carry the override unexpectedly.
+// ---------------------------------------------------------------------------
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/toast-success", () => ({ toastSuccess: vi.fn() }));
+
+import { SocialConnectionsList } from "@/components/SocialConnectionsList";
+
+const fetchMock = vi.fn();
+const openMock = vi.fn();
+const ORIGINAL_FETCH = global.fetch;
+const ORIGINAL_OPEN = window.open;
+
+const COMPANY_ID = "00000000-0000-0000-0000-000000000001";
+const PROFILE_ID = "00000000-0000-0000-0000-000000000002";
+
+function makeFakePopup() {
+  return {
+    closed: false,
+    focus: vi.fn(),
+    close() {
+      (this as { closed: boolean }).closed = true;
+    },
+  };
+}
+
+function renderList() {
+  return render(
+    <SocialConnectionsList
+      companyId={COMPANY_ID}
+      profileId={PROFILE_ID}
+      connections={[]}
+      canManage={true}
+      canReconnect={true}
+    />,
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  openMock.mockReset();
+  Object.defineProperty(window, "open", {
+    configurable: true,
+    writable: true,
+    value: openMock,
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  global.fetch = ORIGINAL_FETCH;
+  Object.defineProperty(window, "open", {
+    configurable: true,
+    writable: true,
+    value: ORIGINAL_OPEN,
+  });
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("R-CROSS-TENANT-OVERRIDE: preflight 'I manage both' sends force_cross_tenant to /connect", () => {
+  it("clicking 'I manage both' in preflight modal includes force_cross_tenant:true in connect POST", async () => {
+    const fakePopup = makeFakePopup();
+    openMock.mockReturnValue(fakePopup);
+
+    fetchMock
+      // preflight → returns warn:true (cross-tenant conflict detected)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            data: {
+              warn: true,
+              others: [
+                { company_name: "Other Client", connected_at: new Date().toISOString() },
+              ],
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+      // connect → URL (fires after "I manage both" click)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            data: { url: "https://linkedin.com/oauth?state=abc" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    renderList();
+
+    // Open platform picker and click LinkedIn.
+    fireEvent.click(screen.getByTestId("connections-connect-button"));
+    fireEvent.click(screen.getByTestId("connect-platform-LINKEDIN"));
+
+    // Wait for preflight fetch to resolve and modal to render.
+    await act(async () => {});
+
+    const modal = screen.getByTestId("preflight-modal");
+    expect(modal).toBeTruthy();
+
+    // Click "I manage both" — should proceed with override.
+    const continueBtn = screen.getByTestId("preflight-modal-continue");
+    expect(continueBtn.textContent).toContain("I manage both");
+    fireEvent.click(continueBtn);
+
+    await act(async () => {});
+
+    // The modal should have closed.
+    expect(screen.queryByTestId("preflight-modal")).toBeNull();
+
+    // Find the connect API call (second fetch: first was preflight).
+    const connectCall = fetchMock.mock.calls.find(
+      (c) =>
+        typeof c[0] === "string" &&
+        (c[0] as string).includes("/connections/connect"),
+    );
+    expect(connectCall).toBeDefined();
+
+    const body = JSON.parse(
+      (connectCall![1] as RequestInit).body as string,
+    ) as Record<string, unknown>;
+
+    // KEY assertion: override flag must be present.
+    expect(body.force_cross_tenant).toBe(true);
+    expect(body.profile_id).toBe(PROFILE_ID);
+    expect(body.platform).toBe("LINKEDIN");
+  });
+});
+
+describe("R-CROSS-TENANT-OVERRIDE: cross-tenant-blocked postMessage surfaces visible error", () => {
+  it("connect=error reason=cross-tenant-blocked renders actionable error banner", async () => {
+    const fakePopup = makeFakePopup();
+    openMock.mockReturnValue(fakePopup);
+
+    fetchMock
+      // preflight → clean (no warning)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: true, data: { warn: false, others: [] } }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      )
+      // connect → URL
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            data: { url: "https://linkedin.com/oauth?state=def" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+    renderList();
+
+    fireEvent.click(screen.getByTestId("connections-connect-button"));
+    fireEvent.click(screen.getByTestId("connect-platform-LINKEDIN"));
+
+    await act(async () => {});
+    expect(openMock).toHaveBeenCalledTimes(1);
+
+    // Callback emits cross-tenant-blocked via postMessage.
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: window.location.origin,
+        data: {
+          type: "bundle-connect-complete",
+          connect: "error",
+          reason: "cross-tenant-blocked",
+        },
+      }),
+    );
+
+    await act(async () => {});
+
+    // Error alert must be visible.
+    const errorEl = screen.getByTestId("connections-error");
+    expect(errorEl.textContent).toMatch(/already connected to another client/i);
+    expect(errorEl.textContent).toMatch(/I manage both/i);
+  });
+});


### PR DESCRIPTION
## Bug

The preflight warning modal's \"Continue\" button discarded the user's override decision. The sync's Layer 2 cross-tenant block then rejected the account unconditionally (`allow_cross_tenant_identity=false` on `platform_companies`). The popup closed with no row created and no visible error.

Two failure modes:
1. User clicked \"Continue\" → `handleConnect` was called WITHOUT `forceCrossTenant:true` → `forceCrossTenantRef.current` stayed `false` → sync blocked silently.
2. Even when the block fired and the callback returned `connect=error reason=cross-tenant-blocked`, `handleMessage` had no handler for it — silent failure.

## Fix

**`force_cross_tenant` flag chain** (connects the user decision to the sync bypass):
- `SocialConnectionsList`: renamed button to \"I manage both\"; wires `forceCrossTenant: true` into `handleConnect`; `forceCrossTenantRef` carries the decision across the async popup open → close cycle; `clearPopupState` resets the ref on every popup close.
- `/connect` route: accepts `force_cross_tenant: boolean` in POST body; encodes `&cross_tenant_override=1` in the callback `redirectUrl` when set.
- `/callback` route: reads `cross_tenant_override` from URL params; passes `forceCrossTenantOverride: true` to `syncBundlesocialConnections` when present.
- `/sync` route: accepts `force_cross_tenant_override: boolean` in POST body; passes through to sync (for `syncOnPopupClose` on X/Twitter path which also carries the override).
- `sync.ts`: `SyncConnectionsInput.forceCrossTenantOverride` combines with the DB `allow_cross_tenant_identity` flag via `effectiveOverrideAllowed`; emits `cross_tenant_override` audit event with `via: "user_confirmed"`.

**Error surfacing**: `handleMessage` now handles `connect=error reason=cross-tenant-blocked` — renders an actionable error banner with instructions to use \"I manage both\" on retry.

## Regression tests

`tests/regressions/cross-tenant-user-override.test.tsx` (2 tests):
1. Clicking \"I manage both\" in preflight modal includes `force_cross_tenant: true` in the `/connect` POST body.
2. `connect=error reason=cross-tenant-blocked` postMessage renders the error banner.

---

**Working analog**: `components/SocialConnectionsList.tsx` — existing `busyPlatformRef` pattern for carrying state across the popup open/close gap. `forceCrossTenantRef` follows the identical shape.

**Diff**: previous code called `handleConnect(platform, { skipPreflight: true })` without `forceCrossTenant: true`; `forceCrossTenantRef.current` was never set; sync always read the DB flag and blocked.

**Fix**: added `forceCrossTenant: true` to the modal's button handler and threaded it through the full URL chain.

---

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (1519 tests, all pass)
- [x] Regression test added
- [x] Risks identified and mitigated section below
- [x] PR is under 500 net lines

## Risks identified and mitigated

- **Audit trail**: `forceCrossTenantOverride: true` emits `cross_tenant_override` audit event with `via: "user_confirmed"` — every user-driven override is traceable.
- **Scope**: override only applies to the single connect flow that set the flag. `forceCrossTenantRef` is reset in `clearPopupState` on every popup close so it can't bleed into a subsequent unrelated connect.
- **DB flag unchanged**: `allow_cross_tenant_identity` on `platform_companies` remains the company-level admin toggle. The new user-decision path is additive — both `OR` together in `effectiveOverrideAllowed`.
- **syncOnPopupClose (X/Twitter)**: the override is also carried into the fallback sync path so X/Twitter accounts with a cross-tenant conflict get the same override behaviour.