### PR TITLE
fix(social): admin connect cross-tenant override + Bug A/B/C

### DIFF
--- a/app/api/admin/companies/[id]/social-profiles/[profileId]/connect/route.ts
+++ b/app/api/admin/companies/[id]/social-profiles/[profileId]/connect/route.ts
@@ -54,6 +54,7 @@ const PLATFORM_ENUM = z.enum([
 const ConnectSchema = z.object({
   platform: PLATFORM_ENUM,
   disable_auto_login: z.boolean().optional(),
+  force_cross_tenant: z.boolean().optional(),
 });
 
 export async function POST(
@@ -89,7 +90,10 @@ export async function POST(
   const origin =
     process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ||
     new URL(req.url).origin;
-  const redirectUrl = `${origin}/api/platform/social/connections/callback?company_id=${idCheck.value}&popup=1`;
+  const redirectUrl =
+    `${origin}/api/platform/social/connections/callback` +
+    `?company_id=${idCheck.value}&popup=1` +
+    (parsed.data.force_cross_tenant ? "&cross_tenant_override=1" : "");
 
   const result = await initiateProfileConnect({
     profileId: profileCheck.value,

--- a/components/AdminProfileConnectionsList.tsx
+++ b/components/AdminProfileConnectionsList.tsx
@@ -113,6 +113,7 @@ type ConnectMessage = {
   type: "bundle-connect-complete";
   connect?: string;
   connection_id?: string;
+  reason?: string;
 };
 
 function isConnectMessage(v: unknown): v is ConnectMessage {
@@ -160,12 +161,14 @@ export function AdminProfileConnectionsList({
   // Shown-set for the auto-open effect. useRef resets on unmount (page
   // refresh) so a new mount always re-evaluates pending rows.
   const pickerShownRef = useRef<Set<string>>(new Set());
+  const forceCrossTenantRef = useRef<boolean>(false);
 
   function clearPopupState() {
     if (pollRef.current) clearInterval(pollRef.current);
     pollRef.current = null;
     popupRef.current = null;
     setBusy(null);
+    forceCrossTenantRef.current = false;
   }
 
   // Sync-on-popup-close (same reasoning as SocialConnectionsList):
@@ -173,6 +176,7 @@ export function AdminProfileConnectionsList({
   // callback URL, so we sync explicitly when the popup closes. If a
   // pending_identity connection appears, auto-open the channel picker.
   async function syncOnPopupClose() {
+    const forceCrossTenant = forceCrossTenantRef.current;
     clearPopupState();
     setPickerOpen(false);
     let inserted = 0;
@@ -180,7 +184,11 @@ export function AdminProfileConnectionsList({
       const r = await fetch("/api/platform/social/connections/sync", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ company_id: companyId }),
+        body: JSON.stringify({
+          company_id: companyId,
+          attribute_new_to_company_id: companyId,
+          ...(forceCrossTenant ? { force_cross_tenant_override: true } : {}),
+        }),
       });
       if (r.ok) {
         const json = (await r.json()) as { data?: { inserted: number } };
@@ -250,6 +258,15 @@ export function AdminProfileConnectionsList({
             label: mapped.label,
           });
         }
+      }
+      if (
+        evt.data.connect === "error" &&
+        evt.data.reason === "cross-tenant-blocked"
+      ) {
+        setError(
+          "This account is already connected to another client. " +
+            'To connect it here, click Connect and choose "I manage both" when prompted.',
+        );
       }
       router.refresh();
     }
@@ -362,7 +379,10 @@ export function AdminProfileConnectionsList({
     }
   }
 
-  async function handleConnect(platform: string, opts?: { skipPreflight?: boolean }) {
+  async function handleConnect(
+    platform: string,
+    opts?: { skipPreflight?: boolean; forceCrossTenant?: boolean },
+  ) {
     setError(null);
 
     if (!opts?.skipPreflight) {
@@ -379,6 +399,7 @@ export function AdminProfileConnectionsList({
       }
     }
 
+    forceCrossTenantRef.current = opts?.forceCrossTenant === true;
     setBusy(platform);
     setPopupBlockedUrl(null);
 
@@ -387,7 +408,10 @@ export function AdminProfileConnectionsList({
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ platform }),
+        body: JSON.stringify({
+          platform,
+          ...(opts?.forceCrossTenant ? { force_cross_tenant: true } : {}),
+        }),
       },
     );
     const json = (await res.json()) as ApiResponse<{
@@ -472,12 +496,11 @@ export function AdminProfileConnectionsList({
               ))}
             </ul>
             <p className="mb-3 text-sm text-muted-foreground">
-              If the OAuth flow auto-approves with the same{" "}
-              <strong>{preflightModal.platformLabel}</strong> account, it
-              will be <strong>rejected</strong> to prevent cross-tenant
-              publishing. To connect a different {preflightModal.platformLabel}{" "}
-              account, log out of {preflightModal.platformLabel} in another
-              browser tab first.
+              If you personally manage{" "}
+              <strong>{preflightModal.platformLabel}</strong> for multiple
+              clients, click &ldquo;I manage both&rdquo; to proceed. The
+              connection will be audited. To connect a different account,
+              log out of {preflightModal.platformLabel} in another tab first.
             </p>
             <div className="flex justify-end gap-2">
               <Button
@@ -491,11 +514,14 @@ export function AdminProfileConnectionsList({
                 onClick={() => {
                   const platform = preflightModal.platform;
                   setPreflightModal(null);
-                  void handleConnect(platform, { skipPreflight: true });
+                  void handleConnect(platform, {
+                    skipPreflight: true,
+                    forceCrossTenant: true,
+                  });
                 }}
                 data-testid="preflight-modal-continue"
               >
-                Continue
+                I manage both
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- **Bug A** — `AdminProfileConnectionsList` preflight modal "Continue" button was missing `forceCrossTenant:true`, causing the sync Layer 2 block to silently reject the account even when the operator acknowledged the conflict. Mirrors the fix from PR #890 (customer `SocialConnectionsList`).
- **Bug B** — DB confirmed healthy `linkedin_personal` row already present for Opollo company (status: healthy, connected 2026-05-13). No split-brain exists; no cleanup needed.
- **Bug C** — X/Twitter OAuth unavailable at time of report. bundle.social-side outage; no code change.

## Changes

### `components/AdminProfileConnectionsList.tsx`
- `ConnectMessage` type: add `reason?: string`
- `forceCrossTenantRef = useRef<boolean>(false)` tracks user override across async popup cycle
- `clearPopupState`: reset `forceCrossTenantRef.current = false` (prevents bleed into subsequent connects)
- `syncOnPopupClose`: capture ref before clear; forward `force_cross_tenant_override` to sync body
- `handleConnect`: accept `forceCrossTenant` opt; stamp ref; include in POST body
- `handleMessage`: surface `cross-tenant-blocked` reason as actionable error banner
- Preflight modal: copy updated from "will be rejected" → "I manage both" UX; button text "I manage both"; passes `forceCrossTenant: true`

### `app/api/admin/companies/[id]/social-profiles/[profileId]/connect/route.ts`
- `ConnectSchema`: add `force_cross_tenant: z.boolean().optional()`
- `redirectUrl`: appends `&cross_tenant_override=1` when `force_cross_tenant` is set

## Working analog

**Working analog**: `components/SocialConnectionsList.tsx` (PR #890) — identical `forceCrossTenantRef` pattern, preflight modal wiring, and `handleMessage` cross-tenant-blocked branch.
**Diff**: `AdminProfileConnectionsList` was missing the same wiring — no `forceCrossTenantRef`, no ref reset in `clearPopupState`, no `force_cross_tenant` in POST body, no `cross-tenant-blocked` error surface.
**Fix**: Mechanically applied the same diff as #890 to the admin component + its backing route.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (1519/1519 pass)
- [x] Regression tests pass (50 test files)
- [x] For bug fixes: working-analog block above

## Risks identified and mitigated

- `forceCrossTenantRef` reset in `clearPopupState` prevents the flag bleeding into a subsequent connect in the same component lifetime. Same mitigation as #890.
- `force_cross_tenant` is optional in ConnectSchema — existing callers unaffected.
- `cross_tenant_override=1` in the redirect URL only appended when the flag is explicitly set; no behaviour change for normal connects.

## Manual test (post-merge)

1. Admin page → social profile → Connect LinkedIn → should see preflight warning if identity conflict detected → click "I manage both" → confirm popup opens to LinkedIn OAuth (not bundle.social dashboard).
2. Verify connections list reflects the outcome.
3. X connect → expected to fail (bundle.social outage) with no regression in other platforms.