### PR TITLE
fix(security): move link-preview auth gate before url/ssrf validation (DI-006)

### DIFF
--- a/app/api/platform/social/link-preview/route.ts
+++ b/app/api/platform/social/link-preview/route.ts
@@ -106,6 +106,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return validationError("url (string) is required.");
   }
 
+  // Auth gate first — don't do URL parsing or SSRF checks for unauthorised callers.
+  const gate = await requireCanDoForApi(company_id, "edit_post");
+  if (gate.kind === "deny") return gate.response;
+
   let parsed: URL;
   try {
     parsed = new URL(url.trim());
@@ -128,9 +132,6 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     }
     return internalError("Failed to validate URL.");
   }
-
-  const gate = await requireCanDoForApi(company_id, "edit_post");
-  if (gate.kind === "deny") return gate.response;
 
   const normalizedUrl = parsed.href;
   const domain = extractDomain(normalizedUrl);

--- a/tests/regressions/di-005-review-link-state-check.test.ts
+++ b/tests/regressions/di-005-review-link-state-check.test.ts
@@ -17,7 +17,12 @@ const DRAFT_ID = "dddddddd-0000-4000-8000-000000000011";
 const COMPANY_ID = "cccccccc-0000-4000-8000-000000000002";
 
 vi.mock("@/lib/logger", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(async () => ({ ok: true })),
+  rateLimitExceeded: vi.fn(),
 }));
 
 vi.mock("@/lib/platform/auth/api-gate", () => ({


### PR DESCRIPTION
## Summary

Hotfix for a test ordering regression introduced by DI-006 (#1095).

The DI-006 SSRF guard was placed before the auth gate in `link-preview/route.ts`. This caused the pre-existing test (`lib/__tests__/link-preview-route.unit.test.ts`) that passes an invalid URL to test auth denial to get 400 (from URL validation) instead of 403 (from auth gate). The `test-unit` CI check was failing on the original Track 1 PR due to the DI-010 mock issue, but this separate test was also broken — it only surfaced when attempting the staging cherry-pick.

**Fix**: Move the auth gate to run immediately after body parsing (`company_id` validation), before URL parsing and the SSRF guard. This is also more correct security posture — unauthenticated callers should not be able to probe URL validation behavior.

Also fixes `di-005-review-link-state-check.test.ts`: missing `@/lib/rate-limit` mock (Track 3 added a rate limit to the review-link route, the DI-005 test wasn't updated).

## Working analog

`app/api/platform/social/cap/generate/route.ts` runs auth gate immediately after body parsing, before any external calls or validation of user-supplied parameters. Diff: link-preview ran auth after URL parsing. Fix: moved auth to match cap/generate ordering.

## Pre-PR checklist
- [x] test:regressions: 43 files, 272 tests pass
- [x] typecheck clean
- [x] Working-analog block above
- [x] Risks identified below

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| Unauthenticated callers no longer get URL validation errors | Auth gate denial (401/403) is the correct first response for unauthenticated callers; no functional loss |
| DI-006 SSRF security posture unchanged | Guard still runs for all authenticated callers; only ordering vs auth changed |
| DI-005 regression test change could mask real failures | Added `checkRateLimit` mock that returns `{ ok: true }` — same pattern as approve/decision tests |