### PR TITLE
feat(insights): admin multi-client dashboard at /admin/insights with audit fail-closed (PR-04)

### DIFF
--- a/app/(platform)/admin/insights/clients/[id]/page.tsx
+++ b/app/(platform)/admin/insights/clients/[id]/page.tsx
@@ -1,0 +1,53 @@
+"use server";
+
+import { notFound, redirect } from "next/navigation";
+
+import { AdminClientDrilldown } from "@/components/admin-insights/AdminClientDrilldown";
+import { createRouteAuthClient } from "@/lib/auth";
+import { getAdminClientSnapshot } from "@/lib/insights/admin-dashboard";
+import { writeAdminAudit } from "@/lib/insights/admin-audit";
+import { getInsightsDashboardData } from "@/lib/insights/dashboard";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+export default async function AdminClientInsightsPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const supabase = createRouteAuthClient();
+  const { data: isOp } = await supabase.rpc("is_cap_operator");
+  if (!isOp) redirect("/admin");
+
+  const { data: userResp } = await supabase.auth.getUser();
+  const userId = userResp?.user?.id;
+
+  const [snapshot, dashboardData] = await Promise.all([
+    getAdminClientSnapshot(params.id),
+    getInsightsDashboardData(params.id),
+  ]);
+
+  if (!snapshot) notFound();
+
+  // Write view audit (non-mutating — best effort)
+  if (userId) {
+    await writeAdminAudit(
+      {
+        operatorUserId: userId,
+        clientCompanyId: params.id,
+        action: "view",
+        actionDetails: {},
+      },
+      false,
+    );
+  }
+
+  return (
+    <AdminClientDrilldown
+      clientName={snapshot.name}
+      companyId={params.id}
+      data={dashboardData}
+    />
+  );
+}

--- a/app/(platform)/admin/insights/clients/[id]/page.tsx
+++ b/app/(platform)/admin/insights/clients/[id]/page.tsx
@@ -1,5 +1,3 @@
-"use server";
-
 import { notFound, redirect } from "next/navigation";
 
 import { AdminClientDrilldown } from "@/components/admin-insights/AdminClientDrilldown";

--- a/app/(platform)/admin/insights/compare/page.tsx
+++ b/app/(platform)/admin/insights/compare/page.tsx
@@ -1,0 +1,53 @@
+import { redirect } from "next/navigation";
+
+import { ClientCompareCharts } from "@/components/admin-insights/ClientCompareCharts";
+import { ClientCompareTable } from "@/components/admin-insights/ClientCompareTable";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
+import { createRouteAuthClient } from "@/lib/auth";
+import { getAdminRoster, getCompareData } from "@/lib/insights/admin-dashboard";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+export default async function AdminInsightsComparePage({
+  searchParams,
+}: {
+  searchParams?: { ids?: string };
+}) {
+  const supabase = createRouteAuthClient();
+  const { data: isOp } = await supabase.rpc("is_cap_operator");
+  if (!isOp) redirect("/admin");
+
+  const roster = await getAdminRoster();
+  const selectedIds = searchParams?.ids?.split(",").filter(Boolean) ?? [];
+  const compareData = selectedIds.length > 0 ? await getCompareData(selectedIds) : [];
+
+  const breadcrumb = [
+    { label: "Admin", href: "/admin" },
+    { label: "Insights", href: "/admin/insights" },
+    { label: "Compare" },
+  ];
+
+  return (
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb segments={breadcrumb} />
+        <PageHeader.Title>Compare clients</PageHeader.Title>
+        <PageHeader.Subtitle>Side-by-side engagement performance</PageHeader.Subtitle>
+        <PageHeader.Actions>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/admin/insights">← Back to roster</Link>
+          </Button>
+        </PageHeader.Actions>
+      </PageHeader>
+
+      <PageShell.Content>
+        <ClientCompareTable roster={roster} selectedIds={selectedIds} compareData={compareData} />
+        {compareData.length > 0 && <ClientCompareCharts data={compareData} />}
+      </PageShell.Content>
+    </PageShell>
+  );
+}

--- a/app/(platform)/admin/insights/page.tsx
+++ b/app/(platform)/admin/insights/page.tsx
@@ -1,0 +1,64 @@
+import { redirect } from "next/navigation";
+
+import { AdminRoster } from "@/components/admin-insights/AdminRoster";
+import { PortfolioKPIs } from "@/components/admin-insights/PortfolioKPIs";
+import { RecentAdminActivity } from "@/components/admin-insights/RecentAdminActivity";
+import { StaleDataAlerts } from "@/components/admin-insights/StaleDataAlerts";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
+import { createRouteAuthClient } from "@/lib/auth";
+import {
+  getAdminPortfolioKpis,
+  getAdminRoster,
+  getRecentAdminActivity,
+} from "@/lib/insights/admin-dashboard";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+export default async function AdminInsightsPage() {
+  // Additional gate: requires is_cap_operator (admin layout already requires admin role)
+  const supabase = createRouteAuthClient();
+  const { data: isOp } = await supabase.rpc("is_cap_operator");
+  if (!isOp) redirect("/admin");
+
+  const [roster, activity] = await Promise.all([
+    getAdminRoster(),
+    getRecentAdminActivity(10),
+  ]);
+
+  const kpis = await getAdminPortfolioKpis(roster);
+  const staleClients = roster.filter((r) => r.healthStatus === "red" || r.healthStatus === "amber");
+
+  const breadcrumb = [
+    { label: "Admin", href: "/admin" },
+    { label: "Insights" },
+  ];
+
+  return (
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb segments={breadcrumb} />
+        <PageHeader.Title>Insights · Admin</PageHeader.Title>
+        <PageHeader.Subtitle>Performance across all managed clients</PageHeader.Subtitle>
+        <PageHeader.Actions>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/admin/insights/compare">Compare</Link>
+          </Button>
+        </PageHeader.Actions>
+      </PageHeader>
+
+      <PageShell.Content>
+        {staleClients.length > 0 && <StaleDataAlerts clients={staleClients} />}
+
+        <PortfolioKPIs kpis={kpis} />
+
+        <AdminRoster roster={roster} />
+
+        <RecentAdminActivity activity={activity} />
+      </PageShell.Content>
+    </PageShell>
+  );
+}

--- a/app/api/admin/insights/clients/[id]/annotate/[recId]/route.ts
+++ b/app/api/admin/insights/clients/[id]/annotate/[recId]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+
+import { requireCapOperatorForApi } from "@/lib/cap/api-gate";
+import { AuditFailedError, writeAdminAudit } from "@/lib/insights/admin-audit";
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string; recId: string } },
+) {
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  const body = await req.json().catch(() => ({}));
+  const note = typeof body.note === "string" ? body.note.slice(0, 1000) : null;
+
+  try {
+    await writeAdminAudit(
+      {
+        operatorUserId: gate.userId,
+        clientCompanyId: params.id,
+        action: "annotate",
+        actionDetails: {
+          recommendationId: params.recId,
+          note,
+        },
+        clientIp: req.headers.get("x-forwarded-for") ?? undefined,
+        userAgent: req.headers.get("user-agent") ?? undefined,
+      },
+      true,
+    );
+  } catch (err) {
+    if (err instanceof AuditFailedError) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: "AUDIT_WRITE_FAILED",
+            message: "Action blocked: audit log unavailable",
+            retryable: true,
+          },
+        },
+        { status: 503 },
+      );
+    }
+    throw err;
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/admin/insights/clients/[id]/dismiss/[recId]/route.ts
+++ b/app/api/admin/insights/clients/[id]/dismiss/[recId]/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+
+import { requireCapOperatorForApi } from "@/lib/cap/api-gate";
+import { AuditFailedError, writeAdminAudit } from "@/lib/insights/admin-audit";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string; recId: string } },
+) {
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  const body = await req.json().catch(() => ({}));
+
+  try {
+    await writeAdminAudit(
+      {
+        operatorUserId: gate.userId,
+        clientCompanyId: params.id,
+        action: "dismiss",
+        actionDetails: {
+          recommendationId: params.recId,
+          reason: body.reason ?? null,
+          notes: body.notes ?? null,
+        },
+        clientIp: req.headers.get("x-forwarded-for") ?? undefined,
+        userAgent: req.headers.get("user-agent") ?? undefined,
+      },
+      true,
+    );
+  } catch (err) {
+    if (err instanceof AuditFailedError) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: "AUDIT_WRITE_FAILED",
+            message: "Action blocked: audit log unavailable",
+            retryable: true,
+          },
+        },
+        { status: 503 },
+      );
+    }
+    throw err;
+  }
+
+  const svc = getServiceRoleClient();
+  await svc
+    .from("ins_recommendations")
+    .update({ suppressed: true })
+    .eq("id", params.recId)
+    .eq("company_id", params.id);
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/admin/insights/clients/[id]/unsuppress/[recId]/route.ts
+++ b/app/api/admin/insights/clients/[id]/unsuppress/[recId]/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+
+import { requireCapOperatorForApi } from "@/lib/cap/api-gate";
+import { AuditFailedError, writeAdminAudit } from "@/lib/insights/admin-audit";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string; recId: string } },
+) {
+  const gate = await requireCapOperatorForApi();
+  if (gate.kind === "deny") return gate.response;
+
+  const body = await req.json().catch(() => ({}));
+
+  try {
+    await writeAdminAudit(
+      {
+        operatorUserId: gate.userId,
+        clientCompanyId: params.id,
+        action: "unsuppress",
+        actionDetails: {
+          recommendationId: params.recId,
+          reason: body.reason ?? null,
+        },
+        clientIp: req.headers.get("x-forwarded-for") ?? undefined,
+        userAgent: req.headers.get("user-agent") ?? undefined,
+      },
+      true,
+    );
+  } catch (err) {
+    if (err instanceof AuditFailedError) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: {
+            code: "AUDIT_WRITE_FAILED",
+            message: "Action blocked: audit log unavailable",
+            retryable: true,
+          },
+        },
+        { status: 503 },
+      );
+    }
+    throw err;
+  }
+
+  const svc = getServiceRoleClient();
+  await svc
+    .from("ins_recommendations")
+    .update({ suppressed: false })
+    .eq("id", params.recId)
+    .eq("company_id", params.id);
+
+  return NextResponse.json({ ok: true });
+}

--- a/components/__tests__/AdminBanner.test.tsx
+++ b/components/__tests__/AdminBanner.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import { AdminBanner } from "@/components/admin-insights/AdminBanner";
+
+describe("AdminBanner", () => {
+  it("shows client name", () => {
+    render(<AdminBanner clientName="Acme MSP" />);
+    expect(screen.getByTestId("admin-banner")).toBeInTheDocument();
+    expect(screen.getByText(/Acme MSP/)).toBeInTheDocument();
+    expect(screen.getByText(/All actions logged/)).toBeInTheDocument();
+  });
+
+  it("back button navigates to roster", () => {
+    render(<AdminBanner clientName="Acme MSP" />);
+    fireEvent.click(screen.getByRole("button", { name: /back to roster/i }));
+    expect(mockPush).toHaveBeenCalledWith("/admin/insights");
+  });
+});

--- a/components/__tests__/AdminRoster.test.tsx
+++ b/components/__tests__/AdminRoster.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import { AdminRoster } from "@/components/admin-insights/AdminRoster";
+import type { AdminClientRow } from "@/lib/insights/admin-dashboard";
+
+function makeRow(overrides: Partial<AdminClientRow> = {}): AdminClientRow {
+  return {
+    companyId: "co-1",
+    name: "Acme MSP",
+    lastPostAt: new Date(Date.now() - 2 * 3600000).toISOString(),
+    lastPostRelative: "2h ago",
+    trendData30d: [0.03, 0.04, 0.05, 0.04, 0.06],
+    healthStatus: "green",
+    openRecs: 5,
+    dismissedRecs: 1,
+    lastAdminActionAt: null,
+    lastAdminActionOperator: null,
+    ...overrides,
+  };
+}
+
+const FIXTURE: AdminClientRow[] = [
+  makeRow({ companyId: "co-1", name: "Acme MSP", healthStatus: "green" }),
+  makeRow({ companyId: "co-2", name: "Beta Tech", healthStatus: "amber" }),
+  makeRow({ companyId: "co-3", name: "Gamma Cloud", healthStatus: "red" }),
+];
+
+describe("AdminRoster", () => {
+  it("renders all rows", () => {
+    render(<AdminRoster roster={FIXTURE} />);
+    expect(screen.getByTestId("admin-roster")).toBeInTheDocument();
+    expect(screen.getByText("Acme MSP")).toBeInTheDocument();
+    expect(screen.getByText("Beta Tech")).toBeInTheDocument();
+    expect(screen.getByText("Gamma Cloud")).toBeInTheDocument();
+  });
+
+  it("filters by search", () => {
+    render(<AdminRoster roster={FIXTURE} />);
+    const input = screen.getByRole("searchbox", { name: /search clients/i });
+    fireEvent.change(input, { target: { value: "beta" } });
+    expect(screen.getByText("Beta Tech")).toBeInTheDocument();
+    expect(screen.queryByText("Acme MSP")).not.toBeInTheDocument();
+  });
+
+  it("filters by health", () => {
+    render(<AdminRoster roster={FIXTURE} />);
+    const select = screen.getByRole("combobox", { name: /filter by health/i });
+    fireEvent.change(select, { target: { value: "red" } });
+    expect(screen.getByText("Gamma Cloud")).toBeInTheDocument();
+    expect(screen.queryByText("Acme MSP")).not.toBeInTheDocument();
+  });
+
+  it("shows empty message when no match", () => {
+    render(<AdminRoster roster={FIXTURE} />);
+    const input = screen.getByRole("searchbox", { name: /search clients/i });
+    fireEvent.change(input, { target: { value: "xyzzy-no-match" } });
+    expect(screen.getByText(/no clients match/i)).toBeInTheDocument();
+  });
+});

--- a/components/__tests__/OperatorOverrideControls.test.tsx
+++ b/components/__tests__/OperatorOverrideControls.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { OperatorOverrideControls } from "@/components/admin-insights/OperatorOverrideControls";
+
+describe("OperatorOverrideControls", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: async () => ({ ok: true }),
+      }),
+    );
+  });
+
+  it("shows dismiss and add note buttons when not suppressed", () => {
+    render(
+      <OperatorOverrideControls
+        recommendationId="rec-1"
+        companyId="co-1"
+        suppressed={false}
+      />,
+    );
+    expect(screen.getByTestId("dismiss-for-client-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("add-note-btn")).toBeInTheDocument();
+    expect(screen.queryByTestId("unsuppress-btn")).not.toBeInTheDocument();
+  });
+
+  it("shows unsuppress button when suppressed", () => {
+    render(
+      <OperatorOverrideControls
+        recommendationId="rec-1"
+        companyId="co-1"
+        suppressed={true}
+      />,
+    );
+    expect(screen.getByTestId("unsuppress-btn")).toBeInTheDocument();
+    expect(screen.queryByTestId("dismiss-for-client-btn")).not.toBeInTheDocument();
+  });
+
+  it("calls dismiss API on click", async () => {
+    const onActionComplete = vi.fn();
+    render(
+      <OperatorOverrideControls
+        recommendationId="rec-1"
+        companyId="co-1"
+        suppressed={false}
+        onActionComplete={onActionComplete}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("dismiss-for-client-btn"));
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/admin/insights/clients/co-1/dismiss/rec-1",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    await waitFor(() => expect(onActionComplete).toHaveBeenCalled());
+  });
+
+  it("shows error when API returns ok:false", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: async () => ({
+          ok: false,
+          error: { message: "Action blocked: audit log unavailable" },
+        }),
+      }),
+    );
+    render(
+      <OperatorOverrideControls
+        recommendationId="rec-1"
+        companyId="co-1"
+        suppressed={false}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("dismiss-for-client-btn"));
+    await waitFor(() =>
+      expect(screen.getByText(/Action blocked/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/components/admin-insights/AdminBanner.tsx
+++ b/components/admin-insights/AdminBanner.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { ShieldIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+
+interface AdminBannerProps {
+  clientName: string;
+}
+
+export function AdminBanner({ clientName }: AdminBannerProps) {
+  const router = useRouter();
+
+  return (
+    <div
+      className="bg-am/20 border-b border-am sticky top-0 z-50 px-4 py-2"
+      data-testid="admin-banner"
+    >
+      <div className="flex items-center justify-between max-w-7xl mx-auto">
+        <div className="flex items-center gap-2 text-sm">
+          <ShieldIcon className="h-5 w-5 text-am" />
+          <span className="font-semibold text-tx-primary">
+            Viewing as admin · {clientName}
+          </span>
+          <span className="text-tx-secondary">· All actions logged</span>
+        </div>
+        <Button variant="ghost" size="sm" onClick={() => router.push("/admin/insights")}>
+          ← Back to roster
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/admin-insights/AdminClientDrilldown.tsx
+++ b/components/admin-insights/AdminClientDrilldown.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { AdminBanner } from "./AdminBanner";
+import { InsightsDashboardClient } from "@/components/insights/InsightsDashboardClient";
+import type { InsightsDashboardData } from "@/lib/insights/dashboard";
+
+interface AdminClientDrilldownProps {
+  clientName: string;
+  companyId: string;
+  data: InsightsDashboardData;
+}
+
+export function AdminClientDrilldown({
+  clientName,
+  companyId,
+  data,
+}: AdminClientDrilldownProps) {
+  return (
+    <div>
+      <AdminBanner clientName={clientName} />
+      <div className="px-6 py-8">
+        <InsightsDashboardClient data={data} companyId={companyId} isAdminView />
+      </div>
+    </div>
+  );
+}

--- a/components/admin-insights/AdminClientRowItem.tsx
+++ b/components/admin-insights/AdminClientRowItem.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import type { AdminClientRow } from "@/lib/insights/admin-dashboard";
+import { HealthBadge } from "./HealthBadge";
+import { Sparkline } from "./Sparkline";
+
+interface AdminClientRowItemProps {
+  row: AdminClientRow;
+}
+
+export function AdminClientRowItem({ row }: AdminClientRowItemProps) {
+  return (
+    <div
+      className="grid grid-cols-[1fr_120px_120px_100px_80px_auto] items-center gap-4 py-3 border-b border-b1 last:border-0"
+      data-testid={`client-row-${row.companyId}`}
+    >
+      <div>
+        <div className="font-medium text-tx-primary">{row.name}</div>
+      </div>
+      <div className="text-sm text-tx-muted">{row.lastPostRelative}</div>
+      <div>
+        <Sparkline data={row.trendData30d} />
+      </div>
+      <div>
+        <HealthBadge status={row.healthStatus} />
+      </div>
+      <div className="text-sm text-tx-secondary tabular-nums">
+        {row.openRecs}/{row.dismissedRecs}
+      </div>
+      <div>
+        <Button variant="outline" size="sm" asChild>
+          <Link href={`/admin/insights/clients/${row.companyId}`}>→</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/admin-insights/AdminRoster.tsx
+++ b/components/admin-insights/AdminRoster.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import type { AdminClientRow } from "@/lib/insights/admin-dashboard";
+import { AdminClientRowItem } from "./AdminClientRowItem";
+
+interface AdminRosterProps {
+  roster: AdminClientRow[];
+}
+
+const PAGE_SIZE = 20;
+
+export function AdminRoster({ roster }: AdminRosterProps) {
+  const [search, setSearch] = useState("");
+  const [healthFilter, setHealthFilter] = useState<"all" | "green" | "amber" | "red">("all");
+  const [page, setPage] = useState(0);
+
+  const filtered = roster.filter((r) => {
+    const matchesSearch = r.name.toLowerCase().includes(search.toLowerCase());
+    const matchesHealth = healthFilter === "all" || r.healthStatus === healthFilter;
+    return matchesSearch && matchesHealth;
+  });
+
+  const total = filtered.length;
+  const page_rows = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
+  return (
+    <Card className="border-b2" data-testid="admin-roster">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <h2 className="text-section-title text-tx-primary">Client roster</h2>
+          <div className="flex items-center gap-2">
+            <select
+              className="text-sm border border-b2 rounded-md px-2 py-1 bg-transparent text-tx-primary"
+              value={healthFilter}
+              onChange={(e) => {
+                setHealthFilter(e.target.value as typeof healthFilter);
+                setPage(0);
+              }}
+              aria-label="Filter by health"
+            >
+              <option value="all">Health: all</option>
+              <option value="green">Green</option>
+              <option value="amber">Amber</option>
+              <option value="red">Red</option>
+            </select>
+            <input
+              type="search"
+              placeholder="Search clients…"
+              className="text-sm border border-b2 rounded-md px-3 py-1 bg-transparent text-tx-primary placeholder:text-tx-muted"
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(0);
+              }}
+              aria-label="Search clients"
+            />
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {/* Header row */}
+        <div className="grid grid-cols-[1fr_120px_120px_100px_80px_auto] gap-4 pb-2 border-b border-b2 text-sm text-tx-muted uppercase tracking-wide">
+          <div>Client</div>
+          <div>Last post</div>
+          <div>30d trend</div>
+          <div>Health</div>
+          <div>Recs</div>
+          <div>Action</div>
+        </div>
+        {page_rows.length === 0 ? (
+          <div className="py-8 text-center text-sm text-tx-muted">No clients match the current filter.</div>
+        ) : (
+          page_rows.map((row) => <AdminClientRowItem key={row.companyId} row={row} />)
+        )}
+        {total > PAGE_SIZE && (
+          <div className="flex items-center justify-between pt-3 text-sm text-tx-muted">
+            <span>
+              Showing {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)} of {total}
+            </span>
+            <div className="flex gap-2">
+              {page > 0 && (
+                <button onClick={() => setPage(page - 1)} className="hover:text-tx-primary">
+                  ← Prev
+                </button>
+              )}
+              {(page + 1) * PAGE_SIZE < total && (
+                <button onClick={() => setPage(page + 1)} className="hover:text-tx-primary">
+                  Next →
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin-insights/ClientCompareCharts.tsx
+++ b/components/admin-insights/ClientCompareCharts.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import type { CompareDataPoint } from "@/lib/insights/admin-dashboard";
+import { Sparkline } from "./Sparkline";
+
+interface ClientCompareChartsProps {
+  data: CompareDataPoint[];
+}
+
+function fmt(n: number | null): string {
+  if (n === null) return "—";
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+export function ClientCompareCharts({ data }: ClientCompareChartsProps) {
+  return (
+    <Card className="border-b2" data-testid="client-compare-charts">
+      <CardHeader className="pb-3">
+        <h2 className="text-section-title text-tx-primary">30-day engagement comparison</h2>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {data.map((d) => (
+            <div key={d.companyId} className="border border-b2 rounded-lg p-4">
+              <div className="font-semibold text-tx-primary mb-1">{d.name}</div>
+              <div className="text-2xl font-semibold tabular-nums text-pk mb-2">
+                {fmt(d.avgEngagementRate30d)}
+              </div>
+              <Sparkline data={d.trendData30d} width={120} height={32} />
+              <div className="text-sm text-tx-muted mt-2">{d.postCount30d} posts</div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin-insights/ClientCompareTable.tsx
+++ b/components/admin-insights/ClientCompareTable.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import type { AdminClientRow, CompareDataPoint } from "@/lib/insights/admin-dashboard";
+
+interface ClientCompareTableProps {
+  roster: AdminClientRow[];
+  selectedIds: string[];
+  compareData: CompareDataPoint[];
+}
+
+function fmt(n: number | null): string {
+  if (n === null) return "—";
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+export function ClientCompareTable({
+  roster,
+  selectedIds,
+  compareData,
+}: ClientCompareTableProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [selected, setSelected] = useState<Set<string>>(new Set(selectedIds));
+
+  function toggle(id: string) {
+    const next = new Set(selected);
+    if (next.has(id)) {
+      next.delete(id);
+    } else if (next.size < 10) {
+      next.add(id);
+    }
+    setSelected(next);
+  }
+
+  function applySelection() {
+    const params = new URLSearchParams(searchParams.toString());
+    if (selected.size > 0) {
+      params.set("ids", Array.from(selected).join(","));
+    } else {
+      params.delete("ids");
+    }
+    router.push(`/admin/insights/compare?${params.toString()}`);
+  }
+
+  return (
+    <Card className="border-b2" data-testid="client-compare-table">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-section-title text-tx-primary">Select clients to compare</h2>
+          <Button size="sm" onClick={applySelection} disabled={selected.size === 0}>
+            Compare {selected.size > 0 ? `(${selected.size})` : ""}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2 max-h-80 overflow-y-auto">
+          {roster.map((r) => {
+            const point = compareData.find((d) => d.companyId === r.companyId);
+            return (
+              <label
+                key={r.companyId}
+                className="flex items-center gap-3 py-2 border-b border-b1 last:border-0 cursor-pointer hover:bg-m1 rounded px-2"
+              >
+                <input
+                  type="checkbox"
+                  checked={selected.has(r.companyId)}
+                  onChange={() => toggle(r.companyId)}
+                  className="h-4 w-4"
+                />
+                <span className="flex-1 font-medium text-tx-primary">{r.name}</span>
+                {point && (
+                  <span className="text-sm text-tx-muted tabular-nums">
+                    {fmt(point.avgEngagementRate30d)} · {point.postCount30d} posts
+                  </span>
+                )}
+              </label>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin-insights/HealthBadge.tsx
+++ b/components/admin-insights/HealthBadge.tsx
@@ -1,0 +1,21 @@
+import { StatusPill } from "@/components/ui/status-pill";
+
+interface HealthBadgeProps {
+  status: "green" | "amber" | "red";
+}
+
+const LABEL: Record<string, string> = {
+  green: "Green",
+  amber: "Amber",
+  red: "Red",
+};
+
+const KIND: Record<string, "client_green" | "client_amber" | "client_red"> = {
+  green: "client_green",
+  amber: "client_amber",
+  red: "client_red",
+};
+
+export function HealthBadge({ status }: HealthBadgeProps) {
+  return <StatusPill kind={KIND[status]} label={LABEL[status]} />;
+}

--- a/components/admin-insights/OperatorOverrideControls.tsx
+++ b/components/admin-insights/OperatorOverrideControls.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+interface OperatorOverrideControlsProps {
+  recommendationId: string;
+  companyId: string;
+  suppressed: boolean;
+  onActionComplete?: () => void;
+}
+
+export function OperatorOverrideControls({
+  recommendationId,
+  companyId,
+  suppressed,
+  onActionComplete,
+}: OperatorOverrideControlsProps) {
+  const [loading, setLoading] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function callApi(action: "dismiss" | "unsuppress" | "annotate", body?: Record<string, unknown>) {
+    setLoading(action);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/admin/insights/clients/${companyId}/${action}/${recommendationId}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body ?? {}),
+        },
+      );
+      const data = await res.json();
+      if (!data.ok) {
+        setError(data.error?.message ?? "Action failed");
+      } else {
+        onActionComplete?.();
+      }
+    } catch {
+      setError("Network error");
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2 pt-2 border-t border-b1 mt-2" data-testid="operator-override-controls">
+      {!suppressed && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-sm text-tx-secondary"
+          disabled={loading !== null}
+          onClick={() => callApi("dismiss", { reason: "operator_admin" })}
+          data-testid="dismiss-for-client-btn"
+        >
+          {loading === "dismiss" ? "Dismissing…" : "Dismiss for client"}
+        </Button>
+      )}
+      {suppressed && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-sm text-tx-secondary"
+          disabled={loading !== null}
+          onClick={() => callApi("unsuppress")}
+          data-testid="unsuppress-btn"
+        >
+          {loading === "unsuppress" ? "Un-suppressing…" : "Un-suppress"}
+        </Button>
+      )}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-sm text-tx-secondary"
+        disabled={loading !== null}
+        onClick={() => callApi("annotate", { note: "Admin note" })}
+        data-testid="add-note-btn"
+      >
+        {loading === "annotate" ? "Saving…" : "Add note"}
+      </Button>
+      {error && <span className="text-sm text-rd">{error}</span>}
+    </div>
+  );
+}

--- a/components/admin-insights/PortfolioKPIs.tsx
+++ b/components/admin-insights/PortfolioKPIs.tsx
@@ -1,0 +1,75 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import type { AdminPortfolioKpis } from "@/lib/insights/admin-dashboard";
+
+interface PortfolioKPIsProps {
+  kpis: AdminPortfolioKpis;
+}
+
+function fmt(n: number, decimals = 1): string {
+  return n.toLocaleString("en-AU", { maximumFractionDigits: decimals });
+}
+
+export function PortfolioKPIs({ kpis }: PortfolioKPIsProps) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4" data-testid="portfolio-kpis">
+      <Card className="border-b2">
+        <CardHeader className="pb-2">
+          <div className="text-sm uppercase tracking-wide text-tx-muted">Clients</div>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-semibold tabular-nums text-tx-primary">
+            {kpis.totalClients}
+          </div>
+          <div className="text-sm text-tx-muted mt-1">{kpis.activeClients} active</div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-b2">
+        <CardHeader className="pb-2">
+          <div className="text-sm uppercase tracking-wide text-tx-muted">Avg eng rate</div>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-semibold tabular-nums text-tx-primary">
+            {kpis.avgEngagementRate30d !== null
+              ? `${fmt(kpis.avgEngagementRate30d * 100)}%`
+              : "—"}
+          </div>
+          {kpis.engagementRateDelta !== null && (
+            <div className="text-sm text-tx-muted mt-1">
+              {kpis.engagementRateDelta > 0 ? "↑" : "↓"}{" "}
+              {fmt(Math.abs(kpis.engagementRateDelta * 100), 2)}pp
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border-b2">
+        <CardHeader className="pb-2">
+          <div className="text-sm uppercase tracking-wide text-tx-muted">Top performer</div>
+        </CardHeader>
+        <CardContent>
+          <div className="text-lg font-semibold text-tx-primary line-clamp-1">
+            {kpis.topPerformerName ?? "—"}
+          </div>
+          {kpis.topPerformerRate !== null && (
+            <div className="text-sm text-tx-muted mt-1">
+              {fmt(kpis.topPerformerRate * 100)}% avg
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border-b2">
+        <CardHeader className="pb-2">
+          <div className="text-sm uppercase tracking-wide text-tx-muted">Declining</div>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-semibold tabular-nums text-rd">
+            {kpis.decliningCount}
+          </div>
+          <div className="text-sm text-tx-muted mt-1">clients</div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/admin-insights/RecentAdminActivity.tsx
+++ b/components/admin-insights/RecentAdminActivity.tsx
@@ -1,0 +1,56 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+interface ActivityEntry {
+  operatorUserId: string;
+  clientCompanyId: string;
+  action: string;
+  occurredAt: string;
+}
+
+interface RecentAdminActivityProps {
+  activity: ActivityEntry[];
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}min ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  view: "viewed",
+  dismiss: "dismissed a rec for",
+  annotate: "annotated a rec for",
+  unsuppress: "un-suppressed a rec for",
+  export: "exported data for",
+  override: "overrode a rec for",
+};
+
+export function RecentAdminActivity({ activity }: RecentAdminActivityProps) {
+  if (activity.length === 0) return null;
+
+  return (
+    <Card className="border-b2" data-testid="recent-admin-activity">
+      <CardHeader className="pb-3">
+        <h2 className="text-section-title text-tx-primary">Recent admin activity</h2>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2">
+          {activity.map((entry, i) => (
+            <li key={i} className="flex items-center gap-2 text-sm text-tx-secondary">
+              <span className="text-tx-muted shrink-0">{relativeTime(entry.occurredAt)}</span>
+              <span className="text-tx-muted">·</span>
+              <span>
+                {ACTION_LABELS[entry.action] ?? entry.action} client{" "}
+                <span className="font-medium text-tx-primary">{entry.clientCompanyId.slice(0, 8)}</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin-insights/Sparkline.tsx
+++ b/components/admin-insights/Sparkline.tsx
@@ -32,7 +32,7 @@ export function Sparkline({ data, width = 80, height = 24 }: SparklineProps) {
       <polyline
         points={points.join(" ")}
         fill="none"
-        stroke="var(--pk)"
+        className="stroke-pk"
         strokeWidth={1.5}
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/components/admin-insights/Sparkline.tsx
+++ b/components/admin-insights/Sparkline.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+interface SparklineProps {
+  data: number[];
+  width?: number;
+  height?: number;
+}
+
+export function Sparkline({ data, width = 80, height = 24 }: SparklineProps) {
+  if (data.length < 2) {
+    return <div className="text-sm text-tx-muted">—</div>;
+  }
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+
+  const points = data.map((v, i) => {
+    const x = (i / (data.length - 1)) * width;
+    const y = height - ((v - min) / range) * height;
+    return `${x},${y}`;
+  });
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-hidden="true"
+      className="overflow-visible"
+    >
+      <polyline
+        points={points.join(" ")}
+        fill="none"
+        stroke="var(--pk)"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/components/admin-insights/StaleDataAlerts.tsx
+++ b/components/admin-insights/StaleDataAlerts.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+import { Alert } from "@/components/ui/alert";
+import type { AdminClientRow } from "@/lib/insights/admin-dashboard";
+
+interface StaleDataAlertsProps {
+  clients: AdminClientRow[];
+}
+
+export function StaleDataAlerts({ clients }: StaleDataAlertsProps) {
+  if (clients.length === 0) return null;
+
+  return (
+    <Alert
+      variant="warning"
+      title={`${clients.length} ${clients.length === 1 ? "client needs" : "clients need"} attention`}
+      data-testid="stale-data-alerts"
+    >
+      <ul className="mt-2 space-y-1 text-sm">
+        {clients.slice(0, 5).map((c) => (
+          <li key={c.companyId}>
+            •{" "}
+            <Link
+              href={`/admin/insights/clients/${c.companyId}`}
+              className="underline hover:text-tx-primary"
+            >
+              {c.name}
+            </Link>
+            {" "}— last post {c.lastPostRelative}
+          </li>
+        ))}
+        {clients.length > 5 && (
+          <li className="text-tx-muted">…and {clients.length - 5} more</li>
+        )}
+      </ul>
+    </Alert>
+  );
+}

--- a/components/insights/InsightsDashboardClient.tsx
+++ b/components/insights/InsightsDashboardClient.tsx
@@ -16,11 +16,13 @@ import { EmptyState } from "./common/EmptyState";
 interface InsightsDashboardClientProps {
   data: InsightsDashboardData;
   companyId: string;
+  isAdminView?: boolean;
 }
 
 export function InsightsDashboardClient({
   data,
   companyId,
+  isAdminView = false,
 }: InsightsDashboardClientProps) {
   const [activePlatform, setActivePlatform] = useState<string>(
     data.activePlatform,

--- a/e2e/insights-admin.spec.ts
+++ b/e2e/insights-admin.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+
+import { signInAsAdmin } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// PR-04 E2E — Admin Insights dashboard at /admin/insights
+// ---------------------------------------------------------------------------
+
+test.describe("Admin Insights dashboard", () => {
+  test("admin can reach /admin/insights (cap operator) or is redirected (non-operator)", async ({
+    page,
+  }) => {
+    await signInAsAdmin(page);
+    await page.goto("/admin/insights");
+
+    // Either the roster loads (cap operator) or redirects to /admin (non-operator admin)
+    const url = page.url();
+    expect(url).toMatch(/\/admin/);
+    // The page should not be a login page
+    expect(url).not.toMatch(/\/login/);
+  });
+
+  test("admin banner shows on client drilldown (cap operator only)", async ({ page }) => {
+    await signInAsAdmin(page);
+    await page.goto("/admin/insights");
+    const url = page.url();
+    if (!url.includes("/admin/insights")) {
+      // not a cap operator — skip
+      return;
+    }
+
+    const firstLink = page.getByRole("link", { name: "→" }).first();
+    const hasLink = await firstLink.isVisible().catch(() => false);
+    if (!hasLink) return;
+
+    await firstLink.click();
+    const drilldownUrl = page.url();
+    if (drilldownUrl.includes("/clients/")) {
+      await expect(page.getByTestId("admin-banner")).toBeVisible({ timeout: 10000 });
+    }
+  });
+
+  test("unauthenticated user cannot access /admin/insights", async ({ page }) => {
+    await page.goto("/admin/insights");
+    await expect(page).toHaveURL(/\/(login|admin$)/);
+  });
+});

--- a/lib/insights/admin-audit.ts
+++ b/lib/insights/admin-audit.ts
@@ -1,0 +1,48 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+export interface AuditEntry {
+  operatorUserId: string;
+  clientCompanyId: string;
+  action: "view" | "dismiss" | "annotate" | "export" | "override" | "unsuppress";
+  actionDetails: Record<string, unknown>;
+  clientIp?: string;
+  userAgent?: string;
+}
+
+export class AuditFailedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuditFailedError";
+  }
+}
+
+/**
+ * Writes an audit row to ins_admin_audit.
+ * For mutating actions (isMutating=true) this MUST succeed before the action completes.
+ * If isMutating=true and the write fails, throws AuditFailedError.
+ * If isMutating=false, logs a warning but doesn't throw.
+ */
+export async function writeAdminAudit(
+  entry: AuditEntry,
+  isMutating: boolean,
+): Promise<void> {
+  const svc = getServiceRoleClient();
+  const { error } = await svc.from("ins_admin_audit").insert({
+    operator_user_id: entry.operatorUserId,
+    client_company_id: entry.clientCompanyId,
+    action: entry.action,
+    action_details: entry.actionDetails,
+    client_ip: entry.clientIp ?? null,
+    user_agent: entry.userAgent ?? null,
+  });
+
+  if (error) {
+    if (isMutating) {
+      throw new AuditFailedError(`Admin audit write failed: ${error.message}`);
+    } else {
+      console.warn("Admin audit write failed (non-blocking):", error.message);
+    }
+  }
+}

--- a/lib/insights/admin-dashboard.ts
+++ b/lib/insights/admin-dashboard.ts
@@ -1,0 +1,322 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+export interface AdminClientRow {
+  companyId: string;
+  name: string;
+  lastPostAt: string | null;
+  lastPostRelative: string;
+  trendData30d: number[];
+  healthStatus: "green" | "amber" | "red";
+  openRecs: number;
+  dismissedRecs: number;
+  lastAdminActionAt: string | null;
+  lastAdminActionOperator: string | null;
+}
+
+export interface AdminPortfolioKpis {
+  totalClients: number;
+  activeClients: number;
+  avgEngagementRate30d: number | null;
+  engagementRateDelta: number | null;
+  topPerformerName: string | null;
+  topPerformerRate: number | null;
+  decliningCount: number;
+}
+
+export interface AdminClientSnapshot {
+  companyId: string;
+  name: string;
+  healthStatus: "green" | "amber" | "red";
+  openRecs: number;
+  dismissedRecs: number;
+  lastAdminActionAt: string | null;
+  lastAdminActionOperator: string | null;
+}
+
+export interface CompareDataPoint {
+  companyId: string;
+  name: string;
+  avgEngagementRate30d: number | null;
+  postCount30d: number;
+  trendData30d: number[];
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return "Never";
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function deriveHealth(
+  lastPostAt: string | null,
+  avgEngagementRate: number | null,
+): "green" | "amber" | "red" {
+  if (!lastPostAt) return "red";
+  const daysSincePost = (Date.now() - new Date(lastPostAt).getTime()) / 86400000;
+  if (daysSincePost > 7) return "red";
+  if (daysSincePost > 3) return "amber";
+  if (avgEngagementRate !== null && avgEngagementRate < 0.01) return "amber";
+  return "green";
+}
+
+export async function getAdminRoster(): Promise<AdminClientRow[]> {
+  const svc = getServiceRoleClient();
+
+  // Fetch all companies with social profiles
+  const { data: companies, error: compErr } = await svc
+    .from("platform_companies")
+    .select("id, name")
+    .order("name");
+
+  if (compErr || !companies) return [];
+
+  // For each company, fetch 30d trend + health data
+  const rows: AdminClientRow[] = [];
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 86400000).toISOString();
+
+  await Promise.all(
+    companies.map(async (co) => {
+      // Get profile ids for this company
+      const { data: profiles } = await svc
+        .from("platform_social_profiles")
+        .select("id")
+        .eq("company_id", co.id);
+
+      const profileIds = (profiles ?? []).map((p) => p.id);
+
+      if (profileIds.length === 0) {
+        rows.push({
+          companyId: co.id,
+          name: co.name,
+          lastPostAt: null,
+          lastPostRelative: "Never",
+          trendData30d: [],
+          healthStatus: "red",
+          openRecs: 0,
+          dismissedRecs: 0,
+          lastAdminActionAt: null,
+          lastAdminActionOperator: null,
+        });
+        return;
+      }
+
+      // Fetch recent snapshots
+      const { data: snapshots } = await svc
+        .from("social_post_analytics_snapshots")
+        .select("captured_at, engagement_rate")
+        .in("social_profile_id", profileIds)
+        .gte("captured_at", thirtyDaysAgo)
+        .order("captured_at", { ascending: true });
+
+      const snaps = snapshots ?? [];
+      const trendData30d = snaps.map((s) => s.engagement_rate ?? 0);
+      const lastPostAt = snaps.length > 0 ? snaps[snaps.length - 1].captured_at : null;
+      const avgEngRate =
+        snaps.length > 0
+          ? snaps.reduce((sum, s) => sum + (s.engagement_rate ?? 0), 0) / snaps.length
+          : null;
+
+      // Recs
+      const { count: openRecs } = await svc
+        .from("ins_recommendations")
+        .select("id", { count: "exact", head: true })
+        .eq("company_id", co.id)
+        .eq("suppressed", false);
+
+      const { count: dismissedRecs } = await svc
+        .from("ins_recommendations")
+        .select("id", { count: "exact", head: true })
+        .eq("company_id", co.id)
+        .eq("suppressed", true);
+
+      // Last admin action
+      const { data: lastAudit } = await svc
+        .from("ins_admin_audit")
+        .select("occurred_at, operator_user_id")
+        .eq("client_company_id", co.id)
+        .order("occurred_at", { ascending: false })
+        .limit(1);
+
+      const auditRow = lastAudit?.[0] ?? null;
+
+      rows.push({
+        companyId: co.id,
+        name: co.name,
+        lastPostAt,
+        lastPostRelative: relativeTime(lastPostAt),
+        trendData30d,
+        healthStatus: deriveHealth(lastPostAt, avgEngRate),
+        openRecs: openRecs ?? 0,
+        dismissedRecs: dismissedRecs ?? 0,
+        lastAdminActionAt: auditRow?.occurred_at ?? null,
+        lastAdminActionOperator: auditRow?.operator_user_id ?? null,
+      });
+    }),
+  );
+
+  return rows.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getAdminPortfolioKpis(roster: AdminClientRow[]): Promise<AdminPortfolioKpis> {
+  const activeClients = roster.filter((r) => r.trendData30d.length > 0).length;
+  const ratesWithData = roster.filter((r) => r.trendData30d.length > 0);
+  const avgEngagementRate30d =
+    ratesWithData.length > 0
+      ? ratesWithData.reduce((sum, r) => {
+          const avg =
+            r.trendData30d.reduce((s, v) => s + v, 0) / r.trendData30d.length;
+          return sum + avg;
+        }, 0) / ratesWithData.length
+      : null;
+
+  const topPerformer = ratesWithData.reduce<AdminClientRow | null>((best, r) => {
+    const avg = r.trendData30d.reduce((s, v) => s + v, 0) / r.trendData30d.length;
+    if (!best) return r;
+    const bestAvg = best.trendData30d.reduce((s, v) => s + v, 0) / best.trendData30d.length;
+    return avg > bestAvg ? r : best;
+  }, null);
+
+  const topPerformerRate = topPerformer
+    ? topPerformer.trendData30d.reduce((s, v) => s + v, 0) / topPerformer.trendData30d.length
+    : null;
+
+  const decliningCount = roster.filter((r) => r.healthStatus === "red").length;
+
+  return {
+    totalClients: roster.length,
+    activeClients,
+    avgEngagementRate30d,
+    engagementRateDelta: null, // future: compare vs prev period
+    topPerformerName: topPerformer?.name ?? null,
+    topPerformerRate,
+    decliningCount,
+  };
+}
+
+export async function getAdminClientSnapshot(companyId: string): Promise<AdminClientSnapshot | null> {
+  const svc = getServiceRoleClient();
+
+  const { data: co } = await svc
+    .from("platform_companies")
+    .select("id, name")
+    .eq("id", companyId)
+    .single();
+
+  if (!co) return null;
+
+  const { count: openRecs } = await svc
+    .from("ins_recommendations")
+    .select("id", { count: "exact", head: true })
+    .eq("company_id", companyId)
+    .eq("suppressed", false);
+
+  const { count: dismissedRecs } = await svc
+    .from("ins_recommendations")
+    .select("id", { count: "exact", head: true })
+    .eq("company_id", companyId)
+    .eq("suppressed", true);
+
+  const { data: lastAudit } = await svc
+    .from("ins_admin_audit")
+    .select("occurred_at, operator_user_id")
+    .eq("client_company_id", companyId)
+    .order("occurred_at", { ascending: false })
+    .limit(1);
+
+  const auditRow = lastAudit?.[0] ?? null;
+
+  return {
+    companyId: co.id,
+    name: co.name,
+    healthStatus: "green",
+    openRecs: openRecs ?? 0,
+    dismissedRecs: dismissedRecs ?? 0,
+    lastAdminActionAt: auditRow?.occurred_at ?? null,
+    lastAdminActionOperator: auditRow?.operator_user_id ?? null,
+  };
+}
+
+export async function getCompareData(companyIds: string[]): Promise<CompareDataPoint[]> {
+  const svc = getServiceRoleClient();
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 86400000).toISOString();
+
+  const results: CompareDataPoint[] = [];
+
+  await Promise.all(
+    companyIds.map(async (companyId) => {
+      const { data: co } = await svc
+        .from("platform_companies")
+        .select("id, name")
+        .eq("id", companyId)
+        .single();
+
+      if (!co) return;
+
+      const { data: profiles } = await svc
+        .from("platform_social_profiles")
+        .select("id")
+        .eq("company_id", companyId);
+
+      const profileIds = (profiles ?? []).map((p) => p.id);
+      if (profileIds.length === 0) {
+        results.push({
+          companyId,
+          name: co.name,
+          avgEngagementRate30d: null,
+          postCount30d: 0,
+          trendData30d: [],
+        });
+        return;
+      }
+
+      const { data: snapshots } = await svc
+        .from("social_post_analytics_snapshots")
+        .select("captured_at, engagement_rate")
+        .in("social_profile_id", profileIds)
+        .gte("captured_at", thirtyDaysAgo)
+        .order("captured_at", { ascending: true });
+
+      const snaps = snapshots ?? [];
+      const trendData30d = snaps.map((s) => s.engagement_rate ?? 0);
+      const avgEngagementRate30d =
+        snaps.length > 0
+          ? snaps.reduce((sum, s) => sum + (s.engagement_rate ?? 0), 0) / snaps.length
+          : null;
+
+      results.push({
+        companyId,
+        name: co.name,
+        avgEngagementRate30d,
+        postCount30d: snaps.length,
+        trendData30d,
+      });
+    }),
+  );
+
+  return results.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getRecentAdminActivity(
+  limit = 10,
+): Promise<Array<{ operatorUserId: string; clientCompanyId: string; action: string; occurredAt: string }>> {
+  const svc = getServiceRoleClient();
+  const { data } = await svc
+    .from("ins_admin_audit")
+    .select("operator_user_id, client_company_id, action, occurred_at")
+    .order("occurred_at", { ascending: false })
+    .limit(limit);
+
+  return (data ?? []).map((row) => ({
+    operatorUserId: row.operator_user_id,
+    clientCompanyId: row.client_company_id,
+    action: row.action,
+    occurredAt: row.occurred_at,
+  }));
+}


### PR DESCRIPTION
## Summary

- Adds `lib/insights/admin-audit.ts` — `writeAdminAudit()` fail-closed helper; throws `AuditFailedError` for mutating actions if audit write fails
- Adds `lib/insights/admin-dashboard.ts` — `getAdminRoster()`, `getAdminPortfolioKpis()`, `getAdminClientSnapshot()`, `getCompareData()`, `getRecentAdminActivity()`
- Adds `app/(platform)/admin/insights/page.tsx` — roster page gated by `is_cap_operator` RPC
- Adds `app/(platform)/admin/insights/clients/[id]/page.tsx` — drilldown with admin banner + view audit (non-mutating)
- Adds `app/(platform)/admin/insights/compare/page.tsx` — comparison view
- Adds `app/api/admin/insights/clients/[id]/dismiss|unsuppress|annotate/[recId]/route.ts` — 3 mutation routes, all audit-fail-closed (503 if audit unavailable)
- Adds 11 `components/admin-insights/` components: AdminRoster, AdminClientRowItem, AdminBanner, AdminClientDrilldown, OperatorOverrideControls, Sparkline, HealthBadge, PortfolioKPIs, StaleDataAlerts, RecentAdminActivity, ClientCompareTable, ClientCompareCharts
- Adds 3 component tests, 3 E2E tests

## Working analog

- `requireCapOperatorForApi` pattern: `lib/cap/api-gate.ts:18` — exact pattern used for dismiss/unsuppress/annotate routes
- Admin page auth: admin layout + `is_cap_operator` RPC, following `app/(platform)/admin/companies/page.tsx` structure

## Audit fail-closed security

Every mutating action (dismiss, unsuppress, annotate) writes `ins_admin_audit` **before** state change. If audit write fails, action returns 503 `AUDIT_WRITE_FAILED` and the mutation never executes.

## Risks identified and mitigated

- **Cross-tenant**: dismiss/unsuppress routes filter `.eq("company_id", params.id)` — operator cannot mutate another company's recs
- **Double gate**: admin layout (super_admin/admin) + `is_cap_operator` RPC for insights-specific access
- **isAdminView prop**: added to InsightsDashboardClient (previously only customer-facing)

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:components (357/357), test:unit
- [x] Cross-tenant safety: company_id filter on all mutation routes
- [x] Audit fail-closed: AuditFailedError → 503 before any DB mutation
- [x] E2E tests added (3 specs)