### PR TITLE
fix(seed): grant admin role to UAT user in opollo_users

### DIFF
--- a/scripts/seed-uat-staging.ts
+++ b/scripts/seed-uat-staging.ts
@@ -137,7 +137,32 @@ async function main() {
   }
 
   // -------------------------------------------------------------------------
-  // 2. platform_users row (extended profile)
+  // 2. opollo_users row (platform admin gate)
+  //
+  // The /admin/* layout gates on opollo_users.role being 'super_admin' or
+  // 'admin' (lib/auth.ts:214 + lib/admin-gate.ts:55). Without an
+  // opollo_users row, the UAT ghost user gets a redirect-loop trying to
+  // visit /admin/sites etc. The admin specs cover this surface, so the
+  // ghost user must hold 'admin' (we deliberately stop short of
+  // 'super_admin' — the UAT ghost should not unlock the DebugFooter).
+  // -------------------------------------------------------------------------
+
+  log("Upserting opollo_users row (admin role)...");
+
+  const { error: ouError } = await supabase.from("opollo_users").upsert(
+    {
+      id: uatUserId,
+      email: uatEmail,
+      display_name: "UAT Bot",
+      role: "admin",
+    },
+    { onConflict: "id" },
+  );
+  if (ouError) fail(`Failed to upsert opollo_users: ${ouError.message}`);
+  log("  opollo_users OK (role: admin)");
+
+  // -------------------------------------------------------------------------
+  // 3. platform_users row (extended profile)
   // -------------------------------------------------------------------------
 
   log("Upserting platform_users row...");
@@ -442,7 +467,8 @@ async function main() {
   log("=== Seed complete ===");
   log(`  Auth user:    ${uatEmail} (${uatUserId})`);
   log(`  Company:      ${UAT_COMPANY_NAME} (${uatCompanyId})`);
-  log(`  Role:         company_admin`);
+  log(`  Platform role: admin (opollo_users)`);
+  log(`  Company role:  admin (platform_company_users)`);
   log(`  Connections:  ${connections.length} (LinkedIn healthy, Facebook auth_required, X healthy)`);
   log(`  Drafts:       ${insertedDrafts?.length ?? 0} (1 draft, 2 scheduled, 1 publishing, 1 published)`);
   log(`  Images:       ${insertedImages?.length ?? 0}`);


### PR DESCRIPTION
## Why
UAT harness run [#26375514633](https://github.com/opollo5/opollo-site-builder/actions/runs/26375514633) surfaced 6 admin specs failing with \`ERR_TOO_MANY_REDIRECTS\`. Root cause traced via:

- \`app/(platform)/admin/layout.tsx:14\` → calls \`checkAdminAccess()\`
- \`lib/admin-gate.ts:55\` → \`ADMIN_ROLES = ['super_admin', 'admin']\`
- \`lib/auth.ts:214\` → \`getCurrentUser\` reads \`role\` from \`opollo_users\`, not \`platform_company_users\`

The UAT seed script only populated \`platform_users\` and \`platform_company_users\` (per-company role). It never inserted an \`opollo_users\` row, so \`getCurrentUser\` returned \`null\` and the admin gate redirected to \`/login\` — which, with an authenticated session, looped.

Closes #1040.

## What
Adds a step in \`scripts/seed-uat-staging.ts\` that upserts the UAT ghost user into \`opollo_users\` with \`role: 'admin'\` (NOT \`super_admin\` — that would unlock the DebugFooter, which we don't want for the harness).

## Verification

Ran the updated seed against staging Supabase locally:
\`\`\`
[SEED] Upserting opollo_users row (admin role)...
[SEED]   opollo_users OK (role: admin)
...
[SEED] === Seed complete ===
[SEED]   Platform role: admin (opollo_users)
[SEED]   Company role:  admin (platform_company_users)
[SEED]   Connections:  3 (LinkedIn healthy, Facebook auth_required, X healthy)
\`\`\`

DB verification post-seed (service-role queries):
\`\`\`
opollo_users:        { role: 'admin' }                  ← was missing entirely
social_connections:  3 rows                              ← seed was already fine
platform_social_profiles: 1 default                      ← trigger 0119 fired
\`\`\`

## Note on connections (Issue #1043)

The original PR brief expected connections seed to be broken. Investigation showed it was NOT — the 3 connections are present and render in the connections-list-wrapper. The 3 connections specs fail because of a Playwright **strict-mode multi-selector violation** in \`e2e/uat/connections.spec.ts\` (the OR-selector \`[data-testid="connections-table"], [data-testid="connections-list-wrapper"]\` matches both elements simultaneously). That's a test-code bug and is being addressed in the next PR of this cleanup series.

## Working analog
\`scripts/global-setup.ts\` and similar test-prep utilities seed \`opollo_users\` directly — same upsert pattern.

## Risks identified and mitigated
- **Wrong role granted** — chose \`admin\` not \`super_admin\` so the UAT user can't surface DebugFooter / super-admin-only routes.
- **Idempotency** — upsert with \`onConflict: 'id'\` matches the rest of the seed; rerunning is a no-op.
- **Production exposure** — seed retains the hard project-ref guard at \`getEnv()\`; will refuse to run if \`SUPABASE_URL\` doesn't contain the staging project ref.

## Pre-PR checklist
- [x] Single-file change to seed script; lint/typecheck untouched
- [x] Seed verified end-to-end against staging Supabase
- [x] DB rows confirmed via service-role read
- [x] Risks section above