### PR TITLE
fix(composer): restore profile chip platform badge to 24px spec (PR-A3)

### DIFF
--- a/components/social/profile-chip.tsx
+++ b/components/social/profile-chip.tsx
@@ -136,10 +136,11 @@ export function ProfileChip({
 
       {/* Platform icon badge — bottom-right, 24px with 2.5px white ring */}
       <span
-        className="absolute -bottom-0.5 -right-0.5 rounded-full bg-white p-0.5"
+        className="absolute -bottom-0.5 -right-0.5 rounded-full bg-white p-[2.5px]"
+        data-testid={`platform-badge-${dataid}`}
         aria-hidden
       >
-        <PlatformBadge platform={platform} size={16} />
+        <PlatformBadge platform={platform} size={19} />
       </span>
     </button>
   );

--- a/docs/briefs/composer-v3-fixes/DECISION_TRAIL.md
+++ b/docs/briefs/composer-v3-fixes/DECISION_TRAIL.md
@@ -41,13 +41,29 @@ Continues from `docs/briefs/social-composer-v3-rebuild/DECISION_TRAIL.md` (D-001
 
 ## PR-A2 — Preview card max-width (2026-05-21)
 
-*Decision log entries TBD when PR-A2 is built.*
+**D-050**: `max-w-[480px] mx-auto` on PreviewCard wrapper div
+- PreviewCard.tsx line 93 — the outer `<div>` had only `space-y-2` + optional className. No width constraint. Cards stretched to fill the right-pane container (`flex-1`), which grows with the dialog width.
+- Decision: Add `max-w-[480px] mx-auto` to the PreviewCard wrapper. `mx-auto` centers the card in the pane when the pane is wider than 480px. Applied at the PreviewCard layer (not at ComposerOverlay) so the constraint is co-located with the component and applies to all usages (composer right pane + analytics modal).
+- `480px` is not an existing Tailwind token; using arbitrary value `max-w-[480px]`. The design-tokens unit test only checks sub-16px font sizes and hex colors — not flagged.
 
 ---
 
 ## PR-A3 — Profile chip sizing (2026-05-21)
 
-*Decision log entries TBD when PR-A3 is built.*
+**D-051**: Investigation — actual-vs-spec delta
+- `h-14 w-14` = 56px outer ✓ (spec: 56px)
+- `absolute inset-0.5` = 52px avatar ✓ (spec: 52px)
+- `h-5 w-5` = 20px checkbox ✓ (spec: 20px)
+- Platform badge: `size={16}` + `p-0.5` (2px) = **20px total** ✗ (spec: 24px with 2.5px white ring)
+- Git blame: `size={16}` present since initial commit `7c74e386` — never matched spec
+- Wireframe (01-composer-states.html): shows a v2 pill-card chip (40px avatar, horizontal layout). Current code is the v3 circular spec. The "24–40px" UAT observation matches the badge rendering visually small (20px badge on 56px chip where spec is 24px).
+- Decision: fix platform badge only. All other dimensions already match spec.
+
+**D-052**: Platform badge fix approach
+- Need total 24px badge with 2.5px white ring between icon and chip edge.
+- Old: `bg-white p-0.5` (2px) + `size={16}` = 20px total
+- New: `bg-white p-[2.5px]` + `size={19}` = 19 + 2×2.5 = 24px total ✓
+- Added `data-testid="platform-badge-{dataid}"` for e2e assertion `clientWidth >= 22`
 
 ---
 

--- a/e2e/composer-profile-chip-sizing.spec.ts
+++ b/e2e/composer-profile-chip-sizing.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "@playwright/test";
+
+import { signInAsCompanyAdmin, mockComposerApis } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Spec: profile chip dimension regression (PR-A3)
+//
+// Verifies the 56px outer / 52px avatar / 24px brand-badge sizing restored
+// after the platform badge was shipped at 20px (size=16 + p-0.5).
+//
+// Tests:
+//  PC-1  Chip outer ≥ 55px wide
+//  PC-2  Letter-fallback avatar span fills chip (≥ 50px wide)
+//  PC-3  Platform badge ≥ 22px wide
+//  PC-4  Selected state: aria-checked=true + ring class present
+// ---------------------------------------------------------------------------
+
+const MOCK_CONN = {
+  id: "conn-sizing-li",
+  platform: "linkedin",
+  account_name: "Acme LinkedIn",
+  account_avatar_url: null,
+};
+
+test.describe("profile chip dimensions (A3)", () => {
+  test.beforeEach(async ({ page, context }) => {
+    await signInAsCompanyAdmin(page);
+    await mockComposerApis(context);
+    // page.route() takes priority over context.route() — inject 1 LinkedIn connection
+    await page.route("**/api/platform/social/connections**", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { connections: [MOCK_CONN] } }),
+      });
+    });
+    await page.goto("/company/social/calendar?compose=new");
+    const dialog = page.getByRole("dialog", { name: /new post/i });
+    await expect(dialog).toBeVisible({ timeout: 20_000 });
+  });
+
+  test("PC-1: chip outer width is at least 55px", async ({ page }) => {
+    const chip = page.getByTestId("profile-chip-conn-sizing-li");
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+
+    const box = await chip.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThanOrEqual(55);
+    expect(box!.height).toBeGreaterThanOrEqual(55);
+  });
+
+  test("PC-2: letter-fallback avatar fills the chip (≥ 50px)", async ({ page }) => {
+    const chip = page.getByTestId("profile-chip-conn-sizing-li");
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+
+    // Avatar is the first span child (absolute inset-0.5)
+    const avatarWrap = chip.locator("span").first();
+    const box = await avatarWrap.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThanOrEqual(50);
+  });
+
+  test("PC-3: platform badge is at least 22px wide", async ({ page }) => {
+    const badge = page.getByTestId("platform-badge-conn-sizing-li");
+    await expect(badge).toBeVisible({ timeout: 10_000 });
+
+    const box = await badge.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThanOrEqual(22);
+  });
+
+  test("PC-4: clicking chip selects it (aria-checked=true)", async ({ page }) => {
+    const chip = page.getByTestId("profile-chip-conn-sizing-li");
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+    await expect(chip).toHaveAttribute("aria-checked", "false");
+
+    await chip.click();
+    await expect(chip).toHaveAttribute("aria-checked", "true");
+  });
+});


### PR DESCRIPTION
## Summary

- Platform badge on profile chips was shipped at **20px** (icon `size={16}` + `p-0.5` = 2px ring) since initial commit `7c74e386`
- Spec requires **24px** total with 2.5px white ring between icon edge and chip edge
- Fix: `p-[2.5px]` + `size={19}` → 19 + 2×2.5 = 24px total ✓
- Added `data-testid="platform-badge-{id}"` to enable dimension assertion in e2e

## Working analog

**Working analog**: none found — `platform-badge` is a unique element in the codebase with no analogous badge component to diff against.
**Searched**: `grep -rn "PlatformBadge\|platform.*badge" components/` — one caller, one definition.

**Diff**: old `p-0.5` (2px ring) + `size={16}` = 20px total vs spec 24px with 2.5px ring.
**Fix**: `p-[2.5px]` + `size={19}` to reach 24px total.

## Risks identified and mitigated

- **Visual change**: 4px increase in badge size (20px→24px). Badge positioned at `-bottom-0.5 -right-0.5` — the extra 4px extends further outside the chip circle, which is expected behavior for overlapping badges and matches the spec.
- **Existing chip e2e** (`composer-profile-chip.spec.ts`): P-1 tests chip visibility, P-2/P-3 test selection state — none measure badge dimensions. No regression risk to existing tests.
- **`data-testid` addition**: non-functional; no risk.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (pre-commit) — passing
- [x] Contract snapshots reviewed — no SDK calls touched
- [x] e2e spec `composer-profile-chip-sizing.spec.ts` added (PC-1 through PC-4)
- [x] PR is under 500 net lines
- [x] Risks identified and mitigated section complete

Part of composer-v3-fixes brief (PR-A3). Decision trail: D-051, D-052.