### PR TITLE
fix(uat): correct AI assist Generate button assertion — false positive

### DIFF
--- a/e2e/uat/composer.spec.ts
+++ b/e2e/uat/composer.spec.ts
@@ -92,8 +92,10 @@ test.describe("P0 — Social composer", () => {
     const generateBtn = page.locator('[data-testid="ai-generate-button"]');
     await expect(generateBtn).toBeVisible({ timeout: 5_000 });
     const generateBtnClass = await generateBtn.getAttribute("class");
-    // Filled variant should NOT be "outline" or "ghost" or "secondary"
-    expect(generateBtnClass).not.toContain("outline");
+    // Positive assertion: default (filled) variant always has bg-primary.
+    // Note: NOT.toContain("outline") is a false positive — the cva base
+    // class includes `focus-visible:outline-none` on every button variant.
+    expect(generateBtnClass).toContain("bg-primary");
     expect(generateBtnClass).not.toContain("ghost");
     await page.screenshot({ path: "test-results/uat/composer/ai-generate-button.png" });
 


### PR DESCRIPTION
## Summary
- Fixes UAT spec failure: `e2e/uat/composer.spec.ts` line 96
- `expect(generateBtnClass).not.toContain("outline")` was a **false positive**: the `Button` cva base class (line 16 of `components/ui/button.tsx`) always includes `focus-visible:outline-none` on every variant for accessibility (removes default browser focus ring in favour of custom shadow)
- The Generate button correctly uses the default (filled) variant — there is no component regression

## Root cause
`Button`'s cva base string: `"...focus-visible:outline-none..."`
All buttons in the app contain "outline" as a substring in their className. The spec was checking for the wrong indicator.

## Fix
Replaced `not.toContain("outline")` with `toContain("bg-primary")` — a positive assertion that the button has the filled primary variant class. `bg-primary` is present on the `default` variant and absent on `outline`, `ghost`, and `secondary`.

## Working analog
None required — this is a single-line spec assertion fix, not a component change.

**New pattern justification**: positive class assertion (`toContain("bg-primary")`) is more precise than negative substring exclusion when base Tailwind utilities share name stems with variant names.

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Unit tests pass (pre-commit hook)
- [x] No component code changed — spec-only fix
- [x] PR is well under 500 net lines

## Risks identified and mitigated
- **Risk**: positive assertion `toContain("bg-primary")` would fail if the button variant is changed in future. Mitigated — that would be a genuine regression and the test *should* fail.
- **No production code changed** — zero runtime risk.

Closes #1041