### PR TITLE
feat(platform): opollo staff full access + audit log + cross-tenant invite block

### DIFF
--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -45,6 +45,7 @@ When a session starts a migration, reserve the number here before writing the fi
 - ~~0073 — S1-10 cancel_post_approval transactional function.~~ Shipped (0073_cancel_post_approval_fn.sql in main).
 - ~~0112 — Session A — Spec 22 PR 1 social_post_drafts table (branch: feat/spec22-pr1-composer-shell).~~ Shipped in #789.
 - ~~0113 — Session A — Spec 22 PR 2 social-media-uploads storage bucket (branch: feat/spec22-pr2-core-editor).~~ Shipped.
+- 0153 — FIX-1 — platform_staff_audit_log (branch: feat/fix1-staff-access-audit-log)
 
 ## Claim block template
 

--- a/docs/inventory/decisions-locked.md
+++ b/docs/inventory/decisions-locked.md
@@ -1,0 +1,78 @@
+# Product decisions — locked
+
+Decisions locked as of 2026-05-27. These are canonical product decisions
+that resolve previously-open questions in `docs/inventory/`. Each
+decision is the authoritative answer for any dependent code change in
+this workstream. Do not re-open without a new explicit signal from Steven.
+
+---
+
+## D1 — Platform access model
+
+- Opollo staff (`@opollo.com` email domain) have full platform access
+  across ALL customer companies via `is_opollo_staff = true` on
+  `platform_users`. RLS policies grant them read/write bypass.
+- Every staff write action is audit-logged (minimum fields: see D4).
+- Customer users are scoped to ONE company per account. The
+  `UNIQUE (user_id)` constraint on `platform_company_users` enforces
+  this at the DB level; `sendInvitation` enforces it at the application
+  level via `ACTIVE_MEMBERSHIP_EXISTS` for non-staff invitees.
+- A user at `rodin.com` only ever sees `rodin.com` data. They cannot
+  be cross-tenant invited; they would need a separate account.
+- Customer admins can invite users within their own company.
+- Opollo staff can invite users into any customer company (e.g. for
+  client onboarding) — checked at the API layer via
+  `requireCanDoForApi(..., 'manage_invitations')` which is OR'd with
+  `is_opollo_staff()` in RLS.
+- Feature gating: Opollo staff toggle per-customer OR customer
+  subscription unlocks features (separate feature-flag workstream).
+- User removal: HARD DELETE. Email is free to reuse afterward. (FIX-2)
+
+## D2 — Bulk CSV permissions
+
+- Bulk CSV upload requires `schedule_post` permission (admin/manager).
+  Editors cannot use bulk CSV.
+- **Already shipped** in PR #1084. No further action.
+
+## D3 — V1→V2 post model migration
+
+- Sunset V1 (`social_post_master`, `social_post_variant`,
+  `social_schedule_entries`). Migrate all functionality to V2
+  (`social_post_drafts`).
+- Separate dedicated workstream — Steven fires a scoping prompt.
+- **Not in scope for the FIX-1–FIX-5 workstream.**
+
+## D4 — Staff audit log fields
+
+Minimum fields for `platform_staff_audit_log`:
+
+| Field | Type | Note |
+|-------|------|------|
+| `timestamp` | `TIMESTAMPTZ` | UTC, NOT NULL, DEFAULT now() |
+| `staff_user_id` | `UUID` | FK → platform_users |
+| `staff_email` | `TEXT` | Denormalised for readability |
+| `company_id` | `UUID` | FK → platform_companies (nullable — global actions) |
+| `company_name` | `TEXT` | Denormalised for readability |
+| `action` | `TEXT` | e.g. `invite.sent`, `user.removed`, `staff_grant.auto` |
+| `resource_id` | `TEXT` | Affected row UUID |
+| `ip_address` | `TEXT` | Captured from request headers |
+
+Explicitly excluded:
+- No before/after data diff
+- No read-action logging
+- No mandatory reason field
+- No customer email notification per action
+
+## D5 — External approver authentication
+
+- Magic-link token in the review URL IS the auth credential for
+  external approvers.
+- Approvers with existing Opollo accounts can also log in to access
+  the same review.
+- Email channel is treated as trusted.
+- Token validation requirements:
+  - Cryptographically signed
+  - Expires after 7 days OR when the post publishes (whichever first)
+  - One-time use for the final Approve/Reject submission
+- Approver identity captured from the email the link was originally
+  sent to.

--- a/lib/platform/invitations/accept.ts
+++ b/lib/platform/invitations/accept.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { logger } from "@/lib/logger";
+import { logStaffAction } from "@/lib/platform/staff-audit";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 import { hashToken } from "./tokens";
@@ -165,13 +166,15 @@ export async function acceptInvitation(
   // with a valid password, just not yet in platform_users). Logged
   // explicitly so an operator can clean up if needed.
 
+  const isOpolloStaff = trimmedEmail.endsWith("@opollo.com");
+
   const userInsert = await svc
     .from("platform_users")
     .insert({
       id: userId,
       email: trimmedEmail,
       full_name: input.fullName.trim(),
-      is_opollo_staff: false,
+      is_opollo_staff: isOpolloStaff,
     })
     .select("id")
     .single();
@@ -208,6 +211,17 @@ export async function acceptInvitation(
     return internal(
       `platform_company_users insert failed: ${membershipInsert.error.message}`,
     );
+  }
+
+  // Audit: log the implicit staff grant for @opollo.com accounts (D1 + D4).
+  if (isOpolloStaff) {
+    await logStaffAction({
+      staffUserId: userId,
+      staffEmail: trimmedEmail,
+      companyId: invitation.company_id,
+      action: "staff_grant.auto",
+      resourceId: userId,
+    });
   }
 
   const acceptUpdate = await svc

--- a/lib/platform/invitations/send.ts
+++ b/lib/platform/invitations/send.ts
@@ -66,28 +66,33 @@ export async function sendInvitation(
     return internal(`User lookup failed: ${userCheck.error.message}`);
   }
   if (userCheck.data) {
-    const membershipCheck = await svc
-      .from("platform_company_users")
-      .select("company_id")
-      .eq("user_id", userCheck.data.id)
-      .limit(1);
-    if (membershipCheck.error) {
-      logger.error("invitations.send.membership_lookup_failed", {
-        err: membershipCheck.error.message,
-      });
-      return internal(
-        `Membership lookup failed: ${membershipCheck.error.message}`,
-      );
-    }
-    if ((membershipCheck.data?.length ?? 0) > 0) {
-      return {
-        ok: false,
-        error: {
-          code: "ACTIVE_MEMBERSHIP_EXISTS",
-          message:
-            "This email is already a member of a company on the platform.",
-        },
-      };
+    // Opollo staff (@opollo.com) have platform-wide access via is_opollo_staff
+    // and may belong to multiple companies. Skip the cross-tenant check for
+    // them. Non-staff are limited to one company per account (D1).
+    if (!email.endsWith("@opollo.com")) {
+      const membershipCheck = await svc
+        .from("platform_company_users")
+        .select("company_id")
+        .eq("user_id", userCheck.data.id)
+        .limit(1);
+      if (membershipCheck.error) {
+        logger.error("invitations.send.membership_lookup_failed", {
+          err: membershipCheck.error.message,
+        });
+        return internal(
+          `Membership lookup failed: ${membershipCheck.error.message}`,
+        );
+      }
+      if ((membershipCheck.data?.length ?? 0) > 0) {
+        return {
+          ok: false,
+          error: {
+            code: "ACTIVE_MEMBERSHIP_EXISTS",
+            message:
+              "This email is already a member of a company on the platform.",
+          },
+        };
+      }
     }
   }
 

--- a/lib/platform/staff-audit.ts
+++ b/lib/platform/staff-audit.ts
@@ -1,0 +1,39 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+export interface StaffAuditParams {
+  staffUserId: string;
+  staffEmail: string;
+  companyId?: string | null;
+  companyName?: string | null;
+  action: string;
+  resourceId?: string | null;
+  ipAddress?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+// Writes one row to platform_staff_audit_log. Never throws — a write failure
+// is logged but must not abort the parent operation (audit is best-effort
+// from the caller's perspective; the parent action already succeeded).
+export async function logStaffAction(params: StaffAuditParams): Promise<void> {
+  const svc = getServiceRoleClient();
+  const { error } = await svc.from("platform_staff_audit_log").insert({
+    staff_user_id: params.staffUserId,
+    staff_email: params.staffEmail,
+    company_id: params.companyId ?? null,
+    company_name: params.companyName ?? null,
+    action: params.action,
+    resource_id: params.resourceId ?? null,
+    ip_address: params.ipAddress ?? null,
+    metadata: params.metadata ?? {},
+  });
+  if (error) {
+    logger.error("staff_audit.write_failed", {
+      action: params.action,
+      staff_user_id: params.staffUserId,
+      err: error.message,
+    });
+  }
+}

--- a/supabase/migrations/0153_platform_staff_audit_log.sql
+++ b/supabase/migrations/0153_platform_staff_audit_log.sql
@@ -1,0 +1,36 @@
+-- 0153 — platform_staff_audit_log
+--
+-- Implements D4 from docs/inventory/decisions-locked.md.
+-- Append-only audit log for Opollo staff write actions against
+-- customer companies. Minimum fields per locked decision:
+-- timestamp, staff identity, company identity, action, resource ID,
+-- IP address. No before/after diffs; no read logging.
+--
+-- Forward-only. lib/platform/staff-audit.ts is the write path.
+
+CREATE TABLE platform_staff_audit_log (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  timestamp     TIMESTAMPTZ NOT NULL    DEFAULT now(),
+  staff_user_id UUID        NOT NULL    REFERENCES platform_users(id)    ON DELETE SET NULL,
+  staff_email   TEXT        NOT NULL,
+  company_id    UUID                    REFERENCES platform_companies(id) ON DELETE SET NULL,
+  company_name  TEXT,
+  action        TEXT        NOT NULL,
+  resource_id   TEXT,
+  ip_address    TEXT,
+  metadata      JSONB       NOT NULL    DEFAULT '{}'::jsonb,
+  created_at    TIMESTAMPTZ NOT NULL    DEFAULT now()
+);
+
+-- Fast lookups by staff user (compliance queries) and by company (per-company review).
+CREATE INDEX idx_staff_audit_log_staff   ON platform_staff_audit_log (staff_user_id, timestamp DESC);
+CREATE INDEX idx_staff_audit_log_company ON platform_staff_audit_log (company_id, timestamp DESC)
+  WHERE company_id IS NOT NULL;
+CREATE INDEX idx_staff_audit_log_time    ON platform_staff_audit_log (timestamp DESC);
+
+-- RLS: only Opollo staff can read; writes are service-role only (no
+-- user-facing INSERT/UPDATE/DELETE policies).
+ALTER TABLE platform_staff_audit_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY staff_audit_log_staff_read ON platform_staff_audit_log
+  FOR SELECT USING (is_opollo_staff());

--- a/tests/regressions/staff-email-auto-grant.test.ts
+++ b/tests/regressions/staff-email-auto-grant.test.ts
@@ -1,0 +1,378 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// FIX-1 / D1 — Opollo staff (@opollo.com) auto-grant regression tests.
+//
+// Invariants:
+//   1. acceptInvitation sets is_opollo_staff=true for @opollo.com invitees.
+//   2. acceptInvitation sets is_opollo_staff=false for non-@opollo.com invitees.
+//   3. acceptInvitation writes a staff_grant.auto audit row for @opollo.com.
+//   4. sendInvitation bypasses ACTIVE_MEMBERSHIP_EXISTS for @opollo.com invitees.
+//   5. sendInvitation still blocks ACTIVE_MEMBERSHIP_EXISTS for non-@opollo.com.
+//
+// Layer 1 — unit, mocked Supabase. No real DB needed.
+// ---------------------------------------------------------------------------
+
+const COMPANY_A = "aaaaaaaa-0000-0000-0000-000000000001";
+const USER_STAFF = "cccccccc-0000-0000-0000-000000000001";
+const USER_CUSTOMER = "dddddddd-0000-0000-0000-000000000001";
+const INVITATION_ID = "eeeeeeee-0000-0000-0000-000000000001";
+
+// Capture what platform_users.insert is called with.
+const platformUserInserts: Array<Record<string, unknown>> = [];
+// Capture what platform_staff_audit_log.insert is called with.
+const auditLogInserts: Array<Record<string, unknown>> = [];
+
+// Build a fake Supabase service role client that intercepts calls by table.
+function makeSupabaseMock({
+  invitationData,
+  authUserId,
+  membershipRows,
+  platformUserExists,
+}: {
+  invitationData: Record<string, unknown>;
+  authUserId: string;
+  membershipRows: Array<{ company_id: string }>;
+  platformUserExists: boolean;
+}) {
+  const tableHandlers: Record<string, unknown> = {
+    platform_invitations: {
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({ data: invitationData, error: null }),
+        }),
+      }),
+      update: () => ({
+        eq: async () => ({ error: null }),
+      }),
+    },
+    platform_users: {
+      insert: (row: Record<string, unknown>) => {
+        platformUserInserts.push(row);
+        return {
+          select: () => ({
+            single: async () => ({ data: { id: authUserId }, error: null }),
+          }),
+        };
+      },
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () =>
+            platformUserExists
+              ? { data: { id: authUserId }, error: null }
+              : { data: null, error: null },
+        }),
+      }),
+    },
+    platform_company_users: {
+      insert: () => ({
+        select: () => ({
+          single: async () => ({ data: { id: "membership-id" }, error: null }),
+        }),
+      }),
+      select: () => ({
+        eq: (field: string, _val: unknown) => ({
+          eq: () => ({
+            limit: async () => ({ data: membershipRows, error: null }),
+          }),
+          limit: async () => ({ data: membershipRows, error: null }),
+        }),
+      }),
+    },
+    platform_staff_audit_log: {
+      insert: (row: Record<string, unknown>) => {
+        auditLogInserts.push(row);
+        return { error: null };
+      },
+    },
+    platform_invitations_send: {
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }),
+          }),
+        }),
+      }),
+    },
+  };
+
+  return {
+    from: (table: string) => tableHandlers[table] ?? {},
+    auth: {
+      admin: {
+        createUser: async () => ({
+          data: { user: { id: authUserId } },
+          error: null,
+        }),
+      },
+    },
+  };
+}
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Module-level mock — replaced per-test via vi.mocked().
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+
+const baseInvitation = {
+  id: INVITATION_ID,
+  company_id: COMPANY_A,
+  role: "admin",
+  status: "pending",
+  expires_at: new Date(Date.now() + 86400_000).toISOString(),
+  invited_by: "inviter-id",
+  accepted_at: null,
+  accepted_user_id: null,
+  revoked_at: null,
+  reminder_sent_at: null,
+  expired_notified_at: null,
+  created_at: new Date().toISOString(),
+};
+
+function makeInput(email: string) {
+  return {
+    rawToken: "a".repeat(32),
+    email,
+    fullName: "Test User",
+    password: "Password123!",
+  };
+}
+
+beforeEach(() => {
+  platformUserInserts.length = 0;
+  auditLogInserts.length = 0;
+});
+
+afterEach(() => vi.clearAllMocks());
+
+// ---------------------------------------------------------------------------
+// Accept-path tests (acceptInvitation)
+// ---------------------------------------------------------------------------
+
+describe("acceptInvitation — is_opollo_staff detection", () => {
+  it("sets is_opollo_staff=true for @opollo.com email", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSupabaseMock({
+        invitationData: { ...baseInvitation, email: "alice@opollo.com" },
+        authUserId: USER_STAFF,
+        membershipRows: [],
+        platformUserExists: false,
+      }) as never,
+    );
+
+    const { acceptInvitation, hashToken } = await import("@/lib/platform/invitations");
+    // The token hash must match what the mock returns — mock always returns
+    // invitationData regardless of hash, so any 32-char token works.
+    const input = makeInput("alice@opollo.com");
+    const result = await acceptInvitation(input);
+    expect(result.ok).toBe(true);
+    expect(platformUserInserts).toHaveLength(1);
+    expect(platformUserInserts[0]).toMatchObject({ is_opollo_staff: true });
+  });
+
+  it("sets is_opollo_staff=false for non-@opollo.com email", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSupabaseMock({
+        invitationData: { ...baseInvitation, email: "bob@customer.com" },
+        authUserId: USER_CUSTOMER,
+        membershipRows: [],
+        platformUserExists: false,
+      }) as never,
+    );
+
+    const { acceptInvitation } = await import("@/lib/platform/invitations");
+    const result = await acceptInvitation(makeInput("bob@customer.com"));
+    expect(result.ok).toBe(true);
+    expect(platformUserInserts).toHaveLength(1);
+    expect(platformUserInserts[0]).toMatchObject({ is_opollo_staff: false });
+  });
+
+  it("writes staff_grant.auto audit row for @opollo.com acceptance", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSupabaseMock({
+        invitationData: { ...baseInvitation, email: "alice@opollo.com" },
+        authUserId: USER_STAFF,
+        membershipRows: [],
+        platformUserExists: false,
+      }) as never,
+    );
+
+    const { acceptInvitation } = await import("@/lib/platform/invitations");
+    const result = await acceptInvitation(makeInput("alice@opollo.com"));
+    expect(result.ok).toBe(true);
+    const auditRow = auditLogInserts.find((r) => r.action === "staff_grant.auto");
+    expect(auditRow).toBeDefined();
+    expect(auditRow?.staff_email).toBe("alice@opollo.com");
+    expect(auditRow?.company_id).toBe(COMPANY_A);
+  });
+
+  it("does NOT write staff_grant.auto audit row for non-staff acceptance", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSupabaseMock({
+        invitationData: { ...baseInvitation, email: "bob@customer.com" },
+        authUserId: USER_CUSTOMER,
+        membershipRows: [],
+        platformUserExists: false,
+      }) as never,
+    );
+
+    const { acceptInvitation } = await import("@/lib/platform/invitations");
+    const result = await acceptInvitation(makeInput("bob@customer.com"));
+    expect(result.ok).toBe(true);
+    const auditRow = auditLogInserts.find((r) => r.action === "staff_grant.auto");
+    expect(auditRow).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Send-path tests (sendInvitation cross-tenant enforcement)
+// ---------------------------------------------------------------------------
+
+// sendInvitation uses its own Supabase calls — we need a different mock
+// structure that handles the send flow.
+
+function makeSendMock({
+  existingUserId,
+  membershipRows,
+}: {
+  existingUserId: string | null;
+  membershipRows: Array<{ company_id: string }>;
+}) {
+  return {
+    from: (table: string) => {
+      if (table === "platform_users") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () =>
+                existingUserId
+                  ? { data: { id: existingUserId }, error: null }
+                  : { data: null, error: null },
+            }),
+          }),
+        };
+      }
+      if (table === "platform_company_users") {
+        return {
+          select: () => ({
+            eq: (_field: string, _val: unknown) => ({
+              limit: async () => ({ data: membershipRows, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === "platform_invitations") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                eq: () => ({
+                  maybeSingle: async () => ({ data: null, error: null }),
+                }),
+              }),
+            }),
+          }),
+          insert: () => ({
+            select: () => ({
+              single: async () => ({
+                data: {
+                  id: "inv-id",
+                  company_id: COMPANY_A,
+                  email: "test@test.com",
+                  role: "editor",
+                  status: "pending",
+                  expires_at: new Date(Date.now() + 86400_000).toISOString(),
+                  invited_by: "inviter-id",
+                  accepted_at: null,
+                  accepted_user_id: null,
+                  revoked_at: null,
+                  reminder_sent_at: null,
+                  expired_notified_at: null,
+                  created_at: new Date().toISOString(),
+                },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    },
+  };
+}
+
+describe("sendInvitation — cross-tenant enforcement (D1)", () => {
+  it("blocks non-@opollo.com invitee already in another company", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSendMock({
+        existingUserId: USER_CUSTOMER,
+        membershipRows: [{ company_id: "other-company-id" }],
+      }) as never,
+    );
+
+    const { sendInvitation } = await import("@/lib/platform/invitations");
+    const result = await sendInvitation({
+      companyId: COMPANY_A,
+      email: "bob@customer.com",
+      role: "editor",
+      invitedBy: "inviter-id",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("ACTIVE_MEMBERSHIP_EXISTS");
+    }
+  });
+
+  it("allows @opollo.com invitee already in another company (D1 staff exemption)", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSendMock({
+        existingUserId: USER_STAFF,
+        membershipRows: [{ company_id: "other-company-id" }],
+      }) as never,
+    );
+
+    const { sendInvitation } = await import("@/lib/platform/invitations");
+    const result = await sendInvitation({
+      companyId: COMPANY_A,
+      email: "alice@opollo.com",
+      role: "admin",
+      invitedBy: "inviter-id",
+    });
+    // Should not be blocked; may succeed or fail on insert (doesn't matter
+    // for this assertion — the key is ACTIVE_MEMBERSHIP_EXISTS is not raised).
+    if (!result.ok) {
+      expect(result.error.code).not.toBe("ACTIVE_MEMBERSHIP_EXISTS");
+    }
+  });
+
+  it("allows non-@opollo.com invitee with no existing company membership", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSendMock({
+        existingUserId: null,
+        membershipRows: [],
+      }) as never,
+    );
+
+    const { sendInvitation } = await import("@/lib/platform/invitations");
+    const result = await sendInvitation({
+      companyId: COMPANY_A,
+      email: "new@customer.com",
+      role: "viewer",
+      invitedBy: "inviter-id",
+    });
+    if (!result.ok) {
+      expect(result.error.code).not.toBe("ACTIVE_MEMBERSHIP_EXISTS");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **D1**: `@opollo.com` email on invite acceptance → `is_opollo_staff=true` auto-granted (was hardcoded `false`)
- **D1**: Non-staff invitees still blocked by `ACTIVE_MEMBERSHIP_EXISTS` when already in another company; `@opollo.com` invitees exempt (staff have global RLS access, may belong to multiple companies)
- **D4**: Migration 0153 adds `platform_staff_audit_log` table with minimum fields (timestamp, staff user ID + email, company, action, resource ID, IP address); RLS: staff-read-only, service-role-write
- **D4**: `logStaffAction()` helper in `lib/platform/staff-audit.ts` — best-effort write (never throws, logs on failure)
- **D4 + FIX-3 ground work**: `staff_grant.auto` audit row written on `@opollo.com` invite acceptance

## Working analog

**Working analog**: `lib/platform/invitations/send.ts:82–91` — existing `ACTIVE_MEMBERSHIP_EXISTS` guard; the new `@opollo.com` exemption wraps it with a domain check
**Diff**: `accept.ts` hardcoded `is_opollo_staff: false`; no audit infrastructure existed
**Fix**: Domain check on `trimmedEmail`; migration + helper to back the audit path

## Risks identified and mitigated

| Risk | Mitigation |
|------|-----------|
| `@opollo.com` domain check is a substring match | Uses `String.endsWith("@opollo.com")` — no subdomain confusion; must be exact suffix |
| logStaffAction write failure could surface to user | Swallowed + logged; audit writes are never on the request critical path |
| Migration 0153 lock | `CREATE TABLE` + 3 indexes + `ALTER TABLE` — no existing data touched; ACCESS EXCLUSIVE only during DDL; completes in <1s |
| Staff invited into a company gets a `platform_company_users` row | This is additive — staff already have global RLS access; having a role row is allowed per D1 |

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (113 files, 2459 tests, all pass)
- [x] Contract snapshots reviewed (no SDK calls touched)
- [x] Regression test added: `tests/regressions/staff-email-auto-grant.test.ts` (7 tests)
- [x] Migration 0153 reserved in `docs/WORK_IN_FLIGHT.md`
- [x] Decisions locked in `docs/inventory/decisions-locked.md`
- [x] PR is under 500 net lines

## Test plan

- [ ] Confirm CI green on all required status checks
- [ ] Post-merge: apply migration 0153 to staging (`supabase db push`)
- [ ] Verify `platform_staff_audit_log` table exists on staging
- [ ] Accept a test invitation for an `@opollo.com` email and verify `is_opollo_staff=true` + audit row written
- [ ] UAT harness: pass count must remain >= 42

🤖 Generated with [Claude Code](https://claude.com/claude-code)