### PR TITLE
feat(social): v1-to-v2 PR-01 — add link_url + source_type to social_post_drafts (migration 0155)

### DIFF
--- a/lib/__tests__/link-preview-route.unit.test.ts
+++ b/lib/__tests__/link-preview-route.unit.test.ts
@@ -26,6 +26,14 @@ vi.mock("@/lib/redis", () => ({
   getRedisClient: () => ({ get: mockRedisGet, set: mockRedisSet }),
 }));
 
+// assertSafeUrl does a live DNS lookup; mock it as pass-through here so
+// unit tests don't require network access. SSRF blocking is covered by
+// tests/regressions/di-006-link-preview-ssrf.test.ts.
+vi.mock("@/lib/ssrf-guard", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("@/lib/ssrf-guard")>();
+  return { ...orig, assertSafeUrl: vi.fn().mockResolvedValue({ resolvedIp: "93.184.216.34", family: 4 }) };
+});
+
 import { POST } from "@/app/api/platform/social/link-preview/route";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
 

--- a/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
+++ b/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeAll, afterAll } from "vitest";
 import { getServiceRoleClient } from "@/lib/supabase";
+import { seedAuthUser } from "./_auth-helpers";
 
 // ---------------------------------------------------------------------------
 // Migration 0155 — V2 schema gaps (link_url + source_type).
@@ -12,7 +13,8 @@ import { getServiceRoleClient } from "@/lib/supabase";
 // ---------------------------------------------------------------------------
 
 const COMPANY_ID = "00001550-0000-0000-0000-000000000001";
-const USER_ID    = "00001550-0000-0000-0000-000000000002";
+
+let seededUserId: string;
 
 async function seedCompany() {
   const svc = getServiceRoleClient();
@@ -31,6 +33,8 @@ async function seedCompany() {
 }
 
 beforeAll(async () => {
+  const user = await seedAuthUser({ email: "m0155-test@opollo.test", persistent: true });
+  seededUserId = user.id;
   await seedCompany();
 });
 
@@ -38,6 +42,9 @@ afterAll(async () => {
   const svc = getServiceRoleClient();
   await svc.from("social_post_drafts").delete().eq("company_id", COMPANY_ID);
   await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
+  if (seededUserId) {
+    await svc.auth.admin.deleteUser(seededUserId);
+  }
 });
 
 describe("Migration 0155 — social_post_drafts schema gaps", () => {
@@ -47,8 +54,8 @@ describe("Migration 0155 — social_post_drafts schema gaps", () => {
       .from("social_post_drafts")
       .insert({
         company_id: COMPANY_ID,
-        created_by: USER_ID,
-        updated_by: USER_ID,
+        created_by: seededUserId,
+        updated_by: seededUserId,
         link_url: "https://example.com/blog/post-1",
       })
       .select("id, link_url")
@@ -69,8 +76,8 @@ describe("Migration 0155 — social_post_drafts schema gaps", () => {
         .from("social_post_drafts")
         .insert({
           company_id: COMPANY_ID,
-          created_by: USER_ID,
-          updated_by: USER_ID,
+          created_by: seededUserId,
+          updated_by: seededUserId,
           source_type,
         })
         .select("id, source_type")
@@ -91,8 +98,8 @@ describe("Migration 0155 — social_post_drafts schema gaps", () => {
       .from("social_post_drafts")
       .insert({
         company_id: COMPANY_ID,
-        created_by: USER_ID,
-        updated_by: USER_ID,
+        created_by: seededUserId,
+        updated_by: seededUserId,
         source_type: "unknown_value" as string,
       })
       .select("id")
@@ -108,8 +115,8 @@ describe("Migration 0155 — social_post_drafts schema gaps", () => {
       .from("social_post_drafts")
       .insert({
         company_id: COMPANY_ID,
-        created_by: USER_ID,
-        updated_by: USER_ID,
+        created_by: seededUserId,
+        updated_by: seededUserId,
       })
       .select("id, link_url, source_type")
       .single();

--- a/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
+++ b/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
@@ -16,6 +16,8 @@ const USER_ID    = "00001550-0000-0000-0000-000000000002";
 
 async function seedCompany() {
   const svc = getServiceRoleClient();
+  // Clean stale drafts first so the company delete doesn't hit FK constraints.
+  await svc.from("social_post_drafts").delete().eq("company_id", COMPANY_ID);
   await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
   const { error } = await svc.from("platform_companies").insert({
     id: COMPANY_ID,
@@ -34,6 +36,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   const svc = getServiceRoleClient();
+  await svc.from("social_post_drafts").delete().eq("company_id", COMPANY_ID);
   await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
 });
 

--- a/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
+++ b/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// Migration 0155 — V2 schema gaps (link_url + source_type).
+//
+// Verifies:
+//   1. social_post_drafts.link_url column accepts a URL string.
+//   2. social_post_drafts.source_type column accepts valid enum values.
+//   3. social_post_drafts.source_type CHECK rejects unknown values.
+//   4. Both columns are nullable (existing drafts not affected).
+// ---------------------------------------------------------------------------
+
+const COMPANY_ID = "00001550-0000-0000-0000-000000000001";
+const USER_ID    = "00001550-0000-0000-0000-000000000002";
+
+async function seedCompany() {
+  const svc = getServiceRoleClient();
+  await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
+  const { error } = await svc.from("platform_companies").insert({
+    id: COMPANY_ID,
+    name: "M0155 Test Co",
+    slug: "m0155-test-co",
+    is_opollo_internal: false,
+    timezone: "UTC",
+    approval_default_rule: "any_one",
+  });
+  if (error) throw new Error(`seed company: ${error.message}`);
+}
+
+beforeAll(async () => {
+  await seedCompany();
+});
+
+afterAll(async () => {
+  const svc = getServiceRoleClient();
+  await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
+});
+
+describe("Migration 0155 — social_post_drafts schema gaps", () => {
+  it("accepts link_url on a draft row", async () => {
+    const svc = getServiceRoleClient();
+    const { data, error } = await svc
+      .from("social_post_drafts")
+      .insert({
+        company_id: COMPANY_ID,
+        created_by: USER_ID,
+        updated_by: USER_ID,
+        link_url: "https://example.com/blog/post-1",
+      })
+      .select("id, link_url")
+      .single();
+
+    expect(error, `insert error: ${error?.message}`).toBeNull();
+    expect(data?.link_url).toBe("https://example.com/blog/post-1");
+
+    if (data?.id) {
+      await svc.from("social_post_drafts").delete().eq("id", data.id);
+    }
+  });
+
+  it("accepts valid source_type values", async () => {
+    const svc = getServiceRoleClient();
+    for (const source_type of ["manual", "csv", "cap", "api"] as const) {
+      const { data, error } = await svc
+        .from("social_post_drafts")
+        .insert({
+          company_id: COMPANY_ID,
+          created_by: USER_ID,
+          updated_by: USER_ID,
+          source_type,
+        })
+        .select("id, source_type")
+        .single();
+
+      expect(error, `insert failed for source_type='${source_type}': ${error?.message}`).toBeNull();
+      expect(data?.source_type).toBe(source_type);
+
+      if (data?.id) {
+        await svc.from("social_post_drafts").delete().eq("id", data.id);
+      }
+    }
+  });
+
+  it("rejects an unknown source_type (CHECK constraint)", async () => {
+    const svc = getServiceRoleClient();
+    const { error } = await svc
+      .from("social_post_drafts")
+      .insert({
+        company_id: COMPANY_ID,
+        created_by: USER_ID,
+        updated_by: USER_ID,
+        // @ts-expect-error intentionally invalid value to test DB constraint
+        source_type: "unknown_value",
+      })
+      .select("id")
+      .single();
+
+    expect(error).not.toBeNull();
+    expect(error?.message).toMatch(/check.*constraint|violates/i);
+  });
+
+  it("both columns are nullable (existing draft creation succeeds without them)", async () => {
+    const svc = getServiceRoleClient();
+    const { data, error } = await svc
+      .from("social_post_drafts")
+      .insert({
+        company_id: COMPANY_ID,
+        created_by: USER_ID,
+        updated_by: USER_ID,
+      })
+      .select("id, link_url, source_type")
+      .single();
+
+    expect(error, `insert error: ${error?.message}`).toBeNull();
+    expect(data?.link_url).toBeNull();
+    expect(data?.source_type).toBeNull();
+
+    if (data?.id) {
+      await svc.from("social_post_drafts").delete().eq("id", data.id);
+    }
+  });
+});

--- a/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
+++ b/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
@@ -90,8 +90,7 @@ describe("Migration 0155 — social_post_drafts schema gaps", () => {
         company_id: COMPANY_ID,
         created_by: USER_ID,
         updated_by: USER_ID,
-        // @ts-expect-error intentionally invalid value to test DB constraint
-        source_type: "unknown_value",
+        source_type: "unknown_value" as string,
       })
       .select("id")
       .single();

--- a/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
+++ b/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { describe, expect, it, beforeAll, beforeEach, afterAll } from "vitest";
 import { getServiceRoleClient } from "@/lib/supabase";
 import { seedAuthUser } from "./_auth-helpers";
 
@@ -16,9 +16,12 @@ const COMPANY_ID = "00001550-0000-0000-0000-000000000001";
 
 let seededUserId: string;
 
+// Company seed is called in beforeEach (not beforeAll) because _setup.ts's
+// global beforeEach runs truncateAll() which wipes platform_companies before
+// each test. The auth user lives in auth.users which is NOT truncated by
+// truncateAll(), so it only needs to be created once in beforeAll.
 async function seedCompany() {
   const svc = getServiceRoleClient();
-  // Clean stale drafts first so the company delete doesn't hit FK constraints.
   await svc.from("social_post_drafts").delete().eq("company_id", COMPANY_ID);
   await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
   const { error } = await svc.from("platform_companies").insert({
@@ -35,6 +38,9 @@ async function seedCompany() {
 beforeAll(async () => {
   const user = await seedAuthUser({ persistent: true });
   seededUserId = user.id;
+});
+
+beforeEach(async () => {
   await seedCompany();
 });
 

--- a/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
+++ b/lib/__tests__/migration-0155-v2-schema-gaps.test.ts
@@ -33,7 +33,7 @@ async function seedCompany() {
 }
 
 beforeAll(async () => {
-  const user = await seedAuthUser({ email: "m0155-test@opollo.test", persistent: true });
+  const user = await seedAuthUser({ persistent: true });
   seededUserId = user.id;
   await seedCompany();
 });

--- a/supabase/migrations/0155_v2_schema_gaps.sql
+++ b/supabase/migrations/0155_v2_schema_gaps.sql
@@ -1,0 +1,28 @@
+-- Migration 0155: V2 schema gaps for V1→V2 migration workstream.
+--
+-- social_post_drafts is missing two columns present on the V1 social_post_master
+-- table that are needed to preserve data fidelity during the V1→V2 backfill:
+--
+--   link_url   — V1 stores link_url as a top-level column. V2 stores it inside
+--                draft_data JSONB only (confirmed by calendar-view/route.ts:68
+--                comment). The backfill script needs a real column to query and
+--                index. The calendar-view route will be updated in a subsequent
+--                PR (PR-03) to read this column directly.
+--
+--   source_type — V1 uses social_post_source ENUM ('manual','csv','cap','api').
+--                 V2 has no equivalent — BSP analytics source-attribution
+--                 (lib/insights/source-attribution.ts) traverses the V1 chain.
+--                 Adding source_type to V2 lets the backfill record the origin
+--                 of each migrated post and preserves attribution after V1 drop.
+--
+-- Both columns are nullable so they don't break existing V2 drafts (which were
+-- created without these fields). The CHECK constraint mirrors V1's enum values
+-- and adds no overhead on existing rows.
+--
+-- Rollback: DROP COLUMN link_url, DROP COLUMN source_type (safe — no data yet).
+
+ALTER TABLE social_post_drafts
+  ADD COLUMN IF NOT EXISTS link_url    TEXT,
+  ADD COLUMN IF NOT EXISTS source_type TEXT CHECK (
+    source_type IN ('manual', 'csv', 'cap', 'api')
+  );


### PR DESCRIPTION
## Summary

Phase 0, PR-01 of the V1→V2 social post model migration (D3, `docs/migrations/v1-to-v2-consolidation/PLAN.md`).

Adds two columns to `social_post_drafts` needed to hold V1 data faithfully during the backfill (PR-04):

| Column | Type | Reason |
|--------|------|--------|
| `link_url TEXT` | nullable | V1 `social_post_master.link_url` has no V2 column equivalent (only in `draft_data` JSONB). Calendar-view route updated in PR-03. |
| `source_type TEXT CHECK(...)` | nullable | V1 `social_post_master.source_type` enum has no V2 equivalent. Required for BSP analytics source attribution after V1 tables drop. |

`idempotency_key` already exists (migration 0126) — no gap.

## Working analog

`supabase/migrations/0126_reliability_and_cap_foundations.sql` — same `ADD COLUMN IF NOT EXISTS` pattern for nullable columns added post-creation.

## Diff

`social_post_drafts` previously had no `link_url` or `source_type` columns.

## Fix

Two `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements, both nullable, one with a CHECK constraint matching V1's enum values.

## Risks identified and mitigated

- **No existing queries break.** Both columns are nullable. Existing `INSERT`s that omit them still succeed.
- **CHECK constraint is additive.** Invalid `source_type` values were never present (column is new). No data scan needed.
- **Rollback:** `DROP COLUMN` on two columns with no dependent objects — trivially safe.

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (2493 pass); test:integration covers migration via migration-0155-v2-schema-gaps.test.ts
- [x] PR is under 500 net lines