### PR TITLE
fix(insights): wire PeriodSelector to ?period= query param — 7d/30d/90d filtering

### DIFF
--- a/app/(platform)/company/social/insights/page.tsx
+++ b/app/(platform)/company/social/insights/page.tsx
@@ -5,7 +5,7 @@ import { PageHeader } from "@/components/ui/page-header";
 import { PageShell } from "@/components/ui/page-shell";
 import { StatusPill } from "@/components/ui/status-pill";
 import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
-import { getInsightsDashboardData } from "@/lib/insights/dashboard";
+import { getInsightsDashboardData, type InsightsPeriod } from "@/lib/insights/dashboard";
 import { InsightsDashboardClient } from "@/components/insights/InsightsDashboardClient";
 import { CompetitorGapAnalysis } from "@/components/insights/CompetitorGapAnalysis";
 import { PeriodSelector } from "@/components/insights/common/PeriodSelector";
@@ -21,7 +21,13 @@ function formatDate(iso: string | null): string {
   });
 }
 
-export default async function InsightsPage() {
+const VALID_PERIODS: InsightsPeriod[] = ["7d", "30d", "90d"];
+
+export default async function InsightsPage({
+  searchParams,
+}: {
+  searchParams?: { period?: string };
+}) {
   const session = await getCurrentPlatformSession();
   if (!session) {
     redirect(`/login?next=${encodeURIComponent("/company/social/insights")}`);
@@ -36,7 +42,12 @@ export default async function InsightsPage() {
     redirect("/company/social");
   }
 
-  const data = await getInsightsDashboardData(companyId);
+  const rawPeriod = searchParams?.period;
+  const period: InsightsPeriod = VALID_PERIODS.includes(rawPeriod as InsightsPeriod)
+    ? (rawPeriod as InsightsPeriod)
+    : "30d";
+
+  const data = await getInsightsDashboardData(companyId, period);
 
   return (
     <PageShell>
@@ -62,7 +73,7 @@ export default async function InsightsPage() {
           )}
         </PageHeader.Meta>
         <PageHeader.Actions>
-          <PeriodSelector defaultValue="30d" />
+          <PeriodSelector value={period} />
         </PageHeader.Actions>
       </PageHeader>
 

--- a/components/__tests__/InsightsDashboardClient.test.tsx
+++ b/components/__tests__/InsightsDashboardClient.test.tsx
@@ -80,7 +80,8 @@ function makeData(overrides: Partial<InsightsDashboardData> = {}): InsightsDashb
     },
     xConnected: false,
     xMetrics: null,
-    postCount90d: 47,
+    postCount: 47,
+    period: "30d" as const,
     ...overrides,
   };
 }
@@ -99,7 +100,7 @@ describe("InsightsDashboardClient", () => {
   it("renders empty state when no posts", () => {
     render(
       <InsightsDashboardClient
-        data={makeData({ postCount90d: 0 })}
+        data={makeData({ postCount: 0 })}
         companyId="c-1"
       />,
     );
@@ -113,7 +114,7 @@ describe("InsightsDashboardClient", () => {
   it("shows 'need more posts' empty state in recommendations when < 20 posts", () => {
     render(
       <InsightsDashboardClient
-        data={makeData({ postCount90d: 12 })}
+        data={makeData({ postCount: 12 })}
         companyId="c-1"
       />,
     );

--- a/components/__tests__/PeriodSelector.test.tsx
+++ b/components/__tests__/PeriodSelector.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@/components/ui/pill-select", () => ({
         <button
           key={o.value}
           data-testid={`option-${o.value}`}
-          aria-selected={o.value === value}
+          data-selected={o.value === value ? "true" : "false"}
           onClick={() => onValueChange(o.value)}
         >
           {o.label}
@@ -49,8 +49,8 @@ describe("PeriodSelector", () => {
   it("marks the value prop as selected", () => {
     render(<PeriodSelector value="7d" />);
     expect(screen.getByTestId("pill-select")).toHaveAttribute("data-value", "7d");
-    expect(screen.getByTestId("option-7d")).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByTestId("option-30d")).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByTestId("option-7d")).toHaveAttribute("data-selected", "true");
+    expect(screen.getByTestId("option-30d")).toHaveAttribute("data-selected", "false");
   });
 
   it("defaults to 30d when no value prop supplied", () => {

--- a/components/__tests__/PeriodSelector.test.tsx
+++ b/components/__tests__/PeriodSelector.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+const mockPush = vi.fn();
+const mockPathname = "/company/social/insights";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => mockPathname,
+}));
+
+// Render all options directly so the test doesn't depend on Radix Popover open/close
+// state in jsdom. Clicking an option fires onValueChange — same contract as PillSelect.
+vi.mock("@/components/ui/pill-select", () => ({
+  PillSelect: ({
+    options,
+    value,
+    onValueChange,
+  }: {
+    options: Array<{ value: string; label: string }>;
+    value: string;
+    onValueChange: (v: string) => void;
+  }) => (
+    <div data-testid="pill-select" data-value={value}>
+      {options.map((o) => (
+        <button
+          key={o.value}
+          data-testid={`option-${o.value}`}
+          aria-selected={o.value === value}
+          onClick={() => onValueChange(o.value)}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+import { PeriodSelector } from "@/components/insights/common/PeriodSelector";
+
+describe("PeriodSelector", () => {
+  it("renders all three period options", () => {
+    render(<PeriodSelector value="30d" />);
+    expect(screen.getByTestId("option-7d")).toBeInTheDocument();
+    expect(screen.getByTestId("option-30d")).toBeInTheDocument();
+    expect(screen.getByTestId("option-90d")).toBeInTheDocument();
+  });
+
+  it("marks the value prop as selected", () => {
+    render(<PeriodSelector value="7d" />);
+    expect(screen.getByTestId("pill-select")).toHaveAttribute("data-value", "7d");
+    expect(screen.getByTestId("option-7d")).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("option-30d")).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("defaults to 30d when no value prop supplied", () => {
+    render(<PeriodSelector />);
+    expect(screen.getByTestId("pill-select")).toHaveAttribute("data-value", "30d");
+  });
+
+  it("calls router.push with ?period=7d when 7d option clicked", () => {
+    mockPush.mockClear();
+    render(<PeriodSelector value="30d" />);
+    fireEvent.click(screen.getByTestId("option-7d"));
+    expect(mockPush).toHaveBeenCalledWith(`${mockPathname}?period=7d`);
+  });
+
+  it("calls router.push with ?period=90d when 90d option clicked", () => {
+    mockPush.mockClear();
+    render(<PeriodSelector value="30d" />);
+    fireEvent.click(screen.getByTestId("option-90d"));
+    expect(mockPush).toHaveBeenCalledWith(`${mockPathname}?period=90d`);
+  });
+
+  it("uses the pathname from usePathname so the URL is correct on any route", () => {
+    mockPush.mockClear();
+    render(<PeriodSelector value="90d" />);
+    fireEvent.click(screen.getByTestId("option-7d"));
+    expect(mockPush).toHaveBeenCalledWith(`${mockPathname}?period=7d`);
+  });
+});

--- a/components/insights/InsightsDashboardClient.tsx
+++ b/components/insights/InsightsDashboardClient.tsx
@@ -28,7 +28,7 @@ export function InsightsDashboardClient({
     data.activePlatform,
   );
 
-  if (data.postCount90d === 0) {
+  if (data.postCount === 0) {
     return (
       <EmptyState
         icon={<BarChart3Icon size={48} />}
@@ -57,7 +57,7 @@ export function InsightsDashboardClient({
       <RecommendationsPanel
         companyId={companyId}
         platform={activePlatform}
-        postCount={data.postCount90d}
+        postCount={data.postCount}
       />
       <BestContentSection
         bestPosts={data.bestPosts}

--- a/components/insights/common/PeriodSelector.tsx
+++ b/components/insights/common/PeriodSelector.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useRouter, usePathname } from "next/navigation";
+
 import { PillSelect, type PillSelectOption } from "@/components/ui/pill-select";
 
 const PERIOD_OPTIONS: PillSelectOption[] = [
@@ -9,16 +11,18 @@ const PERIOD_OPTIONS: PillSelectOption[] = [
 ];
 
 interface PeriodSelectorProps {
-  defaultValue?: string;
-  onChange?: (value: string) => void;
+  value?: string;
 }
 
-export function PeriodSelector({ defaultValue = "30d", onChange }: PeriodSelectorProps) {
+export function PeriodSelector({ value = "30d" }: PeriodSelectorProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+
   return (
     <PillSelect
       options={PERIOD_OPTIONS}
-      value={defaultValue}
-      onValueChange={onChange ?? (() => {})}
+      value={value}
+      onValueChange={(v) => router.push(`${pathname}?period=${v}`)}
     />
   );
 }

--- a/lib/__tests__/insights-dashboard-period.unit.test.ts
+++ b/lib/__tests__/insights-dashboard-period.unit.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase", () => ({ getServiceRoleClient: vi.fn() }));
+
+afterEach(() => vi.resetModules());
+
+// ---------------------------------------------------------------------------
+// Smart supabase mock: .gte("snapshot_date", cutoff) actually filters rows
+// so that different period params produce different postCount values.
+// ---------------------------------------------------------------------------
+
+type MockRow = Record<string, unknown>;
+
+function makeSmartSvc(tableData: Record<string, MockRow[]>) {
+  return {
+    from: (table: string) => {
+      let snapshotDateGte: string | null = null;
+      const rows: MockRow[] = tableData[table] ?? [];
+
+      function filtered(): MockRow[] {
+        if (!snapshotDateGte) return rows;
+        return rows.filter(
+          (r) =>
+            typeof r.snapshot_date === "string" &&
+            (r.snapshot_date as string) >= snapshotDateGte!,
+        );
+      }
+
+      const chain: Record<string, unknown> = {
+        select: vi.fn(() => chain),
+        in: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        is: vi.fn(() => chain),
+        order: vi.fn(() => chain),
+        neq: vi.fn(() => chain),
+        contains: vi.fn(() => chain),
+        lte: vi.fn(() => chain),
+        gt: vi.fn(() => chain),
+        gte: vi.fn((col: string, val: string) => {
+          if (col === "snapshot_date") snapshotDateGte = val;
+          return chain;
+        }),
+        limit: vi.fn(() => Promise.resolve({ data: filtered(), error: null })),
+        then: (
+          onFulfilled: (v: { data: MockRow[]; error: null }) => unknown,
+          onRejected?: (e: unknown) => unknown,
+        ) =>
+          Promise.resolve({ data: filtered(), error: null }).then(
+            onFulfilled,
+            onRejected,
+          ),
+      };
+
+      return chain;
+    },
+  };
+}
+
+function daysAgoDate(n: number): string {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+function makeSnapshot(daysAgo: number, bundlePostId: string): MockRow {
+  return {
+    id: bundlePostId,
+    bundle_post_id: bundlePostId,
+    profile_id: "profile-1",
+    platform: "linkedin_company",
+    posted_at: new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString(),
+    content: "test post",
+    impressions: 100,
+    likes: 5,
+    comments: 2,
+    shares: 1,
+    engagement_rate: 0.05,
+    snapshot_date: daysAgoDate(daysAgo),
+  };
+}
+
+// 2 unique posts within 7d, 4 within 30d, 6 within 90d
+const PERIOD_SNAPSHOTS: MockRow[] = [
+  makeSnapshot(2, "bp-1"),
+  makeSnapshot(5, "bp-2"),
+  makeSnapshot(10, "bp-3"),
+  makeSnapshot(20, "bp-4"),
+  makeSnapshot(50, "bp-5"),
+  makeSnapshot(80, "bp-6"),
+];
+
+const PROFILE_ROW: MockRow = { id: "profile-1" };
+
+describe("getInsightsDashboardData — period filtering", () => {
+  async function runWithPeriod(period: "7d" | "30d" | "90d") {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSmartSvc({
+        platform_social_profiles: [PROFILE_ROW],
+        social_post_analytics_snapshots: PERIOD_SNAPSHOTS,
+        ins_post_features: [],
+        social_connections: [],
+        social_post_master: [],
+        ins_ingest_log: [],
+      }) as never,
+    );
+    const { getInsightsDashboardData } = await import("@/lib/insights/dashboard");
+    return getInsightsDashboardData("company-1", period);
+  }
+
+  it("7d returns 2 posts (only snapshots within 7 days)", async () => {
+    const result = await runWithPeriod("7d");
+    expect(result.postCount).toBe(2);
+    expect(result.period).toBe("7d");
+  });
+
+  it("30d returns 4 posts (snapshots within 30 days)", async () => {
+    vi.resetModules();
+    const result = await runWithPeriod("30d");
+    expect(result.postCount).toBe(4);
+    expect(result.period).toBe("30d");
+  });
+
+  it("90d returns 6 posts (all snapshots within 90 days)", async () => {
+    vi.resetModules();
+    const result = await runWithPeriod("90d");
+    expect(result.postCount).toBe(6);
+    expect(result.period).toBe("90d");
+  });
+
+  it("7d postCount is less than 30d postCount", async () => {
+    vi.resetModules();
+    const r7 = await runWithPeriod("7d");
+    vi.resetModules();
+    const r30 = await runWithPeriod("30d");
+    expect(r7.postCount).toBeLessThan(r30.postCount);
+  });
+
+  it("30d postCount is less than 90d postCount", async () => {
+    vi.resetModules();
+    const r30 = await runWithPeriod("30d");
+    vi.resetModules();
+    const r90 = await runWithPeriod("90d");
+    expect(r30.postCount).toBeLessThan(r90.postCount);
+  });
+
+  it("defaults to 30d when period omitted", async () => {
+    vi.resetModules();
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSmartSvc({
+        platform_social_profiles: [PROFILE_ROW],
+        social_post_analytics_snapshots: PERIOD_SNAPSHOTS,
+        ins_post_features: [],
+        social_connections: [],
+        social_post_master: [],
+        ins_ingest_log: [],
+      }) as never,
+    );
+    const { getInsightsDashboardData } = await import("@/lib/insights/dashboard");
+    const result = await getInsightsDashboardData("company-1");
+    expect(result.period).toBe("30d");
+    expect(result.postCount).toBe(4);
+  });
+
+  it("returns empty dashboard with correct period when no profiles", async () => {
+    vi.resetModules();
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSmartSvc({
+        platform_social_profiles: [],
+        social_post_analytics_snapshots: PERIOD_SNAPSHOTS,
+        ins_post_features: [],
+        social_connections: [],
+        social_post_master: [],
+        ins_ingest_log: [],
+      }) as never,
+    );
+    const { getInsightsDashboardData } = await import("@/lib/insights/dashboard");
+    const result = await getInsightsDashboardData("company-1", "7d");
+    expect(result.postCount).toBe(0);
+    expect(result.period).toBe("7d");
+  });
+});

--- a/lib/insights/dashboard.ts
+++ b/lib/insights/dashboard.ts
@@ -14,8 +14,17 @@ import { getServiceRoleClient } from "@/lib/supabase";
 // here because this runs server-side after auth has been verified.
 // ---------------------------------------------------------------------------
 
+export type InsightsPeriod = "7d" | "30d" | "90d";
+
+export const PERIOD_DAYS: Record<InsightsPeriod, number> = {
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+};
+
 export interface InsightsDashboardData {
   companyId: string;
+  period: InsightsPeriod;
   dataFreshness: {
     lastIngestIso: string | null;
     isStale: boolean;
@@ -56,7 +65,7 @@ export interface InsightsDashboardData {
   } | null;
   xConnected: boolean;
   xMetrics: { published30d: number; scheduled: number } | null;
-  postCount90d: number;
+  postCount: number;
 }
 
 export interface BestPost {
@@ -75,16 +84,18 @@ export interface BestPost {
 
 export async function getInsightsDashboardData(
   companyId: string,
+  period: InsightsPeriod = "30d",
 ): Promise<InsightsDashboardData> {
   const svc = getServiceRoleClient();
 
   const now = new Date();
+  const periodDays = PERIOD_DAYS[period];
   const ago30 = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-  const ago90 = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+  const agoPeriod = new Date(now.getTime() - periodDays * 24 * 60 * 60 * 1000);
   const ago48h = new Date(now.getTime() - 48 * 60 * 60 * 1000);
 
   const ago30str = ago30.toISOString().slice(0, 10);
-  const ago90str = ago90.toISOString().slice(0, 10);
+  const agoPeriodStr = agoPeriod.toISOString().slice(0, 10);
 
   // Step 1: get profile IDs for this company
   const { data: profiles } = await svc
@@ -95,7 +106,7 @@ export async function getInsightsDashboardData(
   const profileIds: string[] = (profiles ?? []).map((p: { id: string }) => p.id);
 
   if (profileIds.length === 0) {
-    return emptyDashboard(companyId);
+    return emptyDashboard(companyId, period);
   }
 
   // Step 2: parallel queries
@@ -107,14 +118,14 @@ export async function getInsightsDashboardData(
     postMasterR,
     ingestLogR,
   ] = await Promise.all([
-    // All snapshots last 90 days for trend + best posts
+    // All snapshots within the selected period for trend + best posts
     svc
       .from("social_post_analytics_snapshots")
       .select(
         "id, bundle_post_id, profile_id, platform, posted_at, content, impressions, likes, comments, shares, engagement_rate, snapshot_date",
       )
       .in("profile_id", profileIds)
-      .gte("snapshot_date", ago90str)
+      .gte("snapshot_date", agoPeriodStr)
       .gte("impressions", 50)
       .order("snapshot_date", { ascending: false }),
 
@@ -130,7 +141,7 @@ export async function getInsightsDashboardData(
       .from("ins_post_features")
       .select("day_of_week, hour_of_day_utc, platform")
       .eq("company_id", companyId)
-      .gte("posted_at", ago90.toISOString()),
+      .gte("posted_at", agoPeriod.toISOString()),
 
     // Connection health
     svc
@@ -172,8 +183,8 @@ export async function getInsightsDashboardData(
     ? new Date(lastIngestIso) < ago48h
     : true;
 
-  // postCount90d: unique bundle_post_ids with a snapshot
-  const postCount90d = new Set(snapshots.map((s: { bundle_post_id: string }) => s.bundle_post_id)).size;
+  // postCount: unique bundle_post_ids with a snapshot in the selected period
+  const postCount = new Set(snapshots.map((s: { bundle_post_id: string }) => s.bundle_post_id)).size;
 
   // availableMetrics: check if columns are non-null in any snapshot
   const hasLikes = snapshots30d.some((s: { likes: number | null }) => s.likes !== null);
@@ -351,6 +362,7 @@ export async function getInsightsDashboardData(
 
   return {
     companyId,
+    period,
     dataFreshness: { lastIngestIso, isStale },
     kpis,
     availableMetrics,
@@ -363,7 +375,7 @@ export async function getInsightsDashboardData(
     sourceComparison,
     xConnected,
     xMetrics,
-    postCount90d,
+    postCount,
   };
 }
 
@@ -414,9 +426,10 @@ function snapshotToPost(s: SnapshotRow, source: "cap" | "composer"): BestPost {
   };
 }
 
-function emptyDashboard(companyId: string): InsightsDashboardData {
+function emptyDashboard(companyId: string, period: InsightsPeriod): InsightsDashboardData {
   return {
     companyId,
+    period,
     dataFreshness: { lastIngestIso: null, isStale: false },
     kpis: null,
     availableMetrics: {
@@ -435,6 +448,6 @@ function emptyDashboard(companyId: string): InsightsDashboardData {
     sourceComparison: null,
     xConnected: false,
     xMetrics: null,
-    postCount90d: 0,
+    postCount: 0,
   };
 }


### PR DESCRIPTION
## Summary

- `getInsightsDashboardData` now accepts `InsightsPeriod` param (`7d` | `30d` | `90d`, default `30d`). The hardcoded 90-day snapshot and heatmap windows are replaced with the selected period. KPI 30d window is unchanged (labels say 30d).
- `postCount90d` renamed to `postCount` on `InsightsDashboardData` — the count now reflects whatever window is active.
- `PeriodSelector` reads the current pathname via `usePathname` and calls `router.push(\`\${pathname}?period=\${v}\`)` on change — no more `() => {}` no-op.
- `/company/social/insights` parses `searchParams.period`, validates it against `['7d','30d','90d']`, defaults to `'30d'`, passes to both `getInsightsDashboardData` and `PeriodSelector value`.

## Tests added

- **L1** `lib/__tests__/insights-dashboard-period.unit.test.ts` — 7 tests. Smart supabase mock with date-aware filtering: verifies `postCount` = 2/4/6 for 7d/30d/90d windows; verifies `period` field echoed; verifies default '30d' when omitted; verifies empty dashboard path.
- **L4** `components/__tests__/PeriodSelector.test.tsx` — 6 tests. Verifies option rendering, value reflection via `data-value`/`data-selected`, `router.push` called with correct `?period=` URL for each option click, pathname from `usePathname` used correctly.

## Working analog

`useRouter` + `usePathname` push pattern: `components/nav/NavRailItem.tsx` — same `router.push(href)` wiring.

## Risks identified and mitigated

- **searchParams injection**: `period` validated against a closed enum before use; invalid values silently default to `'30d'`. No user input reaches the DB query unvalidated.
- **KPI label mismatch at 7d**: KPI cards say "30d" but the window is still 30d regardless of period — intentional. Trend chart, best posts, heatmap, and `postCount` all use the selected window. If the selected period is 7d, the 30d KPI query still pulls 30d data (separate query, separate cutoff). This is standard analytics dashboard behaviour.
- **postCount rename**: only referenced in `InsightsDashboardClient.tsx` (2 occurrences), `InsightsDashboardClient.test.tsx` (3 occurrences), and `dashboard.ts` itself. All updated. Typecheck confirms no remaining `postCount90d` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)