### PR TITLE
fix(cap): split generation-runs cleanup into 365/730-day retention buckets

### DIFF
--- a/docs/briefs/cap-phase-1/CAP_ACCEPTANCE.md
+++ b/docs/briefs/cap-phase-1/CAP_ACCEPTANCE.md
@@ -70,7 +70,7 @@ UPDATE platform_users SET is_cap_operator = true WHERE email = 'hi@opollo.com';
 # Requires CRON_SECRET env var
 curl -H "Authorization: Bearer $CRON_SECRET" \
   https://app.opollo.com/api/cron/cap-generation-runs-cleanup
-# Expected: { "ok": true, "data": { "deletedRows": 0, ... } }
+# Expected: { "ok": true, "data": { "deletedSuccessRows": 0, "deletedErrorRows": 0, "totalDeleted": 0, ... } }
 ```
 
 ---

--- a/lib/__tests__/cap-generation-runs-cleanup.unit.test.ts
+++ b/lib/__tests__/cap-generation-runs-cleanup.unit.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Supabase service-role mock
+// ─────────────────────────────────────────────────────────────────────────────
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { runGenerationRunsCleanup } from "@/lib/cap/generation-runs-cleanup";
+
+function makeDeleteChain(result: { count: number | null; error: null | { message: string } }) {
+  const chain = {
+    delete: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    lt: vi.fn().mockResolvedValue(result),
+  };
+  return chain;
+}
+
+describe("runGenerationRunsCleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns dual-bucket counts when both deletes succeed", async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return makeDeleteChain({ count: 12, error: null });
+      return makeDeleteChain({ count: 3, error: null });
+    });
+
+    const result = await runGenerationRunsCleanup();
+
+    expect(result.deletedSuccessRows).toBe(12);
+    expect(result.deletedErrorRows).toBe(3);
+    expect(result.totalDeleted).toBe(15);
+    expect(result.successCutoff).toBeDefined();
+    expect(result.errorCutoff).toBeDefined();
+  });
+
+  it("success cutoff is ~365 days ago and error cutoff is ~730 days ago", async () => {
+    mockFrom.mockImplementation(() => makeDeleteChain({ count: 0, error: null }));
+
+    const before = Date.now();
+    const result = await runGenerationRunsCleanup();
+    const after = Date.now();
+
+    const successMs = new Date(result.successCutoff).getTime();
+    const errorMs = new Date(result.errorCutoff).getTime();
+
+    // success cutoff within ±60s of 365 days ago
+    expect(successMs).toBeGreaterThan(before - 365 * 24 * 60 * 60 * 1000 - 60_000);
+    expect(successMs).toBeLessThan(after - 365 * 24 * 60 * 60 * 1000 + 60_000);
+
+    // error cutoff within ±60s of 730 days ago
+    expect(errorMs).toBeGreaterThan(before - 730 * 24 * 60 * 60 * 1000 - 60_000);
+    expect(errorMs).toBeLessThan(after - 730 * 24 * 60 * 60 * 1000 + 60_000);
+  });
+
+  it("first delete queries only success status rows", async () => {
+    const firstChain = makeDeleteChain({ count: 5, error: null });
+    const secondChain = makeDeleteChain({ count: 2, error: null });
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? firstChain : secondChain;
+    });
+
+    await runGenerationRunsCleanup();
+
+    expect(firstChain.in).toHaveBeenCalledWith("status", ["success"]);
+    expect(secondChain.in).toHaveBeenCalledWith("status", ["error", "failed"]);
+  });
+
+  it("throws and logs when success delete fails", async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1)
+        return makeDeleteChain({ count: null, error: { message: "db error" } });
+      return makeDeleteChain({ count: 0, error: null });
+    });
+
+    await expect(runGenerationRunsCleanup()).rejects.toThrow(
+      "Generation runs cleanup (success) failed: db error",
+    );
+  });
+
+  it("throws and logs when error delete fails", async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return makeDeleteChain({ count: 0, error: null });
+      return makeDeleteChain({ count: null, error: { message: "delete failed" } });
+    });
+
+    await expect(runGenerationRunsCleanup()).rejects.toThrow(
+      "Generation runs cleanup (error) failed: delete failed",
+    );
+  });
+
+  it("treats null count as 0", async () => {
+    mockFrom.mockImplementation(() => makeDeleteChain({ count: null, error: null }));
+
+    const result = await runGenerationRunsCleanup();
+
+    expect(result.deletedSuccessRows).toBe(0);
+    expect(result.deletedErrorRows).toBe(0);
+    expect(result.totalDeleted).toBe(0);
+  });
+});

--- a/lib/cap/generation-runs-cleanup.ts
+++ b/lib/cap/generation-runs-cleanup.ts
@@ -3,29 +3,67 @@ import "server-only";
 import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 
-const RETENTION_DAYS = 90;
+// Successful runs kept 1 year; error/failed runs kept 2 years for billing reconciliation
+const SUCCESS_RETENTION_DAYS = 365;
+const ERROR_RETENTION_DAYS = 730;
 
 export interface GenerationRunsCleanupResult {
-  deletedRows: number;
-  cutoff: string;
+  deletedSuccessRows: number;
+  deletedErrorRows: number;
+  totalDeleted: number;
+  successCutoff: string;
+  errorCutoff: string;
 }
 
 export async function runGenerationRunsCleanup(): Promise<GenerationRunsCleanupResult> {
-  const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const successCutoff = new Date(
+    Date.now() - SUCCESS_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
+  const errorCutoff = new Date(
+    Date.now() - ERROR_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
 
   const svc = getServiceRoleClient();
-  const { count, error } = await svc
+
+  const { count: successCount, error: successError } = await svc
     .from("cap_generation_runs")
     .delete({ count: "exact" })
-    .lt("created_at", cutoff);
+    .in("status", ["success"])
+    .lt("created_at", successCutoff);
 
-  if (error) {
-    logger.error("cap.generation-runs-cleanup.failed", { error: error.message, cutoff });
-    throw new Error(`Generation runs cleanup failed: ${error.message}`);
+  if (successError) {
+    logger.error("cap.generation-runs-cleanup.success-delete-failed", {
+      error: successError.message,
+      successCutoff,
+    });
+    throw new Error(`Generation runs cleanup (success) failed: ${successError.message}`);
   }
 
-  const deletedRows = count ?? 0;
-  logger.info("cap.generation-runs-cleanup.complete", { deletedRows, cutoff });
+  const { count: errorCount, error: errorError } = await svc
+    .from("cap_generation_runs")
+    .delete({ count: "exact" })
+    .in("status", ["error", "failed"])
+    .lt("created_at", errorCutoff);
 
-  return { deletedRows, cutoff };
+  if (errorError) {
+    logger.error("cap.generation-runs-cleanup.error-delete-failed", {
+      error: errorError.message,
+      errorCutoff,
+    });
+    throw new Error(`Generation runs cleanup (error) failed: ${errorError.message}`);
+  }
+
+  const deletedSuccessRows = successCount ?? 0;
+  const deletedErrorRows = errorCount ?? 0;
+  const totalDeleted = deletedSuccessRows + deletedErrorRows;
+
+  logger.info("cap.generation-runs-cleanup.complete", {
+    deletedSuccessRows,
+    deletedErrorRows,
+    totalDeleted,
+    successCutoff,
+    errorCutoff,
+  });
+
+  return { deletedSuccessRows, deletedErrorRows, totalDeleted, successCutoff, errorCutoff };
 }


### PR DESCRIPTION
## Summary

- `SUCCESS` runs now expire after 365 days (was 90)
- `ERROR`/`FAILED` runs expire after 730 days for billing reconciliation
- Return type changed from `{ deletedRows, cutoff }` to `{ deletedSuccessRows, deletedErrorRows, totalDeleted, successCutoff, errorCutoff }`
- Two separate DELETE queries filtered by `status` column
- Updated `CAP_ACCEPTANCE.md` §6 cron health-check expected response shape

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (6 new tests added)
- [x] Risks identified and mitigated section in PR body
- [x] PR is under 500 net lines

## Risks identified and mitigated

- **Two DELETE queries instead of one**: The status column on `cap_generation_runs` is not nullable per migration 0137, so `.in("status", ["success"])` and `.in("status", ["error", "failed"])` are mutually exclusive and exhaustive. No double-delete risk.
- **Return shape change**: The cron route passes `result` directly into `NextResponse.json` — no change required there. CAP_ACCEPTANCE.md §6 updated.

**Working analog**: `lib/cap/generation-runs-cleanup.ts` (the existing function being updated — same delete pattern, same logger calls)
**Diff**: single 90-day DELETE → two status-filtered DELETEs with different retention windows
**Fix**: split into two queries, return both counts