### PR TITLE
test(uat): selector cleanup — 3 remaining test-code failures

### DIFF
--- a/components/ImagesTable.tsx
+++ b/components/ImagesTable.tsx
@@ -264,6 +264,7 @@ function ImageGrid({
   return (
     <div
       className="mt-3"
+      data-testid="image-library-grid"
       style={{
         display: "grid",
         gridTemplateColumns: "repeat(auto-fill, minmax(149px, 1fr))",

--- a/e2e/uat/media-library.spec.ts
+++ b/e2e/uat/media-library.spec.ts
@@ -75,14 +75,13 @@ test.describe("P1 — Media library", () => {
     const overlay = page.locator('[data-testid="composer-overlay"]');
     await expect(overlay).toBeVisible({ timeout: 10_000 });
 
-    // Open media picker
-    const mediaBtn = page.locator('[data-testid="composer-tool-media"], [aria-label*="media"], [aria-label*="image"]').first();
-    if ((await mediaBtn.count()) > 0) {
-      await mediaBtn.click();
-    } else {
-      test.fixme(true, "Media picker button not found in composer toolbar");
-      return;
-    }
+    // Open media picker via the dedicated toolbar button.
+    // (Previous loose selector `[aria-label*="media"]` matched a decorative
+    // "has media" indicator SVG on post chips — same fix as
+    // composer.spec.ts:114.)
+    const mediaBtn = page.locator('[data-testid="composer-tool-media"]');
+    await expect(mediaBtn).toBeVisible({ timeout: 5_000 });
+    await mediaBtn.click();
 
     const libraryTab = page.locator('[data-testid="media-picker-tab-library"]');
     await expect(libraryTab).toBeVisible({ timeout: 5_000 });

--- a/e2e/uat/visual.spec.ts
+++ b/e2e/uat/visual.spec.ts
@@ -132,9 +132,11 @@ test.describe("P1 — Visual regression", () => {
       return;
     }
 
-    const grid = page.locator(
-      '[data-testid="image-library-grid"], [data-testid="media-library-grid"]',
-    );
+    // image-library-grid is on the /admin/images grid view
+    // (ImagesTable.tsx → ImageGrid); media-library-grid is the composer's
+    // MediaPickerModal (a different surface). The spec targets the admin
+    // page only.
+    const grid = page.locator('[data-testid="image-library-grid"]');
     await expect(grid).toBeVisible({ timeout: 10_000 });
     await expect(grid).toHaveScreenshot("admin-image-library-grid.png");
   });

--- a/e2e/uat/visual.spec.ts
+++ b/e2e/uat/visual.spec.ts
@@ -24,7 +24,9 @@ test.describe("P1 — Visual regression", () => {
   test("calendar grid — current month render", async ({ page }) => {
     await page.goto(`${UAT_BASE_URL}/company/social/calendar`);
 
-    const grid = page.locator('[data-testid="calendar-grid"], [data-testid="calendar-shell"]');
+    // calendar-grid is the inner role="grid" (SocialCalendarGrid.tsx:299);
+    // calendar-shell is the outer wrapper. Visual diff targets the grid only.
+    const grid = page.locator('[data-testid="calendar-grid"]');
     await expect(grid).toBeVisible({ timeout: 10_000 });
 
     // Mask dynamic date cells so today highlight doesn't break baselines


### PR DESCRIPTION
## Why
Final harness run [#26382983507](https://github.com/opollo5/opollo-site-builder/actions/runs/26382983507) reached 37 pass / 5 fail. Three of the 5 fails were leftover test-code issues from prior cleanup sessions. This PR resolves them so only real platform bugs remain.

Expected post-merge: pass count 37 → 40. Remaining 2 fails are [#1041](https://github.com/opollo5/opollo-site-builder/issues/1041) (AI assist) and [#1043](https://github.com/opollo5/opollo-site-builder/issues/1043) (connections disconnect) — real platform bugs.

## What

### Commit 1 — `media-library.spec.ts:63`
Same loose `[aria-label*="media"]` selector that fixed at `composer.spec.ts:114` in PR #1047 but never propagated to this file. The aria-label matched a decorative "has media" SVG on post chips instead of the toolbar button → 60s timeout. Replaced with the dedicated `[data-testid="composer-tool-media"]` selector (`ToolsRow.tsx:527`).

### Commit 2 — `visual.spec.ts:24` calendar grid
Strict-mode OR-selector violation. Both testids exist:
- `calendar-grid` — inner `role="grid"` (`SocialCalendarGrid.tsx:299`)
- `calendar-shell` — outer wrapper (`CalendarShell.tsx:235`)

Visual diff cares about the grid content, not the chrome. Scoped to `calendar-grid`.

### Commit 3 — `visual.spec.ts:121` /admin/images grid
**Both testids the spec referenced (`image-library-grid`, `media-library-grid`) were absent from the `/admin/images` page**. The OR-selector matched nothing → timeout. Investigation:
- `media-library-grid` lives in the composer's `MediaPickerModal.tsx:422` (a different surface entirely)
- `image-library-grid` didn't exist anywhere

Added `data-testid="image-library-grid"` to the grid container in `components/ImagesTable.tsx` `ImageGrid` function (the actual grid wrapper on `/admin/images`). One-line component change, no behavioural impact. Updated the spec to target the now-existing testid.

## Verification

```
$ npm run typecheck
(clean)
$ npm run lint
✔ No ESLint warnings or errors
```

## Working analog
- Commit 1 mirrors the fix in PR #1047 for the same `aria-label*="media"` pattern.
- Commit 2 mirrors the selector-disambiguation pattern from PR #1045 (`connections-list-wrapper`).
- Commit 3 follows the existing testid-on-grid-wrapper convention (e.g., `composer-overlay`, `media-library-grid`).

## Risks identified and mitigated
- **New testid on a deployed component (ImagesTable)**: a `data-testid` attribute has zero runtime impact and no behavioural change. Verified by lint + typecheck.
- **Visual baseline for calendar/admin-images doesn't yet exist** (these specs were timing out before): the regen-baselines workflow at `.github/workflows/uat-harness.yml:232` will capture them on next merge if the commit subject contains `regen-baselines`. Calling that out in the merge step is optional — the next harness run will tell us if the snapshots need a regen pass.

## Pre-PR checklist
- [x] Lint/typecheck pass
- [x] All 3 selectors traced to actual rendered DOM
- [x] One component change (testid only), no behaviour change