### PR TITLE
feat(framework): wave 2b — T-DETAIL-SUMMARY + migrate 10 routes

### DIFF
--- a/app/(platform)/admin/batches/[siteId]/[batchId]/page.tsx
+++ b/app/(platform)/admin/batches/[siteId]/[batchId]/page.tsx
@@ -4,14 +4,12 @@ import { redirect } from "next/navigation";
 import { BatchDetailClient } from "@/components/BatchDetailClient";
 import { BatchSuccessMoment } from "@/components/BatchSuccessMoment";
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import {
   StatusPill,
   jobStatusKind,
   slotStateKind,
 } from "@/components/ui/status-pill";
-import { H3 } from "@/components/ui/typography";
+import { TDetailSummary } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -61,19 +59,15 @@ export default async function BatchDetailPage({
 
   if (jobErr) {
     return (
-      <PageShell>
-        <PageHeader>
-          <PageHeader.Breadcrumb
-            segments={[
-              { label: "Admin", href: "/admin/sites" },
-              { label: "Batches", href: batchesHref },
-              { label: "Error" },
-            ]}
-          />
-          <PageHeader.Title>Failed to load batch</PageHeader.Title>
-        </PageHeader>
-        <Alert variant="destructive">{jobErr.message}</Alert>
-      </PageShell>
+      <TDetailSummary
+        title="Failed to load batch"
+        breadcrumb={[
+          { label: "Admin", href: "/admin/sites" },
+          { label: "Batches", href: batchesHref },
+          { label: "Error" },
+        ]}
+        sections={[{ content: <Alert variant="destructive">{jobErr.message}</Alert> }]}
+      />
     );
   }
   if (!job) {
@@ -120,19 +114,15 @@ export default async function BatchDetailPage({
   const tmpl = job.template as unknown as { name: string; page_type: string };
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Batches", href: batchesHref },
-            { label: `${site.name} · ${tmpl.name}` },
-          ]}
-        />
-        <PageHeader.Title>
-          {site.name} · {tmpl.name}
-        </PageHeader.Title>
-        <PageHeader.Meta>
+    <TDetailSummary
+      title={`${site.name} · ${tmpl.name}`}
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Batches", href: batchesHref },
+        { label: `${site.name} · ${tmpl.name}` },
+      ]}
+      meta={
+        <>
           <StatusPill kind={jobStatusKind(job.status as Parameters<typeof jobStatusKind>[0])} />
           <span>
             {job.succeeded_count} ok · {job.failed_count} fail ·{" "}
@@ -147,25 +137,23 @@ export default async function BatchDetailPage({
           {job.finished_at && (
             <span>finished {formatDate(job.finished_at as string)}</span>
           )}
-        </PageHeader.Meta>
-        <PageHeader.Actions>
-          <BatchDetailClient jobId={params.batchId} status={job.status as string} />
-        </PageHeader.Actions>
-      </PageHeader>
-
-      {job.status === "succeeded" && (
-        <BatchSuccessMoment
-          jobId={params.batchId}
-          succeededCount={Number(job.succeeded_count ?? 0)}
-          siteName={site.name}
-          siteId={params.siteId}
-        />
-      )}
-
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
-        <div>
-          <H3>Slots</H3>
-          <div className="mt-2 overflow-x-auto rounded-md border">
+        </>
+      }
+      actions={<BatchDetailClient jobId={params.batchId} status={job.status as string} />}
+      inlineAlert={
+        job.status === "succeeded" ? (
+          <BatchSuccessMoment
+            jobId={params.batchId}
+            succeededCount={Number(job.succeeded_count ?? 0)}
+            siteName={site.name}
+            siteId={params.siteId}
+          />
+        ) : undefined
+      }
+      sections={[{
+        title: "Slots",
+        content: (
+          <div className="overflow-x-auto rounded-md border">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b bg-muted/40 text-left text-muted-foreground">
@@ -217,11 +205,12 @@ export default async function BatchDetailPage({
               </tbody>
             </table>
           </div>
-        </div>
-
-        <div>
-          <H3>Recent events</H3>
-          <div className="mt-2 flex flex-col gap-2">
+        ),
+      }]}
+      sidebar={
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold">Recent events</h3>
+          <div className="flex flex-col gap-2">
             {(recentEvents ?? []).map((e) => (
               <div key={String(e.id)} className="rounded-md border p-2 text-sm">
                 <div className="flex items-center justify-between">
@@ -240,7 +229,7 @@ export default async function BatchDetailPage({
             )}
           </div>
         </div>
-      </div>
-    </PageShell>
+      }
+    />
   );
 }

--- a/app/(platform)/admin/batches/[siteId]/page.tsx
+++ b/app/(platform)/admin/batches/[siteId]/page.tsx
@@ -4,8 +4,7 @@ import { BatchesTable, type BatchRow } from "@/components/BatchesTable";
 import { NewBatchButton } from "@/components/NewBatchButton";
 import type { BatchTemplateOption } from "@/components/NewBatchModal";
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TListStandard } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -63,23 +62,22 @@ export default async function AdminBatchesSitePage({
 
   const site = { id: siteRes.data.id as string, name: siteRes.data.name as string };
 
+  const breadcrumb = [
+    { label: "Admin", href: "/admin/sites" },
+    { label: "Batches", href: "/admin/batches" },
+    { label: site.name },
+  ];
+
   if (error) {
     return (
-      <PageShell>
-        <PageHeader>
-          <PageHeader.Breadcrumb
-            segments={[
-              { label: "Admin", href: "/admin/sites" },
-              { label: "Batches", href: "/admin/batches" },
-              { label: site.name },
-            ]}
-          />
-          <PageHeader.Title>Batches — {site.name}</PageHeader.Title>
-        </PageHeader>
+      <TListStandard
+        title={`Batches — ${site.name}`}
+        breadcrumb={breadcrumb}
+      >
         <Alert variant="destructive" title="Failed to load batches">
           {error.message}
         </Alert>
-      </PageShell>
+      </TListStandard>
     );
   }
 
@@ -142,25 +140,13 @@ export default async function AdminBatchesSitePage({
   const subtitle = `${rows.length} ${rows.length === 1 ? "batch" : "batches"} for ${site.name}.`;
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Batches", href: "/admin/batches" },
-            { label: site.name },
-          ]}
-        />
-        <PageHeader.Title>Batches — {site.name}</PageHeader.Title>
-        <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>
-        <PageHeader.Actions>
-          <NewBatchButton site={site} templates={templateOptions} label="New batch" />
-        </PageHeader.Actions>
-      </PageHeader>
-
-      <div>
-        <BatchesTable rows={rows} siteId={params.siteId} />
-      </div>
-    </PageShell>
+    <TListStandard
+      title={`Batches — ${site.name}`}
+      breadcrumb={breadcrumb}
+      subtitle={subtitle}
+      actions={<NewBatchButton site={site} templates={templateOptions} label="New batch" />}
+    >
+      <BatchesTable rows={rows} siteId={params.siteId} />
+    </TListStandard>
   );
 }

--- a/app/(platform)/admin/companies/[id]/page.tsx
+++ b/app/(platform)/admin/companies/[id]/page.tsx
@@ -1,8 +1,7 @@
 import { notFound } from "next/navigation";
 
 import { PlatformCompanyDetail } from "@/components/PlatformCompanyDetail";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TDetailSummary } from "@/templates";
 import { getCurrentPlatformSession } from "@/lib/platform/auth";
 import { getPlatformCompany } from "@/lib/platform/companies";
 import { joinCompanyAsAdmin } from "../_actions";
@@ -13,6 +12,11 @@ import { joinCompanyAsAdmin } from "../_actions";
 // (P3-4) wires actions onto this page.
 
 export const dynamic = "force-dynamic";
+
+const BREADCRUMB = [
+  { label: "Admin", href: "/admin/sites" },
+  { label: "Companies", href: "/admin/companies" },
+];
 
 export default async function CompanyDetailPage({
   params,
@@ -27,24 +31,20 @@ export default async function CompanyDetailPage({
   if (!result.ok) {
     if (result.error.code === "NOT_FOUND") notFound();
     return (
-      <PageShell>
-        <PageHeader>
-          <PageHeader.Breadcrumb
-            segments={[
-              { label: "Admin", href: "/admin/sites" },
-              { label: "Companies", href: "/admin/companies" },
-              { label: "Error" },
-            ]}
-          />
-          <PageHeader.Title>Failed to load company</PageHeader.Title>
-        </PageHeader>
-        <div
-          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-          role="alert"
-        >
-          {result.error.message}
-        </div>
-      </PageShell>
+      <TDetailSummary
+        title="Failed to load company"
+        breadcrumb={[...BREADCRUMB, { label: "Error" }]}
+        sections={[{
+          content: (
+            <div
+              className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+              role="alert"
+            >
+              {result.error.message}
+            </div>
+          ),
+        }]}
+      />
     );
   }
 
@@ -59,17 +59,11 @@ export default async function CompanyDetailPage({
   const { company } = result.data;
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Companies", href: "/admin/companies" },
-            { label: company.name },
-          ]}
-        />
-        <PageHeader.Title>{company.name}</PageHeader.Title>
-        <PageHeader.Meta>
+    <TDetailSummary
+      title={company.name}
+      breadcrumb={[...BREADCRUMB, { label: company.name }]}
+      meta={
+        <>
           {company.is_opollo_internal && (
             <span
               className="rounded-full bg-primary/10 px-2 py-0.5 text-sm font-medium text-primary"
@@ -84,14 +78,18 @@ export default async function CompanyDetailPage({
           {company.domain && (
             <span className="font-mono">{company.domain}</span>
           )}
-        </PageHeader.Meta>
-      </PageHeader>
-      <PlatformCompanyDetail
-        detail={result.data}
-        isOpolloStaff={session?.isOpolloStaff ?? false}
-        isCurrentUserMember={isCurrentUserMember}
-        joinAction={boundJoinAction}
-      />
-    </PageShell>
+        </>
+      }
+      sections={[{
+        content: (
+          <PlatformCompanyDetail
+            detail={result.data}
+            isOpolloStaff={session?.isOpolloStaff ?? false}
+            isCurrentUserMember={isCurrentUserMember}
+            joinAction={boundJoinAction}
+          />
+        ),
+      }]}
+    />
   );
 }

--- a/app/(platform)/admin/companies/[id]/social-profiles/[profileId]/connections/page.tsx
+++ b/app/(platform)/admin/companies/[id]/social-profiles/[profileId]/connections/page.tsx
@@ -1,8 +1,7 @@
 import { notFound } from "next/navigation";
 
 import { AdminProfileConnectionsList } from "@/components/AdminProfileConnectionsList";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TDetailSummary } from "@/templates";
 import { getPlatformCompany } from "@/lib/platform/companies";
 import { getProfileById } from "@/lib/platform/social/profiles";
 import { readProfileTeamAccounts } from "@/lib/platform/social/profiles/connect";
@@ -33,17 +32,19 @@ export default async function ProfileConnectionsPage({
   if (!companyResult.ok) {
     if (companyResult.error.code === "NOT_FOUND") notFound();
     return (
-      <PageShell>
-        <PageHeader>
-          <PageHeader.Title>Failed to load company</PageHeader.Title>
-        </PageHeader>
-        <div
-          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-          role="alert"
-        >
-          {companyResult.error.message}
-        </div>
-      </PageShell>
+      <TDetailSummary
+        title="Failed to load company"
+        sections={[{
+          content: (
+            <div
+              className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+              role="alert"
+            >
+              {companyResult.error.message}
+            </div>
+          ),
+        }]}
+      />
     );
   }
   if (!profile) notFound();
@@ -72,42 +73,40 @@ export default async function ProfileConnectionsPage({
   }
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Companies", href: "/admin/companies" },
-            { label: company.name, href: `/admin/companies/${company.id}` },
-            {
-              label: "Social profiles",
-              href: `/admin/companies/${company.id}/social-profiles`,
-            },
-            { label: profile.name },
-          ]}
-        />
-        <PageHeader.Title>
-          {profile.name} — connections
-        </PageHeader.Title>
-        <PageHeader.Meta>
-          {profile.bundle_social_team_id ? (
-            <span className="font-mono" data-testid="profile-team-id">
-              team {profile.bundle_social_team_id}
-            </span>
-          ) : (
-            <span className="italic text-muted-foreground">
-              team not yet provisioned
-            </span>
-          )}
-        </PageHeader.Meta>
-      </PageHeader>
-      <AdminProfileConnectionsList
-        companyId={company.id}
-        profileId={profile.id}
-        profileName={profile.name}
-        initialAccounts={initialAccounts}
-        initialTeamReadError={teamReadError}
-      />
-    </PageShell>
+    <TDetailSummary
+      title={`${profile.name} — connections`}
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Companies", href: "/admin/companies" },
+        { label: company.name, href: `/admin/companies/${company.id}` },
+        {
+          label: "Social profiles",
+          href: `/admin/companies/${company.id}/social-profiles`,
+        },
+        { label: profile.name },
+      ]}
+      meta={
+        profile.bundle_social_team_id ? (
+          <span className="font-mono" data-testid="profile-team-id">
+            team {profile.bundle_social_team_id}
+          </span>
+        ) : (
+          <span className="italic text-muted-foreground">
+            team not yet provisioned
+          </span>
+        )
+      }
+      sections={[{
+        content: (
+          <AdminProfileConnectionsList
+            companyId={company.id}
+            profileId={profile.id}
+            profileName={profile.name}
+            initialAccounts={initialAccounts}
+            initialTeamReadError={teamReadError}
+          />
+        ),
+      }]}
+    />
   );
 }

--- a/app/(platform)/admin/images/[id]/page.tsx
+++ b/app/(platform)/admin/images/[id]/page.tsx
@@ -6,11 +6,8 @@ import { DownloadImageButton } from "@/components/DownloadImageButton";
 import { ImageDeleteButton } from "@/components/ImageDeleteButton";
 import { ImageDetailLightbox } from "@/components/ImageDetailLightbox";
 import { ReextractMetadataButton } from "@/components/ReextractMetadataButton";
-import { Alert } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
-import { H3 } from "@/components/ui/typography";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TDetailSummary } from "@/templates";
 import { EditImageMetadataButton } from "@/components/EditImageMetadataButton";
 import { ImageArchiveButton } from "@/components/ImageArchiveButton";
 import { checkAdminAccess } from "@/lib/admin-gate";
@@ -112,9 +109,23 @@ export default async function AdminImageDetailPage({
   if (!result.ok) {
     if (result.error.code === "NOT_FOUND") notFound();
     return (
-      <Alert variant="destructive" title="Failed to load image">
-        {result.error.message}
-      </Alert>
+      <TDetailSummary
+        title="Failed to load image"
+        breadcrumb={[
+          { label: "Admin", href: "/admin/sites" },
+          { label: "Images", href: "/admin/images" },
+        ]}
+        sections={[{
+          content: (
+            <div
+              className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+              role="alert"
+            >
+              {result.error.message}
+            </div>
+          ),
+        }]}
+      />
     );
   }
 
@@ -133,27 +144,27 @@ export default async function AdminImageDetailPage({
   const thumbUrl = publicUrl;
 
   const titleLabel = image.title ?? image.filename ?? "Untitled image";
+
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Images", href: backHref },
-            { label: image.title ?? image.caption?.slice(0, 60) ?? image.filename ?? image.id },
-          ]}
-        />
-        <PageHeader.Title>{titleLabel}</PageHeader.Title>
-        <PageHeader.Meta>
+    <TDetailSummary
+      title={titleLabel}
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Images", href: backHref },
+        { label: image.title ?? image.caption?.slice(0, 60) ?? image.filename ?? image.id },
+      ]}
+      meta={
+        <>
           <span>Imported {formatDate(image.created_at)}</span>
           {image.deleted_at && (
             <span className="text-destructive">
               archived {formatRelativeTime(image.deleted_at)}
             </span>
           )}
-        </PageHeader.Meta>
-        <PageHeader.Actions>
-          <div className="flex flex-wrap items-center gap-3">
+        </>
+      }
+      actions={
+        <div className="flex flex-wrap items-center gap-3">
           {!image.deleted_at && (
             <EditImageMetadataButton
               image={{
@@ -180,219 +191,210 @@ export default async function AdminImageDetailPage({
           {image.deleted_at && (
             <ImageDeleteButton imageId={image.id} />
           )}
-          </div>
-        </PageHeader.Actions>
-      </PageHeader>
-
-      <section className="grid gap-6 md:grid-cols-[1fr_2fr]">
-        <div className="flex flex-col gap-3">
-          <div className="overflow-hidden rounded-md border bg-muted/30">
-            {publicUrl ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={publicUrl}
-                alt={image.alt_text ?? image.filename ?? "Library image"}
-                className="h-full w-full object-contain"
-                data-testid="image-detail-preview"
-              />
-            ) : (
-              <div className="flex h-64 w-full items-center justify-center text-sm text-muted-foreground">
-                Preview unavailable (no Cloudflare id or delivery hash).
-              </div>
-            )}
-          </div>
-          {thumbUrl && (
-            <div className="flex items-center gap-3 text-sm text-muted-foreground">
-              <span>Thumbnail:</span>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={thumbUrl}
-                alt=""
-                className="h-10 w-10 rounded object-cover"
-              />
-              <ImageDetailLightbox
-                src={thumbUrl}
-                alt={image.alt_text ?? image.filename ?? "Library image"}
-                title={image.title}
-                caption={image.caption}
-                tags={image.tags}
-                width_px={image.width_px}
-                height_px={image.height_px}
-              />
-            </div>
-          )}
         </div>
-
-        <dl
-          className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm"
-          data-testid="image-detail-fields"
-        >
-          <dt className="text-muted-foreground">Title</dt>
-          <dd>
-            {image.title ?? (
-              <span className="text-muted-foreground">(not set)</span>
-            )}
-          </dd>
-          <dt className="text-muted-foreground">Caption</dt>
-          <dd>
-            {image.caption ?? (
-              <span className="text-muted-foreground">(no caption yet)</span>
-            )}
-          </dd>
-          <dt className="text-muted-foreground">Alt text</dt>
-          <dd>
-            {image.alt_text ?? (
-              <span className="text-muted-foreground">(not set)</span>
-            )}
-          </dd>
-          <dt className="text-muted-foreground">Tags</dt>
-          <dd>
-            {image.tags.length === 0 ? (
-              <span className="text-muted-foreground">—</span>
-            ) : (
-              <div className="flex flex-wrap gap-1">
-                {image.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="rounded bg-muted px-2 py-0.5 text-sm"
-                  >
-                    {tag}
-                  </span>
-                ))}
+      }
+      sections={[
+        {
+          content: (
+            <section className="grid gap-6 md:grid-cols-[1fr_2fr]">
+              <div className="flex flex-col gap-3">
+                <div className="overflow-hidden rounded-md border bg-muted/30">
+                  {publicUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={publicUrl}
+                      alt={image.alt_text ?? image.filename ?? "Library image"}
+                      className="h-full w-full object-contain"
+                      data-testid="image-detail-preview"
+                    />
+                  ) : (
+                    <div className="flex h-64 w-full items-center justify-center text-sm text-muted-foreground">
+                      Preview unavailable (no Cloudflare id or delivery hash).
+                    </div>
+                  )}
+                </div>
+                {thumbUrl && (
+                  <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                    <span>Thumbnail:</span>
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={thumbUrl}
+                      alt=""
+                      className="h-10 w-10 rounded object-cover"
+                    />
+                    <ImageDetailLightbox
+                      src={thumbUrl}
+                      alt={image.alt_text ?? image.filename ?? "Library image"}
+                      title={image.title}
+                      caption={image.caption}
+                      tags={image.tags}
+                      width_px={image.width_px}
+                      height_px={image.height_px}
+                    />
+                  </div>
+                )}
               </div>
-            )}
-          </dd>
-          <dt className="text-muted-foreground">Source</dt>
-          <dd className="capitalize">
-            {image.source}
-            {image.source_ref && (
-              <span className="ml-2 text-sm text-muted-foreground">
-                ({image.source_ref})
-              </span>
-            )}
-          </dd>
-          <dt className="text-muted-foreground">Dimensions</dt>
-          <dd>
-            {image.width_px && image.height_px
-              ? `${image.width_px}×${image.height_px} px`
-              : "—"}
-          </dd>
-          <dt className="text-muted-foreground">File size</dt>
-          <dd>{formatBytes(image.bytes)}</dd>
-        </dl>
-      </section>
 
-      <section className="mt-8">
-        <H3>
-          Used on sites{" "}
-          <span className="text-sm font-normal text-muted-foreground">
-            ({usage.length})
-          </span>
-        </H3>
-        <p className="text-base text-muted-foreground">
-          Every WP site this image has been mirrored to via the publish pipeline.
-        </p>
-        <div className="mt-3" data-testid="image-usage-list">
-          {usage.length === 0 ? (
-            <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
-              Not yet used on any site.
-            </div>
-          ) : (
-            <div className="overflow-hidden rounded-md border">
-              <table className="w-full text-sm">
-                <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
-                  <tr>
-                    <th className="px-4 py-2 font-medium">Site</th>
-                    <th className="px-4 py-2 font-medium">State</th>
-                    <th className="px-4 py-2 font-medium">WP media</th>
-                    <th className="px-4 py-2 font-medium">Transferred</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {usage.map((u) => (
-                    <tr
-                      key={u.id}
-                      className="border-b last:border-b-0"
-                      data-site-id={u.site_id}
-                    >
-                      <td className="px-4 py-3">
-                        <Link
-                          href={`/admin/sites/${u.site_id}`}
-                          className="font-medium hover:underline"
+              <dl
+                className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm"
+                data-testid="image-detail-fields"
+              >
+                <dt className="text-muted-foreground">Title</dt>
+                <dd>
+                  {image.title ?? (
+                    <span className="text-muted-foreground">(not set)</span>
+                  )}
+                </dd>
+                <dt className="text-muted-foreground">Caption</dt>
+                <dd>
+                  {image.caption ?? (
+                    <span className="text-muted-foreground">(no caption yet)</span>
+                  )}
+                </dd>
+                <dt className="text-muted-foreground">Alt text</dt>
+                <dd>
+                  {image.alt_text ?? (
+                    <span className="text-muted-foreground">(not set)</span>
+                  )}
+                </dd>
+                <dt className="text-muted-foreground">Tags</dt>
+                <dd>
+                  {image.tags.length === 0 ? (
+                    <span className="text-muted-foreground">—</span>
+                  ) : (
+                    <div className="flex flex-wrap gap-1">
+                      {image.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded bg-muted px-2 py-0.5 text-sm"
                         >
-                          {u.site_name}
-                        </Link>
-                        {u.wp_url && (
-                          <div className="text-sm text-muted-foreground">
-                            {u.wp_url}
-                          </div>
-                        )}
-                      </td>
-                      <td className="px-4 py-3">{usageStateBadge(u.state)}</td>
-                      <td className="px-4 py-3 text-sm text-muted-foreground">
-                        {u.wp_media_id !== null ? (
-                          u.wp_source_url ? (
-                            <a
-                              href={u.wp_source_url}
-                              target="_blank"
-                              rel="noreferrer"
-                              className="hover:underline"
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </dd>
+                <dt className="text-muted-foreground">Source</dt>
+                <dd className="capitalize">
+                  {image.source}
+                  {image.source_ref && (
+                    <span className="ml-2 text-sm text-muted-foreground">
+                      ({image.source_ref})
+                    </span>
+                  )}
+                </dd>
+                <dt className="text-muted-foreground">Dimensions</dt>
+                <dd>
+                  {image.width_px && image.height_px
+                    ? `${image.width_px}×${image.height_px} px`
+                    : "—"}
+                </dd>
+                <dt className="text-muted-foreground">File size</dt>
+                <dd>{formatBytes(image.bytes)}</dd>
+              </dl>
+            </section>
+          ),
+        },
+        {
+          title: `Used on sites (${usage.length})`,
+          subtitle: "Every WP site this image has been mirrored to via the publish pipeline.",
+          content: (
+            <div data-testid="image-usage-list">
+              {usage.length === 0 ? (
+                <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+                  Not yet used on any site.
+                </div>
+              ) : (
+                <div className="overflow-hidden rounded-md border">
+                  <table className="w-full text-sm">
+                    <thead className="border-b bg-muted/40 text-left text-sm uppercase tracking-wide text-muted-foreground">
+                      <tr>
+                        <th className="px-4 py-2 font-medium">Site</th>
+                        <th className="px-4 py-2 font-medium">State</th>
+                        <th className="px-4 py-2 font-medium">WP media</th>
+                        <th className="px-4 py-2 font-medium">Transferred</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {usage.map((u) => (
+                        <tr
+                          key={u.id}
+                          className="border-b last:border-b-0"
+                          data-site-id={u.site_id}
+                        >
+                          <td className="px-4 py-3">
+                            <Link
+                              href={`/admin/sites/${u.site_id}`}
+                              className="font-medium hover:underline"
                             >
-                              #{u.wp_media_id}
-                            </a>
-                          ) : (
-                            `#${u.wp_media_id}`
-                          )
-                        ) : (
-                          "—"
-                        )}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-muted-foreground">
-                        {u.transferred_at
-                          ? formatRelativeTime(u.transferred_at)
-                          : "—"}
-                      </td>
-                    </tr>
+                              {u.site_name}
+                            </Link>
+                            {u.wp_url && (
+                              <div className="text-sm text-muted-foreground">
+                                {u.wp_url}
+                              </div>
+                            )}
+                          </td>
+                          <td className="px-4 py-3">{usageStateBadge(u.state)}</td>
+                          <td className="px-4 py-3 text-sm text-muted-foreground">
+                            {u.wp_media_id !== null ? (
+                              u.wp_source_url ? (
+                                <a
+                                  href={u.wp_source_url}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className="hover:underline"
+                                >
+                                  #{u.wp_media_id}
+                                </a>
+                              ) : (
+                                `#${u.wp_media_id}`
+                              )
+                            ) : (
+                              "—"
+                            )}
+                          </td>
+                          <td className="px-4 py-3 text-sm text-muted-foreground">
+                            {u.transferred_at
+                              ? formatRelativeTime(u.transferred_at)
+                              : "—"}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          ),
+        },
+        {
+          title: `Additional metadata (${metadata.length})`,
+          subtitle: "EXIF, licensing notes, model info, and any other per-image attributes tracked outside the main row.",
+          content: (
+            <div data-testid="image-metadata-list">
+              {metadata.length === 0 ? (
+                <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+                  No additional metadata.
+                </div>
+              ) : (
+                <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 rounded-md border p-4 text-sm">
+                  {metadata.map((m) => (
+                    <Fragment key={m.key}>
+                      <dt className="font-mono text-sm text-muted-foreground">
+                        {m.key}
+                      </dt>
+                      <dd className="break-all font-mono text-sm">
+                        {formatJsonValue(m.value_jsonb)}
+                      </dd>
+                    </Fragment>
                   ))}
-                </tbody>
-              </table>
+                </dl>
+              )}
             </div>
-          )}
-        </div>
-      </section>
-
-      <section className="mt-8">
-        <H3>
-          Additional metadata{" "}
-          <span className="text-sm font-normal text-muted-foreground">
-            ({metadata.length})
-          </span>
-        </H3>
-        <p className="text-base text-muted-foreground">
-          EXIF, licensing notes, model info, and any other per-image attributes
-          tracked outside the main row.
-        </p>
-        <div className="mt-3" data-testid="image-metadata-list">
-          {metadata.length === 0 ? (
-            <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
-              No additional metadata.
-            </div>
-          ) : (
-            <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 rounded-md border p-4 text-sm">
-              {metadata.map((m) => (
-                <Fragment key={m.key}>
-                  <dt className="font-mono text-sm text-muted-foreground">
-                    {m.key}
-                  </dt>
-                  <dd className="break-all font-mono text-sm">
-                    {formatJsonValue(m.value_jsonb)}
-                  </dd>
-                </Fragment>
-              ))}
-            </dl>
-          )}
-        </div>
-      </section>
-    </PageShell>
+          ),
+        },
+      ]}
+    />
   );
 }

--- a/app/(platform)/admin/sites/[id]/appearance/page.tsx
+++ b/app/(platform)/admin/sites/[id]/appearance/page.tsx
@@ -5,8 +5,7 @@ import { AppearancePanelClient } from "@/components/AppearancePanelClient";
 import { ExtractedProfilePanel } from "@/components/ExtractedProfilePanel";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TDetailSummary } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { listAppearanceEventsForSite } from "@/lib/appearance-events";
 import { getSite } from "@/lib/sites";
@@ -80,7 +79,7 @@ export default async function SiteAppearancePage({
     version_lock: number;
   };
 
-  const headerSegments = [
+  const breadcrumb = [
     { label: "Admin", href: "/admin/sites" },
     { label: "Sites", href: "/admin/sites" },
     { label: site.name, href: `/admin/sites/${site.id}` },
@@ -89,43 +88,47 @@ export default async function SiteAppearancePage({
 
   if (modeRow.site_mode === null) {
     return (
-      <PageShell>
-        <PageHeader>
-          <PageHeader.Breadcrumb segments={headerSegments} />
-          <PageHeader.Title>{site.name}</PageHeader.Title>
-          <PageHeader.Subtitle>Appearance</PageHeader.Subtitle>
-        </PageHeader>
-        <div className="max-w-2xl">
-          <Alert title="Finish setting up this site first">
-            Pick whether we&apos;re uploading content to an existing WordPress
-            theme or building a fresh design before opening Appearance.
-            Generation styling and the rest of setup follow from this choice.
-          </Alert>
-          <Button asChild className="mt-4">
-            <Link href={`/admin/sites/${site.id}/onboarding`}>
-              Go to onboarding →
-            </Link>
-          </Button>
-        </div>
-      </PageShell>
+      <TDetailSummary
+        title={site.name}
+        subtitle="Appearance"
+        breadcrumb={breadcrumb}
+        sections={[{
+          content: (
+            <div className="max-w-2xl">
+              <Alert title="Finish setting up this site first">
+                Pick whether we&apos;re uploading content to an existing WordPress
+                theme or building a fresh design before opening Appearance.
+                Generation styling and the rest of setup follow from this choice.
+              </Alert>
+              <Button asChild className="mt-4">
+                <Link href={`/admin/sites/${site.id}/onboarding`}>
+                  Go to onboarding →
+                </Link>
+              </Button>
+            </div>
+          ),
+        }]}
+      />
     );
   }
 
   if (modeRow.site_mode === "copy_existing") {
     return (
-      <PageShell>
-        <PageHeader>
-          <PageHeader.Breadcrumb segments={headerSegments} />
-          <PageHeader.Title>Appearance · {site.name}</PageHeader.Title>
-        </PageHeader>
-        <ExtractedProfilePanel
-          siteId={site.id}
-          siteName={site.name}
-          siteUrl={site.wp_url}
-          extractedDesign={modeRow.extracted_design}
-          extractedClasses={modeRow.extracted_css_classes}
-        />
-      </PageShell>
+      <TDetailSummary
+        title={`Appearance · ${site.name}`}
+        breadcrumb={breadcrumb}
+        sections={[{
+          content: (
+            <ExtractedProfilePanel
+              siteId={site.id}
+              siteName={site.name}
+              siteUrl={site.wp_url}
+              extractedDesign={modeRow.extracted_design}
+              extractedClasses={modeRow.extracted_css_classes}
+            />
+          ),
+        }]}
+      />
     );
   }
 
@@ -136,21 +139,23 @@ export default async function SiteAppearancePage({
     process.env.FEATURE_PATH_B_PUBLISH_GATE === "1";
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb segments={headerSegments} />
-        <PageHeader.Title>Appearance · {site.name}</PageHeader.Title>
-      </PageHeader>
-      <AppearancePanelClient
-        siteId={site.id}
-        siteName={site.name}
-        siteWpUrl={site.wp_url}
-        initialKadenceInstalledAt={modeRow.kadence_installed_at}
-        initialKadenceGlobalsSyncedAt={modeRow.kadence_globals_synced_at}
-        initialSiteVersionLock={modeRow.version_lock}
-        initialEvents={events}
-        publishGateEnabled={publishGateEnabled}
-      />
-    </PageShell>
+    <TDetailSummary
+      title={`Appearance · ${site.name}`}
+      breadcrumb={breadcrumb}
+      sections={[{
+        content: (
+          <AppearancePanelClient
+            siteId={site.id}
+            siteName={site.name}
+            siteWpUrl={site.wp_url}
+            initialKadenceInstalledAt={modeRow.kadence_installed_at}
+            initialKadenceGlobalsSyncedAt={modeRow.kadence_globals_synced_at}
+            initialSiteVersionLock={modeRow.version_lock}
+            initialEvents={events}
+            publishGateEnabled={publishGateEnabled}
+          />
+        ),
+      }]}
+    />
   );
 }

--- a/app/(platform)/admin/sites/[id]/page.tsx
+++ b/app/(platform)/admin/sites/[id]/page.tsx
@@ -17,9 +17,8 @@ import {
 } from "@/components/ui/status-pill";
 import { H3 } from "@/components/ui/typography";
 import { NavIcon } from "@/components/ui/nav-icon";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { UploadBriefButton } from "@/components/UploadBriefButton";
+import { TDetailSummary } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { listSiteBriefs } from "@/lib/briefs";
 import { checkBlogStylingCalibrated } from "@/lib/site-preflight";
@@ -195,21 +194,18 @@ export default async function SiteDetailPage({
     ? await checkBlogStylingCalibrated(site.id, "post")
     : null;
 
+  const hasBanner = needsOnboarding || needsSetupReminder || !!blogStyleBlocker;
+
   return (
-    <PageShell>
-      {needsOnboarding && <OnboardingReminderBanner siteId={site.id} />}
-      {needsSetupReminder && <SetupReminderBanner siteId={site.id} />}
-      {blogStyleBlocker && <BlogStyleCalibrationBanner siteId={site.id} />}
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Sites", href: "/admin/sites" },
-            { label: site.name },
-          ]}
-        />
-        <PageHeader.Title>{site.name}</PageHeader.Title>
-        <PageHeader.Meta>
+    <TDetailSummary
+      title={site.name}
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Sites", href: "/admin/sites" },
+        { label: site.name },
+      ]}
+      meta={
+        <>
           <StatusPill kind={siteStatusKind(site.status as Parameters<typeof siteStatusKind>[0])} />
           <a
             href={site.wp_url}
@@ -217,8 +213,8 @@ export default async function SiteDetailPage({
             rel="noreferrer"
             className="transition-smooth hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
           >
-              {site.wp_url}
-            </a>
+            {site.wp_url}
+          </a>
           <Link
             href={`/admin/sites/${site.id}/pages`}
             className="transition-smooth hover:text-foreground hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
@@ -227,100 +223,108 @@ export default async function SiteDetailPage({
             Pages →
           </Link>
           <span data-screenshot-mask>updated {formatDate(site.updated_at)}</span>
-        </PageHeader.Meta>
-        <PageHeader.Actions>
-          <SiteDetailActions
-            site={{ id: site.id, name: site.name, wp_url: site.wp_url }}
-            templates={batchTemplateOptions}
-          />
-        </PageHeader.Actions>
-      </PageHeader>
-
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div className="space-y-6">
-         <section>
-          <div className="flex items-center justify-between">
-            <H3>Recent batches</H3>
+        </>
+      }
+      actions={
+        <SiteDetailActions
+          site={{ id: site.id, name: site.name, wp_url: site.wp_url }}
+          templates={batchTemplateOptions}
+        />
+      }
+      inlineAlert={
+        hasBanner ? (
+          <>
+            {needsOnboarding && <OnboardingReminderBanner siteId={site.id} />}
+            {needsSetupReminder && <SetupReminderBanner siteId={site.id} />}
+            {blogStyleBlocker && <BlogStyleCalibrationBanner siteId={site.id} />}
+          </>
+        ) : undefined
+      }
+      sections={[
+        {
+          title: "Recent batches",
+          actions: (
             <Link
               href={`/admin/batches/${site.id}`}
               className="text-sm text-muted-foreground transition-smooth hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
             >
               View all →
             </Link>
-          </div>
-          <div className="mt-2 overflow-x-auto rounded-md border">
-            {(batches ?? []).length === 0 ? (
-              <div className="p-3">
-                <EmptyState
-                  density="compact"
-                  icon={<NavIcon name="tree" size={20} />}
-                  iconLabel="No batches"
-                  title="No batches yet"
-                  body={
-                    <>
-                      Run a batch to generate multiple pages from a template
-                      against the active design system.
-                    </>
-                  }
-                />
-              </div>
-            ) : (
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b bg-muted/40 text-left text-muted-foreground">
-                    <th className="px-3 py-2 font-medium">Template</th>
-                    <th className="px-3 py-2 font-medium">Status</th>
-                    <th className="px-3 py-2 font-medium">Progress</th>
-                    <th className="px-3 py-2 font-medium">Cost</th>
-                    <th className="px-3 py-2 font-medium">Created</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {(batches ?? []).map((b) => {
-                    const tmpl = b.template as unknown as {
-                      name: string;
-                    } | null;
-                    return (
-                      <tr
-                        key={b.id as string}
-                        className="border-b last:border-b-0"
-                      >
-                        <td className="px-3 py-2">
-                          <Link
-                            href={`/admin/batches/${site.id}/${b.id as string}`}
-                            className="font-medium hover:underline"
-                          >
-                            {tmpl?.name ?? "—"}
-                          </Link>
-                        </td>
-                        <td className="px-3 py-2">
-                          <StatusPill kind={jobStatusKind(b.status as Parameters<typeof jobStatusKind>[0])} />
-                        </td>
-                        <td className="px-3 py-2 text-muted-foreground">
-                          {b.succeeded_count as number} ok ·{" "}
-                          {b.failed_count as number} fail ·{" "}
-                          {b.requested_count as number} total
-                        </td>
-                        <td className="px-3 py-2 text-muted-foreground">
-                          {formatCostCents(
-                            Number(b.total_cost_usd_cents ?? 0),
-                          )}
-                        </td>
-                        <td className="px-3 py-2 text-muted-foreground">
-                          {formatDate(b.created_at as string)}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            )}
-          </div>
-        </section>
-
-        <section>
-          <div className="flex items-center justify-between">
-            <H3>Briefs</H3>
+          ),
+          content: (
+            <div className="overflow-x-auto rounded-md border">
+              {(batches ?? []).length === 0 ? (
+                <div className="p-3">
+                  <EmptyState
+                    density="compact"
+                    icon={<NavIcon name="tree" size={20} />}
+                    iconLabel="No batches"
+                    title="No batches yet"
+                    body={
+                      <>
+                        Run a batch to generate multiple pages from a template
+                        against the active design system.
+                      </>
+                    }
+                  />
+                </div>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-muted/40 text-left text-muted-foreground">
+                      <th className="px-3 py-2 font-medium">Template</th>
+                      <th className="px-3 py-2 font-medium">Status</th>
+                      <th className="px-3 py-2 font-medium">Progress</th>
+                      <th className="px-3 py-2 font-medium">Cost</th>
+                      <th className="px-3 py-2 font-medium">Created</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(batches ?? []).map((b) => {
+                      const tmpl = b.template as unknown as {
+                        name: string;
+                      } | null;
+                      return (
+                        <tr
+                          key={b.id as string}
+                          className="border-b last:border-b-0"
+                        >
+                          <td className="px-3 py-2">
+                            <Link
+                              href={`/admin/batches/${site.id}/${b.id as string}`}
+                              className="font-medium hover:underline"
+                            >
+                              {tmpl?.name ?? "—"}
+                            </Link>
+                          </td>
+                          <td className="px-3 py-2">
+                            <StatusPill kind={jobStatusKind(b.status as Parameters<typeof jobStatusKind>[0])} />
+                          </td>
+                          <td className="px-3 py-2 text-muted-foreground">
+                            {b.succeeded_count as number} ok ·{" "}
+                            {b.failed_count as number} fail ·{" "}
+                            {b.requested_count as number} total
+                          </td>
+                          <td className="px-3 py-2 text-muted-foreground">
+                            {formatCostCents(
+                              Number(b.total_cost_usd_cents ?? 0),
+                            )}
+                          </td>
+                          <td className="px-3 py-2 text-muted-foreground">
+                            {formatDate(b.created_at as string)}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          ),
+        },
+        {
+          title: "Briefs",
+          actions: (
             <UploadBriefButton
               siteId={site.id}
               binaryParsersEnabled={
@@ -328,64 +332,66 @@ export default async function SiteDetailPage({
                 process.env.OPOLLO_BRIEF_BINARY_PARSERS === "true"
               }
             />
-          </div>
-          <div className="mt-2 overflow-x-auto rounded-md border">
-            {briefs.length === 0 ? (
-              <div className="p-3">
-                <EmptyState
-                  density="compact"
-                  icon={<NavIcon name="file-empty" size={20} />}
-                  iconLabel="No briefs"
-                  title="No briefs yet"
-                  body={
-                    <>
-                      Upload a single markdown / text document and Opollo
-                      parses it into a list of pages, then generates each one.
-                    </>
-                  }
-                />
-              </div>
-            ) : (
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b bg-muted/40 text-left text-muted-foreground">
-                    <th className="px-3 py-2 font-medium">Title</th>
-                    <th className="px-3 py-2 font-medium">Status</th>
-                    <th className="px-3 py-2 font-medium">Parser</th>
-                    <th className="px-3 py-2 font-medium">Updated</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {briefs.map((b) => (
-                    <tr key={b.id} className="border-b last:border-b-0">
-                      <td className="px-3 py-2">
-                        <Link
-                          href={`/admin/sites/${site.id}/briefs/${b.id}/review`}
-                          className="font-medium hover:underline"
-                          data-testid={`brief-row-${b.id}`}
-                        >
-                          {b.title}
-                        </Link>
-                      </td>
-                      <td className="px-3 py-2">
-                        <StatusPill kind={briefStatusKind(b.status as Parameters<typeof briefStatusKind>[0])} />
-                      </td>
-                      <td className="px-3 py-2 text-muted-foreground">
-                        {b.parser_mode ?? "—"}
-                      </td>
-                      <td className="px-3 py-2 text-muted-foreground">
-                        {formatDate(b.updated_at)}
-                      </td>
+          ),
+          content: (
+            <div className="overflow-x-auto rounded-md border">
+              {briefs.length === 0 ? (
+                <div className="p-3">
+                  <EmptyState
+                    density="compact"
+                    icon={<NavIcon name="file-empty" size={20} />}
+                    iconLabel="No briefs"
+                    title="No briefs yet"
+                    body={
+                      <>
+                        Upload a single markdown / text document and Opollo
+                        parses it into a list of pages, then generates each one.
+                      </>
+                    }
+                  />
+                </div>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-muted/40 text-left text-muted-foreground">
+                      <th className="px-3 py-2 font-medium">Title</th>
+                      <th className="px-3 py-2 font-medium">Status</th>
+                      <th className="px-3 py-2 font-medium">Parser</th>
+                      <th className="px-3 py-2 font-medium">Updated</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            )}
-          </div>
-        </section>
-        </div>
-
-        <aside className="space-y-4">
+                  </thead>
+                  <tbody>
+                    {briefs.map((b) => (
+                      <tr key={b.id} className="border-b last:border-b-0">
+                        <td className="px-3 py-2">
+                          <Link
+                            href={`/admin/sites/${site.id}/briefs/${b.id}/review`}
+                            className="font-medium hover:underline"
+                            data-testid={`brief-row-${b.id}`}
+                          >
+                            {b.title}
+                          </Link>
+                        </td>
+                        <td className="px-3 py-2">
+                          <StatusPill kind={briefStatusKind(b.status as Parameters<typeof briefStatusKind>[0])} />
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {b.parser_mode ?? "—"}
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {formatDate(b.updated_at)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          ),
+        },
+      ]}
+      sidebar={
+        <div className="space-y-4">
           <div className="rounded-lg border p-3">
             <div className="flex items-center justify-between">
               <H3>Budget</H3>
@@ -623,8 +629,8 @@ export default async function SiteDetailPage({
               </div>
             </div>
           </div>
-        </aside>
-      </div>
-    </PageShell>
+        </div>
+      }
+    />
   );
 }

--- a/app/(platform)/optimiser/imports/[brief_id]/page.tsx
+++ b/app/(platform)/optimiser/imports/[brief_id]/page.tsx
@@ -2,8 +2,8 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
-import { PageHeader } from "@/components/ui/page-header";
 import { ImportSideBySide } from "@/components/optimiser/ImportSideBySide";
+import { TDetailSummary } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getImportDetails } from "@/lib/optimiser/page-import/read-import";
 
@@ -28,41 +28,44 @@ export default async function OptimiserImportReviewPage({
     : null;
 
   return (
-    <div className="space-y-6">
-      <PageHeader>
-        <PageHeader.Title>
-          Import review — {details.brief_page.title}
-        </PageHeader.Title>
-        <PageHeader.Subtitle>
-          Brief status:{" "}
-          <code className="font-mono text-sm">{details.brief.status}</code>
-          {" · "}
-          {details.brief_page.word_count.toLocaleString()} words captured
+    <TDetailSummary
+      title={`Import review — ${details.brief_page.title}`}
+      breadcrumb={[
+        { label: "Optimiser", href: "/optimiser" },
+        { label: "Imports" },
+      ]}
+      meta={
+        <>
+          <span>
+            Brief status:{" "}
+            <code className="font-mono text-sm">{details.brief.status}</code>
+          </span>
+          <span>{details.brief_page.word_count.toLocaleString()} words captured</span>
           {details.brief_page.import_source_url && (
-            <>
-              {" · "}
-              <span className="font-mono text-sm">
-                {details.brief_page.import_source_url}
-              </span>
-            </>
+            <span className="font-mono text-sm">
+              {details.brief_page.import_source_url}
+            </span>
           )}
-        </PageHeader.Subtitle>
-        {briefRunHref && (
-          <PageHeader.Actions>
-            <Button asChild variant="outline">
-              <Link href={briefRunHref}>Brief run progress</Link>
-            </Button>
-          </PageHeader.Actions>
-        )}
-      </PageHeader>
-
-      <ImportSideBySide
-        cachedHtml={details.brief_page.source_text}
-        liveUrl={details.brief_page.import_source_url}
-        briefRunStatus={details.brief_run?.status ?? null}
-        briefRunHref={briefRunHref}
-        briefRunCreatedAt={details.brief_run?.created_at ?? null}
-      />
-    </div>
+        </>
+      }
+      actions={
+        briefRunHref ? (
+          <Button asChild variant="outline">
+            <Link href={briefRunHref}>Brief run progress</Link>
+          </Button>
+        ) : undefined
+      }
+      sections={[{
+        content: (
+          <ImportSideBySide
+            cachedHtml={details.brief_page.source_text}
+            liveUrl={details.brief_page.import_source_url}
+            briefRunStatus={details.brief_run?.status ?? null}
+            briefRunHref={briefRunHref}
+            briefRunCreatedAt={details.brief_run?.created_at ?? null}
+          />
+        ),
+      }]}
+    />
   );
 }

--- a/app/(platform)/optimiser/pages/[id]/page.tsx
+++ b/app/(platform)/optimiser/pages/[id]/page.tsx
@@ -2,12 +2,12 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
-import { PageHeader } from "@/components/ui/page-header";
 import { AbTestStatusBanner } from "@/components/optimiser/AbTestStatusBanner";
 import { ScoreBreakdownPanel } from "@/components/optimiser/ScoreBreakdownPanel";
 import { StagedRolloutBanner } from "@/components/optimiser/StagedRolloutBanner";
 import { ScoreHistoryTable } from "@/components/optimiser/ScoreHistoryTable";
 import { ScoreSparkline } from "@/components/optimiser/ScoreSparkline";
+import { TDetailSummary } from "@/templates";
 import {
   buildDeltaMapByProposal,
   listCausalDeltasForPage,
@@ -127,48 +127,53 @@ export default async function OptimiserPageDetail({
   const latestRollout = await getLatestRolloutForLandingPage(page.id);
 
   return (
-    <div className="space-y-6">
-      <PageHeader>
-        <PageHeader.Title>{page.display_name ?? page.url}</PageHeader.Title>
-        <PageHeader.Subtitle>
-          <span className="font-mono">{page.url}</span>
-        </PageHeader.Subtitle>
-        <PageHeader.Actions>
-          <Button asChild variant="outline">
-            <Link href={`/optimiser/clients/${client.id}/settings`}>
-              Score weights
-            </Link>
-          </Button>
-        </PageHeader.Actions>
-      </PageHeader>
-
-      <AbTestStatusBanner test={latestTest as never} />
-      <StagedRolloutBanner rollout={latestRollout} />
-
-      {composite ? (
-        <ScoreBreakdownPanel
-          result={composite}
-          subscores={{
-            alignment: alignmentScore,
-            behaviour: behaviour?.score ?? null,
-            conversion: conversion?.score ?? null,
-            technical: technical?.score ?? null,
-          }}
-          reliability={reliability.reliability}
-          draggingSubscore={dragging}
-        />
-      ) : (
-        <section className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
-          Gathering data — composite score available once §9.5 thresholds
-          are met (sessions ≥ 100, freshness ≤ 7 days, behaviour data
-          present).
-        </section>
-      )}
-
-      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
-        <header className="flex items-center justify-between">
-          <h2 className="text-lg font-medium">Score history</h2>
-          {sparkline.length > 0 && (
+    <TDetailSummary
+      title={page.display_name ?? page.url}
+      breadcrumb={[
+        { label: "Optimiser", href: "/optimiser" },
+        { label: "Pages", href: `/optimiser/clients/${client.id}` },
+        { label: page.display_name ?? page.url },
+      ]}
+      meta={<span className="font-mono">{page.url}</span>}
+      actions={
+        <Button asChild variant="outline">
+          <Link href={`/optimiser/clients/${client.id}/settings`}>
+            Score weights
+          </Link>
+        </Button>
+      }
+      sections={[
+        {
+          title: "Performance",
+          content: (
+            <div className="space-y-4">
+              <AbTestStatusBanner test={latestTest as never} />
+              <StagedRolloutBanner rollout={latestRollout} />
+              {composite ? (
+                <ScoreBreakdownPanel
+                  result={composite}
+                  subscores={{
+                    alignment: alignmentScore,
+                    behaviour: behaviour?.score ?? null,
+                    conversion: conversion?.score ?? null,
+                    technical: technical?.score ?? null,
+                  }}
+                  reliability={reliability.reliability}
+                  draggingSubscore={dragging}
+                />
+              ) : (
+                <section className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+                  Gathering data — composite score available once §9.5 thresholds
+                  are met (sessions ≥ 100, freshness ≤ 7 days, behaviour data
+                  present).
+                </section>
+              )}
+            </div>
+          ),
+        },
+        {
+          title: "Score history",
+          actions: sparkline.length > 0 ? (
             <ScoreSparkline
               points={sparkline.map((row) => ({
                 value: row.composite_score,
@@ -178,15 +183,17 @@ export default async function OptimiserPageDetail({
               width={240}
               height={56}
             />
-          )}
-        </header>
-        <ScoreHistoryTable
-          pageId={page.id}
-          history={history}
-          causalDeltas={causalDeltas}
-        />
-      </section>
-    </div>
+          ) : undefined,
+          content: (
+            <ScoreHistoryTable
+              pageId={page.id}
+              history={history}
+              causalDeltas={causalDeltas}
+            />
+          ),
+        },
+      ]}
+    />
   );
 }
 

--- a/app/(platform)/optimiser/proposals/[id]/page.tsx
+++ b/app/(platform)/optimiser/proposals/[id]/page.tsx
@@ -8,6 +8,7 @@ import { PatternPriorsPanel } from "@/components/optimiser/PatternPriorsPanel";
 import { ProposalAppliedMoment } from "@/components/optimiser/ProposalAppliedMoment";
 import { ProposalReview } from "@/components/optimiser/ProposalReview";
 import { ProposalRolloutLink } from "@/components/optimiser/ProposalRolloutLink";
+import { TDetailSummary } from "@/templates";
 import { getClient } from "@/lib/optimiser/clients";
 import { listRecentCausalDeltasForPlaybook } from "@/lib/optimiser/causal/read-deltas";
 import { listRelevantPatterns } from "@/lib/optimiser/pattern-library/priors";
@@ -68,72 +69,88 @@ export default async function OptimiserProposalReviewPage({
   const rollout = await getRolloutForProposal(proposal.id);
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <Button asChild variant="outline" size="sm">
-          <Link href="/optimiser/proposals">← All proposals</Link>
-        </Button>
+    <TDetailSummary
+      title={proposal.headline}
+      breadcrumb={[
+        { label: "Optimiser", href: "/optimiser" },
+        { label: "Proposals", href: "/optimiser/proposals" },
+        { label: "Review" },
+      ]}
+      meta={
         <span className="text-sm text-muted-foreground">
           Status: <code>{proposal.status}</code>
         </span>
-      </div>
-      {proposal.status === "applied" && (
-        <ProposalAppliedMoment
-          proposalId={proposal.id}
-          rolloutHref={
-            rollout
-              ? `/optimiser/pages/${proposal.landing_page_id}`
-              : null
-          }
-        />
-      )}
-      <ProposalRolloutLink
-        rollout={rollout}
-        landingPageId={proposal.landing_page_id}
-      />
-      <PastCausalDeltasPanel
-        deltas={pastDeltas}
-        playbookId={proposal.triggering_playbook_id}
-      />
-      <PatternPriorsPanel
-        patterns={relevantPatterns}
-        playbookId={proposal.triggering_playbook_id}
-      />
-      {canCreateVariant && client && (
-        <CreateVariantButton
-          proposalId={proposal.id}
-          hostingMode={
-            client.hosting_mode as
-              | "opollo_subdomain"
-              | "opollo_cname"
-              | "client_slice"
-          }
-        />
-      )}
-      <ProposalReview
-        proposal={{
-          id: proposal.id,
-          headline: proposal.headline,
-          problem_summary: proposal.problem_summary,
-          risk_level: proposal.risk_level,
-          priority_score: proposal.priority_score,
-          confidence_score: proposal.confidence_score,
-          confidence_sample: proposal.confidence_sample,
-          confidence_freshness: proposal.confidence_freshness,
-          confidence_stability: proposal.confidence_stability,
-          confidence_signal: proposal.confidence_signal,
-          expected_impact_min_pp: proposal.expected_impact_min_pp,
-          expected_impact_max_pp: proposal.expected_impact_max_pp,
-          effort_bucket: proposal.effort_bucket,
-          expires_at: proposal.expires_at,
-          triggering_playbook_id: proposal.triggering_playbook_id,
-          change_set: proposal.change_set,
-          before_snapshot: proposal.before_snapshot,
-          current_performance: proposal.current_performance,
-        }}
-        evidence={evidence}
-        pageUrl={page?.url ?? null}
-      />
-    </div>
+      }
+      actions={
+        <Button asChild variant="outline" size="sm">
+          <Link href="/optimiser/proposals">← All proposals</Link>
+        </Button>
+      }
+      inlineAlert={
+        proposal.status === "applied" ? (
+          <ProposalAppliedMoment
+            proposalId={proposal.id}
+            rolloutHref={
+              rollout
+                ? `/optimiser/pages/${proposal.landing_page_id}`
+                : null
+            }
+          />
+        ) : undefined
+      }
+      sections={[{
+        content: (
+          <div className="space-y-4">
+            <ProposalRolloutLink
+              rollout={rollout}
+              landingPageId={proposal.landing_page_id}
+            />
+            <PastCausalDeltasPanel
+              deltas={pastDeltas}
+              playbookId={proposal.triggering_playbook_id}
+            />
+            <PatternPriorsPanel
+              patterns={relevantPatterns}
+              playbookId={proposal.triggering_playbook_id}
+            />
+            {canCreateVariant && client && (
+              <CreateVariantButton
+                proposalId={proposal.id}
+                hostingMode={
+                  client.hosting_mode as
+                    | "opollo_subdomain"
+                    | "opollo_cname"
+                    | "client_slice"
+                }
+              />
+            )}
+            <ProposalReview
+              proposal={{
+                id: proposal.id,
+                headline: proposal.headline,
+                problem_summary: proposal.problem_summary,
+                risk_level: proposal.risk_level,
+                priority_score: proposal.priority_score,
+                confidence_score: proposal.confidence_score,
+                confidence_sample: proposal.confidence_sample,
+                confidence_freshness: proposal.confidence_freshness,
+                confidence_stability: proposal.confidence_stability,
+                confidence_signal: proposal.confidence_signal,
+                expected_impact_min_pp: proposal.expected_impact_min_pp,
+                expected_impact_max_pp: proposal.expected_impact_max_pp,
+                effort_bucket: proposal.effort_bucket,
+                expires_at: proposal.expires_at,
+                triggering_playbook_id: proposal.triggering_playbook_id,
+                change_set: proposal.change_set,
+                before_snapshot: proposal.before_snapshot,
+                current_performance: proposal.current_performance,
+              }}
+              evidence={evidence}
+              pageUrl={page?.url ?? null}
+            />
+          </div>
+        ),
+      }]}
+    />
   );
 }

--- a/app/(platform)/optimiser/proposals/[id]/page.tsx
+++ b/app/(platform)/optimiser/proposals/[id]/page.tsx
@@ -76,10 +76,25 @@ export default async function OptimiserProposalReviewPage({
         { label: "Proposals", href: "/optimiser/proposals" },
         { label: "Review" },
       ]}
+      subtitle={proposal.problem_summary ?? undefined}
       meta={
-        <span className="text-sm text-muted-foreground">
-          Status: <code>{proposal.status}</code>
-        </span>
+        <>
+          <span className="text-sm text-muted-foreground">
+            Status: <code>{proposal.status}</code>
+          </span>
+          {page?.url && (
+            <span className="font-mono text-sm text-muted-foreground">{page.url}</span>
+          )}
+          <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-sm font-medium ${
+            proposal.risk_level === "high"
+              ? "bg-red-100 text-red-900 border-red-200"
+              : proposal.risk_level === "medium"
+                ? "bg-amber-100 text-amber-900 border-amber-200"
+                : "bg-emerald-100 text-emerald-900 border-emerald-200"
+          }`}>
+            {proposal.risk_level} risk
+          </span>
+        </>
       }
       actions={
         <Button asChild variant="outline" size="sm">
@@ -125,6 +140,7 @@ export default async function OptimiserProposalReviewPage({
               />
             )}
             <ProposalReview
+              hidePageHeader
               proposal={{
                 id: proposal.id,
                 headline: proposal.headline,

--- a/components/optimiser/ProposalReview.tsx
+++ b/components/optimiser/ProposalReview.tsx
@@ -36,6 +36,9 @@ export type ProposalReviewProps = {
     payload: Record<string, unknown>;
   }>;
   pageUrl: string | null;
+  /** When true, suppresses the internal PageHeader (headline/subtitle/actions).
+   *  Use when the parent page already renders page chrome via a template. */
+  hidePageHeader?: boolean;
 };
 
 const REJECTION_REASONS = [
@@ -50,6 +53,7 @@ export function ProposalReview({
   proposal,
   evidence,
   pageUrl,
+  hidePageHeader = false,
 }: ProposalReviewProps) {
   const router = useRouter();
   const [reprompt, setReprompt] = useState("");
@@ -135,20 +139,22 @@ export function ProposalReview({
   return (
     <div className="grid gap-6 lg:grid-cols-[1fr_360px]">
       <div className="space-y-6">
-        <PageHeader>
-          <PageHeader.Title>{proposal.headline}</PageHeader.Title>
-          {proposal.problem_summary && (
-            <PageHeader.Subtitle className="text-sm">
-              {proposal.problem_summary}
-            </PageHeader.Subtitle>
-          )}
-          <PageHeader.Actions>
-            {pageUrl && (
-              <span className="font-mono text-sm text-muted-foreground">{pageUrl}</span>
+        {!hidePageHeader && (
+          <PageHeader>
+            <PageHeader.Title>{proposal.headline}</PageHeader.Title>
+            {proposal.problem_summary && (
+              <PageHeader.Subtitle className="text-sm">
+                {proposal.problem_summary}
+              </PageHeader.Subtitle>
             )}
-            <RiskPill risk={proposal.risk_level} />
-          </PageHeader.Actions>
-        </PageHeader>
+            <PageHeader.Actions>
+              {pageUrl && (
+                <span className="font-mono text-sm text-muted-foreground">{pageUrl}</span>
+              )}
+              <RiskPill risk={proposal.risk_level} />
+            </PageHeader.Actions>
+          </PageHeader>
+        )}
 
         <Section title="Suggested change">
           <div className="rounded-md border border-border bg-card p-4 text-sm whitespace-pre-wrap">

--- a/docs/briefs/social-01-brief/framework/PROGRESS.md
+++ b/docs/briefs/social-01-brief/framework/PROGRESS.md
@@ -1,4 +1,11 @@
-## Wave 2a in progress 2026-05-19
+## Wave 2b in progress 2026-05-19
+
+- Template updated: TDetailSummarySection.title optional; subtitle widened to ReactNode
+- Routes migrated: 10 (T-DETAIL-SUMMARY: /admin/companies/[id], /admin/companies/[id]/social-profiles/[profileId]/connections, /admin/sites/[id], /admin/sites/[id]/appearance, /admin/batches/[siteId]/[batchId], /admin/images/[id], /optimiser/proposals/[id], /optimiser/pages/[id], /optimiser/imports/[brief_id]; TListStandard: /admin/batches/[siteId])
+- Deviation: /admin/batches/[siteId] used TListStandard (list semantics better fit than T-DETAIL-SUMMARY)
+- Deferred: /admin/sites/[id]/design-system, /admin/sites/[id]/design-system/preview — both "use client" layout-driven; shell from client layout, not PageShell/PageHeader; require layout refactor
+
+## Wave 2a complete 2026-05-19
 
 - Templates added: T-LIST-WIDE, T-DETAIL-SUMMARY, T-FORM, T-SETTINGS-FLAT
 - Routes migrated: 11 (T-LIST-WIDE: /admin/users, /admin/users/audit, /admin/companies, /admin/maintenance/social-connections, /admin/images; T-LIST-STANDARD deferred: /optimiser/proposals, /optimiser/change-log, /company/users; T-DASHBOARD-FEED deferred: /admin/_internal/table-examples, /company/internal/autosave-lab)

--- a/templates/T-DETAIL-SUMMARY.tsx
+++ b/templates/T-DETAIL-SUMMARY.tsx
@@ -8,7 +8,7 @@ import type { CalloutProps } from "@/components/ui/callout";
 import type { BreadcrumbSegment } from "./T-LIST-STANDARD";
 
 export interface TDetailSummarySection {
-  title: string;
+  title?: string;
   subtitle?: string;
   actions?: React.ReactNode;
   content: React.ReactNode;
@@ -17,7 +17,7 @@ export interface TDetailSummarySection {
 export interface TDetailSummaryProps {
   title: string;
   breadcrumb?: BreadcrumbSegment[];
-  subtitle?: string;
+  subtitle?: React.ReactNode;
   actions?: React.ReactNode;
   meta?: React.ReactNode;
   /** Optional stacked callout banners above the sections. */
@@ -74,14 +74,19 @@ export function TDetailSummary({
 
       <div className={sidebar ? "flex gap-6" : undefined}>
         <div className={sidebar ? "min-w-0 flex-1 space-y-8" : "space-y-8"}>
-          {sections.map((section) => (
-            <section key={section.title} aria-labelledby={`section-${section.title.replace(/\s+/g, "-").toLowerCase()}`}>
-              <SectionHeader
-                title={section.title}
-                subtitle={section.subtitle}
-                actions={section.actions}
-                className="mb-4"
-              />
+          {sections.map((section, i) => (
+            <section
+              key={section.title ?? i}
+              aria-labelledby={section.title ? `section-${section.title.replace(/\s+/g, "-").toLowerCase()}` : undefined}
+            >
+              {section.title && (
+                <SectionHeader
+                  title={section.title}
+                  subtitle={section.subtitle}
+                  actions={section.actions}
+                  className="mb-4"
+                />
+              )}
               {section.content}
             </section>
           ))}


### PR DESCRIPTION
## Summary

- Migrates 10 routes to `TDetailSummary` (read-mostly detail pages with structured sections)
- Updates template: `TDetailSummarySection.title` made optional; `subtitle` widened to `React.ReactNode`
- Defers 2 layout-driven pages (design-system index + preview — both `"use client"`, shell owned by client layout)

## Routes migrated

| Route | Template | Notes |
|---|---|---|
| `/admin/companies/[id]` | T-DETAIL-SUMMARY | meta: internal badge, slug, domain |
| `/admin/companies/[id]/social-profiles/[profileId]/connections` | T-DETAIL-SUMMARY | meta: team ID or "not provisioned" |
| `/admin/sites/[id]` | T-DETAIL-SUMMARY | 2 sections + 5-card sidebar; banners → inlineAlert (placed after header per template pattern) |
| `/admin/sites/[id]/appearance` | T-DETAIL-SUMMARY | 3 mode branches (null/copy_existing/new_design) |
| `/admin/batches/[siteId]` | **T-LIST-STANDARD** | Wave plan listed as T-DETAIL-SUMMARY but list semantics fit better; deviation noted |
| `/admin/batches/[siteId]/[batchId]` | T-DETAIL-SUMMARY | slots section + events sidebar; BatchSuccessMoment → inlineAlert |
| `/admin/images/[id]` | T-DETAIL-SUMMARY | 3 sections: image details, usage table, additional metadata |
| `/optimiser/proposals/[id]` | T-DETAIL-SUMMARY | adds PageShell chrome (was bare div); status → meta |
| `/optimiser/pages/[id]` | T-DETAIL-SUMMARY | 2 sections: Performance + Score history; sparkline → section.actions |
| `/optimiser/imports/[brief_id]` | T-DETAIL-SUMMARY | adds PageShell chrome (was bare div); subtitle JSX → meta |

## Deferred

- `/admin/sites/[id]/design-system` — `"use client"` layout-driven; chrome provided by `design-system/layout.tsx`; would require client layout refactor
- `/admin/sites/[id]/design-system/preview` — same reason

## Template changes

- `TDetailSummarySection.title` now `string | undefined` — SectionHeader skipped when absent (uses array index as React key)
- `TDetailSummaryProps.subtitle` widened from `string` to `React.ReactNode` to support JSX subtitles in import/page-detail routes

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (1778 passed), audit:static (0 HIGH)
- [x] For bug fixes: N/A — template migration
- [x] Risks identified and mitigated section in PR body
- [x] PR is under 500 net lines OR exception stated (797 ins / 780 del — close to neutral; template churn)

## Risks identified and mitigated

- **Banner reordering on /admin/sites/[id]**: Previously banners appeared before PageHeader; now appear after (as `inlineAlert`). Semantically acceptable — onboarding banner below site title is still prominent. Not a functional regression.
- **Sidebar width /admin/sites/[id]**: Sidebar was 320px (CSS grid); now 288px (`w-72`). Minor visual difference, no content clipping expected for the 5 sidebar cards.
- **Design-system pages skipped**: These pages are fully client-side and get their chrome from the layout component. Attempting T-DETAIL-SUMMARY here would produce double PageShell. Deferred with PROGRESS.md note.
- **/admin/batches/[siteId] template swap**: Used TListStandard instead of T-DETAIL-SUMMARY per wave plan. Functionally identical result — same title/breadcrumb/subtitle/actions/children structure. TListStandard is the correct semantic template for a flat list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)