### PR TITLE
feat(cap): pr4 — subscription management + voice profile UI

### DIFF
--- a/app/(platform)/admin/companies/[id]/cap/page.tsx
+++ b/app/(platform)/admin/companies/[id]/cap/page.tsx
@@ -1,0 +1,69 @@
+import { notFound } from "next/navigation";
+
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
+import { CapSubscriptionPanel } from "@/components/CapSubscriptionPanel";
+import { getPlatformCompany } from "@/lib/platform/companies";
+import { getCapSubscriptionByCompany } from "@/lib/cap/subscriptions";
+import { listVoiceProfiles } from "@/lib/cap/voice-profiles";
+
+export const dynamic = "force-dynamic";
+
+export default async function CompanyCapPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const result = await getPlatformCompany(params.id);
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") notFound();
+    return (
+      <PageShell>
+        <PageHeader>
+          <PageHeader.Breadcrumb
+            segments={[
+              { label: "Admin", href: "/admin/sites" },
+              { label: "Companies", href: "/admin/companies" },
+              { label: "Error" },
+            ]}
+          />
+          <PageHeader.Title>Failed to load company</PageHeader.Title>
+        </PageHeader>
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+          role="alert"
+        >
+          {result.error.message}
+        </div>
+      </PageShell>
+    );
+  }
+
+  const { company } = result.data;
+  const subscription = await getCapSubscriptionByCompany(company.id);
+  const voiceProfiles = subscription ? await listVoiceProfiles(subscription.id) : [];
+
+  return (
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Admin", href: "/admin/sites" },
+            { label: "Companies", href: "/admin/companies" },
+            { label: company.name, href: `/admin/companies/${company.id}` },
+            { label: "CAP" },
+          ]}
+        />
+        <PageHeader.Title>Content Automation — {company.name}</PageHeader.Title>
+        <PageHeader.Meta>
+          <span className="font-mono">{company.slug}</span>
+        </PageHeader.Meta>
+      </PageHeader>
+      <CapSubscriptionPanel
+        companyId={company.id}
+        initialSubscription={subscription}
+        initialVoiceProfiles={voiceProfiles}
+      />
+    </PageShell>
+  );
+}

--- a/app/api/platform/cap/subscriptions/[id]/voice-profiles/[profileId]/route.ts
+++ b/app/api/platform/cap/subscriptions/[id]/voice-profiles/[profileId]/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { validationError, internalError } from "@/lib/http";
+import { requireCapOperatorForApi } from "@/lib/cap/api-gate";
+import {
+  updateVoiceProfile,
+  deleteVoiceProfile,
+  type VoiceTone,
+} from "@/lib/cap/voice-profiles";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-fA-F-]{36}$/;
+const VALID_TONES = new Set<VoiceTone>([
+  "professional-friendly",
+  "authoritative",
+  "conversational",
+  "technical",
+  "irreverent",
+]);
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; profileId: string }> },
+): Promise<NextResponse> {
+  const { id, profileId } = await params;
+  if (!UUID_RE.test(id) || !UUID_RE.test(profileId)) {
+    return validationError("id and profileId must be UUIDs.");
+  }
+
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json() as Record<string, unknown>;
+  } catch {
+    return validationError("Request body must be JSON.");
+  }
+
+  const patch: Record<string, unknown> = {};
+
+  if (body.name !== undefined) {
+    if (typeof body.name !== "string" || body.name.trim().length === 0) {
+      return validationError("name must be a non-empty string.");
+    }
+    patch.name = body.name.trim();
+  }
+  if (body.tone !== undefined) {
+    if (typeof body.tone !== "string" || !VALID_TONES.has(body.tone as VoiceTone)) {
+      return validationError("tone is invalid.");
+    }
+    patch.tone = body.tone as VoiceTone;
+  }
+  if (body.industry !== undefined) patch.industry = String(body.industry).trim();
+  if (body.target_audience !== undefined) patch.targetAudience = String(body.target_audience).trim();
+  if (body.banned_words !== undefined && Array.isArray(body.banned_words)) {
+    patch.bannedWords = (body.banned_words as unknown[]).filter((w): w is string => typeof w === "string");
+  }
+  if (body.on_brand_phrases !== undefined && Array.isArray(body.on_brand_phrases)) {
+    patch.onBrandPhrases = (body.on_brand_phrases as unknown[]).filter((p): p is string => typeof p === "string");
+  }
+  if (body.reference_posts !== undefined && Array.isArray(body.reference_posts)) {
+    patch.referencePosts = (body.reference_posts as unknown[]).filter((p): p is string => typeof p === "string");
+  }
+  if (body.is_default !== undefined) patch.isDefault = body.is_default === true;
+
+  try {
+    await updateVoiceProfile(profileId, patch);
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err) {
+    return internalError(err instanceof Error ? err.message : "Failed to update voice profile");
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string; profileId: string }> },
+): Promise<NextResponse> {
+  const { id, profileId } = await params;
+  if (!UUID_RE.test(id) || !UUID_RE.test(profileId)) {
+    return validationError("id and profileId must be UUIDs.");
+  }
+
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  try {
+    await deleteVoiceProfile(profileId);
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err) {
+    return internalError(err instanceof Error ? err.message : "Failed to delete voice profile");
+  }
+}

--- a/app/api/platform/cap/subscriptions/[id]/voice-profiles/route.ts
+++ b/app/api/platform/cap/subscriptions/[id]/voice-profiles/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { validationError, internalError } from "@/lib/http";
+import { requireCapOperatorForApi } from "@/lib/cap/api-gate";
+import {
+  listVoiceProfiles,
+  createVoiceProfile,
+  type VoiceTone,
+} from "@/lib/cap/voice-profiles";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-fA-F-]{36}$/;
+const VALID_TONES = new Set<VoiceTone>([
+  "professional-friendly",
+  "authoritative",
+  "conversational",
+  "technical",
+  "irreverent",
+]);
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) return validationError("id must be a UUID.");
+
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  const profiles = await listVoiceProfiles(id);
+  return NextResponse.json({ ok: true, data: profiles }, { status: 200 });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) return validationError("id must be a UUID.");
+
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json() as Record<string, unknown>;
+  } catch {
+    return validationError("Request body must be JSON.");
+  }
+
+  const { name, tone, industry, target_audience, banned_words, on_brand_phrases, reference_posts, is_default } = body;
+
+  if (typeof name !== "string" || name.trim().length === 0) {
+    return validationError("name is required.");
+  }
+  if (typeof tone !== "string" || !VALID_TONES.has(tone as VoiceTone)) {
+    return validationError("tone must be one of: professional-friendly, authoritative, conversational, technical, irreverent.");
+  }
+  if (typeof industry !== "string" || industry.trim().length === 0) {
+    return validationError("industry is required.");
+  }
+  if (typeof target_audience !== "string" || target_audience.trim().length === 0) {
+    return validationError("target_audience is required.");
+  }
+
+  try {
+    const profile = await createVoiceProfile({
+      subscriptionId: id,
+      name: name.trim(),
+      tone: tone as VoiceTone,
+      industry: industry.trim(),
+      targetAudience: target_audience.trim(),
+      bannedWords: Array.isArray(banned_words) ? (banned_words as string[]).filter((w): w is string => typeof w === "string") : [],
+      onBrandPhrases: Array.isArray(on_brand_phrases) ? (on_brand_phrases as string[]).filter((p): p is string => typeof p === "string") : [],
+      referencePosts: Array.isArray(reference_posts) ? (reference_posts as string[]).filter((p): p is string => typeof p === "string") : [],
+      isDefault: is_default === true,
+    });
+    return NextResponse.json({ ok: true, data: profile }, { status: 201 });
+  } catch (err) {
+    return internalError(err instanceof Error ? err.message : "Failed to create voice profile");
+  }
+}

--- a/app/api/platform/cap/subscriptions/route.ts
+++ b/app/api/platform/cap/subscriptions/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { validationError, internalError } from "@/lib/http";
+import { requireCapOperatorForApi } from "@/lib/cap/api-gate";
+import {
+  getCapSubscriptionByCompany,
+  createCapSubscription,
+  type CapTier,
+  type CapStatus,
+} from "@/lib/cap/subscriptions";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-fA-F-]{36}$/;
+const VALID_TIERS = new Set<CapTier>(["starter", "growth", "agency"]);
+const VALID_STATUSES = new Set<CapStatus>(["trial", "active", "paused", "cancelled"]);
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  const companyId = new URL(req.url).searchParams.get("company_id");
+  if (!companyId || !UUID_RE.test(companyId)) {
+    return validationError("company_id query param required.");
+  }
+
+  const sub = await getCapSubscriptionByCompany(companyId);
+  return NextResponse.json({ ok: true, data: sub }, { status: 200 });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json() as Record<string, unknown>;
+  } catch {
+    return validationError("Request body must be JSON.");
+  }
+
+  const { company_id, tier, status, approval_required, monthly_cost_cap_usd } = body;
+
+  if (typeof company_id !== "string" || !UUID_RE.test(company_id)) {
+    return validationError("company_id must be a UUID.");
+  }
+  if (typeof tier !== "string" || !VALID_TIERS.has(tier as CapTier)) {
+    return validationError("tier must be one of: starter, growth, agency.");
+  }
+  if (typeof status !== "string" || !VALID_STATUSES.has(status as CapStatus)) {
+    return validationError("status must be one of: trial, active, paused, cancelled.");
+  }
+
+  try {
+    const sub = await createCapSubscription({
+      companyId: company_id,
+      tier: tier as CapTier,
+      status: status as CapStatus,
+      approvalRequired: approval_required === true,
+      monthlyCostCapUsd: typeof monthly_cost_cap_usd === "number" ? monthly_cost_cap_usd : 200,
+    });
+    return NextResponse.json({ ok: true, data: sub }, { status: 201 });
+  } catch (err) {
+    return internalError(err instanceof Error ? err.message : "Failed to create subscription");
+  }
+}

--- a/components/CapSubscriptionPanel.tsx
+++ b/components/CapSubscriptionPanel.tsx
@@ -7,7 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { VOICE_TONE_LABELS, type CapVoiceProfile, type VoiceTone } from "@/lib/cap/voice-profiles";
+import { VOICE_TONE_LABELS, type VoiceTone } from "@/lib/cap/voice-tone-labels";
+import type { CapVoiceProfile } from "@/lib/cap/voice-profiles";
 import type { CapSubscription, CapTier, CapStatus } from "@/lib/cap/subscriptions";
 
 type ApiResponse<T> =

--- a/components/CapSubscriptionPanel.tsx
+++ b/components/CapSubscriptionPanel.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import { useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { VOICE_TONE_LABELS, type CapVoiceProfile, type VoiceTone } from "@/lib/cap/voice-profiles";
+import type { CapSubscription, CapTier, CapStatus } from "@/lib/cap/subscriptions";
+
+type ApiResponse<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: { code: string; message: string } };
+
+interface Props {
+  companyId: string;
+  initialSubscription: CapSubscription | null;
+  initialVoiceProfiles: CapVoiceProfile[];
+}
+
+const TIER_LABELS: Record<CapTier, string> = {
+  starter: "Starter",
+  growth: "Growth",
+  agency: "Agency",
+};
+
+const STATUS_BADGE_TONE: Record<CapStatus, "success" | "info" | "warning" | "error" | "neutral"> = {
+  trial: "info",
+  active: "success",
+  paused: "warning",
+  cancelled: "error",
+};
+
+const TONES = Object.entries(VOICE_TONE_LABELS) as [VoiceTone, string][];
+
+const EMPTY_PROFILE_FORM = {
+  name: "",
+  tone: "professional-friendly" as VoiceTone,
+  industry: "",
+  targetAudience: "",
+  bannedWords: "",
+  onBrandPhrases: "",
+  referencePosts: "",
+};
+
+export function CapSubscriptionPanel({ companyId, initialSubscription, initialVoiceProfiles }: Props) {
+  const [subscription, setSubscription] = useState<CapSubscription | null>(initialSubscription);
+  const [voiceProfiles, setVoiceProfiles] = useState<CapVoiceProfile[]>(initialVoiceProfiles);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [showActivateForm, setShowActivateForm] = useState(false);
+  const [showProfileForm, setShowProfileForm] = useState(false);
+  const [editingProfileId, setEditingProfileId] = useState<string | null>(null);
+  const [profileForm, setProfileForm] = useState(EMPTY_PROFILE_FORM);
+  const [newTier, setNewTier] = useState<CapTier>("starter");
+  const [newStatus, setNewStatus] = useState<CapStatus>("trial");
+  const [newCap, setNewCap] = useState("200");
+
+  async function handleActivate(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    const res = await fetch("/api/platform/cap/subscriptions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        company_id: companyId,
+        tier: newTier,
+        status: newStatus,
+        monthly_cost_cap_usd: parseFloat(newCap) || 200,
+      }),
+    });
+    const json = (await res.json()) as ApiResponse<CapSubscription>;
+    setBusy(false);
+    if (!res.ok || !json.ok) {
+      setError(!json.ok ? json.error.message : "Failed to activate CAP.");
+      return;
+    }
+    setSubscription(json.data);
+    setShowActivateForm(false);
+  }
+
+  function startEditProfile(profile: CapVoiceProfile) {
+    setEditingProfileId(profile.id);
+    setProfileForm({
+      name: profile.name,
+      tone: profile.tone,
+      industry: profile.industry,
+      targetAudience: profile.target_audience,
+      bannedWords: profile.banned_words.join(", "),
+      onBrandPhrases: profile.on_brand_phrases.join(", "),
+      referencePosts: profile.reference_posts.join("\n"),
+    });
+    setShowProfileForm(true);
+  }
+
+  function resetProfileForm() {
+    setEditingProfileId(null);
+    setProfileForm(EMPTY_PROFILE_FORM);
+    setShowProfileForm(false);
+  }
+
+  function splitCSV(val: string): string[] {
+    return val.split(/[,\n]/).map((s) => s.trim()).filter(Boolean);
+  }
+
+  async function handleProfileSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!subscription) return;
+    setError(null);
+    setBusy(true);
+
+    const payload = {
+      name: profileForm.name.trim(),
+      tone: profileForm.tone,
+      industry: profileForm.industry.trim(),
+      target_audience: profileForm.targetAudience.trim(),
+      banned_words: splitCSV(profileForm.bannedWords),
+      on_brand_phrases: splitCSV(profileForm.onBrandPhrases),
+      reference_posts: splitCSV(profileForm.referencePosts),
+    };
+
+    let res: Response;
+    if (editingProfileId) {
+      res = await fetch(
+        `/api/platform/cap/subscriptions/${subscription.id}/voice-profiles/${editingProfileId}`,
+        { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) },
+      );
+    } else {
+      res = await fetch(`/api/platform/cap/subscriptions/${subscription.id}/voice-profiles`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...payload, is_default: voiceProfiles.length === 0 }),
+      });
+    }
+
+    const json = (await res.json()) as ApiResponse<CapVoiceProfile>;
+    setBusy(false);
+
+    if (!res.ok || !json.ok) {
+      setError(!json.ok ? json.error.message : "Failed to save voice profile.");
+      return;
+    }
+
+    if (editingProfileId) {
+      setVoiceProfiles((prev) =>
+        prev.map((p) => (p.id === editingProfileId ? { ...p, ...payload, banned_words: splitCSV(profileForm.bannedWords), on_brand_phrases: splitCSV(profileForm.onBrandPhrases), reference_posts: splitCSV(profileForm.referencePosts) } : p)),
+      );
+    } else {
+      setVoiceProfiles((prev) => [...prev, json.data]);
+    }
+
+    resetProfileForm();
+  }
+
+  async function handleDeleteProfile(profileId: string) {
+    if (!subscription) return;
+    if (!confirm("Delete this voice profile?")) return;
+    setError(null);
+    setBusy(true);
+    const res = await fetch(
+      `/api/platform/cap/subscriptions/${subscription.id}/voice-profiles/${profileId}`,
+      { method: "DELETE" },
+    );
+    setBusy(false);
+    if (!res.ok) {
+      setError("Failed to delete voice profile.");
+      return;
+    }
+    setVoiceProfiles((prev) => prev.filter((p) => p.id !== profileId));
+  }
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive" role="alert">
+          {error}
+        </div>
+      )}
+
+      {/* Subscription status */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>CAP Subscription</span>
+            {subscription && (
+              <Badge tone={STATUS_BADGE_TONE[subscription.status]}>
+                {subscription.status.charAt(0).toUpperCase() + subscription.status.slice(1)}
+              </Badge>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {subscription ? (
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-4">
+              <dt className="text-muted-foreground">Tier</dt>
+              <dd className="font-medium">{TIER_LABELS[subscription.tier]}</dd>
+              <dt className="text-muted-foreground">Monthly cap</dt>
+              <dd className="font-medium">${subscription.monthly_cost_cap_usd.toFixed(2)}</dd>
+              <dt className="text-muted-foreground">Approval required</dt>
+              <dd className="font-medium">{subscription.approval_required ? "Yes" : "No"}</dd>
+              <dt className="text-muted-foreground">Subscription ID</dt>
+              <dd className="font-mono text-xs">{subscription.id}</dd>
+            </dl>
+          ) : showActivateForm ? (
+            <form onSubmit={handleActivate} className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-3">
+                <div className="space-y-2">
+                  <label htmlFor="cap-tier" className="text-sm font-medium">Tier</label>
+                  <select
+                    id="cap-tier"
+                    value={newTier}
+                    onChange={(e) => setNewTier(e.target.value as CapTier)}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  >
+                    {(Object.keys(TIER_LABELS) as CapTier[]).map((t) => (
+                      <option key={t} value={t}>{TIER_LABELS[t]}</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor="cap-status" className="text-sm font-medium">Status</label>
+                  <select
+                    id="cap-status"
+                    value={newStatus}
+                    onChange={(e) => setNewStatus(e.target.value as CapStatus)}
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  >
+                    {(["trial", "active"] as CapStatus[]).map((s) => (
+                      <option key={s} value={s}>{s.charAt(0).toUpperCase() + s.slice(1)}</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor="cap-cost" className="text-sm font-medium">Monthly cap (USD)</label>
+                  <Input
+                    id="cap-cost"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={newCap}
+                    onChange={(e) => setNewCap(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button type="submit" disabled={busy}>Enable CAP</Button>
+                <Button type="button" variant="ghost" onClick={() => setShowActivateForm(false)}>Cancel</Button>
+              </div>
+            </form>
+          ) : (
+            <div className="space-y-3">
+              <p className="text-sm text-muted-foreground">
+                CAP is not enabled for this company. Enable it to start generating automated LinkedIn content.
+              </p>
+              <Button onClick={() => setShowActivateForm(true)}>Enable CAP</Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Voice profiles */}
+      {subscription && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <span>Voice Profiles</span>
+              <Button size="sm" onClick={() => { resetProfileForm(); setShowProfileForm(true); }}>
+                Add profile
+              </Button>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {voiceProfiles.length === 0 && !showProfileForm && (
+              <p className="text-sm text-muted-foreground">
+                No voice profiles yet. Add one to enable content generation.
+              </p>
+            )}
+
+            {voiceProfiles.map((profile) => (
+              <div key={profile.id} className="rounded-md border p-4 text-sm space-y-1">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">
+                    {profile.name}
+                    {profile.is_default && (
+                      <Badge tone="neutral" className="ml-2 text-xs">Default</Badge>
+                    )}
+                  </span>
+                  <div className="flex gap-2">
+                    <Button size="sm" variant="outline" onClick={() => startEditProfile(profile)}>Edit</Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-destructive hover:text-destructive"
+                      onClick={() => void handleDeleteProfile(profile.id)}
+                      disabled={busy}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+                <p className="text-muted-foreground">
+                  {VOICE_TONE_LABELS[profile.tone]} · {profile.industry} · {profile.target_audience}
+                </p>
+              </div>
+            ))}
+
+            {showProfileForm && (
+              <form onSubmit={handleProfileSubmit} className="rounded-md border p-4 space-y-4">
+                <h3 className="font-medium text-sm">
+                  {editingProfileId ? "Edit voice profile" : "New voice profile"}
+                </h3>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <label htmlFor="vp-name" className="text-sm font-medium">Name</label>
+                    <Input
+                      id="vp-name"
+                      placeholder="e.g. Acme IT — LinkedIn"
+                      value={profileForm.name}
+                      onChange={(e) => setProfileForm((f) => ({ ...f, name: e.target.value }))}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="vp-tone" className="text-sm font-medium">Tone</label>
+                    <select
+                      id="vp-tone"
+                      value={profileForm.tone}
+                      onChange={(e) => setProfileForm((f) => ({ ...f, tone: e.target.value as VoiceTone }))}
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    >
+                      {TONES.map(([v, label]) => (
+                        <option key={v} value={v}>{label}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="vp-industry" className="text-sm font-medium">Industry</label>
+                    <Input
+                      id="vp-industry"
+                      placeholder="e.g. Managed IT Services"
+                      value={profileForm.industry}
+                      onChange={(e) => setProfileForm((f) => ({ ...f, industry: e.target.value }))}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="vp-audience" className="text-sm font-medium">Target audience</label>
+                    <Input
+                      id="vp-audience"
+                      placeholder="e.g. SMB IT managers and decision-makers"
+                      value={profileForm.targetAudience}
+                      onChange={(e) => setProfileForm((f) => ({ ...f, targetAudience: e.target.value }))}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="vp-banned" className="text-sm font-medium">Banned words (comma-separated)</label>
+                    <Input
+                      id="vp-banned"
+                      placeholder="synergy, leverage, paradigm"
+                      value={profileForm.bannedWords}
+                      onChange={(e) => setProfileForm((f) => ({ ...f, bannedWords: e.target.value }))}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="vp-onbrand" className="text-sm font-medium">On-brand phrases (comma-separated)</label>
+                    <Input
+                      id="vp-onbrand"
+                      placeholder="peace of mind, proactive support"
+                      value={profileForm.onBrandPhrases}
+                      onChange={(e) => setProfileForm((f) => ({ ...f, onBrandPhrases: e.target.value }))}
+                    />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor="vp-refs" className="text-sm font-medium">Reference posts (one per line)</label>
+                  <Textarea
+                    id="vp-refs"
+                    placeholder="Paste example LinkedIn posts here, one per line…"
+                    rows={4}
+                    value={profileForm.referencePosts}
+                    onChange={(e) => setProfileForm((f) => ({ ...f, referencePosts: e.target.value }))}
+                  />
+                </div>
+                <div className="flex gap-2">
+                  <Button type="submit" disabled={busy}>
+                    {editingProfileId ? "Save changes" : "Create profile"}
+                  </Button>
+                  <Button type="button" variant="ghost" onClick={resetProfileForm}>Cancel</Button>
+                </div>
+              </form>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/lib/cap/subscriptions.ts
+++ b/lib/cap/subscriptions.ts
@@ -1,0 +1,84 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+export type CapTier = "starter" | "growth" | "agency";
+export type CapStatus = "trial" | "active" | "paused" | "cancelled";
+
+export interface CapSubscription {
+  id: string;
+  company_id: string;
+  tier: CapTier;
+  status: CapStatus;
+  approval_required: boolean;
+  monthly_cost_cap_usd: number;
+  trial_ends_at: string | null;
+  cancelled_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function getCapSubscriptionByCompany(
+  companyId: string,
+): Promise<CapSubscription | null> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("cap_subscriptions")
+    .select("*")
+    .eq("company_id", companyId)
+    .maybeSingle();
+
+  if (error) {
+    logger.warn("cap.subscriptions.get_failed", { companyId, error: error.message });
+    return null;
+  }
+  return data as CapSubscription | null;
+}
+
+export interface CreateCapSubscriptionInput {
+  companyId: string;
+  tier: CapTier;
+  status: CapStatus;
+  approvalRequired?: boolean;
+  monthlyCostCapUsd?: number;
+  trialEndsAt?: string | null;
+}
+
+export async function createCapSubscription(
+  input: CreateCapSubscriptionInput,
+): Promise<CapSubscription> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("cap_subscriptions")
+    .insert({
+      company_id: input.companyId,
+      tier: input.tier,
+      status: input.status,
+      approval_required: input.approvalRequired ?? false,
+      monthly_cost_cap_usd: input.monthlyCostCapUsd ?? 200.0,
+      trial_ends_at: input.trialEndsAt ?? null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create CAP subscription: ${error.message}`);
+  }
+  return data as CapSubscription;
+}
+
+export async function updateCapSubscriptionStatus(
+  subscriptionId: string,
+  status: CapStatus,
+): Promise<void> {
+  const svc = getServiceRoleClient();
+  const { error } = await svc
+    .from("cap_subscriptions")
+    .update({ status })
+    .eq("id", subscriptionId);
+
+  if (error) {
+    throw new Error(`Failed to update CAP subscription status: ${error.message}`);
+  }
+}

--- a/lib/cap/voice-profiles.ts
+++ b/lib/cap/voice-profiles.ts
@@ -1,0 +1,148 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+export type VoiceTone =
+  | "professional-friendly"
+  | "authoritative"
+  | "conversational"
+  | "technical"
+  | "irreverent";
+
+export const VOICE_TONE_LABELS: Record<VoiceTone, string> = {
+  "professional-friendly": "Professional & Friendly",
+  authoritative: "Authoritative",
+  conversational: "Conversational",
+  technical: "Technical",
+  irreverent: "Irreverent",
+};
+
+export interface CapVoiceProfile {
+  id: string;
+  cap_subscription_id: string;
+  name: string;
+  tone: VoiceTone;
+  language_patterns: Record<string, unknown>;
+  banned_words: string[];
+  on_brand_phrases: string[];
+  industry: string;
+  target_audience: string;
+  reference_posts: string[];
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function listVoiceProfiles(
+  subscriptionId: string,
+): Promise<CapVoiceProfile[]> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("cap_voice_profiles")
+    .select("*")
+    .eq("cap_subscription_id", subscriptionId)
+    .order("is_default", { ascending: false })
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    logger.warn("cap.voice-profiles.list_failed", { subscriptionId, error: error.message });
+    return [];
+  }
+  return (data ?? []) as CapVoiceProfile[];
+}
+
+export async function getVoiceProfile(profileId: string): Promise<CapVoiceProfile | null> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("cap_voice_profiles")
+    .select("*")
+    .eq("id", profileId)
+    .maybeSingle();
+
+  if (error) {
+    logger.warn("cap.voice-profiles.get_failed", { profileId, error: error.message });
+    return null;
+  }
+  return data as CapVoiceProfile | null;
+}
+
+export interface CreateVoiceProfileInput {
+  subscriptionId: string;
+  name: string;
+  tone: VoiceTone;
+  industry: string;
+  targetAudience: string;
+  bannedWords?: string[];
+  onBrandPhrases?: string[];
+  languagePatterns?: Record<string, unknown>;
+  referencePosts?: string[];
+  isDefault?: boolean;
+}
+
+export async function createVoiceProfile(
+  input: CreateVoiceProfileInput,
+): Promise<CapVoiceProfile> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("cap_voice_profiles")
+    .insert({
+      cap_subscription_id: input.subscriptionId,
+      name: input.name,
+      tone: input.tone,
+      industry: input.industry,
+      target_audience: input.targetAudience,
+      banned_words: input.bannedWords ?? [],
+      on_brand_phrases: input.onBrandPhrases ?? [],
+      language_patterns: input.languagePatterns ?? {},
+      reference_posts: input.referencePosts ?? [],
+      is_default: input.isDefault ?? false,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create voice profile: ${error.message}`);
+  }
+  return data as CapVoiceProfile;
+}
+
+export type UpdateVoiceProfileInput = Partial<Omit<CreateVoiceProfileInput, "subscriptionId">>;
+
+export async function updateVoiceProfile(
+  profileId: string,
+  input: UpdateVoiceProfileInput,
+): Promise<void> {
+  const svc = getServiceRoleClient();
+  const patch: Record<string, unknown> = {};
+  if (input.name !== undefined) patch.name = input.name;
+  if (input.tone !== undefined) patch.tone = input.tone;
+  if (input.industry !== undefined) patch.industry = input.industry;
+  if (input.targetAudience !== undefined) patch.target_audience = input.targetAudience;
+  if (input.bannedWords !== undefined) patch.banned_words = input.bannedWords;
+  if (input.onBrandPhrases !== undefined) patch.on_brand_phrases = input.onBrandPhrases;
+  if (input.languagePatterns !== undefined) patch.language_patterns = input.languagePatterns;
+  if (input.referencePosts !== undefined) patch.reference_posts = input.referencePosts;
+  if (input.isDefault !== undefined) patch.is_default = input.isDefault;
+
+  const { error } = await svc
+    .from("cap_voice_profiles")
+    .update(patch)
+    .eq("id", profileId);
+
+  if (error) {
+    throw new Error(`Failed to update voice profile: ${error.message}`);
+  }
+}
+
+export async function deleteVoiceProfile(profileId: string): Promise<void> {
+  const svc = getServiceRoleClient();
+  const { error } = await svc
+    .from("cap_voice_profiles")
+    .delete()
+    .eq("id", profileId);
+
+  if (error) {
+    throw new Error(`Failed to delete voice profile: ${error.message}`);
+  }
+}

--- a/lib/cap/voice-profiles.ts
+++ b/lib/cap/voice-profiles.ts
@@ -2,21 +2,10 @@ import "server-only";
 
 import { getServiceRoleClient } from "@/lib/supabase";
 import { logger } from "@/lib/logger";
+import type { VoiceTone } from "@/lib/cap/voice-tone-labels";
 
-export type VoiceTone =
-  | "professional-friendly"
-  | "authoritative"
-  | "conversational"
-  | "technical"
-  | "irreverent";
-
-export const VOICE_TONE_LABELS: Record<VoiceTone, string> = {
-  "professional-friendly": "Professional & Friendly",
-  authoritative: "Authoritative",
-  conversational: "Conversational",
-  technical: "Technical",
-  irreverent: "Irreverent",
-};
+export type { VoiceTone };
+export { VOICE_TONE_LABELS } from "@/lib/cap/voice-tone-labels";
 
 export interface CapVoiceProfile {
   id: string;

--- a/lib/cap/voice-tone-labels.ts
+++ b/lib/cap/voice-tone-labels.ts
@@ -1,0 +1,14 @@
+export type VoiceTone =
+  | "professional-friendly"
+  | "authoritative"
+  | "conversational"
+  | "technical"
+  | "irreverent";
+
+export const VOICE_TONE_LABELS: Record<VoiceTone, string> = {
+  "professional-friendly": "Professional & Friendly",
+  authoritative: "Authoritative",
+  conversational: "Conversational",
+  technical: "Technical",
+  irreverent: "Irreverent",
+};

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -799,6 +799,7 @@ function check7_unauthenticatedApi(): Issue[] {
     /verifyToken/,
     /verifyMagicLink/,
     /requireCanDoForApi/, // Platform layer canDo gate
+    /requireCapOperatorForApi/, // CAP operator gate (session + is_cap_operator RPC)
     /verifyQstashSignature/, // QStash webhook signature verification (HMAC)
     /verifyBundlesocialSignature/, // S1-17 bundle.social webhook signature verification (HMAC)
     /recordApprovalDecision/, // S1-7 magic-link token-is-auth (SHA-256 hash compare in the lib)


### PR DESCRIPTION
## CAP Phase 1 — PR 4: Customer UI + Voice Profile Management

### What
- **`lib/cap/subscriptions.ts`** — `getCapSubscriptionByCompany`, `createCapSubscription`, `updateCapSubscriptionStatus`
- **`lib/cap/voice-profiles.ts`** — `listVoiceProfiles`, `getVoiceProfile`, `createVoiceProfile`, `updateVoiceProfile`, `deleteVoiceProfile`
- **`GET/POST /api/platform/cap/subscriptions`** — fetch/create subscription (cap_operator gate)
- **`GET/POST /api/platform/cap/subscriptions/[id]/voice-profiles`** — list/create voice profiles
- **`PATCH/DELETE /api/platform/cap/subscriptions/[id]/voice-profiles/[profileId]`** — update/delete profile
- **`app/(platform)/admin/companies/[id]/cap/page.tsx`** — server-rendered CAP management page under existing admin company layout
- **`components/CapSubscriptionPanel.tsx`** — client component: enable CAP subscription, CRUD voice profiles form

### Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] test:unit 1837/1837 pass
- [x] All API routes gate on `requireCapOperatorForApi()` — `is_cap_operator()` RPC check
- [x] Input validation on all API routes (UUID format, enum values, required fields)
- [x] Risks identified and mitigated below

### Working analog
`app/(platform)/admin/companies/[id]/social-profiles/page.tsx` + `components/AdminSocialProfilesList.tsx` — same server-page + client-component CRUD pattern.

### Risks identified and mitigated
| Risk | Mitigation |
|---|---|
| Unauthorized subscription creation | `requireCapOperatorForApi()` gates all writes — `is_cap_operator()` RPC required |
| Invalid enum values for tier/tone/status | Explicit `VALID_TIERS` / `VALID_TONES` / `VALID_STATUSES` sets checked at boundary |
| UNIQUE constraint violation on company_id | Supabase will 23505 — caller can check for existing subscription first via GET |
| Voice profile default invariant broken | Partial UNIQUE index `cap_voice_profiles_one_default_per_sub` enforced at DB level |