### PR TITLE
feat(ws1-a): schema migration 0126 — reliability and CAP foundations

### DIFF
--- a/lib/__tests__/migration-0126-reliability-cap-foundations.test.ts
+++ b/lib/__tests__/migration-0126-reliability-cap-foundations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { describe, expect, it, beforeEach, afterAll } from "vitest";
 
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -37,20 +37,20 @@ async function seedCompany(id: string, slug: string) {
   if (error) throw new Error(`seed company: ${error.message}`);
 }
 
-beforeAll(async () => {
+// Re-seed before every test so cross-shard deletions by other test files
+// (CI runs 4 shards sharing one Supabase DB) can't invalidate FK parents.
+// Deleting the company cascades away campaigns/drafts/events/grants/deliveries,
+// giving each test a clean slate.
+beforeEach(async () => {
   await seedCompany(COMPANY_ID,   "m0126-co-1");
   await seedCompany(COMPANY_ID_2, "m0126-co-2");
 });
 
 afterAll(async () => {
   const svc = getServiceRoleClient();
-  // Clean up in reverse FK order
-  await svc.from("platform_session_grants").delete().eq("company_id", COMPANY_ID);
-  await svc.from("platform_event_deliveries").delete().neq("id", "00000000-0000-0000-0000-000000000000");
-  await svc.from("platform_event_subscriptions").delete().eq("subscriber_name", "m0126-test-subscriber");
-  await svc.from("platform_events").delete().eq("company_id", COMPANY_ID);
-  await svc.from("social_post_drafts").delete().eq("company_id", COMPANY_ID);
-  await svc.from("social_campaigns").delete().eq("company_id", COMPANY_ID);
+  // Subscriptions have no company FK so they survive cascade — clean them up by name prefix.
+  await svc.from("platform_event_subscriptions").delete().like("subscriber_name", "m0126-%");
+  // Company deletes cascade: campaigns, drafts, events, session_grants, deliveries.
   await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
   await svc.from("platform_companies").delete().eq("id", COMPANY_ID_2);
 });

--- a/lib/__tests__/migration-0126-reliability-cap-foundations.test.ts
+++ b/lib/__tests__/migration-0126-reliability-cap-foundations.test.ts
@@ -558,6 +558,9 @@ describe("platform_events extended CHECK constraint", () => {
     "campaign_completed", "campaign_paused", "campaign_resumed", "campaign_cancelled",
     "worker_died", "webhook_dispatched", "webhook_dispatch_failed",
     "subscription_disabled", "magic_link_consumed", "service_action_taken",
+    // Pre-0126 types that must not be dropped (0122/0123 additions)
+    "cross_tenant_blocked", "cross_tenant_override", "connection_reattributed",
+    "connection_channel_overdue", "connection_disconnected",
   ] as const;
 
   it.each(newEventTypes)("accepts event_type '%s'", async (eventType) => {

--- a/lib/__tests__/migration-0126-reliability-cap-foundations.test.ts
+++ b/lib/__tests__/migration-0126-reliability-cap-foundations.test.ts
@@ -1,0 +1,588 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// Migration 0126 — reliability and CAP foundations.
+//
+// Verifies:
+//   1. social_campaigns CRUD + RLS-skipped service role.
+//   2. social_post_drafts idempotency_key unique index.
+//   3. social_publish_attempts new columns (max_retries, next_retry_at,
+//      dead_lettered_at, claimed_until, worker_id).
+//   4. social_rate_limits insert + UNIQUE (connection_id, window_starts_at).
+//   5. social_connections timezone columns persist.
+//   6. platform_companies timezone provenance columns.
+//   7. platform_event_subscriptions + platform_event_deliveries.
+//   8. Fan-out trigger: INSERT on platform_events creates delivery rows.
+//   9. platform_session_grants token_hash uniqueness.
+//  10. extend_lease RPC extends claimed_until.
+//  11. platform_events: new event types accepted; unknown still rejected.
+// ---------------------------------------------------------------------------
+
+const COMPANY_ID    = "00001260-0000-0000-0000-000000000001";
+const COMPANY_ID_2  = "00001260-0000-0000-0000-000000000002";
+
+async function seedCompany(id: string, slug: string) {
+  const svc = getServiceRoleClient();
+  await svc.from("platform_companies").delete().eq("id", id);
+  const { error } = await svc.from("platform_companies").insert({
+    id,
+    name: `M0126 Test Co ${slug}`,
+    slug,
+    is_opollo_internal: false,
+    timezone: "Australia/Melbourne",
+    approval_default_rule: "any_one",
+  });
+  if (error) throw new Error(`seed company: ${error.message}`);
+}
+
+beforeAll(async () => {
+  await seedCompany(COMPANY_ID,   "m0126-co-1");
+  await seedCompany(COMPANY_ID_2, "m0126-co-2");
+});
+
+afterAll(async () => {
+  const svc = getServiceRoleClient();
+  // Clean up in reverse FK order
+  await svc.from("platform_session_grants").delete().eq("company_id", COMPANY_ID);
+  await svc.from("platform_event_deliveries").delete().neq("id", "00000000-0000-0000-0000-000000000000");
+  await svc.from("platform_event_subscriptions").delete().eq("subscriber_name", "m0126-test-subscriber");
+  await svc.from("platform_events").delete().eq("company_id", COMPANY_ID);
+  await svc.from("social_post_drafts").delete().eq("company_id", COMPANY_ID);
+  await svc.from("social_campaigns").delete().eq("company_id", COMPANY_ID);
+  await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
+  await svc.from("platform_companies").delete().eq("id", COMPANY_ID_2);
+});
+
+// ---------------------------------------------------------------------------
+// 1. social_campaigns
+// ---------------------------------------------------------------------------
+describe("social_campaigns", () => {
+  it("inserts and retrieves a campaign", async () => {
+    const svc = getServiceRoleClient();
+    const { data, error } = await svc
+      .from("social_campaigns")
+      .insert({
+        company_id: COMPANY_ID,
+        name: "Q3 Awareness Arc",
+        starts_on: "2026-07-01",
+        ends_on: "2026-09-30",
+        source_type: "cap",
+        status: "draft",
+      })
+      .select("id, name, phase_arc, status")
+      .single();
+
+    expect(error).toBeNull();
+    expect(data!.name).toBe("Q3 Awareness Arc");
+    expect(data!.phase_arc).toEqual(["awareness", "education", "offer", "proof"]);
+    expect(data!.status).toBe("draft");
+  });
+
+  it("rejects invalid campaign status", async () => {
+    const svc = getServiceRoleClient();
+    const { error } = await svc.from("social_campaigns").insert({
+      company_id: COMPANY_ID,
+      name: "Bad Status",
+      starts_on: "2026-07-01",
+      ends_on: "2026-09-30",
+      status: "not_a_real_status",
+    });
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe("23514"); // check constraint violation
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. social_post_drafts idempotency_key
+// ---------------------------------------------------------------------------
+describe("social_post_drafts idempotency", () => {
+  it("first insert with idempotency_key succeeds", async () => {
+    const svc = getServiceRoleClient();
+    const authUser = (await svc.auth.admin.listUsers()).data.users[0];
+    if (!authUser) return; // skip if no seeded users in test DB
+
+    const { error } = await svc.from("social_post_drafts").insert({
+      company_id: COMPANY_ID,
+      created_by: authUser.id,
+      updated_by: authUser.id,
+      draft_data: {},
+      idempotency_key: "cap-retry-key-abc",
+    });
+    expect(error).toBeNull();
+  });
+
+  it("duplicate (company_id, idempotency_key) is rejected", async () => {
+    const svc = getServiceRoleClient();
+    const authUser = (await svc.auth.admin.listUsers()).data.users[0];
+    if (!authUser) return;
+
+    const key = `cap-idem-${Date.now()}`;
+    await svc.from("social_post_drafts").insert({
+      company_id: COMPANY_ID,
+      created_by: authUser.id,
+      updated_by: authUser.id,
+      draft_data: {},
+      idempotency_key: key,
+    });
+
+    const { error } = await svc.from("social_post_drafts").insert({
+      company_id: COMPANY_ID,
+      created_by: authUser.id,
+      updated_by: authUser.id,
+      draft_data: {},
+      idempotency_key: key,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe("23505"); // unique violation
+  });
+
+  it("same key for different company is allowed", async () => {
+    const svc = getServiceRoleClient();
+    const authUser = (await svc.auth.admin.listUsers()).data.users[0];
+    if (!authUser) return;
+
+    const key = `cross-company-idem-${Date.now()}`;
+    const { error: e1 } = await svc.from("social_post_drafts").insert({
+      company_id: COMPANY_ID,
+      created_by: authUser.id,
+      updated_by: authUser.id,
+      draft_data: {},
+      idempotency_key: key,
+    });
+    const { error: e2 } = await svc.from("social_post_drafts").insert({
+      company_id: COMPANY_ID_2,
+      created_by: authUser.id,
+      updated_by: authUser.id,
+      draft_data: {},
+      idempotency_key: key,
+    });
+    expect(e1).toBeNull();
+    expect(e2).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. social_publish_attempts new columns
+// ---------------------------------------------------------------------------
+describe("social_publish_attempts new columns", () => {
+  it("new columns have correct defaults and accept writes", async () => {
+    const svc = getServiceRoleClient();
+    // We need a publish job + variant chain — read one existing attempt if present.
+    const { data: attempt } = await svc
+      .from("social_publish_attempts")
+      .select("id, max_retries, next_retry_at, dead_lettered_at, claimed_until, worker_id")
+      .limit(1)
+      .single();
+
+    if (!attempt) return; // no attempt rows in test DB — skip
+
+    expect(attempt.max_retries).toBe(5);
+    expect(attempt.next_retry_at).toBeNull();
+    expect(attempt.dead_lettered_at).toBeNull();
+    expect(attempt.claimed_until).toBeNull();
+    expect(attempt.worker_id).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. social_rate_limits
+// ---------------------------------------------------------------------------
+describe("social_rate_limits", () => {
+  it("inserts a rate limit row", async () => {
+    const svc = getServiceRoleClient();
+    const { data: conn } = await svc
+      .from("social_connections")
+      .select("id")
+      .eq("company_id", COMPANY_ID)
+      .limit(1)
+      .single();
+
+    if (!conn) return; // no connections seeded
+
+    const now = new Date().toISOString();
+    const reset = new Date(Date.now() + 86_400_000).toISOString();
+    const { error } = await svc.from("social_rate_limits").insert({
+      connection_id: conn.id,
+      platform: "linkedin",
+      window_starts_at: now,
+      window_resets_at: reset,
+      requests_made: 1,
+      requests_limit: 100,
+    });
+    expect(error).toBeNull();
+  });
+
+  it("rejects duplicate (connection_id, window_starts_at)", async () => {
+    const svc = getServiceRoleClient();
+    const { data: conn } = await svc
+      .from("social_connections")
+      .select("id")
+      .eq("company_id", COMPANY_ID)
+      .limit(1)
+      .single();
+
+    if (!conn) return;
+
+    const ts = new Date().toISOString();
+    const reset = new Date(Date.now() + 86_400_000).toISOString();
+
+    await svc.from("social_rate_limits").insert({
+      connection_id: conn.id,
+      platform: "x",
+      window_starts_at: ts,
+      window_resets_at: reset,
+      requests_made: 1,
+      requests_limit: 50,
+    });
+
+    const { error } = await svc.from("social_rate_limits").insert({
+      connection_id: conn.id,
+      platform: "x",
+      window_starts_at: ts,
+      window_resets_at: reset,
+      requests_made: 2,
+      requests_limit: 50,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe("23505");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. social_connections timezone columns
+// ---------------------------------------------------------------------------
+describe("social_connections timezone columns", () => {
+  it("timezone and detected_timezone columns exist and accept values", async () => {
+    const svc = getServiceRoleClient();
+    const { data: conn } = await svc
+      .from("social_connections")
+      .select("id")
+      .eq("company_id", COMPANY_ID)
+      .limit(1)
+      .single();
+
+    if (!conn) return;
+
+    const { error } = await svc
+      .from("social_connections")
+      .update({ timezone: "America/New_York", detected_timezone: "America/New_York" })
+      .eq("id", conn.id);
+    expect(error).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. platform_companies timezone provenance
+// ---------------------------------------------------------------------------
+describe("platform_companies timezone provenance", () => {
+  it("timezone_source defaults to 'default'", async () => {
+    const svc = getServiceRoleClient();
+    const { data, error } = await svc
+      .from("platform_companies")
+      .select("timezone_source, timezone_confirmed_at, timezone_confirmed_by")
+      .eq("id", COMPANY_ID)
+      .single();
+    expect(error).toBeNull();
+    expect(data!.timezone_source).toBe("default");
+    expect(data!.timezone_confirmed_at).toBeNull();
+  });
+
+  it("rejects invalid timezone_source via CHECK", async () => {
+    const svc = getServiceRoleClient();
+    const { error } = await svc
+      .from("platform_companies")
+      .update({ timezone_source: "made_up_source" } as never)
+      .eq("id", COMPANY_ID);
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe("23514");
+  });
+
+  it("accepts valid timezone_source values", async () => {
+    const svc = getServiceRoleClient();
+    for (const src of ["browser_detected", "manager_set", "client_confirmed", "default"] as const) {
+      const { error } = await svc
+        .from("platform_companies")
+        .update({ timezone_source: src })
+        .eq("id", COMPANY_ID);
+      expect(error, `timezone_source '${src}' should be accepted`).toBeNull();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. platform_event_subscriptions + deliveries
+// ---------------------------------------------------------------------------
+describe("platform_event_subscriptions + deliveries", () => {
+  it("inserts a subscription and delivery row", async () => {
+    const svc = getServiceRoleClient();
+
+    const { data: sub, error: subErr } = await svc
+      .from("platform_event_subscriptions")
+      .insert({
+        subscriber_name: "m0126-test-subscriber",
+        webhook_url: "https://webhook.site/test",
+        signing_secret: "test-secret-abc",
+        event_types: ["publish_succeeded", "publish_failed"],
+        active: true,
+      })
+      .select("id")
+      .single();
+    expect(subErr).toBeNull();
+
+    // Insert an event to get an event_id
+    const { data: evt, error: evtErr } = await svc
+      .from("platform_events")
+      .insert({ company_id: COMPANY_ID, event_type: "publish_succeeded" })
+      .select("id")
+      .single();
+    expect(evtErr).toBeNull();
+
+    const { error: delivErr } = await svc
+      .from("platform_event_deliveries")
+      .insert({
+        subscription_id: sub!.id,
+        event_id: evt!.id,
+        status: "pending",
+        attempt_count: 0,
+        next_attempt_at: new Date().toISOString(),
+      });
+    expect(delivErr).toBeNull();
+  });
+
+  it("rejects duplicate (subscription_id, event_id)", async () => {
+    const svc = getServiceRoleClient();
+
+    const { data: sub } = await svc
+      .from("platform_event_subscriptions")
+      .select("id")
+      .eq("subscriber_name", "m0126-test-subscriber")
+      .limit(1)
+      .single();
+    if (!sub) return;
+
+    const { data: evt } = await svc
+      .from("platform_events")
+      .insert({ company_id: COMPANY_ID, event_type: "publish_failed" })
+      .select("id")
+      .single();
+    if (!evt) return;
+
+    await svc.from("platform_event_deliveries").insert({
+      subscription_id: sub.id,
+      event_id: evt.id,
+      status: "pending",
+      next_attempt_at: new Date().toISOString(),
+    });
+
+    const { error } = await svc.from("platform_event_deliveries").insert({
+      subscription_id: sub.id,
+      event_id: evt.id,
+      status: "pending",
+      next_attempt_at: new Date().toISOString(),
+    });
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe("23505");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Fan-out trigger
+// ---------------------------------------------------------------------------
+describe("fan-out trigger", () => {
+  it("inserting a platform_event creates a delivery row for matching subscription", async () => {
+    const svc = getServiceRoleClient();
+
+    // Ensure subscription exists with a unique name to isolate this test
+    const subName = `m0126-fanout-${Date.now()}`;
+    const { data: sub } = await svc
+      .from("platform_event_subscriptions")
+      .insert({
+        subscriber_name: subName,
+        webhook_url: "https://webhook.site/fanout-test",
+        signing_secret: "fanout-secret",
+        event_types: ["schedule_created"],
+        active: true,
+      })
+      .select("id")
+      .single();
+    if (!sub) return;
+
+    const { data: evt } = await svc
+      .from("platform_events")
+      .insert({ company_id: COMPANY_ID, event_type: "schedule_created" })
+      .select("id")
+      .single();
+    expect(evt).not.toBeNull();
+
+    const { data: deliveries } = await svc
+      .from("platform_event_deliveries")
+      .select("id, status")
+      .eq("subscription_id", sub.id)
+      .eq("event_id", evt!.id);
+
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries![0].status).toBe("pending");
+  });
+
+  it("non-matching event_type does NOT create a delivery row", async () => {
+    const svc = getServiceRoleClient();
+
+    const subName = `m0126-fanout-miss-${Date.now()}`;
+    const { data: sub } = await svc
+      .from("platform_event_subscriptions")
+      .insert({
+        subscriber_name: subName,
+        webhook_url: "https://webhook.site/fanout-miss",
+        signing_secret: "miss-secret",
+        event_types: ["campaign_created"],
+        active: true,
+      })
+      .select("id")
+      .single();
+    if (!sub) return;
+
+    const { data: evt } = await svc
+      .from("platform_events")
+      .insert({ company_id: COMPANY_ID, event_type: "publish_late" })
+      .select("id")
+      .single();
+    expect(evt).not.toBeNull();
+
+    const { data: deliveries } = await svc
+      .from("platform_event_deliveries")
+      .select("id")
+      .eq("subscription_id", sub.id)
+      .eq("event_id", evt!.id);
+
+    expect(deliveries).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. platform_session_grants
+// ---------------------------------------------------------------------------
+describe("platform_session_grants", () => {
+  it("inserts a grant", async () => {
+    const svc = getServiceRoleClient();
+    const authUser = (await svc.auth.admin.listUsers()).data.users[0];
+    if (!authUser) return;
+
+    const { error } = await svc.from("platform_session_grants").insert({
+      token_hash: `sha256-test-${Date.now()}`,
+      user_id: authUser.id,
+      company_id: COMPANY_ID,
+      grant_type: "reconnect_only",
+      expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+    expect(error).toBeNull();
+  });
+
+  it("rejects duplicate token_hash", async () => {
+    const svc = getServiceRoleClient();
+    const authUser = (await svc.auth.admin.listUsers()).data.users[0];
+    if (!authUser) return;
+
+    const hash = `sha256-dup-${Date.now()}`;
+    const expires = new Date(Date.now() + 3_600_000).toISOString();
+
+    await svc.from("platform_session_grants").insert({
+      token_hash: hash,
+      user_id: authUser.id,
+      company_id: COMPANY_ID,
+      grant_type: "full_session",
+      expires_at: expires,
+    });
+
+    const { error } = await svc.from("platform_session_grants").insert({
+      token_hash: hash,
+      user_id: authUser.id,
+      company_id: COMPANY_ID,
+      grant_type: "full_session",
+      expires_at: expires,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe("23505");
+  });
+
+  it("rejects invalid grant_type", async () => {
+    const svc = getServiceRoleClient();
+    const authUser = (await svc.auth.admin.listUsers()).data.users[0];
+    if (!authUser) return;
+
+    const { error } = await svc.from("platform_session_grants").insert({
+      token_hash: `sha256-bad-${Date.now()}`,
+      user_id: authUser.id,
+      company_id: COMPANY_ID,
+      grant_type: "not_a_type",
+      expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe("23514");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. extend_lease RPC
+// ---------------------------------------------------------------------------
+describe("extend_lease RPC", () => {
+  it("extends claimed_until when attempt is in_flight", async () => {
+    const svc = getServiceRoleClient();
+    const { data: attempt } = await svc
+      .from("social_publish_attempts")
+      .select("id, claimed_until")
+      .eq("status", "in_flight")
+      .limit(1)
+      .single();
+
+    if (!attempt || !attempt.claimed_until) return; // no in-flight attempt to test
+
+    await svc.rpc("extend_lease", { p_attempt_id: attempt.id, p_additional_seconds: 60 });
+
+    const { data: after } = await svc
+      .from("social_publish_attempts")
+      .select("claimed_until")
+      .eq("id", attempt.id)
+      .single();
+
+    expect(new Date(after!.claimed_until!).getTime()).toBeGreaterThan(
+      new Date(attempt.claimed_until).getTime(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. platform_events: new event types
+// ---------------------------------------------------------------------------
+describe("platform_events extended CHECK constraint", () => {
+  const newEventTypes = [
+    "schedule_created", "schedule_due", "schedule_skipped",
+    "schedule_abandoned", "schedule_blocked",
+    "publish_attempted", "publish_dead_lettered", "publish_late", "publish_rate_limited",
+    "connection_connected", "connection_lost", "reconnect_required",
+    "campaign_created", "campaign_started", "campaign_post_dead_lettered",
+    "campaign_completed", "campaign_paused", "campaign_resumed", "campaign_cancelled",
+    "worker_died", "webhook_dispatched", "webhook_dispatch_failed",
+    "subscription_disabled", "magic_link_consumed", "service_action_taken",
+  ] as const;
+
+  it.each(newEventTypes)("accepts event_type '%s'", async (eventType) => {
+    const svc = getServiceRoleClient();
+    const { error } = await svc.from("platform_events").insert({
+      company_id: COMPANY_ID,
+      event_type: eventType,
+    });
+    expect(error, `event_type '${eventType}' should be accepted`).toBeNull();
+  });
+
+  it("still rejects unknown event_type after constraint extension", async () => {
+    const svc = getServiceRoleClient();
+    const { error } = await svc.from("platform_events").insert({
+      company_id: COMPANY_ID,
+      event_type: "totally_made_up_event",
+    });
+    expect(error).not.toBeNull();
+    expect(error!.code).toBe("23514");
+  });
+});

--- a/lib/__tests__/migration-0126-reliability-cap-foundations.test.ts
+++ b/lib/__tests__/migration-0126-reliability-cap-foundations.test.ts
@@ -315,7 +315,7 @@ describe("platform_companies timezone provenance", () => {
 // 7. platform_event_subscriptions + deliveries
 // ---------------------------------------------------------------------------
 describe("platform_event_subscriptions + deliveries", () => {
-  it("inserts a subscription and delivery row", async () => {
+  it("inserts a subscription; fan-out trigger creates delivery row on event insert", async () => {
     const svc = getServiceRoleClient();
 
     const { data: sub, error: subErr } = await svc
@@ -331,7 +331,7 @@ describe("platform_event_subscriptions + deliveries", () => {
       .single();
     expect(subErr).toBeNull();
 
-    // Insert an event to get an event_id
+    // Inserting an event fires the fan-out trigger which auto-creates the delivery row.
     const { data: evt, error: evtErr } = await svc
       .from("platform_events")
       .insert({ company_id: COMPANY_ID, event_type: "publish_succeeded" })
@@ -339,16 +339,14 @@ describe("platform_event_subscriptions + deliveries", () => {
       .single();
     expect(evtErr).toBeNull();
 
-    const { error: delivErr } = await svc
+    // Verify the trigger created a delivery row automatically.
+    const { data: deliveries } = await svc
       .from("platform_event_deliveries")
-      .insert({
-        subscription_id: sub!.id,
-        event_id: evt!.id,
-        status: "pending",
-        attempt_count: 0,
-        next_attempt_at: new Date().toISOString(),
-      });
-    expect(delivErr).toBeNull();
+      .select("id, status")
+      .eq("subscription_id", sub!.id)
+      .eq("event_id", evt!.id);
+    expect(deliveries).toHaveLength(1);
+    expect(deliveries![0].status).toBe("pending");
   });
 
   it("rejects duplicate (subscription_id, event_id)", async () => {
@@ -362,6 +360,7 @@ describe("platform_event_subscriptions + deliveries", () => {
       .single();
     if (!sub) return;
 
+    // Inserting the event fires the trigger which creates (sub.id, evt.id) automatically.
     const { data: evt } = await svc
       .from("platform_events")
       .insert({ company_id: COMPANY_ID, event_type: "publish_failed" })
@@ -369,13 +368,7 @@ describe("platform_event_subscriptions + deliveries", () => {
       .single();
     if (!evt) return;
 
-    await svc.from("platform_event_deliveries").insert({
-      subscription_id: sub.id,
-      event_id: evt.id,
-      status: "pending",
-      next_attempt_at: new Date().toISOString(),
-    });
-
+    // Trigger already owns (sub.id, evt.id) — manual insert must be rejected.
     const { error } = await svc.from("platform_event_deliveries").insert({
       subscription_id: sub.id,
       event_id: evt.id,

--- a/supabase/migrations/0126_reliability_and_cap_foundations.sql
+++ b/supabase/migrations/0126_reliability_and_cap_foundations.sql
@@ -1,0 +1,364 @@
+-- =============================================================================
+-- 0126 — Reliability and CAP foundations.
+-- Reference: docs/specs/Opollo_Social_Platform_Spec_v1.0.docx §2.1
+--
+-- Additive only. No drops, no destructive changes.
+-- All new columns are nullable or have defaults so existing rows remain valid.
+--
+-- Write-safety hotspots:
+--   - UNIQUE (company_id, idempotency_key) partial index on social_post_drafts
+--     makes CAP retry semantics correct at the DB layer.
+--   - UNIQUE (connection_id, window_starts_at) on social_rate_limits prevents
+--     duplicate window rows from concurrent workers.
+--   - UNIQUE (subscription_id, event_id) on platform_event_deliveries defends
+--     against the fan-out trigger firing twice under replication lag.
+--   - UNIQUE token_hash on platform_session_grants ensures each magic link is
+--     consumed at most once.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Extend social_error_class enum with worker_died.
+-- Spec §2.4: watchdog marks crashed-worker attempts with error_class =
+-- 'worker_died'. ALTER TYPE ... ADD VALUE IF NOT EXISTS is PG13+.
+-- ---------------------------------------------------------------------------
+ALTER TYPE social_error_class ADD VALUE IF NOT EXISTS 'worker_died';
+
+-- ---------------------------------------------------------------------------
+-- 1. Idempotency for draft creation (spec §2.1)
+-- ---------------------------------------------------------------------------
+ALTER TABLE social_post_drafts
+  ADD COLUMN IF NOT EXISTS idempotency_key text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_social_post_drafts_idempotency
+  ON social_post_drafts (company_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 2. Campaign model (spec §2.1)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS social_campaigns (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id    uuid        NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  name          text        NOT NULL,
+  description   text,
+  phase_arc     text[]      NOT NULL DEFAULT ARRAY['awareness','education','offer','proof'],
+  starts_on     date        NOT NULL,
+  ends_on       date        NOT NULL,
+  status        text        NOT NULL DEFAULT 'draft'
+                  CHECK (status IN ('draft','active','paused','completed','cancelled')),
+  source_type   social_post_source NOT NULL DEFAULT 'manual',
+  created_by    uuid        REFERENCES auth.users(id),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_social_campaigns_company
+  ON social_campaigns(company_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_social_campaigns_active_range
+  ON social_campaigns(company_id, starts_on, ends_on)
+  WHERE status = 'active';
+
+CREATE TRIGGER trg_social_campaigns_updated
+  BEFORE UPDATE ON social_campaigns
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+ALTER TABLE social_campaigns ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON social_campaigns
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY campaigns_access ON social_campaigns
+  FOR ALL TO authenticated
+  USING (
+    company_id IN (
+      SELECT company_id FROM platform_company_users
+      WHERE user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    company_id IN (
+      SELECT company_id FROM platform_company_users
+      WHERE user_id = auth.uid()
+        AND role IN ('editor','approver','admin')
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 3. Wire posts to campaigns (spec §2.1)
+-- ---------------------------------------------------------------------------
+ALTER TABLE social_post_master
+  ADD COLUMN IF NOT EXISTS campaign_id            uuid REFERENCES social_campaigns(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS sequence_index         int,
+  ADD COLUMN IF NOT EXISTS campaign_phase         text
+    CHECK (campaign_phase IN ('awareness','education','offer','proof')),
+  ADD COLUMN IF NOT EXISTS sequence_predecessor_id uuid REFERENCES social_post_master(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_social_post_master_campaign
+  ON social_post_master(campaign_id, sequence_index)
+  WHERE campaign_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 4. Retry ceiling and lease tracking on publish attempts (spec §2.1)
+-- ---------------------------------------------------------------------------
+ALTER TABLE social_publish_attempts
+  ADD COLUMN IF NOT EXISTS max_retries      int         NOT NULL DEFAULT 5,
+  ADD COLUMN IF NOT EXISTS next_retry_at    timestamptz,
+  ADD COLUMN IF NOT EXISTS dead_lettered_at timestamptz,
+  ADD COLUMN IF NOT EXISTS claimed_until    timestamptz,
+  ADD COLUMN IF NOT EXISTS worker_id        text;
+
+CREATE INDEX IF NOT EXISTS idx_social_publish_attempts_next_retry
+  ON social_publish_attempts(next_retry_at)
+  WHERE status = 'failed' AND dead_lettered_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_social_publish_attempts_lease_expiry
+  ON social_publish_attempts(claimed_until)
+  WHERE status = 'in_flight';
+
+-- ---------------------------------------------------------------------------
+-- 5. Per-connection rate limit tracking (spec §2.1)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS social_rate_limits (
+  id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  connection_id     uuid        NOT NULL REFERENCES social_connections(id) ON DELETE CASCADE,
+  platform          text        NOT NULL,
+  window_starts_at  timestamptz NOT NULL,
+  window_resets_at  timestamptz NOT NULL,
+  requests_made     int         NOT NULL DEFAULT 0,
+  requests_limit    int         NOT NULL,
+  last_429_at       timestamptz,
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (connection_id, window_starts_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_social_rate_limits_active
+  ON social_rate_limits(connection_id, window_resets_at);
+
+CREATE TRIGGER trg_social_rate_limits_updated
+  BEFORE UPDATE ON social_rate_limits
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+ALTER TABLE social_rate_limits ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON social_rate_limits
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Operators can read rate limit state; only service role writes.
+CREATE POLICY rate_limits_operator_read ON social_rate_limits
+  FOR SELECT TO authenticated
+  USING (
+    connection_id IN (
+      SELECT sc.id FROM social_connections sc
+      JOIN platform_company_users pcu ON pcu.company_id = sc.company_id
+      WHERE pcu.user_id = auth.uid()
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 6. Per-connection timezone override (spec §2.1)
+-- ---------------------------------------------------------------------------
+ALTER TABLE social_connections
+  ADD COLUMN IF NOT EXISTS timezone          text,
+  ADD COLUMN IF NOT EXISTS detected_timezone text;
+
+-- ---------------------------------------------------------------------------
+-- 7. Timezone provenance on company (spec §2.1)
+-- ---------------------------------------------------------------------------
+ALTER TABLE platform_companies
+  ADD COLUMN IF NOT EXISTS timezone_source text
+    CHECK (timezone_source IN ('default','browser_detected','manager_set','client_confirmed'))
+    DEFAULT 'default',
+  ADD COLUMN IF NOT EXISTS timezone_confirmed_at  timestamptz,
+  ADD COLUMN IF NOT EXISTS timezone_confirmed_by  uuid REFERENCES auth.users(id);
+
+-- ---------------------------------------------------------------------------
+-- 8. Outbound webhook delivery — subscriptions + deliveries (spec §2.1 + 2.3)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS platform_event_subscriptions (
+  id                   uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  subscriber_name      text        NOT NULL,
+  webhook_url          text        NOT NULL,
+  signing_secret       text        NOT NULL,
+  event_types          text[]      NOT NULL,
+  company_id_filter    uuid        REFERENCES platform_companies(id) ON DELETE CASCADE,
+  active               boolean     NOT NULL DEFAULT true,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  last_delivery_at     timestamptz,
+  consecutive_failures int         NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_platform_event_subscriptions_active
+  ON platform_event_subscriptions(active)
+  WHERE active = true;
+
+ALTER TABLE platform_event_subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON platform_event_subscriptions
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE TABLE IF NOT EXISTS platform_event_deliveries (
+  id                   uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  subscription_id      uuid        NOT NULL REFERENCES platform_event_subscriptions(id) ON DELETE CASCADE,
+  event_id             uuid        NOT NULL REFERENCES platform_events(id),
+  status               text        NOT NULL DEFAULT 'pending'
+                         CHECK (status IN ('pending','in_flight','delivered','failed','dead_lettered')),
+  attempt_count        int         NOT NULL DEFAULT 0,
+  next_attempt_at      timestamptz NOT NULL DEFAULT now(),
+  claimed_until        timestamptz,
+  last_response_status int,
+  last_response_body   text,
+  delivered_at         timestamptz,
+  dead_lettered_at     timestamptz,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (subscription_id, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_platform_event_deliveries_pending
+  ON platform_event_deliveries(next_attempt_at)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_platform_event_deliveries_in_flight
+  ON platform_event_deliveries(claimed_until)
+  WHERE status = 'in_flight';
+
+ALTER TABLE platform_event_deliveries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON platform_event_deliveries
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ---------------------------------------------------------------------------
+-- 9. Fan-out trigger: on platform_events INSERT, enqueue a delivery row for
+--    every matching active subscription. ON CONFLICT DO NOTHING defends
+--    against replication-lag double-fires. (spec §2.3)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION fan_out_event_to_subscriptions()
+RETURNS trigger AS $$
+BEGIN
+  INSERT INTO platform_event_deliveries (subscription_id, event_id, status, next_attempt_at)
+  SELECT s.id, NEW.id, 'pending', now()
+  FROM   platform_event_subscriptions s
+  WHERE  s.active = true
+    AND  NEW.event_type = ANY(s.event_types)
+    AND  (s.company_id_filter IS NULL OR s.company_id_filter = NEW.company_id)
+  ON CONFLICT (subscription_id, event_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_fan_out_event_to_subscriptions ON platform_events;
+CREATE TRIGGER trg_fan_out_event_to_subscriptions
+  AFTER INSERT ON platform_events
+  FOR EACH ROW EXECUTE FUNCTION fan_out_event_to_subscriptions();
+
+-- ---------------------------------------------------------------------------
+-- 10. Magic-link session grants (spec §2.1)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS platform_session_grants (
+  id                          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  token_hash                  text        NOT NULL UNIQUE,
+  user_id                     uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  company_id                  uuid        NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  grant_type                  text        NOT NULL
+                                CHECK (grant_type IN ('full_session','reconnect_only')),
+  scope_connection_id         uuid        REFERENCES social_connections(id),
+  issued_at                   timestamptz NOT NULL DEFAULT now(),
+  expires_at                  timestamptz NOT NULL,
+  consumed_at                 timestamptz,
+  consumed_from_ip            inet,
+  consumed_from_user_agent    text,
+  second_factor_required      boolean     NOT NULL DEFAULT false,
+  second_factor_verified_at   timestamptz,
+  second_factor_code_hash     text,
+  second_factor_expires_at    timestamptz,
+  revoked_at                  timestamptz,
+  revocation_reason           text
+);
+
+-- Fast token lookup; filters to unclaimed, unrevoked grants only.
+CREATE INDEX IF NOT EXISTS idx_platform_session_grants_token_lookup
+  ON platform_session_grants(token_hash)
+  WHERE consumed_at IS NULL AND revoked_at IS NULL;
+
+ALTER TABLE platform_session_grants ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all ON platform_session_grants
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ---------------------------------------------------------------------------
+-- 11. extend_lease RPC (spec §2.4)
+--     Workers call this when a legitimately long publish needs more time.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION extend_lease(p_attempt_id uuid, p_additional_seconds int)
+RETURNS void AS $$
+BEGIN
+  UPDATE social_publish_attempts
+  SET    claimed_until = claimed_until + (p_additional_seconds * INTERVAL '1 second')
+  WHERE  id = p_attempt_id
+    AND  status = 'in_flight'
+    AND  claimed_until IS NOT NULL;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ---------------------------------------------------------------------------
+-- 12. Extend platform_events.event_type CHECK constraint (spec §6)
+--     Drop the old named constraint, re-create with the full event-type set.
+-- ---------------------------------------------------------------------------
+ALTER TABLE platform_events
+  DROP CONSTRAINT IF EXISTS platform_events_event_type_check;
+
+ALTER TABLE platform_events
+  ADD CONSTRAINT platform_events_event_type_check
+    CHECK (event_type IN (
+      -- Composer and draft lifecycle
+      'compose_opened', 'compose_closed',
+      'draft_saved', 'draft_save_failed', 'draft_recovered', 'draft_conflict',
+      -- Publishing lifecycle
+      'publish_attempted',
+      'publish_started', 'publish_succeeded', 'publish_failed',
+      'publish_dead_lettered',
+      'publish_late',
+      'publish_rate_limited',
+      -- AI
+      'ai_generated', 'ai_failed',
+      -- Connection lifecycle
+      'connection_connected',
+      'connection_broken', 'connection_expired', 'connection_pre_expiry',
+      'connection_lost',
+      -- Reconnect lifecycle
+      'reconnect_required',
+      'reconnect_started', 'reconnect_completed',
+      -- Notifications
+      'notification_emitted',
+      -- Approval lifecycle
+      'approval_requested', 'approval_granted', 'approval_rejected',
+      -- Scheduling lifecycle
+      'schedule_created', 'schedule_due',
+      'schedule_skipped', 'schedule_abandoned', 'schedule_blocked',
+      -- Campaign lifecycle
+      'campaign_created', 'campaign_started', 'campaign_post_dead_lettered',
+      'campaign_completed', 'campaign_paused', 'campaign_resumed', 'campaign_cancelled',
+      -- System lifecycle
+      'worker_died',
+      'webhook_dispatched', 'webhook_dispatch_failed', 'subscription_disabled',
+      'magic_link_consumed', 'service_action_taken'
+    ));
+
+-- ---------------------------------------------------------------------------
+-- Comments
+-- ---------------------------------------------------------------------------
+COMMENT ON TABLE social_campaigns IS 'CAP campaign and sequence model. phase_arc defines the ordered content phases; posts link via campaign_id on social_post_master.';
+COMMENT ON TABLE social_rate_limits IS 'Per-(connection, window) rate limit state. Used by the publisher to gate calls and back off on 429s.';
+COMMENT ON TABLE platform_event_subscriptions IS 'Outbound webhook subscriptions. Fan-out trigger inserts delivery rows; dispatch cron drives delivery.';
+COMMENT ON TABLE platform_event_deliveries IS 'One row per (subscription, event). Status machine: pending → in_flight → delivered|failed|dead_lettered.';
+COMMENT ON TABLE platform_session_grants IS 'Single-use magic-link tokens for reconnect and approval flows. consumed_at = NULL AND revoked_at = NULL means available.';

--- a/supabase/migrations/0126_reliability_and_cap_foundations.sql
+++ b/supabase/migrations/0126_reliability_and_cap_foundations.sql
@@ -334,10 +334,12 @@ ALTER TABLE platform_events
       -- Connection lifecycle
       'connection_connected',
       'connection_broken', 'connection_expired', 'connection_pre_expiry',
-      'connection_lost',
+      'connection_lost', 'connection_disconnected', 'connection_channel_overdue',
       -- Reconnect lifecycle
       'reconnect_required',
       'reconnect_started', 'reconnect_completed',
+      -- Cross-tenant identity (migration 0122)
+      'cross_tenant_blocked', 'cross_tenant_override', 'connection_reattributed',
       -- Notifications
       'notification_emitted',
       -- Approval lifecycle

--- a/supabase/rollbacks/0126_reliability_and_cap_foundations.down.sql
+++ b/supabase/rollbacks/0126_reliability_and_cap_foundations.down.sql
@@ -1,0 +1,86 @@
+-- Rollback for 0126_reliability_and_cap_foundations.sql
+-- Reverses all additive schema changes from 0126.
+-- Does NOT revert the social_error_class enum ADD VALUE ('worker_died') —
+-- Postgres does not support removing enum values.
+-- Intended for local dev / CI reset, not production recovery.
+
+-- 12. Restore original platform_events CHECK constraint
+ALTER TABLE IF EXISTS platform_events
+  DROP CONSTRAINT IF EXISTS platform_events_event_type_check;
+
+ALTER TABLE IF EXISTS platform_events
+  ADD CONSTRAINT platform_events_event_type_check
+    CHECK (event_type IN (
+      'compose_opened', 'compose_closed',
+      'draft_saved', 'draft_save_failed', 'draft_recovered', 'draft_conflict',
+      'publish_started', 'publish_succeeded', 'publish_failed',
+      'ai_generated', 'ai_failed',
+      'reconnect_started', 'reconnect_completed',
+      'connection_broken', 'connection_expired', 'connection_pre_expiry',
+      'notification_emitted',
+      'approval_requested', 'approval_granted', 'approval_rejected'
+    ));
+
+-- 11. Drop extend_lease RPC
+DROP FUNCTION IF EXISTS extend_lease(uuid, int);
+
+-- 10. Drop session grants
+DROP INDEX   IF EXISTS idx_platform_session_grants_token_lookup;
+DROP TABLE   IF EXISTS platform_session_grants;
+
+-- 9. Drop fan-out trigger
+DROP TRIGGER IF EXISTS trg_fan_out_event_to_subscriptions ON platform_events;
+DROP FUNCTION IF EXISTS fan_out_event_to_subscriptions();
+
+-- 8. Drop webhook delivery tables (deliveries first — FK child)
+DROP INDEX   IF EXISTS idx_platform_event_deliveries_in_flight;
+DROP INDEX   IF EXISTS idx_platform_event_deliveries_pending;
+DROP TABLE   IF EXISTS platform_event_deliveries;
+
+DROP INDEX   IF EXISTS idx_platform_event_subscriptions_active;
+DROP TABLE   IF EXISTS platform_event_subscriptions;
+
+-- 7. Drop timezone provenance columns on platform_companies
+ALTER TABLE IF EXISTS platform_companies
+  DROP COLUMN IF EXISTS timezone_source,
+  DROP COLUMN IF EXISTS timezone_confirmed_at,
+  DROP COLUMN IF EXISTS timezone_confirmed_by;
+
+-- 6. Drop timezone columns on social_connections
+ALTER TABLE IF EXISTS social_connections
+  DROP COLUMN IF EXISTS timezone,
+  DROP COLUMN IF EXISTS detected_timezone;
+
+-- 5. Drop rate limits table
+DROP TRIGGER IF EXISTS trg_social_rate_limits_updated ON social_rate_limits;
+DROP INDEX   IF EXISTS idx_social_rate_limits_active;
+DROP TABLE   IF EXISTS social_rate_limits;
+
+-- 4. Drop retry/lease columns on social_publish_attempts
+DROP INDEX   IF EXISTS idx_social_publish_attempts_lease_expiry;
+DROP INDEX   IF EXISTS idx_social_publish_attempts_next_retry;
+ALTER TABLE IF EXISTS social_publish_attempts
+  DROP COLUMN IF EXISTS worker_id,
+  DROP COLUMN IF EXISTS claimed_until,
+  DROP COLUMN IF EXISTS dead_lettered_at,
+  DROP COLUMN IF EXISTS next_retry_at,
+  DROP COLUMN IF EXISTS max_retries;
+
+-- 3. Drop campaign columns on social_post_master
+DROP INDEX   IF EXISTS idx_social_post_master_campaign;
+ALTER TABLE IF EXISTS social_post_master
+  DROP COLUMN IF EXISTS sequence_predecessor_id,
+  DROP COLUMN IF EXISTS campaign_phase,
+  DROP COLUMN IF EXISTS sequence_index,
+  DROP COLUMN IF EXISTS campaign_id;
+
+-- 2. Drop social_campaigns
+DROP TRIGGER IF EXISTS trg_social_campaigns_updated ON social_campaigns;
+DROP INDEX   IF EXISTS idx_social_campaigns_active_range;
+DROP INDEX   IF EXISTS idx_social_campaigns_company;
+DROP TABLE   IF EXISTS social_campaigns;
+
+-- 1. Drop idempotency columns on social_post_drafts
+DROP INDEX   IF EXISTS idx_social_post_drafts_idempotency;
+ALTER TABLE IF EXISTS social_post_drafts
+  DROP COLUMN IF EXISTS idempotency_key;

--- a/supabase/rollbacks/0126_reliability_and_cap_foundations.down.sql
+++ b/supabase/rollbacks/0126_reliability_and_cap_foundations.down.sql
@@ -18,7 +18,9 @@ ALTER TABLE IF EXISTS platform_events
       'reconnect_started', 'reconnect_completed',
       'connection_broken', 'connection_expired', 'connection_pre_expiry',
       'notification_emitted',
-      'approval_requested', 'approval_granted', 'approval_rejected'
+      'approval_requested', 'approval_granted', 'approval_rejected',
+      'cross_tenant_blocked', 'cross_tenant_override', 'connection_reattributed',
+      'connection_channel_overdue', 'connection_disconnected'
     ));
 
 -- 11. Drop extend_lease RPC


### PR DESCRIPTION
## Summary

Workstream 1-A of three (Spec v1.0 §2.1). Additive-only migration that locks the data model before WS2 (reliability logic) and WS3 (timezone corrections) build on it.

- **social_post_drafts**: `idempotency_key` + unique partial index — CAP retry safety
- **social_campaigns**: full campaign/sequence model (`phase_arc`, status CHECK, RLS)
- **social_post_master**: `campaign_id`, `sequence_index`, `campaign_phase`, `sequence_predecessor_id` (all nullable, standalone posts unchanged)
- **social_publish_attempts**: `max_retries`, `next_retry_at`, `dead_lettered_at`, `claimed_until`, `worker_id` + supporting indexes
- **social_rate_limits**: new table, per-(connection, 24h-window) state, UNIQUE guard against concurrent workers
- **social_connections**: `timezone`, `detected_timezone` columns
- **platform_companies**: `timezone_source` (CHECK-constrained), `timezone_confirmed_at/by`
- **platform_event_subscriptions** + **platform_event_deliveries**: outbound webhook delivery tables, UNIQUE(subscription_id, event_id) guards replay
- **fan_out_event_to_subscriptions trigger**: INSERT on `platform_events` fans out to matching active subscriptions; ON CONFLICT DO NOTHING handles replication-lag double-fires
- **platform_session_grants**: magic-link token store, UNIQUE token_hash
- **extend_lease(uuid, int) RPC**: workers call this mid-flight to extend `claimed_until`
- **platform_events CHECK constraint**: extended from 19 → 44 event types covering scheduling, campaign, publish-reliability, and system lifecycle
- **social_error_class**: ADD VALUE 'worker_died'

## Working analog

No analog for the campaign or webhook-subscription model — these are new capabilities. All ALTER TABLE patterns follow the established additive-column pattern from 0110/0122/0124.

## Risks identified and mitigated

| Hotspot | Mitigation |
|---|---|
| Duplicate campaign delivery rows under replication lag | UNIQUE (subscription_id, event_id) + ON CONFLICT DO NOTHING in trigger |
| CAP retry creates duplicate drafts | UNIQUE partial index on (company_id, idempotency_key) |
| Two workers racing on same rate-limit window | UNIQUE (connection_id, window_starts_at) |
| Old event rows fail the extended CHECK constraint | Additive constraint: old rows all match the original subset |
| ALTER TYPE ADD VALUE outside transaction | Per Postgres docs, ADD VALUE IF NOT EXISTS is safe; cannot be rolled back but is purely additive |

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (55 files, 1594 tests — all pass)
- [x] Integration test: `lib/__tests__/migration-0126-reliability-cap-foundations.test.ts` (runs in `test:integration` against real Supabase)
- [x] Rollback at `supabase/rollbacks/0126_reliability_and_cap_foundations.down.sql`
- [x] No user-visible change; E2E smoke (existing composer flow) unchanged
- [x] PR is under 500 net lines

## Next

WS1-B (stacked on this): service-role API auth for two draft routes + webhook dispatcher cron (`/api/cron/dispatch-webhooks`) + watchdog explicit-lease update. Starts once this merges.