### PR TITLE
feat(insights): recommendations API + composer sidebar + dismissal flow (PR-08)

### DIFF
--- a/app/api/insights/recommendations/[id]/dismiss/route.ts
+++ b/app/api/insights/recommendations/[id]/dismiss/route.ts
@@ -1,0 +1,87 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { notFound, validationError } from "@/lib/http";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+
+const VALID_REASONS = ["not_relevant", "tried_before", "brand_mismatch", "other"] as const;
+type DismissReason = (typeof VALID_REASONS)[number];
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const body = await req.json().catch(() => null);
+  if (!body) return validationError("Invalid JSON body");
+
+  const { reason, notes }: { reason: unknown; notes?: unknown } = body;
+  if (!VALID_REASONS.includes(reason as DismissReason)) {
+    return validationError("reason must be one of: not_relevant, tried_before, brand_mismatch, other");
+  }
+
+  const { searchParams } = new URL(req.url);
+  const companyId = searchParams.get("company_id");
+  if (!companyId) return validationError("company_id is required");
+
+  const gate = await requireCanDoForApi(companyId, "manage_insights");
+  if (gate.kind === "deny") return gate.response;
+
+  const svc = getServiceRoleClient();
+
+  const { data: rec, error: recErr } = await svc
+    .from("ins_recommendations")
+    .select("id, company_id, recommendation_type")
+    .eq("id", params.id)
+    .single();
+
+  if (recErr || !rec) return notFound("Recommendation not found");
+  if (rec.company_id !== companyId) return notFound("Recommendation not found");
+
+  // Write dismissal memory row
+  await svc.from("ins_client_memory").insert({
+    company_id: companyId,
+    memory_type: "dismissal",
+    payload: {
+      recommendation_type: rec.recommendation_type,
+      recommendation_id: rec.id,
+      reason: reason as string,
+      notes: typeof notes === "string" ? notes : null,
+      dismissed_by_user_id: gate.userId,
+    },
+  });
+
+  // Count same-reason dismissals for this type
+  const { count } = await svc
+    .from("ins_client_memory")
+    .select("id", { count: "exact", head: true })
+    .eq("company_id", companyId)
+    .eq("memory_type", "dismissal")
+    .filter("payload->>recommendation_type", "eq", rec.recommendation_type)
+    .filter("payload->>reason", "eq", reason as string)
+    .is("deleted_at", null);
+
+  // Three-strike: suppress all active recs of this type
+  let suppressedAllOfType = false;
+  if ((count ?? 0) >= 3) {
+    await svc
+      .from("ins_recommendations")
+      .update({ suppressed: true })
+      .eq("company_id", companyId)
+      .eq("recommendation_type", rec.recommendation_type)
+      .eq("suppressed", false);
+    suppressedAllOfType = true;
+
+    logger.info("ins.recommendations.suppressed", {
+      companyId,
+      type: rec.recommendation_type,
+      strikeCount: count,
+    });
+  } else {
+    await svc.from("ins_recommendations").update({ suppressed: true }).eq("id", params.id);
+  }
+
+  return NextResponse.json({ ok: true, suppressedAllOfType });
+}

--- a/app/api/insights/recommendations/[id]/evidence/route.ts
+++ b/app/api/insights/recommendations/[id]/evidence/route.ts
@@ -1,0 +1,57 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { notFound } from "@/lib/http";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const companyId = searchParams.get("company_id");
+
+  if (!companyId) {
+    return NextResponse.json(
+      { ok: false, error: { message: "company_id is required" } },
+      { status: 400 },
+    );
+  }
+
+  const gate = await requireCanDoForApi(companyId, "view_insights");
+  if (gate.kind === "deny") return gate.response;
+
+  const svc = getServiceRoleClient();
+
+  // Verify rec belongs to this company
+  const { data: rec, error: recErr } = await svc
+    .from("ins_recommendations")
+    .select("id, company_id, recommendation_type, headline")
+    .eq("id", params.id)
+    .single();
+
+  if (recErr || !rec) return notFound("Recommendation not found");
+  if (rec.company_id !== companyId) return notFound("Recommendation not found");
+
+  const { data: evidence, error: evErr } = await svc
+    .from("ins_recommendation_evidence")
+    .select("id, source_table, source_row_ref, summary")
+    .eq("recommendation_id", params.id)
+    .order("created_at", { ascending: true });
+
+  if (evErr) {
+    return NextResponse.json({ ok: false, error: { message: evErr.message } }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    recommendation: {
+      id: rec.id,
+      recommendation_type: rec.recommendation_type,
+      headline: rec.headline,
+    },
+    evidence: evidence ?? [],
+  });
+}

--- a/app/api/insights/recommendations/route.ts
+++ b/app/api/insights/recommendations/route.ts
@@ -1,0 +1,46 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { validationError } from "@/lib/http";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const companyId = searchParams.get("company_id");
+  const platform = searchParams.get("platform");
+  const limitRaw = searchParams.get("limit") ?? "10";
+  const limit = parseInt(limitRaw, 10);
+
+  if (!companyId) return validationError("company_id is required");
+  if (!platform || !["LINKEDIN", "FACEBOOK"].includes(platform)) {
+    return validationError("platform must be LINKEDIN or FACEBOOK");
+  }
+  if (isNaN(limit) || limit < 1 || limit > 50) {
+    return validationError("limit must be between 1 and 50");
+  }
+
+  const gate = await requireCanDoForApi(companyId, "view_insights");
+  if (gate.kind === "deny") return gate.response;
+
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("ins_recommendations")
+    .select(
+      "id, recommendation_type, headline, body, confidence_band, confidence_score, generated_at, evidence_refs",
+    )
+    .eq("company_id", companyId)
+    .eq("platform", platform)
+    .eq("suppressed", false)
+    .gt("expires_at", new Date().toISOString())
+    .in("confidence_band", ["strong", "moderate"])
+    .order("confidence_score", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    return NextResponse.json({ ok: false, error: { message: error.message } }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, recommendations: data ?? [] });
+}

--- a/components/insights/DismissalModal.tsx
+++ b/components/insights/DismissalModal.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+
+const REASONS = [
+  { value: "not_relevant", label: "Not relevant to my business" },
+  { value: "tried_before", label: "Already tried this" },
+  { value: "brand_mismatch", label: "Doesn't match my brand" },
+  { value: "other", label: "Other" },
+] as const;
+
+type Reason = (typeof REASONS)[number]["value"];
+
+interface DismissalModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (reason: Reason, notes: string) => Promise<void>;
+  headline: string;
+}
+
+export function DismissalModal({ open, onClose, onConfirm, headline }: DismissalModalProps) {
+  const [reason, setReason] = useState<Reason | "">("");
+  const [notes, setNotes] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit() {
+    if (!reason) return;
+    setSubmitting(true);
+    try {
+      await onConfirm(reason, notes);
+      setReason("");
+      setNotes("");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md" data-testid="dismissal-modal">
+        <DialogHeader>
+          <DialogTitle className="text-tx-primary">Dismiss recommendation</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-tx-secondary line-clamp-2">{headline}</p>
+
+        <div className="space-y-2 pt-1">
+          <p className="text-sm font-medium text-tx-primary">Why are you dismissing this?</p>
+          <div className="space-y-2">
+            {REASONS.map((r) => (
+              <label
+                key={r.value}
+                className="flex cursor-pointer items-center gap-3 rounded-lg border border-b2 p-3 hover:border-pk transition-colors"
+                data-testid={`reason-${r.value}`}
+              >
+                <input
+                  type="radio"
+                  name="dismiss-reason"
+                  value={r.value}
+                  checked={reason === r.value}
+                  onChange={() => setReason(r.value)}
+                  className="accent-pk"
+                />
+                <span className="text-sm text-tx-primary">{r.label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="dismiss-notes" className="text-sm text-tx-secondary">
+            Optional notes
+          </label>
+          <Textarea
+            id="dismiss-notes"
+            placeholder="Anything else we should know?"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={2}
+            className="resize-none"
+            data-testid="dismiss-notes"
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!reason || submitting}
+            data-testid="dismiss-confirm"
+          >
+            {submitting ? "Dismissing…" : "Dismiss"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/insights/EvidenceDetail.tsx
+++ b/components/insights/EvidenceDetail.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ExternalLinkIcon } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { StatusPill } from "@/components/ui/status-pill";
+
+interface EvidenceRow {
+  id: string;
+  source_table: string;
+  source_row_ref: string;
+  summary: string;
+}
+
+interface EvidenceDetailProps {
+  open: boolean;
+  onClose: () => void;
+  recommendationId: string;
+  headline: string;
+  companyId: string;
+}
+
+export function EvidenceDetail({
+  open,
+  onClose,
+  recommendationId,
+  headline,
+  companyId,
+}: EvidenceDetailProps) {
+  const [evidence, setEvidence] = useState<EvidenceRow[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !recommendationId) return;
+    setLoading(true);
+    fetch(
+      `/api/insights/recommendations/${recommendationId}/evidence?company_id=${encodeURIComponent(companyId)}`,
+    )
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.ok) setEvidence(d.evidence ?? []);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [open, recommendationId, companyId]);
+
+  return (
+    <Dialog open={open} onOpenChange={(open: boolean) => !open && onClose()}>
+      <DialogContent className="max-w-md" data-testid="evidence-sheet">
+        <DialogHeader>
+          <DialogTitle className="text-tx-primary pr-6">{headline}</DialogTitle>
+        </DialogHeader>
+
+        <div className="mt-2 space-y-3">
+          {loading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="h-16 animate-pulse rounded-lg bg-m2" />
+              ))}
+            </div>
+          ) : evidence.length === 0 ? (
+            <p className="text-sm text-tx-muted">No evidence rows found.</p>
+          ) : (
+            evidence.map((ev) => (
+              <div
+                key={ev.id}
+                className="rounded-lg border border-b2 p-3 space-y-1"
+                data-testid="evidence-row"
+              >
+                <div className="flex items-center gap-2">
+                  <StatusPill
+                    kind={ev.source_table === "ins_post_features" ? "client_green" : "client_amber"}
+                    label={ev.source_table === "ins_post_features" ? "Post feature" : "Analytics"}
+                  />
+                  {ev.source_row_ref && (
+                    <a
+                      href={`/company/social/posts/${ev.source_row_ref}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="ml-auto text-pk hover:text-pk/80"
+                    >
+                      <ExternalLinkIcon size={14} />
+                    </a>
+                  )}
+                </div>
+                <p className="text-sm text-tx-secondary">{ev.summary}</p>
+              </div>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/insights/InsightsDashboardClient.tsx
+++ b/components/insights/InsightsDashboardClient.tsx
@@ -7,7 +7,7 @@ import { BarChart3Icon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { InsightsDashboardData } from "@/lib/insights/dashboard";
 import { KPIRow } from "./KPIRow";
-import { RecommendationsPanelPlaceholder } from "./RecommendationsPanelPlaceholder";
+import { RecommendationsPanel } from "./RecommendationsPanel";
 import { BestContentSection } from "./BestContentSection";
 import { TrendChartSection } from "./TrendChartSection";
 import { DashboardFooterTabs } from "./DashboardFooterTabs";
@@ -54,7 +54,7 @@ export function InsightsDashboardClient({
       {data.kpis && (
         <KPIRow kpis={data.kpis} availableMetrics={data.availableMetrics} />
       )}
-      <RecommendationsPanelPlaceholder
+      <RecommendationsPanel
         companyId={companyId}
         platform={activePlatform}
         postCount={data.postCount90d}

--- a/components/insights/RecommendationCard.tsx
+++ b/components/insights/RecommendationCard.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import { XIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { StatusPill } from "@/components/ui/status-pill";
+import { DismissalModal } from "./DismissalModal";
+import { EvidenceDetail } from "./EvidenceDetail";
+
+interface Recommendation {
+  id: string;
+  recommendation_type: string;
+  headline: string;
+  body: string;
+  confidence_band: "strong" | "moderate";
+  confidence_score: number;
+}
+
+interface RecommendationCardProps {
+  rec: Recommendation;
+  companyId: string;
+  onDismissed: (id: string) => void;
+}
+
+export function RecommendationCard({ rec, companyId, onDismissed }: RecommendationCardProps) {
+  const [dismissOpen, setDismissOpen] = useState(false);
+  const [evidenceOpen, setEvidenceOpen] = useState(false);
+
+  const pillKind = rec.confidence_band === "strong" ? "strong_signal" : "early_signal";
+  const pillLabel = rec.confidence_band === "strong" ? "Strong signal" : "Early signal";
+
+  async function handleDismiss(reason: string, notes: string) {
+    const params = new URLSearchParams({ company_id: companyId });
+    await fetch(`/api/insights/recommendations/${rec.id}/dismiss?${params}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reason, notes }),
+    });
+    setDismissOpen(false);
+    onDismissed(rec.id);
+  }
+
+  return (
+    <>
+      <Card
+        className="border-b2 relative"
+        data-testid="recommendation-card"
+        data-rec-id={rec.id}
+      >
+        <CardContent className="pt-4 pr-10">
+          <div className="flex items-center gap-2 mb-2">
+            <StatusPill kind={pillKind} label={pillLabel} />
+          </div>
+          <p className="text-base text-tx-primary font-medium leading-snug">{rec.headline}</p>
+          <p className="text-sm text-tx-secondary mt-1">{rec.body}</p>
+          <button
+            onClick={() => setEvidenceOpen(true)}
+            className="text-sm text-pk hover:text-pk/80 mt-2 inline-flex items-center gap-1"
+            data-testid="see-evidence"
+          >
+            See evidence →
+          </button>
+        </CardContent>
+        <button
+          onClick={() => setDismissOpen(true)}
+          className="absolute top-3 right-3 text-tx-muted hover:text-tx-primary transition-colors"
+          aria-label="Dismiss recommendation"
+          data-testid="dismiss-button"
+        >
+          <XIcon size={16} />
+        </button>
+      </Card>
+
+      <DismissalModal
+        open={dismissOpen}
+        onClose={() => setDismissOpen(false)}
+        onConfirm={handleDismiss}
+        headline={rec.headline}
+      />
+      <EvidenceDetail
+        open={evidenceOpen}
+        onClose={() => setEvidenceOpen(false)}
+        recommendationId={rec.id}
+        headline={rec.headline}
+        companyId={companyId}
+      />
+    </>
+  );
+}

--- a/components/insights/RecommendationsPanel.tsx
+++ b/components/insights/RecommendationsPanel.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { EmptyState } from "./common/EmptyState";
+import { RecommendationCard } from "./RecommendationCard";
+
+interface Recommendation {
+  id: string;
+  recommendation_type: string;
+  headline: string;
+  body: string;
+  confidence_band: "strong" | "moderate";
+  confidence_score: number;
+}
+
+interface RecommendationsPanelProps {
+  companyId: string;
+  platform: string;
+  postCount: number;
+}
+
+const MIN_POSTS_FOR_RECOMMENDATIONS = 20;
+
+export function RecommendationsPanel({
+  companyId,
+  platform,
+  postCount,
+}: RecommendationsPanelProps) {
+  const [recs, setRecs] = useState<Recommendation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (postCount < MIN_POSTS_FOR_RECOMMENDATIONS) return;
+    setLoading(true);
+    const params = new URLSearchParams({
+      company_id: companyId,
+      platform,
+      limit: "5",
+    });
+    fetch(`/api/insights/recommendations?${params}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.ok) setRecs(d.recommendations ?? []);
+      })
+      .catch(() => {})
+      .finally(() => {
+        setLoading(false);
+        setLoaded(true);
+      });
+  }, [companyId, platform, postCount]);
+
+  function handleDismissed(id: string) {
+    setRecs((prev) => prev.filter((r) => r.id !== id));
+  }
+
+  const remaining = MIN_POSTS_FOR_RECOMMENDATIONS - postCount;
+
+  return (
+    <Card className="border-b2" data-testid="recommendations-panel">
+      <CardHeader className="pb-2">
+        <div className="flex items-baseline justify-between">
+          <h2 className="text-section-title text-tx-primary">
+            What we&apos;ve learned about your audience
+          </h2>
+          <span className="text-sm text-tx-muted">
+            Tracking {postCount} {platform} posts (last 90 days)
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {postCount === 0 ? (
+          <EmptyState
+            title="Still learning"
+            description="We'll surface recommendations as you publish more posts."
+            data-testid="recs-empty-no-posts"
+          />
+        ) : remaining > 0 ? (
+          <EmptyState
+            title={`Need ${remaining} more posts`}
+            description="Insights gets sharper with every post. Recommendations unlock at 20 posts."
+            data-testid="recs-empty-need-more"
+          />
+        ) : loading ? (
+          <div className="space-y-3" data-testid="recs-loading">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="h-20 animate-pulse rounded-lg bg-m2" />
+            ))}
+          </div>
+        ) : loaded && recs.length === 0 ? (
+          <EmptyState
+            title="No recommendations yet"
+            description="Your first recommendations will appear after the next analysis run."
+            data-testid="recs-empty-none"
+          />
+        ) : (
+          recs.map((rec) => (
+            <RecommendationCard
+              key={rec.id}
+              rec={rec}
+              companyId={companyId}
+              onDismissed={handleDismissed}
+            />
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/__tests__/recommendations-route.unit.test.ts
+++ b/lib/__tests__/recommendations-route.unit.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase", () => ({ getServiceRoleClient: vi.fn() }));
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: vi.fn(),
+}));
+vi.mock("@/lib/http", () => ({
+  validationError: (msg: string) =>
+    NextResponse.json({ ok: false, error: { message: msg } }, { status: 400 }),
+  notFound: (msg: string) =>
+    NextResponse.json({ ok: false, error: { message: msg } }, { status: 404 }),
+}));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), error: vi.fn() } }));
+
+import { GET as listRecs } from "@/app/api/insights/recommendations/route";
+import { POST as dismissRec } from "@/app/api/insights/recommendations/[id]/dismiss/route";
+
+const { requireCanDoForApi } = await import("@/lib/platform/auth/api-gate");
+const { getServiceRoleClient } = await import("@/lib/supabase");
+const mockRequireCanDoForApi = vi.mocked(requireCanDoForApi);
+const mockGetServiceRoleClient = vi.mocked(getServiceRoleClient);
+
+const COMPANY_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const REC_ID = "bbbbbbbb-0000-0000-0000-000000000001";
+
+const ALLOW_GATE = { kind: "allow" as const, userId: "user-1", supabase: {} as never };
+const DENY_GATE = {
+  kind: "deny" as const,
+  response: NextResponse.json({ ok: false }, { status: 403 }),
+};
+
+function makeSvcChain(overrides: Record<string, unknown> = {}) {
+  const chain = {
+    from: vi.fn(),
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    eq: vi.fn(),
+    gt: vi.fn(),
+    in: vi.fn(),
+    filter: vi.fn(),
+    is: vi.fn(),
+    order: vi.fn(),
+    limit: vi.fn(),
+    single: vi.fn(),
+    ...overrides,
+  };
+  // Wire all methods to return chain (chainable)
+  (Object.keys(chain) as (keyof typeof chain)[]).forEach((k) => {
+    if (k !== "limit" && k !== "single" && k !== "insert") {
+      (chain[k] as ReturnType<typeof vi.fn>).mockReturnValue(chain);
+    }
+  });
+  chain.limit.mockResolvedValue({ data: [], error: null });
+  chain.single.mockResolvedValue({ data: null, error: { message: "not found" } });
+  chain.insert.mockResolvedValue({ data: null, error: null });
+  chain.from.mockReturnValue(chain);
+  mockGetServiceRoleClient.mockReturnValue(chain as never);
+  return chain;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/insights/recommendations", () => {
+  it("returns 400 when company_id missing", async () => {
+    const req = new NextRequest("http://localhost/api/insights/recommendations?platform=LINKEDIN");
+    const res = await listRecs(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when platform is invalid", async () => {
+    const req = new NextRequest(
+      `http://localhost/api/insights/recommendations?company_id=${COMPANY_ID}&platform=TWITTER`,
+    );
+    const res = await listRecs(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when user cannot view_insights", async () => {
+    mockRequireCanDoForApi.mockResolvedValue(DENY_GATE);
+    const req = new NextRequest(
+      `http://localhost/api/insights/recommendations?company_id=${COMPANY_ID}&platform=LINKEDIN`,
+    );
+    const res = await listRecs(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns recommendations when authorized", async () => {
+    mockRequireCanDoForApi.mockResolvedValue(ALLOW_GATE);
+    const chain = makeSvcChain();
+    chain.limit.mockResolvedValue({
+      data: [
+        {
+          id: REC_ID,
+          recommendation_type: "BEST_LENGTH_BAND",
+          headline: "Test",
+          body: "Body",
+          confidence_band: "strong",
+          confidence_score: 0.82,
+        },
+      ],
+      error: null,
+    });
+
+    const req = new NextRequest(
+      `http://localhost/api/insights/recommendations?company_id=${COMPANY_ID}&platform=LINKEDIN`,
+    );
+    const res = await listRecs(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.recommendations).toHaveLength(1);
+    expect(body.recommendations[0].id).toBe(REC_ID);
+  });
+});
+
+describe("POST /api/insights/recommendations/[id]/dismiss", () => {
+  it("returns 400 when reason is invalid", async () => {
+    mockRequireCanDoForApi.mockResolvedValue(ALLOW_GATE);
+    makeSvcChain();
+
+    const req = new NextRequest(
+      `http://localhost/api/insights/recommendations/${REC_ID}/dismiss?company_id=${COMPANY_ID}`,
+      { method: "POST", body: JSON.stringify({ reason: "fake_reason" }) },
+    );
+    const res = await dismissRec(req, { params: { id: REC_ID } });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when rec not found", async () => {
+    mockRequireCanDoForApi.mockResolvedValue(ALLOW_GATE);
+    makeSvcChain(); // single returns null by default
+
+    const req = new NextRequest(
+      `http://localhost/api/insights/recommendations/${REC_ID}/dismiss?company_id=${COMPANY_ID}`,
+      { method: "POST", body: JSON.stringify({ reason: "not_relevant" }) },
+    );
+    const res = await dismissRec(req, { params: { id: REC_ID } });
+    expect(res.status).toBe(404);
+  });
+
+  it("dismisses single rec when strike count < 3", async () => {
+    mockRequireCanDoForApi.mockResolvedValue(ALLOW_GATE);
+    const chain = makeSvcChain();
+    chain.single.mockResolvedValue({
+      data: { id: REC_ID, company_id: COMPANY_ID, recommendation_type: "BEST_LENGTH_BAND" },
+      error: null,
+    });
+    chain.is.mockResolvedValue({ count: 1, error: null });
+
+    const req = new NextRequest(
+      `http://localhost/api/insights/recommendations/${REC_ID}/dismiss?company_id=${COMPANY_ID}`,
+      { method: "POST", body: JSON.stringify({ reason: "not_relevant" }) },
+    );
+    const res = await dismissRec(req, { params: { id: REC_ID } });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.suppressedAllOfType).toBe(false);
+  });
+
+  it("suppresses all of type when strike count reaches 3", async () => {
+    mockRequireCanDoForApi.mockResolvedValue(ALLOW_GATE);
+    const chain = makeSvcChain();
+    chain.single.mockResolvedValue({
+      data: { id: REC_ID, company_id: COMPANY_ID, recommendation_type: "BEST_LENGTH_BAND" },
+      error: null,
+    });
+    chain.is.mockResolvedValue({ count: 3, error: null });
+
+    const req = new NextRequest(
+      `http://localhost/api/insights/recommendations/${REC_ID}/dismiss?company_id=${COMPANY_ID}`,
+      { method: "POST", body: JSON.stringify({ reason: "tried_before", notes: "Been there" }) },
+    );
+    const res = await dismissRec(req, { params: { id: REC_ID } });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.suppressedAllOfType).toBe(true);
+  });
+
+  it("returns 403 when user cannot manage_insights", async () => {
+    mockRequireCanDoForApi.mockResolvedValue(DENY_GATE);
+    const req = new NextRequest(
+      `http://localhost/api/insights/recommendations/${REC_ID}/dismiss?company_id=${COMPANY_ID}`,
+      { method: "POST", body: JSON.stringify({ reason: "not_relevant" }) },
+    );
+    const res = await dismissRec(req, { params: { id: REC_ID } });
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- GET /api/insights/recommendations - lists active non-suppressed recs for company+platform (view_insights gate)
- GET /api/insights/recommendations/[id]/evidence - returns evidence rows for a rec (view_insights gate, cross-tenant checked)
- POST /api/insights/recommendations/[id]/dismiss - dismissal + three-strike suppression (manage_insights gate)
- RecommendationsPanel client component replaces RecommendationsPanelPlaceholder in InsightsDashboardClient
- RecommendationCard: card with StatusPill (strong_signal/early_signal), dismiss button, evidence link
- DismissalModal: reason radio group + optional notes
- EvidenceDetail: Dialog showing ins_recommendation_evidence rows with source badges
- Three-strike: 3 dismissals of same type+reason triggers suppressed=true on all matching active recs

Note: Composer sidebar integration deferred - composer pages (posts/new, posts/[id]/edit) do not exist in current codebase structure.

## Working analog
Auth: requireCanDoForApi() from lib/platform/auth/api-gate.ts (same pattern as /api/platform/brand, /api/platform/social/posts)
Error helpers: validationError/notFound from lib/http.ts (same pattern across all platform routes)

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Layer 1: 9 unit tests covering auth-failure, validation, three-strike trigger
- [x] Cross-tenant: dismiss route verifies rec.company_id === companyId before mutating

## Risks identified and mitigated
- Cross-tenant: rec ownership verified before dismissal (rec.company_id !== companyId -> 404)
- Three-strike count uses deleted_at IS NULL filter so soft-deleted dismissal rows don't count
- below_floor recs never served to clients (confidence_band IN strong,moderate filter)