### PR TITLE
feat(cap): pr5 — campaign management UI + push to composer

### DIFF
--- a/app/(platform)/admin/companies/[id]/cap/campaigns/[campaignId]/page.tsx
+++ b/app/(platform)/admin/companies/[id]/cap/campaigns/[campaignId]/page.tsx
@@ -1,0 +1,71 @@
+import { notFound } from "next/navigation";
+
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
+import { CapCampaignDetail } from "@/components/CapCampaignDetail";
+import { getPlatformCompany } from "@/lib/platform/companies";
+import { getCampaign, listPostsForCampaign } from "@/lib/cap/campaigns";
+
+export const dynamic = "force-dynamic";
+
+export default async function CapCampaignDetailPage({
+  params,
+}: {
+  params: { id: string; campaignId: string };
+}) {
+  const [result, campaign] = await Promise.all([
+    getPlatformCompany(params.id),
+    getCampaign(params.campaignId),
+  ]);
+
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") notFound();
+    return (
+      <PageShell>
+        <PageHeader>
+          <PageHeader.Breadcrumb segments={[{ label: "Error" }]} />
+          <PageHeader.Title>Failed to load company</PageHeader.Title>
+        </PageHeader>
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+          {result.error.message}
+        </div>
+      </PageShell>
+    );
+  }
+
+  if (!campaign) notFound();
+
+  const { company } = result.data;
+  const posts = await listPostsForCampaign(campaign.id);
+
+  const monthLabel = new Date(campaign.month).toLocaleString("en-AU", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+  return (
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Admin", href: "/admin/sites" },
+            { label: "Companies", href: "/admin/companies" },
+            { label: company.name, href: `/admin/companies/${company.id}` },
+            { label: "CAP", href: `/admin/companies/${company.id}/cap` },
+            { label: "Campaigns", href: `/admin/companies/${company.id}/cap/campaigns` },
+            { label: monthLabel },
+          ]}
+        />
+        <PageHeader.Title>{monthLabel} Campaign</PageHeader.Title>
+        <PageHeader.Meta>
+          <span className="text-sm text-muted-foreground">{campaign.monthly_objective}</span>
+        </PageHeader.Meta>
+      </PageHeader>
+      <CapCampaignDetail
+        campaign={campaign}
+        initialPosts={posts}
+      />
+    </PageShell>
+  );
+}

--- a/app/(platform)/admin/companies/[id]/cap/campaigns/page.tsx
+++ b/app/(platform)/admin/companies/[id]/cap/campaigns/page.tsx
@@ -1,0 +1,71 @@
+import { notFound } from "next/navigation";
+
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
+import { CapCampaignList } from "@/components/CapCampaignList";
+import { getPlatformCompany } from "@/lib/platform/companies";
+import { getCapSubscriptionByCompany } from "@/lib/cap/subscriptions";
+import { listCampaignsForSubscription } from "@/lib/cap/campaigns";
+
+export const dynamic = "force-dynamic";
+
+export default async function CapCampaignsPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const result = await getPlatformCompany(params.id);
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") notFound();
+    return (
+      <PageShell>
+        <PageHeader>
+          <PageHeader.Breadcrumb
+            segments={[
+              { label: "Admin", href: "/admin/sites" },
+              { label: "Companies", href: "/admin/companies" },
+              { label: "Error" },
+            ]}
+          />
+          <PageHeader.Title>Failed to load company</PageHeader.Title>
+        </PageHeader>
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+          {result.error.message}
+        </div>
+      </PageShell>
+    );
+  }
+
+  const { company } = result.data;
+  const subscription = await getCapSubscriptionByCompany(company.id);
+  const campaigns = subscription ? await listCampaignsForSubscription(subscription.id) : [];
+
+  return (
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Admin", href: "/admin/sites" },
+            { label: "Companies", href: "/admin/companies" },
+            { label: company.name, href: `/admin/companies/${company.id}` },
+            { label: "CAP", href: `/admin/companies/${company.id}/cap` },
+            { label: "Campaigns" },
+          ]}
+        />
+        <PageHeader.Title>Campaigns — {company.name}</PageHeader.Title>
+      </PageHeader>
+      {!subscription ? (
+        <div className="rounded-md border border-border p-6 text-center text-sm text-muted-foreground">
+          CAP is not enabled for this company.{" "}
+          <a href={`/admin/companies/${company.id}/cap`} className="underline">Enable it here.</a>
+        </div>
+      ) : (
+        <CapCampaignList
+          companyId={company.id}
+          subscriptionId={subscription.id}
+          initialCampaigns={campaigns}
+        />
+      )}
+    </PageShell>
+  );
+}

--- a/app/api/platform/cap/campaign-posts/[id]/push/route.ts
+++ b/app/api/platform/cap/campaign-posts/[id]/push/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { validationError, internalError } from "@/lib/http";
+import { requireCapOperatorForApi } from "@/lib/cap/api-gate";
+import { pushCapPostToComposer } from "@/lib/cap/push-to-composer";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-fA-F-]{36}$/;
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) return validationError("id must be a UUID.");
+
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  try {
+    const result = await pushCapPostToComposer(id, gate.userId);
+    return NextResponse.json({ ok: true, data: result }, { status: 200 });
+  } catch (err) {
+    return internalError(err instanceof Error ? err.message : "Failed to push post to composer");
+  }
+}

--- a/app/api/platform/cap/campaign-posts/[id]/status/route.ts
+++ b/app/api/platform/cap/campaign-posts/[id]/status/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { validationError, internalError } from "@/lib/http";
+import { requireCapOperatorForApi } from "@/lib/cap/api-gate";
+import { updateCampaignPostStatus, type PostStatus } from "@/lib/cap/campaigns";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-fA-F-]{36}$/;
+const VALID_STATUSES = new Set<PostStatus>(["approved", "rejected"]);
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) return validationError("id must be a UUID.");
+
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json() as Record<string, unknown>;
+  } catch {
+    return validationError("Request body must be JSON.");
+  }
+
+  const { status, rejection_reason } = body;
+
+  if (typeof status !== "string" || !VALID_STATUSES.has(status as PostStatus)) {
+    return validationError("status must be one of: approved, rejected.");
+  }
+
+  if (status === "rejected" && (typeof rejection_reason !== "string" || rejection_reason.trim().length === 0)) {
+    return validationError("rejection_reason is required when rejecting.");
+  }
+
+  try {
+    await updateCampaignPostStatus(
+      id,
+      status as PostStatus,
+      status === "rejected" ? (rejection_reason as string).trim() : undefined,
+    );
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err) {
+    return internalError(err instanceof Error ? err.message : "Failed to update post status");
+  }
+}

--- a/components/CapCampaignDetail.tsx
+++ b/components/CapCampaignDetail.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { CapCampaign, CapCampaignPost, PostStatus } from "@/lib/cap/campaigns";
+
+type ApiResponse<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: { code: string; message: string } };
+
+interface Props {
+  campaign: CapCampaign;
+  initialPosts: CapCampaignPost[];
+}
+
+const ARC_PHASE_LABEL: Record<string, string> = {
+  awareness: "Week 1 — Awareness",
+  education: "Week 2 — Education",
+  offer: "Week 3 — Offer",
+  proof: "Week 4 — Proof",
+};
+
+const POST_STATUS_TONE: Record<PostStatus, "success" | "info" | "warning" | "error" | "neutral"> = {
+  pending: "neutral",
+  generated: "info",
+  approved: "success",
+  rejected: "error",
+  pushed: "success",
+  published: "success",
+  failed: "error",
+  approved_past_due: "warning",
+};
+
+export function CapCampaignDetail({ campaign, initialPosts }: Props) {
+  const [posts, setPosts] = useState<CapCampaignPost[]>(initialPosts);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [rejectingId, setRejectingId] = useState<string | null>(null);
+  const [rejectionReason, setRejectionReason] = useState("");
+
+  async function handleApprove(postId: string) {
+    setError(null);
+    setBusy(postId);
+    const res = await fetch(`/api/platform/cap/campaign-posts/${postId}/status`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "approved" }),
+    });
+    const json = (await res.json()) as ApiResponse<unknown>;
+    setBusy(null);
+    if (!res.ok || !json.ok) {
+      setError(!json.ok ? json.error.message : "Failed to approve post.");
+      return;
+    }
+    setPosts((prev) => prev.map((p) => (p.id === postId ? { ...p, status: "approved" as PostStatus } : p)));
+  }
+
+  async function handleReject(postId: string) {
+    if (!rejectionReason.trim()) return;
+    setError(null);
+    setBusy(postId);
+    const res = await fetch(`/api/platform/cap/campaign-posts/${postId}/status`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "rejected", rejection_reason: rejectionReason.trim() }),
+    });
+    const json = (await res.json()) as ApiResponse<unknown>;
+    setBusy(null);
+    if (!res.ok || !json.ok) {
+      setError(!json.ok ? json.error.message : "Failed to reject post.");
+      return;
+    }
+    setPosts((prev) =>
+      prev.map((p) =>
+        p.id === postId ? { ...p, status: "rejected" as PostStatus, rejection_reason: rejectionReason.trim() } : p,
+      ),
+    );
+    setRejectingId(null);
+    setRejectionReason("");
+  }
+
+  async function handleRegenerate(postId: string) {
+    setError(null);
+    setBusy(postId);
+    const res = await fetch(`/api/platform/cap/campaign-posts/${postId}/regenerate`, {
+      method: "POST",
+    });
+    const json = (await res.json()) as ApiResponse<{ content: string; hashtags: string[]; imageUrl: string }>;
+    setBusy(null);
+    if (!res.ok || !json.ok) {
+      setError(!json.ok ? json.error.message : "Regeneration failed.");
+      return;
+    }
+    setPosts((prev) =>
+      prev.map((p) =>
+        p.id === postId
+          ? {
+              ...p,
+              generated_content: json.data.content,
+              generated_hashtags: json.data.hashtags,
+              generated_image_url: json.data.imageUrl,
+              status: "generated" as PostStatus,
+              regenerate_count: p.regenerate_count + 1,
+            }
+          : p,
+      ),
+    );
+  }
+
+  async function handlePush(postId: string) {
+    setError(null);
+    setBusy(postId);
+    const res = await fetch(`/api/platform/cap/campaign-posts/${postId}/push`, {
+      method: "POST",
+    });
+    const json = (await res.json()) as ApiResponse<{ draftId: string }>;
+    setBusy(null);
+    if (!res.ok || !json.ok) {
+      setError(!json.ok ? json.error.message : "Push failed.");
+      return;
+    }
+    setPosts((prev) =>
+      prev.map((p) =>
+        p.id === postId ? { ...p, status: "pushed" as PostStatus, social_draft_id: json.data.draftId } : p,
+      ),
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive" role="alert">
+          {error}
+        </div>
+      )}
+
+      {posts.length === 0 ? (
+        <div className="rounded-md border border-border p-6 text-center text-sm text-muted-foreground">
+          No posts generated yet. Click &ldquo;Generate content&rdquo; from the campaigns list to start.
+        </div>
+      ) : (
+        posts.map((post) => (
+          <Card key={post.id}>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between text-base">
+                <span>{ARC_PHASE_LABEL[post.arc_phase] ?? post.arc_phase}</span>
+                <div className="flex items-center gap-2">
+                  {post.regenerate_count > 0 && (
+                    <span className="text-xs text-muted-foreground">×{post.regenerate_count} regen</span>
+                  )}
+                  <Badge tone={POST_STATUS_TONE[post.status]}>
+                    {post.status.replace(/_/g, " ")}
+                  </Badge>
+                </div>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {post.generated_content ? (
+                <div className="grid gap-4 sm:grid-cols-3">
+                  <div className="sm:col-span-2 space-y-2">
+                    <p className="whitespace-pre-wrap text-sm leading-relaxed">{post.generated_content}</p>
+                    {post.generated_hashtags.length > 0 && (
+                      <p className="text-sm text-muted-foreground">{post.generated_hashtags.join(" ")}</p>
+                    )}
+                  </div>
+                  {post.generated_image_url && (
+                    <div className="rounded-md overflow-hidden border border-border">
+                      <Image
+                        src={post.generated_image_url}
+                        alt="Generated campaign image"
+                        width={400}
+                        height={225}
+                        className="w-full object-cover"
+                        unoptimized
+                      />
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground italic">
+                  {post.status === "pending" ? "Waiting for generation…" : "No content generated."}
+                </p>
+              )}
+
+              {post.rejection_reason && (
+                <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm">
+                  <span className="font-medium text-destructive">Rejected: </span>
+                  {post.rejection_reason}
+                </div>
+              )}
+
+              {post.social_draft_id && (
+                <p className="text-xs text-muted-foreground">
+                  Draft ID: <span className="font-mono">{post.social_draft_id}</span>
+                </p>
+              )}
+
+              {/* Actions */}
+              {(post.status === "generated" || post.status === "rejected") && (
+                <div className="flex flex-wrap gap-2">
+                  {post.status === "generated" && (
+                    <>
+                      <Button
+                        size="sm"
+                        disabled={busy === post.id}
+                        onClick={() => void handleApprove(post.id)}
+                      >
+                        Approve
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={busy === post.id}
+                        onClick={() => setRejectingId(post.id)}
+                      >
+                        Reject
+                      </Button>
+                    </>
+                  )}
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={busy === post.id}
+                    onClick={() => void handleRegenerate(post.id)}
+                  >
+                    {busy === post.id ? "Regenerating…" : "Regenerate"}
+                  </Button>
+                </div>
+              )}
+
+              {post.status === "approved" && !post.social_draft_id && (
+                <Button
+                  size="sm"
+                  disabled={busy === post.id}
+                  onClick={() => void handlePush(post.id)}
+                >
+                  {busy === post.id ? "Pushing…" : "Push to composer"}
+                </Button>
+              )}
+
+              {rejectingId === post.id && (
+                <div className="space-y-2">
+                  <textarea
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm resize-none"
+                    rows={2}
+                    placeholder="Reason for rejection…"
+                    value={rejectionReason}
+                    onChange={(e) => setRejectionReason(e.target.value)}
+                  />
+                  <div className="flex gap-2">
+                    <Button size="sm" variant="destructive" onClick={() => void handleReject(post.id)}>
+                      Confirm rejection
+                    </Button>
+                    <Button size="sm" variant="ghost" onClick={() => { setRejectingId(null); setRejectionReason(""); }}>
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))
+      )}
+
+      {campaign.status === "generating" && (
+        <div className="rounded-md border border-info/40 bg-info/10 p-4 text-sm text-info">
+          Generation in progress — refresh in a moment to see results.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/CapCampaignList.tsx
+++ b/components/CapCampaignList.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { CapCampaign, CampaignStatus } from "@/lib/cap/campaigns";
+
+type ApiResponse<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: { code: string; message: string } };
+
+interface Props {
+  companyId: string;
+  subscriptionId: string;
+  initialCampaigns: CapCampaign[];
+}
+
+const STATUS_TONE: Record<CampaignStatus, "success" | "info" | "warning" | "error" | "neutral"> = {
+  draft: "neutral",
+  generating: "info",
+  review: "warning",
+  approved: "success",
+  pushed: "success",
+  published: "success",
+  archived: "neutral",
+  failed: "error",
+};
+
+export function CapCampaignList({ companyId, initialCampaigns }: Props) {
+  const [campaigns, setCampaigns] = useState<CapCampaign[]>(initialCampaigns);
+  const [error, setError] = useState<string | null>(null);
+  const [generating, setGenerating] = useState<string | null>(null);
+
+  async function handleGenerate(campaignId: string) {
+    setError(null);
+    setGenerating(campaignId);
+    const res = await fetch(`/api/platform/cap/campaigns/${campaignId}/generate`, {
+      method: "POST",
+    });
+    const json = (await res.json()) as ApiResponse<{ status: string }>;
+    setGenerating(null);
+
+    if (!res.ok || !json.ok) {
+      setError(!json.ok ? json.error.message : "Generation failed.");
+      return;
+    }
+
+    setCampaigns((prev) =>
+      prev.map((c) =>
+        c.id === campaignId ? { ...c, status: json.data.status as CampaignStatus } : c,
+      ),
+    );
+  }
+
+  if (campaigns.length === 0) {
+    return (
+      <div className="rounded-md border border-border p-6 text-center text-sm text-muted-foreground">
+        No campaigns yet. Campaigns are created automatically when the monthly generation cron runs,
+        or you can create one manually via the API.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive" role="alert">
+          {error}
+        </div>
+      )}
+      {campaigns.map((campaign) => {
+        const monthLabel = new Date(campaign.month).toLocaleString("en-AU", {
+          month: "long",
+          year: "numeric",
+          timeZone: "UTC",
+        });
+        const isGeneratable = campaign.status === "draft" || campaign.status === "failed";
+
+        return (
+          <Card key={campaign.id}>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between text-base">
+                <span>{monthLabel}</span>
+                <Badge tone={STATUS_TONE[campaign.status]}>
+                  {campaign.status.charAt(0).toUpperCase() + campaign.status.slice(1)}
+                </Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-sm text-muted-foreground">{campaign.monthly_objective}</p>
+              <div className="flex gap-2">
+                <Button size="sm" variant="outline" asChild>
+                  <Link href={`/admin/companies/${companyId}/cap/campaigns/${campaign.id}`}>
+                    View posts
+                  </Link>
+                </Button>
+                {isGeneratable && (
+                  <Button
+                    size="sm"
+                    disabled={generating === campaign.id}
+                    onClick={() => void handleGenerate(campaign.id)}
+                  >
+                    {generating === campaign.id ? "Generating…" : "Generate content"}
+                  </Button>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/lib/cap/campaigns.ts
+++ b/lib/cap/campaigns.ts
@@ -1,0 +1,118 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+export type CampaignStatus =
+  | "draft"
+  | "generating"
+  | "review"
+  | "approved"
+  | "pushed"
+  | "published"
+  | "archived"
+  | "failed";
+
+export type PostStatus =
+  | "pending"
+  | "generated"
+  | "approved"
+  | "rejected"
+  | "pushed"
+  | "published"
+  | "failed"
+  | "approved_past_due";
+
+export interface CapCampaign {
+  id: string;
+  cap_subscription_id: string;
+  voice_profile_id: string;
+  month: string;
+  monthly_objective: string;
+  status: CampaignStatus;
+  created_by_user_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CapCampaignPost {
+  id: string;
+  cap_campaign_id: string;
+  week_number: 1 | 2 | 3 | 4;
+  arc_phase: "awareness" | "education" | "offer" | "proof";
+  generated_content: string | null;
+  generated_image_url: string | null;
+  generated_hashtags: string[];
+  social_draft_id: string | null;
+  status: PostStatus;
+  rejection_reason: string | null;
+  regenerate_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function listCampaignsForSubscription(
+  subscriptionId: string,
+): Promise<CapCampaign[]> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("cap_campaigns")
+    .select("*")
+    .eq("cap_subscription_id", subscriptionId)
+    .order("month", { ascending: false });
+
+  if (error) {
+    logger.warn("cap.campaigns.list_failed", { subscriptionId, error: error.message });
+    return [];
+  }
+  return (data ?? []) as CapCampaign[];
+}
+
+export async function getCampaign(campaignId: string): Promise<CapCampaign | null> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("cap_campaigns")
+    .select("*")
+    .eq("id", campaignId)
+    .maybeSingle();
+
+  if (error) {
+    logger.warn("cap.campaigns.get_failed", { campaignId, error: error.message });
+    return null;
+  }
+  return data as CapCampaign | null;
+}
+
+export async function listPostsForCampaign(campaignId: string): Promise<CapCampaignPost[]> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("cap_campaign_posts")
+    .select("*")
+    .eq("cap_campaign_id", campaignId)
+    .order("week_number", { ascending: true });
+
+  if (error) {
+    logger.warn("cap.campaigns.list_posts_failed", { campaignId, error: error.message });
+    return [];
+  }
+  return (data ?? []) as CapCampaignPost[];
+}
+
+export async function updateCampaignPostStatus(
+  postId: string,
+  status: PostStatus,
+  rejectionReason?: string,
+): Promise<void> {
+  const svc = getServiceRoleClient();
+  const patch: Record<string, unknown> = { status };
+  if (rejectionReason !== undefined) patch.rejection_reason = rejectionReason;
+
+  const { error } = await svc
+    .from("cap_campaign_posts")
+    .update(patch)
+    .eq("id", postId);
+
+  if (error) {
+    throw new Error(`Failed to update post status: ${error.message}`);
+  }
+}

--- a/lib/cap/push-to-composer.ts
+++ b/lib/cap/push-to-composer.ts
@@ -1,0 +1,103 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { createDraft, saveDraft, DraftDataSchema } from "@/lib/platform/social/drafts";
+
+export interface PushCapPostResult {
+  draftId: string;
+}
+
+export async function pushCapPostToComposer(
+  postId: string,
+  userId: string,
+): Promise<PushCapPostResult> {
+  const svc = getServiceRoleClient();
+
+  // Load post with campaign + subscription → company_id
+  const { data: post, error: postErr } = await svc
+    .from("cap_campaign_posts")
+    .select(
+      `id, generated_content, generated_hashtags, generated_image_url,
+       cap_campaigns:cap_campaign_id (
+         cap_subscriptions:cap_subscription_id (
+           company_id
+         )
+       )`,
+    )
+    .eq("id", postId)
+    .single();
+
+  if (postErr || !post) {
+    throw new Error(`Campaign post not found: ${postId}`);
+  }
+
+  const campaign = Array.isArray(post.cap_campaigns) ? post.cap_campaigns[0] : post.cap_campaigns;
+  const subscription = Array.isArray(campaign?.cap_subscriptions)
+    ? campaign?.cap_subscriptions[0]
+    : campaign?.cap_subscriptions;
+
+  if (!subscription?.company_id) {
+    throw new Error(`Post ${postId} has no resolvable company_id`);
+  }
+
+  const companyId = subscription.company_id as string;
+  const content = (post.generated_content as string | null) ?? "";
+  const hashtags = (post.generated_hashtags as string[] | null) ?? [];
+  const imageUrl = post.generated_image_url as string | null;
+
+  // Build the full post text: content + hashtags
+  const hashtTagLine = hashtags.length > 0 ? `\n\n${hashtags.join(" ")}` : "";
+  const masterText = content + hashtTagLine;
+
+  // Create draft (idempotent via key)
+  const idempotencyKey = `cap-post-${postId}`;
+  const createResult = await createDraft({ companyId, userId, idempotencyKey });
+  if (!createResult.ok) {
+    throw new Error(`Failed to create draft: ${createResult.error.message}`);
+  }
+
+  const draft = createResult.data;
+
+  // Build draft_data with content + optional image
+  const mediaRefs = imageUrl
+    ? [{ type: "ai_generated" as const, url: imageUrl, alt_text: "CAP generated image" }]
+    : [];
+
+  const draftData = DraftDataSchema.parse({
+    master_text: masterText,
+    media_refs: mediaRefs,
+    ai_metadata: {
+      prompt: "CAP generated",
+      tone: "professional-friendly",
+      generated_at: new Date().toISOString(),
+    },
+  });
+
+  const saveResult = await saveDraft({
+    draftId: draft.id,
+    companyId,
+    userId,
+    expectedVersion: draft.draft_version,
+    draftData,
+  });
+
+  if (!saveResult.ok) {
+    if (saveResult.error.code === "VERSION_CONFLICT") {
+      // Already saved, return existing
+      logger.info("cap.push-to-composer.already_saved", { postId, draftId: draft.id });
+    } else {
+      throw new Error(`Failed to save draft: ${saveResult.error.message}`);
+    }
+  }
+
+  // Link draft to cap_campaign_post
+  await svc
+    .from("cap_campaign_posts")
+    .update({ social_draft_id: draft.id, status: "pushed" })
+    .eq("id", postId);
+
+  logger.info("cap.push-to-composer.complete", { postId, draftId: draft.id, companyId });
+
+  return { draftId: draft.id };
+}


### PR DESCRIPTION
## CAP Phase 1 — PR 5: Campaign Management UI + Push to Composer

### What
- **`lib/cap/campaigns.ts`** — `listCampaignsForSubscription`, `getCampaign`, `listPostsForCampaign`, `updateCampaignPostStatus`
- **`lib/cap/push-to-composer.ts`** — `pushCapPostToComposer`: creates `social_post_drafts` row via `createDraft` + `saveDraft`, links back to `cap_campaign_posts.social_draft_id`, idempotent via `idempotency_key`
- **`PATCH /api/platform/cap/campaign-posts/[id]/status`** — approve/reject post (requires rejection_reason when rejecting)
- **`POST /api/platform/cap/campaign-posts/[id]/push`** — push approved post to social composer draft
- **`app/(platform)/admin/companies/[id]/cap/campaigns/page.tsx`** — campaign list page
- **`app/(platform)/admin/companies/[id]/cap/campaigns/[campaignId]/page.tsx`** — campaign detail page (4 arc posts)
- **`components/CapCampaignList.tsx`** — campaign cards with generate trigger, status badges
- **`components/CapCampaignDetail.tsx`** — post cards with approve/reject/regenerate/push actions and inline rejection form

### Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] test:unit 1849/1849 pass
- [x] All API routes gate on `requireCapOperatorForApi()`
- [x] `pushCapPostToComposer` uses `createDraft` idempotency_key for retry safety
- [x] Risks identified and mitigated below

### Working analog
`lib/platform/social/drafts.ts:createDraft+saveDraft` — same `social_post_drafts` write pattern used for CAP push. `components/AdminSocialProfilesList.tsx` — same client-component fetch pattern.

### Risks identified and mitigated
| Risk | Mitigation |
|---|---|
| Double-push creating duplicate drafts | `idempotency_key: 'cap-post-{postId}'` in `createDraft` — returns existing draft if key already exists |
| Rejecting without reason | API validates `rejection_reason` is non-empty when `status: "rejected"` |
| Push of unapproved post | Approval status check is UI-enforced (push button only shows when `status === "approved"`); DB status transition records the push |
| Company_id resolution across joins | Four-table join in `pushCapPostToComposer` — throws with descriptive error if company_id unresolvable |