### PR TITLE
fix(composer): preview card max-w-[480px] cap (PR-A2)

### DIFF
--- a/components/social/composer/PreviewCard.tsx
+++ b/components/social/composer/PreviewCard.tsx
@@ -90,7 +90,7 @@ export function PreviewCard({ platform, content, mediaUrls, connection, classNam
   const profile = { name: connection.account_name, avatarUrl: connection.account_avatar_url };
 
   return (
-    <div className={cn("space-y-2", className)} data-testid="preview-card">
+    <div className={cn("max-w-[480px] mx-auto space-y-2", className)} data-testid="preview-card">
       <p className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
         <span
           className="inline-block h-2 w-2 rounded-full"

--- a/docs/briefs/composer-v3-fixes/DECISION_TRAIL.md
+++ b/docs/briefs/composer-v3-fixes/DECISION_TRAIL.md
@@ -41,7 +41,10 @@ Continues from `docs/briefs/social-composer-v3-rebuild/DECISION_TRAIL.md` (D-001
 
 ## PR-A2 — Preview card max-width (2026-05-21)
 
-*Decision log entries TBD when PR-A2 is built.*
+**D-050**: `max-w-[480px] mx-auto` on PreviewCard wrapper div
+- PreviewCard.tsx line 93 — the outer `<div>` had only `space-y-2` + optional className. No width constraint. Cards stretched to fill the right-pane container (`flex-1`), which grows with the dialog width.
+- Decision: Add `max-w-[480px] mx-auto` to the PreviewCard wrapper. `mx-auto` centers the card in the pane when the pane is wider than 480px. Applied at the PreviewCard layer (not at ComposerOverlay) so the constraint is co-located with the component and applies to all usages (composer right pane + analytics modal).
+- `480px` is not an existing Tailwind token; using arbitrary value `max-w-[480px]`. The design-tokens unit test only checks sub-16px font sizes and hex colors — not flagged.
 
 ---
 

--- a/e2e/composer-preview-card-max-width.spec.ts
+++ b/e2e/composer-preview-card-max-width.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+import { signInAsCompanyAdmin, mockComposerApis } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Spec: preview card max-width cap (PR-A2)
+//
+// The preview card must render at most 480px wide regardless of how wide
+// the right-pane container is. Verifies the max-w-[480px] constraint added
+// to PreviewCard.tsx.
+// ---------------------------------------------------------------------------
+
+const MOCK_LI_CONNECTION = {
+  id: "conn-li-001",
+  platform: "linkedin_company",
+  display_name: "Acme LinkedIn",
+  avatar_url: null,
+  status: "healthy",
+};
+
+test.describe("preview card — max-width cap (A2)", () => {
+  test.beforeEach(async ({ page }) => {
+    await signInAsCompanyAdmin(page);
+  });
+
+  test("PW-1: preview card is at most 480px wide", async ({ page }) => {
+    await mockComposerApis(page, [MOCK_LI_CONNECTION]);
+    await page.goto("/company/social/calendar?compose=new");
+
+    const dialog = page.getByRole("dialog", { name: /new post/i });
+    await expect(dialog).toBeVisible({ timeout: 20_000 });
+
+    // Select the LinkedIn account so the preview card renders.
+    const chip = dialog.getByTestId("profile-chip-conn-li-001");
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+    await chip.click();
+
+    const card = page.getByTestId("preview-card");
+    await expect(card).toBeVisible({ timeout: 5_000 });
+
+    const box = await card.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeLessThanOrEqual(480);
+  });
+
+  test("PW-2: preview card is still visible and not zero-width", async ({ page }) => {
+    await mockComposerApis(page, [MOCK_LI_CONNECTION]);
+    await page.goto("/company/social/calendar?compose=new");
+
+    const dialog = page.getByRole("dialog", { name: /new post/i });
+    await expect(dialog).toBeVisible({ timeout: 20_000 });
+
+    const chip = dialog.getByTestId("profile-chip-conn-li-001");
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+    await chip.click();
+
+    const card = page.getByTestId("preview-card");
+    await expect(card).toBeVisible({ timeout: 5_000 });
+
+    const box = await card.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThan(100);
+  });
+});

--- a/e2e/composer-preview-card-max-width.spec.ts
+++ b/e2e/composer-preview-card-max-width.spec.ts
@@ -12,19 +12,27 @@ import { signInAsCompanyAdmin, mockComposerApis } from "./helpers";
 
 const MOCK_LI_CONNECTION = {
   id: "conn-li-001",
-  platform: "linkedin_company",
-  display_name: "Acme LinkedIn",
-  avatar_url: null,
-  status: "healthy",
+  platform: "linkedin",
+  account_name: "Acme LinkedIn",
+  account_avatar_url: null,
 };
 
 test.describe("preview card — max-width cap (A2)", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, context }) => {
     await signInAsCompanyAdmin(page);
+    await mockComposerApis(context);
+    // page.route() takes priority over context.route() — override connections
+    // to return a single LinkedIn connection so the preview card renders.
+    await page.route("**/api/platform/social/connections**", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { connections: [MOCK_LI_CONNECTION] } }),
+      });
+    });
   });
 
   test("PW-1: preview card is at most 480px wide", async ({ page }) => {
-    await mockComposerApis(page, [MOCK_LI_CONNECTION]);
     await page.goto("/company/social/calendar?compose=new");
 
     const dialog = page.getByRole("dialog", { name: /new post/i });
@@ -44,7 +52,6 @@ test.describe("preview card — max-width cap (A2)", () => {
   });
 
   test("PW-2: preview card is still visible and not zero-width", async ({ page }) => {
-    await mockComposerApis(page, [MOCK_LI_CONNECTION]);
     await page.goto("/company/social/calendar?compose=new");
 
     const dialog = page.getByRole("dialog", { name: /new post/i });


### PR DESCRIPTION
## Summary

- Preview cards previously stretched to fill the right-pane `flex-1` container, growing unboundedly with dialog width
- Added `max-w-[480px] mx-auto` to `PreviewCard.tsx` wrapper div — caps all platform cards at 480px and centers them in wider panes
- Constraint lives at the component layer so it applies to both the composer right pane and the analytics modal

## Working analog

**Working analog**: none found. No other preview/card component in this codebase applies a max-width at the component layer. Closest: shadcn `DialogContent` uses `max-w-lg` at the component level — same pattern applied here.
**New pattern justification**: This is the first preview card width constraint. The brief specifies 480px explicitly.

## Risks identified and mitigated

- **Width regression on narrow viewports**: `mx-auto` is a no-op when container < 480px (card fills available width as normal). No risk.
- **Analytics modal usage**: PreviewCard is also used in the post analytics modal. The 480px cap is appropriate there too — no wider than the modal content area.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (passing pre-commit), test:e2e (new spec PW-1/PW-2)
- [x] For bug fixes: `max-w-[480px] mx-auto` on `PreviewCard.tsx:93` — the diff from "no constraint" to "bounded and centered"
- [x] Risks identified and mitigated
- [x] PR is under 500 net lines