### PR TITLE
fix(uat): test-code cleanup — calendar, connections, sign-out testid

### DIFF
--- a/components/nav/nav-shell-client.tsx
+++ b/components/nav/nav-shell-client.tsx
@@ -366,7 +366,7 @@ function MobileNavContent({
           <form action="/logout" method="POST">
             <button
               type="submit"
-              data-testid="nav-sign-out"
+              data-testid="nav-sign-out-mobile"
               className="flex w-full items-center gap-3 rounded-md px-3 py-2.5 text-sm text-destructive hover:bg-destructive/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-gr"
             >
               Sign out

--- a/e2e/uat/calendar.spec.ts
+++ b/e2e/uat/calendar.spec.ts
@@ -26,9 +26,8 @@ test.describe("P0 — Calendar", () => {
     await expect(calendarShell).toBeVisible({ timeout: 15_000 });
     await page.screenshot({ path: "test-results/uat/calendar/grid-loaded.png" });
 
-    // Should have 7 columns (Mon–Sun) worth of cells
+    // Calendar renders 4-6 weeks of cells depending on month layout.
     const cells = page.locator('[data-testid="calendar-dnd-cell"]');
-    await expect(cells).toHaveCount(expect.any(Number) as never);
     const count = await cells.count();
     expect(count).toBeGreaterThanOrEqual(28); // at least 4 weeks
     expect(count).toBeLessThanOrEqual(42);   // at most 6 weeks

--- a/e2e/uat/connections.spec.ts
+++ b/e2e/uat/connections.spec.ts
@@ -24,9 +24,7 @@ test.describe("P0 — Connections", () => {
     page,
   }) => {
     // Wait for connections to load
-    const table = page.locator(
-      '[data-testid="connections-table"], [data-testid="connections-list-wrapper"]',
-    );
+    const table = page.locator('[data-testid="connections-list-wrapper"]');
     await expect(table).toBeVisible({ timeout: 15_000 });
     await page.screenshot({ path: "test-results/uat/connections/list-loaded.png" });
 
@@ -38,9 +36,7 @@ test.describe("P0 — Connections", () => {
   });
 
   test("status pills render per connection state", async ({ page }) => {
-    const table = page.locator(
-      '[data-testid="connections-table"], [data-testid="connections-list-wrapper"]',
-    );
+    const table = page.locator('[data-testid="connections-list-wrapper"]');
     await expect(table).toBeVisible({ timeout: 15_000 });
     await page.screenshot({ path: "test-results/uat/connections/status-pills.png" });
 


### PR DESCRIPTION
## Why
UAT harness run [#26375514633](https://github.com/opollo5/opollo-site-builder/actions/runs/26375514633) had 4 specs failing for test-code reasons (not platform bugs). This PR clears them so the next run only shows real failures.

Closes #1042 (sign-out testid).
Resolves the connections-spec strict-mode hits (the seed data was already correct — see also PR #1044).

## What

### 1. \`e2e/uat/calendar.spec.ts:24\` — toHaveCount type error
\`\`\`diff
- await expect(cells).toHaveCount(expect.any(Number) as never);
\`\`\`
The line was a no-op cast (rejected by Playwright at runtime: \`expectedNumber: expected float, got object\`). The next two lines already assert the count is between 28-42 — the right check. Removed the broken assertion.

### 2. \`e2e/uat/connections.spec.ts\` — strict-mode multi-selector violation
\`\`\`diff
- const table = page.locator('[data-testid="connections-table"], [data-testid="connections-list-wrapper"]');
+ const table = page.locator('[data-testid="connections-list-wrapper"]');
\`\`\`
The OR-selector matched **both** \`connections-list-wrapper\` (outer) AND \`connections-table\` (inner) — Playwright strict mode failed. Scoping to just the outer wrapper is correct: the inner table is only rendered when rows exist, and the spec asserts row count separately.

Page-snapshot evidence (from failed test artifact) confirmed both elements are present, so the seed data is fine. This is purely a spec selector bug.

### 3. \`components/nav/nav-shell-client.tsx:369\` — duplicate sign-out testid
Both the desktop primary-nav (\`primary-nav.tsx:213\`, visible) and the mobile drawer (\`nav-shell-client.tsx:369\`, hidden on desktop) used \`data-testid=\"nav-sign-out\"\`. The spec did \`.first()\` which picked the hidden mobile one → \"unexpected value 'hidden'\" after 19 resolutions.

Renamed the mobile drawer button to \`nav-sign-out-mobile\` so the desktop variant is now uniquely addressable as \`nav-sign-out\". No spec change needed.

## Working analog
Other specs already use unique-per-variant testids (e.g., \`mobile-nav-button\` on \`nav-shell-client.tsx:151\` for the mobile burger). Same naming convention applied here.

## Risks identified and mitigated
- **Mobile spec that targets sign-out**: none exists (verified via \`grep -rn 'nav-sign-out' e2e/\` — only the desktop auth.spec.ts references it). Safe to rename.
- **Calendar count assertion weakened**: no — the removed line was a no-op (rejected at runtime). The 28-42 range check remains.

## Pre-PR checklist
- [x] Lint/typecheck pass
- [x] No platform behaviour change
- [x] Spec selectors traced to actual DOM state via failed-test artifacts