### PR TITLE
fix(service-health): cross-process recovery sweep via DB query (not in-memory flag)

### DIFF
--- a/lib/__tests__/service-health.unit.test.ts
+++ b/lib/__tests__/service-health.unit.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/lib/logger", () => ({
 vi.mock("@/lib/platform/service-health/record", () => ({
   recordHealthEvent: vi.fn().mockResolvedValue(undefined),
   recordRecovery: vi.fn().mockResolvedValue(undefined),
+  hasUnresolvedHealthEvent: vi.fn().mockResolvedValue(false),
 }));
 
 import { classifyHttpError, classifyThrownError } from "@/lib/platform/service-health/classify";
@@ -177,5 +178,99 @@ describe("getPlatformAdminEmails", () => {
     const { getPlatformAdminEmails } = await import("@/lib/platform/service-health/recipients");
     const result = await getPlatformAdminEmails();
     expect(result).toEqual(["alice@opollo.com", "bob@opollo.com"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withHealthMonitoring cross-process recovery sweep
+//
+// Regression: the previous implementation used an in-memory Map
+// (`lastCallFailed`) to gate `recordRecovery`. Vercel functions are stateless
+// across cold-starts, so the flag was never set when a new process observed
+// a successful call after a failure recorded by a different process. Result:
+// unresolved rows accumulated forever (e.g. the 7-day-stuck bundle.social
+// row from PR #904's env-var typo, even after PR #1128 fixed the typo).
+//
+// The fix replaces the Map with a DB query against service_health_events.
+// These tests cover the three outcomes.
+// ---------------------------------------------------------------------------
+
+describe("withHealthMonitoring cross-process recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("(a) successful call fires recordRecovery when unresolved row exists", async () => {
+    const { hasUnresolvedHealthEvent, recordRecovery } = await import(
+      "@/lib/platform/service-health/record"
+    );
+    vi.mocked(hasUnresolvedHealthEvent).mockResolvedValueOnce(true);
+
+    const { withHealthMonitoring } = await import(
+      "@/lib/platform/service-health/monitor"
+    );
+    const result = await withHealthMonitoring("bundle.social", "analytics", async () => "ok");
+
+    expect(result).toBe("ok");
+    expect(hasUnresolvedHealthEvent).toHaveBeenCalledWith("bundle.social", "analytics");
+    expect(recordRecovery).toHaveBeenCalledWith("bundle.social", "analytics");
+  });
+
+  test("(b) successful call does NOT fire recordRecovery when no unresolved row", async () => {
+    const { hasUnresolvedHealthEvent, recordRecovery } = await import(
+      "@/lib/platform/service-health/record"
+    );
+    vi.mocked(hasUnresolvedHealthEvent).mockResolvedValueOnce(false);
+
+    const { withHealthMonitoring } = await import(
+      "@/lib/platform/service-health/monitor"
+    );
+    const result = await withHealthMonitoring("bundle.social", "analytics", async () => "ok");
+
+    expect(result).toBe("ok");
+    expect(hasUnresolvedHealthEvent).toHaveBeenCalledWith("bundle.social", "analytics");
+    expect(recordRecovery).not.toHaveBeenCalled();
+  });
+
+  test("(c) detector failure does not throw or block the success path", async () => {
+    const { hasUnresolvedHealthEvent, recordRecovery } = await import(
+      "@/lib/platform/service-health/record"
+    );
+    // Real impl returns false on internal failure; mirror that contract here.
+    vi.mocked(hasUnresolvedHealthEvent).mockResolvedValueOnce(false);
+
+    const { withHealthMonitoring } = await import(
+      "@/lib/platform/service-health/monitor"
+    );
+    const result = await withHealthMonitoring("bundle.social", "analytics", async () => "ok");
+
+    expect(result).toBe("ok");
+    expect(recordRecovery).not.toHaveBeenCalled();
+  });
+
+  test("error path records a health event and re-throws (no recovery query)", async () => {
+    const { hasUnresolvedHealthEvent, recordHealthEvent, recordRecovery } = await import(
+      "@/lib/platform/service-health/record"
+    );
+    const err = Object.assign(new Error("boom"), { status: 500 });
+
+    const { withHealthMonitoring } = await import(
+      "@/lib/platform/service-health/monitor"
+    );
+    await expect(
+      withHealthMonitoring("bundle.social", "analytics", async () => {
+        throw err;
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(recordHealthEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serviceName: "bundle.social",
+        operation: "analytics",
+        eventType: "service_5xx",
+      }),
+    );
+    expect(hasUnresolvedHealthEvent).not.toHaveBeenCalled();
+    expect(recordRecovery).not.toHaveBeenCalled();
   });
 });

--- a/lib/platform/service-health/monitor.ts
+++ b/lib/platform/service-health/monitor.ts
@@ -2,11 +2,11 @@ import "server-only";
 
 import { logger } from "@/lib/logger";
 import { classifyHttpError, classifyThrownError } from "./classify";
-import { recordHealthEvent, recordRecovery } from "./record";
-
-// Per-service state: tracks whether the last call was a failure so we can
-// fire a "recovered" event only on the first success after failures.
-const lastCallFailed = new Map<string, boolean>();
+import {
+  hasUnresolvedHealthEvent,
+  recordHealthEvent,
+  recordRecovery,
+} from "./record";
 
 /**
  * Wrap any external API call in health monitoring.
@@ -19,29 +19,32 @@ const lastCallFailed = new Map<string, boolean>();
  * On error: records a service_health_event and re-throws so the caller can
  * handle the failure. The monitoring layer never swallows errors.
  *
- * On recovery: if the previous call for this service/operation was a failure,
- * records a "recovered" event.
+ * On success: queries service_health_events for any unresolved row matching
+ * this service + operation. If one exists, fires a `recovered` event +
+ * resolves all unresolved rows for the service. The previous in-memory flag
+ * (lastCallFailed Map) was per-process and never survived Vercel function
+ * cold-starts, so recovery never fired in production. A single SELECT on
+ * the indexed (service_name, event_type) WHERE resolved_at IS NULL partial
+ * index is the cross-process replacement.
  */
 export async function withHealthMonitoring<T>(
   serviceName: string,
   operation: string,
   fn: () => Promise<T>,
 ): Promise<T> {
-  const key = `${serviceName}:${operation}`;
   try {
     const result = await fn();
 
-    // Fire recovery event only on the first success after prior failures.
-    if (lastCallFailed.get(key)) {
-      lastCallFailed.set(key, false);
-      // Non-blocking — don't await; recovery recording must not delay the caller.
+    // Cross-process recovery sweep: any unresolved row for this service +
+    // operation triggers recordRecovery. Non-blocking — never await; recovery
+    // recording must not delay the caller. hasUnresolvedHealthEvent returns
+    // false on its own errors so a DB blip doesn't break the success path.
+    if (await hasUnresolvedHealthEvent(serviceName, operation)) {
       void recordRecovery(serviceName, operation);
     }
 
     return result;
   } catch (err) {
-    lastCallFailed.set(key, true);
-
     // Extract HTTP status if the error carries one.
     const status =
       typeof (err as { status?: unknown }).status === "number"

--- a/lib/platform/service-health/record.ts
+++ b/lib/platform/service-health/record.ts
@@ -64,6 +64,50 @@ export async function recordHealthEvent(input: RecordEventInput): Promise<void> 
 }
 
 /**
+ * Returns true if any unresolved (non-manual) event exists for the given
+ * service + operation pair. Used by withHealthMonitoring on the success
+ * path to decide whether a `recovered` sweep is warranted, in lieu of an
+ * in-memory flag that doesn't survive Vercel function cold-starts.
+ *
+ * Failures (Supabase error, network blip) return false and log a warning
+ * — the success path must not be blocked by a monitoring-table read.
+ */
+export async function hasUnresolvedHealthEvent(
+  serviceName: string,
+  operation: string,
+): Promise<boolean> {
+  try {
+    const svc = getServiceRoleClient();
+    const { data, error } = await svc
+      .from("service_health_events")
+      .select("id")
+      .eq("service_name", serviceName)
+      .eq("operation", operation)
+      .is("resolved_at", null)
+      .neq("event_type", "manual_flag")
+      .limit(1)
+      .maybeSingle();
+
+    if (error) {
+      logger.warn("service_health.detect_unresolved_failed", {
+        service: serviceName,
+        operation,
+        err: error.message,
+      });
+      return false;
+    }
+    return data !== null;
+  } catch (err) {
+    logger.warn("service_health.detect_unresolved_threw", {
+      service: serviceName,
+      operation,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
+/**
  * Mark a service as recovered — resolves all open events for the service.
  * Called by withHealthMonitoring on a successful call after prior failures.
  */


### PR DESCRIPTION
## Summary

The previous `withHealthMonitoring` used a JS `Map` (`lastCallFailed`) to track whether the previous call for a given service+operation had failed. The flag gated whether `recordRecovery` fired on the next success.

Vercel functions are stateless across cold-starts, so the Map was empty on every fresh process. After the original failure that created an unresolved `service_health_events` row, subsequent successful calls in any new process never observed the in-memory flag as `true`, never called `recordRecovery`, and the row stayed unresolved indefinitely. The 30-minute notification cron then re-sent the same critical alert email every 30 min — forever.

## Why this caused the 7-day stuck bundle.social row

- PR #904 (2026-05-19) shipped a V2 bundle.social client that read `process.env.BUNDLE_SOCIAL_API_KEY` — a name that didn't exist in Vercel; canonical is `BUNDLE_SOCIAL_API`.
- 2026-05-21 02:43 UTC: the V2 analytics path fired, `getApiKey()` threw "BUNDLE_SOCIAL_API_KEY is not set.", `withHealthMonitoring` recorded a `connection_failure` critical row in `service_health_events`.
- PR #1128 (2026-05-28 11:19 UTC, merge commit `3468342d`) corrected the env var name. Deploy `dpl_5qWTSJNrmP56PQ2Kcn3kRmhvNLk6` ready by ~11:34 UTC.
- The stuck row continued re-notifying every 30 minutes after the fix deployed, including a 12:55 UTC alert that prompted the diagnostic session.
- Root cause: even when the fixed code path eventually runs a successful bundle.social call, the new Vercel process has no in-memory record of the 7-day-old failure, so `recordRecovery` never fires. The row sits unresolved indefinitely.

## Fix

Replace the in-memory `Map` with a DB query against `service_health_events`. On every successful call, query whether any unresolved (non-`manual_flag`) row exists for this service + operation. If yes → `recordRecovery`. If no → no-op.

The query uses the existing partial index `idx_service_health_events_active` on `(service_name, event_type) WHERE resolved_at IS NULL`. Detector failures (Supabase blip, network) return `false` and log a warning — the success path is never blocked by the monitoring layer.

`hasUnresolvedHealthEvent` lives in `record.ts` alongside the other DB-persistence functions (`recordHealthEvent`, `recordRecovery`). Reuses the existing `getServiceRoleClient`; no new client.

## Working analog

**Working analog**: `lib/platform/service-health/record.ts:25-35` — `recordHealthEvent` already uses a Supabase query against `service_health_events` to check for an existing row in the 5-minute aggregation window before deciding insert-vs-update. Pattern is "query first to make a cross-process state decision, then persist".

**Diff**: the broken site (`monitor.ts:9, 35`) uses an in-process `Map` for the same kind of decision (does an unresolved row exist for this key?).

**Fix**: make the broken site use the same DB-query pattern. New function `hasUnresolvedHealthEvent` mirrors `recordHealthEvent`'s window-lookup shape; consumed from `monitor.ts:withHealthMonitoring`'s success path. Tests added per the layer harness.

## Risks identified and mitigated

- **Latency on success path**: adds one `SELECT id ... LIMIT 1` per successful external call. Indexed partial index, expected <10ms. Acceptable.
- **Concurrent detection by N processes**: if N processes detect the same unresolved row simultaneously, all call `recordRecovery`. `recordRecovery`'s `UPDATE … WHERE resolved_at IS NULL` is idempotent (only the first wins; the others affect 0 rows). The synthetic `recovered` event insert is duplicated under contention — minor timeline noise, no correctness impact.
- **DB unreachable**: `hasUnresolvedHealthEvent` returns `false` and logs a warning. Same safe-degradation as the prior in-memory miss. No worse than today.
- **Removed Map removes a fast-path optimisation**: a process that just observed a failure-then-success previously skipped the DB read. New code always reads. Steven's brief explicitly chose correctness over the optimisation; complexity of "hybrid Map + DB" not worth the savings.

## Pre-PR checklist

- [x] Lint, typecheck, build all green
- [x] Layer scripts: `test:unit` (2560/2560 passed pre-commit; 18/18 in the focused service-health file)
- [x] Working-analog block (above)
- [x] Risks identified and mitigated section (above)
- [x] PR under 500 net lines (3 files, +156/-14)
- [x] No new dependencies
- [x] Critical-path? Yes — observability touches every external-API call; widened test coverage to compensate
- [x] Pre-commit note: `SKIP_PRECOMMIT_TESTS=1` used because of a pre-existing flake in `tests/regressions/staff-email-auto-grant.test.ts:157` (10s timeout on dynamic `import("@/lib/supabase")` under `--bail=1`); does NOT touch any path modified by this PR; full unit suite passed clean (2560/2560) via `npm run test:unit` immediately before commit. CI will re-run.

## Test plan

- [ ] CI green on all required checks
- [ ] After merge, watch deploy reach Ready
- [ ] Follow-up one-shot DB UPDATE clears the existing `ab8d9d31-…` row (covered by Part 2 of the brief; recon doc has full trace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)