### PR TITLE
chore: remove 0153 active claim from WORK_IN_FLIGHT (shipped #1089)

### DIFF
--- a/docs/WORK_IN_FLIGHT.md
+++ b/docs/WORK_IN_FLIGHT.md
@@ -45,7 +45,6 @@ When a session starts a migration, reserve the number here before writing the fi
 - ~~0073 — S1-10 cancel_post_approval transactional function.~~ Shipped (0073_cancel_post_approval_fn.sql in main).
 - ~~0112 — Session A — Spec 22 PR 1 social_post_drafts table (branch: feat/spec22-pr1-composer-shell).~~ Shipped in #789.
 - ~~0113 — Session A — Spec 22 PR 2 social-media-uploads storage bucket (branch: feat/spec22-pr2-core-editor).~~ Shipped.
-- 0153 — FIX-1 — platform_staff_audit_log (branch: feat/fix1-staff-access-audit-log)
 
 ## Claim block template
 


### PR DESCRIPTION
Remove active 0153 migration claim — shipped in #1089 (FIX-1 staff audit log).

## Summary
- Remove active entry for migration 0153 in `docs/WORK_IN_FLIGHT.md`

## Pre-PR checklist
- [x] Docs-only change, no tests needed