### PR TITLE
fix(uat): remove -f flag from health check curl

### DIFF
--- a/.github/workflows/uat-harness.yml
+++ b/.github/workflows/uat-harness.yml
@@ -197,7 +197,7 @@ jobs:
         run: |
           echo "Waiting for staging deployment to be ready..."
           for i in $(seq 1 18); do
-            STATUS=$(curl -sf "$UAT_BASE_URL/api/health" -o /dev/null -w "%{http_code}" 2>/dev/null || echo "000")
+            STATUS=$(curl -s "$UAT_BASE_URL/api/health" -o /dev/null -w "%{http_code}" 2>/dev/null || echo "000")
             if [ "$STATUS" = "200" ]; then
               echo "✓ Staging is responding (HTTP $STATUS)"
               exit 0


### PR DESCRIPTION
Fixes the health check step in `uat-full` that produced concatenated status strings like `401000` instead of `401`.

## Root cause
`curl -sf` — the `-f` flag causes curl to exit nonzero on 4xx responses, which triggers the `|| echo "000"` fallback **inside the same subshell**, concatenating both outputs into the `STATUS` variable.

## Fix
Remove `-f`; `curl -s` always exits 0 so `%{http_code}` is the only output captured.

**Working analog**: n/a — this is a shell quoting/exit-code bug in a workflow step, no codebase analog.

**Risks identified and mitigated**: CI-only change; no production code path affected.

- [x] Single-line workflow fix
- [x] No tests required (workflow health check step)