### PR TITLE
test(uat): fix timeout specs — Media Library + save-as-draft selectors

### DIFF
--- a/e2e/uat/composer.spec.ts
+++ b/e2e/uat/composer.spec.ts
@@ -118,17 +118,12 @@ test.describe("P0 — Social composer", () => {
     const overlay = page.locator('[data-testid="composer-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 10_000 });
 
-    // Open media picker — look for an attach/media button in the toolbar
-    const mediaBtn = page.locator('[data-testid="composer-tool-media"], [aria-label*="media"], [aria-label*="image"]').first();
-    if ((await mediaBtn.count()) === 0) {
-      // Try the attach button
-      const attachBtn = page.locator('[data-testid="composer-attach"]').first();
-      await expect(attachBtn).toBeVisible({ timeout: 5_000 });
-      await attachBtn.click();
-    } else {
-      await expect(mediaBtn).toBeVisible();
-      await mediaBtn.click();
-    }
+    // Open media picker via the dedicated toolbar button.
+    // (Previous loose selector `[aria-label*="media"]` matched a
+    // decorative "has media" indicator SVG on post chips.)
+    const mediaBtn = page.locator('[data-testid="composer-tool-media"]');
+    await expect(mediaBtn).toBeVisible({ timeout: 5_000 });
+    await mediaBtn.click();
 
     await page.screenshot({ path: "test-results/uat/composer/media-picker-opened.png" });
 
@@ -229,6 +224,13 @@ test.describe("P0 — Social composer", () => {
     const textarea = overlay.locator("textarea, [contenteditable]").first();
     await textarea.fill(draftText);
 
+    // Select at least one target profile — the submit button stays
+    // disabled until both content AND target_profile_ids.length > 0
+    // (see ComposerOverlay.tsx isSubmitDisabled).
+    const firstProfileChip = page.locator('[data-testid^="profile-chip-"]').first();
+    await expect(firstProfileChip).toBeVisible({ timeout: 5_000 });
+    await firstProfileChip.click();
+
     // Click Save as draft (look for draft tab/button in scheduling card)
     const draftTab = page.locator('[role="tablist"] [role="tab"]').filter({ hasText: /draft/i });
     if ((await draftTab.count()) > 0) {
@@ -236,7 +238,7 @@ test.describe("P0 — Social composer", () => {
     }
 
     const submitBtn = page.locator('[data-testid="composer-submit"]');
-    await expect(submitBtn).toBeVisible();
+    await expect(submitBtn).toBeEnabled({ timeout: 5_000 });
     await submitBtn.click();
 
     await page.screenshot({ path: "test-results/uat/composer/draft-saved.png" });


### PR DESCRIPTION
## Why
2 specs in [run #26375514633](https://github.com/opollo5/opollo-site-builder/actions/runs/26375514633) hit the 45s timeout without asserting. Investigation categorised both as **(b) wrong selector**, not real platform bugs or environmental slowness.

## What

### 1. \`composer.spec.ts:114\` — Media Library tab shows images (PR #1024 regression)

**Symptom:** \`locator.click: Test timeout of 45000ms exceeded\`
**Trace evidence:** selector resolved to a decorative \`<svg aria-label=\"has media\">\` inside a post chip — pointer-event-blocked by the composer overlay subtree, so click retries forever.

**Root cause:** The OR-selector \`[data-testid=\"composer-tool-media\"], [aria-label*=\"media\"], [aria-label*=\"image\"]\` was too loose. The dedicated testid exists at \`components/social/composer/ToolsRow.tsx:527\`; the aria-label fallbacks aren't needed.

**Fix:** Drop the loose fallback selectors. Use \`[data-testid=\"composer-tool-media\"]\` only.

### 2. \`composer.spec.ts:219\` — save as draft → post appears

**Symptom:** \`locator.click: Test timeout\` — \`composer-submit\` button stays \`disabled\` indefinitely.

**Root cause:** \`ComposerOverlay.tsx:450\` gates submit on \`draft.target_profile_ids.length === 0 || draft.content.trim().length === 0\`. The spec filled the textarea but never selected a target profile, so the button stayed disabled.

**Fix:** Insert a target-selection step using \`[data-testid^=\"profile-chip-\"]\` (defined at \`components/social/profile-chip.tsx:85\`). Also use \`toBeEnabled\` instead of \`toBeVisible\` for the submit assertion to fail fast if the button is still disabled.

## Working analog
\`components/social/composer/ProfileSelector.tsx:42\` is the canonical target-selection surface; this is the same chip-click flow a real user follows. The spec now matches that user flow.

## Risks identified and mitigated
- **Other target-selection flows differ?** No — \`ProfileSelector\` is the single source of truth (one usage in \`ComposerOverlay.tsx\`).
- **No profile chips on staging?** UAT seed has 3 connections + the default platform_social_profile (PR #1044 verified). The composer's available list is non-empty.

## Pre-PR checklist
- [x] Lint/typecheck pass
- [x] Both specs' failure traces analysed
- [x] Real bugs ruled out (button enablement logic is intentional)