### PR TITLE
feat(social): post create handler writes to social_post_drafts (V2 migration PR-07)

### DIFF
--- a/app/api/platform/social/posts/route.ts
+++ b/app/api/platform/social/posts/route.ts
@@ -1,25 +1,27 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
-import { dbUuid, readJsonBody, validationError, internalError, notFound } from "@/lib/http";
+import { dbUuid, readJsonBody, validationError, internalError } from "@/lib/http";
 import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { logger } from "@/lib/logger";
+import { getServiceRoleClient } from "@/lib/supabase";
 import {
-  createPostMaster,
   listPostMasters,
   type SocialPostState,
 } from "@/lib/platform/social/posts";
 import { listConnections } from "@/lib/platform/social/connections";
-import { upsertVariant } from "@/lib/platform/social/variants/upsert";
 
 // ---------------------------------------------------------------------------
-// S1-2 — HTTP API for social_post_master.
+// S1-2 — HTTP API for social_post_master / social_post_drafts.
 //
-//   POST /api/platform/social/posts — create a new draft post.
+//   POST /api/platform/social/posts — create a new draft post (V2 path:
+//     writes to social_post_drafts). PR-07 V1→V2 migration.
 //     Body: { company_id, master_text?, link_url?, source_type? }
 //     Gate: canDo("create_post", company_id) — editor+.
 //
 //   GET /api/platform/social/posts?company_id=...&state=draft,approved
 //     Gate: canDo("view_calendar", company_id) — viewer+.
+//     Still reads from social_post_master (migrated in PR-15).
 //
 // Errors follow the standard envelope shape used across the platform
 // layer (lib/tool-schemas ApiResponse). State machine transitions
@@ -63,49 +65,63 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const gate = await requireCanDoForApi(parsed.data.company_id, "create_post");
+  const { company_id: companyId, master_text, link_url, source_type, connection_ids } = parsed.data;
+
+  const gate = await requireCanDoForApi(companyId, "create_post");
   if (gate.kind === "deny") return gate.response;
 
-  const result = await createPostMaster({
-    companyId: parsed.data.company_id,
-    masterText: parsed.data.master_text ?? null,
-    linkUrl: parsed.data.link_url ?? null,
-    sourceType: parsed.data.source_type ?? "manual",
-    createdBy: gate.userId,
-  });
+  const content = master_text?.trim() ?? null;
+  const linkUrl = link_url?.trim() ?? null;
 
-  if (!result.ok) {
-    if (result.error.code === "VALIDATION_FAILED") return validationError(result.error.message);
-    if (result.error.code === "NOT_FOUND") return notFound(result.error.message);
-    return internalError(result.error.message);
+  if (content === null && linkUrl === null) {
+    return validationError("A post must have at least master_text or link_url.");
   }
 
-  // If connection_ids were supplied, create variants for each.
-  const connectionIds = parsed.data.connection_ids;
-  if (connectionIds && connectionIds.length > 0) {
-    const connectionsResult = await listConnections({ companyId: parsed.data.company_id });
+  // Resolve connection_ids to target_profiles. Only include IDs that belong
+  // to this company (listConnections is company-scoped). V2 stores targets in
+  // the target_profiles JSONB array instead of variant rows.
+  let targetProfiles: Array<{ profile_id: string }> = [];
+  if (connection_ids && connection_ids.length > 0) {
+    const connectionsResult = await listConnections({ companyId });
     if (connectionsResult.ok) {
-      const connectionMap = new Map(connectionsResult.data.connections.map((c) => [c.id, c]));
-      await Promise.all(
-        connectionIds.map(async (connId) => {
-          const conn = connectionMap.get(connId);
-          if (!conn) return; // unknown / wrong-company connection — skip silently
-          await upsertVariant({
-            postMasterId: result.data.id,
-            companyId: parsed.data.company_id,
-            platform: conn.platform,
-            variantText: null,
-            connectionId: conn.id,
-          });
-        }),
-      );
+      const ownedIds = new Set(connectionsResult.data.connections.map((c) => c.id));
+      targetProfiles = connection_ids
+        .filter((id) => ownedIds.has(id))
+        .map((id) => ({ profile_id: id }));
     }
+  }
+
+  const svc = getServiceRoleClient();
+  const { data: draft, error } = await svc
+    .from("social_post_drafts")
+    .insert({
+      company_id:        companyId,
+      state:             "draft" as const,
+      source_type:       source_type ?? "manual",
+      content,
+      link_url:          linkUrl,
+      created_by:        gate.userId,
+      updated_by:        gate.userId,
+      media_urls:        [] as string[],
+      target_profiles:   targetProfiles,
+      platform_variants: {} as Record<string, unknown>,
+    })
+    .select("id, company_id, state, source_type, content, link_url, created_by, created_at, updated_at")
+    .single();
+
+  if (error) {
+    logger.error("social.posts.create_v2.failed", {
+      companyId,
+      err: error.message,
+      code: error.code,
+    });
+    return internalError(`Failed to create post: ${error.message}`);
   }
 
   return NextResponse.json(
     {
       ok: true,
-      data: { post: result.data },
+      data: { post: draft },
       timestamp: new Date().toISOString(),
     },
     { status: 201 },

--- a/lib/__tests__/social-post-create-v2.unit.test.ts
+++ b/lib/__tests__/social-post-create-v2.unit.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// PR-07 — unit tests for POST /api/platform/social/posts writing to V2.
+//
+// Verifies that the POST handler inserts into social_post_drafts (not
+// social_post_master) and maps connection_ids → target_profiles correctly.
+// All Supabase + auth calls are mocked — no real credentials needed.
+// ---------------------------------------------------------------------------
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+const { mockRequireCanDo } = vi.hoisted(() => ({ mockRequireCanDo: vi.fn() }));
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: mockRequireCanDo,
+}));
+
+const { mockListConnections } = vi.hoisted(() => ({ mockListConnections: vi.fn() }));
+vi.mock("@/lib/platform/social/connections", () => ({
+  listConnections: mockListConnections,
+}));
+
+import { POST } from "@/app/api/platform/social/posts/route";
+
+// RFC 4122 v4-compatible UUIDs (Zod v4 validates version/variant bits).
+const COMPANY_ID = "aaaaaaaa-0000-4000-8000-000000000001";
+const USER_ID    = "bbbbbbbb-0000-4000-8000-000000000002";
+const DRAFT_ID   = "cccccccc-0000-4000-8000-000000000003";
+const CONN_ID_1  = "dddddddd-0000-4000-8000-000000000004";
+const CONN_ID_2  = "eeeeeeee-0000-4000-8000-000000000005";
+
+function fakeDraft(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    id:         DRAFT_ID,
+    company_id: COMPANY_ID,
+    state:      "draft",
+    source_type: "manual",
+    content:    "Hello world",
+    link_url:   null,
+    created_by: USER_ID,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeInsertChain(result: { data: unknown; error: unknown }) {
+  const mockSingle = vi.fn().mockResolvedValue(result);
+  const mockSelect = vi.fn(() => ({ single: mockSingle }));
+  const mockInsert = vi.fn(() => ({ select: mockSelect }));
+  return { mockInsert, mockSelect, mockSingle };
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/platform/social/posts", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireCanDo.mockResolvedValue({ kind: "allow", userId: USER_ID });
+  mockListConnections.mockResolvedValue({ ok: true, data: { connections: [] } });
+});
+
+describe("POST /api/platform/social/posts — V2 migration (PR-07)", () => {
+  it("inserts into social_post_drafts and returns 201", async () => {
+    const { mockInsert } = makeInsertChain({ data: fakeDraft(), error: null });
+    mockFrom.mockReturnValue({ insert: mockInsert });
+
+    const res = await POST(makeRequest({ company_id: COMPANY_ID, master_text: "Hello world" }) as never);
+
+    expect(res.status).toBe(201);
+    const json = await res.json() as { ok: boolean; data: { post: { state: string } } };
+    expect(json.ok).toBe(true);
+    expect(json.data.post.state).toBe("draft");
+
+    // Must target social_post_drafts, NOT social_post_master.
+    expect(mockFrom).toHaveBeenCalledWith("social_post_drafts");
+  });
+
+  it("inserts with all required V2 columns spelled out", async () => {
+    const { mockInsert } = makeInsertChain({ data: fakeDraft(), error: null });
+    mockFrom.mockReturnValue({ insert: mockInsert });
+
+    await POST(makeRequest({ company_id: COMPANY_ID, master_text: "Post text" }) as never);
+
+    const insertArg = (mockInsert.mock.calls[0] as unknown as [Record<string, unknown>])[0];
+    const REQUIRED = [
+      "company_id", "state", "source_type", "content", "link_url",
+      "created_by", "updated_by", "media_urls", "target_profiles", "platform_variants",
+    ] as const;
+    for (const col of REQUIRED) {
+      expect(Object.prototype.hasOwnProperty.call(insertArg, col), `missing column: ${col}`).toBe(true);
+    }
+    expect(insertArg.state).toBe("draft");
+    expect(insertArg.source_type).toBe("manual");
+    expect(insertArg.company_id).toBe(COMPANY_ID);
+    expect(insertArg.created_by).toBe(USER_ID);
+    expect(insertArg.updated_by).toBe(USER_ID);
+  });
+
+  it("returns 400 when both master_text and link_url are absent", async () => {
+    const res = await POST(makeRequest({ company_id: COMPANY_ID }) as never);
+    expect(res.status).toBe(400);
+    const json = await res.json() as { ok: boolean };
+    expect(json.ok).toBe(false);
+  });
+
+  it("returns 400 when body is invalid JSON shape", async () => {
+    const res = await POST(makeRequest({ company_id: "not-a-uuid", master_text: "x" }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it("maps connection_ids to target_profiles (only company-owned)", async () => {
+    mockListConnections.mockResolvedValue({
+      ok: true,
+      data: {
+        connections: [
+          { id: CONN_ID_1, platform: "linkedin_company" },
+          { id: CONN_ID_2, platform: "x" },
+        ],
+      },
+    });
+    const { mockInsert } = makeInsertChain({ data: fakeDraft(), error: null });
+    mockFrom.mockReturnValue({ insert: mockInsert });
+
+    const UNKNOWN_ID = "ffffffff-0000-4000-8000-000000000099";
+    await POST(makeRequest({
+      company_id: COMPANY_ID,
+      master_text: "Post text",
+      connection_ids: [CONN_ID_1, UNKNOWN_ID],
+    }) as never);
+
+    const insertArg = (mockInsert.mock.calls[0] as unknown as [Record<string, unknown>])[0];
+    expect(insertArg.target_profiles).toEqual([{ profile_id: CONN_ID_1 }]);
+  });
+
+  it("returns 500 when DB insert fails", async () => {
+    const { mockInsert } = makeInsertChain({
+      data: null,
+      error: { message: "connection refused", code: "PGRST000" },
+    });
+    mockFrom.mockReturnValue({ insert: mockInsert });
+
+    const res = await POST(makeRequest({ company_id: COMPANY_ID, master_text: "Post" }) as never);
+    expect(res.status).toBe(500);
+  });
+
+  it("accepts link_url-only posts", async () => {
+    const { mockInsert } = makeInsertChain({
+      data: fakeDraft({ content: null, link_url: "https://example.com" }),
+      error: null,
+    });
+    mockFrom.mockReturnValue({ insert: mockInsert });
+
+    const res = await POST(makeRequest({
+      company_id: COMPANY_ID,
+      link_url: "https://example.com",
+    }) as never);
+
+    expect(res.status).toBe(201);
+    const insertArg = (mockInsert.mock.calls[0] as unknown as [Record<string, unknown>])[0];
+    expect(insertArg.content).toBeNull();
+    expect(insertArg.link_url).toBe("https://example.com");
+  });
+
+  it("forwards source_type from request body", async () => {
+    const { mockInsert } = makeInsertChain({
+      data: fakeDraft({ source_type: "csv" }),
+      error: null,
+    });
+    mockFrom.mockReturnValue({ insert: mockInsert });
+
+    await POST(makeRequest({ company_id: COMPANY_ID, master_text: "x", source_type: "csv" }) as never);
+
+    const insertArg = (mockInsert.mock.calls[0] as unknown as [Record<string, unknown>])[0];
+    expect(insertArg.source_type).toBe("csv");
+  });
+});


### PR DESCRIPTION
## Summary

- `POST /api/platform/social/posts` now inserts into `social_post_drafts` instead of `social_post_master`
- `connection_ids` → `target_profiles: [{ profile_id }]` JSONB array (V2 pattern) instead of `social_post_variant` rows
- `GET` handler unchanged — still reads `social_post_master` (migrated in PR-15)
- Unit test added: 8 cases covering happy path, validation, connection_ids filtering, source_type forwarding

## Working analog

**Working analog**: `app/api/platform/social/drafts/route.ts:POST` — V2 create path inserts into `social_post_drafts` with all columns spelled out (PostgREST batch insert rule)
**Diff**: Old route called `createPostMaster` (V1 lib → `social_post_master`) and then `upsertVariant` for each connection
**Fix**: Inline insert to `social_post_drafts` with full column set; `connection_ids` mapped to `target_profiles`

## Risks identified and mitigated

- **Response shape change**: `data.post` now has V2 columns (`content` not `master_text`, no `state_changed_at`). This is the manual-post create path — the UI reads from GET (PR-15 later), not this response body. Acceptable migration risk.
- **connection_ids migration**: V1 created `social_post_variant` rows; V2 stores in `target_profiles`. Variant rows for manual posts are no longer created here. The publish cron reads `target_profiles`, so V2 posts created via this route will publish correctly.
- **PostgREST NOT NULL**: All 10 required V2 columns spelled out on every insert (MEMORY.md rule). Covered by unit test.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: test:unit (8 tests, all pass)
- [x] Contract snapshots reviewed (no SDK calls touched)
- [x] Cross-tenant test added (N/A — auth gate unchanged)
- [x] For bug fixes: working-analog block above
- [x] Risks identified and mitigated section above
- [x] PR is under 500 net lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)