### PR TITLE
feat(image-gen): slice A6 — regenerate loop + escalation email

### DIFF
--- a/lib/image/failure/handler.ts
+++ b/lib/image/failure/handler.ts
@@ -2,13 +2,12 @@ import "server-only";
 
 import { logger } from "@/lib/logger";
 import { getServiceRoleClient } from "@/lib/supabase";
-// I3: dispatch('image_generation_failed') for escalation emails lands
-// when the NotificationEvent enum + migration are extended in I3.
+import { dispatch } from "@/lib/platform/notifications/dispatch";
 
 import type { GeneratedImage, GenerationParams, ImageGenOutcome } from "../types";
-import { IdeogramError, ImageGenerationError, StockUnavailableError } from "../types";
+import { IdeogramError, ImageGenerationError } from "../types";
 import { generateBackground, isRetryable } from "../generator/ideogram";
-import { stockFallback } from "../generator/stock";
+import { thirdAttemptFallback } from "../generator/stock";
 import { qualityCheck } from "./quality-check";
 
 // The entry point for all image generation. All product code calls this —
@@ -53,11 +52,11 @@ export async function generateWithFallback(
     logger.warn("Quality check failed on attempt 1", logBase);
   } catch (err) {
     if (err instanceof IdeogramError && !isRetryable(err)) {
-      logger.warn("Non-retryable Ideogram error", {
+      logger.warn("Non-retryable Ideogram error on attempt 1", {
         ...logBase,
         status: err.status,
       });
-      return stockFallbackWithLog(params, logBase);
+      return regenerateThenEscalate(params, logBase);
     }
     logger.warn("Retryable error on attempt 1", {
       ...logBase,
@@ -96,31 +95,29 @@ export async function generateWithFallback(
     logger.warn("Attempt 2 failed", logBase);
   }
 
-  return stockFallbackWithLog(params, logBase);
+  return regenerateThenEscalate(params, logBase);
 }
 
-async function stockFallbackWithLog(
+/**
+ * Attempt 3: different style + maximum simplification.
+ * If that also fails, escalate to human via email.
+ */
+async function regenerateThenEscalate(
   params: GenerationParams,
   logBase: { companyId: string; styleId: string; compositionType: string },
 ): Promise<GeneratedImage[]> {
   try {
-    const stock = await stockFallback(params);
-    await writeImageLog({
-      ...logBase,
-      brandProfileId: params.brandProfileId,
-      brandProfileVersion: params.brandProfileVersion,
-      aspectRatio: params.aspectRatio,
-      postMasterId: params.postMasterId,
-      triggeredBy: params.triggeredBy,
-      outcome: "stock_fallback",
-      retryCount: 1,
-      fallbackUsed: true,
-      backgroundStoragePath: stock[0]?.storagePath,
-    });
-    return stock;
-  } catch (err) {
-    if (err instanceof StockUnavailableError) {
-      await escalateToHuman(params);
+    const images = await thirdAttemptFallback(params);
+    const checks = await Promise.all(
+      images.map((img) =>
+        img.buffer
+          ? qualityCheck(img.buffer, params.compositionType)
+          : Promise.resolve({ passed: true, luminanceScore: 128, safeZoneScore: 0 }),
+      ),
+    );
+    const passed = images.filter((_, i) => checks[i].passed);
+
+    if (passed.length > 0) {
       await writeImageLog({
         ...logBase,
         brandProfileId: params.brandProfileId,
@@ -128,26 +125,62 @@ async function stockFallbackWithLog(
         aspectRatio: params.aspectRatio,
         postMasterId: params.postMasterId,
         triggeredBy: params.triggeredBy,
-        outcome: "escalated",
-        retryCount: 1,
-        fallbackUsed: true,
-        errorClass: "StockUnavailableError",
-        errorDetail: err.message,
+        outcome: "retry_success",
+        retryCount: 2,
+        backgroundStoragePath: passed[0].storagePath,
+        qualityCheck: checks[0],
       });
-      throw new ImageGenerationError(
-        "Image generation failed after all attempts — Opollo staff notified",
-      );
+      return passed;
     }
-    throw err;
+
+    logger.warn("Quality check failed on attempt 3 (different style)", logBase);
+  } catch (err) {
+    logger.warn("Attempt 3 (different style) failed", {
+      ...logBase,
+      error: String(err),
+    });
   }
+
+  // All 3 attempts failed — escalate to human.
+  await escalateToHuman(params);
+  await writeImageLog({
+    ...logBase,
+    brandProfileId: params.brandProfileId,
+    brandProfileVersion: params.brandProfileVersion,
+    aspectRatio: params.aspectRatio,
+    postMasterId: params.postMasterId,
+    triggeredBy: params.triggeredBy,
+    outcome: "escalated",
+    retryCount: 3,
+    fallbackUsed: true,
+    errorClass: "AllAttemptsExhausted",
+    errorDetail: "3 Ideogram attempts all failed quality check or errored",
+  });
+  throw new ImageGenerationError(
+    "Image generation failed after all attempts — Opollo staff notified",
+  );
 }
 
 async function escalateToHuman(params: GenerationParams): Promise<void> {
-  // I3: extend NotificationEvent + migration, then call dispatch() here.
-  logger.error("Image generation escalated — no stock fallback available", {
+  logger.error("Image generation escalated — all 3 attempts failed", {
     companyId: params.companyId,
     styleId: params.styleId,
     compositionType: params.compositionType,
+    aspectRatio: params.aspectRatio,
+  });
+
+  // Non-blocking — escalation failure must not propagate to the caller.
+  void dispatch({
+    event: "image_generation_failed",
+    companyId: params.companyId,
+    styleId: params.styleId,
+    compositionType: params.compositionType,
+    aspectRatio: params.aspectRatio,
+    attemptsCount: 3,
+  }).catch((err) => {
+    logger.warn("image.escalation.dispatch_failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
   });
 }
 
@@ -183,7 +216,7 @@ async function writeImageLog(params: {
     style_id: params.styleId,
     composition_type: params.compositionType,
     aspect_ratio: params.aspectRatio,
-    model_used: "unknown",
+    model_used: "ideogram-v3-flash",
     model_tier: "standard",
     prompt_used: "",
     outcome: params.outcome,
@@ -199,8 +232,6 @@ async function writeImageLog(params: {
     error_detail: params.errorDetail ?? null,
     generation_duration_ms: params.generationDurationMs ?? null,
     compositing_duration_ms: params.compositingDurationMs ?? null,
-    // triggered_by is a UUID FK — pass null if the caller provided a
-    // non-UUID string (e.g. a cron label). Callers should pass platform_users.id.
     triggered_by: params.triggeredBy ?? null,
   });
 

--- a/lib/image/generator/stock.ts
+++ b/lib/image/generator/stock.ts
@@ -1,64 +1,42 @@
 import "server-only";
 
-import { getServiceRoleClient } from "@/lib/supabase";
+import type { GeneratedImage, GenerationParams, StyleId } from "../types";
+import { generateBackground } from "./ideogram";
 
-import type { GeneratedImage, GenerationParams } from "../types";
-import { StockUnavailableError } from "../types";
+// ---------------------------------------------------------------------------
+// Third-attempt regenerate — replaces the dead image_stock_library fallback.
+//
+// The `image_stock_library` table never existed in any migration (recon §1c).
+// Per the mass-image-gen brief §3 (out of scope), do not create it. Instead,
+// make a third attempt with maximum prompt simplification and a different
+// style_id from the five available styles.
+//
+// If this also fails (quality check or Ideogram error), the caller
+// (handler.ts) escalates to the operator via email.
+// ---------------------------------------------------------------------------
 
-interface StockRow {
-  id: string;
-  storage_path: string;
-  style_id: string;
-  industry_tags: string[] | null;
-  luminance_score: number | null;
-  width: number;
-  height: number;
-  format: string;
-}
+const ALL_STYLES: StyleId[] = [
+  "clean_corporate",
+  "bold_promo",
+  "minimal_modern",
+  "editorial",
+  "product_focus",
+];
 
-export async function stockFallback(
-  params: Pick<GenerationParams, "styleId" | "industry" | "compositionType">,
+/**
+ * Third-attempt generation: try a different style with maximum simplification.
+ * Returns the first image that passes or throws if Ideogram fails.
+ * Quality checks are the caller's responsibility.
+ */
+export async function thirdAttemptFallback(
+  params: GenerationParams,
 ): Promise<GeneratedImage[]> {
-  const supabase = getServiceRoleClient();
+  // Pick the first style that differs from the one that already failed twice.
+  const fallbackStyle = ALL_STYLES.find((s) => s !== params.styleId) ?? "clean_corporate";
 
-  const { data: candidates } = await supabase
-    .from("image_stock_library")
-    .select(
-      "id, storage_path, style_id, industry_tags, luminance_score, width, height, format",
-    )
-    .is("deleted_at", null)
-    .in("style_id", [params.styleId, "neutral"])
-    .limit(20);
-
-  if (!candidates?.length) {
-    throw new StockUnavailableError(
-      `No stock images available for style ${params.styleId}`,
-    );
-  }
-
-  const ranked = (candidates as StockRow[])
-    .map((img) => ({
-      img,
-      score:
-        (img.style_id === params.styleId ? 3 : 0) +
-        (params.industry && img.industry_tags?.includes(params.industry)
-          ? 2
-          : 0) +
-        (img.luminance_score !== null
-          ? img.luminance_score < 160 || img.luminance_score > 180
-            ? 2
-            : 0
-          : 1),
-    }))
-    .sort((a, b) => b.score - a.score);
-
-  const best = ranked[0].img;
-  return [
-    {
-      storagePath: best.storage_path,
-      width: best.width,
-      height: best.height,
-      format: best.format,
-    },
-  ];
+  return generateBackground({
+    ...params,
+    styleId: fallbackStyle,
+    simplifyPrompt: true,
+  });
 }

--- a/lib/platform/notifications/dispatch.ts
+++ b/lib/platform/notifications/dispatch.ts
@@ -128,6 +128,10 @@ async function resolveRecipients(
     case "connection_restored":
       // Company admins only.
       return resolveCompanyAdmins(payload.companyId);
+
+    case "image_generation_failed":
+      // Platform admins of the company — same audience as connection_lost.
+      return resolveCompanyAdmins(payload.companyId);
   }
 }
 
@@ -297,8 +301,9 @@ function renderInApp(
     case "invitation_sent":
     case "invitation_reminder":
     case "invitation_expired":
+    case "image_generation_failed":
       return {
-        title: "Invitation",
+        title: "Image generation failed",
         body: "",
         actionUrl: null,
       };
@@ -437,6 +442,12 @@ function renderEmailContent(
           label: "Open post",
           url: `${siteUrl()}/company/social/posts/${payload.postMasterId}`,
         },
+      };
+    case "image_generation_failed":
+      return {
+        subject: "Image generation failed — action may be required",
+        lead: `All ${payload.attemptsCount} generation attempts for a ${payload.aspectRatio} image failed (style: ${payload.styleId}, composition: ${payload.compositionType}). The image was not produced. Check Ideogram API status or review the image_generation_log for details.`,
+        action: null,
       };
   }
 }

--- a/lib/platform/notifications/types.ts
+++ b/lib/platform/notifications/types.ts
@@ -15,7 +15,8 @@ export type NotificationEvent =
   | "connection_restored"
   | "post_published"
   | "post_failed"
-  | "changes_requested";
+  | "changes_requested"
+  | "image_generation_failed";
 
 export type NotificationChannel = "email" | "in_app";
 
@@ -101,6 +102,14 @@ export type DispatchPayload =
       postMasterId: string;
       submitterUserId: string;
       comment: string;
+    }
+  | {
+      event: "image_generation_failed";
+      companyId: string;
+      styleId: string;
+      compositionType: string;
+      aspectRatio: string;
+      attemptsCount: number;
     };
 
 // The set of channels each event fires on. Mirrors the trigger table in
@@ -115,8 +124,9 @@ export const EVENT_CHANNELS: Record<NotificationEvent, readonly NotificationChan
   connection_lost:       ["email", "in_app"],
   connection_restored:   ["in_app"],
   post_published:        ["in_app"],
-  post_failed:           ["email", "in_app"],
-  changes_requested:     ["email", "in_app"],
+  post_failed:              ["email", "in_app"],
+  changes_requested:        ["email", "in_app"],
+  image_generation_failed:  ["email"],
 };
 
 // Recipient kinds the dispatcher knows how to resolve. Each event maps

--- a/supabase/migrations/0160_add_image_generation_failed_event.sql
+++ b/supabase/migrations/0160_add_image_generation_failed_event.sql
@@ -1,0 +1,11 @@
+-- 0160: add image_generation_failed to the platform_notification_type enum.
+--
+-- Required by A6 (regenerate loop + escalation email). The handler.ts
+-- escalateToHuman() now calls dispatch("image_generation_failed") instead
+-- of logger.error(). This migration extends the enum in the DB to allow
+-- the INSERT to platform_notifications.type = 'image_generation_failed'.
+--
+-- Enum values are append-only in PostgreSQL; cannot be rolled back without
+-- dropping the enum. Rollback stub is intentionally a no-op.
+
+ALTER TYPE platform_notification_type ADD VALUE IF NOT EXISTS 'image_generation_failed';

--- a/supabase/rollbacks/0160_add_image_generation_failed_event.down.sql
+++ b/supabase/rollbacks/0160_add_image_generation_failed_event.down.sql
@@ -1,0 +1,4 @@
+-- Rollback for 0160 — intentional no-op.
+-- PostgreSQL enum values cannot be removed once added without dropping
+-- the type. Leaving the value in place is safe; unused enum values have
+-- no runtime cost. If removal is ever required, DROP TYPE and re-create.


### PR DESCRIPTION
## Summary

Replaces the dead stock-fallback path (`image_stock_library` never existed in any migration — recon §1c) with a third-attempt regenerate loop using a different style, and wires the escalation to the notification dispatch pipeline (email to company admins) instead of `logger.error()` only.

## Changes

**`lib/image/generator/stock.ts`**
- Removed: dead Supabase query against `image_stock_library` (recon confirmed this table has never existed)
- Added: `thirdAttemptFallback()` — calls `generateBackground` with `simplifyPrompt=true` plus a different `StyleId` (first in the enum not matching the style that already failed twice). Quality check is the caller's responsibility.

**`lib/image/failure/handler.ts`**
- `generateWithFallback()` now has 3 attempts: (1) normal prompt, (2) simplified prompt, (3) different style + simplified
- After all 3 fail: `escalateToHuman()` calls `dispatch("image_generation_failed")` non-blocking, then throws `ImageGenerationError`
- `stockFallbackWithLog()` replaced by `regenerateThenEscalate()` which owns all 3 → escalate logic
- `model_used` field updated from `"unknown"` to `"ideogram-v3-flash"` in `writeImageLog`

**`lib/platform/notifications/types.ts`**
- `NotificationEvent` union: added `"image_generation_failed"`
- `DispatchPayload`: new variant `{ event, companyId, styleId, compositionType, aspectRatio, attemptsCount }`
- `EVENT_CHANNELS`: `image_generation_failed → ["email"]`

**`lib/platform/notifications/dispatch.ts`**
- `resolveRecipients`: `image_generation_failed → resolveCompanyAdmins` (same as `connection_lost`)
- `renderInApp`: email-only stub (exhaustive switch)
- `renderEmailContent`: subject + lead with attempt count and style details

**`supabase/migrations/0160_add_image_generation_failed_event.sql`**
- `ALTER TYPE platform_notification_type ADD VALUE IF NOT EXISTS 'image_generation_failed'`

## Pre-PR checklist

- [x] Lint, typecheck clean
- [x] `test:unit` 2583/2584 pass (1 pre-existing flaky timeout)
- [x] No changes to `image_generation_log` schema
- [x] Rollback SQL included (intentional no-op — PostgreSQL enum values are append-only)

## Risks identified and mitigated

- `escalateToHuman()` uses `void dispatch(...)` (non-blocking) — dispatch failure is caught and logged, never propagated to the caller. Image generation failure is the primary concern; notification failure is secondary.
- Third attempt picks the first style that differs from the current one (not brand-filtered) because `GenerationParams` doesn't carry the brand's allowed-styles list. This is pragmatic for V1; a future slice can pass allowed styles through the params if brand-filtering of the fallback style matters.
- `image_stock_library` removal: there's still a `StockUnavailableError` class in `lib/image/types.ts` — left in place as it may be referenced by tests or used as a type elsewhere. It is no longer thrown by any production code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)