### PR TITLE
chore(cap): grant is_cap_operator to hi@opollo.com via migration 0138

### DIFF
--- a/docs/briefs/cap-phase-1/CAP_ACCEPTANCE.md
+++ b/docs/briefs/cap-phase-1/CAP_ACCEPTANCE.md
@@ -7,11 +7,8 @@ All steps require a user with `is_cap_operator = true` on `platform_users`.
 
 ## Prerequisites
 
-Set `is_cap_operator = true` for your admin user:
-
-```sql
-UPDATE platform_users SET is_cap_operator = true WHERE email = 'hi@opollo.com';
-```
+`hi@opollo.com` is granted `is_cap_operator = true` automatically by migration `0138_cap_grant_operator.sql`.
+No manual SQL step required after that migration has applied.
 
 ---
 

--- a/supabase/migrations/0138_cap_grant_operator.sql
+++ b/supabase/migrations/0138_cap_grant_operator.sql
@@ -1,0 +1,5 @@
+-- Grant CAP operator access to the primary Opollo admin account.
+-- is_cap_operator enables access to CAP admin UI and all /api/platform/cap/* routes.
+UPDATE platform_users
+SET is_cap_operator = true
+WHERE email = 'hi@opollo.com';


### PR DESCRIPTION
## Summary

- Adds migration `0138_cap_grant_operator.sql`: `UPDATE platform_users SET is_cap_operator = true WHERE email = 'hi@opollo.com'`
- Removes manual SQL prerequisite from `CAP_ACCEPTANCE.md` — provisioning is now automatic on deploy

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (existing suite passes; migration has no testable logic beyond the UPDATE)
- [x] Risks identified and mitigated section in PR body
- [x] PR is under 500 net lines

## Risks identified and mitigated

- **Idempotency**: `UPDATE ... WHERE email = 'hi@opollo.com'` is fully idempotent — running multiple times has no effect after the first.
- **Wrong user affected**: WHERE clause is on exact email match; no other rows touched.
- **Missing user**: If the row doesn't exist at migration time (e.g. new environment), the UPDATE is a no-op. CAP_ACCEPTANCE.md notes this is automatic after migration applies.

**Working analog**: `supabase/migrations/0137_cap_phase_1_schema.sql` — same pattern of UPDATE on `platform_users` during migration
**Diff**: That migration added the column; this one populates a value for a known user
**Fix**: Simple targeted UPDATE