### PR TITLE
fix(auth): signout before callback exchange + hard-nav after login

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -91,6 +91,19 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   const supabase = createRouteAuthClient();
 
+  // Sign out any existing session before exchanging the incoming code.
+  // Without this, a previously signed-in user's cookies stay in play
+  // during the exchange: the new code is consumed (one-use), but the
+  // session that lands is polluted by the old user's cookie state.
+  // That produces two symptoms: the wrong user name is displayed (the
+  // old session persists), and any subsequent attempt gets "expired
+  // link" because the code was already consumed without a clean login.
+  // The sign-out is best-effort — if it fails we still attempt the
+  // exchange; the worst case is the same broken state as before the fix.
+  await supabase.auth.signOut().catch(() => {
+    logger.warn("auth callback pre-exchange sign-out failed (non-fatal)");
+  });
+
   if (code) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (error) {

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import { cookies, headers } from "next/headers";
-import { redirect } from "next/navigation";
 
 import { createRouteAuthClient } from "@/lib/auth";
 import { buildAuthRedirectUrl } from "@/lib/auth-redirect";
@@ -48,7 +47,16 @@ import { getServiceRoleClient } from "@/lib/supabase";
 // last hour, return an error (per the brief §4 rate limit).
 // ---------------------------------------------------------------------------
 
-export type LoginState = { error?: string };
+export type LoginState = {
+  error?: string;
+  // When set, the client should do a hard navigation (window.location.assign)
+  // to this URL. Using a hard redirect instead of next/navigation redirect()
+  // ensures the browser re-reads the Supabase session Set-Cookie headers
+  // before middleware runs — a soft RSC navigation can skip cookie re-reads
+  // and cause middleware to see no session, producing a stuck "Signing in…"
+  // state. Mirrors the window.location.assign pattern in CheckEmailPolling.tsx.
+  redirectTo?: string;
+};
 
 const MAX_CHALLENGES_PER_HOUR = 5;
 
@@ -99,10 +107,11 @@ export async function loginAction(
     return { error: "Sign-in failed. Please try again." };
   }
 
-  // Flag off → existing behaviour. No 2FA cookies are ever set when the
-  // flag is off, so there's nothing stale to clear on this path.
+  // Flag off → return the destination so the client can do a hard
+  // navigation (window.location.assign). No 2FA cookies are ever set
+  // when the flag is off, so there's nothing stale to clear on this path.
   if (!is2faEnabled()) {
-    redirect(next);
+    return { redirectTo: next };
   }
 
   // Flag on — check for a matching trusted device.
@@ -135,10 +144,10 @@ export async function loginAction(
       deviceId: deviceIdFromCookie,
     });
     if (trusted) {
-      // Skip the challenge — bump last_used_at + go.
+      // Skip the challenge — bump last_used_at + go (hard navigation).
       await touchTrustedDevice({ userId, deviceId: deviceIdFromCookie });
       clearStale2faCookies();
-      redirect(next);
+      return { redirectTo: next };
     }
   }
 
@@ -227,7 +236,7 @@ export async function loginAction(
   const checkEmailUrl = `/login/check-email?challenge_id=${encodeURIComponent(
     challenge.challenge_id,
   )}&next=${encodeURIComponent(next)}${sendResult.ok ? "" : "&email_send_failed=1"}`;
-  redirect(checkEmailUrl);
+  return { redirectTo: checkEmailUrl };
 }
 
 // helper for tests + the admin gate to reach the same env-aware

--- a/components/AuthCallbackClient.tsx
+++ b/components/AuthCallbackClient.tsx
@@ -68,23 +68,30 @@ export function AuthCallbackClient({ supabaseUrl, supabaseAnonKey }: Props) {
 
     // plan.kind === "set_session"
     const supabase = createBrowserClient(supabaseUrl, supabaseAnonKey);
-    supabase.auth
-      .setSession({
-        access_token: plan.access_token,
-        refresh_token: plan.refresh_token,
-      })
-      .then(({ error }) => {
-        setStatus("redirecting");
-        if (error) {
+    // Sign out any existing session before setting the new one.
+    // Without this, a previously signed-in user's in-memory session
+    // state persists after setSession, so the wrong user name is
+    // displayed and subsequent auth checks may return the old user.
+    // Best-effort: if signOut fails we still attempt setSession.
+    supabase.auth.signOut().catch(() => {}).then(() =>
+      supabase.auth
+        .setSession({
+          access_token: plan.access_token,
+          refresh_token: plan.refresh_token,
+        })
+        .then(({ error }) => {
+          setStatus("redirecting");
+          if (error) {
+            window.location.replace("/auth-error?reason=set_session_failed");
+            return;
+          }
+          window.location.replace(plan.destination);
+        })
+        .catch(() => {
+          setStatus("redirecting");
           window.location.replace("/auth-error?reason=set_session_failed");
-          return;
-        }
-        window.location.replace(plan.destination);
-      })
-      .catch(() => {
-        setStatus("redirecting");
-        window.location.replace("/auth-error?reason=set_session_failed");
-      });
+        })
+    );
   }, [supabaseUrl, supabaseAnonKey]);
 
   return (

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { useFormState, useFormStatus } from "react-dom";
 
 import { loginAction, type LoginState } from "@/app/login/actions";
@@ -8,11 +9,11 @@ import { Input } from "@/components/ui/input";
 
 const INITIAL_STATE: LoginState = {};
 
-function SubmitButton() {
+function SubmitButton({ isRedirecting }: { isRedirecting: boolean }) {
   const { pending } = useFormStatus();
   return (
-    <Button type="submit" disabled={pending}>
-      {pending ? "Signing in…" : "Sign in"}
+    <Button type="submit" disabled={pending || isRedirecting}>
+      {pending || isRedirecting ? "Signing in…" : "Sign in"}
     </Button>
   );
 }
@@ -32,6 +33,21 @@ export function LoginForm({ next }: { next: string }) {
   // React's later updates clean — the form still works without this,
   // but the console stays readable.
   const [state, formAction] = useFormState(loginAction, INITIAL_STATE);
+
+  // Hard navigation on successful login. The server action returns
+  // { redirectTo } instead of calling next/navigation redirect() so the
+  // browser performs a full document load (window.location.assign).
+  // This guarantees middleware re-reads the Supabase session cookies
+  // set by signInWithPassword before evaluating the destination route.
+  // A soft RSC navigation (router.push or redirect()) can skip the
+  // Set-Cookie re-read, leaving middleware seeing no session and
+  // causing a loop back to /login — the "Signing in…" hang.
+  // Mirrors the window.location.assign pattern in CheckEmailPolling.tsx.
+  useEffect(() => {
+    if (state.redirectTo) {
+      window.location.assign(state.redirectTo);
+    }
+  }, [state.redirectTo]);
 
   return (
     <form action={formAction} className="flex w-full flex-col gap-4">
@@ -72,7 +88,7 @@ export function LoginForm({ next }: { next: string }) {
         </p>
       )}
 
-      <SubmitButton />
+      <SubmitButton isRedirecting={Boolean(state.redirectTo)} />
 
       <p className="text-center text-sm text-muted-foreground">
         <a

--- a/lib/__tests__/auth-callback-route.test.ts
+++ b/lib/__tests__/auth-callback-route.test.ts
@@ -18,12 +18,17 @@ const mockState = vi.hoisted(() => ({
   exchangeCalls: [] as Array<string>,
   verifyResult: { error: null as { message: string } | null },
   verifyCalls: [] as Array<{ type: string; token_hash: string }>,
+  signOutCalls: 0,
   rateLimitOk: true,
 }));
 
 vi.mock("@/lib/auth", () => ({
   createRouteAuthClient: () => ({
     auth: {
+      signOut: async () => {
+        mockState.signOutCalls++;
+        return { error: null };
+      },
       exchangeCodeForSession: async (code: string) => {
         mockState.exchangeCalls.push(code);
         return mockState.exchangeResult;
@@ -62,6 +67,7 @@ beforeEach(() => {
   mockState.exchangeCalls = [];
   mockState.verifyResult = { error: null };
   mockState.verifyCalls = [];
+  mockState.signOutCalls = 0;
   mockState.rateLimitOk = true;
 });
 
@@ -198,5 +204,38 @@ describe("GET /api/auth/callback: rate limit", () => {
     expect(res.status).toBe(429);
     expect(mockState.exchangeCalls).toEqual([]);
     expect(mockState.verifyCalls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: sign out any existing session before the code exchange.
+//
+// Root cause: an existing session's cookies polluted the code exchange;
+// the code was consumed (one-use) but the session carried the old user's
+// identity. Subsequent attempts got "expired link" because the code was
+// already spent. Fix: signOut() BEFORE exchangeCodeForSession / verifyOtp.
+//
+// Working analog: loginAction (app/login/actions.ts) calls signOut()
+// before returning an error on the 2FA rate-limit path, as the canonical
+// pattern for "clear existing session before changing auth state".
+// ---------------------------------------------------------------------------
+describe("GET /api/auth/callback: sign out before exchange (regression)", () => {
+  it("calls signOut before exchangeCodeForSession on the PKCE path", async () => {
+    await callbackGET(makeReq("?code=pkce-sign-out-test"));
+    expect(mockState.signOutCalls).toBe(1);
+    expect(mockState.exchangeCalls).toEqual(["pkce-sign-out-test"]);
+  });
+
+  it("calls signOut before verifyOtp on the OTP path", async () => {
+    await callbackGET(makeReq("?token_hash=h-so&type=recovery"));
+    expect(mockState.signOutCalls).toBe(1);
+    expect(mockState.verifyCalls).toEqual([{ type: "recovery", token_hash: "h-so" }]);
+  });
+
+  it("does NOT call signOut when neither code nor token_hash is present", async () => {
+    await callbackGET(makeReq(""));
+    // missing_code path redirects before signOut has any value; the
+    // route bails out before the exchange block so signOut is not called.
+    expect(mockState.signOutCalls).toBe(0);
   });
 });

--- a/lib/__tests__/login-action.test.ts
+++ b/lib/__tests__/login-action.test.ts
@@ -77,28 +77,19 @@ function buildFormData(
   return fd;
 }
 
-// redirect() throws a NEXT_REDIRECT digest that includes the target
-// path. Returns the path on a redirect, or null if the action returned
-// normally (validation/auth error).
+// The action now returns { redirectTo } on success (instead of calling
+// next/navigation redirect()). This lets the client do window.location.assign
+// for a hard navigation that guarantees session cookies are re-read.
+// runAction surfaces redirectTo as `redirected` to keep all existing
+// test assertions unchanged.
 async function runAction(
   fd: FormData,
 ): Promise<{ redirected: string | null; state: { error?: string } | null }> {
-  try {
-    const state = await loginAction({}, fd);
-    return { redirected: null, state };
-  } catch (err) {
-    // Next's redirect() throws an error whose `digest` starts with
-    // "NEXT_REDIRECT;<type>;<url>;<status>". Parse out the URL so the
-    // test can assert on it.
-    const digest = (err as { digest?: string }).digest;
-    if (typeof digest === "string" && digest.startsWith("NEXT_REDIRECT")) {
-      const parts = digest.split(";");
-      // parts: ["NEXT_REDIRECT", "replace"|"push", "<url>", "<status>"]
-      const url = parts[2] ?? "";
-      return { redirected: url, state: null };
-    }
-    throw err;
+  const state = await loginAction({}, fd);
+  if (state.redirectTo) {
+    return { redirected: state.redirectTo, state: null };
   }
+  return { redirected: null, state };
 }
 
 beforeEach(() => {

--- a/tests/regressions/auth-callback-signout-before-exchange.test.ts
+++ b/tests/regressions/auth-callback-signout-before-exchange.test.ts
@@ -1,0 +1,116 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Regression: /api/auth/callback signs out any existing session BEFORE
+// exchanging the incoming code (Bug 1 — "expired link" + wrong user).
+//
+// Root cause: without signOut() before exchangeCodeForSession / verifyOtp,
+// a previously signed-in user's cookies stay in play during the exchange.
+// The code is consumed (one-use) but the session lands with the old user's
+// identity. Subsequent attempts get "expired link" because the code was
+// already spent. The wrong user's name is also displayed because the old
+// session persists.
+//
+// Working analog: loginAction (app/login/actions.ts) calls signOut() on the
+// 2FA rate-limit path as the canonical "clear state before auth change"
+// pattern. The fix makes the callback route follow the same pattern.
+// ---------------------------------------------------------------------------
+
+const mockState = vi.hoisted(() => ({
+  exchangeResult: { error: null as { message: string } | null },
+  exchangeCalls: [] as Array<string>,
+  verifyResult: { error: null as { message: string } | null },
+  verifyCalls: [] as Array<{ type: string; token_hash: string }>,
+  signOutCalls: [] as Array<"before_exchange" | "before_verify">,
+  callOrder: [] as Array<"signOut" | "exchange" | "verify">,
+  rateLimitOk: true,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: () => ({
+    auth: {
+      signOut: async () => {
+        mockState.signOutCalls.push("before_exchange");
+        mockState.callOrder.push("signOut");
+        return { error: null };
+      },
+      exchangeCodeForSession: async (code: string) => {
+        mockState.exchangeCalls.push(code);
+        mockState.callOrder.push("exchange");
+        return mockState.exchangeResult;
+      },
+      verifyOtp: async (params: { type: string; token_hash: string }) => {
+        mockState.verifyCalls.push(params);
+        mockState.callOrder.push("verify");
+        return mockState.verifyResult;
+      },
+    },
+  }),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: async () =>
+    mockState.rateLimitOk
+      ? { ok: true, limit: 60, remaining: 59, reset: 0 }
+      : {
+          ok: false,
+          limit: 60,
+          remaining: 0,
+          reset: Date.now() + 60_000,
+          retryAfterSec: 60,
+        },
+  rateLimitExceeded: () =>
+    new Response(
+      JSON.stringify({ ok: false, error: { code: "RATE_LIMITED" } }),
+      { status: 429, headers: { "content-type": "application/json" } },
+    ),
+  getClientIp: () => "127.0.0.1",
+}));
+
+import { GET as callbackGET } from "@/app/api/auth/callback/route";
+
+beforeEach(() => {
+  mockState.exchangeResult = { error: null };
+  mockState.exchangeCalls = [];
+  mockState.verifyResult = { error: null };
+  mockState.verifyCalls = [];
+  mockState.signOutCalls = [];
+  mockState.callOrder = [];
+  mockState.rateLimitOk = true;
+});
+
+function makeReq(query: string): NextRequest {
+  return new NextRequest(`https://opollo.vercel.app/api/auth/callback${query}`);
+}
+
+describe("Regression: auth callback signs out before exchange (Bug 1 — expired link + wrong user)", () => {
+  it("calls signOut BEFORE exchangeCodeForSession on the PKCE path", async () => {
+    const res = await callbackGET(makeReq("?code=pkce-test"));
+    expect(res.status).toBe(307);
+    // signOut must precede exchange
+    expect(mockState.callOrder).toEqual(["signOut", "exchange"]);
+    expect(mockState.signOutCalls).toHaveLength(1);
+    expect(mockState.exchangeCalls).toEqual(["pkce-test"]);
+  });
+
+  it("calls signOut BEFORE verifyOtp on the OTP path", async () => {
+    const res = await callbackGET(makeReq("?token_hash=h-otp&type=recovery"));
+    expect(res.status).toBe(307);
+    // signOut must precede verify
+    expect(mockState.callOrder).toEqual(["signOut", "verify"]);
+    expect(mockState.signOutCalls).toHaveLength(1);
+    expect(mockState.verifyCalls).toEqual([
+      { type: "recovery", token_hash: "h-otp" },
+    ]);
+  });
+
+  it("does NOT call signOut when no code/token_hash is present (early-exit path)", async () => {
+    const res = await callbackGET(makeReq(""));
+    // missing_code redirect fires before supabase is initialised
+    expect(mockState.signOutCalls).toHaveLength(0);
+    expect(mockState.callOrder).toEqual([]);
+    const loc = res.headers.get("location");
+    expect(loc).toContain("/auth-error");
+  });
+});

--- a/tests/regressions/login-action-hard-redirect.test.ts
+++ b/tests/regressions/login-action-hard-redirect.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Regression: loginAction returns { redirectTo } instead of calling
+// next/navigation redirect() so the client can do window.location.assign
+// (Bug 2 — login hangs on "Signing in…").
+//
+// Root cause: next/navigation redirect() triggers a soft RSC navigation
+// from useFormState. The browser doesn't re-read Set-Cookie headers on
+// a soft navigation, so middleware sees no session cookie and redirects
+// the user back to /login, producing a stuck "Signing in…" state.
+//
+// Fix: the action returns { redirectTo: string } and LoginForm.tsx calls
+// window.location.assign(state.redirectTo) — a hard navigation that
+// guarantees middleware sees the new session cookies.
+//
+// Working analog: CheckEmailPolling.tsx (line 95) uses window.location.assign
+// with the same rationale comment ("a hard navigation guarantees middleware
+// sees the cleared cookies before /admin/sites renders").
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: () => ({
+    auth: {
+      signInWithPassword: async ({
+        email,
+        password,
+      }: {
+        email: string;
+        password: string;
+      }) => {
+        if (email === "ok@test.com" && password === "correct-password") {
+          return { data: { user: { id: "uid-1" } }, error: null };
+        }
+        return {
+          data: { user: null },
+          error: { message: "Invalid login credentials" },
+        };
+      },
+    },
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: () => new Headers(),
+  // cookies() is only reached in the 2FA block; 2FA is off in these tests
+  // because AUTH_2FA_ENABLED env is unset.
+  cookies: () => ({
+    get: () => undefined,
+    set: () => {},
+    has: () => false,
+  }),
+}));
+
+// is2faEnabled() reads AUTH_2FA_ENABLED; unset means false → direct login path.
+// No need to mock the 2fa/flag module.
+
+const { loginAction } = await import("@/app/login/actions");
+
+function fd(
+  fields: Record<string, string | undefined>,
+): FormData {
+  const form = new FormData();
+  for (const [k, v] of Object.entries(fields)) {
+    if (v !== undefined) form.set(k, v);
+  }
+  return form;
+}
+
+describe("Regression: loginAction returns { redirectTo } (Bug 2 — Signing in… hang)", () => {
+  it("returns { redirectTo: next } on successful sign-in (no 2FA)", async () => {
+    const result = await loginAction(
+      {},
+      fd({ email: "ok@test.com", password: "correct-password", next: "/admin/sites" }),
+    );
+    // Must NOT throw NEXT_REDIRECT — returns a plain object instead.
+    expect(result).toEqual({ redirectTo: "/admin/sites" });
+    expect(result.redirectTo).toBe("/admin/sites");
+  });
+
+  it("defaults redirectTo to /admin/sites when next is omitted", async () => {
+    const result = await loginAction(
+      {},
+      fd({ email: "ok@test.com", password: "correct-password" }),
+    );
+    expect(result.redirectTo).toBe("/admin/sites");
+  });
+
+  it("sanitises a malicious next — redirectTo falls back to /admin/sites", async () => {
+    const result = await loginAction(
+      {},
+      fd({
+        email: "ok@test.com",
+        password: "correct-password",
+        next: "https://evil.example/steal",
+      }),
+    );
+    expect(result.redirectTo).toBe("/admin/sites");
+  });
+
+  it("returns { error } (no redirectTo) on wrong password", async () => {
+    const result = await loginAction(
+      {},
+      fd({ email: "ok@test.com", password: "wrong" }),
+    );
+    expect(result.redirectTo).toBeUndefined();
+    expect(result.error).toBe("Invalid email or password.");
+  });
+
+  it("returns { error } (no redirectTo) on missing email", async () => {
+    const result = await loginAction({}, fd({ password: "pw" }));
+    expect(result.redirectTo).toBeUndefined();
+    expect(result.error).toBe("Email and password are required.");
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug 1 — Expired link / wrong user on /auth/callback**: Both the server route (`/api/auth/callback`) and the client component (`AuthCallbackClient`) now call `signOut()` before the token exchange (`exchangeCodeForSession` / `verifyOtp` / `setSession`). Without this, a previously signed-in user's cookies polluted the one-use code: the code was consumed but the old user's identity persisted, showing the wrong name and making the next attempt fail with "expired link".

- **Bug 2 — Login hangs on "Signing in…"**: `loginAction` now returns `{ redirectTo }` instead of calling `next/navigation redirect()`. `LoginForm.tsx` calls `window.location.assign(state.redirectTo)` — a hard navigation that forces the browser to re-read Set-Cookie headers before middleware runs. A soft RSC redirect from `useFormState` skips the cookie re-read, so middleware saw no session and redirected back to `/login`, leaving the form permanently stuck in the pending "Signing in…" state. Mirrors the `window.location.assign` pattern already used in `CheckEmailPolling.tsx` (line 95) for the same reason.

## Working analog

**Bug 1**: `loginAction` (app/login/actions.ts:150–152) — calls `supabase.auth.signOut()` before returning an error on the 2FA rate-limit path, as the canonical "clear existing session before changing auth state" pattern. The callback routes are now made to match.

**Bug 2**: `CheckEmailPolling.tsx:95` — uses `window.location.assign(dest)` with the comment "a hard navigation guarantees middleware sees the cleared cookies before /admin/sites renders". `LoginForm.tsx` now follows the same pattern with the same rationale.

## Diff (Bug 1)

- `app/api/auth/callback/route.ts`: adds `await supabase.auth.signOut().catch(...)` before `exchangeCodeForSession` / `verifyOtp`
- `components/AuthCallbackClient.tsx`: chains `signOut().catch(() => {}).then(...)` before `setSession()`

## Diff (Bug 2)

- `app/login/actions.ts`: `LoginState` gains `redirectTo?: string`; both success redirect paths (`!is2faEnabled()` and trusted-device shortcut) return `{ redirectTo: next }` instead of calling `redirect(next)`. The 2FA check-email path also returns `{ redirectTo: checkEmailUrl }`.
- `components/LoginForm.tsx`: adds `useEffect` that calls `window.location.assign(state.redirectTo)` when `state.redirectTo` is set. `SubmitButton` receives `isRedirecting` so the button stays disabled during the hard navigation.

## Tests

- `tests/regressions/auth-callback-signout-before-exchange.test.ts` — 3 tests: signOut is called before exchange (PKCE), before verify (OTP), and NOT called on missing-code early-exit
- `tests/regressions/login-action-hard-redirect.test.ts` — 5 tests: action returns `{ redirectTo }` on success, sanitises next, returns `{ error }` on failure
- Updated `lib/__tests__/auth-callback-route.test.ts` — mock now tracks `signOutCalls`; regression suite added inline
- Updated `lib/__tests__/login-action.test.ts` — `runAction` helper updated to read `state.redirectTo` instead of catching NEXT_REDIRECT

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (2035/2035 pass)
- [x] Contract snapshots reviewed (not touched)
- [x] Regression tests added for both bugs
- [x] Working-analog block above
- [x] Risks identified and mitigated section below
- [x] PR is under 500 net lines

## Risks identified and mitigated

**signOut() before exchange** — best-effort (`catch` swallowed). If signOut fails (Supabase down), we still attempt the exchange. Worst case: same broken state as before the fix. No new failure mode.

**loginAction returns { redirectTo } instead of redirect()** — the `redirect()` from `next/navigation` is no longer called in the success paths. The redirect still fires via `window.location.assign` in the client. For JS-disabled browsers (progressive enhancement concern): the `LoginForm` degrades to a native `<form action={formAction}>` submission, which will POST the Server Action. Without JS, `window.location.assign` never runs and the form doesn't navigate. This is a known trade-off with SSR + `useFormState` — the same limitation exists in `CheckEmailPolling.tsx`. The happy path (JS enabled) is now correct; no-JS users were already blocked by other aspects of the auth flow.

**2FA redirect path** — all three redirect paths in `loginAction` (no-2FA, trusted-device, check-email) now return `{ redirectTo }`. The `CheckEmailPolling` component is not affected — it already uses `window.location.assign` for its own navigation post-challenge-complete.