### PR TITLE
docs(inventory): triage plan for DI-001 through DI-010

### DIFF
--- a/docs/inventory/decisions-needed.md
+++ b/docs/inventory/decisions-needed.md
@@ -1,0 +1,149 @@
+# Decisions Needed
+
+Decisions that must be made before the corresponding fix ships.
+Each entry is a product or architectural choice — not a bug with an obvious correct answer.
+
+---
+
+## DECISION-001: What should the `user` Opollo role be allowed to do?
+
+**Context:**
+`lib/auth.ts:41` declares `Role = "super_admin" | "admin" | "user"`. The migration 0057
+comment (lines 35–40) shows this was created by mapping legacy `viewer` rows to `user`,
+but no admin surface checks for `user` and no route grants it. A staff member with
+`role='user'` silently redirects to `/` from every page.
+
+**Options:**
+- A) **Remove the role** — drop `"user"` from the TypeScript union and add a migration
+  removing it from the DB CHECK constraint. Any existing `opollo_users` rows with
+  `role='user'` need to be promoted to `admin` or soft-deleted.
+- B) **Define read-only surfaces for `user`** — specify which `/admin/*` sub-pages a
+  `user`-role staff member can view (e.g. read-only site list, read-only company list),
+  update `checkAdminAccess()` accordingly, and add those gates.
+- C) **Status quo** — document that `user` is a reserved future role, no behaviour change.
+
+**Impact if deferred:**
+Any `opollo_users` row accidentally set to `role='user'` is locked out of all admin
+surfaces with no explanation. Low probability but confusing when it occurs.
+
+**Files involved:**
+- `lib/auth.ts:41`
+- `lib/admin-gate.ts:55`
+- `supabase/migrations/` (new migration required for Option A)
+
+---
+
+## DECISION-002: Should bulk CSV always import as draft, or match the caller's role?
+
+**Context:**
+`app/api/platform/social/drafts/bulk/route.ts:102` hard-codes `state: "scheduled"` and
+`approval_required: false`. An `editor`-role user (who lacks `schedule_post`) can upload
+a CSV and bypass the approval workflow (DI-003, P0).
+
+**Options:**
+- A) **Force draft state** — all bulk imports create `state='draft'` posts. Approvers
+  then review and schedule them. Clean, safe, no role check needed in the bulk handler.
+- B) **Role-gated state** — check `schedule_post` permission at insert time. If the
+  caller has `schedule_post`, allow `state='scheduled'`. If not, fall back to `draft`.
+  Preserves existing behaviour for approver+ callers.
+
+**Impact if deferred:**
+P0 permission bypass is live. Any editor with CSV access can schedule posts without
+approval. Must be resolved before next release.
+
+**Files involved:**
+- `app/api/platform/social/drafts/bulk/route.ts:95-111`
+
+---
+
+## DECISION-003: Are V1 (`social_post_master`) and V2 (`social_post_drafts`) permanently parallel, or is V1 being retired?
+
+**Context:**
+Two post data models coexist with incompatible state enums (DI-006, P1):
+- V1 (`social_post_master`) — states: `draft`, `pending_client_approval`, `approved`,
+  `rejected`, `changes_requested`, `scheduled`, `publishing`, `published`, `failed`
+- V2 (`social_post_drafts`) — states: `draft`, `pending_approval`, `rejected`,
+  `scheduled`, `recurring`, `paused`, `publishing`, `published`, `failed`
+
+V1 states `pending_client_approval`, `approved`, and `changes_requested` have no V2
+equivalents. V2 states `recurring` and `paused` have no V1 equivalents.
+
+**Options:**
+- A) **Permanently parallel** — V1 lives in `/company/social/posts/[id]` (old tabbed
+  view); V2 lives in the composer + calendar. Document the boundary explicitly. Ensure
+  no UI surface renders V1 posts through V2 state logic.
+- B) **Migrate V1 to V2** — define a state mapping (`pending_client_approval →
+  pending_approval`, `changes_requested → rejected`, `approved → scheduled`), write
+  a data migration, retire V1 tables.
+- C) **Hybrid** — new posts are V2 only; V1 posts are read-only legacy records.
+
+**Impact if deferred:**
+V1 posts in states `pending_client_approval` or `changes_requested` rendered by the V2
+composer will have no matching entry in `ALLOWED_ACTIONS` and may render incorrectly.
+If the calendar or composer ever loads V1 post IDs, the state machine logic will be
+wrong.
+
+**Files involved:**
+- `lib/platform/social/posts/types.ts:5-14`
+- `lib/social/post-state-actions.ts:20-29`
+- `supabase/migrations/0070_platform_foundation.sql` (V1 schema)
+- `supabase/migrations/` (new migration for Option B)
+
+---
+
+## DECISION-004: Should Opollo staff retain implicit write access to customer companies?
+
+**Context:**
+`lib/platform/auth/current-user.ts:112-133` — `resolveStaffCookieCompany()` returns a
+synthetic `{ role: "admin" }` membership for any Opollo staff member who sets the
+selected-company cookie. This grants full write access to the customer's data with no
+audit log (DI-007, P1).
+
+**Options:**
+- A) **Status quo + audit log** — keep implicit admin grant, add a
+  `service_access_log` table write when staff access is resolved. Low friction for
+  staff; adds audit trail.
+- B) **Restrict to `viewer` by default** — implicit grant becomes `viewer`. Staff who
+  need write access must be explicitly added via `platform_company_users`. Requires
+  checking which write operations Opollo staff legitimately need.
+- C) **Restrict to `viewer` + elevated-access request** — staff can request temporary
+  `admin` elevation via a confirmation step that is audit-logged.
+
+**Impact if deferred:**
+Opollo staff mutations in customer companies are indistinguishable from customer-admin
+mutations. No customer visibility. Compliance risk if any customer ever requests an
+audit of their account activity.
+
+**Files involved:**
+- `lib/platform/auth/current-user.ts:112-133`
+- New `service_access_log` table (migration required for Options A/C)
+
+---
+
+## DECISION-005: Are review links intended for external (non-Opollo-account) approvers?
+
+**Context:**
+The `/review/[token]` page is secured by a JWT (DI-009, P1). However, the form
+(`ReviewDecisionForm`) submits to `POST /api/platform/social/drafts/[id]/approve`, which
+requires a Supabase session cookie. External approvers who do not have an Opollo account
+will receive a 401 on form submit — the page looks correct but decisions fail silently.
+
+**Options:**
+- A) **Review links are internal-only** — document that review links only work for
+  users who have an Opollo account and a session. The JWT is for convenience (no login
+  required to *view* the post), but approvals require login. Add an explicit "Please log
+  in to approve" message for unauthenticated visitors.
+- B) **Review links are for external approvers** — fix the approve endpoint to accept
+  the review JWT as authentication in addition to the session cookie. This requires a
+  new public endpoint variant that verifies the JWT and records the decision without a
+  session.
+
+**Impact if deferred:**
+Any customer who sends a review link to an external approver (e.g. a client contact
+without an Opollo account) will find that the approval button silently fails. The post
+stays in `pending_approval` indefinitely.
+
+**Files involved:**
+- `app/(public)/review/[token]/page.tsx`
+- `components/social/review/ReviewDecisionForm.tsx:36`
+- `app/api/platform/social/drafts/[id]/approve/route.ts:48`

--- a/docs/inventory/triage-plan-2026-05-27.md
+++ b/docs/inventory/triage-plan-2026-05-27.md
@@ -1,0 +1,172 @@
+# Inventory Triage Plan — 2026-05-27
+
+All findings verified by reading actual source files and tracing code paths.
+GitHub issue numbers reference issues opened against this repo.
+
+---
+
+## Summary
+
+| ID | Title | Confirmed | Severity | Complexity | GitHub Issue |
+|---|---|---|---|---|---|
+| DI-001 | `user` role declared but never granted or enforced | ✅ Confirmed | P2 | S | #1073 |
+| DI-002 | `/company/social/connections/connect/[platform]` is a stub redirect | ✅ Confirmed | P1 | S | #1074 |
+| DI-003 | Bulk CSV upload does not verify `schedule_post` permission | ✅ Confirmed | P0 | S | #1075 |
+| DI-004 | Missing `loading.tsx` on 97 of 100 page routes | ✅ Confirmed | P2 | M | #1076 |
+| DI-005 | `CLAUDE-ASSUMPTION` comment in production code | ✅ Confirmed | P2 | S | #1077 |
+| DI-006 | V1 (`social_post_master`) and V2 (`social_post_drafts`) coexist with incompatible state enums | ✅ Confirmed | P1 | L | #1078 |
+| DI-007 | Implicit Opollo staff admin grant is not audit-logged | ✅ Confirmed | P1 | S–M | #1079 |
+| DI-008 | CAP `cap_campaign_posts` state machine has no UI affordances | ✅ Confirmed | P2 | M | #1080 |
+| DI-009 | Review token revocation undocumented; V2 review endpoint uses session auth, not JWT | ✅ Confirmed (plus new finding) | P1 | S–M | #1081 |
+| DI-010 | `ApprovalToggle` + PATCH `/drafts/[id]` lets editor disable approval requirement | ✅ Confirmed | P1 | S | #1082 |
+
+No false positives. All 10 findings are real.
+
+---
+
+## Verification notes (per issue)
+
+### DI-001
+
+`lib/auth.ts:41` declares `Role = "super_admin" | "admin" | "user"`. Comment at lines 35–40
+describes migration 0057 which maps legacy `viewer→user`, but `lib/admin-gate.ts:55` has
+`ADMIN_ROLES = ["super_admin", "admin"]` — `user` is excluded. No route grants this role,
+no route requires it. An `opollo_users` row with `role='user'` silently redirects to `/`.
+
+### DI-002
+
+`app/(platform)/company/social/connections/connect/[platform]/page.tsx:1-8` — the entire
+file is a single `redirect("/company/social/connections")`. No flash, no message, no
+explanation. The `CLAUDE-ASSUMPTION` comment is on line 2.
+
+### DI-003
+
+`app/api/platform/social/drafts/bulk/route.ts:31` — gate checks `create_post` only.
+Lines 95–111 — every row in `draftsToInsert` hard-codes `state: "scheduled" as const`
+and `approval_required: false`. `lib/platform/auth/permissions.ts:33` — `schedule_post`
+requires `approver` minimum. An `editor`-role user uploading a CSV bypasses both the
+schedule gate and the approval workflow.
+
+### DI-004
+
+Glob `app/**/loading.tsx` returns exactly 2 files:
+- `app/(platform)/company/social/analytics/loading.tsx`
+- `app/(platform)/social/poster/loading.tsx`
+
+All other ~100 routes lack a colocated `loading.tsx`.
+
+### DI-005
+
+`app/(platform)/company/social/connections/connect/[platform]/page.tsx:2` contains
+`// CLAUDE-ASSUMPTION (PR 1.1): ...`. Confirmed present in production code. Bundled
+with DI-002 — resolved when DI-002 is addressed.
+
+### DI-006
+
+`lib/platform/social/posts/types.ts:5-14` — V1 `SocialPostState` includes
+`pending_client_approval`, `approved`, `changes_requested`.
+`lib/social/post-state-actions.ts:20-29` — V2 `PostState` has `pending_approval`,
+`recurring`, `paused` but no `pending_client_approval`, `approved`, or `changes_requested`.
+The two enums are genuinely incompatible. Additionally, `pending_msp_release` appears in
+migrations `0097_lock_out_pending_msp_release.sql` and `0070_platform_foundation.sql` but
+is absent from both type enums — a third data model fragment.
+
+### DI-007
+
+`lib/platform/auth/current-user.ts:112-133` — `resolveStaffCookieCompany()` returns
+`{ companyId: selectedId, role: "admin" }` with no log write, no audit table insert,
+no notification. The staff user ID will appear in `created_by`/`updated_by` columns but
+there is no surface that flags these writes as staff access.
+
+### DI-008
+
+`supabase/migrations/0137_cap_phase_1_schema.sql:261` — 8 `cap_campaign_posts.status`
+values: `pending`, `generated`, `approved`, `rejected`, `pushed`, `published`, `failed`,
+`approved_past_due`. No retry button for `failed` posts and no cancel button for
+`pending`/`pushed` posts found in any component. This is a known Phase 1 gap.
+
+### DI-009 — extended finding
+
+The issue is confirmed plus an additional defect was found during verification:
+
+The `/review/[token]` JWT page renders `ReviewDecisionForm` (line 105 of the page
+component). `ReviewDecisionForm` calls `POST /api/platform/social/drafts/[id]/approve`
+(`components/social/review/ReviewDecisionForm.tsx:36`). That endpoint calls
+`requireCanDoForApi()` (`app/api/platform/social/drafts/[id]/approve/route.ts:48`), which
+requires a Supabase session cookie.
+
+**External reviewers who do not have an Opollo account have no session cookie.** Their
+form submission will receive a 401 UNAUTHORIZED. The JWT-based review link works for
+rendering the page content, but the decision action is session-gated and will silently
+fail for external reviewers.
+
+The state guard at line 44 (`if ((draft.state as string) !== "pending_approval")`) is
+correctly enforced — this is a partial mitigation. The token revocation concern in the
+original DI-009 is valid but secondary to the broken external-approver flow.
+
+### DI-010
+
+`app/api/platform/social/drafts/[id]/route.ts:140` — PATCH requires only `edit_post`.
+`V2SaveBodySchema` at line 105 accepts `approval_required: z.boolean().default(false)`.
+Line 232 writes `approval_required` directly to the DB. No secondary `schedule_post`
+gate exists. An `editor` can set `approval_required=false` and subsequently schedule
+the post without approval.
+
+---
+
+## P0 Fix Sketches
+
+### DI-003 — Bulk CSV bypasses `schedule_post` permission
+
+**Working analog:** `app/api/platform/social/drafts/route.ts:84` — V2 POST uses
+`requireCanDoForApi(companyId, "create_post")` for the create gate; state is set
+conditionally based on `input.approval_required`.
+
+**Diff:** The bulk route hard-codes `state: "scheduled"` and `approval_required: false`
+regardless of the caller's role.
+
+**Fix (two equivalent options):**
+
+Option A — Force all bulk imports to `draft` state (recommended):
+- `app/api/platform/social/drafts/bulk/route.ts:102` — change `state: "scheduled" as const` to `state: "draft" as const`
+- `app/api/platform/social/drafts/bulk/route.ts:108` — remove `approval_required: false` (or set to company default)
+
+Option B — Add second permission gate before insert:
+```typescript
+// After line 75 (batchId assignment), before draftsToInsert:
+const canSchedule = await requireCanDoForApi(companyId, "schedule_post");
+const bulkState = canSchedule.kind === "allow" ? "scheduled" : "draft";
+```
+Then use `bulkState` instead of `"scheduled"` on line 102.
+
+Option A is preferred: bulk upload is an editorial tool, not a scheduling tool. Editors
+import as drafts; approvers schedule them. Option B is a backward-compatibility shim if
+some existing integration depends on bulk CSV creating scheduled posts.
+
+**Decision needed:** Steven must choose Option A (always draft) or Option B (role-dependent state). Option A is the safe default.
+
+---
+
+## Recommended Fix Order
+
+1. **DI-003** (P0, S) — Bulk CSV permission bypass. Fix in one PR, < 1 day. Regression test already scaffolded in `tests/regressions/bulk-csv-requires-schedule-permission.test.ts` on `docs/feature-inventory-phase-1`.
+2. **DI-010** (P1, S) — ApprovalToggle permission gap. Fix alongside or immediately after DI-003 — same domain, same day.
+3. **DI-009** (P1, S) — Review token flow broken for external approvers. Fix is small: the approve route needs a public JWT-verified path in addition to the session-gated path, or the review page needs to pass the review JWT as a bearer token.
+4. **DI-007** (P1, S–M) — Staff access audit log. Add `service_access_log` write in `resolveStaffCookieCompany`. Decision on read-only restriction is separate.
+5. **DI-002 + DI-005** (P1 + P2, S) — Bundle: fix the stub redirect to show a message, remove `CLAUDE-ASSUMPTION` comment.
+6. **DI-006** (P1, L) — V1/V2 state enum incompatibility. Architectural decision required first.
+7. **DI-001** (P2, S) — `user` role dead code. Decision required first.
+8. **DI-004** (P2, M) — `loading.tsx` gaps. Incremental; start with top 10 routes.
+9. **DI-008** (P2, M) — CAP state machine UI. Phase 2 CAP backlog item.
+
+---
+
+## Decisions Needed Before Any Fix Ships
+
+- **DI-001:** Steven must decide whether `user` is a future role (document its intended surfaces) or dead code (remove + migration).
+- **DI-003:** Steven must confirm Option A (all bulk imports become `draft`) vs Option B (role-dependent bulk state). See §"P0 Fix Sketches".
+- **DI-006:** Steven must define the migration path from V1 (`social_post_master`) to V2 (`social_post_drafts`) or confirm they remain permanently parallel systems with separate UI surfaces.
+- **DI-007:** Steven must decide whether Opollo staff should retain write access via implicit grant, or be restricted to read-only with explicit membership required for writes.
+- **DI-009:** Steven must decide whether the review link is intended for external (non-Opollo-account) approvers. If yes, the approve endpoint needs a public JWT path. If no, the review link is internal-only and docs need to say so.
+
+See `docs/inventory/decisions-needed.md` for full option analysis.


### PR DESCRIPTION
## Summary

- 10 discovered issues from `docs/inventory/discovered-issues.md` verified by code-path tracing (all confirmed, no false positives)
- GitHub issues #1073–#1082 opened (one per finding)
- P0 fix sketch for DI-003 (bulk CSV schedule bypass) documented with exact file:line changes
- 5 product decisions identified that must be made before fixes ship

## Files added

- `docs/inventory/triage-plan-2026-05-27.md` — severity/complexity matrix, per-issue verification notes, P0 fix sketches, recommended fix order
- `docs/inventory/decisions-needed.md` — 5 decisions with options, impact, and file citations

## Key findings

| Severity | Issues |
|---|---|
| P0 (fix immediately) | DI-003: bulk CSV bypasses `schedule_post` permission |
| P1 (fix soon) | DI-002, DI-006, DI-007, DI-009, DI-010 |
| P2 (backlog) | DI-001, DI-004, DI-005, DI-008 |

**DI-009 extended finding:** The `/review/[token]` JWT page calls `POST /api/platform/social/drafts/[id]/approve` which requires a Supabase session. External approvers without an Opollo account receive a silent 401 — the page renders correctly but decisions fail. This is a separate defect from the original revocation concern.

## Pre-PR checklist

- [x] No code changes — documentation only
- [x] Every claim has a file:line citation
- [x] Product decisions (where Steven must choose HOW something behaves) are in decisions-needed.md
- [x] Bug fixes with obvious correct behaviour (DI-003, DI-010) have fix sketches, not decision items

## Risks identified and mitigated

No code changes in this PR. No write-safety concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)