### PR TITLE
feat(users): hard delete on company removal (D1)

### DIFF
--- a/app/api/platform/users/[userId]/route.ts
+++ b/app/api/platform/users/[userId]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { internalError, notFound, validationError } from "@/lib/http";
+import { logger } from "@/lib/logger";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// DELETE /api/platform/users/[userId] — D1 hard delete.
+//
+// Deletes auth.users entry for the given user, which cascades via FK to
+// platform_users (ON DELETE CASCADE) then platform_company_users.
+// Gate: caller must be an admin of the company the target user belongs to.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const UserIdSchema = z.string().uuid();
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { userId: string } },
+): Promise<NextResponse> {
+  const idParse = UserIdSchema.safeParse(params.userId);
+  if (!idParse.success) return validationError("userId must be a UUID.");
+  const userId = idParse.data;
+
+  const svc = getServiceRoleClient();
+
+  // Resolve which company this user belongs to (V1: one user, one company).
+  const membership = await svc
+    .from("platform_company_users")
+    .select("company_id")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (membership.error) {
+    logger.error("platform.users.delete.membership_lookup_failed", {
+      user_id: userId,
+      err: membership.error.message,
+    });
+    return internalError("Membership lookup failed.");
+  }
+  if (!membership.data) return notFound("No platform user with that id.");
+
+  const gate = await requireCanDoForApi(membership.data.company_id as string, "manage_users");
+  if (gate.kind === "deny") return gate.response;
+
+  // Hard delete via auth admin. Cascades: auth.users → platform_users →
+  // platform_company_users (both FK ON DELETE CASCADE).
+  const { error: deleteError } = await svc.auth.admin.deleteUser(userId);
+  if (deleteError) {
+    logger.error("platform.users.delete.auth_delete_failed", {
+      user_id: userId,
+      err: deleteError.message,
+    });
+    return internalError("User deletion failed.");
+  }
+
+  return NextResponse.json(
+    { ok: true, timestamp: new Date().toISOString() },
+    { status: 200 },
+  );
+}

--- a/tests/regressions/hard-delete-user-removal.test.ts
+++ b/tests/regressions/hard-delete-user-removal.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// FIX-2 / D1 — Hard delete on user removal regression tests.
+//
+// Invariants:
+//   1. DELETE /api/platform/users/[userId] returns 200 on success.
+//   2. DELETE /api/platform/users/[userId] returns 404 if user has no membership.
+//   3. DELETE /api/platform/users/[userId] returns 400 if userId is not a UUID.
+//   4. auth.admin.deleteUser is called with the correct userId.
+//   5. Gate: requires manage_users permission (admin role).
+//
+// Layer 1 — unit, mocked Supabase + api-gate. No real DB needed.
+// ---------------------------------------------------------------------------
+
+// Zod v4 z.string().uuid() enforces version nibble (1-8) + variant bits (8/9/a/b).
+// These test constants use version 4, variant 8 to satisfy the stricter regex.
+const COMPANY_A = "aaaaaaaa-0000-4000-8000-000000000001";
+const USER_ID = "cccccccc-0000-4000-8000-000000000001";
+
+let deletedUserId: string | null = null;
+
+function makeSupabaseMock({
+  membershipCompanyId,
+  deleteError,
+}: {
+  membershipCompanyId: string | null;
+  deleteError?: { message: string } | null;
+}) {
+  return {
+    from: (table: string) => {
+      if (table === "platform_company_users") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () =>
+                membershipCompanyId
+                  ? { data: { company_id: membershipCompanyId }, error: null }
+                  : { data: null, error: null },
+            }),
+          }),
+        };
+      }
+      return {};
+    },
+    auth: {
+      admin: {
+        deleteUser: async (uid: string) => {
+          deletedUserId = uid;
+          return deleteError ? { error: deleteError } : { error: null };
+        },
+      },
+    },
+  };
+}
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: vi.fn(),
+}));
+
+beforeEach(() => {
+  deletedUserId = null;
+});
+
+afterEach(() => vi.clearAllMocks());
+
+async function callDelete(userId: string) {
+  const { DELETE } = await import(
+    "@/app/api/platform/users/[userId]/route"
+  );
+  const req = new Request(`http://localhost/api/platform/users/${userId}`, {
+    method: "DELETE",
+  });
+  return DELETE(req as never, { params: { userId } });
+}
+
+describe("DELETE /api/platform/users/[userId]", () => {
+  it("returns 400 for non-UUID userId", async () => {
+    const res = await callDelete("not-a-uuid");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when user has no company membership", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSupabaseMock({ membershipCompanyId: null }) as never,
+    );
+
+    const res = await callDelete(USER_ID);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when caller lacks manage_users permission", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSupabaseMock({ membershipCompanyId: COMPANY_A }) as never,
+    );
+
+    const { requireCanDoForApi } = await import("@/lib/platform/auth/api-gate");
+    vi.mocked(requireCanDoForApi).mockResolvedValue({
+      kind: "deny",
+      response: new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 }),
+    } as never);
+
+    const res = await callDelete(USER_ID);
+    expect(res.status).toBe(403);
+  });
+
+  it("calls auth.admin.deleteUser with the correct userId on success", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSupabaseMock({ membershipCompanyId: COMPANY_A }) as never,
+    );
+
+    const { requireCanDoForApi } = await import("@/lib/platform/auth/api-gate");
+    vi.mocked(requireCanDoForApi).mockResolvedValue({
+      kind: "allow",
+      userId: "admin-user-id",
+      supabase: {} as never,
+    } as never);
+
+    const res = await callDelete(USER_ID);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(deletedUserId).toBe(USER_ID);
+  });
+
+  it("returns 500 when auth.admin.deleteUser fails", async () => {
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSupabaseMock({
+        membershipCompanyId: COMPANY_A,
+        deleteError: { message: "Auth service unavailable" },
+      }) as never,
+    );
+
+    const { requireCanDoForApi } = await import("@/lib/platform/auth/api-gate");
+    vi.mocked(requireCanDoForApi).mockResolvedValue({
+      kind: "allow",
+      userId: "admin-user-id",
+      supabase: {} as never,
+    } as never);
+
+    const res = await callDelete(USER_ID);
+    expect(res.status).toBe(500);
+    expect(deletedUserId).toBe(USER_ID);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/platform/users/[userId]` endpoint that hard-deletes a platform user
- Calls `auth.admin.deleteUser(userId)` which cascades via FK: `auth.users → platform_users → platform_company_users`
- Gate: caller must hold `manage_users` (admin role) in the company the target user belongs to
- Implements D1 decision: user removal is a hard delete, not a soft/flag flip

## Working analog
`app/api/platform/invitations/[id]/route.ts:19-55` — DELETE handler: lookup resource → get company_id → gate → perform action

**Diff**: invitations route calls `revokeInvitation()` lib helper; this route calls `svc.auth.admin.deleteUser()` directly (no lib helper needed — the cascade handles all rows)

**Fix**: match the lookup → gate → delete pattern exactly

## Risks identified and mitigated

- **Cascade irreversibility**: `auth.admin.deleteUser` is permanent. Gate enforces `manage_users` (admin-only) before the delete is issued. V1 design decision (D1) explicitly calls for hard delete.
- **Opollo staff cross-tenant**: staff users belong to multiple `platform_company_users` rows. Current implementation looks up `maybeSingle()` — this returns the first membership. For V1 the endpoint is admin-initiated within a specific company context; multi-tenant staff deletion is out of scope for D1.
- **Regression test coverage**: 5 tests covering 400/403/404/500 and the happy path with `auth.admin.deleteUser` call assertion.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (2466 tests pass)
- [x] Regression test added: `tests/regressions/hard-delete-user-removal.test.ts`
- [x] Risks identified and mitigated section in PR body
- [x] PR is under 500 net lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)