### PR TITLE
test(uat): regen-baselines — capture initial visual regression baselines

### DIFF
--- a/docs/uat-harness/visual-baselines.md
+++ b/docs/uat-harness/visual-baselines.md
@@ -1,0 +1,65 @@
+# UAT Visual Regression Baselines
+
+`e2e/uat/visual.spec.ts` uses Playwright's `toHaveScreenshot()` to detect visual regressions. Baselines live in `e2e/uat/__screenshots__/` and are platform-specific (Linux only — Playwright's snapshot path template appends `-linux` to disambiguate).
+
+## When baselines are missing
+
+A run with a missing baseline reports:
+
+```
+Error: A snapshot doesn't exist at e2e/uat/__screenshots__/visual.spec.ts/<name>-linux.png, writing actual.
+```
+
+This is *not* a test failure in the bug sense — it's the first-run snapshot capture. The spec failed because Playwright refuses to silently accept new baselines.
+
+## How to regenerate (auto via CI)
+
+The `uat-harness.yml` workflow has a regen trigger keyed off the commit message. If the last commit on `staging` (or `main`) contains the phrase `regen-baselines`, the workflow runs Playwright with `--update-snapshots` and auto-commits the new screenshots back to the branch as a `[skip ci]` commit.
+
+Steps:
+
+1. Open a PR against `staging` that touches anything under `e2e/uat/**` or `.github/workflows/uat-harness.yml` (so the workflow's path filter fires on push).
+2. Make sure the **squash-merge commit subject** contains `regen-baselines` — e.g. `test(uat): regen-baselines for composer overlay`. GitHub uses the PR title for squash-merge commits by default; rename the PR before merging if needed.
+3. Merge.
+4. The `uat-full` job in the workflow detects the trigger, runs Playwright with `--update-snapshots`, and pushes a follow-up commit `chore(uat): update visual regression baselines [skip ci]` to staging.
+5. Wait ~10 min for the workflow + auto-commit to complete; pull staging and confirm `e2e/uat/__screenshots__/visual.spec.ts/*.png` exist.
+
+## How to regenerate (manual, when CI mechanism fails)
+
+You need:
+- `STAGING_UAT_SECRET` — bearer token (set in Vercel staging Preview env + GitHub Actions secret; manual capture requires extracting from Vercel Dashboard since `vercel env pull` masks sensitive values).
+- `VERCEL_BYPASS_SECRET` — Vercel protection bypass token.
+
+```bash
+export STAGING_UAT_SECRET=<value>
+export VERCEL_BYPASS_SECRET=<value>
+export UAT_BASE_URL=https://opollo-site-builder-git-staging-opollo5.vercel.app
+
+# Run Playwright with --update-snapshots against staging
+npx playwright test e2e/uat/visual.spec.ts \
+  --config playwright.uat.config.ts \
+  --update-snapshots
+
+# Stage and commit the new baselines
+git add e2e/uat/__screenshots__/
+git commit -m "test(uat): refresh visual baselines (manual)"
+```
+
+## When a baseline diff is expected (intentional UI change)
+
+After a PR that intentionally changes a visually-regressed surface (e.g., calendar grid layout):
+
+1. Add `regen-baselines` to the merge commit subject. The workflow refreshes baselines as part of the merge.
+2. Inspect the diff in the follow-up `[skip ci]` commit — if the new screenshots show a broken UI, revert and fix the underlying change.
+3. Never edit baseline PNGs by hand. Always regenerate from the live staging deployment.
+
+## Baselines are platform-specific
+
+`playwright.uat.config.ts` sets:
+
+```ts
+snapshotPathTemplate:
+  "{testDir}/__screenshots__/{testFilePath}/{arg}-linux{ext}",
+```
+
+Baselines captured on macOS/Windows will not match the Linux CI runner. Always regenerate via CI, never from a local non-Linux machine.

--- a/e2e/uat/__screenshots__/README.md
+++ b/e2e/uat/__screenshots__/README.md
@@ -1,0 +1,1 @@
+# Baseline screenshots are committed here by the uat-harness.yml workflow when a commit message contains 'regen-baselines'. See docs/uat-harness/visual-baselines.md.


### PR DESCRIPTION
## Why
\`e2e/uat/visual.spec.ts\` has been failing since first ship because no baselines exist in \`e2e/uat/__screenshots__/\`. Playwright responds with \"A snapshot doesn't exist… writing actual\" and the spec counts as a fail.

This PR triggers the \`uat-harness.yml\` workflow's built-in \`regen-baselines\` mode to capture and commit the initial baselines.

## What
- Adds \`docs/uat-harness/visual-baselines.md\` documenting the regen process (CI auto-commit path + manual fallback).
- Adds an \`e2e/uat/__screenshots__/README.md\` so the screenshots directory exists in the tree (the workflow path filter requires \`e2e/uat/**\` to be touched).
- **Squash-merge subject MUST contain \`regen-baselines\`** so the workflow detects the trigger at \`.github/workflows/uat-harness.yml:235\` and re-runs Playwright with \`--update-snapshots\`. The PR title already includes it — leave it intact when merging.

## Trigger mechanism
\`\`\`yaml
# .github/workflows/uat-harness.yml
- name: Check for regen-baselines commit message
  if: git log -1 --format=\"%s\" | grep -q \"regen-baselines\"
  → sets UPDATE=--update-snapshots

- name: Commit updated baselines (regen-baselines only)
  if: steps.baselines.outputs.update != ''
  → commits e2e/uat/__screenshots__/ back to staging
\`\`\`

## Expected post-merge effect
1. Squash-merge commit lands on \`staging\` with subject \`test(uat): regen-baselines — capture initial visual regression baselines\`.
2. Workflow's push-trigger fires (path filter \`e2e/uat/**\` matched).
3. \`uat-full\` job runs Playwright with \`--update-snapshots\`.
4. New PNG baselines committed back to \`staging\` as \`chore(uat): update visual regression baselines [skip ci]\`.
5. The 4 visual specs that previously failed with \"snapshot doesn't exist\" now have baselines and run as proper regression checks.

## Risks
- **Captured baseline shows broken UI**: each baseline gets inspected post-commit. If any baseline shows a redirect-loop page or empty state, revert the auto-commit and investigate.
- **Captured baseline includes auth-loop redirect**: PR #1044 (admin role) and the \`SUPABASE_ANON_KEY\` fix landed before this PR, so admin pages should render correctly now. Confirmed pre-merge with the staging DB queries in #1044.

## Pre-PR checklist
- [x] Docs added explaining the workflow
- [x] Path filter touched (\`e2e/uat/**\`)
- [x] PR title contains the trigger phrase