### PR TITLE
feat(image-gen): slice A1 — ideogram v3 FLASH endpoint reshape + MASS_GEN_PLATFORM_MAP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,11 +107,10 @@ CLOUDFLARE_IMAGES_API_TOKEN=
 CLOUDFLARE_IMAGES_HASH=
 
 # AI image generation (company/image/generate)
-# Provider: "ideogram" (default) or "bannerbear".
+# Ideogram v3 endpoint; rendering_speed=FLASH is hardcoded (§3 of mass-image-gen brief).
+# IDEOGRAM_STANDARD_MODEL / IDEOGRAM_PREMIUM_MODEL removed — v3 uses rendering_speed, not model slugs.
 COMPOSITING_PROVIDER=
 IDEOGRAM_API_KEY=
-IDEOGRAM_PREMIUM_MODEL=
-IDEOGRAM_STANDARD_MODEL=
 IMAGE_GENERATION_TIMEOUT_MS=
 IMAGE_GENERATION_BUCKET=generated-images
 IMAGE_FEATURE_MOOD_BOARD=

--- a/app/api/platform/image/generate/route.ts
+++ b/app/api/platform/image/generate/route.ts
@@ -49,12 +49,7 @@ const GenerateSchema = z.object({
     "geometric",
     "texture",
   ]),
-  aspect_ratio: z.enum([
-    "ASPECT_1_1",
-    "ASPECT_4_5",
-    "ASPECT_16_9",
-    "ASPECT_9_16",
-  ]),
+  aspect_ratio: z.enum(["1x1", "4x5", "9x16", "16x9", "4x3"]),
   count: z.number().int().min(1).max(6).default(4),
   post_master_id: z.string().uuid().optional(),
 });

--- a/app/api/platform/social/cap/generate-image/route.ts
+++ b/app/api/platform/social/cap/generate-image/route.ts
@@ -39,7 +39,7 @@ const TIMEOUT_MS = parseInt(process.env.IMAGE_GENERATION_TIMEOUT_MS ?? "30000");
 const BodySchema = z.object({
   company_id: dbUuid(),
   prompt: z.string().min(3).max(500),
-  aspect_ratio: z.enum(["ASPECT_1_1", "ASPECT_4_5", "ASPECT_16_9"]).optional(),
+  aspect_ratio: z.enum(["1x1", "4x5", "16x9"]).optional(),
 });
 
 interface IdeogramImage {
@@ -61,7 +61,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const parsed = BodySchema.safeParse(body);
   if (!parsed.success) {
     return validationError(
-      "Body must be { company_id: uuid, prompt: string(3-500), aspect_ratio?: 'ASPECT_1_1'|'ASPECT_4_5'|'ASPECT_16_9' }.",
+      "Body must be { company_id: uuid, prompt: string(3-500), aspect_ratio?: '1x1'|'4x5'|'16x9' }.",
       { issues: parsed.error.issues },
     );
   }
@@ -86,8 +86,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const model = process.env.IDEOGRAM_STANDARD_MODEL ?? "ideogram-ai/ideogram-v3-flash";
-
+  // NOTE: this route uses the legacy /generate endpoint and will be refactored
+  // to the canonical generateWithFallback() pipeline in slice A3.
   let ideogramData: IdeogramResponse;
   try {
     const resp = await fetch(IDEOGRAM_API, {
@@ -96,8 +96,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       body: JSON.stringify({
         image_request: {
           prompt: parsed.data.prompt,
-          model,
-          aspect_ratio: parsed.data.aspect_ratio ?? "ASPECT_1_1",
+          // model omitted — API defaults to V_2; A3 migrates this to the v3 canonical client
+          aspect_ratio: parsed.data.aspect_ratio ?? "1x1",
           num_images: 1,
           style_type: "REALISTIC",
           negative_prompt: NEGATIVE_PROMPT,

--- a/components/MoodBoardClient.tsx
+++ b/components/MoodBoardClient.tsx
@@ -42,10 +42,11 @@ const COMPOSITION_LABELS: Record<CompositionType, string> = {
 };
 
 const ASPECT_RATIO_LABELS: Record<AspectRatio, string> = {
-  ASPECT_1_1: "1:1 Square",
-  ASPECT_4_5: "4:5 Portrait",
-  ASPECT_16_9: "16:9 Landscape",
-  ASPECT_9_16: "9:16 Story",
+  "1x1": "1:1 Square",
+  "4x5": "4:5 Portrait",
+  "16x9": "16:9 Landscape",
+  "9x16": "9:16 Story",
+  "4x3": "4:3 Landscape (GBP)",
 };
 
 const ALL_COMPOSITIONS: CompositionType[] = [
@@ -57,10 +58,11 @@ const ALL_COMPOSITIONS: CompositionType[] = [
 ];
 
 const ALL_ASPECT_RATIOS: AspectRatio[] = [
-  "ASPECT_1_1",
-  "ASPECT_4_5",
-  "ASPECT_16_9",
-  "ASPECT_9_16",
+  "1x1",
+  "4x5",
+  "16x9",
+  "9x16",
+  "4x3",
 ];
 
 const COUNT_OPTIONS = [4, 5, 6] as const;
@@ -82,7 +84,7 @@ export function MoodBoardClient({
   const [composition, setComposition] = useState<CompositionType>(
     "split_layout",
   );
-  const [aspectRatio, setAspectRatio] = useState<AspectRatio>("ASPECT_1_1");
+  const [aspectRatio, setAspectRatio] = useState<AspectRatio>("1x1");
   const [count, setCount] = useState<(typeof COUNT_OPTIONS)[number]>(4);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/components/social/composer/MediaPickerModal.tsx
+++ b/components/social/composer/MediaPickerModal.tsx
@@ -202,7 +202,7 @@ export function MediaPickerModal({
           body: JSON.stringify({
             company_id: companyId,
             prompt: aiPrompt.trim(),
-            aspect_ratio: "ASPECT_1_1",
+            aspect_ratio: "1x1",
           }),
         })
           .then(

--- a/docs/architecture/BUILD.md
+++ b/docs/architecture/BUILD.md
@@ -321,8 +321,7 @@ Read the image-generation skill before touching anything in `lib/image/`.
 - Watchdog timeout: 3 minutes
 - Reconciliation sweep: every 5 minutes
 - Image retry: 1 automatic retry, then stock fallback
-- Ideogram standard: 3.0 Flash (`ideogram-ai/ideogram-v3-flash`)
-- Ideogram premium: 3.0 Default (`ideogram-ai/ideogram-v3`)
+- Ideogram: v3 endpoint (`/v1/ideogram-v3/generate`), `rendering_speed=FLASH` (premium routing out of scope, §3 of mass-image-gen brief)
 - Image timeout: 30 seconds
 - Mood board options: 4–6 per request
 - version_lock conflict response: HTTP 409 with body `{ error: 'VERSION_CONFLICT' }`

--- a/lib/cap/pal/image-provider.ts
+++ b/lib/cap/pal/image-provider.ts
@@ -22,7 +22,9 @@ export class IdeogramImageProvider implements IImageProvider {
 
   constructor(apiKey?: string, model?: string) {
     this.apiKey = apiKey ?? process.env.IDEOGRAM_API_KEY ?? "";
-    this.model = model ?? process.env.IDEOGRAM_STANDARD_MODEL ?? "ideogram-ai/ideogram-v3-flash";
+    // model field: legacy only — this file is superseded by the canonical
+    // lib/image/generator/ideogram.ts client and will be removed in A3.
+    this.model = model ?? process.env.IDEOGRAM_STANDARD_MODEL ?? "V_2_TURBO";
   }
 
   async generate(req: ImageGenRequest): Promise<ImageGenResponse> {
@@ -36,7 +38,7 @@ export class IdeogramImageProvider implements IImageProvider {
           image_request: {
             prompt: req.prompt,
             model: this.model,
-            aspect_ratio: req.aspectRatio ?? "ASPECT_1_1",
+            aspect_ratio: req.aspectRatio ?? "1x1",
             num_images: 1,
             style_type: "REALISTIC",
             negative_prompt: NEGATIVE_PROMPT,

--- a/lib/cap/pal/types.ts
+++ b/lib/cap/pal/types.ts
@@ -14,7 +14,7 @@ export interface TextGenResponse {
 
 export interface ImageGenRequest {
   prompt: string;
-  aspectRatio?: "ASPECT_1_1" | "ASPECT_16_9" | "ASPECT_4_5";
+  aspectRatio?: "1x1" | "16x9" | "4x5";
 }
 
 export interface ImageGenResponse {

--- a/lib/image/generator/ideogram.ts
+++ b/lib/image/generator/ideogram.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import sharp from "sharp";
+
 import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
 
@@ -31,25 +33,25 @@ const GLOBAL_NEGATIVE_PROMPT = [
 const IMAGE_GEN_BUCKET =
   process.env.IMAGE_GENERATION_BUCKET ?? "generated-images";
 
+// v3 response: url is always present; width/height may or may not be.
+// Dimensions are extracted from the downloaded buffer via sharp — reliable regardless.
 interface IdeogramResponseImage {
   url: string;
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
 }
 
 interface IdeogramResponse {
   data: IdeogramResponseImage[];
 }
 
+// v3 endpoint — always FLASH. Premium routing is out of scope (§3 of brief).
+const IDEOGRAM_V3_URL = "https://api.ideogram.ai/v1/ideogram-v3/generate";
+const RENDERING_SPEED = "FLASH";
+
 export async function generateBackground(
   params: GenerationParams,
 ): Promise<GeneratedImage[]> {
-  const model =
-    params.model === "premium"
-      ? (process.env.IDEOGRAM_PREMIUM_MODEL ?? "ideogram-ai/ideogram-v3")
-      : (process.env.IDEOGRAM_STANDARD_MODEL ??
-          "ideogram-ai/ideogram-v3-flash");
-
   const apiKey = process.env.IDEOGRAM_API_KEY;
   if (!apiKey) {
     throw new IdeogramError(0, "IDEOGRAM_API_KEY is not set");
@@ -67,24 +69,22 @@ export async function generateBackground(
 
   const startMs = Date.now();
 
+  // v3 uses multipart/form-data — do NOT set Content-Type manually;
+  // fetch sets it with the correct boundary when body is FormData.
+  const form = new FormData();
+  form.append("prompt", prompt);
+  form.append("rendering_speed", RENDERING_SPEED);
+  form.append("aspect_ratio", params.aspectRatio); // e.g. "1x1", "16x9"
+  form.append("num_images", String(params.count ?? 1));
+  form.append("style_type", "REALISTIC");
+  form.append("negative_prompt", GLOBAL_NEGATIVE_PROMPT);
+
   let responseData: IdeogramResponse;
   try {
-    const response = await fetch("https://api.ideogram.ai/generate", {
+    const response = await fetch(IDEOGRAM_V3_URL, {
       method: "POST",
-      headers: {
-        "Api-Key": apiKey,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        image_request: {
-          prompt,
-          model,
-          aspect_ratio: params.aspectRatio,
-          num_images: params.count ?? 1,
-          style_type: "REALISTIC",
-          negative_prompt: GLOBAL_NEGATIVE_PROMPT,
-        },
-      }),
+      headers: { "Api-Key": apiKey },
+      body: form,
       signal: AbortSignal.timeout(
         parseInt(process.env.IMAGE_GENERATION_TIMEOUT_MS ?? "30000"),
       ),
@@ -102,7 +102,7 @@ export async function generateBackground(
 
     responseData = (await response.json()) as IdeogramResponse;
     logger.info("Ideogram generation success", {
-      model,
+      renderingSpeed: RENDERING_SPEED,
       styleId: params.styleId,
       count: responseData.data.length,
       durationMs: Date.now() - startMs,
@@ -161,16 +161,24 @@ async function downloadAndStore(
     throw new Error(`Storage upload failed: ${error.message}`);
   }
 
+  // Extract actual dimensions from the buffer — more reliable than API metadata
+  // (v3 may omit width/height in the response, and v2 values can mismatch storage).
+  const metadata = await sharp(buffer).metadata();
+  const width = metadata.width ?? img.width ?? 0;
+  const height = metadata.height ?? img.height ?? 0;
+
   logger.info("Generated image stored", {
     companyId,
     storagePath,
+    width,
+    height,
     durationMs: Date.now() - downloadStart,
   });
 
   return {
     storagePath,
-    width: img.width,
-    height: img.height,
+    width,
+    height,
     format: ext,
     buffer,
   };

--- a/lib/image/types.ts
+++ b/lib/image/types.ts
@@ -15,11 +15,22 @@ export type CompositionType =
   | "geometric"
   | "texture";
 
-export type AspectRatio =
-  | "ASPECT_1_1"
-  | "ASPECT_4_5"
-  | "ASPECT_16_9"
-  | "ASPECT_9_16";
+// Ideogram v3 native aspect-ratio strings (sent verbatim in the API request).
+// Per §1.1 of the mass-image-gen brief — do not invent new values.
+export type AspectRatio = "1x1" | "4x5" | "9x16" | "16x9" | "4x3";
+
+// Platform → Ideogram v3 aspect ratio, per §1.1.
+// One image job is generated per distinct ratio derived from target_platforms.
+export const MASS_GEN_PLATFORM_MAP: Record<string, AspectRatio> = {
+  linkedin: "1x1",
+  linkedin_landscape: "16x9",
+  instagram: "4x5",
+  instagram_story: "9x16",
+  facebook: "1x1",
+  facebook_story: "9x16",
+  x: "16x9",
+  gbp: "4x3",
+};
 
 export type ModelTier = "standard" | "premium";
 

--- a/lib/platform/social/cap/image-trigger.ts
+++ b/lib/platform/social/cap/image-trigger.ts
@@ -39,7 +39,7 @@ function brandToGenerationParams(
     styleId,
     primaryColour,
     compositionType: "split_layout",
-    aspectRatio: "ASPECT_1_1",
+    aspectRatio: "1x1",
     model: "standard",
     count: 1,
     industry: brand?.industry ?? undefined,


### PR DESCRIPTION
## Summary

Fixes the canonical Ideogram client at `lib/image/generator/ideogram.ts` which has never successfully reached Ideogram's image backend. Per recon §6b: every production call returned HTTP 400 because the `model` value was a Replicate model slug (`ideogram-ai/ideogram-v3-flash`), not a valid Ideogram API enum. The probe confirmed the v3 endpoint works correctly once the request shape is corrected (36/36 success across N=8/12/16 concurrency ladder, ~11s/image).

This is slice A1 of the mass image generation programme.

## Changes

**`lib/image/generator/ideogram.ts`** (canonical client)
- URL: `POST /generate` → `POST /v1/ideogram-v3/generate`  
- Content-type: `application/json` → `multipart/form-data` (FormData; Content-Type header removed — fetch sets it with boundary automatically)
- `image_request` JSON wrapper dropped (v3 uses flat fields)
- `model` field removed; `rendering_speed=FLASH` hardcoded (premium routing is out of scope per §3 of the brief)
- Dimensions extracted from downloaded buffer via `sharp` — more reliable than API metadata (v3 may omit `width`/`height` from response)

**`lib/image/types.ts`** (per §1.1)
- `AspectRatio` type: old `ASPECT_1_1 | ASPECT_4_5 | ASPECT_16_9 | ASPECT_9_16` → v3 native strings `"1x1" | "4x5" | "9x16" | "16x9" | "4x3"` (added `4x3` for GBP per §1.1)
- `MASS_GEN_PLATFORM_MAP` constant exported: platform name → `AspectRatio` per §1.1 table; consumed by B1+ batch infrastructure

**All 8 callsites using old `ASPECT_*` values updated:**
- `components/MoodBoardClient.tsx` — labels, `ALL_ASPECT_RATIOS`, initial state; `4x3` GBP option added
- `app/api/platform/image/generate/route.ts` — Zod enum
- `app/api/platform/social/cap/generate-image/route.ts` — Zod enum, default, error message; `model` field removed from legacy endpoint request body (route migrates to canonical client in A3)
- `lib/platform/social/cap/image-trigger.ts` — `ASPECT_1_1` → `"1x1"`
- `components/social/composer/MediaPickerModal.tsx` — `ASPECT_1_1` → `"1x1"`
- `lib/cap/pal/types.ts` — local `ImageGenRequest` type
- `lib/cap/pal/image-provider.ts` — stale model default (file deleted in A3)

**`.env.example`**: `IDEOGRAM_STANDARD_MODEL` + `IDEOGRAM_PREMIUM_MODEL` removed (v3 uses `rendering_speed`, not model slugs).

**`docs/architecture/BUILD.md`**: `§"Defaults (locked)"` lines 324-325 updated to reflect v3 endpoint + `rendering_speed=FLASH`.

## Verification

- `rg "ideogram-ai/ideogram-v3" --type ts` → 0 hits
- typecheck clean
- lint clean
- 2556/2556 unit tests pass

## Pre-PR checklist

- [x] Lint, typecheck clean
- [x] `test:unit` 2556/2556 pass
- [x] `rg "ideogram-ai/ideogram-v3" --type ts` → 0 hits
- [x] `AspectRatio` type change: all 8 callsites updated
- [x] PR references §1.1 of the build brief
- [x] `BUILD.md` Defaults updated
- [x] PR under 500 net lines (78+/62−, 11 files)

## Risks identified and mitigated

- `AspectRatio` is a breaking type change across 8 files; all updated in this PR. No other callers exist (grep confirmed).
- `cap/generate-image/route.ts` still uses the legacy `/generate` endpoint — `model` field omitted so API defaults to V_2; A3 migrates the route to the canonical client.
- `lib/cap/pal/image-provider.ts` is an orphaned file (never called in production per recon §1a); model default updated cosmetically. A3 deletes it.
- A4/A5 (compositing wiring) remain blocked on D1 (Bannerbear dashboard work by Steven); these slices will proceed after D1 env vars are present in Vercel.

## Note for A1 visual checkpoint

Per the brief, A1's checkpoint requires "one passing live-call test against Ideogram in dev" with marker rows in `image_generation_log` tagged `triggered_by='a1_verification'`. This is a live-call gate that requires the A2 bucket migration to be applied first (since `downloadAndStore` writes to the `generated-images` bucket). The visual image review will be done after A2 merges, before proceeding to A3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)