### PR TITLE
feat(cap): pr7 — monthly generation cron + generation runs cleanup

### DIFF
--- a/app/api/cron/cap-generation-runs-cleanup/route.ts
+++ b/app/api/cron/cap-generation-runs-cleanup/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { logger } from "@/lib/logger";
+import { authorisedCronRequest, unauthorisedResponse, updateHeartbeat } from "@/lib/platform/cron/cron-shared";
+import { runGenerationRunsCleanup } from "@/lib/cap/generation-runs-cleanup";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const JOB_NAME = "cap-generation-runs-cleanup";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+
+  logger.info(`${JOB_NAME}.triggered`);
+
+  try {
+    const result = await runGenerationRunsCleanup();
+    await updateHeartbeat(JOB_NAME, "ok");
+    return NextResponse.json({ ok: true, data: result, timestamp: new Date().toISOString() });
+  } catch (err) {
+    await updateHeartbeat(JOB_NAME, "error", err);
+    logger.error(`${JOB_NAME}.failed`, { error: err instanceof Error ? err.message : String(err) });
+    return NextResponse.json(
+      { ok: false, error: { code: "INTERNAL_ERROR", message: err instanceof Error ? err.message : "Cleanup failed", retryable: true }, timestamp: new Date().toISOString() },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/cron/cap-monthly-generation/route.ts
+++ b/app/api/cron/cap-monthly-generation/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { logger } from "@/lib/logger";
+import { authorisedCronRequest, unauthorisedResponse, updateHeartbeat } from "@/lib/platform/cron/cron-shared";
+import { runMonthlyCapGeneration } from "@/lib/cap/monthly-generation";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 299;
+
+const JOB_NAME = "cap-monthly-generation";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+
+  logger.info(`${JOB_NAME}.triggered`);
+
+  try {
+    const result = await runMonthlyCapGeneration();
+    await updateHeartbeat(JOB_NAME, "ok");
+    logger.info(`${JOB_NAME}.complete`, { ...result });
+    return NextResponse.json({ ok: true, data: result, timestamp: new Date().toISOString() });
+  } catch (err) {
+    await updateHeartbeat(JOB_NAME, "error", err);
+    logger.error(`${JOB_NAME}.failed`, { error: err instanceof Error ? err.message : String(err) });
+    return NextResponse.json(
+      { ok: false, error: { code: "INTERNAL_ERROR", message: err instanceof Error ? err.message : "Cron failed", retryable: true }, timestamp: new Date().toISOString() },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/cap/generation-runs-cleanup.ts
+++ b/lib/cap/generation-runs-cleanup.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+const RETENTION_DAYS = 90;
+
+export interface GenerationRunsCleanupResult {
+  deletedRows: number;
+  cutoff: string;
+}
+
+export async function runGenerationRunsCleanup(): Promise<GenerationRunsCleanupResult> {
+  const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+  const svc = getServiceRoleClient();
+  const { count, error } = await svc
+    .from("cap_generation_runs")
+    .delete({ count: "exact" })
+    .lt("created_at", cutoff);
+
+  if (error) {
+    logger.error("cap.generation-runs-cleanup.failed", { error: error.message, cutoff });
+    throw new Error(`Generation runs cleanup failed: ${error.message}`);
+  }
+
+  const deletedRows = count ?? 0;
+  logger.info("cap.generation-runs-cleanup.complete", { deletedRows, cutoff });
+
+  return { deletedRows, cutoff };
+}

--- a/lib/cap/monthly-generation.ts
+++ b/lib/cap/monthly-generation.ts
@@ -1,0 +1,125 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { runCampaign } from "@/lib/cap/generation/campaign-runner";
+
+export interface MonthlyGenerationResult {
+  subscriptionsProcessed: number;
+  campaignsCreated: number;
+  campaignsGenerated: number;
+  failed: number;
+}
+
+export async function runMonthlyCapGeneration(): Promise<MonthlyGenerationResult> {
+  const svc = getServiceRoleClient();
+
+  // Get the first day of the current month as the campaign month
+  const now = new Date();
+  const campaignMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+    .toISOString()
+    .slice(0, 10);
+
+  // Find active/trial subscriptions with at least one voice profile
+  const { data: subscriptions, error: subErr } = await svc
+    .from("cap_subscriptions")
+    .select(
+      `id, company_id,
+       cap_voice_profiles!cap_voice_profiles_cap_subscription_id_fkey(id, is_default)`,
+    )
+    .in("status", ["active", "trial"]);
+
+  if (subErr) {
+    logger.error("cap.monthly-gen.subscriptions_failed", { error: subErr.message });
+    throw new Error(`Failed to load subscriptions: ${subErr.message}`);
+  }
+
+  const activeSubscriptions = (subscriptions ?? []).filter(
+    (s: { cap_voice_profiles?: unknown[] }) =>
+      Array.isArray(s.cap_voice_profiles) && s.cap_voice_profiles.length > 0,
+  );
+
+  logger.info("cap.monthly-gen.start", {
+    campaignMonth,
+    subscriptionCount: activeSubscriptions.length,
+  });
+
+  let campaignsCreated = 0;
+  let campaignsGenerated = 0;
+  let failed = 0;
+
+  for (const sub of activeSubscriptions as {
+    id: string;
+    cap_voice_profiles: { id: string; is_default: boolean }[];
+  }[]) {
+    try {
+      const defaultProfile =
+        sub.cap_voice_profiles.find((p) => p.is_default) ?? sub.cap_voice_profiles[0];
+
+      // Upsert campaign for this month (UNIQUE on subscription + month)
+      const { data: campaign, error: campaignErr } = await svc
+        .from("cap_campaigns")
+        .upsert(
+          {
+            cap_subscription_id: sub.id,
+            voice_profile_id: defaultProfile.id,
+            month: campaignMonth,
+            monthly_objective: `Monthly LinkedIn content campaign for ${campaignMonth}`,
+            status: "draft",
+          },
+          { onConflict: "cap_subscription_id,month", ignoreDuplicates: true },
+        )
+        .select("id, status")
+        .maybeSingle();
+
+      if (campaignErr) {
+        logger.error("cap.monthly-gen.upsert_failed", {
+          subscriptionId: sub.id,
+          error: campaignErr.message,
+        });
+        failed++;
+        continue;
+      }
+
+      // Get the actual campaign (may have been the ignored duplicate)
+      const { data: existingCampaign } = await svc
+        .from("cap_campaigns")
+        .select("id, status")
+        .eq("cap_subscription_id", sub.id)
+        .eq("month", campaignMonth)
+        .single();
+
+      if (!existingCampaign) {
+        failed++;
+        continue;
+      }
+
+      if (campaign && campaign.id) {
+        campaignsCreated++;
+      }
+
+      // Only run generation for draft campaigns (not already generating/review/etc.)
+      if (existingCampaign.status === "draft") {
+        await runCampaign(existingCampaign.id as string);
+        campaignsGenerated++;
+        logger.info("cap.monthly-gen.campaign_generated", {
+          subscriptionId: sub.id,
+          campaignId: existingCampaign.id,
+        });
+      }
+    } catch (err) {
+      logger.error("cap.monthly-gen.subscription_failed", {
+        subscriptionId: sub.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      failed++;
+    }
+  }
+
+  return {
+    subscriptionsProcessed: activeSubscriptions.length,
+    campaignsCreated,
+    campaignsGenerated,
+    failed,
+  };
+}


### PR DESCRIPTION
## Summary
- `runMonthlyCapGeneration`: finds active/trial subscriptions with voice profiles, upserts campaigns for current month (idempotent via `UNIQUE cap_subscription_id,month`), calls `runCampaign()` for any draft campaigns
- `runGenerationRunsCleanup`: deletes `cap_generation_runs` rows older than 90 days, returns `{ deletedRows, cutoff }`
- Cron routes: `GET /api/cron/cap-monthly-generation` (maxDuration=299, fires 1st of month 04:00 UTC) and `GET /api/cron/cap-generation-runs-cleanup` (maxDuration=60, fires daily)
- `scripts/audit.ts`: registered `requireCapOperatorForApi` as a recognised auth gate pattern (was causing HIGH static-audit failures on PR #927)

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (1857 passed)
- [x] Contract snapshots reviewed (no SDK calls in these files)
- [x] No new tenant-scoped resources (cron routes, service-role only)
- [x] Risks identified and mitigated section below
- [x] PR is under 500 net lines

## Working analog
**Working analog**: `app/api/cron/cap-generation-runs-cleanup/route.ts:1-30` matches the existing cron pattern from `app/api/cron/process-brief-runner/route.ts` — same `authorisedCronRequest` + `updateHeartbeat` structure.
**Diff**: new cron job with new business logic, not a fix.
**Fix**: n/a — new addition following existing pattern.

## Risks identified and mitigated
- **Idempotency on monthly run**: `upsert(..., { onConflict: ..., ignoreDuplicates: true })` prevents duplicate campaigns; subsequent `.select()` fetches the canonical row regardless of whether the upsert inserted or ignored.
- **Only runs generation on draft status**: `existingCampaign.status === 'draft'` guard prevents re-running already-generating/review/pushed campaigns on cron re-run.
- **Cost cap guard**: `runCampaign` internally calls `assertCostCapNotExceeded` before any generation; subscription loop catches and logs per-subscription failures without halting the batch.
- **Retention cleanup**: 90-day window is a fixed constant; the `DELETE ... WHERE created_at < cutoff` is bounded by the cutoff date, not unbounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)