### PR TITLE
feat(social): retire V1 QStash publish pipeline (pr-13)

### DIFF
--- a/app/api/cron/social-publish-backfill/route.ts
+++ b/app/api/cron/social-publish-backfill/route.ts
@@ -5,7 +5,6 @@ import {
   authorisedCronRequest,
   unauthorisedResponse,
 } from "@/lib/optimiser/sync/cron-shared";
-import { backfillScheduledPublishes } from "@/lib/platform/social/publishing";
 
 // ---------------------------------------------------------------------------
 // S1-19 — GET /api/cron/social-publish-backfill
@@ -30,42 +29,16 @@ export const maxDuration = 120;
 async function handle(req: NextRequest): Promise<NextResponse> {
   if (!authorisedCronRequest(req)) return unauthorisedResponse();
 
-  const origin =
-    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/+$/, "") ??
-    new URL(req.url).origin;
-
-  const result = await backfillScheduledPublishes({ origin });
-  if (!result.ok) {
-    logger.error("social.publish.backfill.cron_failed", {
-      err: result.error.message,
-    });
-    return NextResponse.json(
-      {
-        ok: false,
-        error: result.error,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    );
-  }
-
-  logger.info("social.publish.backfill.cron_ok", {
-    status: result.data.status,
-    ...(result.data.status === "ok"
-      ? {
-          examined: result.data.examined,
-          enqueued: result.data.enqueued,
-          failed: result.data.failed,
-          retries_attempted: result.data.retries_attempted,
-          retries_failed: result.data.retries_failed,
-        }
-      : { reason: result.data.reason }),
+  // V1 backfill cron retired (pr-12 removed vercel.json schedule entry;
+  // pr-13 retired the V1 QStash pipeline). Route kept alive to avoid 404s
+  // from any in-flight triggers. Returns 200 noop.
+  logger.warn("social.publish.backfill.v1_retired", {
+    note: "V1 backfill cron retired — route is a noop; vercel.json entry removed in pr-12",
   });
-
   return NextResponse.json(
     {
       ok: true,
-      data: result.data,
+      data: { status: "retired", reason: "V1 QStash pipeline retired (pr-13)" },
       timestamp: new Date().toISOString(),
     },
     { status: 200 },

--- a/app/api/cron/social-publish-watchdog/route.ts
+++ b/app/api/cron/social-publish-watchdog/route.ts
@@ -5,7 +5,6 @@ import {
   authorisedCronRequest,
   unauthorisedResponse,
 } from "@/lib/optimiser/sync/cron-shared";
-import { runPublishWatchdog } from "@/lib/platform/social/publishing/watchdog";
 
 // ---------------------------------------------------------------------------
 // GET /api/cron/social-publish-watchdog
@@ -24,22 +23,18 @@ export const maxDuration = 60;
 async function handle(req: NextRequest): Promise<NextResponse> {
   if (!authorisedCronRequest(req)) return unauthorisedResponse();
 
-  const result = await runPublishWatchdog();
-
-  if (!result.ok) {
-    logger.error("social.publish.watchdog.cron_failed", {
-      err: result.error.message,
-    });
-    return NextResponse.json(
-      { ok: false, error: result.error, timestamp: new Date().toISOString() },
-      { status: 500 },
-    );
-  }
-
-  logger.info("social.publish.watchdog.cron_ok", result.data);
-
+  // V1 watchdog cron retired (pr-12 removed vercel.json schedule entry;
+  // pr-13 retired the V1 QStash pipeline). Route kept alive to avoid 404s
+  // from any in-flight triggers. Returns 200 noop.
+  logger.warn("social.publish.watchdog.v1_retired", {
+    note: "V1 watchdog cron retired — route is a noop; vercel.json entry removed in pr-12",
+  });
   return NextResponse.json(
-    { ok: true, data: result.data, timestamp: new Date().toISOString() },
+    {
+      ok: true,
+      data: { status: "retired", reason: "V1 QStash pipeline retired (pr-13)" },
+      timestamp: new Date().toISOString(),
+    },
     { status: 200 },
   );
 }

--- a/app/api/webhooks/qstash/social-publish/route.ts
+++ b/app/api/webhooks/qstash/social-publish/route.ts
@@ -66,6 +66,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
+  logger.info("social.publish.v1_callback.received", {
+    scheduleEntryId: parsed.scheduleEntryId,
+    note: "V1 QStash pipeline draining — pr-13",
+  });
+
   const result = await fireScheduledPublish({
     scheduleEntryId: parsed.scheduleEntryId,
   });

--- a/lib/__tests__/social-publish-enqueue-v1-retired.unit.test.ts
+++ b/lib/__tests__/social-publish-enqueue-v1-retired.unit.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// PR-13 — unit tests for retired V1 enqueueScheduledPublish.
+//
+// After pr-13, enqueueScheduledPublish is a logged no-op. All new posts
+// use the V2 publish-due cron. These tests verify the retirement behaviour:
+// valid inputs return { ok: true, data: { messageId: null } } without
+// calling QStash, and invalid inputs still return validation errors.
+// ---------------------------------------------------------------------------
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const mockPublishJSON = vi.fn();
+vi.mock("@/lib/qstash", () => ({
+  getQstashClient: () => ({ publishJSON: mockPublishJSON }),
+}));
+
+const { enqueueScheduledPublish } = await import("@/lib/platform/social/publishing/enqueue");
+const { logger } = await import("@/lib/logger");
+
+const ENTRY_ID = "aaaaaaaa-0000-4000-8000-000000000001";
+const FUTURE_ISO = new Date(Date.now() + 86400000).toISOString();
+
+describe("enqueueScheduledPublish — V1 retired noop", () => {
+  it("returns messageId: null without calling QStash", async () => {
+    const result = await enqueueScheduledPublish({
+      scheduleEntryId: ENTRY_ID,
+      scheduledAt: FUTURE_ISO,
+      origin: "https://app.opollo.com",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.messageId).toBeNull();
+    }
+    expect(mockPublishJSON).not.toHaveBeenCalled();
+  });
+
+  it("logs a warning on every call", async () => {
+    await enqueueScheduledPublish({
+      scheduleEntryId: ENTRY_ID,
+      scheduledAt: FUTURE_ISO,
+      origin: "https://app.opollo.com",
+    });
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      "social.publish.enqueue.v1_retired",
+      expect.objectContaining({ schedule_entry_id: ENTRY_ID }),
+    );
+  });
+
+  it("returns VALIDATION_FAILED for missing scheduleEntryId", async () => {
+    const result = await enqueueScheduledPublish({
+      scheduleEntryId: "",
+      scheduledAt: FUTURE_ISO,
+      origin: "https://app.opollo.com",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION_FAILED");
+    }
+    expect(mockPublishJSON).not.toHaveBeenCalled();
+  });
+
+  it("returns VALIDATION_FAILED for invalid scheduledAt", async () => {
+    const result = await enqueueScheduledPublish({
+      scheduleEntryId: ENTRY_ID,
+      scheduledAt: "not-a-date",
+      origin: "https://app.opollo.com",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION_FAILED");
+    }
+    expect(mockPublishJSON).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/social-publishing-backfill.test.ts
+++ b/lib/__tests__/social-publishing-backfill.test.ts
@@ -135,17 +135,20 @@ describe("backfillScheduledPublishes — row selection", () => {
     process.env.QSTASH_TOKEN = "test-token";
   });
 
-  it("enqueues future-dated, NULL-message rows and stamps message_id", async () => {
+  it("noop for future-dated NULL-message rows (V1 enqueue retired)", async () => {
+    // enqueueScheduledPublish is a logged noop after pr-13 retirement.
+    // Rows are examined but no QStash message is created (messageId: null
+    // → counted as failed in the backfill loop).
     const futureIso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
     const entryId = await seedScheduleEntry({ scheduledAt: futureIso });
-    mockClient.publishJSON.mockResolvedValueOnce({ messageId: "msg_abc" });
 
     const result = await backfillScheduledPublishes({ origin: ORIGIN });
     expect(result.ok).toBe(true);
     if (!result.ok || result.data.status !== "ok") return;
     expect(result.data.examined).toBe(1);
-    expect(result.data.enqueued).toBe(1);
-    expect(result.data.failed).toBe(0);
+    expect(result.data.enqueued).toBe(0);
+    expect(result.data.failed).toBe(1);
+    expect(mockClient.publishJSON).not.toHaveBeenCalled();
 
     const svc = getServiceRoleClient();
     const row = await svc
@@ -153,7 +156,8 @@ describe("backfillScheduledPublishes — row selection", () => {
       .select("qstash_message_id")
       .eq("id", entryId)
       .single();
-    expect(row.data?.qstash_message_id).toBe("msg_abc");
+    // Entry stays with NULL qstash_message_id — no QStash message was created.
+    expect(row.data?.qstash_message_id).toBeNull();
   });
 
   it("skips rows that already have a message_id", async () => {
@@ -193,20 +197,19 @@ describe("backfillScheduledPublishes — row selection", () => {
     expect(result.data.examined).toBe(0);
   });
 
-  it("counts per-row enqueue failures without aborting", async () => {
+  it("counts all rows as noop (V1 enqueue retired)", async () => {
+    // Both rows are examined; enqueueScheduledPublish returns messageId: null
+    // for each → both counted as failed, no QStash calls made.
     const futureIso = new Date(Date.now() + 60 * 60 * 1000).toISOString();
     await seedScheduleEntry({ scheduledAt: futureIso });
     await seedScheduleEntry({ scheduledAt: futureIso });
-
-    mockClient.publishJSON
-      .mockResolvedValueOnce({ messageId: "msg_ok" })
-      .mockRejectedValueOnce(new Error("HTTP 500"));
 
     const result = await backfillScheduledPublishes({ origin: ORIGIN });
     expect(result.ok).toBe(true);
     if (!result.ok || result.data.status !== "ok") return;
     expect(result.data.examined).toBe(2);
-    expect(result.data.enqueued).toBe(1);
-    expect(result.data.failed).toBe(1);
+    expect(result.data.enqueued).toBe(0);
+    expect(result.data.failed).toBe(2);
+    expect(mockClient.publishJSON).not.toHaveBeenCalled();
   });
 });

--- a/lib/platform/social/publishing/enqueue.ts
+++ b/lib/platform/social/publishing/enqueue.ts
@@ -2,30 +2,20 @@ import "server-only";
 
 import { logger } from "@/lib/logger";
 import { getQstashClient } from "@/lib/qstash";
-import { getServiceRoleClient } from "@/lib/supabase";
 import type { ApiResponse } from "@/lib/tool-schemas";
 
 // ---------------------------------------------------------------------------
-// S1-18 — enqueue a QStash callback for a scheduled publish.
+// S1-18 — V1 QStash enqueue (RETIRED pr-13).
 //
-// Called from createScheduleEntry (after the row is inserted) with
-// the entry id + the absolute scheduled_at. Schedules a single QStash
-// message that POSTs back to /api/webhooks/qstash/social-publish at
-// the scheduled time. Stores the QStash messageId on the schedule
-// entry so cancellation can call back.
+// enqueueScheduledPublish is now a logged no-op. All new social posts use
+// the V2 publish-due cron (social_post_drafts, FOR UPDATE SKIP LOCKED).
+// No new QStash messages should be enqueued after pr-07 migrated all post
+// creation to social_post_drafts.
 //
-// Idempotency:
-//   - QStash deduplicationId = `social-publish-${scheduleEntryId}`. If
-//     this lib runs twice (route retry) the second publishJSON returns
-//     the same messageId without duplicating the queued job.
-//   - The schedule_entry's qstash_message_id is set unconditionally
-//     after a successful publishJSON; any prior id was for the SAME
-//     logical scheduled job (per the deduplicationId scope).
+// cancelScheduledPublish still works — it cancels pending QStash messages
+// for any V1 entries that were enqueued before this retirement.
 //
-// Degraded path: when QSTASH_TOKEN is unset (local dev without
-// Upstash, CI without provisioning) we no-op + log. The schedule entry
-// row still exists; an operator-triggered backfill cron (future slice)
-// can re-enqueue once QSTASH is wired.
+// Full V1 table drop in PRs 16-17.
 // ---------------------------------------------------------------------------
 
 export type EnqueuePublishInput = {
@@ -50,67 +40,13 @@ export async function enqueueScheduledPublish(
     return validation("scheduledAt must be a valid ISO timestamp.");
   }
 
-  const client = getQstashClient();
-  if (!client) {
-    logger.info("social.publish.enqueue.skipped_no_qstash", {
-      schedule_entry_id: input.scheduleEntryId,
-    });
-    return {
-      ok: true,
-      data: { messageId: null },
-      timestamp: new Date().toISOString(),
-    };
-  }
-
-  // QStash takes a delay in seconds. For past/now timestamps we still
-  // enqueue at delay=1 so the callback fires immediately rather than
-  // silently dropping (createScheduleEntry already rejected past
-  // timestamps but a backfill caller might pass one).
-  const delaySeconds = Math.max(1, Math.floor((fireAtMs - Date.now()) / 1000));
-
-  const callbackUrl = `${input.origin.replace(/\/+$/, "")}/api/webhooks/qstash/social-publish`;
-
-  let messageId: string | null = null;
-  try {
-    const response = (await client.publishJSON({
-      url: callbackUrl,
-      body: { scheduleEntryId: input.scheduleEntryId },
-      delay: delaySeconds,
-      // Idempotent across re-enqueues for the same logical job. QStash
-      // returns the existing messageId on collision.
-      deduplicationId: `social-publish-${input.scheduleEntryId}`,
-    })) as { messageId?: string };
-    messageId = response.messageId ?? null;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    logger.error("social.publish.enqueue.publish_failed", {
-      err: message,
-      schedule_entry_id: input.scheduleEntryId,
-    });
-    return internal(`QStash publish failed: ${message}`);
-  }
-
-  if (messageId) {
-    const svc = getServiceRoleClient();
-    const update = await svc
-      .from("social_schedule_entries")
-      .update({ qstash_message_id: messageId })
-      .eq("id", input.scheduleEntryId);
-    if (update.error) {
-      // Log but don't fail — the QStash job is queued, the messageId
-      // just isn't stored. Cancellation lookup will fall through to
-      // best-effort behaviour (the schedule_entry.cancelled_at flag is
-      // the source of truth; the publish callback re-checks it).
-      logger.warn("social.publish.enqueue.message_id_update_failed", {
-        err: update.error.message,
-        schedule_entry_id: input.scheduleEntryId,
-      });
-    }
-  }
-
+  logger.warn("social.publish.enqueue.v1_retired", {
+    schedule_entry_id: input.scheduleEntryId,
+    note: "V1 QStash pipeline retired (pr-13); no QStash message enqueued",
+  });
   return {
     ok: true,
-    data: { messageId },
+    data: { messageId: null },
     timestamp: new Date().toISOString(),
   };
 }


### PR DESCRIPTION
## Summary

- `enqueueScheduledPublish` → logged no-op; no new QStash messages created after pr-07 migrated all post creation to `social_post_drafts`
- `cancelScheduledPublish` → unchanged; still cancels pending V1 QStash messages
- Backfill + watchdog cron routes → 200 noop (vercel.json schedule entries removed in pr-12)
- QStash webhook → drain monitoring log added; processing logic intact for V1 drain period
- Backfill integration tests updated to assert `enqueued=0` (noop, no QStash calls)
- New unit test: 4 assertions verifying noop behavior and validation errors

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (new unit test 4/4 pass), `test:integration` (backfill tests updated)
- [x] Contract snapshots reviewed (no SDK calls touched)
- [x] Regression test: `lib/__tests__/social-publish-enqueue-v1-retired.unit.test.ts`
- [x] PR is under 500 net lines: 130 insertions, 138 deletions

## Risks identified and mitigated

| Hotspot | Mitigation |
|---|---|
| V1 posts scheduled before pr-07 lose their publish path | QStash webhook still processes all pending V1 callbacks — drain period is alive. Only NEW enqueues are blocked |
| `backfillScheduledPublishes` now counts all rows as `failed` | Backfill cron schedule removed in pr-12; function won't run automatically. If called, the "failure" is a no-op (no QStash timeout/retry) |
| cancelScheduledPublish stops working | NOT changed — function still calls QStash to cancel messages for any V1 entries with stored qstash_message_id |

## Working analog

**Working analog**: none — this is a pipeline retirement, not a bug fix.
**New pattern justification**: Retiring a publish pathway by making its enqueue function a logged no-op is the standard dual-write migration drain pattern. The V2 path (`publish-due` cron) has been the sole publisher for 8 days (pr-03, 2026-05-19).

---
Part of V1→V2 social post model migration.
- PR-12 (#1111): vercel.json cron retirement — in CI
- PR-11 (#1110): scheduling dual-lookup — in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)