### PR TITLE
fix(social): channel picker 409 conflict UI, force override, click guard

### DIFF
--- a/app/api/platform/social/connections/[id]/set-channel/route.ts
+++ b/app/api/platform/social/connections/[id]/set-channel/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
 import {
+  conflict,
   internalError,
   invalidState,
   notFound,
@@ -17,6 +18,7 @@ import {
   checkCrossTenantConflict,
   computeIdentityHash,
   emitCrossTenantBlocked,
+  emitCrossTenantOverride,
   resolveIdentityFingerprint,
 } from "@/lib/platform/social/connections/identity";
 import { loadConnectionWithTeam } from "@/lib/platform/social/connections/route-helpers";
@@ -41,6 +43,10 @@ export const dynamic = "force-dynamic";
 
 const SetChannelSchema = z.object({
   channel_id: z.string().min(1).max(512),
+  // Explicit operator override: when true and the target company has
+  // allow_cross_tenant_identity=true, bypass the cross-tenant block and
+  // emit a cross_tenant_override audit event instead of refusing.
+  force: z.boolean().optional(),
 });
 
 export async function POST(
@@ -101,7 +107,7 @@ export async function POST(
     fingerprint.external_user_id,
   );
 
-  const conflict = await checkCrossTenantConflict({
+  const tenantCheck = await checkCrossTenantConflict({
     platform: conn.platform,
     identity_hash: externalIdentityHash,
     external_account_id: fingerprint.external_account_id,
@@ -110,14 +116,63 @@ export async function POST(
     target_profile_id: conn.profile_id,
     excludeConnectionId: conn.id,
   });
-  if (!conflict.ok && !conflict.override_allowed) {
-    logger.warn("social.channels.set_cross_tenant_blocked", {
+  if (!tenantCheck.ok) {
+    const forceOverride = parsed.data.force === true && tenantCheck.override_allowed;
+
+    if (!forceOverride) {
+      // Emit audit + return structured 409 the UI can act on.
+      logger.warn("social.channels.set_cross_tenant_blocked", {
+        connection_id: conn.id,
+        platform: conn.platform,
+        target_company_id: conn.company_id,
+        conflict_code: tenantCheck.code,
+        override_allowed: tenantCheck.override_allowed,
+      });
+      void emitCrossTenantBlocked({
+        platform: conn.platform,
+        identity_hash: externalIdentityHash,
+        external_account_id: fingerprint.external_account_id,
+        external_user_id: fingerprint.external_user_id,
+        target_company_id: conn.company_id,
+        target_profile_id: conn.profile_id,
+        actor_user_id: gate.userId,
+        conflicting_rows: tenantCheck.conflicting_rows,
+      });
+
+      // Look up the conflicting company name for the UI prompt.
+      const conflictingRow = tenantCheck.conflicting_rows[0] ?? null;
+      let conflictingCompany: string | null = null;
+      if (conflictingRow) {
+        const svc2 = getServiceRoleClient();
+        const companyRead = await svc2
+          .from("platform_companies")
+          .select("name")
+          .eq("id", conflictingRow.company_id)
+          .maybeSingle();
+        conflictingCompany =
+          (companyRead.data as { name?: string } | null)?.name ?? null;
+      }
+
+      return conflict(
+        "CROSS_TENANT_CONFLICT",
+        "This channel is already attached to another company on Opollo. " +
+          "If you manage social media for both companies, use the override option.",
+        {
+          conflicting_company: conflictingCompany,
+          conflicting_channel_name: conflictingRow?.display_name ?? null,
+          override_allowed: tenantCheck.override_allowed,
+        },
+      );
+    }
+
+    // force=true + override_allowed: proceed and emit override audit.
+    logger.info("social.channels.set_cross_tenant_override", {
       connection_id: conn.id,
       platform: conn.platform,
       target_company_id: conn.company_id,
-      conflict_code: conflict.code,
+      actor_user_id: gate.userId,
     });
-    void emitCrossTenantBlocked({
+    void emitCrossTenantOverride({
       platform: conn.platform,
       identity_hash: externalIdentityHash,
       external_account_id: fingerprint.external_account_id,
@@ -125,12 +180,8 @@ export async function POST(
       target_company_id: conn.company_id,
       target_profile_id: conn.profile_id,
       actor_user_id: gate.userId,
-      conflicting_rows: conflict.conflicting_rows,
+      conflicting_rows: tenantCheck.conflicting_rows,
     });
-    return invalidState(
-      "This channel is already attached to another company on Opollo. " +
-        "Contact support to set up multi-company sharing.",
-    );
   }
 
   const selectedChannel = fingerprint.channels.find(

--- a/components/ChannelPickerBody.tsx
+++ b/components/ChannelPickerBody.tsx
@@ -47,6 +47,13 @@ type FetchState =
   | { kind: "loaded"; channels: Channel[] }
   | { kind: "error"; message: string };
 
+type ConflictState = {
+  channelId: string;
+  conflictingCompany: string | null;
+  conflictingChannelName: string | null;
+  overrideAllowed: boolean;
+};
+
 export function ChannelPickerBody({
   connectionId,
   platform,
@@ -57,6 +64,7 @@ export function ChannelPickerBody({
   const [state, setState] = useState<FetchState>({ kind: "idle" });
   const [busyChannelId, setBusyChannelId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [conflictError, setConflictError] = useState<ConflictState | null>(null);
   const [busyPersonal, setBusyPersonal] = useState(false);
 
   useEffect(() => {
@@ -95,26 +103,57 @@ export function ChannelPickerBody({
     };
   }, [autoFetch, connectionId]);
 
-  async function handleSelect(channel: Channel) {
+  async function handleSelect(channel: Channel, opts?: { force?: boolean }) {
+    // Fix C: explicit guard prevents duplicate POSTs if React batches or
+    // the user clicks before the disabled attr takes effect.
+    if (busyChannelId !== null) return;
     setBusyChannelId(channel.id);
     setActionError(null);
+    setConflictError(null);
     const res = await fetch(
       `/api/platform/social/connections/${connectionId}/set-channel`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ channel_id: channel.id }),
+        body: JSON.stringify({
+          channel_id: channel.id,
+          ...(opts?.force ? { force: true } : {}),
+        }),
       },
     );
-    const json = (await res.json()) as
-      | { ok: true }
-      | { ok: false; error: { message: string } };
+    type ErrorBody = {
+      ok: false;
+      error: {
+        code: string;
+        message: string;
+        details?: {
+          conflicting_company?: string | null;
+          conflicting_channel_name?: string | null;
+          override_allowed?: boolean;
+        };
+      };
+    };
+    const json = (await res.json()) as { ok: true } | ErrorBody;
     setBusyChannelId(null);
     if (!res.ok || !json.ok) {
-      setActionError(!json.ok ? json.error.message : "Failed to set channel.");
+      const err = (json as ErrorBody).error;
+      if (res.status === 409 && err.code === "CROSS_TENANT_CONFLICT") {
+        setConflictError({
+          channelId: channel.id,
+          conflictingCompany: err.details?.conflicting_company ?? null,
+          conflictingChannelName: err.details?.conflicting_channel_name ?? null,
+          overrideAllowed: err.details?.override_allowed === true,
+        });
+        return;
+      }
+      setActionError(err?.message ?? "Failed to set channel.");
       return;
     }
     onSelected();
+  }
+
+  async function retryWithOverride(channel: Channel) {
+    await handleSelect(channel, { force: true });
   }
 
   async function handlePersonalMode() {
@@ -219,6 +258,63 @@ export function ChannelPickerBody({
           ))}
         </ul>
       )}
+
+      {conflictError ? (
+        <div
+          className="mt-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"
+          role="alert"
+          data-testid="channel-picker-conflict-error"
+        >
+          <p className="mb-1 font-medium">
+            This {platformLabel} channel is already connected to another
+            company
+            {conflictError.conflictingCompany
+              ? ` (${conflictError.conflictingCompany})`
+              : ""}.
+          </p>
+          {conflictError.conflictingChannelName ? (
+            <p className="mb-2 text-amber-800">
+              Channel: {conflictError.conflictingChannelName}
+            </p>
+          ) : null}
+          {conflictError.overrideAllowed ? (
+            <>
+              <p className="mb-2">
+                If you manage social media for both companies, you can connect
+                it to this one too.
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    const ch = (
+                      state.kind === "loaded" ? state.channels : []
+                    ).find((c) => c.id === conflictError.channelId);
+                    if (ch) void retryWithOverride(ch);
+                  }}
+                  disabled={busyChannelId !== null}
+                  data-testid="channel-picker-connect-both"
+                >
+                  {busyChannelId !== null ? "Connecting…" : "Connect to both companies"}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setConflictError(null)}
+                  data-testid="channel-picker-conflict-cancel"
+                >
+                  Cancel
+                </Button>
+              </div>
+            </>
+          ) : (
+            <p className="text-amber-800">
+              Contact support to set up multi-company sharing, or disconnect
+              the channel from the other company first.
+            </p>
+          )}
+        </div>
+      ) : null}
 
       {actionError ? (
         <p

--- a/components/__tests__/ChannelPickerBody-conflict.test.tsx
+++ b/components/__tests__/ChannelPickerBody-conflict.test.tsx
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+// ---------------------------------------------------------------------------
+// COMPONENT — ChannelPickerBody conflict UI + duplicate-click guard.
+//
+// Tests that:
+//   1. A 409 CROSS_TENANT_CONFLICT response renders the conflict banner
+//      with "Connect to both companies" (not silent close).
+//   2. Clicking a channel row twice in quick succession fires only one
+//      set-channel POST (Fix C).
+// ---------------------------------------------------------------------------
+
+import { act, cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn();
+const ORIGINAL_FETCH = global.fetch;
+
+const CONNECTION_ID = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa";
+
+const CHANNEL = { id: "ch-1", name: "Acme LinkedIn Page", subtext: null, avatarUrl: null, kind: "LINKEDIN_ORG" as const };
+
+function channelsResponse(channels: typeof CHANNEL[]) {
+  return new Response(
+    JSON.stringify({ ok: true, data: { channels } }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function conflictResponse(overrideAllowed = true) {
+  return new Response(
+    JSON.stringify({
+      ok: false,
+      error: {
+        code: "CROSS_TENANT_CONFLICT",
+        message: "Channel attached to another company.",
+        details: {
+          conflicting_company: "Acme Corp",
+          conflicting_channel_name: "Acme LinkedIn Page",
+          override_allowed: overrideAllowed,
+        },
+      },
+      timestamp: new Date().toISOString(),
+    }),
+    { status: 409, headers: { "content-type": "application/json" } },
+  );
+}
+
+function successResponse() {
+  return new Response(
+    JSON.stringify({ ok: true, data: { connection_id: CONNECTION_ID, channel_id: "ch-1", external_account_id: "urn:li:org:1" }, timestamp: new Date().toISOString() }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  global.fetch = fetchMock as unknown as typeof fetch;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  global.fetch = ORIGINAL_FETCH;
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+// Lazy import after mocks installed.
+async function renderBody(onSelected = vi.fn()) {
+  const { ChannelPickerBody } = await import("@/components/ChannelPickerBody");
+  return render(
+    <ChannelPickerBody
+      connectionId={CONNECTION_ID}
+      platform="LINKEDIN"
+      platformLabel="LinkedIn"
+      onSelected={onSelected}
+      autoFetch={true}
+    />,
+  );
+}
+
+describe("ChannelPickerBody: 409 conflict renders actionable UI", () => {
+  it("shows conflict banner with company name when set-channel returns 409 CROSS_TENANT_CONFLICT", async () => {
+    fetchMock
+      .mockResolvedValueOnce(channelsResponse([CHANNEL]))  // channels list
+      .mockResolvedValueOnce(conflictResponse(true));       // set-channel → 409
+
+    await act(async () => {
+      await renderBody();
+    });
+
+    // Channel row should be visible.
+    const row = screen.getByTestId("channel-picker-row-ch-1");
+    expect(row).toBeTruthy();
+
+    // Click the channel.
+    await act(async () => {
+      fireEvent.click(row);
+    });
+
+    // Conflict banner should appear.
+    const banner = screen.getByTestId("channel-picker-conflict-error");
+    expect(banner).toBeTruthy();
+    expect(banner.textContent).toMatch(/Acme Corp/i);
+    expect(banner.textContent).toMatch(/Acme LinkedIn Page/i);
+
+    // "Connect to both companies" button should be visible when override_allowed.
+    const overrideBtn = screen.getByTestId("channel-picker-connect-both");
+    expect(overrideBtn).toBeTruthy();
+
+    // onSelected should NOT have been called.
+    // (it can't get the onSelected mock from outside the scope here, but
+    // the absence of a modal close is validated by banner still being visible)
+    expect(screen.queryByTestId("channel-picker-action-error")).toBeNull();
+  });
+
+  it("shows no override button when override_allowed=false", async () => {
+    fetchMock
+      .mockResolvedValueOnce(channelsResponse([CHANNEL]))
+      .mockResolvedValueOnce(conflictResponse(false));
+
+    await act(async () => {
+      await renderBody();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("channel-picker-row-ch-1"));
+    });
+
+    expect(screen.getByTestId("channel-picker-conflict-error")).toBeTruthy();
+    expect(screen.queryByTestId("channel-picker-connect-both")).toBeNull();
+  });
+
+  it("retries with force:true when 'Connect to both companies' is clicked", async () => {
+    fetchMock
+      .mockResolvedValueOnce(channelsResponse([CHANNEL]))
+      .mockResolvedValueOnce(conflictResponse(true))   // first click → 409
+      .mockResolvedValueOnce(successResponse());        // override click → 200
+
+    const onSelected = vi.fn();
+
+    await act(async () => {
+      await renderBody(onSelected);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("channel-picker-row-ch-1"));
+    });
+
+    // Click "Connect to both companies".
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("channel-picker-connect-both"));
+    });
+
+    // Second fetch must include force:true.
+    const calls = fetchMock.mock.calls.filter(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("/set-channel"),
+    );
+    expect(calls.length).toBe(2);
+    const overrideBody = JSON.parse(
+      (calls[1]![1] as RequestInit).body as string,
+    ) as Record<string, unknown>;
+    expect(overrideBody.force).toBe(true);
+
+    // onSelected should have been called after override success.
+    expect(onSelected).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ChannelPickerBody: Fix C — duplicate click fires only one POST", () => {
+  it("clicking a row twice in quick succession fires only one set-channel POST", async () => {
+    // set-channel never resolves — simulates in-flight request.
+    let resolveSetChannel!: (v: Response) => void;
+    const hangingResponse = new Promise<Response>((r) => { resolveSetChannel = r; });
+
+    fetchMock
+      .mockResolvedValueOnce(channelsResponse([CHANNEL]))
+      .mockReturnValueOnce(hangingResponse);
+
+    await act(async () => {
+      await renderBody();
+    });
+
+    const row = screen.getByTestId("channel-picker-row-ch-1");
+
+    // Click twice in the same tick.
+    fireEvent.click(row);
+    fireEvent.click(row);
+
+    // Resolve the pending request so the component doesn't hang.
+    await act(async () => {
+      resolveSetChannel(successResponse());
+    });
+
+    const setChannelCalls = fetchMock.mock.calls.filter(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("/set-channel"),
+    );
+    expect(setChannelCalls.length).toBe(1);
+  });
+});

--- a/lib/tool-schemas.ts
+++ b/lib/tool-schemas.ts
@@ -95,6 +95,8 @@ export const ERROR_CODES = [
   "RECEIVER_NOT_CONFIGURED",
   // S8 reconnect - healthy-connection guard.
   "CONFLICT",
+  // Cross-tenant channel conflict (set-channel Layer 2 block with override path).
+  "CROSS_TENANT_CONFLICT",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];
@@ -225,6 +227,7 @@ export function errorCodeToStatus(code: ErrorCode): number {
     case "RECEIVER_NOT_CONFIGURED":
       return 503;
     case "CONFLICT":
+    case "CROSS_TENANT_CONFLICT":
       return 409;
   }
 }

--- a/tests/regressions/channel-picker-409-conflict.test.ts
+++ b/tests/regressions/channel-picker-409-conflict.test.ts
@@ -1,0 +1,324 @@
+// ---------------------------------------------------------------------------
+// REGRESSION — set-channel cross-tenant conflict surfaces structured 409
+// and the force override path emits audit event.
+//
+// Bug reported 2026-05-14: set-channel returns 409 on cross-tenant conflict
+// (from PR #868 identity layer) but the modal showed no UI — the error body
+// was a plain INVALID_STATE message not surfaced as actionable conflict UI.
+//
+// Fixes:
+//   A. Return CROSS_TENANT_CONFLICT 409 with conflicting_company /
+//      conflicting_channel_name / override_allowed in error.details.
+//   B. Accept force:true; when override_allowed=true proceed and emit
+//      cross_tenant_override audit event.
+//   C. ChannelPickerBody guards duplicate clicks and renders conflict UI.
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  setChannel: vi.fn(),
+  resolveIdentityFingerprint: vi.fn(),
+  checkCrossTenantConflict: vi.fn(),
+  computeIdentityHash: vi.fn(),
+  emitCrossTenantBlocked: vi.fn(),
+  emitCrossTenantOverride: vi.fn(),
+  update: vi.fn(),
+  platformEventInsert: vi.fn(),
+  platformCompaniesSelect: vi.fn(),
+}));
+
+vi.mock("@/lib/platform/social/connections/channels", () => ({
+  setChannel: mocks.setChannel,
+}));
+
+vi.mock("@/lib/platform/social/connections/identity", () => ({
+  resolveIdentityFingerprint: mocks.resolveIdentityFingerprint,
+  checkCrossTenantConflict: mocks.checkCrossTenantConflict,
+  computeIdentityHash: mocks.computeIdentityHash,
+  emitCrossTenantBlocked: mocks.emitCrossTenantBlocked,
+  emitCrossTenantOverride: mocks.emitCrossTenantOverride,
+}));
+
+vi.mock("@/lib/bundlesocial", () => ({}));
+
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: async () => ({
+    kind: "allow" as const,
+    userId: "user-test",
+    supabase: {} as never,
+  }),
+}));
+
+const CONN_ID = "cd339e96-8388-469f-9ef7-d035d9306353";
+const COMPANY_ID = "11111111-1111-1111-1111-111111111111";
+const PROFILE_ID = "22222222-2222-2222-2222-222222222222";
+const OTHER_COMPANY_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+const connRow = {
+  id: CONN_ID,
+  company_id: COMPANY_ID,
+  profile_id: PROFILE_ID,
+  platform: "linkedin_personal",
+  bundle_social_account_id: "bs-acct-1",
+  status: "pending_identity",
+  is_personal_mode: false,
+  display_name: "Opollo LinkedIn",
+  external_account_id: null,
+};
+
+const conflictingRow = {
+  id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  company_id: OTHER_COMPANY_ID,
+  profile_id: null,
+  platform: "linkedin_personal",
+  display_name: "Acme LinkedIn Page",
+  external_account_id: "urn:li:organization:12345",
+  external_user_id: "urn:li:person:Steve",
+  external_identity_hash: "hash-conflict",
+};
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({
+    from: (table: string) => {
+      if (table === "social_connections") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: connRow, error: null }),
+            }),
+          }),
+          update: (vals: unknown) => ({
+            eq: (_col: string, _val: string) => mocks.update(vals),
+          }),
+        };
+      }
+      if (table === "platform_social_profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: { bundle_social_team_id: "team-fixture" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "platform_companies") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () => mocks.platformCompaniesSelect(),
+            }),
+          }),
+        };
+      }
+      if (table === "platform_events") {
+        return {
+          insert: (payload: unknown) => mocks.platformEventInsert(payload),
+        };
+      }
+      throw new Error(`Unexpected table in mock: ${table}`);
+    },
+  }),
+}));
+
+import { POST } from "@/app/api/platform/social/connections/[id]/set-channel/route";
+
+const BASE_FINGERPRINT = {
+  external_account_id: "urn:li:organization:12345",
+  external_user_id: "urn:li:person:Steve",
+  external_identity_hash: "hash-conflict",
+  displayName: "Steve",
+  channels: [
+    {
+      id: "urn:li:organization:12345",
+      name: "Acme LinkedIn Page",
+      username: "acme",
+      address: null,
+      avatarUrl: null,
+    },
+  ],
+  raw: {},
+};
+
+function makeReq(channelId: string, extra?: Record<string, unknown>): Request {
+  return new Request(
+    `http://localhost/api/platform/social/connections/${CONN_ID}/set-channel`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ channel_id: channelId, ...extra }),
+    },
+  );
+}
+
+beforeEach(() => {
+  for (const fn of Object.values(mocks)) fn.mockReset();
+
+  mocks.setChannel.mockResolvedValue({
+    ok: true,
+    data: { externalId: "urn:li:organization:12345", userId: "urn:li:person:Steve" },
+  });
+  mocks.resolveIdentityFingerprint.mockResolvedValue(BASE_FINGERPRINT);
+  mocks.computeIdentityHash.mockReturnValue("hash-conflict");
+  mocks.update.mockResolvedValue({ error: null });
+  mocks.platformEventInsert.mockResolvedValue({ error: null });
+  mocks.platformCompaniesSelect.mockResolvedValue({
+    data: { name: "Acme Corp" },
+    error: null,
+  });
+  mocks.emitCrossTenantBlocked.mockResolvedValue(undefined);
+  mocks.emitCrossTenantOverride.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("R-CHANNEL-409: conflict without force → structured 409 CROSS_TENANT_CONFLICT", () => {
+  beforeEach(() => {
+    mocks.checkCrossTenantConflict.mockResolvedValue({
+      ok: false,
+      code: "CROSS_TENANT",
+      override_allowed: true,
+      conflicting_rows: [conflictingRow],
+    });
+  });
+
+  it("returns 409", async () => {
+    const res = await POST(makeReq("urn:li:organization:12345") as never, {
+      params: { id: CONN_ID },
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("body.error.code is CROSS_TENANT_CONFLICT", async () => {
+    const res = await POST(makeReq("urn:li:organization:12345") as never, {
+      params: { id: CONN_ID },
+    });
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("CROSS_TENANT_CONFLICT");
+  });
+
+  it("body.error.details.conflicting_company is the looked-up company name", async () => {
+    const res = await POST(makeReq("urn:li:organization:12345") as never, {
+      params: { id: CONN_ID },
+    });
+    const body = (await res.json()) as {
+      error: { details: { conflicting_company: string } };
+    };
+    expect(body.error.details.conflicting_company).toBe("Acme Corp");
+  });
+
+  it("body.error.details.conflicting_channel_name is the row display_name", async () => {
+    const res = await POST(makeReq("urn:li:organization:12345") as never, {
+      params: { id: CONN_ID },
+    });
+    const body = (await res.json()) as {
+      error: { details: { conflicting_channel_name: string } };
+    };
+    expect(body.error.details.conflicting_channel_name).toBe("Acme LinkedIn Page");
+  });
+
+  it("body.error.details.override_allowed reflects the conflict result", async () => {
+    const res = await POST(makeReq("urn:li:organization:12345") as never, {
+      params: { id: CONN_ID },
+    });
+    const body = (await res.json()) as {
+      error: { details: { override_allowed: boolean } };
+    };
+    expect(body.error.details.override_allowed).toBe(true);
+  });
+
+  it("emits cross_tenant_blocked audit event", async () => {
+    await POST(makeReq("urn:li:organization:12345") as never, {
+      params: { id: CONN_ID },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mocks.emitCrossTenantBlocked).toHaveBeenCalledTimes(1);
+    expect(mocks.emitCrossTenantOverride).not.toHaveBeenCalled();
+  });
+
+  it("does NOT write a DB row on conflict", async () => {
+    await POST(makeReq("urn:li:organization:12345") as never, {
+      params: { id: CONN_ID },
+    });
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("R-CHANNEL-409: conflict without force, override_allowed=false → 409 no override button", () => {
+  it("override_allowed:false reflected in response details", async () => {
+    mocks.checkCrossTenantConflict.mockResolvedValue({
+      ok: false,
+      code: "CROSS_TENANT",
+      override_allowed: false,
+      conflicting_rows: [conflictingRow],
+    });
+    const res = await POST(makeReq("urn:li:organization:12345") as never, {
+      params: { id: CONN_ID },
+    });
+    const body = (await res.json()) as {
+      error: { details: { override_allowed: boolean } };
+    };
+    expect(body.error.details.override_allowed).toBe(false);
+  });
+});
+
+describe("R-CHANNEL-409: force=true + override_allowed=true → 200 + override audit", () => {
+  beforeEach(() => {
+    mocks.checkCrossTenantConflict.mockResolvedValue({
+      ok: false,
+      code: "CROSS_TENANT",
+      override_allowed: true,
+      conflicting_rows: [conflictingRow],
+    });
+  });
+
+  it("returns 200 when force=true and override_allowed=true", async () => {
+    const res = await POST(
+      makeReq("urn:li:organization:12345", { force: true }) as never,
+      { params: { id: CONN_ID } },
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("emits cross_tenant_override audit event (not blocked)", async () => {
+    await POST(
+      makeReq("urn:li:organization:12345", { force: true }) as never,
+      { params: { id: CONN_ID } },
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mocks.emitCrossTenantOverride).toHaveBeenCalledTimes(1);
+    expect(mocks.emitCrossTenantBlocked).not.toHaveBeenCalled();
+  });
+
+  it("writes status=healthy to DB on successful override", async () => {
+    await POST(
+      makeReq("urn:li:organization:12345", { force: true }) as never,
+      { params: { id: CONN_ID } },
+    );
+    expect(mocks.update).toHaveBeenCalledTimes(1);
+    const written = mocks.update.mock.calls[0]![0] as { status: string };
+    expect(written.status).toBe("healthy");
+  });
+});
+
+describe("R-CHANNEL-409: force=true but override_allowed=false → still 409 (cannot override)", () => {
+  it("returns 409 even with force=true when override_allowed=false", async () => {
+    mocks.checkCrossTenantConflict.mockResolvedValue({
+      ok: false,
+      code: "CROSS_TENANT",
+      override_allowed: false,
+      conflicting_rows: [conflictingRow],
+    });
+    const res = await POST(
+      makeReq("urn:li:organization:12345", { force: true }) as never,
+      { params: { id: CONN_ID } },
+    );
+    expect(res.status).toBe(409);
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix A** — `ChannelPickerBody` now surfaces a 409 `CROSS_TENANT_CONFLICT` response as an actionable conflict banner (company name, channel name, override button) instead of silently swallowing it.
- **Fix B** — `set-channel` route accepts `force: true`; when the target company has `allow_cross_tenant_identity=true` the block is bypassed and a `cross_tenant_override` audit event is emitted. When `override_allowed=false`, `force:true` still returns 409.
- **Fix C** — Explicit `busyChannelId !== null` guard at the top of `handleSelect` prevents duplicate in-flight POSTs even if React batches a double-click before the `disabled` attribute takes effect.

## Working analog

**Working analog**: `SocialConnectionsList.tsx:handleConnect` — same preflight-modal pattern where a 409-like response (cross-tenant-blocked postMessage) now surfaces an actionable "I manage both" UI rather than silently closing.
**Diff**: `ChannelPickerBody.handleSelect` was missing the 409-specific branch; the backend was returning generic `INVALID_STATE` with no override path.
**Fix**: Added `CROSS_TENANT_CONFLICT` error code to `tool-schemas.ts`, structured 409 response body in the route, `conflictError` state + banner in the component, `force:true` retry path matching the pattern from PR #890/#891.

## Changes

### `lib/tool-schemas.ts`
- Add `CROSS_TENANT_CONFLICT` error code → 409

### `app/api/platform/social/connections/[id]/set-channel/route.ts`
- Accept `force: z.boolean().optional()`
- On conflict: look up conflicting company name from `platform_companies`, return structured 409 with `conflicting_company`, `conflicting_channel_name`, `override_allowed`
- When `force=true` + `override_allowed=true`: proceed, write `status=healthy`, emit `cross_tenant_override` audit event
- When `force=true` + `override_allowed=false`: still 409 (cannot override without DB flag)

### `components/ChannelPickerBody.tsx`
- Add `ConflictState` type + `conflictError` state
- Explicit guard at top of `handleSelect` (Fix C)
- On 409 + `CROSS_TENANT_CONFLICT`: set `conflictError` instead of `actionError`
- Render conflict banner with company name, channel name, conditional "Connect to both companies" button
- `retryWithOverride(channel)` fires `handleSelect(channel, { force: true })`

## Tests

- `tests/regressions/channel-picker-409-conflict.test.ts`: 10 regression tests covering conflict→409 body shape, force+allowed→200+audit, force+blocked→409
- `components/__tests__/ChannelPickerBody-conflict.test.tsx`: 4 component tests — conflict banner renders, override button absent when override_allowed=false, retry sends force:true, duplicate click fires one POST

## Risks identified and mitigated

- `force:true` only bypasses when `platform_companies.allow_cross_tenant_identity=true` — DB flag controls the gate, not just the client. A crafted `force:true` POST without the flag still returns 409.
- Auth gate `requireCanDoForApi(company_id, "manage_connections")` already enforced before the conflict check.
- `emitCrossTenantBlocked` fires on every non-override conflict for audit trail continuity.
- `conflictError` is cleared at the start of each `handleSelect` call — stale conflict state cannot bleed into a subsequent attempt.

## Post-merge: backfill query

After deploy, check how many users hit the silent block in the last 48h:

```sql
select count(*), payload->>'platform' as platform
from platform_events
where event_type = 'cross_tenant_blocked'
  and created_at > now() - interval '48 hours'
group by platform;
```