### PR TITLE
fix(social/composer): single-post fetch fails for posts visible on calendar

### DIFF
--- a/components/composer/composer-mount-v2.tsx
+++ b/components/composer/composer-mount-v2.tsx
@@ -23,6 +23,14 @@ import type { Connection, Draft, DraftState } from "@/lib/social/types";
 // ---------------------------------------------------------------------------
 
 // V1 social_post_drafts shape from GET /api/platform/social/drafts/[id].
+//
+// Two column layouts exist in production:
+//   V1 rows: content in draft_data.master_text, media in draft_data.media_refs,
+//            targets in draft_data.target_connection_ids.
+//   V2 rows: content/media/targets in top-level columns; draft_data may be {}.
+//
+// Rows created before the draft_data mirroring patch (PR #993 V2 write-path)
+// have draft_data: {} with populated top-level columns. The mapper handles both.
 interface V1DraftApiResponse {
   ok: boolean;
   data?: {
@@ -34,11 +42,15 @@ interface V1DraftApiResponse {
     // V2 drafts write scheduled_at at the top level; V1 drafts use draft_data.schedule
     scheduled_at?: string | null;
     last_publish_error?: { message?: string } | null;
+    // Top-level V2 columns — present on rows where draft_data is empty
+    media_urls?: string[] | null;
+    target_profiles?: Array<{ profile_id: string }> | null;
+    // draft_data fields are optional: V2 rows may have draft_data: {}
     draft_data: {
-      master_text: string;
-      media_refs: Array<{ url: string }>;
-      target_connection_ids: string[];
-      approval_required: boolean;
+      master_text?: string;
+      media_refs?: Array<{ url: string }>;
+      target_connection_ids?: string[];
+      approval_required?: boolean;
       schedule?: { date: string; times: string[] } | null;
     };
   };
@@ -70,15 +82,26 @@ export function mapV1ToV2Draft(d: NonNullable<V1DraftApiResponse["data"]>): Draf
     scheduled_at = `${s.date}T${time}:00Z`;
   }
 
+  // V2 rows created before the draft_data mirroring patch have draft_data: {} but
+  // populated top-level columns. Fall back in order: V1 draft_data → V2 top-level → empty.
+  const mediaUrls =
+    d.draft_data.media_refs?.map((r) => r.url) ??
+    d.media_urls ??
+    [];
+  const targetProfileIds =
+    d.draft_data.target_connection_ids ??
+    d.target_profiles?.map((p) => p.profile_id) ??
+    [];
+
   return {
     id: d.id,
     draft_version: d.draft_version,
     // V2 drafts write to the top-level content column; fall back to V1 draft_data.master_text
-    content: d.content ?? d.draft_data.master_text,
-    media_urls: d.draft_data.media_refs.map((r) => r.url),
-    target_profile_ids: d.draft_data.target_connection_ids,
+    content: d.content ?? d.draft_data.master_text ?? "",
+    media_urls: mediaUrls,
+    target_profile_ids: targetProfileIds,
     platform_variants: {},
-    approval_required: d.draft_data.approval_required,
+    approval_required: d.draft_data.approval_required ?? false,
     scheduled_at,
   };
 }

--- a/docs/briefs/ui-cleanup-2026-05-23/STATUS.md
+++ b/docs/briefs/ui-cleanup-2026-05-23/STATUS.md
@@ -1,0 +1,3 @@
+# UI Cleanup 2026-05-23 — Status
+
+<!-- Appended after each PR merges and deploys -->

--- a/lib/__tests__/composer-edit-mode.unit.test.ts
+++ b/lib/__tests__/composer-edit-mode.unit.test.ts
@@ -89,6 +89,43 @@ describe("mapV1ToV2Draft", () => {
     const result = mapV1ToV2Draft(d);
     expect(result.scheduled_at).toBe("2026-06-01T10:00:00Z");
   });
+
+  // Regression: V2 rows created before draft_data mirroring have draft_data: {}
+  // with data in top-level columns. Previously threw "Cannot read properties of
+  // undefined (reading 'map')" on draft_data.media_refs — bug fix: #fix/composer-load-scheduled-post
+  it("V2 row with empty draft_data falls back to top-level media_urls and target_profiles", () => {
+    const v2Row = {
+      id: "75701de0-4c4b-4146-831d-4f98069478ef",
+      draft_version: 1,
+      content: "this is a social media post",
+      scheduled_at: "2026-05-26T09:00:00+00:00",
+      state: "scheduled",
+      draft_data: {},
+      media_urls: ["https://example.com/img.gif"],
+      target_profiles: [{ profile_id: "1320da0c-a582-41dd-b158-fdf0bd542659" }],
+    };
+    // Must not throw
+    const result = mapV1ToV2Draft(v2Row);
+    expect(result.content).toBe("this is a social media post");
+    expect(result.media_urls).toEqual(["https://example.com/img.gif"]);
+    expect(result.target_profile_ids).toEqual(["1320da0c-a582-41dd-b158-fdf0bd542659"]);
+    expect(result.scheduled_at).toBe("2026-05-26T09:00:00+00:00");
+    expect(result.approval_required).toBe(false);
+  });
+
+  it("V2 row with empty draft_data and no top-level media returns empty arrays", () => {
+    const v2Row = {
+      id: "abc",
+      draft_version: 1,
+      content: "text only",
+      draft_data: {},
+    };
+    const result = mapV1ToV2Draft(v2Row);
+    expect(result.media_urls).toEqual([]);
+    expect(result.target_profile_ids).toEqual([]);
+    expect(result.approval_required).toBe(false);
+    expect(result.content).toBe("text only");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`mapV1ToV2Draft` (`components/composer/composer-mount-v2.tsx:78`) called `d.draft_data.media_refs.map(r => r.url)` unconditionally. For V2 rows created before the draft_data mirroring patch, `draft_data` is `{}` — `media_refs` is `undefined`. The `.map()` threw a TypeError, the Promise `.catch()` set `fetchError = true`, and the RC-2 "Couldn't load this post" error appeared.

**Working analog**: `content` already had this fallback: `d.content ?? d.draft_data.master_text`
**Diff**: `media_refs` and `target_connection_ids` had no fallback to top-level columns.
**Fix**: add `?.` optional-chaining + `??` fallback to `media_urls` (top-level) and `target_profiles` (top-level).

Repro post: `75701de0-4c4b-4146-831d-4f98069478ef` — `state: scheduled`, `draft_data: {}`, data in `media_urls`/`target_profiles`/`content`/`scheduled_at`.

## What changed

- `components/composer/composer-mount-v2.tsx`: Made `V1DraftApiResponse.data.draft_data.*` fields optional; added `media_urls?` and `target_profiles?` top-level fields; fixed `mapV1ToV2Draft` to fall back to top-level columns.
- `lib/__tests__/composer-edit-mode.unit.test.ts`: Two regression tests covering the exact production row shape and the empty draft_data + no media case.

## Breadth verification

Tested 3 scheduled post UUIDs on preview:
- `75701de0-4c4b-4146-831d-4f98069478ef` — the reported post (draft_data: {})
- Tested via additional rows with populated draft_data — both paths confirmed working

## Risks identified and mitigated

- **Write-path**: No change. The PATCH V2 handler already mirrors into draft_data (added in PR #993). Only the read-path mapping needed fixing.
- **No backfill required**: The mapper now reads top-level columns when draft_data fields absent, so existing rows work as-is.
- **Regression**: Two unit tests lock the fixed behaviour.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (2390 passed)
- [x] Regression test added for this >1-PR production bug
- [x] Working-analog block above
- [x] Risks identified and mitigated
- [x] PR is under 500 net lines