### PR TITLE
fix(seed): spell out every column on every social_post_drafts row

### DIFF
--- a/docs/inventory/INVENTORY_README.md
+++ b/docs/inventory/INVENTORY_README.md
@@ -1,0 +1,148 @@
+# Opollo Site Builder Feature Inventory
+
+**Phase 1** (this document + all documents in this directory): skeleton populated by Claude Code from codebase analysis. Props, validations, routes, state machines, API endpoints, and role gates are extracted from source — not invented.
+
+**Phase 2** (Steven): fill in every `EXPECTED BEHAVIOUR` section with the actual rules that should be enforced. These are the acceptance criteria for Phase 3.
+
+**Phase 3** (Claude Code): convert the filled inventory into UAT specs that enforce the rules. Each `[ ]` checkbox in an `EXPECTED BEHAVIOUR` section becomes one or more test assertions.
+
+---
+
+## Status
+
+| Document | Items | Description | Steven checkboxes | Done |
+|---|---|---|---|---|
+| [routes-and-pages.md](routes-and-pages.md) | 103 routes | All pages + auth gates, search params, loading states, user actions | 155 checkboxes | 0 filled |
+| [state-machines.md](state-machines.md) | 12 entities | All stateful DB entities + valid transitions + UI surfaces | 46 checkboxes | 0 filled |
+| [api-endpoints.md](api-endpoints.md) | ~158 endpoints | All API routes + auth requirements + risk classification | 131 checkboxes | 0 filled |
+| [components-catalog.md](components-catalog.md) | ~35 components | All major UI components + props + variants + testids | 64 checkboxes | 0 filled |
+| [forms-and-validation.md](forms-and-validation.md) | ~15 forms | All forms + current validation rules + error states | 45 checkboxes | 0 filled |
+| [roles-and-permissions.md](roles-and-permissions.md) | 7 roles | 3 operator + 4 platform roles + all action gates | 23 checkboxes | 0 filled |
+| [discovered-issues.md](discovered-issues.md) | 5 issues | Bugs / inconsistencies found during inventory analysis | — | Triage needed |
+
+**Total checkboxes: 464 across all documents.**
+
+---
+
+## How to use this inventory
+
+### For Steven (Phase 2)
+
+Each document has `EXPECTED BEHAVIOUR (Steven to fill)` sections with `[ ]` checkboxes. Fill these in with the rules you want enforced.
+
+**What to write:**
+- `[x]` — the item is correct as described; no clarification needed
+- `[ ] Answer: yes/no — [explanation]` — replace the question with the actual rule
+- `[ ] N/A — [reason]` — the question does not apply
+
+**Example:**
+```markdown
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [x] Closing a dirty composer always shows UnsavedChangesDialog — Answer: yes, for any content change including scheduling mode changes
+- [ ] ~~Should Escape always close?~~ Answer: yes, unless a sub-dialog is open (it closes sub-dialog first)
+```
+
+**Priority order for filling in (suggested):**
+1. `roles-and-permissions.md` — fills in fastest; gates the most other tests
+2. `forms-and-validation.md` — 15 forms; directly drives regression tests
+3. `state-machines.md` — 12 entities; the core business logic
+4. `components-catalog.md` — 35 components; UI fidelity specs
+5. `routes-and-pages.md` — 103 routes; auth and navigation specs
+6. `api-endpoints.md` — 158 endpoints; integration test specs
+
+### For Phase 3 spec generation
+
+Once a document has checkboxes filled, run:
+
+```
+/inventory-to-specs [document-name]
+```
+
+Claude Code will convert each answered `[ ]` into a test assertion in the appropriate layer (unit / integration / component / E2E / smoke).
+
+**Conversion rules:**
+- Role / permission question → integration test using `seedTwoCompanies()` + RLS assertion
+- Form validation question → unit test against the Zod schema
+- UI behaviour question → component test or E2E spec
+- Route auth question → E2E spec with fixture sessions
+- State transition question → integration test against the real DB
+
+---
+
+## Document structure conventions
+
+Every section in every document follows this template:
+
+```markdown
+## EntityName
+
+**File:** `path/to/file.ts`
+**Status:** Active | ⚠️ NO CALLSITES FOUND | Deprecated
+
+[Body: props / fields / routes / states extracted from source]
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Question 1?
+- [ ] Question 2?
+```
+
+The `⚠️ NO CALLSITES FOUND` status means the component or route exists in source but no imports or usages were found during inventory — it may be dead code or only used dynamically.
+
+---
+
+## Coverage notes
+
+### What is covered
+
+- All pages in `app/(platform)/` and `app/api/`
+- All stateful DB entities from the V1 (social_post_masters) and V2 (social_post_drafts) systems
+- All significant UI components under `components/`
+- All forms with explicit field lists
+- Both role systems (operator: opollo_users; platform: platform_company_users)
+
+### What is NOT covered in Phase 1
+
+**Optimiser module (deep):**
+- `/optimiser/*` routes are listed in `routes-and-pages.md` but the internal state machines (opt_proposals, OPT workflow states) are not fully enumerated in `state-machines.md`. The CAP (Content Automation Platform) state machine is included but the Optimiser proposal state machine is only partially covered.
+
+**CAP deep detail:**
+- `cap_campaigns`, `cap_campaign_posts`, `cap_subscriptions` state machines have skeletal entries in `state-machines.md` but the full transition graphs (especially the publish-attempt retry logic) are not documented.
+
+**Brief generation pipeline:**
+- `/api/cron/process-brief-runner`, `/api/cron/process-batch` are in `api-endpoints.md` but the internal job-state transitions of `generation_jobs` are skeletal.
+
+**Component test coverage:**
+- Most components listed in `components-catalog.md` have no corresponding component-layer test. This is flagged as debt in `docs/test-coverage-roadmap.md`.
+
+**Webhook receivers:**
+- `/api/webhooks/bundlesocial` and `/api/webhooks/qstash/social-publish` are in `api-endpoints.md` but their internal message schema and retry logic are not documented here.
+
+---
+
+## Known discovered issues
+
+See [discovered-issues.md](discovered-issues.md) for 5 issues found during Phase 1 inventory analysis:
+
+1. **Issue 1** — Published posts may open in an editable composer (confirmed bug, current branch scope)
+2. **Issue 2** — Two parallel state machines: `SocialPostState` vs `DraftState` (documented technical debt)
+3. **Issue 3** — `pending_identity` connection status added via `ALTER TYPE` in migration 0122 (may be missing from old type checks)
+4. **Issue 4** — Composer edit-mode behaviour for `published`/`failed` states is unverified (open question, current branch scope)
+5. **Issue 5** — `ApproveSchema` does not include `changes_requested` but the UI offers it as a decision (potential API contract gap)
+
+None of these are blocking for Phase 2 filling. They are triage items.
+
+---
+
+## File index
+
+```
+docs/inventory/
+├── INVENTORY_README.md       ← this file (index + how-to)
+├── routes-and-pages.md       ← 103 routes
+├── state-machines.md         ← 12 stateful entities
+├── api-endpoints.md          ← ~158 API endpoints
+├── components-catalog.md     ← ~35 components (Phase 1 — this batch)
+├── forms-and-validation.md   ← ~15 forms        (Phase 1 — this batch)
+├── roles-and-permissions.md  ← 7 roles           (Phase 1 — this batch)
+└── discovered-issues.md      ← 5 issues          (Phase 1 — this batch)
+```

--- a/docs/inventory/api-endpoints.md
+++ b/docs/inventory/api-endpoints.md
@@ -1,0 +1,2294 @@
+# API Endpoints Inventory
+
+> Generated: 2026-05-25.
+> Covers every `route.ts` file discovered under `app/api/`. 230+ endpoints catalogued.
+> EXPECTED BEHAVIOUR checkboxes are intentionally empty — Steven to fill.
+> Risk levels: CRITICAL (auth bypass / production data mutation / spend) · HIGH (multi-tenant data / irreversible) · MEDIUM (reversible / scoped) · LOW (read-only / public).
+
+---
+
+## A. Authentication
+
+### POST /api/auth/ping
+
+**File:** `app/api/auth/ping/route.ts`
+**Method(s):** POST
+**Auth:** None (session probe)
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** LOW — session status check; no state mutation
+
+**Currently tested by:**
+- Unit: None observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does this return 200 when unauthenticated (for client-side session polling)?
+
+---
+
+### POST /api/auth/callback
+
+**File:** `app/api/auth/callback/route.ts`
+**Method(s):** POST / GET
+**Auth:** OAuth callback token in URL (no existing session required)
+**Rate limit:** None observed
+**Body schema:** OAuth provider callback parameters (code, state)
+**Risk:** CRITICAL — exchanges OAuth code for session; incorrect handling allows session hijack
+
+**Currently tested by:**
+- Integration: `lib/__tests__/auth-callback-route.test.ts`, `lib/__tests__/auth-callback.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is PKCE enforced for the code exchange?
+- [ ] Does a mismatched `state` parameter return 400 or silently fail?
+- [ ] What happens when the OAuth provider returns an error code?
+
+---
+
+### POST /api/auth/complete-login
+
+**File:** `app/api/auth/complete-login/route.ts`
+**Method(s):** POST
+**Auth:** Partial session (post-credential, pre-2FA)
+**Rate limit:** None observed
+**Body schema:** Login completion payload (OTP or challenge token)
+**Risk:** CRITICAL — finalises authentication; incorrect implementation allows 2FA bypass
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does this endpoint enforce that a 2FA challenge was issued before accepting completion?
+- [ ] Is there replay protection on the completion token?
+
+---
+
+### POST /api/auth/challenge-status
+
+**File:** `app/api/auth/challenge-status/route.ts`
+**Method(s):** POST
+**Auth:** Partial session (mid-2FA flow)
+**Rate limit:** None observed
+**Body schema:** Challenge identifier
+**Risk:** HIGH — exposes 2FA challenge state; could be used to enumerate challenge validity
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the challenge status endpoint rate-limited?
+
+---
+
+### POST /api/auth/resend-challenge
+
+**File:** `app/api/auth/resend-challenge/route.ts`
+**Method(s):** POST
+**Auth:** Partial session (mid-2FA flow)
+**Rate limit:** None observed
+**Body schema:** Challenge identifier
+**Risk:** MEDIUM — resends 2FA code; abuse could spam user's phone/email
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is there a cooldown between resend requests?
+
+---
+
+### POST /api/auth/forgot-password
+
+**File:** `app/api/auth/forgot-password/route.ts`
+**Method(s):** POST
+**Auth:** None (public)
+**Rate limit:** None observed
+**Body schema:** `{ email: string }`
+**Risk:** MEDIUM — triggers password reset email; could be used to enumerate accounts or spam
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does the response differ for known vs unknown email addresses (user enumeration risk)?
+
+---
+
+### POST /api/auth/reset-password
+
+**File:** `app/api/auth/reset-password/route.ts`
+**Method(s):** POST
+**Auth:** Reset token in body (no session required)
+**Rate limit:** None observed
+**Body schema:** `{ token: string, password: string }`
+**Risk:** HIGH — changes account password; token validation must be strict
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the reset token single-use?
+- [ ] Does a successful reset invalidate all other active sessions?
+
+---
+
+### POST /api/auth/accept-invite
+
+**File:** `app/api/auth/accept-invite/route.ts`
+**Method(s):** POST
+**Auth:** Invite token in body (no session required)
+**Rate limit:** None observed
+**Body schema:** `{ token: string, password: string }` or similar
+**Risk:** HIGH — creates or links platform account; invalid token handling is security-critical
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the invite token invalidated immediately on first use?
+
+---
+
+### POST /api/auth/approve-here
+
+**File:** `app/api/auth/approve-here/route.ts`
+**Method(s):** POST
+**Auth:** Partial or full session
+**Rate limit:** None observed
+**Body schema:** Approval context
+**Risk:** MEDIUM — session-based approval action
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] How does this differ from /api/approve/[token]/decision?
+
+---
+
+### POST /api/uat/sign-in
+
+**File:** `app/api/uat/sign-in/route.ts`
+**Method(s):** POST
+**Auth:** `STAGING_UAT_SECRET` bearer token (staging-only gate)
+**Rate limit:** None observed
+**Body schema:** `{ email: string, secret: string }`
+**Risk:** CRITICAL — bypasses normal authentication for test automation; must be completely disabled in production
+
+**Currently tested by:**
+- E2E: `e2e/uat/` specs
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this route unreachable in production (env var absent = 403)?
+- [ ] Is the `STAGING_UAT_SECRET` rotated between test runs?
+
+---
+
+## B. Account
+
+### POST /api/account/change-password
+
+**File:** `app/api/account/change-password/route.ts`
+**Method(s):** POST
+**Auth:** Authenticated (any role); requires current password in body
+**Rate limit:** None observed
+**Body schema:** `{ current_password: string, new_password: string }`
+**Risk:** HIGH — credential change; incorrect current-password validation is a privilege escalation
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does a successful password change invalidate sessions on other devices?
+
+---
+
+### DELETE /api/account/devices/[id]
+
+**File:** `app/api/account/devices/[id]/route.ts`
+**Method(s):** DELETE
+**Auth:** Authenticated; user can only delete own device sessions
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — signs out a specific device session
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a user delete their currently active session via this endpoint?
+
+---
+
+### POST /api/account/devices/sign-out-others
+
+**File:** `app/api/account/devices/sign-out-others/route.ts`
+**Method(s):** POST
+**Auth:** Authenticated
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — invalidates all sessions except current; broad device revocation
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the current session preserved after calling this endpoint?
+
+---
+
+## C. Social Posts (legacy layer)
+
+### GET/POST /api/platform/social/posts
+
+**File:** `app/api/platform/social/posts/route.ts`
+**Method(s):** GET, POST
+**Auth:** GET: `view_calendar`; POST: `create_post`
+**Rate limit:** None observed
+**Body schema:** POST: post creation payload
+**Risk:** HIGH — reads/creates social posts; tenant-scoped via RLS
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-posts.test.ts`, `lib/__tests__/social-posts-dashboard.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the legacy POST route still used, or has all creation moved to /api/platform/social/drafts?
+
+---
+
+### GET/PATCH/DELETE /api/platform/social/posts/[id]
+
+**File:** `app/api/platform/social/posts/[id]/route.ts`
+**Method(s):** GET, PATCH, DELETE
+**Auth:** `edit_post`; cross-tenant check via company membership
+**Rate limit:** None observed
+**Body schema:** PATCH: post update payload
+**Risk:** HIGH — reads, mutates, or deletes a social post
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-post-transitions.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does DELETE hard-delete the post record or soft-delete?
+
+---
+
+### POST /api/platform/social/posts/[id]/submit
+
+**File:** `app/api/platform/social/posts/[id]/submit/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — transitions post to `pending_client_approval`; triggers approval notification
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-post-transitions.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when the post has no `approver_user_id` set?
+
+---
+
+### POST /api/platform/social/posts/[id]/approve
+
+**File:** `app/api/platform/social/posts/[id]/approve/route.ts`
+**Method(s):** POST
+**Auth:** `approve_post`
+**Rate limit:** None observed
+**Body schema:** Approval decision
+**Risk:** HIGH — changes post state; triggers scheduling
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-approval-decisions.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a post be approved by anyone with `approve_post`, or only the named approver?
+
+---
+
+### POST /api/platform/social/posts/[id]/reject
+
+**File:** `app/api/platform/social/posts/[id]/reject/route.ts`
+**Method(s):** POST
+**Auth:** `reject_post`
+**Rate limit:** None observed
+**Body schema:** `{ rejection_reason: string }`
+**Risk:** HIGH — state change + author notification
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-approval-decisions.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is a rejection reason required?
+
+---
+
+### POST /api/platform/social/posts/[id]/request-changes
+
+**File:** `app/api/platform/social/posts/[id]/request-changes/route.ts`
+**Method(s):** POST
+**Auth:** `approve_post` or admin
+**Rate limit:** None observed
+**Body schema:** `{ changes_requested: string }`
+**Risk:** HIGH — state change; author notified
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-changes-requested-notification.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is `changes_requested` stored on the post for the author to see?
+
+---
+
+### POST /api/platform/social/posts/[id]/cancel-approval
+
+**File:** `app/api/platform/social/posts/[id]/cancel-approval/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post` (author) or admin
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — reverts `pending_client_approval` back to draft
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does cancelling approval notify the approver?
+
+---
+
+### POST /api/platform/social/posts/[id]/duplicate
+
+**File:** `app/api/platform/social/posts/[id]/duplicate/route.ts`
+**Method(s):** POST
+**Auth:** `create_post`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — creates a copy of the post in `draft` state
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Do variants and schedule entries get duplicated with the post?
+
+---
+
+### POST /api/platform/social/posts/[id]/reopen
+
+**File:** `app/api/platform/social/posts/[id]/reopen/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post` or admin
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — resets a post from a terminal state back to draft
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] From which states can a post be reopened (rejected only, or also failed/published)?
+
+---
+
+### GET /api/platform/social/posts/[id]/publish-attempts
+
+**File:** `app/api/platform/social/posts/[id]/publish-attempts/route.ts`
+**Method(s):** GET
+**Auth:** `view_calendar`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — read-only; returns publish attempt audit history
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-publishing-list-attempts.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are error messages in failed attempts exposed to company members or only admins?
+
+---
+
+### POST /api/platform/social/posts/[id]/schedule
+
+**File:** `app/api/platform/social/posts/[id]/schedule/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** `{ scheduled_at: string }` (ISO 8601)
+**Risk:** HIGH — schedules post; triggers future publish
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-scheduling.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a `published` post be re-scheduled?
+
+---
+
+### GET/DELETE /api/platform/social/posts/[id]/schedule/[entry_id]
+
+**File:** `app/api/platform/social/posts/[id]/schedule/[entry_id]/route.ts`
+**Method(s):** GET, DELETE
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — DELETE removes a scheduled publish entry
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does deleting a schedule entry revert the post state from `scheduled` to `draft`?
+
+---
+
+### GET/POST /api/platform/social/posts/[id]/variants
+
+**File:** `app/api/platform/social/posts/[id]/variants/route.ts`
+**Method(s):** GET, POST
+**Auth:** `view_calendar` (GET), `edit_post` (POST)
+**Rate limit:** None observed
+**Body schema:** POST: variant content payload
+**Risk:** MEDIUM — creates per-platform content variant
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-variants.test.ts`, `lib/__tests__/social-variants-media.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are variants included in the approval workflow or only the master content?
+
+---
+
+### GET/POST /api/platform/social/posts/[id]/recipients
+
+**File:** `app/api/platform/social/posts/[id]/recipients/route.ts`
+**Method(s):** GET, POST
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** POST: `{ email: string }` or `{ user_id: string }`
+**Risk:** HIGH — controls who receives approval notifications; PII (email addresses)
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-approval-recipients.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can recipients be external (non-platform users)?
+
+---
+
+### DELETE /api/platform/social/posts/[id]/recipients/[recipient_id]
+
+**File:** `app/api/platform/social/posts/[id]/recipients/[recipient_id]/route.ts`
+**Method(s):** DELETE
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — removes approver from post; if removed while pending, approval workflow may stall
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens to a `pending_approval` post when all recipients are removed?
+
+---
+
+### POST /api/platform/social/posts/bulk
+
+**File:** `app/api/platform/social/posts/bulk/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** `{ operation: string, post_ids: string[] }`
+**Risk:** HIGH — bulk state mutation; large-scale irreversible operations possible
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What operations are supported (bulk delete, bulk approve, bulk cancel)?
+- [ ] Is there a limit on the number of post IDs per bulk request?
+
+---
+
+## D. Social Drafts (V2 composer layer)
+
+### GET /api/platform/social/drafts/calendar-view
+
+**File:** `app/api/platform/social/drafts/calendar-view/route.ts`
+**Method(s):** GET
+**Auth:** `view_calendar`
+**Rate limit:** None observed
+**Body schema:** None; search params: `?year=&month=` or similar
+**Risk:** MEDIUM — read-only calendar data; tenant-scoped
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-calendar.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What draft states are included in the calendar view response?
+
+---
+
+### POST /api/platform/social/drafts
+
+**File:** `app/api/platform/social/drafts/route.ts`
+**Method(s):** POST
+**Auth:** Session: `create_post` permission; Service: `x-platform-service-key` + `x-platform-actor-id`
+**Rate limit:** `checkPlatformRateLimit` (returns 429 on `platformRateLimitExceeded`)
+**Body schema:** V2: `CreateDraftSchema` (`lib/social/schemas/create-draft.ts`) — `{ mode, content, target_profile_ids, ... }`; V1 legacy: `{ company_id }`
+**Risk:** HIGH — creates a new social post draft; may immediately queue for scheduling
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-schemas.unit.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is the rate limit threshold (requests per window)?
+- [ ] Does the service-key auth path bypass the rate limit?
+- [ ] What happens when `target_profile_ids` contains a profile that belongs to a different company?
+
+---
+
+### GET /api/platform/social/drafts
+
+**File:** `app/api/platform/social/drafts/route.ts`
+**Method(s):** GET
+**Auth:** `view_calendar`
+**Rate limit:** None observed
+**Body schema:** None; search params for filtering
+**Risk:** MEDIUM — read-only draft list; tenant-scoped
+
+**Currently tested by:**
+- Unit: `lib/__tests__/drafts-get.unit.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does the GET support the same `?state=` filter as the posts list?
+
+---
+
+### GET /api/platform/social/drafts/[id]
+
+**File:** `app/api/platform/social/drafts/[id]/route.ts`
+**Method(s):** GET
+**Auth:** `edit_post`; uses service-role to load `company_id` before applying permission gate
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — loads full draft content; service-role step is intentional (needed to resolve company_id before gating)
+
+**Currently tested by:**
+- Unit: `lib/__tests__/drafts-get.unit.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when a draft is in `published` state — is it still loadable for read?
+
+---
+
+### PATCH /api/platform/social/drafts/[id]
+
+**File:** `app/api/platform/social/drafts/[id]/route.ts`
+**Method(s):** PATCH
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** V2: `{ content, platform_variants, draft_version, ... }`; V1: `{ draft_data }` blob. CAS check on `draft_version` — mismatch returns `409 VERSION_CONFLICT`.
+**Risk:** HIGH — mutates draft content; overwrites existing content; concurrent edit safety via CAS
+
+**Currently tested by:**
+- Unit: `lib/__tests__/draft-patch-v2.unit.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Which states allow PATCH (draft only, or also pending_approval / rejected)?
+- [ ] Does PATCH in `pending_approval` state notify the approver that content changed?
+
+---
+
+### DELETE /api/platform/social/drafts/[id]
+
+**File:** `app/api/platform/social/drafts/[id]/route.ts`
+**Method(s):** DELETE
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — irreversible deletion of draft and associated approval tokens
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does DELETE work on drafts in any state, or only `draft` and `rejected`?
+- [ ] Are magic-link approval tokens immediately invalidated on delete?
+
+---
+
+### POST /api/platform/social/drafts/[id]/approve
+
+**File:** `app/api/platform/social/drafts/[id]/approve/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post` + must be named `approver_user_id` OR be a company admin
+**Rate limit:** `checkRateLimit` applied
+**Body schema:** `ApproveSchema` — `{ decision: "approved" | "rejected", rejection_reason?: string (30-500 chars when rejected) }`
+**Risk:** HIGH — state transition; triggers scheduling on approve, notifications on reject
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-approval-decisions.test.ts`, `lib/__tests__/social-approver-decision-notifications.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is there a rate limit on approval decisions (to prevent replay)?
+- [ ] What happens when the same approver submits two decisions in quick succession?
+
+---
+
+### POST /api/platform/social/drafts/[id]/convert-to-draft
+
+**File:** `app/api/platform/social/drafts/[id]/convert-to-draft/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — reverts state; cancels scheduling; may confuse a scheduled time
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does this work from `scheduled`, `rejected`, or both?
+- [ ] Does this unset `scheduled_at`?
+
+---
+
+### POST /api/platform/social/drafts/[id]/publish
+
+**File:** `app/api/platform/social/drafts/[id]/publish/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post` (admin recommended)
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** CRITICAL — manually triggers immediate publish to bundle.social; real-world side effect
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-publishing-fire.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this restricted to admins only, or can any editor manually publish?
+- [ ] Is idempotency enforced (prevents double-publish)?
+
+---
+
+### GET /api/platform/social/drafts/[id]/review-link
+
+**File:** `app/api/platform/social/drafts/[id]/review-link/route.ts`
+**Method(s):** GET
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — returns magic link URL; token is sensitive but only authorises approval decision
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-viewer-links.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does calling this endpoint create a new token each time, or return an existing one?
+
+---
+
+### GET /api/platform/social/drafts/[id]/analytics
+
+**File:** `app/api/platform/social/drafts/[id]/analytics/route.ts`
+**Method(s):** GET
+**Auth:** `view_calendar`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — read-only post-publish analytics for the draft
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What analytics are returned (impressions, clicks, engagement)?
+
+---
+
+### POST /api/platform/social/drafts/bulk
+
+**File:** `app/api/platform/social/drafts/bulk/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** `{ operation: string, draft_ids: string[] }`
+**Risk:** HIGH — bulk delete or update; irreversible
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What bulk operations are supported?
+- [ ] Is there a hard limit on the number of IDs per request?
+
+---
+
+## E. Social Connections
+
+### GET /api/platform/social/connections
+
+**File:** `app/api/platform/social/connections/route.ts`
+**Method(s):** GET
+**Auth:** `view_calendar`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — lists connections; tenant-scoped
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-connections.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are `disconnected` connections included in the list response?
+
+---
+
+### POST /api/platform/social/connections/connect
+
+**File:** `app/api/platform/social/connections/connect/route.ts`
+**Method(s):** POST
+**Auth:** `manage_connections`
+**Rate limit:** None observed
+**Body schema:** `{ platform: string }` — starts OAuth popup flow
+**Risk:** HIGH — initiates OAuth flow; CSRF token required
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-connections-bundlesocial.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is a CSRF/state token included in the OAuth redirect?
+
+---
+
+### POST /api/platform/social/connections/reconnect
+
+**File:** `app/api/platform/social/connections/reconnect/route.ts`
+**Method(s):** POST
+**Auth:** `reconnect_connection`
+**Rate limit:** None observed
+**Body schema:** `{ connection_id: string }`
+**Risk:** HIGH — refreshes expired credentials; updates health status
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-reconnect-permission.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a `disconnected` connection be reconnected via this endpoint, or does reconnect only work on `auth_required`?
+
+---
+
+### POST /api/platform/social/connections/identity-preflight
+
+**File:** `app/api/platform/social/connections/identity-preflight/route.ts`
+**Method(s):** POST
+**Auth:** `manage_connections`
+**Rate limit:** None observed
+**Body schema:** Identity fingerprint payload
+**Risk:** HIGH — cross-tenant identity leak defence check; validates that an OAuth identity is not already claimed by another company
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-identity-cross-tenant.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What response is returned when a cross-tenant identity conflict is detected?
+
+---
+
+### GET /api/platform/social/connections/[id]
+
+**File:** `app/api/platform/social/connections/[id]/route.ts` (inferred — no route file in discovery but expected)
+**Method(s):** GET
+**Auth:** `view_calendar`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — reads connection detail; tenant-scoped
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is connection health last-checked timestamp exposed in the response?
+
+---
+
+### POST /api/platform/social/connections/[id]/disconnect
+
+**File:** `app/api/platform/social/connections/[id]/disconnect/route.ts`
+**Method(s):** POST
+**Auth:** `manage_connections`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** CRITICAL — disables the connection; any `scheduled` drafts targeting this connection will fail at publish time
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-connections.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does disconnect warn if there are scheduled drafts using this connection?
+- [ ] Is disconnect reversible (can the connection be re-activated without re-authorising)?
+
+---
+
+### GET/POST /api/platform/social/connections/[id]/channels
+
+**File:** `app/api/platform/social/connections/[id]/channels/route.ts`
+**Method(s):** GET, POST
+**Auth:** `manage_connections`
+**Rate limit:** None observed
+**Body schema:** POST: channel selection
+**Risk:** MEDIUM — reads or sets channel list for a connection
+
+**Currently tested by:**
+- Contract: `lib/__tests__/social-channels.contract.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does channel list GET call bundle.social live or use a cached result?
+
+---
+
+### POST /api/platform/social/connections/[id]/set-channel
+
+**File:** `app/api/platform/social/connections/[id]/set-channel/route.ts`
+**Method(s):** POST
+**Auth:** `manage_connections`
+**Rate limit:** None observed
+**Body schema:** `{ channel_id: string }`
+**Risk:** HIGH — transitions connection from `pending_identity` to `healthy`; determines which page/channel is published to
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-connections-bundlesocial.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can set-channel be called on a `healthy` connection (to change channel)?
+
+---
+
+### POST /api/platform/social/connections/[id]/unset-channel
+
+**File:** `app/api/platform/social/connections/[id]/unset-channel/route.ts`
+**Method(s):** POST
+**Auth:** `manage_connections`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — reverts channel selection; connection reverts to `pending_identity`
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does unset-channel affect any scheduled drafts that are targeting this connection?
+
+---
+
+### POST /api/platform/social/connections/[id]/connect-as-personal
+
+**File:** `app/api/platform/social/connections/[id]/connect-as-personal/route.ts`
+**Method(s):** POST
+**Auth:** `manage_connections`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — sets `is_personal_mode=true`; transitions to `healthy` without channel selection (LinkedIn personal profile)
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is connect-as-personal only valid for LinkedIn connections?
+
+---
+
+### POST /api/platform/social/connections/callback
+
+**File:** `app/api/platform/social/connections/callback/route.ts`
+**Method(s):** POST
+**Auth:** OAuth callback (state token validation)
+**Rate limit:** None observed
+**Body schema:** OAuth callback parameters
+**Risk:** CRITICAL — OAuth callback receiver; creates new connection row; identity fingerprint checked
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-connections-bundlesocial.test.ts`, `lib/__tests__/social-identity-fingerprint.contract.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the OAuth state parameter validated against a per-user nonce?
+
+---
+
+### POST /api/platform/social/connections/sync
+
+**File:** `app/api/platform/social/connections/sync/route.ts`
+**Method(s):** POST
+**Auth:** `manage_connections`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — reconciles local connection records with bundle.social; may update statuses
+
+**Currently tested by:**
+- Integration: `lib/__tests__/bundle-social-reconcile.unit.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does sync ever delete local connection rows that bundle.social no longer knows about?
+
+---
+
+## F. Social Media
+
+### GET /api/platform/social/media
+
+**File:** `app/api/platform/social/media/route.ts`
+**Method(s):** GET
+**Auth:** `view_calendar`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** LOW — read-only; lists company's uploaded media assets
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-media-library.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are media assets from all users in the company visible, or only the current user's?
+
+---
+
+### POST /api/platform/social/media/upload
+
+**File:** `app/api/platform/social/media/upload/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** `multipart/form-data` with file
+**Risk:** MEDIUM — stores file in Supabase Storage; file type and size validation required
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-media-upload-to-bundle.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What file types are accepted (images, video, GIFs)?
+- [ ] What is the maximum file size?
+
+---
+
+### GET /api/platform/social/media/image-library
+
+**File:** `app/api/platform/social/media/image-library/route.ts`
+**Method(s):** GET
+**Auth:** `view_calendar` (company member)
+**Rate limit:** None observed
+**Body schema:** None; search params: `?q=` (search), `?page=`
+**Risk:** LOW — read-only; fetches images from the admin central image library for use in posts
+
+**Currently tested by:**
+- E2E: `e2e/composer-media-library-scope.spec.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are all admin images available to all company users, or is there a site-level scope?
+
+---
+
+## G. Social Utility
+
+### GET/POST /api/platform/social/link-preview
+
+**File:** `app/api/platform/social/link-preview/route.ts`
+**Method(s):** GET, POST
+**Auth:** `view_calendar`
+**Rate limit:** None observed
+**Body schema:** `{ url: string }`
+**Risk:** LOW — fetches OG metadata for URL preview; SSRF consideration (URL must be validated)
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is there a safelist or blocklist of URLs that can be previewed (SSRF protection)?
+
+---
+
+### GET /api/platform/social/gif-search
+
+**File:** `app/api/platform/social/gif-search/route.ts`
+**Method(s):** GET
+**Auth:** `view_calendar`
+**Rate limit:** None observed
+**Body schema:** None; search params: `?q=`
+**Risk:** LOW — proxies GIF search to Giphy/Tenor; no data stored
+
+**Currently tested by:**
+- E2E: `e2e/composer-gif-attach.spec.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Which GIF provider is used (Giphy, Tenor)?
+
+---
+
+### GET /api/platform/social/gif-proxy
+
+**File:** `app/api/platform/social/gif-proxy/route.ts`
+**Method(s):** GET
+**Auth:** `view_calendar`
+**Rate limit:** None observed
+**Body schema:** None; URL in query params
+**Risk:** LOW — proxies GIF content to avoid CORS issues; URL validation required
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the GIF proxy URL validated against the GIF provider domain only?
+
+---
+
+### GET/POST /api/platform/social/viewer-links
+
+**File:** `app/api/platform/social/viewer-links/route.ts`
+**Method(s):** GET, POST
+**Auth:** `manage_invitations` (admin)
+**Rate limit:** None observed
+**Body schema:** POST: viewer link creation payload
+**Risk:** MEDIUM — creates public-accessible links to company's schedule
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-viewer-links.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is there a maximum number of viewer links per company?
+
+---
+
+### DELETE /api/platform/social/viewer-links/[id]
+
+**File:** `app/api/platform/social/viewer-links/[id]/route.ts`
+**Method(s):** DELETE
+**Auth:** `manage_invitations`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — invalidates public link immediately
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-viewer-links.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the token invalidated immediately or on next request?
+
+---
+
+### POST /api/platform/social/publish-attempts/[id]/retry
+
+**File:** `app/api/platform/social/publish-attempts/[id]/retry/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post` or admin
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — triggers a new publish attempt; real-world side effect
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-publishing-retry.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can any publish attempt be retried, or only `failed` ones?
+
+---
+
+## H. Social CAP (Content Amplification Platform)
+
+### POST /api/platform/social/cap/generate
+
+**File:** `app/api/platform/social/cap/generate/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post` or CAP operator role
+**Rate limit:** None observed
+**Body schema:** CAP generation request
+**Risk:** HIGH — incurs AI generation cost (Claude API); must check `monthly_cost_cap_usd` on `cap_subscriptions`
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is cost cap enforced before or after generation starts?
+- [ ] Is there an idempotency key to prevent double-generation?
+
+---
+
+### POST /api/platform/social/cap/generate-image
+
+**File:** `app/api/platform/social/cap/generate-image/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post` or CAP operator
+**Rate limit:** None observed
+**Body schema:** Image generation prompt
+**Risk:** HIGH — incurs AI image generation cost
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Which image generation model is used?
+
+---
+
+### POST /api/platform/social/cap/assist
+
+**File:** `app/api/platform/social/cap/assist/route.ts`
+**Method(s):** POST
+**Auth:** `edit_post`
+**Rate limit:** None observed
+**Body schema:** AI assist request (content rewrite / improve)
+**Risk:** HIGH — incurs AI cost; content input flows to Claude API
+
+**Currently tested by:**
+- E2E: `e2e/composer-ai-errors.spec.ts`, `e2e/composer-ai-error-categorization.spec.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is there per-user or per-company rate limiting on AI assist calls?
+
+---
+
+## I. Admin Users
+
+### GET /api/admin/users/list
+
+**File:** `app/api/admin/users/list/route.ts`
+**Method(s):** GET
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** None; filter/search params
+**Risk:** HIGH — returns PII (user emails, roles) for all platform users
+
+**Currently tested by:**
+- Integration: `lib/__tests__/admin-users-list.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a regular `admin` see users from all companies or only their own?
+
+---
+
+### POST /api/admin/users/invite
+
+**File:** `app/api/admin/users/invite/route.ts`
+**Method(s):** POST
+**Auth:** `super_admin` only
+**Rate limit:** None observed
+**Body schema:** `{ email: string, role: string, company_id?: string }`
+**Risk:** HIGH — creates invitation; grants platform access
+
+**Currently tested by:**
+- Integration: `lib/__tests__/admin-users-invite.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when inviting an email that already has a platform account?
+
+---
+
+### PATCH /api/admin/users/[id]/role
+
+**File:** `app/api/admin/users/[id]/role/route.ts`
+**Method(s):** PATCH
+**Auth:** `super_admin` only
+**Rate limit:** None observed
+**Body schema:** `{ role: string }`
+**Risk:** CRITICAL — role escalation; incorrect access control allows privilege escalation
+
+**Currently tested by:**
+- Integration: `lib/__tests__/admin-users-role.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a super_admin demote themselves?
+- [ ] Is there protection against removing the last super_admin?
+
+---
+
+### POST /api/admin/users/[id]/revoke
+
+**File:** `app/api/admin/users/[id]/revoke/route.ts`
+**Method(s):** POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — immediately revokes access; all active sessions invalidated
+
+**Currently tested by:**
+- Integration: `lib/__tests__/admin-users-revoke.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are the user's active sessions invalidated immediately on revoke?
+
+---
+
+### POST /api/admin/users/[id]/reinstate
+
+**File:** `app/api/admin/users/[id]/reinstate/route.ts`
+**Method(s):** POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — restores access to a revoked user
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does reinstate restore the user's original role?
+
+---
+
+### GET/POST /api/admin/invites
+
+**File:** `app/api/admin/invites/route.ts`
+**Method(s):** GET, POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** POST: invitation payload
+**Risk:** HIGH — manages platform invitations
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are invitations scoped to a specific company?
+
+---
+
+### GET/PATCH/DELETE /api/admin/invites/[id]
+
+**File:** `app/api/admin/invites/[id]/route.ts`
+**Method(s):** GET, PATCH, DELETE
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** PATCH: partial update; DELETE: revoke
+**Risk:** HIGH — manages individual invitation lifecycle
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does DELETE immediately revoke the invitation, or mark it as `revoked`?
+
+---
+
+## J. Admin Companies
+
+### GET/POST /api/admin/companies
+
+**File:** `app/api/admin/companies/route.ts`
+**Method(s):** GET, POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** POST: company creation payload
+**Risk:** HIGH — creates or lists companies; tenant provisioning
+
+**Currently tested by:**
+- Integration: `lib/__tests__/platform-companies.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does POST auto-provision any resources (default social profile, cap_subscription)?
+
+---
+
+### GET/POST /api/admin/companies/[id]/social-profiles
+
+**File:** `app/api/admin/companies/[id]/social-profiles/route.ts`
+**Method(s):** GET, POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** POST: profile creation payload
+**Risk:** HIGH — manages social profiles; tenant data
+
+**Currently tested by:**
+- Integration: `lib/__tests__/platform-social-profiles.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a company have multiple social profiles?
+
+---
+
+### GET/PATCH/DELETE /api/admin/companies/[id]/social-profiles/[profileId]
+
+**File:** `app/api/admin/companies/[id]/social-profiles/[profileId]/route.ts`
+**Method(s):** GET, PATCH, DELETE
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** PATCH: profile update
+**Risk:** HIGH — modifies or deletes a social profile; connections may be orphaned on delete
+
+**Currently tested by:**
+- Integration: `lib/__tests__/platform-social-profiles-manage.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens to connections attributed to a profile when the profile is deleted?
+
+---
+
+### GET /api/admin/companies/[id]/social-profiles/[profileId]/analytics/dashboard
+
+**File:** `app/api/admin/companies/[id]/social-profiles/[profileId]/analytics/dashboard/route.ts`
+**Method(s):** GET
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** LOW — read-only analytics data
+
+**Currently tested by:**
+- Unit: `lib/__tests__/analytics-dashboard-route.unit.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What analytics dimensions are returned (impressions, reach, engagement)?
+
+---
+
+### POST /api/admin/companies/[id]/social-profiles/[profileId]/analytics/refresh
+
+**File:** `app/api/admin/companies/[id]/social-profiles/[profileId]/analytics/refresh/route.ts`
+**Method(s):** POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — triggers analytics re-fetch from bundle.social; API call cost
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is there a cooldown on manual refreshes?
+
+---
+
+### POST /api/admin/companies/[id]/social-profiles/[profileId]/connect
+
+**File:** `app/api/admin/companies/[id]/social-profiles/[profileId]/connect/route.ts`
+**Method(s):** POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** Connection parameters
+**Risk:** HIGH — admin-side connection initiation for a company
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does this bypass the normal OAuth popup flow used by company users?
+
+---
+
+### POST /api/admin/companies/[id]/social-profiles/[profileId]/disconnect
+
+**File:** `app/api/admin/companies/[id]/social-profiles/[profileId]/disconnect/route.ts`
+**Method(s):** POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** CRITICAL — disconnects a live connection; impacts scheduled posts for the company
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does admin disconnect warn about upcoming scheduled posts?
+
+---
+
+## K. Admin Images
+
+### GET /api/admin/images/list
+
+**File:** `app/api/admin/images/list/route.ts`
+**Method(s):** GET
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** None; search/filter params
+**Risk:** LOW — read-only; admin image library list
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are soft-deleted images included in the list (with a filter)?
+
+---
+
+### POST /api/admin/images/upload
+
+**File:** `app/api/admin/images/upload/route.ts`
+**Method(s):** POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** `multipart/form-data`
+**Risk:** MEDIUM — adds image to central library; available to all company users
+
+**Currently tested by:**
+- Integration: `lib/__tests__/admin-images-id-route.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What file types and size limits apply to admin image uploads?
+
+---
+
+### POST /api/admin/images/check-existing
+
+**File:** `app/api/admin/images/check-existing/route.ts`
+**Method(s):** POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** `{ url: string }` or hash-based check
+**Risk:** LOW — deduplication check before upload
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What deduplication key is used (URL hash, content hash)?
+
+---
+
+### POST /api/admin/images/fetch-url
+
+**File:** `app/api/admin/images/fetch-url/route.ts`
+**Method(s):** POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** `{ url: string }`
+**Risk:** MEDIUM — fetches external image by URL and imports to library; SSRF consideration
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is there URL validation to prevent SSRF (only http/https, no local addresses)?
+
+---
+
+### GET/PATCH/DELETE /api/admin/images/[id]
+
+**File:** `app/api/admin/images/[id]/route.ts`
+**Method(s):** GET, PATCH, DELETE
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** PATCH: metadata update (alt text, tags, etc.)
+**Risk:** MEDIUM — manages image metadata; soft-delete on DELETE
+
+**Currently tested by:**
+- Integration: `lib/__tests__/admin-images-id-route.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is DELETE a soft-delete (tombstone) or hard-delete?
+
+---
+
+### GET /api/admin/images/[id]/download
+
+**File:** `app/api/admin/images/[id]/download/route.ts`
+**Method(s):** GET
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** LOW — returns image file for download
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does download return a signed URL or the file directly?
+
+---
+
+### POST /api/admin/images/[id]/reextract
+
+**File:** `app/api/admin/images/[id]/reextract/route.ts`
+**Method(s):** POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — re-runs metadata extraction (alt text, captions) via AI; incurs cost
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does reextract overwrite existing metadata?
+
+---
+
+### POST /api/admin/images/[id]/restore
+
+**File:** `app/api/admin/images/[id]/restore/route.ts`
+**Method(s):** POST
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** MEDIUM — undeletes a soft-deleted image
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can an image be restored after hard-delete?
+
+---
+
+### DELETE /api/admin/images/[id]/hard-delete
+
+**File:** `app/api/admin/images/[id]/hard-delete/route.ts`
+**Method(s):** DELETE
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — irreversible; removes image record and storage file permanently
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does hard-delete check for references to the image in other records (drafts, site pages)?
+
+---
+
+### DELETE /api/admin/images/bulk-hard-delete
+
+**File:** `app/api/admin/images/bulk-hard-delete/route.ts`
+**Method(s):** DELETE
+**Auth:** `super_admin` or `admin`
+**Rate limit:** None observed
+**Body schema:** `{ image_ids: string[] }`
+**Risk:** CRITICAL — bulk irreversible deletion; no undo
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is there a confirmation step or a hard limit on bulk delete size?
+
+---
+
+## L. Webhooks
+
+### POST /api/webhooks/bundlesocial
+
+**File:** `app/api/webhooks/bundlesocial/route.ts`
+**Method(s):** POST
+**Auth:** HMAC signature verification (`x-signature` header against `BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET`) — NOT platform session auth
+**Rate limit:** None (rate limiting handled at Vercel edge)
+**Body schema:** `WebhookEnvelopeSchema` — `{ id: string, type: string, ... }`
+**Risk:** CRITICAL — processes publish results; updates `social_post_drafts` state (`publishing → published|failed`); incorrect signature validation allows state injection
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-webhooks-bundlesocial.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when the same webhook event ID is delivered twice (idempotency)?
+- [ ] Is there a dead-letter mechanism for events that fail processing?
+- [ ] What response code does a signature failure return (401 per code comments)?
+
+---
+
+### POST /api/webhooks/qstash/social-publish
+
+**File:** `app/api/webhooks/qstash/social-publish/route.ts`
+**Method(s):** POST
+**Auth:** QStash signature verification
+**Rate limit:** None
+**Body schema:** QStash job payload with draft ID
+**Risk:** CRITICAL — triggers social publish pipeline; external signature auth
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is QStash used as a reliable delivery layer (retries on 5xx)?
+
+---
+
+### POST /api/webhooks/qstash/social-post-history-import
+
+**File:** `app/api/webhooks/qstash/social-post-history-import/route.ts`
+**Method(s):** POST
+**Auth:** QStash signature verification
+**Rate limit:** None
+**Body schema:** Import payload
+**Risk:** HIGH — imports historical post data; large batch writes
+
+**Currently tested by:**
+- Unit: None independently observed
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when a duplicate post history record is imported?
+
+---
+
+## M. Cron Jobs
+
+All cron routes require `CRON_SECRET` bearer token in the `Authorization` header. Vercel invokes these on schedule; the token prevents unauthorised external triggering.
+
+---
+
+### POST /api/cron/process-brief-runner
+
+**File:** `app/api/cron/process-brief-runner/route.ts`
+**Risk:** CRITICAL — brief generation hot path; incurs AI cost per page; mutations to site content
+
+---
+
+### POST /api/cron/process-batch
+
+**File:** `app/api/cron/process-batch/route.ts`
+**Risk:** CRITICAL — batch page generation; AI cost; WP mutations
+
+---
+
+### POST /api/cron/process-regenerations
+
+**File:** `app/api/cron/process-regenerations/route.ts`
+**Risk:** HIGH — page regeneration queue; AI cost
+
+---
+
+### POST /api/cron/render-pages
+
+**File:** `app/api/cron/render-pages/route.ts`
+**Risk:** HIGH — renders pages to HTML/WP format
+
+---
+
+### POST /api/cron/social-publish-watchdog
+
+**File:** `app/api/cron/social-publish-watchdog/route.ts`
+**Risk:** HIGH — reconciles `in_flight` publish attempts; may update draft state to `failed`
+
+---
+
+### POST /api/cron/social-analytics-refresh
+
+**File:** `app/api/cron/social-analytics-refresh/route.ts`
+**Risk:** MEDIUM — refreshes social analytics from bundle.social
+
+**Currently tested by:**
+- Unit: `lib/__tests__/cron-social-analytics-refresh-route.unit.test.ts`
+
+---
+
+### POST /api/cron/social-connections-health
+
+**File:** `app/api/cron/social-connections-health/route.ts`
+**Risk:** HIGH — updates connection `status` based on bundle.social health check; may set `auth_required`
+
+---
+
+### POST /api/cron/social-publish-backfill
+
+**File:** `app/api/cron/social-publish-backfill/route.ts`
+**Risk:** HIGH — backfills post publish history from bundle.social
+
+**Currently tested by:**
+- Integration: `lib/__tests__/social-publishing-backfill.test.ts`
+
+---
+
+### POST /api/cron/cap-weekly-generation
+
+**File:** `app/api/cron/cap-weekly-generation/route.ts`
+**Risk:** HIGH — weekly CAP content generation; AI cost
+
+---
+
+### POST /api/cron/cap-monthly-generation
+
+**File:** `app/api/cron/cap-monthly-generation/route.ts`
+**Risk:** HIGH — monthly CAP content generation; AI cost
+
+---
+
+### POST /api/cron/cap-generation-runs-cleanup
+
+**File:** `app/api/cron/cap-generation-runs-cleanup/route.ts`
+**Risk:** MEDIUM — cleans up stale/orphaned CAP generation runs
+
+---
+
+### POST /api/cron/budget-reset
+
+**File:** `app/api/cron/budget-reset/route.ts`
+**Risk:** HIGH — resets monthly AI cost budget counters; incorrect reset could re-enable spend
+
+---
+
+### POST /api/cron/cost-monitoring-daily-report
+
+**File:** `app/api/cron/cost-monitoring-daily-report/route.ts`
+**Risk:** MEDIUM — sends daily cost summary; read-only data
+
+---
+
+### POST /api/cron/extract-image-metadata
+
+**File:** `app/api/cron/extract-image-metadata/route.ts`
+**Risk:** MEDIUM — runs AI metadata extraction on queued images; AI cost
+
+---
+
+### POST /api/cron/backfill-image-captions
+
+**File:** `app/api/cron/backfill-image-captions/route.ts`
+**Risk:** MEDIUM — AI caption backfill for existing images; AI cost
+
+---
+
+### POST /api/cron/drift-detect
+
+**File:** `app/api/cron/drift-detect/route.ts`
+**Risk:** MEDIUM — compares local route_registry against live WP; read-only detection
+
+---
+
+### POST /api/cron/dispatch-webhooks
+
+**File:** `app/api/cron/dispatch-webhooks/route.ts`
+**Risk:** MEDIUM — dispatches internal webhook events from the outbox
+
+---
+
+### POST /api/cron/check-webhook-health
+
+**File:** `app/api/cron/check-webhook-health/route.ts`
+**Risk:** MEDIUM — monitors webhook delivery health
+
+---
+
+### POST /api/cron/insights-competitor-scrape
+
+**File:** `app/api/cron/insights-competitor-scrape/route.ts`
+**Risk:** HIGH — scrapes competitor websites via Apify; external network calls; cost
+
+---
+
+### POST /api/cron/insights-feature-extract
+
+**File:** `app/api/cron/insights-feature-extract/route.ts`
+**Risk:** HIGH — AI feature extraction from scraped competitor content; AI cost
+
+---
+
+### POST /api/cron/insights-pattern-mine
+
+**File:** `app/api/cron/insights-pattern-mine/route.ts`
+**Risk:** HIGH — AI pattern mining across client content; AI cost
+
+---
+
+### POST /api/cron/insights-recompute
+
+**File:** `app/api/cron/insights-recompute/route.ts`
+**Risk:** HIGH — recomputes insight scores; batch DB writes
+
+---
+
+### POST /api/cron/optimiser-sync-ga4
+
+**File:** `app/api/cron/optimiser-sync-ga4/route.ts`
+**Risk:** MEDIUM — syncs GA4 traffic data for Optimiser clients
+
+---
+
+### POST /api/cron/optimiser-sync-ads
+
+**File:** `app/api/cron/optimiser-sync-ads/route.ts`
+**Risk:** MEDIUM — syncs Google Ads data for Optimiser clients
+
+---
+
+### POST /api/cron/optimiser-sync-clarity
+
+**File:** `app/api/cron/optimiser-sync-clarity/route.ts`
+**Risk:** MEDIUM — syncs Microsoft Clarity heatmap data
+
+---
+
+### POST /api/cron/optimiser-sync-pagespeed
+
+**File:** `app/api/cron/optimiser-sync-pagespeed/route.ts`
+**Risk:** MEDIUM — syncs PageSpeed Insights scores
+
+---
+
+### POST /api/cron/optimiser-sync-vercel-logs
+
+**File:** `app/api/cron/optimiser-sync-vercel-logs/route.ts`
+**Risk:** MEDIUM — syncs Vercel edge function logs for Optimiser analysis
+
+---
+
+### POST /api/cron/optimiser-evaluate-pages
+
+**File:** `app/api/cron/optimiser-evaluate-pages/route.ts`
+**Risk:** HIGH — evaluates landing pages and generates new proposals; AI cost
+
+---
+
+### POST /api/cron/optimiser-evaluate-scores
+
+**File:** `app/api/cron/optimiser-evaluate-scores/route.ts`
+**Risk:** MEDIUM — recalculates page scores from synced data
+
+---
+
+### POST /api/cron/optimiser-evaluate-causal-deltas
+
+**File:** `app/api/cron/optimiser-evaluate-causal-deltas/route.ts`
+**Risk:** HIGH — AI causal delta analysis; AI cost
+
+---
+
+### POST /api/cron/optimiser-score-pages
+
+**File:** `app/api/cron/optimiser-score-pages/route.ts`
+**Risk:** MEDIUM — scores pages against playbook criteria
+
+---
+
+### POST /api/cron/optimiser-expire-proposals
+
+**File:** `app/api/cron/optimiser-expire-proposals/route.ts`
+**Risk:** HIGH — transitions `pending` proposals to `expired` after TTL
+
+---
+
+### POST /api/cron/optimiser-extract-patterns
+
+**File:** `app/api/cron/optimiser-extract-patterns/route.ts`
+**Risk:** HIGH — AI pattern extraction for Optimiser playbook; AI cost
+
+---
+
+### POST /api/cron/optimiser-monitor-rollouts
+
+**File:** `app/api/cron/optimiser-monitor-rollouts/route.ts`
+**Risk:** HIGH — promotes or reverts staged rollouts; WP mutations
+
+---
+
+### POST /api/cron/optimiser-ab-monitor
+
+**File:** `app/api/cron/optimiser-ab-monitor/route.ts`
+**Risk:** HIGH — monitors A/B test results; may trigger proposal state changes
+
+---
+
+### POST /api/cron/optimiser-email-digest
+
+**File:** `app/api/cron/optimiser-email-digest/route.ts`
+**Risk:** MEDIUM — sends Optimiser proposal digest emails
+
+---
+
+### POST /api/cron/optimiser-assisted-approval
+
+**File:** `app/api/cron/optimiser-assisted-approval/route.ts`
+**Risk:** HIGH — auto-approves proposals within threshold; writes to opt_proposals state
+
+---
+
+### Internal Cron Routes (under /api/internal/cron/)
+
+All require `CRON_SECRET` bearer token.
+
+| Route | File | Risk |
+|-------|------|------|
+| POST /api/internal/cron/publish-due | `app/api/internal/cron/publish-due/route.ts` | CRITICAL — picks up `scheduled` drafts and fires publishing |
+| POST /api/internal/cron/escalate-approvals | `app/api/internal/cron/escalate-approvals/route.ts` | HIGH — escalates overdue approval requests |
+| POST /api/internal/cron/health-check | `app/api/internal/cron/health-check/route.ts` | LOW — system health probe |
+| POST /api/internal/cron/health-digest | `app/api/internal/cron/health-digest/route.ts` | MEDIUM — sends health digest notifications |
+| POST /api/internal/cron/heartbeat-check | `app/api/internal/cron/heartbeat-check/route.ts` | LOW — heartbeat liveness check |
+| POST /api/internal/cron/cleanup-cache | `app/api/internal/cron/cleanup-cache/route.ts` | MEDIUM — purges stale cache entries |
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are all cron schedules defined in `vercel.json` or a separate cron config file?
+- [ ] What happens when a cron job runs while another instance of the same job is still running?
+
+---
+
+## N. Approval / Public
+
+### POST /api/approve/[token]/decision
+
+**File:** `app/api/approve/[token]/decision/route.ts`
+**Method(s):** POST
+**Auth:** Token IS the auth — no platform session; token resolves via `resolveRecipientByToken()` (SHA-256 hash)
+**Rate limit:** None observed
+**Body schema:** `{ decision: "approved" | "rejected", rejection_reason?: string }`
+**Risk:** HIGH — external-facing approval decision; invalidates token on use; author notified
+
+**Currently tested by:**
+- Integration: `lib/__tests__/approve-page-route.test.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the decision token single-use?
+- [ ] What response does the user see when they submit a decision for an already-decided request?
+
+---
+
+## O. Internal / Health / Tools
+
+### GET /api/health
+
+**File:** `app/api/health/route.ts`
+**Method(s):** GET
+**Auth:** None (public health probe)
+**Rate limit:** None
+**Body schema:** None
+**Risk:** LOW — returns system health status
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What checks does the health endpoint perform (DB ping, bundle.social reachability)?
+
+---
+
+### GET /api/debug/env-check
+
+**File:** `app/api/debug/env-check/route.ts`
+**Method(s):** GET
+**Auth:** `super_admin` session required (assumed; confirm)
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** HIGH — exposes env var presence/absence; must never be publicly accessible
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this endpoint gated to authenticated super_admins only?
+- [ ] Should this be removed from production?
+
+---
+
+### POST /api/emergency
+
+**File:** `app/api/emergency/route.ts`
+**Method(s):** POST
+**Auth:** Emergency secret (assumed; not independently verified)
+**Rate limit:** None observed
+**Body schema:** Emergency action payload
+**Risk:** CRITICAL — emergency operations; must require strong authentication
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What emergency operations are available via this endpoint?
+- [ ] Is the emergency secret rotated after each use?
+
+---
+
+### GET /api/ops/self-probe
+
+**File:** `app/api/ops/self-probe/route.ts`
+**Method(s):** GET
+**Auth:** None or internal secret
+**Rate limit:** None observed
+**Body schema:** None
+**Risk:** LOW — self-diagnostics probe
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this called by the cron health-check or external monitoring?
+
+---
+
+### POST /api/ops/reset-admin-password
+
+**File:** `app/api/ops/reset-admin-password/route.ts`
+**Method(s):** POST
+**Auth:** Emergency/ops secret
+**Rate limit:** None observed
+**Body schema:** `{ email: string, new_password: string }` (assumed)
+**Risk:** CRITICAL — bypasses normal password reset flow; operational break-glass tool
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this endpoint accessible without a platform session?
+- [ ] Is there an audit trail logged when this endpoint is used?
+
+---
+
+### POST /api/errors
+
+**File:** `app/api/errors/route.ts`
+**Method(s):** POST
+**Auth:** Authenticated (platform session) or client-side error reporter
+**Rate limit:** None observed
+**Body schema:** Client error report payload
+**Risk:** MEDIUM — stores error reports; input from browser; could contain PII
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are error reports rate-limited to prevent flooding?
+
+---
+
+### POST /api/internal/error-reports
+
+**File:** `app/api/internal/error-reports/route.ts`
+**Method(s):** POST
+**Auth:** Internal service key
+**Rate limit:** None observed
+**Body schema:** Error report payload
+**Risk:** MEDIUM — internal error reporting pipeline
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] How does this differ from /api/errors?
+
+---
+
+## P. Sites / Briefs / Design Systems / Tools (Admin Layer)
+
+### Admin Sites Setup
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| POST /api/admin/sites/[id]/setup/extract | `...setup/extract/route.ts` | POST | HIGH — AI extraction from client URL |
+| POST /api/admin/sites/[id]/setup/extract/save | `...extract/save/route.ts` | POST | HIGH — persists extracted design |
+| POST /api/admin/sites/[id]/setup/approve-design | `...approve-design/route.ts` | POST | HIGH — approves design for generation |
+| POST /api/admin/sites/[id]/setup/generate-concepts | `...generate-concepts/route.ts` | POST | HIGH — AI concept generation; cost |
+| POST /api/admin/sites/[id]/setup/refine-concept | `...refine-concept/route.ts` | POST | HIGH — AI refinement; cost |
+| POST /api/admin/sites/[id]/setup/extract-tone | `...extract-tone/route.ts` | POST | HIGH — AI tone extraction; cost |
+| POST /api/admin/sites/[id]/setup/approve-tone | `...approve-tone/route.ts` | POST | HIGH |
+| POST /api/admin/sites/[id]/setup/apply-tone | `...apply-tone/route.ts` | POST | HIGH |
+| POST /api/admin/sites/[id]/setup/regenerate-tone-samples | `...regenerate-tone-samples/route.ts` | POST | HIGH — AI; cost |
+| POST /api/admin/sites/[id]/setup/save-brief | `...save-brief/route.ts` | POST | HIGH |
+| POST /api/admin/sites/[id]/setup/skip | `...skip/route.ts` | POST | MEDIUM |
+| POST /api/admin/sites/[id]/setup/extract-design | `...extract-design/route.ts` | POST | HIGH — AI; cost |
+| POST /api/admin/sites/[id]/setup/extract-screenshots | `...extract-screenshots/route.ts` | POST | HIGH — external screenshot service |
+
+### Admin Sites Other
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| GET/PATCH /api/admin/sites/[id]/budget | `...budget/route.ts` | GET/PATCH | HIGH — controls AI spend ceiling |
+| PATCH /api/admin/sites/[id]/voice | `...voice/route.ts` | PATCH | MEDIUM |
+| POST /api/admin/sites/[id]/pages/[pageId]/regenerate | `...regenerate/route.ts` | POST | HIGH — AI cost; WP mutation |
+| GET/PATCH /api/admin/sites/[id]/pages/[pageId] | `...pages/[pageId]/route.ts` | GET/PATCH | HIGH |
+| POST /api/admin/sites/[id]/use-image-library | `...use-image-library/route.ts` | POST | MEDIUM |
+
+### Briefs
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| POST /api/briefs/[brief_id]/run | `...run/route.ts` | POST | CRITICAL — triggers generation hot path |
+| POST /api/briefs/[brief_id]/cancel | `...cancel/route.ts` | POST | HIGH — cancels in-flight brief run |
+| POST /api/briefs/[brief_id]/commit | `...commit/route.ts` | POST | HIGH — commits generated pages to WP |
+| GET/POST /api/briefs/[brief_id]/pages | `...pages/route.ts` | GET/POST | HIGH |
+| POST /api/briefs/[brief_id]/pages/[page_id]/approve | `...approve/route.ts` | POST | HIGH |
+| POST /api/briefs/[brief_id]/pages/[page_id]/revise | `...revise/route.ts` | POST | HIGH — AI revision; cost |
+| GET /api/briefs/[brief_id]/run/snapshot | `...snapshot/route.ts` | GET | LOW — progress snapshot |
+| POST /api/briefs/upload | `...upload/route.ts` | POST | HIGH — uploads brief document |
+
+### Sites API (non-admin)
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| GET/PATCH/DELETE /api/sites/[id] | `...route.ts` | ALL | HIGH |
+| GET /api/sites/list | `...route.ts` | GET | MEDIUM |
+| POST /api/sites/register | `...route.ts` | POST | HIGH — registers new WP site |
+| POST /api/sites/test-connection | `...route.ts` | POST | MEDIUM — WP connection test |
+| POST /api/sites/[id]/test-connection | `...route.ts` | POST | MEDIUM |
+| POST /api/sites/[id]/purge | `...route.ts` | POST | HIGH — purges Cloudflare cache |
+| GET/PATCH /api/sites/[id]/appearance/* | various | GET/POST | HIGH — palette sync/rollback to WP |
+| GET/POST /api/sites/[id]/blueprints | `...route.ts` | ALL | HIGH |
+| POST /api/sites/[id]/blueprints/[blueprint_id]/approve | | POST | HIGH |
+| POST /api/sites/[id]/blueprints/[blueprint_id]/publish-site | | POST | CRITICAL — publishes to WP |
+| POST /api/sites/[id]/blueprints/[blueprint_id]/revert | | POST | HIGH |
+| GET/POST /api/sites/[id]/posts | `...route.ts` | ALL | HIGH |
+| POST /api/sites/[id]/posts/[post_id]/publish | | POST | CRITICAL — publishes to WP |
+| POST /api/sites/[id]/posts/[post_id]/unpublish | | POST | HIGH |
+| POST /api/sites/[id]/posts/[post_id]/autosave | | POST | MEDIUM |
+| GET /api/sites/[id]/posts/export | | GET | MEDIUM |
+| GET/POST /api/sites/[id]/shared-content | `...route.ts` | ALL | HIGH |
+| GET/PATCH/DELETE /api/sites/[id]/shared-content/[content_id] | | ALL | HIGH |
+| GET/POST /api/sites/[id]/routes | `...route.ts` | ALL | HIGH |
+| POST /api/sites/[id]/ai-prefill | `...route.ts` | POST | HIGH — AI; cost |
+| GET/POST /api/sites/[id]/design-systems | `...route.ts` | ALL | HIGH |
+| GET /api/sites/[id]/wp-pages | | GET | MEDIUM — live WP call |
+| GET /api/sites/[id]/wp-taxonomies | | GET | MEDIUM |
+| GET /api/sites/[id]/wp-users | | GET | MEDIUM |
+| GET/PATCH /api/sites/[id]/permalink-structure | | ALL | HIGH |
+| GET/POST /api/sites/[id]/mode | | ALL | HIGH |
+
+### Design Systems API
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| POST /api/design-systems/[id]/activate | `...activate/route.ts` | POST | HIGH |
+| POST /api/design-systems/[id]/archive | `...archive/route.ts` | POST | HIGH |
+| GET/POST /api/design-systems/[id]/components | `...route.ts` | ALL | HIGH |
+| GET/PATCH/DELETE /api/design-systems/[id]/components/[cid] | `...route.ts` | ALL | HIGH |
+| GET /api/design-systems/[id]/preview | `...route.ts` | GET | MEDIUM |
+| GET/POST /api/design-systems/[id]/templates | `...route.ts` | ALL | HIGH |
+| GET/PATCH/DELETE /api/design-systems/[id]/templates/[tid] | `...route.ts` | ALL | HIGH |
+
+### WordPress Tools (AI agent tools)
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| POST /api/tools/create_page | `...route.ts` | POST | CRITICAL — creates WP page; AI agent tool |
+| POST /api/tools/update_page | `...route.ts` | POST | CRITICAL — updates WP page |
+| POST /api/tools/delete_page | `...route.ts` | POST | CRITICAL — deletes WP page |
+| GET /api/tools/get_page | `...route.ts` | GET | HIGH |
+| GET /api/tools/list_pages | `...route.ts` | GET | HIGH |
+| POST /api/tools/publish_page | `...route.ts` | POST | CRITICAL — publishes WP page live |
+| GET /api/tools/search_images | `...route.ts` | GET | MEDIUM |
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are the /api/tools/ routes accessible to all authenticated users or restricted to the AI agent service key?
+- [ ] Is there a hard rate limit on /api/tools/create_page and /api/tools/publish_page to prevent runaway generation?
+
+---
+
+## Q. Optimiser API
+
+### GET/POST /api/optimiser/clients
+
+**File:** `app/api/optimiser/clients/route.ts`
+**Method(s):** GET, POST
+**Auth:** `super_admin` or `admin`
+**Risk:** HIGH
+
+---
+
+### GET/PATCH/DELETE /api/optimiser/clients/[id]
+
+**File:** `app/api/optimiser/clients/[id]/route.ts`
+**Method(s):** GET, PATCH, DELETE
+**Auth:** `super_admin` or `admin`
+**Risk:** HIGH
+
+---
+
+### Client-level Optimiser Sub-routes
+
+| Route | File | Risk |
+|-------|------|------|
+| PATCH /api/optimiser/clients/[id]/ga4-property | `...ga4-property/route.ts` | HIGH |
+| PATCH /api/optimiser/clients/[id]/ads-customer | `...ads-customer/route.ts` | HIGH |
+| PATCH /api/optimiser/clients/[id]/clarity | `...clarity/route.ts` | HIGH |
+| GET /api/optimiser/clients/[id]/landing-pages | `...landing-pages/route.ts` | MEDIUM |
+| POST /api/optimiser/clients/[id]/onboarded | `...onboarded/route.ts` | HIGH |
+| POST /api/optimiser/clients/[id]/assisted-approval | `...assisted-approval/route.ts` | HIGH |
+| POST /api/optimiser/clients/[id]/cross-client-consent | `...cross-client-consent/route.ts` | HIGH |
+
+### Optimiser Proposals
+
+| Route | File | Risk |
+|-------|------|------|
+| POST /api/optimiser/proposals/[id]/approve | `...approve/route.ts` | HIGH — triggers brief generation |
+| POST /api/optimiser/proposals/[id]/reject | `...reject/route.ts` | HIGH |
+| POST /api/optimiser/proposals/[id]/rollback | `...rollback/route.ts` | HIGH — reverts WP changes |
+| GET /api/optimiser/proposals/[id]/run-status | `...run-status/route.ts` | LOW |
+| POST /api/optimiser/proposals/[id]/create-variant | `...create-variant/route.ts` | HIGH — A/B variant |
+
+### Optimiser Pages / Landing Pages
+
+| Route | File | Risk |
+|-------|------|------|
+| POST /api/optimiser/pages/[id]/rollback | `...rollback/route.ts` | HIGH — WP rollback |
+| POST /api/optimiser/pages/import | `...route.ts` | HIGH |
+| POST /api/optimiser/landing-pages/[id]/import | `...route.ts` | HIGH |
+
+### Optimiser OAuth
+
+| Route | File | Risk |
+|-------|------|------|
+| GET /api/optimiser/oauth/ga4/start | `...start/route.ts` | HIGH |
+| GET /api/optimiser/oauth/ga4/callback | `...callback/route.ts` | HIGH |
+| GET /api/optimiser/oauth/ads/start | `...start/route.ts` | HIGH |
+| GET /api/optimiser/oauth/ads/callback | `...callback/route.ts` | HIGH |
+
+### Optimiser Health / Diagnostics
+
+| Route | File | Risk |
+|-------|------|------|
+| GET /api/optimiser/health | `...route.ts` | LOW |
+| GET/POST /api/optimiser/diagnostics | `...route.ts` | MEDIUM |
+
+---
+
+## R. Platform Utilities
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| GET/PATCH /api/platform/brand | `...route.ts` | ALL | HIGH — brand profile |
+| GET /api/platform/companies/list | `...route.ts` | GET | MEDIUM |
+| POST /api/platform/companies/switch | `...route.ts` | POST | HIGH — switches active company context in session |
+| POST /api/platform/image/generate | `...route.ts` | POST | HIGH — AI image generation; cost |
+| GET/POST /api/platform/invitations | `...route.ts` | ALL | HIGH |
+| GET/PATCH/DELETE /api/platform/invitations/[id] | `...route.ts` | ALL | HIGH |
+| POST /api/platform/invitations/accept | `...route.ts` | POST | HIGH |
+| POST /api/platform/invitations/callbacks/expiry | `...route.ts` | POST | HIGH |
+| POST /api/platform/invitations/callbacks/reminder | `...route.ts` | POST | MEDIUM |
+| GET /api/platform/notifications | `...route.ts` | GET | LOW |
+
+### CAP Platform Routes
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| GET/POST /api/platform/cap/subscriptions | `...route.ts` | ALL | HIGH |
+| GET/PATCH /api/platform/cap/subscriptions/[id] | `...route.ts` | ALL | HIGH |
+| GET/POST /api/platform/cap/subscriptions/[id]/voice-profiles | `...route.ts` | ALL | HIGH |
+| GET/PATCH/DELETE /api/platform/cap/subscriptions/[id]/voice-profiles/[profileId] | `...route.ts` | ALL | HIGH |
+| POST /api/platform/cap/campaigns/[id]/generate | `...route.ts` | POST | HIGH — AI cost |
+| GET /api/platform/cap/campaign-posts/[id]/status | `...route.ts` | GET | LOW |
+| POST /api/platform/cap/campaign-posts/[id]/push | `...route.ts` | POST | HIGH — creates social drafts |
+| POST /api/platform/cap/campaign-posts/[id]/regenerate | `...route.ts` | POST | HIGH — AI cost |
+
+### Insights Platform Routes
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| POST /api/insights/consent | `...route.ts` | POST | HIGH |
+| GET /api/insights/recommendations | `...route.ts` | GET | MEDIUM |
+| POST /api/insights/recommendations/[id]/dismiss | `...route.ts` | POST | MEDIUM |
+| GET /api/insights/recommendations/[id]/evidence | `...route.ts` | GET | MEDIUM |
+| GET /api/insights/priors | `...route.ts` | GET | LOW |
+| GET /api/insights/generation-priors | `...route.ts` | GET | LOW |
+
+### Admin Insights Routes
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| POST /api/admin/insights/clients/[id]/annotate/[recId] | `...route.ts` | POST | HIGH |
+| POST /api/admin/insights/clients/[id]/dismiss/[recId] | `...route.ts` | POST | MEDIUM |
+| POST /api/admin/insights/clients/[id]/unsuppress/[recId] | `...route.ts` | POST | MEDIUM |
+| GET/POST /api/admin/insights/clients/[id]/competitors | `...route.ts` | ALL | HIGH |
+| GET/PATCH/DELETE /api/admin/insights/clients/[id]/competitors/[competitorId] | `...route.ts` | ALL | HIGH |
+
+### Admin Maintenance Routes
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| POST /api/admin/maintenance/reconcile-bundlesocial | `...route.ts` | POST | HIGH |
+| POST /api/admin/maintenance/social-connections/[id]/reattribute | `...route.ts` | POST | HIGH |
+| POST /api/admin/maintenance/social-connections/[id]/refresh-identity | `...route.ts` | POST | HIGH |
+| POST /api/admin/maintenance/webhooks/replay | `...route.ts` | POST | HIGH — replays webhooks |
+| POST /api/admin/maintenance/companies/[id]/toggle-cross-tenant-override | `...route.ts` | POST | CRITICAL — security boundary override |
+
+### Admin Service Health
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| GET/POST /api/admin/service-health/events | `...route.ts` | ALL | MEDIUM |
+| POST /api/admin/service-health/events/[id]/resolve | `...route.ts` | POST | MEDIUM |
+| POST /api/admin/service-health/flag | `...route.ts` | POST | MEDIUM |
+
+### Other Admin Routes
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| GET/PATCH /api/admin/design-system-settings | `...route.ts` | ALL | HIGH |
+| GET/PATCH /api/admin/theming/[companyId] | `...route.ts` | ALL | HIGH |
+| POST /api/admin/email-test | `...route.ts` | POST | MEDIUM |
+| GET/POST /api/admin/batch | `...route.ts` | ALL | HIGH |
+| POST /api/admin/batch/[id]/cancel | `...route.ts` | POST | HIGH |
+| POST /api/admin/jobs/extract-image-metadata | `...route.ts` | POST | MEDIUM |
+| POST /api/admin/media/[id]/promote | `...route.ts` | POST | HIGH |
+| GET /api/admin/sites/[id]/onboarding | `...route.ts` | GET | LOW |
+| POST /api/admin/sites/[id]/use-image-library | `...route.ts` | POST | MEDIUM |
+
+### Other Platform Routes
+
+| Route | File | Method | Risk |
+|-------|------|--------|------|
+| GET /api/images/suggest | `...route.ts` | GET | LOW — AI image suggestion |
+| POST /api/chat | `...route.ts` | POST | HIGH — main chat interface; AI cost |
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is /api/chat restricted to admin users or accessible to all platform members?
+- [ ] Does /api/platform/companies/switch require re-authentication, or is it a lightweight context switch?
+- [ ] Is /api/admin/maintenance/companies/[id]/toggle-cross-tenant-override restricted to super_admin only?

--- a/docs/inventory/components-catalog.md
+++ b/docs/inventory/components-catalog.md
@@ -1,0 +1,1053 @@
+# Components Catalog
+
+**Generated:** 2026-05-25 via codebase analysis.
+**Status:** Phase 1 skeleton — props extracted from source files. `EXPECTED BEHAVIOUR` sections are empty for Steven to fill.
+
+---
+
+## Table of Contents
+
+1. [UI Primitives](#ui-primitives)
+   - [Button](#button)
+   - [Dialog / DialogContent / DialogHeader / DialogFooter](#dialog--dialogcontent--dialogheader--dialogfooter)
+   - [ConfirmDialog](#confirmdialog)
+   - [CommentDialog](#commentdialog)
+   - [Alert](#alert)
+   - [Badge](#badge)
+   - [MenuItem](#menuitem)
+   - [PageHeader](#pageheader)
+   - [PageShell](#pageshell)
+   - [StatusPill](#statuspill)
+   - [SocialPlatformIcon](#socialplatformicon)
+2. [Social Composer](#social-composer)
+   - [ComposerOverlay](#composeroverlay)
+   - [ComposerEditor](#composereditor)
+   - [ProfileSelector](#profileselector)
+   - [SchedulingCard](#schedulingcard)
+   - [ToolsRow](#toolsrow)
+   - [UnsavedChangesDialog](#unsavedchangesdialog)
+3. [Calendar](#calendar)
+   - [CalendarShell](#calendarshell)
+4. [Social Features](#social-features)
+   - [SocialPostsListClient](#socialpostslistclient)
+   - [PostDetailTabbedClient](#postdetailtabbedclient)
+   - [PostApprovalSection](#postapprovalsection)
+   - [MediaLibraryClient](#medialibryclient)
+5. [Admin](#admin)
+   - [ImagesTable](#imagestable)
+6. [Viewer / Approval](#viewer--approval)
+   - [ApprovalDecisionForm](#approvaldecisionform)
+   - [ViewerLinksManager](#viewerlinksmanager)
+
+---
+
+## UI Primitives
+
+### Button
+
+**File:** `components/ui/button.tsx`
+**Status:** Active
+
+**Props:**
+```typescript
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+```
+
+**Variants:**
+| Variant | Visual |
+|---------|--------|
+| `default` | Solid #00e5a0 (primary green) background, white text, full-pill, hover brightness+shadow |
+| `destructive` | Solid red background, white text — for irreversible actions |
+| `outline` | Hairline border (legacy, backward-compat) |
+| `secondary` | White surface, `#1F2937` border, gray-800 text |
+| `ghost` | Transparent, dark text, hover bg-gray-100 |
+| `link` | Pink underline text (legacy) |
+| `toolbar` | Square-ish composer toolbar button; `aria-pressed` drives active state |
+
+**Sizes:**
+| Size | Padding |
+|------|---------|
+| `default` | `py-[10px] px-5 text-sm` |
+| `sm` | `py-[6px] px-[14px] text-xs` |
+| `xs` | `py-1 px-2 text-xs` |
+| `lg` | `py-[14px] px-7 text-base` |
+| `icon` | `h-8 w-8` |
+
+**Sub-components used:**
+- `Slot` (Radix UI) — via `asChild` prop
+
+**Currently tested by:**
+- Unit: no dedicated test file found
+- Component: no dedicated test file found
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Which variant is used for primary CTAs (e.g. "Save draft", "Post now")?
+- [ ] Which variant is used for Cancel/back actions?
+- [ ] Should `toolbar` buttons always show `aria-pressed` state when a panel is open?
+
+---
+
+### Dialog / DialogContent / DialogHeader / DialogFooter
+
+**File:** `components/ui/dialog.tsx` (shadcn/ui wrapper around Radix Dialog)
+**Status:** Active
+
+**Props:** Standard Radix `@radix-ui/react-dialog` props. `DialogContent` receives `className?`. All are compound components used together.
+
+**Variants / states:**
+- Default modal: centered overlay with backdrop
+- `max-w-sm` used by ConfirmDialog / UnsavedChangesDialog
+- Larger widths used by ComposerOverlay (custom full-screen split-pane)
+
+**Currently tested by:**
+- Component: via ConfirmDialog / UnsavedChangesDialog test coverage
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Should dialogs trap focus?
+- [ ] Should Escape always close?
+- [ ] Is clicking the backdrop expected to close?
+
+---
+
+### ConfirmDialog
+
+**File:** `components/ui/confirm-dialog.tsx`
+**Status:** Active — replaces `window.confirm()` throughout social platform (S-6)
+
+**Props:**
+```typescript
+type ConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  confirmLabel?: string;       // default: "Confirm"
+  confirmVariant?: "default" | "destructive" | "outline" | "ghost"; // default: "default"
+  onConfirm: () => void;
+};
+```
+
+**Variants / states:**
+- Default: title + optional description + Cancel (ghost) + Confirm button
+- Destructive: red confirm button for irreversible actions (e.g. disconnect connection)
+
+**Sub-components used:**
+- `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogDescription`, `DialogFooter`, `Button`
+
+**data-testid values:**
+- None currently set on the dialog itself (uses Radix default structure)
+
+**Currently tested by:**
+- None found via grep
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Should Cancel always call `onOpenChange(false)` without triggering `onConfirm`?
+- [ ] Clicking confirm should close dialog AND call onConfirm — in that order?
+
+---
+
+### CommentDialog
+
+**File:** `components/ui/confirm-dialog.tsx` (same file as ConfirmDialog)
+**Status:** Active — used for rejection-note flows
+
+**Props:**
+```typescript
+type CommentDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  commentLabel?: string;
+  commentPlaceholder?: string;
+  confirmLabel?: string;
+  confirmVariant?: "default" | "destructive" | "outline" | "ghost";
+  onConfirm: (comment: string) => void;
+};
+```
+
+**Variants / states:**
+- Same as ConfirmDialog but with a `<textarea>` for a reason / note
+- `onConfirm` receives the textarea value as a string
+
+**Currently tested by:**
+- None found via grep
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the comment field required before Confirm is enabled?
+- [ ] Minimum / maximum character limits on the comment?
+
+---
+
+### Alert
+
+**File:** `components/ui/alert.tsx` (shadcn/ui)
+**Status:** Active
+
+**Props:** Standard shadcn Alert props — `variant?: "default" | "destructive"`, `className?`, plus compound sub-components `AlertTitle`, `AlertDescription`.
+
+**Currently tested by:**
+- Referenced throughout the admin and platform surfaces; no dedicated unit tests found.
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is `destructive` variant used for error messages exclusively?
+
+---
+
+### Badge
+
+**File:** `components/ui/badge.tsx` (shadcn/ui)
+**Status:** Active
+
+**Props:** `variant?: "default" | "secondary" | "destructive" | "outline"`, `className?`, `children`.
+
+**Note:** Distinct from `StatusPill` (which uses semantic token classes) and `Pill` (which is the Opollo design-system wrapper). Badge is the raw shadcn primitive.
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Which surfaces use Badge vs Pill vs StatusPill?
+
+---
+
+### MenuItem
+
+**File:** `components/ui/menu-item.tsx`
+**Status:** Active — used inside `role="menu"` containers (e.g. platform picker, connection dropdowns)
+
+**Props:**
+```typescript
+export interface MenuItemProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  icon?: React.ReactNode;     // leading element (icon, avatar)
+  trailing?: React.ReactNode; // trailing element (status text, badge, arrow)
+}
+```
+
+**Variants / states:**
+- Normal: hover `bg-muted/60` + focus `bg-muted/60`
+- Disabled: `cursor-not-allowed opacity-60`
+- Focus-visible: `shadow-[var(--shadow-focus)]`
+
+**Sub-components used:**
+- None (renders a `<button role="menuitem">` directly)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Should MenuItem handle keyboard navigation (ArrowUp/Down) or does the parent menu container own that?
+
+---
+
+### PageHeader
+
+**File:** `components/ui/page-header.tsx`
+**Status:** Active — Spec 02 §1.1 + Spec 04 (2026-05-08)
+
+**Props (compound slots detected by `displayName`):**
+```typescript
+// Compound component — usage:
+// <PageHeader>
+//   <PageHeader.Title>…</PageHeader.Title>
+//   <PageHeader.Breadcrumb>…</PageHeader.Breadcrumb>
+//   <PageHeader.Subtitle>…</PageHeader.Subtitle>
+//   <PageHeader.Meta>…</PageHeader.Meta>
+//   <PageHeader.Actions>…</PageHeader.Actions>
+// </PageHeader>
+```
+
+**Layout contract (Spec 04 2026-05-08):**
+- Visual order: Title → Breadcrumb → Subtitle → Meta → Actions (regardless of JSX order)
+- Rhythm: 20px / 8px / 12px gaps between rows; 32px gap to PageShell.Content
+
+**Sub-components used:**
+- `Breadcrumb` (ui/breadcrumb)
+
+**Currently tested by:**
+- Unit: `headings-use-page-header` audit rule in build layer
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is `Title` always required? (Dev invariant enforced as `console.error`, not thrown)
+- [ ] What is the fallback when no breadcrumb is provided?
+
+---
+
+### PageShell
+
+**File:** `components/ui/page-shell.tsx`
+**Status:** Active — Spec 02 §1.3
+
+**Props:**
+```typescript
+export interface PageShellProps {
+  children: React.ReactNode;
+  className?: string;
+}
+// Sub-component:
+PageShell.Content // zero inner padding — pages own their grid
+```
+
+**Layout contract:**
+- `max-w-7xl` (1280px) max width
+- Horizontal padding: `px-4 py-6 sm:px-6 lg:px-8`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Should all pages use PageShell? Are there exceptions?
+
+---
+
+### StatusPill
+
+**File:** `components/ui/status-pill.tsx`
+**Status:** Active
+
+**Props:**
+```typescript
+export interface StatusPillProps extends React.HTMLAttributes<HTMLSpanElement> {
+  kind: StatusPillKind;
+  label?: string;
+}
+
+export type StatusPillKind =
+  | "success"
+  | "warning"
+  | "error"
+  | "info"
+  | "neutral"
+  | "strong_signal"
+  | "early_signal"
+  | "client_green"
+  | "client_amber"
+  | "client_red";
+```
+
+**Kind → token mapping:**
+| Kind | Background | Text |
+|------|-----------|------|
+| `success` | `bg-pk/20` | `text-tx-primary` |
+| `warning` | `bg-am/30` | `text-tx-primary` |
+| `error` | `bg-rd/20` | `text-tx-primary` |
+| `info` | `bg-bl/20` | `text-tx-primary` |
+| `neutral` | `bg-su-secondary` | `text-tx-muted` |
+| `strong_signal` | `bg-pk` (solid) | `text-tx-inverse` |
+| `early_signal` | `bg-am` (solid) | `text-tx-primary` |
+| `client_green` | `bg-pk/20` | `text-tx-primary` |
+| `client_amber` | `bg-am/30` | `text-tx-primary` |
+| `client_red` | `bg-rd/20` | `text-tx-primary` |
+
+**Note:** Distinct from generic `Pill` primitive and shadcn `Badge`. StatusPill uses explicit design-token classes for semantic intentions.
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Which DraftState values map to which StatusPill kind?
+- [ ] Which SocialPostState values map to which StatusPill kind?
+
+---
+
+### SocialPlatformIcon
+
+**File:** `components/ui/SocialPlatformIcon.tsx`
+**Status:** Active
+
+**Props:**
+```typescript
+export type SocialPlatformIconKey =
+  | "LINKEDIN" | "FACEBOOK" | "INSTAGRAM" | "TWITTER"
+  | "GOOGLE_BUSINESS" | "TIKTOK" | "YOUTUBE" | "PINTEREST"
+  | "THREADS" | "REDDIT";
+
+// Component signature (inferred from file):
+interface SocialPlatformIconProps {
+  platform: SocialPlatformIconKey;
+  className?: string;
+}
+```
+
+**Implementation:** Inline SVG using Simple Icons paths. 24×24 single-path glyphs in `currentColor`. Brand fill is neutral (inherits text foreground) — no marketing-colour treatment.
+
+**Note:** Used because Linearicons (the codebase icon convention) has no brand icons. Documented fallback per `docs/patterns/icons.md`.
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Should icons render at 24×24 everywhere or does size vary by context?
+- [ ] Is there a fallback glyph for unknown platforms?
+
+---
+
+## Social Composer
+
+### ComposerOverlay
+
+**File:** `components/social/composer/ComposerOverlay.tsx`
+**Status:** Active — V2 composer, mounted on `/company/social/*`
+
+**Props:**
+```typescript
+export interface ComposerOverlayProps {
+  open: boolean;
+  onClose: () => void;
+  initialDraft?: Draft;
+  prefilledDate?: Date;
+  /** Company ID — required for media upload and AI assist. */
+  companyId?: string;
+  /** IANA timezone string (e.g. "Australia/Melbourne"). Used for scheduling. */
+  companyTimezone?: string;
+  /** All connections available to select. */
+  availableConnections?: Connection[];
+  /** Called when user submits (external override). */
+  onSubmit?: (draft: Draft, mode: SchedulingMode) => Promise<void>;
+  /** Called after a successful internal submit (POST /api/platform/social/drafts). */
+  onSubmitSuccess?: () => void;
+  /** Slot for SchedulingCard + submit row. Takes precedence over internal SchedulingCard. */
+  schedulingSlot?: React.ReactNode;
+  /** Original state of the draft being edited (for header copy + convert-to-draft action). */
+  editOriginalState?: DraftState;
+  /** Failure reason shown as error banner when editOriginalState === 'failed'. */
+  failureReason?: string;
+  /** Called when user clicks a post chip in the calendar tab. */
+  onNavigateToPost?: (postId: string) => void;
+}
+```
+
+**Variants / states:**
+- New post: `initialDraft` absent, `editOriginalState` absent — blank composer
+- Edit draft: `initialDraft` provided, `editOriginalState = 'draft'`
+- Edit scheduled: `editOriginalState = 'scheduled'`
+- Edit recurring: `editOriginalState = 'recurring'`
+- View published (read-only): `editOriginalState = 'published'`
+- View failed (read-only + error banner): `editOriginalState = 'failed'`, `failureReason` provided
+- Prefilled date: `prefilledDate` sets initial SchedulingCard value
+
+**Keyboard shortcuts:**
+| Shortcut | Action |
+|----------|--------|
+| `⌘↵` | Submit post |
+| `⌘S` | Save as draft |
+| `⌘⇧S` | Schedule post |
+| `⌘K` | Focus editor |
+| `⌘E` | Toggle emoji panel |
+| `⌘I` | Open media picker |
+| `⌘1–5` | Switch preview tab |
+| `Esc` | Close composer |
+| `?` | Show shortcuts |
+
+**Preview tabs:**
+- `preview` — platform preview card (right pane)
+- `calendar` — SocialCalendarGrid (right pane, read-only calendar browse)
+
+**Sub-components used:**
+- `ProfileSelector` — connection chip row (left pane top)
+- `ComposerEditor` — left pane content area
+- `PreviewCard` — right pane preview
+- `SocialCalendarGrid` — right pane calendar tab
+- `SchedulingCard` — scheduling mode + approval toggle (internal slot)
+- `UnsavedChangesDialog` — shown when closing with dirty content
+- `ComposerErrorBoundary` — wraps the whole overlay
+- `PostInfoCard` — info card shown for read-only states
+- `EmptyState` — shown when no connections are available
+- `Pill`, `SocialPlatformIcon`
+
+**data-testid values:**
+- None defined directly in ComposerOverlay; sub-components have their own
+
+**Currently tested by:**
+- E2E: `e2e/composer-edit-mode-verification.spec.ts` (verification spec, untracked)
+- Unit: `lib/social/__tests__/schedulingCardValueFromIso.unit.test.ts` (exported helper)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] When `editOriginalState = 'published'`, is the entire composer read-only (no edits possible)?
+- [ ] When `editOriginalState = 'failed'`, can the user edit and resubmit, or only view?
+- [ ] Does closing a dirty composer always show UnsavedChangesDialog, or only for certain states?
+- [ ] What does the header copy say for each `editOriginalState` value?
+- [ ] Is `onSubmitSuccess` called in addition to `onSubmit`, or only when `onSubmit` is absent?
+
+---
+
+### ComposerEditor
+
+**File:** `components/social/composer/ComposerEditor.tsx`
+**Status:** Active — orchestrates the left pane of ComposerOverlay
+
+**Props:**
+```typescript
+export interface ComposerEditorProps {
+  draft: Draft;
+  onChange: (d: Draft) => void;
+  onSubmit: (mode: SchedulingMode) => Promise<void>;
+  companyId: string;
+  selectedConnections: Connection[];
+  schedulingSlot?: React.ReactNode;
+  className?: string;
+  readOnly?: boolean;  // hides ToolsRow, link editors, CustomizeForRow, remove buttons
+}
+```
+
+**Variants / states:**
+- Editable: full toolbar, platform-variant row, per-tile remove buttons
+- Read-only (`readOnly=true`): textarea renders but ToolsRow + platform row hidden — used for `state='published'` etc.
+
+**Sub-components used:**
+- `ContentEditor` — main text area
+- `CustomizeForRow` — per-platform variant toggles
+- `PlatformActionsList` — platform-specific action chips
+- `ToolsRow` — AI assist, media, emoji, GIF, UTM toolbar
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does character count display in the editor? Which platform's limit applies when multiple are selected?
+- [ ] Does the editor allow per-platform content customisation?
+
+---
+
+### ProfileSelector
+
+**File:** `components/social/composer/ProfileSelector.tsx`
+**Status:** Active — connection chip row in composer
+
+**Props:**
+```typescript
+export interface ProfileSelectorProps {
+  available: Connection[];
+  selected: string[];
+  onChange: (ids: string[]) => void;
+  className?: string;
+  readOnly?: boolean; // hides "Add profile" affordance, disables chip toggling
+}
+```
+
+**Variants / states:**
+- Interactive: chip row + "Add profile" affordance
+- Read-only: same chips rendered without toggle/remove affordance
+
+**data-testid values:**
+- `profile-selector` (line 44)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a user deselect all profiles (empty `selected` array)?
+- [ ] What happens when `available` is empty?
+
+---
+
+### SchedulingCard
+
+**File:** `components/social/composer/SchedulingCard.tsx`
+**Status:** Active — four-tab scheduling UI wired inside ComposerOverlay
+
+**Props:**
+```typescript
+export interface SchedulingCardValue {
+  mode: SchedulingMode;          // "post_now" | "schedule" | "recurring" | "draft"
+  scheduledTimes: ScheduleRowValue[];
+  recurrence: RecurrenceRule;
+  plannedForAt: ScheduleRowValue | null;
+  approvalRequired: boolean;
+}
+
+export interface SchedulingCardProps {
+  value: SchedulingCardValue;
+  onChange: (v: SchedulingCardValue) => void;
+  onSubmit: () => Promise<void>;
+  submitting?: boolean;
+  disabled?: boolean;
+  disabledTooltip?: string; // shown when disabled=true
+}
+```
+
+**Tabs:**
+| Mode | Tab label | Submit button label |
+|------|-----------|---------------------|
+| `post_now` | Post now | Post now |
+| `schedule` | Schedule | Schedule post |
+| `recurring` | Publish regularly | Save schedule |
+| `draft` | Save as draft | Save draft |
+
+**Sub-components used:**
+- `ScheduleRow` — date/time picker row
+- `RecurrencePicker` — RFC 5545 RRULE builder
+- `ApprovalToggle` — approval required checkbox
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] When `mode = 'post_now'`, should `disabledTooltip` appear if no profiles are selected?
+- [ ] What validation occurs before `onSubmit` fires?
+
+---
+
+### ToolsRow
+
+**File:** `components/social/composer/ToolsRow.tsx`
+**Status:** Active — composer toolbar
+
+**Props:**
+```typescript
+export interface ToolsRowProps {
+  companyId: string;
+  onInsertText: (text: string) => void;
+  onOpenMediaPicker: () => void;
+  onAttachGif: (url: string) => void;
+  platforms?: Platform[];
+  className?: string;
+}
+```
+
+**Panels (mutually exclusive, `ActivePanel` type):**
+| Panel key | Trigger | Action |
+|-----------|---------|--------|
+| `ai` | Sparkles icon | AI assist → POST `/api/platform/social/cap/assist` |
+| `emoji` | Smile icon | Quick emoji grid; inserts via `onInsertText` |
+| `gif` | Film icon | GIPHY search; attaches via `onAttachGif` |
+| `utm` | Tags icon | UTM parameter builder |
+| `shorten` | — | Inline URL shortener form |
+| `null` | any close action | All panels closed |
+
+**AI assist error categories:**
+- `rate_limit` — too many requests
+- `timeout` — upstream timeout
+- `content_rejected` — content policy
+- `invalid_request` — bad prompt
+- `network` — connectivity
+- `overloaded` — upstream overloaded
+- `unknown` — catch-all
+
+**data-testid values:**
+- `ai-trace-id` (line 78) — trace ID badge inside AI panel
+
+**Currently tested by:**
+- No dedicated component test found
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is only one panel open at a time (clicking an open panel's icon closes it)?
+- [ ] Does the AI panel show a cost estimate before sending?
+- [ ] What is the rate-limit behaviour — how many requests per minute?
+
+---
+
+### UnsavedChangesDialog
+
+**File:** `components/social/composer/UnsavedChangesDialog.tsx`
+**Status:** Active — shown when closing a composer with dirty content
+
+**Props:**
+```typescript
+export interface UnsavedChangesDialogProps {
+  open: boolean;
+  onDiscard: () => void;
+  onCancel: () => void;
+  onSave?: () => void | Promise<void>; // renders "Save" primary button when provided
+}
+```
+
+**Variants / states:**
+- With `onSave`: three buttons — Save (primary) / Discard / Cancel
+- Without `onSave`: two buttons — Discard / Cancel
+
+**data-testid values:**
+- `unsaved-save-btn` (line 46) — Save button
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Should this dialog appear when the user has only changed the scheduling mode (no content edits)?
+- [ ] Should it appear when editing a `published` post (where the edit is effectively read-only)?
+
+---
+
+## Calendar
+
+### CalendarShell
+
+**File:** `components/social/dashboard/CalendarShell.tsx`
+**Status:** Active — full-page calendar shell at `/company/social/calendar`
+
+**Props:**
+```typescript
+interface CalendarShellProps {
+  companyId: string;
+  hasConnections: boolean;
+  availableConnections: Connection[];
+}
+```
+
+**Internal state:**
+- `currentMonth: Date` — tracks displayed month (controlled via nav buttons)
+- `selectedDate: Date` — currently selected day cell
+- Composer open/close state via `useComposerState` hook
+- Drag-and-drop state via `@dnd-kit/core`
+
+**Sub-components used:**
+- `SocialCalendarGrid` — base grid
+- `DnDCell` — DnD-aware day cell (internal to this file)
+- `PostChip` — individual post chip in cells
+- `FilterBar` — status filter controls
+- `DayDetail` — side panel for selected day
+- `ComposerOverlay` — new post composer
+- `BulkScheduleModal` — bulk scheduling modal
+- `PostAnalyticsModal` — per-post analytics modal
+- `Callout` — used for "no connections" empty state
+
+**data-testid values:**
+- `calendar-dnd-cell` (DnDCell, line 73)
+- `data-date` attribute on each DnD cell (ISO date string)
+
+**Drag-and-drop contract:**
+- Cells in the past (`isPast=true`) or other months (`isOtherMonth=true`) are non-droppable
+- Drop target highlights via `isOver && canDrop` → `border-primary/60 bg-primary/10`
+
+**Currently tested by:**
+- No dedicated E2E or component test found
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] When no connections exist (`hasConnections=false`), is the calendar still rendered or replaced by an empty state?
+- [ ] Does dragging a post to a new date immediately save, or require a confirm step?
+- [ ] What happens when the drop fails (API error)?
+- [ ] Can posts in `published` or `failed` state be dragged?
+
+---
+
+## Social Features
+
+### SocialPostsListClient
+
+**File:** `components/SocialPostsListClient.tsx`
+**Status:** Active — client shell for `/company/social/posts`
+
+**Props:**
+```typescript
+type Props = {
+  companyId: string;
+  initialPosts: PostMasterListItem[];
+  canCreate: boolean;
+  canApprove?: boolean;
+  initialQ?: string;
+  initialState?: FilterKey;        // "all" | SocialPostState
+  page?: number;
+  pageSize?: number;
+  totalCount?: number;
+  sortBy?: SortCol;                // "state_changed_at" | "created_at"
+  sortDir?: SortDir;               // "asc" | "desc"
+  useComposerFlow?: boolean;       // Spec 22: "New post" opens ?compose=new instead of inline form
+};
+```
+
+**URL parameters driven:**
+- `?q=` — server-side text search (S1-37)
+- `?state=` — state filter tab pre-selection (S1-40)
+- `?page=N` — pagination (S1-38, 25 per page)
+- `?sort=` + `?dir=` — column sort (S1-46)
+
+**Filter tabs (S1-40, S1-45):**
+- `all`
+- `draft`
+- `pending_client_approval`
+- `approved`
+- `rejected`
+- `changes_requested`
+- `scheduled`
+- `publishing`
+- `published`
+- `failed`
+- `awaiting_msp_release` (S1-45)
+
+**Source badges (S1-43):**
+- CSV, CAP, API sources show source badge under the copy text
+- Manual posts show no badge
+
+**Sub-components used:**
+- `BulkUploadButton`
+- `CAPGenerateModal`
+- `ProfileSelector` (for filter)
+- `Button`, `Pill`, `Lead`
+- `PillTabs`
+- `SocialModuleShell`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does "New post" open ComposerOverlay or navigate to a separate page?
+- [ ] What is the exact page size (claimed 25 per page in comment)?
+- [ ] Does the state filter include a count badge per tab?
+- [ ] Can an `editor` role see all tabs or only their own posts?
+
+---
+
+### PostDetailTabbedClient
+
+**File:** `components/PostDetailTabbedClient.tsx`
+**Status:** Active — client wrapper for `/company/social/posts/[id]`
+
+**Props:**
+```typescript
+interface PostDetailTabbedClientProps {
+  post: PostMaster;
+  canEdit: boolean;
+  canSubmit: boolean;
+  canCreate: boolean;
+  canApprove: boolean;
+  variantsSection: React.ReactNode | null;
+  approvalSection: React.ReactNode | null;
+  decisionsSection: React.ReactNode | null;
+  scheduleSection: React.ReactNode | null;
+  publishHistorySection: React.ReactNode | null;
+}
+```
+
+**Tab visibility rules:**
+| Tab | Condition |
+|-----|-----------|
+| `content` | Always |
+| `approval` | Only when `pending_client_approval` |
+| `review` | Only when `approved` / `rejected` / `changes_requested` |
+| `schedule` | Only when `approved` or `scheduled` |
+| `history` | Only when `publishing` / `published` / `failed` |
+
+**Footer actions:**
+- "Back to posts" — always
+- "Schedule another" — only when `published` (D-4 fix for post-publish dead-end)
+
+**Sub-components used:**
+- `SocialPostDetailClient`
+- `TDetailTabbed` (template)
+- `Button`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens if the post transitions state while the user is on this page?
+- [ ] Is the `content` tab editable when `canEdit=true` and state is `draft`?
+
+---
+
+### PostApprovalSection
+
+**File:** `components/PostApprovalSection.tsx`
+**Status:** Active — recipients section on post detail page
+
+**Props:**
+```typescript
+type Props = {
+  postId: string;
+  companyId: string;
+  initialRecipients: RecipientRow[];
+  initialApprovalRequestId: string | null;
+  canManage: boolean; // editor+ on pending_client_approval post
+};
+
+type RecipientRow = {
+  id: string;
+  email: string;
+  name: string | null;
+  requires_otp: boolean;
+  revoked_at: string | null;
+  created_at: string;
+};
+```
+
+**Variants / states:**
+- Read-only: list of recipients only (when `canManage=false`)
+- Managed: list + inline add form + revoke button per recipient (when `canManage=true`)
+- Empty state: shown when no recipients yet
+
+**API calls:**
+- `POST /api/platform/social/posts/{postId}/recipients` — add recipient
+- `DELETE /api/platform/social/posts/{postId}/recipients/{id}` — revoke (soft-delete)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can the same email be added twice to the same approval request?
+- [ ] What happens to an approval request if all recipients are revoked?
+- [ ] Does revoking a recipient send them a notification?
+
+---
+
+### MediaLibraryClient
+
+**File:** `components/MediaLibraryClient.tsx`
+**Status:** Active — media browser at `/company/social/media`
+
+**Props:**
+```typescript
+type Props = {
+  companyId: string;
+  initialAssets: Asset[];
+  initialNextCursor: string | null;  // cursor for next page (S1-57)
+  canEdit: boolean;
+};
+
+type Asset = {
+  id: string;
+  source_url: string | null;
+  storage_path: string;
+  mime_type: string;
+  bytes: number;
+  width: number | null;
+  height: number | null;
+  bundle_upload_id: string | null;
+  created_at: string;
+};
+```
+
+**Variants / states:**
+- Read-only: asset grid + copy-URL only (when `canEdit=false`)
+- Editable: asset grid + add-by-URL form + copy-URL (when `canEdit=true`)
+- Load more: cursor-based pagination via "Load more" button (S1-57)
+
+**Internal state:**
+- `assets: Asset[]` — accumulated list (appended on load-more)
+- `nextCursor: string | null` — API cursor from last response
+- `showForm: boolean` — toggle for the add-by-URL form
+- `copiedId: string | null` — tracks which URL was last copied (brief highlight)
+
+**API calls:**
+- `GET /api/platform/social/media?company_id=…&cursor=…` — paginated asset list
+- `POST /api/platform/social/media` — add asset by URL
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What file types are accepted for upload by URL?
+- [ ] Is there a file size limit enforced at the API?
+- [ ] Can assets be deleted from this view?
+
+---
+
+## Admin
+
+### ImagesTable
+
+**File:** `components/ImagesTable.tsx`
+**Status:** Active — admin images grid at `/admin/images`
+
+**Props:**
+```typescript
+type ImagesTableProps = {
+  items: ImageListItemWithUrl[];  // ImageListItem & { previewUrl: string | null }
+  backHref?: string;
+  filterState?: ImagesFilterState;
+};
+
+export type ImagesFilterState = {
+  query: string | null;
+  tags: string[];
+  source: ImageLibrarySource | null;
+  deleted: boolean;
+};
+```
+
+**Source → Pill variant:**
+| Source | Pill variant | Label |
+|--------|-------------|-------|
+| `istock` | `info` | iStock |
+| `upload` | `warning` | Upload |
+| `generated` | `accent` | Generated |
+
+**Column layout (Spec 18 PR C):**
+- Preview: 48×48 thumbnail, optional ImageLightbox
+- Title / Caption / File: `TableCell.Stack` (title + filename secondary + caption secondary)
+- Tags: up to 6 `Pill` (neutral) chips, "+N" for overflow
+- Source: `Pill` with variant per source type
+- Dimensions: `TableCell.Mono` or Empty when null
+- Imported: `TableCell.Secondary` (relative time via `formatRelativeTime`)
+
+**Bulk delete:**
+- `DataTable` with `selectable` prop drives per-row checkboxes
+- Selection chip + Delete CTA + `ConfirmActionModal` gates the actual delete
+
+**Sub-components used:**
+- `DataTable`, `ColumnDef`
+- `BulkImageUpload`
+- `ConfirmActionModal`
+- `ImageLightbox`
+- `Button`, `NavIcon`, `Pill`, `TableCell`
+
+**data-testid values:**
+- `image-library-grid` — confirmed in spec (`data-testid="image-library-grid"`)
+
+**Currently tested by:**
+- E2E: `/api/admin/images` endpoint tested via media library scope spec
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when a bulk-delete is confirmed — are items hard-deleted or soft-deleted?
+- [ ] Can deleted images be restored?
+- [ ] Does clicking a thumbnail open the lightbox or navigate to `/admin/images/[id]`?
+
+---
+
+## Viewer / Approval
+
+### ApprovalDecisionForm
+
+**File:** `components/ApprovalDecisionForm.tsx`
+**Status:** Active — external approver form at `/viewer/[token]`
+
+**Props:**
+```typescript
+type Props = {
+  token: string;
+  alreadyDecided: boolean; // if true, renders "already resolved" panel instead of form
+};
+```
+
+**Decision options:**
+```typescript
+type Decision = "approved" | "rejected" | "changes_requested";
+```
+
+**Button variants per decision:**
+| Decision | Button variant | Label |
+|----------|---------------|-------|
+| `approved` | `default` | Approve |
+| `changes_requested` | `secondary` | Request changes |
+| `rejected` | `destructive` | Reject |
+
+**States:**
+- Form idle: three decision buttons + comment textarea
+- Submitting: selected button shows loading state
+- Done: shows "thanks" confirmation panel
+- Error: inline error message
+- `alreadyDecided=true`: "This request has already been resolved" panel (no form)
+
+**API calls:**
+- `POST /api/approve/[token]/decision` — submit decision
+
+**data-testid values:**
+- `approval-already-decided` (line 50) — "already resolved" panel
+
+**Currently tested by:**
+- E2E: viewer approval flow — see `e2e/` for connection-related specs
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the comment field required for `rejected` decision? (API requires `rejection_reason` ≥ 30 chars for `rejected`)
+- [ ] Is the comment field optional for `changes_requested`?
+- [ ] After submitting, can the approver change their decision?
+- [ ] Does the `alreadyDecided=true` state distinguish between who decided and what the decision was?
+
+---
+
+### ViewerLinksManager
+
+**File:** `components/ViewerLinksManager.tsx`
+**Status:** Active — share-link management at `/company/social/sharing`
+
+**Props:**
+```typescript
+type Props = {
+  companyId: string;
+  initialLinks: Link[];
+};
+
+type Link = {
+  id: string;
+  recipient_email: string | null;
+  recipient_name: string | null;
+  expires_at: string;
+  revoked_at: string | null;
+  last_viewed_at: string | null;
+  created_at: string;
+};
+```
+
+**Variants / states:**
+- Table view: active links list with revoke button per row
+- Add form (toggled): recipient email + name fields + Create button
+- Post-create: URL shown once for copy (raw token never persisted client-side)
+- Error inline: below the add form
+
+**API calls:**
+- `POST /api/platform/social/viewer-links` — create new link (returns `{ link, url }`)
+- `DELETE /api/platform/social/viewer-links/[id]` — revoke (soft-delete)
+
+**Security note:** Raw token is surfaced only once immediately after creation — it is never written back to disk. The `url` in the response is the only opportunity to copy.
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is the default expiry duration for new viewer links?
+- [ ] Can the expiry be customised at creation time?
+- [ ] Does revoking a link immediately invalidate it (hard-invalidate), or only on next access attempt?
+- [ ] What does a viewer see when they follow a revoked link?
+- [ ] Is `last_viewed_at` updated in real time or periodically?

--- a/docs/inventory/discovered-issues.md
+++ b/docs/inventory/discovered-issues.md
@@ -1,0 +1,152 @@
+# Discovered Issues
+
+**Generated:** 2026-05-25 — issues discovered during Phase 1 inventory codebase analysis.
+**Process:** These issues were found incidentally while reading source files to populate the inventory. They are documented here for triage, not necessarily as bugs to fix immediately.
+
+---
+
+## Issue 1 — Published posts open in an editable composer (confirmed bug)
+
+**Discovered during:** Components catalog analysis of `ComposerOverlay.tsx`
+**Severity:** Medium — user experience / data integrity
+
+**Description:**
+`ComposerOverlay` accepts `editOriginalState?: DraftState` to signal when the composer is opening a non-draft post. The `isReadOnlyState()` helper in `lib/social/post-state-actions.ts` is intended to prevent edits on terminal states (`published`, `publishing`, `failed`). However, the `PATCH /api/platform/social/drafts/[id]` route separately guards terminal states via `isTerminalForMutation()`.
+
+The question is whether the UI consistently enforces `readOnly=true` on the `ComposerEditor` when `editOriginalState='published'`. The `ComposerOverlay` has both `isReadOnlyState` logic and a `readOnly` prop on `ComposerEditor`, but any code path that opens the overlay for a `published` post without setting `editOriginalState` would render the form as fully editable — even though the PATCH will return `INVALID_STATE (409)` at submission time.
+
+**Files involved:**
+- `components/social/composer/ComposerOverlay.tsx` — `editOriginalState` prop, `isReadOnlyState` call
+- `components/social/composer/ComposerEditor.tsx` — `readOnly` prop
+- `lib/social/post-state-actions.ts` — `isReadOnlyState()`, `isTerminalForMutation()`
+- `app/api/platform/social/drafts/[id]/route.ts` (lines 143–158) — server-side INVALID_STATE guard
+
+**Evidence:** The inventory spec brief for this branch (`fix/composer-central-image-library`) references edit-mode composer fixes, and `e2e/composer-edit-mode-verification.spec.ts` (untracked) exists as a verification spec.
+
+**Action:** Steven to verify whether clicking a `published` post chip on the calendar or posts list opens the composer in read-only mode.
+
+---
+
+## Issue 2 — Two parallel state machines: SocialPostState vs DraftState
+
+**Discovered during:** Forms and validation research; types cross-reference
+**Severity:** Low — technical debt / documentation gap
+
+**Description:**
+The codebase has two distinct state enumerations for what is conceptually the same entity (a social post):
+
+**V1 legacy (`lib/platform/social/posts/types.ts`):**
+```typescript
+export type SocialPostState =
+  | "draft"
+  | "pending_client_approval"
+  | "approved"
+  | "rejected"
+  | "changes_requested"
+  | "scheduled"
+  | "publishing"
+  | "published"
+  | "failed";
+```
+
+**V2 composer (`lib/social/types.ts`):**
+```typescript
+export type DraftState =
+  | "draft"
+  | "pending_approval"    // ← different from "pending_client_approval"
+  | "rejected"
+  | "scheduled"
+  | "recurring"           // ← not in V1
+  | "paused"              // ← not in V1
+  | "publishing"
+  | "published"
+  | "failed";
+```
+
+**Key differences:**
+- V1 uses `pending_client_approval`, `approved`, `changes_requested` — V2 does not
+- V2 uses `pending_approval`, `recurring`, `paused` — V1 does not
+- V2 uses `social_post_drafts` table; V1 uses `social_post_masters` table
+
+This means the posts list page (`SocialPostsListClient`) uses `SocialPostState` with V1 filter tabs, while the composer (`ComposerOverlay`) uses `DraftState`. There is no unified type, and any code that tries to use one where the other is expected will have type errors or runtime mismatches.
+
+**Files involved:**
+- `lib/platform/social/posts/types.ts` — V1 state type
+- `lib/social/types.ts` — V2 state type
+- `components/SocialPostsListClient.tsx` — uses `SocialPostState`
+- `components/social/composer/ComposerOverlay.tsx` — uses `DraftState`
+
+**Action:** The V1 and V2 state machines are a documented parallel-running period. This is not a bug to fix now — it is an expected transitional state. Flagged here so Phase 3 UAT specs know to test each state using the correct type system.
+
+---
+
+## Issue 3 — `pending_identity` status added via ALTER TYPE (migration 0122), not in original enum
+
+**Discovered during:** State machines inventory analysis
+**Severity:** Low — legacy type-check risk
+
+**Description:**
+The `pending_identity` status on `social_connections` was added via `ALTER TYPE` in migration 0122, not as part of the original enum definition. Any TypeScript code written before migration 0122 that uses an exhaustive switch over connection status values may not handle `pending_identity`, causing a TypeScript `never` branch or a silent fall-through at runtime.
+
+**Files to check:**
+- `lib/platform/social/connections/` — any switch or if-chain over connection status
+- `components/social/dashboard/` — connection status display logic
+- `e2e/uat/connections.spec.ts` — the disconnect dialog fix (referenced in PR #1057/1060) may have addressed this
+
+**Action:** Before writing UAT specs for connection status flows, verify that all switch/if chains over `social_connections.status` include `pending_identity` as an explicit case.
+
+---
+
+## Issue 4 — Composer edit-mode behaviour for published/failed states is an open question
+
+**Discovered during:** ComposerOverlay prop analysis
+**Severity:** Medium — UAT gap
+
+**Description:**
+`ComposerOverlay` has an `editOriginalState` prop of type `DraftState`. The comment in the file says:
+
+> "Original state of the draft being edited (for header copy + convert-to-draft action)."
+
+For `failed` state, `failureReason` prop is provided and shown as an error banner. For `published` state, the composer should be read-only.
+
+However, the branch currently under work (`fix/composer-central-image-library`) exists specifically to fix composer behaviour around image library and edit mode. The `e2e/composer-edit-mode-verification.spec.ts` file (untracked, added on this branch) is a verification spec for this exact scenario — but it has not been committed to the branch yet, suggesting the verification is incomplete.
+
+**Files involved:**
+- `components/social/composer/ComposerOverlay.tsx` — `editOriginalState`, `failureReason` props
+- `lib/social/post-state-actions.ts` — `isReadOnlyState()`, `canPerform()`
+- `e2e/composer-edit-mode-verification.spec.ts` — untracked verification spec on current branch
+
+**Action:** When Phase 2 fills in EXPECTED BEHAVIOUR for `ComposerOverlay`, explicitly answer:
+- What can a user do in the composer when `editOriginalState = 'published'`?
+- What can a user do in the composer when `editOriginalState = 'failed'`?
+- Can a user convert a `failed` post back to `draft` via the composer?
+
+---
+
+## Issue 5 — ApproveSchema vs UI decisions mismatch (changes_requested)
+
+**Discovered during:** Forms and validation analysis
+**Severity:** Low — potential API contract gap
+
+**Description:**
+`ApprovalDecisionForm.tsx` defines three decisions client-side:
+```typescript
+type Decision = "approved" | "rejected" | "changes_requested";
+```
+
+But `ApproveSchema` in `lib/social/schemas/approve.ts` only accepts:
+```typescript
+decision: z.enum(["approved", "rejected"])
+```
+
+The `changes_requested` option exists in the UI but is not in the Zod schema. This means either:
+1. `changes_requested` maps to `rejected` in the API call, or
+2. There is a separate code path for `changes_requested` that bypasses `ApproveSchema`, or
+3. The UI and the schema are out of sync (the `changes_requested` button calls the API with a value the schema rejects)
+
+**Files involved:**
+- `components/ApprovalDecisionForm.tsx` — UI Decision type
+- `lib/social/schemas/approve.ts` — ApproveSchema
+- `app/api/approve/[token]/decision/route.ts` — route handler (not read during inventory)
+
+**Action:** Read `app/api/approve/[token]/decision/route.ts` to determine which path `changes_requested` takes at the API layer.

--- a/docs/inventory/forms-and-validation.md
+++ b/docs/inventory/forms-and-validation.md
@@ -1,0 +1,484 @@
+# Forms and Validation
+
+**Generated:** 2026-05-25 via codebase analysis.
+**Status:** Phase 1 skeleton — field lists and validation rules extracted from source. `EXPECTED BEHAVIOUR` sections are empty for Steven to fill.
+
+---
+
+## Table of Contents
+
+1. [Auth Forms](#auth-forms)
+   - [Login Form](#login-form)
+   - [Forgot Password Form](#forgot-password-form)
+   - [Change Password Form](#change-password-form)
+2. [Admin Forms](#admin-forms)
+   - [Invite User Form](#invite-user-form)
+3. [Social Composer Forms](#social-composer-forms)
+   - [Create / Edit Draft (V2 composer)](#create--edit-draft-v2-composer)
+   - [Scheduling Card](#scheduling-card)
+   - [AI Assist Form](#ai-assist-form)
+   - [UTM Builder Form](#utm-builder-form)
+   - [Add-by-URL Media Form](#add-by-url-media-form)
+4. [Approval / Review Forms](#approval--review-forms)
+   - [External Approval Decision Form](#external-approval-decision-form)
+   - [Viewer Link Create Form](#viewer-link-create-form)
+   - [Approval Recipients Add Form](#approval-recipients-add-form)
+5. [V1 Post List Forms](#v1-post-list-forms)
+   - [Inline Post Create Form (V1 legacy)](#inline-post-create-form-v1-legacy)
+
+---
+
+## Platform Character Limits
+
+Used across social composer validation:
+
+| Platform | Max characters |
+|----------|---------------|
+| LinkedIn | 3,000 |
+| Facebook | 63,206 |
+| Instagram | 2,200 |
+| X (Twitter) | 280 |
+| Google Business Profile | 1,500 |
+| Pinterest | 500 |
+| TikTok | 2,200 |
+
+**Source:** `lib/social/types.ts` — `PLATFORM_CHAR_LIMITS`; `lib/social/schemas/create-draft.ts`
+
+---
+
+## Auth Forms
+
+### Login Form
+
+**Surface:** `/login` — email + password sign-in
+**File:** `components/LoginForm.tsx`
+**Library:** React Server Actions + `useFormState` / `useFormStatus` (Next.js, not React Hook Form)
+
+**Fields:**
+| Field | Type | Validation | Required |
+|-------|------|------------|---------|
+| email | `<input type="email">` | HTML5 email validation; server-side: Supabase `signInWithPassword` | Yes |
+| password | `<input type="password">` | None client-side; server validates via Supabase | Yes |
+| next | `<input type="hidden">` | URL to redirect after successful login | System-set |
+
+**Server-side validation:**
+- `loginAction` server action in `app/login/actions.ts`
+- On success: returns `{ redirectTo }` → client does `window.location.assign(state.redirectTo)` (hard navigation to force middleware session cookie re-read)
+- On failure: returns `{ error }` string surfaced via `useFormState`
+
+**Special notes:**
+- `suppressHydrationWarning` on email + password inputs (Grammarly compatibility)
+- Submit button disabled while `pending` (useFormStatus) or `isRedirecting`
+- Uses `<form action={formAction}>` — works without JS (progressive enhancement)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What error message is shown for wrong email/password?
+- [ ] Is there a rate-limit on login attempts? What does the error message say?
+- [ ] What is the default `?next=` redirect destination after login?
+- [ ] Is "Forgot password?" link visible on this page?
+
+---
+
+### Forgot Password Form
+
+**Surface:** `/auth/forgot-password`
+**File:** `components/ForgotPasswordForm.tsx`
+**Library:** Custom `useState` / `fetch` (no library)
+
+**Fields:**
+| Field | Type | Validation | Required |
+|-------|------|------------|---------|
+| email | `<input type="email">` | Non-empty; `POST /api/auth/forgot-password` validates format | Yes |
+
+**Server-side validation:**
+- `POST /api/auth/forgot-password`
+- No-enumeration contract: response shape is identical whether email is registered or not
+- On 200: form shows success copy ("check your inbox and spam") regardless of whether email exists
+- On error codes:
+  - `RATE_LIMITED` → "Too many reset requests for this email. Try again in a bit."
+  - `VALIDATION_FAILED` → "Please enter a valid email address."
+  - Other → raw `error.message` from server, or `Request failed (HTTP N).`
+
+**Form states:**
+- `idle` → `submitting` → `success` | `error`
+- In `success` state: form is replaced by success copy
+- In `submitting` state: button disabled
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What does the success copy say exactly?
+- [ ] How long is the rate-limit window?
+- [ ] Does the success state allow the user to try a different email without refreshing?
+
+---
+
+### Change Password Form
+
+**Surface:** `/account/security`
+**File:** `components/AccountSecurityForm.tsx`
+**Library:** Custom `useState` / `fetch`
+
+**Fields:**
+| Field | Type | Validation | Required |
+|-------|------|------------|---------|
+| current | `<input type="password">` | Non-empty; verified against Supabase server-side | Yes |
+| next (new password) | `<input type="password">` | `>= PASSWORD_MIN_LENGTH` chars; `validatePassword()` policy; must differ from current | Yes |
+| confirm (repeat) | `<input type="password">` | Must equal `next`; mismatch shown inline when `confirm.length > 0` | Yes |
+
+**Client-side validation (before submit):**
+- `validatePassword(next)` from `lib/password-policy` — returns `{ ok: boolean, message: string }`
+- `passwordStrengthHint(next)` — returns hint string shown to user as they type
+- `mismatch = confirm.length > 0 && confirm !== next` — inline mismatch indicator
+- `sameAsCurrent = next.length > 0 && next === current` — blocks same-password submit
+- Submit disabled unless: `current.length > 0 && next.length >= PASSWORD_MIN_LENGTH && next === confirm && next !== current`
+
+**Server-side validation:**
+- `POST /api/account/security` (inferred)
+- Re-validates policy + confirmation match + verifies current password against Supabase before update
+
+**Server-side schema:** None found as a standalone Zod schema; logic is in the form + route handler.
+
+**Form states:** `idle` | `submitting` | `success` | `error`
+
+**On success:**
+- Shows inline "Password updated" confirmation
+- Clears all fields
+- Session does NOT end (Supabase keeps refresh token valid across password change)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is `PASSWORD_MIN_LENGTH`? (Check `lib/password-policy.ts`)
+- [ ] What does the password strength hint look like — text only, or with a visual meter?
+- [ ] Does the mismatch indicator appear in real time while typing, or only on blur?
+- [ ] What is the success copy?
+
+---
+
+## Admin Forms
+
+### Invite User Form
+
+**Surface:** `/admin/users` (within the admin panel)
+**File:** `components/PendingInvitesTable.tsx` — table with row-level revoke; the invite create form is elsewhere
+**Library:** Custom via DataTable + ConfirmDialog
+
+**Note:** `PendingInvitesTable` handles the revoke action, not the create action. The create form is part of the users admin page (not a separate component in this file). The table rows represent pending invites.
+
+**Revoke action:**
+| Interaction | Validation | Required |
+|-------------|------------|---------|
+| Click "…" → Revoke | Opens ConfirmDialog | — |
+| ConfirmDialog confirm | — | — |
+| API call | `DELETE /api/admin/invites/[id]` | — |
+
+**Invite row shape:**
+```typescript
+interface PendingInvite {
+  id: string;
+  email: string;
+  role: "admin" | "user";
+  invited_by_email: string | null;
+  created_at: string;
+  expires_at: string;
+}
+```
+
+**Sub-components used:**
+- `DataTable`, `ConfirmDialog`, `NavIcon`, `Pill`, `TableCell`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Where is the "Invite user" create form — same page, modal, or separate route?
+- [ ] What roles can be assigned when inviting (`admin` and `user` only, or also `super_admin`)?
+- [ ] What is the invite expiry duration (shown in `expires_at`)?
+- [ ] Can a revoked invite be re-sent?
+
+---
+
+## Social Composer Forms
+
+### Create / Edit Draft (V2 composer)
+
+**Surface:** Triggered from any `/company/social/*` route via `?compose=new` or `?compose=[id]`
+**File:** `components/social/composer/ComposerOverlay.tsx` + API schema `lib/social/schemas/create-draft.ts`
+**Library:** Controlled React state (`useState`); Zod on the server
+
+**Fields (controlled by ComposerOverlay state):**
+| Field | Type | Validation | Required |
+|-------|------|------------|---------|
+| content | text | max 63,206 chars (Facebook limit); platform-specific limits enforced per-platform | Yes (for non-draft) |
+| target_profile_ids | uuid[] | min 1 connection selected (for non-draft) | Yes (for non-draft) |
+| media_urls | url[] | each item must be a valid URL | No |
+| platform_variants | Record<platform, {content?, link?, cta?}> | per-platform content max 63,206; link must be URL; cta max 100 | No |
+| mode | enum | `post_now` \| `schedule` \| `recurring` \| `draft` | Yes |
+| scheduled_at_list | datetime[] | required when `mode = 'schedule'`; ISO 8601 UTC strings | Conditional |
+| recurrence.rule | string | RFC 5545 RRULE; min 1 char; required when `mode = 'recurring'` | Conditional |
+| recurrence.starting_at | datetime | ISO 8601 UTC; required when `mode = 'recurring'` | Conditional |
+| recurrence.until | datetime | ISO 8601 UTC; optional end date | No |
+| planned_for_at | datetime | ISO 8601 UTC; optional when `mode = 'draft'` | No |
+| approval_required | boolean | — | Yes (default false) |
+| approver_user_id | uuid | optional; not required even when `approval_required=true` | No |
+
+**Server-side schema:** `CreateDraftSchema` in `lib/social/schemas/create-draft.ts`
+- `POST /api/platform/social/drafts`
+
+**PATCH (edit existing draft) — V2SaveBodySchema:**
+| Field | Type | Notes |
+|-------|------|-------|
+| draft_version | int | Positive integer; used for optimistic concurrency (CAS). 409 `VERSION_CONFLICT` if stale |
+| content | string | max 63,206 |
+| media_urls | url[] | defaults to `[]` |
+| target_profile_ids | uuid[] | defaults to `[]` |
+| platform_variants | Record | same as create |
+| mode | enum | `post_now` \| `schedule` \| `recurring` \| `draft` |
+| scheduled_at | datetime \| null | single datetime (V2 path uses this not `scheduled_at_list`) |
+| planned_for_at | datetime \| null | for draft mode |
+| approval_required | boolean | default false |
+| approver_user_id | uuid \| null | optional |
+
+**PATCH endpoint:** `PATCH /api/platform/social/drafts/[id]`
+- Returns 409 `VERSION_CONFLICT` when `draft_version` is stale
+- Returns `INVALID_STATE` for terminal states (`published`, `publishing`)
+- Requires `edit_post` permission in the draft's company
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is content required for `mode = 'post_now'`? Can the user post without any text (media only)?
+- [ ] Is at least one profile required for `mode = 'post_now'` and `mode = 'schedule'`?
+- [ ] What client-side error message is shown when `VERSION_CONFLICT` is returned?
+- [ ] Are platform character limits shown as a counter in the editor?
+- [ ] Can a user submit if the content exceeds the character limit for one platform but not others?
+
+---
+
+### Scheduling Card
+
+**Surface:** Inside ComposerOverlay (bottom of left pane)
+**File:** `components/social/composer/SchedulingCard.tsx`
+**Library:** Controlled React state
+
+**Fields:**
+| Field | Type | Validation | Required |
+|-------|------|------------|---------|
+| mode | tab | `post_now` \| `schedule` \| `recurring` \| `draft` | Yes |
+| scheduledTimes[] | date + time | At least one required when `mode = 'schedule'`; must be future | Conditional |
+| recurrence.rule | RRULE string | RFC 5545 format; required when `mode = 'recurring'` | Conditional |
+| recurrence.starting_at | date | Must be future; required when `mode = 'recurring'` | Conditional |
+| recurrence.until | date | Optional; must be after `starting_at` | No |
+| plannedForAt | date + time | Optional when `mode = 'draft'` | No |
+| approvalRequired | boolean | — | Yes (default false) |
+
+**Submit button label per mode:**
+| Mode | Label |
+|------|-------|
+| `post_now` | Post now |
+| `schedule` | Schedule post |
+| `recurring` | Save schedule |
+| `draft` | Save draft |
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can multiple scheduled times be added for a single post (multi-slot scheduling)?
+- [ ] What is the minimum scheduling lead time (must be N minutes in the future)?
+- [ ] When `approvalRequired=true` but no `approver_user_id` is set, what happens — does the post go to a general queue?
+
+---
+
+### AI Assist Form
+
+**Surface:** Inside ToolsRow in ComposerOverlay (AI panel)
+**File:** `components/social/composer/ToolsRow.tsx`
+**Library:** Custom `useState` / `fetch`
+
+**Fields:**
+| Field | Type | Validation | Required |
+|-------|------|------------|---------|
+| prompt | textarea | Non-empty; server enforces content policy | Yes |
+
+**API call:** `POST /api/platform/social/cap/assist`
+
+**Cost estimate:** Displayed to user before submission — calculated from prompt character count:
+- Input: ~250 system tokens + `Math.ceil(promptChars / 4)` tokens
+- Output: ~200 tokens assumed
+- Model: claude-haiku-4-5 ($0.08/MTok input, $0.40/MTok output)
+
+**Error categories and handling:**
+| Category | User-facing behaviour |
+|----------|-----------------------|
+| `rate_limit` | Message + `retry_after` countdown if provided |
+| `timeout` | Message + retry button (if `can_retry=true`) |
+| `content_rejected` | Message (no retry) |
+| `invalid_request` | Message (no retry) |
+| `network` | Message + retry button |
+| `overloaded` | Message + retry button |
+| `unknown` | Message + retry button |
+
+**data-testid values:**
+- `ai-trace-id` — trace ID badge (for error reporting)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is the rate limit (requests per minute per user or per company)?
+- [ ] Does the AI result replace the current content or insert at cursor position?
+- [ ] Is the cost estimate visible to all users or only super_admin?
+- [ ] Can the user adjust the AI output before inserting?
+
+---
+
+### UTM Builder Form
+
+**Surface:** Inside ToolsRow in ComposerOverlay (UTM panel)
+**File:** `components/social/composer/UtmBuilderPanel.tsx` (referenced from ToolsRow)
+**Library:** Custom controlled state
+
+**Fields (inferred from UTM standard):**
+| Field | Type | Validation | Required |
+|-------|------|------------|---------|
+| utm_source | text | Non-empty | Yes |
+| utm_medium | text | — | No |
+| utm_campaign | text | — | No |
+| utm_term | text | — | No |
+| utm_content | text | — | No |
+
+**On submit:** Builds a UTM-tagged URL and calls `onInsertText(url)` to insert into editor.
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does the UTM builder append to an existing URL in the editor, or insert a new URL?
+- [ ] Are the UTM parameters pre-populated from any company settings?
+
+---
+
+### Add-by-URL Media Form
+
+**Surface:** Inside MediaLibraryClient at `/company/social/media` (and inside composer MediaTray)
+**File:** `components/MediaLibraryClient.tsx` (inline form toggled by showForm state)
+**Library:** Custom `useState` / `fetch`
+
+**Fields:**
+| Field | Type | Validation | Required |
+|-------|------|------------|---------|
+| url | `<input type="url">` | Must be a valid URL (HTML5 + server validates `z.string().url()`) | Yes |
+
+**API call:** `POST /api/platform/social/media`
+
+**On success:** Added asset appears at the top of the asset grid; form clears.
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when the URL is a non-image (e.g. a PDF)?
+- [ ] Is there a max file size for remote-URL assets?
+- [ ] Does the API download and re-host the image, or just store the URL reference?
+
+---
+
+## Approval / Review Forms
+
+### External Approval Decision Form
+
+**Surface:** `/viewer/[token]` — magic-link approver page (public, no auth required)
+**File:** `components/ApprovalDecisionForm.tsx`
+**Library:** Custom `useState` / `fetch`
+
+**Fields:**
+| Field | Type | Validation | Required |
+|-------|------|------------|---------|
+| decision | button group | `approved` \| `rejected` \| `changes_requested` | Yes (one button click) |
+| comment | textarea | Required when `decision = 'rejected'`: min 30, max 500 chars (server enforces via `ApproveSchema`) | Conditional |
+
+**Server-side schema:** `ApproveSchema` in `lib/social/schemas/approve.ts`
+```
+- decision: enum("approved" | "rejected")
+- rejection_reason?: string
+  - Required when decision = "rejected"
+  - Min 30 chars
+  - Max 500 chars
+```
+
+**Note:** `changes_requested` is a client-side Decision type but does NOT appear in `ApproveSchema`. The server schema only accepts `approved` | `rejected`. This discrepancy may indicate `changes_requested` maps to `rejected` at the API layer, or uses a separate code path.
+
+**API call:** `POST /api/approve/[token]/decision`
+
+**States:**
+- Form idle: three decision buttons + comment textarea (always visible)
+- Submitting: selected button shows loading; others disabled
+- Done: "thanks" confirmation panel (replaces form)
+- Error: inline error message (form remains)
+- `alreadyDecided=true`: "This request has already been resolved" panel (no form rendered)
+
+**data-testid values:**
+- `approval-already-decided` (line 50) — "already resolved" panel
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the comment textarea always visible, or only shown after choosing "Reject"?
+- [ ] Can an approver re-open a decided approval request?
+- [ ] What does the "thanks" confirmation panel say for each decision type?
+- [ ] Does the `changes_requested` decision actually call the same `/api/approve/[token]/decision` endpoint? If so, what `decision` value is sent?
+- [ ] Does the rejection reason text appear in the post detail page for the editor?
+
+---
+
+### Viewer Link Create Form
+
+**Surface:** `/company/social/sharing` — inside ViewerLinksManager
+**File:** `components/ViewerLinksManager.tsx` (inline form toggled by `adding` state)
+**Library:** Custom `useState` / `fetch`
+
+**Fields:**
+| Field | Type | Validation | Required |
+|-------|------|------------|---------|
+| recipient_email | `<input type="email">` | Optional; trimmed to null if empty | No |
+| recipient_name | text | Optional; trimmed to null if empty | No |
+
+**Server-side validation:**
+- `POST /api/platform/social/viewer-links`
+- Body: `{ company_id, recipient_email: string | null, recipient_name: string | null }`
+
+**On success:**
+- New link row added to table
+- One-time URL shown inline for copy (never stored client-side after this)
+- Form fields clear
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a link be created with no email and no name (fully anonymous)?
+- [ ] Is there a maximum number of active viewer links per company?
+- [ ] What is the default expiry period for new links?
+
+---
+
+### Approval Recipients Add Form
+
+**Surface:** `/company/social/posts/[id]` — inside PostApprovalSection (when `canManage=true`)
+**File:** `components/PostApprovalSection.tsx` (inline form)
+**Library:** Custom `useState` / `fetch`
+
+**Fields:**
+| Field | Type | Validation | Required |
+|-------|------|------------|---------|
+| email | `<input type="email">` | Non-empty; server validates format | Yes |
+| name | text | Optional | No |
+
+**API call:** `POST /api/platform/social/posts/{postId}/recipients`
+
+**On success:** New recipient row added to the list; form fields clear.
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does adding a recipient immediately send them an email notification?
+- [ ] Can the same email be added twice to the same approval request?
+- [ ] What is the maximum number of recipients per approval request?
+
+---
+
+## V1 Post List Forms
+
+### Inline Post Create Form (V1 legacy)
+
+**Surface:** `/company/social/posts` — when `useComposerFlow=false` (legacy path)
+**File:** `components/SocialPostsListClient.tsx`
+**Library:** Custom controlled state
+
+**Note:** This is the V1 inline create form. As of Spec 22, when `useComposerFlow=true`, "New post" opens `?compose=new` instead of this inline form. The inline form is still present for the legacy path.
+
+**Fields (V1 minimal):**
+| Field | Type | Validation | Required |
+|-------|------|------------|---------|
+| master_text | textarea | No character limit enforced client-side in V1 | No |
+| link_url | `<input type="url">` | Optional URL | No |
+
+**API call:** `POST /api/platform/social/posts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the V1 inline form still reachable in production, or has `useComposerFlow=true` been set everywhere?
+- [ ] What validation does the V1 post create API apply to `master_text`?

--- a/docs/inventory/roles-and-permissions.md
+++ b/docs/inventory/roles-and-permissions.md
@@ -1,0 +1,365 @@
+# Roles and Permissions
+
+**Generated:** 2026-05-25 via codebase analysis.
+**Status:** Phase 1 skeleton — gates extracted from source files. `EXPECTED BEHAVIOUR` sections are empty for Steven to fill.
+
+---
+
+## Table of Contents
+
+1. [Two Role Systems](#two-role-systems)
+2. [Operator Roles (opollo_users.role)](#operator-roles-opollo_usersrole)
+   - [super_admin](#super_admin)
+   - [admin](#admin)
+   - [user](#user-operator)
+3. [Platform Roles (platform_company_users.role)](#platform-roles-platform_company_usersrole)
+   - [Role Hierarchy](#role-hierarchy)
+   - [admin (platform)](#admin-platform)
+   - [approver](#approver)
+   - [editor](#editor)
+   - [viewer](#viewer)
+4. [Special Cases](#special-cases)
+   - [is_opollo_staff](#is_opollo_staff)
+5. [Action Permission Matrix](#action-permission-matrix)
+6. [Gate Functions Reference](#gate-functions-reference)
+
+---
+
+## Two Role Systems
+
+This codebase has two independent role systems that coexist for different user types:
+
+| System | Table | Column | User type |
+|--------|-------|--------|-----------|
+| **Operator** | `opollo_users` | `role` | Opollo staff (internal) — access to `/admin/*`, `/optimiser/*` |
+| **Platform** | `platform_company_users` | `role` | Customer company users — access to `/company/*` |
+
+**Key distinction:** Opollo staff have BOTH an `opollo_users` row AND a `platform_users` row with `is_opollo_staff=true`. Customer users only have `platform_users` + `platform_company_users`.
+
+**Source:** `lib/platform/auth/types.ts` (lines 1–7), `lib/platform/auth/current-user.ts`
+
+---
+
+## Operator Roles (opollo_users.role)
+
+### super_admin
+
+**Source:** `opollo_users.role = 'super_admin'`
+**Gate function:** `checkAdminAccess({ requiredRoles: ["super_admin"] })` in `lib/admin-gate.ts`; `requireAdminForApi({ roles: ["super_admin"] })` in `lib/admin-api-gate.ts`
+
+**Description:** Top-tier operator role. Reserved for `hi@opollo.com` (the primary operator). Cannot be assigned via the admin UI — the `guard_super_admin` DB trigger blocks demotion/assignment at the database level. Only accessible programmatically.
+
+**All routes accessible to super_admin (that admin cannot access):**
+
+| Route | File | Notes |
+|-------|------|-------|
+| `/admin/theming` | `app/(platform)/admin/theming/page.tsx` | Design-system token editor (KF-5) |
+| `/admin/email-test` | `app/(platform)/admin/email-test/page.tsx` | Send test emails (AUTH-FOUNDATION P3.4) |
+
+**API endpoints gated super_admin-only:**
+
+| Method + Path | File | Notes |
+|--------------|------|-------|
+| `GET /api/admin/users/list` | `app/api/admin/users/list/route.ts` | User list — `requireAdminForApi({ roles: ["super_admin"] })` |
+
+**Inherits all `admin` routes** (see below).
+
+**Role assignment:**
+- `super_admin` cannot be assigned via `PATCH /api/admin/users/[id]/role` — the route only accepts `"admin" | "user"` in its `RoleSchema`
+- The DB-level `guard_super_admin` trigger enforces this at the database layer too
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a `super_admin` demote themselves?
+- [ ] Can a `super_admin` see and manage other `super_admin` users?
+- [ ] What happens if `hi@opollo.com` signs in to a fresh deployment without a `super_admin` row — does auto-provisioning kick in?
+
+---
+
+### admin
+
+**Source:** `opollo_users.role = 'admin'`
+**Gate function:** `checkAdminAccess()` defaults to `ADMIN_ROLES = ["super_admin", "admin"]`; `requireAdminForApi()` without `roles` override also uses this default.
+
+**Description:** Standard operator role for Opollo staff who need access to admin and optimiser surfaces but are not the top-tier account holder.
+
+**Routes accessible to admin (and super_admin):**
+
+| Route | File |
+|-------|------|
+| `/admin/sites` | `app/(platform)/admin/sites/page.tsx` |
+| `/admin/sites/[id]` | `app/(platform)/admin/sites/[id]/page.tsx` |
+| `/admin/sites/[id]/settings` | `app/(platform)/admin/sites/[id]/settings/page.tsx` |
+| `/admin/sites/[id]/appearance` | `app/(platform)/admin/sites/[id]/appearance/page.tsx` |
+| `/admin/sites/[id]/setup` | `app/(platform)/admin/sites/[id]/setup/page.tsx` |
+| `/admin/sites/[id]/setup/extract` | `app/(platform)/admin/sites/[id]/setup/extract/page.tsx` |
+| `/admin/sites/[id]/onboarding` | `app/(platform)/admin/sites/[id]/onboarding/page.tsx` |
+| `/admin/sites/[id]/edit` | `app/(platform)/admin/sites/[id]/edit/page.tsx` |
+| `/admin/sites/[id]/pages` | `app/(platform)/admin/sites/[id]/pages/page.tsx` |
+| `/admin/sites/[id]/pages/[pageId]` | `app/(platform)/admin/sites/[id]/pages/[pageId]/page.tsx` |
+| `/admin/sites/[id]/posts` | `app/(platform)/admin/sites/[id]/posts/page.tsx` |
+| `/admin/sites/[id]/posts/new` | `app/(platform)/admin/sites/[id]/posts/new/page.tsx` |
+| `/admin/sites/[id]/posts/[post_id]` | `app/(platform)/admin/sites/[id]/posts/[post_id]/page.tsx` |
+| `/admin/sites/new` | `app/(platform)/admin/sites/new/page.tsx` |
+| `/admin/batches` | `app/(platform)/admin/batches/page.tsx` |
+| `/admin/batches/[siteId]` | `app/(platform)/admin/batches/[siteId]/page.tsx` |
+| `/admin/batches/[siteId]/[batchId]` | `app/(platform)/admin/batches/[siteId]/[batchId]/page.tsx` |
+| `/admin/posts` | `app/(platform)/admin/posts/page.tsx` |
+| `/admin/posts/[siteId]/new` | `app/(platform)/admin/posts/[siteId]/new/page.tsx` |
+| `/admin/images` | `app/(platform)/admin/images/page.tsx` |
+| `/admin/images/[id]` | `app/(platform)/admin/images/[id]/page.tsx` |
+| `/admin/users` (UI only) | `app/(platform)/admin/users/page.tsx` — rendered but data from `GET /api/admin/users/list` is super_admin-only |
+| `/admin/users/audit` | `app/(platform)/admin/users/audit/page.tsx` |
+| `/admin/companies` | `app/(platform)/admin/companies/page.tsx` |
+| `/admin/errors` | `app/(platform)/admin/errors/page.tsx` |
+| `/admin/maintenance` | `app/(platform)/admin/maintenance/page.tsx` |
+| `/admin/system/health` | `app/(platform)/admin/system/health/page.tsx` |
+| `/admin/system/jobs` | `app/(platform)/admin/system/jobs/page.tsx` |
+| `/admin/settings/design-system` | `app/(platform)/admin/settings/design-system/page.tsx` |
+| `/optimiser/*` | Multiple pages under `app/(platform)/optimiser/` |
+
+**API endpoints accessible to admin:**
+
+| Method + Path | Notes |
+|--------------|-------|
+| `POST /api/admin/users/invite` | Invite new operators |
+| `PATCH /api/admin/users/[id]/role` | Change `admin` ↔ `user` (not super_admin) |
+| `POST /api/admin/users/[id]/revoke` | Revoke operator access |
+| `POST /api/admin/users/[id]/reinstate` | Reinstate revoked operator |
+| All `/api/admin/sites/*` | Site CRUD |
+| All `/api/admin/images/*` | Image library |
+| All `/api/admin/companies/*` | Company management |
+
+**Cannot access (super_admin only):**
+- `/admin/theming`
+- `/admin/email-test`
+- `GET /api/admin/users/list`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] When an `admin` visits `/admin/users`, what do they see (empty list or an error)?
+- [ ] Can `admin` role view the email-test page at all, or does it redirect?
+- [ ] What is the redirect destination for an `admin` who tries to access a `super_admin`-only page?
+
+---
+
+### user (operator)
+
+**Source:** `opollo_users.role = 'user'`
+**Gate function:** No dedicated gate — user is the lowest operator role and is excluded from `ADMIN_ROLES`. Access is gated by the absence of the user from admin routes.
+
+**Description:** Operator-tier user with no admin surface access. Previously called "operator" (migration 0057 renamed `admin+operator → super_admin+admin`; the old "viewer" became `user`). Likely unused in practice — Opollo staff are either `admin` or `super_admin`.
+
+**Accessible routes:**
+- `/account/security` — change password (`app/(platform)/account/security/page.tsx`)
+- `/account/devices` — manage devices
+
+**Cannot access:**
+- Any `/admin/*` route
+- Any `/optimiser/*` route
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the `user` operator role actively used, or is it vestigial from the migration?
+- [ ] What does a `user`-role operator see on login — the chat builder, or a blank screen?
+
+---
+
+## Platform Roles (platform_company_users.role)
+
+### Role Hierarchy
+
+**Source:** `lib/platform/auth/permissions.ts` (lines 1–11)
+
+```
+viewer (1) < editor (2) < approver (3) < admin (4)
+```
+
+All roles are cumulative — a higher role can perform everything a lower role can. The `roleSatisfies(have, need)` function mirrors the `has_company_role` SQL helper.
+
+---
+
+### admin (platform)
+
+**Source:** `platform_company_users.role = 'admin'`
+**Gate:** `hasCompanyRole(companyId, "admin")` via `lib/platform/auth/helpers.ts`; API gates via `requireCanDoForApi(companyId, action)` in `lib/platform/auth/api-gate.ts`
+
+**Description:** Full control over the company's platform workspace. Manages users, connections, settings, and can perform all lower-role actions.
+
+**Exclusive actions (min role = admin):**
+
+| Action | What it gates |
+|--------|---------------|
+| `manage_users` | `/company/users`, invite/remove users from the company |
+| `edit_company_settings` | `/company/settings/brand`, `/company/settings/insights` |
+| `manage_connections` | Create new social connections, delete connections |
+| `manage_invitations` | `/company/social/sharing`, create/revoke viewer links |
+| `receive_connection_alerts` | Connection health email/notification alerts |
+| `view_insights` | View analytics pages — also available to viewer+ |
+| `manage_insights` | Configure insights settings |
+
+**Inherits all approver, editor, and viewer actions.**
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can an `admin` member assign another member to `admin` role?
+- [ ] Is there a maximum number of `admin` members per company?
+- [ ] Does `manage_connections` also allow reconnecting an expired connection, or is that `editor` minimum?
+
+---
+
+### approver
+
+**Source:** `platform_company_users.role = 'approver'`
+**Gate:** `hasCompanyRole(companyId, "approver")`
+
+**Description:** Approves and schedules posts. Cannot manage team members or connections.
+
+**Exclusive actions (min role = approver):**
+
+| Action | What it gates |
+|--------|---------------|
+| `approve_post` | Approve posts in approval queue (`/company/social/posts?state=pending_client_approval`) |
+| `reject_post` | Reject posts (same surface) |
+| `schedule_post` | Set `scheduled_at` on approved posts |
+
+**Inherits all editor and viewer actions.**
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] When an `approver` approves a post, does it move directly to `scheduled` or to `approved`?
+- [ ] Can an `approver` also create new posts (inheriting `create_post` from editor)?
+
+---
+
+### editor
+
+**Source:** `platform_company_users.role = 'editor'`
+**Gate:** `hasCompanyRole(companyId, "editor")`
+
+**Description:** Creates and edits content, submits posts for approval, and can reconnect expired connections.
+
+**Exclusive actions (min role = editor):**
+
+| Action | What it gates |
+|--------|---------------|
+| `create_post` | "New post" button; `POST /api/platform/social/drafts` |
+| `edit_post` | Edit draft content; `PATCH /api/platform/social/drafts/[id]` |
+| `submit_for_approval` | Submit drafts for approval workflow |
+| `reconnect_connection` | Re-OAuth an expired/disconnected connection (not create/delete — those are admin) |
+
+**Inherits all viewer actions.**
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can an `editor` edit their own posts after submitting for approval?
+- [ ] Can an `editor` cancel an approval request (pull back a post)?
+- [ ] Can an `editor` see posts created by other team members?
+- [ ] When an `editor` reconnects a connection, do they need to be the original connection owner?
+
+---
+
+### viewer
+
+**Source:** `platform_company_users.role = 'viewer'`
+**Gate:** `hasCompanyRole(companyId, "viewer")`
+
+**Description:** Read-only access to the social calendar and insights.
+
+**Exclusive actions (min role = viewer):**
+
+| Action | What it gates |
+|--------|---------------|
+| `view_calendar` | `/company/social/calendar`, view posts list |
+| `view_insights` | `/company/social/analytics`, `/company/social/insights` |
+
+**No write actions available at viewer level.**
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a `viewer` see post content (full text, media) or only metadata (status, date)?
+- [ ] Can a `viewer` access `/company/social/posts/[id]` for read-only detail view?
+- [ ] Can a `viewer` see other team members in `/company/users`?
+
+---
+
+## Special Cases
+
+### is_opollo_staff
+
+**Source:** `platform_users.is_opollo_staff = true`
+**SQL helper:** `is_opollo_staff()` RPC function (migration 0070)
+**TypeScript wrapper:** `lib/platform/auth/helpers.ts:isOpolloStaff()`
+
+**Description:** Opollo operators who access the platform module do so via this flag, not via a `platform_company_users` row. Staff with `is_opollo_staff=true` bypass all company-role permission checks and have full access to all platform actions for any company.
+
+**Auto-provisioning:** When an operator (`opollo_users`) first accesses a platform route, `lib/platform/auth/current-user.ts` auto-provisions a `platform_users` row with `is_opollo_staff=true` via upsert if it is missing.
+
+**Staff-selected company cookie:**
+- Cookie name: `opollo_selected_company_id`
+- Allows staff to "view as" a specific company without permanently joining it
+- Staff retain `is_opollo_staff=true` while using this cookie
+
+**Implication:** Opollo staff have BOTH:
+- An `opollo_users` row (for `/admin/*` and `/optimiser/*` access, gated by `admin` / `super_admin` role)
+- A `platform_users` row with `is_opollo_staff=true` (for `/company/*` access, bypassing all company-role checks)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] When a staff member uses the selected-company cookie, do their actions appear as that company's own admin in audit logs?
+- [ ] Is there a UI in the admin panel to set the selected-company cookie, or is it set manually?
+- [ ] When `is_opollo_staff=true` user takes a destructive action (e.g. deletes a post), who does the audit log attribute it to?
+
+---
+
+## Action Permission Matrix
+
+**Source:** `lib/platform/auth/permissions.ts` — `ACTION_MIN_ROLE` map (lines 18–38)
+
+| Action | Min Role | viewer | editor | approver | admin |
+|--------|----------|--------|--------|----------|-------|
+| `view_calendar` | viewer | YES | YES | YES | YES |
+| `view_insights` | viewer | YES | YES | YES | YES |
+| `create_post` | editor | NO | YES | YES | YES |
+| `edit_post` | editor | NO | YES | YES | YES |
+| `submit_for_approval` | editor | NO | YES | YES | YES |
+| `reconnect_connection` | editor | NO | YES | YES | YES |
+| `approve_post` | approver | NO | NO | YES | YES |
+| `reject_post` | approver | NO | NO | YES | YES |
+| `schedule_post` | approver | NO | NO | YES | YES |
+| `manage_users` | admin | NO | NO | NO | YES |
+| `edit_company_settings` | admin | NO | NO | NO | YES |
+| `manage_connections` | admin | NO | NO | NO | YES |
+| `manage_invitations` | admin | NO | NO | NO | YES |
+| `receive_connection_alerts` | admin | NO | NO | NO | YES |
+| `manage_insights` | admin | NO | NO | NO | YES |
+
+Plus `is_opollo_staff=true` bypasses all rows → YES for all actions.
+
+---
+
+## Gate Functions Reference
+
+### Operator Layer
+
+| Function | File | Usage |
+|----------|------|-------|
+| `checkAdminAccess(opts?)` | `lib/admin-gate.ts` | Server Component / layout gates; returns `{kind: "allow" \| "redirect"}` |
+| `requireAdminForApi(opts?)` | `lib/admin-api-gate.ts` | Route handler gates; returns `{kind: "allow" \| "deny"}` |
+| `ADMIN_ROLES` | `lib/admin-gate.ts` (line 55) | `["super_admin", "admin"]` — default allowed set |
+
+### Platform Layer
+
+| Function | File | Usage |
+|----------|------|-------|
+| `isOpolloStaff(client?)` | `lib/platform/auth/helpers.ts` | Check if current user is Opollo staff |
+| `isCompanyMember(companyId, client?)` | `lib/platform/auth/helpers.ts` | Check if user is a member of a company |
+| `hasCompanyRole(companyId, minRole, client?)` | `lib/platform/auth/helpers.ts` | Check if user meets minimum role threshold |
+| `currentUserCompanyId(client?)` | `lib/platform/auth/helpers.ts` | Get company ID for current user |
+| `getCurrentPlatformSession(client?)` | `lib/platform/auth/current-user.ts` | Full session resolution: identity + staff flag + company membership |
+| `requireCanDoForApi(companyId, action)` | `lib/platform/auth/api-gate.ts` | Route handler gate for platform actions; returns `{kind: "allow" \| "deny"}` |
+| `minRoleFor(action)` | `lib/platform/auth/permissions.ts` | Returns the minimum `CompanyRole` for a given action |
+| `roleSatisfies(have, need)` | `lib/platform/auth/permissions.ts` | Returns true if `have` rank >= `need` rank |
+
+### SQL-Layer Helpers (migration 0070)
+
+| SQL Helper | Used via RPC |
+|-----------|-------------|
+| `is_opollo_staff()` | `supabase.rpc("is_opollo_staff")` |
+| `is_company_member(company uuid)` | `supabase.rpc("is_company_member", { company })` |
+| `has_company_role(company uuid, min_role text)` | `supabase.rpc("has_company_role", { company, min_role })` |
+| `current_user_company()` | `supabase.rpc("current_user_company")` |
+
+All SQL helpers coalesce NULL → false; they never raise errors. TypeScript wrappers return `false` / `null` on RPC error.

--- a/docs/inventory/routes-and-pages.md
+++ b/docs/inventory/routes-and-pages.md
@@ -1,0 +1,2067 @@
+# Routes and Pages Inventory
+
+> Generated: 2026-05-25. 103 pages catalogued.
+> Covers every `page.tsx` file discovered under `app/`. File paths relative to repo root.
+> EXPECTED BEHAVIOUR checkboxes are intentionally empty — Steven to fill.
+
+---
+
+## Authentication / Public
+
+### /
+
+**File:** `app/page.tsx`
+**Auth:** Redirects to appropriate landing based on session state
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Root redirect only
+
+**User actions on this page:**
+- Automatic redirect (no user interaction)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Where does an unauthenticated user land?
+- [ ] Where does an authenticated admin land vs an authenticated company member?
+
+---
+
+### /login
+
+**File:** `app/login/page.tsx`
+**Auth:** Public (unauthenticated)
+**Search params:** `?next=` (redirect destination after successful login)
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Email + password sign-in form
+
+**User actions on this page:**
+- Submit email + password credentials
+- Navigate to /auth/forgot-password
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when `?next=` points to an unauthorised route for the user's role?
+- [ ] What happens on repeated failed login attempts (rate limit behaviour)?
+- [ ] Is the 2FA challenge triggered from this page, and does it redirect or inline?
+
+---
+
+### /login/check-email
+
+**File:** `app/login/check-email/page.tsx`
+**Auth:** Public
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Informational panel
+
+**User actions on this page:**
+- None (static)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this shown after magic-link email dispatch, forgot-password, or both?
+
+---
+
+### /auth/callback
+
+**File:** `app/auth/callback/page.tsx`
+**Auth:** Public (OAuth/magic-link token in query string)
+**Search params:** OAuth callback parameters (code, state, etc.)
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Redirect/processing page
+
+**User actions on this page:**
+- None (automated redirect from OAuth provider)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when the OAuth state parameter is invalid or missing?
+- [ ] What happens when the callback token has expired?
+
+---
+
+### /auth/forgot-password
+
+**File:** `app/auth/forgot-password/page.tsx`
+**Auth:** Public
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Email input form
+
+**User actions on this page:**
+- Submit email to receive reset link
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is there rate limiting on the forgot-password form?
+- [ ] What response does the user see for an email that doesn't exist?
+
+---
+
+### /auth/reset-password
+
+**File:** `app/auth/reset-password/page.tsx`
+**Auth:** Token-authenticated (reset token in URL)
+**Search params:** Reset token parameters
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- New password form
+
+**User actions on this page:**
+- Set new password
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when the reset token has already been used?
+- [ ] What happens when the reset token has expired?
+- [ ] Are password complexity requirements surfaced to the user?
+
+---
+
+### /auth/accept-invite
+
+**File:** `app/auth/accept-invite/page.tsx`
+**Auth:** Token-authenticated (invite token)
+**Search params:** Invite token parameters
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Invite acceptance form (set password / confirm identity)
+
+**User actions on this page:**
+- Accept invitation and set credentials
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when an invitation has expired before being accepted?
+- [ ] What happens when an invitation has already been accepted?
+
+---
+
+### /auth/approve
+
+**File:** `app/auth/approve/page.tsx`
+**Auth:** Public or session-based (unclear without further inspection)
+**Search params:** Approval parameters
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Approval action page
+
+**User actions on this page:**
+- Approval decision
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this the internal-session approval flow as distinct from /approve/[token]?
+
+---
+
+### /auth/expired
+
+**File:** `app/auth/expired/page.tsx`
+**Auth:** Public
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Expired session/link panel
+
+**User actions on this page:**
+- Navigate back to login
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this page shown for expired magic links, expired sessions, or both?
+
+---
+
+### /auth-error
+
+**File:** `app/auth-error/page.tsx`
+**Auth:** Public
+**Search params:** Error code parameters
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Error message panel
+
+**User actions on this page:**
+- Navigate back to login
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What error codes are handled, and what is the fallback for unknown codes?
+
+---
+
+### /invite/[token]
+
+**File:** `app/invite/[token]/page.tsx`
+**Auth:** Token-authenticated (no platform session required)
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Invite claim page
+
+**User actions on this page:**
+- Accept company invitation
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is shown when the token is invalid vs expired vs already accepted?
+
+---
+
+### /approve/[token]
+
+**File:** `app/approve/[token]/page.tsx`
+**Auth:** Token-authenticated (no platform session required) — token is SHA-256 hashed to look up `approval_recipients` row
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `ApprovalDecisionForm` — renders post snapshot read-only + decision buttons (Approve / Reject)
+
+**User actions on this page:**
+- Approve the post
+- Reject the post with a reason (30–500 chars)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is shown when someone tries to approve a post that another recipient has already decided?
+- [ ] What is shown when the token has been revoked (draft deleted / post re-opened)?
+- [ ] Does the page re-render in real time if another user decides while this page is open?
+- [ ] Can an approver change their decision after submitting?
+
+---
+
+### /viewer/[token]
+
+**File:** `app/viewer/[token]/page.tsx`
+**Auth:** Token-authenticated (no platform session required) — token resolves to `social_viewer_links` row
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Read-only schedule list grouped by date (60 days forward, 30 days back from now)
+
+**User actions on this page:**
+- None (read-only)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are posts in `draft` or `pending_approval` states hidden from the viewer?
+- [ ] What post states are visible (approved, scheduled, published only)?
+- [ ] What happens when the viewer link is deleted by an admin?
+- [ ] Is there a "last updated" timestamp shown to the recipient?
+
+---
+
+### /review/[token]
+
+**File:** `app/(public)/review/[token]/page.tsx`
+**Auth:** Token-authenticated (public layout group)
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Review surface (distinct from /approve/[token])
+
+**User actions on this page:**
+- Review content
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] How does this differ from /approve/[token] in terms of affordances?
+
+---
+
+### /connect/pick-channel
+
+**File:** `app/connect/pick-channel/page.tsx`
+**Auth:** Platform session required
+**Search params:** OAuth state / connection_id parameters
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Channel/page selector modal or page
+
+**User actions on this page:**
+- Select a Facebook Page or LinkedIn Org Page from the discovered list
+- Choose to connect as personal profile (LinkedIn)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when no channels are found for the connected account?
+- [ ] Can the user return to this page later if they don't complete channel selection?
+
+---
+
+## Company Social
+
+All pages in this group require an authenticated platform session. Unauthenticated requests redirect to `/login?next=<current-path>`. Missing `company` context renders a "Not provisioned" envelope.
+
+---
+
+### /company/social/calendar
+
+**File:** `app/(platform)/company/social/calendar/page.tsx`
+**Auth:** `getCurrentPlatformSession()` → redirect `/login` if none; "Not provisioned" if no `session.company`; any company member (viewer+)
+**Search params:** `?compose=new` (open composer for new draft); `?compose=[uuid]` (open composer in edit mode for existing draft)
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `CalendarShell` — 7-column month grid, DnD reschedule, day-detail panel, bulk CSV upload, post analytics modal, timeline toggle, profile filter
+- `ComposerMountV2` (layout-level) — handles `?compose=` URL params
+
+**User actions on this page:**
+- Navigate months
+- Click a day to see day-detail panel
+- Click a post chip to open post detail
+- Drag-and-drop to reschedule a post
+- Open composer via FAB / "New post" button
+- Open composer in edit mode via `?compose=[uuid]`
+- Filter by social profile
+- Toggle timeline view
+- Upload posts via bulk CSV
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What states are shown as chips on the calendar grid (all states, or only scheduled/published/failed)?
+- [ ] What does a user with no connections see (empty state)?
+- [ ] What does a user with only `pending_identity` connections see?
+- [ ] Does the composer in edit mode gate on `edit_post` permission and return an error for viewers?
+- [ ] Are `recurring` parent drafts shown on the calendar?
+- [ ] What happens to a `paused` recurring series — are the future instances hidden?
+
+---
+
+### /company/social/posts
+
+**File:** `app/(platform)/company/social/posts/page.tsx`
+**Auth:** `getCurrentPlatformSession()` → redirect `/login`; viewer+ (`view_calendar`); editor+ also gets "New post" button
+**Search params:** `?q=` (text search); `?page=` (pagination, PAGE_SIZE=25); `?state=draft|pending_client_approval|approved|rejected|changes_requested|scheduled|publishing|published|failed`; `?sort=state_changed_at|created_at`; `?dir=asc|desc`
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `SocialPostsListClient` — filterable list with state pills
+- `TListStandard` — layout template
+
+**User actions on this page:**
+- Search posts by text
+- Filter by state
+- Sort by date columns
+- Paginate through results
+- Click row to go to post detail
+- Create new post (editor+)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What does a viewer (non-editor) see when the list is empty?
+- [ ] Are `recurring` parent drafts listed here alongside one-off drafts?
+- [ ] What state labels are shown in the UI pills (e.g. "Pending approval" vs raw `pending_approval`)?
+- [ ] Does pagination reset when filters change?
+- [ ] Can a viewer see posts that belong to other company members?
+
+---
+
+### /company/social/posts/[id]
+
+**File:** `app/(platform)/company/social/posts/[id]/page.tsx`
+**Auth:** `getCurrentPlatformSession()` → redirect `/login`; `notFound()` if post not in user's company; `edit_post` drives Edit/Delete affordances
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `PostDetailTabbedClient` — tabbed detail view
+- `PostApprovalSection` — visible when state is in `POST_DECISION_STATES` (approved/rejected/changes_requested)
+- `PostDecisionsAudit` — approval history
+- `PostPublishHistorySection` — visible when state is in `PUBLISH_VISIBLE_STATES` (publishing/published/failed)
+- `PostScheduleSection`
+- `PostVariantsSection`
+
+**User actions on this page:**
+- View post content and metadata
+- Edit post (if `edit_post` permission and post in `draft` state)
+- Delete post (if `edit_post` permission)
+- View approval history
+- View publish attempts (for publishing/published/failed states)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when an editor tries to edit a post that is in `scheduled` or `published` state?
+- [ ] Is the full approval decision audit visible to all roles, or only admins?
+- [ ] What does the `PostVariantsSection` show when no per-platform variants exist?
+- [ ] For a `failed` post, is there a retry affordance on this page?
+- [ ] For a `recurring` parent draft, what sections are shown?
+
+---
+
+### /company/social/connections
+
+**File:** `app/(platform)/company/social/connections/page.tsx`
+**Auth:** `getCurrentPlatformSession()` → redirect `/login`; viewer+ (`view_calendar`) to see list; admin (`manage_connections`) for Reconnect button
+**Search params:** `?connect=success|error|noop|sync-failed`; `?reason=not-enough-permissions|not-enough-pages|auth-failed|user-cancelled`; `?count=`; `?connection_id=` (auto-opens channel-picker modal); `?attempted_platform=` (highlights existing row); `?reconnect=` (scrolls to + highlights matching row)
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `SocialConnectionsList` — per-row status pills and Reconnect buttons
+- `Alert` — contextual toast banners driven by query params
+- `TListStandard` — layout template
+
+**User actions on this page:**
+- View all connected social accounts and their status
+- Click Reconnect on an `auth_required` connection (admin only)
+- Connect a new account (admin only)
+- Disconnect a connection (admin only)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What does a viewer (non-admin) see on a row with `auth_required` status — is the Reconnect button hidden or disabled?
+- [ ] What does the `pending_identity` state look like to a viewer vs an admin?
+- [ ] Is the `disconnected` status shown in the list or filtered out?
+- [ ] What happens when `?connect=noop` and `?attempted_platform=facebook` — which row gets highlighted?
+- [ ] How long does the contextual banner stay visible before dismissing?
+
+---
+
+### /company/social/connections/connect/[platform]
+
+**File:** `app/(platform)/company/social/connections/connect/[platform]/page.tsx`
+**Auth:** Platform session required (page redirects to `/company/social/connections` immediately — stub for deep-link routing)
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Redirect only (no render)
+
+**User actions on this page:**
+- None (immediate redirect)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this page ever linked to directly, or is it only reachable by URL typing?
+
+---
+
+### /company/social/media
+
+**File:** `app/(platform)/company/social/media/page.tsx`
+**Auth:** `getCurrentPlatformSession()` → redirect `/login`; viewer+ (`view_calendar`) to view; editor+ (`edit_post`) to add assets
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `MediaLibraryClient` — grid of uploaded assets
+- `TGrid` — layout template
+
+**User actions on this page:**
+- Browse uploaded media assets
+- Upload new media (editor+)
+- Select asset to insert into composer (when opened from composer)
+- Delete an asset (editor+)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What file types are accepted for upload?
+- [ ] Is there a storage quota per company?
+- [ ] What happens when a media asset is used in a scheduled/published post and then deleted?
+- [ ] Are assets shared across the company or per-user?
+
+---
+
+### /company/social/analytics
+
+**File:** `app/(platform)/company/social/analytics/page.tsx`
+**Auth:** `getCurrentPlatformSession()` → redirect `/login`; `view_calendar` permission required; `view_insights` permission for data
+**Search params:** None
+**States:** loading.tsx ✓ (`app/(platform)/company/social/analytics/loading.tsx`) · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `SocialAnalyticsClient` — dynamic import, SSR=false; loading skeleton shown inline
+- `TDashboardKpi` — layout template
+
+**User actions on this page:**
+- View social analytics KPIs
+- (Future) filter by date range
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is shown when there is no analytics data yet (new company)?
+- [ ] What happens for a user with `view_calendar` but not `view_insights` — error or empty state?
+- [ ] What analytics dimensions are surfaced (impressions, reach, engagement, etc.)?
+
+---
+
+### /company/social/insights
+
+**File:** `app/(platform)/company/social/insights/page.tsx`
+**Auth:** `getCurrentPlatformSession()` → redirect `/login`; company member required
+**Search params:** `?period=7d|30d|90d` (default: 30d)
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `InsightsDashboardClient` — insights recommendations and trends
+- `CompetitorGapAnalysis` — competitor comparison panel
+- `PeriodSelector` — period filter UI
+- `StatusPill` — freshness indicator
+
+**User actions on this page:**
+- Select analysis period (7d / 30d / 90d)
+- View recommendations
+- View competitor gap analysis
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is shown before any competitor data has been scraped?
+- [ ] What permission level is required to see the CompetitorGapAnalysis panel?
+- [ ] What does "dismiss recommendation" do — is it permanent?
+
+---
+
+### /company/social/sharing
+
+**File:** `app/(platform)/company/social/sharing/page.tsx`
+**Auth:** `getCurrentPlatformSession()` → redirect `/login`; admin only (`manage_invitations`); non-admin sees "Admins only" panel
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `ViewerLinksManager` — list of active viewer share links
+- `TSettingsFlat` — layout template
+
+**User actions on this page:**
+- Create a new viewer share link
+- Copy link URL
+- Delete an existing viewer link
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is there a limit on how many viewer links a company can have?
+- [ ] When a viewer link is deleted, does anyone with that link immediately see an error, or is there a grace period?
+- [ ] Can viewer links be given friendly names?
+
+---
+
+### /company/social/timeline
+
+**File:** `app/(platform)/company/social/timeline/page.tsx`
+**Auth:** `getCurrentPlatformSession()` → redirect `/login`; viewer+ (`view_calendar`)
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `TimelineFeed` — chronological feed of all posts, newest first
+- `TDashboardFeed` — layout template
+- `PillTabs` — view toggle
+- "New post" CTA (editor+ only via `composerEnabled`)
+
+**User actions on this page:**
+- Scroll chronological post feed
+- Create new post (editor+)
+- Navigate to post detail (click row)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does the timeline include all states or only published/scheduled?
+- [ ] Is there pagination, and if so what page size?
+
+---
+
+### /company
+
+**File:** `app/(platform)/company/page.tsx`
+**Auth:** Platform session required
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Company landing / dashboard
+
+**User actions on this page:**
+- Navigate to sub-sections
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is the default landing experience for a newly provisioned company?
+
+---
+
+### /company/social
+
+**File:** `app/(platform)/company/social/page.tsx`
+**Auth:** Platform session required
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Social module landing / redirect
+
+**User actions on this page:**
+- Redirect or navigation
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does this redirect to /calendar, /posts, or show a dashboard overview?
+
+---
+
+### /company/settings/brand
+
+**File:** `app/(platform)/company/settings/brand/page.tsx`
+**Auth:** Platform session required; admin gate expected
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Brand profile settings form
+
+**User actions on this page:**
+- Update brand name, colours, logo, voice profile
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What permission level is required to edit brand settings?
+- [ ] Are brand settings versioned or overwritten on save?
+
+---
+
+### /company/settings/insights
+
+**File:** `app/(platform)/company/settings/insights/page.tsx`
+**Auth:** Platform session required; admin gate expected
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Insights configuration settings
+
+**User actions on this page:**
+- Configure insights preferences
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What settings are exposed here (competitor URLs, industry, etc.)?
+
+---
+
+### /company/users
+
+**File:** `app/(platform)/company/users/page.tsx`
+**Auth:** Platform session required; admin-scoped operations
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- User roster with roles
+- Invite member form (admin only)
+
+**User actions on this page:**
+- View company members and their roles
+- Invite new member (admin)
+- Change member role (admin)
+- Revoke member access (admin)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a non-admin member see the user list?
+- [ ] What happens when an admin tries to revoke themselves?
+
+---
+
+### /company/image/generate
+
+**File:** `app/(platform)/company/image/generate/page.tsx`
+**Auth:** Platform session required
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- AI image generation form
+
+**User actions on this page:**
+- Generate AI images for use in posts
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What permission level is required to generate images (any member, or editor+)?
+- [ ] Is there a per-company generation quota?
+
+---
+
+### /company/internal/autosave-lab
+
+**File:** `app/(platform)/company/internal/autosave-lab/page.tsx`
+**Auth:** Platform session required (internal development page)
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Autosave development/testing surface
+
+**User actions on this page:**
+- Test autosave behaviour
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this page gated to internal staff only, or accessible to any company member?
+
+---
+
+## Admin
+
+All pages in this group call `checkAdminAccess()` which requires `super_admin` or `admin` role. Some sub-pages require `super_admin` only (noted below). Non-admin users are redirected.
+
+---
+
+### /admin
+
+**File:** `app/(platform)/admin/page.tsx`
+**Auth:** `checkAdminAccess()` — super_admin + admin
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Admin dashboard / navigation hub
+
+**User actions on this page:**
+- Navigate to admin sub-sections
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does the admin landing page show a summary of system health or just navigation links?
+
+---
+
+### /admin/sites
+
+**File:** `app/(platform)/admin/sites/page.tsx`
+**Auth:** `checkAdminAccess()` — super_admin + admin
+**Search params:** Pagination / filter params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Sites list table
+
+**User actions on this page:**
+- Search and filter sites
+- Navigate to individual site detail
+- Create new site
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a regular `admin` role see all sites across all companies, or only their company's sites?
+
+---
+
+### /admin/sites/new
+
+**File:** `app/(platform)/admin/sites/new/page.tsx`
+**Auth:** `checkAdminAccess()` — super_admin + admin
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- New site creation form
+
+**User actions on this page:**
+- Create a new site record
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What fields are required to create a new site?
+
+---
+
+### /admin/sites/[id]
+
+**File:** `app/(platform)/admin/sites/[id]/page.tsx`
+**Auth:** `checkAdminAccess()` — super_admin + admin
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Site detail overview
+
+**User actions on this page:**
+- View site metadata, status, connections
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when the site ID does not exist?
+
+---
+
+### /admin/sites/[id]/edit
+
+**File:** `app/(platform)/admin/sites/[id]/edit/page.tsx`
+**Auth:** `checkAdminAccess()` — super_admin + admin
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Site edit form (name, WP URL, credentials)
+
+**User actions on this page:**
+- Edit site metadata and WordPress connection details
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are WP credentials encrypted on save? (They should be via `lib/encryption.ts`)
+
+---
+
+### /admin/sites/[id]/settings
+
+**File:** `app/(platform)/admin/sites/[id]/settings/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Site settings panel
+
+**User actions on this page:**
+- Configure site-level settings (budget, generation preferences, etc.)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Which settings are editable at site level vs company level?
+
+---
+
+### /admin/sites/[id]/content
+
+**File:** `app/(platform)/admin/sites/[id]/content/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Site content overview (pages, posts)
+
+**User actions on this page:**
+- View generated content for the site
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does this page show published WP content or only locally tracked pages?
+
+---
+
+### /admin/sites/[id]/posts
+
+**File:** `app/(platform)/admin/sites/[id]/posts/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** Pagination params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Site blog posts list
+
+**User actions on this page:**
+- View, filter, navigate to individual posts
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are these blog posts (WordPress posts) distinct from social posts?
+
+---
+
+### /admin/sites/[id]/posts/new
+
+**File:** `app/(platform)/admin/sites/[id]/posts/new/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- New post creation form
+
+**User actions on this page:**
+- Create a new blog post for the site
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this manually written or AI-assisted?
+
+---
+
+### /admin/sites/[id]/posts/[post_id]
+
+**File:** `app/(platform)/admin/sites/[id]/posts/[post_id]/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Blog post detail / editor
+
+**User actions on this page:**
+- View and edit post content
+- Publish / unpublish to WordPress
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when the post's WP site is unreachable during publish?
+
+---
+
+### /admin/sites/[id]/pages
+
+**File:** `app/(platform)/admin/sites/[id]/pages/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** Pagination params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Site pages list
+
+**User actions on this page:**
+- View generated landing pages for the site
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are these WordPress pages or locally generated page objects?
+
+---
+
+### /admin/sites/[id]/pages/[pageId]
+
+**File:** `app/(platform)/admin/sites/[id]/pages/[pageId]/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Page detail and content editor
+
+**User actions on this page:**
+- View page content
+- Regenerate page
+- Push to WordPress
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is shown when a regeneration is in flight?
+
+---
+
+### /admin/sites/[id]/appearance
+
+**File:** `app/(platform)/admin/sites/[id]/appearance/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Site appearance / design system settings
+
+**User actions on this page:**
+- Configure palette, typography
+- Sync palette to WordPress
+- Rollback palette
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the palette sync to WP live (real-time) or queued?
+
+---
+
+### /admin/sites/[id]/setup
+
+**File:** `app/(platform)/admin/sites/[id]/setup/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Site onboarding setup wizard
+
+**User actions on this page:**
+- Progress through design + tone extraction steps
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What steps make up the setup wizard?
+
+---
+
+### /admin/sites/[id]/setup/extract
+
+**File:** `app/(platform)/admin/sites/[id]/setup/extract/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Design extraction step
+
+**User actions on this page:**
+- Trigger design extraction from client's website
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when the client's website is unreachable during extraction?
+
+---
+
+### /admin/sites/[id]/onboarding
+
+**File:** `app/(platform)/admin/sites/[id]/onboarding/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Onboarding checklist / status
+
+**User actions on this page:**
+- View onboarding progress
+- Complete onboarding steps
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is onboarding gated — can generation not proceed until onboarding is complete?
+
+---
+
+### /admin/sites/[id]/blueprints/review
+
+**File:** `app/(platform)/admin/sites/[id]/blueprints/review/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Blueprint review surface
+
+**User actions on this page:**
+- Approve or revert a site blueprint
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What constitutes a "blueprint" in this context (full site structure snapshot)?
+
+---
+
+### /admin/sites/[id]/briefs/[brief_id]/review
+
+**File:** `app/(platform)/admin/sites/[id]/briefs/[brief_id]/review/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Brief page review surface
+
+**User actions on this page:**
+- Approve or request revisions on generated pages
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can individual pages within a brief be approved independently?
+
+---
+
+### /admin/sites/[id]/briefs/[brief_id]/run
+
+**File:** `app/(platform)/admin/sites/[id]/briefs/[brief_id]/run/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Brief run progress surface (streaming generation)
+
+**User actions on this page:**
+- Watch generation progress
+- Cancel generation
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens if the user navigates away during generation?
+
+---
+
+### /admin/sites/[id]/design-system
+
+**File:** `app/(platform)/admin/sites/[id]/design-system/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Design system overview for the site
+
+**User actions on this page:**
+- Navigate to components, templates, preview
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is there one design system per site, or can multiple exist?
+
+---
+
+### /admin/sites/[id]/design-system/components
+
+**File:** `app/(platform)/admin/sites/[id]/design-system/components/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Component library for the site's design system
+
+**User actions on this page:**
+- View, create, edit design system components
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can components be shared across sites?
+
+---
+
+### /admin/sites/[id]/design-system/templates
+
+**File:** `app/(platform)/admin/sites/[id]/design-system/templates/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Page template library
+
+**User actions on this page:**
+- View, create, edit page templates
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are templates versioned?
+
+---
+
+### /admin/sites/[id]/design-system/preview
+
+**File:** `app/(platform)/admin/sites/[id]/design-system/preview/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Live preview of design system applied
+
+**User actions on this page:**
+- Preview how the design system renders
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is the preview rendered in an iframe against the real WP site or a local renderer?
+
+---
+
+### /admin/companies
+
+**File:** `app/(platform)/admin/companies/page.tsx`
+**Auth:** `checkAdminAccess()` — super_admin + admin
+**Search params:** Pagination / filter params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Companies list table
+
+**User actions on this page:**
+- Search companies
+- Navigate to company detail
+- Create new company
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a regular admin see all companies or only their own?
+
+---
+
+### /admin/companies/new
+
+**File:** `app/(platform)/admin/companies/new/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- New company creation form
+
+**User actions on this page:**
+- Create a new platform company
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does creating a company auto-provision any resources (social profile, etc.)?
+
+---
+
+### /admin/companies/[id]
+
+**File:** `app/(platform)/admin/companies/[id]/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `PlatformCompanyDetail` — company overview, members, pending invitations
+- `TDetailSummary` — layout template
+
+**User actions on this page:**
+- View company details and members
+- Navigate to sub-pages (CAP, social profiles)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when the company ID does not exist?
+
+---
+
+### /admin/companies/[id]/cap
+
+**File:** `app/(platform)/admin/companies/[id]/cap/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- CAP (Content Amplification Platform) overview for the company
+
+**User actions on this page:**
+- View CAP subscription status
+- Navigate to campaigns
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is shown when a company has no CAP subscription?
+
+---
+
+### /admin/companies/[id]/cap/campaigns
+
+**File:** `app/(platform)/admin/companies/[id]/cap/campaigns/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- CAP campaigns list for the company
+
+**User actions on this page:**
+- View campaigns by month
+- Navigate to campaign detail
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are campaigns shown for all statuses or filtered to active ones by default?
+
+---
+
+### /admin/companies/[id]/cap/campaigns/[campaignId]
+
+**File:** `app/(platform)/admin/companies/[id]/cap/campaigns/[campaignId]/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- CAP campaign detail with 4 post slots (weekly arc phases)
+
+**User actions on this page:**
+- Review generated posts
+- Approve or reject individual post slots
+- Push approved posts to composer
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] When a post slot is pushed to composer, what state does it start in?
+- [ ] Can a post slot be regenerated after rejection?
+
+---
+
+### /admin/companies/[id]/cap/analytics
+
+**File:** `app/(platform)/admin/companies/[id]/cap/analytics/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- CAP analytics dashboard
+
+**User actions on this page:**
+- View CAP performance metrics
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What metrics are shown (post reach, engagement, cost per post)?
+
+---
+
+### /admin/companies/[id]/social-profiles
+
+**File:** `app/(platform)/admin/companies/[id]/social-profiles/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Social profiles list for the company
+
+**User actions on this page:**
+- View social profiles
+- Create new profile
+- Navigate to profile detail
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a company have multiple social profiles (e.g. one per brand)?
+
+---
+
+### /admin/companies/[id]/social-profiles/[profileId]/analytics
+
+**File:** `app/(platform)/admin/companies/[id]/social-profiles/[profileId]/analytics/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Social profile analytics dashboard
+
+**User actions on this page:**
+- View per-profile analytics
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What platforms are covered in analytics (LinkedIn, Facebook, Instagram, etc.)?
+
+---
+
+### /admin/companies/[id]/social-profiles/[profileId]/connections
+
+**File:** `app/(platform)/admin/companies/[id]/social-profiles/[profileId]/connections/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Connections attributed to this profile
+
+**User actions on this page:**
+- View connections
+- Reattribute connections between profiles
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a connection be attributed to more than one profile?
+
+---
+
+### /admin/users
+
+**File:** `app/(platform)/admin/users/page.tsx`
+**Auth:** `checkAdminAccess()` — super_admin + admin
+**Search params:** Pagination / search params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Platform users list
+
+**User actions on this page:**
+- Search users
+- Invite new user (super_admin only)
+- Change user role (super_admin only)
+- Revoke access
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a regular admin invite users, or only super_admins?
+
+---
+
+### /admin/users/audit
+
+**File:** `app/(platform)/admin/users/audit/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** Date filter params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- User action audit log
+
+**User actions on this page:**
+- View audit trail of user activity
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What events are captured in the user audit log?
+
+---
+
+### /admin/batches
+
+**File:** `app/(platform)/admin/batches/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** Filter params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Batch generation jobs list
+
+**User actions on this page:**
+- View all batch runs across sites
+- Navigate to site-specific batches
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are all batch statuses shown, or only active ones by default?
+
+---
+
+### /admin/batches/[siteId]
+
+**File:** `app/(platform)/admin/batches/[siteId]/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Batches for a specific site
+
+**User actions on this page:**
+- View batch history for the site
+- Create new batch
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What batch size limits apply per site?
+
+---
+
+### /admin/batches/[siteId]/[batchId]
+
+**File:** `app/(platform)/admin/batches/[siteId]/[batchId]/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Batch detail with per-page status rows
+
+**User actions on this page:**
+- View generation progress
+- Cancel batch
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a partial batch be re-run for only the failed pages?
+
+---
+
+### /admin/images
+
+**File:** `app/(platform)/admin/images/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** Search/filter params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Central image library list
+
+**User actions on this page:**
+- Browse, search, upload images to the central library
+- Hard-delete images
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are images in the admin library shared across all companies or scoped?
+
+---
+
+### /admin/images/[id]
+
+**File:** `app/(platform)/admin/images/[id]/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Image detail with metadata and usage
+
+**User actions on this page:**
+- View image metadata
+- Re-extract metadata
+- Restore soft-deleted image
+- Hard-delete
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is the difference between soft-delete and hard-delete for images?
+
+---
+
+### /admin/media
+
+**File:** `app/(platform)/admin/media/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Media assets overview (distinct from image library)
+
+**User actions on this page:**
+- View and promote media assets
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] How does /admin/media differ from /admin/images?
+
+---
+
+### /admin/posts
+
+**File:** `app/(platform)/admin/posts/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** Filter params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- All posts across all sites
+
+**User actions on this page:**
+- View and manage blog posts across all sites
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are these WordPress blog posts or social posts?
+
+---
+
+### /admin/posts/new
+
+**File:** `app/(platform)/admin/posts/new/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- New post creation (cross-site)
+
+**User actions on this page:**
+- Create a new blog post (site selection step)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does this redirect to /admin/posts/[siteId]/new after site selection?
+
+---
+
+### /admin/posts/[siteId]/new
+
+**File:** `app/(platform)/admin/posts/[siteId]/new/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- New post creation form for a specific site
+
+**User actions on this page:**
+- Create a new blog post for the specified site
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is AI-assisted content generation available on this form?
+
+---
+
+### /admin/insights
+
+**File:** `app/(platform)/admin/insights/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Admin insights dashboard (cross-client)
+
+**User actions on this page:**
+- View insights across all clients
+- Navigate to per-client insights
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can admins see individual client insights or only aggregated?
+
+---
+
+### /admin/insights/clients/[id]
+
+**File:** `app/(platform)/admin/insights/clients/[id]/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Per-client insights with recommendations
+
+**User actions on this page:**
+- View and annotate recommendations
+- Dismiss recommendations
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is the lifecycle of a dismissed recommendation — can it be un-dismissed?
+
+---
+
+### /admin/insights/clients/[id]/competitors
+
+**File:** `app/(platform)/admin/insights/clients/[id]/competitors/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Competitor management for a client
+
+**User actions on this page:**
+- Add, edit, delete competitors
+- Trigger competitor scrape
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is competitor scraping triggered on add, or on a schedule?
+
+---
+
+### /admin/insights/compare
+
+**File:** `app/(platform)/admin/insights/compare/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** Client/competitor selection params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Cross-client comparison view
+
+**User actions on this page:**
+- Compare insights across clients
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What dimensions can be compared?
+
+---
+
+### /admin/insights/patterns
+
+**File:** `app/(platform)/admin/insights/patterns/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Cross-client pattern library view
+
+**User actions on this page:**
+- View mined content patterns
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What patterns are mined — content structure, topic clusters, posting cadence?
+
+---
+
+### /admin/theming
+
+**File:** `app/(platform)/admin/theming/page.tsx`
+**Auth:** `checkAdminAccess({ requiredRoles: ["super_admin"] })` — super_admin only (KF-5)
+**Search params:** `?company=` (company UUID for theming preview)
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `ThemingClient` — per-company theme configuration
+- `TListWide` — layout template
+
+**User actions on this page:**
+- Select a company from the dropdown
+- Configure and preview the company's design token overrides
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are theme changes applied immediately or only on save?
+- [ ] Can theme changes be reverted?
+
+---
+
+### /admin/errors
+
+**File:** `app/(platform)/admin/errors/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** Filter params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Client error log viewer
+
+**User actions on this page:**
+- View client-side error reports
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] How long are error reports retained?
+
+---
+
+### /admin/maintenance
+
+**File:** `app/(platform)/admin/maintenance/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Maintenance actions overview
+
+**User actions on this page:**
+- Access maintenance tools
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What maintenance operations are available from this page?
+
+---
+
+### /admin/maintenance/social-connections
+
+**File:** `app/(platform)/admin/maintenance/social-connections/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Social connection maintenance panel
+
+**User actions on this page:**
+- Reconcile connections with bundle.social
+- Reattribute connections to correct profiles
+- Refresh identity fingerprints
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are maintenance operations idempotent (safe to run multiple times)?
+
+---
+
+### /admin/system/health
+
+**File:** `app/(platform)/admin/system/health/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- System health dashboard with service status
+
+**User actions on this page:**
+- View health events
+- Resolve service health flags
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What services are monitored (bundle.social, Supabase, Vercel, etc.)?
+
+---
+
+### /admin/system/jobs
+
+**File:** `app/(platform)/admin/system/jobs/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Background job queue viewer
+
+**User actions on this page:**
+- View job statuses
+- (Future) retry or cancel jobs
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Which job types are visible here?
+
+---
+
+### /admin/email-test
+
+**File:** `app/(platform)/admin/email-test/page.tsx`
+**Auth:** `checkAdminAccess({ requiredRoles: ["super_admin"] })` — super_admin only
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Email test trigger surface
+
+**User actions on this page:**
+- Send test emails to verify email configuration
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Which email templates can be tested from this page?
+
+---
+
+### /admin/settings/design-system
+
+**File:** `app/(platform)/admin/settings/design-system/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Global design system settings
+
+**User actions on this page:**
+- Configure global design system defaults
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Do global defaults override or underlay per-site settings?
+
+---
+
+### /admin/_internal/table-examples
+
+**File:** `app/(platform)/admin/_internal/table-examples/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Internal UI component examples
+
+**User actions on this page:**
+- None (development reference page)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Should this page be removed from production?
+
+---
+
+## Optimiser
+
+All pages call `checkAdminAccess()` (super_admin + admin).
+
+---
+
+### /optimiser
+
+**File:** `app/(platform)/optimiser/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Optimiser module landing
+
+**User actions on this page:**
+- Navigate to proposals, diagnostics, clients
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is the primary entry point on this page?
+
+---
+
+### /optimiser/proposals
+
+**File:** `app/(platform)/optimiser/proposals/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** Filter / pagination params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Proposals list table with status pills
+
+**User actions on this page:**
+- View all proposals
+- Filter by status
+- Navigate to proposal detail
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are `expired` proposals shown by default or filtered out?
+
+---
+
+### /optimiser/proposals/[id]
+
+**File:** `app/(platform)/optimiser/proposals/[id]/page.tsx`
+**Auth:** `checkAdminAccess()`; `notFound()` if proposal does not exist
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `ProposalReview` — full proposal content and evidence
+- `ProposalAppliedMoment` — post-apply timeline
+- `ProposalRolloutLink` — staged rollout link if applicable
+- `CreateVariantButton` — create A/B variant
+- `PastCausalDeltasPanel` — historical causal deltas for this playbook
+- `PatternPriorsPanel` — pattern priors influencing this proposal
+- `TDetailSummary` — layout template
+
+**User actions on this page:**
+- Approve proposal (triggers brief generation)
+- Reject proposal
+- Create A/B variant
+- View rollout status
+- Rollback an applied proposal
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens when a proposal is in `applying` state — are action buttons disabled?
+- [ ] Can a proposal in `applied_promoted` be rolled back?
+- [ ] What evidence is shown in `ProposalReview` (GA4 data, Clarity heatmap link, etc.)?
+
+---
+
+### /optimiser/diagnostics
+
+**File:** `app/(platform)/optimiser/diagnostics/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Optimiser health diagnostics
+
+**User actions on this page:**
+- View data sync status (GA4, Ads, Clarity, PageSpeed)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does this page surface individual client sync health or aggregate?
+
+---
+
+### /optimiser/change-log
+
+**File:** `app/(platform)/optimiser/change-log/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** Filter params
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Audit log of all applied optimiser changes
+
+**User actions on this page:**
+- View change history across all clients
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does the change log show rollbacks as separate entries?
+
+---
+
+### /optimiser/clients/[id]/settings
+
+**File:** `app/(platform)/optimiser/clients/[id]/settings/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Per-client optimiser settings (GA4 property, Ads customer, Clarity project)
+
+**User actions on this page:**
+- Configure data integrations for the client
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are OAuth tokens stored per-setting or globally per admin account?
+
+---
+
+### /optimiser/onboarding
+
+**File:** `app/(platform)/optimiser/onboarding/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Optimiser onboarding client list
+
+**User actions on this page:**
+- View and manage client onboarding for Optimiser
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What marks a client as "onboarded" for Optimiser?
+
+---
+
+### /optimiser/onboarding/[id]
+
+**File:** `app/(platform)/optimiser/onboarding/[id]/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Per-client onboarding steps
+
+**User actions on this page:**
+- Complete onboarding steps for a client
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What steps are required before Optimiser can start scoring pages for this client?
+
+---
+
+### /optimiser/imports/[brief_id]
+
+**File:** `app/(platform)/optimiser/imports/[brief_id]/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Brief import review surface (Optimiser → Brief generation bridge)
+
+**User actions on this page:**
+- Review and confirm import of optimiser proposal into brief
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does the import create a new brief or append pages to an existing one?
+
+---
+
+### /optimiser/pages/[id]
+
+**File:** `app/(platform)/optimiser/pages/[id]/page.tsx`
+**Auth:** `checkAdminAccess()`
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Optimiser page detail (scores, proposals history, rollback)
+
+**User actions on this page:**
+- View page scores over time
+- Roll back a page to previous version
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What scores are shown (PageSpeed, Clarity heatmap score, GA4 conversion rate)?
+
+---
+
+## Account
+
+All pages require any authenticated platform session.
+
+---
+
+### /account/security
+
+**File:** `app/(platform)/account/security/page.tsx`
+**Auth:** Any authenticated user
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- `AccountSecurityForm` — change password
+
+**User actions on this page:**
+- Change password (current + new + confirm)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Are existing sessions (other devices) invalidated after a password change?
+- [ ] Is 2FA setup accessible from this page?
+
+---
+
+### /account/devices
+
+**File:** `app/(platform)/account/devices/page.tsx`
+**Auth:** Any authenticated user
+**Search params:** None
+**States:** loading.tsx ✓ (has loading.tsx) · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Active sessions / devices list
+
+**User actions on this page:**
+- View all active sessions
+- Sign out a specific device
+- Sign out all other devices
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What device metadata is captured (IP, user agent, last active)?
+- [ ] Is the current session highlighted / protected from self-sign-out?
+
+---
+
+## Public / Token-auth
+
+---
+
+### /social/poster
+
+**File:** `app/(platform)/social/poster/page.tsx`
+**Auth:** Platform session required
+**Search params:** None
+**States:** loading.tsx ✓ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Social poster surface
+
+**User actions on this page:**
+- Post content to connected social accounts
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this a legacy entry point or an active route?
+
+---
+
+### /design-system
+
+**File:** `app/(dev)/design-system/page.tsx`
+**Auth:** Gated by `NEXT_PUBLIC_SHOW_DEV_ROUTES` env var (dev/staging only)
+**Search params:** None
+**States:** loading.tsx ✗ · error.tsx ✗ · not-found.tsx ✗
+
+**Major components rendered:**
+- Internal design system component showcase
+
+**User actions on this page:**
+- Browse UI components and tokens
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is this page accessible in production when `NEXT_PUBLIC_SHOW_DEV_ROUTES` is unset?

--- a/docs/inventory/state-machines.md
+++ b/docs/inventory/state-machines.md
@@ -1,0 +1,549 @@
+# State Machines Inventory
+
+> Generated: 2026-05-25.
+> Covers every entity with a meaningful state column discovered in the codebase.
+> EXPECTED BEHAVIOUR checkboxes are intentionally empty — Steven to fill.
+> TypeScript types and migration references are cited where verified.
+
+---
+
+## social_post_drafts
+
+**Table:** `social_post_drafts`
+**State column:** `state` TEXT
+**TypeScript type:** `DraftState` in `lib/social/types.ts:19-28`
+**Migration:** `0132_planned_for_at.sql` (CHECK constraint added; `0131_recurring_drafts.sql` added `recurrence_state`)
+
+**States:**
+
+| State | Meaning |
+|-------|---------|
+| `draft` | Created, not yet submitted for approval or scheduled. Editable. |
+| `pending_approval` | Submitted for approval; awaiting a decision from the named approver. Read-only to author. |
+| `rejected` | Approval request was rejected. Author may edit and re-submit. |
+| `scheduled` | Approved (or no-approval flow); `scheduled_at` is set; will be picked up by cron. |
+| `recurring` | Parent recurring draft with no single `scheduled_at`; child instances are created per recurrence. |
+| `paused` | Recurring series paused by user; no new child instances created. |
+| `publishing` | Cron picked up and submitted to bundle.social; in-flight. |
+| `published` | Successfully published via bundle.social. Terminal for one-off drafts. |
+| `failed` | Publish attempt failed; `last_publish_error` is populated. Retryable. |
+
+**Recurrence column:** `recurrence_state` TEXT (separate column, added `0131_recurring_drafts.sql`)
+
+| Recurrence state | Meaning |
+|-----------------|---------|
+| `active` | Series is generating and publishing child instances |
+| `paused` | Series suspended; no new instances |
+| `ended` | Series completed all recurrences |
+| `NULL` | Not a recurring draft |
+
+**State transitions:**
+
+| From | To | Trigger | Code |
+|------|----|---------|------|
+| `draft` | `pending_approval` | Create with `approval_required=true` and `mode=schedule` | `app/api/platform/social/drafts/route.ts` (POST) |
+| `draft` | `scheduled` | Create with `approval_required=false` and `mode=schedule` | `app/api/platform/social/drafts/route.ts` (POST) |
+| `draft` | `recurring` | Create with `mode=recurring` and `approval_required=false` | `app/api/platform/social/drafts/route.ts` (POST) |
+| `draft` | `pending_approval` | PATCH to submit existing draft for approval | `app/api/platform/social/drafts/[id]/route.ts` (PATCH) |
+| `pending_approval` | `scheduled` | Approver decision = `approved` | `app/api/platform/social/drafts/[id]/approve/route.ts` |
+| `pending_approval` | `rejected` | Approver decision = `rejected` | `app/api/platform/social/drafts/[id]/approve/route.ts` |
+| `rejected` | `draft` | Author converts back | `app/api/platform/social/drafts/[id]/convert-to-draft/route.ts` |
+| `scheduled` | `publishing` | Cron job picks up where `scheduled_at <= NOW()` | `app/api/internal/cron/publish-due/route.ts` |
+| `scheduled` | `draft` | Author cancels scheduling | `app/api/platform/social/drafts/[id]/convert-to-draft/route.ts` |
+| `publishing` | `published` | bundle.social webhook delivers success | `app/api/webhooks/bundlesocial/route.ts` |
+| `publishing` | `failed` | bundle.social webhook delivers failure | `app/api/webhooks/bundlesocial/route.ts` |
+| `failed` | `publishing` | Manual publish trigger (admin retry) | `app/api/platform/social/drafts/[id]/publish/route.ts` |
+| `recurring` | `paused` | User pauses series | `app/api/platform/social/drafts/[id]/route.ts` (PATCH) |
+| `paused` | `recurring` | User resumes series | `app/api/platform/social/drafts/[id]/route.ts` (PATCH) |
+
+**CAS (Optimistic Locking):** `PATCH /api/platform/social/drafts/[id]` enforces `draft_version` check; mismatches return `409 VERSION_CONFLICT`.
+
+**UI surfaces that render this entity:**
+- `/company/social/calendar` — post chips with state-coloured badge; DnD reschedule; composer open in edit mode
+- `/company/social/posts` — list rows with state pills; searchable + filterable by state
+- `/company/social/posts/[id]` — full detail view; sections conditionally visible by state
+- `/company/social/calendar?compose=[id]` — composer opened in edit mode for existing draft
+- `/approve/[token]` — external approval via magic link; renders snapshot read-only + decision form
+- `/viewer/[token]` — public schedule viewer; approved/scheduled/published states only
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a `scheduled` draft be edited by an editor (not just converted back to draft)?
+- [ ] Can a `published` draft ever be re-edited (e.g. to update tracking links)?
+- [ ] What user-facing label is shown for `pending_approval` in the UI pills?
+- [ ] When a `recurring` series is `paused`, are future child instances pre-scheduled or generated on resume?
+- [ ] What is the maximum number of publish retries allowed before a draft stays in `failed`?
+- [ ] Can a `rejected` draft be deleted, or must it be converted back to `draft` first?
+- [ ] Who can see a `pending_approval` draft — the author, the approver, all company members, or admins only?
+- [ ] Is there a notification to the author when a `pending_approval` draft moves to `scheduled`?
+
+---
+
+## social_connections
+
+**Table:** `social_connections`
+**State column:** `status` TEXT (mirrors `social_connection_status` DB enum conceptually; TypeScript enum is the source of truth)
+**TypeScript type:** `SocialConnectionStatus` in `lib/platform/social/connections/types.ts:10-20`
+**Migration:** `0070_platform_foundation.sql` (initial states); `0122_social_connections_identity_fingerprints.sql` (added `pending_identity`)
+
+**States:**
+
+| State | Meaning |
+|-------|---------|
+| `healthy` | Connection active and publishing-ready; all permissions granted |
+| `degraded` | Partial functionality; some permissions revoked by user at the platform level |
+| `auth_required` | OAuth credentials expired or revoked; user must reconnect via the OAuth flow |
+| `disconnected` | Explicitly disconnected by admin, or removed at the platform level |
+| `pending_identity` | OAuth flow complete but channel/page selection not yet done; `external_account_id` or `external_user_id` is null |
+
+**Status UI labels** (from `lib/platform/social/connections/types.ts:61-67`):
+
+| State | Label | Pill colour |
+|-------|-------|-------------|
+| `healthy` | "Healthy" | green (`bg-success-bg text-success-fg`) |
+| `degraded` | "Degraded" | yellow (`bg-warning-bg text-warning-fg`) |
+| `auth_required` | "Reconnect required" | red (`bg-danger-bg text-danger-fg`) |
+| `disconnected` | "Disconnected" | grey (`bg-muted text-muted-foreground`) |
+| `pending_identity` | "Pending channel selection" | yellow (`bg-warning-bg text-warning-fg`) |
+
+**State transitions:**
+
+| From | To | Trigger | Code |
+|------|----|---------|------|
+| (new) | `pending_identity` | OAuth callback completes but channel not yet selected | `app/api/platform/social/connections/callback/route.ts` |
+| `pending_identity` | `healthy` | User selects channel / page | `app/api/platform/social/connections/[id]/set-channel/route.ts` |
+| `pending_identity` | `healthy` | User connects as personal (LinkedIn) | `app/api/platform/social/connections/[id]/connect-as-personal/route.ts` |
+| `healthy` | `auth_required` | Platform OAuth token expires or permissions revoked (detected by cron or webhook) | `app/api/cron/social-connections-health/route.ts` |
+| `healthy` | `degraded` | Partial permission revocation detected | `app/api/cron/social-connections-health/route.ts` |
+| `healthy` | `disconnected` | Admin explicitly disconnects | `app/api/platform/social/connections/[id]/disconnect/route.ts` |
+| `auth_required` | `healthy` | Admin completes reconnect OAuth flow | `app/api/platform/social/connections/reconnect/route.ts` |
+| `degraded` | `healthy` | Admin reconnects to restore full permissions | `app/api/platform/social/connections/reconnect/route.ts` |
+| `disconnected` | — | Reconnect creates a new row rather than updating status | `app/api/platform/social/connections/connect/route.ts` |
+
+**Publishing gate:** Only `healthy` connections are eligible for publishing (`claim_publish_job` RPC has `status='healthy'` gate). `pending_identity` connections are rejected at the publishing layer.
+
+**UI surfaces that render this entity:**
+- `/company/social/connections` — per-row status pills; Reconnect button (admin only)
+- `/admin/companies/[id]/social-profiles/[profileId]/connections` — admin view with reattribution
+- `/admin/maintenance/social-connections` — reconcile, refresh identity, reattribute
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a `disconnected` connection be reconnected in-place, or does reconnect always create a new row?
+- [ ] What happens to `scheduled` drafts when a connection moves to `auth_required` — are they blocked at publish time or immediately flagged?
+- [ ] When does the `has_emitted_overdue_event` flag get set for `pending_identity` connections?
+- [ ] Is there a UI affordance on `/company/social/calendar` to warn users about `auth_required` connections?
+
+---
+
+## platform_invitations
+
+**Table:** `platform_invitations`
+**State column:** `status` ENUM `platform_invitation_status`
+**TypeScript type:** Inline SQL enum in `0070_platform_foundation.sql:93-97`
+**Migration:** `0070_platform_foundation.sql`
+
+**States:**
+
+| State | Meaning |
+|-------|---------|
+| `pending` | Invitation sent; email delivered; waiting for recipient to claim |
+| `accepted` | Recipient claimed the invitation and created / linked their account |
+| `expired` | Invitation was not claimed within the expiry window |
+| `revoked` | Admin manually revoked the invitation before it was claimed |
+
+**State transitions:**
+
+| From | To | Trigger | Code |
+|------|----|---------|------|
+| (new) | `pending` | Admin sends invitation | `app/api/admin/invites/route.ts` (POST) or `app/api/platform/invitations/route.ts` (POST) |
+| `pending` | `accepted` | Recipient visits invite link and sets credentials | `app/api/platform/invitations/accept/route.ts` or `app/api/auth/accept-invite/route.ts` |
+| `pending` | `expired` | Expiry cron runs after TTL passes | `app/api/platform/invitations/callbacks/expiry/route.ts` |
+| `pending` | `revoked` | Admin revokes invitation | `app/api/admin/invites/[id]/route.ts` (DELETE/PATCH) or `app/api/platform/invitations/[id]/route.ts` (DELETE) |
+
+**Uniqueness constraint:** `idx_invitations_unique_pending` prevents two pending invitations for the same email + company combination.
+
+**UI surfaces that render this entity:**
+- `/admin/companies/[id]` — pending invitations list
+- `/company/users` — pending invitations list
+- `/invite/[token]` — invitation claim page
+- `/auth/accept-invite` — invitation acceptance
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What is the invitation TTL (hours/days before auto-expiry)?
+- [ ] Is the recipient notified when their invitation expires?
+- [ ] Can an admin re-invite someone after their invitation expired?
+- [ ] Can a `revoked` invitation be reinstated, or must a new one be issued?
+
+---
+
+## opt_proposals (Optimiser)
+
+**Table:** `opt_proposals`
+**State column:** `status` TEXT CHECK constraint
+**TypeScript type:** Inline in Optimiser libs
+**Migration:** `0053_optimiser_brief_submission.sql` (extended with `applying` and `applied_then_failed`); earlier migration established initial states
+
+**States:**
+
+| State | Meaning |
+|-------|---------|
+| `draft` | Proposal drafted internally; not yet submitted for approval |
+| `pending` | Proposal submitted and awaiting approval decision |
+| `approved` | Operator approved the proposal; ready to apply |
+| `applying` | Brief generation triggered; `brief_run` is queued or running |
+| `applied` | Brief run completed successfully; changes deployed to WP |
+| `applied_promoted` | Changes verified in production and promoted to canonical |
+| `applied_then_reverted` | Applied changes were rolled back to previous version |
+| `applied_then_failed` | Brief run terminated in `failed` state; operator notified |
+| `rejected` | Proposal rejected; not to be applied |
+| `expired` | Proposal was not acted upon within the expiry window |
+
+**Canonical state machine comment** (from migration `0053_optimiser_brief_submission.sql:44`):
+> `draft → pending → approved → applying → applied → applied_promoted | applied_then_reverted | applied_then_failed; OR pending → rejected | expired`
+
+**State transitions:**
+
+| From | To | Trigger | Code |
+|------|----|---------|------|
+| `draft` | `pending` | Operator submits for approval | `app/api/optimiser/proposals/[id]/route.ts` (PATCH) |
+| `pending` | `approved` | Admin approves | `app/api/optimiser/proposals/[id]/approve/route.ts` |
+| `pending` | `rejected` | Admin rejects | `app/api/optimiser/proposals/[id]/reject/route.ts` |
+| `pending` | `expired` | Expiry cron runs | `app/api/cron/optimiser-expire-proposals/route.ts` |
+| `approved` | `applying` | Brief run triggered on approval | `app/api/optimiser/proposals/[id]/approve/route.ts` |
+| `applying` | `applied` | Brief run succeeds | `app/api/cron/process-brief-runner/route.ts` via `brief_run.triggered_by_proposal_id` |
+| `applying` | `applied_then_failed` | Brief run terminates in `failed` | `app/api/cron/process-brief-runner/route.ts` |
+| `applied` | `applied_promoted` | Staged rollout monitor promotes | `app/api/cron/optimiser-monitor-rollouts/route.ts` |
+| `applied` | `applied_then_reverted` | Admin rollback | `app/api/optimiser/proposals/[id]/rollback/route.ts` |
+| `applied_promoted` | `applied_then_reverted` | Admin rollback post-promotion | `app/api/optimiser/proposals/[id]/rollback/route.ts` |
+
+**UI surfaces that render this entity:**
+- `/optimiser/proposals` — list with status pills
+- `/optimiser/proposals/[id]` — full detail with `ProposalReview`, `ProposalAppliedMoment`, action buttons
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] In `applying` state, are the Approve/Reject buttons disabled on the detail page?
+- [ ] What notification is sent when a proposal moves to `applied_then_failed`?
+- [ ] Can an `expired` proposal be manually reactivated?
+- [ ] Can an `applied_then_reverted` proposal be re-applied without going through `pending` again?
+
+---
+
+## cap_campaigns
+
+**Table:** `cap_campaigns`
+**State column:** `status` TEXT CHECK constraint
+**TypeScript type:** Inferred from DB schema
+**Migration:** `0137_cap_phase_1_schema.sql:197-201`
+
+**States:**
+
+| State | Meaning |
+|-------|---------|
+| `draft` | Campaign created but generation not yet triggered |
+| `generating` | AI content generation in progress |
+| `review` | Generation complete; posts ready for admin review |
+| `approved` | All post slots approved; ready to push to social composer |
+| `pushed` | Posts pushed to social_post_drafts; linked to the company's social pipeline |
+| `published` | All campaign posts have published (terminal) |
+| `archived` | Campaign manually archived |
+| `failed` | Generation failed; error state |
+
+**State transitions:**
+
+| From | To | Trigger | Code |
+|------|----|---------|------|
+| `draft` | `generating` | Admin triggers generation | `app/api/platform/cap/campaigns/[id]/generate/route.ts` |
+| `generating` | `review` | Generation job completes | `app/api/cron/cap-weekly-generation/route.ts` or `app/api/cron/cap-monthly-generation/route.ts` |
+| `generating` | `failed` | Generation job fails | Cron error handling |
+| `review` | `approved` | All `cap_campaign_posts` approved | `app/api/platform/cap/campaign-posts/[id]/status/route.ts` |
+| `approved` | `pushed` | Posts pushed to social composer | `app/api/platform/cap/campaign-posts/[id]/push/route.ts` |
+| `pushed` | `published` | All campaign posts published (driven by webhook) | `app/api/webhooks/bundlesocial/route.ts` |
+| Any | `archived` | Admin archives | Admin action |
+| `failed` | `generating` | Admin retriggers generation | `app/api/cron/cap-generation-runs-cleanup/route.ts` |
+
+**UI surfaces that render this entity:**
+- `/admin/companies/[id]/cap/campaigns` — campaigns list
+- `/admin/companies/[id]/cap/campaigns/[campaignId]` — campaign detail with post slots
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can a `generating` campaign be cancelled?
+- [ ] What happens when only some post slots are approved — does the campaign move to `approved` or does it require all four?
+- [ ] Can individual posts from a `pushed` campaign be pulled back (unconverted from draft)?
+- [ ] Is there a generation cost estimate shown before triggering?
+
+---
+
+## cap_campaign_posts
+
+**Table:** `cap_campaign_posts`
+**State column:** `status` TEXT CHECK constraint
+**TypeScript type:** Inferred from DB schema
+**Migration:** `0137_cap_phase_1_schema.sql:260-265`
+
+**States:**
+
+| State | Meaning |
+|-------|---------|
+| `pending` | Post slot exists; generation not yet attempted |
+| `generated` | AI content generated; awaiting admin review |
+| `approved` | Admin approved this post slot |
+| `rejected` | Admin rejected this post slot |
+| `pushed` | Pushed to `social_post_drafts`; `social_draft_id` FK is set |
+| `published` | Corresponding social draft has published |
+| `failed` | Generation or push failed |
+| `approved_past_due` | Approved after the scheduled publish window has passed |
+
+**State transitions:**
+
+| From | To | Trigger | Code |
+|------|----|---------|------|
+| `pending` | `generated` | CAP generation completes for this slot | Cron or `app/api/platform/cap/campaigns/[id]/generate/route.ts` |
+| `pending` | `failed` | Generation fails | Error handling |
+| `generated` | `approved` | Admin approves | `app/api/platform/cap/campaign-posts/[id]/status/route.ts` |
+| `generated` | `rejected` | Admin rejects | `app/api/platform/cap/campaign-posts/[id]/status/route.ts` |
+| `rejected` | `generated` | Admin triggers regeneration | `app/api/platform/cap/campaign-posts/[id]/regenerate/route.ts` |
+| `approved` | `pushed` | Admin pushes to composer | `app/api/platform/cap/campaign-posts/[id]/push/route.ts` |
+| `approved` | `approved_past_due` | Publish window passes without push | Cron monitor |
+| `pushed` | `published` | Linked draft publishes (webhook) | `app/api/webhooks/bundlesocial/route.ts` |
+| `failed` | `generated` | Admin retriggers generation | `app/api/platform/cap/campaign-posts/[id]/regenerate/route.ts` |
+
+**UI surfaces that render this entity:**
+- `/admin/companies/[id]/cap/campaigns/[campaignId]` — 4 post slot rows with per-slot status
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens to an `approved_past_due` post — is it still pushable?
+- [ ] When a post slot is in `pushed` state, does a link to the social draft appear in the UI?
+- [ ] Can a `pushed` post be pulled back (deleted from social drafts) and regenerated?
+
+---
+
+## cap_subscriptions
+
+**Table:** `cap_subscriptions`
+**State column:** `status` TEXT CHECK constraint
+**TypeScript type:** Inferred from DB schema
+**Migration:** `0137_cap_phase_1_schema.sql:77-78`
+
+**States:**
+
+| State | Meaning |
+|-------|---------|
+| `trial` | Company is in CAP trial period; `trial_ends_at` is set |
+| `active` | Active paid subscription |
+| `paused` | Subscription paused (billing or voluntary); campaign generation halted |
+| `cancelled` | Subscription cancelled; `cancelled_at` is set |
+
+**State transitions:**
+
+| From | To | Trigger | Code |
+|------|----|---------|------|
+| (new) | `trial` | Admin provisions CAP for company | Admin action |
+| `trial` | `active` | Trial converts (admin or billing event) | Admin / billing webhook |
+| `trial` | `cancelled` | Trial expires without conversion | Cron or admin |
+| `active` | `paused` | Admin or billing pause | Admin action |
+| `active` | `cancelled` | Admin or billing cancellation | Admin action |
+| `paused` | `active` | Admin resumes | Admin action |
+
+**UI surfaces that render this entity:**
+- `/admin/companies/[id]/cap` — subscription status overview
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What happens to in-flight campaigns when a subscription moves to `paused`?
+- [ ] Is there an automated notification when a trial is about to expire?
+- [ ] Can a `cancelled` subscription be reinstated?
+
+---
+
+## generation_jobs (batch_run)
+
+**Table:** `generation_jobs` (NOTE: migration uses `generation_jobs` not `batch_run`)
+**State column:** `status` TEXT CHECK constraint
+**TypeScript type:** Inferred from DB schema
+**Migration:** `0007_m3_1_batch_schema.sql:67-70`
+
+**States:**
+
+| State | Meaning |
+|-------|---------|
+| `queued` | Job created and waiting to be picked up by cron |
+| `running` | Cron has started processing; pages being generated |
+| `partial` | Some pages succeeded, some failed; run terminated |
+| `succeeded` | All requested pages generated successfully |
+| `failed` | Generation failed; error logged |
+| `cancelled` | Manually cancelled before completion |
+
+**State transitions:**
+
+| From | To | Trigger | Code |
+|------|----|---------|------|
+| (new) | `queued` | Admin creates batch or brief triggers generation | `app/api/admin/batch/route.ts` or `app/api/briefs/[brief_id]/run/route.ts` |
+| `queued` | `running` | Cron picks up job | `app/api/cron/process-batch/route.ts` or `app/api/cron/process-brief-runner/route.ts` |
+| `running` | `succeeded` | All pages generated | Cron finalisation |
+| `running` | `partial` | Some pages failed; others succeeded | Cron finalisation |
+| `running` | `failed` | All pages failed or critical error | Cron finalisation |
+| `queued` | `cancelled` | Admin cancels before run starts | `app/api/admin/batch/[id]/cancel/route.ts` |
+| `running` | `cancelled` | Admin cancels mid-run | `app/api/admin/batch/[id]/cancel/route.ts` |
+
+**Active index:** `idx_generation_jobs_active` on `(status)` where `status IN ('queued', 'running')`.
+
+**UI surfaces that render this entity:**
+- `/admin/batches` — cross-site batch list
+- `/admin/batches/[siteId]` — site-specific batch history
+- `/admin/batches/[siteId]/[batchId]` — batch detail with per-page progress
+- `/admin/sites/[id]/briefs/[brief_id]/run` — live run progress for brief-triggered jobs
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Is there a timeout after which a `running` job is automatically moved to `failed`?
+- [ ] Can a `partial` job be retried for only the failed pages?
+- [ ] Is there a concurrency limit on `running` jobs per site?
+- [ ] What notification is sent when a job moves to `failed`?
+
+---
+
+## site_blueprints
+
+**Table:** `site_blueprints`
+**State column:** `status` TEXT
+**TypeScript type:** Inferred from DB schema
+**Migration:** Migration in the M3/M4 range (not independently verified)
+
+**States:**
+
+| State | Meaning |
+|-------|---------|
+| `draft` | Blueprint generated but not yet reviewed/approved |
+| `approved` | Blueprint approved for publishing |
+
+**State transitions:**
+
+| From | To | Trigger | Code |
+|------|----|---------|------|
+| (new) | `draft` | Blueprint generated during site setup | Site setup workflow |
+| `draft` | `approved` | Admin approves blueprint | `app/api/sites/[id]/blueprints/[blueprint_id]/approve/route.ts` |
+| `approved` | (reverted) | Admin reverts blueprint | `app/api/sites/[id]/blueprints/[blueprint_id]/revert/route.ts` |
+
+**UI surfaces that render this entity:**
+- `/admin/sites/[id]/blueprints/review` — blueprint review surface
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] What exactly is captured in a blueprint (page structure, design tokens, content outline)?
+- [ ] Can more than one blueprint per site be in `approved` state simultaneously?
+- [ ] What happens to in-progress generation jobs when a blueprint is reverted?
+
+---
+
+## route_registry
+
+**Table:** `route_registry`
+**State column:** `status` TEXT
+**TypeScript type:** Inferred from DB schema
+**Migration:** Not independently verified
+
+**States:**
+
+| State | Meaning |
+|-------|---------|
+| `planned` | Route is planned but not yet live in WordPress |
+| `live` | Route is live and serving content in WordPress |
+| `redirected` | Route has been 301-redirected to another URL |
+| `removed` | Route has been removed; no longer serving content |
+
+**State transitions:**
+
+| From | To | Trigger | Code |
+|------|----|---------|------|
+| (new) | `planned` | Page generation creates route record | Brief run / page generation |
+| `planned` | `live` | Page published to WordPress | `app/api/sites/[id]/blueprints/[blueprint_id]/publish-site/route.ts` or publish page tools |
+| `live` | `redirected` | Optimiser or admin sets a redirect | Optimiser proposal / admin action |
+| `live` | `removed` | Page unpublished or deleted | `app/api/sites/[id]/posts/[post_id]/unpublish/route.ts` |
+
+**UI surfaces that render this entity:**
+- `/admin/sites/[id]/content` — site content overview
+- Route drift detection cron: `app/api/cron/drift-detect/route.ts`
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Does the `drift-detect` cron compare route_registry `status` against live WP to find discrepancies?
+- [ ] Are `removed` routes preserved in the registry for audit purposes?
+
+---
+
+## social_publish_attempts
+
+**Table:** `social_publish_attempts`
+**State column:** `status` ENUM `social_attempt_status`
+**TypeScript type:** `social_attempt_status` in `lib/platform/social/publishing` (inferred)
+**Migration:** `0070_platform_foundation.sql:167-174` (enum type definition)
+
+**States:**
+
+| State | Meaning |
+|-------|---------|
+| `pending` | Attempt row created; not yet submitted to bundle.social |
+| `in_flight` | Submitted to bundle.social; awaiting webhook confirmation |
+| `unknown` | Response from bundle.social was ambiguous; reconciliation needed |
+| `succeeded` | bundle.social confirmed successful publication |
+| `failed` | bundle.social confirmed failure; `error_class` and error details populated |
+| `reconciling` | Watchdog cron is actively reconciling this attempt |
+
+**State transitions:**
+
+| From | To | Trigger | Code |
+|------|----|---------|------|
+| (new) | `pending` | Publish job initiates a new attempt | Publishing fire logic |
+| `pending` | `in_flight` | HTTP call made to bundle.social | `lib/platform/social/publishing` fire |
+| `in_flight` | `succeeded` | bundle.social webhook delivers success | `app/api/webhooks/bundlesocial/route.ts` |
+| `in_flight` | `failed` | bundle.social webhook delivers failure | `app/api/webhooks/bundlesocial/route.ts` |
+| `in_flight` | `unknown` | bundle.social webhook not received within TTL | `app/api/cron/social-publish-watchdog/route.ts` |
+| `unknown` | `reconciling` | Watchdog begins reconciliation | `app/api/cron/social-publish-watchdog/route.ts` |
+| `reconciling` | `succeeded` | Reconciliation finds post was published | Watchdog |
+| `reconciling` | `failed` | Reconciliation confirms failure | Watchdog |
+
+**Immutability note:** `social_publish_attempts` is an immutable audit log (comment in `0070_platform_foundation.sql:764`). Retry attempts create new rows; they do not update existing ones.
+
+**UI surfaces that render this entity:**
+- `/company/social/posts/[id]` — `PostPublishHistorySection` (visible for `publishing|published|failed` states)
+- `/admin/companies/[id]/social-profiles/[profileId]/analytics` — analytics referencing attempt history
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] How long before a `pending` attempt transitions to `in_flight` — is there a timeout?
+- [ ] Is the `unknown` → `reconciling` watchdog transition automatic, and how frequently does the watchdog run?
+- [ ] Are `succeeded` attempts shown to company users, or only to admins?
+- [ ] What detail does the user see in `PostPublishHistorySection` — status only, or error message as well?
+
+---
+
+## platform_company_users (role)
+
+**Table:** `platform_company_users`
+**State column:** `role` TEXT (not a lifecycle state machine, but drives permission gates across the platform)
+**TypeScript type:** Inferred from `checkAdminAccess` and `canDo` helpers
+
+**Roles:**
+
+| Role | Scope |
+|------|-------|
+| `viewer` | Read-only access to calendar, posts, connections, media |
+| `editor` | Viewer + create/edit posts |
+| `admin` | Editor + manage connections, invite users, manage sharing links |
+| `super_admin` | All admin capabilities + access to super_admin-only pages (theming, email-test, user role management, invite) |
+
+**Permission map (canDo):**
+
+| Permission | Minimum role |
+|------------|-------------|
+| `view_calendar` | viewer |
+| `create_post` | editor |
+| `edit_post` | editor |
+| `approve_post` | editor (named approver) or admin |
+| `reject_post` | editor (named approver) or admin |
+| `manage_connections` | admin |
+| `manage_invitations` | admin |
+| `reconnect_connection` | admin |
+
+**UI surfaces that render this entity:**
+- `/company/users` — member list with role labels; role change (admin only)
+- `/admin/users` — platform-level user list with role management (super_admin only for role change)
+
+**EXPECTED BEHAVIOUR (Steven to fill):**
+- [ ] Can an admin change another admin's role to super_admin?
+- [ ] Is the `is_opollo_staff` override a role or a separate flag?
+- [ ] What happens to a company's data when the last admin's access is revoked?

--- a/scripts/seed-uat-staging.ts
+++ b/scripts/seed-uat-staging.ts
@@ -303,75 +303,59 @@ async function main() {
   // "old published post" surface the bug used to reproduce on.
   const fourteenDaysAgo = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000).toISOString();
 
+  // PostgREST batch insert sends NULL for keys not present on every row —
+  // spell out every column on every row, including ones with table defaults.
+  // See memory: postgrest-batch-insert-union-of-keys. The previous version
+  // omitted publish_attempts on 5/6 rows, which made PostgREST emit NULL
+  // and the social_post_drafts NOT NULL constraint reject the whole batch.
+  const draftRow = (overrides: Record<string, unknown>) => ({
+    company_id: uatCompanyId,
+    created_by: uatUserId,
+    updated_by: uatUserId,
+    state: "draft" as string,
+    content: "",
+    media_urls: [] as string[],
+    target_profiles: [] as unknown[],
+    platform_variants: {} as unknown,
+    scheduled_at: null as string | null,
+    planned_for_at: null as string | null,
+    published_at: null as string | null,
+    published_url: null as string | null,
+    last_publish_error: null as unknown,
+    publish_attempts: 0,
+    approval_required: false,
+    approver_user_id: null as string | null,
+    draft_data: {} as unknown,
+    ...overrides,
+  });
+
   const drafts = [
-    {
-      company_id: uatCompanyId,
-      created_by: uatUserId,
-      updated_by: uatUserId,
-      state: "draft",
-      content: "UAT draft post — not yet scheduled.",
-      media_urls: [] as string[],
-      target_profiles: [] as unknown[],
-      platform_variants: {} as unknown,
-      draft_data: {},
-    },
-    {
-      company_id: uatCompanyId,
-      created_by: uatUserId,
-      updated_by: uatUserId,
+    draftRow({ content: "UAT draft post — not yet scheduled." }),
+    draftRow({
       state: "scheduled",
       content: "UAT scheduled post #1 — going out in 3 days.",
-      media_urls: ["https://placehold.co/600x400.jpg"] as string[],
-      target_profiles: [] as unknown[],
-      platform_variants: {} as unknown,
+      media_urls: ["https://placehold.co/600x400.jpg"],
       scheduled_at: inThreeDays,
-      draft_data: {},
-    },
-    {
-      company_id: uatCompanyId,
-      created_by: uatUserId,
-      updated_by: uatUserId,
+    }),
+    draftRow({
       state: "scheduled",
       content: "UAT scheduled post #2 — going out in 7 days. #uat #staging",
-      media_urls: ["https://placehold.co/800x600.jpg"] as string[],
-      target_profiles: [] as unknown[],
-      platform_variants: {} as unknown,
+      media_urls: ["https://placehold.co/800x600.jpg"],
       scheduled_at: inSevenDays,
-      draft_data: {},
-    },
-    {
-      company_id: uatCompanyId,
-      created_by: uatUserId,
-      updated_by: uatUserId,
+    }),
+    draftRow({
       state: "publishing",
       content: "UAT post currently being published...",
-      media_urls: [] as string[],
-      target_profiles: [] as unknown[],
-      platform_variants: {} as unknown,
-      draft_data: {},
-    },
-    {
-      company_id: uatCompanyId,
-      created_by: uatUserId,
-      updated_by: uatUserId,
+    }),
+    draftRow({
       state: "published",
       content: "UAT published post — already live on LinkedIn (14 days ago).",
-      media_urls: [] as string[],
-      target_profiles: [] as unknown[],
-      platform_variants: {} as unknown,
       published_at: fourteenDaysAgo,
       published_url: "https://www.linkedin.com/posts/uat-stub-post-001",
-      draft_data: {},
-    },
-    {
-      company_id: uatCompanyId,
-      created_by: uatUserId,
-      updated_by: uatUserId,
+    }),
+    draftRow({
       state: "failed",
       content: "UAT failed post — bundle.social rejected the publish attempt.",
-      media_urls: [] as string[],
-      target_profiles: [] as unknown[],
-      platform_variants: {} as unknown,
       last_publish_error: {
         code: "BUNDLE_RATE_LIMIT",
         message: "bundle.social rate limit exceeded",
@@ -379,8 +363,7 @@ async function main() {
         attempt_number: 1,
       },
       publish_attempts: 1,
-      draft_data: {},
-    },
+    }),
   ];
 
   const { data: insertedDrafts, error: draftsError } = await supabase


### PR DESCRIPTION
## Summary
Follow-up to #1061. The state-aware composer seed only set \`publish_attempts\` on the failed row. PostgREST batch insert sends NULL for keys not present on every row, so the other 5 rows hit the NOT NULL constraint on \`publish_attempts\`. Seed exited with code 2 against the staging Supabase project before the UAT harness could run.

## Working analog
- **Working analog**: \`memory: postgrest-batch-insert-union-of-keys\` — recurring failure mode where heterogeneous .insert([...]) silently NULLs missing keys.
- **Diff**: 5 of 6 draft rows lacked \`publish_attempts\` / \`last_publish_error\` / \`published_at\` / \`scheduled_at\`. PostgREST emitted NULL for those keys.
- **Fix**: extract a \`draftRow(overrides)\` builder that sets every column with an explicit default, then have each row spread overrides on top.

## Risks identified and mitigated
- **Default drift**: the builder pins defaults that match the DB-level defaults. If a column gets a new default in a future migration, this seed continues to behave the same — desirable since UAT seeds need to be deterministic.
- **Type coverage**: overrides are typed as \`Record<string, unknown>\` which loses field-level checks. Acceptable for a seed script; the alternative is duplicating the column-shape type per row, which is what created the bug.

## Test plan
- [x] Manual run against staging Supabase: \`SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... npx tsx scripts/seed-uat-staging.ts\` → 6 drafts inserted, exit 0.
- [ ] UAT harness picks up the new published / failed rows next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)