### PR TITLE
feat(social): v1-to-v2 PR-03 — calendar-view reads link_url from column (migration 0155)

### DIFF
--- a/app/api/platform/social/drafts/calendar-view/route.ts
+++ b/app/api/platform/social/drafts/calendar-view/route.ts
@@ -35,7 +35,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const svc = getServiceRoleClient();
   let query = svc
     .from("social_post_drafts")
-    .select("id, state, scheduled_at, published_at, content, media_urls, target_profiles, parent_draft_id")
+    .select("id, state, scheduled_at, published_at, content, media_urls, target_profiles, parent_draft_id, link_url")
     .eq("company_id", companyId)
     .is("archived_at", null)
     .or(`scheduled_at.gte.${from},published_at.gte.${from}`)
@@ -65,7 +65,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       published_at: row.published_at as string | null,
       content_excerpt: ((row.content as string | null) ?? "").slice(0, 100),
       primary_media_url: ((row.media_urls as string[] | null) ?? [])[0] ?? null,
-      link_url: null, // link_url is not a column on social_post_drafts; always null until migration adds it
+      link_url: (row.link_url as string | null) ?? null,
       target_profiles: ((row.target_profiles as Array<{ profile_id: string }> | null) ?? []).map(
         (p) => ({ platform: null, account_avatar_url: null, profile_id: p.profile_id }),
       ),


### PR DESCRIPTION
## Summary

Updates `GET /api/platform/social/drafts/calendar-view` to read `link_url` directly from the `social_post_drafts` column added in migration 0155 (PR-01, #1100).

**Before**: `link_url: null // link_url is not a column on social_post_drafts; always null until migration adds it`

**After**: `link_url: (row.link_url as string | null) ?? null`

## Merge dependency

**Must merge AFTER migration 0155 is applied to production.** The SELECT query now includes `link_url` — if the column doesn't exist in the DB, PostgREST returns a 400 error. Migration 0155 is in PR-01 (#1100).

Merge order: #1100 merges + production migration applies → then this PR merges.

## Working analog

`app/api/platform/social/drafts/calendar-view/route.ts` — same route; same column-selection pattern as `content`, `media_urls`, etc. The null placeholder was a deliberate marker for this exact PR.

## Test coverage

This change is covered by the existing calendar-view route tests (which mock the Supabase client and don't hit the DB). No additional tests needed — the integration test in PR-01 verifies the column exists on the DB.

## Risks identified and mitigated

| Risk | Mitigation |
|------|-----------|
| Deploy before migration 0155 is on production | Route returns 400; calendar grid shows error. Mitigation: note in PR and in deploy order. Migration is idempotent — safe to apply |
| link_url is null for pre-backfill V2 drafts | That's correct — these posts genuinely have no link_url yet |

## Pre-PR checklist

- [x] Lint, typecheck, build all green (pre-commit ran)
- [x] Layer scripts run: test:unit (no new tests needed — existing coverage)
- [x] Risks identified and mitigated section in PR body
- [x] PR is under 500 net lines (2 net changes)