### PR TITLE
fix(approval): check insert error on auto-reject decision row (audit LOW #8)

### DIFF
--- a/lib/social/approval/escalate.ts
+++ b/lib/social/approval/escalate.ts
@@ -43,12 +43,15 @@ export async function runEscalationCycle(): Promise<{ escalated: number; autoRej
         .from("social_post_drafts")
         .update({ state: "rejected", updated_at: new Date().toISOString() })
         .eq("id", draft.id);
-      await svc.from("social_post_approval_decisions").insert({
+      const { error: decisionErr } = await svc.from("social_post_approval_decisions").insert({
         draft_id: draft.id,
         approver_user_id: null,
         decision: "rejected",
         rejection_reason: "Approval timeout (96h).",
       });
+      if (decisionErr) {
+        logger.warn("escalate.decision_insert_failed", { draftId: draft.id, err: decisionErr.message });
+      }
       autoRejected++;
       logger.info("escalate.auto_rejected", { draftId: draft.id });
     } else if (age >= 72 * 60 * 60 * 1000) {


### PR DESCRIPTION
## Summary

Closes audit LOW item #8: `runEscalationCycle` silently swallowed the error returned by the `social_post_approval_decisions` insert when auto-rejecting a draft at the 96h timeout boundary.

**Change**: Capture `{ error: decisionErr }` from the insert and call `logger.warn("escalate.decision_insert_failed", ...)` when it's present. The auto-reject counter still increments (the draft state update succeeded) and processing continues — we don't want one bad audit-log insert to halt the entire escalation cycle.

## Working analog

**Working analog**: `app/api/platform/social/drafts/[id]/approve/route.ts` — same `social_post_approval_decisions` insert with destructured `error` and a `logger.warn` on failure; draft state update is the primary effect and the decision row is secondary.
**Diff**: `escalate.ts` previously used `.insert(...)` without capturing the return value.
**Fix**: Destructured `{ error: decisionErr }` and added `if (decisionErr) logger.warn(...)` after the insert, matching the approve route pattern.

## Test coverage

- Existing `test:unit` suite (1778 tests) passes — no new unit test needed; this is a one-line error-capture added to a logging path with no branching logic change.

## Risks identified and mitigated

- **Silent swallow on insert failure**: mitigated — now logged with draft ID for ops visibility.
- **No change to auto-reject state machine**: draft state update (`state: 'rejected'`) precedes the decision insert; counter increments regardless of decision insert outcome. Escalation cycle is not halted by a decision-row failure.
- **No schema change**: existing `social_post_approval_decisions` table; no migration needed.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (1778 pass)
- [ ] Contract snapshots reviewed — no SDK calls touched
- [ ] Cross-tenant test — no new tenant-scoped resource
- [ ] XSS payload coverage — no user-content rendering
- [ ] Probe script — no SDK boundary change
- [ ] Regression test — single-line logging fix, not a >1-PR production bug
- [x] Working-analog block present
- [x] Risks identified and mitigated
- [x] PR is under 500 net lines (< 10 lines changed)