### PR TITLE
docs(hardening): close IDEOGRAM action + mark staging branch created

### DIFF
--- a/docs/briefs/hardening-pass/HARDENING_REPORT.md
+++ b/docs/briefs/hardening-pass/HARDENING_REPORT.md
@@ -8,10 +8,10 @@ Generated: 2026-05-20
 |---|---|---|---|
 | WS1 | CAP backlog — objective template, health events, cron skip | #939 | ✅ merged |
 | WS2 | Wireframe audit + HIGH gap fixes | #940, #941 | ✅ merged |
-| WS3 | Smoke test harness + composer + CAP probes | #942, #943, #944 | CI running / stacked |
-| WS4 | Cost monitoring daily report | #945 | CI running |
-| WS5 | Staging environment scaffold + guards | #946 | CI running |
-| WS6 | README + ARCHITECTURE + RUNBOOK | #947 | CI running |
+| WS3 | Smoke test harness + composer + CAP probes | #942, #943, #944 | ✅ #942 #943 merged; #944 (CAP smoke) CI pending |
+| WS4 | Cost monitoring daily report | #945 | ✅ merged |
+| WS5 | Staging environment scaffold + guards | #946 | ✅ merged |
+| WS6 | README + ARCHITECTURE + RUNBOOK | #947 | ✅ merged |
 
 ## What shipped (merged to main)
 
@@ -96,8 +96,10 @@ Generated: 2026-05-20
 
 See `docs/briefs/hardening-pass/STEVEN_ACTIONS.md`:
 
-1. **IDEOGRAM_API_KEY production scope** — confirm `Production` env is checked in Vercel (WS1, image generation in CAP)
-2. **Staging Vercel branch setup** — create `staging` branch, set `APP_ENV=staging`, `STAGING_EMAIL_RECIPIENT` (WS5)
+1. **Staging Vercel env vars** — `staging` branch created 2026-05-20 ✅; add `APP_ENV=staging` and `STAGING_EMAIL_RECIPIENT` for the `staging` branch in Vercel dashboard (WS5)
+
+**Resolved**:
+- ~~**IDEOGRAM_API_KEY production scope**~~ — confirmed Production-scoped in Vercel as of 2026-05-20 ✅
 
 ## Deferred gaps (from wireframe audit)
 

--- a/docs/briefs/hardening-pass/STEVEN_ACTIONS.md
+++ b/docs/briefs/hardening-pass/STEVEN_ACTIONS.md
@@ -6,21 +6,19 @@ Actions that require Steven's manual intervention. Appended as work surfaces the
 
 ## WS5 — Staging environment setup
 
-**When**: after PR #feat/staging-environment-scaffold merges.
+**Branch**: `staging` branch created and pushed to GitHub on 2026-05-20. ✅
 
-**What to do in Vercel**:
+**Remaining action — Vercel env vars** (dashboard only):
 
-1. In the Vercel dashboard for `opollo-site-builder`, go to **Settings → Git → Preview Branches**.
-2. Create a long-lived branch named `staging` in GitHub: `git checkout main && git checkout -b staging && git push origin staging`.
-3. In Vercel → **Settings → Environment Variables**, add the following for the `staging` branch only (under the "Custom Environment" or "Branch Environment" override):
+In Vercel → **Settings → Environment Variables**, add the following for the `staging` branch only (under the "Custom Environment" or "Branch Environment" override):
 
-   | Variable | Value |
-   |---|---|
-   | `APP_ENV` | `staging` |
-   | `STAGING_EMAIL_RECIPIENT` | `hi@opollo.com` (or a dedicated staging inbox) |
-   | `STAGING_SIDE_EFFECTS_ENABLED` | (leave unset — side effects blocked by default) |
+| Variable | Value |
+|---|---|
+| `APP_ENV` | `staging` |
+| `STAGING_EMAIL_RECIPIENT` | `hi@opollo.com` (or a dedicated staging inbox) |
+| `STAGING_SIDE_EFFECTS_ENABLED` | (leave unset — side effects blocked by default) |
 
-4. Vercel will auto-deploy the `staging` branch as a preview URL (e.g. `opollo-site-builder-git-staging-opollo5.vercel.app`). Share that URL with the team as the staging URL.
+Vercel will auto-deploy the `staging` branch as a preview URL (e.g. `opollo-site-builder-git-staging-opollo5.vercel.app`). Share that URL with the team as the staging URL.
 
 **What this gives you**:
 - `isStaging()` returns `true` on the staging branch.
@@ -30,13 +28,5 @@ Actions that require Steven's manual intervention. Appended as work surfaces the
 
 **Optional: dedicated staging Supabase project**
 If you want full data isolation, provision a new Supabase project and override `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL` for the `staging` branch. Then run migrations on it separately.
-
----
-
-## WS1 — IDEOGRAM_API_KEY in production
-
-**When**: immediately (image generation in CAP is silently skipped without it).
-
-**What to do**: confirm `IDEOGRAM_API_KEY` is set for the `Production` environment in Vercel (it was added to Development + Preview on 2026-05-19 but may need Production scope). Check: Vercel → Settings → Environment Variables → IDEOGRAM_API_KEY → ensure `Production` is checked.
 
 ---


### PR DESCRIPTION
## Summary

- Remove IDEOGRAM_API_KEY item from STEVEN_ACTIONS.md — confirmed Production-scoped in Vercel 2026-05-20
- Remove staging branch-creation step from STEVEN_ACTIONS.md — `staging` branch pushed to GitHub this session
- HARDENING_REPORT.md: mark WS4/WS5/WS6 merged; update WS5 staging action to Vercel env vars only; resolve IDEOGRAM item

## Remaining Steven action

Only one item remains in STEVEN_ACTIONS.md:
> In Vercel → Settings → Environment Variables, add `APP_ENV=staging` and `STAGING_EMAIL_RECIPIENT` for the `staging` branch.

## Risks identified and mitigated

Docs-only change. No code, no migrations, no env vars. Zero risk.

## Pre-PR checklist

- [x] Lint, typecheck, build all green (docs only — no TS changes)
- [x] No tests required (no code changes)
- [x] PR is under 500 net lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)