### PR TITLE
fix(ci): use PRODUCTION_SUPABASE_DB_PASSWORD in deploy-migrations workflow

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -11,7 +11,7 @@ name: Deploy Supabase migrations
 #   SUPABASE_ACCESS_TOKEN — personal access token from
 #                           https://supabase.com/dashboard/account/tokens
 #                           (scope: "Link a project" + "Access the API").
-#   STAGING_SUPABASE_DB_PASSWORD  — direct-connection Postgres password from
+#   PRODUCTION_SUPABASE_DB_PASSWORD  — direct-connection Postgres password from
 #                                   Project Settings → Database → Connection
 #                                   string. Required by `supabase db push` to
 #                                   open the management tunnel.
@@ -83,7 +83,7 @@ jobs:
       - name: Verify required secrets are set
         run: |
           missing=0
-          for var in SUPABASE_PROJECT_REF SUPABASE_ACCESS_TOKEN STAGING_SUPABASE_DB_PASSWORD; do
+          for var in SUPABASE_PROJECT_REF SUPABASE_ACCESS_TOKEN PRODUCTION_SUPABASE_DB_PASSWORD; do
             if [ -z "${!var:-}" ]; then
               echo "::error::Required secret $var is not set."
               missing=1
@@ -95,7 +95,7 @@ jobs:
           fi
         env:
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-          STAGING_SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
+          PRODUCTION_SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_SUPABASE_DB_PASSWORD }}
 
       - name: Link to production project
         run: supabase link --project-ref "${{ secrets.SUPABASE_PROJECT_REF }}"
@@ -106,7 +106,7 @@ jobs:
       - name: Repair flagged versions (mark reverted — clear tracking row)
         if: github.event_name == 'workflow_dispatch' && inputs.repair_versions_reverted != ''
         env:
-          SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_SUPABASE_DB_PASSWORD }}
         run: |
           set -euo pipefail
           for v in ${{ inputs.repair_versions_reverted }}; do
@@ -117,7 +117,7 @@ jobs:
       - name: Repair flagged versions (mark applied without re-running SQL)
         if: github.event_name == 'workflow_dispatch' && inputs.repair_versions_applied != ''
         env:
-          SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_SUPABASE_DB_PASSWORD }}
         run: |
           set -euo pipefail
           for v in ${{ inputs.repair_versions_applied }}; do
@@ -127,7 +127,7 @@ jobs:
 
       - name: Push pending migrations
         env:
-          SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_SUPABASE_DB_PASSWORD }}
         # --include-all ensures no migrations are skipped when the
         # production schema has drifted from the linked state (e.g. a
         # row was manually inserted but the migration files themselves

--- a/lib/__tests__/link-preview-route.unit.test.ts
+++ b/lib/__tests__/link-preview-route.unit.test.ts
@@ -26,6 +26,14 @@ vi.mock("@/lib/redis", () => ({
   getRedisClient: () => ({ get: mockRedisGet, set: mockRedisSet }),
 }));
 
+// assertSafeUrl does a live DNS lookup; mock it as pass-through here so
+// unit tests don't require network access. SSRF blocking is covered by
+// tests/regressions/di-006-link-preview-ssrf.test.ts.
+vi.mock("@/lib/ssrf-guard", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("@/lib/ssrf-guard")>();
+  return { ...orig, assertSafeUrl: vi.fn().mockResolvedValue({ resolvedIp: "93.184.216.34", family: 4 }) };
+});
+
 import { POST } from "@/app/api/platform/social/link-preview/route";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
 


### PR DESCRIPTION
## Summary

- Renames `STAGING_SUPABASE_DB_PASSWORD` → `PRODUCTION_SUPABASE_DB_PASSWORD` in `deploy-migrations.yml`
- Every production migration push since PR #1033 has failed with SASL auth failure; this PR unblocks it
- Mocks `assertSafeUrl` in `link-preview-route.unit.test.ts` so unit tests don't require DNS access

## Root cause

PR #1033 renamed the CI secret `SUPABASE_DB_PASSWORD` → `STAGING_SUPABASE_DB_PASSWORD`. The `deploy-migrations.yml` (production workflow) was updated to reference `STAGING_SUPABASE_DB_PASSWORD`, but that secret holds the *staging* project's Postgres password. The production workflow connects to `SUPABASE_PROJECT_REF` (production project) but authenticates with the staging password — SASL auth fails on every push.

All migration runs since #1033 have failed: `failed SASL auth (FATAL: password authentication failed for user "postgres")`.

**Pending migrations NOT applied to production:** 0139 through 0154.

## Action required from Steven

Go to **GitHub → Settings → Secrets and variables → Actions** and add:
- Name: `PRODUCTION_SUPABASE_DB_PASSWORD`
- Value: the production Supabase DB password (from Supabase dashboard → Project Settings → Database → Connection string → password field)

Once the secret is set and this PR merges, the workflow will auto-run and apply all pending migrations.

## Working analog

`staging-migrations.yml:41` — same pattern, correct secret reference for staging project.

## Risks identified and mitigated

- **All migrations 0139–0154 are pending on production.** This PR does not apply them; it only unblocks the workflow. The workflow will apply them as a batch when it next runs. Each migration has been run on staging first. All are non-destructive (ADD COLUMN / ADD INDEX / ADD POLICY).
- **Secret mismatch until Steven adds the secret.** The workflow will continue to fail until `PRODUCTION_SUPABASE_DB_PASSWORD` is added. This is the same failure as before; no regression.

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit
- [x] PR is under 500 net lines