### PR TITLE
fix(tests): proactive audit of slow-import flake class

### DIFF
--- a/lib/__tests__/analytics-ingest-platform-map.unit.test.ts
+++ b/lib/__tests__/analytics-ingest-platform-map.unit.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 
+// Sub-path import: the barrel @/lib/platform/social/analytics-ingest also
+// re-exports ./refresh + ./post-history-import which transitively pull
+// @/lib/bundlesocial + @/lib/qstash. This test only needs pure-function
+// platform mappers, so importing the leaf file directly skips those heavy
+// deps. Avoids the slow-import flake class from PR #1136.
 import {
   analyticsPlatformFor,
   internalPlatformsFor,
   postImportPlatformFor,
-} from "@/lib/platform/social/analytics-ingest";
+} from "@/lib/platform/social/analytics-ingest/platform-map";
 
 // LAYER 1 — Unit. Pure functions, no SDK, no DB.
 //

--- a/lib/__tests__/analytics-post-history-import.unit.test.ts
+++ b/lib/__tests__/analytics-post-history-import.unit.test.ts
@@ -68,7 +68,10 @@ vi.mock("@/lib/supabase", () => ({
   }),
 }));
 
-import { enqueuePostHistoryImport } from "@/lib/platform/social/analytics-ingest";
+// Sub-path import: barrel @/lib/platform/social/analytics-ingest also pulls
+// in ./refresh + ./dashboard. This test only needs enqueuePostHistoryImport;
+// importing the leaf file skips the other heavy sub-modules' transforms.
+import { enqueuePostHistoryImport } from "@/lib/platform/social/analytics-ingest/post-history-import";
 
 const PROFILE_ID = "11111111-1111-1111-1111-111111111111";
 


### PR DESCRIPTION
## Summary

Audited the unit/contract/regression test scope (the tests pre-commit runs) for the same defect class behind the two flakes that hit in the last 48 hours:

1. **PR #1136** — `tests/regressions/staff-email-auto-grant.test.ts` — barrel `@/lib/platform/invitations` pulled QStash + SendGrid via `callbacks.ts`. 10s import-timeout under `--bail=1` strict ordering. Fixed via sub-path imports.
2. **PR #1134 commit attempt** — flake reported on `lib/__tests__/image-lease.unit.test.ts`. On inspection, that file imports cleanly from `@/lib/image/lease` (sub-path), properly mocks `@/lib/redis` at the top. Not the same defect class.

## Audit scope

Per `vitest.unit.config.ts`, pre-commit's `npm run test:unit` runs `lib/__tests__/**/*.contract.test.ts`, `lib/__tests__/**/*.unit.test.ts`, `lib/**/__tests__/**/*.unit.test.ts`, `tests/regressions/**/*.test.{ts,tsx}`, `tests/security/**/*.security.test.ts`.

Searched every file in this scope for imports of `@/lib/<barrel>` (no sub-path), then cross-referenced each barrel's transitive imports to find heavy deps the consuming test doesn't actually use.

## Tests fixed

### `lib/__tests__/analytics-ingest-platform-map.unit.test.ts`

**Before:** imported pure-function platform mappers from the `@/lib/platform/social/analytics-ingest` barrel. Barrel also re-exports `./refresh` (bundle.social SDK) + `./post-history-import` (QStash + bundle.social SDK) + `./dashboard`. All three platform mappers live in `./platform-map.ts` — none of the heavy modules used.

**Fix:** sub-path import to `@/lib/platform/social/analytics-ingest/platform-map`.

| | Transform | Import | Total |
|---|---|---|---|
| Before | 101ms | 246ms | 1.21s |
| After  | **37ms (-63%)** | **50ms (-80%)** | **978ms** |

10/10 runs pass.

### `lib/__tests__/analytics-post-history-import.unit.test.ts`

**Before:** imported `enqueuePostHistoryImport` from the barrel. Barrel pulls `./refresh` + `./dashboard` unnecessarily.

**Fix:** sub-path import to `@/lib/platform/social/analytics-ingest/post-history-import`.

**Measured:** transform 82→68ms (-17%), import 115→103ms (-10%). Smaller win because the leaf module itself uses QStash + bundle.social SDK. Still a real improvement.

10/10 runs pass.

## Tests left alone with rationale

### `tests/regressions/callback-platform-prefixed-params.test.ts`

Attempted to switch to `./sync` sub-path. The test uses `vi.mocked(syncBundlesocialConnections as unknown as MockInstance).mockResolvedValueOnce(...)` to control mock state per-test. The route handler being tested imports from the barrel; `vi.mock` targets the barrel path; the test's reference must resolve to the **same** mocked function the route sees. A sub-path import here breaks that binding — `vi.mocked()` would point at the unmocked real leaf.

Per CLAUDE.md `§\"Decision policy\"` principle 7, this is a real conflict — left alone.

### `lib/__tests__/image-lease.unit.test.ts`

Imports cleanly from `@/lib/image/lease` (sub-path). `@/lib/redis` fully mocked at the top. The flake reported during PR #1134's commit attempt does not match the slow-import-class symptoms (transform is ~30ms, import is ~80ms). May be a separate issue — unhandled rejection race, or vitest pinning a different test's failure to this file's cursor under `--bail=1`. Out of scope for this PR; flag if it recurs.

### Slow regression tests (out of class)

Top 5 by file duration: external-approver-magic-link.test.ts (3.7s), di-006-link-preview-ssrf.test.ts (2.3s), di-005-review-link-state-check.test.ts (2.3s), disconnect-ordering.test.ts (1.8s), approval-toggle-permission-gate.test.ts (1.6s). All five import route handlers directly (e.g. `@/app/api/.../route`) — not barrels. Their slowness is intrinsic to what they test. Not the same defect class. Left alone.

## System-fix proposal (Decision policy principle 3 — proposed, not implemented here)

Add a static-audit rule in `scripts/audit.ts` (severity LOW) that flags any test file importing from a barrel `@/lib/<X>` where the barrel exists at `lib/<X>/index.ts`. The rule should accept an inline `// barrel-import-ok: <reason>` comment as an explicit waiver (the `callback-platform-prefixed-params` case is the canonical waiver — vi.mock binding to a route handler's import path).

Three test files hit this rule today (two fixed here + one waiver candidate). Below the proposed 3+ recurrences threshold, but the next QStash-or-similar barrel growth would push it over. Worth codifying as a one-PR follow-up once a 4th case appears.

## Pre-commit hook verification

Commit `3e79a938` was created **without `SKIP_PRECOMMIT_TESTS`**. Full hook ran lint-staged + eslint on 2 staged files (clean) + `vitest run --bail=1` → **134 test files, 2584 tests passed in 91.06s**. Hook is usable end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)