### PR TITLE
chore(ci): rename SUPABASE_DB_PASSWORD secret to STAGING_SUPABASE_DB_PASSWORD

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -11,10 +11,10 @@ name: Deploy Supabase migrations
 #   SUPABASE_ACCESS_TOKEN — personal access token from
 #                           https://supabase.com/dashboard/account/tokens
 #                           (scope: "Link a project" + "Access the API").
-#   SUPABASE_DB_PASSWORD  — direct-connection Postgres password from
-#                           Project Settings → Database → Connection
-#                           string. Required by `supabase db push` to
-#                           open the management tunnel.
+#   STAGING_SUPABASE_DB_PASSWORD  — direct-connection Postgres password from
+#                                   Project Settings → Database → Connection
+#                                   string. Required by `supabase db push` to
+#                                   open the management tunnel.
 #
 # Without these three secrets the job fails at the first `supabase`
 # command — that is intentional. Production migrations are a privileged
@@ -83,7 +83,7 @@ jobs:
       - name: Verify required secrets are set
         run: |
           missing=0
-          for var in SUPABASE_PROJECT_REF SUPABASE_ACCESS_TOKEN SUPABASE_DB_PASSWORD; do
+          for var in SUPABASE_PROJECT_REF SUPABASE_ACCESS_TOKEN STAGING_SUPABASE_DB_PASSWORD; do
             if [ -z "${!var:-}" ]; then
               echo "::error::Required secret $var is not set."
               missing=1
@@ -95,7 +95,7 @@ jobs:
           fi
         env:
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          STAGING_SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
 
       - name: Link to production project
         run: supabase link --project-ref "${{ secrets.SUPABASE_PROJECT_REF }}"
@@ -106,7 +106,7 @@ jobs:
       - name: Repair flagged versions (mark reverted — clear tracking row)
         if: github.event_name == 'workflow_dispatch' && inputs.repair_versions_reverted != ''
         env:
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
         run: |
           set -euo pipefail
           for v in ${{ inputs.repair_versions_reverted }}; do
@@ -117,7 +117,7 @@ jobs:
       - name: Repair flagged versions (mark applied without re-running SQL)
         if: github.event_name == 'workflow_dispatch' && inputs.repair_versions_applied != ''
         env:
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
         run: |
           set -euo pipefail
           for v in ${{ inputs.repair_versions_applied }}; do
@@ -127,7 +127,7 @@ jobs:
 
       - name: Push pending migrations
         env:
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
         # --include-all ensures no migrations are skipped when the
         # production schema has drifted from the linked state (e.g. a
         # row was manually inserted but the migration files themselves

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ three repository secrets:
 | ---------------------- | -------------------------------------------------------------------------------------------------------- |
 | `SUPABASE_PROJECT_REF` | Project Settings → General → Reference ID.                                                               |
 | `SUPABASE_ACCESS_TOKEN`| [Account → Access Tokens](https://supabase.com/dashboard/account/tokens). Scope: link + API access.      |
-| `SUPABASE_DB_PASSWORD` | Project Settings → Database → Connection string (the `password` component of the direct-connection URI). |
+| `STAGING_SUPABASE_DB_PASSWORD` | Project Settings → Database → Connection string (the `password` component of the direct-connection URI). |
 
 Without these secrets the workflow fails at the "Verify required
 secrets" step. The production Environment (Settings → Environments →


### PR DESCRIPTION
## Summary
- Renames the GitHub Actions secret reference from `SUPABASE_DB_PASSWORD` → `STAGING_SUPABASE_DB_PASSWORD` in `deploy-migrations.yml` (header comment, verification loop, and all step env blocks)
- Updates `CONTRIBUTING.md` to document the new secret name
- The supabase CLI env var (`SUPABASE_DB_PASSWORD:` on the left-hand side of env blocks) is unchanged — the CLI requires that specific name

## What to add in GitHub Actions
After merge: **Settings → Secrets and variables → Actions → New repository secret**
- Name: `STAGING_SUPABASE_DB_PASSWORD`
- Value: Supabase DB password from Project Settings → Database → Connection string

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] No migration changes — no test layers required
- [x] PR is under 500 net lines

## Risks identified and mitigated
- **Risk**: Renaming the secret reference means the workflow fails until the new secret is added — but the workflow was already failing with the old name. Net change: same failure until the secret is populated.
- **Mitigation**: Steven adds the secret immediately after merge per the instruction above.