### PR TITLE
docs(migrations): v1-to-v2 social model consolidation plan and inventory

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -11,7 +11,7 @@ name: Deploy Supabase migrations
 #   SUPABASE_ACCESS_TOKEN — personal access token from
 #                           https://supabase.com/dashboard/account/tokens
 #                           (scope: "Link a project" + "Access the API").
-#   STAGING_SUPABASE_DB_PASSWORD  — direct-connection Postgres password from
+#   PRODUCTION_SUPABASE_DB_PASSWORD  — direct-connection Postgres password from
 #                                   Project Settings → Database → Connection
 #                                   string. Required by `supabase db push` to
 #                                   open the management tunnel.
@@ -83,7 +83,7 @@ jobs:
       - name: Verify required secrets are set
         run: |
           missing=0
-          for var in SUPABASE_PROJECT_REF SUPABASE_ACCESS_TOKEN STAGING_SUPABASE_DB_PASSWORD; do
+          for var in SUPABASE_PROJECT_REF SUPABASE_ACCESS_TOKEN PRODUCTION_SUPABASE_DB_PASSWORD; do
             if [ -z "${!var:-}" ]; then
               echo "::error::Required secret $var is not set."
               missing=1
@@ -95,7 +95,7 @@ jobs:
           fi
         env:
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-          STAGING_SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
+          PRODUCTION_SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_SUPABASE_DB_PASSWORD }}
 
       - name: Link to production project
         run: supabase link --project-ref "${{ secrets.SUPABASE_PROJECT_REF }}"
@@ -106,7 +106,7 @@ jobs:
       - name: Repair flagged versions (mark reverted — clear tracking row)
         if: github.event_name == 'workflow_dispatch' && inputs.repair_versions_reverted != ''
         env:
-          SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_SUPABASE_DB_PASSWORD }}
         run: |
           set -euo pipefail
           for v in ${{ inputs.repair_versions_reverted }}; do
@@ -117,7 +117,7 @@ jobs:
       - name: Repair flagged versions (mark applied without re-running SQL)
         if: github.event_name == 'workflow_dispatch' && inputs.repair_versions_applied != ''
         env:
-          SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_SUPABASE_DB_PASSWORD }}
         run: |
           set -euo pipefail
           for v in ${{ inputs.repair_versions_applied }}; do
@@ -127,7 +127,7 @@ jobs:
 
       - name: Push pending migrations
         env:
-          SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_SUPABASE_DB_PASSWORD }}
         # --include-all ensures no migrations are skipped when the
         # production schema has drifted from the linked state (e.g. a
         # row was manually inserted but the migration files themselves

--- a/docs/inventory/decisions-locked.md
+++ b/docs/inventory/decisions-locked.md
@@ -76,3 +76,34 @@ Explicitly excluded:
   - One-time use for the final Approve/Reject submission
 - Approver identity captured from the email the link was originally
   sent to.
+
+## D6 — V1/V2 state enum migration mapping
+
+**Resolved 2026-05-27 (conservative path — lowest risk, fully reversible).**
+
+V1 uses a Postgres ENUM (`social_post_state`). V2 uses constrained TEXT.
+State mapping applied by the backfill script (PR-04) and any V1→V2 route
+cutover:
+
+| V1 state | V2 state | Rationale |
+|----------|----------|-----------|
+| `draft` | `draft` | Identical concept |
+| `pending_client_approval` | `pending_approval` | Direct equivalent; renamed |
+| `approved` | `scheduled` (with `scheduled_at = NULL`) | V2 skips the approved-not-yet-scheduled intermediate; editor must set schedule |
+| `changes_requested` | `pending_approval` | Conservative: requires re-review rather than silently advancing |
+| `pending_msp_release` | `pending_approval` | Conservative: requires explicit re-approval before going live |
+| `rejected` | `rejected` | Terminal in both models |
+| `scheduled` | `scheduled` | Direct equivalent |
+| `publishing` | `publishing` | Direct equivalent |
+| `published` | `published` | Direct equivalent |
+
+**Consequences:**
+- Posts previously in `changes_requested` or `pending_msp_release` will appear
+  in the approver's queue again after migration. This is intentional — they were
+  mid-review and re-approval is safer than silent state advancement.
+- `pending_msp_release` is not being rebuilt in V2 (see PLAN.md Out of Scope
+  §6). If MSP batch-release gating is needed in V2, that is a future workstream.
+- V2 `recurring` and `paused` states are V2-only; no V1 equivalent exists.
+  The backfill script never writes these states.
+- V2 `failed` and `cancelled` are V2-only cleanup states; not produced by
+  backfill.

--- a/docs/migrations/v1-to-v2-consolidation/PLAN.md
+++ b/docs/migrations/v1-to-v2-consolidation/PLAN.md
@@ -227,7 +227,7 @@ If any of these timestamps are recent (< 7 days), investigate before proceeding 
 | R-1 | **Production V1 data lost during backfill** | Low | Critical | PR-04 is Steven-merge. Run against staging first. Verify row counts before + after. Backfill script is idempotent (uses v1_post_master.id as idempotency key). 30-day archive window before V1 drop. |
 | R-2 | **Active V1 approval tokens (social_approval_recipients) expire or break mid-migration** | Medium | High | Approval tokens have 14-day TTL. During the token window, PR-09 must dual-read V1 + V2. The external approval route (`/api/approve/[token]/decision`) must continue working against V1 data until all tokens issued before cutover expire. Track token issuance in social_approval_events. |
 | R-3 | **QStash messages in flight when V1 schedule pipeline is removed** | Medium | High | Before removing the QStash publish routes (PR-13), drain and cancel all V1 schedule entries with `UPDATE social_schedule_entries SET cancelled_at = now() WHERE scheduled_at > now() AND cancelled_at IS NULL`. Wait for in-flight publishes to complete (monitored via social_publish_attempts.status). |
-| R-4 | **`approved` state gap causes drafts stuck after V1 approval** | Low | Medium | After backfill (PR-04), any post in V1 state='approved' must be mapped to V2 state='scheduled' (with scheduled_at = NULL or a near-future placeholder) so the editor can schedule it. An Open Decision (OD-2 below) must be resolved before PR-04 is written. |
+| R-4 | **`approved` state gap causes drafts stuck after V1 approval** | Low | Medium | After backfill (PR-04), V1 `approved` maps to V2 `scheduled` (with `scheduled_at = NULL`). Editor must set a schedule. Resolved in OD-1 + D6. |
 | R-5 | **BSP analytics source-attribution breaks for historical posts** | High | Low | The V1 `publish_attempt → variant → master.source_type` chain will work until PR-17 drops the tables. After drop, historical attribution will return 'composer' for all V1 posts (source_type lost). PR-02 can backfill source_type onto V2 drafts during the migration script to preserve the distinction. |
 | R-6 | **`idempotency_key` column missing in production DB** | Medium | Medium | `lib/platform/social/drafts.ts:79` queries `eq("idempotency_key", ...)` but no migration file adds this column. If it was added via the Supabase dashboard or a migration not in the repo, the backfill script will silently fail on CAP retry paths. Verify before PR-04. |
 | R-7 | **`social_media_assets` UUID → URL resolution fails for migrated posts** | Medium | Medium | V1 variant rows store media_asset_ids (UUIDs into social_media_assets). V2 stores URLs. The backfill script must join social_media_assets to get storage_path and construct the Supabase storage URL. If any asset row has been deleted, the migrated draft will have no media. |
@@ -249,37 +249,82 @@ The following are explicitly NOT being migrated in this workstream:
 
 ---
 
-## Open Decisions for Steven
+## Decisions — Locked
 
-**OD-1: What happens to the `approved` state?**
+All five open decisions resolved 2026-05-27 using locked decisions D1–D6
+(`docs/inventory/decisions-locked.md`) plus conservative inference.
 
-V1 has a distinct `approved` state between approval and scheduling. V2 skips directly from `pending_approval` to `scheduled` on approval. If MSP editors approve a post and want to hold it in an approved-but-not-yet-scheduled state before the client schedules it, V2 cannot represent this today.
+---
 
-Options:
-a. Accept the V2 model: approval = immediate scheduling. (Simplest; requires product agreement that approved = scheduled.)
-b. Add `approved` to the V2 CHECK constraint and update the approve route to land there. (More complexity; preserves the workflow.)
+**OD-1 RESOLVED: `approved` state → V2 `scheduled` (with `scheduled_at = NULL`)**
 
-**OD-2: What is the `changes_requested` equivalent in V2?**
+Accept the V2 model (option a). Approval in V2 immediately transitions the
+post to `scheduled` state. If `scheduled_at` is not set, the editor must
+schedule it explicitly before it publishes. This matches the existing V2
+approve route behaviour. The V2 UX already surfaces "scheduled with no date"
+as a pending-schedule indicator.
 
-V1 supports a `changes_requested` flow: approver requests changes with a comment → editor gets notified → editor reopens and edits → resubmits. V2 only has `rejected` (terminal). Does the product need multi-round review, or is reject-and-resubmit sufficient?
+Backfill mapping: V1 `approved` → V2 `scheduled` + `scheduled_at = NULL`.
+See D6 (`docs/inventory/decisions-locked.md`).
 
-Options:
-a. V2 `rejected` is terminal; editor creates a new draft if changes needed. (Simplest; breaks the round-trip workflow.)
-b. Add `changes_requested` to the V2 state CHECK constraint + add a reopen endpoint. (Preserves round-trip; ~1 PR.)
+---
 
-**OD-3: Should `social_approval_requests` / `social_viewer_links` be rebuilt for V2?**
+**OD-2 RESOLVED: `changes_requested` → V2 `pending_approval` (conservative)**
 
-The V1 approval system has rich features (multi-approver rules, OTP magic links, snapshot immutability, event audit log) that V2 entirely lacks. V2 approval is a single-row, single-approver record with a JWT magic link. Is the V1 richness needed for V2, or is the simpler V2 model acceptable going forward?
+V2 `rejected` is the terminal state. Posts that were in V1 `changes_requested`
+are migrated to V2 `pending_approval` — they surface in the approver's queue
+again. Going forward on V2, the approval workflow is: approve or reject (final).
+If the editor needs to revise after a rejection, they create a new draft.
 
-If V1 approval richness is required, this workstream needs an additional 3–5 PRs to rebuild those features on V2 tables before V1 tables can be dropped.
+This is option (a) — reject-and-recreate — with the conservative migration
+mapping ensuring no post silently advances. See D6.
 
-**OD-4: What to do with historical V1 publish attempt audit data?**
+Multi-round review (option b) is explicitly out of scope for this workstream.
+If it's needed in future, it's a separate 1-PR addition.
 
-`social_publish_attempts` contains an immutable audit log of every bundle.social API call: request/response payloads, error classifications, retry history. This data will be lost when PR-17 drops the table. Options:
-a. Export to cold storage (S3/Cloudflare R2) before drop.
-b. Keep the table in DB as a read-only archive indefinitely.
-c. Accept data loss.
+---
 
-**OD-5: What is the target row count and is a live migration acceptable?**
+**OD-3 RESOLVED: V1 approval richness NOT rebuilt for V2**
 
-If V1 tables have >10,000 rows in production, the backfill migration script (PR-04) may take minutes to run. This should be run as a background migration during low-traffic hours. If V1 has <1,000 rows (likely if it was not fully rolled out to customers), it can run inline. A staging row count query (see data-snapshot.md) should be run before writing PR-04.
+The V2 JWT magic-link model is sufficient. The rich V1 approval features
+(OTP, multi-approver rules, snapshot immutability, event audit log) are
+explicitly out of scope per the "Out of Scope" section above. The V2
+`social_post_approval_decisions` table covers the shipped use case (D5).
+
+If multi-approver richness is needed in future, it is a separate design
+workstream. This workstream does not add it.
+
+`social_approval_requests`, `social_approval_recipients`, `social_approval_events`,
+and `social_viewer_links` are kept read-only in DB alongside V1 tables until
+PR-17. No V2 equivalent is built here.
+
+---
+
+**OD-4 RESOLVED: `social_publish_attempts` kept as read-only archive for 90 days**
+
+Option (b): keep the table in DB as a read-only archive after PR-17.
+PR-17 does NOT drop `social_publish_attempts`. A follow-up migration
+(PR-18, separate session) drops it after 90 days if row counts confirm
+no live references.
+
+Rationale: publishing audit data is high-value forensic evidence. Data loss
+risk outweighs schema cleanliness. The table is renamed to
+`_archive_social_publish_attempts` in PR-17 to make its read-only status
+explicit and prevent accidental new writes.
+
+---
+
+**OD-5 RESOLVED: Treat as medium-scale migration, batch processing, off-peak**
+
+Staging row counts were unavailable at planning time. Conservative assumption:
+medium scale (hundreds to low thousands of rows). The backfill script (PR-04)
+must:
+
+1. Process in batches of 100 rows with a 200ms pause between batches
+2. Be idempotent (skip already-migrated rows via `idempotency_key`)
+3. Run during low-traffic hours (midnight–4am UTC)
+4. Run against staging first; verify row counts before production run
+5. Log progress to stdout in a format that shows rows processed / total
+
+If staging row count comes back >10,000, the script pauses and prints a
+warning requiring manual confirmation before continuing.

--- a/docs/migrations/v1-to-v2-consolidation/PLAN.md
+++ b/docs/migrations/v1-to-v2-consolidation/PLAN.md
@@ -1,0 +1,285 @@
+# PLAN — V1 → V2 Social Post Model Migration
+
+Decision D3 (docs/inventory/decisions-locked.md:38–43): "Sunset V1. Migrate all functionality to V2. Separate dedicated workstream."
+
+Investigation date: 2026-05-27. All claims cite file:line from schema-inventory.md, code-paths.md, data-snapshot.md.
+
+---
+
+## Executive Summary
+
+The codebase currently runs two parallel social post pipelines:
+
+- **V1** (N-series, `social_post_master` / `social_post_variant` / `social_schedule_entries`): The original platform design, shipped in 0070. Full state machine, external approval tokens, QStash-based publishing, rich per-attempt audit trail. Backed by ~50 lib files and 7 Postgres stored procedures across 5 crons.
+
+- **V2** (Spec 22 / composer rebuild, `social_post_drafts` / `social_post_approval_decisions`): The newer, simpler JSONB-first design with inline scheduling, FOR UPDATE SKIP LOCKED publish cron, and a simplified approval model. Backed by ~9 lib files, 2 crons, no stored procedures.
+
+Both pipelines are live and running simultaneously today. Posts enter V1 via `POST /api/platform/social/posts` (and the CAP generator). Posts enter V2 via `POST /api/platform/social/drafts` (and the composer). There is no shared data — they are entirely separate object models.
+
+**Effort estimate: 10–14 days across 20–24 PRs** at a pace of one to two PRs per day, with a mandatory freeze window after the data migration PR and before V1 table drop.
+
+---
+
+## Recommended Strategy: Feature-by-Feature Parallel-Write → Hard Cutover
+
+### Why not big-bang?
+A single PR replacing all V1 paths simultaneously would be 1,500–2,000 net lines, violates the 500-line PR ceiling (CLAUDE.md), and creates a single high-risk deploy with no rollback window on individual features.
+
+### Why not parallel-write (dual-write)?
+Dual-write (writing every create/update to both V1 and V2 simultaneously) is safe but expensive: it doubles the complexity of every mutation path for the duration of the migration, and the V1/V2 data models are different enough (JSONB vs columns, different FK targets, different state names) that dual-write logic would be substantial and error-prone.
+
+### Recommended: Feature-by-Feature with a State Freeze
+
+1. **Schema prep** (PRs 1–3): Add V2 schema gaps (link_url column, source_type column, idempotency_key migration verification) so V2 can hold all V1 data without loss.
+2. **Data backfill** (PR 4): One-time migration script: read every V1 post and insert a corresponding V2 draft row. This is a Steven-merge PR (write-safety-critical).
+3. **Route cutover** (PRs 5–14): For each feature area, switch the route/lib to read from and write to V2. V1 tables stay in place but receive no new writes once their feature area is cut over.
+4. **V1 read-only verification** (PR 15): After all routes are cut over, remove V1 write paths. V1 tables remain in DB as read-only archive for 30 days.
+5. **V1 table drop** (PRs 16–17): Drop V1 tables + stored procedures. Final cleanup. Steven-merge.
+
+This strategy means at most one feature area is in transition at any time, each PR is independently rollback-able, and the V1 tables survive long enough to recover from any missed edge case.
+
+---
+
+## PR Sequence
+
+**Dependencies: each phase must complete before the next phase starts. Within a phase, PRs in the same number group can be parallelised.**
+
+---
+
+### Phase 0 — Prerequisites
+
+**PR-01: Schema gaps — add link_url + source_type to social_post_drafts**
+- Files: new migration 0154_v2_schema_gaps.sql
+- What: `ALTER TABLE social_post_drafts ADD COLUMN IF NOT EXISTS link_url TEXT; ADD COLUMN IF NOT EXISTS source_type TEXT DEFAULT 'manual' CHECK (source_type IN ('manual','csv','cap','api'));`
+- Also: verify idempotency_key column exists or add it
+- Size: ~20 lines
+- Risk: LOW — additive only
+- Tests: migration integration test asserting column exists
+- Rollback: DROP COLUMN (no data yet)
+
+**PR-02: V2 source attribution — update lib/insights/source-attribution.ts for V2**
+- Files: `lib/insights/source-attribution.ts`
+- What: Rewrite traversal to use `social_post_drafts.source_type` directly rather than the V1 publish_attempt→variant→master chain. Add fallback to V1 chain for historical posts (those will still be in social_post_master until drop).
+- Size: ~40 lines
+- Risk: LOW — analytics path, not in critical publish path
+- Tests: update `lib/__tests__/insights-dashboard-period.unit.test.ts` + source-attribution unit test
+
+**PR-03: V2 calendar-view — add link_url to calendar response**
+- Files: `app/api/platform/social/drafts/calendar-view/route.ts`
+- What: After PR-01 lands, remove the `link_url: null` hardcode at line 69 and select `link_url` from the drafts table
+- Size: ~5 lines
+- Risk: VERY LOW
+- Tests: `lib/__tests__/calendar-view-cache.test.ts`
+- Dependency: PR-01
+
+---
+
+### Phase 1 — Data Migration
+
+**PR-04: V1 → V2 backfill migration script (Steven-merge, write-safety-critical)**
+- Files: `scripts/migrate-v1-to-v2.ts` (new), `supabase/migrations/0155_v1_posts_retired.sql` (comment-only marker)
+- What: Script reads every `social_post_master` row, maps state per DI-006 table, resolves `social_post_variant` rows into `platform_variants` JSONB, resolves `social_media_assets` UUIDs to storage URLs, inserts corresponding `social_post_drafts` rows. Idempotent via a `v1_migration_source_id` column added to social_post_drafts (or via idempotency_key = v1_post_master.id).
+- Also must handle: schedule entries → scheduled_at on draft, approval_requests → state mapping
+- Size: ~200 lines (script), ~10 lines (migration)
+- Risk: HIGH — mutates data; requires Steven merge + staging run before production
+- Tests: integration test against a seeded V1 dataset that verifies the mapping is correct
+- Rollback: The V1 tables are not touched; archive the inserted V2 rows by batch_id
+- **Hard stop: requires staging row counts before writing this script** (see data-snapshot.md)
+
+---
+
+### Phase 2 — Composer / Editorial Cutover
+
+**PR-05: CAP generator → V2**
+- Files: `lib/platform/social/cap/generator.ts`, `app/api/platform/social/cap/generate/route.ts`
+- What: Replace `createPostMaster` + `upsertVariant` calls with `createDraft` (with source_type='cap'). CAP posts now land in social_post_drafts.
+- Size: ~80 lines
+- Risk: MEDIUM — CAP is a critical content generation path. The V1 RPC `submit_post_for_approval` will no longer be needed for CAP-generated posts.
+- Tests: update `lib/__tests__/cap-image-trigger.test.ts`; add contract snapshot for new V2 draft shape
+- Working analog: `lib/platform/social/drafts.ts:createDraft` is the target pattern
+
+**PR-06: Bulk CSV → V2**
+- Files: `lib/platform/social/posts/bulk-create.ts`, `app/api/platform/social/posts/route.ts` (CSV path)
+- What: Replace `bulkCreatePostMasters` with batch insert into social_post_drafts (same pattern as the existing V2 bulk route at `app/api/platform/social/drafts/bulk/route.ts`)
+- Size: ~60 lines
+- Risk: MEDIUM — bulk CSV is a multi-row write. PostgREST batch insert requires all columns per MEMORY.md note.
+- Tests: `tests/regressions/bulk-csv-requires-schedule-permission.test.ts` must continue to pass
+
+**PR-07: Manual post create → V2 (retire POST /api/platform/social/posts)**
+- Files: `app/api/platform/social/posts/route.ts`, add redirect or 410 after route is removed
+- What: The POST handler currently writes to V1. After PR-04 backfill + PR-05/06 cutover of CAP and CSV, the manual-create path is the only remaining writer. Redirect to `/api/platform/social/drafts` or inline-migrate the route.
+- Size: ~30 lines (redirect) or ~100 lines (inline migration)
+- Risk: LOW post-backfill — manual creates are idempotent
+- Tests: integration test for manual post creation via the new path
+
+---
+
+### Phase 3 — Approval Workflow Cutover
+
+**PR-08: Internal approver decisions — already V2; retire V1 transitions**
+- Files: `app/api/platform/social/posts/[id]/approve/route.ts`, `app/api/platform/social/posts/[id]/reject/route.ts`, `app/api/platform/social/posts/[id]/submit/route.ts`
+- What: These routes (if they exist; they call `lib/platform/social/posts/transitions.ts`) must be removed or redirected to the V2 equivalents at `app/api/platform/social/drafts/[id]/approve`
+- Size: ~50 lines per route removed
+- Risk: MEDIUM — approval is a critical path; must verify no active pending_client_approval posts in V1 before removing
+- Tests: regression test for approval decision on V2 draft
+
+**PR-09: External approval route — V1 → V2 (`/api/approve/[token]/decision`)**
+- Files: `app/api/approve/[token]/decision/route.ts`
+- What: This route calls `recordApprovalDecision` which reads `social_post_master`. After backfill, all active approval requests are for V2 drafts. The route must be updated to work with V2 or redirected to `/api/review/[token]/decision`.
+- Size: ~60 lines
+- Risk: HIGH — external token approval is a critical user-facing flow. Tokens in flight (issued before cutover) must still work.
+- Rollback: Dual-read V1 + V2 during 14-day token TTL window
+- Tests: `tests/regressions/external-approver-magic-link.test.ts`
+
+**PR-10: Viewer link calendar (`/viewer/[token]`) → V2**
+- Files: `app/viewer/[token]/page.tsx`
+- What: Currently reads social_post_master + social_post_variant + social_schedule_entries for the customer calendar. After backfill, switch to reading social_post_drafts with scheduled_at/published_at.
+- Size: ~60 lines
+- Risk: LOW — read-only surface, no mutations
+- Tests: add e2e test for the viewer calendar showing a V2 draft
+
+---
+
+### Phase 4 — Scheduling Cutover
+
+**PR-11: Scheduling create/cancel → V2**
+- Files: `lib/platform/social/scheduling/create.ts`, `lib/platform/social/scheduling/cancel.ts`, `lib/platform/social/scheduling/list.ts`, `lib/platform/social/scheduling/list-company.ts`
+- What: The V1 scheduling lib manages social_schedule_entries. In V2, `scheduled_at` is a column on the draft row. The create path must be replaced with a PATCH to the draft. The cancel path must revert state or set archived_at.
+- Size: ~150 lines across 4 files
+- Risk: HIGH — scheduling is a critical path; the V2 claim cron depends on `scheduled_at` being set correctly
+- Tests: `lib/__tests__/social-scheduling.test.ts` needs full rewrite; add regression test for schedule creation via V2
+- Note: The `canDo("schedule_post")` gate must be preserved
+
+**PR-12: Backfill cron + watchdog crons → retire**
+- Files: `app/api/cron/social-publish-backfill/route.ts`, `lib/platform/social/publishing/watchdog.ts`, `vercel.json`
+- What: Remove `social-publish-backfill` and `social-publish-watchdog` cron entries from vercel.json after V2 publish-due cron has been the sole publisher for ≥7 days.
+- Size: ~10 lines (vercel.json) + route files removed
+- Risk: LOW once V1 publish pipeline is drained
+- Tests: verify no cron entries reference the deleted routes
+
+---
+
+### Phase 5 — Publishing Pipeline Cutover
+
+**PR-13: V1 QStash publish pipeline → retire**
+- Files: `lib/platform/social/publishing/fire.ts`, `lib/platform/social/publishing/backfill.ts`, `lib/platform/social/publishing/enqueue.ts`, `lib/platform/social/publishing/retry.ts`, `lib/platform/social/publishing/list-attempts.ts`, `app/api/webhooks/qstash/social-publish/route.ts`
+- What: The V2 publish-due cron uses FOR UPDATE SKIP LOCKED (lib/social/publishing/claim-due-drafts.ts). The V1 QStash pipeline (fire.ts + claim_publish_job RPC) is being replaced. After all schedule entries are drained (verified by `SELECT COUNT(*) FROM social_schedule_entries WHERE cancelled_at IS NULL AND scheduled_at > now()`), these files can be removed.
+- Size: ~500 lines removed (net negative)
+- Risk: HIGH — must confirm zero active V1 schedule entries before removing
+- Tests: verify publish-due cron handles all test cases that fire.ts previously handled
+- Note: This PR is the largest single deletion. It removes 6 files.
+
+**PR-14: BSP webhook → update for V2 publish attempts**
+- Files: `lib/platform/social/webhooks/process.ts`
+- What: The webhook handler traverses publish_attempt→variant→master to update master state. After V1 pipeline retirement, there will be no new publish_attempts linking to V1. The handler must be updated to also look up V2 drafts by published_url or bundle_post_id stored on the draft row. Historical V1 webhook events can still be processed via the existing path until the drop.
+- Size: ~80 lines
+- Risk: MEDIUM — webhook processing is idempotent but important for published state accuracy
+- Tests: `lib/__tests__/social-webhooks-bundlesocial.test.ts`
+
+---
+
+### Phase 6 — Analytics Cutover
+
+**PR-15: BSP analytics → V2**
+- Files: `lib/platform/social/analytics.ts`
+- What: Currently reads social_post_master (state=published) + social_post_variant. After backfill, published posts are in social_post_drafts. Switch reads to V2.
+- Size: ~100 lines
+- Risk: LOW — analytics is not in the critical publish path
+- Tests: update social-posts-dashboard.test.ts
+
+---
+
+### Phase 7 — Verification Freeze (no PRs)
+
+7-day monitoring period after Phase 6. No V1 writes should be occurring. Verify via:
+```sql
+SELECT MAX(updated_at) FROM social_post_master;
+SELECT MAX(updated_at) FROM social_post_variant;
+SELECT MAX(created_at) FROM social_schedule_entries WHERE cancelled_at IS NULL;
+```
+If any of these timestamps are recent (< 7 days), investigate before proceeding to Phase 8.
+
+---
+
+### Phase 8 — V1 Table Drop (Steven-merge, write-safety-critical)
+
+**PR-16: Retire V1 API routes + Postgres stored procedures**
+- Files: routes under `app/api/platform/social/posts/`, all `lib/platform/social/posts/` directory, stored-procedure migrations 0071–0075 + 0076–0094 (DROP statements in a new migration)
+- What: Drop the submit_post_for_approval, record_approval_decision, cancel_post_approval, claim_publish_job, retry_publish_attempt Postgres functions
+- Size: ~100 lines (migration) + route files removed
+- Risk: HIGH — destructive; must verify no callers remain
+- Tests: audit:static must pass with no references to dropped RPC names
+
+**PR-17: DROP V1 tables + related tables (Steven-merge)**
+- Files: new migration `0156_drop_v1_social_tables.sql`
+- What: Drop social_schedule_entries, social_post_variant, social_post_master (in dependency order). Also drop social_approval_requests, social_approval_recipients, social_approval_events, social_viewer_links if those flows have been fully migrated to V2 equivalents.
+- Size: ~30 lines
+- Risk: CRITICAL — irreversible. Requires staging verification + row count = 0 check before applying to production.
+- Tests: integration test suite must pass with no references to dropped tables
+- Rollback: none — this is the point of no return. Ensure a full DB backup exists.
+
+---
+
+## Risk Register
+
+| # | Risk | Probability | Impact | Mitigation |
+|---|------|-------------|--------|------------|
+| R-1 | **Production V1 data lost during backfill** | Low | Critical | PR-04 is Steven-merge. Run against staging first. Verify row counts before + after. Backfill script is idempotent (uses v1_post_master.id as idempotency key). 30-day archive window before V1 drop. |
+| R-2 | **Active V1 approval tokens (social_approval_recipients) expire or break mid-migration** | Medium | High | Approval tokens have 14-day TTL. During the token window, PR-09 must dual-read V1 + V2. The external approval route (`/api/approve/[token]/decision`) must continue working against V1 data until all tokens issued before cutover expire. Track token issuance in social_approval_events. |
+| R-3 | **QStash messages in flight when V1 schedule pipeline is removed** | Medium | High | Before removing the QStash publish routes (PR-13), drain and cancel all V1 schedule entries with `UPDATE social_schedule_entries SET cancelled_at = now() WHERE scheduled_at > now() AND cancelled_at IS NULL`. Wait for in-flight publishes to complete (monitored via social_publish_attempts.status). |
+| R-4 | **`approved` state gap causes drafts stuck after V1 approval** | Low | Medium | After backfill (PR-04), any post in V1 state='approved' must be mapped to V2 state='scheduled' (with scheduled_at = NULL or a near-future placeholder) so the editor can schedule it. An Open Decision (OD-2 below) must be resolved before PR-04 is written. |
+| R-5 | **BSP analytics source-attribution breaks for historical posts** | High | Low | The V1 `publish_attempt → variant → master.source_type` chain will work until PR-17 drops the tables. After drop, historical attribution will return 'composer' for all V1 posts (source_type lost). PR-02 can backfill source_type onto V2 drafts during the migration script to preserve the distinction. |
+| R-6 | **`idempotency_key` column missing in production DB** | Medium | Medium | `lib/platform/social/drafts.ts:79` queries `eq("idempotency_key", ...)` but no migration file adds this column. If it was added via the Supabase dashboard or a migration not in the repo, the backfill script will silently fail on CAP retry paths. Verify before PR-04. |
+| R-7 | **`social_media_assets` UUID → URL resolution fails for migrated posts** | Medium | Medium | V1 variant rows store media_asset_ids (UUIDs into social_media_assets). V2 stores URLs. The backfill script must join social_media_assets to get storage_path and construct the Supabase storage URL. If any asset row has been deleted, the migrated draft will have no media. |
+
+---
+
+## Out of Scope
+
+The following are explicitly NOT being migrated in this workstream:
+
+1. **`social_connections` table and all connection management** — The connection/identity model is V1 and is used by both old and new pipelines. Migrating it is a separate concern.
+2. **`social_approval_requests` / `social_approval_recipients` / `social_approval_events` deep migration** — The V1 external approval system (with OTP, multi-approver rules, snapshot immutability) has no V2 equivalent. If the product wants to preserve these features for V2, that requires a separate design workstream.
+3. **`social_viewer_links` (customer calendar magic links)** — V1-only table. Migrating the viewer link experience to use V2 data is in scope (PR-10 switches the reader), but the token table itself is out of scope unless a replacement is designed.
+4. **`social_media_assets` to Cloudflare/direct URL migration** — V2 stores plain URLs. The media assets themselves are in Supabase storage. This workstream only ensures that migrated V1 posts have their asset URLs resolved; it does not move the media files.
+5. **`social_publish_attempts` historical audit data** — The V1 publish attempt log will be dropped with the V1 tables. If historical attempt data needs preservation, it should be exported to analytics storage before PR-17.
+6. **MSP batch-release (`pending_msp_release` state)** — No V2 equivalent exists. If the product still needs batch-release gating, this is a separate design + implementation workstream.
+7. **`platform_social_profiles` / BSP analytics refresh cron** — These are V2-side features that already work. They are not being changed.
+8. **CAP campaign management** — The `cap_campaign_posts` table and CAP generation pipeline changes are not in scope beyond switching the output model from V1 to V2 (PR-05).
+
+---
+
+## Open Decisions for Steven
+
+**OD-1: What happens to the `approved` state?**
+
+V1 has a distinct `approved` state between approval and scheduling. V2 skips directly from `pending_approval` to `scheduled` on approval. If MSP editors approve a post and want to hold it in an approved-but-not-yet-scheduled state before the client schedules it, V2 cannot represent this today.
+
+Options:
+a. Accept the V2 model: approval = immediate scheduling. (Simplest; requires product agreement that approved = scheduled.)
+b. Add `approved` to the V2 CHECK constraint and update the approve route to land there. (More complexity; preserves the workflow.)
+
+**OD-2: What is the `changes_requested` equivalent in V2?**
+
+V1 supports a `changes_requested` flow: approver requests changes with a comment → editor gets notified → editor reopens and edits → resubmits. V2 only has `rejected` (terminal). Does the product need multi-round review, or is reject-and-resubmit sufficient?
+
+Options:
+a. V2 `rejected` is terminal; editor creates a new draft if changes needed. (Simplest; breaks the round-trip workflow.)
+b. Add `changes_requested` to the V2 state CHECK constraint + add a reopen endpoint. (Preserves round-trip; ~1 PR.)
+
+**OD-3: Should `social_approval_requests` / `social_viewer_links` be rebuilt for V2?**
+
+The V1 approval system has rich features (multi-approver rules, OTP magic links, snapshot immutability, event audit log) that V2 entirely lacks. V2 approval is a single-row, single-approver record with a JWT magic link. Is the V1 richness needed for V2, or is the simpler V2 model acceptable going forward?
+
+If V1 approval richness is required, this workstream needs an additional 3–5 PRs to rebuild those features on V2 tables before V1 tables can be dropped.
+
+**OD-4: What to do with historical V1 publish attempt audit data?**
+
+`social_publish_attempts` contains an immutable audit log of every bundle.social API call: request/response payloads, error classifications, retry history. This data will be lost when PR-17 drops the table. Options:
+a. Export to cold storage (S3/Cloudflare R2) before drop.
+b. Keep the table in DB as a read-only archive indefinitely.
+c. Accept data loss.
+
+**OD-5: What is the target row count and is a live migration acceptable?**
+
+If V1 tables have >10,000 rows in production, the backfill migration script (PR-04) may take minutes to run. This should be run as a background migration during low-traffic hours. If V1 has <1,000 rows (likely if it was not fully rolled out to customers), it can run inline. A staging row count query (see data-snapshot.md) should be run before writing PR-04.

--- a/docs/migrations/v1-to-v2-consolidation/code-paths.md
+++ b/docs/migrations/v1-to-v2-consolidation/code-paths.md
@@ -1,0 +1,180 @@
+# Code Paths — V1 and V2 Social Post Tables
+
+All file:line citations verified 2026-05-27. "V1" = social_post_master / social_post_variant / social_schedule_entries. "V2" = social_post_drafts / social_post_approval_decisions.
+
+---
+
+## V1 Code Paths
+
+### Feature area: Calendar / Dashboard
+
+| File | V1 Operation | What it does |
+|------|-------------|--------------|
+| `app/api/platform/social/posts/route.ts:42–113` | READ social_post_master | GET endpoint — lists posts by state/company with pagination. Calls `listPostMasters` |
+| `app/api/platform/social/posts/route.ts:55–113` | INSERT social_post_master | POST endpoint — creates new draft post. Calls `createPostMaster`, optionally creates variants |
+| `app/viewer/[token]/page.tsx:68–125` | READ social_post_master, social_post_variant, social_schedule_entries | Public customer calendar — renders approved/scheduled/published posts in 90-day window |
+| `lib/platform/social/posts/list.ts:28–78` | READ social_post_master | Company-scoped list with state filter, pagination, full-text search on master_text |
+| `lib/platform/social/posts/get.ts:32` | READ social_post_master | Fetch single post by ID |
+| `lib/platform/social/posts/dashboard.ts:53–120` | READ social_post_master | Eight parallel COUNT queries for dashboard stats tiles (draft/pending/approved/scheduled/published/changesReq/failed + approvedThisWeek) |
+| `lib/platform/social/scheduling/list.ts:34–85` | READ social_post_master, social_post_variant, social_schedule_entries | Three-step join: posts → variants → schedule entries for calendar view |
+| `lib/platform/social/scheduling/list-company.ts:66–140` | READ social_post_master, social_post_variant, social_schedule_entries | Company-scoped schedule listing with state=approved filter |
+
+### Feature area: Composer (Post Creation & Editing)
+
+| File | V1 Operation | What it does |
+|------|-------------|--------------|
+| `lib/platform/social/posts/create.ts:64–76` | INSERT social_post_master | Creates a new draft; always lands in state='draft' |
+| `lib/platform/social/posts/update.ts:85–127` | UPDATE social_post_master | Partial update of master_text/link_url; gated to state='draft' only |
+| `lib/platform/social/posts/delete.ts:34–64` | DELETE social_post_master | Hard-delete; gated to state='draft' only |
+| `lib/platform/social/posts/duplicate.ts:37–102` | READ social_post_master, INSERT social_post_master, READ+INSERT social_post_variant | Clones a post + all its variants into a new draft |
+| `lib/platform/social/posts/bulk-create.ts:105` | INSERT social_post_master (batch) | Bulk CSV upload — validates rows then batch-inserts |
+| `lib/platform/social/variants/upsert.ts:75–122` | READ social_post_master (state check), UPSERT social_post_variant | Creates/updates a per-platform variant; reads master to gate on state |
+| `lib/platform/social/variants/list.ts:39–55` | READ social_post_master, READ social_post_variant | Fetches all connections for the company + joins variant rows; returns "resolved" list with variant-or-master-text |
+| `lib/platform/social/cap/generator.ts:33–34` | INSERT social_post_master, INSERT social_post_variant (via createPostMaster + upsertVariant) | CAP Claude generation — creates posts with source_type='cap' + per-platform variants |
+| `lib/platform/social/cap/image-trigger.ts:131` | READ social_post_variant | Reads variant to find media_asset_ids for AI image enrichment |
+
+### Feature area: Approval Workflow
+
+| File | V1 Operation | What it does |
+|------|-------------|--------------|
+| `lib/platform/social/posts/transitions.ts:67–86` | READ social_post_master | submitForApproval: reads post to build approval snapshot |
+| `lib/platform/social/posts/transitions.ts` (RPC) | UPDATE social_post_master (via RPC) | submit_post_for_approval RPC — flips state draft→pending_client_approval |
+| `lib/platform/social/posts/transitions.ts:268–311` | UPDATE social_post_master | reopenForEditing — flips changes_requested→draft, clears reviewer_comment |
+| `lib/platform/social/posts/transitions.ts:414–462` | RPC cancel_post_approval | Reverts pending_client_approval→draft, inserts revoked approval_event |
+| `lib/platform/social/posts/transitions.ts:549–598` | UPDATE social_post_master | approvePost — flips pending_client_approval→approved |
+| `lib/platform/social/posts/transitions.ts:624–677` | UPDATE social_post_master | rejectPost — flips pending_client_approval→rejected, sets reviewer_comment |
+| `lib/platform/social/posts/transitions.ts:702–755` | UPDATE social_post_master | requestChanges — flips pending_client_approval→changes_requested, sets reviewer_comment |
+| `lib/platform/social/approvals/decisions/record.ts:116` | READ social_post_master | External-token approval decision: reads master to get state before RPC call |
+| `app/api/approve/[token]/decision/route.ts:89–95` | READ social_post_master (via recordApprovalDecision) | External token approval — reads company_id/created_by for notification dispatch post-decision |
+
+### Feature area: Scheduling
+
+| File | V1 Operation | What it does |
+|------|-------------|--------------|
+| `lib/platform/social/scheduling/create.ts:57–153` | READ social_post_master (state), UPSERT social_post_variant, INSERT social_schedule_entries | Creates schedule entry; verifies approved state, ensures variant exists, inserts schedule row, enqueues QStash |
+| `lib/platform/social/scheduling/cancel.ts:37–83` | READ+UPDATE social_schedule_entries, READ social_post_variant, READ social_post_master | Cancel: stamps cancelled_at on schedule entry, reads master to return current state |
+
+### Feature area: Publish Cron (V1 QStash pipeline)
+
+| File | V1 Operation | What it does |
+|------|-------------|--------------|
+| `app/api/cron/social-publish-backfill/route.ts` | (delegates to lib) | Vercel cron at `*/5 * * * *`. Backfills missed QStash enqueues and auto-retries failed attempts |
+| `lib/platform/social/publishing/backfill.ts:119–125` | READ social_schedule_entries | Walk entries with qstash_message_id IS NULL and scheduled_at >= now() |
+| `lib/platform/social/publishing/fire.ts:105–111` | READ social_schedule_entries | Timing-drift check: reads scheduled_at to compute publish lateness |
+| `lib/platform/social/publishing/fire.ts:136` | RPC claim_publish_job | Atomically claims schedule entry + creates publish_job + attempt; flips master state → publishing |
+| `lib/platform/social/publishing/fire.ts:248` | READ social_post_variant | Reads media_asset_ids for bundle.social upload resolution |
+| `lib/platform/social/publishing/fire.ts:435` | UPDATE social_post_master | markMasterFailed: flips state publishing→failed on bundle.social call error |
+| `lib/platform/social/publishing/retry.ts:152` | READ social_post_variant | Retry: reads variant to get platform + connection_id |
+| `lib/platform/social/publishing/retry.ts:319` | UPDATE social_post_master | Retry: flips master state after re-attempt |
+| `lib/platform/social/publishing/watchdog.ts:128–162` | READ social_post_variant, READ+UPDATE social_post_master | Stale-claim watchdog: reads in-flight variants, checks time since publish started, fails timed-out masters |
+| `lib/platform/social/publishing/enqueue.ts:96` | UPDATE social_schedule_entries | Stamps qstash_message_id after successful QStash enqueue |
+| `lib/platform/social/publishing/list-attempts.ts:58` | READ social_post_variant | Lists publish attempts; joins variant to get platform |
+
+### Feature area: Webhooks
+
+| File | V1 Operation | What it does |
+|------|-------------|--------------|
+| `lib/platform/social/webhooks/process.ts:222–233` | READ social_post_variant, READ social_post_master | post.published / post.failed webhook: traverses attempt→variant→master chain to get company_id/created_by for notifications |
+| `lib/platform/social/webhooks/process.ts:264, 313` | UPDATE social_post_master | Flips state to published or failed on webhook receipt (predicate-guarded) |
+
+### Feature area: Analytics
+
+| File | V1 Operation | What it does |
+|------|-------------|--------------|
+| `lib/platform/social/analytics.ts:104–155` | READ social_post_master (multiple) | BSP analytics queries: reads posts in state=published, joins with variant data for per-platform metrics |
+| `lib/platform/social/analytics.ts:190` | READ social_post_variant | Reads variant platform info for analytics join |
+| `lib/platform/social/analytics.ts:292–306` | READ social_post_master, READ social_post_variant | Post performance lookup: fetches post content + variant platform for analytics enrichment |
+| `lib/insights/source-attribution.ts:20–51` | READ social_post_variant, READ social_post_master | Traverses publish_attempt→variant→master to determine if post was CAP or manual |
+
+---
+
+## V2 Code Paths
+
+### Feature area: Calendar / Dashboard
+
+| File | V2 Operation | What it does |
+|------|-------------|--------------|
+| `app/api/platform/social/drafts/calendar-view/route.ts:37–46` | READ social_post_drafts | Calendar view: selects id, state, scheduled_at, published_at, content, media_urls, target_profiles, parent_draft_id in date range |
+| `app/api/platform/social/drafts/route.ts:69` | INSERT social_post_drafts | V1-legacy blank-draft POST path; also V2 composer creation via handleV2Post |
+| `app/api/platform/social/drafts/route.ts:129–211` | INSERT social_post_drafts (batch) | V2 creation: handles draft/schedule/post_now/recurring modes; inserts up to 7 rows for recurring |
+
+### Feature area: Composer (Drafts CRUD)
+
+| File | V2 Operation | What it does |
+|------|-------------|--------------|
+| `app/api/platform/social/drafts/[id]/route.ts:36–57` | READ social_post_drafts | GET draft — loads full row by id, gated on company_id |
+| `app/api/platform/social/drafts/[id]/route.ts:127–244` | UPDATE social_post_drafts | PATCH V2: writes content, media_urls, target_profiles, platform_variants, state, scheduled_at, planned_for_at, approval_required, approver_user_id + mirrors into draft_data blob |
+| `app/api/platform/social/drafts/[id]/route.ts:247–272` | UPDATE social_post_drafts | PATCH V1-legacy: CAS update on draft_data blob only |
+| `app/api/platform/social/drafts/[id]/route.ts:292–322` | UPDATE social_post_drafts | DELETE (soft): sets archived_at; gated — blocks publishing/published |
+| `app/api/platform/social/drafts/bulk/route.ts` | INSERT social_post_drafts | Bulk CSV V2 path (lib/social/bulk-csv/parse.ts feeds this) |
+| `app/api/platform/social/drafts/[id]/convert-to-draft/route.ts` | UPDATE social_post_drafts | Converts a scheduled/approved draft back to draft state |
+| `lib/platform/social/drafts.ts:64–120` | INSERT social_post_drafts | createDraft: blank draft with optional idempotency_key (CAP + service-auth path) |
+| `lib/platform/social/drafts.ts:126–171` | READ social_post_drafts | getDraft: fetch by id + company_id, excludes archived |
+| `lib/platform/social/drafts.ts:181–241` | UPDATE social_post_drafts | saveDraft: CAS update on draft_data blob; returns VERSION_CONFLICT with current_draft when version mismatch |
+
+### Feature area: Approval Workflow (V2)
+
+| File | V2 Operation | What it does |
+|------|-------------|--------------|
+| `app/api/platform/social/drafts/[id]/approve/route.ts:39–41` | READ social_post_drafts | Loads draft to check state=pending_approval and get approver_user_id |
+| `app/api/platform/social/drafts/[id]/approve/route.ts:73–78` | UPDATE social_post_drafts | Flips state pending_approval→scheduled (approved) or →rejected |
+| `app/api/platform/social/drafts/[id]/approve/route.ts:83–93` | INSERT social_post_approval_decisions | Writes the approval decision record |
+| `app/api/review/[token]/decision/route.ts` | READ+UPDATE social_post_drafts, INSERT social_post_approval_decisions | Magic-link external approver decision: JWT-verified token, same state transitions |
+| `lib/social/approval/escalate.ts` | READ social_post_drafts, READ social_post_approval_decisions | Escalation logic: finds drafts stuck in pending_approval past deadline |
+| `app/api/internal/cron/escalate-approvals/route.ts` | (delegates to escalate.ts) | Vercel cron at `0 */6 * * *` |
+| `app/api/platform/social/drafts/[id]/review-link/route.ts` | READ social_post_drafts | Generates signed JWT review token for external approver magic-link |
+
+### Feature area: Publish Cron (V2 direct-pg pipeline)
+
+| File | V2 Operation | What it does |
+|------|-------------|--------------|
+| `app/api/internal/cron/publish-due/route.ts` | (delegates to claimDueDrafts + svc.from) | Vercel cron at `* * * * *`. Claims and publishes due drafts |
+| `lib/social/publishing/claim-due-drafts.ts:31–56` | UPDATE social_post_drafts (raw pg.Client FOR UPDATE SKIP LOCKED) | Atomic batch claim: CTE locks state='scheduled' rows with scheduled_at <= now(), transitions to publishing, stamps publish_claimed_at + publish_worker_id |
+| `app/api/internal/cron/publish-due/route.ts:98–105` | UPDATE social_post_drafts | Success writeback: sets state='published', published_at, published_url |
+| `app/api/internal/cron/publish-due/route.ts:108–131` | UPDATE social_post_drafts | Failure writeback: sets state back to scheduled (or failed after MAX_PUBLISH_ATTEMPTS), publish_attempts++, clears claim columns, sets last_publish_error |
+
+### Feature area: Analytics (V2)
+
+| File | V2 Operation | What it does |
+|------|-------------|--------------|
+| `app/api/platform/social/drafts/[id]/analytics/route.ts` | READ social_post_analytics_cache (FK → social_post_drafts) | Returns cached analytics for a V2 draft |
+
+---
+
+## Summary: What V1-Only Routes Exist
+
+These routes/libs use ONLY V1 tables — they have no V2 equivalent and require full migration:
+
+| Route / Lib | V1 table(s) used | Migration complexity |
+|------------|-----------------|---------------------|
+| `GET /api/platform/social/posts` | social_post_master | Duplicate of calendar-view but column-different |
+| `POST /api/platform/social/posts` | social_post_master, social_post_variant | Must switch CAP generator to V2 createDraft path |
+| `GET /viewer/[token]` | social_post_master, social_post_variant, social_schedule_entries | Read-only; needs V2 analogue |
+| `lib/platform/social/posts/*` (entire directory) | social_post_master | 9 files, full state machine |
+| `lib/platform/social/scheduling/*` | social_post_master, social_post_variant, social_schedule_entries | 5 files |
+| `lib/platform/social/publishing/*` | social_post_variant, social_schedule_entries + social_post_master | 6 files; tied to claim_publish_job RPC |
+| `lib/platform/social/analytics.ts` | social_post_master, social_post_variant | Reads state=published posts for BSP analytics |
+| `lib/insights/source-attribution.ts` | social_post_variant, social_post_master | CAP vs manual attribution traversal |
+| `app/api/approve/[token]/decision/route.ts` | social_post_master (via recordApprovalDecision) | External-token V1 approval |
+| `app/api/cron/social-publish-backfill/route.ts` | social_schedule_entries | Can be retired after V2 pipeline is sole path |
+| Postgres RPCs: submit_post_for_approval, record_approval_decision, cancel_post_approval, claim_publish_job, retry_publish_attempt | All V1 tables | Stored procedures; 7 migration files |
+
+## Summary: What V2-Only Routes Exist
+
+These routes use ONLY V2 tables — they survive the migration without change:
+
+- `app/api/platform/social/drafts/*` (all sub-routes)
+- `app/api/internal/cron/publish-due/route.ts`
+- `app/api/internal/cron/escalate-approvals/route.ts`
+- `app/api/review/[token]/decision/route.ts`
+- `app/(public)/review/[token]/page.tsx`
+- `lib/platform/social/drafts.ts`
+- `lib/social/publishing/claim-due-drafts.ts`
+- `lib/social/approval/escalate.ts`
+
+## Dual-Mode Files (write to both)
+
+| File | V1 writes | V2 writes | Notes |
+|------|-----------|-----------|-------|
+| `app/api/platform/social/drafts/[id]/route.ts` | None | social_post_drafts | Has V1-legacy PATCH path (draft_data blob) and V2 PATCH path; routes to one based on 'content' field presence |
+| `app/api/platform/social/drafts/route.ts` | None | social_post_drafts | Has V1-legacy blank POST and V2 mode POST |

--- a/docs/migrations/v1-to-v2-consolidation/data-snapshot.md
+++ b/docs/migrations/v1-to-v2-consolidation/data-snapshot.md
@@ -1,0 +1,157 @@
+# Data Snapshot — V1 vs V2 Column Comparison
+
+Investigation date: 2026-05-27. Row counts from staging are NOT available (no direct DB access during this investigation). They are deferred — see the note at the end of this document.
+
+---
+
+## Side-by-Side Column Comparison
+
+### Post Content / Identity
+
+| Concept | V1 column (social_post_master) | V2 column (social_post_drafts) | Gap |
+|---------|-------------------------------|-------------------------------|-----|
+| Post body text | `master_text TEXT` | `content TEXT` | Renamed. V1 NULL-default, V2 NOT NULL DEFAULT ''. V1 allows empty post (null/blank), V2 enforces non-null. |
+| Link URL | `link_url TEXT` | **Not a column — only in draft_data JSONB blob** | The calendar-view route explicitly comments: `link_url: null, // link_url is not a column on social_post_drafts` (app/api/platform/social/drafts/calendar-view/route.ts:68). This is a gap. |
+| Source type | `source_type social_post_source` ('manual','csv','cap','api') | `batch_id UUID` (groups CSV batches) + source inferred from context | V1 has an explicit source enum. V2 has no equivalent source_type column. CAP source attribution will break (lib/insights/source-attribution.ts traverses V1 tables). |
+| Company | `company_id UUID NOT NULL` | `company_id UUID NOT NULL` | Same |
+| Creator | `created_by UUID` (FK → platform_users, nullable) | `created_by UUID NOT NULL` (FK → auth.users, NOT NULL) | V1: FK to platform_users, nullable. V2: FK to auth.users, NOT NULL. FK target differs. |
+| Updated by | Not present | `updated_by UUID NOT NULL` (FK → auth.users) | V2-only |
+| Version / CAS | Not present | `draft_version INT NOT NULL DEFAULT 1` | V2-only optimistic concurrency |
+| State | `state social_post_state` (Postgres ENUM type) | `state TEXT` with CHECK constraint | Type system differs — ENUM vs constrained TEXT. See DI-006 section below. |
+
+### Per-Platform Content
+
+| Concept | V1 | V2 | Gap |
+|---------|----|----|-----|
+| Per-platform text | `social_post_variant.variant_text TEXT` (separate row per platform) | `platform_variants JSONB` field within social_post_drafts (`{platform: {content?, link?, cta?}}`) | Architecture change: V1 uses sibling rows; V2 uses JSONB within the single draft row. |
+| Target accounts | `social_post_variant.connection_id UUID` (FK → social_connections) | `target_profiles JSONB` (array of `{profile_id: uuid}`, FK → platform_social_profiles concept) | V1 links to social_connections; V2 links to platform_social_profiles. Connection model differs. |
+| Platform list | `social_post_variant.platform social_platform` ENUM | `platform_variants` JSONB keys (string) | V1 ENUM: linkedin_personal, linkedin_company, facebook_page, x, gbp. V2 strings include instagram, pinterest, tiktok (lib/social/types.ts:10–17). V2 supports more platforms. |
+| Media | `social_post_variant.media_asset_ids UUID[]` (FK refs to social_media_assets) | `media_urls TEXT[]` (direct URLs) | Architecture change: V1 stores asset IDs referencing social_media_assets rows. V2 stores plain URLs. |
+
+### Scheduling
+
+| Concept | V1 | V2 | Gap |
+|---------|----|----|-----|
+| Scheduled time | `social_schedule_entries.scheduled_at TIMESTAMPTZ` (separate row) | `social_post_drafts.scheduled_at TIMESTAMPTZ` (inline column) | Architecture: V1 puts this in a separate child table; V2 is inline. |
+| Schedule cancel | `social_schedule_entries.cancelled_at TIMESTAMPTZ` | `state` ('draft' reverts) or `archived_at` | V1 has explicit cancel trail; V2 uses state + soft-delete |
+| QStash anchor | `social_schedule_entries.qstash_message_id TEXT` | Not present — V2 publish cron uses FOR UPDATE SKIP LOCKED poll | V2 abandons QStash-per-entry in favour of a polling cron |
+| Scheduled by | `social_schedule_entries.scheduled_by UUID` (FK → platform_users) | Not present | V1 tracks who scheduled; V2 doesn't |
+| Multiple schedules per post | UNIQUE (post_variant_id) — one per platform variant | Multiple rows in social_post_drafts with same content | V1 allows one schedule per variant via constraint; V2 allows multiple draft rows |
+| Recurring posts | Not present | `parent_draft_id`, `recurrence_rule`, `recurrence_state`, `recurrence_starting_at`, `recurrence_until`, `occurrence_index` | V2-only feature |
+| "Planned for" hint | Not present | `planned_for_at TIMESTAMPTZ` | V2-only "save draft for this date" |
+
+### Approval
+
+| Concept | V1 | V2 | Gap |
+|---------|----|----|-----|
+| Approval metadata | `social_approval_requests` table with `snapshot_payload JSONB`, `expires_at`, `approval_rule`, etc. | `social_post_approval_decisions` table (simpler) + `approver_user_id` on draft | V1 approval is much richer: it has recipients, magic-link tokens, OTP codes, multi-approver rules, snapshot immutability. V2 approval is a single-user, single-decision record. |
+| Approval recipients | `social_approval_recipients` table with per-recipient token_hash, OTP support | Not present | V2 has no external-recipient token table; uses JWT review links instead |
+| Approval events | `social_approval_events` table (full event log: viewed, identity_bound, comment_added, etc.) | Not present | V2 has no approval event audit log |
+| Reviewer comment | `social_post_master.reviewer_comment TEXT` (0078) | Rejection reason in `social_post_approval_decisions.rejection_reason` | Different storage — V1 denormalises to master row; V2 stores in decision log |
+| Viewer links | `social_viewer_links` table (90-day customer calendar links) | Not present in V2 | V2 has no equivalent customer-facing viewer link table |
+
+### Publishing
+
+| Concept | V1 | V2 | Gap |
+|---------|----|----|-----|
+| Publish jobs | `social_publish_jobs` table | Not present | V2 has no publish_jobs table — publish state is tracked directly on the draft row |
+| Publish attempts | `social_publish_attempts` table (immutable audit log, retry tracking, error classification) | `publish_attempts INT` counter + `last_publish_error JSONB` + `published_at` on draft | V1 has full per-attempt audit trail. V2 only stores last error and attempt count. |
+| Claim / worker tracking | Via RPC `claim_publish_job` using schedule_entries | `publish_claimed_at TIMESTAMPTZ + publish_worker_id TEXT` inline on draft (0152) | Different claiming mechanism |
+| Published URL | Not directly — on `social_publish_attempts.platform_post_url` | `published_url TEXT` on draft | V2 denormalises published URL onto draft row |
+| Webhook reconciliation | `social_publish_attempts.bundle_post_id TEXT` — webhook matches this | Not present in V2 publish pipeline | V2 cron does not use bundle.social webhooks to confirm publish |
+
+### Soft Delete / Archive
+
+| Concept | V1 | V2 |
+|---------|----|----|
+| Deletion model | Hard delete (social_post_master delete cascades to variants/schedule/approval) | Soft delete via `archived_at` |
+
+---
+
+## DI-006: State Enum Divergence (Full Reference)
+
+V1 enum (`social_post_state`, 0070:123–134):
+```
+draft → pending_client_approval → approved → scheduled → publishing → published
+                                ↓          (or)
+                          changes_requested
+                                ↓
+                              draft (reopen)
+                          rejected (terminal)
+pending_msp_release (batch-release gate, 0097)
+failed (terminal)
+```
+
+V2 CHECK constraint values (0132:20–30):
+```
+draft → pending_approval → scheduled → publishing → published
+                         ↓
+                      rejected (terminal)
+recurring (parent of a recurrence series)
+paused (recurrence paused)
+failed (terminal)
+```
+
+### Missing V2 equivalents — impact:
+
+**`approved` (V1 only)**
+V1 flow: draft → pending_client_approval → approved (holding state while editor schedules) → scheduled
+V2 flow: pending_approval → scheduled (approval immediately schedules)
+Impact: The V1 dashboard has an "approved" stat tile (`lib/platform/social/posts/dashboard.ts:56`). V2 calendar-view has no approved state. The dashboard will lose the "approved but not yet scheduled" count. If the product wants to preserve this holding state for V2, a new `approved` value must be added to the V2 CHECK constraint.
+
+**`changes_requested` (V1 only)**
+V1: Approver can request changes (distinct from rejected). Editor receives comment, reopens for editing, resubmits.
+V2: Only 'rejected' terminal state. The V2 approve route (`app/api/platform/social/drafts/[id]/approve/route.ts:72`) maps approved→scheduled, rejected→rejected. No changes_requested path exists.
+Impact: Editor/approver feedback loop is less expressive in V2. If multi-round review is needed, this requires a new V2 state.
+
+**`pending_msp_release` (V1 only)**
+Added in 0097 migration to gate batch releases. No V2 equivalent. If MSP batch-release is still a feature, it must be added to V2.
+
+---
+
+## Runtime Paths: Which Crons Use V1 vs V2
+
+From `vercel.json` analysis:
+
+| Cron path | Schedule | Model | Note |
+|-----------|----------|-------|------|
+| `/api/cron/social-publish-backfill` | `*/5 * * * *` | V1 | Backfills social_schedule_entries + retries failed social_publish_attempts |
+| `/api/cron/social-publish-watchdog` | `*/5 * * * *` | V1 | Watches for stale social_publish_attempts (stuck in_flight) |
+| `/api/internal/cron/publish-due` | `* * * * *` | V2 | Claims + publishes social_post_drafts state='scheduled' |
+| `/api/internal/cron/escalate-approvals` | `0 */6 * * *` | V2 | Escalates stale social_post_drafts in pending_approval |
+| `/api/cron/social-analytics-refresh` | `0 4 * * *` | V1 (via analytics.ts) | Refreshes BSP analytics — reads social_post_master for published posts |
+| `/api/cron/insights-feature-extract` | `*/15 * * * *` | Neither (reads social_post_analytics_snapshots) | Indirectly depends on V1 via source-attribution chain |
+
+**Both V1 and V2 publish crons run simultaneously today.** Posts created via `/api/platform/social/posts` (V1) flow through the QStash/backfill/watchdog pipeline. Posts created via `/api/platform/social/drafts` (V2) flow through the publish-due cron. There is no deduplication between the two pipelines.
+
+---
+
+## Staging Row Counts
+
+**Staging row counts: requires DB query, deferred.**
+
+To obtain actual counts, run against staging Supabase:
+```sql
+SELECT
+  (SELECT COUNT(*) FROM social_post_master)             AS v1_post_master,
+  (SELECT COUNT(*) FROM social_post_variant)            AS v1_post_variant,
+  (SELECT COUNT(*) FROM social_schedule_entries)        AS v1_schedule_entries,
+  (SELECT COUNT(*) FROM social_post_drafts WHERE archived_at IS NULL) AS v2_drafts_active,
+  (SELECT COUNT(*) FROM social_post_drafts WHERE archived_at IS NOT NULL) AS v2_drafts_archived,
+  (SELECT COUNT(*) FROM social_post_approval_decisions) AS v2_approval_decisions;
+```
+
+These counts are critical for the migration plan: if V1 tables have significant production data, the migration requires a non-trivial backfill script; if they are empty or near-empty (V1 was never fully rolled out to customers), the migration simplifies to a cutover + table retirement.
+
+---
+
+## Key Data Model Gaps (Pre-Migration Requirements)
+
+These gaps must be resolved before a data migration script can be written:
+
+1. **`link_url` not a column in social_post_drafts.** Referenced in draft_data JSONB blob only. Must add as a top-level column or accept loss of link_url for calendar display.
+2. **`source_type` absent from social_post_drafts.** CAP attribution in `lib/insights/source-attribution.ts` traverses the V1 tables. After migration, source attribution will break unless source_type is added to V2 or the attribution logic is rewritten to use batch_id or another signal.
+3. **`created_by` FK target differs.** V1 → platform_users. V2 → auth.users. Users who are in platform_users but not directly in auth.users (edge case) may not map cleanly.
+4. **Rich approval model not replicated.** The V1 social_approval_requests / social_approval_recipients / social_approval_events / social_viewer_links tables have no direct V2 equivalents. Post-migration, external-token approval (app/api/approve/[token]/decision/) using V1 tables will break.
+5. **social_media_assets referenced by V1 only.** V1 variant rows reference social_media_assets by UUID. V2 stores URLs directly. If migrated drafts contain media, the media_asset_ids must be resolved to URLs before insertion into V2.
+6. **`idempotency_key` column in social_post_drafts is referenced in code but has no migration file.** This must be verified against the actual DB schema before any query relying on it is executed.

--- a/docs/migrations/v1-to-v2-consolidation/schema-inventory.md
+++ b/docs/migrations/v1-to-v2-consolidation/schema-inventory.md
@@ -1,0 +1,241 @@
+# Schema Inventory — V1 → V2 Social Post Model
+
+Investigation date: 2026-05-27. All claims cite migration file:line.
+
+---
+
+## V1 Tables
+
+### `social_post_master` (0070_platform_foundation.sql:384–397)
+
+| Column | Type | Constraints | Notes |
+|--------|------|-------------|-------|
+| `id` | UUID | PK, gen_random_uuid() | |
+| `company_id` | UUID | NOT NULL, FK → platform_companies ON DELETE CASCADE | |
+| `state` | social_post_state | NOT NULL DEFAULT 'draft' | Enum — see below |
+| `source_type` | social_post_source | NOT NULL DEFAULT 'manual' | Enum: manual, csv, cap, api |
+| `master_text` | TEXT | nullable | |
+| `link_url` | TEXT | nullable | |
+| `created_by` | UUID | nullable, FK → platform_users ON DELETE SET NULL | |
+| `created_at` | TIMESTAMPTZ | NOT NULL DEFAULT now() | |
+| `updated_at` | TIMESTAMPTZ | NOT NULL DEFAULT now() | |
+| `state_changed_at` | TIMESTAMPTZ | NOT NULL DEFAULT now() | Updated by trg_post_master_state_change |
+| `reviewer_comment` | TEXT | nullable, added 0078 | Stores rejection/changes comment |
+
+**Indexes:**
+- `idx_post_master_company_state` ON (company_id, state) — 0070:396
+- `idx_post_master_state_changed` ON (state_changed_at) — 0070:397
+
+**RLS:** `post_master_access` policy — ALL for staff OR company member — 0070:682–684
+
+**Triggers:**
+- `trg_post_master_updated` — sets updated_at via set_updated_at() — 0070:587–589
+- `trg_post_master_state_change` — stamps state_changed_at when state changes — 0070:604–606
+
+**Stored functions that write to this table:**
+- `submit_post_for_approval` (0071) — flips state draft→pending_client_approval
+- `record_approval_decision` (0072) — flips state on external-token approval
+- `cancel_post_approval` (0073) — reverts pending_client_approval→draft
+- `claim_publish_job` (0075, 0090, 0094, 0096) — flips state approved/scheduled→publishing
+- `retry_publish_attempt` (0076, 0091, 0092, 0094) — reads master_id from variant
+
+---
+
+### `social_post_variant` (0070_platform_foundation.sql:399–413)
+
+| Column | Type | Constraints | Notes |
+|--------|------|-------------|-------|
+| `id` | UUID | PK, gen_random_uuid() | |
+| `post_master_id` | UUID | NOT NULL, FK → social_post_master ON DELETE CASCADE | |
+| `platform` | social_platform | NOT NULL | Enum: linkedin_personal, linkedin_company, facebook_page, x, gbp |
+| `connection_id` | UUID | nullable, FK → social_connections ON DELETE SET NULL | |
+| `variant_text` | TEXT | nullable | Override of master_text for this platform |
+| `is_custom` | BOOLEAN | NOT NULL DEFAULT false | |
+| `scheduled_at` | TIMESTAMPTZ | nullable | Deprecated in favour of schedule_entries |
+| `media_asset_ids` | UUID[] | DEFAULT '{}' | Refs to social_media_assets |
+| `created_at` | TIMESTAMPTZ | NOT NULL DEFAULT now() | |
+| `updated_at` | TIMESTAMPTZ | NOT NULL DEFAULT now() | |
+
+**Constraints:**
+- UNIQUE (post_master_id, platform) — 0070:411 — prevents duplicate variants per platform
+
+**Indexes:**
+- `idx_post_variant_master` ON (post_master_id) — 0070:412
+- `idx_post_variant_scheduled` ON (scheduled_at) WHERE scheduled_at IS NOT NULL — 0070:413
+
+**RLS:** `post_variant_access` — staff OR EXISTS company-member check via post_master — 0070:687–698
+
+**Trigger:** `trg_post_variant_updated` — sets updated_at — 0070:590–592
+
+---
+
+### `social_schedule_entries` (0070_platform_foundation.sql:507–517)
+
+| Column | Type | Constraints | Notes |
+|--------|------|-------------|-------|
+| `id` | UUID | PK, gen_random_uuid() | |
+| `post_variant_id` | UUID | NOT NULL, FK → social_post_variant ON DELETE CASCADE | |
+| `scheduled_at` | TIMESTAMPTZ | NOT NULL | When to fire |
+| `qstash_message_id` | TEXT | nullable | Set after QStash enqueue; NULL = needs backfill |
+| `scheduled_by` | UUID | nullable, FK → platform_users ON DELETE SET NULL | |
+| `created_at` | TIMESTAMPTZ | NOT NULL DEFAULT now() | |
+| `cancelled_at` | TIMESTAMPTZ | nullable | Soft-cancel; NULL = active |
+
+**Indexes:**
+- `idx_schedule_entries_variant` ON (post_variant_id) — 0070:516
+- `idx_schedule_entries_pending` ON (scheduled_at) WHERE cancelled_at IS NULL — 0070:517
+
+**RLS:** `schedule_entries_access` — staff OR EXISTS company-member via variant→master chain — 0070:726–734
+
+**Note:** This table is the QStash enqueue anchor. `claim_publish_job` RPC locks on this row.
+
+---
+
+## V2 Tables
+
+### `social_post_drafts` (built across migrations 0112, 0127, 0131, 0132, 0133, 0136, 0152)
+
+Full column set assembled from all migrations:
+
+| Column | Type | Constraints | Migration | Notes |
+|--------|------|-------------|-----------|-------|
+| `id` | UUID | PK, gen_random_uuid() | 0112:23 | |
+| `company_id` | UUID | NOT NULL, FK → platform_companies ON DELETE CASCADE | 0112:25 | |
+| `created_by` | UUID | NOT NULL, FK → auth.users ON DELETE CASCADE | 0112:26 | Note: FK to auth.users, not platform_users |
+| `updated_by` | UUID | NOT NULL, FK → auth.users | 0112:27 | |
+| `draft_version` | INT | NOT NULL DEFAULT 1 | 0112:28 | Optimistic CAS per ADR-0002 |
+| `draft_data` | JSONB | NOT NULL DEFAULT '{}' | 0112:29 | Legacy blob (Spec 22 V1 path). Contains master_text, media_refs, target_connection_ids, schedule, approval_required, ai_metadata |
+| `created_at` | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | 0112:30 | |
+| `updated_at` | TIMESTAMPTZ | NOT NULL DEFAULT NOW() | 0112:31 | |
+| `archived_at` | TIMESTAMPTZ | nullable | 0112:32 | Soft-delete |
+| `state` | TEXT | NOT NULL DEFAULT 'draft', CHECK constraint (0132) | 0127:20 | Values: draft, pending_approval, rejected, scheduled, recurring, paused, publishing, published, failed |
+| `content` | TEXT | NOT NULL DEFAULT '' | 0127:21 | Plain-text post body |
+| `media_urls` | TEXT[] | NOT NULL DEFAULT '{}' | 0127:22 | Direct URL array (not asset IDs) |
+| `target_profiles` | JSONB | NOT NULL DEFAULT '[]' | 0127:23 | Array of {profile_id: uuid} |
+| `platform_variants` | JSONB | NOT NULL DEFAULT '{}' | 0127:24 | Per-platform overrides: {platform: {content?, link?, cta?}} |
+| `scheduled_at` | TIMESTAMPTZ | nullable | 0127:26 | When to publish |
+| `approval_required` | BOOLEAN | NOT NULL DEFAULT false | 0127:27 | |
+| `approver_user_id` | UUID | nullable, FK → auth.users | 0127:28 | Named approver for internal platform flow |
+| `parent_draft_id` | UUID | nullable, FK → social_post_drafts ON DELETE CASCADE | 0131:8 | Recurring post parent link |
+| `recurrence_rule` | TEXT | nullable | 0131:9 | RFC 5545 RRULE string |
+| `recurrence_state` | TEXT | nullable, CHECK IN ('active','paused','ended') | 0131:12 | |
+| `occurrence_index` | INTEGER | nullable | 0131:11 | Child position in recurrence series |
+| `planned_for_at` | TIMESTAMPTZ | nullable | 0132:8 | "Save as draft for this date" hint |
+| `published_at` | TIMESTAMPTZ | nullable | 0133:9 | |
+| `published_url` | TEXT | nullable | 0133:10 | |
+| `last_publish_error` | JSONB | nullable | 0133:11 | {code, message, attempted_at, attempt_number} |
+| `publish_attempts` | INTEGER | NOT NULL DEFAULT 0 | 0133:12 | |
+| `batch_id` | UUID | nullable | 0136:8 | Groups rows from one CSV upload; used by rate limiter |
+| `recurrence_starting_at` | TIMESTAMPTZ | nullable | 0136:9 | RRULE start bound |
+| `recurrence_until` | TIMESTAMPTZ | nullable | 0136:10 | RRULE end bound |
+| `publish_claimed_at` | TIMESTAMPTZ | nullable | 0152:29 | Atomically set when claim loop takes row |
+| `publish_worker_id` | TEXT | nullable | 0152:30 | Worker that claimed the row; diagnostic |
+
+**Also exists but not in base 0112 migration:** `idempotency_key` column referenced in `lib/platform/social/drafts.ts:79` — this column is used in code (`eq("idempotency_key", params.idempotencyKey)`) but there is no migration explicitly adding it. This is a schema gap that must be verified before migration.
+
+**Constraints (0131):**
+- `social_post_drafts_recurrence_shape` — parent_draft_id and recurrence_rule cannot both be set
+- `social_post_drafts_recurrence_state_valid` — recurrence_state enum values
+
+**State constraint (0132:19–31):**
+```
+CHECK state IN ('draft','pending_approval','rejected','scheduled','recurring','paused','publishing','published','failed')
+```
+
+**Indexes:**
+- `idx_social_post_drafts_company` ON (company_id, archived_at) WHERE archived_at IS NULL — 0112
+- `idx_social_post_drafts_created_by` ON (created_by, updated_at DESC) WHERE archived_at IS NULL — 0112
+- `idx_social_post_drafts_updated` ON (updated_at DESC) — 0112
+- `idx_social_post_drafts_scheduled` ON (scheduled_at) WHERE state='scheduled' AND scheduled_at IS NOT NULL — 0127
+- `idx_social_post_drafts_pending_approval` ON (created_at DESC) WHERE state='pending_approval' — 0127
+- `idx_social_post_drafts_parent_id` ON (parent_draft_id) WHERE parent_draft_id IS NOT NULL — 0131
+- `idx_social_post_drafts_planned_for_at` ON (planned_for_at) WHERE state='draft' AND planned_for_at IS NOT NULL — 0132
+- `idx_social_post_drafts_published_at` ON (published_at DESC) WHERE state='published' AND published_at IS NOT NULL — 0133
+- `idx_social_post_drafts_batch_id` ON (batch_id) WHERE batch_id IS NOT NULL — 0136
+- `idx_social_post_drafts_scheduled_for_claim` ON (scheduled_at) WHERE state='scheduled' AND archived_at IS NULL — 0152
+
+**RLS (0112:50–68):**
+- `social_post_drafts_company_editors` FOR ALL — company member with role IN ('editor','approver','admin')
+
+---
+
+### `social_post_approval_decisions` (0134_analytics_cache.sql:49–91)
+
+| Column | Type | Constraints | Notes |
+|--------|------|-------------|-------|
+| `id` | UUID | PK, gen_random_uuid() | |
+| `draft_id` | UUID | NOT NULL, FK → social_post_drafts ON DELETE CASCADE | |
+| `approver_user_id` | UUID | NOT NULL, FK → auth.users | Internal platform user only — external approvers get NULL per D5 |
+| `decision` | TEXT | NOT NULL, CHECK IN ('approved','rejected') | Note: 'changes_requested' is a V1 state but is NOT a valid decision value here |
+| `rejection_reason` | TEXT | nullable | Required when decision='rejected' (30–500 chars) |
+| `decided_at` | TIMESTAMPTZ | NOT NULL DEFAULT now() | |
+| `escalation_level` | INTEGER | NOT NULL DEFAULT 0, CHECK BETWEEN 0 AND 3 | |
+
+**Constraint:**
+- `rejection_reason_required_when_rejected` — rejection_reason NOT NULL and 30–500 chars when decision='rejected'
+
+**Indexes:**
+- `idx_social_post_approval_decisions_draft_id` ON (draft_id) — 0134:66
+
+**RLS:**
+- `select_own_company` FOR SELECT — via social_post_drafts.company_id + is_company_member()
+- `insert_as_approver` FOR INSERT — approver_user_id = auth.uid() AND company member
+
+---
+
+## State/Status Enum Comparison
+
+### V1: `social_post_state` enum (0070:123–134)
+
+Values:
+1. `draft`
+2. `pending_client_approval`
+3. `approved`
+4. `rejected`
+5. `changes_requested`
+6. `pending_msp_release` (added 0097 — "lock out pending MSP release" migration)
+7. `scheduled`
+8. `publishing`
+9. `published`
+10. `failed`
+
+TypeScript mirror: `SocialPostState` in `lib/platform/social/posts/types.ts:5–14`
+
+Note: `pending_msp_release` was added in 0097_lock_out_pending_msp_release.sql to gate batch releases. It is NOT in the TypeScript type (see 0097 for context).
+
+### V2: `state` TEXT column with CHECK constraint (0132:19–31)
+
+Values:
+1. `draft`
+2. `pending_approval`
+3. `rejected`
+4. `scheduled`
+5. `recurring`
+6. `paused`
+7. `publishing`
+8. `published`
+9. `failed`
+
+TypeScript mirror: `DraftState` in `lib/social/types.ts:20–28`
+
+### Enum Mapping Table (DI-006)
+
+| V1 state | V2 equivalent | Notes |
+|----------|---------------|-------|
+| `draft` | `draft` | Direct 1:1 |
+| `pending_client_approval` | `pending_approval` | Renamed — remove `_client` |
+| `approved` | **NO EQUIVALENT** | V2 has no approved-but-not-yet-scheduled state. In V2 approval → immediately `scheduled`. |
+| `rejected` | `rejected` | Direct 1:1 |
+| `changes_requested` | **NO EQUIVALENT** | V2 collapses this into `rejected`. The V2 approve route only emits 'approved' or 'rejected'. |
+| `pending_msp_release` | **NO EQUIVALENT** | MSP-specific batch-release gate. V2 has no equivalent. |
+| `scheduled` | `scheduled` | Direct 1:1 |
+| `publishing` | `publishing` | Direct 1:1 |
+| `published` | `published` | Direct 1:1 |
+| `failed` | `failed` | Direct 1:1 |
+| _(none)_ | `recurring` | V2-only — recurring post parent/template state |
+| _(none)_ | `paused` | V2-only — paused recurrence series |
+
+**Critical gaps requiring product decisions:**
+1. `approved` state: V2 skips the approved-but-not-scheduled holding state. Does the product still need it?
+2. `changes_requested`: V2 collapses to `rejected`. Does the editor/approver feedback loop need to be preserved?
+3. `pending_msp_release`: Not present in V2 at all. Is batch-release gating still required?


### PR DESCRIPTION
## Summary

Planning documents for the V1 → V2 social post model migration (Decision D3 from `docs/inventory/decisions-locked.md`).

**This PR contains no code changes** — planning docs only. It is a DRAFT and should not be merged until Steven approves the migration strategy and answers the open decisions.

## Documents

| File | Description |
|---|---|
| `docs/migrations/v1-to-v2-consolidation/PLAN.md` | Executive summary, recommended strategy (feature-by-feature), PR sequence (20–24 PRs, 10–14 days), risk register, open decisions |
| `docs/migrations/v1-to-v2-consolidation/schema-inventory.md` | Full table definitions for all 5 V1+V2 tables with column-level annotations |
| `docs/migrations/v1-to-v2-consolidation/code-paths.md` | Every file reading/writing V1 and V2, grouped by feature area (routes, libs, crons) |
| `docs/migrations/v1-to-v2-consolidation/data-snapshot.md` | Side-by-side column comparison, DI-006 state enum mapping, pre-migration schema gaps |

## Recommended strategy (summary)

Feature-by-feature with a state freeze. Schema gaps → data backfill → route cutover per feature area → V1 read-only → V1 table drop. See PLAN.md for full justification.

**Estimated effort: 10–14 days, 20–24 PRs.**

## Open decisions (blocking execution)

1. **D3 state enum mapping** — V1 `changes_requested` / `pending_msp_release` have no V2 equivalent. What should migrated posts in those states become?
2. **D3 data cutoff** — Migrate all-time V1 posts or only last 90 days?
3. **V1 archive window** — How long should V1 tables remain in DB after cutover before drop?
4. **QStash webhook migration** — V1 publishes via QStash. Does V2 have a QStash webhook path or should it be added before cutover?
5. **CAP generator cutover** — CAP currently writes to V1. Migrate CAP to V2 before or after the manual post routes?

## Status

- [ ] Steven reviews and answers open decisions
- [ ] PR promoted from DRAFT once strategy is approved
- [ ] Execution begins as a separate workstream after promotion