### PR TITLE
feat(insights): phase 3 closeout — gap analysis wiring, competitors nav + probe (PR-15/16)

### DIFF
--- a/app/(platform)/admin/insights/clients/[id]/page.tsx
+++ b/app/(platform)/admin/insights/clients/[id]/page.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from "react";
 import { notFound, redirect } from "next/navigation";
 
 import { AdminClientDrilldown } from "@/components/admin-insights/AdminClientDrilldown";
+import { CompetitorGapAnalysis } from "@/components/insights/CompetitorGapAnalysis";
 import { createRouteAuthClient } from "@/lib/auth";
 import { getAdminClientSnapshot } from "@/lib/insights/admin-dashboard";
 import { writeAdminAudit } from "@/lib/insights/admin-audit";
@@ -42,10 +44,17 @@ export default async function AdminClientInsightsPage({
   }
 
   return (
-    <AdminClientDrilldown
-      clientName={snapshot.name}
-      companyId={params.id}
-      data={dashboardData}
-    />
+    <>
+      <AdminClientDrilldown
+        clientName={snapshot.name}
+        companyId={params.id}
+        data={dashboardData}
+      />
+      <div className="px-6 pb-8">
+        <Suspense fallback={null}>
+          <CompetitorGapAnalysis companyId={params.id} />
+        </Suspense>
+      </div>
+    </>
   );
 }

--- a/app/(platform)/company/social/insights/page.tsx
+++ b/app/(platform)/company/social/insights/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { redirect } from "next/navigation";
 
 import { PageHeader } from "@/components/ui/page-header";
@@ -6,6 +7,7 @@ import { StatusPill } from "@/components/ui/status-pill";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
 import { getInsightsDashboardData } from "@/lib/insights/dashboard";
 import { InsightsDashboardClient } from "@/components/insights/InsightsDashboardClient";
+import { CompetitorGapAnalysis } from "@/components/insights/CompetitorGapAnalysis";
 import { PeriodSelector } from "@/components/insights/common/PeriodSelector";
 
 export const dynamic = "force-dynamic";
@@ -66,6 +68,9 @@ export default async function InsightsPage() {
 
       <PageShell.Content>
         <InsightsDashboardClient data={data} companyId={companyId} />
+        <Suspense fallback={null}>
+          <CompetitorGapAnalysis companyId={companyId} />
+        </Suspense>
       </PageShell.Content>
     </PageShell>
   );

--- a/components/__tests__/AdminBanner.test.tsx
+++ b/components/__tests__/AdminBanner.test.tsx
@@ -10,14 +10,14 @@ import { AdminBanner } from "@/components/admin-insights/AdminBanner";
 
 describe("AdminBanner", () => {
   it("shows client name", () => {
-    render(<AdminBanner clientName="Acme MSP" />);
+    render(<AdminBanner clientName="Acme MSP" companyId="test-id" />);
     expect(screen.getByTestId("admin-banner")).toBeInTheDocument();
     expect(screen.getByText(/Acme MSP/)).toBeInTheDocument();
     expect(screen.getByText(/All actions logged/)).toBeInTheDocument();
   });
 
   it("back button navigates to roster", () => {
-    render(<AdminBanner clientName="Acme MSP" />);
+    render(<AdminBanner clientName="Acme MSP" companyId="test-id" />);
     fireEvent.click(screen.getByRole("button", { name: /back to roster/i }));
     expect(mockPush).toHaveBeenCalledWith("/admin/insights");
   });

--- a/components/__tests__/admin-insights/AdminBanner.test.tsx
+++ b/components/__tests__/admin-insights/AdminBanner.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AdminBanner } from "@/components/admin-insights/AdminBanner";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+beforeEach(() => {
+  mockPush.mockClear();
+});
+
+const COMPANY_ID = "test-company-id";
+
+describe("AdminBanner", () => {
+  it("renders the client name and admin label", () => {
+    render(<AdminBanner clientName="Acme Corp" companyId={COMPANY_ID} />);
+    expect(screen.getByTestId("admin-banner")).toBeInTheDocument();
+    expect(screen.getByText(/Viewing as admin · Acme Corp/)).toBeInTheDocument();
+  });
+
+  it("back button navigates to roster", () => {
+    render(<AdminBanner clientName="Acme Corp" companyId={COMPANY_ID} />);
+    fireEvent.click(screen.getByText(/Back to roster/));
+    expect(mockPush).toHaveBeenCalledWith("/admin/insights");
+  });
+
+  it("manage competitors button navigates to competitors page", () => {
+    render(<AdminBanner clientName="Acme Corp" companyId={COMPANY_ID} />);
+    fireEvent.click(screen.getByText("Manage competitors"));
+    expect(mockPush).toHaveBeenCalledWith(
+      `/admin/insights/clients/${COMPANY_ID}/competitors`,
+    );
+  });
+});

--- a/components/admin-insights/AdminBanner.tsx
+++ b/components/admin-insights/AdminBanner.tsx
@@ -7,9 +7,10 @@ import { Button } from "@/components/ui/button";
 
 interface AdminBannerProps {
   clientName: string;
+  companyId: string;
 }
 
-export function AdminBanner({ clientName }: AdminBannerProps) {
+export function AdminBanner({ clientName, companyId }: AdminBannerProps) {
   const router = useRouter();
 
   return (
@@ -25,9 +26,18 @@ export function AdminBanner({ clientName }: AdminBannerProps) {
           </span>
           <span className="text-tx-secondary">· All actions logged</span>
         </div>
-        <Button variant="ghost" size="sm" onClick={() => router.push("/admin/insights")}>
-          ← Back to roster
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => router.push(`/admin/insights/clients/${companyId}/competitors`)}
+          >
+            Manage competitors
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => router.push("/admin/insights")}>
+            ← Back to roster
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/components/admin-insights/AdminClientDrilldown.tsx
+++ b/components/admin-insights/AdminClientDrilldown.tsx
@@ -17,7 +17,7 @@ export function AdminClientDrilldown({
 }: AdminClientDrilldownProps) {
   return (
     <div>
-      <AdminBanner clientName={clientName} />
+      <AdminBanner clientName={clientName} companyId={companyId} />
       <div className="px-6 py-8">
         <InsightsDashboardClient data={data} companyId={companyId} isAdminView />
       </div>

--- a/e2e/smoke/critical-path.smoke.spec.ts
+++ b/e2e/smoke/critical-path.smoke.spec.ts
@@ -80,6 +80,7 @@ test.describe("smoke — critical path read-only sweep", () => {
       { name: "users", path: "/admin/users" },
       { name: "companies", path: "/admin/companies" },
       { name: "optimiser", path: "/optimiser" },
+      { name: "insights-admin", path: "/admin/insights" },
     ];
 
     for (const { name, path } of pages) {

--- a/scripts/probes/insights-recommendations.ts
+++ b/scripts/probes/insights-recommendations.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env tsx
+export {};
+/**
+ * scripts/probes/insights-recommendations.ts
+ *
+ * LAYER 7 — Live probe for GET /api/insights/recommendations
+ * and the consent/priors surfaces that feed it.
+ *
+ * Usage:
+ *   PROBE_BASE_URL=https://opollo-site-builder.vercel.app \
+ *   PROBE_ACCESS_TOKEN=<bearer-token> \
+ *   PROBE_COMPANY_ID=<uuid> \
+ *   npx tsx scripts/probes/insights-recommendations.ts
+ *
+ * Required env:
+ *   PROBE_BASE_URL      — base URL of the deployed app
+ *   PROBE_ACCESS_TOKEN  — a valid session JWT for a user with view_insights access
+ *   PROBE_COMPANY_ID    — a fixture company UUID with insights data
+ */
+
+const base = process.env.PROBE_BASE_URL ?? "http://localhost:3000";
+const token = process.env.PROBE_ACCESS_TOKEN ?? "";
+const companyId = process.env.PROBE_COMPANY_ID ?? "";
+
+const PLATFORMS = ["LINKEDIN", "FACEBOOK"] as const;
+
+async function probeAuth(): Promise<boolean> {
+  console.log("\n## Auth gate");
+  const res = await fetch(
+    `${base}/api/insights/recommendations?company_id=${encodeURIComponent(companyId)}&platform=LINKEDIN`,
+  );
+  if (res.status !== 401) {
+    console.error(`FAIL: expected 401 without auth, got ${res.status}`);
+    return false;
+  }
+  console.log("PASS: 401 without auth token");
+  return true;
+}
+
+async function probeValidation(): Promise<boolean> {
+  console.log("\n## Validation");
+  const headers = { Authorization: `Bearer ${token}` };
+
+  const noPlatform = await fetch(
+    `${base}/api/insights/recommendations?company_id=${encodeURIComponent(companyId)}`,
+    { headers },
+  );
+  if (noPlatform.status !== 400) {
+    console.error(`FAIL: expected 400 for missing platform, got ${noPlatform.status}`);
+    return false;
+  }
+  console.log("PASS: 400 for missing platform");
+
+  const badPlatform = await fetch(
+    `${base}/api/insights/recommendations?company_id=${encodeURIComponent(companyId)}&platform=TWITTER`,
+    { headers },
+  );
+  if (badPlatform.status !== 400) {
+    console.error(`FAIL: expected 400 for invalid platform, got ${badPlatform.status}`);
+    return false;
+  }
+  console.log("PASS: 400 for invalid platform");
+
+  return true;
+}
+
+async function probeRecommendations(platform: string): Promise<boolean> {
+  console.log(`\n## Recommendations — ${platform}`);
+  const url = `${base}/api/insights/recommendations?company_id=${encodeURIComponent(companyId)}&platform=${platform}&limit=5`;
+  console.log(`GET ${url}`);
+
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  console.log(`Status: ${res.status}`);
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.error(`FAIL: non-2xx response\n${body}`);
+    return false;
+  }
+
+  const data = await res.json();
+
+  if (!Array.isArray(data)) {
+    console.error(`FAIL: expected array, got ${typeof data}`);
+    return false;
+  }
+
+  console.log(`Recommendations returned: ${data.length}`);
+
+  if (data.length > 0) {
+    const rec = data[0];
+    const REQUIRED = ["id", "recommendation_type", "headline", "body", "confidence_band"];
+    const missing = REQUIRED.filter((f) => !(f in rec));
+    if (missing.length > 0) {
+      console.error(`FAIL: missing fields in first recommendation: ${missing.join(", ")}`);
+      return false;
+    }
+    console.log(`First rec type: ${rec.recommendation_type}, band: ${rec.confidence_band}`);
+  }
+
+  console.log("PASS");
+  return true;
+}
+
+async function probeConsentRoute(): Promise<boolean> {
+  console.log("\n## Consent route");
+  const url = `${base}/api/insights/consent`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  console.log(`Status: ${res.status}`);
+
+  if (res.status === 401) {
+    console.error("FAIL: 401 with valid token");
+    return false;
+  }
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.error(`FAIL: non-2xx response\n${body}`);
+    return false;
+  }
+
+  const data = await res.json();
+  const REQUIRED = ["cross_client_learning_consent", "competitor_tracking_consent"];
+  const missing = REQUIRED.filter((f) => !(f in data));
+  if (missing.length > 0) {
+    console.error(`FAIL: missing consent fields: ${missing.join(", ")}`);
+    return false;
+  }
+
+  console.log(`cross_client_learning_consent: ${data.cross_client_learning_consent}`);
+  console.log(`competitor_tracking_consent: ${data.competitor_tracking_consent}`);
+  console.log("PASS");
+  return true;
+}
+
+async function main(): Promise<void> {
+  console.log("# Insights Recommendations Probe");
+  console.log(`Base URL: ${base}`);
+  console.log(`Company ID: ${companyId}`);
+
+  if (!companyId) {
+    console.error("PROBE_COMPANY_ID env var required");
+    process.exit(1);
+  }
+  if (!token) {
+    console.error("PROBE_ACCESS_TOKEN env var required");
+    process.exit(1);
+  }
+
+  let allPass = true;
+
+  if (!(await probeAuth())) allPass = false;
+  if (!(await probeValidation())) allPass = false;
+  if (!(await probeConsentRoute())) allPass = false;
+
+  for (const platform of PLATFORMS) {
+    if (!(await probeRecommendations(platform))) allPass = false;
+  }
+
+  if (!allPass) {
+    console.error("\n## PROBE FAILED");
+    process.exit(1);
+  }
+
+  console.log("\n## All probes PASSED");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Wires `CompetitorGapAnalysis` server component into the user-facing company insights page (`/company/social/insights`) and admin client drilldown (`/admin/insights/clients/[id]`)
- Adds "Manage competitors" button to `AdminBanner`, linking to `/admin/insights/clients/:id/competitors`
- Adds `scripts/probes/insights-recommendations.ts` — Layer 7 live probe covering `GET /api/insights/recommendations`
- Adds `/admin/insights` to the production smoke page sweep

## Changes by file
| File | Change |
|---|---|
| `app/(platform)/company/social/insights/page.tsx` | Add `<Suspense><CompetitorGapAnalysis />`  below dashboard |
| `app/(platform)/admin/insights/clients/[id]/page.tsx` | Add `<Suspense><CompetitorGapAnalysis />` below drilldown |
| `components/admin-insights/AdminBanner.tsx` | Add `companyId` prop + "Manage competitors" button |
| `components/admin-insights/AdminClientDrilldown.tsx` | Pass `companyId` to `AdminBanner` |
| `scripts/probes/insights-recommendations.ts` | New Layer 7 probe |
| `e2e/smoke/critical-path.smoke.spec.ts` | Add `/admin/insights` to page sweep |

## Test coverage
- L4 component: `components/__tests__/admin-insights/AdminBanner.test.tsx` — 3 tests: renders client name, back button, manage competitors button
- Updated existing `components/__tests__/AdminBanner.test.tsx` to pass required `companyId` prop

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (104/104), test:components (41/41)
- [x] PR is under 500 net lines

## Working analog
`CompetitorGapAnalysis` wiring follows the same `<Suspense fallback={null}>` streaming pattern used elsewhere in this module. Probe follows the pattern from `scripts/probes/insights-generation-priors.ts`.

## Risks identified and mitigated
- **Streaming/fallback**: `Suspense fallback={null}` — gap section streams async; error bubbles to existing page-level error boundary
- **No new mutations or RLS**: both gap analysis queries are read-only, consent-gated inside `computeGapAnalysis`
- **AdminBanner prop change**: `companyId` added as required — existing test updated accordingly
- **Smoke sweep addition**: `/admin/insights` requires admin role — smoke user already admin-scoped