### PR TITLE
feat(image-gen): slice A4 — wire compositeImage() into mood board route

### DIFF
--- a/app/api/platform/image/generate/route.ts
+++ b/app/api/platform/image/generate/route.ts
@@ -10,24 +10,33 @@ import {
   getAllowedStyles,
   validateStyleForBrand,
 } from "@/lib/image";
+import { compositeImage, TEXT_ZONE_MAP } from "@/lib/image/compositing";
+import type { CompositeInput } from "@/lib/image/compositing";
+import { getTemplateV1 } from "@/lib/image/compositing/templates-v1";
 import { getServiceRoleClient } from "@/lib/supabase";
 import type { AspectRatio, CompositionType, StyleId } from "@/lib/image";
 
 // ---------------------------------------------------------------------------
-// POST /api/platform/image/generate — I4 mood board generation
+// POST /api/platform/image/generate — I4 mood board generation (A4)
 //
-// Generates 4–6 background images for the customer to select from.
-// Each image goes through generateWithFallback() (Ideogram → quality
-// check → stock fallback if needed) and is stored in Supabase Storage.
-// Returns signed URLs for immediate display in the mood board UI.
+// Generates 4–6 composited images for the customer to select from.
+// Each image goes through:
+//   1. generateWithFallback() → Ideogram background → Supabase Storage
+//   2. compositeImage() → sharp renderer → overlay band + headline text
+//      + brand logo (if available) → composite stored at /composite/ prefix
 //
-// Auth: requires `create_post` permission (editor+ or Opollo staff).
+// Returns signed URLs for the composites (not raw backgrounds).
+//
+// Uses code templates from lib/image/compositing/templates-v1.ts (A-NEW-1).
+// Will be migrated to database templates in A-NEW-4's follow-up.
+//
+// Auth: canDo("create_post") — editor+.
 // Feature gate: IMAGE_FEATURE_MOOD_BOARD must be "true".
 // ---------------------------------------------------------------------------
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-export const maxDuration = 120; // Ideogram can take ~30s per image
+export const maxDuration = 120; // ~11s Ideogram + ~1s compositing per image; 6 parallel = ~15s total
 
 const IMAGE_GEN_BUCKET =
   process.env.IMAGE_GENERATION_BUCKET ?? "generated-images";
@@ -52,6 +61,9 @@ const GenerateSchema = z.object({
   aspect_ratio: z.enum(["1x1", "4x5", "9x16", "16x9", "4x3"]),
   count: z.number().int().min(1).max(6).default(4),
   post_master_id: z.string().uuid().optional(),
+  // A4 addition: user-supplied headline for the overlay text.
+  // Default "Headline preview" is applied server-side when blank.
+  headline: z.string().max(120).optional(),
 });
 
 export async function POST(req: NextRequest) {
@@ -80,7 +92,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const { company_id: companyId, style_id, composition_type, aspect_ratio, count, post_master_id } =
+  const { company_id: companyId, style_id, composition_type, aspect_ratio, count, post_master_id, headline } =
     parsed.data;
 
   const gateResult = await requireCanDoForApi(companyId, "create_post");
@@ -90,7 +102,7 @@ export async function POST(req: NextRequest) {
 
   const { userId } = gateResult;
 
-  // Validate style against brand profile (safe_mode + approved_style_ids)
+  // Validate style against brand profile (safe_mode + approved_style_ids).
   const brand = await getActiveBrandProfile(companyId);
   try {
     validateStyleForBrand(style_id as StyleId, brand);
@@ -117,11 +129,20 @@ export async function POST(req: NextRequest) {
     userId,
   });
 
-  // Generate all images in parallel; use allSettled so partial failure
-  // doesn't abort the whole board.
   const primaryColour = brand?.primary_colour ?? "#1A1A1A";
   const industry = brand?.industry ?? undefined;
+  const headlineText = headline?.trim() || "Headline preview";
 
+  // Code template for this aspect ratio (from A-NEW-1 templates-v1.ts).
+  // Migrated to DB templates in A-NEW-4.
+  const template = getTemplateV1(aspect_ratio as AspectRatio);
+  const textZone = TEXT_ZONE_MAP[composition_type as CompositionType];
+
+  // Brand logo: prefer icon variant, fall back to primary.
+  // Used directly as-is; compositor handles fetch failure gracefully.
+  const logoUrl = brand?.logo_icon_url ?? brand?.logo_primary_url ?? null;
+
+  // Generate all backgrounds in parallel.
   const generationTasks = Array.from({ length: count }, (_, i) =>
     generateWithFallback({
       styleId: style_id as StyleId,
@@ -145,31 +166,73 @@ export async function POST(req: NextRequest) {
     }),
   );
 
-  const results = await Promise.all(generationTasks);
-  const successful = results.filter(
-    (r): r is NonNullable<typeof r> => r !== null,
-  );
+  const generationResults = await Promise.all(generationTasks);
+  const backgrounds = generationResults.filter((r): r is NonNullable<typeof r> => r !== null);
 
-  if (successful.length === 0) {
+  if (backgrounds.length === 0) {
     return NextResponse.json(
       { ok: false, error: { code: "GENERATION_FAILED", message: "All image generation attempts failed." } },
       { status: 502 },
     );
   }
 
-  // Get signed URLs for display
+  // Composite each background with overlay + text + logo.
+  const compositeResults = await Promise.all(
+    backgrounds.map(async (bg) => {
+      const compositeInput: CompositeInput = {
+        backgroundStoragePath: bg.storagePath,
+        textZones: [{
+          ...textZone,
+          text: headlineText,
+          maxFontSize: template.maxHeadlineFontSize,
+          colour: "white", // white text on dark overlay band
+        }],
+        logo: logoUrl
+          ? {
+              url: logoUrl,
+              position: template.logoPosition,
+              sizePercent: template.logoSizePercent,
+              padding: template.logoPadding,
+            }
+          : null,
+        outputFormat: bg.format === "png" ? "png" : "jpeg",
+        outputWidth: bg.width,
+        outputHeight: bg.height,
+      };
+
+      try {
+        return await compositeImage(compositeInput);
+      } catch (err) {
+        logger.warn("mood-board.composite.partial-failure", {
+          companyId,
+          backgroundPath: bg.storagePath,
+          error: String(err),
+        });
+        // Degrade: return the raw background path so the board doesn't lose a slot
+        return {
+          storagePath: bg.storagePath,
+          provider: "fallback_raw",
+          durationMs: 0,
+        };
+      }
+    }),
+  );
+
+  // Sign URLs for display (composite paths).
   const supabase = getServiceRoleClient();
   const images = await Promise.all(
-    successful.map(async (img) => {
+    compositeResults.map(async (comp, i) => {
+      const bg = backgrounds[i]!;
       const { data } = await supabase.storage
         .from(IMAGE_GEN_BUCKET)
-        .createSignedUrl(img.storagePath, SIGNED_URL_TTL);
+        .createSignedUrl(comp.storagePath, SIGNED_URL_TTL);
       return {
-        storagePath: img.storagePath,
+        storagePath: comp.storagePath,
         signedUrl: data?.signedUrl ?? null,
-        width: img.width,
-        height: img.height,
-        format: img.format,
+        width: bg.width,
+        height: bg.height,
+        format: bg.format,
+        composited: comp.provider !== "fallback_raw",
       };
     }),
   );
@@ -178,6 +241,7 @@ export async function POST(req: NextRequest) {
     companyId,
     requested: count,
     generated: images.length,
+    composited: images.filter((i) => i.composited).length,
     userId,
   });
 

--- a/components/MoodBoardClient.tsx
+++ b/components/MoodBoardClient.tsx
@@ -86,6 +86,7 @@ export function MoodBoardClient({
   );
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>("1x1");
   const [count, setCount] = useState<(typeof COUNT_OPTIONS)[number]>(4);
+  const [headline, setHeadline] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [images, setImages] = useState<GeneratedImageResult[]>([]);
@@ -107,6 +108,7 @@ export function MoodBoardClient({
           composition_type: composition,
           aspect_ratio: aspectRatio,
           count,
+          headline: headline.trim() || undefined, // blank → server default "Headline preview"
         }),
       });
       const json = (await res.json()) as {
@@ -222,6 +224,25 @@ export function MoodBoardClient({
           </div>
         </div>
       </section>
+
+      {/* Headline text input — composited onto each generated image */}
+      <div>
+        <label htmlFor="mood-board-headline" className="mb-1.5 block text-sm font-medium">
+          Headline text
+        </label>
+        <input
+          id="mood-board-headline"
+          type="text"
+          value={headline}
+          onChange={(e) => setHeadline(e.target.value)}
+          maxLength={120}
+          placeholder="Headline preview"
+          className="w-full max-w-md rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          Appears as an overlay on each generated image. Leave blank for &quot;Headline preview&quot;.
+        </p>
+      </div>
 
       {/* Generate button */}
       <div>


### PR DESCRIPTION
## Summary

The mood board route now returns **composited images** (overlay band + headline text + brand logo) instead of raw Ideogram backgrounds. First real composited output visible to operators.

**Visual checkpoint**: A4 requires Steven's visual review of a live mood board output before merge. To test: set `IMAGE_FEATURE_MOOD_BOARD=true` in Vercel, open `/company/image/generate`, enter a headline, generate. Per the addendum, Steven reviews and approves before this PR merges.

## Changes

**`app/api/platform/image/generate/route.ts`**
- Added `headline` field to request schema (optional, max 120 chars)
- After each background: builds `CompositeInput` from `TEXT_ZONE_MAP[compositionType]` + `getTemplateV1(aspectRatio)` → calls `compositeImage()`
- Brand logo: `brand.logo_icon_url ?? brand.logo_primary_url` — compositor handles download failure gracefully (no logo if URL fails, slot not lost)
- Composite failure degrades to raw background path so the board never loses a slot
- Returns `composited: boolean` per image so UI can surface status
- Uses code templates from `lib/image/compositing/templates-v1.ts` (A-NEW-1); migrated to DB templates in A-NEW-4

**`components/MoodBoardClient.tsx`**
- Added `headline` state + `<input>` ("Headline text", max 120 chars, placeholder "Headline preview")
- Headline sent in POST body; blank → server default "Headline preview"

## Pre-PR checklist

- [x] Lint, typecheck clean
- [x] `test:unit` 2608/2608 pass
- [x] PR references §1.8 of addendum (code templates, A-NEW-4 migration note)
- [x] PR under 500 net lines (108+/23−, 2 files)

## Risks identified and mitigated

- Logo fetch is best-effort. If `brand.logo_icon_url` is a signed URL that has expired, the compositor logs a warning and renders without logo. Acceptable for v1 — A-NEW-4 will sign fresh URLs at composite time.
- `IMAGE_FEATURE_MOOD_BOARD` is not set in Vercel production currently. The visual checkpoint requires enabling it temporarily in a preview deployment or production.
- Composite failure falls back to raw background (no silent data loss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)