### PR TITLE
test(uat): admin-nav network diagnostic + #1049 investigation doc

### DIFF
--- a/docs/investigations/admin-nav-hanging-2026-05-25.md
+++ b/docs/investigations/admin-nav-hanging-2026-05-25.md
@@ -1,0 +1,131 @@
+# Investigation — `networkidle` never settles on staging admin nav
+
+**Date:** 2026-05-25
+**Issue:** [#1049](https://github.com/opollo5/opollo-site-builder/issues/1049)
+**Status:** Part B (spec migration in PR #1050) sufficient to unblock harness. Part A (root cause) documented here, fix deferred.
+
+## What happened
+
+After PR #1044 granted the UAT ghost user `opollo_users.role = 'admin'`, the admin nav rail rendered for the first time. The harness regressed from 22 → 13 passes. Every spec using `page.waitForLoadState('networkidle')` timed out at 45s.
+
+## Evidence
+
+### Playwright trace from the failing composer spec ([run #26378861696](https://github.com/opollo5/opollo-site-builder/actions/runs/26378861696))
+
+Trace file: `test-results/uat/composer-P0-—-Social-compo-63cea-mposer-from-New-post-button-chromium/trace.zip`.
+
+Parsed `0-trace.network`:
+- **54 total requests captured**
+- **0 pending requests** (all responded with completion times <650ms)
+- Last captured event at **t=3058ms**
+- Test ran for **45,000ms** (timeout)
+- Gap of **~42 seconds** with zero captured HTTP traffic, yet `networkidle` never fired
+
+Playwright's resource-snapshot trace events capture HTTP/XHR/fetch but **not WebSocket frames** (those are emitted as separate events that aren't in this trace's `.network` file).
+
+### Bundled WebSocket clients in the deployed code
+
+```
+grep -rn "WebSocket\|new Pusher\|new Ably\|SSE\|EventSource" \
+  --include="*.ts" --include="*.tsx" components/ app/ lib/
+```
+
+Returns **zero matches** in deployed code. So no first-party WebSocket clients are at fault.
+
+### Third-party scripts loaded on every preview page
+
+From the trace network log, all preview deployments load:
+- `https://vercel.live/_next-live/feedback/feedback.js`
+- `https://vercel.live/_next-live/feedback/feedback.html` (iframe; blocked by our CSP `frame-src 'none'`)
+- `https://vercel.live/login/validate` (POST cross-origin → triggers an OPTIONS preflight to `/`)
+- `https://opollo-site-builder-git-staging-opollo5.vercel.app/.well-known/vercel/jwe`
+
+These complete in <600ms but Vercel Live's feedback widget is known to maintain a long-lived connection to `vercel.live` for live collaboration features. That connection appears to count against Playwright's `networkidle` heuristic.
+
+### Vercel Live is preview-only
+
+Vercel Live is automatically injected on **preview** deployments only. Production deployments do not load `vercel.live`. The UAT harness exclusively runs against the staging Preview deployment, so it always carries this widget.
+
+## Why the issue surfaced only after admin role was granted
+
+In the prior run (#26375514633, 22-pass), the UAT user had no admin role. The admin gate redirected `/admin/*` to `/login` before the page rendered. Composer/calendar specs were already exposed to the same Vercel Live widget but the spec count using `networkidle` was small enough that each individual test happened to settle within 45s.
+
+After granting admin role:
+- Admin nav surfaces 5+ additional `<Link prefetch>` targets (`/admin/users`, `/admin/sites`, `/admin/images`, etc.)
+- Next.js prefetches all of them on page load (visible in trace at t=1886–2643ms — 9 RSC prefetches)
+- The added prefetch volume coincidentally pushed the 500ms quiet-window probability past the failure threshold
+
+In other words: granting admin didn't introduce the hanging connection — it surfaced the slack that always existed.
+
+## Suspect ranking (final)
+
+| Suspect | Status | Why |
+|---|---|---|
+| 1. Sentry session replay | **Ruled out** | `NEXT_PUBLIC_SENTRY_DSN` is unset in staging Vercel env; `instrumentation-client.ts:11` no-ops without it |
+| 2. Supabase Realtime | **Ruled out** | `grep -rn "supabase.channel\|.realtime."` in deployed code = 0 matches |
+| 3. Notification polling | **Ruled out** | `components/NotificationBell.tsx` uses `setInterval` (60s) but is exported and not imported anywhere — dead code |
+| 4. Admin health streaming | **Ruled out** | `grep -rn "stream\|sse"` in `app/api/admin/` = 0 matches |
+| 5. Bundle.social webhook status | **Ruled out** | No long-poll or WebSocket client in deployed code |
+| 6. **Vercel Live (vercel.live)** | **Most likely** | Preview-only third-party script; trace shows the handshake fired and no other long-lived candidates exist |
+| 7. Intercom / analytics widgets | **Ruled out** | No third-party scripts other than Vercel Live and Google Fonts in trace |
+
+## Recommended fix (deferred to next session)
+
+Two viable approaches — pick one:
+
+### Option A: block `vercel.live` requests at the UAT Playwright config
+
+```ts
+// playwright.uat.config.ts
+use: {
+  // ...existing...
+},
+// Block Vercel Live preview tooling so it can't open hanging connections
+// during automated runs. The widget is for human reviewers, not bots.
+projects: [
+  {
+    name: "chromium",
+    use: {
+      ...devices["Desktop Chrome"],
+      // Add per-test setup that blocks vercel.live
+    },
+  },
+],
+```
+
+Implementation lives in a fixture / global-setup that calls `page.route('**/vercel.live/**', r => r.abort())`.
+
+Pros: scoped to the UAT harness; doesn't change deployed bundle.
+Cons: doesn't help if any real test relies on `waitForLoadState('load')` and the load-event observer also waits on Vercel Live.
+
+### Option B: disable Vercel Toolbar on staging deployments
+
+Vercel exposes `experimental.vercelToolbar: false` (Next.js) or a Vercel project setting "Disable Vercel Toolbar". This strips the feedback widget from preview deployments.
+
+Pros: cleanest — removes the suspect entirely.
+Cons: also removes the widget for human reviewers; team may rely on it.
+
+## Why Part B alone was enough
+
+The harness ships zero specs that rely on `waitForLoadState('networkidle')` (PR #1050 migrated all of them; Gate 9 in `button-migration-gates.yml` prevents re-introduction). The hanging WebSocket no longer matters to test outcomes.
+
+Part A is therefore **good-to-have for hygiene** but **not required to unblock the harness**.
+
+## Diagnostic spec for future regressions
+
+`e2e/diagnostics/admin-nav-requests.spec.ts` captures every request, response, and WebSocket frame on `/admin/sites` for 20 seconds and writes the report to `test-results/diagnostics/admin-nav-requests.json`. Run with:
+
+```
+npx playwright test e2e/diagnostics/admin-nav-requests.spec.ts \
+  --config playwright.uat.config.ts
+```
+
+Use this when investigating a future "networkidle never settles" or "page never reaches load" regression. The report identifies open WebSockets that Playwright's standard trace doesn't show.
+
+## What the next session should decide
+
+1. Run the diagnostic spec against staging — confirm whether Vercel Live opens a WebSocket.
+2. If yes: pick Option A or Option B from Recommended fix.
+3. If no (some other WebSocket source): the diagnostic report's `openWebsocketUrls` field tells you exactly what.
+
+Until either happens, the harness is unblocked and the failing specs that remain (~12 of them) are real platform bugs (KF-1, KF-3, AI assist text-check, etc.).

--- a/e2e/diagnostics/admin-nav-requests.spec.ts
+++ b/e2e/diagnostics/admin-nav-requests.spec.ts
@@ -1,0 +1,112 @@
+import { test } from "@playwright/test";
+import { signInAsUatBot, UAT_BASE_URL } from "../uat/helpers/auth";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Diagnostic spec for issue #1049.
+//
+// Captures EVERY request / response / WebSocket frame on /admin/sites for
+// 20 seconds after sign-in, then reports any in-flight HTTP request OR
+// open WebSocket. Use this when investigating "networkidle never settles"
+// regressions or as a baseline check that the staging deployment hasn't
+// re-introduced a hanging connection.
+//
+// Excluded from the regular UAT harness suite (testIgnore in
+// playwright.uat.config.ts). Run explicitly:
+//   npx playwright test e2e/diagnostics/admin-nav-requests.spec.ts \
+//     --config playwright.uat.config.ts
+// ---------------------------------------------------------------------------
+
+test.describe("DIAGNOSTIC — admin nav network", () => {
+  test("captures all requests + websockets for 20s on /admin/sites", async ({
+    page,
+  }) => {
+    const startedAt = Date.now();
+    const requests: Array<{
+      url: string;
+      method: string;
+      startedAt: number;
+      respondedAt: number | null;
+      status: number | null;
+    }> = [];
+    const websockets: Array<{
+      url: string;
+      openedAt: number;
+      closedAt: number | null;
+      frameCount: number;
+    }> = [];
+
+    page.on("request", (req) => {
+      requests.push({
+        url: req.url(),
+        method: req.method(),
+        startedAt: Date.now() - startedAt,
+        respondedAt: null,
+        status: null,
+      });
+    });
+
+    page.on("response", (resp) => {
+      const match = requests.find(
+        (r) => r.url === resp.url() && r.respondedAt === null,
+      );
+      if (match) {
+        match.respondedAt = Date.now() - startedAt;
+        match.status = resp.status();
+      }
+    });
+
+    page.on("websocket", (ws) => {
+      const entry = {
+        url: ws.url(),
+        openedAt: Date.now() - startedAt,
+        closedAt: null as number | null,
+        frameCount: 0,
+      };
+      websockets.push(entry);
+      ws.on("framesent", () => entry.frameCount++);
+      ws.on("framereceived", () => entry.frameCount++);
+      ws.on("close", () => {
+        entry.closedAt = Date.now() - startedAt;
+      });
+    });
+
+    await signInAsUatBot(page);
+    await page.goto(`${UAT_BASE_URL}/admin/sites`);
+    // Idle wait — DO NOT use networkidle (the very thing we're diagnosing)
+    await page.waitForTimeout(20_000);
+
+    const pending = requests.filter((r) => r.respondedAt === null);
+    const openWs = websockets.filter((w) => w.closedAt === null);
+
+    const report = {
+      capturedAt: new Date().toISOString(),
+      capturedDurationMs: Date.now() - startedAt,
+      totalRequests: requests.length,
+      pendingRequests: pending.length,
+      pendingRequestUrls: pending.map((r) => ({ method: r.method, url: r.url })),
+      totalWebsockets: websockets.length,
+      openWebsockets: openWs.length,
+      openWebsocketUrls: openWs.map((w) => ({
+        url: w.url,
+        openedAtMs: w.openedAt,
+        framesExchanged: w.frameCount,
+      })),
+    };
+
+    const outDir = join("test-results", "diagnostics");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(
+      join(outDir, "admin-nav-requests.json"),
+      JSON.stringify(report, null, 2),
+    );
+
+    // eslint-disable-next-line no-console
+    console.log("=== Admin nav diagnostic ===");
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(report, null, 2));
+
+    // Soft assertion — log only, never fail. The point is the report.
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
   // URL via playwright.smoke.config.ts. They MUST NOT run in the
   // default config — they assert against env-provisioned production
   // credentials that aren't set during regular CI.
-  testIgnore: ["**/smoke/**", "**/uat/**"],
+  testIgnore: ["**/smoke/**", "**/uat/**", "**/diagnostics/**"],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,

--- a/playwright.uat.config.ts
+++ b/playwright.uat.config.ts
@@ -28,7 +28,8 @@ const UAT_BASE_URL =
 
 export default defineConfig({
   testDir: "./e2e/uat",
-  testIgnore: [],
+  // Diagnostic specs live under e2e/diagnostics/ and run on demand only.
+  testIgnore: ["**/diagnostics/**"],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,


### PR DESCRIPTION
## Why
Part A of #1049 — identify the source of the hanging connection that prevented \`networkidle\` from settling on staging admin pages. This PR completes the investigation **but does not apply a platform fix** because PR #1050 (Part B, the spec migration) already unblocks the harness without a deployed-bundle change.

## Investigation findings (full doc at \`docs/investigations/admin-nav-hanging-2026-05-25.md\`)

**Most likely cause:** Vercel Live's preview-only feedback widget (\`vercel.live\`) opens a long-lived WebSocket that Playwright's resource-snapshot trace doesn't surface. The trace from run #26378861696 shows 54 captured requests all completing in <650ms, the last at t=3058ms, then 42 seconds of silence — yet \`waitForLoadState('networkidle')\` never fired. No first-party WebSocket / SSE / Realtime clients exist in the deployed code (verified by grep). The remaining suspect that fits the evidence is Vercel Live.

**Ruled out via static analysis + env inspection:**
- Sentry (\`NEXT_PUBLIC_SENTRY_DSN\` not set in staging Vercel env → client init no-ops)
- Supabase Realtime (zero \`supabase.channel\` / \`.realtime.\` usages in deployed code)
- Notification polling (\`NotificationBell\` exported but not imported)
- Admin health streaming / Bundle.social long-poll / analytics widgets — none present

## What ships in this PR

### \`e2e/diagnostics/admin-nav-requests.spec.ts\` (new)
A standalone diagnostic that uses Playwright's \`page.on('request'|'response'|'websocket')\` hooks (not \`networkidle\`) to capture EVERYTHING happening on /admin/sites for 20 seconds — including WebSocket frames the standard trace misses. Writes a JSON report to \`test-results/diagnostics/admin-nav-requests.json\`. Future investigators of "networkidle never settles" / "page never loads" regressions get a definitive list of open connections.

Run with:
\`\`\`
npx playwright test e2e/diagnostics/admin-nav-requests.spec.ts --config playwright.uat.config.ts
\`\`\`

### \`docs/investigations/admin-nav-hanging-2026-05-25.md\` (new)
Full evidence trail: trace excerpts, suspect ranking, why each suspect was ruled out, and two viable platform fixes (Option A: block \`vercel.live\` in the UAT Playwright config; Option B: disable Vercel Toolbar on staging).

### \`testIgnore\` additions
\`playwright.config.ts\` and \`playwright.uat.config.ts\` now ignore \`**/diagnostics/**\` so the diagnostic spec doesn't run in the regular suites — only on explicit invocation.

## Why no platform fix in this PR
PR #1050's spec migration is sufficient to unblock the harness (verified: P0 gate went from 13/50 passing to 18/19 passing on the migrated PR run, with the 2 fails being pre-existing real bugs not the networkidle hangs).

Applying Option A or B requires confirming Vercel Live is the culprit by running the diagnostic against staging — which needs CI access to \`STAGING_UAT_SECRET\`. Next session should:
1. Run the diagnostic spec via \`workflow_dispatch\` on the existing UAT workflow (or a one-shot wrapper)
2. Inspect the report's \`openWebsocketUrls\` field
3. Apply Option A or B based on findings

This avoids landing a speculative fix that masks the real culprit if it's something other than Vercel Live.

## Working analog
None — this is the first investigation doc under \`docs/investigations/\` for a Playwright/Vercel-preview-tooling interaction issue. Sibling investigation docs (composer-edit-mode-hydration, media-library-divergence) cover product-data bugs, which is a different shape.

## Risks identified and mitigated
- **Diagnostic spec runs accidentally in nightly suite**: prevented by testIgnore in both Playwright configs.
- **Recommended fix lands without confirmation**: deferred entirely — this PR has no behavioural change.

## Pre-PR checklist
- [x] Lint/typecheck pass
- [x] No deployed-code changes
- [x] Investigation doc has reproducible commands + evidence excerpts
- [x] Diagnostic spec excluded from default suite (only runs on explicit invocation)