### PR TITLE
feat(social): v2 dual-lookup in BSP webhook post events (pr-14)

### DIFF
--- a/lib/__tests__/bsp-webhook-v2.unit.test.ts
+++ b/lib/__tests__/bsp-webhook-v2.unit.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// PR-14 — unit tests for V2 dual-lookup in BSP webhook processBundlesocialWebhook.
+//
+// When a post.published / post.failed event arrives for a bundle_post_id
+// that is NOT in social_publish_attempts (V1), we fall back to checking
+// social_post_drafts.bundle_post_id (V2). If found, we dispatch the
+// notification and return kind: "ok".
+// ---------------------------------------------------------------------------
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const mockNotifyDispatch = vi.fn().mockResolvedValue({ inApp: 1, emails: 0, errors: [] });
+vi.mock("@/lib/platform/notifications", () => ({
+  dispatch: mockNotifyDispatch,
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+
+const COMPANY_ID = "aaaaaaaa-0000-4000-8000-000000000001";
+const DRAFT_ID   = "aaaaaaaa-0000-4000-8000-000000000002";
+const EVENT_ID   = "bsp_event_001";
+const BUNDLE_POST_ID = "bsp_post_abc123";
+
+const { getServiceRoleClient } = await import("@/lib/supabase");
+const { processBundlesocialWebhook } = await import("@/lib/platform/social/webhooks/process");
+
+// Build a mock svc where:
+//   - social_webhook_events.insert → success
+//   - social_publish_attempts lookup → returns null (V1 not found)
+//   - social_post_drafts lookup → returns the provided draftRow or null
+function makeSvc(draftRow: Record<string, unknown> | null) {
+  return {
+    from: (table: string) => {
+      if (table === "social_webhook_events") {
+        return {
+          insert: () => ({
+            select: () => ({
+              single: async () => ({
+                data: { id: "wh_row_01", processed_at: null },
+                error: null,
+              }),
+            }),
+          }),
+          update: () => ({
+            eq: () => ({ error: null }),
+          }),
+        };
+      }
+      if (table === "social_publish_attempts") {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: () => ({
+                limit: () => ({
+                  maybeSingle: async () => ({ data: null, error: null }),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "social_post_drafts") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: draftRow, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("processBundlesocialWebhook — V2 post.published", () => {
+  it("dispatches post_published notification when V2 draft found by bundle_post_id", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSvc({
+        id: DRAFT_ID,
+        company_id: COMPANY_ID,
+        created_by: "user_001",
+        target_profiles: [{ profile_id: "p1", platform: "linkedin" }],
+        published_url: "https://linkedin.com/post/123",
+      }) as never,
+    );
+
+    const result = await processBundlesocialWebhook({
+      envelope: {
+        id: EVENT_ID,
+        type: "post.published",
+        teamId: "team_01",
+        data: { bundlePostId: BUNDLE_POST_ID, platformPostUrl: "https://linkedin.com/post/123" },
+      },
+      rawPayload: {},
+      signatureValid: true,
+    });
+
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.action).toContain("post_published");
+    }
+    expect(mockNotifyDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "post_published",
+        companyId: COMPANY_ID,
+        postMasterId: DRAFT_ID,
+        platform: "linkedin",
+      }),
+    );
+  });
+
+  it("dispatches post_failed notification when V2 draft found", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSvc({
+        id: DRAFT_ID,
+        company_id: COMPANY_ID,
+        created_by: "user_001",
+        target_profiles: [{ profile_id: "p1", platform: "instagram" }],
+        published_url: null,
+      }) as never,
+    );
+
+    const result = await processBundlesocialWebhook({
+      envelope: {
+        id: EVENT_ID,
+        type: "post.failed",
+        teamId: "team_01",
+        data: {
+          bundlePostId: BUNDLE_POST_ID,
+          error: { class: "AUTH_ERROR", message: "Token expired" },
+        },
+      },
+      rawPayload: {},
+      signatureValid: true,
+    });
+
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.action).toContain("post_failed");
+    }
+    expect(mockNotifyDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "post_failed",
+        companyId: COMPANY_ID,
+        postMasterId: DRAFT_ID,
+        platform: "instagram",
+        errorMessage: "Token expired",
+      }),
+    );
+  });
+
+  it("returns stored_no_action when neither V1 attempt nor V2 draft found", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(makeSvc(null) as never);
+
+    const result = await processBundlesocialWebhook({
+      envelope: {
+        id: EVENT_ID,
+        type: "post.published",
+        teamId: "team_01",
+        data: { bundlePostId: BUNDLE_POST_ID },
+      },
+      rawPayload: {},
+      signatureValid: true,
+    });
+
+    expect(result.kind).toBe("stored_no_action");
+    expect(mockNotifyDispatch).not.toHaveBeenCalled();
+  });
+
+  it("uses unknown platform when target_profiles is empty", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSvc({
+        id: DRAFT_ID,
+        company_id: COMPANY_ID,
+        created_by: "user_001",
+        target_profiles: [],
+        published_url: null,
+      }) as never,
+    );
+
+    const result = await processBundlesocialWebhook({
+      envelope: {
+        id: EVENT_ID,
+        type: "post.published",
+        teamId: "team_01",
+        data: { bundlePostId: BUNDLE_POST_ID },
+      },
+      rawPayload: {},
+      signatureValid: true,
+    });
+
+    expect(result.kind).toBe("ok");
+    expect(mockNotifyDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: "unknown" }),
+    );
+  });
+});

--- a/lib/platform/social/webhooks/process.ts
+++ b/lib/platform/social/webhooks/process.ts
@@ -208,12 +208,67 @@ async function handlePostEvent(
     };
   }
   if (!attempt.data) {
-    // Common during S1-17 rollout — the publish path (S1-18+) hasn't
-    // run yet so there's no attempt row. Audit the event and move on.
+    // V2 fallback: check social_post_drafts.bundle_post_id. V2 posts are
+    // published directly by the publish-due cron (no social_publish_attempts
+    // row); the state change has already happened when the webhook arrives.
+    // We just need to dispatch the post_published / post_failed notification.
+    const v2draft = await svc
+      .from("social_post_drafts")
+      .select("id, company_id, created_by, target_profiles, published_url")
+      .eq("bundle_post_id", bundlePostId)
+      .maybeSingle();
+
+    if (v2draft.error) {
+      logger.warn("bundlesocial.webhook.v2_draft_lookup_failed", {
+        err: v2draft.error.message,
+        bundle_post_id: bundlePostId,
+      });
+    }
+
+    if (v2draft.data) {
+      const draftId = v2draft.data.id as string;
+      const draftCompanyId = v2draft.data.company_id as string | null;
+      const draftCreatedBy = v2draft.data.created_by as string | null;
+      const profiles =
+        (v2draft.data.target_profiles as Array<{ profile_id: string; platform: string }> | null) ?? [];
+      const platform = profiles[0]?.platform ?? "unknown";
+
+      if (type === "post.published" && draftCompanyId && draftCreatedBy) {
+        void notifyDispatch({
+          event: "post_published",
+          companyId: draftCompanyId,
+          postMasterId: draftId,
+          submitterUserId: draftCreatedBy,
+          platform,
+          postUrl: (v2draft.data.published_url as string | null) ?? parsed.data.platformPostUrl ?? "",
+        });
+      } else if (type === "post.failed" && draftCompanyId && draftCreatedBy) {
+        const errorClass = mapErrorClass(parsed.data.error?.class ?? null);
+        void notifyDispatch({
+          event: "post_failed",
+          companyId: draftCompanyId,
+          postMasterId: draftId,
+          submitterUserId: draftCreatedBy,
+          platform,
+          errorClass,
+          errorMessage:
+            (parsed.data.error as { message?: string } | null)?.message ?? "Publish failed.",
+        });
+      }
+
+      return {
+        kind: "ok",
+        webhookEventId,
+        action: `${type === "post.published" ? "post_published" : "post_failed"}_v2`,
+      };
+    }
+
+    // Common during S1-17 rollout and after V1 drain — the publish path
+    // may not have run yet or the bundle_post_id is not yet stamped.
     return {
       kind: "stored_no_action",
       webhookEventId,
-      reason: `No publish_attempt for bundle_post_id=${bundlePostId}.`,
+      reason: `No publish_attempt or V2 draft for bundle_post_id=${bundlePostId}.`,
     };
   }
 


### PR DESCRIPTION
## Summary

- `handlePostEvent` in `lib/platform/social/webhooks/process.ts` now checks `social_post_drafts.bundle_post_id` when no `social_publish_attempts` row is found for a `bundle_post_id`
- Restores `post_published` / `post_failed` notification dispatch for V2 posts (V2 publish-due cron sets `bundle_post_id` on draft; no publish_attempts row exists)
- No DB state update in webhook — cron already transitioned draft state before webhook arrives
- Platform sourced from `target_profiles[0].platform`; falls back to `"unknown"`
- 4 new unit tests covering V2 published, V2 failed, neither found, empty profiles

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts run: `test:unit` (4 new tests pass)
- [x] Contract snapshots reviewed (no SDK calls changed)
- [x] PR is under 500 net lines: **268 insertions, 3 deletions**

## Risks identified and mitigated

| Hotspot | Mitigation |
|---|---|
| Race: webhook arrives before cron sets bundle_post_id on draft | Webhook falls through to `stored_no_action` (existing behavior for V1); bundle.social will retry on 5xx — but we return 200 for no-match, so only one attempt |
| Duplicate webhook delivery dispatches notification twice | `social_webhook_events.event_id` unique constraint + `already_processed` short-circuit prevents reprocessing |
| V2 draft with no created_by skips notification silently | Guard `if (draftCompanyId && draftCreatedBy)` — same pattern as V1 path |

## Working analog

**Working analog**: `handlePostEvent` V1 path (`process.ts:220-285`) — exact same notification dispatch pattern; the only diff is looking up `social_post_drafts` instead of `social_post_master` for the metadata.
**Diff**: V1 uses `social_post_variant` → `social_post_master` chain for company_id/created_by; V2 reads directly from `social_post_drafts` which carries both.
**Fix**: Added V2 fallback inside the `if (!attempt.data)` branch, before the existing `stored_no_action` return.

---
Part of V1→V2 social post model migration. Follows pr-13 (V1 QStash retirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)