### PR TITLE
fix(audit): log implicit staff admin grants via opollo_users auto-provision (DI-007)

### DIFF
--- a/lib/platform/auth/current-user.ts
+++ b/lib/platform/auth/current-user.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { createRouteAuthClient } from "@/lib/auth";
+import { logStaffAction } from "@/lib/platform/staff-audit";
 import { getServiceRoleClient } from "@/lib/supabase";
 
 import type {
@@ -66,6 +67,16 @@ export async function getCurrentPlatformSession(
     await svc
       .from("platform_users")
       .upsert({ id: userId, email, is_opollo_staff: true }, { onConflict: "id" });
+
+    // Audit: log the implicit staff grant for Opollo operators auto-provisioned
+    // via opollo_users (DI-007 / D4). No company_id yet — they haven't selected
+    // a company. Best-effort: never throws.
+    await logStaffAction({
+      staffUserId: userId,
+      staffEmail: email,
+      action: "staff_grant.auto",
+      resourceId: userId,
+    });
 
     // No company membership yet for auto-provisioned staff.
     return { userId, email, isOpolloStaff: true, company: null };

--- a/tests/regressions/staff-admin-grant-audit.test.ts
+++ b/tests/regressions/staff-admin-grant-audit.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// FIX-3 / DI-007 — Implicit staff admin grant audit logging regression tests.
+//
+// When an Opollo operator logs in via the platform but has no platform_users
+// row yet, getCurrentPlatformSession auto-provisions them via opollo_users
+// and sets is_opollo_staff=true. This implicit grant MUST be logged in
+// platform_staff_audit_log (D4).
+//
+// Invariants:
+//   1. Auto-provision path calls logStaffAction with action="staff_grant.auto".
+//   2. Auto-provision path calls logStaffAction with the correct staff userId.
+//   3. Non-staff path (existing platform_users row) does NOT call logStaffAction.
+//
+// Layer 1 — unit, mocked Supabase + staff-audit helper.
+// ---------------------------------------------------------------------------
+
+const STAFF_USER_ID = "cccccccc-0000-4000-8000-000000000001";
+const STAFF_EMAIL = "alice@opollo.com";
+
+const logStaffActionCalls: Array<Record<string, unknown>> = [];
+
+vi.mock("@/lib/platform/staff-audit", () => ({
+  logStaffAction: vi.fn(async (params: Record<string, unknown>) => {
+    logStaffActionCalls.push(params);
+  }),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  createRouteAuthClient: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+
+// next/headers.cookies() is called in resolveStaffCookieCompany; mock it to
+// avoid "outside request context" throws in the test environment.
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(() => ({ get: () => undefined })),
+}));
+
+function makeAuthClient(userId: string, email: string) {
+  return {
+    auth: {
+      getUser: async () => ({
+        data: { user: { id: userId, email } },
+        error: null,
+      }),
+    },
+  };
+}
+
+function makeServiceClient({
+  platformUserData,
+  opolloUserData,
+  upsertError,
+}: {
+  platformUserData: Record<string, unknown> | null;
+  opolloUserData: Record<string, unknown> | null;
+  upsertError?: { message: string } | null;
+}) {
+  return {
+    from: (table: string) => {
+      if (table === "platform_users") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: platformUserData, error: null }),
+            }),
+          }),
+          upsert: () =>
+            upsertError
+              ? Promise.resolve({ error: upsertError })
+              : Promise.resolve({ error: null }),
+        };
+      }
+      if (table === "opollo_users") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: opolloUserData, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === "platform_company_users") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    },
+  };
+}
+
+beforeEach(() => {
+  logStaffActionCalls.length = 0;
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("getCurrentPlatformSession — implicit staff grant audit (DI-007)", () => {
+  it("calls logStaffAction with staff_grant.auto on opollo_users auto-provision", async () => {
+    const { createRouteAuthClient } = await import("@/lib/auth");
+    vi.mocked(createRouteAuthClient).mockReturnValue(
+      makeAuthClient(STAFF_USER_ID, STAFF_EMAIL) as never,
+    );
+
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeServiceClient({
+        platformUserData: null,       // no platform_users row yet
+        opolloUserData: { id: STAFF_USER_ID }, // exists in opollo_users
+      }) as never,
+    );
+
+    const { getCurrentPlatformSession } = await import(
+      "@/lib/platform/auth/current-user"
+    );
+    const session = await getCurrentPlatformSession();
+
+    expect(session).not.toBeNull();
+    expect(session?.isOpolloStaff).toBe(true);
+    expect(logStaffActionCalls).toHaveLength(1);
+    expect(logStaffActionCalls[0]).toMatchObject({
+      action: "staff_grant.auto",
+      staffUserId: STAFF_USER_ID,
+    });
+  });
+
+  it("includes the staff email in the logStaffAction call", async () => {
+    const { createRouteAuthClient } = await import("@/lib/auth");
+    vi.mocked(createRouteAuthClient).mockReturnValue(
+      makeAuthClient(STAFF_USER_ID, STAFF_EMAIL) as never,
+    );
+
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeServiceClient({
+        platformUserData: null,
+        opolloUserData: { id: STAFF_USER_ID },
+      }) as never,
+    );
+
+    const { getCurrentPlatformSession } = await import(
+      "@/lib/platform/auth/current-user"
+    );
+    await getCurrentPlatformSession();
+
+    expect(logStaffActionCalls[0]).toMatchObject({
+      staffEmail: STAFF_EMAIL,
+    });
+  });
+
+  it("does NOT call logStaffAction for existing platform_users row", async () => {
+    const { createRouteAuthClient } = await import("@/lib/auth");
+    vi.mocked(createRouteAuthClient).mockReturnValue(
+      makeAuthClient(STAFF_USER_ID, STAFF_EMAIL) as never,
+    );
+
+    const { getServiceRoleClient } = await import("@/lib/supabase");
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeServiceClient({
+        platformUserData: { is_opollo_staff: true }, // row already exists
+        opolloUserData: { id: STAFF_USER_ID },
+      }) as never,
+    );
+
+    const { getCurrentPlatformSession } = await import(
+      "@/lib/platform/auth/current-user"
+    );
+    await getCurrentPlatformSession();
+
+    expect(logStaffActionCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- `getCurrentPlatformSession` in `lib/platform/auth/current-user.ts` auto-provisions Opollo operators who exist in `opollo_users` but have no `platform_users` row, setting `is_opollo_staff: true`
- This implicit staff grant was never logged — DI-007 gap
- Now calls `logStaffAction("staff_grant.auto")` after the upsert with `staffUserId` + `staffEmail` (D4 minimum fields; no `company_id` at this point as the operator hasn't selected a company yet)

## Working analog
`lib/platform/invitations/accept.ts:217-225` — same `logStaffAction("staff_grant.auto")` call after the invitation-accept flow sets `is_opollo_staff: true`

**Diff**: `accept.ts` has `company_id` from the invitation; auto-provision path has no company context yet, so `company_id` is omitted (nullable per D4 schema)

**Fix**: add the same `logStaffAction` call after the upsert in the auto-provision branch

## Risks identified and mitigated

- **Best-effort write**: `logStaffAction` never throws — if the audit write fails, the session still resolves and the user can log in. Consistent with the design decision in FIX-1.
- **No company_id on auto-provision**: `company_id` is `NULL` in the audit row for this path. This is correct — the operator hasn't "viewed as" any company yet. D4 minimum fields don't require company_id.
- **Regression test coverage**: 3 tests covering the audit call, email field, and the no-audit path for existing users.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (all tests pass)
- [x] Regression test added: `tests/regressions/staff-admin-grant-audit.test.ts`
- [x] Risks identified and mitigated section in PR body
- [x] PR is under 500 net lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)