### PR TITLE
fix(social/composer): chip click shows discard dialog when draft is dirty

### DIFF
--- a/components/social/composer/ComposerOverlay.tsx
+++ b/components/social/composer/ComposerOverlay.tsx
@@ -150,6 +150,9 @@ export function ComposerOverlay({
 
   // Unsaved-changes guard
   const [showDiscard, setShowDiscard] = React.useState(false);
+  // When the dialog was triggered by a Calendar chip click, holds the target post ID.
+  // null means the dialog was triggered by the close action.
+  const [pendingNavigateId, setPendingNavigateId] = React.useState<string | null>(null);
   // Keyboard shortcuts panel
   const [showShortcuts, setShowShortcuts] = React.useState(false);
   // Overlay ref for scoped querySelector
@@ -218,12 +221,34 @@ export function ComposerOverlay({
 
   function handleDiscard() {
     setShowDiscard(false);
-    onClose();
+    const navId = pendingNavigateId;
+    setPendingNavigateId(null);
+    if (navId) {
+      onNavigateToPost?.(navId);
+    } else {
+      onClose();
+    }
   }
 
   async function handleSaveFromDialog() {
     setShowDiscard(false);
-    await handleSubmit("draft");
+    const navId = pendingNavigateId;
+    setPendingNavigateId(null);
+    const saved = await handleSubmit("draft");
+    // handleSubmit calls onClose() on success. If triggered by a chip click,
+    // re-open the composer at the intended post after the save completes.
+    if (saved && navId) {
+      onNavigateToPost?.(navId);
+    }
+  }
+
+  function handleChipClick(postId: string) {
+    if (isDirty(draft)) {
+      setPendingNavigateId(postId);
+      setShowDiscard(true);
+    } else {
+      onNavigateToPost?.(postId);
+    }
   }
 
   async function handleConvertToDraft() {
@@ -242,14 +267,14 @@ export function ComposerOverlay({
     }
   }
 
-  async function handleSubmit(mode: SchedulingMode) {
+  async function handleSubmit(mode: SchedulingMode): Promise<boolean> {
     // External onSubmit takes precedence if provided.
     if (onSubmit) {
       await onSubmit(draft, mode);
-      return;
+      return true;
     }
 
-    if (!companyId) return;
+    if (!companyId) return false;
 
     setSubmitError(null);
     setSubmitting(true);
@@ -333,8 +358,10 @@ export function ComposerOverlay({
       );
       onSubmitSuccess?.();
       onClose();
+      return true;
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : "Something went wrong. Please try again.");
+      return false;
     } finally {
       setSubmitting(false);
     }
@@ -440,7 +467,7 @@ export function ComposerOverlay({
       <SchedulingCard
         value={scheduling}
         onChange={setScheduling}
-        onSubmit={() => handleSubmit(scheduling.mode)}
+        onSubmit={async () => { await handleSubmit(scheduling.mode); }}
         submitting={submitting}
         disabled={isSubmitDisabled}
         disabledTooltip={
@@ -588,7 +615,7 @@ export function ComposerOverlay({
               <ComposerEditor
                 draft={draft}
                 onChange={setDraft}
-                onSubmit={handleSubmit}
+                onSubmit={async (mode) => { await handleSubmit(mode); }}
                 companyId={companyId}
                 selectedConnections={selectedConnections}
                 schedulingSlot={schedulingSlot ?? internalSchedulingSlot}
@@ -664,7 +691,7 @@ export function ComposerOverlay({
                   companyId={companyId}
                   selectedDate={prefilledDate}
                   highlightPostId={initialDraft?.id}
-                  onClickPost={onNavigateToPost ? (post) => onNavigateToPost(post.id) : undefined}
+                  onClickPost={onNavigateToPost ? (post) => handleChipClick(post.id) : undefined}
                 />
               )}
             </div>
@@ -677,7 +704,7 @@ export function ComposerOverlay({
       <UnsavedChangesDialog
         open={showDiscard}
         onDiscard={handleDiscard}
-        onCancel={() => setShowDiscard(false)}
+        onCancel={() => { setShowDiscard(false); setPendingNavigateId(null); }}
         onSave={companyId ? () => void handleSaveFromDialog() : undefined}
       />
     </>

--- a/e2e/composer-d3-edit-mode.spec.ts
+++ b/e2e/composer-d3-edit-mode.spec.ts
@@ -243,4 +243,61 @@ test.describe("PR-D3 edit-mode parity", () => {
       page.locator('[data-testid="composer-overlay"] h2'),
     ).toContainText("Publishing", { timeout: 5_000 });
   });
+
+  test("(D3-7) calendar chip click with dirty draft shows UnsavedChangesDialog", async ({
+    page,
+    context,
+  }) => {
+    await signInAsCompanyAdmin(page);
+    await context.route("**/api/platform/social/connections**", (route) => {
+      void route.fulfill({ status: 200, contentType: "application/json", body: mockConnections() });
+    });
+    await page.route("**/api/platform/social/drafts/calendar-view**", (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: mockCalendarView([makeCalendarPost(MOCK_DRAFT_ID, "scheduled")]),
+      });
+    });
+    await page.route(`**/api/platform/social/drafts/${MOCK_DRAFT_ID}`, (route) => {
+      if (route.request().method() === "GET") {
+        void route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: makeDraftApiResponse("scheduled"),
+        });
+      } else {
+        void route.continue();
+      }
+    });
+
+    await page.goto(`/company/social/posts?compose=${MOCK_DRAFT_ID}`);
+    await page.waitForSelector('[data-testid="composer-overlay"]', { timeout: 20_000 });
+
+    // Make the draft dirty by editing content
+    const textarea = page.getByTestId("content-textarea");
+    await expect(textarea).toBeVisible({ timeout: 5_000 });
+    await textarea.click();
+    await textarea.fill("D3-7 dirty edit — should trigger UnsavedChangesDialog");
+
+    // Switch to Calendar tab in the right pane
+    const calendarTabBtn = page
+      .locator('[data-testid="composer-overlay"]')
+      .getByRole("button", { name: "Calendar" });
+    await expect(calendarTabBtn).toBeVisible({ timeout: 3_000 });
+    await calendarTabBtn.click();
+
+    // Wait for the post chip to appear in the calendar view
+    const chip = page.locator('[data-testid="post-chip"]').first();
+    await expect(chip).toBeVisible({ timeout: 5_000 });
+    await chip.click();
+
+    // UnsavedChangesDialog should appear
+    await expect(page.getByTestId("unsaved-continue-btn")).toBeVisible({ timeout: 3_000 });
+
+    // "Continue editing" closes the dialog and preserves content
+    await page.getByTestId("unsaved-continue-btn").click();
+    await expect(page.getByTestId("unsaved-continue-btn")).not.toBeVisible({ timeout: 2_000 });
+    await expect(textarea).toHaveValue("D3-7 dirty edit — should trigger UnsavedChangesDialog");
+  });
 });


### PR DESCRIPTION
## Summary

- Wires `handleChipClick` in `ComposerOverlay` to show `UnsavedChangesDialog` when the draft is dirty
- Adds `pendingNavigateId` state to distinguish a chip-click-triggered dialog from a close-action-triggered dialog
- "Continue editing" clears both `showDiscard` and `pendingNavigateId` and returns to the composer
- "Don't save" closes the dialog and calls `onNavigateToPost(postId)` to navigate to the clicked post
- "Save" saves the draft first, then navigates to the clicked post if save succeeded
- `handleSubmit` return type changed from `Promise<void>` to `Promise<boolean>` to support the conditional navigate-after-save path

## Working analog

**Working analog**: `ComposerOverlay.tsx:214–220` — the existing close-action guard that sets `showDiscard(true)` when `isDirty(draft)` is true; `handleDiscard` and `handleSaveFromDialog` already handled the close path.
**Diff**: the close path always called `onClose()`; there was no concept of a post ID to navigate to after the dialog resolved.
**Fix**: `pendingNavigateId` tracks the target post ID when the dialog was opened from a chip click (vs `null` for close); `handleDiscard` / `handleSaveFromDialog` branch on it.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (2058 tests pass)
- [x] E2E test added: `(D3-7)` in `composer-d3-edit-mode.spec.ts` — chip click with dirty draft shows dialog, Continue preserves content
- [x] Risks identified and mitigated section below
- [x] PR is under 500 net lines (93 net lines)

## Risks identified and mitigated

- **Dialog shown on every chip click while draft is loaded** — `isDirty` returns true whenever content/profiles are non-empty, including on initial load from an existing draft. This is consistent with the close-button guard (same pre-existing behavior). Acceptable: the user always has the option to "Continue editing" to dismiss.
- **`handleSubmit` now returns `Promise<boolean>`** — the two internal call sites that pass `handleSubmit` to child-component props (`SchedulingCard.onSubmit`, `ComposerEditor.onSubmit`) have been wrapped in `async () => { await handleSubmit(...); }` to satisfy the `Promise<void>` prop types. No behavioral change.
- **`pendingNavigateId` not cleared if dialog closed via backdrop** — `UnsavedChangesDialog` calls `onCancel` on outside click (`onOpenChange`), which now also clears `pendingNavigateId`. Covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)