### PR TITLE
feat(framework): wave 2c — T-FORM (6) + T-SETTINGS-FLAT (7) migrations

### DIFF
--- a/app/(platform)/account/devices/page.tsx
+++ b/app/(platform)/account/devices/page.tsx
@@ -3,8 +3,7 @@ import { redirect } from "next/navigation";
 
 import { TrustedDevicesList } from "@/components/TrustedDevicesList";
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TSettingsFlat } from "@/templates";
 import {
   DEVICE_ID_COOKIE,
   decodeDeviceCookie,
@@ -48,46 +47,47 @@ export default async function AccountDevicesPage() {
     ? await listTrustedDevicesForUser(user.id, currentDeviceId)
     : [];
 
+  const inlineAlerts: React.ReactNode[] = [];
+  if (!flagOn) {
+    inlineAlerts.push(
+      <Alert key="flag-off">
+        Email-2FA is not currently enabled on this environment.
+        Trusted-device tracking starts when{" "}
+        <code className="font-mono text-sm">AUTH_2FA_ENABLED</code>{" "}
+        is flipped to <code>true</code> in env.
+      </Alert>,
+    );
+  } else if (devices.length === 0) {
+    inlineAlerts.push(
+      <Alert key="no-devices">
+        No trusted devices yet. The next time you sign in and tick
+        &quot;Trust this device for 30 days&quot;, it will appear here.
+      </Alert>,
+    );
+  }
+
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Account", href: "/account/security" },
-            { label: "Trusted devices" },
-          ]}
-        />
-        <PageHeader.Title>Trusted devices</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Devices that skip the email-approval step on sign-in. Trust
-          lasts 30 days from last sign-in; sign out any device you
-          don&apos;t recognise.
-        </PageHeader.Subtitle>
-      </PageHeader>
-
-      {!flagOn && (
-        <Alert>
-          Email-2FA is not currently enabled on this environment.
-          Trusted-device tracking starts when{" "}
-          <code className="font-mono text-sm">AUTH_2FA_ENABLED</code>{" "}
-          is flipped to <code>true</code> in env.
-        </Alert>
-      )}
-
-      {flagOn && devices.length === 0 && (
-        <Alert>
-          No trusted devices yet. The next time you sign in and tick
-          &quot;Trust this device for 30 days&quot;, it will appear
-          here.
-        </Alert>
-      )}
-
-      {flagOn && devices.length > 0 && (
-        <TrustedDevicesList
-          devices={devices}
-          hasCurrentDevice={currentDeviceId !== null}
-        />
-      )}
-    </PageShell>
+    <TSettingsFlat
+      title="Trusted devices"
+      breadcrumb={[
+        { label: "Account", href: "/account/security" },
+        { label: "Trusted devices" },
+      ]}
+      subtitle="Devices that skip the email-approval step on sign-in. Trust lasts 30 days from last sign-in; sign out any device you don't recognise."
+      inlineAlerts={inlineAlerts.length > 0 ? inlineAlerts : undefined}
+      sections={
+        flagOn && devices.length > 0
+          ? [{
+              title: "Active devices",
+              content: (
+                <TrustedDevicesList
+                  devices={devices}
+                  hasCurrentDevice={currentDeviceId !== null}
+                />
+              ),
+            }]
+          : []
+      }
+    />
   );
 }

--- a/app/(platform)/account/security/page.tsx
+++ b/app/(platform)/account/security/page.tsx
@@ -1,8 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { AccountSecurityForm } from "@/components/AccountSecurityForm";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TSettingsFlat } from "@/templates";
 import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
 
 // ---------------------------------------------------------------------------
@@ -31,20 +30,17 @@ export default async function AccountSecurityPage() {
   }
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Account", href: "/account/security" },
-            { label: "Security" },
-          ]}
-        />
-        <PageHeader.Title>Account security</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Change your password. Minimum 12 characters.
-        </PageHeader.Subtitle>
-      </PageHeader>
-      <AccountSecurityForm userEmail={user.email} />
-    </PageShell>
+    <TSettingsFlat
+      title="Account security"
+      breadcrumb={[
+        { label: "Account", href: "/account/security" },
+        { label: "Security" },
+      ]}
+      subtitle="Change your password. Minimum 12 characters."
+      sections={[{
+        title: "Password",
+        content: <AccountSecurityForm userEmail={user.email} />,
+      }]}
+    />
   );
 }

--- a/app/(platform)/admin/companies/new/page.tsx
+++ b/app/(platform)/admin/companies/new/page.tsx
@@ -1,6 +1,5 @@
 import { PlatformCompanyCreateForm } from "@/components/PlatformCompanyCreateForm";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TForm } from "@/templates";
 
 // P3-2 — Opollo admin "create company" page. Server-rendered shell;
 // the form posts to POST /api/admin/companies. Gated by
@@ -10,22 +9,15 @@ export const dynamic = "force-dynamic";
 
 export default function NewCompanyPage() {
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Companies", href: "/admin/companies" },
-            { label: "New" },
-          ]}
-        />
-        <PageHeader.Title>New company</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Create a customer company. The first admin will be invited
-          separately from the company detail page.
-        </PageHeader.Subtitle>
-      </PageHeader>
-      <PlatformCompanyCreateForm />
-    </PageShell>
+    <TForm
+      title="New company"
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Companies", href: "/admin/companies" },
+        { label: "New" },
+      ]}
+      subtitle="Create a customer company. The first admin will be invited separately from the company detail page."
+      formSections={[{ content: <PlatformCompanyCreateForm /> }]}
+    />
   );
 }

--- a/app/(platform)/admin/email-test/page.tsx
+++ b/app/(platform)/admin/email-test/page.tsx
@@ -2,8 +2,7 @@ import { redirect } from "next/navigation";
 
 import { EmailTestForm } from "@/components/EmailTestForm";
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TForm } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 
 // AUTH-FOUNDATION P3.4 — /admin/email-test now gated on super_admin.
@@ -23,34 +22,21 @@ export default async function EmailTestPage() {
   if (access.kind === "redirect") redirect(access.to);
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Email test" },
-          ]}
-        />
-        <PageHeader.Title>SendGrid wrapper test</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Fire a one-shot test email through{" "}
-          <code className="font-mono text-sm">lib/email/sendgrid.ts</code>.
-          Same code path as the runtime uses — invites, login challenges,
-          every transactional send.
-        </PageHeader.Subtitle>
-      </PageHeader>
-
-      <div className="max-w-2xl">
+    <TForm
+      title="SendGrid wrapper test"
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Email test" },
+      ]}
+      subtitle="Fire a one-shot test email through lib/email/sendgrid.ts. Same code path as the runtime uses — invites, login challenges, every transactional send."
+      inlineAlert={
         <Alert>
           Restricted to <strong>super_admin</strong>. Every send is
           captured in <code className="font-mono text-sm">email_log</code>{" "}
           for audit.
         </Alert>
-
-        <div className="mt-6">
-          <EmailTestForm />
-        </div>
-      </div>
-    </PageShell>
+      }
+      formSections={[{ content: <EmailTestForm /> }]}
+    />
   );
 }

--- a/app/(platform)/admin/posts/[siteId]/new/page.tsx
+++ b/app/(platform)/admin/posts/[siteId]/new/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 
-import { PageHeader } from "@/components/ui/page-header";
 import { PostsNewClient } from "@/components/PostsNewClient";
+import { TForm } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { listSites } from "@/lib/sites";
 
@@ -30,23 +30,18 @@ export default async function PostsSiteNewPage({
   }
 
   return (
-    <>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Blog", href: "/admin/posts" },
-            { label: site.name },
-          ]}
-        />
-        <PageHeader.Title>Post a blog</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Paste or drop your post for {site.name}. Metadata pre-fills from
-          front-matter, inline labels, or the first heading — every value is
-          editable before save.
-        </PageHeader.Subtitle>
-      </PageHeader>
-      <PostsNewClient siteId={site.id} siteName={site.name} />
-    </>
+    <TForm
+      title="Post a blog"
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Blog", href: "/admin/posts" },
+        { label: site.name },
+      ]}
+      subtitle={`Paste or drop your post for ${site.name}. Metadata pre-fills from front-matter, inline labels, or the first heading — every value is editable before save.`}
+      width="standard"
+      formSections={[{
+        content: <PostsNewClient siteId={site.id} siteName={site.name} />,
+      }]}
+    />
   );
 }

--- a/app/(platform)/admin/settings/design-system/page.tsx
+++ b/app/(platform)/admin/settings/design-system/page.tsx
@@ -1,8 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { DesignSystemSettingsClient } from "@/components/DesignSystemSettingsClient";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TSettingsFlat } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -23,23 +22,18 @@ export default async function DesignSystemSettingsPage() {
     .maybeSingle();
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Settings" },
-            { label: "Design system" },
-          ]}
-        />
-        <PageHeader.Title>Design system settings</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Override design tokens globally. Changes inject CSS variables at the
-          root layout level — all operator surfaces update immediately after
-          save.
-        </PageHeader.Subtitle>
-      </PageHeader>
-      <DesignSystemSettingsClient initialSettings={data ?? null} />
-    </PageShell>
+    <TSettingsFlat
+      title="Design system settings"
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Settings" },
+        { label: "Design system" },
+      ]}
+      subtitle="Override design tokens globally. Changes inject CSS variables at the root layout level — all operator surfaces update immediately after save."
+      sections={[{
+        title: "Global tokens",
+        content: <DesignSystemSettingsClient initialSettings={data ?? null} />,
+      }]}
+    />
   );
 }

--- a/app/(platform)/admin/sites/[id]/edit/page.tsx
+++ b/app/(platform)/admin/sites/[id]/edit/page.tsx
@@ -2,8 +2,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { SiteEditForm } from "@/components/SiteEditForm";
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TForm } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getSite } from "@/lib/sites";
 
@@ -31,21 +30,19 @@ export default async function EditSitePage({
   if (!result.ok) {
     if (result.error.code === "NOT_FOUND") notFound();
     return (
-      <PageShell>
-        <PageHeader>
-          <PageHeader.Breadcrumb
-            segments={[
-              { label: "Admin", href: "/admin/sites" },
-              { label: "Sites", href: "/admin/sites" },
-              { label: "Edit" },
-            ]}
-          />
-          <PageHeader.Title>Edit site</PageHeader.Title>
-        </PageHeader>
-        <div className="mx-auto max-w-2xl">
-          <Alert variant="destructive">{result.error.message}</Alert>
-        </div>
-      </PageShell>
+      <TForm
+        title="Edit site"
+        breadcrumb={[
+          { label: "Admin", href: "/admin/sites" },
+          { label: "Sites", href: "/admin/sites" },
+          { label: "Edit" },
+        ]}
+        formSections={[{
+          content: (
+            <Alert variant="destructive">{result.error.message}</Alert>
+          ),
+        }]}
+      />
     );
   }
 
@@ -53,33 +50,28 @@ export default async function EditSitePage({
   const creds = result.data.credentials;
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Sites", href: "/admin/sites" },
-            { label: site.name, href: `/admin/sites/${site.id}` },
-            { label: "Edit" },
-          ]}
-        />
-        <PageHeader.Title>Edit site</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Update the basics or rotate the WordPress credentials. The
-          Application Password stays as-is unless you enter a new one.
-        </PageHeader.Subtitle>
-      </PageHeader>
-      <div className="mx-auto max-w-2xl">
-        <SiteEditForm
-          site={{
-            id: site.id,
-            name: site.name,
-            wp_url: site.wp_url,
-            wp_user: creds?.wp_user ?? "",
-          }}
-          hasStoredCredentials={creds !== null}
-        />
-      </div>
-    </PageShell>
+    <TForm
+      title="Edit site"
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Sites", href: "/admin/sites" },
+        { label: site.name, href: `/admin/sites/${site.id}` },
+        { label: "Edit" },
+      ]}
+      subtitle="Update the basics or rotate the WordPress credentials. The Application Password stays as-is unless you enter a new one."
+      formSections={[{
+        content: (
+          <SiteEditForm
+            site={{
+              id: site.id,
+              name: site.name,
+              wp_url: site.wp_url,
+              wp_user: creds?.wp_user ?? "",
+            }}
+            hasStoredCredentials={creds !== null}
+          />
+        ),
+      }]}
+    />
   );
 }

--- a/app/(platform)/admin/sites/[id]/posts/new/page.tsx
+++ b/app/(platform)/admin/sites/[id]/posts/new/page.tsx
@@ -2,8 +2,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { BlogPostComposer } from "@/components/BlogPostComposer";
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TForm } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getSite } from "@/lib/sites";
 
@@ -39,25 +38,18 @@ export default async function BlogPostEntryPage({
   const site = result.data.site;
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Sites", href: "/admin/sites" },
-            { label: site.name, href: `/admin/sites/${site.id}` },
-            { label: "Posts", href: `/admin/sites/${site.id}/posts` },
-            { label: "New post" },
-          ]}
-        />
-        <PageHeader.Title>New blog post</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Paste a markdown / HTML / YAML-fronted post. We&apos;ll parse the
-          metadata into the fields below — every value is editable before you
-          save the draft.
-        </PageHeader.Subtitle>
-      </PageHeader>
-      <BlogPostComposer siteId={site.id} />
-    </PageShell>
+    <TForm
+      title="New blog post"
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Sites", href: "/admin/sites" },
+        { label: site.name, href: `/admin/sites/${site.id}` },
+        { label: "Posts", href: `/admin/sites/${site.id}/posts` },
+        { label: "New post" },
+      ]}
+      subtitle="Paste a markdown / HTML / YAML-fronted post. We'll parse the metadata into the fields below — every value is editable before you save the draft."
+      width="standard"
+      formSections={[{ content: <BlogPostComposer siteId={site.id} /> }]}
+    />
   );
 }

--- a/app/(platform)/admin/sites/[id]/settings/page.tsx
+++ b/app/(platform)/admin/sites/[id]/settings/page.tsx
@@ -3,9 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { SiteVoiceSettingsForm } from "@/components/SiteVoiceSettingsForm";
 import { UseImageLibraryToggle } from "@/components/UseImageLibraryToggle";
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
-import { H2 } from "@/components/ui/typography";
+import { TSettingsFlat } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getSite } from "@/lib/sites";
 import { getServiceRoleClient } from "@/lib/supabase";
@@ -69,62 +67,41 @@ export default async function SiteSettingsPage({
   const imagesWithMetadata = metadataCountRow.count ?? 0;
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Sites", href: "/admin/sites" },
-            { label: site.name, href: `/admin/sites/${site.id}` },
-            { label: "Settings" },
-          ]}
-        />
-        <PageHeader.Title>{site.name} — Settings</PageHeader.Title>
-        <PageHeader.Subtitle>
-          These values pre-populate every new brief. Each brief can still
-          override at commit time without changing the site default.
-        </PageHeader.Subtitle>
-      </PageHeader>
-      <div className="mx-auto max-w-3xl">
-
-      <section
-        aria-labelledby="voice-heading"
-        className="rounded-lg border p-4"
-      >
-        <H2 id="voice-heading">Brand voice &amp; design direction</H2>
-        <p className="mt-1 text-base text-muted-foreground">
-          Set once for the site; the brief commit form inherits these as
-          defaults.
-        </p>
-        <div className="mt-4">
-          <SiteVoiceSettingsForm
-            siteId={site.id}
-            initialBrandVoice={site.brand_voice}
-            initialDesignDirection={site.design_direction}
-            initialVersionLock={site.version_lock}
-          />
-        </div>
-      </section>
-
-      <section
-        aria-labelledby="image-library-heading"
-        className="mt-6 rounded-lg border p-4"
-      >
-        <H2 id="image-library-heading">Image library</H2>
-        <p className="mt-1 text-base text-muted-foreground">
-          When enabled, brief generation can suggest images from the shared
-          library where the page topic matches.
-        </p>
-        <div className="mt-4">
-          <UseImageLibraryToggle
-            siteId={site.id}
-            initialEnabled={useImageLibrary}
-            totalImages={totalImages}
-            imagesWithMetadata={imagesWithMetadata}
-          />
-        </div>
-      </section>
-      </div>
-    </PageShell>
+    <TSettingsFlat
+      title={`${site.name} — Settings`}
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Sites", href: "/admin/sites" },
+        { label: site.name, href: `/admin/sites/${site.id}` },
+        { label: "Settings" },
+      ]}
+      subtitle="These values pre-populate every new brief. Each brief can still override at commit time without changing the site default."
+      sections={[
+        {
+          title: "Brand voice & design direction",
+          description: "Set once for the site; the brief commit form inherits these as defaults.",
+          content: (
+            <SiteVoiceSettingsForm
+              siteId={site.id}
+              initialBrandVoice={site.brand_voice}
+              initialDesignDirection={site.design_direction}
+              initialVersionLock={site.version_lock}
+            />
+          ),
+        },
+        {
+          title: "Image library",
+          description: "When enabled, brief generation can suggest images from the shared library where the page topic matches.",
+          content: (
+            <UseImageLibraryToggle
+              siteId={site.id}
+              initialEnabled={useImageLibrary}
+              totalImages={totalImages}
+              imagesWithMetadata={imagesWithMetadata}
+            />
+          ),
+        },
+      ]}
+    />
   );
 }

--- a/app/(platform)/admin/sites/new/page.tsx
+++ b/app/(platform)/admin/sites/new/page.tsx
@@ -1,8 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { SiteCreateForm } from "@/components/SiteCreateForm";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TForm } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 
 // AUTH-FOUNDATION P2.2 — /admin/sites/new.
@@ -21,25 +20,15 @@ export default async function NewSitePage() {
   if (access.kind === "redirect") redirect(access.to);
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Sites", href: "/admin/sites" },
-            { label: "New site" },
-          ]}
-        />
-        <PageHeader.Title>Add a WordPress site</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Connect a site by providing its URL plus a WordPress Application
-          Password. We&apos;ll verify the connection before storing the
-          credentials.
-        </PageHeader.Subtitle>
-      </PageHeader>
-      <div className="mx-auto max-w-2xl">
-        <SiteCreateForm />
-      </div>
-    </PageShell>
+    <TForm
+      title="Add a WordPress site"
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Sites", href: "/admin/sites" },
+        { label: "New site" },
+      ]}
+      subtitle="Connect a site by providing its URL plus a WordPress Application Password. We'll verify the connection before storing the credentials."
+      formSections={[{ content: <SiteCreateForm /> }]}
+    />
   );
 }

--- a/app/(platform)/company/settings/brand/page.tsx
+++ b/app/(platform)/company/settings/brand/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 
 import { CustomerBrandProfileEditor } from "@/components/CustomerBrandProfileEditor";
+import { Alert } from "@/components/ui/alert";
+import { TSettingsFlat } from "@/templates";
 import { getCurrentPlatformSession } from "@/lib/platform/auth";
 import { getActiveBrandProfile } from "@/lib/platform/brand";
 import { getPlatformCompany } from "@/lib/platform/companies";
@@ -18,6 +20,11 @@ import { getPlatformCompany } from "@/lib/platform/companies";
 
 export const dynamic = "force-dynamic";
 
+const BREADCRUMB = [
+  { label: "Company", href: "/company" },
+  { label: "Brand" },
+];
+
 export default async function CompanyBrandPage() {
   const session = await getCurrentPlatformSession();
   if (!session) {
@@ -26,13 +33,20 @@ export default async function CompanyBrandPage() {
 
   if (!session.company) {
     return (
-      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm">
-        <p className="font-medium">Account not provisioned to a company.</p>
-        <p className="mt-1 text-muted-foreground">
-          Your account isn&apos;t a member of any company on the platform
-          yet. Ask an admin to invite you, or contact Opollo support.
-        </p>
-      </div>
+      <TSettingsFlat
+        title="Brand profile"
+        breadcrumb={BREADCRUMB}
+        inlineAlerts={[
+          <Alert key="not-provisioned">
+            <p className="font-medium">Account not provisioned to a company.</p>
+            <p className="mt-1 text-muted-foreground">
+              Your account isn&apos;t a member of any company on the platform
+              yet. Ask an admin to invite you, or contact Opollo support.
+            </p>
+          </Alert>,
+        ]}
+        sections={[]}
+      />
     );
   }
 
@@ -40,13 +54,20 @@ export default async function CompanyBrandPage() {
     session.isOpolloStaff || session.company.role === "admin";
   if (!isAdmin) {
     return (
-      <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
-        <p className="font-medium">Admins only.</p>
-        <p className="mt-1">
-          Only admins can view and edit the brand profile. Ask an admin
-          in your company to update your role if you need access.
-        </p>
-      </div>
+      <TSettingsFlat
+        title="Brand profile"
+        breadcrumb={BREADCRUMB}
+        inlineAlerts={[
+          <Alert key="admins-only" variant="destructive">
+            <p className="font-medium">Admins only.</p>
+            <p className="mt-1">
+              Only admins can view and edit the brand profile. Ask an admin
+              in your company to update your role if you need access.
+            </p>
+          </Alert>,
+        ]}
+        sections={[]}
+      />
     );
   }
 
@@ -59,19 +80,34 @@ export default async function CompanyBrandPage() {
 
   if (!companyResult.ok) {
     return (
-      <div
-        className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
-        role="alert"
-      >
-        Failed to load company: {companyResult.error.message}
-      </div>
+      <TSettingsFlat
+        title="Brand profile"
+        breadcrumb={BREADCRUMB}
+        inlineAlerts={[
+          <Alert key="load-error" variant="destructive">
+            Failed to load company: {companyResult.error.message}
+          </Alert>,
+        ]}
+        sections={[]}
+      />
     );
   }
 
   return (
-    <CustomerBrandProfileEditor
-      company={companyResult.data.company}
-      brand={brand}
+    <TSettingsFlat
+      title="Brand profile"
+      breadcrumb={BREADCRUMB}
+      subtitle={`How ${companyResult.data.company.name} looks, sounds, and behaves across every Opollo product.`}
+      sections={[{
+        title: "Identity & voice",
+        content: (
+          <CustomerBrandProfileEditor
+            hidePageHeader
+            company={companyResult.data.company}
+            brand={brand}
+          />
+        ),
+      }]}
     />
   );
 }

--- a/app/(platform)/company/social/sharing/page.tsx
+++ b/app/(platform)/company/social/sharing/page.tsx
@@ -1,7 +1,8 @@
 import { redirect } from "next/navigation";
 
 import { ViewerLinksManager } from "@/components/ViewerLinksManager";
-import { PageHeader } from "@/components/ui/page-header";
+import { Alert } from "@/components/ui/alert";
+import { TSettingsFlat } from "@/templates";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
 import { listViewerLinks } from "@/lib/platform/social/viewer-links";
 
@@ -19,6 +20,12 @@ import { listViewerLinks } from "@/lib/platform/social/viewer-links";
 
 export const dynamic = "force-dynamic";
 
+const BREADCRUMB = [
+  { label: "Company", href: "/company" },
+  { label: "Social", href: "/company/social/posts" },
+  { label: "Sharing" },
+];
+
 export default async function CompanySocialSharingPage() {
   const session = await getCurrentPlatformSession();
   if (!session) {
@@ -27,16 +34,21 @@ export default async function CompanySocialSharingPage() {
 
   if (!session.company) {
     return (
-      <main className="mx-auto max-w-3xl p-6">
-        <div className="rounded-md border border-amber-300 bg-amber-50 p-4">
-          <p className="font-medium">Account not provisioned to a company.</p>
-          <p className="mt-1 text-muted-foreground">
-            Your account isn&apos;t a member of any company on the
-            platform yet. Ask an admin to invite you, or contact
-            Opollo support.
-          </p>
-        </div>
-      </main>
+      <TSettingsFlat
+        title="Calendar sharing"
+        breadcrumb={BREADCRUMB}
+        inlineAlerts={[
+          <Alert key="not-provisioned">
+            <p className="font-medium">Account not provisioned to a company.</p>
+            <p className="mt-1 text-muted-foreground">
+              Your account isn&apos;t a member of any company on the
+              platform yet. Ask an admin to invite you, or contact
+              Opollo support.
+            </p>
+          </Alert>,
+        ]}
+        sections={[]}
+      />
     );
   }
 
@@ -44,46 +56,48 @@ export default async function CompanySocialSharingPage() {
   const isAdmin = await canDo(companyId, "manage_invitations");
   if (!isAdmin) {
     return (
-      <main className="mx-auto max-w-3xl p-6">
-        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-destructive">
-          <p className="font-medium">Admins only.</p>
-          <p className="mt-1">
-            Only admins can manage calendar-sharing links. Ask an admin
-            in your company to share the calendar with you, or to
-            promote your role.
-          </p>
-        </div>
-      </main>
+      <TSettingsFlat
+        title="Calendar sharing"
+        breadcrumb={BREADCRUMB}
+        inlineAlerts={[
+          <Alert key="admins-only" variant="destructive">
+            <p className="font-medium">Admins only.</p>
+            <p className="mt-1">
+              Only admins can manage calendar-sharing links. Ask an admin
+              in your company to share the calendar with you, or to
+              promote your role.
+            </p>
+          </Alert>,
+        ]}
+        sections={[]}
+      />
     );
   }
 
   const linksResult = await listViewerLinks({ companyId });
 
   return (
-    <main className="mx-auto max-w-4xl p-6 space-y-6">
-      <PageHeader>
-        <PageHeader.Title>Calendar sharing</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Mint 90-day read-only links to share the content calendar
-          with clients or stakeholders. They don&apos;t need an Opollo
-          account.
-        </PageHeader.Subtitle>
-      </PageHeader>
-
-      {linksResult.ok ? (
-        <ViewerLinksManager
-          companyId={companyId}
-          initialLinks={linksResult.data.links}
-        />
-      ) : (
-        <div
-          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive"
-          role="alert"
-          data-testid="viewer-links-load-error"
-        >
-          Failed to load viewer links: {linksResult.error.message}
-        </div>
-      )}
-    </main>
+    <TSettingsFlat
+      title="Calendar sharing"
+      breadcrumb={BREADCRUMB}
+      subtitle="Mint 90-day read-only links to share the content calendar with clients or stakeholders. They don't need an Opollo account."
+      sections={[{
+        title: "Viewer links",
+        content: linksResult.ok ? (
+          <ViewerLinksManager
+            companyId={companyId}
+            initialLinks={linksResult.data.links}
+          />
+        ) : (
+          <div
+            className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive"
+            role="alert"
+            data-testid="viewer-links-load-error"
+          >
+            Failed to load viewer links: {linksResult.error.message}
+          </div>
+        ),
+      }]}
+    />
   );
 }

--- a/app/(platform)/optimiser/clients/[id]/settings/page.tsx
+++ b/app/(platform)/optimiser/clients/[id]/settings/page.tsx
@@ -2,9 +2,9 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
-import { PageHeader } from "@/components/ui/page-header";
 import { AssistedApprovalToggle } from "@/components/optimiser/AssistedApprovalToggle";
 import { CrossClientConsentToggle } from "@/components/optimiser/CrossClientConsentToggle";
+import { TSettingsFlat } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getClient } from "@/lib/optimiser/clients";
 import { isPatternLibraryEnabled } from "@/lib/optimiser/pattern-library/feature-flag";
@@ -63,104 +63,115 @@ export default async function ClientSettingsPage({
     DEFAULT_CONVERSION_COMPONENTS;
 
   return (
-    <div className="space-y-6">
-      <PageHeader>
-        <PageHeader.Title>{client.name} — score settings</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Phase 1 surface is read-only. Phase 2 wires the manual override
-          via this page.
-        </PageHeader.Subtitle>
-        <PageHeader.Actions>
-          <Button asChild variant="outline">
-            <Link href={`/optimiser/onboarding/${client.id}`}>
-              Connector settings
-            </Link>
-          </Button>
-        </PageHeader.Actions>
-      </PageHeader>
-
-      <section className="space-y-4 rounded-lg border border-border bg-card p-6">
-        <h2 className="text-lg font-medium">Composite score weights</h2>
-        <p className="text-sm text-muted-foreground">
-          The composite is{" "}
-          <code className="font-mono text-sm">
-            (alignment × {weights.alignment.toFixed(2)}) + (behaviour × {weights.behaviour.toFixed(2)}) + (conversion × {weights.conversion.toFixed(2)}) + (technical × {weights.technical.toFixed(2)})
-          </code>
-          . Defaults are{" "}
-          <code className="font-mono text-sm">0.25 / 0.30 / 0.30 / 0.15</code>.
-        </p>
-        <ul className="space-y-3">
-          {(Object.keys(weights) as Array<keyof ScoreWeights>).map((key) => (
-            <li key={key} className="flex items-start gap-3">
-              <span className="mt-1 inline-block w-16 font-mono text-sm tabular-nums">
-                ×{weights[key].toFixed(2)}
-              </span>
-              <div className="flex-1">
-                <p className="font-medium">{WEIGHT_LABELS[key]}</p>
-                <p className="text-sm text-muted-foreground">
-                  {WEIGHT_DESCRIPTIONS[key]}
-                </p>
-              </div>
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
-        <h2 className="text-lg font-medium">Conversion components present</h2>
-        <p className="text-sm text-muted-foreground">
-          Drives the §2.3 redistribution: when revenue tracking is missing,
-          its 0.20 weight folds into CR (×0.65) + CPA (×0.35).
-        </p>
-        <ul className="space-y-1 text-sm">
-          <li>
-            <span className="inline-block w-32 text-muted-foreground">Conversion rate</span>
-            <strong>{componentsPresent.cr ? "tracked" : "not tracked"}</strong>
-          </li>
-          <li>
-            <span className="inline-block w-32 text-muted-foreground">Cost per conversion</span>
-            <strong>{componentsPresent.cpa ? "tracked" : "not tracked"}</strong>
-          </li>
-          <li>
-            <span className="inline-block w-32 text-muted-foreground">Revenue per visit</span>
-            <strong>{componentsPresent.revenue ? "tracked" : "not tracked"}</strong>
-          </li>
-        </ul>
-      </section>
-
-      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
-        <h2 className="text-lg font-medium">Causal-delta measurement window</h2>
-        <p className="text-sm">
-          <span className="font-mono tabular-nums">{client.causal_eval_window_days}</span> days
-        </p>
-        <p className="text-sm text-muted-foreground">
-          After a regenerated page has been live for this many days (or
-          accumulated 300+ sessions on the new version, whichever is sooner),
-          the engine evaluates its actual impact and writes a row to
-          opt_causal_deltas. Lower-traffic B2B clients may extend this; default 14 days.
-        </p>
-      </section>
-
-      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
-        <h2 className="text-lg font-medium">Assisted approval (Phase 2)</h2>
-        <AssistedApprovalToggle
-          clientId={client.id}
-          enabled={client.assisted_approval_enabled}
-          isAdmin={isAdmin}
-        />
-      </section>
-
-      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
-        <h2 className="text-lg font-medium">
-          Cross-client learning (Phase 3)
-        </h2>
-        <CrossClientConsentToggle
-          clientId={client.id}
-          enabled={client.cross_client_learning_consent}
-          isAdmin={isAdmin}
-          patternLibraryEnabled={isPatternLibraryEnabled()}
-        />
-      </section>
-    </div>
+    <TSettingsFlat
+      title={`${client.name} — score settings`}
+      subtitle="Phase 1 surface is read-only. Phase 2 wires the manual override via this page."
+      actions={
+        <Button asChild variant="outline">
+          <Link href={`/optimiser/onboarding/${client.id}`}>
+            Connector settings
+          </Link>
+        </Button>
+      }
+      width="standard"
+      sections={[
+        {
+          title: "Composite score weights",
+          content: (
+            <div className="space-y-4 rounded-lg border border-border bg-card p-6">
+              <p className="text-sm text-muted-foreground">
+                The composite is{" "}
+                <code className="font-mono text-sm">
+                  (alignment × {weights.alignment.toFixed(2)}) + (behaviour × {weights.behaviour.toFixed(2)}) + (conversion × {weights.conversion.toFixed(2)}) + (technical × {weights.technical.toFixed(2)})
+                </code>
+                . Defaults are{" "}
+                <code className="font-mono text-sm">0.25 / 0.30 / 0.30 / 0.15</code>.
+              </p>
+              <ul className="space-y-3">
+                {(Object.keys(weights) as Array<keyof ScoreWeights>).map((key) => (
+                  <li key={key} className="flex items-start gap-3">
+                    <span className="mt-1 inline-block w-16 font-mono text-sm tabular-nums">
+                      ×{weights[key].toFixed(2)}
+                    </span>
+                    <div className="flex-1">
+                      <p className="font-medium">{WEIGHT_LABELS[key]}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {WEIGHT_DESCRIPTIONS[key]}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ),
+        },
+        {
+          title: "Conversion components present",
+          content: (
+            <div className="space-y-3 rounded-lg border border-border bg-card p-6">
+              <p className="text-sm text-muted-foreground">
+                Drives the §2.3 redistribution: when revenue tracking is missing,
+                its 0.20 weight folds into CR (×0.65) + CPA (×0.35).
+              </p>
+              <ul className="space-y-1 text-sm">
+                <li>
+                  <span className="inline-block w-32 text-muted-foreground">Conversion rate</span>
+                  <strong>{componentsPresent.cr ? "tracked" : "not tracked"}</strong>
+                </li>
+                <li>
+                  <span className="inline-block w-32 text-muted-foreground">Cost per conversion</span>
+                  <strong>{componentsPresent.cpa ? "tracked" : "not tracked"}</strong>
+                </li>
+                <li>
+                  <span className="inline-block w-32 text-muted-foreground">Revenue per visit</span>
+                  <strong>{componentsPresent.revenue ? "tracked" : "not tracked"}</strong>
+                </li>
+              </ul>
+            </div>
+          ),
+        },
+        {
+          title: "Causal-delta measurement window",
+          content: (
+            <div className="space-y-3 rounded-lg border border-border bg-card p-6">
+              <p className="text-sm">
+                <span className="font-mono tabular-nums">{client.causal_eval_window_days}</span> days
+              </p>
+              <p className="text-sm text-muted-foreground">
+                After a regenerated page has been live for this many days (or
+                accumulated 300+ sessions on the new version, whichever is sooner),
+                the engine evaluates its actual impact and writes a row to
+                opt_causal_deltas. Lower-traffic B2B clients may extend this; default 14 days.
+              </p>
+            </div>
+          ),
+        },
+        {
+          title: "Assisted approval (Phase 2)",
+          content: (
+            <div className="rounded-lg border border-border bg-card p-6">
+              <AssistedApprovalToggle
+                clientId={client.id}
+                enabled={client.assisted_approval_enabled}
+                isAdmin={isAdmin}
+              />
+            </div>
+          ),
+        },
+        {
+          title: "Cross-client learning (Phase 3)",
+          content: (
+            <div className="rounded-lg border border-border bg-card p-6">
+              <CrossClientConsentToggle
+                clientId={client.id}
+                enabled={client.cross_client_learning_consent}
+                isAdmin={isAdmin}
+                patternLibraryEnabled={isPatternLibraryEnabled()}
+              />
+            </div>
+          ),
+        },
+      ]}
+    />
   );
 }

--- a/components/CustomerBrandProfileEditor.tsx
+++ b/components/CustomerBrandProfileEditor.tsx
@@ -42,6 +42,9 @@ import type { PlatformCompany } from "@/lib/platform/companies";
 type Props = {
   company: PlatformCompany;
   brand: BrandProfile | null;
+  /** When true, suppresses the internal <H1> + Lead block.
+   *  Use when the parent page already provides page chrome. */
+  hidePageHeader?: boolean;
 };
 
 function initialState(brand: BrandProfile | null): FormState {
@@ -62,7 +65,7 @@ function initialState(brand: BrandProfile | null): FormState {
   };
 }
 
-export function CustomerBrandProfileEditor({ company, brand }: Props) {
+export function CustomerBrandProfileEditor({ company, brand, hidePageHeader = false }: Props) {
   const router = useRouter();
   const [form, setForm] = useState<FormState>(() => initialState(brand));
 
@@ -119,13 +122,15 @@ export function CustomerBrandProfileEditor({ company, brand }: Props) {
 
   return (
     <div className="space-y-8">
-      <header>
-        <H1>Brand profile</H1>
-        <Lead className="mt-1">
-          How <strong>{company.name}</strong> looks, sounds, and behaves
-          across every Opollo product.
-        </Lead>
-      </header>
+      {!hidePageHeader && (
+        <header>
+          <H1>Brand profile</H1>
+          <Lead className="mt-1">
+            How <strong>{company.name}</strong> looks, sounds, and behaves
+            across every Opollo product.
+          </Lead>
+        </header>
+      )}
 
       <section
         className="rounded-lg border bg-card p-4"

--- a/docs/briefs/social-01-brief/framework/PROGRESS.md
+++ b/docs/briefs/social-01-brief/framework/PROGRESS.md
@@ -1,4 +1,11 @@
-## Wave 2b in progress 2026-05-19
+## Wave 2c in progress 2026-05-19
+
+- Templates used: T-FORM (6 routes), T-SETTINGS-FLAT (7 routes)
+- Routes migrated (T-FORM): /admin/sites/new, /admin/sites/[id]/edit, /admin/sites/[id]/posts/new, /admin/companies/new, /admin/posts/[siteId]/new, /admin/email-test
+- Routes migrated (T-SETTINGS-FLAT): /admin/sites/[id]/settings, /admin/settings/design-system, /account/security, /account/devices, /company/settings/brand, /optimiser/clients/[id]/settings, /company/social/sharing
+- Deviations: company/settings/brand and optimiser/clients/[id]/settings retain card wrappers inside section content (layout intentional); CustomerBrandProfileEditor gained hidePageHeader prop to avoid duplicate H1
+
+## Wave 2b complete 2026-05-19
 
 - Template updated: TDetailSummarySection.title optional; subtitle widened to ReactNode
 - Routes migrated: 10 (T-DETAIL-SUMMARY: /admin/companies/[id], /admin/companies/[id]/social-profiles/[profileId]/connections, /admin/sites/[id], /admin/sites/[id]/appearance, /admin/batches/[siteId]/[batchId], /admin/images/[id], /optimiser/proposals/[id], /optimiser/pages/[id], /optimiser/imports/[brief_id]; TListStandard: /admin/batches/[siteId])


### PR DESCRIPTION
## Summary

- Migrates 6 routes to **T-FORM** and 7 routes to **T-SETTINGS-FLAT**, completing Wave 2c of the design-system framework rollout
- Adds `hidePageHeader` prop to `CustomerBrandProfileEditor` — brand settings page now wraps it in T-SETTINGS-FLAT without a duplicate H1

**T-FORM routes (6):**
- `admin/sites/new/page.tsx`
- `admin/sites/[id]/edit/page.tsx`
- `admin/sites/[id]/posts/new/page.tsx`
- `admin/companies/new/page.tsx`
- `admin/posts/[siteId]/new/page.tsx`
- `admin/email-test/page.tsx`

**T-SETTINGS-FLAT routes (7):**
- `admin/sites/[id]/settings/page.tsx`
- `admin/settings/design-system/page.tsx`
- `account/security/page.tsx`
- `account/devices/page.tsx`
- `company/settings/brand/page.tsx`
- `optimiser/clients/[id]/settings/page.tsx`
- `company/social/sharing/page.tsx`

## Working analog

All migrations follow the established Wave 2a/2b pattern: replace ad-hoc `<div>` wrappers + `<PageHeader>` with typed template components. No new patterns introduced.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit
- [x] No new DB queries, SDK calls, or API routes — no contract/integration tests required
- [x] No tenant-scoped resource changes — cross-tenant test not required
- [x] No user-content rendering surfaces — XSS coverage not required
- [x] No migration files — migration-version check not applicable

## Risks identified and mitigated

- **Duplicate H1 risk**: `CustomerBrandProfileEditor` had its own `<H1>`. Mitigated by adding `hidePageHeader` prop (same pattern as `ProposalReview` in Wave 2b). The prop is `false` by default — existing usages unaffected.
- **T-SETTINGS-FLAT `sections={[]}`**: Empty-sections array renders clean; used for error/restricted-access cases. Template handles this gracefully.
- **`inlineAlert` vs `inlineAlerts`**: T-FORM uses singular `inlineAlert?: ReactNode`; T-SETTINGS-FLAT uses plural `inlineAlerts?: ReactNode[]`. No confusion — each template has the right shape for its use cases.