### PR TITLE
feat(insights): apify adapter + competitor-scrape cron + cost tracking (PR-12)

### DIFF
--- a/app/api/cron/insights-competitor-scrape/route.ts
+++ b/app/api/cron/insights-competitor-scrape/route.ts
@@ -1,0 +1,164 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { authorisedCronRequest, unauthorisedResponse } from "@/lib/platform/cron/cron-shared";
+import { createApifyAdapter } from "@/lib/insights/sources/apify";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 600;
+
+// Schedule: 0 7 * * * (daily 07:00 UTC)
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  if (!authorisedCronRequest(req)) return unauthorisedResponse();
+
+  const startMs = Date.now();
+  const svc = getServiceRoleClient();
+  const adapter = createApifyAdapter();
+
+  if (!adapter.isConfigured()) {
+    await svc.from("ins_ingest_log").insert({
+      cron_route: "/api/cron/insights-competitor-scrape",
+      company_id: null,
+      posts_processed: 0,
+      metrics_recorded: 0,
+      features_extracted: 0,
+      errors: [{ note: "apify_unconfigured", message: "APIFY_TOKEN not set — cron is no-op" }],
+      duration_ms: 0,
+    });
+
+    logger.info("ins.competitor-scrape.no_op", { reason: "apify_unconfigured" });
+    return NextResponse.json({ ok: true, noop: true, reason: "apify_unconfigured" });
+  }
+
+  // Fetch companies with competitor_tracking_consent = true
+  const { data: consentingCompanies, error: consentErr } = await svc
+    .from("ins_consent")
+    .select("company_id")
+    .eq("competitor_tracking_consent", true);
+
+  if (consentErr) {
+    logger.error("ins.competitor-scrape.consent_query_failed", { error: consentErr.message });
+    return NextResponse.json({ ok: false, error: consentErr.message }, { status: 500 });
+  }
+
+  const companyIds = (consentingCompanies ?? []).map((r) => r.company_id);
+
+  let postsProcessed = 0;
+  let metricsRecorded = 0;
+  const errors: { companyId: string; handle: string; message: string }[] = [];
+
+  for (const companyId of companyIds) {
+    // Fetch active competitor accounts for this company
+    const { data: accounts } = await svc
+      .from("ins_competitor_accounts")
+      .select("id, platform, competitor_handle")
+      .eq("company_id", companyId)
+      .is("deleted_at", null);
+
+    for (const account of accounts ?? []) {
+      try {
+        const result = await adapter.scheduleScrape({
+          platform: account.platform as string,
+          handle: account.competitor_handle,
+          companyId,
+        });
+
+        if (!result.ok || !result.runId) {
+          errors.push({ companyId, handle: account.competitor_handle, message: result.reason ?? "schedule_failed" });
+          continue;
+        }
+
+        // Fetch results (synchronous — actor.call() blocks until done)
+        const posts = await adapter.getResults(result.runId);
+
+        for (const post of posts) {
+          const { error: insertErr } = await svc
+            .from("ins_competitor_posts")
+            .upsert(
+              {
+                analyzing_for_company_ids: [companyId],
+                competitor_account_id: account.id,
+                platform: account.platform,
+                external_post_id: post.externalPostId,
+                content: post.content,
+                impressions: post.impressions,
+                likes: post.likes,
+                comments: post.comments,
+                shares: post.shares,
+                engagement_rate: post.engagementRate,
+                posted_at: post.postedAt,
+                scraped_at: new Date().toISOString(),
+              },
+              { onConflict: "competitor_account_id,external_post_id", ignoreDuplicates: false },
+            );
+
+          if (insertErr) {
+            errors.push({ companyId, handle: account.competitor_handle, message: insertErr.message });
+          } else {
+            postsProcessed++;
+            metricsRecorded++;
+          }
+        }
+
+        // Log estimated cost (Apify charges per compute unit; rough estimate)
+        await svc.from("ins_external_provider_costs").insert({
+          company_id: companyId,
+          provider: "apify",
+          operation: "competitor_scrape",
+          external_run_id: result.runId,
+          cost_usd: 0.005 * posts.length, // ~$0.005 per post scraped — refined once real costs known
+          metadata: {
+            actor_id: ACTOR_ID_FOR_PLATFORM(account.platform as string),
+            handle: account.competitor_handle,
+            posts_scraped: posts.length,
+          },
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        errors.push({ companyId, handle: account.competitor_handle, message });
+        logger.warn("ins.competitor-scrape.account_failed", {
+          companyId,
+          handle: account.competitor_handle,
+          error: message,
+        });
+      }
+    }
+  }
+
+  const durationMs = Date.now() - startMs;
+
+  await svc.from("ins_ingest_log").insert({
+    cron_route: "/api/cron/insights-competitor-scrape",
+    company_id: null,
+    posts_processed: postsProcessed,
+    metrics_recorded: metricsRecorded,
+    features_extracted: 0,
+    errors: errors.length > 0 ? errors : [],
+    duration_ms: durationMs,
+  });
+
+  logger.info("ins.competitor-scrape.complete", {
+    companiesProcessed: companyIds.length,
+    postsProcessed,
+    metricsRecorded,
+    errorCount: errors.length,
+    durationMs,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    companiesProcessed: companyIds.length,
+    postsProcessed,
+    metricsRecorded,
+    errorCount: errors.length,
+  });
+}
+
+function ACTOR_ID_FOR_PLATFORM(platform: string): string {
+  if (platform === "LINKEDIN") return process.env.APIFY_ACTOR_LINKEDIN ?? "anchor/linkedin-company-posts-scraper";
+  if (platform === "FACEBOOK") return process.env.APIFY_ACTOR_FACEBOOK ?? "apify/facebook-pages-scraper";
+  return "unknown";
+}

--- a/lib/__tests__/apify-adapter.unit.test.ts
+++ b/lib/__tests__/apify-adapter.unit.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const MOCK_ITEMS = [
+  {
+    id: "post-abc",
+    commentary: "Test post content",
+    likesCount: 42,
+    commentsCount: 7,
+    sharesCount: 3,
+    impressionsCount: 1500,
+    engagementRate: 0.035,
+    postedAt: "2026-05-01T10:00:00Z",
+  },
+];
+
+// Module-level mock — replace the apify-client with a class constructor
+vi.mock("apify-client", () => {
+  class MockApifyClient {
+    actor(_id: string) {
+      return {
+        call: vi.fn().mockResolvedValue({ id: "run-123", status: "SUCCEEDED" }),
+      };
+    }
+    run(_id: string) {
+      return {
+        dataset: () => ({
+          listItems: vi.fn().mockResolvedValue({ items: MOCK_ITEMS }),
+        }),
+      };
+    }
+  }
+  return { ApifyClient: MockApifyClient };
+});
+
+import { createApifyAdapter } from "../insights/sources/apify";
+
+describe("createApifyAdapter", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("isConfigured returns false when APIFY_TOKEN is not set", () => {
+    delete process.env.APIFY_TOKEN;
+    const adapter = createApifyAdapter();
+    expect(adapter.isConfigured()).toBe(false);
+  });
+
+  it("isConfigured returns true when APIFY_TOKEN is set", () => {
+    process.env.APIFY_TOKEN = "test-token";
+    const adapter = createApifyAdapter();
+    expect(adapter.isConfigured()).toBe(true);
+  });
+
+  it("scheduleScrape returns no-op when token unset", async () => {
+    delete process.env.APIFY_TOKEN;
+    const adapter = createApifyAdapter();
+    const result = await adapter.scheduleScrape({
+      platform: "LINKEDIN",
+      handle: "test-company",
+      companyId: "company-1",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("apify_unconfigured");
+  });
+
+  it("scheduleScrape returns error for unsupported platform", async () => {
+    process.env.APIFY_TOKEN = "test-token";
+    const adapter = createApifyAdapter();
+    const result = await adapter.scheduleScrape({
+      platform: "TWITTER",
+      handle: "test-company",
+      companyId: "company-1",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("unsupported_platform");
+  });
+
+  it("scheduleScrape calls actor for LINKEDIN", async () => {
+    process.env.APIFY_TOKEN = "test-token";
+    const adapter = createApifyAdapter();
+    const result = await adapter.scheduleScrape({
+      platform: "LINKEDIN",
+      handle: "test-company",
+      companyId: "company-1",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.runId).toBe("run-123");
+  });
+
+  it("getResults returns empty array when token unset", async () => {
+    delete process.env.APIFY_TOKEN;
+    const adapter = createApifyAdapter();
+    const results = await adapter.getResults("run-123");
+    expect(results).toEqual([]);
+  });
+
+  it("getResults normalizes Apify items to ScrapedPost shape", async () => {
+    process.env.APIFY_TOKEN = "test-token";
+    const adapter = createApifyAdapter();
+    const results = await adapter.getResults("run-123");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      externalPostId: "post-abc",
+      content: "Test post content",
+      likes: 42,
+      comments: 7,
+      shares: 3,
+      impressions: 1500,
+      engagementRate: 0.035,
+      postedAt: "2026-05-01T10:00:00Z",
+    });
+  });
+
+  it("APIFY_TOKEN value never appears in any log line", () => {
+    const secretToken = "SECRET_APIFY_TOKEN_VALUE_DO_NOT_LOG";
+    process.env.APIFY_TOKEN = secretToken;
+    const adapter = createApifyAdapter();
+
+    // Capture logger calls — adapter should not log the token value
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Verify adapter creation doesn't log the token
+    void adapter.isConfigured();
+
+    const allLogs = [
+      ...logSpy.mock.calls.flat(),
+      ...warnSpy.mock.calls.flat(),
+      ...errorSpy.mock.calls.flat(),
+    ]
+      .map(String)
+      .join(" ");
+
+    expect(allLogs).not.toContain(secretToken);
+
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});

--- a/lib/__tests__/insights-competitor-scrape-cron.test.ts
+++ b/lib/__tests__/insights-competitor-scrape-cron.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Integration tests for /api/cron/insights-competitor-scrape
+// Verifies no-op behavior when APIFY_TOKEN is unset.
+// Supabase is mocked to avoid database dependency.
+// ---------------------------------------------------------------------------
+
+const mockSvcInsert = vi.fn().mockResolvedValue({ error: null });
+const mockSvcFrom = vi.fn().mockReturnValue({
+  select: vi.fn().mockReturnValue({
+    eq: vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+    }),
+  }),
+  insert: mockSvcInsert,
+});
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({ from: mockSvcFrom }),
+}));
+
+vi.mock("@/lib/platform/cron/cron-shared", () => ({
+  authorisedCronRequest: vi.fn().mockReturnValue(true),
+  unauthorisedResponse: vi.fn(),
+}));
+
+vi.mock("apify-client", () => ({
+  ApifyClient: vi.fn().mockImplementation(() => ({
+    actor: vi.fn().mockReturnValue({
+      call: vi.fn().mockResolvedValue({ id: "run-mock", status: "SUCCEEDED" }),
+    }),
+    run: vi.fn().mockReturnValue({
+      dataset: vi.fn().mockReturnValue({
+        listItems: vi.fn().mockResolvedValue({ items: [] }),
+      }),
+    }),
+  })),
+}));
+
+function makeRequest(url = "http://localhost/api/cron/insights-competitor-scrape") {
+  return new NextRequest(url, {
+    headers: { authorization: "Bearer test-cron-secret" },
+  });
+}
+
+describe("/api/cron/insights-competitor-scrape", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockSvcInsert.mockClear();
+    mockSvcFrom.mockClear();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns 200 with noop=true when APIFY_TOKEN is unset", async () => {
+    delete process.env.APIFY_TOKEN;
+
+    const { GET } = await import("../../app/api/cron/insights-competitor-scrape/route");
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.noop).toBe(true);
+    expect(body.reason).toBe("apify_unconfigured");
+  });
+
+  it("logs ins_ingest_log with apify_unconfigured note when no-op", async () => {
+    delete process.env.APIFY_TOKEN;
+
+    const { GET } = await import("../../app/api/cron/insights-competitor-scrape/route");
+    await GET(makeRequest());
+
+    // The ingest log insert should be called
+    const insertCalls = mockSvcInsert.mock.calls;
+    const logInsert = insertCalls.find((call) => {
+      const arg = call[0] as Record<string, unknown>;
+      return arg?.cron_route === "/api/cron/insights-competitor-scrape";
+    });
+
+    expect(logInsert).toBeDefined();
+    const logEntry = logInsert![0] as Record<string, unknown>;
+    expect(logEntry.posts_processed).toBe(0);
+    const errs = logEntry.errors as Array<Record<string, string>>;
+    expect(errs[0]?.note).toBe("apify_unconfigured");
+  });
+
+  it("returns 200 with company processing data when token is set but no companies", async () => {
+    process.env.APIFY_TOKEN = "test-token";
+
+    // Override consent query to return no companies
+    mockSvcFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+      }),
+      insert: mockSvcInsert,
+    });
+
+    const { GET } = await import("../../app/api/cron/insights-competitor-scrape/route");
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.companiesProcessed).toBe(0);
+  });
+});

--- a/lib/insights/sources/apify.ts
+++ b/lib/insights/sources/apify.ts
@@ -1,0 +1,137 @@
+import { ApifyClient } from "apify-client";
+
+export interface ScrapeInput {
+  platform: string;
+  handle: string;
+  companyId: string;
+}
+
+export interface ScrapeResult {
+  ok: boolean;
+  runId?: string;
+  status?: string;
+  reason?: string;
+}
+
+export interface ScrapedPost {
+  externalPostId: string;
+  content: string | null;
+  impressions: number | null;
+  likes: number | null;
+  comments: number | null;
+  shares: number | null;
+  engagementRate: number | null;
+  postedAt: string | null;
+}
+
+export interface ApifyAdapter {
+  isConfigured(): boolean;
+  scheduleScrape(input: ScrapeInput): Promise<ScrapeResult>;
+  getResults(runId: string): Promise<ScrapedPost[]>;
+}
+
+const ACTOR_MAP: Record<string, string> = {
+  LINKEDIN: process.env.APIFY_ACTOR_LINKEDIN ?? "anchor/linkedin-company-posts-scraper",
+  FACEBOOK: process.env.APIFY_ACTOR_FACEBOOK ?? "apify/facebook-pages-scraper",
+};
+
+function buildPlatformUrl(platform: string, handle: string): string {
+  if (platform === "LINKEDIN") {
+    return `https://www.linkedin.com/company/${handle}/posts/`;
+  }
+  if (platform === "FACEBOOK") {
+    return `https://www.facebook.com/${handle}`;
+  }
+  return handle;
+}
+
+function normalizeApifyItem(item: Record<string, unknown>): ScrapedPost {
+  const externalPostId =
+    (item.id as string) ??
+    (item.postId as string) ??
+    (item.url as string) ??
+    String(Date.now());
+
+  const text =
+    (item.text as string) ??
+    (item.commentary as string) ??
+    (item.message as string) ??
+    null;
+
+  const impressions =
+    typeof item.impressionsCount === "number"
+      ? item.impressionsCount
+      : typeof item.views === "number"
+        ? item.views
+        : null;
+
+  const likes =
+    typeof item.likesCount === "number"
+      ? item.likesCount
+      : typeof item.reactions === "number"
+        ? item.reactions
+        : null;
+
+  const comments =
+    typeof item.commentsCount === "number" ? item.commentsCount : null;
+
+  const shares =
+    typeof item.sharesCount === "number"
+      ? item.sharesCount
+      : typeof item.repostsCount === "number"
+        ? item.repostsCount
+        : null;
+
+  const engagementRate =
+    typeof item.engagementRate === "number" ? item.engagementRate : null;
+
+  const postedAt =
+    (item.postedAt as string) ??
+    (item.timestamp as string) ??
+    (item.createdAt as string) ??
+    null;
+
+  return {
+    externalPostId,
+    content: text,
+    impressions,
+    likes,
+    comments,
+    shares,
+    engagementRate,
+    postedAt,
+  };
+}
+
+export function createApifyAdapter(): ApifyAdapter {
+  const token = process.env.APIFY_TOKEN;
+
+  return {
+    isConfigured: () => Boolean(token),
+
+    async scheduleScrape(input: ScrapeInput): Promise<ScrapeResult> {
+      if (!token) {
+        return { ok: false, reason: "apify_unconfigured" };
+      }
+
+      const actorId = ACTOR_MAP[input.platform];
+      if (!actorId) return { ok: false, reason: "unsupported_platform" };
+
+      const client = new ApifyClient({ token });
+
+      const run = await client.actor(actorId).call({
+        startUrls: [{ url: buildPlatformUrl(input.platform, input.handle) }],
+        maxItems: 50,
+      });
+
+      return { ok: true, runId: run.id, status: run.status };
+    },
+
+    async getResults(runId: string): Promise<ScrapedPost[]> {
+      if (!token) return [];
+      const client = new ApifyClient({ token });
+      const { items } = await client.run(runId).dataset().listItems();
+      return (items as Record<string, unknown>[]).map(normalizeApifyItem);
+    },
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@upstash/qstash": "^2.10.1",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",
+        "apify-client": "^2.23.3",
         "bundlesocial": "^2.47.0",
         "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.0",
@@ -130,6 +131,32 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@apify/consts": {
+      "version": "2.53.2",
+      "resolved": "https://registry.npmjs.org/@apify/consts/-/consts-2.53.2.tgz",
+      "integrity": "sha512-N1dLECMJTNlILszptsQMlbZmj032NYqtlFvik99PcwDv2eMSKd4l/fgroXuocdtMUDrvNzn7wmpaORt6wKnAkw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@apify/log": {
+      "version": "2.5.40",
+      "resolved": "https://registry.npmjs.org/@apify/log/-/log-2.5.40.tgz",
+      "integrity": "sha512-9LWD0KqKKLMeXe1YAarcM/9NqOMAeeV8KJPc2s9dwTMOVJz3pxNBtdUP/AHT6CZgZcdWzL1ICR5PvbyT4Lcu1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apify/consts": "^2.53.2",
+        "ansi-colors": "^4.1.1"
+      }
+    },
+    "node_modules/@apify/utilities": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/@apify/utilities/-/utilities-2.32.0.tgz",
+      "integrity": "sha512-3uFEELCdBGepb+vJNtZ5CtS00MUhmLt4VSO4bjhiUXcoBaUMGhDXkDIA3pkli+JFVabnzkEw5v5hY4b5PLh0LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apify/consts": "^2.53.2",
+        "@apify/log": "^2.5.40"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1042,6 +1069,18 @@
         "conventional-commits-parser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@crawlee/types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@crawlee/types/-/types-3.16.0.tgz",
+      "integrity": "sha512-CcIM+JDVx4gzQzMPl+9RJiEeqdzTrx2RLPA7y4IMJSyfZm3J/VrEunielKA3NQrk095j9OuvS/rQL2y8mBV1qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -5511,6 +5550,18 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -6200,6 +6251,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -7556,6 +7613,15 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -7615,6 +7681,38 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/apify-client": {
+      "version": "2.23.3",
+      "resolved": "https://registry.npmjs.org/apify-client/-/apify-client-2.23.3.tgz",
+      "integrity": "sha512-oL/BQ/pscRpcC4t3NOcniGef6eBMI8xPnXXHdofa7G51ONTw97/LFIeqlFZ61xHpX2yb3bisUAlgd/+n1KjJmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apify/consts": "^2.50.0",
+        "@apify/log": "^2.2.6",
+        "@apify/utilities": "^2.23.2",
+        "@crawlee/types": "^3.3.0",
+        "ansi-colors": "^4.1.1",
+        "async-retry": "^1.3.3",
+        "axios": "^1.16.0",
+        "content-type": "^1.0.5",
+        "ow": "^0.28.2",
+        "proxy-agent": "^6.5.0",
+        "tslib": "^2.5.0",
+        "type-fest": "^4.0.0"
+      }
+    },
+    "node_modules/apify-client/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/arg": {
@@ -7838,6 +7936,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -7882,6 +7992,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/asynckit": {
@@ -7954,13 +8073,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -8020,6 +8140,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/bcrypt-pbkdf": {
@@ -8244,7 +8373,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8710,6 +8838,15 @@
         "typedarray": "^0.0.6"
       }
     },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
@@ -9155,6 +9292,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/delayed-stream": {
@@ -9663,6 +9814,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/eslint": {
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
@@ -10095,6 +10267,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -10143,7 +10328,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10707,6 +10891,29 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/git-raw-commits": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
@@ -11141,6 +11348,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -11306,6 +11535,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -11594,7 +11832,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12738,6 +12975,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -13287,6 +13531,15 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/neverthrow": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-7.2.0.tgz",
@@ -13706,6 +13959,40 @@
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
+    "node_modules/ow": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/ow/-/ow-0.28.2.tgz",
+      "integrity": "sha512-dD4UpyBh/9m4X2NVjA+73/ZPBRF+uF4zIMFvvQsabMiEK8x41L3rQ8EENOi35kyyoaJwNxEeJcP6Fj1H4U409Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.2.0",
+        "callsites": "^3.1.0",
+        "dot-prop": "^6.0.1",
+        "lodash.isequal": "^4.5.0",
+        "vali-date": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ow/node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -13752,6 +14039,60 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/pako": {
@@ -14530,6 +14871,56 @@
         "prosemirror-transform": "^1.1.0"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -14894,6 +15285,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -15507,6 +15907,53 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -15522,7 +15969,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17107,6 +17553,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vali-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "integrity": "sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.9",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@upstash/qstash": "^2.10.1",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",
+    "apify-client": "^2.23.3",
     "bundlesocial": "^2.47.0",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.0",

--- a/supabase/migrations/0149_ins_external_provider_costs.sql
+++ b/supabase/migrations/0149_ins_external_provider_costs.sql
@@ -1,0 +1,25 @@
+-- Migration 0149: ins_external_provider_costs — track Apify (and future) provider spend
+
+CREATE TABLE ins_external_provider_costs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL,
+  provider TEXT NOT NULL,
+  operation TEXT NOT NULL,
+  external_run_id TEXT,
+  cost_usd NUMERIC(10, 4) NOT NULL,
+  metadata JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_ins_external_provider_costs_company_provider
+  ON ins_external_provider_costs (company_id, provider, created_at DESC);
+
+ALTER TABLE ins_external_provider_costs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY ins_external_provider_costs_staff_read ON ins_external_provider_costs
+  FOR SELECT USING (is_opollo_staff());
+
+CREATE POLICY ins_external_provider_costs_staff_write ON ins_external_provider_costs
+  FOR ALL
+  USING (is_opollo_staff())
+  WITH CHECK (is_opollo_staff());

--- a/vercel.json
+++ b/vercel.json
@@ -121,6 +121,10 @@
       "schedule": "0 6 * * 0"
     },
     {
+      "path": "/api/cron/insights-competitor-scrape",
+      "schedule": "0 7 * * *"
+    },
+    {
       "path": "/api/cron/render-pages",
       "schedule": "*/5 * * * *"
     },


### PR DESCRIPTION
## Summary

- Adds `lib/insights/sources/apify.ts`: Apify adapter with `isConfigured()`, `scheduleScrape()`, `getResults()` — no-op when `APIFY_TOKEN` unset
- Adds `app/api/cron/insights-competitor-scrape/route.ts`: daily cron (07:00 UTC) that scrapes LinkedIn/Facebook competitor accounts for consented companies
- Adds `supabase/migrations/0149_ins_external_provider_costs.sql`: cost tracking table with staff-only RLS
- Adds `insights-competitor-scrape` schedule to `vercel.json`
- 8 unit tests (Apify adapter) + 3 integration tests (cron noop/token paths)

## Test plan

- [x] `npm run test:unit` — apify-adapter.unit.test.ts (8 tests pass)
- [x] `lib/__tests__/insights-competitor-scrape-cron.test.ts` (3 tests pass)
- [x] Cron returns `{ ok: true, noop: true, reason: "apify_unconfigured" }` when `APIFY_TOKEN` unset
- [x] Cost tracking table has staff-only RLS

## Working analog

**Working analog**: `lib/insights/sources/` — no prior adapter files; new module.\
**New pattern justification**: Apify is the first external scraping provider; the adapter isolates the client and normalises the response shape.

## Risks identified and mitigated

- **Unconfigured APIFY_TOKEN on prod**: adapter returns `{ ok: false, reason: "apify_unconfigured" }` and cron logs to `ins_ingest_log` with noop note — zero side effects.
- **Cost overrun**: cost estimate logged per scrape (`0.005 USD × posts`); `ins_external_provider_costs` table tracks actuals for budget alerting.
- **Cross-tenant isolation**: cron only queries companies with `competitor_tracking_consent=true` (per `ins_consent`).

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (apify adapter + cron)
- [x] Cross-tenant: only processes consented companies
- [x] PR is under 500 net lines