### PR TITLE
fix(service-health): dedup cron_stale events to prevent unresolved-row spam

### DIFF
--- a/app/api/internal/cron/heartbeat-check/route.ts
+++ b/app/api/internal/cron/heartbeat-check/route.ts
@@ -9,13 +9,23 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 // Heartbeat staleness threshold: each job must have run within 2× its schedule.
+//
+// Adding a new cron? Put its threshold here. The default fallback (30 min) is
+// wrong for anything other than a sub-30-min schedule — daily / weekly /
+// monthly crons trip the default constantly and create FALSE_POSITIVE
+// cron_stale rows. The dedup in record.ts now latches those to a single row
+// per cron, but the right fix is still to set the correct threshold.
 const STALENESS_THRESHOLDS: Record<string, number> = {
-  "publish-due":        2 * 60 * 1000,       // 2 min (runs every 1 min)
-  "heartbeat-check":    15 * 60 * 1000,      // 15 min (runs every 5 min)
-  "health-check":       15 * 60 * 1000,      // 15 min
-  "cleanup-cache":      26 * 60 * 60 * 1000, // 26h (runs daily)
-  "escalate-approvals": 8 * 60 * 60 * 1000,  // 8h (runs every 6h)
-  "health-digest":      26 * 60 * 60 * 1000, // 26h (runs daily)
+  "publish-due":                  2 * 60 * 1000,            // 2 min (runs every 1 min)
+  "heartbeat-check":              15 * 60 * 1000,           // 15 min (runs every 5 min)
+  "health-check":                 15 * 60 * 1000,           // 15 min
+  "cleanup-cache":                26 * 60 * 60 * 1000,      // 26h (runs daily)
+  "escalate-approvals":           8 * 60 * 60 * 1000,       // 8h (runs every 6h)
+  "health-digest":                26 * 60 * 60 * 1000,      // 26h (runs daily)
+  "cap-generation-runs-cleanup":  26 * 60 * 60 * 1000,      // 26h (runs daily at 02:00)
+  "cap-monthly-generation":       32 * 24 * 60 * 60 * 1000, // 32 days (runs 1st of month at 04:00)
+  "cap-weekly-generation":        8 * 24 * 60 * 60 * 1000,  // 8 days (runs Mondays at 06:00)
+  "cost-monitoring-daily-report": 26 * 60 * 60 * 1000,      // 26h (runs daily at 07:00)
 };
 
 // ---------------------------------------------------------------------------

--- a/lib/__tests__/service-health-record.unit.test.ts
+++ b/lib/__tests__/service-health-record.unit.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+
+// Tests the REAL recordHealthEvent dedup logic (other tests in
+// service-health.unit.test.ts mock the entire record module, so we need a
+// separate file to exercise it).
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// We control the Supabase client fully — every call is a mock we record.
+const supabaseCalls: Array<{ table: string; op: string; payload: unknown }> = [];
+
+interface QueryState {
+  filters: Record<string, unknown>;
+  isNull: string[];
+  notNull: string[];
+  gte: Record<string, string>;
+  orderBy: string | null;
+  limitVal: number | null;
+}
+
+let nextMaybeSingle: { data: unknown; error: unknown } = { data: null, error: null };
+
+function makeChain(table: string): unknown {
+  const state: QueryState = {
+    filters: {},
+    isNull: [],
+    notNull: [],
+    gte: {},
+    orderBy: null,
+    limitVal: null,
+  };
+  const chain: Record<string, unknown> = {
+    eq(field: string, value: unknown) {
+      state.filters[field] = value;
+      return chain;
+    },
+    is(field: string, value: unknown) {
+      if (value === null) state.isNull.push(field);
+      return chain;
+    },
+    gte(field: string, value: string) {
+      state.gte[field] = value;
+      return chain;
+    },
+    order(field: string, _opts: unknown) {
+      state.orderBy = field;
+      return chain;
+    },
+    limit(n: number) {
+      state.limitVal = n;
+      return chain;
+    },
+    async maybeSingle() {
+      supabaseCalls.push({ table, op: "select", payload: state });
+      return nextMaybeSingle;
+    },
+  };
+  return chain;
+}
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({
+    from(table: string) {
+      return {
+        select() {
+          return makeChain(table);
+        },
+        update(patch: unknown) {
+          return {
+            async eq(field: string, value: unknown) {
+              supabaseCalls.push({
+                table,
+                op: "update",
+                payload: { patch, where: { [field]: value } },
+              });
+              return { error: null };
+            },
+          };
+        },
+        async insert(row: unknown) {
+          supabaseCalls.push({ table, op: "insert", payload: row });
+          return { error: null };
+        },
+      };
+    },
+  }),
+}));
+
+import { recordHealthEvent } from "@/lib/platform/service-health/record";
+
+beforeEach(() => {
+  supabaseCalls.length = 0;
+  nextMaybeSingle = { data: null, error: null };
+});
+
+// ---------------------------------------------------------------------------
+// Dedup behaviour — latched event types (cron_stale)
+//
+// Regression: pre-fix, recordHealthEvent's dedup query did not filter by
+// operation, so different stale crons collided on the same row and
+// overwrote each other's operation field. It also used a 5-min window
+// regardless of event type, so a heartbeat-check fire every 5 min produced
+// ~12 unresolved rows per stale cron per hour (one per detector run after
+// the window expired). Multiply by N stale crons → email-spam from the
+// 30-min notification cooldown.
+// ---------------------------------------------------------------------------
+
+describe("recordHealthEvent — cron_stale latched dedup", () => {
+  test("first detection inserts a new row", async () => {
+    nextMaybeSingle = { data: null, error: null };
+
+    await recordHealthEvent({
+      serviceName: "cron",
+      operation: "cleanup-cache",
+      eventType: "cron_stale",
+      severity: "warning",
+      details: { jobName: "cleanup-cache" },
+    });
+
+    const inserts = supabaseCalls.filter((c) => c.op === "insert");
+    const updates = supabaseCalls.filter((c) => c.op === "update");
+    expect(inserts).toHaveLength(1);
+    expect(updates).toHaveLength(0);
+    expect((inserts[0].payload as { operation: string }).operation).toBe("cleanup-cache");
+  });
+
+  test("second detection of the SAME cron updates existing row (not insert)", async () => {
+    nextMaybeSingle = { data: { id: "row-1", occurrence_count: 1 }, error: null };
+
+    await recordHealthEvent({
+      serviceName: "cron",
+      operation: "cleanup-cache",
+      eventType: "cron_stale",
+      severity: "warning",
+      details: { jobName: "cleanup-cache" },
+    });
+
+    const inserts = supabaseCalls.filter((c) => c.op === "insert");
+    const updates = supabaseCalls.filter((c) => c.op === "update");
+    expect(inserts).toHaveLength(0);
+    expect(updates).toHaveLength(1);
+    expect((updates[0].payload as { patch: { occurrence_count: number } }).patch.occurrence_count).toBe(2);
+  });
+
+  test("cron_stale dedup query filters by operation (so different crons get separate rows)", async () => {
+    nextMaybeSingle = { data: null, error: null };
+
+    await recordHealthEvent({
+      serviceName: "cron",
+      operation: "health-digest",
+      eventType: "cron_stale",
+      severity: "warning",
+      details: { jobName: "health-digest" },
+    });
+
+    // The select chain captured the filter state. Verify operation was applied.
+    const selects = supabaseCalls.filter((c) => c.op === "select");
+    expect(selects).toHaveLength(1);
+    const state = selects[0].payload as QueryState;
+    expect(state.filters.operation).toBe("health-digest");
+    expect(state.filters.service_name).toBe("cron");
+    expect(state.filters.event_type).toBe("cron_stale");
+    expect(state.isNull).toContain("resolved_at");
+    // Latched event type → NO time-window filter on last_seen_at.
+    expect(state.gte.last_seen_at).toBeUndefined();
+  });
+
+  test("non-latched event types KEEP the 5-min aggregation window", async () => {
+    nextMaybeSingle = { data: null, error: null };
+
+    await recordHealthEvent({
+      serviceName: "bundle.social",
+      operation: "publish",
+      eventType: "service_5xx",
+      severity: "warning",
+      details: {},
+    });
+
+    const selects = supabaseCalls.filter((c) => c.op === "select");
+    const state = selects[0].payload as QueryState;
+    // Bursty event type → time-window filter applied.
+    expect(state.gte.last_seen_at).toBeDefined();
+    expect(state.filters.operation).toBe("publish");
+  });
+
+  test("undefined operation matches IS NULL (service-level events)", async () => {
+    nextMaybeSingle = { data: null, error: null };
+
+    await recordHealthEvent({
+      serviceName: "sendgrid",
+      // no operation
+      eventType: "service_5xx",
+      severity: "critical",
+      details: {},
+    });
+
+    const selects = supabaseCalls.filter((c) => c.op === "select");
+    const state = selects[0].payload as QueryState;
+    expect(state.isNull).toContain("operation");
+    expect(state.isNull).toContain("resolved_at");
+  });
+});

--- a/lib/platform/service-health/record.ts
+++ b/lib/platform/service-health/record.ts
@@ -5,34 +5,70 @@ import { logger } from "@/lib/logger";
 import type { RecordEventInput } from "./types";
 
 // Aggregation window: events of the same (service, operation, event_type)
-// within this window are merged by incrementing occurrence_count.
+// within this window are merged by incrementing occurrence_count. Used for
+// bursty failure types (5xx, rate_limit, connection_failure) where multiple
+// occurrences within a few minutes are the same incident.
 const AGGREGATE_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+// Latched event types: once raised, they stay true until a recovery flips
+// resolved_at. There is no point inserting multiple unresolved rows for the
+// same (service, operation) — they all describe the same persistent state.
+// Dedup these by ANY existing unresolved row, regardless of time window.
+//
+// Why this matters: the heartbeat-check cron fires every 5 minutes. Without
+// latched dedup, a single stale cron produces ~12 rows per hour (one per
+// detector run after the 5-min window expires). Multiply by N stale crons
+// and the unresolved-row count grows without bound. The notifier cooldown
+// fires on every new row → email spam.
+const LATCHED_EVENT_TYPES = new Set<string>(["cron_stale"]);
 
 /**
  * Write a service health event to service_health_events.
  *
- * Within the 5-min aggregation window, updates the existing unresolved row
- * (increments occurrence_count + bumps last_seen_at). Outside the window,
- * or when no unresolved row exists, inserts a new row.
+ * Dedup behaviour depends on event type:
+ *   - Bursty types (default): within a 5-min window, update the existing
+ *     unresolved row matching (service, operation, event_type). Outside the
+ *     window or on first occurrence, insert.
+ *   - Latched types (LATCHED_EVENT_TYPES — currently cron_stale): drop the
+ *     time window. Any existing unresolved row matching
+ *     (service, operation, event_type) is updated; otherwise insert.
+ *
+ * The dedup query MUST include operation — multiple distinct operations of
+ * the same service can be failing simultaneously and need separate rows.
+ * Pre-fix code didn't filter on operation, so different crons collided on
+ * a single row, overwriting each other's operation field.
  *
  * Never throws — a logging failure must not cascade into the caller.
  */
 export async function recordHealthEvent(input: RecordEventInput): Promise<void> {
   try {
     const svc = getServiceRoleClient();
-    const windowStart = new Date(Date.now() - AGGREGATE_WINDOW_MS).toISOString();
+    const isLatched = LATCHED_EVENT_TYPES.has(input.eventType);
 
-    // Look for an existing unresolved event in the aggregation window.
-    const { data: existing } = await svc
+    // Look for an existing unresolved event matching service+operation+type.
+    let query = svc
       .from("service_health_events")
       .select("id, occurrence_count")
       .eq("service_name", input.serviceName)
       .eq("event_type", input.eventType)
       .is("resolved_at", null)
-      .gte("last_seen_at", windowStart)
       .order("last_seen_at", { ascending: false })
-      .limit(1)
-      .maybeSingle();
+      .limit(1);
+
+    // Operation may be undefined (e.g. service-level events); match exactly.
+    if (input.operation !== undefined) {
+      query = query.eq("operation", input.operation);
+    } else {
+      query = query.is("operation", null);
+    }
+
+    // Bursty types: scope to the recent window. Latched types: any unresolved row.
+    if (!isLatched) {
+      const windowStart = new Date(Date.now() - AGGREGATE_WINDOW_MS).toISOString();
+      query = query.gte("last_seen_at", windowStart);
+    }
+
+    const { data: existing } = await query.maybeSingle();
 
     if (existing) {
       await svc
@@ -40,7 +76,6 @@ export async function recordHealthEvent(input: RecordEventInput): Promise<void> 
         .update({
           occurrence_count: existing.occurrence_count + 1,
           last_seen_at: new Date().toISOString(),
-          ...(input.operation !== undefined && { operation: input.operation }),
           details: input.details ?? {},
         })
         .eq("id", existing.id);


### PR DESCRIPTION
## Symptom

Daily service-health digest showed ~100 cron_stale events firing every 5 minutes over 5 hours. Diagnostic query confirmed **276 unresolved cron_stale rows across 7 distinct crons in the last 24 hours.**

Same architectural pattern as PR #1132 (the bundle.social stuck-row incident) — a dedup mechanism keyed on per-process / time-window state that fails to converge across the long-running nature of latched failures.

## Phase 1 classification breakdown

| Cron | Rows (24h) | last_run_at | Schedule | Threshold (actual / correct) | Classification |
|---|---|---|---|---|---|
| `cap-generation-runs-cleanup` | 79 | 2026-05-28T02:00:30 | daily 02:00 | 30min default / **~26h needed** | **FALSE_POSITIVE** — missing from threshold table |
| `cap-monthly-generation` | 57 | 2026-05-19T10:38:59 | monthly | 30min default / **~32d needed** | **FALSE_POSITIVE** — missing threshold; next due 2026-06-01 |
| `cleanup-cache` | 78 | 2026-05-18 (seed) | daily 03:00 | 26h / correct | **REAL_STALE** — needs human triage |
| `health-digest` | 51 | 2026-05-18 (seed) | daily 23:00 | 26h / correct | **REAL_STALE** — needs human triage |
| `escalate-approvals` | 9 | 2026-05-18 (seed) | every 6h | 8h / correct | **REAL_STALE** — needs human triage |
| `health-check` | 1 | 2026-05-18 (seed) | every 5min | 15min / correct | **AMBIGUOUS** — cron IS running (sent bundle.social alert at 22:15 UTC yesterday) but heartbeat not updating |
| `heartbeat-check` | 1 | 2026-05-18 (seed) | every 5min | 15min / correct | **AMBIGUOUS** — cron IS running (it created the 276 events) but heartbeat not updating |

The `2026-05-18T13:43:45` timestamp on 6 of the 7 stale entries is the moment migration 0135 was applied. That migration seeded the `cron_heartbeats` table; for crons whose `updateHeartbeat()` calls aren't landing, the seed value persists.

## Root causes (this PR addresses both)

**1. Dedup query didn't filter by operation.** Different stale crons collided on the same `service_health_events` row, overwriting each other's `operation` field. The detector then inserted new rows on subsequent 5-min passes because the time-window kept expiring between the latest update and the next detector pass.

**2. 5-minute aggregation window is wrong for latched events.** `cron_stale` describes a persistent state — once a cron is stale, it stays stale until the cron runs again. Bursty event types (5xx, 429, connection_failure) genuinely want the 5-min window because multiple errors in a few minutes are the same incident. `cron_stale` doesn't.

**3. Missing thresholds.** `cap-generation-runs-cleanup`, `cap-monthly-generation`, `cap-weekly-generation`, `cost-monitoring-daily-report` weren't in the `STALENESS_THRESHOLDS` table. They hit the 30-min default — wildly wrong for daily / weekly / monthly schedules.

## Fix

- **`lib/platform/service-health/record.ts`**:
  - Added `LATCHED_EVENT_TYPES = new Set(['cron_stale'])`.
  - Dedup query now filters by `operation` (exact `eq` or `is null` for service-level events).
  - For latched types, the `gte(last_seen_at, windowStart)` filter is dropped — any existing unresolved row matching service+operation+event_type is a dedup target.
  - Bursty types keep the 5-min window — no behaviour change.
- **`app/api/internal/cron/heartbeat-check/route.ts`**:
  - Added thresholds for the 4 missing crons.

## Tests

`lib/__tests__/service-health-record.unit.test.ts` (new file — the existing `service-health.unit.test.ts` mocks the entire record module, so a separate file is needed to exercise the real `recordHealthEvent`). 5 tests covering:
- First detection inserts.
- Second detection of the same cron updates the existing row (not insert).
- Dedup query filters by operation.
- Latched event types skip the time window.
- Non-latched event types keep the window.
- IS NULL operation handling for service-level events.

## Verification

Pre-commit hook ran clean **without `SKIP_PRECOMMIT_TESTS`** — 135 files, 2589 tests passed in 97.78s.

## Follow-up after merge + deploy

1. **One-shot UPDATE to clear FALSE_POSITIVE rows** — only for `cap-generation-runs-cleanup` and `cap-monthly-generation` (the two crons whose only issue was the missing threshold). Leave REAL_STALE and AMBIGUOUS rows alone.
2. **REAL_STALE triage (Phase 3)**: `cleanup-cache`, `health-digest`, `escalate-approvals` have not run since migration 0135 applied 11 days ago. All three live at `/api/internal/cron/...`. Possibly a Vercel cron config issue (the routes are scheduled in `vercel.json` but may not be wired to actually fire), possibly a deploy regression. **Surfaced separately — not auto-fixed.**
3. **AMBIGUOUS triage**: `health-check` and `heartbeat-check` are confirmed running (one sent the bundle.social notification email yesterday at 22:15 UTC, the other created the 276 cron_stale events). Their `updateHeartbeat()` calls aren't landing. Separate bug — out of scope here. Surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)