### PR TITLE
fix(composer): route 400 Anthropic errors to invalid_request not content_rejected (PR-B1)

### DIFF
--- a/app/api/platform/social/cap/assist/route.ts
+++ b/app/api/platform/social/cap/assist/route.ts
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   if (!result.ok) {
     const { category, code, message, trace_id, retry_after, can_retry } = result.error;
-    const httpStatus = category === "rate_limit" ? 429 : category === "content_rejected" ? 422 : 500;
+    const httpStatus = category === "rate_limit" ? 429 : category === "content_rejected" ? 422 : category === "invalid_request" ? 400 : 500;
     const headers: Record<string, string> = {};
     if (retry_after !== undefined) headers["Retry-After"] = String(retry_after);
     return NextResponse.json(

--- a/components/social/composer/ToolsRow.tsx
+++ b/components/social/composer/ToolsRow.tsx
@@ -39,7 +39,7 @@ type ActivePanel = "ai" | "emoji" | "gif" | "shorten" | "utm" | null;
 // ---------------------------------------------------------------------------
 
 type AiErrorState = {
-  category: "rate_limit" | "timeout" | "content_rejected" | "network" | "overloaded" | "unknown";
+  category: "rate_limit" | "timeout" | "content_rejected" | "invalid_request" | "network" | "overloaded" | "unknown";
   message: string;
   trace_id: string;
   retry_after?: number;
@@ -122,7 +122,7 @@ function AiErrorDisplay({
 
   return (
     <div role="alert" aria-live="assertive" className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-xs" data-testid="ai-error-display">
-      <p className="font-medium text-destructive">{err.category === "rate_limit" ? "Anthropic API rate-limited" : err.category === "overloaded" ? "Anthropic model is busy" : err.category === "timeout" ? "Generation timed out" : err.category === "network" ? "Network error" : err.category === "content_rejected" ? "Content rejected" : "Generation failed"}</p>
+      <p className="font-medium text-destructive">{err.category === "rate_limit" ? "Anthropic API rate-limited" : err.category === "overloaded" ? "Anthropic model is busy" : err.category === "timeout" ? "Generation timed out" : err.category === "network" ? "Network error" : err.category === "content_rejected" ? "Content rejected" : err.category === "invalid_request" ? "Request failed" : "Generation failed"}</p>
       <p className="mt-1 text-muted-foreground">{err.message}</p>
       <div className="mt-2 flex gap-2">
         {err.can_retry && err.category !== "overloaded" && (
@@ -135,7 +135,7 @@ function AiErrorDisplay({
             {retryLabel}
           </button>
         )}
-        {err.category === "content_rejected" && (
+        {(err.category === "content_rejected" || err.category === "invalid_request") && (
           <button
             type="button"
             onClick={onEdit}

--- a/docs/briefs/composer-v3-fixes/DECISION_TRAIL.md
+++ b/docs/briefs/composer-v3-fixes/DECISION_TRAIL.md
@@ -56,7 +56,17 @@ Continues from `docs/briefs/social-composer-v3-rebuild/DECISION_TRAIL.md` (D-001
 
 ## PR-B1 — AI assistant error categorization (2026-05-21)
 
-*Decision log entries TBD when PR-B1 is built.*
+**D-053**: Investigation — root cause of content_rejected false-positive
+- `client_errors` table not accessible via PostgREST (not in schema cache); trace_id `ai-gen-45b8-fe84` cannot be queried from REST API.
+- Root cause identified from code analysis (case b per brief): `categorizeError` in `lib/platform/social/cap/assist.ts` — `BadRequestError` catch (line 113) routes ALL HTTP 400s to `content_rejected`.
+- Anthropic SDK `ErrorType` (`node_modules/@anthropic-ai/sdk/resources/shared.d.ts`): `'invalid_request_error' | 'authentication_error' | 'permission_error' | ... | 'billing_error'` — NO content policy type. All 400s from Anthropic are `invalid_request_error` (malformed request, bad model name, bad system prompt, etc.).
+- Content refusals in Anthropic API arrive as 200 responses with `stop_reason === 'refusal'`, NOT as 400 errors.
+- Decision: Route `BadRequestError` → `invalid_request`. Add `stop_reason === 'refusal'` check in `generateAssistText` for actual `content_rejected`.
+
+**D-054**: HTTP status for `invalid_request` in route handler
+- `app/api/platform/social/cap/assist/route.ts` line 66 mapped `content_rejected → 422`.
+- `invalid_request` should map to `400` (it mirrors the Anthropic 400 status).
+- Decision: add `category === 'invalid_request' ? 400 :` before the `500` default in the status ternary.
 
 ---
 

--- a/e2e/composer-ai-error-categorization.spec.ts
+++ b/e2e/composer-ai-error-categorization.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "@playwright/test";
+
+import { signInAsCompanyAdmin, mockComposerApis } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Spec: AI assistant error categorization (PR-B1)
+//
+// Regression guard: a 400 from the AI assist endpoint must NOT show
+// "Content rejected" — it must show the "Request failed" bucket.
+// Covers the BadRequestError → invalid_request fix.
+//
+// Tests:
+//  AI-1  400 (invalid_request) response → shows "Request failed", not "Content rejected"
+//  AI-2  trace_id visible in the error display
+// ---------------------------------------------------------------------------
+
+const MOCK_INVALID_REQUEST_ERROR = {
+  ok: false,
+  error: {
+    category: "invalid_request",
+    code: "INVALID_REQUEST",
+    message: "Something went wrong with your request. Please try again.",
+    trace_id: "ai-gen-test-1234",
+    can_retry: false,
+  },
+};
+
+test.describe("AI assistant error categorization (B1)", () => {
+  test.beforeEach(async ({ page, context }) => {
+    await signInAsCompanyAdmin(page);
+    await mockComposerApis(context);
+    // Mock the error log endpoint to avoid noise.
+    await context.route("**/api/errors", (route) => {
+      void route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ ok: true, data: { trace_id: "ai-gen-test-1234" } }) });
+    });
+  });
+
+  test("AI-1: 400 response shows 'Request failed', not 'Content rejected'", async ({ page }) => {
+    // Mock the AI assist endpoint to return a 400 invalid_request error.
+    await page.route("**/api/platform/social/cap/assist", (route) => {
+      void route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_INVALID_REQUEST_ERROR),
+      });
+    });
+
+    await page.goto("/company/social/calendar?compose=new");
+    const dialog = page.getByRole("dialog", { name: /new post/i });
+    await expect(dialog).toBeVisible({ timeout: 20_000 });
+
+    // Open AI panel.
+    const aiBtn = dialog.getByTestId("composer-tool-ai");
+    await expect(aiBtn).toBeVisible({ timeout: 10_000 });
+    await aiBtn.click();
+    await expect(page.getByTestId("ai-panel")).toBeVisible({ timeout: 5_000 });
+
+    // Enter a prompt and click Generate.
+    await page.getByTestId("ai-prompt-input").fill("Write a post about cheese");
+    await page.getByTestId("ai-generate-button").click();
+
+    // The error display must appear.
+    const errorDisplay = page.getByTestId("ai-error-display");
+    await expect(errorDisplay).toBeVisible({ timeout: 5_000 });
+
+    // Must show "Request failed", NOT "Content rejected".
+    await expect(errorDisplay).toContainText("Request failed");
+    await expect(errorDisplay).not.toContainText("Content rejected");
+  });
+
+  test("AI-2: trace_id is visible in the error display", async ({ page }) => {
+    await page.route("**/api/platform/social/cap/assist", (route) => {
+      void route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_INVALID_REQUEST_ERROR),
+      });
+    });
+
+    await page.goto("/company/social/calendar?compose=new");
+    const dialog = page.getByRole("dialog", { name: /new post/i });
+    await expect(dialog).toBeVisible({ timeout: 20_000 });
+
+    const aiBtn = dialog.getByTestId("composer-tool-ai");
+    await expect(aiBtn).toBeVisible({ timeout: 10_000 });
+    await aiBtn.click();
+    await expect(page.getByTestId("ai-panel")).toBeVisible({ timeout: 5_000 });
+
+    await page.getByTestId("ai-prompt-input").fill("Write a post about cheese");
+    await page.getByTestId("ai-generate-button").click();
+
+    await expect(page.getByTestId("ai-error-display")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("ai-trace-id")).toBeVisible();
+    await expect(page.getByTestId("ai-trace-id")).toContainText("ai-gen-test-1234");
+  });
+});

--- a/lib/__tests__/social-ai-assist-categorizer.unit.test.ts
+++ b/lib/__tests__/social-ai-assist-categorizer.unit.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Server-only stubs (handled by vitest.unit.config.ts alias, but explicit here for clarity)
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/platform/brand/get", () => ({
+  getActiveBrandProfile: vi.fn().mockResolvedValue(null),
+}));
+
+import {
+  BadRequestError,
+  RateLimitError,
+  APIConnectionTimeoutError,
+  APIConnectionError,
+  InternalServerError,
+} from "@anthropic-ai/sdk";
+
+import { generateAssistText } from "@/lib/platform/social/cap/assist";
+import type { AnthropicCallFn, AnthropicResponse } from "@/lib/anthropic-call";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_INPUT = {
+  companyId: "company-1",
+  prompt: "Write a post about cheese",
+  tone: "casual" as const,
+  length: "short" as const,
+  requestedBy: "user-1",
+};
+
+function makeOkResponse(text: string, stop_reason = "end_turn"): AnthropicResponse {
+  return {
+    id: "msg-1",
+    model: "claude-haiku-4-5-20251001",
+    content: [{ type: "text", text }],
+    stop_reason,
+    usage: { input_tokens: 100, output_tokens: 50 },
+  };
+}
+
+function throwingCallFn(err: unknown): AnthropicCallFn {
+  return async () => { throw err; };
+}
+
+function resolvingCallFn(resp: AnthropicResponse): AnthropicCallFn {
+  return async () => resp;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AI assist error categorizer", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("200 normal completion → ok: true", async () => {
+    const result = await generateAssistText(VALID_INPUT, resolvingCallFn(makeOkResponse("Great cheese post!")));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.text).toBe("Great cheese post!");
+  });
+
+  it("200 with stop_reason=refusal → content_rejected", async () => {
+    const result = await generateAssistText(VALID_INPUT, resolvingCallFn(makeOkResponse("", "refusal")));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.category).toBe("content_rejected");
+      expect(result.error.can_retry).toBe(false);
+    }
+  });
+
+  it("400 BadRequestError → invalid_request (NOT content_rejected)", async () => {
+    const err = new BadRequestError(400, {}, "Bad request", new Headers());
+    const result = await generateAssistText(VALID_INPUT, throwingCallFn(err));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.category).toBe("invalid_request");
+      expect(result.error.category).not.toBe("content_rejected");
+      expect(result.error.can_retry).toBe(false);
+    }
+  });
+
+  it("400 with any error.type → invalid_request (Anthropic has no content_policy 400 type)", async () => {
+    const err = new BadRequestError(400, { error: { type: "invalid_request_error" } }, "Bad", new Headers());
+    const result = await generateAssistText(VALID_INPUT, throwingCallFn(err));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.category).toBe("invalid_request");
+  });
+
+  it("429 RateLimitError → rate_limit with retry_after", async () => {
+    const headers = new Headers({ "retry-after": "30" });
+    const err = new RateLimitError(429, {}, "Rate limit", headers);
+    const result = await generateAssistText(VALID_INPUT, throwingCallFn(err));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.category).toBe("rate_limit");
+      expect(result.error.retry_after).toBe(30);
+      expect(result.error.can_retry).toBe(true);
+    }
+  });
+
+  it("APIConnectionTimeoutError → timeout", async () => {
+    const err = new APIConnectionTimeoutError();
+    const result = await generateAssistText(VALID_INPUT, throwingCallFn(err));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.category).toBe("timeout");
+      expect(result.error.can_retry).toBe(true);
+    }
+  });
+
+  it("APIConnectionError (network) → network", async () => {
+    const err = new APIConnectionError({ message: "ECONNREFUSED" });
+    const result = await generateAssistText(VALID_INPUT, throwingCallFn(err));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.category).toBe("network");
+      expect(result.error.can_retry).toBe(true);
+    }
+  });
+
+  it("500 InternalServerError → unknown", async () => {
+    const err = new InternalServerError(500, {}, "Server error", new Headers());
+    const result = await generateAssistText(VALID_INPUT, throwingCallFn(err));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.category).toBe("unknown");
+      expect(result.error.can_retry).toBe(true);
+    }
+  });
+
+  it("529 overloaded InternalServerError → overloaded", async () => {
+    const err = new InternalServerError(529, {}, "Overloaded", new Headers());
+    const result = await generateAssistText(VALID_INPUT, throwingCallFn(err));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.category).toBe("overloaded");
+      expect(result.error.can_retry).toBe(true);
+    }
+  });
+
+  it("each error result includes a trace_id", async () => {
+    const err = new BadRequestError(400, {}, "Bad", new Headers());
+    const result = await generateAssistText(VALID_INPUT, throwingCallFn(err));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.trace_id).toMatch(/^ai-gen-/);
+  });
+});

--- a/lib/platform/social/cap/assist.ts
+++ b/lib/platform/social/cap/assist.ts
@@ -27,7 +27,7 @@ import {
 export type AssistTone = "professional" | "casual" | "playful";
 export type AssistLength = "short" | "medium" | "long";
 export type AssistGoal = "educate" | "promote" | "announce" | "engage";
-export type AssistErrorCategory = "rate_limit" | "timeout" | "content_rejected" | "network" | "overloaded" | "unknown";
+export type AssistErrorCategory = "rate_limit" | "timeout" | "content_rejected" | "invalid_request" | "network" | "overloaded" | "unknown";
 
 export interface AssistInput {
   companyId: string;
@@ -111,10 +111,13 @@ function categorizeError(err: unknown): Omit<AssistError, "trace_id"> {
   }
 
   if (err instanceof BadRequestError) {
+    // Anthropic 400s are always invalid_request_error (malformed request, bad
+    // model name, etc.) — never a content policy violation. Content refusals
+    // come as stop_reason='refusal' in a 200 response, handled below.
     return {
-      category: "content_rejected",
-      code: "CONTENT_REJECTED",
-      message: "The prompt was rejected. Please review your content and try again.",
+      category: "invalid_request",
+      code: "INVALID_REQUEST",
+      message: "Something went wrong with your request. Please try again.",
       can_retry: false,
     };
   }
@@ -181,6 +184,18 @@ export async function generateAssistText(
       idempotency_key: randomUUID(),
     });
     rawText = resp.content.map((b) => b.text).join("").trim();
+    if (resp.stop_reason === "refusal") {
+      return {
+        ok: false,
+        error: {
+          category: "content_rejected",
+          code: "CONTENT_REJECTED",
+          message: "This prompt was declined. Please revise your content and try again.",
+          trace_id: generateTraceId(),
+          can_retry: false,
+        },
+      };
+    }
   } catch (err) {
     const traceId = generateTraceId();
     const categorized = categorizeError(err);


### PR DESCRIPTION
## Summary

- `BadRequestError` catch-all was routing all Anthropic HTTP 400s to `content_rejected`
- Anthropic SDK `ErrorType` has **no content policy violation type** — all 400s are `invalid_request_error` (malformed request, bad model, bad system prompt, etc.)
- Content refusals arrive as `stop_reason === 'refusal'` in **200 responses**, not as 400 errors
- Benign prompts (e.g. "write me a post about cheese") triggered a 400 due to request formatting, showing false "Content rejected" UI

## Changes

- `lib/platform/social/cap/assist.ts`: `BadRequestError` → `invalid_request` (not `content_rejected`); add `stop_reason === 'refusal'` check → `content_rejected`
- `AssistErrorCategory`: added `'invalid_request'` variant  
- `ToolsRow.tsx`: `AiErrorState` type + label `"Request failed"` + "Edit prompt" button for `invalid_request`
- `app/api/platform/social/cap/assist/route.ts`: `invalid_request → HTTP 400` (not 500)

## Working analog

**Working analog**: `lib/__tests__/auto-retry.unit.test.ts:54` — tests error category routing using fixture values. Same shape: throw specific SDK error → assert category output.

**Diff**: `BadRequestError` handler returned `content_rejected` regardless of `err.type`. Anthropic SDK `ErrorType` does not include content-policy codes in 400 responses.

**Fix**: `BadRequestError` → `invalid_request`. Content refusals detected via `stop_reason === 'refusal'`.

## Risks identified and mitigated

- **`content_rejected` still used**: Only fires when `stop_reason === 'refusal'` (genuine model refusal). Not removed from the type.
- **`invalid_request` not retryable**: `can_retry: false` — matching existing `content_rejected` behavior. Users see "Edit prompt" button.
- **HTTP status 400**: Was previously 500 for `invalid_request` category. Now returns 400, matching the upstream Anthropic error status.
- **No DB schema change**: Pure logic fix, no migration needed.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (10 new tests, 2015 total — all pass)
- [x] e2e spec `composer-ai-error-categorization.spec.ts` added (AI-1, AI-2)
- [x] Contract snapshots reviewed — no SDK call shape changed
- [x] Risks identified and mitigated section complete
- [x] PR under 500 net lines

Part of composer-v3-fixes brief (PR-B1). Decision trail: D-053, D-054.