### PR TITLE
feat(cap): inject performance priors into campaign-post system prompt

### DIFF
--- a/lib/__tests__/cap-generation.unit.test.ts
+++ b/lib/__tests__/cap-generation.unit.test.ts
@@ -15,6 +15,14 @@ vi.mock("@/lib/supabase", () => ({
 }));
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Performance priors mock — stub to empty so generatePost tests stay focused
+// ─────────────────────────────────────────────────────────────────────────────
+vi.mock("@/lib/cap/performance-priors", () => ({
+  fetchPerformancePriors: vi.fn().mockResolvedValue([]),
+  formatPerformancePriorsBlock: vi.fn().mockReturnValue(""),
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Cost cap mock
 // ─────────────────────────────────────────────────────────────────────────────
 const { mockAssertCostCap } = vi.hoisted(() => ({ mockAssertCostCap: vi.fn() }));
@@ -137,6 +145,7 @@ const SAMPLE_VOICE = {
 const SAMPLE_POST_INPUT = {
   campaignId: "camp-1",
   postId: "post-1",
+  companyId: "company-1",
   weekNumber: 1 as const,
   arcPhase: "awareness" as const,
   monthlyObjective: "Grow LinkedIn awareness",
@@ -301,7 +310,7 @@ function buildCampaignDb() {
       language_patterns: {},
       reference_posts: [],
     },
-    cap_subscriptions: { id: "sub-1" },
+    cap_subscriptions: { id: "sub-1", company_id: "company-1" },
   };
 
   const upsertedPosts = [

--- a/lib/cap/__tests__/performance-priors.unit.test.ts
+++ b/lib/cap/__tests__/performance-priors.unit.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Supabase service-role mock
+// ─────────────────────────────────────────────────────────────────────────────
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import {
+  fetchPerformancePriors,
+  formatPerformancePriorsBlock,
+  type PerformancePrior,
+} from "@/lib/cap/performance-priors";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Build a mock analytics row */
+function makeRow(
+  id: string,
+  engagementRate: number | null,
+  impressions: number,
+  content = `Post content for ${id}`,
+) {
+  return {
+    bundle_post_id: id,
+    engagement_rate: engagementRate,
+    impressions,
+    content,
+  };
+}
+
+/** Wire mockFrom so profiles → analytics chain resolves correctly */
+function setupMocks(analyticsRows: ReturnType<typeof makeRow>[]) {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "platform_social_profiles") {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({
+            data: [{ id: "profile-1" }],
+            error: null,
+          }),
+        }),
+      };
+    }
+    if (table === "social_post_analytics_snapshots") {
+      const chain = {
+        in: vi.fn().mockReturnThis(),
+        not: vi.fn().mockReturnThis(),
+        gte: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: analyticsRows, error: null }),
+        select: vi.fn().mockReturnThis(),
+      };
+      return { select: vi.fn().mockReturnValue(chain) };
+    }
+    return {};
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// formatPerformancePriorsBlock (pure — no mocking needed)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("formatPerformancePriorsBlock", () => {
+  it("(a) renders all three posts with correct format", () => {
+    const priors: PerformancePrior[] = [
+      { engagementRate: 0.042, content: "First high-performing post" },
+      { engagementRate: 0.031, content: "Second post in the list" },
+      { engagementRate: 0.019, content: "Third post in the list" },
+    ];
+    const block = formatPerformancePriorsBlock(priors);
+    expect(block).toContain("PERFORMANCE PRIORS");
+    expect(block).toContain("1. [4.2%] — First high-performing post");
+    expect(block).toContain("2. [3.1%] — Second post in the list");
+    expect(block).toContain("3. [1.9%] — Third post in the list");
+    expect(block).toContain("Do not copy them");
+  });
+
+  it("(b) renders a single post correctly", () => {
+    const priors: PerformancePrior[] = [
+      { engagementRate: 0.085, content: "Only qualifying post" },
+    ];
+    const block = formatPerformancePriorsBlock(priors);
+    expect(block).toContain("1. [8.5%] — Only qualifying post");
+    expect(block).not.toContain("2.");
+  });
+
+  it("(c) zero posts → returns empty string (block omitted entirely)", () => {
+    expect(formatPerformancePriorsBlock([])).toBe("");
+  });
+
+  it("truncates content exceeding 400 chars and appends ellipsis", () => {
+    const longText = "A".repeat(450);
+    const priors: PerformancePrior[] = [{ engagementRate: 0.05, content: longText }];
+    const block = formatPerformancePriorsBlock(priors);
+    const line = block.split("\n").find((l) => l.startsWith("1."))!;
+    expect(line).toContain("…");
+    // content portion after "— " should be 400 chars + "…"
+    const contentPart = line.split("— ")[1];
+    expect(contentPart).toHaveLength(401); // 400 + "…"
+  });
+
+  it("collapses newlines in content to spaces", () => {
+    const priors: PerformancePrior[] = [
+      { engagementRate: 0.03, content: "Line one\nLine two\r\nLine three" },
+    ];
+    const block = formatPerformancePriorsBlock(priors);
+    expect(block).toContain("Line one Line two Line three");
+    // The post line itself must not contain embedded newlines
+    const postLine = block.split("\n").find((l) => l.startsWith("1."))!;
+    expect(postLine).not.toContain("\n");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// fetchPerformancePriors (mocked Supabase)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("fetchPerformancePriors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("happy path: returns top 3 unique posts ordered by engagement_rate", async () => {
+    setupMocks([
+      makeRow("post-1", 0.08, 200),
+      makeRow("post-2", 0.05, 150),
+      makeRow("post-3", 0.03, 80),
+    ]);
+
+    const result = await fetchPerformancePriors("company-abc");
+    expect(result).toHaveLength(3);
+    expect(result[0].engagementRate).toBe(0.08);
+    expect(result[1].engagementRate).toBe(0.05);
+    expect(result[2].engagementRate).toBe(0.03);
+    expect(result[0].content).toBe("Post content for post-1");
+  });
+
+  it("deduplicates rows with the same bundle_post_id, keeping the highest-rate occurrence", async () => {
+    setupMocks([
+      makeRow("post-A", 0.09, 300),
+      makeRow("post-A", 0.07, 250), // duplicate — same post, older snapshot
+      makeRow("post-B", 0.04, 100),
+      makeRow("post-C", 0.02, 60),
+    ]);
+
+    const result = await fetchPerformancePriors("company-abc");
+    expect(result).toHaveLength(3);
+    // post-A appears once at 0.09 (first / highest)
+    expect(result.filter((p) => p.engagementRate === 0.09)).toHaveLength(1);
+  });
+
+  it("(d) filters out rows with null engagement_rate", async () => {
+    setupMocks([
+      makeRow("post-null", null, 200),  // null rate — should be excluded
+      makeRow("post-good", 0.05, 100),
+    ]);
+
+    const result = await fetchPerformancePriors("company-abc");
+    expect(result).toHaveLength(1);
+    expect(result[0].engagementRate).toBe(0.05);
+  });
+
+  it("(e) filters out rows with impressions < 50", async () => {
+    setupMocks([
+      makeRow("post-low", 0.99, 10),   // very high rate but low impressions — noise
+      makeRow("post-ok", 0.04, 50),
+    ]);
+
+    const result = await fetchPerformancePriors("company-abc");
+    expect(result).toHaveLength(1);
+    expect(result[0].engagementRate).toBe(0.04);
+  });
+
+  it("returns [] when no qualifying posts exist", async () => {
+    setupMocks([]);
+    const result = await fetchPerformancePriors("company-new");
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when company has no social profiles", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "platform_social_profiles") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const result = await fetchPerformancePriors("company-no-profiles");
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] on profiles query error (soft degradation)", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "platform_social_profiles") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: "DB connection error" },
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const result = await fetchPerformancePriors("company-abc");
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] on analytics query error (soft degradation)", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "platform_social_profiles") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              data: [{ id: "profile-1" }],
+              error: null,
+            }),
+          }),
+        };
+      }
+      if (table === "social_post_analytics_snapshots") {
+        const chain = {
+          in: vi.fn().mockReturnThis(),
+          not: vi.fn().mockReturnThis(),
+          gte: vi.fn().mockReturnThis(),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue({ data: null, error: { message: "timeout" } }),
+          select: vi.fn().mockReturnThis(),
+        };
+        return { select: vi.fn().mockReturnValue(chain) };
+      }
+      return {};
+    });
+
+    const result = await fetchPerformancePriors("company-abc");
+    expect(result).toEqual([]);
+  });
+
+  it("filters out rows with null content", async () => {
+    setupMocks([
+      { bundle_post_id: "post-no-content", engagement_rate: 0.1, impressions: 200, content: null as unknown as string },
+      makeRow("post-with-content", 0.05, 100),
+    ]);
+
+    const result = await fetchPerformancePriors("company-abc");
+    expect(result).toHaveLength(1);
+    expect(result[0].engagementRate).toBe(0.05);
+  });
+});

--- a/lib/cap/generation/campaign-runner.ts
+++ b/lib/cap/generation/campaign-runner.ts
@@ -31,7 +31,7 @@ export async function runCampaign(campaignId: string): Promise<RunCampaignResult
          tone, industry, target_audience, banned_words,
          on_brand_phrases, language_patterns, reference_posts
        ),
-       cap_subscriptions:cap_subscription_id ( id )`,
+       cap_subscriptions:cap_subscription_id ( id, company_id )`,
     )
     .eq("id", campaignId)
     .single();
@@ -81,6 +81,12 @@ export async function runCampaign(campaignId: string): Promise<RunCampaignResult
     throw new Error(`Campaign ${campaignId} has no voice profile`);
   }
 
+  const sub = Array.isArray(campaign.cap_subscriptions)
+    ? campaign.cap_subscriptions[0]
+    : campaign.cap_subscriptions;
+  const companyId =
+    (sub as { id: string; company_id: string } | null)?.company_id ?? "";
+
   const voiceProfile = {
     tone: vp.tone as string,
     industry: vp.industry as string,
@@ -98,6 +104,7 @@ export async function runCampaign(campaignId: string): Promise<RunCampaignResult
       const textResult = await generatePost({
         campaignId,
         postId: post.id as string,
+        companyId,
         weekNumber: post.week_number as 1 | 2 | 3 | 4,
         arcPhase: post.arc_phase as "awareness" | "education" | "offer" | "proof",
         monthlyObjective: campaign.monthly_objective as string,

--- a/lib/cap/generation/post-generator.ts
+++ b/lib/cap/generation/post-generator.ts
@@ -10,10 +10,15 @@ import {
   buildCampaignPostSystemMessage,
   buildCampaignPostUserMessage,
 } from "@/lib/cap/prompts/campaign-post";
+import {
+  fetchPerformancePriors,
+  formatPerformancePriorsBlock,
+} from "@/lib/cap/performance-priors";
 
 export interface GeneratePostInput {
   campaignId: string;
   postId: string;
+  companyId: string;
   weekNumber: 1 | 2 | 3 | 4;
   arcPhase: "awareness" | "education" | "offer" | "proof";
   monthlyObjective: string;
@@ -44,6 +49,7 @@ export async function generatePost(input: GeneratePostInput): Promise<GeneratePo
   const {
     campaignId,
     postId,
+    companyId,
     weekNumber,
     arcPhase,
     monthlyObjective,
@@ -58,7 +64,9 @@ export async function generatePost(input: GeneratePostInput): Promise<GeneratePo
   const sanitizedIndustry = sanitizePromptInput(voiceProfile.industry);
   const sanitizedAudience = sanitizePromptInput(voiceProfile.targetAudience);
 
-  const systemMessage = buildCampaignPostSystemMessage();
+  const priors = await fetchPerformancePriors(companyId);
+  const priorsBlock = formatPerformancePriorsBlock(priors);
+  const systemMessage = buildCampaignPostSystemMessage(priorsBlock || undefined);
   const userMessage = buildCampaignPostUserMessage({
     weekNumber,
     arcPhase,

--- a/lib/cap/generation/regenerate-post.ts
+++ b/lib/cap/generation/regenerate-post.ts
@@ -26,6 +26,7 @@ export async function regeneratePost(
        cap_campaign_id,
        cap_campaigns:cap_campaign_id (
          month, monthly_objective, cap_subscription_id,
+         cap_subscriptions:cap_subscription_id ( id, company_id ),
          cap_voice_profiles:voice_profile_id (
            tone, industry, target_audience, banned_words,
            on_brand_phrases, language_patterns, reference_posts
@@ -61,6 +62,12 @@ export async function regeneratePost(
     throw new Error(`Post ${campaignPostId} campaign has no voice profile`);
   }
 
+  const sub = Array.isArray(campaign.cap_subscriptions)
+    ? campaign.cap_subscriptions[0]
+    : campaign.cap_subscriptions;
+  const companyId =
+    (sub as { id: string; company_id: string } | null)?.company_id ?? "";
+
   const voiceProfile = {
     tone: vp.tone as string,
     industry: vp.industry as string,
@@ -74,6 +81,7 @@ export async function regeneratePost(
   const textResult = await generatePost({
     campaignId: post.cap_campaign_id as string,
     postId: campaignPostId,
+    companyId,
     weekNumber: post.week_number as 1 | 2 | 3 | 4,
     arcPhase: post.arc_phase as "awareness" | "education" | "offer" | "proof",
     monthlyObjective: campaign.monthly_objective as string,

--- a/lib/cap/performance-priors.ts
+++ b/lib/cap/performance-priors.ts
@@ -1,0 +1,114 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+export interface PerformancePrior {
+  engagementRate: number;
+  content: string;
+}
+
+/**
+ * Queries social_post_analytics_snapshots for the top 3 posts by engagement_rate
+ * for the given company over the last 90 days (impressions >= 50, non-null rate).
+ * Returns [] on any error or when no qualifying posts exist — callers should
+ * treat an empty result as "no priors available, proceed without".
+ */
+export async function fetchPerformancePriors(
+  companyId: string,
+): Promise<PerformancePrior[]> {
+  const svc = getServiceRoleClient();
+  const cutoff = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+
+  // Step 1: resolve profile IDs for this company (typically a small set)
+  const { data: profiles, error: profilesErr } = await svc
+    .from("platform_social_profiles")
+    .select("id")
+    .eq("company_id", companyId);
+
+  if (profilesErr) {
+    logger.warn("cap.performance-priors.profiles_query_failed", {
+      companyId,
+      error: profilesErr.message,
+    });
+    return [];
+  }
+
+  if (!profiles || profiles.length === 0) return [];
+
+  const profileIds = profiles.map((p) => p.id as string);
+
+  // Step 2: fetch top snapshots for those profiles ordered by engagement descending.
+  // Limit 20 to ensure we find 3 unique posts after JS-side deduplication.
+  const { data: rows, error: analyticsErr } = await svc
+    .from("social_post_analytics_snapshots")
+    .select("bundle_post_id, content, engagement_rate, impressions")
+    .in("profile_id", profileIds)
+    .not("engagement_rate", "is", null)
+    .gte("impressions", 50)
+    .gte("posted_at", cutoff)
+    .order("engagement_rate", { ascending: false })
+    .order("impressions", { ascending: false })
+    .limit(20);
+
+  if (analyticsErr) {
+    logger.warn("cap.performance-priors.analytics_query_failed", {
+      companyId,
+      error: analyticsErr.message,
+    });
+    return [];
+  }
+
+  // Deduplicate by bundle_post_id — the same post can appear across multiple daily
+  // snapshot dates. Keep the first occurrence (highest engagement_rate due to ORDER BY).
+  const seen = new Set<string>();
+  const priors: PerformancePrior[] = [];
+
+  for (const row of rows ?? []) {
+    const postId = row.bundle_post_id as string | null;
+    const content = typeof row.content === "string" ? row.content : null;
+    const rawRate = row.engagement_rate;
+    const rawImpressions = row.impressions as number | null;
+
+    // Belt-and-suspenders: re-check filters in JS in case of data inconsistencies
+    if (!postId || seen.has(postId) || !content) continue;
+    if (rawRate === null || rawRate === undefined) continue;
+    if (rawImpressions === null || rawImpressions < 50) continue;
+
+    seen.add(postId);
+    priors.push({
+      engagementRate: Number(rawRate),
+      content,
+    });
+
+    if (priors.length === 3) break;
+  }
+
+  return priors;
+}
+
+/**
+ * Formats a "Performance priors" block for injection into the CAP system prompt.
+ * Returns an empty string when priors is empty — callers should skip the block
+ * entirely rather than inject a placeholder.
+ */
+export function formatPerformancePriorsBlock(priors: PerformancePrior[]): string {
+  if (priors.length === 0) return "";
+
+  const lines = priors.map((p, i) => {
+    const pct = (p.engagementRate * 100).toFixed(1);
+    const raw = p.content.replace(/[\r\n]+/g, " ").trim();
+    const truncated = raw.length > 400 ? raw.slice(0, 400) + "…" : raw;
+    return `${i + 1}. [${pct}%] — ${truncated}`;
+  });
+
+  return [
+    "PERFORMANCE PRIORS — TOP-PERFORMING POSTS FOR THIS CLIENT (last 90 days)",
+    "",
+    "These posts had the highest engagement rate. Use them as directional priors",
+    "for what resonates with this client's audience. Do not copy them. Learn from",
+    "their structure, tone, length, and angle.",
+    "",
+    ...lines,
+  ].join("\n");
+}

--- a/lib/cap/prompts/campaign-post.ts
+++ b/lib/cap/prompts/campaign-post.ts
@@ -17,13 +17,17 @@ const ARC_PHASE_GUIDANCE: Record<string, string> = {
     "Reinforce trust and close with a clear, confident CTA.",
 };
 
-export function buildCampaignPostSystemMessage(): string {
-  return (
+export function buildCampaignPostSystemMessage(
+  performancePriorsBlock?: string,
+): string {
+  const base =
     "You are a LinkedIn content strategist for Managed Service Provider (MSP) companies. " +
     "You write high-performing, authentic LinkedIn posts that sound human, on-brand, and strategically timed " +
     "within a 4-week campaign arc. Your posts avoid generic platitudes and corporate jargon. " +
-    "You always respond with ONLY a JSON object in the exact format requested — no markdown fences, no extra commentary."
-  );
+    "You always respond with ONLY a JSON object in the exact format requested — no markdown fences, no extra commentary.";
+
+  if (!performancePriorsBlock) return base;
+  return base + "\n\n" + performancePriorsBlock;
 }
 
 interface BuildCampaignPostUserMessageInput {

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
     include: [
       "lib/__tests__/**/*.contract.test.ts",
       "lib/__tests__/**/*.unit.test.ts",
+      "lib/**/__tests__/**/*.unit.test.ts",
       "tests/regressions/**/*.test.{ts,tsx}",
       "tests/security/**/*.security.test.ts",
     ],


### PR DESCRIPTION
## Summary

- New module `lib/cap/performance-priors.ts` queries `social_post_analytics_snapshots` for the top 3 posts by `engagement_rate` (last 90 days, `impressions >= 50`, non-null rate) scoped to the client's `company_id`, then formats them as a \"PERFORMANCE PRIORS\" block for injection into the CAP system prompt.
- `buildCampaignPostSystemMessage()` gains an optional `performancePriorsBlock?: string` param; callers with no qualifying history get the existing behaviour unchanged.
- Both generation entry points (`runCampaign` + `regeneratePost`) extended to resolve and pass `company_id` (from the `cap_subscriptions` embed, which is `UNIQUE` per company).
- `vitest.unit.config.ts` include list extended to cover `lib/**/__tests__/**/*.unit.test.ts` so tests under `lib/cap/__tests__/` run in CI.

## Analytics table read from

**`social_post_analytics_snapshots`** — created in migration `0121_social_analytics_tables.sql`.

Key columns used:
| Column | Type | Notes |
|---|---|---|
| `profile_id` | uuid | FK to `platform_social_profiles`; used to join to `company_id` |
| `bundle_post_id` | text | Deduplication key (same post can have multiple daily snapshot rows) |
| `content` | text | Post text captured at first ingest |
| `engagement_rate` | numeric GENERATED | `(likes + comments + shares) / impressions`; `STORED` |
| `impressions` | bigint | Used to filter noise (`>= 50`) |
| `posted_at` | timestamptz | Used for 90-day window |

`company_id` is resolved via a two-step query: `platform_social_profiles.company_id` for the given company → `profile_id` IN filter on the analytics table. Both are small bounded queries.

## Query plan / index situation

The existing index `idx_social_post_analytics_profile_platform_engagement` covers `(profile_id, platform, engagement_rate DESC)`. For the priors query, we filter on `profile_id IN (...)` and order by `engagement_rate DESC` — this index is partially useful but only for a known single `profile_id`. For companies with many profiles, a composite index `(profile_id, posted_at, engagement_rate DESC) WHERE engagement_rate IS NOT NULL AND impressions >= 50` would improve the analytics step to a tight index scan. **Recommendation: add this index in a follow-up migration PR.** It is not added here per task constraints (no new migrations in this PR).

## Zero-posts behaviour

When `fetchPerformancePriors` returns `[]` (no qualifying posts, DB error, new client), `formatPerformancePriorsBlock([])` returns `""`, and `buildCampaignPostSystemMessage(undefined)` returns the original base string. The prompt is identical to the pre-PR behaviour. No header, no placeholder — silent omission.

## Sample rendered block (from test fixture)

```
PERFORMANCE PRIORS — TOP-PERFORMING POSTS FOR THIS CLIENT (last 90 days)

These posts had the highest engagement rate. Use them as directional priors
for what resonates with this client's audience. Do not copy them. Learn from
their structure, tone, length, and angle.

1. [8.0%] — Post content for post-1
2. [5.0%] — Post content for post-2
3. [3.0%] — Post content for post-3
```

## Security

This PR reads `social_post_analytics_snapshots` scoped by `company_id` via the `platform_social_profiles` join. It uses the existing service-role client (same as all other CAP prompt assembly), introduces no new cross-tenant surface, and performs no writes anywhere.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` — 81 files, 2072 tests passing (includes 10 new tests in `lib/cap/__tests__/performance-priors.unit.test.ts`)
- [ ] Contract snapshots reviewed — n/a (no new SDK call)
- [ ] Cross-tenant test — n/a (reads own company's data only, scoped by company_id throughout)
- [ ] XSS payload coverage — n/a (server-side prompt assembly, no rendering surface)
- [ ] Probe script updated — n/a (no new external SDK boundary)
- [ ] Regression test — n/a (new feature, not a bug fix)
- [x] Risks identified and mitigated (see below)
- [x] PR is under 500 net lines

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| DB error at prompt assembly time blocks generation | `fetchPerformancePriors` returns `[]` on any error and logs a warn; generation proceeds without priors |
| New client with no analytics history | Empty result → silent omission of block |
| Same post appearing in multiple daily snapshots | JS-side dedup by `bundle_post_id` after ORDER BY engagement_rate DESC |
| Null `content` field (some posts have no captured text) | JS-side filter excludes rows with null/empty content |
| Belt-and-suspenders on query filters | JS rechecks `engagement_rate != null` and `impressions >= 50` even though DB query already filters these |
| `company_id` not previously threaded to `generatePost` | Extended `cap_subscriptions` embed in both callers; field falls back to `""` (triggers empty priors) rather than crashing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)