### PR TITLE
fix(security): rate-limit review-link and social-publish endpoints (INFRA-003/004)

### DIFF
--- a/app/api/platform/social/drafts/[id]/publish/route.ts
+++ b/app/api/platform/social/drafts/[id]/publish/route.ts
@@ -4,6 +4,7 @@ import { fromZonedTime } from "date-fns-tz";
 
 import { dbUuid, internalError, invalidState, notFound, readJsonBody, validationError } from "@/lib/http";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 import {
   authenticateRequest,
   validateServiceActorCompany,
@@ -95,6 +96,12 @@ export async function POST(
     userId = gate.userId;
     const { canDo } = await import("@/lib/platform/auth");
     hasApprovePermission = await canDo(companyId, "approve_post");
+  }
+
+  // Rate-limit user sessions only (service actors / CAP bypass).
+  if (auth.kind !== "service") {
+    const rl = await checkRateLimit("social_publish", `user:${userId}`);
+    if (!rl.ok) return rateLimitExceeded(rl);
   }
 
   // Load draft.

--- a/app/api/platform/social/drafts/[id]/review-link/route.ts
+++ b/app/api/platform/social/drafts/[id]/review-link/route.ts
@@ -4,6 +4,7 @@ import { SignJWT } from "jose";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
 import { getServiceRoleClient } from "@/lib/supabase";
 import { notFound, validateUuidParam, internalError } from "@/lib/http";
+import { checkRateLimit, rateLimitExceeded } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 
 export const runtime = "nodejs";
@@ -19,7 +20,7 @@ export const dynamic = "force-dynamic";
 const REVIEW_LINK_TTL_SECS = 14 * 24 * 60 * 60; // 14 days
 
 export async function GET(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   const { id } = await params;
@@ -37,6 +38,9 @@ export async function GET(
 
   const gate = await requireCanDoForApi(draft.company_id as string, "edit_post");
   if (gate.kind === "deny") return gate.response;
+
+  const rl = await checkRateLimit("review_link", `ip:${new Headers(req.headers).get("x-forwarded-for") ?? "unknown"}`);
+  if (!rl.ok) return rateLimitExceeded(rl);
 
   const secret = process.env.NEXTAUTH_SECRET ?? process.env.AUTH_SECRET;
   if (!secret) {

--- a/docs/inventory/infrastructure-fixes-shipped.md
+++ b/docs/inventory/infrastructure-fixes-shipped.md
@@ -1,0 +1,57 @@
+# Infrastructure Fixes — Shipped
+
+**Session:** 2026-05-27 evening  
+**Audited from:** `docs/inventory/infrastructure-gaps.md`  
+**Scope:** Top 3 ranked findings by risk score + additional MEDIUM-severity rate-limiting gaps
+
+---
+
+## Top 3 HIGH-impact fixes
+
+All three findings from the INFRA audit rankings that met the shipping criteria (HIGH impact, M or smaller complexity, no product decision needed) were addressed in **PR #1095** (`fix/di-inventory-bugs`).
+
+| Finding | Risk Score | PR | Status |
+|---------|------------|----|--------|
+| INFRA-001: `cap-weekly-generation` not in `vercel.json` | 9/10 | #1095 (DI-002) | Shipped |
+| INFRA-006: `approver_user_id NOT NULL` violated on external review | 8/10 | #1095 (DI-001) | Shipped |
+| INFRA-002: `check-webhook-health` not in `vercel.json` | 7/10 | #1095 (DI-002) | Shipped |
+
+**Fix details:**
+
+- **INFRA-001 + INFRA-002**: Added two missing cron entries to `vercel.json` — `cap-weekly-generation` (Mon 06:00 UTC) and `check-webhook-health` (daily 09:00 UTC). Both routes were already implemented with correct auth; they were simply unscheduled.
+- **INFRA-006**: Migration 0154 drops the `NOT NULL` constraint on `social_post_approval_decisions.approver_user_id` and adds an `approver_email TEXT` column. External-approver decision inserts no longer throw a silent constraint violation. Regression test `tests/regressions/di-001-approver-audit-trail.test.ts` verifies the null insert succeeds and the route returns 200.
+
+---
+
+## Track 3 additional fixes (INFRA-003, INFRA-004)
+
+Two MEDIUM-severity rate-limiting gaps were fixed in **PR #1097** (`fix/infra-hardening-rate-limits`) as Track 3 contributions. Neither was in the original top-3 but both had S complexity and no product decision needed.
+
+| Finding | Risk Score | PR | Status |
+|---------|------------|----|--------|
+| INFRA-003: Review-link generation not rate-limited | 4/10 | #1097 | Shipped |
+| INFRA-004: Social publish endpoint not rate-limited | 4/10 | #1097 | Shipped |
+
+**Fix details:**
+
+- **INFRA-003** (`GET /api/platform/social/drafts/[id]/review-link`): Added `checkRateLimit("review_link", "ip:<x-forwarded-for>")` after the auth gate. Bucket: 10 requests/hour/IP. 14-day JWTs should not be bulk-generated; 10/hour covers all legitimate editorial use (one link per draft per approval cycle) while bounding token-farming.
+
+- **INFRA-004** (`POST /api/platform/social/drafts/[id]/publish`): Added `checkRateLimit("social_publish", "user:<userId>")` after auth resolution. Bucket: 30 requests/hour/user. Service actors (CAP) bypass the limiter — they have their own per-company `cap_generate` bucket. User sessions are throttled to prevent runaway bundle.social API calls that accumulate credits.
+
+Both new buckets are defined in `lib/rate-limit.ts` with documented rationale.
+
+---
+
+## Remaining items — not shipped this session
+
+| Finding | Risk Score | Reason not shipped |
+|---------|------------|--------------------|
+| INFRA-010: Raw DB error messages in admin `internalError()` | 5/10 | Admin-only gate; not blocking. Follow-up cleanup PR. |
+| INFRA-007: `debug/env-check` unauthenticated | 3/10 | No actual secrets leaked; informational only. |
+| INFRA-016: Import webhook error message leakage to QStash logs | 2/10 | Not user-visible; low risk. |
+| INFRA-011: `internalError()` structural note | 2/10 | Pattern issue, not an exploit. |
+| INFRA-013: Direct-publish missing body Zod validation | 2/10 | Route already has `BodySchema.safeParse(body)`. Risk is low if handler reads only from parsed fields. |
+| INFRA-008: `rejectUnauthorized: false` on pg SSL | 1/10 | Vercel-to-Supabase traffic is private VPC; MITM not realistic. |
+| INFRA-005: Webhook rate limiting | N/A | Resolved by design; HMAC signature verification is the correct control. |
+| INFRA-014: `publish-due` race condition | N/A | Resolved by migration 0152 (`FOR UPDATE SKIP LOCKED`). |
+| INFRA-015: QStash retry idempotency | N/A | Resolved by existing `deduplicationId` + `claim_publish_job()` RPC. |

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -48,7 +48,9 @@ export type LimiterName =
   | "approval_decision"
   | "ai_prefill"
   | "error_report"
-  | "client_errors";
+  | "client_errors"
+  | "review_link"
+  | "social_publish";
 
 type LimiterConfig = {
   requests: number;
@@ -127,6 +129,16 @@ const CONFIGS: Record<LimiterName, LimiterConfig> = {
   // guard against client-side retry loops; must not block legitimate
   // error bursts during a bad session.
   client_errors: { requests: 20, window: "1 m" },
+  // INFRA-003: review-link JWT generation. 10/hour/IP — long-lived 14d
+  // tokens should not be issued in bulk. Normal use is one link per draft
+  // per approval cycle. Keyed by IP (caller is authenticated but we want
+  // to bound token-farming independent of which account is used).
+  review_link: { requests: 10, window: "1 h" },
+  // INFRA-004: direct-publish from composer. 30/hour/user — each call
+  // creates a post + schedule entry and may trigger a bundle.social API
+  // call. 30/hour covers rapid editorial use without opening cost-amplification
+  // paths. Keyed by user ID; service actors (CAP) bypass this limiter.
+  social_publish: { requests: 30, window: "1 h" },
 };
 
 export type RateLimitResult =


### PR DESCRIPTION
## Summary

Two MEDIUM-severity rate-limiting gaps from the infrastructure audit (`docs/inventory/infrastructure-gaps.md`).

- **INFRA-003** (`GET /api/platform/social/drafts/[id]/review-link`): No rate limit on JWT-signed review-link generation. Added `checkRateLimit("review_link", "ip:<x-forwarded-for>")` — 10 requests/hour/IP. 14-day tokens should not be bulk-generated; 10/hour covers all legitimate use (one link per draft per approval cycle).
- **INFRA-004** (`POST /api/platform/social/drafts/[id]/publish`): No rate limit on direct-publish path that triggers bundle.social API calls. Added `checkRateLimit("social_publish", "user:<userId>")` — 30 requests/hour/user. Service actors (CAP) bypass the limiter — they have their own `cap_generate` bucket. User sessions are throttled to prevent cost amplification.

Both new buckets defined in `lib/rate-limit.ts` with rationale comments.

Also ships `docs/inventory/infrastructure-fixes-shipped.md` — full accounting of which INFRA findings were fixed in this session and which remain.

## Working analog

- **Both routes**: `app/api/platform/social/drafts/[id]/approve/route.ts` already uses `checkRateLimit("approval_decision", "ip:...")` with the same import pattern. Diff: review-link and publish routes were missing the guard. Fix: identical `checkRateLimit` + `rateLimitExceeded` pattern.

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:regressions (258 pass), typecheck clean
- [x] Contract snapshots reviewed (rate-limit.ts exports no SDK snapshot)
- [x] Working-analog block in PR body
- [x] Risks identified and mitigated below
- [x] PR is under 500 net lines (~82 net lines)

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Rate limit false-positives for legitimate high-volume review use | 10/hour/IP for review-link is generous for editorial use; INFRA-003 finding notes normal use is one link per draft per cycle. Fail-open: if Redis is unavailable, limiter passes all requests. |
| CAP service actor throttled by social_publish bucket | Explicitly bypassed: `if (auth.kind !== "service")` guard. CAP has its own `cap_generate` bucket (10/24h/company). |
| New `LimiterName` union breaks TypeScript consumers | Union is additive; no existing code references the new names. TypeScript check passes cleanly. |