### PR TITLE
fix(ci): use supabase db query instead of db execute in staging backfill

### DIFF
--- a/.github/workflows/staging-backfill.yml
+++ b/.github/workflows/staging-backfill.yml
@@ -69,7 +69,7 @@ jobs:
           SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
         run: |
           echo "=== Pre-backfill row counts ==="
-          supabase db execute --linked -- "
+          supabase db query --linked "
             SELECT 'v1_posts_active'    AS metric, COUNT(*) AS cnt
               FROM social_post_master WHERE deleted_at IS NULL
             UNION ALL
@@ -85,7 +85,7 @@ jobs:
           SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
         run: |
           echo "Running backfill SQL..."
-          supabase db execute --linked -- "
+          supabase db query --linked "
             INSERT INTO social_post_drafts (
               company_id, created_by, updated_by, state, content, link_url,
               source_type, media_urls, target_profiles, platform_variants,
@@ -130,7 +130,7 @@ jobs:
           SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_SUPABASE_DB_PASSWORD }}
         run: |
           echo "=== Post-backfill row counts ==="
-          supabase db execute --linked -- "
+          supabase db query --linked "
             SELECT 'v1_posts_active'    AS metric, COUNT(*) AS cnt
               FROM social_post_master WHERE deleted_at IS NULL
             UNION ALL


### PR DESCRIPTION
## Summary
- `supabase db execute` is not a valid Supabase CLI subcommand — the CLI returned help text and exit code 1
- Correct subcommand is `supabase db query --linked`
- Replaces all three occurrences in staging-backfill.yml (pre-backfill counts, backfill SQL, post-backfill counts)

## Context
Staging-backfill.yml (added in #1117, indexed in #1118) failed its first run at the "Pre-backfill counts" step. Migrations 0155/0156 **did apply successfully** in that run — only the SQL query steps were broken.

## Working analog
`supabase db push --linked --include-all` (line 65, same file) — `--linked` is a valid flag for the `db` subgroup. `supabase db query --linked "<SQL>"` uses the same pattern.

**Diff**: `db execute` → `db query`, removed the `--` separator (not used by `db query`)
**Fix**: mechanical replacement of the invalid subcommand

## Risks identified and mitigated
- No schema or data changes — workflow file only
- Migrations 0155/0156 already applied to staging; re-running `db push` is idempotent (skip-applied)
- `db query` is read-only for the count steps; backfill INSERT uses `ON CONFLICT DO NOTHING`

## Pre-PR checklist
- [ ] Lint, typecheck, build all green (workflow-only change, no TS)
- [x] No test layers affected — no app code changed
- [x] PR is under 500 net lines (3 line changes)