### PR TITLE
chore(social): retire V1 publish backfill + watchdog crons (pr-12)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -81,14 +81,6 @@
       "schedule": "* * * * *"
     },
     {
-      "path": "/api/cron/social-publish-backfill",
-      "schedule": "*/5 * * * *"
-    },
-    {
-      "path": "/api/cron/social-publish-watchdog",
-      "schedule": "*/5 * * * *"
-    },
-    {
       "path": "/api/cron/cap-monthly-generation",
       "schedule": "0 4 1 * *"
     },


### PR DESCRIPTION
## Summary

- Removes `social-publish-backfill` (every 5 min) and `social-publish-watchdog` (every 5 min) from `vercel.json` cron schedule
- V2 `publish-due` cron has been sole publisher for 8 days (since 2026-05-19, commit 29b16059) — past the ≥7 day prerequisite
- Route files retained (not deleted) — PR-13 covers full V1 QStash pipeline retirement

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: N/A (config-only change)
- [x] Contract snapshots reviewed (no SDK calls touched)
- [x] PR is under 500 net lines: **8 deletions, 0 additions**

## Risks identified and mitigated

| Hotspot | Mitigation |
|---|---|
| Active V1 schedule entries stop getting backfilled | Confirmed V2 publish-due cron live 8 days; all new posts via V2 pipeline; V1 entries either already published or being handled by dual-lookup shim |
| Watchdog stops recovering stuck V1 in_flight attempts | Same — V1 publish attempts only exist for V1 schedule entries; V2 pipeline uses FOR UPDATE SKIP LOCKED with no watchdog needed |

## Working analog

**Working analog**: none — this is a pure config deletion, no code pattern to match.

**New pattern justification**: Retiring a scheduled cron entry from vercel.json is safe once the underlying work is confirmed complete. The only risk is residual in_flight V1 work, mitigated by the 8-day observation window.

---
Part of V1→V2 social post model migration. PR-11 (scheduling dual-lookup) in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)