### PR TITLE
feat(framework): wave 4 — 3 new templates + migrate 11 routes

### DIFF
--- a/app/(platform)/company/image/generate/page.tsx
+++ b/app/(platform)/company/image/generate/page.tsx
@@ -1,8 +1,8 @@
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { MoodBoardClient } from "@/components/MoodBoardClient";
-import { PageHeader } from "@/components/ui/page-header";
+import { Alert } from "@/components/ui/alert";
+import { TFullBleedEditor } from "@/templates";
 import { getAllowedStyles } from "@/lib/image";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
 import { getActiveBrandProfile } from "@/lib/platform/brand";
@@ -34,15 +34,17 @@ export default async function MoodBoardPage() {
 
   if (!session.company) {
     return (
-      <main className="mx-auto max-w-3xl p-6 text-sm">
-        <div className="rounded-md border border-amber-300 bg-amber-50 p-4">
-          <p className="font-medium">Account not provisioned to a company.</p>
-          <p className="mt-1 text-muted-foreground">
-            Your account isn&apos;t a member of any company on the platform
-            yet. Ask an admin to invite you, or contact Opollo support.
-          </p>
-        </div>
-      </main>
+      <TFullBleedEditor
+        title="Mood board generator"
+        subtitle="Generate background images for your social posts. Click an image to select it and copy its URL."
+        backHref="/company"
+        backLabel="Dashboard"
+      >
+        <Alert variant="destructive" title="Account not provisioned">
+          Your account isn&apos;t a member of any company on the platform yet. Ask an
+          admin to invite you, or contact Opollo support.
+        </Alert>
+      </TFullBleedEditor>
     );
   }
 
@@ -55,41 +57,33 @@ export default async function MoodBoardPage() {
 
   if (!canCreate) {
     return (
-      <main className="mx-auto max-w-3xl p-6 text-sm">
-        <div className="rounded-md border border-amber-300 bg-amber-50 p-4">
-          <p className="font-medium">Permission denied.</p>
-          <p className="mt-1 text-muted-foreground">
-            Editor or admin permissions are required to generate images.
-          </p>
-        </div>
-      </main>
+      <TFullBleedEditor
+        title="Mood board generator"
+        subtitle="Generate background images for your social posts. Click an image to select it and copy its URL."
+        backHref="/company"
+        backLabel="Dashboard"
+      >
+        <Alert variant="destructive" title="Permission denied">
+          Editor or admin permissions are required to generate images.
+        </Alert>
+      </TFullBleedEditor>
     );
   }
 
   const allowedStyles = getAllowedStyles(brand);
 
   return (
-    <>
-      <div className="mb-4 text-sm">
-        <Link
-          href="/company"
-          className="text-muted-foreground hover:text-foreground"
-        >
-          ← Dashboard
-        </Link>
-      </div>
-      <PageHeader>
-        <PageHeader.Title>Mood board generator</PageHeader.Title>
-        <PageHeader.Subtitle>
-          Generate background images for your social posts. Click an image to
-          select it and copy its URL.
-        </PageHeader.Subtitle>
-      </PageHeader>
+    <TFullBleedEditor
+      title="Mood board generator"
+      subtitle="Generate background images for your social posts. Click an image to select it and copy its URL."
+      backHref="/company"
+      backLabel="Dashboard"
+    >
       <MoodBoardClient
         companyId={companyId}
         allowedStyles={allowedStyles}
         primaryColour={brand?.primary_colour ?? null}
       />
-    </>
+    </TFullBleedEditor>
   );
 }

--- a/app/auth-error/page.tsx
+++ b/app/auth-error/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { TErrorState } from "@/templates";
+
 // ---------------------------------------------------------------------------
 // /auth-error
 //
@@ -18,18 +20,17 @@ export const dynamic = "force-static";
 
 export default function AuthErrorPage() {
   return (
-    <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-4 p-6 text-center">
-      <h1 className="text-page-title text-foreground">Authentication error</h1>
-      <p className="text-base text-muted-foreground">
-        We couldn&rsquo;t verify your session. Try signing in again — if this
-        keeps happening, contact an operator.
-      </p>
-      <Link
-        href="/login"
-        className="text-sm font-medium underline underline-offset-4"
-      >
-        Back to sign in
-      </Link>
-    </main>
+    <TErrorState
+      title="Authentication error"
+      body="We couldn't verify your session. Try signing in again — if this keeps happening, contact an operator."
+      cta={
+        <Link
+          href="/login"
+          className="text-sm font-medium underline underline-offset-4"
+        >
+          Back to sign in
+        </Link>
+      }
+    />
   );
 }

--- a/app/auth/accept-invite/page.tsx
+++ b/app/auth/accept-invite/page.tsx
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 
 import { AcceptInviteForm } from "@/components/AcceptInviteForm";
 import { Alert } from "@/components/ui/alert";
-import { H1, Lead } from "@/components/ui/typography";
+import { TAuthChrome } from "@/templates";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // AUTH-FOUNDATION P3.2 — /auth/accept-invite.
@@ -68,8 +68,7 @@ export default async function AcceptInvitePage({ searchParams }: PageProps) {
 
   if (result.kind === "err") {
     return (
-      <div className="mx-auto max-w-md space-y-4">
-        <H1>Invite link</H1>
+      <TAuthChrome title="Invite link">
         <Alert variant="destructive">
           {result.reason === "missing" && "No invite token provided."}
           {result.reason === "invalid" &&
@@ -79,20 +78,23 @@ export default async function AcceptInvitePage({ searchParams }: PageProps) {
           {result.reason === "consumed" &&
             "This invite has already been accepted. Sign in normally."}
         </Alert>
-      </div>
+      </TAuthChrome>
     );
   }
 
   return (
-    <div className="mx-auto max-w-md">
-      <H1>Set your password</H1>
-      <Lead className="mt-1">
-        Setting up Opollo Site Builder for{" "}
-        <strong className="text-foreground">{result.invite.email}</strong>.
-      </Lead>
-      <div className="mt-6">
+    <TAuthChrome
+      title="Set your password"
+      subtitle={
+        <>
+          Setting up Opollo Site Builder for{" "}
+          <strong className="text-foreground">{result.invite.email}</strong>.
+        </>
+      }
+    >
+      <div className="rounded-lg border bg-background p-6 shadow-sm">
         <AcceptInviteForm token={rawToken} email={result.invite.email} />
       </div>
-    </div>
+    </TAuthChrome>
   );
 }

--- a/app/auth/approve/page.tsx
+++ b/app/auth/approve/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { ApproveAutoClose } from "@/components/ApproveAutoClose";
 import { ApproveCompleteHere } from "@/components/ApproveCompleteHere";
 import { Alert } from "@/components/ui/alert";
-import { H1, Lead } from "@/components/ui/typography";
+import { TAuthChrome } from "@/templates";
 import {
   approveChallenge,
   lookupChallengeByToken,
@@ -87,30 +87,6 @@ async function resolveState(rawToken: string | undefined): Promise<RenderState> 
   };
 }
 
-function PageShell({
-  title,
-  subtitle,
-  children,
-}: {
-  title: string;
-  subtitle?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
-      <div className="w-full max-w-md space-y-6">
-        <div className="text-center">
-          <H1>{title}</H1>
-          {subtitle && <Lead className="mt-1">{subtitle}</Lead>}
-        </div>
-        <div className="rounded-lg border bg-background p-6 shadow-sm space-y-4">
-          {children}
-        </div>
-      </div>
-    </main>
-  );
-}
-
 function StartOverLink() {
   return (
     <Link
@@ -127,39 +103,43 @@ export default async function ApprovePage({ searchParams }: PageProps) {
 
   if (state.kind === "invalid") {
     return (
-      <PageShell title="Approval link">
-        <Alert variant="destructive">
-          This approval link is invalid. Sign in again from your
-          original device to receive a fresh email.
-        </Alert>
-        <StartOverLink />
-      </PageShell>
+      <TAuthChrome title="Approval link">
+        <div className="rounded-lg border bg-background p-6 shadow-sm space-y-4">
+          <Alert variant="destructive">
+            This approval link is invalid. Sign in again from your original
+            device to receive a fresh email.
+          </Alert>
+          <StartOverLink />
+        </div>
+      </TAuthChrome>
     );
   }
   if (state.kind === "expired") {
     return (
-      <PageShell title="Approval link expired">
-        <Alert variant="destructive">
-          This link expired (15-minute window). Sign in again to
-          receive a fresh email.
-        </Alert>
-        <StartOverLink />
-      </PageShell>
+      <TAuthChrome title="Approval link expired">
+        <div className="rounded-lg border bg-background p-6 shadow-sm space-y-4">
+          <Alert variant="destructive">
+            This link expired (15-minute window). Sign in again to receive a
+            fresh email.
+          </Alert>
+          <StartOverLink />
+        </div>
+      </TAuthChrome>
     );
   }
   if (state.kind === "consumed") {
     return (
-      <PageShell title="Approval link used">
-        <Alert>
-          This approval link has been used. You can close this tab.
-        </Alert>
-        <StartOverLink />
-      </PageShell>
+      <TAuthChrome title="Approval link used">
+        <div className="rounded-lg border bg-background p-6 shadow-sm space-y-4">
+          <Alert>This approval link has been used. You can close this tab.</Alert>
+          <StartOverLink />
+        </div>
+      </TAuthChrome>
     );
   }
 
   return (
-    <PageShell
+    <TAuthChrome
       title="Sign-in approved"
       subtitle={
         state.tokenWasJustApproved
@@ -167,16 +147,17 @@ export default async function ApprovePage({ searchParams }: PageProps) {
           : "Sign-in already approved. Return to your original tab, or complete here if that tab is gone."
       }
     >
-      <ApproveAutoClose tokenWasJustApproved={state.tokenWasJustApproved} />
+      <div className="rounded-lg border bg-background p-6 shadow-sm space-y-4">
+        <ApproveAutoClose tokenWasJustApproved={state.tokenWasJustApproved} />
 
-      <div className="border-t pt-4">
-        <p className="text-sm font-medium">Lost your original tab?</p>
-        <p className="text-sm text-muted-foreground mt-1 mb-3">
-          Use the button below to finish signing in on this device
-          instead.
-        </p>
-        <ApproveCompleteHere challengeId={state.challengeId} />
+        <div className="border-t pt-4">
+          <p className="text-sm font-medium">Lost your original tab?</p>
+          <p className="text-sm text-muted-foreground mt-1 mb-3">
+            Use the button below to finish signing in on this device instead.
+          </p>
+          <ApproveCompleteHere challengeId={state.challengeId} />
+        </div>
       </div>
-    </PageShell>
+    </TAuthChrome>
   );
 }

--- a/app/auth/expired/page.tsx
+++ b/app/auth/expired/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { NavIcon } from "@/components/ui/nav-icon";
-import { H1, Lead } from "@/components/ui/typography";
+import { TAuthChrome } from "@/templates";
 
 // ---------------------------------------------------------------------------
 // /auth/expired — Spec 14 PR C.
@@ -70,50 +70,43 @@ export default function SessionExpiredPage({
   const loginHref = `/login?returnTo=${encodeURIComponent(returnToSafe)}`;
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
-      <div className="w-full max-w-lg space-y-8">
-        {/* Header */}
-        <div className="text-center">
-          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-950">
-            <NavIcon name="lock" size={24} className="text-amber-600 dark:text-amber-400" />
-          </div>
-          <H1>Your session has expired</H1>
-          <Lead className="mt-2">
-            Opollo signs you out automatically every 48 hours. Here&apos;s
-            why this policy exists.
-          </Lead>
+    <TAuthChrome
+      title="Your session has expired"
+      subtitle="Opollo signs you out automatically every 48 hours. Here's why this policy exists."
+      titleIcon={
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-950">
+          <NavIcon name="lock" size={24} className="text-amber-600 dark:text-amber-400" />
         </div>
-
-        {/* Why-bullets card */}
-        <div className="rounded-lg border bg-background p-6 shadow-sm">
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-            Why Opollo has a 48-hour session limit
-          </h2>
-          <ul className="space-y-5">
-            {WHY_BULLETS.map(({ icon, heading, body }) => (
-              <li key={heading} className="flex gap-3">
-                <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted">
-                  <NavIcon name={icon} size={14} className="text-muted-foreground" />
-                </div>
-                <div>
-                  <p className="text-sm font-medium text-foreground">{heading}</p>
-                  <p className="mt-0.5 text-sm text-muted-foreground">{body}</p>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-
-        {/* CTA */}
-        <div className="flex flex-col items-center gap-3">
-          <Button asChild className="w-full">
-            <Link href={loginHref}>Sign in again</Link>
-          </Button>
-          <p className="text-xs text-muted-foreground">
-            Your work was auto-saved before sign-out.
-          </p>
-        </div>
+      }
+      width="lg"
+    >
+      <div className="rounded-lg border bg-background p-6 shadow-sm">
+        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Why Opollo has a 48-hour session limit
+        </h2>
+        <ul className="space-y-5">
+          {WHY_BULLETS.map(({ icon, heading, body }) => (
+            <li key={heading} className="flex gap-3">
+              <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted">
+                <NavIcon name={icon} size={14} className="text-muted-foreground" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-foreground">{heading}</p>
+                <p className="mt-0.5 text-sm text-muted-foreground">{body}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
-    </main>
+
+      <div className="flex flex-col items-center gap-3">
+        <Button asChild className="w-full">
+          <Link href={loginHref}>Sign in again</Link>
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          Your work was auto-saved before sign-out.
+        </p>
+      </div>
+    </TAuthChrome>
   );
 }

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,5 +1,7 @@
+import Link from "next/link";
+
 import { ForgotPasswordForm } from "@/components/ForgotPasswordForm";
-import { H1, Lead } from "@/components/ui/typography";
+import { TAuthChrome } from "@/templates";
 
 // ---------------------------------------------------------------------------
 // /auth/forgot-password — M14-3.
@@ -18,26 +20,21 @@ export const dynamic = "force-static";
 
 export default function ForgotPasswordPage() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
-      <div className="w-full max-w-md space-y-6">
-        <div className="text-center">
-          <H1>Forgot your password?</H1>
-          <Lead className="mt-2">
-            Enter your email and we&apos;ll send you a reset link.
-          </Lead>
-        </div>
-        <div className="rounded-lg border bg-background p-6 shadow-sm">
-          <ForgotPasswordForm />
-        </div>
-        <p className="text-center text-sm text-muted-foreground">
-          <a
-            href="/login"
-            className="underline transition-smooth hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
-          >
-            Back to sign in
-          </a>
-        </p>
+    <TAuthChrome
+      title="Forgot your password?"
+      subtitle="Enter your email and we'll send you a reset link."
+      footer={
+        <Link
+          href="/login"
+          className="underline transition-smooth hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+        >
+          Back to sign in
+        </Link>
+      }
+    >
+      <div className="rounded-lg border bg-background p-6 shadow-sm">
+        <ForgotPasswordForm />
       </div>
-    </main>
+    </TAuthChrome>
   );
 }

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -1,6 +1,8 @@
+import Link from "next/link";
+
 import { ResetPasswordForm } from "@/components/ResetPasswordForm";
 import { Button } from "@/components/ui/button";
-import { H1, Lead } from "@/components/ui/typography";
+import { TAuthChrome } from "@/templates";
 import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
 
 // ---------------------------------------------------------------------------
@@ -21,52 +23,43 @@ import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
 
+const backLink = (
+  <Link
+    href="/login"
+    className="underline transition-smooth hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+  >
+    Back to sign in
+  </Link>
+);
+
 export default async function ResetPasswordPage() {
   const supabase = createRouteAuthClient();
   const user = await getCurrentUser(supabase);
 
   if (!user) {
     return (
-      <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
-        <div className="w-full max-w-md space-y-6">
-          <div className="text-center">
-            <H1>Reset link expired</H1>
-            <Lead className="mt-2">
-              This reset link has expired or was already used. Request a new
-              link to continue.
-            </Lead>
-          </div>
-          <div className="rounded-lg border bg-background p-6 text-center shadow-sm">
-            <Button asChild>
-              <a href="/auth/forgot-password">Request a new link</a>
-            </Button>
-          </div>
-          <p className="text-center text-sm text-muted-foreground">
-            <a
-              href="/login"
-              className="underline transition-smooth hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
-            >
-              Back to sign in
-            </a>
-          </p>
+      <TAuthChrome
+        title="Reset link expired"
+        subtitle="This reset link has expired or was already used. Request a new link to continue."
+        footer={backLink}
+      >
+        <div className="rounded-lg border bg-background p-6 text-center shadow-sm">
+          <Button asChild>
+            <a href="/auth/forgot-password">Request a new link</a>
+          </Button>
         </div>
-      </main>
+      </TAuthChrome>
     );
   }
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
-      <div className="w-full max-w-md space-y-6">
-        <div className="text-center">
-          <H1>Set a new password</H1>
-          <Lead className="mt-2">
-            Choose a strong password. Minimum 12 characters.
-          </Lead>
-        </div>
-        <div className="rounded-lg border bg-background p-6 shadow-sm">
-          <ResetPasswordForm userEmail={user.email} />
-        </div>
+    <TAuthChrome
+      title="Set a new password"
+      subtitle="Choose a strong password. Minimum 12 characters."
+    >
+      <div className="rounded-lg border bg-background p-6 shadow-sm">
+        <ResetPasswordForm userEmail={user.email} />
       </div>
-    </main>
+    </TAuthChrome>
   );
 }

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 
 import { PlatformAcceptInviteForm } from "@/components/PlatformAcceptInviteForm";
 import { Alert } from "@/components/ui/alert";
-import { H1, Lead } from "@/components/ui/typography";
+import { TAuthChrome } from "@/templates";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 // Platform-layer invitation accept page (P2-3 follow-up).
@@ -94,8 +94,7 @@ export default async function PlatformInviteAcceptPage({ params }: PageProps) {
 
   if (result.kind === "err") {
     return (
-      <div className="mx-auto max-w-md space-y-4">
-        <H1>Invitation</H1>
+      <TAuthChrome title="Invitation">
         <Alert variant="destructive">
           {result.reason === "missing" && "No invitation token provided."}
           {result.reason === "invalid" &&
@@ -107,28 +106,31 @@ export default async function PlatformInviteAcceptPage({ params }: PageProps) {
           {result.reason === "revoked" &&
             "This invitation was revoked. Ask the inviter for a new one."}
         </Alert>
-      </div>
+      </TAuthChrome>
     );
   }
 
   return (
-    <div className="mx-auto max-w-md">
-      <H1>Join {result.invite.companyName}</H1>
-      <Lead className="mt-1">
-        Setting up your Opollo account for{" "}
-        <strong className="text-foreground">{result.invite.email}</strong> as{" "}
-        <strong className="text-foreground">
-          {capitaliseRole(result.invite.role)}
-        </strong>
-        .
-      </Lead>
-      <div className="mt-6">
+    <TAuthChrome
+      title={`Join ${result.invite.companyName}`}
+      subtitle={
+        <>
+          Setting up your Opollo account for{" "}
+          <strong className="text-foreground">{result.invite.email}</strong> as{" "}
+          <strong className="text-foreground">
+            {capitaliseRole(result.invite.role)}
+          </strong>
+          .
+        </>
+      }
+    >
+      <div className="rounded-lg border bg-background p-6 shadow-sm">
         <PlatformAcceptInviteForm
           token={params.token}
           email={result.invite.email}
         />
       </div>
-    </div>
+    </TAuthChrome>
   );
 }
 

--- a/app/login/check-email/page.tsx
+++ b/app/login/check-email/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 
 import { CheckEmailPolling } from "@/components/CheckEmailPolling";
 import { Alert } from "@/components/ui/alert";
-import { H1, Lead } from "@/components/ui/typography";
+import { TAuthChrome } from "@/templates";
 import { lookupChallengeById } from "@/lib/2fa/challenges";
 import {
   PENDING_2FA_COOKIE,
@@ -69,33 +69,29 @@ export default async function CheckEmailPage({ searchParams }: PageProps) {
   const next = searchParams.next ?? "/admin/sites";
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
-      <div className="w-full max-w-md space-y-6">
-        <div className="text-center">
-          <H1>Check your email</H1>
-          <Lead className="mt-1">
-            We sent an approval link to{" "}
-            <strong className="text-foreground">{userEmail}</strong>.
-            Click the link and this page will sign you in
-            automatically.
-          </Lead>
-        </div>
-
-        <div className="rounded-lg border bg-background p-6 shadow-sm space-y-4">
-          {emailSendFailed && (
-            <Alert variant="destructive">
-              Email delivery failed. Use the Resend button below — it
-              skips the cooldown.
-            </Alert>
-          )}
-
-          <CheckEmailPolling
-            challengeId={challenge.id}
-            next={next}
-            initialEmailFailed={emailSendFailed}
-          />
-        </div>
+    <TAuthChrome
+      title="Check your email"
+      subtitle={
+        <>
+          We sent an approval link to{" "}
+          <strong className="text-foreground">{userEmail}</strong>.
+          Click the link and this page will sign you in automatically.
+        </>
+      }
+    >
+      <div className="rounded-lg border bg-background p-6 shadow-sm space-y-4">
+        {emailSendFailed && (
+          <Alert variant="destructive">
+            Email delivery failed. Use the Resend button below — it skips
+            the cooldown.
+          </Alert>
+        )}
+        <CheckEmailPolling
+          challengeId={challenge.id}
+          next={next}
+          initialEmailFailed={emailSendFailed}
+        />
       </div>
-    </main>
+    </TAuthChrome>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { LoginForm } from "@/components/LoginForm";
-import { H1, Lead } from "@/components/ui/typography";
+import { TAuthChrome } from "@/templates";
 import { PENDING_2FA_COOKIE } from "@/lib/2fa/cookies";
 import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
 import { isAuthKillSwitchOn } from "@/lib/auth-kill-switch";
@@ -68,16 +68,10 @@ export default async function LoginPage({
   }
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
-      <div className="w-full max-w-md space-y-6">
-        <div className="text-center">
-          <H1>Opollo Site Builder</H1>
-          <Lead className="mt-1">Sign in to continue.</Lead>
-        </div>
-        <div className="rounded-lg border bg-background p-6 shadow-sm">
-          <LoginForm next={next} />
-        </div>
+    <TAuthChrome title="Opollo Site Builder" subtitle="Sign in to continue.">
+      <div className="rounded-lg border bg-background p-6 shadow-sm">
+        <LoginForm next={next} />
       </div>
-    </main>
+    </TAuthChrome>
   );
 }

--- a/docs/briefs/social-01-brief/framework/PROGRESS.md
+++ b/docs/briefs/social-01-brief/framework/PROGRESS.md
@@ -1,3 +1,17 @@
+## Wave 4 in progress 2026-05-19
+
+- Templates used: T-AUTH-CHROME (8 routes), T-FULL-BLEED-EDITOR (1 route), T-ERROR-STATE (1 route)
+- Routes migrated: login, login/check-email, auth/forgot-password, auth/reset-password, auth/accept-invite, invite/[token], auth/approve, auth/expired, auth-error, company/image/generate
+- Redirect stubs already existed: admin, admin/settings, admin/posts/new, company/social — added all to PAGE_HEADER_EXEMPT_ROUTES
+- Deferred: auth/callback (renders AuthCallbackClient only, no chrome needed)
+- Waves 2c + 3 + 4 stacked PRs open: #916, #917, wave-4
+
+## Wave 3 in progress 2026-05-19
+
+- Templates used: T-DETAIL-EDITOR (2 routes), T-WIZARD-STEP (5 routes), T-REVIEW-LINK (1 route), T-GRID (1 route)
+- Routes migrated: admin/sites/[id]/posts/[post_id], admin/sites/[id]/pages/[pageId], admin/sites/[id]/setup, admin/sites/[id]/setup/extract, admin/sites/[id]/onboarding, optimiser/onboarding, optimiser/onboarding/[id], admin/sites/[id]/briefs/[brief_id]/review, company/social/media
+- Deferred: admin/sites/[id]/blueprints/review (use client with own PageShell), design-system/components (layout-driven)
+
 ## Wave 2c in progress 2026-05-19
 
 - Templates used: T-FORM (6 routes), T-SETTINGS-FLAT (7 routes)

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -1243,9 +1243,15 @@ const PAGE_HEADER_EXEMPT_ROUTES: readonly string[] = [
   // PageHeader would be dead code. The file is a single
   // `redirect("/admin/sites")` call (Spec 04 PR B).
   "app/admin/page.tsx",
+  "app/(platform)/admin/page.tsx",
   // reason: redirect-only — `redirect("/admin/settings/design-system")`.
   // No chrome to host (Spec 04 PR C).
   "app/admin/settings/page.tsx",
+  "app/(platform)/admin/settings/page.tsx",
+  // reason: redirect-only — permanentRedirect("/admin/posts"). No chrome.
+  "app/(platform)/admin/posts/new/page.tsx",
+  // reason: redirect-only — redirect("/company/social/calendar"). No chrome.
+  "app/(platform)/company/social/page.tsx",
 ];
 
 function isPageHeaderDeferred(rel: string): boolean {

--- a/templates/T-AUTH-CHROME.tsx
+++ b/templates/T-AUTH-CHROME.tsx
@@ -1,0 +1,56 @@
+import { H1, Lead } from "@/components/ui/typography";
+
+export interface TAuthChromeProps {
+  title: string;
+  /** Rendered beneath the title as a Lead paragraph. Accepts ReactNode for inline emphasis. */
+  subtitle?: React.ReactNode;
+  /** Icon/badge element rendered above the title (e.g. auth/expired lock icon). */
+  titleIcon?: React.ReactNode;
+  /** Back-link or supplementary action rendered below the card. */
+  footer?: React.ReactNode;
+  /**
+   * "md" (default) — max-w-md (448px). Standard auth forms.
+   * "lg" — max-w-lg (512px). Wider for informational pages (e.g. session-expired).
+   */
+  width?: "md" | "lg";
+  children: React.ReactNode;
+}
+
+/**
+ * T-AUTH-CHROME
+ *
+ * Full-screen centered layout for unauthenticated surfaces.
+ * Provides: min-h-screen bg-canvas centering, title/subtitle header,
+ * optional icon above title, optional footer below card area.
+ * Children are rendered as-is — each page owns its own card wrapper.
+ */
+export function TAuthChrome({
+  title,
+  subtitle,
+  titleIcon,
+  footer,
+  width = "md",
+  children,
+}: TAuthChromeProps) {
+  const maxWidth = width === "lg" ? "max-w-lg" : "max-w-md";
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-canvas p-4">
+      <div className={`w-full ${maxWidth} space-y-6`}>
+        <div className="text-center">
+          {titleIcon && (
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center">
+              {titleIcon}
+            </div>
+          )}
+          <H1>{title}</H1>
+          {subtitle && <Lead className="mt-1">{subtitle}</Lead>}
+        </div>
+        {children}
+        {footer && (
+          <p className="text-center text-sm text-muted-foreground">{footer}</p>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/templates/T-ERROR-STATE.tsx
+++ b/templates/T-ERROR-STATE.tsx
@@ -1,0 +1,22 @@
+export interface TErrorStateProps {
+  title: string;
+  body: string;
+  /** Optional CTA rendered below the body (e.g. a back-link or Button). */
+  cta?: React.ReactNode;
+}
+
+/**
+ * T-ERROR-STATE
+ *
+ * Full-screen error page for unauthenticated/static error surfaces.
+ * No nav, no session dependency. Minimal markup.
+ */
+export function TErrorState({ title, body, cta }: TErrorStateProps) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-4 p-6 text-center">
+      <h1 className="text-page-title text-foreground">{title}</h1>
+      <p className="text-base text-muted-foreground">{body}</p>
+      {cta}
+    </main>
+  );
+}

--- a/templates/T-FULL-BLEED-EDITOR.tsx
+++ b/templates/T-FULL-BLEED-EDITOR.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+
+import { PageHeader } from "@/components/ui/page-header";
+
+export interface TFullBleedEditorProps {
+  title: string;
+  subtitle?: string;
+  backHref?: string;
+  backLabel?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+/**
+ * T-FULL-BLEED-EDITOR
+ *
+ * Full-width editor surface for platform routes whose layout already
+ * provides the outer shell (no additional PageShell wrapper needed).
+ * Provides: optional back-link above header, PageHeader with
+ * title/subtitle/actions, then full-bleed children.
+ */
+export function TFullBleedEditor({
+  title,
+  subtitle,
+  backHref,
+  backLabel = "Back",
+  actions,
+  children,
+}: TFullBleedEditorProps) {
+  return (
+    <>
+      {backHref && (
+        <div className="mb-4 text-sm">
+          <Link href={backHref} className="text-muted-foreground hover:text-foreground">
+            ← {backLabel}
+          </Link>
+        </div>
+      )}
+      <PageHeader>
+        <PageHeader.Title>{title}</PageHeader.Title>
+        {subtitle && <PageHeader.Subtitle>{subtitle}</PageHeader.Subtitle>}
+        {actions && <PageHeader.Actions>{actions}</PageHeader.Actions>}
+      </PageHeader>
+      {children}
+    </>
+  );
+}

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -33,3 +33,12 @@ export type { TReviewLinkProps } from "./T-REVIEW-LINK";
 
 export { TGrid } from "./T-GRID";
 export type { TGridProps } from "./T-GRID";
+
+export { TAuthChrome } from "./T-AUTH-CHROME";
+export type { TAuthChromeProps } from "./T-AUTH-CHROME";
+
+export { TFullBleedEditor } from "./T-FULL-BLEED-EDITOR";
+export type { TFullBleedEditorProps } from "./T-FULL-BLEED-EDITOR";
+
+export { TErrorState } from "./T-ERROR-STATE";
+export type { TErrorStateProps } from "./T-ERROR-STATE";


### PR DESCRIPTION
## Summary

Stacked on Wave 3 (#917). Completes the framework rollout across all 4 waves.

**New templates:**
- `T-AUTH-CHROME` — full-screen centered auth layout (`bg-canvas`, `max-w-md`/`lg`, `title` + `subtitle` + `titleIcon` + `footer` slots)
- `T-FULL-BLEED-EDITOR` — full-width platform editor (`back-link` + `PageHeader` + `children`, no extra `PageShell` — lives inside `(platform)` layout)
- `T-ERROR-STATE` — minimal static error page (`title` + `body` + optional `cta`)

**Migrated routes (11):**
| Route | Template |
|---|---|
| `login` | T-AUTH-CHROME |
| `login/check-email` | T-AUTH-CHROME |
| `auth/forgot-password` | T-AUTH-CHROME |
| `auth/reset-password` | T-AUTH-CHROME |
| `auth/accept-invite` | T-AUTH-CHROME (adds `bg-canvas` centering — previously bare `div`) |
| `invite/[token]` | T-AUTH-CHROME (adds `bg-canvas` centering — previously bare `div`) |
| `auth/approve` | T-AUTH-CHROME (replaces local `PageShell` function) |
| `auth/expired` | T-AUTH-CHROME (`width="lg"` + `titleIcon` for lock icon) |
| `auth-error` | T-ERROR-STATE |
| `company/image/generate` | T-FULL-BLEED-EDITOR |

**Deferred (1):**
- `auth/callback` — renders `<AuthCallbackClient>` only; no page chrome needed (full-screen async redirect handler)

**Redirect stubs (4 — T-REDIRECT-STUB):**
- `admin/page.tsx`, `admin/settings/page.tsx`, `admin/posts/new/page.tsx`, `company/social/page.tsx` — all already exist as `redirect()`/`permanentRedirect()` calls. Added all to `PAGE_HEADER_EXEMPT_ROUTES` (with both pre- and post-route-group path variants).

## Working analog

- `T-AUTH-CHROME` is a direct extraction of the local `PageShell` function already in `auth/approve/page.tsx` — the same `flex min-h-screen items-center justify-center bg-canvas p-4` pattern used by every auth page.
- `T-FULL-BLEED-EDITOR` matches the existing pattern in `company/image/generate/page.tsx` (back-link + `PageHeader` + children, no outer `PageShell`).
- `T-ERROR-STATE` matches the existing `auth-error/page.tsx` structure.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit
- [x] No new DB queries, SDK calls, or API routes
- [x] No user-content rendering surfaces — XSS coverage not required

## Risks identified and mitigated

- **`auth/accept-invite` + `invite/[token]` now have `bg-canvas` background**: these previously rendered inside whatever layout their parent provided. T-AUTH-CHROME adds `min-h-screen bg-canvas` — a visible improvement but technically a layout change. Both pages were already standalone with no outer shell, so this is safe.
- **`auth/expired` `titleIcon` slot**: The icon is passed as `React.ReactNode` and rendered inside a fixed `h-12 w-12` wrapper. The `mx-auto` centering from the original is now provided by the wrapper. No visual regression.
- **`T-FULL-BLEED-EDITOR` no PageShell**: Intentional — `company/image/generate` lives inside `(platform)` layout which provides the nav shell. Adding PageShell would double-nest.