### PR TITLE
feat(social): v2 dual-lookup in social analytics (pr-15)

### DIFF
--- a/lib/__tests__/social-analytics-v2.unit.test.ts
+++ b/lib/__tests__/social-analytics-v2.unit.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// PR-15 — unit tests for V2 dual-lookup in getSocialAnalytics.
+//
+// Verifies that KPI counts sum V1 (social_post_master) + V2
+// (social_post_drafts), and that V2 pending_approval drafts appear in
+// the pendingApproval list.
+// ---------------------------------------------------------------------------
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(),
+}));
+
+const COMPANY_ID = "aaaaaaaa-0000-4000-8000-000000000001";
+
+const { getServiceRoleClient } = await import("@/lib/supabase");
+const { getSocialAnalytics } = await import("@/lib/platform/social/analytics");
+
+// Builds a chainable mock that terminates with the provided value.
+// Any method call returns the same proxy; awaiting resolves to terminal.
+function chainable(terminal: unknown): unknown {
+  // proxy is declared first so the getter closure can reference it
+  let proxy: unknown;
+  proxy = new Proxy({} as Record<string | symbol, unknown>, {
+    get(_t, prop) {
+      if (prop === "then") {
+        // Make it a proper thenable so `await chainable(x)` → x
+        return (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+          Promise.resolve(terminal).then(resolve, reject);
+      }
+      if (prop === Symbol.toPrimitive) return () => "[chainable]";
+      // All method calls return the same proxy (keeps chain going)
+      return (..._args: unknown[]) => proxy;
+    },
+  });
+  return proxy;
+}
+
+// Build a mock svc that uses chainable() for each table.
+// Override specific responses by specifying them in `overrides`.
+function makeSvc(overrides: {
+  v1PublishedCount?: number;
+  v2PublishedCount?: number;
+  v1ScheduledCount?: number;
+  v2ScheduledCount?: number;
+  v2Pending?: Array<{ id: string; content: string; created_at: string }>;
+} = {}) {
+  const {
+    v1PublishedCount = 0,
+    v2PublishedCount = 0,
+    v1ScheduledCount = 0,
+    v2ScheduledCount = 0,
+    v2Pending = [],
+  } = overrides;
+
+  const calls: { table: string; select?: string }[] = [];
+
+  const svc = {
+    _calls: calls,
+    from(table: string) {
+      return {
+        select(cols: string, opts?: { count?: string; head?: boolean }) {
+          calls.push({ table, select: cols });
+          if (opts?.count === "exact" && opts?.head) {
+            // Count queries: identify by table + surrounding chain
+            if (table === "social_post_master") {
+              // Return a chainable that resolves with different counts
+              // based on eq("state") call
+              let resolvedState: string | null = null;
+              const countChain = makeCountChain(
+                (state: string) => {
+                  resolvedState = state;
+                },
+                () => {
+                  if (resolvedState === "published") return { count: v1PublishedCount, error: null };
+                  if (resolvedState === "scheduled") return { count: v1ScheduledCount, error: null };
+                  return { count: 0, error: null };
+                },
+              );
+              return countChain;
+            }
+            if (table === "social_post_drafts") {
+              let resolvedState: string | null = null;
+              return makeCountChain(
+                (state: string) => { resolvedState = state; },
+                () => {
+                  if (resolvedState === "published") return { count: v2PublishedCount, error: null };
+                  if (resolvedState === "scheduled") return { count: v2ScheduledCount, error: null };
+                  return { count: 0, error: null };
+                },
+              );
+            }
+            return chainable({ count: 1, error: null });
+          }
+          // Non-count selects
+          if (table === "social_post_drafts") {
+            // pending query
+            if (cols.includes("content")) {
+              return {
+                eq: () => ({
+                  eq: (_c: string, val: unknown) => {
+                    if (val === "pending_approval") {
+                      return {
+                        order: () => ({ limit: async () => ({ data: v2Pending, error: null }) }),
+                      };
+                    }
+                    return {
+                      not: () => ({ order: () => ({ limit: async () => ({ data: [], error: null }) }) }),
+                      limit: async () => ({ data: [], error: null }),
+                      gte: () => ({ order: async () => ({ data: [], error: null }) }),
+                    };
+                  },
+                }),
+              };
+            }
+            // default: return empty arrays for all V2 draft queries
+            return chainable({ data: [], error: null });
+          }
+          // V1 non-count: return empty
+          return chainable({ data: [], error: null });
+        },
+      };
+    },
+  };
+
+  return svc;
+}
+
+// Build a chainable object that tracks eq("state", ...) and resolves count
+function makeCountChain(
+  onState: (state: string) => void,
+  getResult: () => { count: number; error: null },
+): unknown {
+  const self = {
+    eq(_col: string, val: unknown) {
+      if (typeof val === "string") onState(val);
+      return self;
+    },
+    is() {
+      return Object.assign(Promise.resolve(getResult()), self);
+    },
+    gte() {
+      return Object.assign(Promise.resolve(getResult()), self);
+    },
+    then(resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) {
+      return Promise.resolve(getResult()).then(resolve, reject);
+    },
+  };
+  return self;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getSocialAnalytics — V2 KPI merging", () => {
+  it("returns VALIDATION_FAILED when companyId is empty", async () => {
+    const result = await getSocialAnalytics("");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION_FAILED");
+    }
+  });
+
+  it("sums V1 + V2 totalPublished counts", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSvc({ v1PublishedCount: 3, v2PublishedCount: 7 }) as never,
+    );
+    const result = await getSocialAnalytics(COMPANY_ID);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.totalPublished).toBe(10);
+    }
+  });
+
+  it("sums V1 + V2 scheduledUpcoming counts", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSvc({ v1ScheduledCount: 2, v2ScheduledCount: 3 }) as never,
+    );
+    const result = await getSocialAnalytics(COMPANY_ID);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.scheduledUpcoming).toBe(5);
+    }
+  });
+
+  it("includes V2 pending_approval drafts in pendingApproval list", async () => {
+    vi.mocked(getServiceRoleClient).mockReturnValue(
+      makeSvc({
+        v2Pending: [
+          { id: "draft-001", content: "Hello V2", created_at: "2026-05-27T10:00:00Z" },
+        ],
+      }) as never,
+    );
+    const result = await getSocialAnalytics(COMPANY_ID);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const v2Item = result.data.pendingApproval.find((p) => p.id === "draft-001");
+      expect(v2Item).toBeDefined();
+      expect(v2Item?.master_text).toBe("Hello V2");
+    }
+  });
+});

--- a/lib/platform/social/analytics.ts
+++ b/lib/platform/social/analytics.ts
@@ -13,8 +13,11 @@ import type { ApiResponse, ErrorCode } from "@/lib/tool-schemas";
 //
 // Design: run all counts / fetches in parallel, aggregate in TypeScript.
 // Supabase-js lacks a GROUP BY surface so we fetch minimal projections
-// and group here. Capped at 2 000 post-master rows for source/state
-// grouping — sufficient for a social media calendar workload.
+// and group here. Capped at 2 000 rows per table for source/state grouping.
+//
+// V2 dual-lookup (pr-15): each KPI now sums V1 (social_post_master) +
+// V2 (social_post_drafts) so the analytics page reflects posts on both
+// pipelines during the migration window.
 // ---------------------------------------------------------------------------
 
 export type PlatformCount = { platform: string; count: number };
@@ -54,9 +57,16 @@ export type SocialAnalytics = {
 const PLATFORM_LABELS: Record<string, string> = {
   linkedin_personal: "LinkedIn (personal)",
   linkedin_company: "LinkedIn (company)",
+  linkedin: "LinkedIn",
   facebook_page: "Facebook Page",
+  facebook: "Facebook",
+  instagram: "Instagram",
   x: "X",
+  twitter: "X",
   gbp: "Google Business Profile",
+  google_business_profile: "Google Business Profile",
+  pinterest: "Pinterest",
+  tiktok: "TikTok",
 };
 
 const SOURCE_LABELS: Record<string, string> = {
@@ -67,6 +77,7 @@ const SOURCE_LABELS: Record<string, string> = {
 };
 
 const STATE_LABELS: Record<string, string> = {
+  // V1 states
   draft: "Draft",
   pending_client_approval: "Awaiting approval",
   approved: "Approved",
@@ -76,6 +87,8 @@ const STATE_LABELS: Record<string, string> = {
   published: "Published",
   failed: "Failed",
   rejected: "Rejected",
+  // V2 states (where different from V1)
+  pending_approval: "Awaiting approval",
 };
 
 export async function getSocialAnalytics(
@@ -91,6 +104,7 @@ export async function getSocialAnalytics(
   const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
 
   const [
+    // V1 queries
     totalPublishedR,
     publishedThisMonthR,
     scheduledR,
@@ -98,8 +112,15 @@ export async function getSocialAnalytics(
     mastersR,
     publishedRecentR,
     pendingR,
+    // V2 queries
+    v2TotalPublishedR,
+    v2PublishedThisMonthR,
+    v2ScheduledR,
+    v2DraftsR,
+    v2PublishedRecentR,
+    v2PendingR,
   ] = await Promise.all([
-    // KPI: total published all time
+    // V1 KPI: total published all time
     svc
       .from("social_post_master")
       .select("id", { count: "exact", head: true })
@@ -107,7 +128,7 @@ export async function getSocialAnalytics(
       .eq("state", "published")
       .is("deleted_at", null),
 
-    // KPI: published this calendar month
+    // V1 KPI: published this calendar month
     svc
       .from("social_post_master")
       .select("id", { count: "exact", head: true })
@@ -116,7 +137,7 @@ export async function getSocialAnalytics(
       .gte("state_changed_at", startOfMonth)
       .is("deleted_at", null),
 
-    // KPI: upcoming scheduled
+    // V1 KPI: upcoming scheduled
     svc
       .from("social_post_master")
       .select("id", { count: "exact", head: true })
@@ -124,7 +145,7 @@ export async function getSocialAnalytics(
       .eq("state", "scheduled")
       .is("deleted_at", null),
 
-    // KPI: active (healthy) connections
+    // KPI: active (healthy) connections — shared by V1 + V2
     svc
       .from("social_connections")
       .select("id", { count: "exact", head: true })
@@ -132,7 +153,7 @@ export async function getSocialAnalytics(
       .eq("status", "healthy")
       .is("deleted_at", null),
 
-    // Chart source: all posts (source_type + state) capped at 2 000
+    // V1 chart source: all posts (source_type + state) capped at 2 000
     svc
       .from("social_post_master")
       .select("id, source_type, state")
@@ -140,7 +161,7 @@ export async function getSocialAnalytics(
       .is("deleted_at", null)
       .limit(2000),
 
-    // Trend: published in the last 30 days — small dataset
+    // V1 trend: published in the last 30 days
     svc
       .from("social_post_master")
       .select("id, state_changed_at")
@@ -150,7 +171,7 @@ export async function getSocialAnalytics(
       .is("deleted_at", null)
       .order("state_changed_at", { ascending: true }),
 
-    // List: pending approval (most recently created first)
+    // V1 list: pending approval (most recently created first)
     svc
       .from("social_post_master")
       .select("id, master_text, created_at")
@@ -159,9 +180,56 @@ export async function getSocialAnalytics(
       .is("deleted_at", null)
       .order("created_at", { ascending: false })
       .limit(20),
+
+    // V2 KPI: total published all time
+    svc
+      .from("social_post_drafts")
+      .select("id", { count: "exact", head: true })
+      .eq("company_id", companyId)
+      .eq("state", "published"),
+
+    // V2 KPI: published this calendar month (uses published_at, not state_changed_at)
+    svc
+      .from("social_post_drafts")
+      .select("id", { count: "exact", head: true })
+      .eq("company_id", companyId)
+      .eq("state", "published")
+      .gte("published_at", startOfMonth),
+
+    // V2 KPI: upcoming scheduled (state=scheduled, not by scheduled_at since that's the time)
+    svc
+      .from("social_post_drafts")
+      .select("id", { count: "exact", head: true })
+      .eq("company_id", companyId)
+      .eq("state", "scheduled"),
+
+    // V2 chart source: all drafts for state/source/platform aggregation (cap 2 000)
+    svc
+      .from("social_post_drafts")
+      .select("id, state, source_type, target_profiles, published_at")
+      .eq("company_id", companyId)
+      .limit(2000),
+
+    // V2 trend: published in the last 30 days (published_at)
+    svc
+      .from("social_post_drafts")
+      .select("id, published_at")
+      .eq("company_id", companyId)
+      .eq("state", "published")
+      .gte("published_at", thirtyDaysAgo)
+      .order("published_at", { ascending: true }),
+
+    // V2 list: pending approval
+    svc
+      .from("social_post_drafts")
+      .select("id, content, created_at")
+      .eq("company_id", companyId)
+      .eq("state", "pending_approval")
+      .order("created_at", { ascending: false })
+      .limit(20),
   ]);
 
-  // Surface the first query error we encounter.
+  // Surface the first V1 query error.
   const queryError =
     totalPublishedR.error ??
     publishedThisMonthR.error ??
@@ -179,11 +247,33 @@ export async function getSocialAnalytics(
     return err("INTERNAL_ERROR", `Analytics query failed: ${queryError.message}`);
   }
 
+  // V2 query errors are non-fatal — log and continue with V1-only data.
+  const v2Error =
+    v2TotalPublishedR.error ??
+    v2PublishedThisMonthR.error ??
+    v2ScheduledR.error ??
+    v2DraftsR.error ??
+    v2PublishedRecentR.error ??
+    v2PendingR.error;
+  if (v2Error) {
+    logger.warn("social.analytics.v2_query_failed", {
+      err: v2Error.message,
+      company_id: companyId,
+    });
+  }
+
+  // --- KPIs: V1 + V2 ---
+  const totalPublished = (totalPublishedR.count ?? 0) + (v2TotalPublishedR.count ?? 0);
+  const publishedThisMonth = (publishedThisMonthR.count ?? 0) + (v2PublishedThisMonthR.count ?? 0);
+  const scheduledUpcoming = (scheduledR.count ?? 0) + (v2ScheduledR.count ?? 0);
+
+  // --- Charts ---
+
   const masters = mastersR.data ?? [];
   const masterIds = masters.map((m) => m.id as string);
+  const v2Drafts = v2Error ? [] : (v2DraftsR.data ?? []);
 
-  // Fetch variants (platforms) for all posts so we can aggregate by platform.
-  // Uses the same 2 000-post cap (same IDs).
+  // V1 variants (for platform aggregation)
   let variants: Array<{ post_master_id: string; platform: string }> = [];
   if (masterIds.length > 0) {
     const variantsR = await svc
@@ -196,24 +286,30 @@ export async function getSocialAnalytics(
         err: variantsR.error.message,
         company_id: companyId,
       });
-      // Non-fatal: continue with empty platform data.
     } else {
       variants = (variantsR.data ?? []) as typeof variants;
     }
   }
 
-  // Fetch recent published posts with their platforms.
-  const recentPublished = await buildRecentPublished(svc, companyId);
-
-  // --- Aggregations ---
-
-  // postsByPlatform: unique post_master_id per platform
+  // postsByPlatform: V1 via variants + V2 via target_profiles expansion
   const platformMap = new Map<string, Set<string>>();
   for (const v of variants) {
     const pid = v.post_master_id as string;
     const plat = v.platform as string;
     if (!platformMap.has(plat)) platformMap.set(plat, new Set());
     platformMap.get(plat)!.add(pid);
+  }
+  for (const d of v2Drafts) {
+    const profiles =
+      (d.target_profiles as Array<{ profile_id: string; platform: string }> | null) ?? [];
+    const seenPlats = new Set<string>();
+    for (const p of profiles) {
+      if (!seenPlats.has(p.platform)) {
+        seenPlats.add(p.platform);
+        if (!platformMap.has(p.platform)) platformMap.set(p.platform, new Set());
+        platformMap.get(p.platform)!.add(d.id as string);
+      }
+    }
   }
   const postsByPlatform: PlatformCount[] = Array.from(platformMap.entries())
     .map(([platform, ids]) => ({
@@ -222,10 +318,14 @@ export async function getSocialAnalytics(
     }))
     .sort((a, b) => b.count - a.count);
 
-  // postsBySource
+  // postsBySource: V1 + V2
   const sourceMap = new Map<string, number>();
   for (const m of masters) {
     const src = (m.source_type as string) ?? "manual";
+    sourceMap.set(src, (sourceMap.get(src) ?? 0) + 1);
+  }
+  for (const d of v2Drafts) {
+    const src = (d.source_type as string | null) ?? "manual";
     sourceMap.set(src, (sourceMap.get(src) ?? 0) + 1);
   }
   const postsBySource: SourceCount[] = Array.from(sourceMap.entries())
@@ -235,10 +335,14 @@ export async function getSocialAnalytics(
     }))
     .sort((a, b) => b.count - a.count);
 
-  // postsByState
+  // postsByState: V1 + V2
   const stateMap = new Map<string, number>();
   for (const m of masters) {
     const st = (m.state as string) ?? "draft";
+    stateMap.set(st, (stateMap.get(st) ?? 0) + 1);
+  }
+  for (const d of v2Drafts) {
+    const st = (d.state as string) ?? "draft";
     stateMap.set(st, (stateMap.get(st) ?? 0) + 1);
   }
   const postsByState: StateCount[] = Array.from(stateMap.entries())
@@ -248,13 +352,21 @@ export async function getSocialAnalytics(
     }))
     .sort((a, b) => b.count - a.count);
 
-  // publishedByDay: 30-day trend
+  // publishedByDay: V1 (state_changed_at) + V2 (published_at)
   const dayMap = new Map<string, number>();
   for (const p of publishedRecentR.data ?? []) {
     const day = (p.state_changed_at as string).slice(0, 10);
     dayMap.set(day, (dayMap.get(day) ?? 0) + 1);
   }
-  // Fill in all 30 days, even those with zero posts.
+  if (!v2Error) {
+    for (const d of v2PublishedRecentR.data ?? []) {
+      const pubAt = d.published_at as string | null;
+      if (pubAt) {
+        const day = pubAt.slice(0, 10);
+        dayMap.set(day, (dayMap.get(day) ?? 0) + 1);
+      }
+    }
+  }
   const publishedByDay: DayCount[] = [];
   for (let i = 29; i >= 0; i--) {
     const d = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
@@ -262,23 +374,39 @@ export async function getSocialAnalytics(
     publishedByDay.push({ date: dateStr, count: dayMap.get(dateStr) ?? 0 });
   }
 
+  // recentPublished: V1 + V2 merged and sorted by most recent
+  const recentPublished = await buildRecentPublished(svc, companyId, !!v2Error);
+
+  // pendingApproval: V1 + V2 merged, sorted by created_at desc, capped at 20
+  const v1Pending = (pendingR.data ?? []).map((p) => ({
+    id: p.id as string,
+    master_text: (p.master_text as string | null) ?? null,
+    created_at: p.created_at as string,
+  }));
+  const v2Pending = v2Error
+    ? []
+    : (v2PendingR.data ?? []).map((d) => ({
+        id: d.id as string,
+        master_text: (d.content as string | null) ?? null,
+        created_at: d.created_at as string,
+      }));
+  const pendingApproval = [...v1Pending, ...v2Pending]
+    .sort((a, b) => b.created_at.localeCompare(a.created_at))
+    .slice(0, 20);
+
   return {
     ok: true,
     data: {
-      totalPublished: totalPublishedR.count ?? 0,
-      publishedThisMonth: publishedThisMonthR.count ?? 0,
-      scheduledUpcoming: scheduledR.count ?? 0,
+      totalPublished,
+      publishedThisMonth,
+      scheduledUpcoming,
       activeConnectionsCount: connectionsR.count ?? 0,
       postsByPlatform,
       postsBySource,
       postsByState,
       publishedByDay,
       recentPublished,
-      pendingApproval: (pendingR.data ?? []).map((p) => ({
-        id: p.id as string,
-        master_text: (p.master_text as string | null) ?? null,
-        created_at: p.created_at as string,
-      })),
+      pendingApproval,
     },
     timestamp: new Date().toISOString(),
   };
@@ -287,7 +415,9 @@ export async function getSocialAnalytics(
 async function buildRecentPublished(
   svc: ReturnType<typeof getServiceRoleClient>,
   companyId: string,
+  skipV2: boolean,
 ): Promise<RecentPost[]> {
+  // V1 recent published
   const postsR = await svc
     .from("social_post_master")
     .select("id, master_text, state_changed_at")
@@ -297,31 +427,63 @@ async function buildRecentPublished(
     .order("state_changed_at", { ascending: false })
     .limit(10);
 
-  if (postsR.error || !postsR.data || postsR.data.length === 0) {
-    return [];
+  const v1Posts: RecentPost[] = [];
+  if (!postsR.error && postsR.data && postsR.data.length > 0) {
+    const ids = postsR.data.map((p) => p.id as string);
+    const variantsR = await svc
+      .from("social_post_variant")
+      .select("post_master_id, platform")
+      .in("post_master_id", ids)
+      .is("deleted_at", null);
+
+    const platformsByPost = new Map<string, string[]>();
+    for (const v of variantsR.data ?? []) {
+      const pid = v.post_master_id as string;
+      const plat = v.platform as string;
+      if (!platformsByPost.has(pid)) platformsByPost.set(pid, []);
+      platformsByPost.get(pid)!.push(PLATFORM_LABELS[plat] ?? plat);
+    }
+
+    for (const p of postsR.data) {
+      v1Posts.push({
+        id: p.id as string,
+        master_text: (p.master_text as string | null) ?? null,
+        state_changed_at: p.state_changed_at as string,
+        platforms: platformsByPost.get(p.id as string) ?? [],
+      });
+    }
   }
 
-  const ids = postsR.data.map((p) => p.id as string);
-  const variantsR = await svc
-    .from("social_post_variant")
-    .select("post_master_id, platform")
-    .in("post_master_id", ids)
-    .is("deleted_at", null);
+  // V2 recent published
+  const v2Posts: RecentPost[] = [];
+  if (!skipV2) {
+    const v2R = await svc
+      .from("social_post_drafts")
+      .select("id, content, published_at, target_profiles")
+      .eq("company_id", companyId)
+      .eq("state", "published")
+      .not("published_at", "is", null)
+      .order("published_at", { ascending: false })
+      .limit(10);
 
-  const platformsByPost = new Map<string, string[]>();
-  for (const v of variantsR.data ?? []) {
-    const pid = v.post_master_id as string;
-    const plat = (v.platform as string);
-    if (!platformsByPost.has(pid)) platformsByPost.set(pid, []);
-    platformsByPost.get(pid)!.push(PLATFORM_LABELS[plat] ?? plat);
+    if (!v2R.error) {
+      for (const d of v2R.data ?? []) {
+        const profiles =
+          (d.target_profiles as Array<{ profile_id: string; platform: string }> | null) ?? [];
+        v2Posts.push({
+          id: d.id as string,
+          master_text: (d.content as string | null) ?? null,
+          state_changed_at: (d.published_at as string) ?? new Date().toISOString(),
+          platforms: [...new Set(profiles.map((p) => PLATFORM_LABELS[p.platform] ?? p.platform))],
+        });
+      }
+    }
   }
 
-  return postsR.data.map((p) => ({
-    id: p.id as string,
-    master_text: (p.master_text as string | null) ?? null,
-    state_changed_at: p.state_changed_at as string,
-    platforms: platformsByPost.get(p.id as string) ?? [],
-  }));
+  // Merge V1 + V2, sort by state_changed_at desc, take top 10
+  return [...v1Posts, ...v2Posts]
+    .sort((a, b) => b.state_changed_at.localeCompare(a.state_changed_at))
+    .slice(0, 10);
 }
 
 function err(


### PR DESCRIPTION
## Summary

- `getSocialAnalytics` now fires 13 parallel queries (7 V1 + 6 V2) and sums `totalPublished`, `publishedThisMonth`, `scheduledUpcoming` across both tables
- V2 `target_profiles` JSONB array expanded for platform aggregation chart
- `pendingApproval` merges V1 `pending_client_approval` + V2 `pending_approval` drafts
- V2 query errors are non-fatal — logs warn and falls back to V1-only data
- 4 unit tests in `social-analytics-v2.unit.test.ts` (all passing)

## Working analog
`lib/platform/social/webhooks/process.ts` (pr-14) — same V2 fallback pattern: check V2 table, merge with V1 result, non-fatal on V2 error.

**Diff**: analytics previously only queried `social_post_master`; V2 posts on `social_post_drafts` were invisible.
**Fix**: 6 additional parallel queries against `social_post_drafts`; counts summed; pending list merged.

## Risks identified and mitigated
- **Non-fatal V2 errors**: V2 table may not exist in old migrations or may have schema drift. Mitigated: V2 errors logged as warn, function continues with V1-only data.
- **JSONB expansion**: `target_profiles` cast inline; null-coalesced to `[]`. No panic path.
- **Over-counting**: V1 and V2 use disjoint post IDs (different tables). No double-counting possible.

## Pre-PR checklist
- [x] Lint, typecheck, build all green (pre-commit passed)
- [x] Layer scripts run: test:unit (4 new tests, all pass)
- [x] Contract snapshots reviewed (no SDK calls touched)
- [x] PR is under 500 net lines

## Part of V1→V2 migration workstream
PR-11 (#1110) → PR-12 (#1111) → PR-13 (#1112) → PR-14 (#1113) → **PR-15 (this)** → PR-16 → PR-17