### PR TITLE
feat(image-gen): slice B2 — batch tracking + dispatch endpoint

### DIFF
--- a/app/api/internal/image/qstash-handler/route.ts
+++ b/app/api/internal/image/qstash-handler/route.ts
@@ -185,6 +185,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       completed_at: new Date().toISOString(),
     }).eq("id", jobId);
 
+    // Update batch state after job completion (non-blocking).
+    if (batchId) void updateBatchProgress(svc, batchId);
+
     logger.info("image.qstash.completed", { jobId, storagePath: image.storagePath });
     return NextResponse.json({ ok: true, status: "completed", storagePath: image.storagePath });
 
@@ -202,6 +205,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       completed_at: new Date().toISOString(),
     }).eq("id", jobId);
 
+    // Update batch state after job failure (non-blocking).
+    if (batchId) void updateBatchProgress(svc, batchId);
+
     logger.error("image.qstash.generation_failed", { jobId, state, errorClass, errorDetail });
 
     // Return 200 — generation failure is permanent; QStash retrying won't help
@@ -211,5 +217,49 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   } finally {
     // Always release the lease — runs even when generation throws.
     await releaseImageLease(jobId);
+  }
+}
+
+/**
+ * Recalculate batch progress from live job counts and update batch state.
+ * Non-blocking — called via void; errors are logged, never thrown.
+ */
+async function updateBatchProgress(
+  svc: ReturnType<typeof import("@/lib/supabase").getServiceRoleClient>,
+  batchId: string,
+): Promise<void> {
+  try {
+    const { data: counts } = await svc
+      .from("image_generation_jobs")
+      .select("state")
+      .eq("batch_id", batchId);
+
+    if (!counts) return;
+
+    const total = counts.length;
+    const completed = counts.filter((j) => j.state === "completed").length;
+    const failed = counts.filter((j) => j.state === "failed" || j.state === "escalated").length;
+    const pending = counts.filter((j) => j.state === "pending" || j.state === "running").length;
+
+    let state: string;
+    if (pending > 0) {
+      state = "running";
+    } else if (failed === total) {
+      state = "failed";
+    } else if (failed > 0) {
+      state = "partial";
+    } else {
+      state = "completed";
+    }
+
+    await svc
+      .from("image_generation_batches")
+      .update({ state, completed_jobs: completed, failed_jobs: failed, updated_at: new Date().toISOString() })
+      .eq("id", batchId);
+  } catch (err) {
+    logger.warn("image.batch.progress_update_failed", {
+      batchId,
+      err: err instanceof Error ? err.message : String(err),
+    });
   }
 }

--- a/app/api/platform/image/batch/[id]/route.ts
+++ b/app/api/platform/image/batch/[id]/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { internalError, notFound, validateUuidParam } from "@/lib/http";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// GET /api/platform/image/batch/[id]
+//
+// Returns batch state + all job results. Signed URLs for completed jobs are
+// generated fresh on each read (never stored — §1.6).
+//
+// Auth: canDo("create_post") — editor+.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const IMAGE_GEN_BUCKET = process.env.IMAGE_GENERATION_BUCKET ?? "generated-images";
+const SIGNED_URL_TTL = 3600; // 1 hour — sufficient for UI display
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+  const idCheck = validateUuidParam(id, "id");
+  if (!idCheck.ok) return idCheck.response;
+
+  const svc = getServiceRoleClient();
+
+  // Fetch batch.
+  const { data: batch, error: batchErr } = await svc
+    .from("image_generation_batches")
+    .select("id, company_id, state, total_jobs, completed_jobs, failed_jobs, source_filename, source_row_count, created_at, updated_at")
+    .eq("id", idCheck.value)
+    .single();
+
+  if (batchErr || !batch) {
+    if (batchErr?.code === "PGRST116") return notFound(`Batch ${id} not found.`);
+    logger.error("image.batch.fetch_failed", { batchId: id, error: batchErr?.message });
+    return internalError("Failed to fetch batch.");
+  }
+
+  const gate = await requireCanDoForApi(batch.company_id as string, "create_post");
+  if (gate.kind === "deny") return gate.response;
+
+  // Fetch jobs.
+  const { data: jobs, error: jobsErr } = await svc
+    .from("image_generation_jobs")
+    .select("id, state, generation_params, result_storage_path, error_class, error_detail, target_platforms, target_publish_date, parent_post_index, started_at, completed_at")
+    .eq("batch_id", idCheck.value)
+    .order("parent_post_index", { ascending: true, nullsFirst: true })
+    .order("created_at", { ascending: true });
+
+  if (jobsErr) {
+    logger.error("image.batch.jobs_fetch_failed", { batchId: id, error: jobsErr.message });
+    return internalError("Failed to fetch batch jobs.");
+  }
+
+  // Sign URLs for completed jobs fresh on read (never stored — §1.6).
+  const jobsWithUrls = await Promise.all(
+    (jobs ?? []).map(async (job) => {
+      let signedUrl: string | null = null;
+
+      if (job.result_storage_path && job.state === "completed") {
+        const { data: signed } = await svc.storage
+          .from(IMAGE_GEN_BUCKET)
+          .createSignedUrl(job.result_storage_path as string, SIGNED_URL_TTL);
+        signedUrl = signed?.signedUrl ?? null;
+      }
+
+      return {
+        id: job.id,
+        state: job.state,
+        resultSignedUrl: signedUrl, // null if not completed or signing failed
+        errorClass: job.error_class,
+        errorDetail: job.error_detail,
+        targetPlatforms: job.target_platforms,
+        targetPublishDate: job.target_publish_date,
+        parentPostIndex: job.parent_post_index,
+        startedAt: job.started_at,
+        completedAt: job.completed_at,
+      };
+    }),
+  );
+
+  return NextResponse.json({
+    ok: true,
+    data: {
+      id: batch.id,
+      state: batch.state,
+      totalJobs: batch.total_jobs,
+      completedJobs: batch.completed_jobs,
+      failedJobs: batch.failed_jobs,
+      sourceFilename: batch.source_filename,
+      sourceRowCount: batch.source_row_count,
+      createdAt: batch.created_at,
+      updatedAt: batch.updated_at,
+      jobs: jobsWithUrls,
+    },
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/app/api/platform/image/batch/route.ts
+++ b/app/api/platform/image/batch/route.ts
@@ -1,0 +1,174 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { dbUuid, internalError, readJsonBody, validationError } from "@/lib/http";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+import { enqueueImageJob } from "@/lib/image/enqueue";
+import type { GenerationParams } from "@/lib/image/types";
+
+// ---------------------------------------------------------------------------
+// POST /api/platform/image/batch
+//
+// Creates a batch + N image_generation_jobs, enqueues one QStash message per
+// job, returns the batchId for the operator to poll.
+//
+// Budget pre-flight check (B3) is enforced in the next slice. This endpoint
+// creates and enqueues immediately; budget enforcement is added in B3 without
+// schema changes here.
+//
+// §1.2: route under /api/platform/image/*, not /social/
+// §1.7: one job per distinct aspect ratio derived from target_platforms.
+// §1.6: no signed URLs stored; result_storage_path set by the handler.
+//
+// Auth: canDo("create_post") — editor+.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const JobSpecSchema = z.object({
+  styleId: z.enum(["clean_corporate", "bold_promo", "minimal_modern", "editorial", "product_focus"]),
+  primaryColour: z.string(),
+  compositionType: z.enum(["split_layout", "gradient_fade", "full_background", "geometric", "texture"]),
+  aspectRatio: z.enum(["1x1", "4x5", "9x16", "16x9", "4x3"]),
+  industry: z.string().optional(),
+  targetPlatforms: z.array(z.string()).optional(),
+  targetPublishDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  parentPostIndex: z.number().int().min(0).optional(),
+});
+
+const BatchSchema = z.object({
+  company_id: dbUuid(),
+  jobs: z.array(JobSpecSchema).min(1).max(100),
+  source_filename: z.string().optional(),
+  source_row_count: z.number().int().min(1).optional(),
+  mode: z.enum(["generate", "preview"]).default("generate"),
+});
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const body = await readJsonBody(req);
+  if (body === undefined) return validationError("Request body must be valid JSON.");
+
+  const parsed = BatchSchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError("Invalid batch spec.", { issues: parsed.error.issues });
+  }
+
+  const { company_id, jobs, source_filename, source_row_count, mode } = parsed.data;
+
+  const gate = await requireCanDoForApi(company_id, "create_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const svc = getServiceRoleClient();
+
+  // Create the batch row.
+  const { data: batch, error: batchErr } = await svc
+    .from("image_generation_batches")
+    .insert({
+      company_id,
+      state: "pending",
+      total_jobs: jobs.length,
+      source_filename: source_filename ?? null,
+      source_row_count: source_row_count ?? null,
+      triggered_by: gate.userId,
+    })
+    .select("id")
+    .single();
+
+  if (batchErr || !batch) {
+    logger.error("image.batch.create_failed", { companyId: company_id, error: batchErr?.message });
+    return internalError("Failed to create batch.");
+  }
+
+  const batchId = batch.id as string;
+
+  // Create job rows + enqueue to QStash.
+  const jobErrors: string[] = [];
+  const jobIds: string[] = [];
+
+  for (const spec of jobs) {
+    const generationParams: GenerationParams = {
+      styleId: spec.styleId,
+      primaryColour: spec.primaryColour,
+      compositionType: spec.compositionType,
+      aspectRatio: spec.aspectRatio,
+      industry: spec.industry,
+      companyId: company_id,
+      count: 1,
+    };
+
+    // Create job row.
+    const { data: job, error: jobErr } = await svc
+      .from("image_generation_jobs")
+      .insert({
+        company_id,
+        batch_id: batchId,
+        state: "pending",
+        generation_params: generationParams,
+        target_platforms: spec.targetPlatforms ?? null,
+        target_publish_date: spec.targetPublishDate ?? null,
+        parent_post_index: spec.parentPostIndex ?? null,
+      })
+      .select("id")
+      .single();
+
+    if (jobErr || !job) {
+      logger.error("image.batch.job_create_failed", { batchId, error: jobErr?.message });
+      jobErrors.push(`Failed to create job: ${jobErr?.message ?? "unknown"}`);
+      continue;
+    }
+
+    const jobId = job.id as string;
+    jobIds.push(jobId);
+
+    // Preview mode: skip QStash; job state stays 'pending' as a draft marker.
+    if (mode === "preview") continue;
+
+    // Enqueue to QStash.
+    const enqueue = await enqueueImageJob({ jobId, generationParams, batchId });
+    if (!enqueue.ok) {
+      logger.error("image.batch.enqueue_failed", { batchId, jobId, error: enqueue.error });
+      // Mark job failed immediately so the batch tracker has accurate counts.
+      await svc
+        .from("image_generation_jobs")
+        .update({ state: "failed", error_class: "EnqueueFailed", error_detail: enqueue.error })
+        .eq("id", jobId);
+      jobErrors.push(`Job ${jobId} failed to enqueue: ${enqueue.error}`);
+    }
+  }
+
+  // Advance batch to running (or failed if everything errored).
+  const allFailed = jobErrors.length === jobs.length;
+  await svc
+    .from("image_generation_batches")
+    .update({
+      state: mode === "preview" ? "pending" : allFailed ? "failed" : "running",
+      failed_jobs: jobErrors.length,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", batchId);
+
+  logger.info("image.batch.created", {
+    batchId,
+    companyId: company_id,
+    totalJobs: jobs.length,
+    enqueuedJobs: jobIds.length - jobErrors.length,
+    mode,
+  });
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        batchId,
+        totalJobs: jobs.length,
+        mode,
+        ...(jobErrors.length > 0 && { enqueueErrors: jobErrors }),
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 201 },
+  );
+}

--- a/lib/__tests__/image-batch-route.unit.test.ts
+++ b/lib/__tests__/image-batch-route.unit.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mocks
+// ─────────────────────────────────────────────────────────────────────────────
+const { mockGate } = vi.hoisted(() => ({ mockGate: vi.fn() }));
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: mockGate,
+}));
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/image/enqueue", () => ({
+  enqueueImageJob: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+const COMPANY_UUID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const BATCH_UUID   = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const JOB_UUID     = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+const VALID_JOB_SPEC = {
+  styleId: "clean_corporate",
+  primaryColour: "#1a56db",
+  compositionType: "split_layout",
+  aspectRatio: "1x1",
+};
+
+function makePostRequest(body: unknown): Request {
+  return new Request("http://localhost/api/platform/image/batch", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/platform/image/batch
+// ─────────────────────────────────────────────────────────────────────────────
+import { POST } from "@/app/api/platform/image/batch/route";
+import type { NextRequest } from "next/server";
+
+describe("POST /api/platform/image/batch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGate.mockResolvedValue({ kind: "allow", userId: "user-uuid-1" });
+  });
+
+  it("returns 400 when jobs array is empty", async () => {
+    const req = makePostRequest({ company_id: COMPANY_UUID, jobs: [] }) as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when auth gate denies", async () => {
+    mockGate.mockResolvedValue({
+      kind: "deny",
+      response: new Response(JSON.stringify({ ok: false }), { status: 401 }),
+    });
+    const req = makePostRequest({ company_id: COMPANY_UUID, jobs: [VALID_JOB_SPEC] }) as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("creates batch + job and enqueues, returns 201 with batchId", async () => {
+    const mockInsert = vi.fn();
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "image_generation_batches") {
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: { id: BATCH_UUID }, error: null }),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+        };
+      }
+      if (table === "image_generation_jobs") {
+        mockInsert.mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { id: JOB_UUID }, error: null }),
+          }),
+        });
+        return { insert: mockInsert };
+      }
+      return {};
+    });
+
+    const req = makePostRequest({
+      company_id: COMPANY_UUID,
+      jobs: [VALID_JOB_SPEC],
+    }) as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+
+    const json = await res.json() as { ok: boolean; data: { batchId: string; totalJobs: number } };
+    expect(json.ok).toBe(true);
+    expect(json.data.batchId).toBe(BATCH_UUID);
+    expect(json.data.totalJobs).toBe(1);
+
+    const { enqueueImageJob } = await import("@/lib/image/enqueue");
+    expect(vi.mocked(enqueueImageJob)).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: JOB_UUID, batchId: BATCH_UUID }),
+    );
+  });
+
+  it("mode=preview skips QStash enqueue", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "image_generation_batches") {
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: { id: BATCH_UUID }, error: null }),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+        };
+      }
+      if (table === "image_generation_jobs") {
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: { id: JOB_UUID }, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const req = makePostRequest({
+      company_id: COMPANY_UUID,
+      jobs: [VALID_JOB_SPEC],
+      mode: "preview",
+    }) as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+
+    const json = await res.json() as { data: { mode: string } };
+    expect(json.data.mode).toBe("preview");
+
+    const { enqueueImageJob } = await import("@/lib/image/enqueue");
+    expect(vi.mocked(enqueueImageJob)).not.toHaveBeenCalled();
+  });
+});

--- a/supabase/migrations/0161_create_image_generation_batches.sql
+++ b/supabase/migrations/0161_create_image_generation_batches.sql
@@ -1,0 +1,70 @@
+-- 0161: image_generation_batches and batch-level columns on image_generation_jobs.
+--
+-- image_generation_batches: groups N image jobs under one operator action.
+-- image_generation_jobs gains batch_id FK + per-job routing columns.
+--
+-- §1.7 of the mass-image-gen brief: budget and counts are in jobs, not rows.
+-- total_jobs = sum of distinct aspect ratios across all source rows.
+-- source_row_count is optional metadata for UI display ("30 posts → 90 images").
+
+-- ─── image_generation_batches ────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS image_generation_batches (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id       UUID        NOT NULL REFERENCES platform_companies(id) ON DELETE CASCADE,
+  state            TEXT        NOT NULL DEFAULT 'pending',
+  CONSTRAINT image_generation_batches_state_check
+    CHECK (state IN ('pending', 'running', 'completed', 'partial', 'failed')),
+  total_jobs       INT         NOT NULL DEFAULT 0,
+  completed_jobs   INT         NOT NULL DEFAULT 0,
+  failed_jobs      INT         NOT NULL DEFAULT 0,
+  -- Operator-facing metadata (populated by C4 ingestion route).
+  source_filename  TEXT,
+  source_row_count INT,                -- source document row count (not job count)
+  triggered_by     UUID        REFERENCES platform_users(id) ON DELETE SET NULL,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_image_generation_batches_company_state
+  ON image_generation_batches(company_id, state);
+
+ALTER TABLE image_generation_batches ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS image_generation_batches_company_read ON image_generation_batches;
+CREATE POLICY image_generation_batches_company_read
+  ON image_generation_batches FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM platform_company_users pcu
+      WHERE pcu.user_id   = auth.uid()
+        AND pcu.company_id = image_generation_batches.company_id
+        AND pcu.role IN ('editor', 'approver', 'admin')
+    )
+  );
+
+-- ─── Extend image_generation_jobs (created in 0159) ─────────────────────────
+
+-- batch_id FK — nullable so B1-era standalone jobs stay valid.
+ALTER TABLE image_generation_jobs
+  ADD COLUMN IF NOT EXISTS batch_id UUID REFERENCES image_generation_batches(id) ON DELETE SET NULL;
+
+-- Per §1.7: the aspect ratio this job was generated for.
+-- Used by auto-attach (B4) to match image → platform variant.
+ALTER TABLE image_generation_jobs
+  ADD COLUMN IF NOT EXISTS target_platforms JSONB;          -- array of platform codes, e.g. ["linkedin", "instagram"]
+
+-- Per §1.5: populated by C4 from the source row's publish_date.
+ALTER TABLE image_generation_jobs
+  ADD COLUMN IF NOT EXISTS target_publish_date DATE;        -- auto-attach date; null = no auto-attach
+
+-- UI grouping (D2): which row of the source document this job came from.
+ALTER TABLE image_generation_jobs
+  ADD COLUMN IF NOT EXISTS parent_post_index INT;           -- 0-based row index within the batch
+
+-- Partial index for batch-level queries: which jobs in a batch need attention.
+CREATE INDEX IF NOT EXISTS idx_image_generation_jobs_batch_state
+  ON image_generation_jobs(batch_id, state)
+  WHERE batch_id IS NOT NULL;

--- a/supabase/rollbacks/0161_create_image_generation_batches.down.sql
+++ b/supabase/rollbacks/0161_create_image_generation_batches.down.sql
@@ -1,0 +1,9 @@
+-- Rollback for 0161. Only safe when both tables are empty.
+DROP INDEX IF EXISTS idx_image_generation_jobs_batch_state;
+ALTER TABLE image_generation_jobs
+  DROP COLUMN IF EXISTS parent_post_index,
+  DROP COLUMN IF EXISTS target_publish_date,
+  DROP COLUMN IF EXISTS target_platforms,
+  DROP COLUMN IF EXISTS batch_id;
+DROP POLICY IF EXISTS image_generation_batches_company_read ON image_generation_batches;
+DROP TABLE IF EXISTS image_generation_batches;


### PR DESCRIPTION
## Summary

Adds the `image_generation_batches` table, extends `image_generation_jobs` with batch-level routing columns, ships the `POST /api/platform/image/batch` dispatch endpoint, and the `GET /api/platform/image/batch/[id]` detail endpoint with live signed URL generation.

## Changes

**`supabase/migrations/0161_create_image_generation_batches.sql`**
- `image_generation_batches`: `id`, `company_id`, `state` (pending/running/completed/partial/failed), `total_jobs`, `completed_jobs`, `failed_jobs`, `source_filename`, `source_row_count` (for "N posts → M images" UI display), RLS for company members
- `image_generation_jobs` ALTER: `batch_id` FK, `target_platforms` JSONB (array of platform codes), `target_publish_date` DATE (for B4 auto-attach), `parent_post_index` INT (for D2 grouping). Partial index on `(batch_id, state)`.

**`app/api/platform/image/batch/route.ts`** (POST)
- Accepts `{ company_id, jobs[], mode?, source_filename?, source_row_count? }`
- Creates batch row, then for each job: creates `image_generation_jobs` row + enqueues via `enqueueImageJob()`
- `mode=preview`: creates rows but skips QStash — no Ideogram calls, no spend (per B5 preview semantics)
- Returns `201 { batchId, totalJobs, mode }`
- Auth: `canDo("create_post")` — editor+

**`app/api/platform/image/batch/[id]/route.ts`** (GET)
- Returns batch state + all job results
- Signs `result_storage_path` → `resultSignedUrl` fresh on each read (1hr TTL) — URLs never stored per §1.6
- Auth: `canDo("create_post")` on the batch's `company_id`

**`app/api/internal/image/qstash-handler/route.ts`**
- Added `updateBatchProgress()`: after each job completes or fails, recalculates `completed_jobs`, `failed_jobs`, and batch `state` from live job counts. Non-blocking (`void`).

## Pre-PR checklist

- [x] Lint, typecheck clean
- [x] `test:unit` 2592/2592 pass
- [x] New tests: `image-batch-route.unit.test.ts` (4 tests)
- [x] Migration rollback included
- [x] No signed URLs in DB — `result_storage_path` is a storage path; `resultSignedUrl` signed on GET read
- [x] `mode=preview` tested: creates rows, skips QStash

## Risks identified and mitigated

- `updateBatchProgress()` uses SELECT + UPDATE (not atomic increment). Concurrent job completions can race on the counter. Final count converges correctly; intermediate readings during a burst may be stale. Acceptable for V1.
- Budget pre-flight check (B3) is not yet wired — this endpoint creates and enqueues without checking spend. B3 adds it in the next slice without schema changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)