### PR TITLE
feat(social): composer PR C — shell + primitives + preview + hook

### DIFF
--- a/app/(platform)/social/poster/page.tsx
+++ b/app/(platform)/social/poster/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import { ComposerOverlay } from "@/components/social/composer/ComposerOverlay";
+import { useComposerState } from "@/hooks/use-composer-state";
+
+// ---------------------------------------------------------------------------
+// Social Poster — placeholder dashboard page (PR C).
+// Mounts the ComposerOverlay shell so it can be exercised and tested.
+// Replaced by the real dashboard in PR F.
+// Feature flag: FEATURE_COMPOSER_V2 must be "true".
+// ---------------------------------------------------------------------------
+
+const FEATURE_ON = process.env.NEXT_PUBLIC_FEATURE_COMPOSER_V2 === "true";
+
+export default function SocialPosterPage() {
+  const { composerState, openComposer, discardChanges, cancelClose } =
+    useComposerState();
+
+  if (!FEATURE_ON) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        FEATURE_COMPOSER_V2 is not enabled.
+      </div>
+    );
+  }
+
+  return (
+    <main className="flex h-full flex-col items-center justify-center gap-4">
+      <h1 className="text-lg font-semibold">Social Poster (Composer V2)</h1>
+      <p className="text-sm text-muted-foreground">
+        Dashboard coming in PR F. Open the composer to preview the shell.
+      </p>
+      <button
+        type="button"
+        onClick={() => openComposer()}
+        className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+      >
+        Open composer
+      </button>
+
+      <ComposerOverlay
+        open={composerState.open}
+        onClose={() => {
+          if (composerState.dirty && !composerState.pendingClose) {
+            // Trigger pending-close path in the hook
+            openComposer(); // no-op shape — overlay handles dirty state via pendingClose
+          }
+          discardChanges();
+        }}
+        initialDraft={composerState.draft}
+        prefilledDate={composerState.prefilledDate}
+        availableConnections={[]}
+      />
+    </main>
+  );
+}

--- a/components/__tests__/ComposerPrimitives.test.tsx
+++ b/components/__tests__/ComposerPrimitives.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import * as React from "react";
+
+import { Callout } from "@/components/ui/callout";
+import { SectionHeader } from "@/components/ui/section-header";
+import { Pagination } from "@/components/ui/pagination";
+
+// ---------------------------------------------------------------------------
+// Callout
+// ---------------------------------------------------------------------------
+
+describe("Callout", () => {
+  it("renders title", () => {
+    render(<Callout title="Heads up" />);
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.getByText("Heads up")).toBeTruthy();
+  });
+
+  it("renders body when provided", () => {
+    render(<Callout title="T" body="Some detail" />);
+    expect(screen.getByText("Some detail")).toBeTruthy();
+  });
+
+  it("renders CTA button when provided", () => {
+    const onClick = vi.fn();
+    render(<Callout title="T" cta={{ label: "Act now", onClick }} />);
+    const btn = screen.getByRole("button", { name: "Act now" });
+    expect(btn).toBeTruthy();
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders dismiss button when onDismiss provided", () => {
+    const onDismiss = vi.fn();
+    render(<Callout title="T" onDismiss={onDismiss} />);
+    const btn = screen.getByRole("button", { name: /dismiss/i });
+    fireEvent.click(btn);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render dismiss button when onDismiss is absent", () => {
+    render(<Callout title="T" />);
+    expect(screen.queryByRole("button", { name: /dismiss/i })).toBeNull();
+  });
+
+  it("applies info variant classes", () => {
+    const { container } = render(<Callout title="T" variant="info" />);
+    expect((container.firstChild as HTMLElement).className).toContain("bg-blue-50");
+  });
+
+  it("applies warning variant classes", () => {
+    const { container } = render(<Callout title="T" variant="warning" />);
+    expect((container.firstChild as HTMLElement).className).toContain("bg-amber-50");
+  });
+
+  it("applies helpful variant classes", () => {
+    const { container } = render(<Callout title="T" variant="helpful" />);
+    expect((container.firstChild as HTMLElement).className).toContain("bg-yellow-50");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SectionHeader
+// ---------------------------------------------------------------------------
+
+describe("SectionHeader", () => {
+  it("renders the title", () => {
+    render(<SectionHeader title="My section" />);
+    expect(screen.getByText("My section")).toBeTruthy();
+  });
+
+  it("renders subtitle when provided", () => {
+    render(<SectionHeader title="T" subtitle="Subtitle text" />);
+    expect(screen.getByText("Subtitle text")).toBeTruthy();
+  });
+
+  it("renders actions slot", () => {
+    render(<SectionHeader title="T" actions={<button>New</button>} />);
+    expect(screen.getByRole("button", { name: "New" })).toBeTruthy();
+  });
+
+  it("does not render subtitle when absent", () => {
+    render(<SectionHeader title="T" />);
+    expect(screen.queryByRole("paragraph")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pagination
+// ---------------------------------------------------------------------------
+
+describe("Pagination", () => {
+  it("renders previous and next buttons with accessible labels", () => {
+    render(
+      <Pagination total={100} page={2} pageSize={10} onPageChange={() => undefined} />,
+    );
+    expect(screen.getByRole("button", { name: /previous page/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /next page/i })).toBeTruthy();
+  });
+
+  it("prev is disabled on page 1", () => {
+    render(
+      <Pagination total={50} page={1} pageSize={10} onPageChange={() => undefined} />,
+    );
+    expect(screen.getByRole("button", { name: /previous page/i }).getAttribute("disabled")).toBeDefined();
+  });
+
+  it("next is disabled on last page", () => {
+    render(
+      <Pagination total={20} page={2} pageSize={10} onPageChange={() => undefined} />,
+    );
+    expect(screen.getByRole("button", { name: /next page/i }).getAttribute("disabled")).toBeDefined();
+  });
+
+  it("calls onPageChange with next page on next click", () => {
+    const onChange = vi.fn();
+    render(<Pagination total={50} page={1} pageSize={10} onPageChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /next page/i }));
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+
+  it("calls onPageChange with prev page on prev click", () => {
+    const onChange = vi.fn();
+    render(<Pagination total={50} page={3} pageSize={10} onPageChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /previous page/i }));
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+
+  it("wraps in nav with aria-label Pagination", () => {
+    const { container } = render(
+      <Pagination total={10} page={1} pageSize={10} onPageChange={() => undefined} />,
+    );
+    const nav = container.querySelector("nav");
+    expect(nav?.getAttribute("aria-label")).toBe("Pagination");
+  });
+
+  it("shows correct range text", () => {
+    render(
+      <Pagination total={35} page={2} pageSize={10} onPageChange={() => undefined} />,
+    );
+    expect(screen.getByText("11–20 of 35")).toBeTruthy();
+  });
+
+  it("shows 'No results' when total is 0", () => {
+    render(
+      <Pagination total={0} page={1} pageSize={10} onPageChange={() => undefined} />,
+    );
+    expect(screen.getByText("No results")).toBeTruthy();
+  });
+});

--- a/components/__tests__/ComposerState.test.ts
+++ b/components/__tests__/ComposerState.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useComposerState } from "@/hooks/use-composer-state";
+
+describe("useComposerState", () => {
+  test("starts closed with empty draft", () => {
+    const { result } = renderHook(() => useComposerState());
+    expect(result.current.composerState.open).toBe(false);
+    expect(result.current.composerState.dirty).toBe(false);
+    expect(result.current.composerState.draft.content).toBe("");
+  });
+
+  test("openComposer sets open=true and dirty=false", () => {
+    const { result } = renderHook(() => useComposerState());
+    act(() => result.current.openComposer());
+    expect(result.current.composerState.open).toBe(true);
+    expect(result.current.composerState.dirty).toBe(false);
+  });
+
+  test("openComposer accepts initialDraft and prefilledDate", () => {
+    const { result } = renderHook(() => useComposerState());
+    const draft = {
+      content: "Hello",
+      media_urls: [],
+      target_profile_ids: ["p1"],
+      platform_variants: {},
+      approval_required: false,
+    };
+    const date = new Date("2026-05-21");
+    act(() => result.current.openComposer({ initialDraft: draft, prefilledDate: date }));
+    expect(result.current.composerState.draft.content).toBe("Hello");
+    expect(result.current.composerState.prefilledDate?.toISOString()).toBe(date.toISOString());
+  });
+
+  test("updateDraft sets dirty=true and merges patch", () => {
+    const { result } = renderHook(() => useComposerState());
+    act(() => result.current.openComposer());
+    act(() => result.current.updateDraft({ content: "Updated" }));
+    expect(result.current.composerState.dirty).toBe(true);
+    expect(result.current.composerState.draft.content).toBe("Updated");
+  });
+
+  test("discardChanges resets to closed + clean", () => {
+    const { result } = renderHook(() => useComposerState());
+    act(() => result.current.openComposer());
+    act(() => result.current.updateDraft({ content: "x" }));
+    act(() => result.current.discardChanges());
+    expect(result.current.composerState.open).toBe(false);
+    expect(result.current.composerState.dirty).toBe(false);
+    expect(result.current.composerState.draft.content).toBe("");
+  });
+
+  test("closing with dirty draft sets pendingClose instead of closing", () => {
+    const { result } = renderHook(() => useComposerState());
+    act(() => result.current.openComposer());
+    act(() => result.current.updateDraft({ content: "dirty" }));
+    act(() => result.current.setComposerState({ open: false }));
+    expect(result.current.composerState.open).toBe(true);
+    expect(result.current.composerState.pendingClose).toBe(true);
+  });
+
+  test("cancelClose clears pendingClose without closing", () => {
+    const { result } = renderHook(() => useComposerState());
+    act(() => result.current.openComposer());
+    act(() => result.current.updateDraft({ content: "dirty" }));
+    act(() => result.current.setComposerState({ open: false }));
+    act(() => result.current.cancelClose());
+    expect(result.current.composerState.pendingClose).toBe(false);
+    expect(result.current.composerState.open).toBe(true);
+  });
+
+  test("closing without dirty draft closes immediately", () => {
+    const { result } = renderHook(() => useComposerState());
+    act(() => result.current.openComposer());
+    act(() => result.current.setComposerState({ open: false }));
+    expect(result.current.composerState.open).toBe(false);
+    expect(result.current.composerState.pendingClose).toBe(false);
+  });
+});

--- a/components/social/composer/ComposerOverlay.tsx
+++ b/components/social/composer/ComposerOverlay.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { ProfileSelector } from "@/components/social/composer/ProfileSelector";
+import { PreviewCard } from "@/components/social/composer/PreviewCard";
+import { MiniCalendar } from "@/components/social/composer/MiniCalendar";
+import { EmptyState } from "@/components/ui/empty-state";
+import type { Connection, Draft } from "@/lib/social/types";
+
+// ---------------------------------------------------------------------------
+// ComposerOverlay — split-pane shell (PR C).
+//
+// Left pane: profile selector + slots for ContentEditor, SchedulingCard,
+//   submit row (PR D fills those slots).
+// Right pane: preview / calendar tabs.
+//
+// PR C builds the shell + profile chips + preview + mini calendar.
+// Scheduling, content editing, and form submission are wired in PR D.
+// ---------------------------------------------------------------------------
+
+export interface ComposerOverlayProps {
+  open: boolean;
+  onClose: () => void;
+  initialDraft?: Draft;
+  prefilledDate?: Date;
+  /** All connections available to select for this company. */
+  availableConnections?: Connection[];
+  /** Slot for content editor (PR D). When absent, shows placeholder. */
+  editorSlot?: React.ReactNode;
+  /** Slot for scheduling card + submit row (PR D). */
+  schedulingSlot?: React.ReactNode;
+}
+
+type PreviewTab = "preview" | "calendar";
+
+export function ComposerOverlay({
+  open,
+  onClose,
+  initialDraft,
+  prefilledDate,
+  availableConnections = [],
+  editorSlot,
+  schedulingSlot,
+}: ComposerOverlayProps) {
+  const [selectedIds, setSelectedIds] = React.useState<string[]>(
+    initialDraft?.target_profile_ids ?? [],
+  );
+  const [previewTab, setPreviewTab] = React.useState<PreviewTab>("preview");
+  const [activePreviewIndex, setActivePreviewIndex] = React.useState(0);
+
+  // Reset state whenever the overlay opens with new content.
+  React.useEffect(() => {
+    if (open) {
+      setSelectedIds(initialDraft?.target_profile_ids ?? []);
+      setPreviewTab("preview");
+      setActivePreviewIndex(0);
+    }
+  }, [open, initialDraft]);
+
+  // Advance preview to the next selected connection.
+  const selectedConnections = availableConnections.filter((c) =>
+    selectedIds.includes(c.id),
+  );
+  const previewConnection = selectedConnections[activePreviewIndex] ?? null;
+
+  // Close on Escape
+  React.useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col bg-background"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Compose post"
+    >
+      {/* ---------------------------------------------------------------- */}
+      {/* Two-pane layout                                                   */}
+      {/* ---------------------------------------------------------------- */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Left pane — editor */}
+        <div className="relative flex w-full flex-col overflow-y-auto border-r border-border md:w-[560px] lg:w-[600px]">
+          {/* Header row */}
+          <div className="flex items-center justify-between border-b border-border px-6 py-4">
+            <h2 className="text-base font-semibold text-foreground">
+              {initialDraft?.id ? "Edit post" : "New post"}
+            </h2>
+            <button
+              type="button"
+              aria-label="Close composer"
+              onClick={onClose}
+              className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <div className="flex flex-1 flex-col gap-5 px-6 py-5">
+            {/* Profile selector */}
+            <ProfileSelector
+              available={availableConnections}
+              selected={selectedIds}
+              onChange={(ids) => {
+                setSelectedIds(ids);
+                setActivePreviewIndex(0);
+              }}
+            />
+
+            {/* Content editor slot (PR D) */}
+            {editorSlot ?? (
+              <div className="flex h-40 items-center justify-center rounded-xl border border-dashed border-border text-sm text-muted-foreground">
+                Content editor loads in PR D
+              </div>
+            )}
+
+            {/* Scheduling + submit slot (PR D) */}
+            {schedulingSlot}
+          </div>
+        </div>
+
+        {/* Right pane — preview / calendar */}
+        <div className="hidden flex-1 flex-col overflow-y-auto bg-muted/30 md:flex">
+          {/* Tab bar */}
+          <div className="flex items-center gap-1 border-b border-border bg-background px-6 py-3">
+            {(["preview", "calendar"] as PreviewTab[]).map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                onClick={() => setPreviewTab(tab)}
+                className={cn(
+                  "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                  previewTab === tab
+                    ? "bg-muted text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {tab === "preview" ? "Post preview" : "Calendar"}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-6 py-5">
+            {previewTab === "preview" ? (
+              <>
+                {previewConnection ? (
+                  <>
+                    {/* Per-connection switcher when multiple are selected */}
+                    {selectedConnections.length > 1 && (
+                      <div className="mb-3 flex flex-wrap gap-1.5">
+                        {selectedConnections.map((c, i) => (
+                          <button
+                            key={c.id}
+                            type="button"
+                            onClick={() => setActivePreviewIndex(i)}
+                            className={cn(
+                              "rounded-md px-2 py-1 text-xs font-medium transition-colors",
+                              i === activePreviewIndex
+                                ? "bg-primary text-primary-foreground"
+                                : "bg-muted text-muted-foreground hover:text-foreground",
+                            )}
+                          >
+                            {c.account_name}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                    <PreviewCard
+                      platform={previewConnection.platform}
+                      content={initialDraft?.content ?? ""}
+                      mediaUrls={initialDraft?.media_urls ?? []}
+                      connection={previewConnection}
+                    />
+                  </>
+                ) : (
+                  <EmptyState
+                    icon={
+                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                        <rect width="18" height="18" x="3" y="3" rx="2" />
+                        <circle cx="9" cy="9" r="2" />
+                        <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
+                      </svg>
+                    }
+                    title="Select a profile to preview"
+                    body="Pick at least one social profile above. Your post will render here exactly as it will appear when published."
+                  />
+                )}
+              </>
+            ) : (
+              <MiniCalendar
+                selectedDate={prefilledDate}
+                className="mx-auto max-w-xs"
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/social/composer/MiniCalendar.tsx
+++ b/components/social/composer/MiniCalendar.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// MiniCalendar — compact month grid shown in the composer right-pane
+// "Calendar" tab. Highlights dates that have scheduled posts.
+// ---------------------------------------------------------------------------
+
+export interface MiniCalendarProps {
+  /** Currently selected / targeted date. */
+  selectedDate?: Date;
+  /** Dates with scheduled posts. */
+  scheduledDates?: Date[];
+  onDateSelect?: (date: Date) => void;
+  className?: string;
+}
+
+const DAY_LABELS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+function isSameDay(a: Date, b: Date) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function buildGrid(year: number, month: number): Array<Date | null> {
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const cells: Array<Date | null> = Array.from({ length: firstDay }, () => null);
+  for (let d = 1; d <= daysInMonth; d++) {
+    cells.push(new Date(year, month, d));
+  }
+  // Pad to full weeks
+  while (cells.length % 7 !== 0) cells.push(null);
+  return cells;
+}
+
+export function MiniCalendar({
+  selectedDate,
+  scheduledDates = [],
+  onDateSelect,
+  className,
+}: MiniCalendarProps) {
+  const today = new Date();
+  const [viewYear, setViewYear] = React.useState(
+    selectedDate?.getFullYear() ?? today.getFullYear(),
+  );
+  const [viewMonth, setViewMonth] = React.useState(
+    selectedDate?.getMonth() ?? today.getMonth(),
+  );
+
+  const cells = buildGrid(viewYear, viewMonth);
+
+  function prevMonth() {
+    if (viewMonth === 0) {
+      setViewYear((y) => y - 1);
+      setViewMonth(11);
+    } else {
+      setViewMonth((m) => m - 1);
+    }
+  }
+
+  function nextMonth() {
+    if (viewMonth === 11) {
+      setViewYear((y) => y + 1);
+      setViewMonth(0);
+    } else {
+      setViewMonth((m) => m + 1);
+    }
+  }
+
+  return (
+    <div className={cn("select-none rounded-xl border border-border bg-white p-4", className)}>
+      {/* Header */}
+      <div className="mb-3 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={prevMonth}
+          aria-label="Previous month"
+          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted transition-colors"
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+        </button>
+        <p className="text-sm font-semibold">
+          {MONTH_NAMES[viewMonth]} {viewYear}
+        </p>
+        <button
+          type="button"
+          onClick={nextMonth}
+          aria-label="Next month"
+          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted transition-colors"
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Day-of-week headers */}
+      <div className="mb-1 grid grid-cols-7 gap-0.5">
+        {DAY_LABELS.map((d) => (
+          <div key={d} className="text-center text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* Date cells */}
+      <div className="grid grid-cols-7 gap-0.5">
+        {cells.map((date, i) => {
+          if (!date) {
+            return <div key={`empty-${i}`} />;
+          }
+          const isToday = isSameDay(date, today);
+          const isSelected = selectedDate ? isSameDay(date, selectedDate) : false;
+          const hasPost = scheduledDates.some((d) => isSameDay(d, date));
+          const isPast = date < today && !isToday;
+
+          return (
+            <button
+              key={date.toISOString()}
+              type="button"
+              onClick={() => onDateSelect?.(date)}
+              aria-label={date.toLocaleDateString("en-AU", { weekday: "long", year: "numeric", month: "long", day: "numeric" })}
+              className={cn(
+                "relative flex h-7 w-full items-center justify-center rounded text-xs transition-colors",
+                isSelected
+                  ? "bg-primary text-primary-foreground font-semibold"
+                  : isToday
+                  ? "border border-primary text-primary font-semibold"
+                  : isPast
+                  ? "text-muted-foreground/50"
+                  : "hover:bg-muted",
+              )}
+            >
+              {date.getDate()}
+              {hasPost && !isSelected && (
+                <span
+                  className="absolute bottom-0.5 left-1/2 -translate-x-1/2 h-1 w-1 rounded-full bg-primary"
+                  aria-hidden
+                />
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/social/composer/PreviewCard.tsx
+++ b/components/social/composer/PreviewCard.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import type { Connection, Platform } from "@/lib/social/types";
+
+// ---------------------------------------------------------------------------
+// PreviewCard — renders post content in the visual style of the target platform.
+// Used in the composer right pane and the post analytics modal (PR H).
+// ---------------------------------------------------------------------------
+
+export interface PreviewCardProps {
+  platform: Platform;
+  content: string;
+  mediaUrls: string[];
+  connection: Connection;
+  className?: string;
+}
+
+const PLATFORM_NAME: Record<Platform, string> = {
+  linkedin: "LinkedIn",
+  facebook: "Facebook",
+  instagram: "Instagram",
+  x: "X (Twitter)",
+  google_business_profile: "Google Business",
+  pinterest: "Pinterest",
+  tiktok: "TikTok",
+};
+
+const PLATFORM_BG: Record<Platform, string> = {
+  linkedin: "#0A66C2",
+  facebook: "#1877F2",
+  instagram: "#DD2A7B",
+  x: "#000000",
+  google_business_profile: "#4584ED",
+  pinterest: "#E60023",
+  tiktok: "#010101",
+};
+
+function AvatarFallback({ name, bg }: { name: string; bg: string }) {
+  const initials = name
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
+  return (
+    <div
+      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-semibold text-white"
+      style={{ backgroundColor: bg }}
+      aria-hidden
+    >
+      {initials || "?"}
+    </div>
+  );
+}
+
+function LinkedInPreview({ content, mediaUrls, connection }: Omit<PreviewCardProps, "platform" | "className">) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-white text-sm shadow-sm">
+      <div className="flex items-start gap-3 p-4">
+        <AvatarFallback name={connection.account_name} bg={PLATFORM_BG.linkedin} />
+        <div className="min-w-0 flex-1">
+          <p className="font-semibold text-gray-900 leading-tight">{connection.account_name}</p>
+          <p className="text-xs text-gray-500">Just now · 🌐</p>
+        </div>
+      </div>
+      <p className="px-4 pb-3 text-gray-800 leading-relaxed whitespace-pre-wrap break-words">
+        {content || <span className="italic text-gray-400">Your post content will appear here.</span>}
+      </p>
+      {mediaUrls[0] && (
+        <div className="border-t">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={mediaUrls[0]} alt="" className="w-full object-cover aspect-[1.91/1]" />
+        </div>
+      )}
+      <div className="flex items-center gap-4 border-t px-4 py-2 text-xs text-gray-500">
+        <span>👍 Like</span>
+        <span>💬 Comment</span>
+        <span>↗ Share</span>
+        <span>✉ Send</span>
+      </div>
+    </div>
+  );
+}
+
+function FacebookPreview({ content, mediaUrls, connection }: Omit<PreviewCardProps, "platform" | "className">) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-white text-sm shadow-sm">
+      <div className="flex items-start gap-3 p-4">
+        <AvatarFallback name={connection.account_name} bg={PLATFORM_BG.facebook} />
+        <div>
+          <p className="font-semibold text-gray-900">{connection.account_name}</p>
+          <p className="text-xs text-gray-500">Just now · 🌐</p>
+        </div>
+      </div>
+      <p className="px-4 pb-3 text-gray-800 whitespace-pre-wrap break-words">
+        {content || <span className="italic text-gray-400">Your post content will appear here.</span>}
+      </p>
+      {mediaUrls[0] && (
+        <div className="border-t">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={mediaUrls[0]} alt="" className="w-full object-cover" />
+        </div>
+      )}
+      <div className="flex items-center gap-4 border-t px-4 py-2 text-xs text-gray-500">
+        <span>👍 Like</span>
+        <span>💬 Comment</span>
+        <span>↗ Share</span>
+      </div>
+    </div>
+  );
+}
+
+function XPreview({ content, mediaUrls, connection }: Omit<PreviewCardProps, "platform" | "className">) {
+  const truncated = content.length > 280 ? content.slice(0, 280) + "…" : content;
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-white text-sm shadow-sm">
+      <div className="flex gap-3 p-4">
+        <AvatarFallback name={connection.account_name} bg={PLATFORM_BG.x} />
+        <div className="min-w-0 flex-1">
+          <p className="font-bold text-gray-900">{connection.account_name}</p>
+          <p className="mt-1 text-gray-800 whitespace-pre-wrap break-words">
+            {truncated || <span className="italic text-gray-400">Your post content will appear here.</span>}
+          </p>
+          {mediaUrls[0] && (
+            <div className="mt-3 overflow-hidden rounded-xl border">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={mediaUrls[0]} alt="" className="w-full object-cover aspect-[16/9]" />
+            </div>
+          )}
+          <div className="mt-2 flex items-center gap-4 text-xs text-gray-500">
+            <span>💬</span>
+            <span>🔁</span>
+            <span>❤️</span>
+            <span>📤</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function InstagramPreview({ content, mediaUrls, connection }: Omit<PreviewCardProps, "platform" | "className">) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-white text-sm shadow-sm">
+      <div className="flex items-center gap-2 p-3 border-b">
+        <AvatarFallback name={connection.account_name} bg={PLATFORM_BG.instagram} />
+        <p className="font-semibold text-gray-900">{connection.account_name}</p>
+      </div>
+      {mediaUrls[0] ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={mediaUrls[0]} alt="" className="w-full object-cover aspect-square" />
+      ) : (
+        <div className="aspect-square bg-muted flex items-center justify-center text-muted-foreground text-xs">No image</div>
+      )}
+      <div className="p-3">
+        <p className="text-gray-800 whitespace-pre-wrap break-words">
+          {content || <span className="italic text-gray-400">Caption will appear here.</span>}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function GenericPreview({ platform, content, mediaUrls, connection }: PreviewCardProps) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-white text-sm shadow-sm">
+      <div className="flex items-start gap-3 p-4">
+        <AvatarFallback name={connection.account_name} bg={PLATFORM_BG[platform]} />
+        <div>
+          <p className="font-semibold text-gray-900">{connection.account_name}</p>
+          <p className="text-xs text-gray-500">{PLATFORM_NAME[platform]}</p>
+        </div>
+      </div>
+      <p className="px-4 pb-4 text-gray-800 whitespace-pre-wrap break-words">
+        {content || <span className="italic text-gray-400">Your post content will appear here.</span>}
+      </p>
+      {mediaUrls[0] && (
+        <div className="border-t">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={mediaUrls[0]} alt="" className="w-full object-cover" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PreviewCard({ platform, content, mediaUrls, connection, className }: PreviewCardProps) {
+  return (
+    <div className={cn("space-y-2", className)}>
+      <p className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        <span
+          className="inline-block h-2 w-2 rounded-full"
+          style={{ backgroundColor: PLATFORM_BG[platform] }}
+          aria-hidden
+        />
+        {PLATFORM_NAME[platform]}
+      </p>
+      {platform === "linkedin" && (
+        <LinkedInPreview content={content} mediaUrls={mediaUrls} connection={connection} />
+      )}
+      {platform === "facebook" && (
+        <FacebookPreview content={content} mediaUrls={mediaUrls} connection={connection} />
+      )}
+      {platform === "x" && (
+        <XPreview content={content} mediaUrls={mediaUrls} connection={connection} />
+      )}
+      {platform === "instagram" && (
+        <InstagramPreview content={content} mediaUrls={mediaUrls} connection={connection} />
+      )}
+      {(platform === "google_business_profile" || platform === "pinterest" || platform === "tiktok") && (
+        <GenericPreview platform={platform} content={content} mediaUrls={mediaUrls} connection={connection} />
+      )}
+    </div>
+  );
+}

--- a/components/social/composer/ProfileSelector.tsx
+++ b/components/social/composer/ProfileSelector.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import type { Connection, Platform } from "@/lib/social/types";
+
+// ---------------------------------------------------------------------------
+// Composer ProfileSelector — chip row + "Add profile" affordance.
+// Controlled component: caller owns selected[] + onChange.
+// ---------------------------------------------------------------------------
+
+export interface ProfileSelectorProps {
+  available: Connection[];
+  selected: string[];
+  onChange: (ids: string[]) => void;
+  className?: string;
+}
+
+// Minimal colour tokens per platform — used for the chip ring when selected.
+const PLATFORM_COLOR: Record<Platform, string> = {
+  linkedin: "#0A66C2",
+  facebook: "#1877F2",
+  instagram: "#DD2A7B",
+  x: "#000000",
+  google_business_profile: "#4584ED",
+  pinterest: "#E60023",
+  tiktok: "#010101",
+};
+
+// Platform SVG icons (22 × 22 viewBox, matching wireframe sprites).
+function PlatformIcon({ platform, size = 22 }: { platform: Platform; size?: number }) {
+  switch (platform) {
+    case "linkedin":
+      return (
+        <svg width={size} height={size} viewBox="0 0 22 22" aria-hidden>
+          <rect width="22" height="22" rx="3" fill="#0A66C2" />
+          <path fill="white" d="M5.5 8.5h2.6v8H5.5zm1.3-3.5a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3zm3.7 3.5h2.5v1.1c.4-.7 1.4-1.4 2.8-1.4 3 0 3.6 2 3.6 4.6v4.7h-2.6v-4.2c0-1 0-2.3-1.4-2.3s-1.6 1.1-1.6 2.2v4.3h-2.5z" />
+        </svg>
+      );
+    case "facebook":
+      return (
+        <svg width={size} height={size} viewBox="0 0 22 22" aria-hidden>
+          <circle cx="11" cy="11" r="11" fill="#1877F2" />
+          <path fill="white" d="M14.9 14l.4-2.9h-2.8V9.1c0-.8.4-1.5 1.6-1.5h1.3V5.1S14.3 4.9 13.2 4.9c-2.3 0-3.8 1.4-3.8 3.9V11H6.9v2.9h2.5V21h3.1v-7h2.4z" />
+        </svg>
+      );
+    case "instagram":
+      return (
+        <svg width={size} height={size} viewBox="0 0 22 22" aria-hidden>
+          <defs>
+            <linearGradient id="ig-composer-grad" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0" stopColor="#F58529" />
+              <stop offset=".3" stopColor="#DD2A7B" />
+              <stop offset=".6" stopColor="#8134AF" />
+              <stop offset="1" stopColor="#515BD4" />
+            </linearGradient>
+          </defs>
+          <rect width="22" height="22" rx="6" fill="url(#ig-composer-grad)" />
+          <rect x="5" y="5" width="12" height="12" rx="4" fill="none" stroke="white" strokeWidth="1.6" />
+          <circle cx="11" cy="11" r="3" fill="none" stroke="white" strokeWidth="1.6" />
+          <circle cx="15.2" cy="6.8" r=".9" fill="white" />
+        </svg>
+      );
+    case "x":
+      return (
+        <svg width={size} height={size} viewBox="0 0 22 22" aria-hidden>
+          <rect width="22" height="22" rx="3" fill="#000" />
+          <path fill="white" d="M14.7 5h2.4l-5.2 5.9 6.1 8.1h-4.7L9.5 14l-4.2 5H3l5.5-6.3L2.7 5H7.5l3.3 4.4L14.7 5z" />
+        </svg>
+      );
+    case "google_business_profile":
+      return (
+        <svg width={size} height={size} viewBox="0 0 22 22" aria-hidden>
+          <rect width="22" height="22" rx="3" fill="#4584ED" />
+          <path fill="white" d="M18.9 10.3h-3.8v1.5h2.2c-.3 1.3-1.4 2.2-2.8 2.2-1.7 0-3-1.4-3-3s1.3-3 3-3c.8 0 1.5.3 2 .8l1.2-1.1c-.9-.9-2-1.4-3.2-1.4-2.5 0-4.6 2-4.6 4.6S11 15.6 13.5 15.6c2.7 0 4.5-1.9 4.5-4.6 0-.2 0-.5-.1-.7z" />
+        </svg>
+      );
+    case "pinterest":
+      return (
+        <svg width={size} height={size} viewBox="0 0 22 22" aria-hidden>
+          <circle cx="11" cy="11" r="11" fill="#E60023" />
+          <path fill="white" d="M11 4C7.1 4 4 7.1 4 11c0 3.1 1.9 5.7 4.6 6.8-.1-.6-.1-1.5.1-2.2l.8-3.3s-.2-.4-.2-1c0-1 .6-1.7 1.3-1.7.6 0 .9.5.9 1 0 .6-.4 1.5-.6 2.3-.2.7.3 1.3 1 1.3 1.2 0 2-1.2 2-3 0-1.6-1.1-2.7-2.8-2.7-1.9 0-3 1.4-3 2.9 0 .6.2 1.2.5 1.5.1.1.1.2.1.3l-.2.8c0 .1-.1.2-.3.1-1.1-.5-1.8-2-1.8-3.2 0-2.6 1.9-5 5.5-5 2.9 0 5.1 2 5.1 4.8 0 2.9-1.8 5.2-4.4 5.2-.9 0-1.7-.5-2-1l-.5 2c-.2.7-.7 1.6-1 2.1.7.2 1.5.3 2.2.3 3.9 0 7-3.1 7-7S14.9 4 11 4z" />
+        </svg>
+      );
+    case "tiktok":
+      return (
+        <svg width={size} height={size} viewBox="0 0 22 22" aria-hidden>
+          <rect width="22" height="22" rx="3" fill="#010101" />
+          <path fill="white" d="M16.5 6.5a3.5 3.5 0 0 1-3.5-3.5h-2.5v9.5a1.5 1.5 0 1 1-1.5-1.5v-2.5a4 4 0 1 0 4 4V9a6 6 0 0 0 3.5 1.1z" />
+        </svg>
+      );
+  }
+}
+
+export function ProfileSelector({ available, selected, onChange, className }: ProfileSelectorProps) {
+  function toggle(id: string) {
+    if (selected.includes(id)) {
+      onChange(selected.filter((x) => x !== id));
+    } else {
+      onChange([...selected, id]);
+    }
+  }
+
+  function deselectAll() {
+    onChange([]);
+  }
+
+  const hasSelected = selected.length > 0;
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>
+      {available.map((conn) => {
+        const isSelected = selected.includes(conn.id);
+        const color = PLATFORM_COLOR[conn.platform];
+        return (
+          <button
+            key={conn.id}
+            type="button"
+            aria-label={conn.account_name}
+            aria-pressed={isSelected}
+            onClick={() => toggle(conn.id)}
+            className={cn(
+              "profile-chip relative flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-all",
+              isSelected
+                ? "ring-2 ring-offset-1"
+                : "opacity-50 hover:opacity-80",
+            )}
+          >
+            <PlatformIcon platform={conn.platform} size={22} />
+            {isSelected && (
+              <span
+                className="absolute inset-0 rounded-full"
+                style={{ boxShadow: `0 0 0 2px white, 0 0 0 4px ${color}` }}
+                aria-hidden
+              />
+            )}
+          </button>
+        );
+      })}
+
+      {/* "Add profile" chip — links to connection settings */}
+      <a
+        href="/company/social/connections"
+        aria-label="Add profile"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-dashed border-muted-foreground/40 text-muted-foreground hover:border-primary hover:text-primary transition-colors"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M12 5v14" />
+          <path d="M5 12h14" />
+        </svg>
+      </a>
+
+      {hasSelected && (
+        <button
+          type="button"
+          onClick={deselectAll}
+          className="ml-1 text-xs text-muted-foreground hover:text-foreground underline"
+        >
+          Deselect all
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/ui/callout.tsx
+++ b/components/ui/callout.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+// ---------------------------------------------------------------------------
+// Callout — D-10. Banner-shape alert variant for the composer + dashboard.
+// Variants: info (blue tint), warning (amber), helpful (yellow / brand).
+// ---------------------------------------------------------------------------
+
+export interface CalloutProps {
+  variant?: "info" | "warning" | "helpful";
+  icon?: React.ReactNode;
+  title: string;
+  body?: string;
+  cta?: { label: string; onClick: () => void };
+  onDismiss?: () => void;
+  className?: string;
+}
+
+const VARIANT_STYLES: Record<NonNullable<CalloutProps["variant"]>, string> = {
+  info:    "bg-blue-50 border-blue-200 text-blue-900",
+  warning: "bg-amber-50 border-amber-200 text-amber-900",
+  helpful: "bg-yellow-50 border-yellow-200 text-yellow-900",
+};
+
+export function Callout({
+  variant = "info",
+  icon,
+  title,
+  body,
+  cta,
+  onDismiss,
+  className,
+}: CalloutProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex items-start gap-3 rounded-xl border p-4",
+        VARIANT_STYLES[variant],
+        className,
+      )}
+    >
+      {icon && <div className="mt-0.5 shrink-0 text-lg leading-none">{icon}</div>}
+      <div className="flex-1 space-y-1">
+        <p className="text-sm font-semibold">{title}</p>
+        {body && <p className="text-sm opacity-80">{body}</p>}
+        {cta && (
+          <Button
+            variant="link"
+            size="sm"
+            className="h-auto p-0 text-sm font-medium underline"
+            onClick={cta.onClick}
+          >
+            {cta.label}
+          </Button>
+        )}
+      </div>
+      {onDismiss && (
+        <button
+          type="button"
+          aria-label="Dismiss"
+          onClick={onDismiss}
+          className="shrink-0 text-current opacity-50 hover:opacity-100 transition-opacity"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+// ---------------------------------------------------------------------------
+// Pagination — D-8. Accessible pagination bar with optional page-size selector.
+// ---------------------------------------------------------------------------
+
+export interface PaginationProps {
+  total: number;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  pageSizeOptions?: number[];
+  onPageSizeChange?: (size: number) => void;
+  className?: string;
+}
+
+const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+export function Pagination({
+  total,
+  page,
+  pageSize,
+  onPageChange,
+  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
+  onPageSizeChange,
+  className,
+}: PaginationProps) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const isPrevDisabled = page <= 1;
+  const isNextDisabled = page >= totalPages;
+
+  const from = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const to = Math.min(page * pageSize, total);
+
+  return (
+    <nav
+      aria-label="Pagination"
+      className={cn("flex flex-wrap items-center justify-between gap-3 text-sm", className)}
+    >
+      <p className="text-muted-foreground">
+        {total === 0 ? "No results" : `${from}–${to} of ${total}`}
+      </p>
+
+      <div className="flex items-center gap-2">
+        {onPageSizeChange && (
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground">Rows</span>
+            <select
+              value={pageSize}
+              onChange={(e) => onPageSizeChange(Number(e.target.value))}
+              aria-label="Rows per page"
+              className="h-8 rounded-md border border-input bg-background px-2 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              {pageSizeOptions.map((size) => (
+                <option key={size} value={size}>
+                  {size}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 px-2"
+          onClick={() => onPageChange(page - 1)}
+          disabled={isPrevDisabled}
+          aria-disabled={isPrevDisabled}
+          aria-label="Previous page"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+        </Button>
+
+        <span className="min-w-[4rem] text-center text-muted-foreground">
+          {page} / {totalPages}
+        </span>
+
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 px-2"
+          onClick={() => onPageChange(page + 1)}
+          disabled={isNextDisabled}
+          aria-disabled={isNextDisabled}
+          aria-label="Next page"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+        </Button>
+      </div>
+    </nav>
+  );
+}

--- a/components/ui/section-header.tsx
+++ b/components/ui/section-header.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// SectionHeader — D-7. Consistent page / section title strip.
+// ---------------------------------------------------------------------------
+
+export interface SectionHeaderProps {
+  title: string;
+  subtitle?: string;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export function SectionHeader({ title, subtitle, actions, className }: SectionHeaderProps) {
+  return (
+    <div className={cn("flex items-start justify-between gap-4", className)}>
+      <div className="min-w-0">
+        <h2 className="text-section-title text-foreground truncate">{title}</h2>
+        {subtitle && (
+          <p className="mt-0.5 text-sm text-muted-foreground">{subtitle}</p>
+        )}
+      </div>
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </div>
+  );
+}

--- a/hooks/use-composer-state.ts
+++ b/hooks/use-composer-state.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import * as React from "react";
+import type { Draft } from "@/lib/social/types";
+
+// ---------------------------------------------------------------------------
+// useComposerState — manages open/closed, draft, dirty flag.
+//
+// Dirty = user has modified the draft content since it was last saved or opened.
+// When setComposerState({ open: false }) is called with dirty === true, the
+// overlay does NOT close immediately — it sets pendingClose=true, allowing the
+// ComposerOverlay to show the UnsavedChangesDialog.
+// ---------------------------------------------------------------------------
+
+export interface ComposerState {
+  open: boolean;
+  draft: Draft;
+  dirty: boolean;
+  /** True while the overlay is trying to close but awaiting the discard/save decision. */
+  pendingClose: boolean;
+  prefilledDate?: Date;
+}
+
+export interface SetComposerStateArg {
+  open?: boolean;
+  draft?: Partial<Draft>;
+  prefilledDate?: Date;
+}
+
+const DEFAULT_DRAFT: Draft = {
+  content: "",
+  media_urls: [],
+  target_profile_ids: [],
+  platform_variants: {},
+  approval_required: false,
+};
+
+export function useComposerState() {
+  const [state, setState] = React.useState<ComposerState>({
+    open: false,
+    draft: DEFAULT_DRAFT,
+    dirty: false,
+    pendingClose: false,
+  });
+
+  const setComposerState = React.useCallback(
+    (arg: SetComposerStateArg) => {
+      setState((prev) => {
+        const nextOpen = arg.open ?? prev.open;
+
+        // Requesting close while dirty → flag pending close instead
+        if (nextOpen === false && prev.open && prev.dirty) {
+          return { ...prev, pendingClose: true };
+        }
+
+        const nextDraft = arg.draft
+          ? { ...prev.draft, ...arg.draft }
+          : prev.draft;
+
+        return {
+          ...prev,
+          open: nextOpen,
+          draft: nextDraft,
+          prefilledDate: arg.prefilledDate ?? prev.prefilledDate,
+          dirty: false,
+          pendingClose: false,
+        };
+      });
+    },
+    [],
+  );
+
+  const updateDraft = React.useCallback((patch: Partial<Draft>) => {
+    setState((prev) => ({
+      ...prev,
+      draft: { ...prev.draft, ...patch },
+      dirty: true,
+    }));
+  }, []);
+
+  const openComposer = React.useCallback(
+    (opts?: { initialDraft?: Draft; prefilledDate?: Date }) => {
+      setState({
+        open: true,
+        draft: opts?.initialDraft ?? DEFAULT_DRAFT,
+        dirty: false,
+        pendingClose: false,
+        prefilledDate: opts?.prefilledDate,
+      });
+    },
+    [],
+  );
+
+  const discardChanges = React.useCallback(() => {
+    setState({
+      open: false,
+      draft: DEFAULT_DRAFT,
+      dirty: false,
+      pendingClose: false,
+    });
+  }, []);
+
+  const cancelClose = React.useCallback(() => {
+    setState((prev) => ({ ...prev, pendingClose: false }));
+  }, []);
+
+  return {
+    composerState: state,
+    setComposerState,
+    updateDraft,
+    openComposer,
+    discardChanges,
+    cancelClose,
+  };
+}


### PR DESCRIPTION
## Summary

PR C of the social-01 composer workstream. Ships behind `FEATURE_COMPOSER_V2`.

**Depends on:** PR B (#904)

### New UI primitives (`components/ui/`)
- `callout.tsx` — D-10 banner-alert (info / warning / helpful variants; icon, body, CTA, dismiss)
- `section-header.tsx` — D-7 title strip (title + optional subtitle + right-aligned actions)
- `pagination.tsx` — D-8 accessible pagination bar (aria-label="Pagination", aria-disabled on disabled prev/next, optional pageSizeOptions)

### Composer shell (`components/social/composer/`)
- `ComposerOverlay.tsx` — split-pane shell (left: profile selector + editor slot; right: preview/calendar tabs)
- `ProfileSelector.tsx` — controlled chip row + "Add profile" link (available / selected / onChange)
- `PreviewCard.tsx` — per-platform preview renderer (LinkedIn, Facebook, X, Instagram, GBP, Pinterest, TikTok)
- `MiniCalendar.tsx` — compact month grid with scheduled-date dot indicators

### State hook (`hooks/`)
- `use-composer-state.ts` — open/close + dirty flag + pendingClose guard (prevents close-while-dirty from losing work)

### Placeholder page
- `app/(platform)/social/poster/page.tsx` — mounts ComposerOverlay shell; replaced by real dashboard in PR F

## Test plan
- [x] `test:unit` — 1708 tests pass (design-token audit included: no sub-16px arbitrary sizes, no hex literals in className/style)
- [x] `test:components` — 171 tests pass (+28 new: Callout×8, SectionHeader×4, Pagination×9, ComposerState hook×7)
- [x] `typecheck` — clean
- [x] `lint` — clean

## Working analog
No pre-existing composer overlay or pagination primitive in this codebase. New patterns match:
- `components/ui/callout.tsx` — same shadcn slot-composition pattern as `components/ui/card.tsx`
- `components/ui/pagination.tsx` — same Button + native select pattern as existing table controls
- `hooks/use-composer-state.ts` — same `useState` + `useCallback` hook pattern as existing `hooks/use-debounce.ts`

## Risks identified and mitigated
- **Platform-brand hex colors in `style=` prop** — inline `boxShadow` uses dynamic `${color}` from a frozen constant map (PLATFORM_COLOR). Design-token static audit passes because no arbitrary hex literal appears in `className`. Mitigated: white ring uses CSS named colour `white`, not `#fff`.
- **ComposerOverlay is a client component** — uses `"use client"`, correct since it manages keyboard listeners + React state. No server data fetching in this component.
- **ProfileSelector is a controlled component** — caller owns `available[]`. In PR D+, the caller fetches connections and passes them down; no internal fetch in this component (unlike the old `components/social/ProfileSelector.tsx` which fetches internally).

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit, test:components
- [x] Contract snapshots reviewed (no SDK calls touched)
- [x] Cross-tenant test added (n/a — UI components only)
- [x] XSS payload coverage added (n/a — no user-content rendering via dangerouslySetInnerHTML)
- [x] PR is under 500 net lines