### PR TITLE
feat(composer): replace MiniCalendar with PostChip-based MonthCalendar (PR-C2)

### DIFF
--- a/components/social/calendar/DayCell.tsx
+++ b/components/social/calendar/DayCell.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { PostChip } from "@/components/social/dashboard/PostChip";
+import type { CalendarPost } from "@/lib/social/types";
+
+interface DayCellProps {
+  date: Date;
+  posts: CalendarPost[];
+  isSelected: boolean;
+  isToday: boolean;
+  isPast: boolean;
+  isOtherMonth: boolean;
+  onClick: (date: Date) => void;
+}
+
+const MAX_VISIBLE = 3;
+
+export function DayCell({
+  date,
+  posts,
+  isSelected,
+  isToday,
+  isPast,
+  isOtherMonth,
+  onClick,
+}: DayCellProps) {
+  const overflow = posts.length - MAX_VISIBLE;
+
+  return (
+    <div
+      role="gridcell"
+      aria-label={date.toLocaleDateString("en-AU", {
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })}
+      aria-selected={isSelected}
+      onClick={() => onClick(date)}
+      data-testid={`calendar-day-${date.toISOString().slice(0, 10)}`}
+      className={cn(
+        "relative flex min-h-[64px] flex-col gap-0.5 rounded border border-border p-1 cursor-pointer transition-colors",
+        isOtherMonth && "bg-muted/30 text-muted-foreground",
+        isPast && !isOtherMonth && "bg-muted/20",
+        isSelected && "border-primary bg-primary/5 ring-1 ring-primary",
+        !isOtherMonth && !isPast && !isSelected && "hover:border-primary/40 hover:bg-muted/30",
+      )}
+    >
+      <span
+        className={cn(
+          "text-xs font-medium leading-none",
+          isToday &&
+            "flex h-5 w-5 items-center justify-center rounded-full bg-primary text-primary-foreground text-xs font-semibold",
+          !isToday && isOtherMonth && "text-muted-foreground/60",
+        )}
+      >
+        {date.getDate()}
+      </span>
+
+      <div className="flex flex-col gap-0.5 overflow-hidden">
+        {posts.slice(0, MAX_VISIBLE).map((post) => (
+          <PostChip key={post.id} post={post} />
+        ))}
+        {overflow > 0 && (
+          <span className="pl-1 text-xs text-muted-foreground">+{overflow} more</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/social/calendar/MonthCalendar.tsx
+++ b/components/social/calendar/MonthCalendar.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { DayCell } from "./DayCell";
+import { useCalendarView } from "@/hooks/use-calendar-view";
+
+// ---------------------------------------------------------------------------
+// MonthCalendar — PR-C2
+//
+// Richer replacement for MiniCalendar in the ComposerOverlay right-pane
+// "Calendar" tab. Fetches scheduled/published posts via useCalendarView and
+// renders them as PostChip items in each day cell.
+//
+// Props:
+//   companyId    — required for the calendar-view API call
+//   selectedDate — date currently targeted by the composer scheduling card
+//   onDateSelect — called when the user clicks a day
+//   className    — optional wrapper class
+// ---------------------------------------------------------------------------
+
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const MONTH_NAMES = [
+  "January", "February", "March", "April",
+  "May", "June", "July", "August",
+  "September", "October", "November", "December",
+];
+
+function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+// Monday-first 7-column grid (mirrors CalendarShell)
+function buildGrid(year: number, month: number): Date[] {
+  const first = new Date(year, month, 1);
+  const last = new Date(year, month + 1, 0);
+
+  const firstDow = (first.getDay() + 6) % 7;
+  const lastDow = (last.getDay() + 6) % 7;
+
+  const cells: Date[] = [];
+
+  for (let i = firstDow - 1; i >= 0; i--) {
+    cells.push(new Date(year, month, -i));
+  }
+  for (let d = 1; d <= last.getDate(); d++) {
+    cells.push(new Date(year, month, d));
+  }
+  const trailing = lastDow < 6 ? 6 - lastDow : 0;
+  for (let d = 1; d <= trailing; d++) {
+    cells.push(new Date(year, month + 1, d));
+  }
+
+  return cells;
+}
+
+function isSameDay(a: Date, b: Date) {
+  return isoDate(a) === isoDate(b);
+}
+
+export interface MonthCalendarProps {
+  companyId: string;
+  selectedDate?: Date;
+  onDateSelect?: (date: Date) => void;
+  className?: string;
+}
+
+export function MonthCalendar({
+  companyId,
+  selectedDate,
+  onDateSelect,
+  className,
+}: MonthCalendarProps) {
+  const today = new Date();
+  const [viewYear, setViewYear] = React.useState(
+    selectedDate?.getFullYear() ?? today.getFullYear(),
+  );
+  const [viewMonth, setViewMonth] = React.useState(
+    selectedDate?.getMonth() ?? today.getMonth(),
+  );
+
+  const from = isoDate(new Date(viewYear, viewMonth, 1));
+  const to = isoDate(new Date(viewYear, viewMonth + 1, 0));
+
+  const { posts, isLoading } = useCalendarView(companyId, from, to);
+
+  const cells = buildGrid(viewYear, viewMonth);
+
+  function prevMonth() {
+    if (viewMonth === 0) {
+      setViewYear((y) => y - 1);
+      setViewMonth(11);
+    } else {
+      setViewMonth((m) => m - 1);
+    }
+  }
+
+  function nextMonth() {
+    if (viewMonth === 11) {
+      setViewYear((y) => y + 1);
+      setViewMonth(0);
+    } else {
+      setViewMonth((m) => m + 1);
+    }
+  }
+
+  return (
+    <div
+      className={cn("select-none rounded-xl border border-border bg-white p-3", className)}
+      data-testid="month-calendar"
+    >
+      {/* Header */}
+      <div className="mb-3 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={prevMonth}
+          aria-label="Previous month"
+          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted transition-colors"
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+        </button>
+
+        <p className="flex items-center gap-2 text-sm font-semibold">
+          {MONTH_NAMES[viewMonth]} {viewYear}
+          {isLoading && (
+            <span
+              className="inline-block h-3 w-3 rounded-full border-2 border-primary border-t-transparent animate-spin"
+              aria-label="Loading"
+            />
+          )}
+        </p>
+
+        <button
+          type="button"
+          onClick={nextMonth}
+          aria-label="Next month"
+          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-muted transition-colors"
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Day-of-week labels */}
+      <div
+        className="mb-1 grid grid-cols-7 gap-0.5"
+        role="row"
+        aria-label="Days of the week"
+      >
+        {DAY_LABELS.map((d) => (
+          <div
+            key={d}
+            className="text-center text-xs font-medium uppercase tracking-wide text-muted-foreground"
+          >
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* Day cells */}
+      <div className="grid grid-cols-7 gap-0.5" role="grid" aria-label="Calendar">
+        {cells.map((date) => {
+          const key = isoDate(date);
+          const dayPosts = posts.filter((p) => {
+            const at = p.scheduled_at ?? p.published_at;
+            return at ? at.slice(0, 10) === key : false;
+          });
+          const isCurrentMonth = date.getMonth() === viewMonth;
+
+          return (
+            <DayCell
+              key={key}
+              date={date}
+              posts={dayPosts}
+              isSelected={selectedDate ? isSameDay(date, selectedDate) : false}
+              isToday={isSameDay(date, today)}
+              isPast={date < today && !isSameDay(date, today)}
+              isOtherMonth={!isCurrentMonth}
+              onClick={(d) => onDateSelect?.(d)}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/social/composer/ComposerOverlay.tsx
+++ b/components/social/composer/ComposerOverlay.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import { ProfileSelector } from "@/components/social/composer/ProfileSelector";
 import { ComposerEditor } from "@/components/social/composer/ComposerEditor";
 import { PreviewCard } from "@/components/social/composer/PreviewCard";
-import { MiniCalendar } from "@/components/social/composer/MiniCalendar";
+import { MonthCalendar } from "@/components/social/calendar/MonthCalendar";
 import { SchedulingCard, defaultSchedulingCardValue, type SchedulingCardValue } from "@/components/social/composer/SchedulingCard";
 import { UnsavedChangesDialog } from "@/components/social/composer/UnsavedChangesDialog";
 import { ComposerErrorBoundary } from "@/components/social/composer/ComposerErrorBoundary";
@@ -468,9 +468,9 @@ export function ComposerOverlay({
                   />
                 )
               ) : (
-                <MiniCalendar
+                <MonthCalendar
+                  companyId={companyId}
                   selectedDate={prefilledDate}
-                  className="mx-auto max-w-xs"
                 />
               )}
             </div>

--- a/docs/briefs/composer-v3-fixes/DECISION_TRAIL.md
+++ b/docs/briefs/composer-v3-fixes/DECISION_TRAIL.md
@@ -112,4 +112,18 @@ Continues from `docs/briefs/social-composer-v3-rebuild/DECISION_TRAIL.md` (D-001
 
 ## PR-C2 — Calendar month grid (2026-05-21)
 
-*Decision log entries TBD when PR-C2 is built.*
+**D-061**: Reuse `PostChip` from `components/social/dashboard/PostChip.tsx`
+- The same chip already exists and works. Creating a new one at `components/social/calendar/PostChip.tsx` would be duplication.
+- Decision: import from `@/components/social/dashboard/PostChip`. No copy.
+
+**D-062**: `DayCell` omits drag-and-drop
+- `CalendarCell` (dashboard) uses `@dnd-kit/core` for drag-to-reschedule. The composer right-pane calendar is read-only — no reschedule UX in this context.
+- Decision: `DayCell` is a plain div, no `useDroppable`. Keeps the composer bundle lighter.
+
+**D-063**: Monday-first grid (mirrors CalendarShell)
+- `CalendarShell` uses `(day.getDay() + 6) % 7` for Monday-first offset. `MiniCalendar` uses Sunday-first (`getDay()` direct). Using Monday-first matches what users see on `/company/social/calendar`.
+- Decision: adopt Monday-first layout from `CalendarShell.buildGridDates`.
+
+**D-064**: `companyId` passed through from `ComposerOverlay`
+- `ComposerOverlay` already receives `companyId` as a prop (defaults to `""`). `useCalendarView` returns empty posts when `companyId` is falsy (null URL). No guard needed.
+- Decision: `MonthCalendar` accepts `companyId: string`; works silently when empty.

--- a/e2e/composer-calendar-month-grid.spec.ts
+++ b/e2e/composer-calendar-month-grid.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "@playwright/test";
+
+import { signInAsCompanyAdmin, mockComposerApis } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// PR-C2 — Composer right-pane calendar month grid
+//
+// (CMG-1) Clicking the Calendar tab shows the MonthCalendar component.
+// (CMG-2) MonthCalendar fetches posts via calendar-view API and shows a
+//         PostChip for a scheduled post on the correct date.
+// (CMG-3) Prev/Next month navigation updates the displayed month.
+// ---------------------------------------------------------------------------
+
+const TODAY = new Date();
+const THIS_YEAR = TODAY.getFullYear();
+const THIS_MONTH = TODAY.getMonth();
+
+function isoDate(year: number, month: number, day: number): string {
+  return `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+const SCHEDULED_DATE = isoDate(THIS_YEAR, THIS_MONTH, 15);
+
+const MOCK_POSTS = [
+  {
+    id: "post-cal-001",
+    state: "scheduled",
+    scheduled_at: `${SCHEDULED_DATE}T09:00:00Z`,
+    published_at: null,
+    content_excerpt: "Test post",
+    primary_media_url: null,
+    target_profiles: [{ platform: "instagram", account_avatar_url: "" }],
+    is_recurring_child: false,
+  },
+];
+
+test.describe("composer calendar month grid (C2)", () => {
+  test("(CMG-1) Calendar tab renders MonthCalendar", async ({ page, context }) => {
+    await signInAsCompanyAdmin(page);
+    await mockComposerApis(context);
+
+    await context.route("**/api/platform/social/connections**", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { connections: [] } }),
+      });
+    });
+
+    await context.route("**/api/platform/social/drafts/calendar-view**", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { posts: [], range: { from: "", to: "" } } }),
+      });
+    });
+
+    await page.goto("/company/social/posts?compose=new");
+    await page.waitForSelector('[data-testid="composer-overlay"]', { timeout: 15_000 });
+
+    // Switch to Calendar tab
+    await page.getByRole("button", { name: "Calendar" }).click();
+
+    await expect(page.getByTestId("month-calendar")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("(CMG-2) scheduled post appears as PostChip on correct date", async ({ page, context }) => {
+    await signInAsCompanyAdmin(page);
+    await mockComposerApis(context);
+
+    await context.route("**/api/platform/social/connections**", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { connections: [] } }),
+      });
+    });
+
+    await context.route("**/api/platform/social/drafts/calendar-view**", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          data: { posts: MOCK_POSTS, range: { from: "", to: "" } },
+        }),
+      });
+    });
+
+    await page.goto("/company/social/posts?compose=new");
+    await page.waitForSelector('[data-testid="composer-overlay"]', { timeout: 15_000 });
+
+    await page.getByRole("button", { name: "Calendar" }).click();
+    await expect(page.getByTestId("month-calendar")).toBeVisible({ timeout: 5_000 });
+
+    // Day cell for the 15th should contain a PostChip
+    const dayCell = page.getByTestId(`calendar-day-${SCHEDULED_DATE}`);
+    await expect(dayCell).toBeVisible();
+    await expect(dayCell.getByTestId("post-chip")).toBeVisible();
+  });
+
+  test("(CMG-3) Prev/Next month navigation changes the header", async ({ page, context }) => {
+    await signInAsCompanyAdmin(page);
+    await mockComposerApis(context);
+
+    await context.route("**/api/platform/social/connections**", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { connections: [] } }),
+      });
+    });
+
+    await context.route("**/api/platform/social/drafts/calendar-view**", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, data: { posts: [], range: { from: "", to: "" } } }),
+      });
+    });
+
+    await page.goto("/company/social/posts?compose=new");
+    await page.waitForSelector('[data-testid="composer-overlay"]', { timeout: 15_000 });
+
+    await page.getByRole("button", { name: "Calendar" }).click();
+    await expect(page.getByTestId("month-calendar")).toBeVisible({ timeout: 5_000 });
+
+    // Navigate to next month
+    await page.getByLabel("Next month").click();
+
+    const nextMonth = new Date(THIS_YEAR, THIS_MONTH + 1, 1);
+    const nextMonthName = nextMonth.toLocaleString("en-AU", { month: "long" });
+    const nextMonthYear = nextMonth.getFullYear().toString();
+
+    await expect(page.getByTestId("month-calendar")).toContainText(nextMonthName);
+    await expect(page.getByTestId("month-calendar")).toContainText(nextMonthYear);
+  });
+});


### PR DESCRIPTION
## Summary

- New `DayCell` component: day number + up to 3 `PostChip` + overflow count. No drag-and-drop (read-only context).
- New `MonthCalendar` component: fetches posts via `useCalendarView` SWR hook, Monday-first grid, prev/next month nav, loading spinner.
- `ComposerOverlay` Calendar tab now renders `MonthCalendar` instead of `MiniCalendar`.

Users opening the Calendar tab in the composer will now see their actual scheduled posts as platform chips, matching what they see on `/company/social/calendar`.

## Working analog

`components/social/dashboard/CalendarShell.tsx` + `CalendarCell.tsx` — same PostChip / grid structure, same `useCalendarView` SWR hook. `MonthCalendar` is a lighter version (no dnd, no add-post button).

## Diff

- `MiniCalendar` used dot indicators and no API call. `MonthCalendar` uses PostChip and `useCalendarView` for real post data.
- Monday-first offset: `(day.getDay() + 6) % 7` (matches CalendarShell, not MiniCalendar's Sunday-first).
- `PostChip` is re-imported from `components/social/dashboard/PostChip.tsx` — no duplication.

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| `companyId` empty on first render | `useCalendarView` returns null URL when `companyId` is falsy → no fetch, empty posts shown. Safe. |
| `MiniCalendar` still referenced elsewhere | Grep confirms only one call site: `ComposerOverlay.tsx`. `MiniCalendar.tsx` remains but is unused (can be deleted in a cleanup PR). |
| Bundle impact from SWR in right pane | SWR already used throughout; no new import. `@dnd-kit/core` is not imported (kept out intentionally). |

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] `test:unit` — 2025 pass
- [x] 3 e2e tests: `(CMG-1)` Calendar tab renders, `(CMG-2)` PostChip on scheduled date, `(CMG-3)` month navigation
- [x] No new dependencies
- [x] Existing design tokens only
- [x] PR under 500 net lines

## Decision trail

D-061–D-064 appended to `docs/briefs/composer-v3-fixes/DECISION_TRAIL.md`.