### PR TITLE
feat(social/composer): state-aware composer — read-only view for published posts

### DIFF
--- a/.github/workflows/button-migration-gates.yml
+++ b/.github/workflows/button-migration-gates.yml
@@ -104,6 +104,38 @@ jobs:
           fi
           echo "✓ AiPanel has no duplicate close button"
 
+      - name: Gate 10 — Composer enforces post-state actions matrix
+        # Pins the state→action contract from
+        # docs/investigations/composer-state-model-2026-05-25.md.
+        # The matrix file must exist, the composer must consume it,
+        # and the drafts PATCH endpoint must guard terminal states.
+        run: |
+          # 1. The matrix file must exist.
+          if [ ! -f lib/social/post-state-actions.ts ]; then
+            echo "❌ FAIL: lib/social/post-state-actions.ts missing — the canonical state→action matrix has been removed"
+            exit 1
+          fi
+
+          # 2. canPerform / ALLOWED_ACTIONS must be referenced from the composer.
+          if ! grep -rqE "canPerform|ALLOWED_ACTIONS" \
+            components/social/composer/ --include="*.tsx"; then
+            echo "❌ FAIL: composer/*.tsx does not import canPerform or ALLOWED_ACTIONS — the matrix is not enforced in the UI"
+            exit 1
+          fi
+
+          # 3. The drafts/[id] PATCH endpoint must guard against terminal states.
+          DRAFT_ROUTE="app/api/platform/social/drafts/[id]/route.ts"
+          if [ ! -f "$DRAFT_ROUTE" ]; then
+            echo "⚠ WARN: drafts/[id] route file not found at $DRAFT_ROUTE — skipping guard check"
+          else
+            if ! grep -qE "published|publishing" "$DRAFT_ROUTE"; then
+              echo "❌ FAIL: drafts PATCH endpoint at $DRAFT_ROUTE does not guard terminal states (no 'published'/'publishing' reference)"
+              exit 1
+            fi
+          fi
+
+          echo "✓ post-state contract enforced"
+
       - name: Gate 9 — UAT specs do not use waitForLoadState('networkidle')
         # See issue #1049. networkidle is a Playwright anti-pattern that
         # never settles against real pages (telemetry, websockets, realtime

--- a/app/api/platform/social/drafts/[id]/route.ts
+++ b/app/api/platform/social/drafts/[id]/route.ts
@@ -16,6 +16,10 @@ import {
   validateUuidParam,
   conflict,
 } from "@/lib/http";
+import {
+  isTerminalForMutation,
+  type PostState,
+} from "@/lib/social/post-state-actions";
 
 // ---------------------------------------------------------------------------
 // GET /api/platform/social/drafts/[id]
@@ -126,7 +130,7 @@ export async function PATCH(
   const client = getServiceRoleClient();
   const { data: row } = await client
     .from("social_post_drafts")
-    .select("company_id, draft_data, draft_version")
+    .select("company_id, draft_data, draft_version, state")
     .eq("id", idCheck.value)
     .is("archived_at", null)
     .maybeSingle();
@@ -135,6 +139,33 @@ export async function PATCH(
 
   const gate = await requireCanDoForApi(row.company_id as string, "edit_post");
   if (gate.kind === "deny") return gate.response;
+
+  // State guard: published + publishing rows are not mutable via PATCH.
+  // Published posts are already live on the social platform; mutating
+  // them via composer would silently flip state back to scheduled
+  // (see MODE_TO_STATE below). Publishing rows are owned by the
+  // publish job. The matrix in lib/social/post-state-actions.ts is
+  // the single source of truth — keep this guard aligned with
+  // isTerminalForMutation.
+  const currentState = row.state as PostState;
+  if (isTerminalForMutation(currentState)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: {
+          code: "INVALID_STATE",
+          message: `Cannot modify post in state '${currentState}'.`,
+          retryable: false,
+          suggested_action:
+            currentState === "published"
+              ? "Use repost-as-new to clone this post into a new draft."
+              : "Wait for the publish job to finish, then retry if needed.",
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 422 },
+    );
+  }
 
   if (isV2) {
     const parsed = parseBodyWith(V2SaveBodySchema, body);

--- a/components/composer/composer-mount-v2.tsx
+++ b/components/composer/composer-mount-v2.tsx
@@ -41,6 +41,9 @@ interface V1DraftApiResponse {
     state?: string | null;
     // V2 drafts write scheduled_at at the top level; V1 drafts use draft_data.schedule
     scheduled_at?: string | null;
+    // Published-post metadata for the read-only Post Info card (migration 0133).
+    published_at?: string | null;
+    published_url?: string | null;
     last_publish_error?: { message?: string } | null;
     // Top-level V2 columns — present on rows where draft_data is empty
     media_urls?: string[] | null;
@@ -103,6 +106,8 @@ export function mapV1ToV2Draft(d: NonNullable<V1DraftApiResponse["data"]>): Draf
     platform_variants: {},
     approval_required: d.draft_data.approval_required ?? false,
     scheduled_at,
+    published_url: d.published_url ?? null,
+    published_at: d.published_at ?? null,
   };
 }
 

--- a/components/social/composer/ComposerEditor.tsx
+++ b/components/social/composer/ComposerEditor.tsx
@@ -26,6 +26,13 @@ export interface ComposerEditorProps {
   /** Slot for SchedulingCard + submit row (PR E). */
   schedulingSlot?: React.ReactNode;
   className?: string;
+  /**
+   * Read-only mode: textarea + media tray render but the tools row, link
+   * editors, customize-per-platform row, and per-tile remove buttons
+   * are hidden. Used for state='published' etc. See
+   * lib/social/post-state-actions.ts.
+   */
+  readOnly?: boolean;
 }
 
 export function ComposerEditor({
@@ -36,6 +43,7 @@ export function ComposerEditor({
   selectedConnections,
   schedulingSlot,
   className,
+  readOnly = false,
 }: ComposerEditorProps) {
   const [activePlatform, setActivePlatform] = React.useState<Platform | null>(null);
 
@@ -116,9 +124,10 @@ export function ComposerEditor({
         maxLength={charLimit}
         companyId={companyId}
         platforms={platforms}
+        readOnly={readOnly}
       />
 
-      {platforms.length >= 2 && (
+      {!readOnly && platforms.length >= 2 && (
         <CustomizeForRow
           platforms={platforms}
           activePlatform={activePlatform}
@@ -126,7 +135,7 @@ export function ComposerEditor({
         />
       )}
 
-      {platforms.length > 0 && (
+      {!readOnly && platforms.length > 0 && (
         <PlatformActionsList
           platforms={activePlatform ? [activePlatform] : platforms}
           links={links}
@@ -136,24 +145,28 @@ export function ComposerEditor({
         />
       )}
 
-      {/* SchedulingCard + ApprovalToggle + submit row (PR E) */}
+      {/* SchedulingCard + ApprovalToggle + submit row (PR E).
+          In read-only mode, the caller passes a PostInfoCard via
+          schedulingSlot instead of the default Save/Post now row. */}
       {schedulingSlot ?? (
-        <div className="flex items-center justify-end gap-3 border-t border-border pt-4">
-          <button
-            type="button"
-            className="rounded-md border border-border px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
-            onClick={() => _onSubmit("draft")}
-          >
-            Save as draft
-          </button>
-          <button
-            type="button"
-            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-            onClick={() => _onSubmit("post_now")}
-          >
-            Post now
-          </button>
-        </div>
+        !readOnly && (
+          <div className="flex items-center justify-end gap-3 border-t border-border pt-4">
+            <button
+              type="button"
+              className="rounded-md border border-border px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+              onClick={() => _onSubmit("draft")}
+            >
+              Save as draft
+            </button>
+            <button
+              type="button"
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+              onClick={() => _onSubmit("post_now")}
+            >
+              Post now
+            </button>
+          </div>
+        )
       )}
     </div>
   );

--- a/components/social/composer/ComposerOverlay.tsx
+++ b/components/social/composer/ComposerOverlay.tsx
@@ -12,10 +12,16 @@ import { SocialCalendarGrid } from "@/components/social/calendar/SocialCalendarG
 import { SchedulingCard, defaultSchedulingCardValue, type SchedulingCardValue } from "@/components/social/composer/SchedulingCard";
 import { UnsavedChangesDialog } from "@/components/social/composer/UnsavedChangesDialog";
 import { ComposerErrorBoundary } from "@/components/social/composer/ComposerErrorBoundary";
+import { PostInfoCard } from "@/components/social/composer/PostInfoCard";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Pill } from "@/components/ui/pill";
 import { SocialPlatformIcon } from "@/components/ui/SocialPlatformIcon";
 import type { Connection, Draft, DraftState, Platform, SchedulingMode } from "@/lib/social/types";
+import {
+  canPerform,
+  isReadOnlyState,
+  type PostState,
+} from "@/lib/social/post-state-actions";
 import type { SocialPlatformIconKey } from "@/components/ui/SocialPlatformIcon";
 
 // ---------------------------------------------------------------------------
@@ -141,6 +147,11 @@ export function ComposerOverlay({
   );
   const [previewTab, setPreviewTab] = React.useState<PreviewTab>("preview");
   const [activePreviewIndex, setActivePreviewIndex] = React.useState(0);
+  // Local override for editOriginalState so Repost-as-new can downgrade
+  // a published-post overlay into a fresh-draft overlay without needing
+  // a parent navigation. Initialised from the incoming prop and reset
+  // whenever the hydration effect re-fires.
+  const [localEditState, setLocalEditState] = React.useState<DraftState | undefined>(editOriginalState);
 
   // Scheduling state (internal slot — used when schedulingSlot prop is absent)
   const [scheduling, setScheduling] = React.useState<SchedulingCardValue>(
@@ -198,8 +209,9 @@ export function ComposerOverlay({
     setActivePreviewIndex(0);
     setScheduling(schedulingCardValueFromIso(initialDraft?.scheduled_at, companyTimezone));
     setSubmitError(null);
+    setLocalEditState(editOriginalState);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, initialDraft, companyTimezone]);
+  }, [open, initialDraft, companyTimezone, editOriginalState]);
 
   const selectedConnections = availableConnections.filter((c) =>
     selectedIds.includes(c.id),
@@ -266,6 +278,61 @@ export function ComposerOverlay({
     } catch {
       // ignore — UI shows nothing on failure; user can retry
     }
+  }
+
+  // ---------------------------------------------------------------------
+  // PostInfoCard handlers — published / publishing / recurring / paused /
+  // pending_approval flows. See lib/social/post-state-actions.ts.
+  // ---------------------------------------------------------------------
+
+  async function handleDeleteFromRecords() {
+    if (!draft.id) return;
+    try {
+      // NEVER calls bundle.social — this only soft-deletes the Opollo row.
+      // The post stays live on the social platform. The PostInfoCard
+      // confirmation copy spells this out.
+      const res = await fetch(`/api/platform/social/drafts/${draft.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok && res.status !== 204) {
+        throw new Error(`Delete failed (${res.status})`);
+      }
+      void swrMutate(
+        (key) => typeof key === "string" && key.includes("/api/platform/social/drafts/calendar-view"),
+      );
+      onClose();
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Delete failed.");
+    }
+  }
+
+  function handleRepostAsNew() {
+    // In-place reset to "new draft" mode. The Repost button is only
+    // visible when state='published' (matrix). Clearing id + version
+    // means the next Submit POSTs a fresh draft instead of PATCHing
+    // the published row (which the server would reject as 422).
+    setDraft((d) => ({
+      content: d.content,
+      media_urls: d.media_urls,
+      target_profile_ids: d.target_profile_ids,
+      platform_variants: d.platform_variants,
+      approval_required: false,
+    }));
+    setLocalEditState(undefined);
+    setScheduling(defaultSchedulingCardValue());
+    setSubmitError(null);
+  }
+
+  async function handleRetryPublish() {
+    // For failed posts the retry is a re-schedule. We POST mode=schedule
+    // with the existing scheduled_at (or now+2min if unset) so the
+    // publish-due cron picks it up on the next sweep.
+    if (!draft.id) return;
+    const targetIso =
+      draft.scheduled_at ??
+      new Date(Date.now() + 2 * 60 * 1000).toISOString();
+    setScheduling(schedulingCardValueFromIso(targetIso, companyTimezone));
+    await handleSubmit("schedule");
   }
 
   async function handleSubmit(mode: SchedulingMode): Promise<boolean> {
@@ -445,7 +512,13 @@ export function ComposerOverlay({
 
   if (!open) return null;
 
-  const isPublishing = editOriginalState === "publishing";
+  // State-aware affordances. localEditState lets Repost-as-new
+  // downgrade a 'published' overlay to a fresh-draft overlay in-place
+  // (handleRepostAsNew sets it to undefined).
+  const effectiveState = localEditState;
+  const postState = (effectiveState ?? "draft") as PostState;
+  const composerReadOnly = effectiveState ? isReadOnlyState(postState) : false;
+  const isPublishing = effectiveState === "publishing";
 
   const isSubmitDisabled =
     submitting ||
@@ -453,42 +526,83 @@ export function ComposerOverlay({
     draft.target_profile_ids.length === 0 ||
     draft.content.trim().length === 0;
 
-  const internalSchedulingSlot = (
-    <div className="flex flex-col gap-2">
-      {submitError && (
-        <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-          {submitError}
-        </p>
-      )}
-      {draft.target_profile_ids.length === 0 && (
-        <p className="text-xs text-muted-foreground">
-          Select at least one account to post to.
-        </p>
-      )}
-      <SchedulingCard
-        value={scheduling}
-        onChange={setScheduling}
-        onSubmit={async () => { await handleSubmit(scheduling.mode); }}
-        submitting={submitting}
-        disabled={isSubmitDisabled}
-        disabledTooltip={
-          draft.target_profile_ids.length === 0
-            ? "Select at least one account to post to"
+  // The internal slot has three shapes depending on state:
+  //   1. Read-only states (published, publishing, recurring, paused,
+  //      pending_approval) → PostInfoCard replaces SchedulingCard.
+  //   2. failed → PostInfoCard above SchedulingCard so the user can
+  //      Retry publish OR edit + reschedule.
+  //   3. Everything else (draft, scheduled, rejected) → default
+  //      SchedulingCard + optional Convert-to-draft for 'scheduled'.
+  let internalSchedulingSlot: React.ReactNode;
+  if (composerReadOnly) {
+    internalSchedulingSlot = (
+      <PostInfoCard
+        state={postState}
+        publishedAt={draft.published_at ?? null}
+        publishedUrl={draft.published_url ?? null}
+        onDeleteFromRecords={() => void handleDeleteFromRecords()}
+        onRepostAsNew={handleRepostAsNew}
+        onViewAnalytics={
+          canPerform(postState, "view_analytics")
+            ? () => {
+                // Best-effort destination — opens the dashboard-level
+                // analytics surface. Per-post analytics is a future PR
+                // (see docs/investigations/composer-state-gaps-backlog-2026-05-25.md).
+                window.location.assign("/company/social/analytics");
+              }
             : undefined
         }
       />
-      {editOriginalState === "scheduled" && (
-        <button
-          type="button"
-          onClick={() => void handleConvertToDraft()}
-          data-testid="convert-to-draft-btn"
-          className="w-full rounded-md border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:border-primary/40 hover:text-foreground transition-colors"
-        >
-          Convert to draft
-        </button>
-      )}
-    </div>
-  );
+    );
+  } else {
+    internalSchedulingSlot = (
+      <div className="flex flex-col gap-2">
+        {submitError && (
+          <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {submitError}
+          </p>
+        )}
+        {effectiveState === "failed" && (
+          <PostInfoCard
+            state="failed"
+            publishedAt={null}
+            publishedUrl={null}
+            failureReason={failureReason}
+            onDeleteFromRecords={() => void handleDeleteFromRecords()}
+            onRepostAsNew={handleRepostAsNew}
+            onRetryPublish={() => void handleRetryPublish()}
+          />
+        )}
+        {draft.target_profile_ids.length === 0 && (
+          <p className="text-xs text-muted-foreground">
+            Select at least one account to post to.
+          </p>
+        )}
+        <SchedulingCard
+          value={scheduling}
+          onChange={setScheduling}
+          onSubmit={async () => { await handleSubmit(scheduling.mode); }}
+          submitting={submitting}
+          disabled={isSubmitDisabled}
+          disabledTooltip={
+            draft.target_profile_ids.length === 0
+              ? "Select at least one account to post to"
+              : undefined
+          }
+        />
+        {effectiveState === "scheduled" && (
+          <button
+            type="button"
+            onClick={() => void handleConvertToDraft()}
+            data-testid="convert-to-draft-btn"
+            className="w-full rounded-md border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:border-primary/40 hover:text-foreground transition-colors"
+          >
+            Convert to draft
+          </button>
+        )}
+      </div>
+    );
+  }
 
   return (
     <>
@@ -526,11 +640,13 @@ export function ComposerOverlay({
                 <ChevronLeft size={20} aria-hidden />
               </button>
 
-              {/* Title */}
+              {/* Title — "Post info" for read-only states, "Edit post" for editable. */}
               <h2 className="flex-1 text-base font-semibold text-foreground min-w-0">
-                {editOriginalState ? (
+                {effectiveState ? (
                   <span className="flex items-center gap-1.5 min-w-0 truncate">
-                    <span className="shrink-0">Edit post</span>
+                    <span className="shrink-0">
+                      {composerReadOnly ? "Post info" : "Edit post"}
+                    </span>
                     {selectedConnections.length > 0 && (
                       <>
                         <span className="shrink-0 text-muted-foreground font-normal">for</span>
@@ -539,11 +655,14 @@ export function ComposerOverlay({
                         {selectedConnections.length > 1 && <span className="shrink-0">…</span>}
                       </>
                     )}
-                    {editOriginalState === "failed" && (
+                    {effectiveState === "failed" && (
                       <span className="shrink-0 text-destructive font-medium">· Failed</span>
                     )}
                     {isPublishing && (
                       <Pill variant="warning" className="shrink-0 text-xs">Publishing…</Pill>
+                    )}
+                    {effectiveState === "published" && (
+                      <Pill variant="success" className="shrink-0 text-xs">Published</Pill>
                     )}
                   </span>
                 ) : draft.id ? "Edit post" : "New post"}
@@ -601,9 +720,10 @@ export function ComposerOverlay({
                 available={availableConnections}
                 selected={selectedIds}
                 onChange={handleProfileChange}
+                readOnly={composerReadOnly}
               />
 
-              {editOriginalState === "failed" && failureReason && (
+              {effectiveState === "failed" && failureReason && (
                 <div
                   className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm"
                   data-testid="failure-banner"
@@ -620,6 +740,7 @@ export function ComposerOverlay({
                 companyId={companyId}
                 selectedConnections={selectedConnections}
                 schedulingSlot={schedulingSlot ?? internalSchedulingSlot}
+                readOnly={composerReadOnly}
               />
             </div>
           </div>

--- a/components/social/composer/ContentEditor.tsx
+++ b/components/social/composer/ContentEditor.tsx
@@ -24,6 +24,13 @@ export interface ContentEditorProps {
   companyId: string;
   platforms?: Platform[];
   className?: string;
+  /**
+   * When true, renders the textarea as readOnly and hides edit-only
+   * affordances (tools row, media upload "+", link-preview dismiss).
+   * Used for state='published' / 'publishing' / other read-only states
+   * — see lib/social/post-state-actions.ts.
+   */
+  readOnly?: boolean;
 }
 
 const MAX_FILES = 4;
@@ -40,6 +47,7 @@ export function ContentEditor({
   companyId,
   platforms,
   className,
+  readOnly = false,
 }: ContentEditorProps) {
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
@@ -192,6 +200,7 @@ export function ContentEditor({
         className="block w-full resize-none bg-transparent px-4 pt-4 pb-2 text-sm leading-relaxed text-foreground placeholder:text-muted-foreground focus:outline-none"
         style={{ minHeight: "100px" }}
         aria-label="Post content"
+        readOnly={readOnly}
       />
 
       {/* Link preview */}
@@ -230,6 +239,7 @@ export function ContentEditor({
             onRequestUpload={openFilePicker}
             gifIndices={gifIndices}
             uploading={uploading}
+            readOnly={readOnly}
           />
         </div>
       )}
@@ -256,13 +266,15 @@ export function ContentEditor({
           <p className="text-xs text-destructive" role="alert">{uploadError}</p>
         )}
 
-        <ToolsRow
-          companyId={companyId}
-          onInsertText={insertText}
-          onOpenMediaPicker={openMediaModal}
-          onAttachGif={attachGif}
-          platforms={platforms}
-        />
+        {!readOnly && (
+          <ToolsRow
+            companyId={companyId}
+            onInsertText={insertText}
+            onOpenMediaPicker={openMediaModal}
+            onAttachGif={attachGif}
+            platforms={platforms}
+          />
+        )}
       </div>
 
       {/* File input for MediaTray "+" direct upload */}

--- a/components/social/composer/MediaTile.tsx
+++ b/components/social/composer/MediaTile.tsx
@@ -11,7 +11,8 @@ import { cn } from "@/lib/utils";
 export interface MediaTileProps {
   url: string;
   index: number;
-  onRemove: (index: number) => void;
+  /** Undefined → no remove affordance is rendered (read-only mode). */
+  onRemove?: (index: number) => void;
   isGif?: boolean;
   className?: string;
 }
@@ -43,15 +44,17 @@ export function MediaTile({ url, index, onRemove, isGif = false, className }: Me
         </span>
       )}
 
-      {/* Hover-reveal trash */}
-      <button
-        type="button"
-        aria-label={`Remove media ${index + 1}`}
-        onClick={() => onRemove(index)}
-        className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-      >
-        <Trash2 size={16} strokeWidth={1.75} className="text-white" aria-hidden />
-      </button>
+      {/* Hover-reveal trash — omitted in read-only mode */}
+      {onRemove && (
+        <button
+          type="button"
+          aria-label={`Remove media ${index + 1}`}
+          onClick={() => onRemove(index)}
+          className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+        >
+          <Trash2 size={16} strokeWidth={1.75} className="text-white" aria-hidden />
+        </button>
+      )}
     </div>
   );
 }

--- a/components/social/composer/MediaTray.tsx
+++ b/components/social/composer/MediaTray.tsx
@@ -17,6 +17,8 @@ export interface MediaTrayProps {
   uploading?: boolean;
   maxFiles?: number;
   className?: string;
+  /** Hide the "Add more" tile and the per-tile remove affordance. */
+  readOnly?: boolean;
 }
 
 export function MediaTray({
@@ -27,6 +29,7 @@ export function MediaTray({
   uploading = false,
   maxFiles = 4,
   className,
+  readOnly = false,
 }: MediaTrayProps) {
   if (urls.length === 0 && !uploading) return null;
 
@@ -40,7 +43,7 @@ export function MediaTray({
           key={url}
           url={url}
           index={i}
-          onRemove={onRemove}
+          onRemove={readOnly ? undefined : onRemove}
           isGif={gifIndices?.has(i)}
         />
       ))}
@@ -53,7 +56,7 @@ export function MediaTray({
       )}
 
       {/* Add more tile */}
-      {urls.length < maxFiles && !uploading && (
+      {!readOnly && urls.length < maxFiles && !uploading && (
         <button
           type="button"
           aria-label="Add media"

--- a/components/social/composer/PostInfoCard.tsx
+++ b/components/social/composer/PostInfoCard.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import * as React from "react";
+import { ExternalLink, BarChart3, RefreshCcw, Repeat2, Trash2, AlertTriangle } from "lucide-react";
+import type { DraftState } from "@/lib/social/types";
+import {
+  canPerform,
+  type PostState,
+} from "@/lib/social/post-state-actions";
+
+// ---------------------------------------------------------------------------
+// PostInfoCard — read-only / state-aware footer that replaces SchedulingCard
+// when the post is not in an editable state.
+//
+// Renders the actions allowed by lib/social/post-state-actions.ts for the
+// post's state. Specifically NEVER calls a bundle.social unpublish API —
+// "Delete from records" only removes the Opollo database row. The
+// confirmation copy spells this out explicitly.
+//
+// Wired by ComposerOverlay when isReadOnlyState(editOriginalState) is true,
+// or when state === 'failed' (failed is editable but adds Retry publish).
+// ---------------------------------------------------------------------------
+
+export interface PostInfoCardProps {
+  state: DraftState;
+  publishedAt: string | null;
+  publishedUrl: string | null;
+  /** Called when the user confirms "Delete from records" — caller owns the DELETE call. */
+  onDeleteFromRecords: () => void;
+  /** Called when the user clicks "Repost as new" — caller creates a fresh draft. */
+  onRepostAsNew: () => void;
+  /** Called when the user clicks "Retry publish" (failed state only). */
+  onRetryPublish?: () => void;
+  /** Called when the user clicks "View analytics". */
+  onViewAnalytics?: () => void;
+  /** Failure message for state='failed'. */
+  failureReason?: string;
+}
+
+function formatPublishedAt(iso: string | null): string {
+  if (!iso) return "";
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return "";
+    return d.toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+}
+
+function stateLabel(state: DraftState): string {
+  switch (state) {
+    case "published":
+      return "Published";
+    case "publishing":
+      return "Publishing…";
+    case "pending_approval":
+      return "Waiting for approval";
+    case "recurring":
+      return "Recurring";
+    case "paused":
+      return "Paused";
+    case "failed":
+      return "Failed to publish";
+    case "rejected":
+      return "Changes requested";
+    default:
+      return state;
+  }
+}
+
+export function PostInfoCard({
+  state,
+  publishedAt,
+  publishedUrl,
+  onDeleteFromRecords,
+  onRepostAsNew,
+  onRetryPublish,
+  onViewAnalytics,
+  failureReason,
+}: PostInfoCardProps) {
+  const postState = state as PostState;
+  const [confirmingDelete, setConfirmingDelete] = React.useState(false);
+
+  return (
+    <div
+      className="flex flex-col gap-3 rounded-lg border border-border bg-muted/30 p-4"
+      data-testid="composer-readonly-banner"
+      data-post-state={state}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-foreground">
+            {stateLabel(state)}
+          </p>
+          {publishedAt && (
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {formatPublishedAt(publishedAt)}
+            </p>
+          )}
+          {state === "failed" && failureReason && (
+            <p className="mt-1 flex items-start gap-1 text-xs text-destructive">
+              <AlertTriangle size={12} className="mt-0.5 shrink-0" aria-hidden />
+              <span>{failureReason}</span>
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {canPerform(postState, "view_on_platform") && publishedUrl && (
+          <a
+            href={publishedUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="view-on-platform-link"
+            className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:border-primary/40 transition-colors"
+          >
+            <ExternalLink size={14} aria-hidden />
+            View on platform
+          </a>
+        )}
+
+        {canPerform(postState, "view_analytics") && onViewAnalytics && (
+          <button
+            type="button"
+            onClick={onViewAnalytics}
+            data-testid="view-analytics-link"
+            className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:border-primary/40 transition-colors"
+          >
+            <BarChart3 size={14} aria-hidden />
+            View analytics
+          </button>
+        )}
+
+        {canPerform(postState, "repost_as_new") && (
+          <button
+            type="button"
+            onClick={onRepostAsNew}
+            data-testid="repost-as-new-button"
+            className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:border-primary/40 transition-colors"
+          >
+            <Repeat2 size={14} aria-hidden />
+            Repost as new
+          </button>
+        )}
+
+        {canPerform(postState, "retry_publish") && onRetryPublish && (
+          <button
+            type="button"
+            onClick={onRetryPublish}
+            data-testid="retry-publish-button"
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            <RefreshCcw size={14} aria-hidden />
+            Retry publish
+          </button>
+        )}
+
+        {canPerform(postState, "delete_from_records") && !confirmingDelete && (
+          <button
+            type="button"
+            onClick={() => setConfirmingDelete(true)}
+            data-testid="delete-from-records-button"
+            className="inline-flex items-center gap-1.5 rounded-md border border-destructive/30 bg-background px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 transition-colors"
+          >
+            <Trash2 size={14} aria-hidden />
+            Delete from records
+          </button>
+        )}
+      </div>
+
+      {confirmingDelete && (
+        <div
+          className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-xs"
+          data-testid="delete-from-records-confirm"
+        >
+          {/*
+            CRITICAL UX COPY — do not soften. The published post stays live
+            on the social platform; we only delete Opollo's database row.
+            We never call any bundle.social unpublish API.
+          */}
+          <p className="font-medium text-foreground">
+            Remove this post from Opollo?
+          </p>
+          <p className="mt-0.5 text-muted-foreground">
+            This will remove the post from Opollo. <strong>The post will
+            remain visible on the social platform.</strong> Opollo does not
+            unpublish posts on your behalf.
+          </p>
+          <div className="mt-2 flex gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setConfirmingDelete(false);
+                onDeleteFromRecords();
+              }}
+              data-testid="delete-from-records-confirm-yes"
+              className="rounded-md bg-destructive px-3 py-1 text-xs font-medium text-destructive-foreground hover:bg-destructive/90"
+            >
+              Yes, remove from Opollo
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmingDelete(false)}
+              className="rounded-md border border-border bg-background px-3 py-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/social/composer/ProfileSelector.tsx
+++ b/components/social/composer/ProfileSelector.tsx
@@ -21,10 +21,16 @@ export interface ProfileSelectorProps {
   selected: string[];
   onChange: (ids: string[]) => void;
   className?: string;
+  /**
+   * Hide the "Add profile" affordance and disable chip toggling.
+   * Used in read-only composer states (state='published' etc.).
+   */
+  readOnly?: boolean;
 }
 
-export function ProfileSelector({ available, selected, onChange, className }: ProfileSelectorProps) {
+export function ProfileSelector({ available, selected, onChange, className, readOnly = false }: ProfileSelectorProps) {
   function toggle(id: string) {
+    if (readOnly) return;
     if (selected.includes(id)) {
       onChange(selected.filter((x) => x !== id));
     } else {
@@ -61,20 +67,22 @@ export function ProfileSelector({ available, selected, onChange, className }: Pr
         })}
       </TooltipProvider>
 
-      {/* "Add profile" chip — links to connection settings */}
-      <a
-        href="/company/social/connections"
-        aria-label="Add profile"
-        data-testid="connections-connect-button"
-        className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border-2 border-dashed border-muted-foreground/40 text-muted-foreground hover:border-primary hover:text-primary transition-colors"
-      >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-          <path d="M12 5v14" />
-          <path d="M5 12h14" />
-        </svg>
-      </a>
+      {/* "Add profile" chip — links to connection settings (edit-mode only) */}
+      {!readOnly && (
+        <a
+          href="/company/social/connections"
+          aria-label="Add profile"
+          data-testid="connections-connect-button"
+          className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border-2 border-dashed border-muted-foreground/40 text-muted-foreground hover:border-primary hover:text-primary transition-colors"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="M12 5v14" />
+            <path d="M5 12h14" />
+          </svg>
+        </a>
+      )}
 
-      {hasSelected && (
+      {!readOnly && hasSelected && (
         <button
           type="button"
           onClick={() => onChange([])}

--- a/docs/investigations/composer-state-gaps-backlog-2026-05-25.md
+++ b/docs/investigations/composer-state-gaps-backlog-2026-05-25.md
@@ -1,0 +1,173 @@
+# Composer state-machine gaps — backlog for future PRs
+
+Generated while implementing `feat/composer-state-aware`. Each entry
+is a state-machine gap that the composer-only fix does NOT address.
+These feed into the Feature Inventory tab and become individual PRs.
+
+Severity legend: **P0** = silent data corruption or mutation of a
+terminal-state row; **P1** = wrong affordance shown but no mutation
+risk; **P2** = polish / consistency.
+
+---
+
+## G1 — Posts list filter does not gate actions by state — P1
+
+**Surface**: `components/SocialPostsListClient.tsx` posts table on
+`/company/social/posts`.
+
+**Current**: bulk action menu offers Delete / Reschedule / Convert
+to draft across mixed-state selections without per-row eligibility.
+
+**Expected**: bulk actions should only enable on rows whose state
+permits the action per `lib/social/post-state-actions.ts`. A bulk
+delete that includes a `publishing` row should refuse (or skip and
+report) rather than silently 409 on the server.
+
+**Notes**: server `DELETE` already returns 409 for `published`/
+`publishing` (`app/api/platform/social/drafts/[id]/route.ts:286`),
+so this is UI-only.
+
+---
+
+## G2 — Calendar chip click handler treats every state the same — P1
+
+**Surface**: `components/social/dashboard/PostChip.tsx` +
+`components/social/dashboard/CalendarShell.tsx`.
+
+**Current**: clicking any post chip — published, scheduled, failed —
+opens the composer overlay. With this PR the composer is now state-
+aware, but the chip itself does not visually differentiate (same
+hover state, same click affordance). A published chip should
+visually read "tap to view" rather than "tap to edit".
+
+**Expected**: chip visual treatment derived from state (e.g.
+`data-post-state` + CSS distinguishing terminal vs editable);
+optional tooltip "Read-only — published 14 days ago" on hover.
+
+---
+
+## G3 — Bulk delete across mixed states has no per-row preview — P0
+
+**Surface**: posts list bulk action menu (selection model in
+`SocialPostsListClient.tsx`).
+
+**Current**: "Delete N posts" message gives a count but no breakdown
+by state. If the selection contains a `publishing` row, the server
+will reject only that row but the user sees a generic error.
+
+**Expected**: confirmation dialog enumerates "X drafts, Y scheduled,
+Z published → Z published will only be removed from records (post
+stays live on the social platform)". Driven by
+`ALLOWED_ACTIONS[state]` per row.
+
+**Why P0**: a user might assume "delete" means "delete everywhere"
+on a published post — the explicit copy from the composer's
+`PostInfoCard` should propagate to the bulk surface, or the bulk
+action should refuse to delete published rows.
+
+---
+
+## G4 — Recurring / paused state transitions are not surfaced in UI — P1
+
+**Surface**: composer + posts list.
+
+**Current**: `state IN ('recurring', 'paused')` is a valid DB enum
+value (migration 0132) but there is no UI for transitioning between
+them. A user cannot pause or resume a recurring post from the
+composer.
+
+**Expected**: matrix already allows `convert_to_draft` from both
+states. Add explicit `pause_recurring` / `resume_recurring` actions
+to the matrix + a server transition endpoint, then expose them in
+PostInfoCard.
+
+---
+
+## G5 — Approval-flow state transitions are not state-aware — P1
+
+**Surface**: approval routes under
+`app/api/platform/social/drafts/[id]/approve/route.ts` + composer
+for `pending_approval` state.
+
+**Current**: the matrix declares `pending_approval` → view, approve,
+reject. The composer renders PostInfoCard for `pending_approval` but
+there is currently no Approve/Reject button surfaced from it. The
+existing approval UI lives at a separate review-link surface.
+
+**Expected**: when the viewing user has the approver role, the
+PostInfoCard for `pending_approval` should render Approve/Reject
+buttons inline. Server-side `record_approval_decision` already exists
+(migration 0072).
+
+---
+
+## G6 — Failed publish retry flow does not call a dedicated endpoint — P1
+
+**Surface**: composer Retry button + publish path.
+
+**Current**: this PR wires the Retry button to PATCH(mode=schedule)
+which resets state from `failed` → `scheduled`. The next publish-due
+cron sweep picks it up. This is a reasonable interim, but it loses
+the `publish_attempts` and `last_publish_error` context that the
+analytics / observability layer relies on.
+
+**Expected**: dedicated POST
+`/api/platform/social/drafts/[id]/retry-publish` that preserves the
+attempt history. Matrix already declares `retry_publish` as the verb.
+
+---
+
+## G7 — Composer URL `?compose=<id>` does not validate row state before
+fetch — P2
+
+**Surface**: `components/composer/composer-mount-v2.tsx`.
+
+**Current**: the mount fetches the row regardless of state. If the
+draft was published, the composer hydrates fine (now read-only).
+If the draft was deleted while another tab was open, the user sees
+the generic `composer-fetch-error` shell.
+
+**Expected**: when the GET response indicates the row is archived,
+show "This post was deleted from Opollo" specifically, with a back-
+to-calendar CTA. Today the user has to read the small print.
+
+---
+
+## G8 — `bulk` insert sets `state="scheduled"` without enforcement of
+target_profile count — P2
+
+**Surface**: `app/api/platform/social/drafts/bulk/route.ts:102`.
+
+**Current**: CSV upload sets `state: "scheduled"` even when the row
+has no resolved target profiles (mapper at line 89-93 can produce
+an empty array if `connectionsByPlatform.get(ch)` returns
+undefined). A `scheduled` row with zero target_profile_ids cannot
+publish — it lives in a "stuck scheduled" state.
+
+**Expected**: enforce target_profile_ids ≥ 1 at the bulk-row level
+or fall back to `state="draft"` when empty.
+
+---
+
+## G9 — `convert-to-draft` endpoint only allows `scheduled` source — P2
+
+**Surface**:
+`app/api/platform/social/drafts/[id]/convert-to-draft/route.ts:39`.
+
+**Current**: rejects every non-`scheduled` row. The matrix declares
+`convert_to_draft` allowed from `recurring`, `paused`, and `scheduled`.
+
+**Expected**: widen the source-state check to match the matrix.
+Trivial change once G4 (UI for paused / recurring) lands.
+
+---
+
+## How to use this list
+
+Pick one ID per follow-up PR. Lead the PR description with
+`Backlog → G<N>` so the closeout maps cleanly back here. Update or
+remove the row when the corresponding PR merges.
+
+The matrix in `lib/social/post-state-actions.ts` is the load-bearing
+artefact — every entry above should be resolvable by either tightening
+the matrix or driving more callers through it.

--- a/docs/investigations/composer-state-model-2026-05-25.md
+++ b/docs/investigations/composer-state-model-2026-05-25.md
@@ -1,0 +1,150 @@
+# Composer state-model investigation — 2026-05-25
+
+Bug: every post opens in fully-editable mode regardless of `state` —
+including posts already published to LinkedIn weeks ago.
+
+## 1. State enum
+
+Source of truth: `supabase/migrations/0132_planned_for_at.sql:18-31` —
+`social_post_drafts.state` CHECK constraint:
+
+```sql
+CHECK ( state IN (
+  'draft', 'pending_approval', 'rejected', 'scheduled',
+  'recurring', 'paused', 'publishing', 'published', 'failed'
+))
+```
+
+Mirrored in TypeScript at `lib/social/types.ts:19-28` as `DraftState`.
+
+The brief lists `needs_approval`; the actual column value is
+**`pending_approval`** — using the DB value.
+
+## 2. Composer behaviour per state today
+
+Single entry path: `components/composer/composer-mount-v2.tsx` mounts
+`ComposerOverlay` on `/company/social/*` when `?compose=<id>` is set
+(`composer-mount-v2.tsx:135-141`). The mount fetches the draft and
+passes the row's `state` as `editOriginalState`
+(`composer-mount-v2.tsx:189-191`).
+
+`components/social/composer/ComposerOverlay.tsx` consumes
+`editOriginalState`:
+
+| Branch | Where | What it does |
+|---|---|---|
+| `publishing` | `ComposerOverlay.tsx:448, 599` | `isSubmitDisabled` forced true; body gets `pointer-events-none opacity-60`; "Publishing…" pill in header |
+| `failed` | `ComposerOverlay.tsx:542-544, 606-614` | `· Failed` suffix in header; red `failure-banner` shown above editor |
+| `scheduled` | `ComposerOverlay.tsx:480-490` | Renders extra "Convert to draft" button under SchedulingCard |
+| `draft` | (no branch) | Default editable layout |
+| `pending_approval`, `rejected`, `recurring`, `paused`, **`published`** | (no branch) | **Falls through to default editable layout — this is the bug** |
+
+So when `editOriginalState === "published"`:
+- Textarea is editable
+- Schedule / Post now / Save as draft CTAs render
+- PATCH is enabled — clicking Schedule re-flips state to `scheduled`
+
+## 3. State → action mapping today
+
+There is **no central mapping**. State checks are scattered:
+
+- `ComposerOverlay.tsx:448` — `isPublishing`
+- `ComposerOverlay.tsx:480` — `editOriginalState === "scheduled"`
+- `ComposerOverlay.tsx:542, 606` — `failed` UI
+- `app/api/platform/social/drafts/[id]/route.ts:105-110` — `MODE_TO_STATE`
+  silently overwrites state via PATCH **without consulting current state**.
+  A PATCH with `mode: "schedule"` against a `published` row flips it
+  back to `scheduled` — published-post mutation is unguarded.
+- `app/api/platform/social/drafts/[id]/route.ts:286-288` — DELETE
+  already guards `published`/`publishing` (returns 409). PATCH does not.
+- `app/api/platform/social/drafts/[id]/convert-to-draft/route.ts:39-43`
+  — only allows `scheduled` → `draft` (correct).
+
+No file owns the "what can a post in state X actually do" question.
+That gap is the bug.
+
+## 4. Failures the current model produces
+
+Reproduced or trivially derivable from the code:
+
+| # | Surface | State | Current bug |
+|---|---|---|---|
+| F1 | Composer header | `published` | Renders "Edit post" + editable layout instead of read-only "Post info" |
+| F2 | Composer body | `published` | Textarea editable; user can rewrite content that's already live on LinkedIn |
+| F3 | Scheduling row | `published` | "Schedule post" CTA visible; clicking it issues PATCH that silently flips `published` → `scheduled` |
+| F4 | Save as draft | `published` | Renders; clicking PATCHes state back to `draft` |
+| F5 | PATCH endpoint | `published`/`publishing` | No server-side state guard — UI-bypass via curl mutates terminal-state rows |
+| F6 | Composer body | `pending_approval` | Editable; editor can edit a post that's queued for approver |
+| F7 | Composer body | `recurring`/`paused` | Editable like a draft; no recurrence-aware UI |
+| F8 | "Convert to draft" | `published` | Brief exists for `scheduled`; missing for `failed` (where a back-to-draft retry makes sense) |
+| F9 | Failure banner + retry | `failed` | Failure banner shows but there is no "Retry publish" affordance — user has to re-schedule |
+| F10 | View on platform | `published` | No "View on LinkedIn" / open-post affordance even when `published_url` is populated |
+| F11 | Repost as new | `published` | No way to clone a published post into a fresh draft |
+| F12 | Delete affordance | `publishing` | DELETE returns 409 from the API (good) but the composer does not surface this; user can still click |
+| F13 | Analytics | `published` | No path from composer to the analytics modal; modal exists elsewhere |
+
+(F1–F5 are the Steven-reported set. F6–F13 are derived from the same
+"no central matrix" root cause and are the basis for the backlog doc
+in Part 5.)
+
+## 5. Recommended state-action matrix
+
+`PostState` = the DB enum, verbatim. `PostAction` is the set of UX
+verbs we want to govern. Read-only by default for terminal states
+(`published`, `publishing`).
+
+| State | Allowed actions |
+|---|---|
+| `draft` | `edit`, `schedule`, `save_draft`, `delete` |
+| `pending_approval` | `view`, `approve`, `reject`, `delete` |
+| `rejected` | `edit`, `save_draft`, `delete` |
+| `scheduled` | `edit`, `reschedule`, `convert_to_draft`, `delete` |
+| `recurring` | `view`, `convert_to_draft`, `delete` |
+| `paused` | `view`, `convert_to_draft`, `delete` |
+| `publishing` | `view` (read-only; transient) |
+| `published` | `view`, `view_on_platform`, `view_analytics`, `repost_as_new`, `delete_from_records` |
+| `failed` | `edit`, `retry_publish`, `save_draft`, `delete` |
+
+Explicit FORBIDDEN — assert in tests:
+
+- `published` → never `edit`, never `schedule`, never `save_draft`,
+  never `reschedule`, never `convert_to_draft`. **Never call any
+  bundle.social unpublish API on delete.** `delete_from_records`
+  only removes Opollo's row.
+- `publishing` → never `edit`, never `schedule`, never `delete`
+  (the publish job still owns the row); allow `view` only.
+- `pending_approval` → only the approver can `approve`/`reject`;
+  editors must `view` (they can recall via the existing
+  approval-cancel flow, which is a separate transition, not an `edit`).
+
+This is the matrix that Part 2 will encode in
+`lib/social/post-state-actions.ts`.
+
+## 6. Server-side enforcement gap
+
+The composer fix is necessary but not sufficient. The PATCH endpoint
+at `app/api/platform/social/drafts/[id]/route.ts:191` writes
+`state = MODE_TO_STATE[mode]` with no current-state check. Any caller
+(direct API, curl, future client) can mutate a `published` row.
+
+The fix is a server-side guard at `route.ts` that returns 422 when
+the existing row's `state` is `published` or `publishing`, before
+the UPDATE fires. DELETE already does this at `route.ts:286-288` —
+the working analog. PATCH must copy that shape.
+
+## 7. Working analogs
+
+For the read-only composer view:
+- `components/SocialPostDetailClient.tsx` has a read-only post-info
+  page used by the legacy posts list — reference pattern for
+  metadata layout and "View on platform" link.
+- `app/api/platform/social/drafts/[id]/analytics/route.ts` already
+  joins to `social_post_analytics_snapshots` — analytics surface
+  can be linked from the read-only view.
+
+For the server guard:
+- `app/api/platform/social/drafts/[id]/route.ts:286-288` (DELETE) —
+  the exact shape the PATCH guard must mirror.
+- `lib/platform/social/posts/transitions.ts` — `social_post_master`
+  flow returns `INVALID_STATE` on predicate-guarded UPDATEs. Same
+  conceptual pattern, different table.

--- a/e2e/uat/composer.spec.ts
+++ b/e2e/uat/composer.spec.ts
@@ -367,3 +367,212 @@ test.describe("P0 — Social composer", () => {
     await page.screenshot({ path: "test-results/uat/composer/post-still-on-calendar-after-discard.png" });
   });
 });
+
+// ---------------------------------------------------------------------------
+// P0 — Composer state-aware behaviour (PR feat/composer-state-aware).
+//
+// Regression cover for the bug where every post — including posts already
+// published to LinkedIn — opened in fully-editable mode with a "Schedule
+// post" CTA. The matrix lives at lib/social/post-state-actions.ts and is
+// also pinned by a permanent CI gate in button-migration-gates.yml.
+//
+// Each spec opens the composer at /company/social/calendar?compose=<id>
+// where <id> is looked up at runtime from the calendar-view endpoint
+// rather than hard-coded — the staging seed assigns fresh UUIDs each run.
+// ---------------------------------------------------------------------------
+
+test.describe("P0 — Composer state-aware behaviour", () => {
+  let consoleMessages: string[];
+
+  test.beforeEach(async ({ page }) => {
+    consoleMessages = collectConsole(page);
+    await signInAsUatBot(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    await saveFailureReport(page, testInfo, { consoleMessages });
+  });
+
+  // Resolve a seeded post id for the requested state via the same
+  // endpoint the calendar uses, so the spec doesn't need to know the
+  // UUIDs minted by scripts/seed-uat-staging.ts.
+  async function findSeededDraftIdByContent(
+    page: import("@playwright/test").Page,
+    needle: string,
+  ): Promise<string | null> {
+    const res = await page.request.get(
+      `${UAT_BASE_URL}/api/platform/social/drafts/calendar-view`,
+    );
+    if (!res.ok()) return null;
+    const json = (await res.json()) as {
+      data?: { posts?: Array<{ id: string; content_excerpt?: string }> };
+    };
+    const posts = json.data?.posts ?? [];
+    const hit = posts.find((p) =>
+      (p.content_excerpt ?? "").toLowerCase().includes(needle.toLowerCase()),
+    );
+    return hit?.id ?? null;
+  }
+
+  async function openComposerForState(
+    page: import("@playwright/test").Page,
+    contentNeedle: string,
+  ): Promise<{ overlay: import("@playwright/test").Locator; draftId: string } | null> {
+    const id = await findSeededDraftIdByContent(page, contentNeedle);
+    if (!id) {
+      test.fixme(true, `No seeded draft matching "${contentNeedle}" found — re-seed staging.`);
+      return null;
+    }
+    await page.goto(`${UAT_BASE_URL}/company/social/calendar?compose=${id}`);
+    const overlay = page.locator('[data-testid="composer-overlay"]');
+    await expect(overlay).toBeVisible({ timeout: 15_000 });
+    return { overlay, draftId: id };
+  }
+
+  test("published post opens read-only — textarea is readOnly", async ({ page }) => {
+    const opened = await openComposerForState(page, "already live on LinkedIn");
+    if (!opened) return;
+    const { overlay } = opened;
+
+    const textarea = overlay.locator('[data-testid="content-textarea"]');
+    await expect(textarea).toBeVisible({ timeout: 5_000 });
+    // The textarea must carry the readOnly attribute. Brief explicitly
+    // forbids the published post from being edited.
+    await expect(textarea).toHaveAttribute("readonly", "");
+    await page.screenshot({
+      path: "test-results/uat/composer/state-published-readonly.png",
+    });
+  });
+
+  test("published post shows the read-only banner with post-state metadata", async ({ page }) => {
+    const opened = await openComposerForState(page, "already live on LinkedIn");
+    if (!opened) return;
+    const { overlay } = opened;
+
+    const banner = overlay.locator('[data-testid="composer-readonly-banner"]');
+    await expect(banner).toBeVisible({ timeout: 5_000 });
+    await expect(banner).toHaveAttribute("data-post-state", "published");
+  });
+
+  test("published post shows View on platform link", async ({ page }) => {
+    const opened = await openComposerForState(page, "already live on LinkedIn");
+    if (!opened) return;
+    const { overlay } = opened;
+
+    const link = overlay.locator('[data-testid="view-on-platform-link"]');
+    await expect(link).toBeVisible({ timeout: 5_000 });
+    await expect(link).toHaveAttribute("href", /linkedin\.com|facebook\.com|x\.com/);
+    await expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  test("published post shows Repost as new button", async ({ page }) => {
+    const opened = await openComposerForState(page, "already live on LinkedIn");
+    if (!opened) return;
+    const { overlay } = opened;
+    await expect(
+      overlay.locator('[data-testid="repost-as-new-button"]'),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("published post shows analytics link", async ({ page }) => {
+    const opened = await openComposerForState(page, "already live on LinkedIn");
+    if (!opened) return;
+    const { overlay } = opened;
+    await expect(
+      overlay.locator('[data-testid="view-analytics-link"]'),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("published post does NOT show Schedule/Save submit", async ({ page }) => {
+    const opened = await openComposerForState(page, "already live on LinkedIn");
+    if (!opened) return;
+    const { overlay } = opened;
+
+    // SchedulingCard's primary submit button is `composer-submit`. In
+    // read-only mode SchedulingCard is replaced by PostInfoCard, so the
+    // submit button must not be in the DOM at all.
+    await expect(
+      overlay.locator('[data-testid="composer-submit"]'),
+    ).toHaveCount(0);
+  });
+
+  test("published post Delete from records uses confirmation copy that the post stays live", async ({ page }) => {
+    const opened = await openComposerForState(page, "already live on LinkedIn");
+    if (!opened) return;
+    const { overlay } = opened;
+
+    await overlay.locator('[data-testid="delete-from-records-button"]').click();
+    const confirm = overlay.locator('[data-testid="delete-from-records-confirm"]');
+    await expect(confirm).toBeVisible({ timeout: 3_000 });
+    // The copy must spell out that the social-platform post stays up.
+    // We never call any bundle.social unpublish API.
+    await expect(confirm).toContainText(/remain visible on the social platform/i);
+  });
+
+  test("publishing post opens read-only — no edit affordances", async ({ page }) => {
+    const opened = await openComposerForState(page, "currently being published");
+    if (!opened) return;
+    const { overlay } = opened;
+
+    const textarea = overlay.locator('[data-testid="content-textarea"]');
+    await expect(textarea).toHaveAttribute("readonly", "");
+    await expect(
+      overlay.locator('[data-testid="composer-readonly-banner"]'),
+    ).toHaveAttribute("data-post-state", "publishing");
+    await expect(
+      overlay.locator('[data-testid="composer-submit"]'),
+    ).toHaveCount(0);
+  });
+
+  test("failed post shows Retry publish button", async ({ page }) => {
+    const opened = await openComposerForState(page, "bundle.social rejected");
+    if (!opened) return;
+    const { overlay } = opened;
+    await expect(
+      overlay.locator('[data-testid="retry-publish-button"]'),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("failed post is editable — textarea is NOT readOnly", async ({ page }) => {
+    const opened = await openComposerForState(page, "bundle.social rejected");
+    if (!opened) return;
+    const { overlay } = opened;
+    const textarea = overlay.locator('[data-testid="content-textarea"]');
+    await expect(textarea).toBeVisible({ timeout: 5_000 });
+    // The matrix allows `edit` for state='failed'; readOnly attr must be absent.
+    await expect(textarea).not.toHaveAttribute("readonly", "");
+  });
+
+  test("draft post is fully editable (regression)", async ({ page }) => {
+    const opened = await openComposerForState(page, "not yet scheduled");
+    if (!opened) return;
+    const { overlay } = opened;
+    const textarea = overlay.locator('[data-testid="content-textarea"]');
+    await expect(textarea).toBeVisible({ timeout: 5_000 });
+    await expect(textarea).not.toHaveAttribute("readonly", "");
+    // SchedulingCard must render — composer-submit is the primary CTA.
+    await expect(
+      overlay.locator('[data-testid="composer-submit"]'),
+    ).toBeVisible({ timeout: 5_000 });
+    // PostInfoCard must NOT render in editable mode.
+    await expect(
+      overlay.locator('[data-testid="composer-readonly-banner"]'),
+    ).toHaveCount(0);
+  });
+
+  test("scheduled post is fully editable (regression)", async ({ page }) => {
+    const opened = await openComposerForState(page, "going out in 3 days");
+    if (!opened) return;
+    const { overlay } = opened;
+    const textarea = overlay.locator('[data-testid="content-textarea"]');
+    await expect(textarea).toBeVisible({ timeout: 5_000 });
+    await expect(textarea).not.toHaveAttribute("readonly", "");
+    await expect(
+      overlay.locator('[data-testid="composer-submit"]'),
+    ).toBeVisible({ timeout: 5_000 });
+    // Convert-to-draft is the scheduled-state affordance.
+    await expect(
+      overlay.locator('[data-testid="convert-to-draft-btn"]'),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/lib/__tests__/draft-patch-v2.unit.test.ts
+++ b/lib/__tests__/draft-patch-v2.unit.test.ts
@@ -39,6 +39,7 @@ const CONN_ID   = "ffffffff-0000-0000-0000-000000000003";
 const BASE_ROW = {
   company_id: COMPANY_ID,
   draft_version: 3,
+  state: "draft",
   draft_data: {
     master_text: "old content",
     media_refs: [],
@@ -256,6 +257,56 @@ describe("PATCH /api/platform/social/drafts/[id] — V2 body", () => {
     );
 
     expect(res.status).toBe(404);
+  });
+
+  it("returns 422 INVALID_STATE when the draft is already published (state guard)", async () => {
+    // The composer must never silently flip a published post back to
+    // scheduled / draft. See lib/social/post-state-actions.ts.
+    mockFrom.mockReturnValueOnce(
+      makeQueryChain({ ...BASE_ROW, state: "published" }),
+    );
+
+    const res = await PATCH(
+      makeRequest({
+        draft_version: 3,
+        content: "trying to edit a live post",
+        media_urls: [],
+        target_profile_ids: [],
+        platform_variants: {},
+        mode: "schedule",
+        scheduled_at: "2026-06-01T23:00:00.000Z",
+        approval_required: false,
+      }),
+      makeParams(),
+    );
+
+    expect(res.status).toBe(422);
+    const json = (await res.json()) as { error: { code: string; message: string } };
+    expect(json.error.code).toBe("INVALID_STATE");
+    expect(json.error.message).toContain("published");
+  });
+
+  it("returns 422 INVALID_STATE when the draft is currently publishing", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeQueryChain({ ...BASE_ROW, state: "publishing" }),
+    );
+
+    const res = await PATCH(
+      makeRequest({
+        draft_version: 3,
+        content: "trying to edit during publish",
+        media_urls: [],
+        target_profile_ids: [],
+        platform_variants: {},
+        mode: "draft",
+        approval_required: false,
+      }),
+      makeParams(),
+    );
+
+    expect(res.status).toBe(422);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("INVALID_STATE");
   });
 
   it("returns 400 (VALIDATION_FAILED) on invalid V2 body (mode field missing)", async () => {

--- a/lib/__tests__/post-state-actions.unit.test.ts
+++ b/lib/__tests__/post-state-actions.unit.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ALLOWED_ACTIONS,
+  canPerform,
+  isReadOnlyState,
+  isTerminalForMutation,
+  type PostAction,
+  type PostState,
+} from "@/lib/social/post-state-actions";
+
+// ---------------------------------------------------------------------------
+// post-state-actions matrix — one assertion per (state, action) cell.
+//
+// The matrix is the single source of truth for composer + PATCH guard.
+// If any cell flips, both the UI and the server contract have to change
+// in lockstep. This test pins the matrix so a silent drift fails CI.
+// ---------------------------------------------------------------------------
+
+const ALL_STATES: readonly PostState[] = [
+  "draft",
+  "pending_approval",
+  "rejected",
+  "scheduled",
+  "recurring",
+  "paused",
+  "publishing",
+  "published",
+  "failed",
+];
+
+const ALL_ACTIONS: readonly PostAction[] = [
+  "edit",
+  "schedule",
+  "reschedule",
+  "save_draft",
+  "convert_to_draft",
+  "delete",
+  "view",
+  "view_on_platform",
+  "view_analytics",
+  "repost_as_new",
+  "delete_from_records",
+  "cancel_publish",
+  "retry_publish",
+  "approve",
+  "reject",
+];
+
+// Explicit expected matrix — duplicated here intentionally so a change
+// in lib/social/post-state-actions.ts cannot pass tests by accident.
+const EXPECTED: Record<PostState, readonly PostAction[]> = {
+  draft: ["edit", "schedule", "save_draft", "delete"],
+  pending_approval: ["view", "approve", "reject", "delete"],
+  rejected: ["edit", "save_draft", "delete"],
+  scheduled: ["edit", "reschedule", "convert_to_draft", "delete"],
+  recurring: ["view", "convert_to_draft", "delete"],
+  paused: ["view", "convert_to_draft", "delete"],
+  publishing: ["view"],
+  published: [
+    "view",
+    "view_on_platform",
+    "view_analytics",
+    "repost_as_new",
+    "delete_from_records",
+  ],
+  failed: ["edit", "retry_publish", "save_draft", "delete"],
+};
+
+describe("post-state-actions — matrix shape", () => {
+  it("covers every state in the DraftState enum", () => {
+    for (const s of ALL_STATES) {
+      expect(ALLOWED_ACTIONS[s]).toBeDefined();
+    }
+  });
+
+  it("matches the expected matrix exactly", () => {
+    for (const s of ALL_STATES) {
+      expect([...ALLOWED_ACTIONS[s]].sort()).toEqual(
+        [...EXPECTED[s]].sort(),
+      );
+    }
+  });
+});
+
+describe("canPerform — every (state, action) cell", () => {
+  for (const state of ALL_STATES) {
+    for (const action of ALL_ACTIONS) {
+      const expected = EXPECTED[state].includes(action);
+      it(`${state} → ${action} = ${expected}`, () => {
+        expect(canPerform(state, action)).toBe(expected);
+      });
+    }
+  }
+});
+
+describe("isReadOnlyState — terminal/transient states", () => {
+  it("returns true for published", () => {
+    expect(isReadOnlyState("published")).toBe(true);
+  });
+
+  it("returns true for publishing", () => {
+    expect(isReadOnlyState("publishing")).toBe(true);
+  });
+
+  it("returns true for pending_approval (editors view only)", () => {
+    expect(isReadOnlyState("pending_approval")).toBe(true);
+  });
+
+  it("returns true for recurring + paused (use convert-to-draft to edit)", () => {
+    expect(isReadOnlyState("recurring")).toBe(true);
+    expect(isReadOnlyState("paused")).toBe(true);
+  });
+
+  it("returns false for draft, scheduled, rejected, failed", () => {
+    expect(isReadOnlyState("draft")).toBe(false);
+    expect(isReadOnlyState("scheduled")).toBe(false);
+    expect(isReadOnlyState("rejected")).toBe(false);
+    expect(isReadOnlyState("failed")).toBe(false);
+  });
+});
+
+describe("isTerminalForMutation — PATCH guard contract", () => {
+  it("returns true only for published and publishing", () => {
+    expect(isTerminalForMutation("published")).toBe(true);
+    expect(isTerminalForMutation("publishing")).toBe(true);
+  });
+
+  it("returns false for every other state", () => {
+    const guarded: PostState[] = ["published", "publishing"];
+    for (const s of ALL_STATES) {
+      if (guarded.includes(s)) continue;
+      expect(isTerminalForMutation(s)).toBe(false);
+    }
+  });
+});
+
+describe("safety invariants", () => {
+  it("published never allows edit/schedule/save_draft/convert_to_draft/reschedule", () => {
+    const forbidden: PostAction[] = [
+      "edit",
+      "schedule",
+      "save_draft",
+      "convert_to_draft",
+      "reschedule",
+    ];
+    for (const a of forbidden) {
+      expect(canPerform("published", a)).toBe(false);
+    }
+  });
+
+  it("publishing only allows view — no mutations of a transient state", () => {
+    const forbidden: PostAction[] = [
+      "edit",
+      "schedule",
+      "save_draft",
+      "convert_to_draft",
+      "reschedule",
+      "delete",
+      "delete_from_records",
+    ];
+    for (const a of forbidden) {
+      expect(canPerform("publishing", a)).toBe(false);
+    }
+  });
+
+  it("published exposes view_on_platform + view_analytics so users can find the live post", () => {
+    expect(canPerform("published", "view_on_platform")).toBe(true);
+    expect(canPerform("published", "view_analytics")).toBe(true);
+    expect(canPerform("published", "repost_as_new")).toBe(true);
+  });
+});

--- a/lib/social/post-state-actions.ts
+++ b/lib/social/post-state-actions.ts
@@ -1,0 +1,83 @@
+// Post state → allowed actions matrix.
+//
+// Single source of truth for "what can a post in state X do?".
+// Consumed by:
+//   - components/social/composer/ComposerOverlay.tsx — read-only mode
+//   - app/api/platform/social/drafts/[id]/route.ts (PATCH) — server guard
+//
+// State enum mirrors supabase/migrations/0132_planned_for_at.sql §CHECK.
+// Action enum is a UX vocabulary; not every action maps to a single
+// route — `edit` is the right to render the textarea + Save/Schedule
+// CTAs; `delete_from_records` calls the same DELETE route as `delete`
+// but is a separate verb because the user-facing copy differs (the
+// published-post deletion only removes the Opollo row; the post stays
+// live on the social platform).
+//
+// NEVER UNPUBLISH FROM THE EXTERNAL PLATFORM. `delete_from_records`
+// must only remove the social_post_drafts row. Bundle.social has no
+// unpublish API call wired up here and we don't want one.
+
+export type PostState =
+  | "draft"
+  | "pending_approval"
+  | "rejected"
+  | "scheduled"
+  | "recurring"
+  | "paused"
+  | "publishing"
+  | "published"
+  | "failed";
+
+export type PostAction =
+  | "edit"
+  | "schedule"
+  | "reschedule"
+  | "save_draft"
+  | "convert_to_draft"
+  | "delete"
+  | "view"
+  | "view_on_platform"
+  | "view_analytics"
+  | "repost_as_new"
+  | "delete_from_records"
+  | "cancel_publish"
+  | "retry_publish"
+  | "approve"
+  | "reject";
+
+export const ALLOWED_ACTIONS: Record<PostState, readonly PostAction[]> = {
+  draft: ["edit", "schedule", "save_draft", "delete"],
+  pending_approval: ["view", "approve", "reject", "delete"],
+  rejected: ["edit", "save_draft", "delete"],
+  scheduled: ["edit", "reschedule", "convert_to_draft", "delete"],
+  recurring: ["view", "convert_to_draft", "delete"],
+  paused: ["view", "convert_to_draft", "delete"],
+  publishing: ["view"],
+  published: [
+    "view",
+    "view_on_platform",
+    "view_analytics",
+    "repost_as_new",
+    "delete_from_records",
+  ],
+  failed: ["edit", "retry_publish", "save_draft", "delete"],
+} as const;
+
+export function canPerform(state: PostState, action: PostAction): boolean {
+  return ALLOWED_ACTIONS[state].includes(action);
+}
+
+// True for states the composer should render in read-only mode
+// (textarea not editable, no Schedule/Save CTAs).
+export function isReadOnlyState(state: PostState): boolean {
+  return !canPerform(state, "edit");
+}
+
+// True for states the server-side PATCH endpoint must reject as 422.
+// Mutating these states is never legitimate from the composer write
+// path — `published` is on the social platform; `publishing` is owned
+// by the publish job. Transitions out of these states happen via
+// dedicated endpoints (retry, repost-as-new), not generic PATCH.
+export function isTerminalForMutation(state: PostState): boolean {
+  return state === "published" || state === "publishing";
+}

--- a/lib/social/types.ts
+++ b/lib/social/types.ts
@@ -46,6 +46,10 @@ export interface Draft {
   approval_required: boolean;
   approver_user_id?: string;
   scheduled_at?: string | null; // ISO 8601 UTC — populated when editing a scheduled draft
+  // Populated for state='published' rows so the read-only Post Info card
+  // can render a "View on platform" link without an extra fetch.
+  published_url?: string | null;
+  published_at?: string | null;
 }
 
 export interface CalendarPost {

--- a/scripts/seed-uat-staging.ts
+++ b/scripts/seed-uat-staging.ts
@@ -299,7 +299,9 @@ async function main() {
   const now = new Date();
   const inThreeDays = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000).toISOString();
   const inSevenDays = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString();
-  const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString();
+  // Published 14 days ago per state-aware composer brief — the
+  // "old published post" surface the bug used to reproduce on.
+  const fourteenDaysAgo = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000).toISOString();
 
   const drafts = [
     {
@@ -353,12 +355,30 @@ async function main() {
       created_by: uatUserId,
       updated_by: uatUserId,
       state: "published",
-      content: "UAT published post — already live.",
+      content: "UAT published post — already live on LinkedIn (14 days ago).",
       media_urls: [] as string[],
       target_profiles: [] as unknown[],
       platform_variants: {} as unknown,
-      published_at: twoDaysAgo,
+      published_at: fourteenDaysAgo,
       published_url: "https://www.linkedin.com/posts/uat-stub-post-001",
+      draft_data: {},
+    },
+    {
+      company_id: uatCompanyId,
+      created_by: uatUserId,
+      updated_by: uatUserId,
+      state: "failed",
+      content: "UAT failed post — bundle.social rejected the publish attempt.",
+      media_urls: [] as string[],
+      target_profiles: [] as unknown[],
+      platform_variants: {} as unknown,
+      last_publish_error: {
+        code: "BUNDLE_RATE_LIMIT",
+        message: "bundle.social rate limit exceeded",
+        attempted_at: now.toISOString(),
+        attempt_number: 1,
+      },
+      publish_attempts: 1,
       draft_data: {},
     },
   ];
@@ -422,6 +442,7 @@ async function main() {
   log("Seeding analytics snapshot...");
 
   const publishedDraft = insertedDrafts?.find((d) => d.state === "published");
+  const fourteenDaysAgoIso = fourteenDaysAgo;
   if (publishedDraft) {
     // Analytics snapshots require a profile_id; look up or skip gracefully
     const { data: profiles } = await supabase
@@ -439,8 +460,8 @@ async function main() {
           bundle_post_id: "uat-stub-bundle-post-001",
           platform: "linkedin_company",
           bundle_social_account_id: "uat-stub-linkedin-001",
-          snapshot_date: new Date(twoDaysAgo).toISOString().slice(0, 10),
-          posted_at: twoDaysAgo,
+          snapshot_date: new Date(fourteenDaysAgoIso).toISOString().slice(0, 10),
+          posted_at: fourteenDaysAgoIso,
           post_url: "https://www.linkedin.com/posts/uat-stub-post-001",
           content: "UAT published post — already live.",
           impressions: 142,
@@ -470,7 +491,7 @@ async function main() {
   log(`  Platform role: admin (opollo_users)`);
   log(`  Company role:  admin (platform_company_users)`);
   log(`  Connections:  ${connections.length} (LinkedIn healthy, Facebook auth_required, X healthy)`);
-  log(`  Drafts:       ${insertedDrafts?.length ?? 0} (1 draft, 2 scheduled, 1 publishing, 1 published)`);
+  log(`  Drafts:       ${insertedDrafts?.length ?? 0} (1 draft, 2 scheduled, 1 publishing, 1 published, 1 failed)`);
   log(`  Images:       ${insertedImages?.length ?? 0}`);
   log("");
 


### PR DESCRIPTION
## Summary
- Composer now consumes `lib/social/post-state-actions.ts` matrix. Published / publishing / recurring / paused / pending_approval render read-only with `PostInfoCard` (View on platform · Repost as new · Delete from records · View analytics). Failed adds Retry publish; textarea stays editable per the matrix.
- PATCH `/api/platform/social/drafts/[id]` now returns 422 `INVALID_STATE` for terminal states. Mirrors the existing DELETE guard at `route.ts:286-288`.
- Permanent CI gate in `button-migration-gates.yml` asserts the matrix exists, composer references `canPerform` / `ALLOWED_ACTIONS`, and the PATCH route literally references `published`/`publishing`.
- Seed adds a 14-days-ago `published` row + a `failed` row so the new UAT specs have deterministic coverage.

## Working analog
- **Working analog**: `app/api/platform/social/drafts/[id]/route.ts:286-288` — DELETE returns 409 when `state IN ('published', 'publishing')`.
- **Diff**: PATCH had no current-state check; `MODE_TO_STATE` at line 105-110 was overwriting state on every update.
- **Fix**: added `isTerminalForMutation` guard before the UPDATE; returns 422 with `INVALID_STATE` + a state-specific `suggested_action`. The composer UI mirrors the same matrix so the affordances disappear before the server has to refuse.

## Risks identified and mitigated
- **Silent published-post mutation**: PATCH 422 guard + per-cell unit test (every (state, action) cell pinned) + permanent CI gate that fails if the matrix file is removed or the composer stops referencing it.
- **Server-side bypass**: 422 is enforced even when the caller skips the UI. Tests at `lib/__tests__/draft-patch-v2.unit.test.ts` assert the response shape against the published + publishing paths.
- **Unpublish-on-delete**: \`delete_from_records\` ONLY soft-deletes the Opollo row. No bundle.social call. The confirmation copy in `PostInfoCard.tsx` spells out that the post stays live on the social platform.
- **Repost-as-new locality**: handler clears local id+version in-place so the next Submit POSTs a fresh draft instead of PATCHing the published row (which the server would now reject).
- **Test coverage drift**: the matrix is pinned by a duplicated EXPECTED table in `post-state-actions.unit.test.ts` — a silent change to `ALLOWED_ACTIONS` cannot pass tests by accident.

## Test plan
- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run test:unit\` — 2561 tests, all passing (includes 156 new tests across the matrix + 422 PATCH guard)
- [x] \`npm run test:components\` — 388 tests, all passing
- [ ] UAT harness run against staging post-deploy — 12 new specs in \`P0 — Composer state-aware behaviour\` describe block, exercising each (state, expected-affordance) pair.
- [ ] Manual: visit staging \`/company/social/calendar?compose=<seeded published id>\` — published post opens read-only with \"View on platform\" + \"Repost as new\" visible, no \"Schedule post\" button.

## Size warrant
1312 net lines. Above the 500-line soft ceiling because the matrix + server guard + UI consumer + tests + CI gate + seed + UAT specs are co-dependent in a single contract change. Splitting them would create intermediate states where the matrix exists but isn't enforced, or specs exist for an unimplemented feature. Per the original brief: \"Parts 1-5 end-to-end in one session. No pausing.\"

## Follow-up backlog
Documented in \`docs/investigations/composer-state-gaps-backlog-2026-05-25.md\` (G1–G9): posts-list per-state filtering, calendar chip state visuals, bulk-action state preview, recurring/paused UI, approver inline actions in PostInfoCard, dedicated `/retry-publish` endpoint that preserves attempt history, mixed-archive composer hydration messaging, bulk-CSV zero-target scheduling bug, and \`convert-to-draft\` widening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)