### PR TITLE
fix(uat): narrow disconnect dialog locator to exclude nav sidebar

### DIFF
--- a/e2e/uat/connections.spec.ts
+++ b/e2e/uat/connections.spec.ts
@@ -65,8 +65,10 @@ test.describe("P0 — Connections", () => {
     await disconnectBtns.first().click();
     await page.screenshot({ path: "test-results/uat/connections/disconnect-dialog.png" });
 
-    // A confirmation dialog should appear
-    const dialog = page.locator('[role="dialog"], [role="alertdialog"]');
+    // A confirmation dialog should appear.
+    // Use [data-state="open"] to exclude the mobile-nav sidebar which also
+    // carries role="dialog" but is always hidden (no data-state attribute).
+    const dialog = page.locator('[role="dialog"][data-state="open"], [role="alertdialog"]');
     await expect(dialog).toBeVisible({ timeout: 5_000 });
     // Cancel to avoid actually disconnecting the seed account
     const cancelBtn = dialog.locator('button:has-text("Cancel"), button:has-text("No")');


### PR DESCRIPTION
## Summary
- Fixes UAT spec strict-mode violation introduced after PR #1057 landed
- After the ConfirmDialog fix, the disconnect confirmation dialog renders correctly as a DOM `[role="dialog"]`; but the locator `'[role="dialog"], [role="alertdialog"]'` now matches TWO elements: the confirmation dialog AND the mobile-nav sidebar (`role="dialog" hidden="" aria-hidden="true"`)
- Playwright strict mode fails when a locator resolves to >1 element

## Root cause
The connections page includes a mobile-nav sidebar with `role="dialog"` that is always present in the DOM (just hidden). The original spec locator worked before because `window.confirm()` rendered nothing in the DOM — now that ConfirmDialog renders a second `role="dialog"`, strict mode fires.

## Fix
Add `[data-state="open"]` qualifier: `'[role="dialog"][data-state="open"], [role="alertdialog"]'`

Radix Dialog sets `data-state="open"` on the dialog element when open. The nav sidebar uses custom markup without this attribute. Zero component changes.

## Working analog
None required — single-line spec locator fix.

**New pattern justification**: `[data-state="open"]` is the Radix Dialog open-state attribute; this pattern is the correct way to scope a Radix dialog locator when multiple `role="dialog"` elements coexist.

## Pre-PR checklist
- [x] Lint, typecheck, unit tests pass
- [x] No component code changed
- [x] PR under 500 net lines

## Risks identified and mitigated
- Zero runtime risk — spec-only change
- If the nav sidebar ever gains `data-state="open"` in future, this locator would need updating — acceptable since that would be a structural change