### PR TITLE
feat(social): cap generator writes to social_post_drafts (v2 migration)

### DIFF
--- a/lib/__tests__/cap-generator.test.ts
+++ b/lib/__tests__/cap-generator.test.ts
@@ -20,21 +20,24 @@ vi.mock("@/lib/platform/brand/get", () => ({
   getActiveBrandProfile: vi.fn(),
 }));
 
-vi.mock("@/lib/platform/social/posts/create", () => ({
-  createPostMaster: vi.fn(),
-}));
-
-vi.mock("@/lib/platform/social/variants/upsert", () => ({
-  upsertVariant: vi.fn(),
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(),
 }));
 
 import { getActiveBrandProfile } from "@/lib/platform/brand/get";
-import { createPostMaster } from "@/lib/platform/social/posts/create";
-import { upsertVariant } from "@/lib/platform/social/variants/upsert";
+import { getServiceRoleClient } from "@/lib/supabase";
 
 const mockGetBrand = getActiveBrandProfile as MockedFunction<typeof getActiveBrandProfile>;
-const mockCreate = createPostMaster as MockedFunction<typeof createPostMaster>;
-const mockUpsert = upsertVariant as MockedFunction<typeof upsertVariant>;
+const mockGetSvc = getServiceRoleClient as MockedFunction<typeof getServiceRoleClient>;
+
+function makeMockSvc(draftId = "draft-1") {
+  const mockSingle = vi.fn().mockResolvedValue({ data: { id: draftId }, error: null });
+  const mockSelect = vi.fn().mockReturnValue({ single: mockSingle });
+  const mockInsert = vi.fn().mockReturnValue({ select: mockSelect });
+  return {
+    from: vi.fn().mockReturnValue({ insert: mockInsert }),
+  };
+}
 
 const BASE_BRAND: BrandProfile = {
   id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -158,39 +161,7 @@ describe("PLATFORM_CHAR_LIMITS", () => {
 describe("generateCAPPosts", () => {
   it("returns created posts on happy path", async () => {
     mockGetBrand.mockResolvedValue(BASE_BRAND);
-    mockCreate.mockResolvedValue({
-      ok: true,
-      data: {
-        id: "post-1",
-        company_id: COMPANY_ID,
-        state: "draft",
-        source_type: "cap",
-        master_text: "Test post",
-        link_url: null,
-        reviewer_comment: null,
-        created_by: null,
-        created_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-01T00:00:00Z",
-        state_changed_at: "2026-01-01T00:00:00Z",
-      },
-      timestamp: "2026-01-01T00:00:00Z",
-    });
-    mockUpsert.mockResolvedValue({
-      ok: true,
-      data: {
-        id: "var-1",
-        post_master_id: "post-1",
-        platform: "linkedin_company",
-        connection_id: null,
-        variant_text: "LinkedIn version",
-        is_custom: true,
-        scheduled_at: null,
-        media_asset_ids: [],
-        created_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-01T00:00:00Z",
-      },
-      timestamp: "2026-01-01T00:00:00Z",
-    });
+    mockGetSvc.mockReturnValue(makeMockSvc("draft-1") as never);
 
     const callFn = makeStubCallFn(makeCannedResponse([
       { master_text: "Full post text about digital marketing", variants: { linkedin_company: "LinkedIn version", x: "X version" } },
@@ -205,28 +176,12 @@ describe("generateCAPPosts", () => {
     if (!result.ok) return;
     expect(result.posts).toHaveLength(1);
     expect(result.posts[0].masterText).toBe("Full post text about digital marketing");
+    expect(result.posts[0].draftId).toBe("draft-1");
   });
 
   it("calls Claude with correct model", async () => {
     mockGetBrand.mockResolvedValue(null);
-    mockCreate.mockResolvedValue({
-      ok: true,
-      data: {
-        id: "post-2",
-        company_id: COMPANY_ID,
-        state: "draft",
-        source_type: "cap",
-        master_text: "Test",
-        link_url: null,
-        reviewer_comment: null,
-        created_by: null,
-        created_at: "2026-01-01T00:00:00Z",
-        updated_at: "2026-01-01T00:00:00Z",
-        state_changed_at: "2026-01-01T00:00:00Z",
-      },
-      timestamp: "2026-01-01T00:00:00Z",
-    });
-    mockUpsert.mockResolvedValue({ ok: true, data: {} as never, timestamp: "" });
+    mockGetSvc.mockReturnValue(makeMockSvc("draft-2") as never);
 
     const callFn = vi.fn().mockResolvedValue(makeCannedResponse([
       { master_text: "Test", variants: { linkedin_company: "Test LI" } },
@@ -272,24 +227,7 @@ describe("generateCAPPosts", () => {
       variants: { linkedin_company: `LI ${i + 1}` },
     }));
     const callFn = makeStubCallFn(makeCannedResponse(posts));
-    mockCreate.mockResolvedValue({
-      ok: true,
-      data: {
-        id: "p",
-        company_id: COMPANY_ID,
-        state: "draft",
-        source_type: "cap",
-        master_text: "Post",
-        link_url: null,
-        reviewer_comment: null,
-        created_by: null,
-        created_at: "",
-        updated_at: "",
-        state_changed_at: "",
-      },
-      timestamp: "",
-    });
-    mockUpsert.mockResolvedValue({ ok: true, data: {} as never, timestamp: "" });
+    mockGetSvc.mockReturnValue(makeMockSvc("p") as never);
 
     const result = await generateCAPPosts({ companyId: COMPANY_ID, count: 99, triggeredBy: null }, callFn);
 
@@ -311,24 +249,7 @@ describe("generateCAPPosts", () => {
       stop_reason: "end_turn",
       usage: { input_tokens: 10, output_tokens: 20 },
     });
-    mockCreate.mockResolvedValue({
-      ok: true,
-      data: {
-        id: "p2",
-        company_id: COMPANY_ID,
-        state: "draft",
-        source_type: "cap",
-        master_text: "Clean text",
-        link_url: null,
-        reviewer_comment: null,
-        created_by: null,
-        created_at: "",
-        updated_at: "",
-        state_changed_at: "",
-      },
-      timestamp: "",
-    });
-    mockUpsert.mockResolvedValue({ ok: true, data: {} as never, timestamp: "" });
+    mockGetSvc.mockReturnValue(makeMockSvc("p2") as never);
 
     const result = await generateCAPPosts({ companyId: COMPANY_ID, count: 1, triggeredBy: null }, callFn);
 

--- a/lib/__tests__/cap-image-trigger.test.ts
+++ b/lib/__tests__/cap-image-trigger.test.ts
@@ -30,7 +30,7 @@ const mockGetSvc = getServiceRoleClient as MockedFunction<typeof getServiceRoleC
 function makeMockSvc(overrides?: {
   signedUrlError?: boolean;
   assetInsertError?: boolean;
-  variantUpdateError?: boolean;
+  draftUpdateError?: boolean;
 }) {
   const mockSingle = vi.fn().mockResolvedValue(
     overrides?.assetInsertError
@@ -41,7 +41,7 @@ function makeMockSvc(overrides?: {
   const mockInsert = vi.fn().mockReturnValue({ select: mockSelect });
 
   const mockEq = vi.fn().mockResolvedValue(
-    overrides?.variantUpdateError
+    overrides?.draftUpdateError
       ? { error: { message: "update failed" } }
       : { error: null },
   );
@@ -57,7 +57,7 @@ function makeMockSvc(overrides?: {
   const svc = {
     from: vi.fn().mockImplementation((table: string) => {
       if (table === "social_media_assets") return { insert: mockInsert };
-      if (table === "social_post_variant") return { update: mockUpdate };
+      if (table === "social_post_drafts") return { update: mockUpdate };
       return {};
     }),
     storage: { from: mockStorageFrom },
@@ -91,7 +91,7 @@ describe("triggerCAPImageGen", () => {
 
     await triggerCAPImageGen({
       companyId: "company-id",
-      postMasterId: "post-master-id",
+      draftId: "draft-id-1",
       brand: null,
     });
 
@@ -107,7 +107,7 @@ describe("triggerCAPImageGen", () => {
     mockGetSvc.mockReturnValue(svc as never);
 
     await expect(
-      triggerCAPImageGen({ companyId: "c", postMasterId: "p", brand: null }),
+      triggerCAPImageGen({ companyId: "c", draftId: "d", brand: null }),
     ).resolves.toBeUndefined();
 
     expect(mockGenerate).not.toHaveBeenCalled();
@@ -120,7 +120,7 @@ describe("triggerCAPImageGen", () => {
     mockGenerate.mockRejectedValue(new Error("Ideogram unreachable"));
 
     await expect(
-      triggerCAPImageGen({ companyId: "c", postMasterId: "p", brand: null }),
+      triggerCAPImageGen({ companyId: "c", draftId: "d", brand: null }),
     ).resolves.toBeUndefined();
 
     expect(mockInsert).not.toHaveBeenCalled();
@@ -132,7 +132,7 @@ describe("triggerCAPImageGen", () => {
     mockGenerate.mockResolvedValue([]);
 
     await expect(
-      triggerCAPImageGen({ companyId: "c", postMasterId: "p", brand: null }),
+      triggerCAPImageGen({ companyId: "c", draftId: "d", brand: null }),
     ).resolves.toBeUndefined();
 
     expect(mockInsert).not.toHaveBeenCalled();
@@ -144,7 +144,7 @@ describe("triggerCAPImageGen", () => {
     mockGenerate.mockResolvedValue([makeFakeImage()]);
 
     await expect(
-      triggerCAPImageGen({ companyId: "c", postMasterId: "p", brand: null }),
+      triggerCAPImageGen({ companyId: "c", draftId: "d", brand: null }),
     ).resolves.toBeUndefined();
 
     expect(mockInsert).not.toHaveBeenCalled();
@@ -161,7 +161,7 @@ describe("triggerCAPImageGen", () => {
     };
     mockGenerate.mockResolvedValue([imageWithoutBuffer]);
 
-    await triggerCAPImageGen({ companyId: "c", postMasterId: "p", brand: null });
+    await triggerCAPImageGen({ companyId: "c", draftId: "d", brand: null });
 
     const insertArg = mockInsert.mock.calls[0][0] as Record<string, unknown>;
     expect(insertArg.bytes).toBe(0);
@@ -174,10 +174,10 @@ describe("triggerCAPImageGen", () => {
 
     await triggerCAPImageGen({
       companyId: "company-id",
-      postMasterId: "post-master-id",
+      draftId: "draft-id-1",
       brand: null,
     });
 
-    expect(mockEq).toHaveBeenCalledWith("post_master_id", "post-master-id");
+    expect(mockEq).toHaveBeenCalledWith("id", "draft-id-1");
   });
 });

--- a/lib/__tests__/cap-v2-generator.test.ts
+++ b/lib/__tests__/cap-v2-generator.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi, beforeAll, beforeEach, afterAll } from "vitest";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { generateCAPPosts } from "@/lib/platform/social/cap/generator";
+import { seedAuthUser } from "./_auth-helpers";
+import type { AnthropicCallFn } from "@/lib/anthropic-call";
+
+// ---------------------------------------------------------------------------
+// CAP generator V2 integration test.
+//
+// Verifies that generateCAPPosts writes to social_post_drafts (V2) with the
+// correct state, source_type, and content. Does NOT call real Anthropic or
+// Ideogram APIs — AnthropicCallFn is stubbed, IDEOGRAM_API_KEY is absent.
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/platform/brand/get", () => ({
+  getActiveBrandProfile: vi.fn().mockResolvedValue(null),
+}));
+
+const COMPANY_ID = "00000500-0000-0000-0000-000000000001";
+let seededUserId: string;
+
+async function seedCompany() {
+  const svc = getServiceRoleClient();
+  await svc.from("social_post_drafts").delete().eq("company_id", COMPANY_ID);
+  await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
+  const { error } = await svc.from("platform_companies").insert({
+    id: COMPANY_ID,
+    name: "CAP V2 Test Co",
+    slug: "cap-v2-test-co",
+    is_opollo_internal: false,
+    timezone: "UTC",
+    approval_default_rule: "any_one",
+  });
+  if (error) throw new Error(`seed company: ${error.message}`);
+}
+
+function makeCannedCallFn(masterText: string, variants: Record<string, string>): AnthropicCallFn {
+  const json = JSON.stringify({ posts: [{ master_text: masterText, variants }] });
+  return vi.fn().mockResolvedValue({
+    id: "msg_test",
+    model: "claude-sonnet-4-6",
+    content: [{ type: "text" as const, text: json }],
+    stop_reason: "end_turn",
+    usage: { input_tokens: 50, output_tokens: 100 },
+  });
+}
+
+beforeAll(async () => {
+  const user = await seedAuthUser({ persistent: true });
+  seededUserId = user.id;
+});
+
+beforeEach(async () => {
+  await seedCompany();
+});
+
+afterAll(async () => {
+  const svc = getServiceRoleClient();
+  await svc.from("social_post_drafts").delete().eq("company_id", COMPANY_ID);
+  await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
+  if (seededUserId) {
+    await svc.auth.admin.deleteUser(seededUserId);
+  }
+});
+
+describe("CAP generator — V2 social_post_drafts", () => {
+  it("creates a draft row with state=draft and source_type=cap", async () => {
+    const svc = getServiceRoleClient();
+    const masterText = "Grow your business with confidence this season.";
+    const callFn = makeCannedCallFn(masterText, {
+      linkedin_company: "LinkedIn version of the post.",
+      x: "X version #growth",
+    });
+
+    const result = await generateCAPPosts(
+      { companyId: COMPANY_ID, platforms: ["linkedin_company", "x"], count: 1, triggeredBy: seededUserId },
+      callFn,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.posts).toHaveLength(1);
+    expect(result.posts[0].draftId).toBeTruthy();
+    expect(result.posts[0].masterText).toBe(masterText);
+
+    const { data: draft, error } = await svc
+      .from("social_post_drafts")
+      .select("id, state, source_type, content, platform_variants")
+      .eq("company_id", COMPANY_ID)
+      .single();
+
+    expect(error, `draft fetch error: ${error?.message}`).toBeNull();
+    expect(draft?.state).toBe("draft");
+    expect(draft?.source_type).toBe("cap");
+    expect(draft?.content).toBe(masterText);
+    expect(draft?.id).toBe(result.posts[0].draftId);
+
+    const variants = draft?.platform_variants as Record<string, { content: string }>;
+    expect(variants?.linkedin_company?.content).toBe("LinkedIn version of the post.");
+    expect(variants?.x?.content).toBe("X version #growth");
+  });
+
+  it("returns ALL_FAILED when Claude response has empty master_text", async () => {
+    const callFn = makeCannedCallFn("", {});
+    const result = await generateCAPPosts(
+      { companyId: COMPANY_ID, count: 1, triggeredBy: seededUserId },
+      callFn,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("ALL_FAILED");
+  });
+
+  it("creates multiple draft rows when count > 1", async () => {
+    const json = JSON.stringify({
+      posts: [
+        { master_text: "Post one content.", variants: { x: "Tweet one." } },
+        { master_text: "Post two content.", variants: { x: "Tweet two." } },
+      ],
+    });
+    const callFn = vi.fn().mockResolvedValue({
+      id: "msg_multi",
+      model: "claude-sonnet-4-6",
+      content: [{ type: "text" as const, text: json }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 100, output_tokens: 200 },
+    }) as AnthropicCallFn;
+
+    const result = await generateCAPPosts(
+      { companyId: COMPANY_ID, platforms: ["x"], count: 2, triggeredBy: seededUserId },
+      callFn,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.posts).toHaveLength(2);
+
+    const svc = getServiceRoleClient();
+    const { data: drafts } = await svc
+      .from("social_post_drafts")
+      .select("id, source_type, state")
+      .eq("company_id", COMPANY_ID);
+
+    expect(drafts).toHaveLength(2);
+    expect(drafts?.every((d) => d.state === "draft")).toBe(true);
+    expect(drafts?.every((d) => d.source_type === "cap")).toBe(true);
+  });
+});

--- a/lib/platform/social/cap/generator.ts
+++ b/lib/platform/social/cap/generator.ts
@@ -8,8 +8,7 @@ import {
   defaultAnthropicCall,
   type AnthropicCallFn,
 } from "@/lib/anthropic-call";
-import { createPostMaster } from "@/lib/platform/social/posts/create";
-import { upsertVariant } from "@/lib/platform/social/variants/upsert";
+import { getServiceRoleClient } from "@/lib/supabase";
 import { SUPPORTED_PLATFORMS } from "@/lib/platform/social/variants/types";
 import type { SocialPlatform } from "@/lib/platform/social/variants/types";
 
@@ -27,11 +26,11 @@ import type {
 } from "./types";
 
 // ---------------------------------------------------------------------------
-// D1 — CAP copy generator.
+// D1 — CAP copy generator (V2).
 //
 // Reads the company's active brand profile → builds prompts → calls Claude
-// → parses structured JSON response → creates social_post_master rows with
-// source_type='cap' + per-platform social_post_variant rows.
+// → parses structured JSON response → inserts social_post_drafts rows with
+// source_type='cap' + platform_variants JSONB (one entry per platform).
 //
 // AnthropicCallFn is dependency-injected (default = defaultAnthropicCall)
 // so unit tests substitute a stub without real API credentials.
@@ -125,58 +124,52 @@ export async function generateCAPPosts(
   }
 
   const created: CAPGeneratedPost[] = [];
+  const svc = getServiceRoleClient();
 
   for (const post of parsed.posts.slice(0, count)) {
     const masterText = post.master_text?.trim() ?? "";
     if (!masterText) continue;
 
-    const masterResult = await createPostMaster({
-      companyId,
-      masterText,
-      sourceType: "cap",
-      createdBy: triggeredBy,
-    });
+    // Build platform_variants JSONB in one pass before the DB insert.
+    const platformVariants: Record<string, { content: string }> = {};
+    const variantMap: Partial<Record<SocialPlatform, string>> = {};
+    for (const platform of platforms) {
+      const raw = post.variants?.[platform];
+      if (!raw?.trim()) continue;
+      const text = truncateToLimit(raw.trim(), platform);
+      platformVariants[platform] = { content: text };
+      variantMap[platform] = text;
+    }
 
-    if (!masterResult.ok) {
+    const { data: draft, error: draftErr } = await svc
+      .from("social_post_drafts")
+      .insert({
+        company_id:        companyId,
+        created_by:        triggeredBy,
+        updated_by:        triggeredBy,
+        content:           masterText,
+        source_type:       "cap",
+        state:             "draft",
+        media_urls:        [],
+        target_profiles:   [],
+        platform_variants: platformVariants,
+      })
+      .select("id")
+      .single();
+
+    if (draftErr || !draft?.id) {
       logger.error("cap.generate.post_create_failed", {
         companyId,
-        err: masterResult.error.message,
+        err: draftErr?.message,
       });
       continue;
     }
 
-    const postMasterId = masterResult.data.id;
-    const variantMap: Partial<Record<SocialPlatform, string>> = {};
+    const draftId = draft.id as string;
+    created.push({ draftId, masterText, variants: variantMap });
 
-    for (const platform of platforms) {
-      const raw = post.variants?.[platform];
-      if (!raw?.trim()) continue;
-      const variantText = truncateToLimit(raw.trim(), platform);
-
-      const vResult = await upsertVariant({
-        postMasterId,
-        companyId,
-        platform,
-        variantText,
-      });
-
-      if (vResult.ok) {
-        variantMap[platform] = variantText;
-      } else {
-        logger.warn("cap.generate.variant_failed", {
-          companyId,
-          postMasterId,
-          platform,
-          err: vResult.error.message,
-        });
-      }
-    }
-
-    created.push({ postMasterId, masterText, variants: variantMap });
-
-    // I5 — fire-and-forget image generation. Runs after variants are
-    // upserted so the variant rows exist before the link step.
-    void triggerCAPImageGen({ companyId, postMasterId, brand });
+    // I5 — fire-and-forget image generation.
+    void triggerCAPImageGen({ companyId, draftId, brand });
   }
 
   if (created.length === 0) {

--- a/lib/platform/social/cap/image-trigger.ts
+++ b/lib/platform/social/cap/image-trigger.ts
@@ -29,7 +29,7 @@ const DEFAULT_COLOUR = "#1a56db";
 function brandToGenerationParams(
   brand: BrandProfile | null,
   companyId: string,
-  postMasterId: string,
+  draftId: string,
 ): GenerationParams {
   const allowedStyles = getAllowedStyles(brand);
   const styleId = allowedStyles[0] ?? DEFAULT_STYLE;
@@ -46,32 +46,32 @@ function brandToGenerationParams(
     companyId,
     brandProfileId: brand?.id,
     brandProfileVersion: brand?.version,
-    postMasterId,
+    postMasterId: draftId,
     triggeredBy: undefined,
   };
 }
 
 export async function triggerCAPImageGen(opts: {
   companyId: string;
-  postMasterId: string;
+  draftId: string;
   brand: BrandProfile | null;
 }): Promise<void> {
-  const { companyId, postMasterId, brand } = opts;
+  const { companyId, draftId, brand } = opts;
 
   // Skip silently when image generation is not configured.
   if (!process.env.IDEOGRAM_API_KEY) {
-    logger.debug("cap.image.skipped — IDEOGRAM_API_KEY not set", { postMasterId });
+    logger.debug("cap.image.skipped — IDEOGRAM_API_KEY not set", { draftId });
     return;
   }
 
-  const params = brandToGenerationParams(brand, companyId, postMasterId);
+  const params = brandToGenerationParams(brand, companyId, draftId);
 
   let images: Awaited<ReturnType<typeof generateWithFallback>>;
   try {
     images = await generateWithFallback(params);
   } catch (err) {
     logger.warn("cap.image.generate_failed", {
-      postMasterId,
+      draftId,
       companyId,
       err: err instanceof Error ? err.message : String(err),
     });
@@ -79,7 +79,7 @@ export async function triggerCAPImageGen(opts: {
   }
 
   if (!images || images.length === 0) {
-    logger.warn("cap.image.no_images_returned", { postMasterId, companyId });
+    logger.warn("cap.image.no_images_returned", { draftId, companyId });
     return;
   }
 
@@ -93,7 +93,7 @@ export async function triggerCAPImageGen(opts: {
 
   if (signedErr || !signed?.signedUrl) {
     logger.warn("cap.image.signed_url_failed", {
-      postMasterId,
+      draftId,
       path: image.storagePath,
       err: signedErr?.message,
     });
@@ -117,7 +117,7 @@ export async function triggerCAPImageGen(opts: {
 
   if (assetErr || !asset?.id) {
     logger.warn("cap.image.asset_insert_failed", {
-      postMasterId,
+      draftId,
       err: assetErr?.message,
     });
     return;
@@ -125,21 +125,20 @@ export async function triggerCAPImageGen(opts: {
 
   const assetId = asset.id as string;
 
-  // Link the asset to all variants of this post (fresh drafts — no
-  // existing media_asset_ids to preserve).
-  const { error: variantErr } = await svc
-    .from("social_post_variant")
-    .update({ media_asset_ids: [assetId] })
-    .eq("post_master_id", postMasterId);
+  // Link the signed URL to the V2 draft's media_urls array.
+  const { error: draftErr } = await svc
+    .from("social_post_drafts")
+    .update({ media_urls: [signed.signedUrl] })
+    .eq("id", draftId);
 
-  if (variantErr) {
-    logger.warn("cap.image.variant_link_failed", {
-      postMasterId,
+  if (draftErr) {
+    logger.warn("cap.image.draft_link_failed", {
+      draftId,
       assetId,
-      err: variantErr.message,
+      err: draftErr.message,
     });
     return;
   }
 
-  logger.info("cap.image.done", { postMasterId, companyId, assetId });
+  logger.info("cap.image.done", { draftId, companyId, assetId });
 }

--- a/lib/platform/social/cap/types.ts
+++ b/lib/platform/social/cap/types.ts
@@ -4,8 +4,8 @@ import type { SocialPlatform } from "@/lib/platform/social/variants/types";
 // D1 — CAP (Content Automation Platform) types.
 //
 // CAP generates social post copy from a company's brand profile via Claude.
-// Generated posts land in social_post_master with source_type='cap' and
-// flow through the normal draft → approval → schedule → publish pipeline.
+// Generated posts land in social_post_drafts (V2) with source_type='cap'
+// and flow through the V2 draft → approval → schedule → publish pipeline.
 // ---------------------------------------------------------------------------
 
 export type CAPGenerateInput = {
@@ -21,7 +21,7 @@ export type CAPGenerateInput = {
 };
 
 export type CAPGeneratedPost = {
-  postMasterId: string;
+  draftId: string;
   masterText: string;
   /** Keys are SocialPlatform values; values are the generated variant text. */
   variants: Partial<Record<SocialPlatform, string>>;


### PR DESCRIPTION
## Summary

- Rewrites `generateCAPPosts` to insert into `social_post_drafts` (V2) instead of the V1 `createPostMaster` + `upsertVariant` path
- Updates `triggerCAPImageGen` to accept `draftId` (was `postMasterId`) and link the generated asset via `media_urls` on `social_post_drafts`
- Renames `CAPGeneratedPost.postMasterId` → `draftId` in the shared types
- Adds integration test (`cap-v2-generator.test.ts`) verifying `state=draft`, `source_type=cap`, and `platform_variants` roundtrip against real Supabase

## Working analog

**Working analog**: `lib/__tests__/migration-0155-v2-schema-gaps.test.ts:1-80` — beforeEach seed pattern for `social_post_drafts` integration tests  
**Diff**: old generator used V1 helper functions; new generator directly inserts into `social_post_drafts` with `platform_variants` JSONB  
**Fix**: replaced `createPostMaster` + `upsertVariant` calls with a single `.from("social_post_drafts").insert({...}).select("id").single()` per post

## Risks identified and mitigated

| Risk | Mitigation |
|---|---|
| V1 references still compile | `CAPGeneratedPost.draftId` rename; `generator.ts` no longer imports V1 helpers; `image-trigger.ts` references `draftId` throughout — typecheck passes |
| `postMasterId` dangling reference in image-trigger catch block | Fixed: `draftId` used in both logger.warn calls |
| Integration test truncateAll() wipes company seed | `seedCompany()` called in `beforeEach`; auth user seeded in `beforeAll` with `persistent: true` |
| `platform_variants` JSONB shape | Stored as `Record<string, { content: string }>`; test asserts `.linkedin_company.content` and `.x.content` roundtrip |

## Pre-PR checklist

- [x] Lint, typecheck, build all green (lint-staged passed on commit)
- [x] Layer scripts: test:unit (cap-generator.test.ts, cap-image-trigger.test.ts), test:integration (cap-v2-generator.test.ts)
- [x] Contract snapshots: no SDK boundary changes
- [x] Working-analog block above
- [x] Risks identified and mitigated above
- [x] PR under 500 net lines