### PR TITLE
feat(dashboard): AddProfileDropdown in FilterBar (audit gap G-3)

### DIFF
--- a/components/__tests__/AddProfileDropdown.test.tsx
+++ b/components/__tests__/AddProfileDropdown.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import * as React from "react";
+import { AddProfileDropdown } from "@/components/social/dashboard/AddProfileDropdown";
+
+// ---------------------------------------------------------------------------
+// Regression test for audit gap G-3 — AddProfileDropdown must exist in the
+// dashboard FilterBar and surface all five platform options.
+// ---------------------------------------------------------------------------
+
+describe("AddProfileDropdown (audit gap G-3)", () => {
+  it("renders the Add profile button", () => {
+    render(<AddProfileDropdown />);
+    expect(screen.getByTestId("add-profile-btn")).toBeDefined();
+  });
+
+  it("menu is hidden before button click", () => {
+    render(<AddProfileDropdown />);
+    expect(screen.queryByTestId("add-profile-menu")).toBeNull();
+  });
+
+  it("menu opens on button click and shows all 5 platforms", () => {
+    render(<AddProfileDropdown />);
+    fireEvent.click(screen.getByTestId("add-profile-btn"));
+
+    expect(screen.getByTestId("add-profile-menu")).toBeDefined();
+    expect(screen.getByTestId("add-profile-linkedin")).toBeDefined();
+    expect(screen.getByTestId("add-profile-facebook")).toBeDefined();
+    expect(screen.getByTestId("add-profile-instagram")).toBeDefined();
+    expect(screen.getByTestId("add-profile-twitter")).toBeDefined();
+    expect(screen.getByTestId("add-profile-google_business")).toBeDefined();
+  });
+
+  it("each platform item links to /company/social/connections", () => {
+    render(<AddProfileDropdown />);
+    fireEvent.click(screen.getByTestId("add-profile-btn"));
+
+    const linkedinLink = screen.getByTestId("add-profile-linkedin");
+    expect((linkedinLink as HTMLAnchorElement).getAttribute("href")).toBe(
+      "/company/social/connections",
+    );
+  });
+
+  it("clicking a platform item closes the menu", () => {
+    render(<AddProfileDropdown />);
+    fireEvent.click(screen.getByTestId("add-profile-btn"));
+    expect(screen.getByTestId("add-profile-menu")).toBeDefined();
+
+    fireEvent.click(screen.getByTestId("add-profile-linkedin"));
+    expect(screen.queryByTestId("add-profile-menu")).toBeNull();
+  });
+});

--- a/components/social/dashboard/AddProfileDropdown.tsx
+++ b/components/social/dashboard/AddProfileDropdown.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { SocialPlatformIcon, type SocialPlatformIconKey } from "@/components/ui/SocialPlatformIcon";
+
+// ---------------------------------------------------------------------------
+// AddProfileDropdown — "Add profile" button + platform picker.
+// Brief audit gap G-3 (C-2 in original audit): dashboard FilterBar needs an
+// affordance to connect additional social profiles.
+//
+// Route: each item links to /company/social/connections, which is the
+// canonical profile-connection management page. The brief specifies
+// /company/social/connections/connect/[platform] but that route does not
+// exist; the connections page opens the platform OAuth popup from there.
+// ---------------------------------------------------------------------------
+
+const PLATFORMS: Array<{ value: SocialPlatformIconKey; label: string }> = [
+  { value: "LINKEDIN", label: "LinkedIn" },
+  { value: "FACEBOOK", label: "Facebook" },
+  { value: "INSTAGRAM", label: "Instagram" },
+  { value: "TWITTER", label: "X (Twitter)" },
+  { value: "GOOGLE_BUSINESS", label: "Google Business" },
+];
+
+interface AddProfileDropdownProps {
+  className?: string;
+}
+
+export function AddProfileDropdown({ className }: AddProfileDropdownProps) {
+  const [open, setOpen] = React.useState(false);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  return (
+    <div className={cn("relative", className)} ref={menuRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Add profile"
+        data-testid="add-profile-btn"
+        className="flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted transition-colors"
+      >
+        <svg
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 5v14M5 12h14" />
+        </svg>
+        Add profile
+        <svg
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="opacity-50"
+          aria-hidden="true"
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          aria-label="Choose platform to connect"
+          data-testid="add-profile-menu"
+          className="absolute left-0 top-full z-20 mt-1 w-52 rounded-lg border border-border bg-popover shadow-lg"
+        >
+          <div className="p-1">
+            {PLATFORMS.map(({ value, label }) => (
+              <Link
+                key={value}
+                href="/company/social/connections"
+                role="menuitem"
+                data-testid={`add-profile-${value.toLowerCase()}`}
+                onClick={() => setOpen(false)}
+                className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-muted transition-colors"
+              >
+                <SocialPlatformIcon platform={value} size={16} className="shrink-0" />
+                {label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/social/dashboard/FilterBar.tsx
+++ b/components/social/dashboard/FilterBar.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 import type { Connection } from "@/lib/social/types";
 import { SocialPlatformIcon, type SocialPlatformIconKey } from "@/components/ui/SocialPlatformIcon";
+import { AddProfileDropdown } from "@/components/social/dashboard/AddProfileDropdown";
 
 interface FilterBarProps {
   profileFilter: string[];
@@ -152,6 +153,9 @@ export function FilterBar({
           </div>
         )}
       </div>
+
+      {/* Add profile */}
+      <AddProfileDropdown />
 
       {/* View mode toggle (Month / Timeline) */}
       <div

--- a/docs/briefs/social-01-brief/AUDIT_REPORT.md
+++ b/docs/briefs/social-01-brief/AUDIT_REPORT.md
@@ -158,6 +158,45 @@ ORDER BY ordinal_position;
 
 ---
 
+## Auth & Email Delivery (Investigation 2 — 2026-05-19)
+
+**Investigated:** Auth email non-delivery for `steven.m@opollo.com`  
+**Method:** Supabase admin auth API, SendGrid REST API v3 messages, SendGrid domain authentication
+
+### Finding 1 — `steven.m@opollo.com` does not exist in `auth.users` (ROOT CAUSE for reset failure)
+
+The Supabase project (`sazapxgmrdaewrkwoxby`) contains only 2 auth users. `steven.m@opollo.com` is not among them. A password reset email was never sent because there was no user record to reset. **Action: create the account via Supabase dashboard invite flow or `auth.admin.inviteUserByEmail()`.**
+
+### Finding 2 — `SENDGRID_FROM_EMAIL` env var points to an unauthenticated domain (HIGH — approval magic links will fail)
+
+| Setting | Value |
+|---|---|
+| `.env.local` / production `SENDGRID_FROM_EMAIL` | `noreply@opollo.com.au` |
+| Code comment expectation (`lib/email/sendgrid.ts:47`) | `noreply@opollo.com` |
+| `opollo.com` in SendGrid domain auth | **VALID** (subdomain `em3442`) |
+| `opollo.com.au` in SendGrid domain auth | **NOT PRESENT** |
+
+All application-level emails (composer approval magic links, invite accepts, bulk CSV approvals) use `SENDGRID_FROM_EMAIL`. If this is set to `noreply@opollo.com.au`, SendGrid will either reject or soft-bounce every email, because `opollo.com.au` has no DKIM/SPF records configured in SendGrid.
+
+**Fix (required before approval flow goes to production):** Set `SENDGRID_FROM_EMAIL=noreply@opollo.com` in Vercel production env vars. The `opollo.com` domain is already authenticated.
+
+### Finding 3 — Supabase auth emails use `hi@opollo.com` (correct — no action needed)
+
+Supabase SMTP is configured as:
+- Host: `smtp.sendgrid.net:587`
+- From: `hi@opollo.com` (configured as `smtp_admin_email`)
+- `hi@opollo.com` is a verified sender in SendGrid
+
+Password reset, signup confirmation, and invite emails from Supabase will deliver correctly once the account exists.
+
+### Finding 4 — Zero SendGrid message history for `steven.m@opollo.com`
+
+SendGrid Activity API (30-day window) returned 0 messages to `steven.m@opollo.com`. Consistent with the account not existing.
+
+**Cross-impact:** The approval magic link in social post approval flow uses `SENDGRID_FROM_EMAIL`. If Finding 2 is not fixed before approval flow is exercised in production, approvers will never receive their action links.
+
+---
+
 ## PR State at Audit Time
 
 | PR | Title | State | Merged |

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -283,4 +283,36 @@ test.describe("dashboard — calendar grid (PR F)", () => {
     await page.getByTestId("view-month-btn").click();
     await expect(page.getByTestId("calendar-grid")).toBeVisible();
   });
+
+  test("(F-8) add-profile dropdown opens platform picker and links to connections page (audit gap G-3)", async ({ page, context }) => {
+    await mockDashboardApis(context, []);
+    const ready = await goToDashboard(page);
+    if (!ready) return;
+
+    // Button is visible in filter bar
+    const btn = page.getByTestId("add-profile-btn");
+    await expect(btn).toBeVisible();
+
+    // Menu is not visible before click
+    await expect(page.getByTestId("add-profile-menu")).not.toBeVisible();
+
+    // Open dropdown
+    await btn.click();
+    await expect(page.getByTestId("add-profile-menu")).toBeVisible();
+
+    // All 5 platform items are rendered
+    const linkedinItem = page.getByTestId("add-profile-linkedin");
+    const twitterItem = page.getByTestId("add-profile-twitter");
+    const googleItem = page.getByTestId("add-profile-google_business");
+    await expect(linkedinItem).toBeVisible();
+    await expect(twitterItem).toBeVisible();
+    await expect(googleItem).toBeVisible();
+
+    // Each item links to the connections page
+    await expect(linkedinItem).toHaveAttribute("href", "/company/social/connections");
+
+    // Clicking an item closes the dropdown and navigates
+    await linkedinItem.click();
+    await expect(page.getByTestId("add-profile-menu")).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `components/social/dashboard/AddProfileDropdown.tsx` — the \"Add profile\" button + platform picker dropdown missing from the social poster dashboard (audit gap G-3 / C-2)
- Mounts in `FilterBar.tsx` between the profile filter and view-mode toggle
- 5 platform options: LinkedIn, Facebook, Instagram, X, Google Business — each links to `/company/social/connections`
- 5 component tests + e2e guard (F-8)
- Auth/email delivery findings documented in AUDIT_REPORT.md

## Working analog

**Working analog**: `components/social/dashboard/FilterBar.tsx:91–153` — profile filter dropdown uses the same click-outside + absolute-positioned-menu pattern.

**Diff**: `AddProfileDropdown` needs `next/link` items rather than buttons, and no multi-select — each item navigates.

**Fix**: Matches FilterBar's dropdown pattern with `Link` elements as menu items.

**Brief gap note**: COMPONENT_MAP.md specifies items link to `/company/social/connections/connect/[platform]` but that route does not exist in the app. The connections roster at `/company/social/connections` is the canonical page where the platform OAuth popup is launched. All items link there.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run --config vitest.components.config.ts "AddProfileDropdown"` — 5 pass
- [x] e2e F-8 test added to `e2e/dashboard.spec.ts`
- [x] No new audit:static findings

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| `dropdown-menu.tsx` doesn't exist — brief spec uses it | Used FilterBar's existing custom dropdown pattern (working analog). No new dependency. |
| Brief's connect route doesn't exist | Link to `/company/social/connections` — the canonical connect page. Documented in PR description. |
| `Link` navigation closes the popover state | `onClick={() => setOpen(false)}` on each item clears the dropdown before navigation. |

## PR size

~120 net lines (well under 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)