### PR TITLE
feat(framework): wave 2a — 4 new templates + migrate 11 routes

### DIFF
--- a/app/(platform)/admin/_internal/table-examples/page.tsx
+++ b/app/(platform)/admin/_internal/table-examples/page.tsx
@@ -1,8 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { ExampleTablesClient } from "@/components/admin/internal/ExampleTablesClient";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TDashboardFeed } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 
 // ---------------------------------------------------------------------------
@@ -30,22 +29,15 @@ export default async function TableExamplesPage() {
   if (access.kind === "redirect") redirect(access.to);
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Internal", href: "/admin/_internal/table-examples" },
-            { label: "Table examples" },
-          ]}
-        />
-        <PageHeader.Title>DataTable examples</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Visual reference for the canonical DataTable primitive (Spec 18).
-          Admin-only.
-        </PageHeader.Subtitle>
-      </PageHeader>
-      <ExampleTablesClient />
-    </PageShell>
+    <TDashboardFeed
+      title="DataTable examples"
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Internal", href: "/admin/_internal/table-examples" },
+        { label: "Table examples" },
+      ]}
+      subtitle="Visual reference for the canonical DataTable primitive (Spec 18). Admin-only."
+      feed={<ExampleTablesClient />}
+    />
   );
 }

--- a/app/(platform)/admin/companies/page.tsx
+++ b/app/(platform)/admin/companies/page.tsx
@@ -4,8 +4,7 @@ import { FirstCustomerOnboardedMoment } from "@/components/onboarding/first-cust
 import { PlatformCompaniesListClient } from "@/components/PlatformCompaniesListClient";
 import { Button } from "@/components/ui/button";
 import { NavIcon } from "@/components/ui/nav-icon";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TListWide } from "@/templates";
 import { listPlatformCompanies } from "@/lib/platform/companies";
 
 // P3-1 — Opollo admin companies list. Gated by app/admin/layout.tsx's
@@ -22,26 +21,22 @@ export default async function AdminCompaniesPage({
 }: {
   searchParams?: { created?: string; name?: string };
 }) {
+  const breadcrumb = [
+    { label: "Admin", href: "/admin/sites" },
+    { label: "Companies" },
+  ];
+
   const result = await listPlatformCompanies();
   if (!result.ok) {
     return (
-      <PageShell>
-        <PageHeader>
-          <PageHeader.Breadcrumb
-            segments={[
-              { label: "Admin", href: "/admin/sites" },
-              { label: "Companies" },
-            ]}
-          />
-          <PageHeader.Title>Companies</PageHeader.Title>
-        </PageHeader>
+      <TListWide title="Companies" breadcrumb={breadcrumb}>
         <div
           className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
           role="alert"
         >
           Failed to load companies: {result.error.message}
         </div>
-      </PageShell>
+      </TListWide>
     );
   }
 
@@ -52,25 +47,19 @@ export default async function AdminCompaniesPage({
       : `${companies.length} ${companies.length === 1 ? "company" : "companies"} on the platform.`;
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Companies" },
-          ]}
-        />
-        <PageHeader.Title>Companies</PageHeader.Title>
-        <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>
-        <PageHeader.Actions>
-          <Button asChild data-testid="add-company-button">
-            <Link href="/admin/companies/new">
-              <NavIcon name="plus" size={16} />
-              New company
-            </Link>
-          </Button>
-        </PageHeader.Actions>
-      </PageHeader>
+    <TListWide
+      title="Companies"
+      breadcrumb={breadcrumb}
+      subtitle={subtitle}
+      actions={
+        <Button asChild data-testid="add-company-button">
+          <Link href="/admin/companies/new">
+            <NavIcon name="plus" size={16} />
+            New company
+          </Link>
+        </Button>
+      }
+    >
       {searchParams?.created && (
         <div className="mb-6">
           <FirstCustomerOnboardedMoment
@@ -80,6 +69,6 @@ export default async function AdminCompaniesPage({
         </div>
       )}
       <PlatformCompaniesListClient companies={companies} />
-    </PageShell>
+    </TListWide>
   );
 }

--- a/app/(platform)/admin/images/page.tsx
+++ b/app/(platform)/admin/images/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 
 import { ImagesTable, type ImagesFilterState } from "@/components/ImagesTable";
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
+import { TListWide } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { deliveryUrl } from "@/lib/cloudflare-images";
 import {
@@ -126,22 +126,18 @@ export default async function AdminImagesPage({
     offset: offset > LIST_IMAGES_MAX_LIMIT * 1000 ? 0 : offset,
   });
 
+  const breadcrumb = [
+    { label: "Admin", href: "/admin/sites" },
+    { label: "Images" },
+  ];
+
   if (!result.ok) {
     return (
-      <>
-        <PageHeader>
-          <PageHeader.Breadcrumb
-            segments={[
-              { label: "Admin", href: "/admin/sites" },
-              { label: "Images" },
-            ]}
-          />
-          <PageHeader.Title>Image library</PageHeader.Title>
-        </PageHeader>
+      <TListWide title="Image library" breadcrumb={breadcrumb}>
         <Alert variant="destructive" title="Failed to load images">
           {result.error.message}
         </Alert>
-      </>
+      </TListWide>
     );
   }
 
@@ -155,74 +151,67 @@ export default async function AdminImagesPage({
   const rangeStart = total === 0 ? 0 : offset + 1;
   const rangeEnd = Math.min(offset + limit, total);
 
-  return (
-    <>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Images" },
-          ]}
-        />
-        <PageHeader.Title>Image library</PageHeader.Title>
-        <PageHeader.Subtitle>
-          {parsed.deleted
-            ? `${total} archived ${total === 1 ? "image" : "images"} (soft-deleted). Restore from the detail view.`
-            : `${total} ${total === 1 ? "image" : "images"} available to the chat builder. Filter by caption, tag, or source.`}
-        </PageHeader.Subtitle>
-        <PageHeader.Actions>
+  const subtitle = parsed.deleted
+    ? `${total} archived ${total === 1 ? "image" : "images"} (soft-deleted). Restore from the detail view.`
+    : `${total} ${total === 1 ? "image" : "images"} available to the chat builder. Filter by caption, tag, or source.`;
+
+  const pagination = (
+    <div className="flex items-center justify-between text-sm text-muted-foreground">
+      <div data-testid="images-range">
+        {total === 0
+          ? "0 images"
+          : `Showing ${rangeStart}–${rangeEnd} of ${total}`}
+      </div>
+      <div className="flex items-center gap-2">
+        {currentPage > 1 && (
           <Link
-            href={buildHref(parsed, { deleted: !parsed.deleted, page: 1 })}
-            className="text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+            href={buildHref(parsed, { page: currentPage - 1 })}
+            className="rounded border px-2 py-1 hover:bg-muted"
+            rel="prev"
           >
-            {parsed.deleted ? "← Active images" : "View archived →"}
+            ← Previous
           </Link>
-        </PageHeader.Actions>
-      </PageHeader>
-
-      <div className="mt-6">
-        <ImagesTable
-          items={items}
-          backHref={buildHref(parsed, {})}
-          filterState={
-            {
-              query: parsed.query,
-              tags: parsed.tags,
-              source: parsed.source,
-              deleted: parsed.deleted,
-            } satisfies ImagesFilterState
-          }
-        />
+        )}
+        {currentPage < totalPages && (
+          <Link
+            href={buildHref(parsed, { page: currentPage + 1 })}
+            className="rounded border px-2 py-1 hover:bg-muted"
+            rel="next"
+          >
+            Next →
+          </Link>
+        )}
       </div>
+    </div>
+  );
 
-      {/* Pagination — bottom of container */}
-      <div className="mt-4 flex items-center justify-between text-sm text-muted-foreground">
-        <div data-testid="images-range">
-          {total === 0
-            ? "0 images"
-            : `Showing ${rangeStart}–${rangeEnd} of ${total}`}
-        </div>
-        <div className="flex items-center gap-2">
-          {currentPage > 1 && (
-            <Link
-              href={buildHref(parsed, { page: currentPage - 1 })}
-              className="rounded border px-2 py-1 hover:bg-muted"
-              rel="prev"
-            >
-              ← Previous
-            </Link>
-          )}
-          {currentPage < totalPages && (
-            <Link
-              href={buildHref(parsed, { page: currentPage + 1 })}
-              className="rounded border px-2 py-1 hover:bg-muted"
-              rel="next"
-            >
-              Next →
-            </Link>
-          )}
-        </div>
-      </div>
-    </>
+  return (
+    <TListWide
+      title="Image library"
+      breadcrumb={breadcrumb}
+      subtitle={subtitle}
+      actions={
+        <Link
+          href={buildHref(parsed, { deleted: !parsed.deleted, page: 1 })}
+          className="text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+        >
+          {parsed.deleted ? "← Active images" : "View archived →"}
+        </Link>
+      }
+      pagination={pagination}
+    >
+      <ImagesTable
+        items={items}
+        backHref={buildHref(parsed, {})}
+        filterState={
+          {
+            query: parsed.query,
+            tags: parsed.tags,
+            source: parsed.source,
+            deleted: parsed.deleted,
+          } satisfies ImagesFilterState
+        }
+      />
+    </TListWide>
   );
 }

--- a/app/(platform)/admin/maintenance/social-connections/page.tsx
+++ b/app/(platform)/admin/maintenance/social-connections/page.tsx
@@ -1,7 +1,6 @@
 import { AdminSocialConnectionsMaintenance } from "@/components/AdminSocialConnectionsMaintenance";
 import { BundlesocialReconcileSection } from "@/components/BundlesocialReconcileSection";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TListWide } from "@/templates";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // Cross-tenant identity-leak defence — Layer 4 admin maintenance page.
@@ -48,12 +47,15 @@ export default async function SocialConnectionsMaintenancePage() {
     svc.from("platform_social_profiles").select("id, company_id, name"),
   ]);
 
+  const breadcrumb = [
+    { label: "Admin", href: "/admin/sites" },
+    { label: "Maintenance" },
+    { label: "Social connections" },
+  ];
+
   if (connectionsRead.error || companiesRead.error || profilesRead.error) {
     return (
-      <PageShell>
-        <PageHeader>
-          <PageHeader.Title>Social connections maintenance</PageHeader.Title>
-        </PageHeader>
+      <TListWide title="Social connections maintenance" breadcrumb={breadcrumb}>
         <div
           className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
           role="alert"
@@ -64,33 +66,22 @@ export default async function SocialConnectionsMaintenancePage() {
             profilesRead.error?.message ??
             "unknown"}
         </div>
-      </PageShell>
+      </TListWide>
     );
   }
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Maintenance" },
-            { label: "Social connections" },
-          ]}
-        />
-        <PageHeader.Title>Social connections maintenance</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Cross-company view of every social_connections row. Identity
-          columns surface cross-tenant collisions; per-row actions
-          disconnect, refresh, or reattribute.
-        </PageHeader.Subtitle>
-      </PageHeader>
+    <TListWide
+      title="Social connections maintenance"
+      breadcrumb={breadcrumb}
+      subtitle="Cross-company view of every social_connections row. Identity columns surface cross-tenant collisions; per-row actions disconnect, refresh, or reattribute."
+    >
       <BundlesocialReconcileSection />
       <AdminSocialConnectionsMaintenance
         connections={(connectionsRead.data ?? []) as ConnectionRow[]}
         companies={(companiesRead.data ?? []) as CompanyRow[]}
         profiles={(profilesRead.data ?? []) as ProfileRow[]}
       />
-    </PageShell>
+    </TListWide>
   );
 }

--- a/app/(platform)/admin/users/audit/page.tsx
+++ b/app/(platform)/admin/users/audit/page.tsx
@@ -2,8 +2,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TListWide } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 import { formatRelativeTime } from "@/lib/utils";
@@ -46,21 +45,15 @@ export default async function UserAuditPage({ searchParams }: PageProps) {
   const totalPages = count ? Math.max(1, Math.ceil(count / PAGE_SIZE)) : 1;
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Users", href: "/admin/users" },
-            { label: "Audit log" },
-          ]}
-        />
-        <PageHeader.Title>User audit log</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Append-only record of every user-management action. super_admin only.
-        </PageHeader.Subtitle>
-      </PageHeader>
-
+    <TListWide
+      title="User audit log"
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Users", href: "/admin/users" },
+        { label: "Audit log" },
+      ]}
+      subtitle="Append-only record of every user-management action. super_admin only."
+    >
       {error ? (
         <Alert variant="destructive" className="mt-6" title="Failed to load audit log">
           {error.message}
@@ -152,6 +145,6 @@ export default async function UserAuditPage({ searchParams }: PageProps) {
           )}
         </>
       )}
-    </PageShell>
+    </TListWide>
   );
 }

--- a/app/(platform)/admin/users/page.tsx
+++ b/app/(platform)/admin/users/page.tsx
@@ -4,24 +4,11 @@ import { redirect } from "next/navigation";
 import { InviteUserButton } from "@/components/InviteUserButton";
 import { PendingInvitesTable } from "@/components/PendingInvitesTable";
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { UsersTable } from "@/components/UsersTable";
+import { TListWide } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 import type { AdminUserRow } from "@/app/api/admin/users/list/route";
-
-// ---------------------------------------------------------------------------
-// /admin/users — M2d-1 + AUTH-FOUNDATION P3.3.
-//
-// P3.3 layered onto the existing M2d page:
-//   - Pending invites section (read from `invites` table) with
-//     per-row revoke action.
-//   - Actor role threaded through to InviteUserButton so the modal
-//     filters role-dropdown options (super_admin → admin/user;
-//     admin → user only).
-//   - Audit-log link (super_admin only) to /admin/users/audit.
-// ---------------------------------------------------------------------------
 
 export const dynamic = "force-dynamic";
 
@@ -52,7 +39,6 @@ export default async function AdminUsersPage() {
     .select("id, email, display_name, role, created_at, revoked_at")
     .order("created_at", { ascending: false });
 
-  // Pending invites + their inviter email (joined via FK).
   const invitesRes = await svc
     .from("invites")
     .select(
@@ -82,31 +68,31 @@ export default async function AdminUsersPage() {
       ? "No users yet."
       : `${userCount} ${userCount === 1 ? "user" : "users"} with access. Change a role inline; the server blocks self-modification, last-admin demotions, and any change to the super_admin row.`;
 
-  return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Users" },
-          ]}
-        />
-        <PageHeader.Title>Users</PageHeader.Title>
-        <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>
-        <PageHeader.Actions>
-          {isSuperAdmin && (
-            <Link
-              href="/admin/users/audit"
-              className="rounded-md border px-3 py-2 text-sm transition-smooth hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              data-testid="users-audit-link"
-            >
-              Audit log
-            </Link>
-          )}
-          <InviteUserButton actorRole={actorRole} />
-        </PageHeader.Actions>
-      </PageHeader>
+  const actions = (
+    <>
+      {isSuperAdmin && (
+        <Link
+          href="/admin/users/audit"
+          className="rounded-md border px-3 py-2 text-sm transition-smooth hover:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          data-testid="users-audit-link"
+        >
+          Audit log
+        </Link>
+      )}
+      <InviteUserButton actorRole={actorRole} />
+    </>
+  );
 
+  return (
+    <TListWide
+      title="Users"
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Users" },
+      ]}
+      subtitle={subtitle}
+      actions={actions}
+    >
       {pendingInvites.length > 0 && (
         <div className="mt-6">
           <h2 className="mb-2 text-sm font-medium text-muted-foreground">
@@ -133,6 +119,6 @@ export default async function AdminUsersPage() {
           </>
         )}
       </div>
-    </PageShell>
+    </TListWide>
   );
 }

--- a/app/(platform)/company/internal/autosave-lab/page.tsx
+++ b/app/(platform)/company/internal/autosave-lab/page.tsx
@@ -1,7 +1,7 @@
 ﻿import type { Metadata } from "next";
 
 import { AutosaveLabClient } from "./AutosaveLabClient";
-import { PageHeader } from "@/components/ui/page-header";
+import { TDashboardFeed } from "@/templates";
 
 export const metadata: Metadata = {
   title: "Autosave Validation Lab -- Opollo Internal",
@@ -20,15 +20,15 @@ export const metadata: Metadata = {
 
 export default function AutosaveLabPage() {
   return (
-    <main className="mx-auto max-w-4xl p-6">
-      <PageHeader>
-        <PageHeader.Title>Autosave Validation Lab</PageHeader.Title>
-        <PageHeader.Subtitle className="text-sm">
-          Spec 14 PR B — Week 0 item 0.5. Run all 12 scenarios before enabling{" "}
-          <code className="rounded bg-muted px-1 py-0.5 text-xs">FEATURE_AUTOSAVE_ADOPTED</code>.
-        </PageHeader.Subtitle>
-      </PageHeader>
-      <AutosaveLabClient />
-    </main>
+    <TDashboardFeed
+      title="Autosave Validation Lab"
+      subtitle="Spec 14 PR B — Week 0 item 0.5. Run all 12 scenarios before enabling FEATURE_AUTOSAVE_ADOPTED."
+      breadcrumb={[
+        { label: "Company", href: "/company" },
+        { label: "Internal" },
+        { label: "Autosave lab" },
+      ]}
+      feed={<AutosaveLabClient />}
+    />
   );
 }

--- a/app/(platform)/company/users/page.tsx
+++ b/app/(platform)/company/users/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { CustomerCompanyUsersView } from "@/components/CustomerCompanyUsersView";
+import { TListStandard } from "@/templates";
 import { getCurrentPlatformSession } from "@/lib/platform/auth";
 import { getPlatformCompany } from "@/lib/platform/companies";
 
@@ -26,15 +27,22 @@ export default async function CompanyUsersPage() {
     redirect(`/login?next=${encodeURIComponent("/company/users")}`);
   }
 
+  const breadcrumb = [
+    { label: "Company", href: "/company" },
+    { label: "Users" },
+  ];
+
   if (!session.company) {
     return (
-      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-base">
-        <p className="font-medium">Account not provisioned to a company.</p>
-        <p className="mt-1 text-muted-foreground">
-          Your account isn&apos;t a member of any company on the platform
-          yet. Ask an admin to invite you, or contact Opollo support.
-        </p>
-      </div>
+      <TListStandard title="Users" breadcrumb={breadcrumb}>
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-base">
+          <p className="font-medium">Account not provisioned to a company.</p>
+          <p className="mt-1 text-muted-foreground">
+            Your account isn&apos;t a member of any company on the platform
+            yet. Ask an admin to invite you, or contact Opollo support.
+          </p>
+        </div>
+      </TListStandard>
     );
   }
 
@@ -42,27 +50,39 @@ export default async function CompanyUsersPage() {
     session.isOpolloStaff || session.company.role === "admin";
   if (!isAdmin) {
     return (
-      <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive">
-        <p className="font-medium">Admins only.</p>
-        <p className="mt-1">
-          Only admins can manage company users. Ask an admin in your
-          company to update your role if you need access.
-        </p>
-      </div>
+      <TListStandard title="Users" breadcrumb={breadcrumb}>
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive">
+          <p className="font-medium">Admins only.</p>
+          <p className="mt-1">
+            Only admins can manage company users. Ask an admin in your
+            company to update your role if you need access.
+          </p>
+        </div>
+      </TListStandard>
     );
   }
 
   const detailResult = await getPlatformCompany(session.company.companyId);
   if (!detailResult.ok) {
     return (
-      <div
-        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive"
-        role="alert"
-      >
-        Failed to load company: {detailResult.error.message}
-      </div>
+      <TListStandard title="Users" breadcrumb={breadcrumb}>
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive"
+          role="alert"
+        >
+          Failed to load company: {detailResult.error.message}
+        </div>
+      </TListStandard>
     );
   }
 
-  return <CustomerCompanyUsersView detail={detailResult.data} />;
+  return (
+    <TListStandard
+      title="Users"
+      breadcrumb={breadcrumb}
+      subtitle={`Manage users for ${detailResult.data.company.name}.`}
+    >
+      <CustomerCompanyUsersView detail={detailResult.data} />
+    </TListStandard>
+  );
 }

--- a/app/(platform)/optimiser/change-log/page.tsx
+++ b/app/(platform)/optimiser/change-log/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
-import { PageHeader } from "@/components/ui/page-header";
+import { TListStandard } from "@/templates";
 import { listClients } from "@/lib/optimiser/clients";
 import { listChangeLog } from "@/lib/optimiser/change-log";
 
@@ -20,37 +20,39 @@ export default async function OptimiserChangeLogPage({
     ? await listChangeLog({ clientId: selectedId, limit: 200 })
     : [];
 
-  return (
-    <div className="space-y-6">
-      <PageHeader>
-        <PageHeader.Title>Change log</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Append-only audit trail of every page change applied through the engine.
-        </PageHeader.Subtitle>
-        <PageHeader.Actions>
-          {onboarded.length > 1 && (
-            <form method="get" action="/optimiser/change-log" className="flex items-center gap-1">
-              <select
-                name="client"
-                defaultValue={selectedId}
-                className="rounded-md border border-border bg-background px-2 py-1.5 text-sm"
-              >
-                {onboarded.map((c) => (
-                  <option key={c.id} value={c.id}>
-                    {c.name}
-                  </option>
-                ))}
-              </select>
-              <Button size="sm" variant="outline" type="submit">
-                Switch
-              </Button>
-            </form>
-          )}
-          <Button asChild variant="outline">
-            <Link href="/optimiser">Page browser</Link>
+  const actions = (
+    <>
+      {onboarded.length > 1 && (
+        <form method="get" action="/optimiser/change-log" className="flex items-center gap-1">
+          <select
+            name="client"
+            defaultValue={selectedId}
+            className="rounded-md border border-border bg-background px-2 py-1.5 text-sm"
+          >
+            {onboarded.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          <Button size="sm" variant="outline" type="submit">
+            Switch
           </Button>
-        </PageHeader.Actions>
-      </PageHeader>
+        </form>
+      )}
+      <Button asChild variant="outline">
+        <Link href="/optimiser">Page browser</Link>
+      </Button>
+    </>
+  );
+
+  return (
+    <TListStandard
+      title="Change log"
+      breadcrumb={[{ label: "Optimiser", href: "/optimiser" }, { label: "Change log" }]}
+      subtitle="Append-only audit trail of every page change applied through the engine."
+      actions={actions}
+    >
       <div className="overflow-x-auto rounded-md border border-border">
         <table className="w-full text-sm">
           <thead className="bg-muted/40 text-left">
@@ -101,6 +103,6 @@ export default async function OptimiserChangeLogPage({
           </tbody>
         </table>
       </div>
-    </div>
+    </TListStandard>
   );
 }

--- a/app/(platform)/optimiser/proposals/page.tsx
+++ b/app/(platform)/optimiser/proposals/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
-import { PageHeader } from "@/components/ui/page-header";
+import { TListStandard } from "@/templates";
 import { listClients } from "@/lib/optimiser/clients";
 import { listPendingProposals } from "@/lib/optimiser/proposals";
 
@@ -27,38 +27,39 @@ export default async function OptimiserProposalsList({
     limit: 100,
   });
 
-  return (
-    <div className="space-y-6">
-      <PageHeader>
-        <PageHeader.Title>Proposals</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Pending optimisation proposals, sorted by priority.
-        </PageHeader.Subtitle>
-        <PageHeader.Actions>
-          {onboarded.length > 1 && (
-            <form method="get" action="/optimiser/proposals" className="flex items-center gap-1">
-              <select
-                name="client"
-                defaultValue={selectedId}
-                className="rounded-md border border-border bg-background px-2 py-1.5 text-sm"
-              >
-                {onboarded.map((c) => (
-                  <option key={c.id} value={c.id}>
-                    {c.name}
-                  </option>
-                ))}
-              </select>
-              <Button size="sm" variant="outline" type="submit">
-                Switch
-              </Button>
-            </form>
-          )}
-          <Button asChild variant="outline">
-            <Link href="/optimiser">Page browser</Link>
+  const actions = (
+    <>
+      {onboarded.length > 1 && (
+        <form method="get" action="/optimiser/proposals" className="flex items-center gap-1">
+          <select
+            name="client"
+            defaultValue={selectedId}
+            className="rounded-md border border-border bg-background px-2 py-1.5 text-sm"
+          >
+            {onboarded.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+          <Button size="sm" variant="outline" type="submit">
+            Switch
           </Button>
-        </PageHeader.Actions>
-      </PageHeader>
+        </form>
+      )}
+      <Button asChild variant="outline">
+        <Link href="/optimiser">Page browser</Link>
+      </Button>
+    </>
+  );
 
+  return (
+    <TListStandard
+      title="Proposals"
+      breadcrumb={[{ label: "Optimiser", href: "/optimiser" }, { label: "Proposals" }]}
+      subtitle="Pending optimisation proposals, sorted by priority."
+      actions={actions}
+    >
       <div className="overflow-x-auto rounded-md border border-border">
         <table className="w-full text-sm">
           <thead className="bg-muted/40 text-left">
@@ -121,6 +122,6 @@ export default async function OptimiserProposalsList({
           </tbody>
         </table>
       </div>
-    </div>
+    </TListStandard>
   );
 }

--- a/components/CustomerCompanyUsersView.tsx
+++ b/components/CustomerCompanyUsersView.tsx
@@ -6,7 +6,6 @@ import { DataTable, type ColumnDef } from "@/components/ui/data-table";
 import { NavIcon } from "@/components/ui/nav-icon";
 import { Pill, type PillVariant } from "@/components/ui/pill";
 import { TableCell } from "@/components/ui/table-cell";
-import { H1, Lead } from "@/components/ui/typography";
 import type {
   CompanyDetail,
   CompanyMember,
@@ -121,13 +120,6 @@ export function CustomerCompanyUsersView({
 
   return (
     <div className="space-y-8">
-      <header>
-        <H1>Users</H1>
-        <Lead className="mt-1">
-          Manage users for <strong>{company.name}</strong>.
-        </Lead>
-      </header>
-
       <section
         className="space-y-3"
         aria-labelledby="customer-members"

--- a/docs/briefs/social-01-brief/framework/PROGRESS.md
+++ b/docs/briefs/social-01-brief/framework/PROGRESS.md
@@ -1,3 +1,9 @@
+## Wave 2a in progress 2026-05-19
+
+- Templates added: T-LIST-WIDE, T-DETAIL-SUMMARY, T-FORM, T-SETTINGS-FLAT
+- Routes migrated: 11 (T-LIST-WIDE: /admin/users, /admin/users/audit, /admin/companies, /admin/maintenance/social-connections, /admin/images; T-LIST-STANDARD deferred: /optimiser/proposals, /optimiser/change-log, /company/users; T-DASHBOARD-FEED deferred: /admin/_internal/table-examples, /company/internal/autosave-lab)
+- Wave 2b (T-DETAIL-SUMMARY) and Wave 2c (T-FORM + T-SETTINGS-FLAT) to follow
+
 ## Wave 1 complete 2026-05-19
 
 - Templates shipped: T-DETAIL-TABBED, T-LIST-STANDARD, T-DASHBOARD-FEED, T-DASHBOARD-KPI

--- a/templates/T-DASHBOARD-FEED.tsx
+++ b/templates/T-DASHBOARD-FEED.tsx
@@ -7,6 +7,7 @@ import type { BreadcrumbSegment } from "./T-LIST-STANDARD";
 export interface TDashboardFeedProps {
   title: string;
   breadcrumb?: BreadcrumbSegment[];
+  subtitle?: string;
   /** Right-aligned actions in PageHeader. */
   actions?: React.ReactNode;
   /**
@@ -39,6 +40,7 @@ export interface TDashboardFeedProps {
 export function TDashboardFeed({
   title,
   breadcrumb,
+  subtitle,
   actions,
   inlineAlert,
   feed,
@@ -48,6 +50,7 @@ export function TDashboardFeed({
     <PageHeader>
       {breadcrumb && <PageHeader.Breadcrumb segments={breadcrumb} />}
       <PageHeader.Title>{title}</PageHeader.Title>
+      {subtitle && <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>}
       {actions && <PageHeader.Actions>{actions}</PageHeader.Actions>}
     </PageHeader>
   );

--- a/templates/T-DETAIL-SUMMARY.tsx
+++ b/templates/T-DETAIL-SUMMARY.tsx
@@ -1,0 +1,102 @@
+import type * as React from "react";
+
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { SectionHeader } from "@/components/ui/section-header";
+import { Callout } from "@/components/ui/callout";
+import type { CalloutProps } from "@/components/ui/callout";
+import type { BreadcrumbSegment } from "./T-LIST-STANDARD";
+
+export interface TDetailSummarySection {
+  title: string;
+  subtitle?: string;
+  actions?: React.ReactNode;
+  content: React.ReactNode;
+}
+
+export interface TDetailSummaryProps {
+  title: string;
+  breadcrumb?: BreadcrumbSegment[];
+  subtitle?: string;
+  actions?: React.ReactNode;
+  meta?: React.ReactNode;
+  /** Optional stacked callout banners above the sections. */
+  callout?: CalloutProps;
+  /** Optional inline alert between the callout and sections. */
+  inlineAlert?: React.ReactNode;
+  sections: TDetailSummarySection[];
+  /** Optional sidebar — rendered alongside sections on wide mode. */
+  sidebar?: React.ReactNode;
+  width?: "standard" | "wide";
+}
+
+/**
+ * T-DETAIL-SUMMARY — read-mostly entity detail template.
+ *
+ * Composition: PageShell ▸ PageHeader ▸ [Callout] ▸ [inlineAlert] ▸
+ *              Section×N (SectionHeader + content) ▸ [Sidebar — wide only]
+ *
+ * Wave 2 routes: /admin/sites/[id], /admin/sites/[id]/appearance,
+ * /admin/companies/[id], /admin/companies/[id]/social-profiles/[id]/connections,
+ * /admin/batches/[siteId]/[batchId], /admin/images/[id],
+ * /admin/sites/[id]/design-system, /admin/sites/[id]/design-system/preview,
+ * /optimiser/pages/[id], /optimiser/proposals/[id], /optimiser/imports/[brief_id]
+ */
+export function TDetailSummary({
+  title,
+  breadcrumb,
+  subtitle,
+  actions,
+  meta,
+  callout,
+  inlineAlert,
+  sections,
+  sidebar,
+  width = "standard",
+}: TDetailSummaryProps) {
+  const content = (
+    <>
+      <PageHeader>
+        {breadcrumb && <PageHeader.Breadcrumb segments={breadcrumb} />}
+        <PageHeader.Title>{title}</PageHeader.Title>
+        {subtitle && <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>}
+        {meta && <PageHeader.Meta>{meta}</PageHeader.Meta>}
+        {actions && <PageHeader.Actions>{actions}</PageHeader.Actions>}
+      </PageHeader>
+
+      {callout && (
+        <div className="mb-4">
+          <Callout {...callout} />
+        </div>
+      )}
+
+      {inlineAlert && <div className="mb-4">{inlineAlert}</div>}
+
+      <div className={sidebar ? "flex gap-6" : undefined}>
+        <div className={sidebar ? "min-w-0 flex-1 space-y-8" : "space-y-8"}>
+          {sections.map((section) => (
+            <section key={section.title} aria-labelledby={`section-${section.title.replace(/\s+/g, "-").toLowerCase()}`}>
+              <SectionHeader
+                title={section.title}
+                subtitle={section.subtitle}
+                actions={section.actions}
+                className="mb-4"
+              />
+              {section.content}
+            </section>
+          ))}
+        </div>
+
+        {sidebar && (
+          <aside className="w-72 shrink-0">{sidebar}</aside>
+        )}
+      </div>
+    </>
+  );
+
+  return (
+    <PageShell className={width === "wide" ? "max-w-screen-2xl" : undefined}>
+      {content}
+    </PageShell>
+  );
+}

--- a/templates/T-FORM.tsx
+++ b/templates/T-FORM.tsx
@@ -1,0 +1,92 @@
+import type * as React from "react";
+
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import type { BreadcrumbSegment } from "./T-LIST-STANDARD";
+
+export interface TFormSection {
+  title?: string;
+  description?: string;
+  content: React.ReactNode;
+}
+
+export interface TFormProps {
+  title: string;
+  breadcrumb?: BreadcrumbSegment[];
+  subtitle?: string;
+  actions?: React.ReactNode;
+  /** Optional top-of-form error alert. */
+  inlineAlert?: React.ReactNode;
+  /** Form sections with optional title/description headers. */
+  formSections: TFormSection[];
+  /**
+   * Width mode.
+   * - 'form' (default): max-w-2xl — optimal for form line length.
+   * - 'standard': max-w-7xl
+   * - 'wide': max-w-screen-2xl
+   */
+  width?: "narrow" | "form" | "standard" | "wide";
+}
+
+const WIDTH_CLASS: Record<NonNullable<TFormProps["width"]>, string | undefined> = {
+  narrow: "max-w-xl",
+  form: "max-w-2xl",
+  standard: undefined,
+  wide: "max-w-screen-2xl",
+};
+
+/**
+ * T-FORM — create/edit form shell template.
+ *
+ * Composition: PageShell (form-width) ▸ PageHeader ▸ [inlineAlert] ▸
+ *              FormSection×N (optional title + description + content)
+ *
+ * Form submit/cancel actions stay in the inner form component —
+ * this shell provides page chrome only.
+ *
+ * Wave 2 routes: /admin/sites/new, /admin/sites/[id]/edit,
+ * /admin/sites/[id]/posts/new, /admin/companies/new,
+ * /admin/posts/[siteId]/new, /admin/email-test
+ */
+export function TForm({
+  title,
+  breadcrumb,
+  subtitle,
+  actions,
+  inlineAlert,
+  formSections,
+  width = "form",
+}: TFormProps) {
+  return (
+    <PageShell className={WIDTH_CLASS[width]}>
+      <PageHeader>
+        {breadcrumb && <PageHeader.Breadcrumb segments={breadcrumb} />}
+        <PageHeader.Title>{title}</PageHeader.Title>
+        {subtitle && <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>}
+        {actions && <PageHeader.Actions>{actions}</PageHeader.Actions>}
+      </PageHeader>
+
+      {inlineAlert && <div className="mb-4">{inlineAlert}</div>}
+
+      <div className="space-y-8">
+        {formSections.map((section, i) => (
+          <div key={section.title ?? i}>
+            {(section.title || section.description) && (
+              <div className="mb-4">
+                {section.title && (
+                  <h2 className="text-base font-semibold">{section.title}</h2>
+                )}
+                {section.description && (
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {section.description}
+                  </p>
+                )}
+              </div>
+            )}
+            {section.content}
+          </div>
+        ))}
+      </div>
+    </PageShell>
+  );
+}

--- a/templates/T-LIST-STANDARD.tsx
+++ b/templates/T-LIST-STANDARD.tsx
@@ -26,6 +26,12 @@ export interface TListStandardProps {
   children: React.ReactNode;
   /** Optional pagination bar below the list. */
   pagination?: React.ReactNode;
+  /**
+   * Width mode.
+   * - 'standard' (default): max-w-7xl
+   * - 'wide': max-w-screen-2xl (used by T-LIST-WIDE)
+   */
+  width?: "standard" | "wide";
 }
 
 /**
@@ -46,9 +52,10 @@ export function TListStandard({
   filterBar,
   children,
   pagination,
+  width = "standard",
 }: TListStandardProps) {
   return (
-    <PageShell>
+    <PageShell className={width === "wide" ? "max-w-screen-2xl" : undefined}>
       <PageHeader>
         {breadcrumb && <PageHeader.Breadcrumb segments={breadcrumb} />}
         <PageHeader.Title>{title}</PageHeader.Title>

--- a/templates/T-LIST-WIDE.tsx
+++ b/templates/T-LIST-WIDE.tsx
@@ -1,0 +1,18 @@
+import type { TListStandardProps } from "./T-LIST-STANDARD";
+import { TListStandard } from "./T-LIST-STANDARD";
+
+export type TListWideProps = Omit<TListStandardProps, "width">;
+
+/**
+ * T-LIST-WIDE — wide-layout index list template.
+ *
+ * Same composition as T-LIST-STANDARD but rendered at max-w-screen-2xl.
+ * Use for admin tabular data that benefits from more horizontal space.
+ *
+ * Wave 2 routes: /admin/users, /admin/users/audit, /admin/companies,
+ * /admin/companies/[id]/social-profiles, /admin/batches/[siteId],
+ * /admin/maintenance/social-connections, /admin/images
+ */
+export function TListWide(props: TListWideProps) {
+  return <TListStandard {...props} width="wide" />;
+}

--- a/templates/T-SETTINGS-FLAT.tsx
+++ b/templates/T-SETTINGS-FLAT.tsx
@@ -1,0 +1,91 @@
+import type * as React from "react";
+
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { SectionHeader } from "@/components/ui/section-header";
+import type { BreadcrumbSegment } from "./T-LIST-STANDARD";
+
+export interface TSettingsFlatSection {
+  title: string;
+  description?: string;
+  content: React.ReactNode;
+}
+
+export interface TSettingsFlatProps {
+  title: string;
+  breadcrumb?: BreadcrumbSegment[];
+  subtitle?: string;
+  actions?: React.ReactNode;
+  /** Optional inline alerts stacked at the top. */
+  inlineAlerts?: React.ReactNode[];
+  sections: TSettingsFlatSection[];
+  /**
+   * Width mode.
+   * - 'form' (default): max-w-2xl — keeps settings pages readable.
+   * - 'standard': max-w-7xl
+   * - 'wide': max-w-screen-2xl
+   */
+  width?: "narrow" | "form" | "standard" | "wide";
+}
+
+const WIDTH_CLASS: Record<NonNullable<TSettingsFlatProps["width"]>, string | undefined> = {
+  narrow: "max-w-xl",
+  form: "max-w-2xl",
+  standard: undefined,
+  wide: "max-w-screen-2xl",
+};
+
+/**
+ * T-SETTINGS-FLAT — flat settings page template.
+ *
+ * Composition: PageShell ▸ PageHeader ▸ [Alert×N] ▸
+ *              Section×N (SectionHeader + content)
+ *
+ * Wave 2 routes: /admin/sites/[id]/settings, /admin/settings/design-system,
+ * /account/security, /account/devices, /company/settings/brand,
+ * /optimiser/clients/[id]/settings, /company/social/sharing
+ */
+export function TSettingsFlat({
+  title,
+  breadcrumb,
+  subtitle,
+  actions,
+  inlineAlerts,
+  sections,
+  width = "form",
+}: TSettingsFlatProps) {
+  return (
+    <PageShell className={WIDTH_CLASS[width]}>
+      <PageHeader>
+        {breadcrumb && <PageHeader.Breadcrumb segments={breadcrumb} />}
+        <PageHeader.Title>{title}</PageHeader.Title>
+        {subtitle && <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>}
+        {actions && <PageHeader.Actions>{actions}</PageHeader.Actions>}
+      </PageHeader>
+
+      {inlineAlerts && inlineAlerts.length > 0 && (
+        <div className="mb-4 space-y-2">
+          {inlineAlerts.map((alert, i) => (
+            <div key={i}>{alert}</div>
+          ))}
+        </div>
+      )}
+
+      <div className="space-y-8">
+        {sections.map((section) => (
+          <section
+            key={section.title}
+            aria-labelledby={`settings-${section.title.replace(/\s+/g, "-").toLowerCase()}`}
+          >
+            <SectionHeader
+              title={section.title}
+              subtitle={section.description}
+              className="mb-4"
+            />
+            {section.content}
+          </section>
+        ))}
+      </div>
+    </PageShell>
+  );
+}

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -1,6 +1,18 @@
 export { TListStandard } from "./T-LIST-STANDARD";
 export type { TListStandardProps, BreadcrumbSegment } from "./T-LIST-STANDARD";
 
+export { TListWide } from "./T-LIST-WIDE";
+export type { TListWideProps } from "./T-LIST-WIDE";
+
+export { TDetailSummary } from "./T-DETAIL-SUMMARY";
+export type { TDetailSummaryProps, TDetailSummarySection } from "./T-DETAIL-SUMMARY";
+
+export { TForm } from "./T-FORM";
+export type { TFormProps, TFormSection } from "./T-FORM";
+
+export { TSettingsFlat } from "./T-SETTINGS-FLAT";
+export type { TSettingsFlatProps, TSettingsFlatSection } from "./T-SETTINGS-FLAT";
+
 export { TDashboardFeed } from "./T-DASHBOARD-FEED";
 export type { TDashboardFeedProps } from "./T-DASHBOARD-FEED";
 


### PR DESCRIPTION
## Summary

- **4 new templates** added to `templates/`: T-LIST-WIDE, T-DETAIL-SUMMARY, T-FORM, T-SETTINGS-FLAT
- **T-LIST-STANDARD** updated with optional `width` prop (`'standard'` | `'wide'`)
- **T-DASHBOARD-FEED** updated with optional `subtitle` prop
- **11 routes migrated** to use new templates:
  - T-LIST-WIDE: `/admin/users`, `/admin/users/audit`, `/admin/companies`, `/admin/maintenance/social-connections`, `/admin/images`
  - T-LIST-STANDARD (deferred from Wave 1): `/optimiser/proposals`, `/optimiser/change-log`, `/company/users`
  - T-DASHBOARD-FEED (deferred from Wave 1): `/admin/_internal/table-examples`, `/company/internal/autosave-lab`
- `CustomerCompanyUsersView` H1/Lead header removed (title/subtitle now provided by TListStandard at page level)

## Templates built

| Template | Routes | Width default |
|---|---|---|
| T-LIST-WIDE | 5 + future | max-w-screen-2xl |
| T-DETAIL-SUMMARY | 11 routes (Wave 2b) | standard / wide |
| T-FORM | 6 routes (Wave 2c) | max-w-2xl |
| T-SETTINGS-FLAT | 7 routes (Wave 2c) | max-w-2xl |

**Working analog**: `templates/T-LIST-STANDARD.tsx` — T-LIST-WIDE is a thin wrapper passing `width="wide"`. T-DETAIL-SUMMARY, T-FORM, T-SETTINGS-FLAT follow the same PageShell ▸ PageHeader ▸ [optional slots] ▸ content pattern.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (1778 tests pass)
- [x] audit:static: 0 HIGH violations (17 MEDIUM pre-existing)
- [x] PR is under 500 net lines — 601 insertions but ~300 are template additions (new files); net route-migration change is ~300 lines

## Risks identified and mitigated

- **T-LIST-WIDE adds PageShell to `/admin/images`**: This page previously rendered inside a fragment with no PageShell. Adding one provides consistent chrome. No regressions — the page data loading is unchanged.
- **CustomerCompanyUsersView H1 removed**: Same pattern as SocialPostsListClient in Wave 1. The company name subtitle moves to the TListStandard `subtitle` prop at the page level. Server has the `detailResult.data.company.name` available.
- **T-FORM / T-SETTINGS-FLAT not yet migrated**: Templates are built and exported; route migrations are Wave 2c. No broken routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)