### PR TITLE
feat(cap): pr8 — phase 1 cutover (cron schedule activation)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -89,8 +89,12 @@
       "schedule": "*/5 * * * *"
     },
     {
-      "path": "/api/cron/cap-weekly-generation",
-      "schedule": "0 6 * * 1"
+      "path": "/api/cron/cap-monthly-generation",
+      "schedule": "0 4 1 * *"
+    },
+    {
+      "path": "/api/cron/cap-generation-runs-cleanup",
+      "schedule": "0 2 * * *"
     },
     {
       "path": "/api/cron/social-connections-health",


### PR DESCRIPTION
## Summary
- `vercel.json`: replace `cap-weekly-generation` (old D4 placeholder) with two new Phase 1 cron entries:
  - `cap-monthly-generation`: `0 4 1 * *` — fires 1st of each month at 04:00 UTC; upserts campaigns for all active/trial subscriptions and runs generation for draft campaigns
  - `cap-generation-runs-cleanup`: `0 2 * * *` — fires daily at 02:00 UTC; deletes `cap_generation_runs` rows older than 90 days

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (1857 passed)
- [x] No new DB schema / migrations
- [x] Risks identified and mitigated below
- [x] PR is under 500 net lines

## Working analog
**Working analog**: existing cron entries in `vercel.json:80-93` follow the same `{ path, schedule }` shape.
**Diff**: new entries — `cap-weekly-generation` is removed (no route handler changes needed; the old route file remains but is no longer scheduled).
**Fix**: n/a — new addition following existing pattern.

## Risks identified and mitigated
- **Idempotent generation**: `runMonthlyCapGeneration` upserts campaigns with `ignoreDuplicates: true` and only calls `runCampaign` for `status=draft` — re-running the cron is safe.
- **Cost cap guard**: `assertCostCapNotExceeded` is called inside `runCampaign` before any billed API call; subscriptions over cap are skipped, not failed.
- **Time-slot conflicts**: cleanup (`0 2 * * *`) is at 02:00 UTC, separate from other daily jobs at 03:00/04:00.
- **⚠️ Hard stop — missing env var**: `IDEOGRAM_API_KEY` is NOT set in Vercel production. Image generation for CAP posts will fail with empty-key errors until this is added. Text generation will still succeed; image generation failure is recorded in `cap_generation_runs` and does not block the campaign from reaching `review` status. Please add `IDEOGRAM_API_KEY` to Vercel production env vars when ready to enable image generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)