### PR TITLE
feat(cap): pr6 — analytics dashboard

### DIFF
--- a/app/(platform)/admin/companies/[id]/cap/analytics/page.tsx
+++ b/app/(platform)/admin/companies/[id]/cap/analytics/page.tsx
@@ -1,0 +1,62 @@
+import { notFound } from "next/navigation";
+
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
+import { CapAnalyticsDashboard } from "@/components/CapAnalyticsDashboard";
+import { getPlatformCompany } from "@/lib/platform/companies";
+import { getCapSubscriptionByCompany } from "@/lib/cap/subscriptions";
+import { getCapAnalyticsSummary } from "@/lib/cap/analytics";
+
+export const dynamic = "force-dynamic";
+
+export default async function CapAnalyticsPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const result = await getPlatformCompany(params.id);
+  if (!result.ok) {
+    if (result.error.code === "NOT_FOUND") notFound();
+    return (
+      <PageShell>
+        <PageHeader>
+          <PageHeader.Breadcrumb segments={[{ label: "Error" }]} />
+          <PageHeader.Title>Failed to load company</PageHeader.Title>
+        </PageHeader>
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive" role="alert">
+          {result.error.message}
+        </div>
+      </PageShell>
+    );
+  }
+
+  const { company } = result.data;
+  const subscription = await getCapSubscriptionByCompany(company.id);
+  const analytics = subscription ? await getCapAnalyticsSummary(subscription.id) : null;
+
+  return (
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb
+          segments={[
+            { label: "Admin", href: "/admin/sites" },
+            { label: "Companies", href: "/admin/companies" },
+            { label: company.name, href: `/admin/companies/${company.id}` },
+            { label: "CAP", href: `/admin/companies/${company.id}/cap` },
+            { label: "Analytics" },
+          ]}
+        />
+        <PageHeader.Title>CAP Analytics — {company.name}</PageHeader.Title>
+      </PageHeader>
+      {!subscription || !analytics ? (
+        <div className="rounded-md border border-border p-6 text-center text-sm text-muted-foreground">
+          {!subscription
+            ? "CAP is not enabled for this company."
+            : "No analytics data available yet."}
+        </div>
+      ) : (
+        <CapAnalyticsDashboard analytics={analytics} />
+      )}
+    </PageShell>
+  );
+}

--- a/components/CapAnalyticsDashboard.tsx
+++ b/components/CapAnalyticsDashboard.tsx
@@ -1,0 +1,126 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { CapAnalyticsSummary } from "@/lib/cap/analytics";
+
+interface Props {
+  analytics: CapAnalyticsSummary;
+}
+
+function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-2xl font-bold">{value}</p>
+        {sub && <p className="text-xs text-muted-foreground mt-1">{sub}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function CapAnalyticsDashboard({ analytics }: Props) {
+  const capPct =
+    analytics.monthlyCostCapUsd > 0
+      ? Math.round((analytics.spentLast30DaysUsd / analytics.monthlyCostCapUsd) * 100)
+      : 0;
+
+  const approvalRate =
+    analytics.totalPostsGenerated > 0
+      ? Math.round((analytics.totalPostsApproved / analytics.totalPostsGenerated) * 100)
+      : 0;
+
+  const latestMonth = analytics.latestCampaignMonth
+    ? new Date(analytics.latestCampaignMonth).toLocaleString("en-AU", {
+        month: "long",
+        year: "numeric",
+        timeZone: "UTC",
+      })
+    : "—";
+
+  return (
+    <div className="space-y-6">
+      {/* Cost overview */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+          Cost (last 30 days)
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-3">
+          <StatCard
+            label="Spend"
+            value={`$${analytics.spentLast30DaysUsd.toFixed(2)}`}
+            sub={`of $${analytics.monthlyCostCapUsd.toFixed(2)} cap (${capPct}%)`}
+          />
+          <StatCard
+            label="Total generation runs"
+            value={String(analytics.totalGenerationRuns)}
+          />
+          <StatCard
+            label="Avg cost per campaign"
+            value={`$${analytics.avgCostPerCampaignUsd.toFixed(2)}`}
+          />
+        </div>
+
+        {/* Cost cap bar */}
+        <div className="mt-3">
+          <div className="flex justify-between text-xs text-muted-foreground mb-1">
+            <span>Monthly cost cap usage</span>
+            <span>{capPct}%</span>
+          </div>
+          <div className="h-2 rounded-full bg-muted overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all ${capPct >= 90 ? "bg-destructive" : capPct >= 70 ? "bg-warning" : "bg-success"}`}
+              style={{ width: `${Math.min(capPct, 100)}%` }}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Campaign stats */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+          Campaigns
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-3">
+          <StatCard
+            label="Total campaigns"
+            value={String(analytics.totalCampaigns)}
+            sub={`Latest: ${latestMonth}`}
+          />
+          <StatCard
+            label="Posts generated"
+            value={String(analytics.totalPostsGenerated)}
+          />
+          <StatCard
+            label="Approval rate"
+            value={`${approvalRate}%`}
+            sub={`${analytics.totalPostsApproved} approved, ${analytics.totalPostsPushed} pushed`}
+          />
+        </div>
+      </section>
+
+      {/* Campaign status breakdown */}
+      {Object.keys(analytics.campaignsByStatus).length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+            Campaign status breakdown
+          </h2>
+          <div className="grid gap-2 sm:grid-cols-4">
+            {Object.entries(analytics.campaignsByStatus).map(([status, count]) => (
+              <div key={status} className="rounded-md border border-border p-3 text-sm">
+                <p className="font-medium capitalize">{status.replace(/_/g, " ")}</p>
+                <p className="text-2xl font-bold">{count}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {analytics.totalRegenerateCount > 0 && (
+        <p className="text-sm text-muted-foreground">
+          Total regenerations: {analytics.totalRegenerateCount}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lib/cap/analytics.ts
+++ b/lib/cap/analytics.ts
@@ -1,0 +1,123 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+export interface CapAnalyticsSummary {
+  subscriptionId: string;
+  /** 30-day spend window */
+  spentLast30DaysUsd: number;
+  monthlyCostCapUsd: number;
+  totalCampaigns: number;
+  campaignsByStatus: Record<string, number>;
+  totalPostsGenerated: number;
+  totalPostsApproved: number;
+  totalPostsPushed: number;
+  totalRegenerateCount: number;
+  totalGenerationRuns: number;
+  avgCostPerCampaignUsd: number;
+  /** Most recent campaign month (ISO date string) or null */
+  latestCampaignMonth: string | null;
+}
+
+export async function getCapAnalyticsSummary(
+  subscriptionId: string,
+): Promise<CapAnalyticsSummary | null> {
+  const svc = getServiceRoleClient();
+
+  const { data: sub, error: subErr } = await svc
+    .from("cap_subscriptions")
+    .select("id, monthly_cost_cap_usd")
+    .eq("id", subscriptionId)
+    .maybeSingle();
+
+  if (subErr || !sub) {
+    logger.warn("cap.analytics.sub_not_found", { subscriptionId });
+    return null;
+  }
+
+  const since30 = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [campaigns, recentRuns] = await Promise.all([
+    svc
+      .from("cap_campaigns")
+      .select("id, status, month")
+      .eq("cap_subscription_id", subscriptionId),
+    svc
+      .from("cap_generation_runs")
+      .select("estimated_cost_usd, cap_campaign_id")
+      .gte("created_at", since30),
+  ]);
+
+  if (campaigns.error) {
+    logger.warn("cap.analytics.campaigns_failed", { subscriptionId, error: campaigns.error.message });
+  }
+
+  const campaignRows = campaigns.data ?? [];
+  const campaignIds = new Set(campaignRows.map((c: { id: string }) => c.id));
+
+  // Filter recent runs to this subscription's campaigns
+  const relevantRuns = (recentRuns.data ?? []).filter(
+    (r: { cap_campaign_id: string }) => campaignIds.has(r.cap_campaign_id),
+  );
+
+  const spentLast30DaysUsd = relevantRuns.reduce(
+    (sum: number, r: { estimated_cost_usd: string | number }) => sum + Number(r.estimated_cost_usd),
+    0,
+  );
+
+  const campaignsByStatus: Record<string, number> = {};
+  let latestCampaignMonth: string | null = null;
+
+  for (const c of campaignRows as { id: string; status: string; month: string }[]) {
+    campaignsByStatus[c.status] = (campaignsByStatus[c.status] ?? 0) + 1;
+    if (!latestCampaignMonth || c.month > latestCampaignMonth) {
+      latestCampaignMonth = c.month;
+    }
+  }
+
+  // Post stats
+  let totalPostsGenerated = 0;
+  let totalPostsApproved = 0;
+  let totalPostsPushed = 0;
+  let totalRegenerateCount = 0;
+
+  if (campaignIds.size > 0) {
+    const { data: posts } = await svc
+      .from("cap_campaign_posts")
+      .select("status, regenerate_count")
+      .in("cap_campaign_id", [...campaignIds]);
+
+    for (const p of (posts ?? []) as { status: string; regenerate_count: number }[]) {
+      if (["generated", "approved", "rejected", "pushed", "published", "approved_past_due"].includes(p.status)) {
+        totalPostsGenerated++;
+      }
+      if (p.status === "approved" || p.status === "pushed" || p.status === "published") {
+        totalPostsApproved++;
+      }
+      if (p.status === "pushed" || p.status === "published") {
+        totalPostsPushed++;
+      }
+      totalRegenerateCount += p.regenerate_count ?? 0;
+    }
+  }
+
+  const totalCampaigns = campaignRows.length;
+  const avgCostPerCampaignUsd =
+    totalCampaigns > 0 ? spentLast30DaysUsd / totalCampaigns : 0;
+
+  return {
+    subscriptionId,
+    spentLast30DaysUsd,
+    monthlyCostCapUsd: Number(sub.monthly_cost_cap_usd),
+    totalCampaigns,
+    campaignsByStatus,
+    totalPostsGenerated,
+    totalPostsApproved,
+    totalPostsPushed,
+    totalRegenerateCount,
+    totalGenerationRuns: relevantRuns.length,
+    avgCostPerCampaignUsd,
+    latestCampaignMonth,
+  };
+}


### PR DESCRIPTION
## CAP Phase 1 — PR 6: Analytics Dashboard

### What
- **`lib/cap/analytics.ts`** — `getCapAnalyticsSummary`: 30-day spend, campaign counts by status, post approval/push rates, avg cost per campaign
- **`app/(platform)/admin/companies/[id]/cap/analytics/page.tsx`** — server-rendered analytics page under existing admin layout
- **`components/CapAnalyticsDashboard.tsx`** — stat cards with cost cap progress bar (color-coded: green/warning/red), campaign status grid, approval rate

### Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] test:unit 1849/1849 pass
- [x] Server component only (no client state needed — pure display)
- [x] Risks identified and mitigated below

### Working analog
`app/(platform)/admin/companies/[id]/social-profiles/[profileId]/analytics/page.tsx` — same server-rendered analytics page pattern.

### Risks identified and mitigated
| Risk | Mitigation |
|---|---|
| N+1 query for post stats | Single `.in()` query across all campaign IDs for the subscription |
| Spend query hitting other subscriptions' campaigns | `campaignIds` set filtered from subscription's own campaigns before join |
| Division by zero for approval rate | Guarded with `totalPostsGenerated > 0` check |