### PR TITLE
chore(insights): document INSIGHTS_PRIORS_VIA_API in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -179,6 +179,11 @@ FEATURE_PATH_B_PUBLISH_GATE=
 # inline form. Rollout: super_admin → 10% → 50% → 100% per spec §10.
 FEATURE_COMPOSER_V2=
 
+# Insights — use richer API-based performance priors for CAP post generation
+# (includes recommendations, edit preferences, dismissed types).
+# Default: unset / false (uses direct DB query: top-3 posts by engagement only).
+# Enable in production once the Insights module has ≥20 posts of history per company.
+INSIGHTS_PRIORS_VIA_API=
 
 # -----------------------------------------------------------------------------
 # Logging + observability (OPTIONAL — degrades gracefully when unset)


### PR DESCRIPTION
## Summary
- Adds `INSIGHTS_PRIORS_VIA_API=` to `.env.example` in the feature-flags section
- Flag already exists in `lib/cap/generation/post-generator.ts:18` but had no env template entry
- When `true`, CAP uses the richer `/api/insights/generation-priors` API (recommendations + edit preferences + dismissed types) instead of direct DB top-3 posts query

## When to enable in production
Set `INSIGHTS_PRIORS_VIA_API=true` in Vercel once companies have ≥20 posts of Insights history (the minimum for meaningful recommendations). Currently unset = safe default (direct DB path).

## Pre-PR checklist
- [x] Lint, typecheck, build all green (env.example change only — no code paths affected)
- [x] No test changes required
- [x] PR is under 500 net lines

## Risks identified and mitigated
- No risk: documentation-only change, no runtime behaviour change