### PR TITLE
feat(framework): wave 3 — 4 new templates + migrate 9 routes

### DIFF
--- a/app/(platform)/admin/sites/[id]/briefs/[brief_id]/review/page.tsx
+++ b/app/(platform)/admin/sites/[id]/briefs/[brief_id]/review/page.tsx
@@ -1,8 +1,7 @@
 import { notFound, redirect } from "next/navigation";
 
 import { BriefReviewClient } from "@/components/BriefReviewClient";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TReviewLink } from "@/templates";
 import { getBriefWithPages } from "@/lib/briefs";
 import { getSite } from "@/lib/sites";
 
@@ -58,22 +57,21 @@ export default async function BriefReviewPage({
   const { brief, pages } = briefResult.data;
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Sites", href: "/admin/sites" },
-            { label: site.name, href: `/admin/sites/${site.id}` },
-            { label: "Briefs", href: `/admin/sites/${site.id}` },
-            { label: brief.title },
-          ]}
-        />
-        <PageHeader.Title>{brief.title}</PageHeader.Title>
-        <PageHeader.Subtitle>
+    <TReviewLink
+      title={brief.title}
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Sites", href: "/admin/sites" },
+        { label: site.name, href: `/admin/sites/${site.id}` },
+        { label: "Briefs", href: `/admin/sites/${site.id}` },
+        { label: brief.title },
+      ]}
+      subtitle={
+        <>
           Brief for <span className="font-medium">{site.name}</span>
-        </PageHeader.Subtitle>
-      </PageHeader>
+        </>
+      }
+    >
       <BriefReviewClient
         siteId={site.id}
         siteName={site.name}
@@ -82,6 +80,6 @@ export default async function BriefReviewPage({
         brief={brief}
         initialPages={pages}
       />
-    </PageShell>
+    </TReviewLink>
   );
 }

--- a/app/(platform)/admin/sites/[id]/onboarding/page.tsx
+++ b/app/(platform)/admin/sites/[id]/onboarding/page.tsx
@@ -4,9 +4,8 @@ import { notFound, redirect } from "next/navigation";
 import { FirstSiteConnectedMoment } from "@/components/onboarding/first-site-connected-moment";
 import { SiteOnboardingForm } from "@/components/SiteOnboardingForm";
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { H3 } from "@/components/ui/typography";
+import { TWizardStep } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -66,25 +65,16 @@ export default async function SiteOnboardingPage({
   }
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Sites", href: "/admin/sites" },
-            { label: site.name, href: `/admin/sites/${site.id}` },
-            { label: "Onboarding" },
-          ]}
-        />
-        <PageHeader.Title>
-          How would you like to use this site?
-        </PageHeader.Title>
-        <PageHeader.Subtitle>
-          Pick one. We&apos;ll tailor the rest of the setup — and how
-          generated content is styled — based on your choice. You can
-          re-onboard later if you change your mind.
-        </PageHeader.Subtitle>
-      </PageHeader>
+    <TWizardStep
+      title="How would you like to use this site?"
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Sites", href: "/admin/sites" },
+        { label: site.name, href: `/admin/sites/${site.id}` },
+        { label: "Onboarding" },
+      ]}
+      subtitle="Pick one. We'll tailor the rest of the setup — and how generated content is styled — based on your choice. You can re-onboard later if you change your mind."
+    >
       <div className="max-w-3xl">
         {searchParams?.fresh === "1" && (
           <div className="mb-6">
@@ -117,6 +107,6 @@ export default async function SiteOnboardingPage({
           </Link>
         </section>
       </div>
-    </PageShell>
+    </TWizardStep>
   );
 }

--- a/app/(platform)/admin/sites/[id]/pages/[pageId]/page.tsx
+++ b/app/(platform)/admin/sites/[id]/pages/[pageId]/page.tsx
@@ -3,13 +3,12 @@ import { notFound, redirect } from "next/navigation";
 
 import { EditPageMetadataButton } from "@/components/EditPageMetadataButton";
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
 import { StatusPill, postStatusKind } from "@/components/ui/status-pill";
 import { H3 } from "@/components/ui/typography";
 import { PageHtmlPreview } from "@/components/PageHtmlPreview";
 import { RegenHistoryPanel } from "@/components/RegenHistoryPanel";
 import { RegenerateButton } from "@/components/RegenerateButton";
+import { TDetailEditor } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getPage } from "@/lib/pages";
 import { listRegenJobsForPage } from "@/lib/regeneration-publisher";
@@ -113,28 +112,27 @@ export default async function PageDetail({
   );
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Sites", href: "/admin/sites" },
-            { label: page.site_name, href: `/admin/sites/${params.id}` },
-            { label: "Pages", href: backHref },
-            { label: page.title.slice(0, 60) },
-          ]}
-        />
-        <PageHeader.Title>{page.title}</PageHeader.Title>
-        <PageHeader.Meta>
+    <TDetailEditor
+      title={page.title}
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Sites", href: "/admin/sites" },
+        { label: page.site_name, href: `/admin/sites/${params.id}` },
+        { label: "Pages", href: backHref },
+        { label: page.title.slice(0, 60) },
+      ]}
+      meta={
+        <>
           {statusBadge(page.status)}
           <span className="rounded bg-muted px-2 py-0.5">
             {page.page_type.replace(/_/g, " ")}
           </span>
           <span>/{page.slug}</span>
           <span>· updated {formatRelativeTime(page.updated_at)}</span>
-        </PageHeader.Meta>
-        <PageHeader.Actions>
-          <div className="flex items-center gap-3">
+        </>
+      }
+      actions={
+        <div className="flex items-center gap-3">
           <RegenerateButton
             siteId={params.id}
             pageId={page.id}
@@ -177,10 +175,9 @@ export default async function PageDetail({
               )}
             </>
           )}
-          </div>
-        </PageHeader.Actions>
-      </PageHeader>
-
+        </div>
+      }
+    >
       <section className="grid gap-6 md:grid-cols-[2fr_1fr]">
         <PageHtmlPreview html={page.generated_html} />
 
@@ -232,6 +229,6 @@ export default async function PageDetail({
           <RegenHistoryPanel jobs={regenJobs} />
         </div>
       </section>
-    </PageShell>
+    </TDetailEditor>
   );
 }

--- a/app/(platform)/admin/sites/[id]/posts/[post_id]/page.tsx
+++ b/app/(platform)/admin/sites/[id]/posts/[post_id]/page.tsx
@@ -1,8 +1,7 @@
 import { notFound, redirect } from "next/navigation";
 
 import { PostDetailClient } from "@/components/PostDetailClient";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TDetailEditor } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getPost } from "@/lib/posts";
 import { preflightSitePublish } from "@/lib/site-preflight";
@@ -76,25 +75,22 @@ export default async function PostDetailPage({
   const preflight = await preflightSitePublish(params.id);
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Sites", href: "/admin/sites" },
-            { label: site.name, href: `/admin/sites/${site.id}` },
-            { label: "Posts", href: `/admin/sites/${site.id}/posts` },
-            { label: post.title },
-          ]}
-        />
-        <PageHeader.Title>{post.title}</PageHeader.Title>
-      </PageHeader>
+    <TDetailEditor
+      title={post.title}
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Sites", href: "/admin/sites" },
+        { label: site.name, href: `/admin/sites/${site.id}` },
+        { label: "Posts", href: `/admin/sites/${site.id}/posts` },
+        { label: post.title },
+      ]}
+    >
       <PostDetailClient
         siteId={site.id}
         siteWpUrl={site.wp_url}
         post={post}
         preflight={preflight}
       />
-    </PageShell>
+    </TDetailEditor>
   );
 }

--- a/app/(platform)/admin/sites/[id]/setup/extract/page.tsx
+++ b/app/(platform)/admin/sites/[id]/setup/extract/page.tsx
@@ -2,8 +2,7 @@ import { notFound, redirect } from "next/navigation";
 
 import { CopyExistingExtractionWizard } from "@/components/CopyExistingExtractionWizard";
 import { Alert } from "@/components/ui/alert";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TWizardStep } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -69,23 +68,16 @@ export default async function CopyExistingExtractPage({
   }
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Sites", href: "/admin/sites" },
-            { label: site.name, href: `/admin/sites/${site.id}` },
-            { label: "Extract design" },
-          ]}
-        />
-        <PageHeader.Title>Extract design from {site.wp_url}</PageHeader.Title>
-        <PageHeader.Subtitle>
-          We&apos;ll fetch your live site and pull out the colours, fonts, and
-          common CSS class names so generated content matches the existing
-          theme. Review and tweak before saving.
-        </PageHeader.Subtitle>
-      </PageHeader>
+    <TWizardStep
+      title={`Extract design from ${site.wp_url}`}
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Sites", href: "/admin/sites" },
+        { label: site.name, href: `/admin/sites/${site.id}` },
+        { label: "Extract design" },
+      ]}
+      subtitle="We'll fetch your live site and pull out the colours, fonts, and common CSS class names so generated content matches the existing theme. Review and tweak before saving."
+    >
       <div className="max-w-3xl">
         <CopyExistingExtractionWizard
           siteId={site.id}
@@ -94,6 +86,6 @@ export default async function CopyExistingExtractPage({
           existingClasses={site.extracted_css_classes}
         />
       </div>
-    </PageShell>
+    </TWizardStep>
   );
 }

--- a/app/(platform)/admin/sites/[id]/setup/page.tsx
+++ b/app/(platform)/admin/sites/[id]/setup/page.tsx
@@ -1,8 +1,7 @@
 import { notFound, redirect } from "next/navigation";
 
 import { SetupWizard } from "@/components/SetupWizard";
-import { PageHeader } from "@/components/ui/page-header";
-import { PageShell } from "@/components/ui/page-shell";
+import { TWizardStep } from "@/templates";
 import { checkAdminAccess } from "@/lib/admin-gate";
 import {
   computeResumeStep,
@@ -89,24 +88,16 @@ export default async function SiteSetupPage({
   const step: SetupStep = requested;
 
   return (
-    <PageShell>
-      <PageHeader>
-        <PageHeader.Breadcrumb
-          segments={[
-            { label: "Admin", href: "/admin/sites" },
-            { label: "Sites", href: "/admin/sites" },
-            { label: site.name, href: `/admin/sites/${site.id}` },
-            { label: "Setup" },
-          ]}
-        />
-        <PageHeader.Title>Set up {site.name}</PageHeader.Title>
-        <PageHeader.Subtitle>
-          A two-step setup that gives every generated page a consistent
-          look and voice. Skip any step to fall back to the default
-          styles — you can return any time.
-        </PageHeader.Subtitle>
-      </PageHeader>
-
+    <TWizardStep
+      title={`Set up ${site.name}`}
+      breadcrumb={[
+        { label: "Admin", href: "/admin/sites" },
+        { label: "Sites", href: "/admin/sites" },
+        { label: site.name, href: `/admin/sites/${site.id}` },
+        { label: "Setup" },
+      ]}
+      subtitle="A two-step setup that gives every generated page a consistent look and voice. Skip any step to fall back to the default styles — you can return any time."
+    >
       <div className="mx-auto max-w-4xl">
         <SetupWizard
           siteId={site.id}
@@ -114,6 +105,6 @@ export default async function SiteSetupPage({
           status={status}
         />
       </div>
-    </PageShell>
+    </TWizardStep>
   );
 }

--- a/app/(platform)/company/social/media/page.tsx
+++ b/app/(platform)/company/social/media/page.tsx
@@ -1,7 +1,8 @@
 import { redirect } from "next/navigation";
 
 import { MediaLibraryClient } from "@/components/MediaLibraryClient";
-import { H1, Lead } from "@/components/ui/typography";
+import { Alert } from "@/components/ui/alert";
+import { TGrid } from "@/templates";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
 import { listMediaAssets } from "@/lib/platform/social/media";
 
@@ -23,15 +24,21 @@ export default async function CompanySocialMediaPage() {
   if (!session) {
     redirect(`/login?next=${encodeURIComponent("/company/social/media")}`);
   }
+
   if (!session.company) {
     return (
-      <div className="rounded-md border border-amber-300 bg-amber-50 p-4 text-base">
-        <p className="font-medium">Account not provisioned to a company.</p>
-        <p className="mt-1 text-muted-foreground">
-          Your account isn&apos;t a member of any company on the platform
-          yet. Ask an admin to invite you, or contact Opollo support.
-        </p>
-      </div>
+      <TGrid
+        title="Media library"
+        subtitle="Reusable images and video for your social posts. Add an asset here, then attach by id when scheduling."
+        inlineAlert={
+          <Alert variant="destructive" title="Account not provisioned">
+            Your account isn&apos;t a member of any company on the platform yet. Ask an admin to
+            invite you, or contact Opollo support.
+          </Alert>
+        }
+      >
+        <></>
+      </TGrid>
     );
   }
 
@@ -42,31 +49,25 @@ export default async function CompanySocialMediaPage() {
   ]);
 
   return (
-    <>
-      <header>
-        <H1>Media library</H1>
-        <Lead className="mt-0.5">
-          Reusable images and video for your social posts. Add an asset
-          here, then attach by id when scheduling.
-        </Lead>
-      </header>
-      <div className="mt-6">
-        {listResult.ok ? (
-          <MediaLibraryClient
-            companyId={companyId}
-            initialAssets={listResult.data.assets}
-            initialNextCursor={listResult.data.nextCursor}
-            canEdit={canEdit}
-          />
-        ) : (
-          <div
-            className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-base text-destructive"
-            role="alert"
-          >
-            Failed to load media: {listResult.error.message}
-          </div>
-        )}
-      </div>
-    </>
+    <TGrid
+      title="Media library"
+      subtitle="Reusable images and video for your social posts. Add an asset here, then attach by id when scheduling."
+      inlineAlert={
+        listResult.ok ? undefined : (
+          <Alert variant="destructive" title="Failed to load media">
+            {listResult.error.message}
+          </Alert>
+        )
+      }
+    >
+      {listResult.ok && (
+        <MediaLibraryClient
+          companyId={companyId}
+          initialAssets={listResult.data.assets}
+          initialNextCursor={listResult.data.nextCursor}
+          canEdit={canEdit}
+        />
+      )}
+    </TGrid>
   );
 }

--- a/app/(platform)/optimiser/onboarding/[id]/page.tsx
+++ b/app/(platform)/optimiser/onboarding/[id]/page.tsx
@@ -2,9 +2,9 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
-import { PageHeader } from "@/components/ui/page-header";
 import { ConnectorBannerView } from "@/components/optimiser/ConnectorBanner";
 import { OnboardingWizard } from "@/components/optimiser/OnboardingWizard";
+import { TWizardStep } from "@/templates";
 import { getClient } from "@/lib/optimiser/clients";
 import {
   bannerForConnector,
@@ -25,31 +25,33 @@ export default async function OptimiserOnboardingClientPage({
     .map((c) => bannerForConnector(c, params.id))
     .filter((b): b is NonNullable<typeof b> => Boolean(b));
 
+  const subtitle = `${client.client_slug} · ${client.hosting_mode.replace("_", " ")} · ${client.onboarded_at ? "onboarded" : "in progress"}`;
+
   return (
-    <div className="space-y-6">
-      <PageHeader>
-        <PageHeader.Title>{client.name}</PageHeader.Title>
-        <PageHeader.Subtitle>
-          <code className="font-mono">{client.client_slug}</code> ·{" "}
-          {client.hosting_mode.replace("_", " ")} ·{" "}
-          {client.onboarded_at ? "onboarded" : "in progress"}
-        </PageHeader.Subtitle>
-        <PageHeader.Actions>
-          <Button asChild variant="outline">
-            <Link href="/optimiser/onboarding">All clients</Link>
-          </Button>
-        </PageHeader.Actions>
-      </PageHeader>
-
-      {banners.length > 0 && (
-        <div className="space-y-2">
-          {banners.map((b) => (
-            <ConnectorBannerView key={`${b.source}-${b.kind}`} banner={b} />
-          ))}
-        </div>
-      )}
-
-      <OnboardingWizard client={client} connectors={connectors} />
-    </div>
+    <TWizardStep
+      title={client.name}
+      subtitle={subtitle}
+      breadcrumb={[
+        { label: "Optimiser", href: "/optimiser" },
+        { label: "Onboarding", href: "/optimiser/onboarding" },
+        { label: client.name },
+      ]}
+      actions={
+        <Button asChild variant="outline">
+          <Link href="/optimiser/onboarding">All clients</Link>
+        </Button>
+      }
+    >
+      <div className="space-y-6">
+        {banners.length > 0 && (
+          <div className="space-y-2">
+            {banners.map((b) => (
+              <ConnectorBannerView key={`${b.source}-${b.kind}`} banner={b} />
+            ))}
+          </div>
+        )}
+        <OnboardingWizard client={client} connectors={connectors} />
+      </div>
+    </TWizardStep>
   );
 }

--- a/app/(platform)/optimiser/onboarding/page.tsx
+++ b/app/(platform)/optimiser/onboarding/page.tsx
@@ -2,8 +2,8 @@ import Link from "next/link";
 
 import { listClients } from "@/lib/optimiser/clients";
 import { Button } from "@/components/ui/button";
-import { PageHeader } from "@/components/ui/page-header";
 import { NewClientForm } from "@/components/optimiser/NewClientForm";
+import { TWizardStep } from "@/templates";
 
 export const metadata = { title: "Optimiser · Onboarding" };
 export const dynamic = "force-dynamic";
@@ -14,78 +14,76 @@ export default async function OptimiserOnboardingHome() {
   const onboarded = clients.filter((c) => c.onboarded_at);
 
   return (
-    <div className="space-y-8">
-      <PageHeader>
-        <PageHeader.Title>Onboarding</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Five-step gated checklist per spec §7.1. Steps unlock as each verification passes.
-        </PageHeader.Subtitle>
-        <PageHeader.Actions>
-          <Button asChild variant="outline">
-            <Link href="/optimiser">Back to optimiser</Link>
-          </Button>
-        </PageHeader.Actions>
-      </PageHeader>
+    <TWizardStep
+      title="Onboarding"
+      subtitle="Five-step gated checklist per spec §7.1. Steps unlock as each verification passes."
+      actions={
+        <Button asChild variant="outline">
+          <Link href="/optimiser">Back to optimiser</Link>
+        </Button>
+      }
+    >
+      <div className="space-y-8">
+        <section className="space-y-3 rounded-lg border border-border bg-card p-6">
+          <h2 className="text-lg font-medium">Add a client</h2>
+          <NewClientForm />
+        </section>
 
-      <section className="space-y-3 rounded-lg border border-border bg-card p-6">
-        <h2 className="text-lg font-medium">Add a client</h2>
-        <NewClientForm />
-      </section>
+        <section className="space-y-3">
+          <h2 className="text-lg font-medium">In progress</h2>
+          {onboarding.length === 0 ? (
+            <p className="text-sm text-muted-foreground">None.</p>
+          ) : (
+            <ul className="space-y-2">
+              {onboarding.map((c) => (
+                <li
+                  key={c.id}
+                  className="flex items-center justify-between rounded-md border border-border bg-card px-4 py-3"
+                >
+                  <div>
+                    <p className="font-medium">{c.name}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {c.client_slug} · created {new Date(c.created_at).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <Button asChild>
+                    <Link href={`/optimiser/onboarding/${c.id}`}>Continue</Link>
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
 
-      <section className="space-y-3">
-        <h2 className="text-lg font-medium">In progress</h2>
-        {onboarding.length === 0 ? (
-          <p className="text-sm text-muted-foreground">None.</p>
-        ) : (
-          <ul className="space-y-2">
-            {onboarding.map((c) => (
-              <li
-                key={c.id}
-                className="flex items-center justify-between rounded-md border border-border bg-card px-4 py-3"
-              >
-                <div>
-                  <p className="font-medium">{c.name}</p>
-                  <p className="text-sm text-muted-foreground">
-                    {c.client_slug} · created {new Date(c.created_at).toLocaleDateString()}
-                  </p>
-                </div>
-                <Button asChild>
-                  <Link href={`/optimiser/onboarding/${c.id}`}>Continue</Link>
-                </Button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-
-      <section className="space-y-3">
-        <h2 className="text-lg font-medium">Onboarded</h2>
-        {onboarded.length === 0 ? (
-          <p className="text-sm text-muted-foreground">None yet.</p>
-        ) : (
-          <ul className="space-y-2">
-            {onboarded.map((c) => (
-              <li
-                key={c.id}
-                className="flex items-center justify-between rounded-md border border-border bg-card px-4 py-3"
-              >
-                <div>
-                  <p className="font-medium">{c.name}</p>
-                  <p className="text-sm text-muted-foreground">
-                    {c.client_slug} ·{" "}
-                    {c.onboarded_at
-                      ? `onboarded ${new Date(c.onboarded_at).toLocaleDateString()}`
-                      : ""}
-                  </p>
-                </div>
-                <Button asChild variant="outline">
-                  <Link href={`/optimiser/onboarding/${c.id}`}>Settings</Link>
-                </Button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-    </div>
+        <section className="space-y-3">
+          <h2 className="text-lg font-medium">Onboarded</h2>
+          {onboarded.length === 0 ? (
+            <p className="text-sm text-muted-foreground">None yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {onboarded.map((c) => (
+                <li
+                  key={c.id}
+                  className="flex items-center justify-between rounded-md border border-border bg-card px-4 py-3"
+                >
+                  <div>
+                    <p className="font-medium">{c.name}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {c.client_slug} ·{" "}
+                      {c.onboarded_at
+                        ? `onboarded ${new Date(c.onboarded_at).toLocaleDateString()}`
+                        : ""}
+                    </p>
+                  </div>
+                  <Button asChild variant="outline">
+                    <Link href={`/optimiser/onboarding/${c.id}`}>Settings</Link>
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </TWizardStep>
   );
 }

--- a/templates/T-DETAIL-EDITOR.tsx
+++ b/templates/T-DETAIL-EDITOR.tsx
@@ -1,0 +1,52 @@
+import type * as React from "react";
+
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import type { BreadcrumbSegment } from "./T-LIST-STANDARD";
+
+export interface TDetailEditorProps {
+  title: string;
+  breadcrumb?: BreadcrumbSegment[];
+  subtitle?: string;
+  meta?: React.ReactNode;
+  actions?: React.ReactNode;
+  /** Optional inline alert between the header and main content. */
+  inlineAlert?: React.ReactNode;
+  children: React.ReactNode;
+  width?: "standard" | "wide";
+}
+
+/**
+ * T-DETAIL-EDITOR — editor/preview detail page template.
+ *
+ * Composition: PageShell ▸ PageHeader ▸ [inlineAlert] ▸ children
+ *
+ * Wave 3 routes: /admin/sites/[id]/posts/[post_id],
+ * /admin/sites/[id]/pages/[pageId]
+ */
+export function TDetailEditor({
+  title,
+  breadcrumb,
+  subtitle,
+  meta,
+  actions,
+  inlineAlert,
+  children,
+  width,
+}: TDetailEditorProps) {
+  return (
+    <PageShell className={width === "wide" ? "max-w-screen-2xl" : undefined}>
+      <PageHeader>
+        {breadcrumb && <PageHeader.Breadcrumb segments={breadcrumb} />}
+        <PageHeader.Title>{title}</PageHeader.Title>
+        {subtitle && <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>}
+        {meta && <PageHeader.Meta>{meta}</PageHeader.Meta>}
+        {actions && <PageHeader.Actions>{actions}</PageHeader.Actions>}
+      </PageHeader>
+
+      {inlineAlert && <div className="mb-4">{inlineAlert}</div>}
+
+      {children}
+    </PageShell>
+  );
+}

--- a/templates/T-GRID.tsx
+++ b/templates/T-GRID.tsx
@@ -1,0 +1,49 @@
+import type * as React from "react";
+
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import type { BreadcrumbSegment } from "./T-LIST-STANDARD";
+
+export interface TGridProps {
+  title: string;
+  breadcrumb?: BreadcrumbSegment[];
+  subtitle?: string;
+  actions?: React.ReactNode;
+  /** Optional inline alert between the header and grid. */
+  inlineAlert?: React.ReactNode;
+  children: React.ReactNode;
+  width?: "standard" | "wide";
+}
+
+/**
+ * T-GRID — card/asset grid index template.
+ *
+ * Composition: PageShell ▸ PageHeader ▸ [inlineAlert] ▸ children
+ *
+ * Wave 3 routes: /company/social/media,
+ * /admin/sites/[id]/design-system/components (layout-driven, deferred)
+ */
+export function TGrid({
+  title,
+  breadcrumb,
+  subtitle,
+  actions,
+  inlineAlert,
+  children,
+  width,
+}: TGridProps) {
+  return (
+    <PageShell className={width === "wide" ? "max-w-screen-2xl" : undefined}>
+      <PageHeader>
+        {breadcrumb && <PageHeader.Breadcrumb segments={breadcrumb} />}
+        <PageHeader.Title>{title}</PageHeader.Title>
+        {subtitle && <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>}
+        {actions && <PageHeader.Actions>{actions}</PageHeader.Actions>}
+      </PageHeader>
+
+      {inlineAlert && <div className="mb-4">{inlineAlert}</div>}
+
+      {children}
+    </PageShell>
+  );
+}

--- a/templates/T-REVIEW-LINK.tsx
+++ b/templates/T-REVIEW-LINK.tsx
@@ -1,0 +1,49 @@
+import type * as React from "react";
+
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import type { BreadcrumbSegment } from "./T-LIST-STANDARD";
+
+export interface TReviewLinkProps {
+  title: string;
+  breadcrumb?: BreadcrumbSegment[];
+  subtitle?: React.ReactNode;
+  actions?: React.ReactNode;
+  /** Optional inline alert below the header. */
+  inlineAlert?: React.ReactNode;
+  children: React.ReactNode;
+  width?: "standard" | "wide";
+}
+
+/**
+ * T-REVIEW-LINK — review/approval page template.
+ *
+ * Composition: PageShell ▸ PageHeader ▸ [inlineAlert] ▸ children
+ *
+ * Wave 3 routes: /admin/sites/[id]/briefs/[brief_id]/review,
+ * /admin/sites/[id]/blueprints/review
+ */
+export function TReviewLink({
+  title,
+  breadcrumb,
+  subtitle,
+  actions,
+  inlineAlert,
+  children,
+  width,
+}: TReviewLinkProps) {
+  return (
+    <PageShell className={width === "wide" ? "max-w-screen-2xl" : undefined}>
+      <PageHeader>
+        {breadcrumb && <PageHeader.Breadcrumb segments={breadcrumb} />}
+        <PageHeader.Title>{title}</PageHeader.Title>
+        {subtitle && <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>}
+        {actions && <PageHeader.Actions>{actions}</PageHeader.Actions>}
+      </PageHeader>
+
+      {inlineAlert && <div className="mb-4">{inlineAlert}</div>}
+
+      {children}
+    </PageShell>
+  );
+}

--- a/templates/T-WIZARD-STEP.tsx
+++ b/templates/T-WIZARD-STEP.tsx
@@ -1,0 +1,56 @@
+import type * as React from "react";
+
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { Callout } from "@/components/ui/callout";
+import type { CalloutProps } from "@/components/ui/callout";
+import type { BreadcrumbSegment } from "./T-LIST-STANDARD";
+
+export interface TWizardStepProps {
+  title: string;
+  breadcrumb?: BreadcrumbSegment[];
+  subtitle?: string;
+  actions?: React.ReactNode;
+  /** Optional banner callout above the wizard content. */
+  callout?: CalloutProps;
+  children: React.ReactNode;
+  width?: "standard" | "wide";
+}
+
+/**
+ * T-WIZARD-STEP — multi-step wizard page template.
+ *
+ * Composition: PageShell ▸ PageHeader ▸ [Callout] ▸ children
+ *
+ * Wave 3 routes: /admin/sites/[id]/setup, /admin/sites/[id]/setup/extract,
+ * /admin/sites/[id]/onboarding, /optimiser/onboarding,
+ * /optimiser/onboarding/[id]
+ */
+export function TWizardStep({
+  title,
+  breadcrumb,
+  subtitle,
+  actions,
+  callout,
+  children,
+  width,
+}: TWizardStepProps) {
+  return (
+    <PageShell className={width === "wide" ? "max-w-screen-2xl" : undefined}>
+      <PageHeader>
+        {breadcrumb && <PageHeader.Breadcrumb segments={breadcrumb} />}
+        <PageHeader.Title>{title}</PageHeader.Title>
+        {subtitle && <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>}
+        {actions && <PageHeader.Actions>{actions}</PageHeader.Actions>}
+      </PageHeader>
+
+      {callout && (
+        <div className="mb-4">
+          <Callout {...callout} />
+        </div>
+      )}
+
+      {children}
+    </PageShell>
+  );
+}

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -21,3 +21,15 @@ export type { TDashboardKpiProps, KpiItem } from "./T-DASHBOARD-KPI";
 
 export { TDetailTabbed } from "./T-DETAIL-TABBED";
 export type { TDetailTabbedProps, TabItem } from "./T-DETAIL-TABBED";
+
+export { TDetailEditor } from "./T-DETAIL-EDITOR";
+export type { TDetailEditorProps } from "./T-DETAIL-EDITOR";
+
+export { TWizardStep } from "./T-WIZARD-STEP";
+export type { TWizardStepProps } from "./T-WIZARD-STEP";
+
+export { TReviewLink } from "./T-REVIEW-LINK";
+export type { TReviewLinkProps } from "./T-REVIEW-LINK";
+
+export { TGrid } from "./T-GRID";
+export type { TGridProps } from "./T-GRID";


### PR DESCRIPTION
## Summary

Stacked on Wave 2c (#916). Introduces 4 new page templates and migrates 9 routes.

**New templates:**
- `T-DETAIL-EDITOR` — `PageShell ▸ PageHeader[title+meta+actions] ▸ [inlineAlert] ▸ children`
- `T-WIZARD-STEP` — `PageShell ▸ PageHeader[title+subtitle+actions] ▸ [Callout] ▸ children`
- `T-REVIEW-LINK` — `PageShell ▸ PageHeader[title+subtitle:ReactNode+actions] ▸ [inlineAlert] ▸ children`
- `T-GRID` — `PageShell ▸ PageHeader[title+subtitle+actions] ▸ [inlineAlert] ▸ children`

**Migrated routes (9):**
| Route | Template |
|---|---|
| `admin/sites/[id]/posts/[post_id]` | T-DETAIL-EDITOR |
| `admin/sites/[id]/pages/[pageId]` | T-DETAIL-EDITOR |
| `admin/sites/[id]/setup` | T-WIZARD-STEP |
| `admin/sites/[id]/setup/extract` | T-WIZARD-STEP |
| `admin/sites/[id]/onboarding` | T-WIZARD-STEP |
| `optimiser/onboarding` | T-WIZARD-STEP |
| `optimiser/onboarding/[id]` | T-WIZARD-STEP |
| `admin/sites/[id]/briefs/[brief_id]/review` | T-REVIEW-LINK |
| `company/social/media` | T-GRID |

**Deferred (2):**
- `admin/sites/[id]/blueprints/review` — `"use client"` component with own `PageShell` + `PageHeader`; would require a client-shell refactor (out of scope for Wave 3)
- `design-system/components` — layout-driven (no `page.tsx`)

## Working analog

All migrations follow the same pattern established in Wave 2a–2c: replace ad-hoc wrappers + direct `PageShell`/`PageHeader` usage with typed template components. No new patterns introduced.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit
- [x] No new DB queries, SDK calls, or API routes — no contract/integration tests required
- [x] No tenant-scoped resource additions — cross-tenant test not required
- [x] No user-content rendering surfaces — XSS coverage not required

## Risks identified and mitigated

- **`T-REVIEW-LINK.subtitle` is `ReactNode`**: The briefs/review page uses JSX subtitle (`<>Brief for <span>{site.name}</span></>`). T-REVIEW-LINK accepts `ReactNode` for subtitle, unlike T-FORM/T-SETTINGS-FLAT which only accept `string`. This is intentional — review pages often need styled author/context in the subtitle.
- **`optimiser/onboarding/[id]` subtitle flattened**: The original subtitle used `<code>` for `client_slug`. Flattened to a plain string for T-WIZARD-STEP compat (TWizardStep.subtitle is `string`). Visual regression is minor — the slug was already in a `font-mono` class.
- **`company/social/media` empty children for unpro case**: When `!session.company`, renders `<TGrid><></></TGrid>` with `inlineAlert`. TGrid renders gracefully with empty fragment children.