### PR TITLE
feat(ws1-b): service-role API auth, webhook dispatcher, watchdog lease

### DIFF
--- a/app/api/cron/dispatch-webhooks/route.ts
+++ b/app/api/cron/dispatch-webhooks/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { logger } from "@/lib/logger";
+import {
+  authorisedCronRequest,
+  unauthorisedResponse,
+} from "@/lib/optimiser/sync/cron-shared";
+import { dispatchWebhooks } from "@/lib/platform/social/publishing/dispatch-webhooks";
+
+// ---------------------------------------------------------------------------
+// GET /api/cron/dispatch-webhooks
+//
+// Vercel cron (every minute). Spec §2.3 specifies 30-second frequency but
+// Vercel cron's minimum interval is 1 minute; documented in PR description.
+//
+// Claims up to 50 pending platform_event_deliveries, POSTs each to its
+// subscriber's webhook_url with HMAC-SHA256 signature, and updates delivery
+// status. Backoff schedule: 30 s, 5 min, 30 min, 2 h, 12 h; after 6 attempts
+// the delivery is dead-lettered.
+//
+// Auth: shared CRON_SECRET bearer (lib/optimiser/sync/cron-shared).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+async function handle(req: NextRequest): Promise<NextResponse> {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+
+  const result = await dispatchWebhooks();
+
+  if (!result.ok) {
+    logger.error("dispatch_webhooks.cron_failed", { err: result.error.message });
+    return NextResponse.json(
+      { ok: false, error: result.error, timestamp: new Date().toISOString() },
+      { status: 500 },
+    );
+  }
+
+  logger.info("dispatch_webhooks.cron_ok", result.data);
+
+  return NextResponse.json(
+    { ok: true, data: result.data, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/app/api/platform/social/drafts/[id]/publish/route.ts
+++ b/app/api/platform/social/drafts/[id]/publish/route.ts
@@ -2,8 +2,12 @@ import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
 import { dbUuid, internalError, invalidState, notFound, readJsonBody, validationError } from "@/lib/http";
-import { canDo } from "@/lib/platform/auth";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import {
+  authenticateRequest,
+  validateServiceActorCompany,
+  recordServiceAction,
+} from "@/lib/platform/auth/service-auth";
 import { getDraft } from "@/lib/platform/social/drafts";
 import {
   approvePost,
@@ -65,10 +69,32 @@ export async function POST(
 
   const { company_id: companyId, mode } = parsed.data;
 
-  // For "draft" mode we only need create_post; for post/schedule we also
-  // need submit_for_approval. Use the stricter gate to cover both paths.
-  const gate = await requireCanDoForApi(companyId, "create_post");
-  if (gate.kind === "deny") return gate.response;
+  // Auth: service key (CAP) or user session.
+  const auth = await authenticateRequest(req);
+  if (auth.kind === "deny") return auth.response;
+
+  let userId: string;
+  let hasApprovePermission: boolean;
+
+  if (auth.kind === "service") {
+    const companyCheck = await validateServiceActorCompany(companyId);
+    if (!companyCheck.ok) return companyCheck.response;
+    recordServiceAction(companyId, auth.actorId, {
+      route: `POST /api/platform/social/drafts/${draftId}/publish`,
+      mode,
+    });
+    userId = auth.actorId;
+    // Service actors auto-approve (CAP manages the approval lifecycle itself).
+    hasApprovePermission = true;
+  } else {
+    // For "draft" mode we only need create_post; for post/schedule we also
+    // need submit_for_approval. Use the stricter gate to cover both paths.
+    const gate = await requireCanDoForApi(companyId, "create_post");
+    if (gate.kind === "deny") return gate.response;
+    userId = gate.userId;
+    const { canDo } = await import("@/lib/platform/auth");
+    hasApprovePermission = await canDo(companyId, "approve_post");
+  }
 
   // Load draft.
   const draftResult = await getDraft({ draftId, companyId });
@@ -89,7 +115,7 @@ export async function POST(
     masterText: dd.master_text || null,
     linkUrl: dd.link_url || null,
     sourceType: "manual",
-    createdBy: gate.userId,
+    createdBy: userId,
   });
   if (!postResult.ok) {
     if (postResult.error.code === "VALIDATION_FAILED") return validationError(postResult.error.message);
@@ -149,9 +175,8 @@ export async function POST(
   }
 
   // 4. Auto-approve unless the post explicitly requires a human approval step
-  //    or the user lacks approve_post permission.
-  const canApprove = await canDo(companyId, "approve_post");
-  if (!canApprove || dd.approval_required) {
+  //    or the actor lacks approve_post permission.
+  if (!hasApprovePermission || dd.approval_required) {
     return NextResponse.json(
       {
         ok: true,
@@ -230,7 +255,7 @@ export async function POST(
           companyId,
           platform: platform as SocialPlatform,
           scheduledAt,
-          scheduledBy: gate.userId,
+          scheduledBy: userId,
           origin,
         }),
       ),

--- a/app/api/platform/social/drafts/route.ts
+++ b/app/api/platform/social/drafts/route.ts
@@ -1,17 +1,26 @@
 import { NextResponse } from "next/server";
 
-import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
-import { createDraft } from "@/lib/platform/social/drafts";
 import { logger } from "@/lib/logger";
-import { forbidden, internalError, readJsonBody, validationError } from "@/lib/http";
+import { internalError, readJsonBody, validationError } from "@/lib/http";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import {
+  authenticateRequest,
+  validateServiceActorCompany,
+  recordServiceAction,
+} from "@/lib/platform/auth/service-auth";
+import { createDraft } from "@/lib/platform/social/drafts";
 
 // ---------------------------------------------------------------------------
 // POST /api/platform/social/drafts
 //
-// Creates a new blank social post draft. Requires "create_post" permission.
-// Returns the new draft row with id + draft_version=1.
+// Creates a new blank social post draft.
 //
-// Body: { company_id: string }
+// Auth path A — user session (existing): requires "create_post" permission.
+// Auth path B — service key (spec §2.2): x-platform-service-key +
+//   x-platform-actor-id headers. Company must have cap_weekly_enabled = true.
+//   Records a service_action_taken platform_events row.
+//
+// Body: { company_id: string, idempotency_key?: string }
 // ---------------------------------------------------------------------------
 
 export async function POST(req: Request): Promise<NextResponse> {
@@ -26,11 +35,28 @@ export async function POST(req: Request): Promise<NextResponse> {
   }
 
   const companyId = (body as Record<string, unknown>).company_id as string;
+  const idempotencyKey =
+    typeof (body as Record<string, unknown>).idempotency_key === "string"
+      ? ((body as Record<string, unknown>).idempotency_key as string)
+      : undefined;
 
-  const gate = await requireCanDoForApi(companyId, "create_post");
-  if (gate.kind === "deny") return gate.response;
+  const auth = await authenticateRequest(req);
+  if (auth.kind === "deny") return auth.response;
 
-  const result = await createDraft({ companyId, userId: gate.userId });
+  let userId: string;
+
+  if (auth.kind === "service") {
+    const companyCheck = await validateServiceActorCompany(companyId);
+    if (!companyCheck.ok) return companyCheck.response;
+    recordServiceAction(companyId, auth.actorId, { route: "POST /api/platform/social/drafts" });
+    userId = auth.actorId;
+  } else {
+    const gate = await requireCanDoForApi(companyId, "create_post");
+    if (gate.kind === "deny") return gate.response;
+    userId = gate.userId;
+  }
+
+  const result = await createDraft({ companyId, userId, idempotencyKey });
   if (!result.ok) {
     logger.error("draft_create_failed", { company_id: companyId, error: result.error });
     return internalError(result.error.message, result.error.retryable);

--- a/lib/__tests__/service-auth.unit.test.ts
+++ b/lib/__tests__/service-auth.unit.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// service-auth.ts unit tests.
+//
+// Tests the authenticate/validate logic without hitting Supabase. The
+// Supabase client and auth session are mocked at module boundaries.
+// ---------------------------------------------------------------------------
+
+// Mock @/lib/supabase before importing service-auth so the module never
+// tries to instantiate a real Supabase client.
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: vi.fn(),
+}));
+
+// server-only is a no-op in vitest
+vi.mock("server-only", () => ({}));
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { createRouteAuthClient } from "@/lib/auth";
+import {
+  authenticateRequest,
+  validateServiceActorCompany,
+} from "@/lib/platform/auth/service-auth";
+
+const mockSvcClient = {
+  from: vi.fn(),
+};
+const mockRouteClient = {
+  auth: {
+    getUser: vi.fn(),
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getServiceRoleClient).mockReturnValue(mockSvcClient as never);
+  vi.mocked(createRouteAuthClient).mockReturnValue(mockRouteClient as never);
+});
+
+// ---------------------------------------------------------------------------
+// authenticateRequest
+// ---------------------------------------------------------------------------
+
+describe("authenticateRequest — service key path", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV, PLATFORM_SERVICE_API_KEY: "test-secret-key-abc" };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it("returns kind=service when api key + actor id are correct", async () => {
+    const req = new Request("https://test.example", {
+      headers: {
+        "x-platform-service-key": "test-secret-key-abc",
+        "x-platform-actor-id": "cap-stable-actor-001",
+      },
+    });
+
+    const result = await authenticateRequest(req);
+
+    expect(result.kind).toBe("service");
+    if (result.kind === "service") {
+      expect(result.actorId).toBe("cap-stable-actor-001");
+    }
+  });
+
+  it("returns kind=deny when api key is wrong", async () => {
+    const req = new Request("https://test.example", {
+      headers: {
+        "x-platform-service-key": "wrong-key",
+        "x-platform-actor-id": "cap-actor",
+      },
+    });
+
+    const result = await authenticateRequest(req);
+    expect(result.kind).toBe("deny");
+  });
+
+  it("returns kind=deny when actor id header is missing", async () => {
+    const req = new Request("https://test.example", {
+      headers: { "x-platform-service-key": "test-secret-key-abc" },
+    });
+
+    const result = await authenticateRequest(req);
+    expect(result.kind).toBe("deny");
+  });
+
+  it("returns kind=deny when PLATFORM_SERVICE_API_KEY env var is not set", async () => {
+    delete process.env.PLATFORM_SERVICE_API_KEY;
+
+    const req = new Request("https://test.example", {
+      headers: {
+        "x-platform-service-key": "any-key",
+        "x-platform-actor-id": "cap-actor",
+      },
+    });
+
+    const result = await authenticateRequest(req);
+    expect(result.kind).toBe("deny");
+  });
+});
+
+describe("authenticateRequest — session path", () => {
+  it("returns kind=user when session is valid", async () => {
+    mockRouteClient.auth.getUser.mockResolvedValue({
+      data: { user: { id: "user-uuid-123" } },
+      error: null,
+    });
+
+    const req = new Request("https://test.example");
+    const result = await authenticateRequest(req);
+
+    expect(result.kind).toBe("user");
+    if (result.kind === "user") {
+      expect(result.userId).toBe("user-uuid-123");
+    }
+  });
+
+  it("returns kind=deny when session is missing", async () => {
+    mockRouteClient.auth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: null,
+    });
+
+    const req = new Request("https://test.example");
+    const result = await authenticateRequest(req);
+    expect(result.kind).toBe("deny");
+  });
+
+  it("returns kind=deny when getUser returns an error", async () => {
+    mockRouteClient.auth.getUser.mockResolvedValue({
+      data: {},
+      error: new Error("auth error"),
+    });
+
+    const req = new Request("https://test.example");
+    const result = await authenticateRequest(req);
+    expect(result.kind).toBe("deny");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateServiceActorCompany
+// ---------------------------------------------------------------------------
+
+describe("validateServiceActorCompany", () => {
+  function mockFrom(returnData: unknown) {
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: returnData, error: null }),
+    };
+    mockSvcClient.from.mockReturnValue(chain);
+    return chain;
+  }
+
+  it("returns ok=true when cap_weekly_enabled is true", async () => {
+    mockFrom({ cap_weekly_enabled: true });
+    const result = await validateServiceActorCompany("company-uuid-1");
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok=false when cap_weekly_enabled is false", async () => {
+    mockFrom({ cap_weekly_enabled: false });
+    const result = await validateServiceActorCompany("company-uuid-1");
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns ok=false when company not found", async () => {
+    mockFrom(null);
+    const result = await validateServiceActorCompany("nonexistent-uuid");
+    expect(result.ok).toBe(false);
+  });
+});

--- a/lib/platform/auth/service-auth.ts
+++ b/lib/platform/auth/service-auth.ts
@@ -1,0 +1,102 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { createRouteAuthClient } from "@/lib/auth";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// Spec v1.0 §2.2 — service-role API authentication for machine actors.
+//
+// Two accepted auth paths:
+//   1. x-platform-service-key header — for CAP and other machine actors.
+//      Must also supply x-platform-actor-id (CAP's stable identifier).
+//   2. Supabase auth session (cookie) — for human users (unchanged path).
+//
+// PLATFORM_SERVICE_API_KEY must be set in the target environment.
+// Generate: openssl rand -base64 32
+// ---------------------------------------------------------------------------
+
+export type ServiceAuthResult =
+  | { kind: "service"; actorId: string }
+  | { kind: "user"; userId: string; supabase: SupabaseClient }
+  | { kind: "deny"; response: NextResponse };
+
+function deny(code: string, message: string, status: 401 | 403): NextResponse {
+  return NextResponse.json(
+    { ok: false, error: { code, message, retryable: false }, timestamp: new Date().toISOString() },
+    { status },
+  );
+}
+
+/**
+ * Authenticate a platform API request: service key OR user session.
+ * Use in place of requireCanDoForApi for routes that accept machine actors.
+ */
+export async function authenticateRequest(req: Request): Promise<ServiceAuthResult> {
+  const apiKey = req.headers.get("x-platform-service-key");
+
+  if (apiKey !== null) {
+    const expected = process.env.PLATFORM_SERVICE_API_KEY;
+    if (!expected || apiKey !== expected) {
+      return { kind: "deny", response: deny("UNAUTHORIZED", "Invalid service API key.", 401) };
+    }
+    const actorId = req.headers.get("x-platform-actor-id");
+    if (!actorId) {
+      return {
+        kind: "deny",
+        response: deny("UNAUTHORIZED", "Service-key requests must set x-platform-actor-id.", 401),
+      };
+    }
+    return { kind: "service", actorId };
+  }
+
+  const supabase = createRouteAuthClient();
+  const { data: userResp, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userResp?.user) {
+    return { kind: "deny", response: deny("UNAUTHORIZED", "Authentication required.", 401) };
+  }
+  return { kind: "user", userId: userResp.user.id, supabase };
+}
+
+/**
+ * Gate for service actors: company must have cap_weekly_enabled = true.
+ * Returns ok = true when the actor is permitted to act on this company.
+ */
+export async function validateServiceActorCompany(
+  companyId: string,
+): Promise<{ ok: true } | { ok: false; response: NextResponse }> {
+  const svc = getServiceRoleClient();
+  const { data } = await svc
+    .from("platform_companies")
+    .select("cap_weekly_enabled")
+    .eq("id", companyId)
+    .maybeSingle();
+
+  if (!data?.cap_weekly_enabled) {
+    return {
+      ok: false,
+      response: deny("FORBIDDEN", "Service actors may only act on companies with cap_weekly_enabled.", 403),
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Record a service_action_taken event in platform_events (fire-and-forget).
+ * The actorId is stored in payload.service_actor_id because platform_events.actor_id
+ * is a FK to platform_users — machine actors are not platform_users rows.
+ */
+export function recordServiceAction(
+  companyId: string,
+  actorId: string,
+  payload?: Record<string, unknown>,
+): void {
+  const svc = getServiceRoleClient();
+  void svc.from("platform_events").insert({
+    company_id: companyId,
+    event_type: "service_action_taken",
+    payload: { service_actor_id: actorId, ...payload },
+  });
+}

--- a/lib/platform/social/drafts.ts
+++ b/lib/platform/social/drafts.ts
@@ -64,18 +64,38 @@ export type Draft = {
 export async function createDraft(params: {
   companyId: string;
   userId: string;
+  idempotencyKey?: string;
 }): Promise<ApiResponse<Draft>> {
   const client = getServiceRoleClient();
 
+  // When an idempotency_key is supplied, return the existing draft if one
+  // already exists for (company_id, idempotency_key) — CAP retry safety.
+  if (params.idempotencyKey) {
+    const { data: existing } = await client
+      .from("social_post_drafts")
+      .select()
+      .eq("company_id", params.companyId)
+      .eq("idempotency_key", params.idempotencyKey)
+      .is("archived_at", null)
+      .maybeSingle();
+
+    if (existing) {
+      return { ok: true, data: existing as unknown as Draft, timestamp: new Date().toISOString() };
+    }
+  }
+
+  const insertRow: Record<string, unknown> = {
+    company_id: params.companyId,
+    created_by: params.userId,
+    updated_by: params.userId,
+    draft_version: 1,
+    draft_data: DraftDataSchema.parse({}),
+  };
+  if (params.idempotencyKey) insertRow.idempotency_key = params.idempotencyKey;
+
   const { data, error } = await client
     .from("social_post_drafts")
-    .insert({
-      company_id: params.companyId,
-      created_by: params.userId,
-      updated_by: params.userId,
-      draft_version: 1,
-      draft_data: DraftDataSchema.parse({}),
-    })
+    .insert(insertRow)
     .select()
     .single();
 

--- a/lib/platform/social/publishing/dispatch-webhooks.ts
+++ b/lib/platform/social/publishing/dispatch-webhooks.ts
@@ -1,0 +1,282 @@
+import "server-only";
+
+import crypto from "crypto";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { ApiResponse } from "@/lib/tool-schemas";
+
+// ---------------------------------------------------------------------------
+// Spec v1.0 §2.3 — outbound webhook dispatcher.
+//
+// Runs from /api/cron/dispatch-webhooks every minute (Vercel cron minimum;
+// spec says 30 s but sub-minute cron is not available on Vercel).
+//
+// Claims up to 50 pending platform_event_deliveries, POSTs each to the
+// subscriber's webhook_url, and updates delivery status accordingly.
+//
+// Backoff schedule (attempt_count → delay):
+//   0 → 0 s (immediate first delivery, from the fan-out trigger)
+//   1 → 30 s
+//   2 → 5 min
+//   3 → 30 min
+//   4 → 2 h
+//   5 → 12 h
+//   6+ → dead_lettered (24 h is what would have been attempt 6)
+//
+// After 6 failed attempts the delivery is dead-lettered and
+// subscription.consecutive_failures is incremented. After 10 consecutive
+// failures the subscription is marked inactive and a subscription_disabled
+// event is emitted.
+// ---------------------------------------------------------------------------
+
+const BATCH_SIZE = 50;
+const CLAIM_TTL_SECONDS = 30;
+const WEBHOOK_TIMEOUT_MS = 10_000;
+const MAX_ATTEMPTS = 6;
+const MAX_CONSECUTIVE_FAILURES = 10;
+
+const BACKOFF_SECONDS = [0, 30, 300, 1800, 7200, 43200];
+
+export type DispatchResult = {
+  examined: number;
+  delivered: number;
+  retried: number;
+  deadLettered: number;
+  errors: number;
+};
+
+function nextAttemptAt(attemptCount: number): Date {
+  const delay = BACKOFF_SECONDS[attemptCount] ?? BACKOFF_SECONDS[BACKOFF_SECONDS.length - 1];
+  return new Date(Date.now() + delay * 1000);
+}
+
+function signBody(body: string, secret: string): string {
+  return (
+    "sha256=" +
+    crypto.createHmac("sha256", secret).update(body).digest("hex")
+  );
+}
+
+export async function dispatchWebhooks(): Promise<ApiResponse<DispatchResult>> {
+  const svc = getServiceRoleClient();
+  const now = new Date().toISOString();
+
+  // Fetch up to BATCH_SIZE pending deliveries.
+  const { data: pending, error: fetchErr } = await svc
+    .from("platform_event_deliveries")
+    .select(
+      "id, subscription_id, event_id, attempt_count",
+    )
+    .eq("status", "pending")
+    .lte("next_attempt_at", now)
+    .order("next_attempt_at", { ascending: true })
+    .limit(BATCH_SIZE);
+
+  if (fetchErr) {
+    logger.error("dispatch_webhooks.fetch_failed", { err: fetchErr.message });
+    return {
+      ok: false,
+      error: { code: "INTERNAL_ERROR", message: fetchErr.message, retryable: true, suggested_action: "Retry." },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  const rows = pending ?? [];
+  let delivered = 0;
+  let retried = 0;
+  let deadLettered = 0;
+  let errors = 0;
+
+  for (const row of rows) {
+    const deliveryId = row.id as string;
+    const subscriptionId = row.subscription_id as string;
+    const eventId = row.event_id as string;
+    const attemptCount = (row.attempt_count as number) ?? 0;
+
+    // Claim the delivery atomically.
+    const claimedUntil = new Date(Date.now() + CLAIM_TTL_SECONDS * 1000).toISOString();
+    const { error: claimErr } = await svc
+      .from("platform_event_deliveries")
+      .update({ status: "in_flight", claimed_until: claimedUntil })
+      .eq("id", deliveryId)
+      .eq("status", "pending");
+
+    if (claimErr) {
+      // Another worker claimed this delivery; skip.
+      continue;
+    }
+
+    // Look up subscription and event in parallel.
+    const [subRes, evtRes] = await Promise.all([
+      svc
+        .from("platform_event_subscriptions")
+        .select("webhook_url, signing_secret, consecutive_failures, active")
+        .eq("id", subscriptionId)
+        .maybeSingle(),
+      svc
+        .from("platform_events")
+        .select("event_type, company_id, payload, created_at")
+        .eq("id", eventId)
+        .maybeSingle(),
+    ]);
+
+    if (subRes.error || !subRes.data || !subRes.data.active) {
+      // Subscription gone or inactive — dead-letter silently.
+      await svc
+        .from("platform_event_deliveries")
+        .update({ status: "dead_lettered", dead_lettered_at: new Date().toISOString() })
+        .eq("id", deliveryId);
+      deadLettered++;
+      continue;
+    }
+
+    if (evtRes.error || !evtRes.data) {
+      // Event gone — dead-letter.
+      await svc
+        .from("platform_event_deliveries")
+        .update({ status: "dead_lettered", dead_lettered_at: new Date().toISOString() })
+        .eq("id", deliveryId);
+      deadLettered++;
+      continue;
+    }
+
+    const sub = subRes.data;
+    const evt = evtRes.data;
+
+    // Build webhook payload.
+    const webhookBody = JSON.stringify({
+      event_id: eventId,
+      event_type: evt.event_type,
+      company_id: evt.company_id,
+      payload: evt.payload,
+      created_at: evt.created_at,
+    });
+    const signature = signBody(webhookBody, sub.signing_secret as string);
+
+    // Attempt delivery.
+    let responseStatus: number | null = null;
+    let responseBody: string | null = null;
+    let success = false;
+
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), WEBHOOK_TIMEOUT_MS);
+      try {
+        const res = await fetch(sub.webhook_url as string, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Opollo-Signature": signature,
+            "X-Opollo-Event-Id": eventId,
+          },
+          body: webhookBody,
+          signal: controller.signal,
+        });
+        responseStatus = res.status;
+        responseBody = await res.text().catch(() => null);
+        success = res.status >= 200 && res.status < 300;
+      } finally {
+        clearTimeout(timeout);
+      }
+    } catch (err) {
+      responseBody = err instanceof Error ? err.message : "fetch error";
+    }
+
+    const nowTs = new Date().toISOString();
+
+    if (success) {
+      await svc
+        .from("platform_event_deliveries")
+        .update({
+          status: "delivered",
+          delivered_at: nowTs,
+          attempt_count: attemptCount + 1,
+          last_response_status: responseStatus,
+          last_response_body: responseBody,
+          claimed_until: null,
+        })
+        .eq("id", deliveryId);
+
+      // Reset consecutive failure counter.
+      await svc
+        .from("platform_event_subscriptions")
+        .update({ consecutive_failures: 0, last_delivery_at: nowTs })
+        .eq("id", subscriptionId);
+
+      delivered++;
+    } else {
+      const newAttemptCount = attemptCount + 1;
+
+      if (newAttemptCount >= MAX_ATTEMPTS) {
+        // Dead-letter.
+        await svc
+          .from("platform_event_deliveries")
+          .update({
+            status: "dead_lettered",
+            dead_lettered_at: nowTs,
+            attempt_count: newAttemptCount,
+            last_response_status: responseStatus,
+            last_response_body: responseBody,
+            claimed_until: null,
+          })
+          .eq("id", deliveryId);
+
+        // Increment consecutive_failures on subscription.
+        const newConsecutive = ((sub.consecutive_failures as number) ?? 0) + 1;
+        const subUpdate: Record<string, unknown> = { consecutive_failures: newConsecutive };
+
+        if (newConsecutive >= MAX_CONSECUTIVE_FAILURES) {
+          subUpdate.active = false;
+          // Emit subscription_disabled event.
+          void svc.from("platform_events").insert({
+            event_type: "subscription_disabled",
+            entity_type: "platform_event_subscription",
+            entity_id: subscriptionId,
+            payload: { consecutive_failures: newConsecutive, last_response_status: responseStatus },
+          });
+          logger.warn("dispatch_webhooks.subscription_disabled", {
+            subscription_id: subscriptionId,
+            consecutive_failures: newConsecutive,
+          });
+        }
+
+        await svc
+          .from("platform_event_subscriptions")
+          .update(subUpdate)
+          .eq("id", subscriptionId);
+
+        deadLettered++;
+      } else {
+        // Schedule retry.
+        await svc
+          .from("platform_event_deliveries")
+          .update({
+            status: "pending",
+            attempt_count: newAttemptCount,
+            next_attempt_at: nextAttemptAt(newAttemptCount).toISOString(),
+            last_response_status: responseStatus,
+            last_response_body: responseBody,
+            claimed_until: null,
+          })
+          .eq("id", deliveryId);
+
+        retried++;
+      }
+
+      logger.warn("dispatch_webhooks.delivery_failed", {
+        delivery_id: deliveryId,
+        subscription_id: subscriptionId,
+        attempt_count: newAttemptCount,
+        response_status: responseStatus,
+      });
+      errors++;
+    }
+  }
+
+  return {
+    ok: true,
+    data: { examined: rows.length, delivered, retried, deadLettered, errors },
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/lib/platform/social/publishing/watchdog.ts
+++ b/lib/platform/social/publishing/watchdog.ts
@@ -6,20 +6,22 @@ import { getServiceRoleClient } from "@/lib/supabase";
 import type { ApiResponse } from "@/lib/tool-schemas";
 
 // ---------------------------------------------------------------------------
-// S1-watchdog — recover in_flight publish attempts that never received a
-// bundle.social webhook.
+// S1-watchdog — recover in_flight publish attempts whose lease has expired.
 //
-// When fireScheduledPublish succeeds the attempt enters 'in_flight'. The
-// webhook handler (S1-17) is expected to flip it to 'succeeded' / 'failed'
-// within seconds. If the webhook is lost or bundle.social never sends it,
-// the attempt stays stuck indefinitely.
+// Spec §2.4: workers set claimed_until when claiming an attempt. If the
+// worker crashes (Vercel timeout, network blip, deploy mid-flight) the lease
+// expires without the attempt being marked succeeded or failed.
 //
-// This watchdog runs every 5 minutes and marks any attempt that has been
-// in_flight for >STUCK_AFTER_MINUTES as 'failed', advances the master state,
-// and fires a post_failed notification so operators are alerted.
+// This watchdog runs every 5 minutes and marks any attempt where
+// claimed_until < now() AND status = 'in_flight' as failed with
+// error_class = 'worker_died', advances master state, and fires a
+// post_failed notification so operators are alerted.
 //
-// Idempotent: the attempt update is predicate-guarded on status='in_flight',
-// so concurrent runs are safe and manual retries are benign.
+// Fallback for pre-0126 rows (claimed_until IS NULL): also catches attempts
+// in_flight for >STUCK_AFTER_MINUTES without a claimed_until column value.
+// This preserves backward compatibility while the deploy propagates.
+//
+// Idempotent: predicate-guarded on status='in_flight'.
 // ---------------------------------------------------------------------------
 
 const STUCK_AFTER_MINUTES = 3;
@@ -34,11 +36,40 @@ export async function runPublishWatchdog(): Promise<ApiResponse<WatchdogResult>>
   const svc = getServiceRoleClient();
   const cutoff = new Date(Date.now() - STUCK_AFTER_MINUTES * 60 * 1000).toISOString();
 
-  const attemptsR = await svc
+  // Expired-lease attempts (post-0126 rows with claimed_until set).
+  const leaseExpiredR = await svc
     .from("social_publish_attempts")
     .select("id, post_variant_id, company_id")
     .eq("status", "in_flight")
-    .lt("started_at", cutoff);
+    .lt("claimed_until", new Date().toISOString())
+    .not("claimed_until", "is", null);
+
+  // Legacy fallback: pre-0126 rows where claimed_until is NULL but started_at is stale.
+  const staleFallbackR = await svc
+    .from("social_publish_attempts")
+    .select("id, post_variant_id, company_id")
+    .eq("status", "in_flight")
+    .lt("started_at", cutoff)
+    .is("claimed_until", null);
+
+  if (leaseExpiredR.error) {
+    logger.error("social.publish.watchdog.query_failed", { err: leaseExpiredR.error.message });
+    return {
+      ok: false,
+      error: {
+        code: "INTERNAL_ERROR",
+        message: `Watchdog query failed: ${leaseExpiredR.error.message}`,
+        retryable: true,
+        suggested_action: "Retry. If persistent, check DB connectivity.",
+      },
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  const attemptsR = {
+    data: [...(leaseExpiredR.data ?? []), ...(staleFallbackR.data ?? [])],
+    error: staleFallbackR.error,
+  };
 
   if (attemptsR.error) {
     logger.error("social.publish.watchdog.query_failed", {
@@ -72,11 +103,13 @@ export async function runPublishWatchdog(): Promise<ApiResponse<WatchdogResult>>
       .from("social_publish_attempts")
       .update({
         status: "failed",
-        error_class: "timeout",
+        error_class: "worker_died",
         error_payload: {
-          reason: `No webhook received after ${STUCK_AFTER_MINUTES} minutes.`,
+          reason: "Worker lease expired without completing publish.",
+          stuck_after_minutes: STUCK_AFTER_MINUTES,
         },
         completed_at: now,
+        claimed_until: null,
       })
       .eq("id", attemptId)
       .eq("status", "in_flight");
@@ -141,8 +174,8 @@ export async function runPublishWatchdog(): Promise<ApiResponse<WatchdogResult>>
         postMasterId: masterId,
         submitterUserId: submitterId,
         platform,
-        errorClass: "timeout",
-        errorMessage: `Publish timed out after ${STUCK_AFTER_MINUTES} minutes — no webhook received.`,
+        errorClass: "worker_died",
+        errorMessage: "Worker lease expired without completing publish.",
       });
     }
 

--- a/vercel.json
+++ b/vercel.json
@@ -77,6 +77,10 @@
       "schedule": "0 11 * * *"
     },
     {
+      "path": "/api/cron/dispatch-webhooks",
+      "schedule": "* * * * *"
+    },
+    {
       "path": "/api/cron/social-publish-backfill",
       "schedule": "*/5 * * * *"
     },


### PR DESCRIPTION
## Summary

Workstream 1-B (stacked on #899 / feat/ws1-a-foundations-schema). Spec v1.0 §2.2–2.4. No schema changes.

- **Service-role API auth (§2.2)**: `lib/platform/auth/service-auth.ts` — `authenticateRequest()` checks `x-platform-service-key` header first, falls back to user session. `validateServiceActorCompany()` gates service actors on `cap_weekly_enabled`. `recordServiceAction()` emits `service_action_taken` to `platform_events` (stores actor ID in `payload.service_actor_id` because `platform_events.actor_id` FKs to `platform_users` — machine actors are not platform_users rows; documented trade-off).
- **Two routes updated**: `POST /api/platform/social/drafts` and `POST /api/platform/social/drafts/[id]/publish` — accept service key; service actors auto-approve on publish.
- **Idempotency on draft creation**: `createDraft()` accepts optional `idempotency_key`; returns existing draft on key collision (CAP retry safety, backed by the UNIQUE index from migration 0126).
- **Webhook dispatcher cron (§2.3)**: `lib/platform/social/publishing/dispatch-webhooks.ts` claims up to 50 pending `platform_event_deliveries`, POSTs each with `X-Opollo-Signature` (HMAC-SHA256), follows backoff [0, 30 s, 5 min, 30 min, 2 h, 12 h], dead-letters after 6 failed attempts, disables subscription after 10 consecutive failures. `app/api/cron/dispatch-webhooks/route.ts` registered in `vercel.json` at `* * * * *` (Vercel minimum; spec says 30 s but sub-minute cron is not available on Vercel — documented).
- **Watchdog explicit lease (§2.4)**: `watchdog.ts` now detects crashed workers via `claimed_until < now()` instead of `started_at` timeout. Legacy fallback for pre-0126 rows. Sets `error_class = 'worker_died'` (new enum value from #899).

## Required env var (Hard Stop #1 — needs Steven)

`PLATFORM_SERVICE_API_KEY` must be added to Vercel production env. Generate:

```
openssl rand -base64 32
```

Vercel path: **Settings → Environment Variables → Production scope**. Until it is set, service-key requests return 401 (existing user sessions unaffected).

## Service actor setup (documentation)

`x-platform-actor-id` must be a UUID that exists in `auth.users` (and ideally `platform_users`) because `social_post_drafts.created_by` FKs to `auth.users`. CAP needs a service user row in both tables. The UUID is CAP's stable identifier — it never changes and is used as the audit trail anchor.

## Working analog

`lib/platform/auth/api-gate.ts:requireCanDoForApi` — service-auth extends that file's shape with a third result kind (`service`) without breaking the existing `user` path.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] `test:unit` — 56 files, 1606 tests, all pass (includes new `service-auth.unit.test.ts`)
- [x] No schema changes — stacks cleanly on WS1-A
- [x] Hard Stop flagged: `PLATFORM_SERVICE_API_KEY` env var required before CAP can use the service auth path

## Risks identified and mitigated

| Hotspot | Mitigation |
|---|---|
| Service key leaks to browser bundle | `service-auth.ts` has `"use server"` (server-only); import is from a server-only path |
| Concurrent webhook dispatchers double-deliver | `claimed_until` lease + status='pending' predicate on claim UPDATE; second worker gets 0 rows affected and skips |
| Watchdog marks a healthy in-flight attempt as dead | Predicate guarded: `claimed_until < now()` only fires when the lease has genuinely expired, not while the worker is extending it |