### PR TITLE
feat(cap): pr3 — generation pipeline, prompts, campaign-runner, api routes

### DIFF
--- a/app/api/platform/cap/campaign-posts/[id]/regenerate/route.ts
+++ b/app/api/platform/cap/campaign-posts/[id]/regenerate/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { internalError, validationError } from "@/lib/http";
+import { requireCapOperatorForApi } from "@/lib/cap/api-gate";
+import { regeneratePost } from "@/lib/cap/generation/regenerate-post";
+import { CostCapExceededError } from "@/lib/cap/cost-cap";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+const UUID_RE = /^[0-9a-fA-F-]{36}$/;
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) return validationError("id must be a UUID.");
+
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  let reason: string | undefined;
+  try {
+    const body = await req.json() as Record<string, unknown>;
+    if (typeof body.reason === "string") reason = body.reason.slice(0, 500);
+  } catch {
+    // body is optional
+  }
+
+  try {
+    const result = await regeneratePost(id, reason);
+    return NextResponse.json({ ok: true, data: result }, { status: 200 });
+  } catch (err) {
+    if (err instanceof CostCapExceededError) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: "COST_CAP_EXCEEDED",
+            message: err.message,
+            retryable: false,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 402 },
+      );
+    }
+    return internalError(err instanceof Error ? err.message : "Regeneration failed");
+  }
+}

--- a/app/api/platform/cap/campaigns/[id]/generate/route.ts
+++ b/app/api/platform/cap/campaigns/[id]/generate/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { internalError, validationError } from "@/lib/http";
+import { requireCapOperatorForApi } from "@/lib/cap/api-gate";
+import { runCampaign } from "@/lib/cap/generation/campaign-runner";
+import { CostCapExceededError } from "@/lib/cap/cost-cap";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+const UUID_RE = /^[0-9a-fA-F-]{36}$/;
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) return validationError("id must be a UUID.");
+
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  try {
+    const result = await runCampaign(id);
+    return NextResponse.json({ ok: true, data: result }, { status: 200 });
+  } catch (err) {
+    if (err instanceof CostCapExceededError) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: "COST_CAP_EXCEEDED",
+            message: err.message,
+            retryable: false,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 402 },
+      );
+    }
+    return internalError(err instanceof Error ? err.message : "Generation failed");
+  }
+}

--- a/lib/__tests__/cap-generation.unit.test.ts
+++ b/lib/__tests__/cap-generation.unit.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Supabase service-role mock
+// ─────────────────────────────────────────────────────────────────────────────
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cost cap mock
+// ─────────────────────────────────────────────────────────────────────────────
+const { mockAssertCostCap } = vi.hoisted(() => ({ mockAssertCostCap: vi.fn() }));
+vi.mock("@/lib/cap/cost-cap", () => ({
+  assertCostCapNotExceeded: mockAssertCostCap,
+  CostCapExceededError: class CostCapExceededError extends Error {
+    constructor(
+      public subscriptionId: string,
+      public spentUsd: number,
+      public capUsd: number,
+    ) {
+      super(`Cost cap exceeded for ${subscriptionId}`);
+      this.name = "CostCapExceededError";
+    }
+  },
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Provider mocks
+// ─────────────────────────────────────────────────────────────────────────────
+const { mockGenerateText, mockGenerateImage } = vi.hoisted(() => ({
+  mockGenerateText: vi.fn(),
+  mockGenerateImage: vi.fn(),
+}));
+vi.mock("@/lib/cap/pal", () => ({
+  getTextProvider: vi.fn(() => ({ generate: mockGenerateText })),
+  getImageProvider: vi.fn(() => ({ generate: mockGenerateImage })),
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prompt builders
+// ─────────────────────────────────────────────────────────────────────────────
+import {
+  buildCampaignPostSystemMessage,
+  buildCampaignPostUserMessage,
+  PROMPT_VERSION,
+} from "@/lib/cap/prompts/campaign-post";
+
+import { buildImagePrompt, IMAGE_PROMPT_VERSION } from "@/lib/cap/prompts/image-prompt";
+
+describe("buildCampaignPostSystemMessage", () => {
+  it("returns a non-empty string", () => {
+    expect(buildCampaignPostSystemMessage()).toMatch(/LinkedIn/);
+  });
+});
+
+describe("buildCampaignPostUserMessage", () => {
+  const base = {
+    weekNumber: 1 as const,
+    arcPhase: "awareness" as const,
+    monthlyObjective: "Grow LinkedIn awareness for our MSP",
+    month: "2026-06-01",
+    tone: "professional-friendly",
+    industry: "IT Services",
+    targetAudience: "SMB IT managers",
+    bannedWords: ["synergy", "leverage"],
+    onBrandPhrases: ["peace of mind", "proactive support"],
+    languagePatterns: {},
+    referencePosts: [],
+  };
+
+  it("includes arc phase guidance for awareness", () => {
+    const msg = buildCampaignPostUserMessage(base);
+    expect(msg).toContain("AWARENESS");
+    expect(msg).toContain("June 2026");
+  });
+
+  it("includes banned words section", () => {
+    const msg = buildCampaignPostUserMessage(base);
+    expect(msg).toContain("synergy");
+    expect(msg).toContain("leverage");
+  });
+
+  it("includes on-brand phrases", () => {
+    const msg = buildCampaignPostUserMessage(base);
+    expect(msg).toContain("peace of mind");
+  });
+
+  it("omits banned words section when empty", () => {
+    const msg = buildCampaignPostUserMessage({ ...base, bannedWords: [] });
+    expect(msg).not.toContain("BANNED WORDS");
+  });
+
+  it("PROMPT_VERSION is 1", () => {
+    expect(PROMPT_VERSION).toBe(1);
+  });
+});
+
+describe("buildImagePrompt", () => {
+  it("includes arc phase visual tone for offer", () => {
+    const prompt = buildImagePrompt({
+      arcPhase: "offer",
+      industry: "IT Services",
+      postContentSummary: "Why your MSP should act now.",
+    });
+    expect(prompt).toContain("action-oriented");
+    expect(prompt).toContain("IT Services");
+  });
+
+  it("IMAGE_PROMPT_VERSION is 1", () => {
+    expect(IMAGE_PROMPT_VERSION).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// generatePost
+// ─────────────────────────────────────────────────────────────────────────────
+import { generatePost } from "@/lib/cap/generation/post-generator";
+
+const SAMPLE_VOICE = {
+  tone: "professional-friendly",
+  industry: "IT Services",
+  targetAudience: "SMB IT managers",
+  bannedWords: [] as string[],
+  onBrandPhrases: [] as string[],
+  languagePatterns: {},
+  referencePosts: [] as string[],
+};
+
+const SAMPLE_POST_INPUT = {
+  campaignId: "camp-1",
+  postId: "post-1",
+  weekNumber: 1 as const,
+  arcPhase: "awareness" as const,
+  monthlyObjective: "Grow LinkedIn awareness",
+  month: "2026-06-01",
+  voiceProfile: SAMPLE_VOICE,
+};
+
+function buildInsertChain() {
+  return { insert: vi.fn().mockResolvedValue({ error: null }) };
+}
+
+describe("generatePost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFrom.mockReturnValue(buildInsertChain());
+  });
+
+  it("happy path: parses JSON response and returns structured result", async () => {
+    mockGenerateText.mockResolvedValue({
+      text: JSON.stringify({
+        content: "LinkedIn post about IT challenges",
+        hashtags: ["#MSP", "#ITServices", "#ManagedServices"],
+      }),
+      inputTokens: 200,
+      outputTokens: 80,
+      latencyMs: 1200,
+    });
+
+    const result = await generatePost(SAMPLE_POST_INPUT);
+    expect(result.content).toBe("LinkedIn post about IT challenges");
+    expect(result.hashtags).toEqual(["#MSP", "#ITServices", "#ManagedServices"]);
+    expect(result.inputTokens).toBe(200);
+    expect(result.outputTokens).toBe(80);
+    expect(result.costUsd).toBeGreaterThan(0);
+    expect(result.latencyMs).toBe(1200);
+  });
+
+  it("falls back gracefully when model returns non-JSON", async () => {
+    mockGenerateText.mockResolvedValue({
+      text: "Here is a post about IT challenges.",
+      inputTokens: 50,
+      outputTokens: 20,
+      latencyMs: 800,
+    });
+
+    const result = await generatePost(SAMPLE_POST_INPUT);
+    expect(result.content).toBe("Here is a post about IT challenges.");
+    expect(result.hashtags).toEqual([]);
+  });
+
+  it("records a generation run on success", async () => {
+    const mockInsert = vi.fn().mockResolvedValue({ error: null });
+    mockFrom.mockReturnValue({ insert: mockInsert });
+
+    mockGenerateText.mockResolvedValue({
+      text: JSON.stringify({ content: "post", hashtags: [] }),
+      inputTokens: 100,
+      outputTokens: 50,
+      latencyMs: 500,
+    });
+
+    await generatePost(SAMPLE_POST_INPUT);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: "text_generation",
+        status: "success",
+        cap_campaign_id: "camp-1",
+        cap_campaign_post_id: "post-1",
+      }),
+    );
+  });
+
+  it("records error run and re-throws when provider fails", async () => {
+    const mockInsert = vi.fn().mockResolvedValue({ error: null });
+    mockFrom.mockReturnValue({ insert: mockInsert });
+
+    mockGenerateText.mockRejectedValue(new Error("Anthropic 429: rate limited"));
+
+    await expect(generatePost(SAMPLE_POST_INPUT)).rejects.toThrow("rate limited");
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "error" }),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// generateImageForPost
+// ─────────────────────────────────────────────────────────────────────────────
+import { generateImageForPost } from "@/lib/cap/generation/image-orchestrator";
+
+describe("generateImageForPost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFrom.mockReturnValue(buildInsertChain());
+  });
+
+  it("happy path returns image URL and records run", async () => {
+    const mockInsert = vi.fn().mockResolvedValue({ error: null });
+    mockFrom.mockReturnValue({ insert: mockInsert });
+
+    mockGenerateImage.mockResolvedValue({
+      url: "https://cdn.ideogram.ai/image.jpg",
+      latencyMs: 2000,
+    });
+
+    const result = await generateImageForPost({
+      campaignId: "camp-1",
+      postId: "post-1",
+      arcPhase: "awareness",
+      industry: "IT Services",
+      postContent: "LinkedIn post about IT challenges",
+    });
+
+    expect(result.url).toBe("https://cdn.ideogram.ai/image.jpg");
+    expect(result.costUsd).toBe(0.08);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: "image_generation",
+        status: "success",
+      }),
+    );
+  });
+
+  it("records error and re-throws on failure", async () => {
+    const mockInsert = vi.fn().mockResolvedValue({ error: null });
+    mockFrom.mockReturnValue({ insert: mockInsert });
+
+    mockGenerateImage.mockRejectedValue(new Error("Ideogram 503"));
+
+    await expect(
+      generateImageForPost({
+        campaignId: "camp-1",
+        postId: "post-1",
+        arcPhase: "education",
+        industry: "IT Services",
+        postContent: "post text",
+      }),
+    ).rejects.toThrow("Ideogram 503");
+
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({ status: "error" }));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// runCampaign
+// ─────────────────────────────────────────────────────────────────────────────
+import { runCampaign } from "@/lib/cap/generation/campaign-runner";
+
+function buildCampaignDb() {
+  const campaign = {
+    id: "camp-1",
+    month: "2026-06-01",
+    monthly_objective: "Grow LinkedIn awareness",
+    status: "draft",
+    cap_subscription_id: "sub-1",
+    cap_voice_profiles: {
+      tone: "professional-friendly",
+      industry: "IT Services",
+      target_audience: "SMB IT managers",
+      banned_words: [],
+      on_brand_phrases: [],
+      language_patterns: {},
+      reference_posts: [],
+    },
+    cap_subscriptions: { id: "sub-1" },
+  };
+
+  const upsertedPosts = [
+    { id: "post-w1", week_number: 1, arc_phase: "awareness" },
+    { id: "post-w2", week_number: 2, arc_phase: "education" },
+    { id: "post-w3", week_number: 3, arc_phase: "offer" },
+    { id: "post-w4", week_number: 4, arc_phase: "proof" },
+  ];
+
+  return { campaign, upsertedPosts };
+}
+
+describe("runCampaign", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAssertCostCap.mockResolvedValue(undefined);
+  });
+
+  it("happy path: generates all 4 posts and sets status to review", async () => {
+    const { campaign, upsertedPosts } = buildCampaignDb();
+
+    mockGenerateText.mockResolvedValue({
+      text: JSON.stringify({ content: "post content", hashtags: ["#MSP"] }),
+      inputTokens: 100,
+      outputTokens: 50,
+      latencyMs: 500,
+    });
+    mockGenerateImage.mockResolvedValue({ url: "https://cdn.ideogram.ai/img.jpg", latencyMs: 2000 });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "cap_campaigns") {
+        callCount++;
+        if (callCount === 1) {
+          // First call: .select().eq().single()
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({ data: campaign, error: null }),
+              }),
+            }),
+          };
+        }
+        // Subsequent calls: .update().eq()
+        return { update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }) };
+      }
+      if (table === "cap_campaign_posts") {
+        return {
+          upsert: vi.fn().mockReturnValue({
+            select: vi.fn().mockResolvedValue({ data: upsertedPosts, error: null }),
+          }),
+          update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+        };
+      }
+      if (table === "cap_generation_runs") {
+        return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      }
+      return {};
+    });
+
+    const result = await runCampaign("camp-1");
+    expect(result.status).toBe("review");
+    expect(result.postsGenerated).toBe(4);
+    expect(mockAssertCostCap).toHaveBeenCalledWith("sub-1");
+  });
+
+  it("throws and marks campaign failed when cost cap exceeded", async () => {
+    const { campaign } = buildCampaignDb();
+
+    let fromCallCount = 0;
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "cap_campaigns") {
+        fromCallCount++;
+        if (fromCallCount === 1) {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({ data: campaign, error: null }),
+              }),
+            }),
+          };
+        }
+        return { update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }) };
+      }
+      return {};
+    });
+
+    mockAssertCostCap.mockRejectedValue(new Error("Cost cap exceeded"));
+
+    await expect(runCampaign("camp-1")).rejects.toThrow("Cost cap exceeded");
+  });
+
+  it("throws when campaign not found", async () => {
+    mockFrom.mockImplementation(() => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: null, error: { message: "not found" } }),
+        }),
+      }),
+    }));
+
+    await expect(runCampaign("nonexistent")).rejects.toThrow("Campaign not found");
+  });
+});

--- a/lib/cap/api-gate.ts
+++ b/lib/cap/api-gate.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+import { createRouteAuthClient } from "@/lib/auth";
+
+export type CapApiGateResult =
+  | { kind: "allow"; userId: string }
+  | { kind: "deny"; response: NextResponse };
+
+function denyResponse(code: string, message: string, status: 401 | 403): NextResponse {
+  return NextResponse.json(
+    { ok: false, error: { code, message, retryable: false }, timestamp: new Date().toISOString() },
+    { status },
+  );
+}
+
+export async function requireCapOperatorForApi(): Promise<CapApiGateResult> {
+  const supabase = createRouteAuthClient();
+  const { data: userResp, error: userErr } = await supabase.auth.getUser();
+
+  if (userErr || !userResp?.user) {
+    return { kind: "deny", response: denyResponse("UNAUTHORIZED", "Authentication required.", 401) };
+  }
+
+  const { data: isOp, error: rpErr } = await supabase.rpc("is_cap_operator");
+  if (rpErr || isOp !== true) {
+    return { kind: "deny", response: denyResponse("FORBIDDEN", "CAP operator access required.", 403) };
+  }
+
+  return { kind: "allow", userId: userResp.user.id };
+}

--- a/lib/cap/generation/campaign-runner.ts
+++ b/lib/cap/generation/campaign-runner.ts
@@ -1,0 +1,149 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { assertCostCapNotExceeded } from "@/lib/cap/cost-cap";
+import { generatePost } from "@/lib/cap/generation/post-generator";
+import { generateImageForPost } from "@/lib/cap/generation/image-orchestrator";
+
+const ARC_PHASES = [
+  { weekNumber: 1 as const, arcPhase: "awareness" as const },
+  { weekNumber: 2 as const, arcPhase: "education" as const },
+  { weekNumber: 3 as const, arcPhase: "offer" as const },
+  { weekNumber: 4 as const, arcPhase: "proof" as const },
+];
+
+export interface RunCampaignResult {
+  campaignId: string;
+  postsGenerated: number;
+  status: "review" | "failed";
+}
+
+export async function runCampaign(campaignId: string): Promise<RunCampaignResult> {
+  const svc = getServiceRoleClient();
+
+  // Load campaign with voice profile + subscription
+  const { data: campaign, error: campaignErr } = await svc
+    .from("cap_campaigns")
+    .select(
+      `id, month, monthly_objective, status, cap_subscription_id,
+       cap_voice_profiles:voice_profile_id (
+         tone, industry, target_audience, banned_words,
+         on_brand_phrases, language_patterns, reference_posts
+       ),
+       cap_subscriptions:cap_subscription_id ( id )`,
+    )
+    .eq("id", campaignId)
+    .single();
+
+  if (campaignErr || !campaign) {
+    throw new Error(`Campaign not found: ${campaignId}`);
+  }
+
+  // Cost cap check
+  await assertCostCapNotExceeded(campaign.cap_subscription_id);
+
+  // Transition to generating
+  await svc
+    .from("cap_campaigns")
+    .update({ status: "generating" })
+    .eq("id", campaignId);
+
+  logger.info("cap.campaign-runner.start", { campaignId });
+
+  // Upsert 4 pending posts (idempotent — UNIQUE on (cap_campaign_id, week_number))
+  const pendingPosts = ARC_PHASES.map((p) => ({
+    cap_campaign_id: campaignId,
+    week_number: p.weekNumber,
+    arc_phase: p.arcPhase,
+    status: "pending" as const,
+    generated_content: null,
+    generated_image_url: null,
+    generated_hashtags: [] as string[],
+  }));
+
+  const { data: upsertedPosts, error: upsertErr } = await svc
+    .from("cap_campaign_posts")
+    .upsert(pendingPosts, { onConflict: "cap_campaign_id,week_number" })
+    .select("id, week_number, arc_phase");
+
+  if (upsertErr || !upsertedPosts) {
+    await svc.from("cap_campaigns").update({ status: "failed" }).eq("id", campaignId);
+    throw new Error(`Failed to upsert campaign posts: ${upsertErr?.message}`);
+  }
+
+  const vp = Array.isArray(campaign.cap_voice_profiles)
+    ? campaign.cap_voice_profiles[0]
+    : campaign.cap_voice_profiles;
+
+  if (!vp) {
+    await svc.from("cap_campaigns").update({ status: "failed" }).eq("id", campaignId);
+    throw new Error(`Campaign ${campaignId} has no voice profile`);
+  }
+
+  const voiceProfile = {
+    tone: vp.tone as string,
+    industry: vp.industry as string,
+    targetAudience: vp.target_audience as string,
+    bannedWords: (vp.banned_words as string[]) ?? [],
+    onBrandPhrases: (vp.on_brand_phrases as string[]) ?? [],
+    languagePatterns: (vp.language_patterns as Record<string, unknown>) ?? {},
+    referencePosts: (vp.reference_posts as string[]) ?? [],
+  };
+
+  let postsGenerated = 0;
+
+  for (const post of upsertedPosts) {
+    try {
+      const textResult = await generatePost({
+        campaignId,
+        postId: post.id as string,
+        weekNumber: post.week_number as 1 | 2 | 3 | 4,
+        arcPhase: post.arc_phase as "awareness" | "education" | "offer" | "proof",
+        monthlyObjective: campaign.monthly_objective as string,
+        month: campaign.month as string,
+        voiceProfile,
+      });
+
+      const imageResult = await generateImageForPost({
+        campaignId,
+        postId: post.id as string,
+        arcPhase: post.arc_phase as "awareness" | "education" | "offer" | "proof",
+        industry: voiceProfile.industry,
+        postContent: textResult.content,
+      });
+
+      await svc
+        .from("cap_campaign_posts")
+        .update({
+          generated_content: textResult.content,
+          generated_hashtags: textResult.hashtags,
+          generated_image_url: imageResult.url,
+          status: "generated",
+        })
+        .eq("id", post.id);
+
+      postsGenerated++;
+      logger.info("cap.campaign-runner.post_generated", { campaignId, postId: post.id, week: post.week_number });
+    } catch (err) {
+      logger.error("cap.campaign-runner.post_failed", {
+        campaignId,
+        postId: post.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+
+      await svc
+        .from("cap_campaign_posts")
+        .update({ status: "failed" })
+        .eq("id", post.id);
+
+      await svc.from("cap_campaigns").update({ status: "failed" }).eq("id", campaignId);
+      throw err;
+    }
+  }
+
+  await svc.from("cap_campaigns").update({ status: "review" }).eq("id", campaignId);
+  logger.info("cap.campaign-runner.complete", { campaignId, postsGenerated });
+
+  return { campaignId, postsGenerated, status: "review" };
+}

--- a/lib/cap/generation/image-orchestrator.ts
+++ b/lib/cap/generation/image-orchestrator.ts
@@ -1,0 +1,95 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { getImageProvider } from "@/lib/cap/pal";
+import { calculateIdeogramCost } from "@/lib/cap/pal/cost-tracker";
+import { buildImagePrompt, IMAGE_PROMPT_VERSION } from "@/lib/cap/prompts/image-prompt";
+
+export interface GenerateImageInput {
+  campaignId: string;
+  postId: string;
+  arcPhase: "awareness" | "education" | "offer" | "proof";
+  industry: string;
+  postContent: string;
+}
+
+export interface GenerateImageResult {
+  url: string;
+  costUsd: number;
+  latencyMs: number;
+}
+
+const IMAGE_MODEL = "V_2_TURBO";
+
+export async function generateImageForPost(
+  input: GenerateImageInput,
+): Promise<GenerateImageResult> {
+  const { campaignId, postId, arcPhase, industry, postContent } = input;
+
+  const prompt = buildImagePrompt({
+    arcPhase,
+    industry,
+    postContentSummary: postContent,
+  });
+
+  const provider = getImageProvider();
+  let genResult;
+  let status: "success" | "error" = "success";
+  let errorDetails: Record<string, unknown> | null = null;
+
+  try {
+    genResult = await provider.generate({ prompt });
+  } catch (err) {
+    status = "error";
+    errorDetails = { message: err instanceof Error ? err.message : String(err) };
+    await recordImageRun({ postId, campaignId, prompt, status, errorDetails });
+    throw err;
+  }
+
+  await recordImageRun({
+    postId,
+    campaignId,
+    prompt,
+    estimatedCostUsd: calculateIdeogramCost(),
+    latencyMs: genResult.latencyMs,
+    status,
+  });
+
+  return {
+    url: genResult.url,
+    costUsd: calculateIdeogramCost(),
+    latencyMs: genResult.latencyMs,
+  };
+}
+
+interface RecordImageRunInput {
+  postId: string;
+  campaignId: string;
+  prompt: string;
+  estimatedCostUsd?: number;
+  latencyMs?: number;
+  status: "success" | "error";
+  errorDetails?: Record<string, unknown> | null;
+}
+
+async function recordImageRun(input: RecordImageRunInput): Promise<void> {
+  const svc = getServiceRoleClient();
+  const { error } = await svc.from("cap_generation_runs").insert({
+    cap_campaign_post_id: input.postId,
+    cap_campaign_id: input.campaignId,
+    operation: "image_generation",
+    prompt_version: IMAGE_PROMPT_VERSION,
+    prompt_used: input.prompt,
+    model: IMAGE_MODEL,
+    input_tokens: null,
+    output_tokens: null,
+    estimated_cost_usd: input.estimatedCostUsd ?? 0,
+    latency_ms: input.latencyMs ?? null,
+    status: input.status,
+    error_details: input.errorDetails ?? null,
+  });
+  if (error) {
+    logger.warn("cap.image-orchestrator.run_record_failed", { error: error.message });
+  }
+}

--- a/lib/cap/generation/post-generator.ts
+++ b/lib/cap/generation/post-generator.ts
@@ -1,0 +1,191 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { getTextProvider } from "@/lib/cap/pal";
+import { calculateAnthropicCost } from "@/lib/cap/pal/cost-tracker";
+import { sanitizePromptInput, sanitizePromptArray } from "@/lib/cap/generation/sanitize";
+import {
+  PROMPT_VERSION,
+  buildCampaignPostSystemMessage,
+  buildCampaignPostUserMessage,
+} from "@/lib/cap/prompts/campaign-post";
+
+export interface GeneratePostInput {
+  campaignId: string;
+  postId: string;
+  weekNumber: 1 | 2 | 3 | 4;
+  arcPhase: "awareness" | "education" | "offer" | "proof";
+  monthlyObjective: string;
+  month: string;
+  voiceProfile: {
+    tone: string;
+    industry: string;
+    targetAudience: string;
+    bannedWords: string[];
+    onBrandPhrases: string[];
+    languagePatterns: Record<string, unknown>;
+    referencePosts: string[];
+  };
+}
+
+export interface GeneratePostResult {
+  content: string;
+  hashtags: string[];
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+}
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+
+export async function generatePost(input: GeneratePostInput): Promise<GeneratePostResult> {
+  const {
+    campaignId,
+    postId,
+    weekNumber,
+    arcPhase,
+    monthlyObjective,
+    month,
+    voiceProfile,
+  } = input;
+
+  const sanitizedObjective = sanitizePromptInput(monthlyObjective);
+  const sanitizedBanned = sanitizePromptArray(voiceProfile.bannedWords);
+  const sanitizedOnBrand = sanitizePromptArray(voiceProfile.onBrandPhrases);
+  const sanitizedRefs = sanitizePromptArray(voiceProfile.referencePosts);
+  const sanitizedIndustry = sanitizePromptInput(voiceProfile.industry);
+  const sanitizedAudience = sanitizePromptInput(voiceProfile.targetAudience);
+
+  const systemMessage = buildCampaignPostSystemMessage();
+  const userMessage = buildCampaignPostUserMessage({
+    weekNumber,
+    arcPhase,
+    monthlyObjective: sanitizedObjective,
+    month,
+    tone: voiceProfile.tone,
+    industry: sanitizedIndustry,
+    targetAudience: sanitizedAudience,
+    bannedWords: sanitizedBanned,
+    onBrandPhrases: sanitizedOnBrand,
+    languagePatterns: voiceProfile.languagePatterns,
+    referencePosts: sanitizedRefs,
+  });
+
+  const provider = getTextProvider();
+  let genResult;
+  let status: "success" | "error" = "success";
+  let errorDetails: Record<string, unknown> | null = null;
+
+  try {
+    genResult = await provider.generate({
+      model: DEFAULT_MODEL,
+      systemMessage,
+      userMessage,
+    });
+  } catch (err) {
+    status = "error";
+    errorDetails = { message: err instanceof Error ? err.message : String(err) };
+    await recordGenerationRun({
+      postId,
+      campaignId,
+      operation: "text_generation",
+      promptVersion: PROMPT_VERSION,
+      promptUsed: userMessage,
+      model: DEFAULT_MODEL,
+      status,
+      errorDetails,
+    });
+    throw err;
+  }
+
+  const costUsd = calculateAnthropicCost(
+    DEFAULT_MODEL,
+    genResult.inputTokens,
+    genResult.outputTokens,
+  );
+
+  await recordGenerationRun({
+    postId,
+    campaignId,
+    operation: "text_generation",
+    promptVersion: PROMPT_VERSION,
+    promptUsed: userMessage,
+    model: DEFAULT_MODEL,
+    inputTokens: genResult.inputTokens,
+    outputTokens: genResult.outputTokens,
+    estimatedCostUsd: costUsd,
+    latencyMs: genResult.latencyMs,
+    status,
+  });
+
+  // Parse JSON response from the model
+  let content: string;
+  let hashtags: string[];
+
+  try {
+    const parsed = JSON.parse(genResult.text) as { content?: string; hashtags?: string[] };
+    if (!parsed.content || typeof parsed.content !== "string") {
+      throw new Error("missing content field in model response");
+    }
+    content = parsed.content;
+    hashtags = Array.isArray(parsed.hashtags)
+      ? parsed.hashtags.filter((h): h is string => typeof h === "string").slice(0, 10)
+      : [];
+  } catch (parseErr) {
+    logger.warn("cap.post-generator.parse_failed", {
+      postId,
+      raw: genResult.text.slice(0, 200),
+      error: parseErr instanceof Error ? parseErr.message : String(parseErr),
+    });
+    // Treat the raw text as content with no hashtags — still usable by reviewers
+    content = genResult.text;
+    hashtags = [];
+  }
+
+  return {
+    content,
+    hashtags,
+    inputTokens: genResult.inputTokens,
+    outputTokens: genResult.outputTokens,
+    costUsd,
+    latencyMs: genResult.latencyMs,
+  };
+}
+
+interface RecordRunInput {
+  postId: string;
+  campaignId: string;
+  operation: "text_generation" | "image_generation" | "full_campaign";
+  promptVersion: number;
+  promptUsed: string;
+  model: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  estimatedCostUsd?: number;
+  latencyMs?: number;
+  status: "success" | "error";
+  errorDetails?: Record<string, unknown> | null;
+}
+
+async function recordGenerationRun(input: RecordRunInput): Promise<void> {
+  const svc = getServiceRoleClient();
+  const { error } = await svc.from("cap_generation_runs").insert({
+    cap_campaign_post_id: input.postId,
+    cap_campaign_id: input.campaignId,
+    operation: input.operation,
+    prompt_version: input.promptVersion,
+    prompt_used: input.promptUsed,
+    model: input.model,
+    input_tokens: input.inputTokens ?? null,
+    output_tokens: input.outputTokens ?? null,
+    estimated_cost_usd: input.estimatedCostUsd ?? 0,
+    latency_ms: input.latencyMs ?? null,
+    status: input.status,
+    error_details: input.errorDetails ?? null,
+  });
+  if (error) {
+    logger.warn("cap.post-generator.run_record_failed", { error: error.message });
+  }
+}

--- a/lib/cap/generation/regenerate-post.ts
+++ b/lib/cap/generation/regenerate-post.ts
@@ -1,0 +1,111 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { assertCostCapNotExceeded } from "@/lib/cap/cost-cap";
+import { generatePost } from "@/lib/cap/generation/post-generator";
+import { generateImageForPost } from "@/lib/cap/generation/image-orchestrator";
+
+export interface RegeneratePostResult {
+  postId: string;
+  content: string;
+  hashtags: string[];
+  imageUrl: string;
+}
+
+export async function regeneratePost(
+  campaignPostId: string,
+  reason?: string,
+): Promise<RegeneratePostResult> {
+  const svc = getServiceRoleClient();
+
+  const { data: post, error: postErr } = await svc
+    .from("cap_campaign_posts")
+    .select(
+      `id, week_number, arc_phase, regenerate_count,
+       cap_campaign_id,
+       cap_campaigns:cap_campaign_id (
+         month, monthly_objective, cap_subscription_id,
+         cap_voice_profiles:voice_profile_id (
+           tone, industry, target_audience, banned_words,
+           on_brand_phrases, language_patterns, reference_posts
+         )
+       )`,
+    )
+    .eq("id", campaignPostId)
+    .single();
+
+  if (postErr || !post) {
+    throw new Error(`Campaign post not found: ${campaignPostId}`);
+  }
+
+  const campaign = Array.isArray(post.cap_campaigns)
+    ? post.cap_campaigns[0]
+    : post.cap_campaigns;
+
+  if (!campaign) {
+    throw new Error(`Post ${campaignPostId} has no associated campaign`);
+  }
+
+  await assertCostCapNotExceeded(campaign.cap_subscription_id as string);
+
+  if (reason) {
+    logger.info("cap.regenerate-post.reason", { campaignPostId, reason: reason.slice(0, 200) });
+  }
+
+  const vp = Array.isArray(campaign.cap_voice_profiles)
+    ? campaign.cap_voice_profiles[0]
+    : campaign.cap_voice_profiles;
+
+  if (!vp) {
+    throw new Error(`Post ${campaignPostId} campaign has no voice profile`);
+  }
+
+  const voiceProfile = {
+    tone: vp.tone as string,
+    industry: vp.industry as string,
+    targetAudience: vp.target_audience as string,
+    bannedWords: (vp.banned_words as string[]) ?? [],
+    onBrandPhrases: (vp.on_brand_phrases as string[]) ?? [],
+    languagePatterns: (vp.language_patterns as Record<string, unknown>) ?? {},
+    referencePosts: (vp.reference_posts as string[]) ?? [],
+  };
+
+  const textResult = await generatePost({
+    campaignId: post.cap_campaign_id as string,
+    postId: campaignPostId,
+    weekNumber: post.week_number as 1 | 2 | 3 | 4,
+    arcPhase: post.arc_phase as "awareness" | "education" | "offer" | "proof",
+    monthlyObjective: campaign.monthly_objective as string,
+    month: campaign.month as string,
+    voiceProfile,
+  });
+
+  const imageResult = await generateImageForPost({
+    campaignId: post.cap_campaign_id as string,
+    postId: campaignPostId,
+    arcPhase: post.arc_phase as "awareness" | "education" | "offer" | "proof",
+    industry: voiceProfile.industry,
+    postContent: textResult.content,
+  });
+
+  await svc
+    .from("cap_campaign_posts")
+    .update({
+      generated_content: textResult.content,
+      generated_hashtags: textResult.hashtags,
+      generated_image_url: imageResult.url,
+      status: "generated",
+      regenerate_count: (post.regenerate_count as number) + 1,
+    })
+    .eq("id", campaignPostId);
+
+  logger.info("cap.regenerate-post.complete", { campaignPostId });
+
+  return {
+    postId: campaignPostId,
+    content: textResult.content,
+    hashtags: textResult.hashtags,
+    imageUrl: imageResult.url,
+  };
+}

--- a/lib/cap/prompts/campaign-post.ts
+++ b/lib/cap/prompts/campaign-post.ts
@@ -1,0 +1,105 @@
+import "server-only";
+
+export const PROMPT_VERSION = 1;
+
+const ARC_PHASE_GUIDANCE: Record<string, string> = {
+  awareness:
+    "WEEK 1 — AWARENESS: Open with a striking statistic, question, or observation about a problem your audience faces. " +
+    "Do NOT pitch products or services. Goal: make the reader feel seen and curious. End with a thought-provoking question or statement.",
+  education:
+    "WEEK 2 — EDUCATION: Share practical insight, a framework, or tips that help the reader understand the solution space. " +
+    "Position the author as a knowledgeable guide. No hard sell — the value is in the learning. End with a key takeaway.",
+  offer:
+    "WEEK 3 — OFFER: Build the case for why action is timely. Reference the problem (week 1) and the solution direction (week 2). " +
+    "Include a soft, natural CTA toward the company's services — never pushy. The reader should feel invited, not sold to.",
+  proof:
+    "WEEK 4 — PROOF: Anchor the campaign with social proof — a result, a transformation, or a generalised case example. " +
+    "Reinforce trust and close with a clear, confident CTA.",
+};
+
+export function buildCampaignPostSystemMessage(): string {
+  return (
+    "You are a LinkedIn content strategist for Managed Service Provider (MSP) companies. " +
+    "You write high-performing, authentic LinkedIn posts that sound human, on-brand, and strategically timed " +
+    "within a 4-week campaign arc. Your posts avoid generic platitudes and corporate jargon. " +
+    "You always respond with ONLY a JSON object in the exact format requested — no markdown fences, no extra commentary."
+  );
+}
+
+interface BuildCampaignPostUserMessageInput {
+  weekNumber: 1 | 2 | 3 | 4;
+  arcPhase: "awareness" | "education" | "offer" | "proof";
+  monthlyObjective: string;
+  month: string;
+  tone: string;
+  industry: string;
+  targetAudience: string;
+  bannedWords: string[];
+  onBrandPhrases: string[];
+  languagePatterns: Record<string, unknown>;
+  referencePosts: string[];
+}
+
+export function buildCampaignPostUserMessage(
+  input: BuildCampaignPostUserMessageInput,
+): string {
+  const {
+    weekNumber,
+    arcPhase,
+    monthlyObjective,
+    month,
+    tone,
+    industry,
+    targetAudience,
+    bannedWords,
+    onBrandPhrases,
+    languagePatterns,
+    referencePosts,
+  } = input;
+
+  const monthLabel = new Date(month).toLocaleString("en-AU", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+  const refSection =
+    referencePosts.length > 0
+      ? `\nEXAMPLE POSTS FROM THIS BRAND (match the voice, not the content):\n${referencePosts
+          .slice(0, 3)
+          .map((p, i) => `[${i + 1}] ${p}`)
+          .join("\n")}`
+      : "";
+
+  const patternsSection =
+    Object.keys(languagePatterns).length > 0
+      ? `\nLANGUAGE PATTERNS: ${JSON.stringify(languagePatterns)}`
+      : "";
+
+  return `Write a LinkedIn post for week ${weekNumber} of the ${monthLabel} campaign.
+
+CAMPAIGN OBJECTIVE: ${monthlyObjective}
+INDUSTRY: ${industry}
+TARGET AUDIENCE: ${targetAudience}
+BRAND TONE: ${tone}
+ARC PHASE GUIDANCE:
+${ARC_PHASE_GUIDANCE[arcPhase]}
+${onBrandPhrases.length > 0 ? `\nON-BRAND PHRASES TO WEAVE IN (use naturally, not forcefully):\n${onBrandPhrases.join(", ")}` : ""}
+${bannedWords.length > 0 ? `\nBANNED WORDS (never use): ${bannedWords.join(", ")}` : ""}
+${patternsSection}
+${refSection}
+
+REQUIREMENTS:
+- 150–280 words
+- No hashtags in the post body
+- Conversational yet professional
+- No generic openers like "In today's world" or "As we all know"
+- No em-dashes
+- Blank line between paragraphs
+
+Respond with exactly this JSON (no markdown, no extra keys):
+{
+  "content": "<the full post text>",
+  "hashtags": ["<tag1>", "<tag2>", "<tag3>", "<tag4>", "<tag5>"]
+}`;
+}

--- a/lib/cap/prompts/image-prompt.ts
+++ b/lib/cap/prompts/image-prompt.ts
@@ -1,0 +1,29 @@
+import "server-only";
+
+export const IMAGE_PROMPT_VERSION = 1;
+
+const ARC_PHASE_VISUAL_TONE: Record<string, string> = {
+  awareness: "thought-provoking, slightly dramatic, evoking a challenge or tension",
+  education: "clear, informative, professional whitespace, diagrams or people collaborating",
+  offer: "optimistic, action-oriented, warm light, forward momentum",
+  proof: "confident, celebratory, trustworthy, evidence of success",
+};
+
+interface BuildImagePromptInput {
+  arcPhase: "awareness" | "education" | "offer" | "proof";
+  industry: string;
+  postContentSummary: string;
+}
+
+export function buildImagePrompt(input: BuildImagePromptInput): string {
+  const { arcPhase, industry, postContentSummary } = input;
+  const visualTone = ARC_PHASE_VISUAL_TONE[arcPhase];
+
+  return (
+    `Professional LinkedIn post image for a ${industry} company. ` +
+    `Visual tone: ${visualTone}. ` +
+    `The post is about: ${postContentSummary.slice(0, 120)}. ` +
+    `Style: clean corporate photography or flat illustration, no text overlays, ` +
+    `16:9 aspect ratio, high resolution, suitable for professional social media.`
+  );
+}

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -799,6 +799,7 @@ function check7_unauthenticatedApi(): Issue[] {
     /verifyToken/,
     /verifyMagicLink/,
     /requireCanDoForApi/, // Platform layer canDo gate
+    /requireCapOperatorForApi/, // CAP operator gate (session + is_cap_operator RPC)
     /verifyQstashSignature/, // QStash webhook signature verification (HMAC)
     /verifyBundlesocialSignature/, // S1-17 bundle.social webhook signature verification (HMAC)
     /recordApprovalDecision/, // S1-7 magic-link token-is-auth (SHA-256 hash compare in the lib)


### PR DESCRIPTION
## CAP Phase 1 — PR 3: Generation Pipeline

### What
- **`lib/cap/prompts/campaign-post.ts`** — `CAMPAIGN_POST_PROMPT_V1` with 4-arc-phase guidance (awareness → education → offer → proof). `PROMPT_VERSION = 1`. Builds system + user messages from sanitized voice profile fields.
- **`lib/cap/prompts/image-prompt.ts`** — `IMAGE_PROMPT_V1` with arc-phase visual tone mapping.
- **`lib/cap/generation/post-generator.ts`** — `generatePost()`: sanitize inputs → build prompt → call Anthropic via PAL → parse JSON response → record `cap_generation_runs` row. Graceful fallback if model returns non-JSON.
- **`lib/cap/generation/image-orchestrator.ts`** — `generateImageForPost()`: build image prompt → call Ideogram via PAL → record run.
- **`lib/cap/generation/campaign-runner.ts`** — `runCampaign(campaignId)`: assert cost cap → set `generating` → upsert 4 arc posts → generate each post (text + image) → set `review`. Marks `failed` on any error.
- **`lib/cap/generation/regenerate-post.ts`** — `regeneratePost(postId, reason?)`: cost cap guard → regen single post → increment `regenerate_count`.
- **`lib/cap/api-gate.ts`** — `requireCapOperatorForApi()`: session check + `is_cap_operator()` RPC gate.
- **`POST /api/platform/cap/campaigns/[id]/generate`** — triggers `runCampaign`; returns 402 on cost cap exceeded.
- **`POST /api/platform/cap/campaign-posts/[id]/regenerate`** — triggers `regeneratePost`; accepts optional `{ reason }` body.
- **`lib/__tests__/cap-generation.unit.test.ts`** — 17 unit tests covering all layers.

### Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (17/17 pass)
- [x] Prompt injection: all user-supplied fields sanitized via `sanitizePromptInput` / `sanitizePromptArray` before injection into Anthropic prompts
- [x] All external calls wrapped in `withHealthMonitoring` (via PAL providers)
- [x] Cost cap checked before every generation call
- [x] `cap_generation_runs` records written for every Anthropic + Ideogram call (success + error)
- [x] Risks identified and mitigated section below

### Working analog
`lib/cap/cost-cap.ts:25-72` — same `getServiceRoleClient()` + `.from().select()` pattern for DB reads. `lib/cap/pal/text-provider.ts` — `withHealthMonitoring` wrapper pattern.

### Risks identified and mitigated
| Risk | Mitigation |
|---|---|
| Prompt injection via MSP voice profile fields | `sanitizePromptInput` / `sanitizePromptArray` applied to all user-supplied strings before prompt assembly |
| Cost overrun | `assertCostCapNotExceeded` called before every campaign run and regeneration |
| Partial campaign failure leaving inconsistent state | Per-post try/catch: failed post marked `failed`, campaign marked `failed`, error re-thrown |
| Concurrent duplicate campaigns for same (subscription, month) | DB UNIQUE constraint on `(cap_campaign_id, week_number)` via upsert |
| Model returning non-JSON | Parse fallback: raw text used as content with empty hashtags — reviewers see it rather than losing output |
| `cap_generation_runs` write failure | Logged as warning only — audit write failure doesn't abort generation |