### PR TITLE
fix(social): correct BUNDLE_SOCIAL_API env var name in V2 client + harden regression test

### DIFF
--- a/docs/briefs/social-01-brief/DECISIONS_LOCKED.md
+++ b/docs/briefs/social-01-brief/DECISIONS_LOCKED.md
@@ -102,7 +102,7 @@ Listed for clarity. Full descriptions in `composer/.env.example`.
 
 | Variable | Source | Required | Purpose |
 |---|---|---|---|
-| `BUNDLE_SOCIAL_API_KEY` | bundle.social dashboard | yes | Authenticate publish + analytics calls |
+| `BUNDLE_SOCIAL_API` | bundle.social dashboard | yes | Authenticate publish + analytics calls |
 | `BUNDLE_SOCIAL_WEBHOOK_SECRET` | bundle.social dashboard | yes | Verify incoming publish-status webhooks |
 | `IDEOGRAM_API_KEY` | Ideogram dashboard | yes | Image generation for CAP and composer |
 | `SENDGRID_API_KEY` | SendGrid dashboard | yes | Approval email notifications |

--- a/docs/briefs/social-01-brief/README.md
+++ b/docs/briefs/social-01-brief/README.md
@@ -94,7 +94,7 @@ Open `composer/.env.example`. Every variable listed must be set in `.env.local` 
 **Required (set all of these before kickoff):**
 
 ```
-BUNDLE_SOCIAL_API_KEY=               # bundle.social dashboard
+BUNDLE_SOCIAL_API=                   # bundle.social dashboard
 BUNDLE_SOCIAL_WEBHOOK_SECRET=        # bundle.social or self-generated hex
 IDEOGRAM_API_KEY=                    # Ideogram dashboard
 UPSTASH_REDIS_REST_URL=              # Upstash console

--- a/docs/briefs/social-01-brief/SERVICE_HEALTH.md
+++ b/docs/briefs/social-01-brief/SERVICE_HEALTH.md
@@ -65,7 +65,7 @@ export async function publishToProfile(profileId: string, payload: PublishPayloa
     async () => {
       const res = await fetch(`${BASE_URL}/post`, {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${BUNDLE_SOCIAL_API_KEY}` },
+        headers: { 'Authorization': `Bearer ${BUNDLE_SOCIAL_API}` },
         body: JSON.stringify(payload)
       });
       if (!res.ok) {

--- a/docs/briefs/social-01-brief/composer/.env.example
+++ b/docs/briefs/social-01-brief/composer/.env.example
@@ -5,7 +5,7 @@
 
 # ─── bundle.social (publishing layer) ───────────────────────
 # Get from https://bundle.social dashboard
-BUNDLE_SOCIAL_API_KEY=
+BUNDLE_SOCIAL_API=
 # HMAC-SHA256 signing secret for incoming webhooks
 BUNDLE_SOCIAL_WEBHOOK_SECRET=
 

--- a/docs/briefs/social-01-brief/composer/ENV.md
+++ b/docs/briefs/social-01-brief/composer/ENV.md
@@ -10,7 +10,7 @@ These must be set before PR B (API surface) ships. Without them, integration tes
 
 | Variable | Source | Used by |
 |---|---|---|
-| `BUNDLE_SOCIAL_API_KEY` | bundle.social dashboard | `lib/social/publishing/bundle-social-client.ts`. Publish + analytics calls. |
+| `BUNDLE_SOCIAL_API` | bundle.social dashboard | `lib/social/publishing/bundle-social-client.ts`. Publish + analytics calls. |
 | `BUNDLE_SOCIAL_WEBHOOK_SECRET` | bundle.social dashboard (if signing supported) or self-generated random hex | `app/api/webhooks/bundle-social/route.ts`. HMAC-SHA256 signature verification. |
 | `IDEOGRAM_API_KEY` | Ideogram dashboard | Composer image-generation tool + CAP. |
 | `UPSTASH_REDIS_REST_URL` | Upstash console → Redis | Hot analytics cache. |
@@ -88,7 +88,7 @@ After setting env vars in `.env.local`:
 
 ```bash
 node -e "
-['BUNDLE_SOCIAL_API_KEY','BUNDLE_SOCIAL_WEBHOOK_SECRET','IDEOGRAM_API_KEY','UPSTASH_REDIS_REST_URL','UPSTASH_REDIS_REST_TOKEN','SENDGRID_API_KEY','SENDGRID_FROM_EMAIL','ANTHROPIC_API_KEY','GIPHY_API_KEY','CRON_SECRET','NEXT_PUBLIC_FEATURE_COMPOSER_V2','NEXT_PUBLIC_SITE_URL','SUPABASE_URL','SUPABASE_ANON_KEY','SUPABASE_SERVICE_ROLE_KEY','DATABASE_URL']
+['BUNDLE_SOCIAL_API','BUNDLE_SOCIAL_WEBHOOK_SECRET','IDEOGRAM_API_KEY','UPSTASH_REDIS_REST_URL','UPSTASH_REDIS_REST_TOKEN','SENDGRID_API_KEY','SENDGRID_FROM_EMAIL','ANTHROPIC_API_KEY','GIPHY_API_KEY','CRON_SECRET','NEXT_PUBLIC_FEATURE_COMPOSER_V2','NEXT_PUBLIC_SITE_URL','SUPABASE_URL','SUPABASE_ANON_KEY','SUPABASE_SERVICE_ROLE_KEY','DATABASE_URL']
   .filter(k => !process.env[k])
   .forEach(k => console.log('MISSING:', k));
 "

--- a/lib/social/publishing/bundle-social-client.ts
+++ b/lib/social/publishing/bundle-social-client.ts
@@ -30,8 +30,8 @@ interface AnalyticsResult {
 }
 
 function getApiKey(): string {
-  const key = process.env.BUNDLE_SOCIAL_API_KEY;
-  if (!key) throw new Error("BUNDLE_SOCIAL_API_KEY is not set.");
+  const key = process.env.BUNDLE_SOCIAL_API;
+  if (!key) throw new Error("BUNDLE_SOCIAL_API is not configured.");
   return key;
 }
 

--- a/tests/regressions/bundle-social-env-var-names.test.ts
+++ b/tests/regressions/bundle-social-env-var-names.test.ts
@@ -1,46 +1,139 @@
 import { describe, expect, it } from "vitest";
 
 // ---------------------------------------------------------------------------
-// REGRESSION R7 — env var names are stable
+// REGRESSION R7 — env var names are stable across every consumer
 //
-// Incident: bundle.social uses TEAMID (no underscore) while every
-// other Vercel-provisioned env var in this project uses snake_case
-// like `_TEAM_ID`. The pre-fix code looked up `BUNDLE_SOCIAL_TEAM_ID`,
-// which was `undefined`, so `getBundlesocialTeamId()` returned null
-// silently and the create-portal-link call shipped without a team id —
-// resulting in a tokenless URL.
+// Original incident (2026-01): bundle.social uses TEAMID (no underscore)
+// while every other Vercel-provisioned env var in this project uses
+// snake_case like `_TEAM_ID`. The pre-fix code looked up
+// `BUNDLE_SOCIAL_TEAM_ID`, which was `undefined`, so the create-portal-link
+// call shipped without a team id — resulting in a tokenless URL.
 //
-// Pinned invariant: the lib reads the EXACTLY-spelled env var names
-// `BUNDLE_SOCIAL_API`, `BUNDLE_SOCIAL_TEAMID`,
-// `BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET`. A typo in any of these
-// fires this test.
+// Second incident (PR #904, 2026-05-19, alert fired 2026-05-21 02:43 UTC):
+// a new V2 bundle.social client at lib/social/publishing/bundle-social-client.ts
+// looked up `BUNDLE_SOCIAL_API_KEY` (a name that does not exist in Vercel)
+// instead of the canonical `BUNDLE_SOCIAL_API`. The original R7 test only
+// inspected lib/bundlesocial.ts, so it did not catch the new file.
+//
+// Broadened invariant: ANY `process.env.BUNDLE_SOCIAL_*` reference anywhere
+// under `lib/` or `app/` must use a name from the canonical allowlist below.
+// The canonical allowlist is what is actually set in Vercel production
+// (verified 2026-05-28 via `vercel env ls production`):
+//
+//   BUNDLE_SOCIAL_API       — API key from the bundle.social dashboard
+//   BUNDLE_SOCIAL_TEAMID    — team id (no underscore — matches Vercel env)
+//
+// Note: `BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET` uses a different prefix
+// (`BUNDLESOCIAL_*`, no underscore between BUNDLE and SOCIAL) and is not
+// matched by the `BUNDLE_SOCIAL_*` regex below.
 //
 // Why pinned at the unit layer: a daily drift detector covers the
 // "are they SET in production" question. This test covers the
 // "is the code looking for the right names" question — orthogonal.
 // ---------------------------------------------------------------------------
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, sep } from "node:path";
 
-describe("R7: bundle.social env var names are pinned", () => {
-  const src = readFileSync(
-    join(process.cwd(), "lib", "bundlesocial.ts"),
-    "utf8",
-  );
+const CANONICAL_BUNDLE_SOCIAL_NAMES = new Set([
+  "BUNDLE_SOCIAL_API",
+  "BUNDLE_SOCIAL_TEAMID",
+]);
 
-  it("reads BUNDLE_SOCIAL_API (no _KEY suffix, no _APIKEY)", () => {
-    expect(src).toMatch(/process\.env\.BUNDLE_SOCIAL_API\b/);
-    expect(src).not.toMatch(/process\.env\.BUNDLE_SOCIAL_API_KEY/);
-    expect(src).not.toMatch(/process\.env\.BUNDLE_SOCIAL_APIKEY/);
+const SCAN_ROOTS = ["lib", "app"];
+const SCAN_EXTENSIONS = [".ts", ".tsx"];
+
+function walkTsFiles(root: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [join(process.cwd(), root)];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    if (!dir) break;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry);
+      let st;
+      try {
+        st = statSync(full);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) {
+        if (entry === "node_modules" || entry === ".next" || entry === "dist") continue;
+        stack.push(full);
+      } else if (SCAN_EXTENSIONS.some((ext) => entry.endsWith(ext))) {
+        out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+interface Hit {
+  file: string;
+  line: number;
+  name: string;
+}
+
+function scanAll(): Hit[] {
+  const hits: Hit[] = [];
+  const re = /process\.env\.(BUNDLE_SOCIAL_[A-Z0-9_]+)/g;
+  for (const root of SCAN_ROOTS) {
+    for (const file of walkTsFiles(root)) {
+      const src = readFileSync(file, "utf8");
+      const lines = src.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        let m: RegExpExecArray | null;
+        re.lastIndex = 0;
+        while ((m = re.exec(line)) !== null) {
+          hits.push({ file: file.split(process.cwd() + sep).join(""), line: i + 1, name: m[1] });
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+describe("R7: bundle.social env var names are pinned across lib/ and app/", () => {
+  const hits = scanAll();
+
+  it("scans something — guards against the scan silently finding zero files", () => {
+    expect(hits.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("reads BUNDLE_SOCIAL_TEAMID (no underscore — matches Vercel env)", () => {
+  it("every process.env.BUNDLE_SOCIAL_* reference uses a canonical name", () => {
+    const violations = hits.filter((h) => !CANONICAL_BUNDLE_SOCIAL_NAMES.has(h.name));
+    if (violations.length > 0) {
+      const detail = violations
+        .map((v) => `  - ${v.file}:${v.line} reads process.env.${v.name}`)
+        .join("\n");
+      throw new Error(
+        `Found ${violations.length} non-canonical BUNDLE_SOCIAL_* env var reference(s).\n` +
+          `Canonical names (set in Vercel): ${[...CANONICAL_BUNDLE_SOCIAL_NAMES].join(", ")}\n` +
+          `Violations:\n${detail}`,
+      );
+    }
+  });
+
+  it("lib/bundlesocial.ts still reads BUNDLE_SOCIAL_API (canonical anchor)", () => {
+    const src = readFileSync(join(process.cwd(), "lib", "bundlesocial.ts"), "utf8");
+    expect(src).toMatch(/process\.env\.BUNDLE_SOCIAL_API\b/);
+  });
+
+  it("lib/bundlesocial.ts still reads BUNDLE_SOCIAL_TEAMID (no underscore — matches Vercel env)", () => {
+    const src = readFileSync(join(process.cwd(), "lib", "bundlesocial.ts"), "utf8");
     expect(src).toMatch(/process\.env\.BUNDLE_SOCIAL_TEAMID\b/);
     expect(src).not.toMatch(/process\.env\.BUNDLE_SOCIAL_TEAM_ID/);
   });
 
-  it("reads BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET (single word, no separator before WEBHOOK)", () => {
+  it("BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET prefix (no underscore) is preserved in lib/bundlesocial.ts", () => {
+    const src = readFileSync(join(process.cwd(), "lib", "bundlesocial.ts"), "utf8");
     expect(src).toMatch(/BUNDLESOCIAL_WEBHOOK_SIGNING_SECRET/);
     expect(src).not.toMatch(/BUNDLE_SOCIAL_WEBHOOK_SIGNING_SECRET/);
   });


### PR DESCRIPTION
## Summary

The V2 bundle.social client at `lib/social/publishing/bundle-social-client.ts:33-34` was reading `process.env.BUNDLE_SOCIAL_API_KEY` — a name that does not exist in Vercel. The canonical name set in production is `BUNDLE_SOCIAL_API` (verified 2026-05-28 via `vercel env ls production`), used by `lib/bundlesocial.ts` and every other consumer for ~25 days. This PR fixes that one site, broadens regression test R7 so a similar slip in any other `lib/**` or `app/**` file fails CI immediately, and corrects the five stale `docs/briefs/social-01-brief/**` files that were the source of the original typo.

**Triggering alert**: 2026-05-21 02:43–02:46 UTC — bundle.social analytics operation failed twice with the message `"BUNDLE_SOCIAL_API_KEY is not set."` That literal string originated verbatim from the `new Error(...)` thrown at line 34 of the V2 client; the `withHealthMonitoring → recordHealthEvent → notify` pipeline is pass-through (confirmed in `lib/platform/service-health/monitor.ts:74` and `notify.ts:94`).

**Introducing commit**: PR #904 — commit `29b16059`, merged 2026-05-19 — `feat(social): composer pr-b — service health + api surface + cron infrastructure`. The wrong name was copied verbatim from the social-01 brief docs.

**Latent second consumer also fixed**: `app/api/internal/cron/publish-due/route.ts` (every-minute V2 publish-due cron) imports `publishPost` from the same broken file. It would throw the identical error with `operation="publish"` the first time it tried to publish a V2 scheduled draft. This change resolves the publish path as well as the analytics path that fired the alert.

## Working analog (per CLAUDE.md §"Diagnose by working analog")

- **Working analog**: `lib/bundlesocial.ts:43` reads `process.env.BUNDLE_SOCIAL_API` and throws `"BUNDLE_SOCIAL_API is not configured."` — same shape, used by every other consumer (the social-connections-health cron, social-analytics-refresh cron, channels, profiles, reconcile, sync, scripts).
- **Diff**: V2 client invented a new env-var name (`_KEY` suffix) instead of reading the existing one. The brief docs under `docs/briefs/social-01-brief/**` used the wrong name and the V2-composer author followed the brief instead of the canonical code path.
- **Fix**: V2 client now reads the canonical name and throws the canonical message, matching every sibling path.

## Risks identified and mitigated

- **Risk**: the env-var rename could mask a real "API key missing" config problem in non-prod environments.
  **Mitigation**: the same canonical name is already used by every existing bundle.social caller in production for ~25 days. If `BUNDLE_SOCIAL_API` were unset, the social-connections-health cron would already be in its "skipped" no-op branch (per `app/api/cron/social-connections-health/route.ts:35-36`); production logs show it is not.
- **Risk**: broadened R7 could miss test files via the test directory not being scanned.
  **Mitigation**: scan covers `lib/` and `app/`, which is where production code lives. Tests deliberately set `process.env.BUNDLE_SOCIAL_API` in `beforeEach` — that is correct usage and would not be in `lib/` or `app/`.
- No write-safety-critical paths touched; no billed external calls added or modified; no schema or migration changes; no auth, RLS, or webhook changes.

## Pre-PR checklist

- [x] Lint, typecheck, build all green (`npm run lint` clean, `npm run typecheck` clean)
- [x] Layer scripts run: `test:unit` (via pre-commit) — 286/286 pass; broadened R7 specifically verified to fail on pre-fix code and pass on fixed code
- [x] Working-analog block in PR body (file:lines + diff + fix)
- [x] Risks identified and mitigated section in PR body
- [x] PR is under 500 net lines (124 +, 31 −, 7 files)
- [x] Stale brief docs corrected so the next agent does not reintroduce the bug

## Test plan

- [x] CI green on every required status check
- [x] Broadened R7 in `tests/regressions/bundle-social-env-var-names.test.ts` would catch any future `process.env.BUNDLE_SOCIAL_*` reference outside the canonical allowlist
- [ ] Post-merge: confirm analytics route stops emitting `service_health_event` rows with `operation="analytics"` and `details.message="BUNDLE_SOCIAL_API_KEY is not set."`
- [ ] Post-merge: hit `/api/platform/social/drafts/<id>/analytics` for a real V2 draft and confirm 200 + analytics payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)