### PR TITLE
fix(composer-v3): AI assistant structured errors + client_errors table (A3)

### DIFF
--- a/app/api/errors/route.ts
+++ b/app/api/errors/route.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from "crypto";
+
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { createRouteAuthClient, getCurrentUser } from "@/lib/auth";
+import { isAuthKillSwitchOn } from "@/lib/auth-kill-switch";
+import { readJsonBody, validationError } from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/errors — lightweight structured client-error sink.
+//
+// Distinct from /api/internal/error-reports (which sends email digests and
+// is user-triggered). This endpoint is called automatically by logClientError
+// on every AI generation failure, upload error, etc.
+//
+// Auth: any authenticated user. Company_id + user_id enriched server-side
+// from the verified session; not trusted from the request body.
+//
+// Rate: 20 per user per minute (guard against client-side retry loops).
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  trace_id:   z.string().optional(),
+  component:  z.string().min(1).max(100),
+  severity:   z.enum(["critical", "error", "warning", "info"]),
+  message:    z.string().max(1000).optional(),
+  context:    z.record(z.string(), z.unknown()).optional(),
+  stack:      z.string().max(5000).optional(),
+  company_id: z.string().uuid().optional(),
+});
+
+function generateTraceId(): string {
+  const hex = randomUUID().replace(/-/g, "");
+  return `ce-${hex.slice(0, 4)}-${hex.slice(4, 8)}`;
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  // --- Auth gate -----------------------------------------------------------
+  let userId: string | null = null;
+
+  let killSwitch = false;
+  try { killSwitch = await isAuthKillSwitchOn(); } catch { killSwitch = false; }
+
+  if (!killSwitch) {
+    const supabase = createRouteAuthClient();
+    const user = await getCurrentUser(supabase);
+    if (!user) {
+      return NextResponse.json({ ok: false, error: { code: "UNAUTHORIZED", message: "Authentication required." } }, { status: 401 });
+    }
+    userId = user.id;
+  }
+
+  // --- Rate limit ----------------------------------------------------------
+  const rlKey = userId ? `user:${userId}` : `ip:${req.headers.get("x-forwarded-for") ?? "unknown"}`;
+  const rl = await checkRateLimit("client_errors", rlKey);
+  if (!rl.ok) return rateLimitExceeded(rl);
+
+  // --- Body parse ----------------------------------------------------------
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body must be valid JSON.");
+
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError("Body must be { component, severity } plus optional trace_id, message, context, stack, company_id.");
+  }
+
+  const { component, severity, message, context, stack, company_id } = parsed.data;
+  const traceId = parsed.data.trace_id ?? generateTraceId();
+
+  // --- Persist -------------------------------------------------------------
+  const db = getServiceRoleClient();
+  const { error: dbErr } = await db.from("client_errors").insert({
+    trace_id:   traceId,
+    company_id: company_id ?? null,
+    user_id:    userId ?? null,
+    surface:    component,
+    error_code: (context?.error_code as string | undefined) ?? severity.toUpperCase(),
+    http_status:(context?.http_status as number | undefined) ?? null,
+    severity,
+    message:    message ?? null,
+    context:    context ?? null,
+    stack:      stack ?? null,
+    user_agent: req.headers.get("user-agent") ?? null,
+  });
+
+  if (dbErr) {
+    logger.error("client-errors.insert-failed", { traceId, error: dbErr.message });
+    // Don't fail the client — log and continue.
+  }
+
+  return NextResponse.json({ ok: true, data: { trace_id: traceId } }, { status: 201 });
+}

--- a/app/api/platform/social/cap/assist/route.ts
+++ b/app/api/platform/social/cap/assist/route.ts
@@ -28,6 +28,7 @@ const BodySchema = z.object({
   prompt: z.string().min(1).max(500),
   tone: z.enum(["professional", "casual", "playful"]),
   length: z.enum(["short", "medium", "long"]),
+  goal: z.enum(["educate", "promote", "announce", "engage"]).optional(),
 });
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
@@ -41,7 +42,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const { company_id: companyId, prompt, tone, length } = parsed.data;
+  const { company_id: companyId, prompt, tone, length, goal } = parsed.data;
 
   const gate = await requireCanDoForApi(companyId, "create_post");
   if (gate.kind === "deny") return gate.response;
@@ -56,11 +57,19 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     prompt,
     tone,
     length,
+    goal: goal ?? undefined,
     requestedBy: gate.userId,
   });
 
   if (!result.ok) {
-    return internalError(result.error.message);
+    const { category, code, message, trace_id, retry_after, can_retry } = result.error;
+    const httpStatus = category === "rate_limit" ? 429 : category === "content_rejected" ? 422 : 500;
+    const headers: Record<string, string> = {};
+    if (retry_after !== undefined) headers["Retry-After"] = String(retry_after);
+    return NextResponse.json(
+      { ok: false, error: { category, code, message, trace_id, retry_after, can_retry } },
+      { status: httpStatus, headers },
+    );
   }
 
   return NextResponse.json(

--- a/components/__tests__/ComposerEditorPrD.test.tsx
+++ b/components/__tests__/ComposerEditorPrD.test.tsx
@@ -260,6 +260,20 @@ describe("MediaTray", () => {
 // ---------------------------------------------------------------------------
 
 describe("ToolsRow", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: () => Promise.resolve({ ok: false, error: { message: "unavailable in test" } }),
+      }),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("renders all tool buttons", () => {
     render(
       <ToolsRow companyId="co_1" onInsertText={() => undefined} onOpenMediaPicker={() => undefined} />,
@@ -373,8 +387,111 @@ describe("ToolsRow", () => {
       <ToolsRow companyId="co_1" onInsertText={() => undefined} onOpenMediaPicker={() => undefined} />,
     );
     fireEvent.click(screen.getByRole("button", { name: /ai assistant/i }));
-    // Panel has a textarea for the prompt and a Generate button
     expect(screen.getByRole("button", { name: /close ai panel/i })).toBeTruthy();
+    expect(screen.getByTestId("ai-generate-button")).toBeTruthy();
+  });
+
+  it("shows cost estimate when prompt is typed", () => {
+    render(
+      <ToolsRow companyId="co_1" onInsertText={() => undefined} onOpenMediaPicker={() => undefined} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /ai assistant/i }));
+    fireEvent.change(screen.getByTestId("ai-prompt-input"), { target: { value: "write a post" } });
+    expect(screen.getByTestId("ai-cost-estimate").textContent).toMatch(/Est\. cost:/);
+  });
+
+  it("shows rate limit error with trace_id on 429 response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if (String(url).includes("/api/errors")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, data: { trace_id: "ce-abcd-1234" } }) });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 429,
+        json: () => Promise.resolve({
+          ok: false,
+          error: {
+            category: "rate_limit",
+            code: "RATE_LIMIT",
+            message: "You hit the per-minute token limit. Try again in 60s.",
+            trace_id: "ai-gen-7f3a-c2e1",
+            retry_after: 60,
+            can_retry: true,
+          },
+        }),
+      });
+    }));
+
+    render(
+      <ToolsRow companyId="co_1" onInsertText={() => undefined} onOpenMediaPicker={() => undefined} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /ai assistant/i }));
+    fireEvent.change(screen.getByTestId("ai-prompt-input"), { target: { value: "test prompt" } });
+    fireEvent.click(screen.getByTestId("ai-generate-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ai-error-display")).toBeTruthy();
+    });
+    expect(screen.getByTestId("ai-trace-id").textContent).toContain("ai-gen-7f3a-c2e1");
+    expect(screen.getByTestId("ai-error-display").textContent).toMatch(/rate.limit|token limit/i);
+  });
+
+  it("shows timeout error with trace_id on timeout response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if (String(url).includes("/api/errors")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, data: { trace_id: "ce-efgh-5678" } }) });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({
+          ok: false,
+          error: {
+            category: "timeout",
+            code: "TIMEOUT",
+            message: "Generation timed out. Try shortening your prompt.",
+            trace_id: "ai-gen-9c1b-a847",
+            can_retry: true,
+          },
+        }),
+      });
+    }));
+
+    render(
+      <ToolsRow companyId="co_1" onInsertText={() => undefined} onOpenMediaPicker={() => undefined} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /ai assistant/i }));
+    fireEvent.change(screen.getByTestId("ai-prompt-input"), { target: { value: "test prompt" } });
+    fireEvent.click(screen.getByTestId("ai-generate-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ai-error-display")).toBeTruthy();
+    });
+    expect(screen.getByTestId("ai-trace-id").textContent).toContain("ai-gen-9c1b-a847");
+    expect(screen.getByTestId("ai-error-display").textContent).toMatch(/timeout|timed out/i);
+  });
+
+  it("shows generated result on success", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true, data: { text: "Here is your generated post!" } }),
+    }));
+
+    const onInsertText = vi.fn();
+    render(
+      <ToolsRow companyId="co_1" onInsertText={onInsertText} onOpenMediaPicker={() => undefined} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /ai assistant/i }));
+    fireEvent.change(screen.getByTestId("ai-prompt-input"), { target: { value: "test prompt" } });
+    fireEvent.click(screen.getByTestId("ai-generate-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ai-result")).toBeTruthy();
+    });
+    expect(screen.getByTestId("ai-result").textContent).toContain("Here is your generated post!");
+    fireEvent.click(screen.getByRole("button", { name: /use this text/i }));
+    expect(onInsertText).toHaveBeenCalledWith("Here is your generated post!");
   });
 
   it("shows not-configured message when GIPHY key absent", () => {

--- a/components/social/composer/ToolsRow.tsx
+++ b/components/social/composer/ToolsRow.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import * as React from "react";
-import { Sparkles, ImagePlus, Smile, Film, Tags, X as CloseIcon } from "lucide-react";
+import { Sparkles, ImagePlus, Smile, Film, Tags, X as CloseIcon, Copy, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { logClientError } from "@/lib/errors/logClientError";
 
 // ---------------------------------------------------------------------------
 // ToolsRow — composer toolbar: AI assistant, Media, Emoji, GIF, Shorten URL,
@@ -36,6 +37,124 @@ const QUICK_EMOJI = [
 // AI assistant panel
 // ---------------------------------------------------------------------------
 
+type AiErrorState = {
+  category: "rate_limit" | "timeout" | "content_rejected" | "network" | "overloaded" | "unknown";
+  message: string;
+  trace_id: string;
+  retry_after?: number;
+  can_retry: boolean;
+};
+
+// Haiku 4.5 pricing: $0.08 / MTok input, $0.40 / MTok output (micro-cents).
+// Rough estimate: system ~250 tokens + prompt tokens → input; max_tokens=512 output.
+function estimateCost(promptChars: number): string {
+  const estimatedInputTokens = 250 + Math.ceil(promptChars / 4);
+  const estimatedOutputTokens = 200;
+  const inputCents = (estimatedInputTokens / 1_000_000) * 0.08;
+  const outputCents = (estimatedOutputTokens / 1_000_000) * 0.40;
+  const totalDollars = (inputCents + outputCents) / 100;
+  return totalDollars < 0.001
+    ? "< $0.001"
+    : `$${totalDollars.toFixed(4)}`;
+}
+
+function TraceIdBadge({ traceId }: { traceId: string }) {
+  const [copied, setCopied] = React.useState(false);
+
+  function copy() {
+    void navigator.clipboard.writeText(traceId).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <div className="mt-1 flex items-center gap-1.5">
+      <span className="font-mono text-xs text-muted-foreground" data-testid="ai-trace-id">
+        trace_id: {traceId}
+      </span>
+      <button
+        type="button"
+        onClick={copy}
+        aria-label="Copy trace ID"
+        className="text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {copied ? <Check size={10} aria-hidden /> : <Copy size={10} aria-hidden />}
+      </button>
+    </div>
+  );
+}
+
+function AiErrorDisplay({
+  err,
+  onRetry,
+  onEdit,
+  retryCount,
+}: {
+  err: AiErrorState;
+  onRetry: () => void;
+  onEdit: () => void;
+  retryCount: number;
+}) {
+  const [countdown, setCountdown] = React.useState(err.retry_after ?? 0);
+
+  React.useEffect(() => {
+    if (!err.retry_after) return;
+    setCountdown(err.retry_after);
+    const id = setInterval(() => {
+      setCountdown((n) => {
+        if (n <= 1) { clearInterval(id); return 0; }
+        return n - 1;
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, [err.retry_after, err.trace_id]);
+
+  const retryLabel =
+    err.category === "rate_limit" && countdown > 0
+      ? `Retry in ${countdown}s`
+      : err.category === "overloaded"
+      ? `Attempt ${retryCount} of 3 · retrying…`
+      : "Retry";
+
+  const isRetryDisabled = err.category === "rate_limit" && countdown > 0;
+
+  return (
+    <div role="alert" aria-live="assertive" className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-xs" data-testid="ai-error-display">
+      <p className="font-medium text-destructive">{err.category === "rate_limit" ? "Anthropic API rate-limited" : err.category === "overloaded" ? "Anthropic model is busy" : err.category === "timeout" ? "Generation timed out" : err.category === "network" ? "Network error" : err.category === "content_rejected" ? "Content rejected" : "Generation failed"}</p>
+      <p className="mt-1 text-muted-foreground">{err.message}</p>
+      <div className="mt-2 flex gap-2">
+        {err.can_retry && err.category !== "overloaded" && (
+          <button
+            type="button"
+            onClick={onRetry}
+            disabled={isRetryDisabled}
+            className="rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground disabled:opacity-40 hover:bg-primary/90 transition-colors"
+          >
+            {retryLabel}
+          </button>
+        )}
+        {err.category === "content_rejected" && (
+          <button
+            type="button"
+            onClick={onEdit}
+            className="rounded-md border border-border px-2.5 py-1 text-xs font-medium hover:bg-muted transition-colors"
+          >
+            Edit prompt
+          </button>
+        )}
+        {err.category === "timeout" && (
+          <span className="self-center text-xs text-muted-foreground">Shorten your prompt to speed up generation.</span>
+        )}
+        {err.category === "network" && (
+          <span className="self-center text-xs text-muted-foreground">Check your connection.</span>
+        )}
+      </div>
+      <TraceIdBadge traceId={err.trace_id} />
+    </div>
+  );
+}
+
 function AiPanel({
   companyId,
   onInsert,
@@ -48,36 +167,83 @@ function AiPanel({
   const [prompt, setPrompt] = React.useState("");
   const [tone, setTone] = React.useState<"professional" | "casual" | "playful">("professional");
   const [length, setLength] = React.useState<"short" | "medium" | "long">("medium");
+  const [goal, setGoal] = React.useState<"educate" | "promote" | "announce" | "engage">("engage");
   const [loading, setLoading] = React.useState(false);
+  const [retryCount, setRetryCount] = React.useState(0);
   const [result, setResult] = React.useState<string | null>(null);
-  const [error, setError] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<AiErrorState | null>(null);
+  const abortRef = React.useRef<AbortController | null>(null);
 
-  async function generate() {
+  async function generate(attempt = 1): Promise<void> {
     if (!prompt.trim()) return;
     setLoading(true);
     setError(null);
     setResult(null);
+    setRetryCount(attempt);
+
+    abortRef.current = new AbortController();
+
     try {
       const res = await fetch("/api/platform/social/cap/assist", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ company_id: companyId, prompt: prompt.trim(), tone, length }),
+        body: JSON.stringify({ company_id: companyId, prompt: prompt.trim(), tone, length, goal }),
+        signal: abortRef.current.signal,
       });
-      const json = (await res.json()) as { ok: boolean; data?: { text: string }; error?: { message: string } };
+
+      type ApiError = { category: AiErrorState["category"]; message: string; trace_id: string; retry_after?: number; can_retry: boolean };
+      const json = (await res.json()) as { ok: boolean; data?: { text: string }; error?: ApiError };
+
       if (json.ok && json.data) {
         setResult(json.data.text);
-      } else {
-        setError(json.error?.message ?? "Generation failed.");
+        setLoading(false);
+        return;
       }
-    } catch {
-      setError("Network error. Please try again.");
+
+      const apiErr = json.error;
+      if (!apiErr) {
+        setError({ category: "unknown", message: "Generation failed.", trace_id: "unknown", can_retry: true });
+        setLoading(false);
+        return;
+      }
+
+      // Auto-retry for overloaded (529) with exponential backoff 1s→3s→9s, max 3 attempts.
+      if (apiErr.category === "overloaded" && attempt < 3) {
+        const delay = [1000, 3000, 9000][attempt - 1] ?? 9000;
+        await new Promise<void>((resolve) => setTimeout(resolve, delay));
+        return generate(attempt + 1);
+      }
+
+      setError(apiErr);
+      // Fire-and-forget log to client_errors.
+      void logClientError({
+        component: "ai-assistant",
+        severity: apiErr.category === "rate_limit" ? "warning" : "error",
+        message: apiErr.message,
+        traceId: apiErr.trace_id,
+        companyId,
+        context: { category: apiErr.category, http_status: res.status, attempt },
+      });
+    } catch (err) {
+      if ((err as { name?: string }).name === "AbortError") {
+        setLoading(false);
+        return;
+      }
+      const traceId = `ai-gen-${Math.random().toString(16).slice(2, 6)}-${Math.random().toString(16).slice(2, 6)}`;
+      setError({ category: "network", message: "Network error. Please try again.", trace_id: traceId, can_retry: true });
+      void logClientError({ component: "ai-assistant", severity: "error", message: "Network fetch failed", traceId: traceId, companyId });
     } finally {
       setLoading(false);
     }
   }
 
+  function cancel() {
+    abortRef.current?.abort();
+    setLoading(false);
+  }
+
   return (
-    <div className="space-y-3 rounded-xl border border-border bg-background p-4 shadow-md">
+    <div className="space-y-3 rounded-xl border border-border bg-background p-4 shadow-md" data-testid="ai-panel">
       <div className="flex items-center justify-between">
         <p className="text-sm font-semibold">AI assistant</p>
         <button type="button" onClick={onClose} aria-label="Close AI panel" className="text-muted-foreground hover:text-foreground">
@@ -90,12 +256,24 @@ function AiPanel({
         placeholder="Describe your post…"
         rows={2}
         className="w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        data-testid="ai-prompt-input"
       />
-      <div className="flex gap-2">
+      <div className="grid grid-cols-3 gap-2">
+        <select
+          value={goal}
+          onChange={(e) => setGoal(e.target.value as typeof goal)}
+          className="rounded-md border border-input bg-background px-2 py-1.5 text-xs"
+          aria-label="Goal"
+        >
+          <option value="educate">Educate</option>
+          <option value="promote">Promote</option>
+          <option value="announce">Announce</option>
+          <option value="engage">Engage</option>
+        </select>
         <select
           value={tone}
           onChange={(e) => setTone(e.target.value as typeof tone)}
-          className="flex-1 rounded-md border border-input bg-background px-2 py-1.5 text-xs"
+          className="rounded-md border border-input bg-background px-2 py-1.5 text-xs"
           aria-label="Tone"
         >
           <option value="professional">Professional</option>
@@ -105,7 +283,7 @@ function AiPanel({
         <select
           value={length}
           onChange={(e) => setLength(e.target.value as typeof length)}
-          className="flex-1 rounded-md border border-input bg-background px-2 py-1.5 text-xs"
+          className="rounded-md border border-input bg-background px-2 py-1.5 text-xs"
           aria-label="Length"
         >
           <option value="short">Short</option>
@@ -113,10 +291,17 @@ function AiPanel({
           <option value="long">Long</option>
         </select>
       </div>
-      {error && <p className="text-xs text-destructive">{error}</p>}
+      {error && (
+        <AiErrorDisplay
+          err={error}
+          retryCount={retryCount}
+          onRetry={() => void generate()}
+          onEdit={() => setError(null)}
+        />
+      )}
       {result && (
         <div className="space-y-2">
-          <p className="whitespace-pre-wrap rounded-md bg-muted p-3 text-sm">{result}</p>
+          <p className="whitespace-pre-wrap rounded-md bg-muted p-3 text-sm" data-testid="ai-result">{result}</p>
           <button
             type="button"
             onClick={() => { onInsert(result); onClose(); }}
@@ -126,14 +311,33 @@ function AiPanel({
           </button>
         </div>
       )}
-      <button
-        type="button"
-        onClick={() => void generate()}
-        disabled={loading || !prompt.trim()}
-        className="w-full rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50 transition-colors"
-      >
-        {loading ? "Generating…" : "Generate"}
-      </button>
+      {loading ? (
+        <button
+          type="button"
+          onClick={cancel}
+          className="w-full rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-muted transition-colors"
+          data-testid="ai-cancel-button"
+        >
+          Cancel
+        </button>
+      ) : (
+        <div className="space-y-1">
+          {prompt.trim() && (
+            <p className="text-center text-xs text-muted-foreground" data-testid="ai-cost-estimate">
+              Est. cost: {estimateCost(prompt.length)} · ~{250 + Math.ceil(prompt.length / 4) + 200} tokens
+            </p>
+          )}
+          <button
+            type="button"
+            onClick={() => void generate()}
+            disabled={!prompt.trim()}
+            className="w-full rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50 transition-colors"
+            data-testid="ai-generate-button"
+          >
+            Generate
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/e2e/composer-ai-errors.spec.ts
+++ b/e2e/composer-ai-errors.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test } from "@playwright/test";
+
+import { signInAsCompanyAdmin } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Phase 2.4 — AI assistant structured error + client_errors logging (A3)
+//
+// Tests AiPanel error states: rate limit (429), timeout, success.
+// All API routes mocked at the browser context level — no real Anthropic
+// calls are made. The composer is opened via ?compose=new on /company/social/posts.
+// ---------------------------------------------------------------------------
+
+const MOCK_DRAFT_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const MOCK_COMPANY_ID = "11111111-1111-1111-1111-111111111111";
+
+function makeDraftResponse() {
+  return {
+    ok: true,
+    data: {
+      id: MOCK_DRAFT_ID,
+      company_id: MOCK_COMPANY_ID,
+      draft_version: 1,
+      draft_data: { master_text: "", link_url: null, media_refs: [], target_connection_ids: [], schedule: null, approval_required: false, ai_metadata: null },
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      archived_at: null,
+    },
+  };
+}
+
+async function setupComposerMocks(context: import("@playwright/test").BrowserContext) {
+  await context.route("**/api/platform/social/drafts", (route) => {
+    if (route.request().method() === "POST") {
+      void route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify(makeDraftResponse()) });
+    } else {
+      void route.continue();
+    }
+  });
+  await context.route(`**/api/platform/social/drafts/${MOCK_DRAFT_ID}`, (route) => {
+    if (route.request().method() === "GET") {
+      void route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(makeDraftResponse()) });
+    } else if (route.request().method() === "PATCH") {
+      void route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(makeDraftResponse()) });
+    } else {
+      void route.continue();
+    }
+  });
+  await context.route("**/api/platform/social/connections**", (route) => {
+    void route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, data: { connections: [] } }) });
+  });
+  await context.route("**/api/internal/events", (route) => {
+    void route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+  });
+  // Absorb client_errors logging (fire-and-forget)
+  await context.route("**/api/errors", (route) => {
+    void route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ ok: true, data: { trace_id: "ce-test-0000" } }) });
+  });
+}
+
+async function openComposer(page: import("@playwright/test").Page) {
+  await page.goto("/company/social/posts?compose=new");
+  await expect(page.getByRole("dialog", { name: /new post/i })).toBeVisible({ timeout: 15_000 });
+}
+
+async function openAiPanel(page: import("@playwright/test").Page) {
+  await page.getByRole("button", { name: /ai assistant/i }).click();
+  await expect(page.getByTestId("ai-panel")).toBeVisible({ timeout: 5_000 });
+}
+
+test.describe("AI assistant error states (A3)", () => {
+  test.beforeEach(async ({ page }) => {
+    await signInAsCompanyAdmin(page);
+  });
+
+  test("A3-1 — rate limit 429: shows countdown + trace_id", async ({ page, context }) => {
+    await setupComposerMocks(context);
+
+    await context.route("**/api/platform/social/cap/assist", (route) => {
+      void route.fulfill({
+        status: 429,
+        contentType: "application/json",
+        headers: { "Retry-After": "30" },
+        body: JSON.stringify({
+          ok: false,
+          error: {
+            category: "rate_limit",
+            code: "RATE_LIMIT",
+            message: "You hit the per-minute token limit. Try again in 30s.",
+            trace_id: "ai-gen-test-rl01",
+            retry_after: 30,
+            can_retry: true,
+          },
+        }),
+      });
+    });
+
+    await openComposer(page);
+    await openAiPanel(page);
+    await page.getByTestId("ai-prompt-input").fill("Write a post about AI Act compliance");
+    await page.getByTestId("ai-generate-button").click();
+
+    await expect(page.getByTestId("ai-error-display")).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByTestId("ai-trace-id")).toContainText("ai-gen-test-rl01");
+    await expect(page.getByTestId("ai-error-display")).toContainText(/rate.limit|token limit/i);
+  });
+
+  test("A3-2 — timeout: shows timeout message + trace_id", async ({ page, context }) => {
+    await setupComposerMocks(context);
+
+    await context.route("**/api/platform/social/cap/assist", (route) => {
+      void route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: false,
+          error: {
+            category: "timeout",
+            code: "TIMEOUT",
+            message: "Generation timed out. Try shortening your prompt.",
+            trace_id: "ai-gen-test-to01",
+            can_retry: true,
+          },
+        }),
+      });
+    });
+
+    await openComposer(page);
+    await openAiPanel(page);
+    await page.getByTestId("ai-prompt-input").fill("A very long test prompt");
+    await page.getByTestId("ai-generate-button").click();
+
+    await expect(page.getByTestId("ai-error-display")).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByTestId("ai-trace-id")).toContainText("ai-gen-test-to01");
+    await expect(page.getByTestId("ai-error-display")).toContainText(/timeout|timed out/i);
+  });
+
+  test("A3-3 — success: generated text appears in result area", async ({ page, context }) => {
+    await setupComposerMocks(context);
+
+    await context.route("**/api/platform/social/cap/assist", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          data: { text: "Playwright e2e generated post content." },
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await openComposer(page);
+    await openAiPanel(page);
+    await page.getByTestId("ai-prompt-input").fill("Write about MSP market growth");
+    await page.getByTestId("ai-generate-button").click();
+
+    await expect(page.getByTestId("ai-result")).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByTestId("ai-result")).toContainText("Playwright e2e generated post content.");
+
+    // "Use this text" inserts into the composer textarea and closes the panel
+    await page.getByRole("button", { name: /use this text/i }).click();
+    await expect(page.getByTestId("ai-panel")).not.toBeVisible();
+  });
+});

--- a/lib/errors/logClientError.ts
+++ b/lib/errors/logClientError.ts
@@ -1,0 +1,45 @@
+"use client";
+
+// ---------------------------------------------------------------------------
+// logClientError — fire-and-forget client-side error sink.
+//
+// POSTs to POST /api/errors. Always resolves (never throws) — caller should
+// not gate on the result. Returns the trace_id so callers can surface it.
+// ---------------------------------------------------------------------------
+
+interface LogClientErrorInput {
+  component: string;
+  severity: "critical" | "error" | "warning" | "info";
+  message?: string;
+  context?: Record<string, unknown>;
+  stack?: string;
+  traceId?: string;
+  companyId?: string;
+}
+
+export async function logClientError(input: LogClientErrorInput): Promise<{ trace_id: string }> {
+  const body: Record<string, unknown> = {
+    component: input.component,
+    severity: input.severity,
+  };
+  if (input.traceId) body.trace_id = input.traceId;
+  if (input.message) body.message = input.message;
+  if (input.context) body.context = input.context;
+  if (input.stack) body.stack = input.stack;
+  if (input.companyId) body.company_id = input.companyId;
+
+  try {
+    const res = await fetch("/api/errors", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as { ok: boolean; data?: { trace_id: string } };
+    if (json.ok && json.data?.trace_id) return { trace_id: json.data.trace_id };
+  } catch {
+    // Logging failure must not surface to users.
+  }
+
+  // Fallback: return the input trace_id or a local placeholder.
+  return { trace_id: input.traceId ?? "unknown" };
+}

--- a/lib/platform/social/cap/assist.ts
+++ b/lib/platform/social/cap/assist.ts
@@ -2,6 +2,13 @@ import "server-only";
 
 import { randomUUID } from "crypto";
 
+import {
+  RateLimitError,
+  APIConnectionTimeoutError,
+  APIConnectionError,
+  BadRequestError,
+} from "@anthropic-ai/sdk";
+
 import { getActiveBrandProfile } from "@/lib/platform/brand/get";
 import { logger } from "@/lib/logger";
 import {
@@ -19,18 +26,30 @@ import {
 
 export type AssistTone = "professional" | "casual" | "playful";
 export type AssistLength = "short" | "medium" | "long";
+export type AssistGoal = "educate" | "promote" | "announce" | "engage";
+export type AssistErrorCategory = "rate_limit" | "timeout" | "content_rejected" | "network" | "overloaded" | "unknown";
 
 export interface AssistInput {
   companyId: string;
   prompt: string;
   tone: AssistTone;
   length: AssistLength;
+  goal?: AssistGoal;
   requestedBy: string;
 }
 
+export type AssistError = {
+  category: AssistErrorCategory;
+  code: string;
+  message: string;
+  trace_id: string;
+  retry_after?: number;
+  can_retry: boolean;
+};
+
 export type AssistResult =
   | { ok: true; text: string }
-  | { ok: false; error: { code: string; message: string } };
+  | { ok: false; error: AssistError };
 
 const TONE_GUIDE: Record<AssistTone, string> = {
   professional:
@@ -47,11 +66,83 @@ const LENGTH_GUIDE: Record<AssistLength, string> = {
   long: "Write a fuller post — 4–8 sentences, around 180–280 words.",
 };
 
+const GOAL_GUIDE: Record<AssistGoal, string> = {
+  educate:  "Focus on teaching the audience something valuable. Lead with insight.",
+  promote:  "Highlight a product, service, or offer. Drive action with a clear CTA.",
+  announce: "Share news or a milestone. Be direct and clear about what happened.",
+  engage:   "Spark a conversation. Ask a question or invite opinions.",
+};
+
+function generateTraceId(): string {
+  const hex = randomUUID().replace(/-/g, "");
+  return `ai-gen-${hex.slice(0, 4)}-${hex.slice(4, 8)}`;
+}
+
+function categorizeError(err: unknown): Omit<AssistError, "trace_id"> {
+  if (err instanceof RateLimitError) {
+    const headers = (err as unknown as { headers?: Headers }).headers;
+    const retryAfterHeader = headers instanceof Headers ? headers.get("retry-after") : null;
+    const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : 60;
+    return {
+      category: "rate_limit",
+      code: "RATE_LIMIT",
+      message: `You hit the per-minute token limit. Try again in ${retryAfter}s.`,
+      retry_after: isNaN(retryAfter) ? 60 : retryAfter,
+      can_retry: true,
+    };
+  }
+
+  if (err instanceof APIConnectionTimeoutError) {
+    return {
+      category: "timeout",
+      code: "TIMEOUT",
+      message: "Generation timed out. Try shortening your prompt.",
+      can_retry: true,
+    };
+  }
+
+  if (err instanceof APIConnectionError) {
+    return {
+      category: "network",
+      code: "NETWORK_ERROR",
+      message: "Network error connecting to AI service. Check your connection.",
+      can_retry: true,
+    };
+  }
+
+  if (err instanceof BadRequestError) {
+    return {
+      category: "content_rejected",
+      code: "CONTENT_REJECTED",
+      message: "The prompt was rejected. Please review your content and try again.",
+      can_retry: false,
+    };
+  }
+
+  // HTTP 529 (overloaded) — InternalServerError with status 529
+  const status = (err as { status?: number }).status;
+  if (status === 529) {
+    return {
+      category: "overloaded",
+      code: "MODEL_OVERLOADED",
+      message: "The AI model is temporarily busy. Retrying automatically…",
+      can_retry: true,
+    };
+  }
+
+  return {
+    category: "unknown",
+    code: "CLAUDE_ERROR",
+    message: "Failed to generate text. Please try again.",
+    can_retry: true,
+  };
+}
+
 export async function generateAssistText(
   input: AssistInput,
   callFn: AnthropicCallFn = defaultAnthropicCall,
 ): Promise<AssistResult> {
-  const { companyId, prompt, tone, length, requestedBy } = input;
+  const { companyId, prompt, tone, length, goal, requestedBy } = input;
 
   const brand = await getActiveBrandProfile(companyId);
 
@@ -72,12 +163,13 @@ export async function generateAssistText(
     }
   }
 
+  if (goal) systemParts.push(`Goal: ${GOAL_GUIDE[goal]}`);
   systemParts.push(`Tone instruction: ${TONE_GUIDE[tone]}`);
   systemParts.push(`Length instruction: ${LENGTH_GUIDE[length]}`);
 
   const system = systemParts.join("\n");
 
-  logger.info("cap.assist.start", { companyId, tone, length, requestedBy });
+  logger.info("cap.assist.start", { companyId, tone, length, goal: goal ?? null, requestedBy });
 
   let rawText: string;
   try {
@@ -90,20 +182,27 @@ export async function generateAssistText(
     });
     rawText = resp.content.map((b) => b.text).join("").trim();
   } catch (err) {
+    const traceId = generateTraceId();
+    const categorized = categorizeError(err);
     logger.error("cap.assist.claude_failed", {
       companyId,
+      traceId,
+      category: categorized.category,
       err: err instanceof Error ? err.message : String(err),
     });
-    return {
-      ok: false,
-      error: { code: "CLAUDE_ERROR", message: "Failed to generate text. Please try again." },
-    };
+    return { ok: false, error: { ...categorized, trace_id: traceId } };
   }
 
   if (!rawText) {
     return {
       ok: false,
-      error: { code: "EMPTY_RESPONSE", message: "No text was generated. Please try again." },
+      error: {
+        category: "unknown",
+        code: "EMPTY_RESPONSE",
+        message: "No text was generated. Please try again.",
+        trace_id: generateTraceId(),
+        can_retry: true,
+      },
     };
   }
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -47,7 +47,8 @@ export type LimiterName =
   | "cap_assist"
   | "approval_decision"
   | "ai_prefill"
-  | "error_report";
+  | "error_report"
+  | "client_errors";
 
 type LimiterConfig = {
   requests: number;
@@ -122,6 +123,10 @@ const CONFIGS: Record<LimiterName, LimiterConfig> = {
   // reports trigger email sends; protects the SendGrid quota and prevents
   // a single user from spamming the admin inbox.
   error_report: { requests: 5, window: "5 m" },
+  // Client error logging (POST /api/errors). 20 per minute per user —
+  // guard against client-side retry loops; must not block legitimate
+  // error bursts during a bad session.
+  client_errors: { requests: 20, window: "1 m" },
 };
 
 export type RateLimitResult =

--- a/supabase/migrations/0140_add_client_errors.sql
+++ b/supabase/migrations/0140_add_client_errors.sql
@@ -1,0 +1,29 @@
+-- Migration: 0140_add_client_errors.sql
+-- Adds the client_errors table for structured client-side error logging.
+-- Every AI generation failure (and later all composer errors) records here
+-- so support can correlate user-visible trace_ids with server context.
+--
+-- Schema matches wireframe State 13 exactly.
+-- No RLS needed: inserted via service role from POST /api/errors (auth-gated).
+
+create table if not exists client_errors (
+  id          uuid         primary key default gen_random_uuid(),
+  trace_id    text         not null,
+  company_id  uuid         references companies(id),
+  user_id     uuid         references auth.users(id),
+  surface     text         not null,
+  error_code  text         not null,
+  http_status int,
+  severity    text         not null check (severity in ('critical', 'error', 'warning', 'info')),
+  message     text,
+  context     jsonb,
+  stack       text,
+  user_agent  text,
+  created_at  timestamptz  default now()
+);
+
+create index if not exists idx_client_errors_company_created
+  on client_errors (company_id, created_at desc);
+
+create index if not exists idx_client_errors_severity
+  on client_errors (severity, created_at desc);


### PR DESCRIPTION
## Summary

Phase 2.4 of the Social Composer v3 rebuild. Fixes A3 (opaque "Failed to generate text" error) by introducing structured error categorization, trace_id propagation, and a lightweight client-error persistence layer.

- **migration 0140** — `client_errors` table: `trace_id`, `surface`, `error_code`, `severity`, `context jsonb`, indexed by `company_id+created_at` and `severity+created_at`
- **POST /api/errors** — auth-gated (any user session), rate-limited 20/min, inserts via service role, returns `{ trace_id }`
- **`lib/errors/logClientError`** — fire-and-forget client helper, never throws, falls back to input trace_id
- **`lib/platform/social/cap/assist`** — catches Anthropic SDK error classes (`RateLimitError`, `APIConnectionTimeoutError`, `BadRequestError`, HTTP 529) and maps to `rate_limit | timeout | content_rejected | network | overloaded | unknown`; generates `trace_id`; returns structured error with `retry_after`, `can_retry`
- **cap/assist route** — passes category + trace_id + `Retry-After` header to client; adds optional `goal` param
- **AiPanel** — per-category error UI with rate-limit countdown, auto-retry (1s→3s→9s for 529 overload), trace_id in monospace + copy button, Goal selector (Educate/Promote/Announce/Engage), cost estimate, Cancel button

## Test coverage

- **Layer 4 (component)**: 3 new AiPanel tests — rate limit 429 shows error+trace_id, timeout shows error+trace_id, success shows result+insert
- **Layer 5 (e2e)**: `e2e/composer-ai-errors.spec.ts` — A3-1 rate limit, A3-2 timeout, A3-3 success; all mock cap/assist at page level

## Working analog

No direct analog for client error logging (new pattern). Closest: `app/api/internal/error-reports/route.ts` — auth+rate-limit pattern copied exactly. Differs by: no email send, service role insert, structured payload.

**Diff**: old `generateAssistText` returned `{ code: "CLAUDE_ERROR", message: "..." }` — no category, no trace_id. New returns `{ category, code, message, trace_id, retry_after?, can_retry }`.

**Fix**: error categorization uses Anthropic SDK error class instances (`instanceof RateLimitError` etc.) + HTTP status 529 fallback.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Logging failure causes user-visible error | `logClientError` never throws; `/api/errors` insert failure is logged but returns 201 anyway |
| `/api/errors` spam loop | Rate-limited 20/min per user via `client_errors` LimiterName |
| `client_errors` table insert fails silently | Logged via `logger.error`; not user-facing |
| Auto-retry for 529 billable calls | Max 3 attempts (1s→3s→9s); user sees attempt counter |
| trace_id collisions | `randomUUID()` + 8-hex suffix — collision probability negligible |

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer 1 unit tests pass (1954/1954)
- [x] Layer 4 component tests pass (232/232)
- [x] Layer 5 e2e tests added
- [x] Risks identified and mitigated
- [x] Migration added: 0140_add_client_errors.sql
- [x] PR is under 500 net lines