### PR TITLE
feat(insights): recommendation generators + get_posts_with_engagement RPC (PR-07)

### DIFF
--- a/app/api/cron/insights-recompute/route.ts
+++ b/app/api/cron/insights-recompute/route.ts
@@ -2,6 +2,13 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import { authorisedCronRequest, unauthorisedResponse } from "@/lib/platform/cron/cron-shared";
 import { aggregateEditPatterns } from "@/lib/insights/memory-aggregator";
+import { generateBestLengthBand } from "@/lib/insights/recommenders/best-length-band";
+import { generateBestPostingWindow } from "@/lib/insights/recommenders/best-posting-window";
+import { generateHashtagDiminishingReturns } from "@/lib/insights/recommenders/hashtag-diminishing-returns";
+import { generateMediaTypeLift } from "@/lib/insights/recommenders/media-type-lift";
+import { generateQuestionPatternLift } from "@/lib/insights/recommenders/question-pattern-lift";
+import { generateTopicPerformance } from "@/lib/insights/recommenders/topic-performance";
+import type { GeneratorFn } from "@/lib/insights/recommenders/types";
 import { getServiceRoleClient } from "@/lib/supabase";
 import { logger } from "@/lib/logger";
 
@@ -9,22 +16,14 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const maxDuration = 600;
 
-// Generators imported in PR-07 — empty harness for now
-const RECOMMENDATION_GENERATORS: Array<
-  (
-    companyId: string,
-    platform: string,
-    opts: { days: number },
-  ) => Promise<{
-    type: string;
-    headline: string;
-    body: string;
-    successMetric: string;
-    confidenceScore: number;
-    confidenceBand: "strong" | "moderate" | "below_floor";
-    evidence?: Array<{ sourceTable: string; sourceRowRef: string; summary: string }>;
-  } | null>
-> = [];
+const RECOMMENDATION_GENERATORS: GeneratorFn[] = [
+  generateBestLengthBand,
+  generateBestPostingWindow,
+  generateQuestionPatternLift,
+  generateMediaTypeLift,
+  generateHashtagDiminishingReturns,
+  generateTopicPerformance,
+];
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   if (!authorisedCronRequest(req)) return unauthorisedResponse();
@@ -51,7 +50,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       await aggregateEditPatterns(company.company_id);
 
       for (const generator of RECOMMENDATION_GENERATORS) {
-        for (const platform of ["LINKEDIN", "FACEBOOK"]) {
+        for (const platform of ["LINKEDIN", "FACEBOOK"] as const) {
           const candidate = await generator(company.company_id, platform, { days: 90 });
           if (candidate && candidate.confidenceBand !== "below_floor") {
             const expiresAt = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString();

--- a/lib/__tests__/recommendations-end-to-end.integration.test.ts
+++ b/lib/__tests__/recommendations-end-to-end.integration.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Integration test: recommendation generators → confidence formula pipeline.
+ * Runs against a real Supabase instance with seeded data.
+ * Focuses on the pipeline mechanics without network calls to the cron endpoint.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { computeConfidence, MIN_POSTS_FOR_RECOMMENDATION } from "@/lib/insights/confidence";
+import { generateBestLengthBand } from "@/lib/insights/recommenders/best-length-band";
+import { generateBestPostingWindow } from "@/lib/insights/recommenders/best-posting-window";
+import { generateQuestionPatternLift } from "@/lib/insights/recommenders/question-pattern-lift";
+import { generateMediaTypeLift } from "@/lib/insights/recommenders/media-type-lift";
+import { generateHashtagDiminishingReturns } from "@/lib/insights/recommenders/hashtag-diminishing-returns";
+import { generateTopicPerformance } from "@/lib/insights/recommenders/topic-performance";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+const ALL_GENERATORS = [
+  generateBestLengthBand,
+  generateBestPostingWindow,
+  generateQuestionPatternLift,
+  generateMediaTypeLift,
+  generateHashtagDiminishingReturns,
+  generateTopicPerformance,
+];
+
+describe("Recommendation generators — integration", () => {
+  let companyId: string;
+  let hasEnoughData = false;
+
+  beforeAll(async () => {
+    const svc = getServiceRoleClient();
+    // Find any company that has ≥ MIN_POSTS_FOR_RECOMMENDATION posts in ins_post_features
+    const { data } = await svc.rpc("find_companies_eligible_for_recompute", {
+      min_posts: MIN_POSTS_FOR_RECOMMENDATION,
+      cutoff_iso: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+    if (data && data.length > 0) {
+      companyId = data[0].company_id;
+      hasEnoughData = true;
+    }
+  });
+
+  it("confidence formula produces valid bands for all score ranges", () => {
+    const floor = computeConfidence({
+      postsInWindow: MIN_POSTS_FOR_RECOMMENDATION - 1,
+      postsFromLast30d: 0,
+      postsFromLast60d: 0,
+      coefficientOfVariation: 0,
+      effectMagnitude: 1,
+    });
+    expect(floor.band).toBe("below_floor");
+    expect(floor.score).toBe(0);
+
+    const strong = computeConfidence({
+      postsInWindow: 100,
+      postsFromLast30d: 70,
+      postsFromLast60d: 90,
+      coefficientOfVariation: 0.1,
+      effectMagnitude: 1.0,
+    });
+    expect(strong.band).toBe("strong");
+    expect(strong.score).toBeGreaterThanOrEqual(0.75);
+
+    const moderate = computeConfidence({
+      postsInWindow: 50,
+      postsFromLast30d: 20,
+      postsFromLast60d: 35,
+      coefficientOfVariation: 0.35,
+      effectMagnitude: 0.6,
+    });
+    expect(["moderate", "below_floor"]).toContain(moderate.band);
+  });
+
+  it("all generators return null or a valid candidate shape against live data", async () => {
+    if (!hasEnoughData) {
+      console.warn("No company with enough posts found — skipping live generator assertions");
+      return;
+    }
+
+    for (const generator of ALL_GENERATORS) {
+      const result = await generator(companyId, "LINKEDIN", { days: 90 });
+
+      if (result !== null) {
+        expect(typeof result.type).toBe("string");
+        expect(typeof result.headline).toBe("string");
+        expect(typeof result.body).toBe("string");
+        expect(result.successMetric).toBe("engagement_rate");
+        expect(typeof result.confidenceScore).toBe("number");
+        expect(result.confidenceBand).toMatch(/^(strong|moderate|below_floor)$/);
+        expect(Array.isArray(result.evidence)).toBe(true);
+        for (const ev of result.evidence) {
+          expect(["social_post_analytics_snapshots", "ins_post_features"]).toContain(ev.sourceTable);
+          expect(typeof ev.sourceRowRef).toBe("string");
+          expect(typeof ev.summary).toBe("string");
+        }
+        // confidence band must not be below_floor (generators filter those out)
+        expect(result.confidenceBand).not.toBe("below_floor");
+      }
+      // null is also valid — not enough data for this company/platform/window combination
+    }
+  });
+
+  it("generators do not throw on empty platforms", async () => {
+    if (!hasEnoughData) return;
+
+    // FACEBOOK may have zero data — generators should return null gracefully
+    for (const generator of ALL_GENERATORS) {
+      await expect(
+        generator(companyId, "FACEBOOK", { days: 90 })
+      ).resolves.toSatisfy((r: unknown) => r === null || typeof r === "object");
+    }
+  });
+});

--- a/lib/insights/recommenders/__tests__/best-length-band.unit.test.ts
+++ b/lib/insights/recommenders/__tests__/best-length-band.unit.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { generateBestLengthBand } from "../best-length-band";
+
+vi.mock("server-only", () => ({}));
+
+const mockRpc = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({ rpc: mockRpc }),
+}));
+
+const now = Date.now();
+const makePost = (overrides: Record<string, unknown> = {}) => ({
+  bundle_post_id: crypto.randomUUID(),
+  posted_at: new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString(),
+  engagement_rate: 0.05,
+  impressions: 200,
+  word_count: 150,
+  has_question: false,
+  hashtag_count: 3,
+  media_type: "text",
+  day_of_week: 1,
+  hour_of_day_client_tz: 9,
+  topic_tags: [],
+  ...overrides,
+});
+
+const makePosts = (count: number, overrides: Record<string, unknown> = {}) =>
+  Array.from({ length: count }, (_, i) => makePost({ bundle_post_id: `post-${i}`, ...overrides }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("generateBestLengthBand", () => {
+  it("returns null when fewer than MIN_POSTS_FOR_RECOMMENDATION posts", async () => {
+    mockRpc.mockResolvedValue({ data: makePosts(19) });
+    const result = await generateBestLengthBand("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no posts returned", async () => {
+    mockRpc.mockResolvedValue({ data: null });
+    const result = await generateBestLengthBand("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fewer than 2 valid buckets (each needs ≥5 posts)", async () => {
+    // 25 posts all in medium bucket — only 1 valid bucket
+    const posts = makePosts(25, { word_count: 150 });
+    mockRpc.mockResolvedValue({ data: posts });
+    const result = await generateBestLengthBand("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns a BEST_LENGTH_BAND recommendation when 2 buckets differ in engagement", async () => {
+    // Need 50+ posts so sampleFactor = 0.5 → score = 0.5 * 1.0 * 1.0 * 1.0 = 0.5 ≥ 0.45 (moderate)
+    const shortPosts = Array.from({ length: 15 }, (_, i) =>
+      makePost({ bundle_post_id: `s${i}`, word_count: 80, engagement_rate: 0.12, posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString() })
+    );
+    const mediumPosts = Array.from({ length: 35 }, (_, i) =>
+      makePost({ bundle_post_id: `m${i}`, word_count: 150, engagement_rate: 0.05, posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString() })
+    );
+    mockRpc.mockResolvedValue({ data: [...shortPosts, ...mediumPosts] });
+
+    const result = await generateBestLengthBand("company-1", "LINKEDIN", { days: 90 });
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("BEST_LENGTH_BAND");
+    expect(result?.headline).toContain("under 100 words");
+    expect(result?.successMetric).toBe("engagement_rate");
+    expect(result?.evidence.length).toBeGreaterThan(0);
+  });
+
+  it("includes confidence band in returned candidate", async () => {
+    const shortPosts = Array.from({ length: 10 }, (_, i) => makePost({
+      bundle_post_id: `short-${i}`,
+      word_count: 50,
+      engagement_rate: 0.15,
+      posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+    }));
+    const longPosts = Array.from({ length: 50 }, (_, i) => makePost({
+      bundle_post_id: `long-${i}`,
+      word_count: 350,
+      engagement_rate: 0.04,
+      posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+    }));
+    mockRpc.mockResolvedValue({ data: [...shortPosts, ...longPosts] });
+
+    const result = await generateBestLengthBand("company-1", "LINKEDIN", { days: 90 });
+    expect(result).not.toBeNull();
+    expect(result?.confidenceBand).toMatch(/^(strong|moderate)$/);
+    expect(typeof result?.confidenceScore).toBe("number");
+  });
+
+  it("returns null when confidence is below_floor", async () => {
+    // 20 posts with identical engagement_rate — lift = 0% → signalFactor = 0 → score = 0
+    const posts = [
+      ...makePosts(10, { word_count: 50, engagement_rate: 0.05 }),
+      ...makePosts(10, { word_count: 150, engagement_rate: 0.05 }),
+    ].map((p, i) => ({ ...p, bundle_post_id: `post-${i}` }));
+    mockRpc.mockResolvedValue({ data: posts });
+
+    const result = await generateBestLengthBand("company-1", "LINKEDIN", { days: 90 });
+    // lift = 0, signalFactor = 0, score = 0 → below_floor → null
+    expect(result).toBeNull();
+  });
+});

--- a/lib/insights/recommenders/__tests__/best-posting-window.unit.test.ts
+++ b/lib/insights/recommenders/__tests__/best-posting-window.unit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { generateBestPostingWindow } from "../best-posting-window";
+
+vi.mock("server-only", () => ({}));
+
+const mockRpc = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({ rpc: mockRpc }),
+}));
+
+const now = Date.now();
+const makePost = (overrides: Record<string, unknown> = {}) => ({
+  bundle_post_id: crypto.randomUUID(),
+  posted_at: new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString(),
+  engagement_rate: 0.05,
+  impressions: 200,
+  word_count: 150,
+  has_question: false,
+  hashtag_count: 3,
+  media_type: "text",
+  day_of_week: 1,
+  hour_of_day_client_tz: 9,
+  topic_tags: [],
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("generateBestPostingWindow", () => {
+  it("returns null when fewer than MIN_POSTS_FOR_RECOMMENDATION posts", async () => {
+    mockRpc.mockResolvedValue({ data: Array.from({ length: 19 }, (_, i) => makePost({ bundle_post_id: `p${i}` })) });
+    const result = await generateBestPostingWindow("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no posts returned", async () => {
+    mockRpc.mockResolvedValue({ data: null });
+    const result = await generateBestPostingWindow("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no cell has ≥12 posts (cells need min 12)", async () => {
+    // 25 posts spread across many cells (1 each)
+    const posts = Array.from({ length: 25 }, (_, i) =>
+      makePost({ bundle_post_id: `p${i}`, day_of_week: i % 7, hour_of_day_client_tz: i % 24 })
+    );
+    mockRpc.mockResolvedValue({ data: posts });
+    const result = await generateBestPostingWindow("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns BEST_POSTING_WINDOW when two dense cells have meaningful lift", async () => {
+    // Need 50+ posts total, all recent, for sampleFactor=0.5 → score=0.5≥0.45 (moderate)
+    // Cell A: Mon 9am — 25 posts, high engagement
+    const cellA = Array.from({ length: 25 }, (_, i) =>
+      makePost({
+        bundle_post_id: `a${i}`,
+        day_of_week: 1,
+        hour_of_day_client_tz: 9,
+        engagement_rate: 0.18,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    // Cell B: Wed 14pm — 25 posts, lower engagement
+    const cellB = Array.from({ length: 25 }, (_, i) =>
+      makePost({
+        bundle_post_id: `b${i}`,
+        day_of_week: 3,
+        hour_of_day_client_tz: 14,
+        engagement_rate: 0.05,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    mockRpc.mockResolvedValue({ data: [...cellA, ...cellB] });
+
+    const result = await generateBestPostingWindow("company-1", "LINKEDIN", { days: 90 });
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("BEST_POSTING_WINDOW");
+    expect(result?.headline).toContain("Mon");
+    expect(result?.headline).toContain("9am");
+  });
+
+  it("returns null when lift is < 1.2× (not meaningful enough)", async () => {
+    // Cell A: 1.1× cell B — below threshold
+    const cellA = Array.from({ length: 12 }, (_, i) =>
+      makePost({ bundle_post_id: `a${i}`, day_of_week: 1, hour_of_day_client_tz: 9, engagement_rate: 0.055 })
+    );
+    const cellB = Array.from({ length: 12 }, (_, i) =>
+      makePost({ bundle_post_id: `b${i}`, day_of_week: 2, hour_of_day_client_tz: 10, engagement_rate: 0.05 })
+    );
+    mockRpc.mockResolvedValue({ data: [...cellA, ...cellB] });
+
+    const result = await generateBestPostingWindow("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("includes evidence rows referencing social_post_analytics_snapshots", async () => {
+    const cellA = Array.from({ length: 25 }, (_, i) =>
+      makePost({
+        bundle_post_id: `a${i}`,
+        day_of_week: 0,
+        hour_of_day_client_tz: 8,
+        engagement_rate: 0.20,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    const cellB = Array.from({ length: 25 }, (_, i) =>
+      makePost({
+        bundle_post_id: `b${i}`,
+        day_of_week: 5,
+        hour_of_day_client_tz: 17,
+        engagement_rate: 0.05,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    mockRpc.mockResolvedValue({ data: [...cellA, ...cellB] });
+
+    const result = await generateBestPostingWindow("company-1", "LINKEDIN", { days: 90 });
+    expect(result).not.toBeNull();
+    expect(result?.evidence[0].sourceTable).toBe("social_post_analytics_snapshots");
+  });
+});

--- a/lib/insights/recommenders/__tests__/hashtag-diminishing-returns.unit.test.ts
+++ b/lib/insights/recommenders/__tests__/hashtag-diminishing-returns.unit.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { generateHashtagDiminishingReturns } from "../hashtag-diminishing-returns";
+
+vi.mock("server-only", () => ({}));
+
+const mockRpc = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({ rpc: mockRpc }),
+}));
+
+const now = Date.now();
+const makePost = (overrides: Record<string, unknown> = {}) => ({
+  bundle_post_id: crypto.randomUUID(),
+  posted_at: new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString(),
+  engagement_rate: 0.05,
+  impressions: 200,
+  word_count: 150,
+  has_question: false,
+  hashtag_count: 3,
+  media_type: "text",
+  day_of_week: 1,
+  hour_of_day_client_tz: 9,
+  topic_tags: [],
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("generateHashtagDiminishingReturns", () => {
+  it("returns null when fewer than MIN_POSTS_FOR_RECOMMENDATION posts", async () => {
+    mockRpc.mockResolvedValue({
+      data: Array.from({ length: 19 }, (_, i) => makePost({ bundle_post_id: `p${i}` })),
+    });
+    const result = await generateHashtagDiminishingReturns("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no posts returned", async () => {
+    mockRpc.mockResolvedValue({ data: null });
+    const result = await generateHashtagDiminishingReturns("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fewer than 2 valid buckets (each needs ≥3 posts)", async () => {
+    // All posts in "1-3" bucket
+    const posts = Array.from({ length: 25 }, (_, i) =>
+      makePost({ bundle_post_id: `p${i}`, hashtag_count: 2 })
+    );
+    mockRpc.mockResolvedValue({ data: posts });
+    const result = await generateHashtagDiminishingReturns("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when engagement increases monotonically (no diminishing returns)", async () => {
+    // 0 < 1-3 < 4-6 < 7+ — no inflection
+    const bucket0 = Array.from({ length: 5 }, (_, i) =>
+      makePost({ bundle_post_id: `b0-${i}`, hashtag_count: 0, engagement_rate: 0.03 })
+    );
+    const bucket1 = Array.from({ length: 5 }, (_, i) =>
+      makePost({ bundle_post_id: `b1-${i}`, hashtag_count: 2, engagement_rate: 0.05 })
+    );
+    const bucket2 = Array.from({ length: 5 }, (_, i) =>
+      makePost({ bundle_post_id: `b2-${i}`, hashtag_count: 5, engagement_rate: 0.08 })
+    );
+    const bucket3 = Array.from({ length: 5 }, (_, i) =>
+      makePost({ bundle_post_id: `b3-${i}`, hashtag_count: 10, engagement_rate: 0.10 })
+    );
+    mockRpc.mockResolvedValue({ data: [...bucket0, ...bucket1, ...bucket2, ...bucket3] });
+    const result = await generateHashtagDiminishingReturns("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns HASHTAG_DIMINISHING_RETURNS when 4-6 drops vs 1-3", async () => {
+    // effectMagnitude = drop ≈ 0.6 (capped at 1), so need sampleFactor ≥ 0.75 (75+ posts)
+    // score = 0.8 * 1.0 * 1.0 * 0.6 = 0.48 ≥ 0.45 → moderate with 80 posts
+    const bucket1 = Array.from({ length: 20 }, (_, i) =>
+      makePost({
+        bundle_post_id: `b1-${i}`,
+        hashtag_count: 2,
+        engagement_rate: 0.10,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    const bucket2 = Array.from({ length: 60 }, (_, i) =>
+      makePost({
+        bundle_post_id: `b2-${i}`,
+        hashtag_count: 5,
+        engagement_rate: 0.04,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    mockRpc.mockResolvedValue({ data: [...bucket1, ...bucket2] });
+
+    const result = await generateHashtagDiminishingReturns("company-1", "LINKEDIN", { days: 90 });
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("HASHTAG_DIMINISHING_RETURNS");
+    expect(result?.headline).toContain("3 hashtags");
+    expect(result?.successMetric).toBe("engagement_rate");
+  });
+
+  it("returns null when drop is < 10%", async () => {
+    const bucket1 = Array.from({ length: 6 }, (_, i) =>
+      makePost({ bundle_post_id: `b1-${i}`, hashtag_count: 2, engagement_rate: 0.055 })
+    );
+    const bucket2 = Array.from({ length: 20 }, (_, i) =>
+      makePost({ bundle_post_id: `b2-${i}`, hashtag_count: 5, engagement_rate: 0.05 })
+    );
+    mockRpc.mockResolvedValue({ data: [...bucket1, ...bucket2] });
+
+    const result = await generateHashtagDiminishingReturns("company-1", "LINKEDIN", { days: 90 });
+    // drop = (0.055 - 0.05) / 0.055 ≈ 9% < 10% → null
+    expect(result).toBeNull();
+  });
+
+  it("evidence references ins_post_features and shows hashtag count", async () => {
+    const bucket1 = Array.from({ length: 20 }, (_, i) =>
+      makePost({
+        bundle_post_id: `b1-${i}`,
+        hashtag_count: 1,
+        engagement_rate: 0.12,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    const bucket2 = Array.from({ length: 60 }, (_, i) =>
+      makePost({
+        bundle_post_id: `b2-${i}`,
+        hashtag_count: 8,
+        engagement_rate: 0.04,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    mockRpc.mockResolvedValue({ data: [...bucket1, ...bucket2] });
+
+    const result = await generateHashtagDiminishingReturns("company-1", "LINKEDIN", { days: 90 });
+    expect(result).not.toBeNull();
+    expect(result?.evidence[0].sourceTable).toBe("ins_post_features");
+    expect(result?.evidence[0].summary).toContain("hashtags");
+  });
+});

--- a/lib/insights/recommenders/__tests__/media-type-lift.unit.test.ts
+++ b/lib/insights/recommenders/__tests__/media-type-lift.unit.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { generateMediaTypeLift } from "../media-type-lift";
+
+vi.mock("server-only", () => ({}));
+
+const mockRpc = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({ rpc: mockRpc }),
+}));
+
+const now = Date.now();
+const makePost = (overrides: Record<string, unknown> = {}) => ({
+  bundle_post_id: crypto.randomUUID(),
+  posted_at: new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString(),
+  engagement_rate: 0.05,
+  impressions: 200,
+  word_count: 150,
+  has_question: false,
+  hashtag_count: 3,
+  media_type: "text",
+  day_of_week: 1,
+  hour_of_day_client_tz: 9,
+  topic_tags: [],
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("generateMediaTypeLift", () => {
+  it("returns null when fewer than MIN_POSTS_FOR_RECOMMENDATION posts", async () => {
+    mockRpc.mockResolvedValue({
+      data: Array.from({ length: 19 }, (_, i) => makePost({ bundle_post_id: `p${i}` })),
+    });
+    const result = await generateMediaTypeLift("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no posts returned", async () => {
+    mockRpc.mockResolvedValue({ data: null });
+    const result = await generateMediaTypeLift("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when only 1 media type has ≥5 posts", async () => {
+    const posts = Array.from({ length: 25 }, (_, i) =>
+      makePost({ bundle_post_id: `p${i}`, media_type: "video" })
+    );
+    mockRpc.mockResolvedValue({ data: posts });
+    const result = await generateMediaTypeLift("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns MEDIA_TYPE_LIFT when two types differ by ≥10%", async () => {
+    // Need 50+ total posts for sampleFactor ≥ 0.5 → score ≥ 0.45 (moderate)
+    const videoPosts = Array.from({ length: 15 }, (_, i) =>
+      makePost({
+        bundle_post_id: `v${i}`,
+        media_type: "video",
+        engagement_rate: 0.12,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    const textPosts = Array.from({ length: 35 }, (_, i) =>
+      makePost({
+        bundle_post_id: `t${i}`,
+        media_type: "text",
+        engagement_rate: 0.05,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    mockRpc.mockResolvedValue({ data: [...videoPosts, ...textPosts] });
+
+    const result = await generateMediaTypeLift("company-1", "LINKEDIN", { days: 90 });
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("MEDIA_TYPE_LIFT");
+    expect(result?.headline).toContain("Video");
+    expect(result?.successMetric).toBe("engagement_rate");
+  });
+
+  it("returns null when lift is < 10%", async () => {
+    const videoPosts = Array.from({ length: 8 }, (_, i) =>
+      makePost({ bundle_post_id: `v${i}`, media_type: "video", engagement_rate: 0.053 })
+    );
+    const textPosts = Array.from({ length: 15 }, (_, i) =>
+      makePost({ bundle_post_id: `t${i}`, media_type: "text", engagement_rate: 0.05 })
+    );
+    mockRpc.mockResolvedValue({ data: [...videoPosts, ...textPosts] });
+
+    const result = await generateMediaTypeLift("company-1", "LINKEDIN", { days: 90 });
+    // lift = (0.053 - 0.05) / 0.05 = 6% < 10% → null
+    expect(result).toBeNull();
+  });
+
+  it("evidence rows reference social_post_analytics_snapshots", async () => {
+    const imagePosts = Array.from({ length: 15 }, (_, i) =>
+      makePost({
+        bundle_post_id: `img${i}`,
+        media_type: "image",
+        engagement_rate: 0.14,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    const textPosts = Array.from({ length: 35 }, (_, i) =>
+      makePost({
+        bundle_post_id: `txt${i}`,
+        media_type: "text",
+        engagement_rate: 0.04,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    mockRpc.mockResolvedValue({ data: [...imagePosts, ...textPosts] });
+
+    const result = await generateMediaTypeLift("company-1", "LINKEDIN", { days: 90 });
+    expect(result).not.toBeNull();
+    expect(result?.evidence[0].sourceTable).toBe("social_post_analytics_snapshots");
+  });
+});

--- a/lib/insights/recommenders/__tests__/question-pattern-lift.unit.test.ts
+++ b/lib/insights/recommenders/__tests__/question-pattern-lift.unit.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { generateQuestionPatternLift } from "../question-pattern-lift";
+
+vi.mock("server-only", () => ({}));
+
+const mockRpc = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({ rpc: mockRpc }),
+}));
+
+const now = Date.now();
+const makePost = (overrides: Record<string, unknown> = {}) => ({
+  bundle_post_id: crypto.randomUUID(),
+  posted_at: new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString(),
+  engagement_rate: 0.05,
+  impressions: 200,
+  word_count: 150,
+  has_question: false,
+  hashtag_count: 3,
+  media_type: "text",
+  day_of_week: 1,
+  hour_of_day_client_tz: 9,
+  topic_tags: [],
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("generateQuestionPatternLift", () => {
+  it("returns null when fewer than MIN_POSTS_FOR_RECOMMENDATION posts", async () => {
+    mockRpc.mockResolvedValue({
+      data: Array.from({ length: 19 }, (_, i) => makePost({ bundle_post_id: `p${i}` })),
+    });
+    const result = await generateQuestionPatternLift("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no posts returned", async () => {
+    mockRpc.mockResolvedValue({ data: null });
+    const result = await generateQuestionPatternLift("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fewer than 5 posts in either group", async () => {
+    // Only 3 posts with questions — below threshold
+    const posts = [
+      ...Array.from({ length: 3 }, (_, i) =>
+        makePost({ bundle_post_id: `q${i}`, has_question: true, engagement_rate: 0.15 })
+      ),
+      ...Array.from({ length: 20 }, (_, i) =>
+        makePost({ bundle_post_id: `n${i}`, has_question: false, engagement_rate: 0.05 })
+      ),
+    ];
+    mockRpc.mockResolvedValue({ data: posts });
+    const result = await generateQuestionPatternLift("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when lift is < 1.5×", async () => {
+    const posts = [
+      ...Array.from({ length: 10 }, (_, i) =>
+        makePost({ bundle_post_id: `q${i}`, has_question: true, engagement_rate: 0.065 })
+      ),
+      ...Array.from({ length: 15 }, (_, i) =>
+        makePost({ bundle_post_id: `n${i}`, has_question: false, engagement_rate: 0.05 })
+      ),
+    ];
+    mockRpc.mockResolvedValue({ data: posts });
+    const result = await generateQuestionPatternLift("company-1", "LINKEDIN", { days: 90 });
+    // lift = 0.065/0.05 = 1.3× < 1.5 → null
+    expect(result).toBeNull();
+  });
+
+  it("returns QUESTION_PATTERN_LIFT when lift ≥ 1.5×", async () => {
+    // Need 50+ total posts for sampleFactor ≥ 0.5 → score ≥ 0.45 (moderate)
+    const withQ = Array.from({ length: 15 }, (_, i) =>
+      makePost({
+        bundle_post_id: `q${i}`,
+        has_question: true,
+        engagement_rate: 0.15,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    const withoutQ = Array.from({ length: 35 }, (_, i) =>
+      makePost({
+        bundle_post_id: `n${i}`,
+        has_question: false,
+        engagement_rate: 0.05,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    mockRpc.mockResolvedValue({ data: [...withQ, ...withoutQ] });
+
+    const result = await generateQuestionPatternLift("company-1", "LINKEDIN", { days: 90 });
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("QUESTION_PATTERN_LIFT");
+    expect(result?.headline).toMatch(/3\.0×/);
+    expect(result?.body).toContain("15 posts with questions");
+  });
+
+  it("evidence rows reference ins_post_features", async () => {
+    const withQ = Array.from({ length: 15 }, (_, i) =>
+      makePost({
+        bundle_post_id: `q${i}`,
+        has_question: true,
+        engagement_rate: 0.18,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    const withoutQ = Array.from({ length: 35 }, (_, i) =>
+      makePost({
+        bundle_post_id: `n${i}`,
+        has_question: false,
+        engagement_rate: 0.05,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    mockRpc.mockResolvedValue({ data: [...withQ, ...withoutQ] });
+
+    const result = await generateQuestionPatternLift("company-1", "LINKEDIN", { days: 90 });
+    expect(result).not.toBeNull();
+    expect(result?.evidence[0].sourceTable).toBe("ins_post_features");
+  });
+});

--- a/lib/insights/recommenders/__tests__/topic-performance.unit.test.ts
+++ b/lib/insights/recommenders/__tests__/topic-performance.unit.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { generateTopicPerformance } from "../topic-performance";
+
+vi.mock("server-only", () => ({}));
+
+const mockRpc = vi.fn();
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({ rpc: mockRpc }),
+}));
+
+const now = Date.now();
+const makePost = (overrides: Record<string, unknown> = {}) => ({
+  bundle_post_id: crypto.randomUUID(),
+  posted_at: new Date(now - 10 * 24 * 60 * 60 * 1000).toISOString(),
+  engagement_rate: 0.05,
+  impressions: 200,
+  word_count: 150,
+  has_question: false,
+  hashtag_count: 3,
+  media_type: "text",
+  day_of_week: 1,
+  hour_of_day_client_tz: 9,
+  topic_tags: [] as string[],
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("generateTopicPerformance", () => {
+  it("returns null when fewer than MIN_POSTS_FOR_RECOMMENDATION posts", async () => {
+    mockRpc.mockResolvedValue({
+      data: Array.from({ length: 19 }, (_, i) =>
+        makePost({ bundle_post_id: `p${i}`, topic_tags: ["leadership"] })
+      ),
+    });
+    const result = await generateTopicPerformance("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no posts returned", async () => {
+    mockRpc.mockResolvedValue({ data: null });
+    const result = await generateTopicPerformance("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no posts have topic_tags", async () => {
+    const posts = Array.from({ length: 25 }, (_, i) =>
+      makePost({ bundle_post_id: `p${i}`, topic_tags: [] })
+    );
+    mockRpc.mockResolvedValue({ data: posts });
+    const result = await generateTopicPerformance("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no topic has ≥5 posts", async () => {
+    // Each topic only appears 4 times
+    const posts = Array.from({ length: 20 }, (_, i) =>
+      makePost({ bundle_post_id: `p${i}`, topic_tags: [`topic-${i % 5}`], engagement_rate: 0.05 })
+    );
+    mockRpc.mockResolvedValue({ data: posts });
+    const result = await generateTopicPerformance("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fewer than 2 valid topics with ≥5 posts each", async () => {
+    // Only "leadership" has 6 posts; "culture" has only 2
+    const posts = [
+      ...Array.from({ length: 6 }, (_, i) =>
+        makePost({ bundle_post_id: `l${i}`, topic_tags: ["leadership"], engagement_rate: 0.12 })
+      ),
+      ...Array.from({ length: 2 }, (_, i) =>
+        makePost({ bundle_post_id: `c${i}`, topic_tags: ["culture"], engagement_rate: 0.05 })
+      ),
+      ...Array.from({ length: 15 }, (_, i) =>
+        makePost({ bundle_post_id: `x${i}`, topic_tags: [] })
+      ),
+    ];
+    mockRpc.mockResolvedValue({ data: posts });
+    const result = await generateTopicPerformance("company-1", "LINKEDIN", { days: 90 });
+    expect(result).toBeNull();
+  });
+
+  it("returns TOPIC_PERFORMANCE when best topic outperforms median by ≥20%", async () => {
+    // Need 50+ total posts for sampleFactor ≥ 0.5 → score ≥ 0.45 (moderate)
+    const leadershipPosts = Array.from({ length: 10 }, (_, i) =>
+      makePost({
+        bundle_post_id: `l${i}`,
+        topic_tags: ["leadership"],
+        engagement_rate: 0.15,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    const culturePosts = Array.from({ length: 10 }, (_, i) =>
+      makePost({
+        bundle_post_id: `c${i}`,
+        topic_tags: ["culture"],
+        engagement_rate: 0.06,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    const hrPosts = Array.from({ length: 30 }, (_, i) =>
+      makePost({
+        bundle_post_id: `h${i}`,
+        topic_tags: ["hr"],
+        engagement_rate: 0.04,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    mockRpc.mockResolvedValue({ data: [...leadershipPosts, ...culturePosts, ...hrPosts] });
+
+    const result = await generateTopicPerformance("company-1", "LINKEDIN", { days: 90 });
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("TOPIC_PERFORMANCE");
+    expect(result?.headline).toContain("leadership");
+    expect(result?.successMetric).toBe("engagement_rate");
+  });
+
+  it("returns null when lift < 20% over median", async () => {
+    const t1 = Array.from({ length: 6 }, (_, i) =>
+      makePost({ bundle_post_id: `t1-${i}`, topic_tags: ["topic1"], engagement_rate: 0.07 })
+    );
+    const t2 = Array.from({ length: 6 }, (_, i) =>
+      makePost({ bundle_post_id: `t2-${i}`, topic_tags: ["topic2"], engagement_rate: 0.065 })
+    );
+    const filler = Array.from({ length: 10 }, (_, i) =>
+      makePost({ bundle_post_id: `f${i}`, topic_tags: [] })
+    );
+    mockRpc.mockResolvedValue({ data: [...t1, ...t2, ...filler] });
+
+    const result = await generateTopicPerformance("company-1", "LINKEDIN", { days: 90 });
+    // lift = (0.07 - 0.065) / 0.065 ≈ 7.7% < 20% → null
+    expect(result).toBeNull();
+  });
+
+  it("evidence rows reference ins_post_features", async () => {
+    const leadershipPosts = Array.from({ length: 10 }, (_, i) =>
+      makePost({
+        bundle_post_id: `l${i}`,
+        topic_tags: ["leadership"],
+        engagement_rate: 0.18,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    const otherPosts = Array.from({ length: 40 }, (_, i) =>
+      makePost({
+        bundle_post_id: `o${i}`,
+        topic_tags: ["generic"],
+        engagement_rate: 0.04,
+        posted_at: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      })
+    );
+    mockRpc.mockResolvedValue({ data: [...leadershipPosts, ...otherPosts] });
+
+    const result = await generateTopicPerformance("company-1", "LINKEDIN", { days: 90 });
+    expect(result).not.toBeNull();
+    expect(result?.evidence[0].sourceTable).toBe("ins_post_features");
+    expect(result?.evidence[0].summary).toContain("leadership");
+  });
+});

--- a/lib/insights/recommenders/best-length-band.ts
+++ b/lib/insights/recommenders/best-length-band.ts
@@ -1,0 +1,87 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  computeConfidence,
+  coefficientOfVariation,
+  MIN_POSTS_FOR_RECOMMENDATION,
+} from "../confidence";
+import type { GeneratorFn, PostWithEngagement } from "./types";
+
+export const generateBestLengthBand: GeneratorFn = async (companyId, platform, window) => {
+  const svc = getServiceRoleClient();
+  const cutoff = new Date(Date.now() - window.days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: rawPosts } = await svc.rpc("get_posts_with_engagement", {
+    p_company_id: companyId,
+    p_platform: platform,
+    p_cutoff: cutoff,
+    p_min_impressions: 50,
+  });
+  const posts = rawPosts as PostWithEngagement[] | null;
+
+  if (!posts || posts.length < MIN_POSTS_FOR_RECOMMENDATION) return null;
+
+  const buckets = {
+    short: posts.filter((p) => p.word_count <= 100),
+    medium: posts.filter((p) => p.word_count > 100 && p.word_count <= 200),
+    long: posts.filter((p) => p.word_count > 200 && p.word_count <= 300),
+    very_long: posts.filter((p) => p.word_count > 300),
+  };
+
+  const validBuckets = Object.entries(buckets).filter(([, ps]) => ps.length >= 5);
+  if (validBuckets.length < 2) return null;
+
+  const bucketStats = validBuckets.map(([name, ps]) => {
+    const rates = ps.map((p) => Number(p.engagement_rate));
+    return {
+      name,
+      meanRate: rates.reduce((a, b) => a + b, 0) / rates.length,
+      cov: coefficientOfVariation(rates),
+      sampleN: ps.length,
+      examplePosts: ps.slice(0, 3),
+    };
+  });
+
+  const [best, second] = bucketStats.sort((a, b) => b.meanRate - a.meanRate);
+  const lift = (best.meanRate - second.meanRate) / (second.meanRate || 1);
+
+  const now = Date.now();
+  const recentPosts = posts.filter(
+    (p) => new Date(p.posted_at).getTime() > now - 30 * 24 * 60 * 60 * 1000,
+  ).length;
+  const sixtyDayPosts = posts.filter(
+    (p) => new Date(p.posted_at).getTime() > now - 60 * 24 * 60 * 60 * 1000,
+  ).length;
+
+  const confidence = computeConfidence({
+    postsInWindow: posts.length,
+    postsFromLast30d: recentPosts,
+    postsFromLast60d: sixtyDayPosts,
+    coefficientOfVariation: best.cov,
+    effectMagnitude: Math.min(1, Math.abs(lift)),
+  });
+
+  if (confidence.band === "below_floor") return null;
+
+  const bandLabel: Record<string, string> = {
+    short: "under 100 words",
+    medium: "100–200 words",
+    long: "200–300 words",
+    very_long: "300+ words",
+  };
+
+  return {
+    type: "BEST_LENGTH_BAND",
+    headline: `Posts ${bandLabel[best.name]} get ${(lift * 100).toFixed(0)}% more engagement`,
+    body: `Based on ${posts.length} ${platform} posts in the last ${window.days} days.`,
+    successMetric: "engagement_rate",
+    confidenceScore: confidence.score,
+    confidenceBand: confidence.band,
+    evidence: best.examplePosts.map((p) => ({
+      sourceTable: "social_post_analytics_snapshots" as const,
+      sourceRowRef: p.bundle_post_id,
+      summary: `${p.word_count} words, ${(Number(p.engagement_rate) * 100).toFixed(1)}% engagement`,
+    })),
+  };
+};

--- a/lib/insights/recommenders/best-posting-window.ts
+++ b/lib/insights/recommenders/best-posting-window.ts
@@ -1,0 +1,91 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  computeConfidence,
+  coefficientOfVariation,
+  MIN_POSTS_FOR_RECOMMENDATION,
+} from "../confidence";
+import type { GeneratorFn, PostWithEngagement } from "./types";
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export const generateBestPostingWindow: GeneratorFn = async (companyId, platform, window) => {
+  const svc = getServiceRoleClient();
+  const cutoff = new Date(Date.now() - window.days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: rawPosts } = await svc.rpc("get_posts_with_engagement", {
+    p_company_id: companyId,
+    p_platform: platform,
+    p_cutoff: cutoff,
+    p_min_impressions: 50,
+  });
+  const posts = rawPosts as PostWithEngagement[] | null;
+
+  if (!posts || posts.length < MIN_POSTS_FOR_RECOMMENDATION) return null;
+
+  // Group by day_of_week × hour_of_day_client_tz
+  const cells = new Map<string, PostWithEngagement[]>();
+  for (const post of posts) {
+    const key = `${post.day_of_week}:${post.hour_of_day_client_tz}`;
+    if (!cells.has(key)) cells.set(key, []);
+    cells.get(key)!.push(post);
+  }
+
+  // Need at least 12 posts per cell
+  const validCells = [...cells.entries()].filter(([, ps]) => ps.length >= 12);
+  if (validCells.length < 2) return null;
+
+  const cellStats = validCells.map(([key, ps]) => {
+    const [day, hour] = key.split(":").map(Number);
+    const rates = ps.map((p) => Number(p.engagement_rate));
+    return {
+      day,
+      hour,
+      meanRate: rates.reduce((a, b) => a + b, 0) / rates.length,
+      cov: coefficientOfVariation(rates),
+      sampleN: ps.length,
+      examplePosts: ps.slice(0, 3),
+    };
+  });
+
+  const [best, second] = cellStats.sort((a, b) => b.meanRate - a.meanRate);
+  const lift = best.meanRate / (second.meanRate || 1);
+
+  if (lift < 1.2) return null; // Not meaningful enough
+
+  const now = Date.now();
+  const recentPosts = posts.filter(
+    (p) => new Date(p.posted_at).getTime() > now - 30 * 24 * 60 * 60 * 1000,
+  ).length;
+  const sixtyDayPosts = posts.filter(
+    (p) => new Date(p.posted_at).getTime() > now - 60 * 24 * 60 * 60 * 1000,
+  ).length;
+
+  const confidence = computeConfidence({
+    postsInWindow: posts.length,
+    postsFromLast30d: recentPosts,
+    postsFromLast60d: sixtyDayPosts,
+    coefficientOfVariation: best.cov,
+    effectMagnitude: Math.min(1, lift - 1),
+  });
+
+  if (confidence.band === "below_floor") return null;
+
+  const dayLabel = DAY_LABELS[best.day] ?? `Day ${best.day}`;
+  const hourLabel = best.hour === 12 ? "12pm" : best.hour > 12 ? `${best.hour - 12}pm` : `${best.hour}am`;
+
+  return {
+    type: "BEST_POSTING_WINDOW",
+    headline: `${dayLabel} ${hourLabel} is your best window — ${lift.toFixed(1)}× median`,
+    body: `Posts published ${dayLabel} at ${hourLabel} average ${(best.meanRate * 100).toFixed(1)}% engagement (${best.sampleN} posts).`,
+    successMetric: "engagement_rate",
+    confidenceScore: confidence.score,
+    confidenceBand: confidence.band,
+    evidence: best.examplePosts.map((p) => ({
+      sourceTable: "social_post_analytics_snapshots" as const,
+      sourceRowRef: p.bundle_post_id,
+      summary: `${DAY_LABELS[p.day_of_week]} ${p.hour_of_day_client_tz}:00, ${(Number(p.engagement_rate) * 100).toFixed(1)}% engagement`,
+    })),
+  };
+};

--- a/lib/insights/recommenders/hashtag-diminishing-returns.ts
+++ b/lib/insights/recommenders/hashtag-diminishing-returns.ts
@@ -1,0 +1,101 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  computeConfidence,
+  coefficientOfVariation,
+  MIN_POSTS_FOR_RECOMMENDATION,
+} from "../confidence";
+import type { GeneratorFn, PostWithEngagement } from "./types";
+
+export const generateHashtagDiminishingReturns: GeneratorFn = async (
+  companyId,
+  platform,
+  window,
+) => {
+  const svc = getServiceRoleClient();
+  const cutoff = new Date(Date.now() - window.days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: rawPosts } = await svc.rpc("get_posts_with_engagement", {
+    p_company_id: companyId,
+    p_platform: platform,
+    p_cutoff: cutoff,
+    p_min_impressions: 50,
+  });
+  const posts = rawPosts as PostWithEngagement[] | null;
+
+  if (!posts || posts.length < MIN_POSTS_FOR_RECOMMENDATION) return null;
+
+  // Bucket by hashtag count: 0, 1-3, 4-6, 7+
+  const buckets: Record<string, PostWithEngagement[]> = {
+    "0": posts.filter((p) => p.hashtag_count === 0),
+    "1-3": posts.filter((p) => p.hashtag_count >= 1 && p.hashtag_count <= 3),
+    "4-6": posts.filter((p) => p.hashtag_count >= 4 && p.hashtag_count <= 6),
+    "7+": posts.filter((p) => p.hashtag_count >= 7),
+  };
+
+  const validBuckets = Object.entries(buckets).filter(([, ps]) => ps.length >= 3);
+  if (validBuckets.length < 2) return null;
+
+  const bucketStats = validBuckets.map(([name, ps]) => ({
+    name,
+    meanRate: ps.reduce((s, p) => s + Number(p.engagement_rate), 0) / ps.length,
+    cov: coefficientOfVariation(ps.map((p) => Number(p.engagement_rate))),
+    sampleN: ps.length,
+    examplePosts: ps.slice(0, 3),
+  }));
+
+  // Find inflection point: where adding more hashtags decreases engagement
+  const ordered = ["0", "1-3", "4-6", "7+"].map((n) => bucketStats.find((b) => b.name === n)).filter(Boolean) as typeof bucketStats;
+  if (ordered.length < 2) return null;
+
+  let inflectionIdx = -1;
+  for (let i = 1; i < ordered.length; i++) {
+    if (ordered[i].meanRate < ordered[i - 1].meanRate) {
+      inflectionIdx = i;
+      break;
+    }
+  }
+
+  if (inflectionIdx < 1) return null; // No diminishing returns found
+
+  const peakBucket = ordered[inflectionIdx - 1];
+  const declineBucket = ordered[inflectionIdx];
+  const drop = (peakBucket.meanRate - declineBucket.meanRate) / (peakBucket.meanRate || 1);
+
+  if (drop < 0.1) return null; // < 10% drop — not meaningful
+
+  const now = Date.now();
+  const recentPosts = posts.filter(
+    (p) => new Date(p.posted_at).getTime() > now - 30 * 24 * 60 * 60 * 1000,
+  ).length;
+  const sixtyDayPosts = posts.filter(
+    (p) => new Date(p.posted_at).getTime() > now - 60 * 24 * 60 * 60 * 1000,
+  ).length;
+
+  const confidence = computeConfidence({
+    postsInWindow: posts.length,
+    postsFromLast30d: recentPosts,
+    postsFromLast60d: sixtyDayPosts,
+    coefficientOfVariation: peakBucket.cov,
+    effectMagnitude: Math.min(1, drop),
+  });
+
+  if (confidence.band === "below_floor") return null;
+
+  const thresholdLabel = peakBucket.name === "0" ? "0" : peakBucket.name === "1-3" ? "3" : "6";
+
+  return {
+    type: "HASHTAG_DIMINISHING_RETURNS",
+    headline: `Posts with more than ${thresholdLabel} hashtags get ${(drop * 100).toFixed(0)}% less engagement`,
+    body: `Your sweet spot is ${peakBucket.name} hashtags (${(peakBucket.meanRate * 100).toFixed(1)}% avg). More hashtags drop to ${(declineBucket.meanRate * 100).toFixed(1)}%.`,
+    successMetric: "engagement_rate",
+    confidenceScore: confidence.score,
+    confidenceBand: confidence.band,
+    evidence: peakBucket.examplePosts.map((p) => ({
+      sourceTable: "ins_post_features" as const,
+      sourceRowRef: p.bundle_post_id,
+      summary: `${p.hashtag_count} hashtags, ${(Number(p.engagement_rate) * 100).toFixed(1)}% engagement`,
+    })),
+  };
+};

--- a/lib/insights/recommenders/media-type-lift.ts
+++ b/lib/insights/recommenders/media-type-lift.ts
@@ -1,0 +1,87 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  computeConfidence,
+  coefficientOfVariation,
+  MIN_POSTS_FOR_RECOMMENDATION,
+} from "../confidence";
+import type { GeneratorFn, PostWithEngagement } from "./types";
+
+export const generateMediaTypeLift: GeneratorFn = async (companyId, platform, window) => {
+  const svc = getServiceRoleClient();
+  const cutoff = new Date(Date.now() - window.days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: rawPosts } = await svc.rpc("get_posts_with_engagement", {
+    p_company_id: companyId,
+    p_platform: platform,
+    p_cutoff: cutoff,
+    p_min_impressions: 50,
+  });
+  const posts = rawPosts as PostWithEngagement[] | null;
+
+  if (!posts || posts.length < MIN_POSTS_FOR_RECOMMENDATION) return null;
+
+  // Group by media_type
+  const byType = new Map<string, PostWithEngagement[]>();
+  for (const post of posts) {
+    const type = post.media_type ?? "text";
+    if (!byType.has(type)) byType.set(type, []);
+    byType.get(type)!.push(post);
+  }
+
+  const validTypes = [...byType.entries()].filter(([, ps]) => ps.length >= 5);
+  if (validTypes.length < 2) return null;
+
+  const typeStats = validTypes.map(([type, ps]) => {
+    const rates = ps.map((p) => Number(p.engagement_rate));
+    return {
+      type,
+      meanRate: rates.reduce((a, b) => a + b, 0) / rates.length,
+      cov: coefficientOfVariation(rates),
+      sampleN: ps.length,
+      examplePosts: ps.slice(0, 3),
+    };
+  });
+
+  const [best, second] = typeStats.sort((a, b) => b.meanRate - a.meanRate);
+  const lift = (best.meanRate - second.meanRate) / (second.meanRate || 1);
+
+  if (lift < 0.1) return null; // < 10% difference — not worth surfacing
+
+  const now = Date.now();
+  const recentPosts = posts.filter(
+    (p) => new Date(p.posted_at).getTime() > now - 30 * 24 * 60 * 60 * 1000,
+  ).length;
+  const sixtyDayPosts = posts.filter(
+    (p) => new Date(p.posted_at).getTime() > now - 60 * 24 * 60 * 60 * 1000,
+  ).length;
+
+  const confidence = computeConfidence({
+    postsInWindow: posts.length,
+    postsFromLast30d: recentPosts,
+    postsFromLast60d: sixtyDayPosts,
+    coefficientOfVariation: best.cov,
+    effectMagnitude: Math.min(1, lift),
+  });
+
+  if (confidence.band === "below_floor") return null;
+
+  return {
+    type: "MEDIA_TYPE_LIFT",
+    headline: `${capitalize(best.type)} posts outperform ${best.type === "text" ? "media" : "text"} by ${(lift * 100).toFixed(0)}%`,
+    body: `${best.sampleN} ${best.type} posts averaged ${(best.meanRate * 100).toFixed(1)}% engagement vs ${(second.meanRate * 100).toFixed(1)}% for ${second.type}.`,
+    successMetric: "engagement_rate",
+    confidenceScore: confidence.score,
+    confidenceBand: confidence.band,
+    evidence: best.examplePosts.map((p) => ({
+      sourceTable: "social_post_analytics_snapshots" as const,
+      sourceRowRef: p.bundle_post_id,
+      summary: `${p.media_type ?? "text"} post, ${(Number(p.engagement_rate) * 100).toFixed(1)}% engagement`,
+    })),
+  };
+};
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/lib/insights/recommenders/question-pattern-lift.ts
+++ b/lib/insights/recommenders/question-pattern-lift.ts
@@ -1,0 +1,69 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  computeConfidence,
+  coefficientOfVariation,
+  MIN_POSTS_FOR_RECOMMENDATION,
+} from "../confidence";
+import type { GeneratorFn, PostWithEngagement } from "./types";
+
+export const generateQuestionPatternLift: GeneratorFn = async (companyId, platform, window) => {
+  const svc = getServiceRoleClient();
+  const cutoff = new Date(Date.now() - window.days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: rawPosts } = await svc.rpc("get_posts_with_engagement", {
+    p_company_id: companyId,
+    p_platform: platform,
+    p_cutoff: cutoff,
+    p_min_impressions: 50,
+  });
+  const posts = rawPosts as PostWithEngagement[] | null;
+
+  if (!posts || posts.length < MIN_POSTS_FOR_RECOMMENDATION) return null;
+
+  const withQuestion = posts.filter((p) => p.has_question);
+  const withoutQuestion = posts.filter((p) => !p.has_question);
+
+  if (withQuestion.length < 5 || withoutQuestion.length < 5) return null;
+
+  const meanWith =
+    withQuestion.reduce((s, p) => s + Number(p.engagement_rate), 0) / withQuestion.length;
+  const meanWithout =
+    withoutQuestion.reduce((s, p) => s + Number(p.engagement_rate), 0) / withoutQuestion.length;
+
+  const lift = meanWith / (meanWithout || 1);
+  if (lift < 1.5) return null;
+
+  const now = Date.now();
+  const recentPosts = posts.filter(
+    (p) => new Date(p.posted_at).getTime() > now - 30 * 24 * 60 * 60 * 1000,
+  ).length;
+  const sixtyDayPosts = posts.filter(
+    (p) => new Date(p.posted_at).getTime() > now - 60 * 24 * 60 * 60 * 1000,
+  ).length;
+
+  const confidence = computeConfidence({
+    postsInWindow: posts.length,
+    postsFromLast30d: recentPosts,
+    postsFromLast60d: sixtyDayPosts,
+    coefficientOfVariation: coefficientOfVariation(withQuestion.map((p) => Number(p.engagement_rate))),
+    effectMagnitude: Math.min(1, lift - 1),
+  });
+
+  if (confidence.band === "below_floor") return null;
+
+  return {
+    type: "QUESTION_PATTERN_LIFT",
+    headline: `Posts with questions get ${lift.toFixed(1)}× the engagement`,
+    body: `Based on ${withQuestion.length} posts with questions vs ${withoutQuestion.length} without.`,
+    successMetric: "engagement_rate",
+    confidenceScore: confidence.score,
+    confidenceBand: confidence.band,
+    evidence: withQuestion.slice(0, 3).map((p) => ({
+      sourceTable: "ins_post_features" as const,
+      sourceRowRef: p.bundle_post_id,
+      summary: `Question post, ${(Number(p.engagement_rate) * 100).toFixed(1)}% engagement`,
+    })),
+  };
+};

--- a/lib/insights/recommenders/topic-performance.ts
+++ b/lib/insights/recommenders/topic-performance.ts
@@ -1,0 +1,92 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import {
+  computeConfidence,
+  coefficientOfVariation,
+  MIN_POSTS_FOR_RECOMMENDATION,
+} from "../confidence";
+import type { GeneratorFn, PostWithEngagement } from "./types";
+
+export const generateTopicPerformance: GeneratorFn = async (companyId, platform, window) => {
+  const svc = getServiceRoleClient();
+  const cutoff = new Date(Date.now() - window.days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: rawPosts } = await svc.rpc("get_posts_with_engagement", {
+    p_company_id: companyId,
+    p_platform: platform,
+    p_cutoff: cutoff,
+    p_min_impressions: 50,
+  });
+  const posts = rawPosts as PostWithEngagement[] | null;
+
+  if (!posts || posts.length < MIN_POSTS_FOR_RECOMMENDATION) return null;
+
+  // Phase 2 W8 prerequisite: topic_tags must be populated
+  const postsWithTopics = posts.filter((p) => p.topic_tags && p.topic_tags.length > 0);
+  if (postsWithTopics.length === 0) return null;
+
+  // Build topic → engagement rate map
+  const topicRates = new Map<string, number[]>();
+  for (const post of postsWithTopics) {
+    for (const tag of post.topic_tags ?? []) {
+      if (!topicRates.has(tag)) topicRates.set(tag, []);
+      topicRates.get(tag)!.push(Number(post.engagement_rate));
+    }
+  }
+
+  // Filter to topics with ≥ 5 posts
+  const validTopics = [...topicRates.entries()]
+    .filter(([, rates]) => rates.length >= 5)
+    .map(([topic, rates]) => ({
+      topic,
+      meanRate: rates.reduce((a, b) => a + b, 0) / rates.length,
+      cov: coefficientOfVariation(rates),
+      sampleN: rates.length,
+    }));
+
+  if (validTopics.length < 2) return null;
+
+  const sorted = validTopics.sort((a, b) => b.meanRate - a.meanRate);
+  const best = sorted[0];
+  const median = sorted[Math.floor(sorted.length / 2)];
+  const lift = (best.meanRate - median.meanRate) / (median.meanRate || 1);
+
+  if (lift < 0.2) return null; // < 20% lift over median — not worth surfacing
+
+  const now = Date.now();
+  const recentPosts = posts.filter(
+    (p) => new Date(p.posted_at).getTime() > now - 30 * 24 * 60 * 60 * 1000,
+  ).length;
+  const sixtyDayPosts = posts.filter(
+    (p) => new Date(p.posted_at).getTime() > now - 60 * 24 * 60 * 60 * 1000,
+  ).length;
+
+  const confidence = computeConfidence({
+    postsInWindow: posts.length,
+    postsFromLast30d: recentPosts,
+    postsFromLast60d: sixtyDayPosts,
+    coefficientOfVariation: best.cov,
+    effectMagnitude: Math.min(1, lift),
+  });
+
+  if (confidence.band === "below_floor") return null;
+
+  const topPosts = postsWithTopics
+    .filter((p) => (p.topic_tags ?? []).includes(best.topic))
+    .slice(0, 3);
+
+  return {
+    type: "TOPIC_PERFORMANCE",
+    headline: `"${best.topic}" posts outperform your median by ${(lift * 100).toFixed(0)}%`,
+    body: `${best.sampleN} posts tagged "${best.topic}" average ${(best.meanRate * 100).toFixed(1)}% engagement.`,
+    successMetric: "engagement_rate",
+    confidenceScore: confidence.score,
+    confidenceBand: confidence.band,
+    evidence: topPosts.map((p) => ({
+      sourceTable: "ins_post_features" as const,
+      sourceRowRef: p.bundle_post_id,
+      summary: `Topic: ${best.topic}, ${(Number(p.engagement_rate) * 100).toFixed(1)}% engagement`,
+    })),
+  };
+};

--- a/lib/insights/recommenders/types.ts
+++ b/lib/insights/recommenders/types.ts
@@ -1,0 +1,33 @@
+export interface PostWithEngagement {
+  bundle_post_id: string;
+  posted_at: string;
+  engagement_rate: number | string;
+  impressions: number;
+  word_count: number;
+  has_question: boolean;
+  hashtag_count: number;
+  media_type: string | null;
+  day_of_week: number;
+  hour_of_day_client_tz: number;
+  topic_tags: string[] | null;
+}
+
+export interface RecommendationCandidate {
+  type: string;
+  headline: string;
+  body: string;
+  successMetric: string;
+  confidenceScore: number;
+  confidenceBand: "strong" | "moderate" | "below_floor";
+  evidence: Array<{
+    sourceTable: "social_post_analytics_snapshots" | "ins_post_features";
+    sourceRowRef: string;
+    summary: string;
+  }>;
+}
+
+export type GeneratorFn = (
+  companyId: string,
+  platform: "LINKEDIN" | "FACEBOOK",
+  window: { days: number },
+) => Promise<RecommendationCandidate | null>;

--- a/supabase/migrations/0147_insights_get_posts_with_engagement.sql
+++ b/supabase/migrations/0147_insights_get_posts_with_engagement.sql
@@ -1,0 +1,48 @@
+-- PR-07: SQL helper for recommendation generators
+-- Joins ins_post_features with social_post_analytics_snapshots
+
+CREATE OR REPLACE FUNCTION get_posts_with_engagement(
+  p_company_id UUID,
+  p_platform TEXT,
+  p_cutoff TIMESTAMPTZ,
+  p_min_impressions INTEGER DEFAULT 50
+)
+RETURNS TABLE (
+  bundle_post_id TEXT,
+  posted_at TIMESTAMPTZ,
+  engagement_rate NUMERIC,
+  impressions BIGINT,
+  word_count INTEGER,
+  has_question BOOLEAN,
+  hashtag_count INTEGER,
+  media_type TEXT,
+  day_of_week INTEGER,
+  hour_of_day_client_tz INTEGER,
+  topic_tags TEXT[]
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    ipf.bundle_post_id,
+    ipf.posted_at,
+    spas.engagement_rate,
+    spas.impressions::bigint,
+    ipf.word_count,
+    ipf.has_question,
+    ipf.hashtag_count,
+    ipf.media_type::text,
+    ipf.day_of_week,
+    ipf.hour_of_day_client_tz,
+    ipf.topic_tags
+  FROM ins_post_features ipf
+  INNER JOIN social_post_analytics_snapshots spas
+    ON spas.bundle_post_id = ipf.bundle_post_id
+   AND spas.platform::text = p_platform
+  WHERE ipf.company_id = p_company_id
+    AND ipf.platform::text = p_platform
+    AND ipf.posted_at >= p_cutoff
+    AND ipf.deleted_at IS NULL
+    AND spas.impressions >= p_min_impressions
+    AND spas.engagement_rate IS NOT NULL;
+END;
+$$ LANGUAGE plpgsql STABLE;


### PR DESCRIPTION
## Summary
- Six recommendation generators: BEST_LENGTH_BAND, BEST_POSTING_WINDOW, QUESTION_PATTERN_LIFT, MEDIA_TYPE_LIFT, HASHTAG_DIMINISHING_RETURNS, TOPIC_PERFORMANCE
- Migration 0147: get_posts_with_engagement Postgres function joining ins_post_features x social_post_analytics_snapshots
- Wires generators into /api/cron/insights-recompute (replaces empty RECOMMENDATION_GENERATORS array)
- PostWithEngagement typed interface — all generators strict-TypeScript clean
- 39 unit tests covering: floor not met, single-winner case, multi-bucket winner, confidence band boundaries, evidence assertions
- Integration test: lib/__tests__/recommendations-end-to-end.integration.test.ts

## Working analog
No direct analog for generator pattern. New pattern justified: first statistical-lift recommenders in the codebase.

## Risks identified and mitigated
- RPC type safety: get_posts_with_engagement returns untyped any[] from Supabase client; mitigated by explicit PostWithEngagement cast.
- Confidence below_floor on sparse data: all generators guard with confidence.band === below_floor return null.
- Topic tags Phase 2 dependency: generateTopicPerformance returns null when topic_tags unpopulated — safe before W8 lands.