### PR TITLE
fix(types): align DraftResponse.created_by with DB column (audit A-5)

### DIFF
--- a/lib/social/types.ts
+++ b/lib/social/types.ts
@@ -7,9 +7,6 @@
 // CLAUDE-ASSUMPTION: Platform type uses brief's social_connections.platform
 // values, not the existing SocialPlatform publishing-layer type.
 //
-// CLAUDE-ASSUMPTION: created_by_user_id in API responses maps to the DB
-// column `created_by` (existing column name from migration 0112).
-
 export type Platform =
   | "linkedin"
   | "facebook"
@@ -70,7 +67,7 @@ export interface RecurrenceRule {
 export interface DraftResponse {
   id: string;
   company_id: string;
-  created_by_user_id: string; // maps to DB column `created_by`
+  created_by: string;
   state: DraftState;
   content: string;
   media_urls: string[];


### PR DESCRIPTION
## Summary

One-line type fix: `DraftResponse.created_by_user_id` → `created_by`

The API endpoint `GET /api/platform/social/drafts/[id]` calls `getDraft()` which returns the raw Supabase row via `.select()` (no aliasing). The DB column name is `created_by` (migration 0112). But `DraftResponse` in `lib/social/types.ts` declared it as `created_by_user_id`, so any code reading `draft.created_by_user_id` from the API response would get `undefined` at runtime.

## Working analog

**Working analog**: `lib/platform/social/drafts.ts:51` — `Draft` type already uses `created_by: string` throughout.  
**Diff**: `DraftResponse` was inconsistent with `Draft` — used `created_by_user_id` which has no DB/API backing.  
**Fix**: Rename to `created_by` to match the actual JSON key returned by the API.

## Impact

- No consuming code was actively reading `created_by_user_id` (grep confirms zero usages outside the type definition), so no UI regression to fix.
- `PostAnalyticsModal.onScheduleAgain(draft)` and any future attribution displays will now correctly receive the author user ID.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 1778 pass
- [x] 1-line change, no new test needed (type-only fix, no runtime code changed)

## Risks

None. Pure TypeScript type rename. The API response JSON already contains `created_by`; this just makes the TS type match what was already true at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)