### PR TITLE
fix(composer): wireframe HIGH gaps — unsaved Save button + TikTok item

### DIFF
--- a/components/__tests__/AddProfileDropdown.test.tsx
+++ b/components/__tests__/AddProfileDropdown.test.tsx
@@ -18,7 +18,7 @@ describe("AddProfileDropdown (audit gap C-1)", () => {
     expect(screen.queryByTestId("add-profile-menu")).toBeNull();
   });
 
-  it("menu opens on trigger click and shows all 5 platforms", () => {
+  it("menu opens on trigger click and shows all 6 platforms including TikTok", () => {
     render(<AddProfileDropdown />);
     fireEvent.click(screen.getByTestId("add-profile-trigger"));
 
@@ -27,7 +27,16 @@ describe("AddProfileDropdown (audit gap C-1)", () => {
     expect(screen.getByTestId("add-profile-facebook")).toBeDefined();
     expect(screen.getByTestId("add-profile-instagram")).toBeDefined();
     expect(screen.getByTestId("add-profile-x")).toBeDefined();
+    expect(screen.getByTestId("add-profile-tiktok")).toBeDefined();
     expect(screen.getByTestId("add-profile-google_business_profile")).toBeDefined();
+  });
+
+  it("TikTok item shows a 'New' badge", () => {
+    render(<AddProfileDropdown />);
+    fireEvent.click(screen.getByTestId("add-profile-trigger"));
+
+    const tiktokItem = screen.getByTestId("add-profile-tiktok");
+    expect(tiktokItem.textContent).toContain("New");
   });
 
   it("each platform item links to per-platform connect URL", () => {

--- a/components/__tests__/UnsavedChangesDialog.test.tsx
+++ b/components/__tests__/UnsavedChangesDialog.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { UnsavedChangesDialog } from "@/components/social/composer/UnsavedChangesDialog";
+
+describe("UnsavedChangesDialog (wireframe 08 gap fix)", () => {
+  it("renders title and description when open", () => {
+    render(
+      <UnsavedChangesDialog open onDiscard={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(screen.getByText("Unsaved changes")).toBeDefined();
+    expect(screen.getByText(/save as a draft/i)).toBeDefined();
+  });
+
+  it("calls onCancel when Keep editing is clicked", () => {
+    const onCancel = vi.fn();
+    render(<UnsavedChangesDialog open onDiscard={vi.fn()} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText("Keep editing"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDiscard when Discard is clicked", () => {
+    const onDiscard = vi.fn();
+    render(<UnsavedChangesDialog open onDiscard={onDiscard} onCancel={vi.fn()} />);
+    fireEvent.click(screen.getByText("Discard"));
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders Save as draft button only when onSave is provided", () => {
+    const { rerender } = render(
+      <UnsavedChangesDialog open onDiscard={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(screen.queryByTestId("unsaved-save-btn")).toBeNull();
+
+    rerender(
+      <UnsavedChangesDialog open onDiscard={vi.fn()} onCancel={vi.fn()} onSave={vi.fn()} />,
+    );
+    expect(screen.getByTestId("unsaved-save-btn")).toBeDefined();
+  });
+
+  it("calls onSave and shows saving state", async () => {
+    let resolve: () => void;
+    const onSave = vi.fn(
+      () =>
+        new Promise<void>((res) => {
+          resolve = res;
+        }),
+    );
+
+    render(
+      <UnsavedChangesDialog open onDiscard={vi.fn()} onCancel={vi.fn()} onSave={onSave} />,
+    );
+
+    fireEvent.click(screen.getByTestId("unsaved-save-btn"));
+    expect(screen.getByTestId("unsaved-save-btn").textContent).toBe("Saving…");
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    resolve!();
+    await waitFor(() =>
+      expect(screen.getByTestId("unsaved-save-btn").textContent).toBe("Save as draft"),
+    );
+  });
+});

--- a/components/social/composer/ComposerOverlay.tsx
+++ b/components/social/composer/ComposerOverlay.tsx
@@ -125,6 +125,11 @@ export function ComposerOverlay({
     onClose();
   }
 
+  async function handleSaveFromDialog() {
+    setShowDiscard(false);
+    await handleSubmit("draft");
+  }
+
   async function handleSubmit(mode: SchedulingMode) {
     // External onSubmit takes precedence if provided.
     if (onSubmit) {
@@ -347,6 +352,7 @@ export function ComposerOverlay({
         open={showDiscard}
         onDiscard={handleDiscard}
         onCancel={() => setShowDiscard(false)}
+        onSave={companyId ? () => void handleSaveFromDialog() : undefined}
       />
     </>
   );

--- a/components/social/composer/UnsavedChangesDialog.tsx
+++ b/components/social/composer/UnsavedChangesDialog.tsx
@@ -14,16 +14,30 @@ export interface UnsavedChangesDialogProps {
   open: boolean;
   onDiscard: () => void;
   onCancel: () => void;
+  /** When provided, renders a "Save as draft" button that saves before closing. */
+  onSave?: () => void | Promise<void>;
 }
 
-export function UnsavedChangesDialog({ open, onDiscard, onCancel }: UnsavedChangesDialogProps) {
+export function UnsavedChangesDialog({ open, onDiscard, onCancel, onSave }: UnsavedChangesDialogProps) {
+  const [saving, setSaving] = React.useState(false);
+
+  async function handleSave() {
+    if (!onSave) return;
+    setSaving(true);
+    try {
+      await onSave();
+    } finally {
+      setSaving(false);
+    }
+  }
+
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onCancel()}>
       <DialogContent className="max-w-sm">
         <DialogHeader>
-          <DialogTitle>Discard changes?</DialogTitle>
+          <DialogTitle>Unsaved changes</DialogTitle>
           <DialogDescription>
-            You have unsaved changes. If you close now, your draft will be lost.
+            You have unsaved changes. Would you like to save as a draft before closing?
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
@@ -37,10 +51,21 @@ export function UnsavedChangesDialog({ open, onDiscard, onCancel }: UnsavedChang
           <button
             type="button"
             onClick={onDiscard}
-            className="rounded-md bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 transition-colors"
+            className="rounded-md border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-muted transition-colors"
           >
             Discard
           </button>
+          {onSave && (
+            <button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={saving}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+              data-testid="unsaved-save-btn"
+            >
+              {saving ? "Saving…" : "Save as draft"}
+            </button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/components/social/dashboard/AddProfileDropdown.tsx
+++ b/components/social/dashboard/AddProfileDropdown.tsx
@@ -16,11 +16,12 @@ import { SocialPlatformIcon, type SocialPlatformIconKey } from "@/components/ui/
 // CLAUDE-ASSUMPTION (PR 1.1): /company/social/connections/connect/[platform] is a
 // redirect stub because the real connect flow is popup-based via POST
 // /api/platform/social/connections/connect. Logged in DECISION_TRAIL.md.
-const PLATFORMS: Array<{ value: string; icon: SocialPlatformIconKey; label: string }> = [
+const PLATFORMS: Array<{ value: string; icon: SocialPlatformIconKey; label: string; isNew?: boolean }> = [
   { value: "linkedin", icon: "LINKEDIN", label: "LinkedIn" },
   { value: "facebook", icon: "FACEBOOK", label: "Facebook" },
   { value: "instagram", icon: "INSTAGRAM", label: "Instagram" },
   { value: "x", icon: "TWITTER", label: "X (Twitter)" },
+  { value: "tiktok", icon: "TIKTOK", label: "TikTok", isNew: true },
   { value: "google_business_profile", icon: "GOOGLE_BUSINESS", label: "Google Business Profile" },
 ];
 
@@ -91,7 +92,7 @@ export function AddProfileDropdown({ className }: AddProfileDropdownProps) {
           className="absolute left-0 top-full z-20 mt-1 w-52 rounded-lg border border-border bg-popover shadow-lg"
         >
           <div className="p-1">
-            {PLATFORMS.map(({ value, icon, label }) => (
+            {PLATFORMS.map(({ value, icon, label, isNew }) => (
               <Link
                 key={value}
                 href={`/company/social/connections/connect/${value}`}
@@ -101,7 +102,12 @@ export function AddProfileDropdown({ className }: AddProfileDropdownProps) {
                 className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-muted transition-colors"
               >
                 <SocialPlatformIcon platform={icon} size={16} className="shrink-0" />
-                {label}
+                <span className="flex-1">{label}</span>
+                {isNew && (
+                  <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-semibold text-primary leading-none">
+                    New
+                  </span>
+                )}
               </Link>
             ))}
           </div>


### PR DESCRIPTION
## Summary

Fixes 2 HIGH-severity gaps identified in wireframe audit (`docs/audits/WIREFRAME_AUDIT_2026-05-19.md`).

**Gap 1 — Wireframe 08: UnsavedChangesDialog missing "Save" button**  
Wireframe shows three buttons: "Don't save" / "Continue editing" / "Save". Built dialog only had "Keep editing" + "Discard" — no path to save before closing. Users could lose unsaved work.
- Added optional `onSave?: () => void | Promise<void>` prop to dialog
- Renders "Save as draft" button (with loading state) when provided
- `ComposerOverlay` wires `handleSubmit("draft")` as the save handler; only shown when `companyId` is set (i.e. internal submit path is available)

**Gap 2 — Wireframe 11: TikTok missing from AddProfileDropdown**  
Wireframe shows TikTok with a "new" badge. Component had 5 platforms (no TikTok). Added TikTok with `isNew: true` badge rendered as a `text-xs` rounded pill. The existing `[platform]` redirect stub covers the connect URL.

## Working analog
- `UnsavedChangesDialog` follows the same pattern as `ConfirmActionModal` (optional async callback, loading state, disabled button)
- `isNew` badge follows the same inline conditional pattern as other platform-conditional rendering in the same file

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Layer 4 component tests: 5 new tests, all 228 pass
- [x] Design-tokens test passes (no sub-16px arbitrary sizes)
- [x] PR is under 500 net lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)