### PR TITLE
fix(social): conflict banner replaces channel list — prevents 6x POST loop

### DIFF
--- a/components/ChannelPickerBody.tsx
+++ b/components/ChannelPickerBody.tsx
@@ -133,11 +133,23 @@ export function ChannelPickerBody({
         };
       };
     };
-    const json = (await res.json()) as { ok: true } | ErrorBody;
+    // Clear spinner before JSON parse so a parse failure doesn't leave the
+    // channel row stuck in "Selecting…" forever.
     setBusyChannelId(null);
+    let json: { ok: true } | ErrorBody;
+    try {
+      json = (await res.json()) as { ok: true } | ErrorBody;
+    } catch {
+      setActionError("Failed to set channel.");
+      return;
+    }
     if (!res.ok || !json.ok) {
       const err = (json as ErrorBody).error;
       if (res.status === 409 && err.code === "CROSS_TENANT_CONFLICT") {
+        console.error("channel-picker: cross-tenant conflict", {
+          code: err.code,
+          details: err.details,
+        });
         setConflictError({
           channelId: channel.id,
           conflictingCompany: err.details?.conflicting_company ?? null,
@@ -178,7 +190,64 @@ export function ChannelPickerBody({
 
   return (
     <div data-testid="channel-picker-body">
-      {state.kind === "loading" || state.kind === "idle" ? (
+      {conflictError ? (
+        // Conflict replaces the channel list entirely so the user can't
+        // click another channel while the override prompt is visible.
+        <div
+          className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"
+          role="alert"
+          data-testid="channel-picker-conflict-error"
+        >
+          <p className="mb-1 font-medium">
+            This {platformLabel} channel is already connected to another
+            company
+            {conflictError.conflictingCompany
+              ? ` (${conflictError.conflictingCompany})`
+              : ""}.
+          </p>
+          {conflictError.conflictingChannelName ? (
+            <p className="mb-2 text-amber-800">
+              Channel: {conflictError.conflictingChannelName}
+            </p>
+          ) : null}
+          {conflictError.overrideAllowed ? (
+            <>
+              <p className="mb-2">
+                If you manage social media for both companies, you can connect
+                it to this one too.
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    const ch = (
+                      state.kind === "loaded" ? state.channels : []
+                    ).find((c) => c.id === conflictError.channelId);
+                    if (ch) void retryWithOverride(ch);
+                  }}
+                  disabled={busyChannelId !== null}
+                  data-testid="channel-picker-connect-both"
+                >
+                  {busyChannelId !== null ? "Connecting…" : "Connect to both companies"}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setConflictError(null)}
+                  data-testid="channel-picker-conflict-cancel"
+                >
+                  Cancel
+                </Button>
+              </div>
+            </>
+          ) : (
+            <p className="text-amber-800">
+              Contact support to set up multi-company sharing, or disconnect
+              the channel from the other company first.
+            </p>
+          )}
+        </div>
+      ) : state.kind === "loading" || state.kind === "idle" ? (
         <p
           className="text-sm text-muted-foreground"
           data-testid="channel-picker-loading"
@@ -258,63 +327,6 @@ export function ChannelPickerBody({
           ))}
         </ul>
       )}
-
-      {conflictError ? (
-        <div
-          className="mt-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"
-          role="alert"
-          data-testid="channel-picker-conflict-error"
-        >
-          <p className="mb-1 font-medium">
-            This {platformLabel} channel is already connected to another
-            company
-            {conflictError.conflictingCompany
-              ? ` (${conflictError.conflictingCompany})`
-              : ""}.
-          </p>
-          {conflictError.conflictingChannelName ? (
-            <p className="mb-2 text-amber-800">
-              Channel: {conflictError.conflictingChannelName}
-            </p>
-          ) : null}
-          {conflictError.overrideAllowed ? (
-            <>
-              <p className="mb-2">
-                If you manage social media for both companies, you can connect
-                it to this one too.
-              </p>
-              <div className="flex gap-2">
-                <Button
-                  size="sm"
-                  onClick={() => {
-                    const ch = (
-                      state.kind === "loaded" ? state.channels : []
-                    ).find((c) => c.id === conflictError.channelId);
-                    if (ch) void retryWithOverride(ch);
-                  }}
-                  disabled={busyChannelId !== null}
-                  data-testid="channel-picker-connect-both"
-                >
-                  {busyChannelId !== null ? "Connecting…" : "Connect to both companies"}
-                </Button>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => setConflictError(null)}
-                  data-testid="channel-picker-conflict-cancel"
-                >
-                  Cancel
-                </Button>
-              </div>
-            </>
-          ) : (
-            <p className="text-amber-800">
-              Contact support to set up multi-company sharing, or disconnect
-              the channel from the other company first.
-            </p>
-          )}
-        </div>
-      ) : null}
 
       {actionError ? (
         <p

--- a/components/__tests__/ChannelPickerBody-conflict.test.tsx
+++ b/components/__tests__/ChannelPickerBody-conflict.test.tsx
@@ -167,6 +167,57 @@ describe("ChannelPickerBody: 409 conflict renders actionable UI", () => {
   });
 });
 
+describe("ChannelPickerBody: conflict banner replaces channel list (mutual exclusion)", () => {
+  it("hides the channel list when conflict is active", async () => {
+    fetchMock
+      .mockResolvedValueOnce(channelsResponse([CHANNEL]))
+      .mockResolvedValueOnce(conflictResponse(true));
+
+    await act(async () => {
+      await renderBody();
+    });
+
+    // List visible before click.
+    expect(screen.getByTestId("channel-picker-list")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("channel-picker-row-ch-1"));
+    });
+
+    // Conflict banner must be visible.
+    expect(screen.getByTestId("channel-picker-conflict-error")).toBeTruthy();
+
+    // Channel list must be gone — user cannot click another channel while
+    // override prompt is shown (prevents the 6× POST loop).
+    expect(screen.queryByTestId("channel-picker-list")).toBeNull();
+    expect(screen.queryByTestId("channel-picker-row-ch-1")).toBeNull();
+  });
+
+  it("restores the channel list after Cancel is clicked", async () => {
+    fetchMock
+      .mockResolvedValueOnce(channelsResponse([CHANNEL]))
+      .mockResolvedValueOnce(conflictResponse(true));
+
+    await act(async () => {
+      await renderBody();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("channel-picker-row-ch-1"));
+    });
+
+    expect(screen.getByTestId("channel-picker-conflict-error")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("channel-picker-conflict-cancel"));
+    });
+
+    // After cancel, list is restored.
+    expect(screen.queryByTestId("channel-picker-conflict-error")).toBeNull();
+    expect(screen.getByTestId("channel-picker-list")).toBeTruthy();
+  });
+});
+
 describe("ChannelPickerBody: Fix C — duplicate click fires only one POST", () => {
   it("clicking a row twice in quick succession fires only one set-channel POST", async () => {
     // set-channel never resolves — simulates in-flight request.


### PR DESCRIPTION
## Summary

- **Root cause**: After a 409 `CROSS_TENANT_CONFLICT`, `busyChannelId` was cleared (re-enabling channel buttons), but the override banner rendered *below* the channel list — off-screen. Users kept clicking the same channel row, generating 6 consecutive POSTs before noticing the prompt.
- **Fix A (render)**: Conflict banner is now the *first* branch of the render ternary, replacing the channel list entirely when `conflictError` is set. Channel buttons cannot be clicked while the override prompt is visible.
- **Fix B (spinner)**: Moved `setBusyChannelId(null)` before `await res.json()` — spinner now always clears even if JSON parse throws, wrapped in try/catch.
- **Fix C (logging)**: Added `console.error("channel-picker: cross-tenant conflict", ...)` to aid future debugging.

## Tests

Two new component tests added to `ChannelPickerBody-conflict.test.tsx`:
- `hides the channel list when conflict is active` — asserts `channel-picker-list` is absent and `channel-picker-conflict-error` is present after a 409.
- `restores the channel list after Cancel is clicked` — asserts list reappears after dismissal.

All 90 component tests pass.

## Working analog

**Working analog**: `components/ChannelPickerBody.tsx` — the fetch-error branch (`state.kind === "error"`) already uses a single-state exclusive render. The fix copies that pattern: `conflictError` state is the outermost condition, not an additive append.

**Diff**: Conflict banner was appended after the channel list ternary; channel list remained rendered and interactive.

**Fix**: Conflict banner moved to outermost branch of the render ternary, so when it is active the channel list branch is not reached.

## Risks identified and mitigated

- **Cancel path**: Clicking Cancel calls `setConflictError(null)`, which falls through to the channel-list arm. Tested.
- **Override path**: `retryWithOverride` calls `handleSelect(ch, { force: true })` — the `busyChannelId !== null` guard still fires if button is clicked twice. Tested in existing test 3.
- **Spinner stuck**: try/catch around `res.json()` prevents infinite "Selecting…" on malformed response.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:components`
- [x] No new API routes, SDK calls, or DB schema changes
- [x] PR is under 500 net lines