### PR TITLE
fix(tests): resolve staff-email-auto-grant flake blocking pre-commit hook

### DIFF
--- a/tests/regressions/staff-email-auto-grant.test.ts
+++ b/tests/regressions/staff-email-auto-grant.test.ts
@@ -118,6 +118,16 @@ vi.mock("@/lib/supabase", () => ({
   getServiceRoleClient: vi.fn(),
 }));
 
+// Static sub-path imports avoid the barrel (@/lib/platform/invitations), which
+// re-exports callbacks.ts → @/lib/qstash + @/lib/platform/notifications. Those
+// transitive deps caused a 10s cold-transform timeout under pre-commit's
+// --bail=1 strict ordering. acceptInvitation + sendInvitation only need
+// supabase (mocked) + logger (mocked) + node:crypto, so sub-path imports get
+// the transform done once at file load with zero unused heavy modules.
+import { getServiceRoleClient } from "@/lib/supabase";
+import { acceptInvitation } from "@/lib/platform/invitations/accept";
+import { sendInvitation } from "@/lib/platform/invitations/send";
+
 const baseInvitation = {
   id: INVITATION_ID,
   company_id: COMPANY_A,
@@ -155,7 +165,6 @@ afterEach(() => vi.clearAllMocks());
 
 describe("acceptInvitation — is_opollo_staff detection", () => {
   it("sets is_opollo_staff=true for @opollo.com email", async () => {
-    const { getServiceRoleClient } = await import("@/lib/supabase");
     vi.mocked(getServiceRoleClient).mockReturnValue(
       makeSupabaseMock({
         invitationData: { ...baseInvitation, email: "alice@opollo.com" },
@@ -165,18 +174,15 @@ describe("acceptInvitation — is_opollo_staff detection", () => {
       }) as never,
     );
 
-    const { acceptInvitation, hashToken } = await import("@/lib/platform/invitations");
     // The token hash must match what the mock returns — mock always returns
     // invitationData regardless of hash, so any 32-char token works.
-    const input = makeInput("alice@opollo.com");
-    const result = await acceptInvitation(input);
+    const result = await acceptInvitation(makeInput("alice@opollo.com"));
     expect(result.ok).toBe(true);
     expect(platformUserInserts).toHaveLength(1);
     expect(platformUserInserts[0]).toMatchObject({ is_opollo_staff: true });
   });
 
   it("sets is_opollo_staff=false for non-@opollo.com email", async () => {
-    const { getServiceRoleClient } = await import("@/lib/supabase");
     vi.mocked(getServiceRoleClient).mockReturnValue(
       makeSupabaseMock({
         invitationData: { ...baseInvitation, email: "bob@customer.com" },
@@ -186,7 +192,6 @@ describe("acceptInvitation — is_opollo_staff detection", () => {
       }) as never,
     );
 
-    const { acceptInvitation } = await import("@/lib/platform/invitations");
     const result = await acceptInvitation(makeInput("bob@customer.com"));
     expect(result.ok).toBe(true);
     expect(platformUserInserts).toHaveLength(1);
@@ -194,7 +199,6 @@ describe("acceptInvitation — is_opollo_staff detection", () => {
   });
 
   it("writes staff_grant.auto audit row for @opollo.com acceptance", async () => {
-    const { getServiceRoleClient } = await import("@/lib/supabase");
     vi.mocked(getServiceRoleClient).mockReturnValue(
       makeSupabaseMock({
         invitationData: { ...baseInvitation, email: "alice@opollo.com" },
@@ -204,7 +208,6 @@ describe("acceptInvitation — is_opollo_staff detection", () => {
       }) as never,
     );
 
-    const { acceptInvitation } = await import("@/lib/platform/invitations");
     const result = await acceptInvitation(makeInput("alice@opollo.com"));
     expect(result.ok).toBe(true);
     const auditRow = auditLogInserts.find((r) => r.action === "staff_grant.auto");
@@ -214,7 +217,6 @@ describe("acceptInvitation — is_opollo_staff detection", () => {
   });
 
   it("does NOT write staff_grant.auto audit row for non-staff acceptance", async () => {
-    const { getServiceRoleClient } = await import("@/lib/supabase");
     vi.mocked(getServiceRoleClient).mockReturnValue(
       makeSupabaseMock({
         invitationData: { ...baseInvitation, email: "bob@customer.com" },
@@ -224,7 +226,6 @@ describe("acceptInvitation — is_opollo_staff detection", () => {
       }) as never,
     );
 
-    const { acceptInvitation } = await import("@/lib/platform/invitations");
     const result = await acceptInvitation(makeInput("bob@customer.com"));
     expect(result.ok).toBe(true);
     const auditRow = auditLogInserts.find((r) => r.action === "staff_grant.auto");
@@ -311,7 +312,6 @@ function makeSendMock({
 
 describe("sendInvitation — cross-tenant enforcement (D1)", () => {
   it("blocks non-@opollo.com invitee already in another company", async () => {
-    const { getServiceRoleClient } = await import("@/lib/supabase");
     vi.mocked(getServiceRoleClient).mockReturnValue(
       makeSendMock({
         existingUserId: USER_CUSTOMER,
@@ -319,7 +319,6 @@ describe("sendInvitation — cross-tenant enforcement (D1)", () => {
       }) as never,
     );
 
-    const { sendInvitation } = await import("@/lib/platform/invitations");
     const result = await sendInvitation({
       companyId: COMPANY_A,
       email: "bob@customer.com",
@@ -333,7 +332,6 @@ describe("sendInvitation — cross-tenant enforcement (D1)", () => {
   });
 
   it("allows @opollo.com invitee already in another company (D1 staff exemption)", async () => {
-    const { getServiceRoleClient } = await import("@/lib/supabase");
     vi.mocked(getServiceRoleClient).mockReturnValue(
       makeSendMock({
         existingUserId: USER_STAFF,
@@ -341,7 +339,6 @@ describe("sendInvitation — cross-tenant enforcement (D1)", () => {
       }) as never,
     );
 
-    const { sendInvitation } = await import("@/lib/platform/invitations");
     const result = await sendInvitation({
       companyId: COMPANY_A,
       email: "alice@opollo.com",
@@ -356,7 +353,6 @@ describe("sendInvitation — cross-tenant enforcement (D1)", () => {
   });
 
   it("allows non-@opollo.com invitee with no existing company membership", async () => {
-    const { getServiceRoleClient } = await import("@/lib/supabase");
     vi.mocked(getServiceRoleClient).mockReturnValue(
       makeSendMock({
         existingUserId: null,
@@ -364,7 +360,6 @@ describe("sendInvitation — cross-tenant enforcement (D1)", () => {
       }) as never,
     );
 
-    const { sendInvitation } = await import("@/lib/platform/invitations");
     const result = await sendInvitation({
       companyId: COMPANY_A,
       email: "new@customer.com",


### PR DESCRIPTION
## Root cause

`tests/regressions/staff-email-auto-grant.test.ts` imported `acceptInvitation` + `sendInvitation` from the barrel `@/lib/platform/invitations`. That barrel re-exports `callbacks.ts`, which transitively pulls:

- `@/lib/qstash` (Upstash QStash SDK)
- `@/lib/platform/notifications` (SendGrid + email templates)

Neither is needed by this test. Both are heavy modules. Under pre-commit's `--bail=1` strict ordering, the first test in this file would be the first to pay the cold transform cost for those modules and time out at vitest's 10s default.

Two contributing factors made the symptom intermittent rather than constant:

1. **Vitest's transform cache survives across files inside a single `vitest run`** — once any other test had loaded qstash + notifications, this file ran fast. The flake only fired when `staff-email-auto-grant` happened to be scheduled before any other consumer of those modules.
2. **Each `it()` block did `await import(...)`** dynamically — so the cost was paid on first test invocation, not once at file load.

This explains why `PR #1132` and `PR #1134` both saw the flake reproducibly (pre-commit `--bail=1` + this file ordered first), but the broader unit suite passed cleanly when invoked directly (other files loaded the modules first).

## Fix (root cause, per CLAUDE.md "Decision policy" principle 1)

1. **Sub-path imports** instead of barrel: `@/lib/platform/invitations/accept` and `@/lib/platform/invitations/send`. These files transitively touch only `@/lib/supabase` (mocked), `@/lib/logger` (mocked), `@/lib/platform/staff-audit` (same mocked deps), `@/lib/platform/invitations/tokens` (`node:crypto`), and type-only imports. Zero unused heavy modules loaded.
2. **Static top-level imports** instead of per-test dynamic imports. `vi.mock` is hoisted, so per-test `vi.mocked(getServiceRoleClient).mockReturnValue(...)` still works correctly. Transform happens once at file load.
3. Dropped the unused `hashToken` destructure — mock returns `invitationData` regardless of hash per the inline comment.

## Validation (per CLAUDE.md "Decision policy" principle 2)

**10 consecutive runs**, all green, all under 1.1s:

```
run 1  : Tests 7 passed | Duration 1.04s (transform 71ms, import 98ms)
run 2  : Tests 7 passed | Duration 1.01s (transform 77ms, import 104ms)
run 3  : Tests 7 passed | Duration 996ms  (transform 73ms, import 98ms)
run 4  : Tests 7 passed | Duration 962ms  (transform 76ms, import 102ms)
run 5  : Tests 7 passed | Duration 963ms  (transform 69ms, import 99ms)
run 6  : Tests 7 passed | Duration 1.02s (transform 78ms, import 107ms)
run 7  : Tests 7 passed | Duration 1.00s (transform 65ms, import 89ms)
run 8  : Tests 7 passed | Duration 1.09s (transform 87ms, import 117ms)
run 9  : Tests 7 passed | Duration 1.02s (transform 70ms, import 97ms)
run 10 : Tests 7 passed | Duration 1.02s (transform 74ms, import 100ms)

passes detected: 10 / 10
```

Transform cost dropped from "10s timeout" to ~70–90ms (>100× faster). The bug wasn't a slow test; it was loading two heavy modules the test never used.

**Pre-commit hook used to land THIS commit**: `git commit` (no `SKIP_PRECOMMIT_TESTS`), full hook ran lint-staged + `vitest run --bail=1` on the entire 132-file unit suite. Result: **132 files / 2564 tests passed in 89.52s.** The hook is usable again — this commit itself proves it.

## Test plan

- [ ] CI green on all required checks
- [ ] After merge, future PRs commit without `SKIP_PRECOMMIT_TESTS` cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)