### PR TITLE
fix(composer): ai assist modal — filled Generate button + remove duplicate close

### DIFF
--- a/.github/workflows/button-migration-gates.yml
+++ b/.github/workflows/button-migration-gates.yml
@@ -67,3 +67,25 @@ jobs:
             fi
           done
           echo "✓ semantic colour tokens defined"
+
+      - name: Gate 6 — AI Generate button uses filled (default) variant
+        run: |
+          MATCHES=$(grep -n 'data-testid="ai-generate-button"' \
+            components/social/composer/ToolsRow.tsx || true)
+          if echo "$MATCHES" | grep -q 'variant='; then
+            echo "❌ FAIL: ai-generate-button has an explicit variant (should use default filled)"
+            echo "$MATCHES"
+            exit 1
+          fi
+          echo "✓ ai-generate-button uses default filled variant"
+
+      - name: Gate 7 — AI assist Dialog has exactly one close affordance (DialogContent built-in)
+        run: |
+          # AiPanel must NOT render its own close button alongside DialogContent's built-in one.
+          PANEL_BLOCK=$(awk '/function AiPanel/,/^}/' components/social/composer/ToolsRow.tsx)
+          COUNT=$(echo "$PANEL_BLOCK" | grep -c 'label="Close AI panel"\|data-testid="ai-close"' || true)
+          if [ "$COUNT" -gt 0 ]; then
+            echo "❌ FAIL: AiPanel renders $COUNT custom close button(s) — DialogContent already provides one"
+            exit 1
+          fi
+          echo "✓ AiPanel has no duplicate close button"

--- a/components/__tests__/ComposerEditorPrD.test.tsx
+++ b/components/__tests__/ComposerEditorPrD.test.tsx
@@ -411,7 +411,7 @@ describe("ToolsRow", () => {
       <ToolsRow companyId="co_1" onInsertText={() => undefined} onOpenMediaPicker={() => undefined} onAttachGif={() => undefined} />,
     );
     fireEvent.click(screen.getByRole("button", { name: /ai assistant/i }));
-    expect(screen.getByRole("button", { name: /close ai panel/i })).toBeTruthy();
+    expect(screen.getByTestId("ai-panel")).toBeTruthy();
     expect(screen.getByTestId("ai-generate-button")).toBeTruthy();
   });
 

--- a/components/social/composer/ToolsRow.tsx
+++ b/components/social/composer/ToolsRow.tsx
@@ -249,9 +249,6 @@ function AiPanel({
     <div className="space-y-3 rounded-xl border border-border bg-background p-4 shadow-md" data-testid="ai-panel">
       <div className="flex items-center justify-between">
         <p className="text-sm font-semibold">AI assistant</p>
-        <IconButton label="Close AI panel" onClick={onClose} className="h-6 w-6 text-muted-foreground hover:text-foreground">
-          <CloseIcon size={14} strokeWidth={1.75} aria-hidden />
-        </IconButton>
       </div>
       <textarea
         value={prompt}
@@ -332,7 +329,6 @@ function AiPanel({
             </p>
           )}
           <Button
-            variant="outline"
             size="xs"
             className="w-full"
             onClick={() => void generate()}

--- a/docs/briefs/ui-cleanup-2026-05-23/STATUS.md
+++ b/docs/briefs/ui-cleanup-2026-05-23/STATUS.md
@@ -1,3 +1,11 @@
 # UI Cleanup 2026-05-23 — Status
 
 <!-- Appended after each PR merges and deploys -->
+
+## Bug 1 — composer-load-scheduled-post
+
+- **PR**: #1022 `fix/composer-load-scheduled-post`
+- **Merge SHA**: `1ddd48645edaf4185f4e8519164d2b3bfbbfc4e4`
+- **Deploy**: production, 2026-05-23T23:08:40Z, state: success
+- **Root cause**: `mapV1ToV2Draft` called `d.draft_data.media_refs.map(...)` unconditionally; V2 rows with `draft_data: {}` threw TypeError, triggering the fetch-error UI ("Couldn't load this post").
+- **Fix**: Optional chaining on `draft_data.media_refs` + `target_connection_ids`; falls back to top-level `media_urls` / `target_profiles` columns for V2 rows.


### PR DESCRIPTION
## Summary

- **Bug 2a** — Generate button was `variant="outline"` (ghost border on white modal background, effectively invisible). Removed explicit variant so it uses the default filled emerald CTA.
- **Bug 2b** — `AiPanel` rendered its own `<IconButton label="Close AI panel">` inside the Dialog. `DialogContent` (shadcn/Radix) always renders a built-in close button with correct ARIA role and Escape key handling. Removed the duplicate custom button.
- **Gate 6 + Gate 7** added to `button-migration-gates.yml` to prevent both regressions.

## Working analog

**Working analog**: `components/social/composer/ToolsRow.tsx:308-314` — "Use this text" `Button` (no explicit variant, default filled CTA); `DialogContent` in `components/ui/dialog.tsx:30-33` — built-in `DialogPrimitive.Close` X button with `sr-only` label.

**Diff**:
- Generate button had `variant="outline"` making it transparent on white.
- AiPanel duplicated a close affordance that `DialogContent` already provides.

**Fix**: Removed `variant="outline"` from Generate button; removed `<IconButton label="Close AI panel">` block from `AiPanel` entirely.

## Visual proof (before → after)

**Before**: Generate button renders as a ghost outline — indistinguishable from the white modal background. Two stacked X close icons top-right.

**After**: Generate button uses filled emerald CTA variant. Single X close button (Radix built-in, top-right of dialog chrome).

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (2388 passed)
- [x] Gate 6 + Gate 7 added to button-migration-gates.yml and verified passing locally
- [x] No new silent catches (`git diff origin/main...HEAD | grep -E 'catch\s*\([^)]*\)\s*{\s*}'` → empty)
- [x] PR is under 500 net lines

## Risks identified and mitigated

- **Removing close button from AiPanel**: Radix `DialogContent` renders a built-in close button with `aria-label="Close"` and fires on Escape key. Removing the custom duplicate restores single-affordance UX and correct accessibility without any loss of function. Verified by reading `components/ui/dialog.tsx`.
- **Removing `variant="outline"` from Generate button**: No visual side-effect beyond fixing the invisibility bug. The default variant is the canonical filled emerald CTA — same as "Use this text" and all other primary actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)