### PR TITLE
feat(media): global asset scope — schema, admin promote UI, library picker (PR-C1)

### DIFF
--- a/app/(platform)/admin/media/page.tsx
+++ b/app/(platform)/admin/media/page.tsx
@@ -1,0 +1,70 @@
+import { AdminMediaClient } from "@/components/AdminMediaClient";
+import { TListWide } from "@/templates";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// /admin/media — C1
+//
+// Admin view of all social_media_assets across companies.
+// Staff can promote any company-scoped asset to global scope so it appears
+// in every company's composer media library tab.
+//
+// Auth is handled by app/(platform)/admin/layout.tsx (checkAdminAccess).
+// Lists newest-first, up to 100 rows. No pagination needed for admin use.
+// ---------------------------------------------------------------------------
+
+export const dynamic = "force-dynamic";
+
+type AdminMediaAsset = {
+  id: string;
+  company_id: string;
+  source_url: string | null;
+  mime_type: string;
+  bytes: number;
+  scope: "company" | "global";
+  created_at: string;
+};
+
+export default async function AdminMediaPage() {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("social_media_assets")
+    .select("id, company_id, source_url, mime_type, bytes, scope, created_at")
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  if (error) {
+    return (
+      <TListWide
+        title="Social media assets"
+        subtitle="Promote assets to global scope to make them available in every company's composer library."
+      >
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+          role="alert"
+        >
+          Failed to load assets: {error.message}
+        </div>
+      </TListWide>
+    );
+  }
+
+  const assets: AdminMediaAsset[] = (data ?? []).map((r) => ({
+    id: r.id as string,
+    company_id: r.company_id as string,
+    source_url: (r.source_url as string | null) ?? null,
+    mime_type: r.mime_type as string,
+    bytes: Number(r.bytes ?? 0),
+    scope: ((r.scope as string) === "global" ? "global" : "company") as "company" | "global",
+    created_at: r.created_at as string,
+  }));
+
+  return (
+    <TListWide
+      title="Social media assets"
+      subtitle="Promote assets to global scope to make them available in every company's composer library."
+    >
+      <AdminMediaClient initialAssets={assets} />
+    </TListWide>
+  );
+}

--- a/app/api/admin/media/[id]/promote/route.ts
+++ b/app/api/admin/media/[id]/promote/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireAdminForApi } from "@/lib/admin-api-gate";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/media/[id]/promote — C1
+//
+// Promotes a social_media_asset to scope='global', making it visible in the
+// composer media library for all companies.
+//
+// Admin-only (requireAdminForApi). Uses service-role client to bypass RLS.
+//
+// Response:
+//   200  { ok: true }
+//   400  { ok: false, error: { message } }   — invalid id
+//   401/403                                  — auth
+//   404  { ok: false, error: { message } }   — asset not found
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const gate = await requireAdminForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  const { id } = params;
+  if (!id || !UUID_RE.test(id)) {
+    return NextResponse.json(
+      { ok: false, error: { message: "Invalid asset id." } },
+      { status: 400 },
+    );
+  }
+
+  const svc = getServiceRoleClient();
+
+  // Verify asset exists.
+  const { data: existing, error: fetchErr } = await svc
+    .from("social_media_assets")
+    .select("id, scope")
+    .eq("id", id)
+    .single();
+
+  if (fetchErr || !existing) {
+    return NextResponse.json(
+      { ok: false, error: { message: "Asset not found." } },
+      { status: 404 },
+    );
+  }
+
+  if (existing.scope === "global") {
+    return NextResponse.json({ ok: true, data: { already_global: true } }, { status: 200 });
+  }
+
+  const { error: updateErr } = await svc
+    .from("social_media_assets")
+    .update({ scope: "global" })
+    .eq("id", id);
+
+  if (updateErr) {
+    logger.error("admin.media.promote.failed", { id, err: updateErr.message });
+    return NextResponse.json(
+      { ok: false, error: { message: "Failed to promote asset." } },
+      { status: 500 },
+    );
+  }
+
+  logger.info("admin.media.promote.success", { id, by: gate.user?.id });
+  return NextResponse.json({ ok: true }, { status: 200 });
+}

--- a/app/api/platform/social/media/route.ts
+++ b/app/api/platform/social/media/route.ts
@@ -45,8 +45,9 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const before = url.searchParams.get("before") ?? undefined;
   const limitRaw = url.searchParams.get("limit");
   const limit = limitRaw ? Number(limitRaw) : undefined;
+  const includeGlobal = url.searchParams.get("include_global") === "true";
 
-  const result = await listMediaAssets({ companyId, before, limit });
+  const result = await listMediaAssets({ companyId, before, limit, includeGlobal });
   if (!result.ok) {
     return internalError(result.error.message);
   }

--- a/components/AdminMediaClient.tsx
+++ b/components/AdminMediaClient.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import * as React from "react";
+
+// ---------------------------------------------------------------------------
+// AdminMediaClient — C1
+//
+// Client component rendered in /admin/media. Lists all social_media_assets
+// across companies. Staff can click "Promote" to set scope='global' on any
+// company-scoped asset.
+// ---------------------------------------------------------------------------
+
+type AdminMediaAsset = {
+  id: string;
+  company_id: string;
+  source_url: string | null;
+  mime_type: string;
+  bytes: number;
+  scope: "company" | "global";
+  created_at: string;
+};
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function AdminMediaClient({ initialAssets }: { initialAssets: AdminMediaAsset[] }) {
+  const [assets, setAssets] = React.useState(initialAssets);
+  const [promoting, setPromoting] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  async function promote(id: string) {
+    setPromoting(id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/media/${id}/promote`, { method: "POST" });
+      const json = (await res.json()) as { ok: boolean; error?: { message: string } };
+      if (!json.ok) {
+        setError(json.error?.message ?? "Promote failed.");
+      } else {
+        setAssets((prev) =>
+          prev.map((a) => (a.id === id ? { ...a, scope: "global" as const } : a)),
+        );
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setPromoting(null);
+    }
+  }
+
+  if (assets.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">No media assets found.</p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {error && (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border bg-muted/40">
+              <th className="px-4 py-2 text-left font-medium text-muted-foreground">Preview</th>
+              <th className="px-4 py-2 text-left font-medium text-muted-foreground">Type</th>
+              <th className="px-4 py-2 text-left font-medium text-muted-foreground">Size</th>
+              <th className="px-4 py-2 text-left font-medium text-muted-foreground">Scope</th>
+              <th className="px-4 py-2 text-left font-medium text-muted-foreground">Company</th>
+              <th className="px-4 py-2 text-left font-medium text-muted-foreground">Uploaded</th>
+              <th className="px-4 py-2 text-right font-medium text-muted-foreground">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {assets.map((asset) => (
+              <tr
+                key={asset.id}
+                data-testid={`admin-media-row-${asset.id}`}
+                className="border-b border-border last:border-0 hover:bg-muted/20 transition-colors"
+              >
+                <td className="px-4 py-2">
+                  {asset.source_url && asset.mime_type.startsWith("image/") ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={asset.source_url}
+                      alt=""
+                      className="h-10 w-10 rounded object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-10 w-10 items-center justify-center rounded bg-muted text-xs text-muted-foreground">
+                      {asset.mime_type.split("/")[1]?.toUpperCase().slice(0, 3) ?? "FILE"}
+                    </div>
+                  )}
+                </td>
+                <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
+                  {asset.mime_type}
+                </td>
+                <td className="px-4 py-2 text-muted-foreground">{formatBytes(asset.bytes)}</td>
+                <td className="px-4 py-2">
+                  <span
+                    data-testid={`scope-badge-${asset.id}`}
+                    className={
+                      asset.scope === "global"
+                        ? "rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700"
+                        : "rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                    }
+                  >
+                    {asset.scope}
+                  </span>
+                </td>
+                <td className="px-4 py-2 font-mono text-xs text-muted-foreground">
+                  {asset.company_id.slice(0, 8)}…
+                </td>
+                <td className="px-4 py-2 text-muted-foreground">{formatDate(asset.created_at)}</td>
+                <td className="px-4 py-2 text-right">
+                  {asset.scope === "company" ? (
+                    <button
+                      type="button"
+                      data-testid={`promote-btn-${asset.id}`}
+                      disabled={promoting === asset.id}
+                      onClick={() => void promote(asset.id)}
+                      className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+                    >
+                      {promoting === asset.id ? "Promoting…" : "Promote to global"}
+                    </button>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">Global</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/components/social/composer/MediaPickerModal.tsx
+++ b/components/social/composer/MediaPickerModal.tsx
@@ -25,6 +25,7 @@ type MediaAsset = {
   source_url: string | null;
   mime_type: string;
   bytes: number;
+  scope: "company" | "global";
   created_at: string;
 };
 
@@ -109,7 +110,7 @@ export function MediaPickerModal({
     setLibLoading(true);
     setLibError(null);
     try {
-      const params = new URLSearchParams({ company_id: companyId });
+      const params = new URLSearchParams({ company_id: companyId, include_global: "true" });
       if (cursor) params.set("before", cursor);
       const res = await fetch(`/api/platform/social/media?${params.toString()}`);
       const json = (await res.json()) as {

--- a/docs/briefs/composer-v3-fixes/DECISION_TRAIL.md
+++ b/docs/briefs/composer-v3-fixes/DECISION_TRAIL.md
@@ -85,7 +85,28 @@ Continues from `docs/briefs/social-composer-v3-rebuild/DECISION_TRAIL.md` (D-001
 
 ## PR-C1 — Media library scope (2026-05-21)
 
-*Decision log entries TBD when PR-C1 is built.*
+**D-055**: `scope` query filter approach — service-role bypass of RLS
+- `listMediaAssets` uses service-role client, which bypasses RLS entirely. Adding RLS `OR scope = 'global'` is correct for anon/authenticated calls but does nothing for service-role queries.
+- Decision: filter at the query layer via PostgREST `.or("company_id.eq.{id},scope.eq.global")` when `includeGlobal: true`. This is self-contained, explicit, and auditable.
+
+**D-056**: Partial index on `scope = 'global'`
+- Global assets are a small minority. A partial index `WHERE scope = 'global'` keeps the index tiny and makes the OR filter's global branch a quick index scan.
+- Decision: `CREATE INDEX IF NOT EXISTS idx_media_assets_scope ON social_media_assets(scope) WHERE scope = 'global'`
+
+**D-057**: Admin promote endpoint — `gate.user?.id` not `gate.userId`
+- `ApiGateResult` (`lib/admin-api-gate.ts`) shape: `{ kind: "allow"; user: SessionUser | null }` — no `userId` field at the top level.
+- Decision: log with `gate.user?.id` (nullable — system-level ops via service tokens have no user context).
+
+**D-058**: Admin media page under `app/(platform)/admin/media/page.tsx`
+- Pattern matches existing admin pages: `checkAdminAccess()` + `redirect("/login")`, service-role query, pass to client component.
+- Working analog: `app/(platform)/admin/companies/page.tsx`.
+
+**D-059**: `scope` field added to `MediaAsset` type in `MediaPickerModal.tsx`
+- API now returns `scope` on every asset. Adding it to the local type keeps the shape consistent and enables future UI differentiation (e.g. staff-pick badge) without a type change.
+
+**D-060**: Library fetch param `include_global=true` always set
+- All authenticated users with `view_calendar` can see global (staff-promoted) assets — that's the intent. No per-user toggle needed.
+- Decision: always pass `include_global=true` in `MediaPickerModal.fetchLibrary`.
 
 ---
 

--- a/e2e/composer-media-library-scope.spec.ts
+++ b/e2e/composer-media-library-scope.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+
+import { signInAsCompanyAdmin, mockComposerApis } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// PR-C1 — Media library global scope
+//
+// (MLS-1) Library fetch sends include_global=true so staff-promoted assets
+//         are returned alongside company assets.
+// (MLS-2) A global-scoped asset returned by the API appears in the grid
+//         alongside a company-scoped asset.
+// ---------------------------------------------------------------------------
+
+const COMPANY_ASSET = {
+  id: "asset-company-c1",
+  source_url: "https://picsum.photos/seed/co1/200/200",
+  mime_type: "image/jpeg",
+  bytes: 24000,
+  scope: "company",
+  created_at: "2026-05-21T10:00:00Z",
+};
+
+const GLOBAL_ASSET = {
+  id: "asset-global-c1",
+  source_url: "https://picsum.photos/seed/gl1/200/200",
+  mime_type: "image/jpeg",
+  bytes: 32000,
+  scope: "global",
+  created_at: "2026-05-21T09:00:00Z",
+};
+
+test.describe("composer media library scope (C1)", () => {
+  test("(MLS-1) library fetch includes include_global=true", async ({ page, context }) => {
+    await signInAsCompanyAdmin(page);
+    await mockComposerApis(context);
+
+    await context.route("**/api/platform/social/connections**", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { connections: [] } }),
+      });
+    });
+
+    let capturedUrl: string | null = null;
+    await context.route("**/api/platform/social/media**", (route) => {
+      capturedUrl = route.request().url();
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          data: { assets: [COMPANY_ASSET, GLOBAL_ASSET], next_cursor: null },
+        }),
+      });
+    });
+
+    await page.goto("/company/social/posts?compose=new");
+    await page.waitForSelector('[data-testid="composer-overlay"]', { timeout: 15_000 });
+
+    await page.getByRole("button", { name: /media/i }).click();
+    await expect(page.getByTestId("media-picker-modal")).toBeVisible({ timeout: 5_000 });
+
+    await page.getByTestId("media-picker-tab-library").click();
+    await expect(page.getByTestId("media-library-grid")).toBeVisible({ timeout: 5_000 });
+
+    expect(capturedUrl).toContain("include_global=true");
+  });
+
+  test("(MLS-2) global-scoped asset appears in grid alongside company asset", async ({
+    page,
+    context,
+  }) => {
+    await signInAsCompanyAdmin(page);
+    await mockComposerApis(context);
+
+    await context.route("**/api/platform/social/connections**", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { connections: [] } }),
+      });
+    });
+
+    await context.route("**/api/platform/social/media**", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          data: { assets: [COMPANY_ASSET, GLOBAL_ASSET], next_cursor: null },
+        }),
+      });
+    });
+
+    await page.goto("/company/social/posts?compose=new");
+    await page.waitForSelector('[data-testid="composer-overlay"]', { timeout: 15_000 });
+
+    await page.getByRole("button", { name: /media/i }).click();
+    await expect(page.getByTestId("media-picker-modal")).toBeVisible({ timeout: 5_000 });
+
+    await page.getByTestId("media-picker-tab-library").click();
+    await expect(page.getByTestId("media-library-grid")).toBeVisible({ timeout: 5_000 });
+
+    await expect(
+      page.getByTestId(`media-library-item-${COMPANY_ASSET.id}`),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId(`media-library-item-${GLOBAL_ASSET.id}`),
+    ).toBeVisible();
+  });
+});

--- a/lib/platform/social/media/list.ts
+++ b/lib/platform/social/media/list.ts
@@ -9,6 +9,8 @@ import type { ApiResponse } from "@/lib/tool-schemas";
 // S1-57 — cursor pagination via created_at; default 50 rows, max 100.
 //          Caller passes `before` (created_at ISO of last asset seen) to
 //          fetch the next page.
+// C1     — `includeGlobal: true` unions company-scoped assets with all
+//          scope='global' assets (promoted by staff) for the picker library.
 // ---------------------------------------------------------------------------
 
 const DEFAULT_LIMIT = 50;
@@ -23,6 +25,7 @@ export type MediaAsset = {
   width: number | null;
   height: number | null;
   bundle_upload_id: string | null;
+  scope: "company" | "global";
   created_at: string;
 };
 
@@ -30,20 +33,31 @@ export async function listMediaAssets(args: {
   companyId: string;
   before?: string;
   limit?: number;
+  /** When true, global (staff-promoted) assets are included alongside company assets. */
+  includeGlobal?: boolean;
 }): Promise<ApiResponse<{ assets: MediaAsset[]; nextCursor: string | null }>> {
   if (!args.companyId) {
     return validation("companyId required.");
   }
   const pageSize = Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
   const svc = getServiceRoleClient();
-  const base = svc
+
+  const selectFields =
+    "id, source_url, storage_path, mime_type, bytes, width, height, bundle_upload_id, scope, created_at";
+
+  let base = svc
     .from("social_media_assets")
-    .select(
-      "id, source_url, storage_path, mime_type, bytes, width, height, bundle_upload_id, created_at",
-    )
-    .eq("company_id", args.companyId)
+    .select(selectFields)
     .order("created_at", { ascending: false })
     .limit(pageSize + 1);
+
+  if (args.includeGlobal) {
+    // company-owned OR globally promoted
+    base = base.or(`company_id.eq.${args.companyId},scope.eq.global`);
+  } else {
+    base = base.eq("company_id", args.companyId);
+  }
+
   const result = await (args.before ? base.lt("created_at", args.before) : base);
   if (result.error) {
     logger.error("social.media.list.failed", {
@@ -64,6 +78,7 @@ export async function listMediaAssets(args: {
     width: (r.width as number | null) ?? null,
     height: (r.height as number | null) ?? null,
     bundle_upload_id: (r.bundle_upload_id as string | null) ?? null,
+    scope: ((r.scope as string) === "global" ? "global" : "company") as "company" | "global",
     created_at: r.created_at as string,
   }));
   const nextCursor = hasMore ? (page[page.length - 1].created_at as string) : null;

--- a/supabase/migrations/0142_social_media_assets_scope.sql
+++ b/supabase/migrations/0142_social_media_assets_scope.sql
@@ -1,0 +1,40 @@
+-- =============================================================================
+-- 0142 — social_media_assets scope column
+--
+-- Adds a `scope` column to social_media_assets with two values:
+--   'company'  — default; asset visible only to its owning company
+--   'global'   — promoted by staff; visible to all companies in the composer
+--                media library tab
+--
+-- RLS update: existing media_access policy is replaced so that rows with
+-- scope = 'global' are readable by any authenticated company member.
+-- The WITH CHECK clause is unchanged — users can only write to assets they
+-- own (by company membership), and only staff can set scope = 'global' via
+-- the admin promote endpoint (which uses the service role client).
+-- =============================================================================
+
+BEGIN;
+
+ALTER TABLE social_media_assets
+  ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'company'
+    CHECK (scope IN ('company', 'global'));
+
+CREATE INDEX IF NOT EXISTS idx_media_assets_scope
+  ON social_media_assets(scope)
+  WHERE scope = 'global';
+
+-- Drop the old policy and replace it with the scope-aware version.
+DROP POLICY IF EXISTS media_access ON social_media_assets;
+
+CREATE POLICY media_access ON social_media_assets FOR ALL
+  USING (
+    is_opollo_staff()
+    OR is_company_member(company_id)
+    OR scope = 'global'
+  )
+  WITH CHECK (
+    is_opollo_staff()
+    OR is_company_member(company_id)
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Adds `scope` column (`company` | `global`) to `social_media_assets` via migration 0142
- New `POST /api/admin/media/[id]/promote` endpoint lets staff set `scope='global'`
- New `/admin/media` page lists all assets across companies with Promote buttons
- `listMediaAssets` gains `includeGlobal` param using PostgREST `.or()` filter
- `GET /api/platform/social/media` accepts `include_global=true` query param
- `MediaPickerModal` library tab now always fetches global + company assets

> **Note for Steven**: After merge, run migration `0142_social_media_assets_scope.sql` in Supabase production before testing.

## Working analog

`app/(platform)/admin/companies/page.tsx` — same auth-by-layout + service-role query + client component pattern.

## Diff

- `app/(platform)/admin/media/page.tsx` — server component; relies on `/admin/layout.tsx` for `checkAdminAccess` (same as all other admin pages)
- `components/AdminMediaClient.tsx` — scope badge + promote button with optimistic update
- `lib/platform/social/media/list.ts` — `.or()` filter when `includeGlobal: true`; service-role bypasses RLS so the filter lives at the query layer, not in the policy

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Service-role bypasses RLS so scope='global' filter must be in query | Applied via `.or("company_id.eq.X,scope.eq.global")` in `listMediaAssets` |
| Admin promote endpoint could be called by non-staff | `requireAdminForApi()` gates it; 401/403 returned for non-admin callers |
| Existing assets have no `scope` column before migration | Migration adds `DEFAULT 'company'` — zero downtime; all existing rows become `scope='company'` |
| PostgREST OR filter syntax correctness | Pattern already used in `lib/platform/social/connections/list.ts` |

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (2021 pass)
- [x] Cross-tenant: global assets visible to any authenticated member (RLS policy updated)
- [x] 2 e2e tests: `(MLS-1)` fetch URL includes `include_global=true`, `(MLS-2)` global asset visible in grid
- [x] Migration `0142` included; Steven runs manually in production
- [x] PR is under 500 net lines

## Decision trail

D-055–D-060 appended to `docs/briefs/composer-v3-fixes/DECISION_TRAIL.md`.