### PR TITLE
feat(social): migration 0157 — V1 social post soft-delete (pr-16) [WRITE-SAFETY-CRITICAL]

### DIFF
--- a/lib/__tests__/migration-0157-v1-soft-delete.test.ts
+++ b/lib/__tests__/migration-0157-v1-soft-delete.test.ts
@@ -30,6 +30,13 @@ async function seedCompany() {
   await svc.from("social_post_master").delete().eq("company_id", COMPANY_ID);
   await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
 
+  // platform_users is truncated by _setup.ts global beforeEach; re-seed so
+  // social_post_master.created_by FK resolves on every test run.
+  const { error: puErr } = await svc
+    .from("platform_users")
+    .upsert({ id: seededUserId }, { onConflict: "id" });
+  if (puErr) throw new Error(`seed platform_users: ${puErr.message}`);
+
   const { error } = await svc.from("platform_companies").insert({
     id: COMPANY_ID,
     name: "M0157 Test Co",

--- a/lib/__tests__/migration-0157-v1-soft-delete.test.ts
+++ b/lib/__tests__/migration-0157-v1-soft-delete.test.ts
@@ -135,7 +135,8 @@ describe("Migration 0157 — V1 social post soft-delete", () => {
       .eq("id", inserted!.id)
       .single();
     // deleted_at should still equal the original value, not be updated
-    expect(after?.deleted_at).toBe(existingDeletedAt);
+    // Compare as timestamps — Postgres may return +00:00 instead of Z suffix
+    expect(new Date(after?.deleted_at as string).getTime()).toBe(new Date(existingDeletedAt).getTime());
   });
 
   it("soft-deletes social_post_variant rows that have deleted_at IS NULL", async () => {

--- a/lib/__tests__/migration-0157-v1-soft-delete.test.ts
+++ b/lib/__tests__/migration-0157-v1-soft-delete.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, beforeAll, beforeEach, afterAll } from "vitest";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { seedAuthUser } from "./_auth-helpers";
+
+// ---------------------------------------------------------------------------
+// Migration 0157 — V1 social post soft-delete.
+//
+// Verifies that the migration SQL correctly soft-deletes all V1 rows:
+//   1. social_post_master rows get deleted_at set.
+//   2. social_post_variant rows get deleted_at set (via migration UPDATE).
+//   3. social_schedule_entries rows get cancelled_at set.
+//
+// Note: this test executes the same UPDATE SQL as the migration against the
+// test database. It does NOT apply the migration file itself (which would be
+// idempotent since the test DB already has the schema). It validates the SQL
+// logic — that the WHERE clause and column names are correct.
+// ---------------------------------------------------------------------------
+
+const COMPANY_ID = "00001570-0000-0000-0000-000000000001";
+
+let seededUserId: string;
+
+async function seedCompany() {
+  const svc = getServiceRoleClient();
+  await svc.from("social_schedule_entries").delete().match({ scheduled_by: seededUserId });
+  await svc.from("social_post_variant").delete().in(
+    "post_master_id",
+    (await svc.from("social_post_master").select("id").eq("company_id", COMPANY_ID)).data?.map((r) => r.id as string) ?? [],
+  );
+  await svc.from("social_post_master").delete().eq("company_id", COMPANY_ID);
+  await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
+
+  const { error } = await svc.from("platform_companies").insert({
+    id: COMPANY_ID,
+    name: "M0157 Test Co",
+    slug: "m0157-test-co",
+    is_opollo_internal: false,
+    timezone: "UTC",
+    approval_default_rule: "any_one",
+  });
+  if (error) throw new Error(`seed company: ${error.message}`);
+}
+
+beforeAll(async () => {
+  const user = await seedAuthUser({ persistent: true });
+  seededUserId = user.id;
+});
+
+beforeEach(async () => {
+  await seedCompany();
+});
+
+afterAll(async () => {
+  const svc = getServiceRoleClient();
+  await svc.from("social_post_master").delete().eq("company_id", COMPANY_ID);
+  await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
+  if (seededUserId) {
+    await svc.auth.admin.deleteUser(seededUserId);
+  }
+});
+
+describe("Migration 0157 — V1 social post soft-delete", () => {
+  it("soft-deletes social_post_master rows (sets deleted_at where NULL)", async () => {
+    const svc = getServiceRoleClient();
+
+    // Insert a V1 master row (deleted_at IS NULL)
+    const { data: inserted, error: insertErr } = await svc
+      .from("social_post_master")
+      .insert({
+        company_id: COMPANY_ID,
+        state: "published",
+        source_type: "manual",
+        created_by: seededUserId,
+      })
+      .select("id, deleted_at")
+      .single();
+    expect(insertErr, `insert: ${insertErr?.message}`).toBeNull();
+    expect(inserted?.deleted_at).toBeNull();
+
+    // Run the migration SQL equivalent
+    await svc
+      .from("social_post_master")
+      .update({ deleted_at: new Date().toISOString() })
+      .is("deleted_at", null)
+      .eq("company_id", COMPANY_ID);
+
+    // Verify deleted_at is now set
+    const { data: after, error: selectErr } = await svc
+      .from("social_post_master")
+      .select("id, deleted_at")
+      .eq("id", inserted!.id)
+      .single();
+    expect(selectErr, `select: ${selectErr?.message}`).toBeNull();
+    expect(after?.deleted_at).not.toBeNull();
+  });
+
+  it("does not re-stamp rows that already have deleted_at set", async () => {
+    const svc = getServiceRoleClient();
+    const existingDeletedAt = "2025-01-01T00:00:00Z";
+
+    // Insert a row that is ALREADY soft-deleted
+    const { data: inserted, error: insertErr } = await svc
+      .from("social_post_master")
+      .insert({
+        company_id: COMPANY_ID,
+        state: "draft",
+        source_type: "manual",
+        created_by: seededUserId,
+        deleted_at: existingDeletedAt,
+      })
+      .select("id, deleted_at")
+      .single();
+    expect(insertErr, `insert: ${insertErr?.message}`).toBeNull();
+
+    // Run the migration SQL (only updates where deleted_at IS NULL)
+    await svc
+      .from("social_post_master")
+      .update({ deleted_at: new Date().toISOString() })
+      .is("deleted_at", null)
+      .eq("company_id", COMPANY_ID);
+
+    // The pre-existing deleted_at should be unchanged
+    const { data: after } = await svc
+      .from("social_post_master")
+      .select("id, deleted_at")
+      .eq("id", inserted!.id)
+      .single();
+    // deleted_at should still equal the original value, not be updated
+    expect(after?.deleted_at).toBe(existingDeletedAt);
+  });
+
+  it("soft-deletes social_post_variant rows that have deleted_at IS NULL", async () => {
+    const svc = getServiceRoleClient();
+
+    // Insert master + variant (variant has no connection_id)
+    const { data: master, error: masterErr } = await svc
+      .from("social_post_master")
+      .insert({
+        company_id: COMPANY_ID,
+        state: "published",
+        source_type: "manual",
+        created_by: seededUserId,
+      })
+      .select("id")
+      .single();
+    expect(masterErr, `master insert: ${masterErr?.message}`).toBeNull();
+
+    const { data: variant, error: variantErr } = await svc
+      .from("social_post_variant")
+      .insert({
+        post_master_id: master!.id,
+        platform: "x",
+        is_custom: false,
+      })
+      .select("id, deleted_at")
+      .single();
+    expect(variantErr, `variant insert: ${variantErr?.message}`).toBeNull();
+    expect(variant?.deleted_at).toBeNull();
+
+    // Run migration SQL for variants
+    await svc
+      .from("social_post_variant")
+      .update({ deleted_at: new Date().toISOString() })
+      .is("deleted_at", null)
+      .eq("post_master_id", master!.id);
+
+    const { data: after } = await svc
+      .from("social_post_variant")
+      .select("id, deleted_at")
+      .eq("id", variant!.id)
+      .single();
+    expect(after?.deleted_at).not.toBeNull();
+  });
+
+  it("cancels open social_schedule_entries (sets cancelled_at where NULL)", async () => {
+    const svc = getServiceRoleClient();
+
+    // Need a master → variant chain first
+    const { data: master } = await svc
+      .from("social_post_master")
+      .insert({
+        company_id: COMPANY_ID,
+        state: "scheduled",
+        source_type: "manual",
+        created_by: seededUserId,
+      })
+      .select("id")
+      .single();
+
+    const { data: variant } = await svc
+      .from("social_post_variant")
+      .insert({
+        post_master_id: master!.id,
+        platform: "linkedin_personal",
+        is_custom: false,
+        scheduled_at: new Date(Date.now() + 86400000).toISOString(),
+      })
+      .select("id")
+      .single();
+
+    const { data: entry, error: entryErr } = await svc
+      .from("social_schedule_entries")
+      .insert({
+        post_variant_id: variant!.id,
+        scheduled_at: new Date(Date.now() + 86400000).toISOString(),
+        scheduled_by: seededUserId,
+      })
+      .select("id, cancelled_at")
+      .single();
+    expect(entryErr, `entry insert: ${entryErr?.message}`).toBeNull();
+    expect(entry?.cancelled_at).toBeNull();
+
+    // Run migration SQL for schedule entries
+    await svc
+      .from("social_schedule_entries")
+      .update({ cancelled_at: new Date().toISOString() })
+      .is("cancelled_at", null)
+      .eq("post_variant_id", variant!.id);
+
+    const { data: after } = await svc
+      .from("social_schedule_entries")
+      .select("id, cancelled_at")
+      .eq("id", entry!.id)
+      .single();
+    expect(after?.cancelled_at).not.toBeNull();
+  });
+});

--- a/lib/__tests__/migration-0157-v1-soft-delete.test.ts
+++ b/lib/__tests__/migration-0157-v1-soft-delete.test.ts
@@ -19,6 +19,7 @@ import { seedAuthUser } from "./_auth-helpers";
 const COMPANY_ID = "00001570-0000-0000-0000-000000000001";
 
 let seededUserId: string;
+let seededUserEmail: string;
 
 async function seedCompany() {
   const svc = getServiceRoleClient();
@@ -31,10 +32,10 @@ async function seedCompany() {
   await svc.from("platform_companies").delete().eq("id", COMPANY_ID);
 
   // platform_users is truncated by _setup.ts global beforeEach; re-seed so
-  // social_post_master.created_by FK resolves on every test run.
+  // social_post_master.created_by FK (NOT NULL) resolves on every test.
   const { error: puErr } = await svc
     .from("platform_users")
-    .upsert({ id: seededUserId }, { onConflict: "id" });
+    .upsert({ id: seededUserId, email: seededUserEmail }, { onConflict: "id" });
   if (puErr) throw new Error(`seed platform_users: ${puErr.message}`);
 
   const { error } = await svc.from("platform_companies").insert({
@@ -51,6 +52,7 @@ async function seedCompany() {
 beforeAll(async () => {
   const user = await seedAuthUser({ persistent: true });
   seededUserId = user.id;
+  seededUserEmail = user.email;
 });
 
 beforeEach(async () => {

--- a/supabase/migrations/0157_v1_soft_delete.sql
+++ b/supabase/migrations/0157_v1_soft_delete.sql
@@ -1,0 +1,50 @@
+-- Migration 0157: Soft-delete all V1 social post data.
+--
+-- WRITE-SAFETY-CRITICAL — do NOT run this migration until:
+--   1. The V1→V2 backfill (PR-04 / migration 0153-tier) has been verified
+--      complete in production (all social_post_master rows have a corresponding
+--      social_post_drafts row via the backfill script).
+--   2. Steven has reviewed and confirmed the V2 dual-lookup code (PR-11 through
+--      PR-15) is serving correct data in production.
+--
+-- What this does:
+--   - Sets deleted_at = NOW() on all social_post_master rows where deleted_at
+--     IS NULL. After this, all V1 queries (which filter IS NULL) return zero
+--     rows. V2 analytics / calendar / webhook paths (already in dual-lookup
+--     mode) continue to serve data from social_post_drafts.
+--   - Sets deleted_at = NOW() on all social_post_variant rows similarly.
+--   - Cancels all open social_schedule_entries (V1 QStash pipeline retired
+--     in PR-13; the V2 publish-due cron handles all future publishes).
+--
+-- Rollback:
+--   UPDATE social_post_master SET deleted_at = NULL
+--     WHERE deleted_at >= '<migration_run_timestamp>';
+--   UPDATE social_post_variant SET deleted_at = NULL
+--     WHERE deleted_at >= '<migration_run_timestamp>';
+--   UPDATE social_schedule_entries SET cancelled_at = NULL
+--     WHERE cancelled_at >= '<migration_run_timestamp>';
+--   (Replace <migration_run_timestamp> with the value seen in pg_stat_activity
+--    or the Supabase migration run log.)
+--
+-- Next step: migration 0158_v1_table_drop.sql (PR-17) — drop V1 tables entirely.
+--            Run only after verifying production behaviour post-0157.
+
+BEGIN;
+
+-- Soft-delete all V1 post master rows not already deleted
+UPDATE social_post_master
+   SET deleted_at = NOW()
+ WHERE deleted_at IS NULL;
+
+-- Soft-delete all V1 post variant rows not already deleted
+UPDATE social_post_variant
+   SET deleted_at = NOW()
+ WHERE deleted_at IS NULL;
+
+-- Cancel all open V1 schedule entries
+-- (QStash pipeline retired in pr-13; no new entries are expected here)
+UPDATE social_schedule_entries
+   SET cancelled_at = NOW()
+ WHERE cancelled_at IS NULL;
+
+COMMIT;


### PR DESCRIPTION
## ⚠️ WRITE-SAFETY-CRITICAL — Steven merges only

**DO NOT merge this PR until:**
1. PR #1103 (V1→V2 backfill) has been reviewed, merged, and verified complete in production
2. Deployed SHA is confirmed via `vercel inspect` matching the post-backfill state
3. Analytics, calendar, and webhook paths confirmed serving correct data from V2

## What this does

Migration `0157_v1_soft_delete.sql` sets `deleted_at = NOW()` on all `social_post_master` and `social_post_variant` rows, and `cancelled_at = NOW()` on all open `social_schedule_entries`.

After this migration:
- All V1-only queries (which filter `WHERE deleted_at IS NULL`) return zero rows
- V2 dual-lookup code (PR-11 through PR-15) continues serving data from `social_post_drafts`
- This is the final data-isolation step before table drop (PR-17)

## Working analog
`supabase/migrations/0074_platform_audit_and_brand.sql` — same soft-delete pattern used for `platform_companies`, `platform_users`, `social_connections`.

**Diff**: Previous soft-deletes targeted individual rows; this migration bulk-retires all remaining V1 rows.
**Fix**: `UPDATE ... WHERE deleted_at IS NULL` — same WHERE clause as existing soft-delete patterns.

## Risks identified and mitigated
- **Irreversible without backup**: Setting `deleted_at` on ALL rows cannot be undone cleanly. Mitigated: rollback instructions in migration comments; must run after backfill verified.
- **Data loss if backfill incomplete**: If PR #1103 backfill didn't copy all V1 data to V2, posts become invisible. Mitigated: prerequisite gate — verify backfill row counts before running.
- **In-flight V1 schedules**: Any V1 schedule entries that were still active would be cancelled. Mitigated: V1 QStash pipeline retired in PR-13 (merged); no new entries expected.

## Pre-PR checklist
- [x] Lint, typecheck, build all green (pre-commit passed)
- [x] Layer scripts run: test:integration (4 new tests in migration-0157-v1-soft-delete.test.ts)
- [x] Migration is WRITE-SAFETY-CRITICAL — Steven must merge
- [x] PR is under 500 net lines

## Part of V1→V2 migration workstream
PR-01 → ... → PR-15 (all merged) → **PR-16 (this)** → PR-17

**Dependency order**: PR #1103 (backfill) → PR-16 (this) → PR-17 (table drop)