### PR TITLE
fix(middleware): exempt /api/internal/cron/* from auth gate

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -149,10 +149,11 @@ function isPublicPath(pathname: string): boolean {
   // All /api/auth/* endpoints (login, logout-not-applicable-here,
   // callback, future invite/reset routes) are by definition pre-session.
   if (pathname.startsWith("/api/auth/")) return true;
-  // /api/cron/* carries its own CRON_SECRET check; Supabase Auth isn't
-  // involved. Required so the Vercel cron tick can reach the worker
-  // endpoint without a session.
+  // /api/cron/* and /api/internal/cron/* carry their own CRON_SECRET
+  // check; Supabase Auth isn't involved. Required so the Vercel cron
+  // tick can reach the worker endpoint without a session.
   if (pathname.startsWith("/api/cron/")) return true;
+  if (pathname.startsWith("/api/internal/cron/")) return true;
   // /api/webhooks/* carries its own HMAC signature verification (S1-17
   // bundle.social). External services aren't platform users — the
   // signature IS the auth. Without this, every webhook bounces to /login.
@@ -189,6 +190,15 @@ function basicAuthGate(req: NextRequest): NextResponse {
   // itself exposes only connectivity + build info. Mirrors the
   // isPublicPath check in the Supabase Auth gate.
   if (req.nextUrl.pathname === "/api/health") {
+    return NextResponse.next();
+  }
+  // Cron endpoints carry their own CRON_SECRET auth; Basic Auth is
+  // irrelevant. Without this, Vercel cron ticks return 401 when
+  // BASIC_AUTH_USER/PASSWORD are set, silently breaking the publish pipeline.
+  if (
+    req.nextUrl.pathname.startsWith("/api/cron/") ||
+    req.nextUrl.pathname.startsWith("/api/internal/cron/")
+  ) {
     return NextResponse.next();
   }
 

--- a/tests/regressions/internal-cron-middleware-401.test.ts
+++ b/tests/regressions/internal-cron-middleware-401.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Regression: /api/internal/cron/* must not be blocked by the auth gate.
+//
+// When the V2 publish-due cron was added at /api/internal/cron/publish-due,
+// the middleware only exempted /api/cron/* but not /api/internal/cron/*.
+// Vercel cron ticks hit the edge middleware before reaching the route handler.
+// Under FEATURE_SUPABASE_AUTH=true the middleware returned 401 (no session).
+// Under Basic Auth mode it also returned 401 (CRON_SECRET uses Bearer, not Basic).
+// The cron fired every minute and always failed silently — no posts published.
+//
+// Fix: isPublicPath() now also exempts /api/internal/cron/*, and basicAuthGate
+// passes through both /api/cron/ and /api/internal/cron/ without Basic check.
+// ---------------------------------------------------------------------------
+
+const mockGetUser = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    data: { user: null },
+    error: { message: "no session" },
+  }),
+);
+const mockCreateMiddlewareAuthClient = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", () => ({
+  createMiddlewareAuthClient: mockCreateMiddlewareAuthClient,
+}));
+vi.mock("@/lib/auth-kill-switch", () => ({
+  isAuthKillSwitchOn: vi.fn().mockResolvedValue(false),
+}));
+vi.mock("@/lib/security-headers", () => ({
+  applySecurityHeaders: vi.fn((res: NextResponse) => res),
+  ensureRequestId: vi.fn().mockReturnValue("test-request-id"),
+}));
+
+const { middleware } = await import("@/middleware");
+
+const ORIG_FEATURE = process.env.FEATURE_SUPABASE_AUTH;
+const ORIG_BASIC_USER = process.env.BASIC_AUTH_USER;
+const ORIG_BASIC_PASS = process.env.BASIC_AUTH_PASSWORD;
+
+beforeEach(() => {
+  mockCreateMiddlewareAuthClient.mockImplementation(() => ({
+    supabase: { auth: { getUser: mockGetUser } },
+    response: NextResponse.next(),
+  }));
+});
+
+afterEach(() => {
+  if (ORIG_FEATURE === undefined) delete process.env.FEATURE_SUPABASE_AUTH;
+  else process.env.FEATURE_SUPABASE_AUTH = ORIG_FEATURE;
+  if (ORIG_BASIC_USER === undefined) delete process.env.BASIC_AUTH_USER;
+  else process.env.BASIC_AUTH_USER = ORIG_BASIC_USER;
+  if (ORIG_BASIC_PASS === undefined) delete process.env.BASIC_AUTH_PASSWORD;
+  else process.env.BASIC_AUTH_PASSWORD = ORIG_BASIC_PASS;
+  vi.restoreAllMocks();
+});
+
+function makeRequest(pathname: string, headers?: Record<string, string>): NextRequest {
+  return new NextRequest(`http://localhost${pathname}`, { headers });
+}
+
+describe("middleware — /api/internal/cron/* exempt from auth gate", () => {
+  describe("Supabase Auth path (FEATURE_SUPABASE_AUTH=true)", () => {
+    beforeEach(() => {
+      process.env.FEATURE_SUPABASE_AUTH = "true";
+    });
+
+    it("does NOT return 401 for /api/internal/cron/publish-due without a session", async () => {
+      const res = await middleware(makeRequest("/api/internal/cron/publish-due"));
+      expect(res.status).not.toBe(401);
+      expect(res.status).not.toBe(307);
+    });
+
+    it("does NOT return 401 for /api/internal/cron/heartbeat-check without a session", async () => {
+      const res = await middleware(makeRequest("/api/internal/cron/heartbeat-check"));
+      expect(res.status).not.toBe(401);
+      expect(res.status).not.toBe(307);
+    });
+
+    it("does NOT return 401 for /api/internal/cron/health-check without a session", async () => {
+      const res = await middleware(makeRequest("/api/internal/cron/health-check"));
+      expect(res.status).not.toBe(401);
+      expect(res.status).not.toBe(307);
+    });
+
+    it("still blocks /api/internal/other without a session", async () => {
+      const res = await middleware(makeRequest("/api/internal/other"));
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("Basic Auth path (FEATURE_SUPABASE_AUTH=false, credentials set)", () => {
+    beforeEach(() => {
+      process.env.FEATURE_SUPABASE_AUTH = "false";
+      process.env.BASIC_AUTH_USER = "admin";
+      process.env.BASIC_AUTH_PASSWORD = "password";
+    });
+
+    it("does NOT return 401 for /api/internal/cron/publish-due with Bearer CRON_SECRET", async () => {
+      const res = await middleware(
+        makeRequest("/api/internal/cron/publish-due", {
+          authorization: "Bearer test-cron-secret",
+        }),
+      );
+      expect(res.status).not.toBe(401);
+    });
+
+    it("does NOT return 401 for /api/cron/ with Bearer CRON_SECRET", async () => {
+      const res = await middleware(
+        makeRequest("/api/cron/social-publish-watchdog", {
+          authorization: "Bearer test-cron-secret",
+        }),
+      );
+      expect(res.status).not.toBe(401);
+    });
+
+    it("still blocks non-cron /api/ paths without Basic Auth", async () => {
+      const res = await middleware(makeRequest("/api/platform/social/posts"));
+      expect(res.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Every `/api/internal/cron/*` cron tick was returning 401 — the middleware exempted `/api/cron/*` but not `/api/internal/cron/*`
- The V2 publish-due cron (`/api/internal/cron/publish-due`) has been deployed since the V1→V2 migration but never successfully ran
- Vercel's cron system sends `Authorization: Bearer $CRON_SECRET` — this passes the route handler's own `authorisedCronRequest` check, but never reached it because middleware rejected the request first
- Both auth paths affected: `supabaseAuthGate` (no session = 401) and `basicAuthGate` (Bearer != Basic = 401)

## Fix

- `isPublicPath()` now also short-circuits for `/api/internal/cron/` (covers Supabase Auth path)
- `basicAuthGate()` now passes through `/api/cron/` and `/api/internal/cron/` before the Basic Auth check (covers legacy path)
- Regression test: `tests/regressions/internal-cron-middleware-401.test.ts` (7 assertions, covers both auth paths)

## Working analog

`middleware.ts:152-155` — `/api/cron/*` was already exempt with the same rationale. The diff is adding the `/api/internal/cron/` prefix alongside it.

## Risks identified and mitigated

- **Security**: cron routes carry their own `CRON_SECRET` check in the route handler (`lib/platform/cron/cron-shared.ts:authorisedCronRequest`). Bypassing middleware auth for these paths does not bypass authentication — the CRON_SECRET gate remains.
- **Scope creep**: only `/api/internal/cron/` paths are added. Other `/api/internal/` paths remain auth-gated.

## Pre-PR checklist
- [x] Lint, typecheck, build all green
- [x] Regression test added: `tests/regressions/internal-cron-middleware-401.test.ts`
- [x] PR is under 500 net lines

🤖 Generated with [Claude Code](https://claude.ai/claude-code)