### PR TITLE
ci: force GitHub Actions indexing of staging-backfill workflow

### DIFF
--- a/.github/workflows/staging-backfill.yml
+++ b/.github/workflows/staging-backfill.yml
@@ -1,4 +1,5 @@
 name: V1→V2 staging backfill
+# v2 — force GitHub Actions indexing
 
 # Applies schema migrations 0155/0156 to the staging DB, then backfills
 # social_post_master rows into social_post_drafts (idempotent, safe to re-run).


### PR DESCRIPTION
Adds a no-op comment to `.github/workflows/staging-backfill.yml` to trigger GitHub Actions re-indexing.

The workflow file was added in #1117 but GitHub has not indexed it yet (still returning 404 from the workflow dispatch API ~25 minutes after merge). This touch commit causes a push event on main which forces re-indexing.

## Risk
None — single comment line added to a workflow-dispatch-only workflow.

## Risks identified and mitigated
- No schema changes, no logic changes. Zero blast radius.