### PR TITLE
fix(service-health): cron heartbeat triggers recovery sweep for stale events

### DIFF
--- a/lib/__tests__/cron-heartbeat-recovery.unit.test.ts
+++ b/lib/__tests__/cron-heartbeat-recovery.unit.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+
+// Tests the recovery-sweep wiring added in fix/cron-heartbeat-recovery-sweep:
+//   1. recordCronRecovery() finds + resolves unresolved cron_stale rows for a
+//      given jobName, safe-degrades on Supabase error.
+//   2. updateHeartbeat() calls recordCronRecovery() ONLY when status='ok'.
+//
+// Companion to service-health-record.unit.test.ts (which mocks the entire
+// supabase chain for recordHealthEvent's dedup logic). This file uses its own
+// chainable mock because recordCronRecovery's UPDATE chain is deeper:
+//   .update(...).eq().eq().eq().is().select()
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Chainable Supabase mock — captures (filters, terminal verb, result)
+// ---------------------------------------------------------------------------
+
+interface ChainCall {
+  table: string;
+  op: "select" | "update" | "insert" | "delete";
+  filters: Record<string, unknown>;
+  isNull: string[];
+  patch?: unknown;
+  inserted?: unknown;
+  terminal: "select" | "maybeSingle" | "single" | "none";
+}
+
+const calls: ChainCall[] = [];
+let nextUpdateSelectResult: { data: unknown; error: unknown } = { data: [], error: null };
+let nextHeartbeatMaybeSingleResult: { data: unknown; error: unknown } = {
+  data: { run_count: 5 },
+  error: null,
+};
+
+function makeUpdateChain(table: string, patch: unknown): unknown {
+  const call: ChainCall = {
+    table,
+    op: "update",
+    filters: {},
+    isNull: [],
+    patch,
+    terminal: "none",
+  };
+  const chain: Record<string, unknown> = {
+    eq(field: string, value: unknown) {
+      call.filters[field] = value;
+      return chain;
+    },
+    is(field: string, value: unknown) {
+      if (value === null) call.isNull.push(field);
+      return chain;
+    },
+    neq(_field: string, _value: unknown) {
+      return chain;
+    },
+    async select(_cols?: string) {
+      call.terminal = "select";
+      calls.push(call);
+      return nextUpdateSelectResult;
+    },
+  };
+  // Also handle the terminal-eq case used by updateHeartbeat (no .select()).
+  // Solution: wrap chain so awaiting it (the final .eq) resolves to a result.
+  const thenable: Record<string, unknown> & PromiseLike<unknown> = {
+    ...chain,
+    then(onfulfilled: ((v: unknown) => unknown) | null | undefined) {
+      call.terminal = "none";
+      calls.push(call);
+      return Promise.resolve({ error: null }).then(onfulfilled ?? ((v) => v));
+    },
+  } as never;
+  // Make .eq chainable AND awaitable.
+  const eqHandler = (field: string, value: unknown): unknown => {
+    call.filters[field] = value;
+    return thenable;
+  };
+  thenable.eq = eqHandler;
+  return thenable;
+}
+
+function makeSelectChain(table: string): unknown {
+  const call: ChainCall = {
+    table,
+    op: "select",
+    filters: {},
+    isNull: [],
+    terminal: "none",
+  };
+  const chain: Record<string, unknown> = {
+    eq(field: string, value: unknown) {
+      call.filters[field] = value;
+      return chain;
+    },
+    is(field: string, value: unknown) {
+      if (value === null) call.isNull.push(field);
+      return chain;
+    },
+    async maybeSingle() {
+      call.terminal = "maybeSingle";
+      calls.push(call);
+      return nextHeartbeatMaybeSingleResult;
+    },
+  };
+  return chain;
+}
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({
+    from(table: string) {
+      return {
+        select(_cols?: string) {
+          return makeSelectChain(table);
+        },
+        update(patch: unknown) {
+          return makeUpdateChain(table, patch);
+        },
+      };
+    },
+  }),
+}));
+
+import { recordCronRecovery } from "@/lib/platform/service-health/record";
+import { updateHeartbeat } from "@/lib/platform/cron/cron-shared";
+import { logger } from "@/lib/logger";
+
+beforeEach(() => {
+  calls.length = 0;
+  nextUpdateSelectResult = { data: [], error: null };
+  nextHeartbeatMaybeSingleResult = { data: { run_count: 5 }, error: null };
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// recordCronRecovery
+// ---------------------------------------------------------------------------
+
+describe("recordCronRecovery", () => {
+  test("issues an UPDATE filtered by service+event_type+operation+resolved_at=null", async () => {
+    nextUpdateSelectResult = { data: [], error: null };
+
+    await recordCronRecovery("cleanup-cache");
+
+    const updates = calls.filter((c) => c.op === "update" && c.table === "service_health_events");
+    expect(updates).toHaveLength(1);
+    const u = updates[0];
+    expect(u.filters.service_name).toBe("cron");
+    expect(u.filters.event_type).toBe("cron_stale");
+    expect(u.filters.operation).toBe("cleanup-cache");
+    expect(u.isNull).toContain("resolved_at");
+    expect((u.patch as { resolved_at: string }).resolved_at).toBeDefined();
+  });
+
+  test("logs sweep info when rows were resolved", async () => {
+    nextUpdateSelectResult = { data: [{ id: "row-1" }, { id: "row-2" }], error: null };
+
+    await recordCronRecovery("escalate-approvals");
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "service_health.cron_recovery_swept",
+      expect.objectContaining({ jobName: "escalate-approvals", resolved_count: 2 }),
+    );
+  });
+
+  test("does NOT log a sweep when zero rows resolved (steady-state, common case)", async () => {
+    nextUpdateSelectResult = { data: [], error: null };
+
+    await recordCronRecovery("publish-due");
+
+    expect(logger.info).not.toHaveBeenCalledWith(
+      "service_health.cron_recovery_swept",
+      expect.anything(),
+    );
+  });
+
+  test("safe-degrades on Supabase error (logs warn, does not throw)", async () => {
+    nextUpdateSelectResult = { data: null, error: { message: "connection refused" } };
+
+    await expect(recordCronRecovery("any-cron")).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "service_health.cron_recovery_failed",
+      expect.objectContaining({ jobName: "any-cron" }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateHeartbeat — recovery sweep is gated on status
+// ---------------------------------------------------------------------------
+
+describe("updateHeartbeat — recovery sweep gating", () => {
+  test("status='ok' triggers the recovery sweep", async () => {
+    nextHeartbeatMaybeSingleResult = { data: { run_count: 10 }, error: null };
+    nextUpdateSelectResult = { data: [{ id: "stale-1" }], error: null };
+
+    await updateHeartbeat("cleanup-cache", "ok");
+
+    // Two updates against service_health_events: zero. One update against
+    // cron_heartbeats (the heartbeat itself). One update against
+    // service_health_events (the recovery sweep).
+    const heartbeatUpdates = calls.filter(
+      (c) => c.op === "update" && c.table === "cron_heartbeats",
+    );
+    const recoveryUpdates = calls.filter(
+      (c) => c.op === "update" && c.table === "service_health_events",
+    );
+    expect(heartbeatUpdates).toHaveLength(1);
+    expect(recoveryUpdates).toHaveLength(1);
+    expect(recoveryUpdates[0].filters.operation).toBe("cleanup-cache");
+  });
+
+  test("status='error' does NOT trigger the recovery sweep", async () => {
+    nextHeartbeatMaybeSingleResult = { data: { run_count: 10 }, error: null };
+
+    await updateHeartbeat("cleanup-cache", "error", new Error("db error"));
+
+    const recoveryUpdates = calls.filter(
+      (c) => c.op === "update" && c.table === "service_health_events",
+    );
+    expect(recoveryUpdates).toHaveLength(0);
+  });
+
+  test("recovery-sweep error does not break the heartbeat update", async () => {
+    nextHeartbeatMaybeSingleResult = { data: { run_count: 10 }, error: null };
+    nextUpdateSelectResult = { data: null, error: { message: "boom" } };
+
+    await expect(updateHeartbeat("cleanup-cache", "ok")).resolves.toBeUndefined();
+
+    const heartbeatUpdates = calls.filter(
+      (c) => c.op === "update" && c.table === "cron_heartbeats",
+    );
+    expect(heartbeatUpdates).toHaveLength(1); // heartbeat still wrote
+    expect(logger.warn).toHaveBeenCalledWith(
+      "service_health.cron_recovery_failed",
+      expect.objectContaining({ jobName: "cleanup-cache" }),
+    );
+  });
+});

--- a/lib/platform/cron/cron-shared.ts
+++ b/lib/platform/cron/cron-shared.ts
@@ -5,6 +5,7 @@ import { getServiceRoleClient } from "@/lib/supabase";
 import { logger } from "@/lib/logger";
 import { constantTimeEqual } from "@/lib/crypto-compare";
 import { sideEffectsGuarded } from "@/lib/runtime-env";
+import { recordCronRecovery } from "@/lib/platform/service-health/record";
 
 export function authorisedCronRequest(req: NextRequest): boolean {
   const secret = process.env.CRON_SECRET;
@@ -60,5 +61,17 @@ export async function updateHeartbeat(jobName: string, status: "ok" | "error", l
       .eq("job_name", jobName);
   } catch (err) {
     logger.warn("cron.heartbeat_update_failed", { jobName, err: err instanceof Error ? err.message : String(err) });
+  }
+
+  // Recovery sweep — only on success. A successful cron run means the cron
+  // is no longer stale; any unresolved cron_stale events for it should be
+  // marked resolved. Failures must NOT clear unresolved alerts; that would
+  // mask the very failure the alert is reporting.
+  //
+  // The sweep is non-blocking and never throws: recordCronRecovery catches
+  // its own errors. Mirrors the withHealthMonitoring → recordRecovery
+  // pattern from PR #1132 for external-service recovery.
+  if (status === "ok") {
+    await recordCronRecovery(jobName);
   }
 }

--- a/lib/platform/service-health/record.ts
+++ b/lib/platform/service-health/record.ts
@@ -143,6 +143,54 @@ export async function hasUnresolvedHealthEvent(
 }
 
 /**
+ * Resolve stale-cron events for a job that just ran successfully.
+ *
+ * Parallel to recordRecovery() (PR #1132) — that function handles
+ * external-service recovery via withHealthMonitoring; this one handles
+ * cron recovery via updateHeartbeat(). Both clear unresolved health rows
+ * the moment the underlying thing starts working again, so the system
+ * self-heals across the deploy / restart / process-restart boundary.
+ *
+ * Called from updateHeartbeat() ONLY on the success path (status='ok').
+ * A failed heartbeat must NOT clear unresolved alerts — that would mask
+ * the very failure the alert is reporting.
+ *
+ * Never throws — a recovery-sweep failure must never break the cron's
+ * main work or its heartbeat update. Logs warn on Supabase errors.
+ */
+export async function recordCronRecovery(jobName: string): Promise<void> {
+  try {
+    const svc = getServiceRoleClient();
+    const { data, error } = await svc
+      .from("service_health_events")
+      .update({ resolved_at: new Date().toISOString() })
+      .eq("service_name", "cron")
+      .eq("event_type", "cron_stale")
+      .eq("operation", jobName)
+      .is("resolved_at", null)
+      .select("id");
+    if (error) {
+      logger.warn("service_health.cron_recovery_failed", {
+        jobName,
+        err: error.message,
+      });
+      return;
+    }
+    if (data && data.length > 0) {
+      logger.info("service_health.cron_recovery_swept", {
+        jobName,
+        resolved_count: data.length,
+      });
+    }
+  } catch (err) {
+    logger.warn("service_health.cron_recovery_threw", {
+      jobName,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
  * Mark a service as recovered — resolves all open events for the service.
  * Called by withHealthMonitoring on a successful call after prior failures.
  */


### PR DESCRIPTION
## Summary

Parallel pattern to **PR #1132** (`fix(service-health): cross-process recovery sweep via DB query`). PR #1132 wired `withHealthMonitoring → recordRecovery` for external-service health events — a successful API call clears unresolved health rows for that service. This PR wires `updateHeartbeat → recordCronRecovery` for crons — a successful cron run clears unresolved `cron_stale` rows for that job.

This is the system-fix complement to **PR #1141** (`fix(service-health): dedup cron_stale events`):
- #1141 stopped the row count from growing (latched event type + per-operation dedup).
- This PR self-heals existing rows — once a cron starts running again, its old `cron_stale` events get marked `resolved_at` on the next successful heartbeat.

## Why this is needed

After PR #1123 unblocked `/api/internal/cron/*` on 2026-05-28, every previously-stuck cron started running again. But the 278 `cron_stale` rows accumulated during the 10-day middleware-blocked window never self-resolved — they sat unresolved until I manually cleared them in Part 1 of this work session.

Without this PR, the same pattern would recur on every future deploy / middleware / config change that briefly blocks a cron. Manual cleanup is not a system fix.

## Implementation

### `lib/platform/service-health/record.ts` — new function

```typescript
export async function recordCronRecovery(jobName: string): Promise<void>
```

Issues a single UPDATE filtered by:
- `service_name = 'cron'`
- `event_type = 'cron_stale'`
- `operation = <jobName>`
- `resolved_at IS NULL`

Returns ids of resolved rows. Logs `service_health.cron_recovery_swept` only when count > 0 (no noise in the steady-state-no-rows case). Safe-degrades on Supabase error (logs warn, never throws).

### `lib/platform/cron/cron-shared.ts` — `updateHeartbeat` wiring

```typescript
if (status === \"ok\") {
  await recordCronRecovery(jobName);
}
```

Called outside the try/catch around the heartbeat write, so a sweep failure doesn't roll back the heartbeat update. **Gating: only on success.** A failed heartbeat must not clear unresolved alerts — that would mask the very failure the alert is reporting.

## Tests

`lib/__tests__/cron-heartbeat-recovery.unit.test.ts` — 7 tests:

1. `recordCronRecovery` issues UPDATE with correct filters (service+event_type+operation+resolved_at IS NULL).
2. Logs `service_health.cron_recovery_swept` when rows resolved.
3. Does NOT log a sweep when zero rows resolved (steady-state).
4. Safe-degrades on Supabase error (logs warn, does not throw).
5. `updateHeartbeat` status='ok' triggers the sweep.
6. `updateHeartbeat` status='error' does NOT trigger the sweep.
7. Recovery-sweep failure does not break the heartbeat update.

## Verification

Pre-commit hook ran clean **without `SKIP_PRECOMMIT_TESTS`** — 137 files, 2604 tests passed in 91.50s.

Service-health test cluster (`service-health.unit.test.ts` + `service-health-record.unit.test.ts` + `cron-heartbeat-recovery.unit.test.ts`): 30/30 pass in 2.27s.

## Operational impact

Once deployed, every cron at `/api/cron/*` and `/api/internal/cron/*` that successfully runs will sweep its own unresolved `cron_stale` events. The next cron tick after the deploy (~1 min for `publish-due`, ~5 min for `heartbeat-check`/`health-check`, ~6h for `escalate-approvals`, etc.) starts the self-healing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)