### PR TITLE
fix(ci): add partial index predicate to ON CONFLICT in staging backfill

### DIFF
--- a/.github/workflows/staging-backfill.yml
+++ b/.github/workflows/staging-backfill.yml
@@ -121,7 +121,7 @@ jobs:
             FROM social_post_master m
             WHERE m.created_by IS NOT NULL
               AND m.deleted_at IS NULL
-            ON CONFLICT (company_id, idempotency_key) DO NOTHING;
+            ON CONFLICT (company_id, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING;
           "
           echo "Backfill SQL complete."
 


### PR DESCRIPTION
## Summary
- Staging backfill live run failed with `42P10: there is no unique or exclusion constraint matching the ON CONFLICT specification`
- Root cause: `idx_social_post_drafts_idempotency` (migration 0126) is a **partial** unique index with `WHERE idempotency_key IS NOT NULL`
- PostgreSQL requires `ON CONFLICT` to include the partial index predicate to match it; a bare `ON CONFLICT (company_id, idempotency_key)` doesn't match a partial index

## Working analog
`supabase/migrations/0126_reliability_and_cap_foundations.sql`:
```sql
CREATE UNIQUE INDEX IF NOT EXISTS idx_social_post_drafts_idempotency
  ON social_post_drafts (company_id, idempotency_key)
  WHERE idempotency_key IS NOT NULL;
```

**Diff**: `ON CONFLICT (company_id, idempotency_key) DO NOTHING` → missing `WHERE idempotency_key IS NOT NULL` predicate  
**Fix**: `ON CONFLICT (company_id, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING`

The backfill always sets `idempotency_key = 'v1-migration-' || m.id::text` (never NULL), so the partial index applies to every inserted row.

## Risks identified and mitigated
- No schema or data changes — workflow file only
- `ON CONFLICT ... DO NOTHING` is idempotent; re-running is safe
- Staging already has 0 V1 active posts — backfill will insert 0 rows; verifying SQL path executes cleanly

## Pre-PR checklist
- [x] No app code changed — workflow only
- [x] PR is under 500 net lines (1 line change)