### PR TITLE
feat(insights): industry-signal application in recommendations + generation-priors (PR-11)

### DIFF
--- a/app/(platform)/admin/insights/patterns/page.tsx
+++ b/app/(platform)/admin/insights/patterns/page.tsx
@@ -1,0 +1,96 @@
+import { redirect } from "next/navigation";
+
+import { PageHeader } from "@/components/ui/page-header";
+import { PageShell } from "@/components/ui/page-shell";
+import { createRouteAuthClient } from "@/lib/auth";
+import { getServiceRoleClient } from "@/lib/supabase";
+import type { IndustryPattern } from "@/lib/insights/pattern-application";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+
+const BREADCRUMB = [
+  { label: "Admin", href: "/admin" },
+  { label: "Insights", href: "/admin/insights" },
+  { label: "Industry Patterns" },
+];
+
+export default async function AdminInsightsPatternsPage() {
+  const supabase = createRouteAuthClient();
+  const { data: isOp } = await supabase.rpc("is_cap_operator");
+  if (!isOp) redirect("/admin");
+
+  const svc = getServiceRoleClient();
+  const { data: patterns, error } = await svc
+    .from("ins_pattern_library")
+    .select("*")
+    .order("mined_at", { ascending: false })
+    .limit(100);
+
+  const rows = (patterns ?? []) as IndustryPattern[];
+
+  return (
+    <PageShell>
+      <PageHeader>
+        <PageHeader.Breadcrumb segments={BREADCRUMB} />
+        <PageHeader.Title>Industry Patterns</PageHeader.Title>
+        <PageHeader.Subtitle>
+          Cross-client anonymised patterns mined from consenting companies.
+        </PageHeader.Subtitle>
+      </PageHeader>
+
+      <PageShell.Content>
+        {error && (
+          <p className="rounded-md border border-[var(--rd-2)] bg-[var(--rd-1)] px-4 py-3 text-sm text-[var(--rd-3)]">
+            Failed to load patterns: {error.message}
+          </p>
+        )}
+        {rows.length === 0 && !error && (
+          <p className="text-sm text-[var(--tx-muted)]">
+            No patterns mined yet. The weekly cron runs Sunday 06:00 UTC.
+          </p>
+        )}
+        {rows.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--b2)] text-left">
+                  <th className="pb-3 pr-6 font-medium text-[var(--tx-secondary)]">Type</th>
+                  <th className="pb-3 pr-6 font-medium text-[var(--tx-secondary)]">Platforms</th>
+                  <th className="pb-3 pr-6 font-medium text-[var(--tx-secondary)]">Data</th>
+                  <th className="pb-3 pr-6 font-medium text-[var(--tx-secondary)]">Companies</th>
+                  <th className="pb-3 pr-6 font-medium text-[var(--tx-secondary)]">Posts</th>
+                  <th className="pb-3 pr-6 font-medium text-[var(--tx-secondary)]">Confidence</th>
+                  <th className="pb-3 pr-6 font-medium text-[var(--tx-secondary)]">Mined</th>
+                  <th className="pb-3 font-medium text-[var(--tx-secondary)]">Expires</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.id} className="border-b border-[var(--b1)] text-[var(--tx-primary)]">
+                    <td className="py-3 pr-6 font-mono text-sm">{row.pattern_type}</td>
+                    <td className="py-3 pr-6">{row.applies_to_platforms.join(", ")}</td>
+                    <td className="py-3 pr-6 max-w-xs truncate font-mono text-sm text-[var(--tx-secondary)]">
+                      {JSON.stringify(row.pattern_data)}
+                    </td>
+                    <td className="py-3 pr-6 text-center">{row.sample_size_n_companies}</td>
+                    <td className="py-3 pr-6 text-center">{row.sample_size_n_posts}</td>
+                    <td className="py-3 pr-6 text-center">
+                      {(row.confidence_score * 100).toFixed(1)}%
+                    </td>
+                    <td className="py-3 pr-6 text-[var(--tx-muted)]">
+                      {new Date(row.mined_at).toLocaleDateString()}
+                    </td>
+                    <td className="py-3 text-[var(--tx-muted)]">
+                      {new Date(row.expires_at).toLocaleDateString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </PageShell.Content>
+    </PageShell>
+  );
+}

--- a/app/api/insights/generation-priors/route.ts
+++ b/app/api/insights/generation-priors/route.ts
@@ -7,6 +7,7 @@ import {
   fetchPerformancePriors,
   formatPerformancePriorsBlock,
 } from "@/lib/cap/performance-priors";
+import { getIndustrySignal } from "@/lib/insights/pattern-application";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -73,23 +74,6 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   }
 
   const svc = getServiceRoleClient();
-
-  // Check industry signal consent
-  if (includeIndustrySignal) {
-    const { data: consent } = await svc
-      .from("ins_consent")
-      .select("cross_client_learning_consent")
-      .eq("company_id", companyId)
-      .maybeSingle();
-
-    if (!consent?.cross_client_learning_consent) {
-      return errorJson(
-        "CONSENT_REQUIRED",
-        "Company has not consented to cross-client learning.",
-        400,
-      );
-    }
-  }
 
   // Parallel queries
   const [recsResult, memoryResult, featuresResult, priorsResult] = await Promise.all([
@@ -239,12 +223,20 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     clientEditingPreferences,
   });
 
+  // Industry signal — populated only when requested and consent is on
+  const industrySignal =
+    includeIndustrySignal
+      ? await getIndustrySignal(companyId, platform).catch(() => null)
+      : null;
+
   logger.info("ins.generation-priors.served", {
     companyId,
     platform,
     arcPhase,
     recCount: recs.length,
     featureCount: features.length,
+    includeIndustrySignal,
+    industrySignalPatterns: industrySignal?.patterns.length ?? 0,
   });
 
   return NextResponse.json({
@@ -270,7 +262,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     dismissed_recommendation_types: dismissedTypes,
     tone_or_formatting_flags: [],
 
-    industry_signal: null,
+    industry_signal: industrySignal,
 
     priors_text: priorsText,
 

--- a/lib/__tests__/generation-priors-industry-signal.unit.test.ts
+++ b/lib/__tests__/generation-priors-industry-signal.unit.test.ts
@@ -1,0 +1,198 @@
+/**
+ * L1/L6 — generation-priors API: industry_signal field behaviour
+ *
+ * Tests:
+ * - include_industry_signal not set → industry_signal is null
+ * - include_industry_signal=true + consent OFF → null (graceful degradation, NOT 400)
+ * - include_industry_signal=true + consent ON → populated
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase", () => ({ getServiceRoleClient: vi.fn() }));
+vi.mock("@/lib/platform/cron/cron-shared", () => ({
+  authorisedCronRequest: vi.fn().mockReturnValue(true),
+  unauthorisedResponse: vi.fn(),
+}));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/cap/performance-priors", () => ({
+  fetchPerformancePriors: vi.fn().mockResolvedValue([]),
+  formatPerformancePriorsBlock: vi.fn().mockReturnValue(""),
+}));
+
+import { getServiceRoleClient } from "@/lib/supabase";
+
+const COMPANY_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const PLATFORM = "LINKEDIN";
+
+const SAMPLE_PATTERN = {
+  id: "p1",
+  pattern_type: "cross_segment_format_pattern",
+  applies_to_platforms: ["LINKEDIN", "FACEBOOK"],
+  pattern_data: { word_count_band: "short", mean_engagement: 0.065 },
+  sample_size_n_companies: 8,
+  sample_size_n_posts: 250,
+  confidence_score: 0.72,
+  mined_at: new Date().toISOString(),
+  expires_at: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString(),
+};
+
+function makeSvc(opts: { consent: boolean; hasPatterns: boolean }) {
+  return {
+    from: (table: string) => {
+      if (table === "ins_recommendations") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  gt: vi.fn().mockReturnValue({
+                    in: vi.fn().mockReturnValue({
+                      order: vi.fn().mockReturnValue({
+                        data: [
+                          {
+                            id: "r1",
+                            recommendation_type: "BEST_LENGTH_BAND",
+                            confidence_score: 0.75,
+                            confidence_band: "strong",
+                            suppressed: false,
+                            expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+                          },
+                        ],
+                        error: null,
+                      }),
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "ins_client_memory") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              is: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === "ins_post_features") {
+        const row = {
+          posted_at: new Date().toISOString(),
+          media_type: null,
+          has_question: true,
+          day_of_week: 2,
+          hour_of_day_client_tz: 9,
+          topic_tags: null,
+        };
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                is: vi.fn().mockReturnValue({
+                  order: vi.fn().mockReturnValue({
+                    data: [row],
+                    error: null,
+                    limit: vi.fn().mockResolvedValue({ data: [row], error: null }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "ins_consent") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi
+                .fn()
+                .mockResolvedValue({
+                  data: { cross_client_learning_consent: opts.consent },
+                  error: null,
+                }),
+            }),
+          }),
+        };
+      }
+      if (table === "ins_pattern_library") {
+        return {
+          select: vi.fn().mockReturnValue({
+            gt: vi.fn().mockReturnValue({
+              order: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue({
+                  data: opts.hasPatterns ? [SAMPLE_PATTERN] : [],
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      // suppressed recs
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          }),
+        }),
+      };
+    },
+  };
+}
+
+function makeRequest(params: Record<string, string>): NextRequest {
+  const url = `http://localhost/api/insights/generation-priors?${new URLSearchParams(params).toString()}`;
+  return new NextRequest(url, { headers: { "X-Cron-Secret": "test-secret" } });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SECURITY: industry_signal graceful degradation", () => {
+  it("returns null industry_signal when include_industry_signal is not set", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSvc({ consent: false, hasPatterns: false }) as never,
+    );
+    const { GET } = await import("@/app/api/insights/generation-priors/route");
+    const res = await GET(makeRequest({ company_id: COMPANY_ID, platform: PLATFORM }));
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.industry_signal).toBeNull();
+  });
+
+  it("returns null industry_signal (NOT 400) when consent is OFF but include_industry_signal=true", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSvc({ consent: false, hasPatterns: false }) as never,
+    );
+    const { GET } = await import("@/app/api/insights/generation-priors/route");
+    const res = await GET(
+      makeRequest({ company_id: COMPANY_ID, platform: PLATFORM, include_industry_signal: "true" }),
+    );
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.industry_signal).toBeNull();
+  });
+
+  it("populates industry_signal when consent is ON and include_industry_signal=true", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSvc({ consent: true, hasPatterns: true }) as never,
+    );
+    const { GET } = await import("@/app/api/insights/generation-priors/route");
+    const res = await GET(
+      makeRequest({ company_id: COMPANY_ID, platform: PLATFORM, include_industry_signal: "true" }),
+    );
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.industry_signal).not.toBeNull();
+    expect(data.industry_signal.patterns).toHaveLength(1);
+    expect(data.industry_signal.summary).toBeTruthy();
+  });
+});

--- a/lib/__tests__/generation-priors.unit.test.ts
+++ b/lib/__tests__/generation-priors.unit.test.ts
@@ -83,22 +83,6 @@ describe("GET /api/insights/generation-priors", () => {
     expect(body.error.code).toBe("VALIDATION_FAILED");
   });
 
-  it("returns 400 for CONSENT_REQUIRED when cross_client_learning_consent is false", async () => {
-    mockAuth.mockReturnValue(true);
-    const chain = makeChain();
-    chain.maybeSingle.mockResolvedValue({
-      data: { cross_client_learning_consent: false },
-      error: null,
-    });
-    const req = new NextRequest(
-      `http://localhost/api/insights/generation-priors?company_id=${COMPANY_ID}&platform=LINKEDIN&include_industry_signal=true`,
-    );
-    const res = await GET(req);
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error.code).toBe("CONSENT_REQUIRED");
-  });
-
   it("returns 503 when no recommendations or features exist", async () => {
     mockAuth.mockReturnValue(true);
     const chain = makeChain();

--- a/lib/__tests__/pattern-application.unit.test.ts
+++ b/lib/__tests__/pattern-application.unit.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+const COMPANY_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const PLATFORM = "LINKEDIN";
+
+const SAMPLE_PATTERN = {
+  id: "p1",
+  pattern_type: "cross_segment_format_pattern",
+  applies_to_platforms: ["LINKEDIN", "FACEBOOK"],
+  pattern_data: { word_count_band: "short", mean_engagement: 0.065 },
+  sample_size_n_companies: 8,
+  sample_size_n_posts: 250,
+  confidence_score: 0.72,
+  mined_at: new Date().toISOString(),
+  expires_at: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString(),
+};
+
+describe("pattern-application: findApplicablePatterns", () => {
+  it("returns empty array when company has not consented", async () => {
+    vi.doMock("@/lib/supabase", () => ({
+      getServiceRoleClient: () => ({
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () =>
+                Promise.resolve({ data: { cross_client_learning_consent: false }, error: null }),
+            }),
+          }),
+        }),
+      }),
+    }));
+
+    const { findApplicablePatterns } = await import("@/lib/insights/pattern-application");
+    const result = await findApplicablePatterns(COMPANY_ID, PLATFORM, "BEST_LENGTH_BAND");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when company has no consent row", async () => {
+    vi.doMock("@/lib/supabase", () => ({
+      getServiceRoleClient: () => ({
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () => Promise.resolve({ data: null, error: null }),
+            }),
+          }),
+        }),
+      }),
+    }));
+
+    const { findApplicablePatterns } = await import("@/lib/insights/pattern-application");
+    const result = await findApplicablePatterns(COMPANY_ID, PLATFORM, "BEST_LENGTH_BAND");
+    expect(result).toEqual([]);
+  });
+
+  it("returns patterns when company has consented", async () => {
+    vi.doMock("@/lib/supabase", () => ({
+      getServiceRoleClient: () => ({
+        from: (table: string) => {
+          if (table === "ins_consent") {
+            return {
+              select: () => ({
+                eq: () => ({
+                  maybeSingle: () =>
+                    Promise.resolve({
+                      data: { cross_client_learning_consent: true },
+                      error: null,
+                    }),
+                }),
+              }),
+            };
+          }
+          // ins_pattern_library
+          return {
+            select: () => ({
+              eq: () => ({
+                contains: () => ({
+                  gt: () => ({
+                    order: () => ({
+                      limit: () => Promise.resolve({ data: [SAMPLE_PATTERN], error: null }),
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          };
+        },
+      }),
+    }));
+
+    const { findApplicablePatterns } = await import("@/lib/insights/pattern-application");
+    const result = await findApplicablePatterns(COMPANY_ID, PLATFORM, "BEST_LENGTH_BAND");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ pattern_type: "cross_segment_format_pattern" });
+  });
+
+  it("maps TOPIC_PERFORMANCE to cross_segment_topic_lift pattern type", async () => {
+    const patternQueryCalls: string[] = [];
+    vi.doMock("@/lib/supabase", () => ({
+      getServiceRoleClient: () => ({
+        from: (table: string) => {
+          if (table === "ins_consent") {
+            return {
+              select: () => ({
+                eq: () => ({
+                  maybeSingle: () =>
+                    Promise.resolve({ data: { cross_client_learning_consent: true }, error: null }),
+                }),
+              }),
+            };
+          }
+          return {
+            select: () => ({
+              eq: (_col: string, val: string) => {
+                patternQueryCalls.push(val);
+                return {
+                  contains: () => ({
+                    gt: () => ({
+                      order: () => ({
+                        limit: () => Promise.resolve({ data: [], error: null }),
+                      }),
+                    }),
+                  }),
+                };
+              },
+            }),
+          };
+        },
+      }),
+    }));
+
+    const { findApplicablePatterns } = await import("@/lib/insights/pattern-application");
+    await findApplicablePatterns(COMPANY_ID, PLATFORM, "TOPIC_PERFORMANCE");
+    expect(patternQueryCalls).toContain("cross_segment_topic_lift");
+  });
+});
+
+describe("pattern-application: buildIndustrySignalSummary", () => {
+  it("returns empty string for empty patterns array", async () => {
+    const { buildIndustrySignalSummary } = await import("@/lib/insights/pattern-application");
+    expect(buildIndustrySignalSummary([])).toBe("");
+  });
+
+  it("builds a format pattern summary", async () => {
+    const { buildIndustrySignalSummary } = await import("@/lib/insights/pattern-application");
+    const summary = buildIndustrySignalSummary([
+      {
+        ...SAMPLE_PATTERN,
+        pattern_type: "cross_segment_format_pattern",
+        pattern_data: { word_count_band: "short", mean_engagement: 0.065 },
+      },
+    ]);
+    expect(summary).toContain("short");
+    expect(summary).toContain("6.5%");
+  });
+
+  it("builds a topic lift summary", async () => {
+    const { buildIndustrySignalSummary } = await import("@/lib/insights/pattern-application");
+    const summary = buildIndustrySignalSummary([
+      {
+        ...SAMPLE_PATTERN,
+        pattern_type: "cross_segment_topic_lift",
+        pattern_data: { topic: "ransomware", mean_engagement: 0.08, lift: 1.6 },
+      },
+    ]);
+    expect(summary).toContain("ransomware");
+    expect(summary).toContain("1.6");
+  });
+});

--- a/lib/insights/pattern-application.ts
+++ b/lib/insights/pattern-application.ts
@@ -1,0 +1,117 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+export interface IndustryPattern {
+  id: string;
+  pattern_type: string;
+  applies_to_platforms: string[];
+  pattern_data: Record<string, unknown>;
+  sample_size_n_companies: number;
+  sample_size_n_posts: number;
+  confidence_score: number;
+  mined_at: string;
+  expires_at: string;
+}
+
+export interface IndustrySignal {
+  patterns: IndustryPattern[];
+  summary: string;
+}
+
+const PATTERN_TYPE_MAP: Record<string, string> = {
+  BEST_LENGTH_BAND: "cross_segment_format_pattern",
+  BEST_POSTING_WINDOW: "cross_segment_winning_pattern",
+  QUESTION_PATTERN_LIFT: "cross_segment_winning_pattern",
+  MEDIA_TYPE_LIFT: "cross_segment_winning_pattern",
+  HASHTAG_DIMINISHING_RETURNS: "cross_segment_winning_pattern",
+  TOPIC_PERFORMANCE: "cross_segment_topic_lift",
+};
+
+export async function findApplicablePatterns(
+  companyId: string,
+  platform: string,
+  recommendationType: string,
+): Promise<IndustryPattern[]> {
+  // Check consent
+  const svc = getServiceRoleClient();
+  const { data: consentRow } = await svc
+    .from("ins_consent")
+    .select("cross_client_learning_consent")
+    .eq("company_id", companyId)
+    .maybeSingle();
+
+  if (!consentRow?.cross_client_learning_consent) return [];
+
+  const patternType = PATTERN_TYPE_MAP[recommendationType];
+  if (!patternType) return [];
+
+  const { data, error } = await svc
+    .from("ins_pattern_library")
+    .select("*")
+    .eq("pattern_type", patternType)
+    .contains("applies_to_platforms", [platform])
+    .gt("expires_at", new Date().toISOString())
+    .order("confidence_score", { ascending: false })
+    .limit(3);
+
+  if (error) {
+    logger.warn("ins.pattern-application.query-failed", {
+      companyId,
+      error: error.message,
+    });
+    return [];
+  }
+
+  return (data ?? []) as IndustryPattern[];
+}
+
+export function buildIndustrySignalSummary(patterns: IndustryPattern[]): string {
+  if (patterns.length === 0) return "";
+
+  const lines = patterns.map((p) => {
+    const data = p.pattern_data;
+    if (p.pattern_type === "cross_segment_format_pattern" && data.word_count_band) {
+      return `Across the MSP segment (${p.sample_size_n_companies} companies, ${p.sample_size_n_posts} posts), ${data.word_count_band} posts average ${((data.mean_engagement as number) * 100).toFixed(1)}% engagement.`;
+    }
+    if (p.pattern_type === "cross_segment_winning_pattern" && data.pattern) {
+      return `Industry pattern "${data.pattern}" shows ${data.lift}× lift vs baseline across ${p.sample_size_n_companies} MSP companies.`;
+    }
+    if (p.pattern_type === "cross_segment_topic_lift" && data.topic) {
+      return `Topic "${data.topic}" delivers ${data.lift}× the median engagement across ${p.sample_size_n_companies} MSP companies.`;
+    }
+    return "";
+  });
+
+  return lines.filter(Boolean).join(" ");
+}
+
+export async function getIndustrySignal(
+  companyId: string,
+  platform: string,
+): Promise<IndustrySignal | null> {
+  const svc = getServiceRoleClient();
+  const { data: consentRow } = await svc
+    .from("ins_consent")
+    .select("cross_client_learning_consent")
+    .eq("company_id", companyId)
+    .maybeSingle();
+
+  if (!consentRow?.cross_client_learning_consent) return null;
+
+  const { data, error } = await svc
+    .from("ins_pattern_library")
+    .select("*")
+    .gt("expires_at", new Date().toISOString())
+    .order("confidence_score", { ascending: false })
+    .limit(5);
+
+  if (error || !data || data.length === 0) return null;
+
+  const patterns = data as IndustryPattern[];
+  return {
+    patterns,
+    summary: buildIndustrySignalSummary(patterns),
+  };
+}


### PR DESCRIPTION
## Summary

- **Pattern application module** (`lib/insights/pattern-application.ts`): `findApplicablePatterns()` maps recommendation types to pattern types and checks consent before querying; `getIndustrySignal()` fetches top patterns for the priors API; `buildIndustrySignalSummary()` produces human-readable text
- **Generation-priors API extension**: populates `industry_signal` field (patterns array + summary text) when `include_industry_signal=true` AND consent is on; graceful null degradation when consent is off (no longer 400)
- **Admin patterns page** (`/admin/insights/patterns`): read-only operator view of current `ins_pattern_library` rows with sample sizes, confidence, TTL

## Test coverage

- **L1**: `lib/__tests__/pattern-application.unit.test.ts` — consent gate, pattern type mapping, summary builder
- **L6**: `lib/__tests__/generation-priors-industry-signal.unit.test.ts` — graceful degradation (consent OFF returns null, NOT 400); populated when consent ON

## Working analog

- Pattern query: mirrors `lib/insights/recommenders/best-length-band.ts` (Supabase chain + filters)
- Admin page: mirrors `app/(platform)/admin/insights/page.tsx` (PageShell + PageHeader compound, is_cap_operator gate)

## Risks identified and mitigated

- **Consent check duplication**: `getIndustrySignal()` checks consent independently; not relying on caller — safe even if called from multiple code paths
- **Pattern query fallback**: `getIndustrySignal()` catches errors and returns null — industry signal failure never blocks the generation-priors response
- **Stacked on PR-09**: this PR is stacked on `feat/insights-generation-priors-contract` — when PR-09 merges, run `gh pr update-branch` to rebase onto main

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (pattern-application, industry-signal)
- [x] Contract snapshot unchanged
- [x] PR is under 500 net lines