### PR TITLE
feat(smoke): smoke harness scaffold — client, assertions, budget guard

### DIFF
--- a/lib/__tests__/smoke-budget.unit.test.ts
+++ b/lib/__tests__/smoke-budget.unit.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock node:fs so budget tests don't touch the real filesystem
+// ─────────────────────────────────────────────────────────────────────────────
+const { mockReadFileSync, mockWriteFileSync, mockMkdirSync } = vi.hoisted(() => ({
+  mockReadFileSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  default: {
+    readFileSync: mockReadFileSync,
+    writeFileSync: mockWriteFileSync,
+    mkdirSync: mockMkdirSync,
+  },
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
+}));
+
+// Budget file is resolved relative to import.meta.dirname, which vitest
+// will evaluate. We mock fs, so reads / writes never touch disk.
+import { guardBudget, recordSpend, getBudgetRemaining, resetBudget } from "@/scripts/smoke/budget";
+
+describe("smoke budget guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: budget file doesn't exist (fresh state)
+    mockReadFileSync.mockImplementation(() => { throw new Error("ENOENT"); });
+    mockWriteFileSync.mockImplementation(() => undefined);
+    mockMkdirSync.mockImplementation(() => undefined);
+  });
+
+  it("passes when estimated cost is within budget cap ($5)", () => {
+    expect(() => guardBudget(1.50)).not.toThrow();
+  });
+
+  it("passes when estimated cost exactly equals remaining budget", () => {
+    expect(() => guardBudget(5.0)).not.toThrow();
+  });
+
+  it("throws when estimated cost exceeds remaining budget", () => {
+    expect(() => guardBudget(5.01)).toThrow(/Budget guard/);
+  });
+
+  it("throws when cumulative spend has reduced budget and new estimate overflows", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ cumulative_usd: 4.50, runs: [] }),
+    );
+    // $4.50 spent; $0.50 remaining — $0.60 estimate should fail
+    expect(() => guardBudget(0.60)).toThrow(/Budget guard/);
+  });
+
+  it("passes when cumulative spend leaves enough room for the estimate", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ cumulative_usd: 4.50, runs: [] }),
+    );
+    // $4.50 spent; $0.50 remaining — $0.40 estimate should pass
+    expect(() => guardBudget(0.40)).not.toThrow();
+  });
+
+  it("getBudgetRemaining returns 5.0 on fresh state", () => {
+    expect(getBudgetRemaining()).toBe(5.0);
+  });
+
+  it("getBudgetRemaining returns reduced value after spend recorded", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ cumulative_usd: 2.00, runs: [] }),
+    );
+    expect(getBudgetRemaining()).toBe(3.0);
+  });
+
+  it("recordSpend writes updated cumulative total to budget file", () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ cumulative_usd: 1.00, runs: [] }),
+    );
+
+    recordSpend(0.25, "test run");
+
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    const [, written] = mockWriteFileSync.mock.calls[0] as [string, string];
+    const parsed = JSON.parse(written) as { cumulative_usd: number; runs: unknown[] };
+    expect(parsed.cumulative_usd).toBe(1.25);
+    expect(parsed.runs).toHaveLength(1);
+  });
+
+  it("resetBudget writes zero state", () => {
+    resetBudget();
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+    const [, written] = mockWriteFileSync.mock.calls[0] as [string, string];
+    const parsed = JSON.parse(written) as { cumulative_usd: number };
+    expect(parsed.cumulative_usd).toBe(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "screenshots": "RUN_SCREENSHOTS=1 playwright test screenshots.spec.ts",
     "screenshots:baseline": "RUN_SCREENSHOTS=1 playwright test screenshots.spec.ts --update-snapshots",
     "audit:static": "tsx scripts/audit.ts",
+    "smoke:harness": "vitest run --config vitest.unit.config.ts lib/__tests__/smoke-budget.unit.test.ts",
     "backfill:image-embeddings": "tsx scripts/backfill-image-embeddings.ts",
     "gen:types": "supabase gen types typescript --local > types/supabase.ts",
     "analyze": "ANALYZE=true next build",

--- a/scripts/smoke/assertions.ts
+++ b/scripts/smoke/assertions.ts
@@ -1,0 +1,34 @@
+/**
+ * scripts/smoke/assertions.ts
+ *
+ * Assertion helpers for smoke tests.
+ */
+
+export function assertStatus(
+  res: Response,
+  expected: number,
+  context = "",
+): void {
+  if (res.status !== expected) {
+    throw new Error(
+      `${context ? `[${context}] ` : ""}Expected HTTP ${expected}, got ${res.status} ${res.url}`,
+    );
+  }
+}
+
+export function assertShape(
+  obj: Record<string, unknown>,
+  keys: string[],
+  context = "",
+): void {
+  const missing = keys.filter((k) => !(k in obj));
+  if (missing.length > 0) {
+    throw new Error(
+      `${context ? `[${context}] ` : ""}Response missing keys: ${missing.join(", ")}. Got: ${JSON.stringify(obj).slice(0, 200)}`,
+    );
+  }
+}
+
+export function assertTruthy(value: unknown, message: string): void {
+  if (!value) throw new Error(message);
+}

--- a/scripts/smoke/budget.ts
+++ b/scripts/smoke/budget.ts
@@ -1,0 +1,71 @@
+/**
+ * scripts/smoke/budget.ts
+ *
+ * $5 cumulative budget guard for smoke tests that trigger real AI calls.
+ * Reads scripts/smoke/output/budget.json to track spend across runs.
+ * Throws if the remaining budget would go negative.
+ *
+ * Usage:
+ *   await guardBudget(estimatedCostUsd);
+ *   // ... run AI operations ...
+ *   await recordSpend(actualCostUsd);
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const BUDGET_CAP_USD = 5.0;
+const BUDGET_FILE = path.join(import.meta.dirname, "output", "budget.json");
+
+interface BudgetState {
+  cumulative_usd: number;
+  runs: Array<{ timestamp: string; cost_usd: number; description: string }>;
+}
+
+function readBudget(): BudgetState {
+  try {
+    const raw = fs.readFileSync(BUDGET_FILE, "utf-8");
+    return JSON.parse(raw) as BudgetState;
+  } catch {
+    return { cumulative_usd: 0, runs: [] };
+  }
+}
+
+function writeBudget(state: BudgetState): void {
+  fs.mkdirSync(path.dirname(BUDGET_FILE), { recursive: true });
+  fs.writeFileSync(BUDGET_FILE, JSON.stringify(state, null, 2), "utf-8");
+}
+
+export function getBudgetRemaining(): number {
+  const state = readBudget();
+  return BUDGET_CAP_USD - state.cumulative_usd;
+}
+
+export function guardBudget(estimatedCostUsd: number): void {
+  const state = readBudget();
+  const remaining = BUDGET_CAP_USD - state.cumulative_usd;
+
+  if (estimatedCostUsd > remaining) {
+    throw new Error(
+      `Budget guard: estimated cost $${estimatedCostUsd.toFixed(2)} exceeds ` +
+        `remaining budget $${remaining.toFixed(2)} ` +
+        `(cap $${BUDGET_CAP_USD.toFixed(2)}, spent $${state.cumulative_usd.toFixed(2)}). ` +
+        `Delete scripts/smoke/output/budget.json to reset.`,
+    );
+  }
+}
+
+export function recordSpend(costUsd: number, description = "smoke run"): void {
+  const state = readBudget();
+  state.cumulative_usd = parseFloat((state.cumulative_usd + costUsd).toFixed(4));
+  state.runs.push({
+    timestamp: new Date().toISOString(),
+    cost_usd: costUsd,
+    description,
+  });
+  writeBudget(state);
+}
+
+export function resetBudget(): void {
+  writeBudget({ cumulative_usd: 0, runs: [] });
+}

--- a/scripts/smoke/client.ts
+++ b/scripts/smoke/client.ts
@@ -1,0 +1,56 @@
+/**
+ * scripts/smoke/client.ts
+ *
+ * Typed fetch wrapper for smoke tests. Reads SMOKE_BASE_URL (default:
+ * https://app.opollo.com) and injects the SMOKE_SESSION_COOKIE if set.
+ *
+ * Usage:
+ *   const res = await smokeGet("/api/platform/social/drafts/123");
+ *   const res = await smokePost("/api/platform/social/drafts", { ... });
+ */
+
+export const SMOKE_BASE_URL =
+  process.env.SMOKE_BASE_URL ?? "https://app.opollo.com";
+
+const SMOKE_SESSION_COOKIE = process.env.SMOKE_SESSION_COOKIE ?? "";
+
+function buildHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...extra,
+  };
+  if (SMOKE_SESSION_COOKIE) {
+    headers["Cookie"] = SMOKE_SESSION_COOKIE;
+  }
+  return headers;
+}
+
+export async function smokeGet(path: string): Promise<Response> {
+  return fetch(`${SMOKE_BASE_URL}${path}`, {
+    method: "GET",
+    headers: buildHeaders(),
+  });
+}
+
+export async function smokePost(path: string, body: unknown): Promise<Response> {
+  return fetch(`${SMOKE_BASE_URL}${path}`, {
+    method: "POST",
+    headers: buildHeaders(),
+    body: JSON.stringify(body),
+  });
+}
+
+export async function smokePatch(path: string, body: unknown): Promise<Response> {
+  return fetch(`${SMOKE_BASE_URL}${path}`, {
+    method: "PATCH",
+    headers: buildHeaders(),
+    body: JSON.stringify(body),
+  });
+}
+
+export async function smokeDelete(path: string): Promise<Response> {
+  return fetch(`${SMOKE_BASE_URL}${path}`, {
+    method: "DELETE",
+    headers: buildHeaders(),
+  });
+}

--- a/scripts/smoke/output/.gitignore
+++ b/scripts/smoke/output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/smoke/test-data.ts
+++ b/scripts/smoke/test-data.ts
@@ -1,0 +1,32 @@
+/**
+ * scripts/smoke/test-data.ts
+ *
+ * Exports smoke test identifiers from environment variables.
+ * Set these before running smoke tests:
+ *
+ *   SMOKE_TEST_COMPANY_ID   — UUID of the test company
+ *   SMOKE_TEST_CONNECTION_ID — UUID of a live social connection for the test company
+ *   SMOKE_CAP_SUBSCRIPTION_ID — UUID of an active CAP subscription (for PR 3.3)
+ */
+
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Missing required env var: ${name}. Set it before running smoke tests.`,
+    );
+  }
+  return value;
+}
+
+export function getTestCompanyId(): string {
+  return requireEnv("SMOKE_TEST_COMPANY_ID");
+}
+
+export function getTestConnectionId(): string {
+  return requireEnv("SMOKE_TEST_CONNECTION_ID");
+}
+
+export function getCapSubscriptionId(): string {
+  return requireEnv("SMOKE_CAP_SUBSCRIPTION_ID");
+}


### PR DESCRIPTION
## Summary

Creates `scripts/smoke/` — a typed harness for programmatic smoke testing of the live production app.

- **`client.ts`**: Typed fetch wrapper reading `SMOKE_BASE_URL` (default `https://app.opollo.com`) with `SMOKE_SESSION_COOKIE` injection
- **`test-data.ts`**: Env-driven test IDs (`SMOKE_TEST_COMPANY_ID`, `SMOKE_TEST_CONNECTION_ID`, `SMOKE_CAP_SUBSCRIPTION_ID`)
- **`assertions.ts`**: `assertStatus(res, expected)`, `assertShape(obj, keys[])`, `assertTruthy(value, msg)`
- **`budget.ts`**: $5 cumulative budget guard — reads `scripts/smoke/output/budget.json`, throws if spend would exceed cap; `recordSpend()` updates the file; `resetBudget()` clears it
- **`output/.gitignore`**: Excludes all run outputs from git
- **`npm run smoke:harness`**: Runs budget unit tests (no real network, no cost)

PRs 3.2 (composer smoke) and 3.3 (CAP smoke) will add smoke test scripts that consume this harness.

## Working analog
None — first smoke harness. Pattern follows `scripts/probes/` style (standalone tsx scripts with typed fetch wrappers).

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] 9 unit tests for budget guard (threshold, overflow, recordSpend, reset)
- [x] No production code changes
- [x] PR is under 500 net lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)