### PR TITLE
fix(env): add Supabase env consistency CI guard

### DIFF
--- a/.github/workflows/env-consistency.yml
+++ b/.github/workflows/env-consistency.yml
@@ -1,0 +1,82 @@
+name: Supabase env consistency
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches: [main]
+
+# Catches the class of env-drift that caused the 2026-05-29 publish-due
+# incident: SUPABASE_URL pointing at one Supabase project while
+# SUPABASE_DB_URL pointed at a different one (or used the direct-connection
+# host format that's IPv6-only and unreachable from Vercel).
+#
+# Required GitHub repo secrets to enable the "production-mirror" check job:
+#   SUPABASE_URL                — same value as in Vercel production env
+#   SUPABASE_DB_URL             — same value as in Vercel production env
+#   NEXT_PUBLIC_SUPABASE_URL    — optional; only set if Vercel production has it
+#
+# The unit-tests job runs unconditionally on every push/PR and proves the
+# check script's logic is correct. The production-mirror job only fires when
+# the secrets above are configured; otherwise it skips with a notice (so a
+# new fork or unconfigured repo doesn't see a permanent red check).
+
+env:
+  RUN_CI: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+
+jobs:
+  # Unit tests proving the check script's logic. Independent from production
+  # secrets; runs always.
+  env-consistency-unit:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - uses: actions/cache@v5
+        id: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Run check-supabase-env-consistency unit tests
+        run: npx vitest run --config vitest.unit.config.ts scripts/__tests__/check-supabase-env-consistency.test.ts
+
+  # Production-mirror check: runs the actual script against secrets that
+  # mirror Vercel production env. Catches drift between the two scopes.
+  # Skipped (not failed) when secrets aren't configured.
+  env-consistency-production:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: [env-consistency-unit]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - uses: actions/cache@v5
+        id: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Run consistency check against production-mirror secrets
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          if [ -z "${SUPABASE_URL:-}" ] || [ -z "${SUPABASE_DB_URL:-}" ]; then
+            echo "::notice::SUPABASE_URL / SUPABASE_DB_URL repo secrets not configured. Skipping production-mirror check."
+            echo "::notice::To enable: add SUPABASE_URL and SUPABASE_DB_URL as GitHub repo secrets (mirroring Vercel production values)."
+            exit 0
+          fi
+          npm run check:supabase-env-consistency

--- a/docs/recon/ENV_DRIFT_KNOWN_ISSUES.md
+++ b/docs/recon/ENV_DRIFT_KNOWN_ISSUES.md
@@ -1,0 +1,7 @@
+# Env drift — known issues
+
+Resolved 2026-05-29. No outstanding drift.
+
+History: 2026-05-29 publish-due outage was caused by `SUPABASE_URL` and `SUPABASE_DB_URL` drifting to different Supabase projects in Vercel preview + development scopes, and production's `SUPABASE_DB_URL` having the wrong pooler region segment. Manual dashboard fix + the consistency CI guard introduced in `scripts/check-supabase-env-consistency.ts` should prevent recurrence.
+
+Re-open this doc if Supabase env drift is detected in any environment.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "screenshots": "RUN_SCREENSHOTS=1 playwright test screenshots.spec.ts",
     "screenshots:baseline": "RUN_SCREENSHOTS=1 playwright test screenshots.spec.ts --update-snapshots",
     "audit:static": "tsx scripts/audit.ts",
+    "check:supabase-env-consistency": "tsx scripts/check-supabase-env-consistency.ts",
     "smoke:harness": "vitest run --config vitest.unit.config.ts lib/__tests__/smoke-budget.unit.test.ts",
     "smoke:composer": "tsx scripts/smoke/composer.smoke.ts",
     "smoke:cap": "tsx scripts/smoke/cap.smoke.ts",

--- a/scripts/__tests__/check-supabase-env-consistency.test.ts
+++ b/scripts/__tests__/check-supabase-env-consistency.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "vitest";
+
+import { checkConsistency } from "../check-supabase-env-consistency";
+
+const PROD_REF = "sazapxgmrdaewrkwoxby";
+const STAGING_REF = "bjiiqnetaxoibhcaukqm";
+
+const POOLER_HOST_PROD = "aws-1-ap-southeast-2.pooler.supabase.com";
+const POOLER_HOST_STAGING = "aws-1-ap-southeast-2.pooler.supabase.com";
+
+function poolerUrl(ref: string, host: string): string {
+  return `postgresql://postgres.${ref}:somepassword@${host}:5432/postgres`;
+}
+
+function restUrl(ref: string): string {
+  return `https://${ref}.supabase.co`;
+}
+
+function directUrl(ref: string): string {
+  return `postgresql://postgres:pwd@db.${ref}.supabase.co:5432/postgres`;
+}
+
+describe("checkConsistency — happy paths", () => {
+  test("all three refs match + pooler host → ok", () => {
+    const result = checkConsistency({
+      SUPABASE_URL: restUrl(PROD_REF),
+      NEXT_PUBLIC_SUPABASE_URL: restUrl(PROD_REF),
+      SUPABASE_DB_URL: poolerUrl(PROD_REF, POOLER_HOST_PROD),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.summary).toMatch(/OK/);
+  });
+
+  test("NEXT_PUBLIC_SUPABASE_URL absent → still ok (production scope intentionally omits it)", () => {
+    const result = checkConsistency({
+      SUPABASE_URL: restUrl(PROD_REF),
+      SUPABASE_DB_URL: poolerUrl(PROD_REF, POOLER_HOST_PROD),
+      NEXT_PUBLIC_SUPABASE_URL: undefined,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.vars.NEXT_PUBLIC_SUPABASE_URL.value_present).toBe(false);
+  });
+
+  test("staging refs (bjiiq) consistent → ok", () => {
+    const result = checkConsistency({
+      SUPABASE_URL: restUrl(STAGING_REF),
+      NEXT_PUBLIC_SUPABASE_URL: restUrl(STAGING_REF),
+      SUPABASE_DB_URL: poolerUrl(STAGING_REF, POOLER_HOST_STAGING),
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("checkConsistency — ref mismatch", () => {
+  test("SUPABASE_URL and SUPABASE_DB_URL disagree → fail (the 2026-05-29 incident shape)", () => {
+    // The exact mismatch shape that caused publish-due to fail: REST URL at staging,
+    // DB URL at production. The pooler returned "Tenant or user not found" because
+    // it couldn't reconcile the user-portion ref (sazap) against the project tenant.
+    const result = checkConsistency({
+      SUPABASE_URL: restUrl(STAGING_REF),
+      NEXT_PUBLIC_SUPABASE_URL: restUrl(STAGING_REF),
+      SUPABASE_DB_URL: poolerUrl(PROD_REF, POOLER_HOST_PROD),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("Project ref mismatch"))).toBe(true);
+    // Error message must surface BOTH refs so debugger can see the divergence.
+    expect(result.errors.join("\n")).toContain(STAGING_REF);
+    expect(result.errors.join("\n")).toContain(PROD_REF);
+  });
+
+  test("NEXT_PUBLIC disagrees with the other two → fail", () => {
+    const result = checkConsistency({
+      SUPABASE_URL: restUrl(PROD_REF),
+      NEXT_PUBLIC_SUPABASE_URL: restUrl(STAGING_REF),
+      SUPABASE_DB_URL: poolerUrl(PROD_REF, POOLER_HOST_PROD),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("Project ref mismatch"))).toBe(true);
+  });
+});
+
+describe("checkConsistency — direct host rejected", () => {
+  test("SUPABASE_DB_URL is direct connection (db.<ref>.supabase.co) → fail", () => {
+    const result = checkConsistency({
+      SUPABASE_URL: restUrl(PROD_REF),
+      NEXT_PUBLIC_SUPABASE_URL: restUrl(PROD_REF),
+      SUPABASE_DB_URL: directUrl(PROD_REF),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("direct-connection format"))).toBe(true);
+    // Error message must mention pooler as the fix.
+    expect(result.errors.join("\n")).toContain("pooler");
+    expect(result.errors.join("\n")).toContain("ENOTFOUND");
+  });
+
+  test("direct host + ref-matching → still fails on the host shape alone", () => {
+    // refs match (all PROD_REF) but the DB URL is still direct format.
+    // This must fail — the URL would ENOTFOUND at runtime regardless of refs.
+    const result = checkConsistency({
+      SUPABASE_URL: restUrl(PROD_REF),
+      SUPABASE_DB_URL: directUrl(PROD_REF),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("direct-connection format"))).toBe(true);
+  });
+});
+
+describe("checkConsistency — missing required vars", () => {
+  test("SUPABASE_URL missing → fail", () => {
+    const result = checkConsistency({
+      SUPABASE_DB_URL: poolerUrl(PROD_REF, POOLER_HOST_PROD),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("Missing required env var: SUPABASE_URL"))).toBe(true);
+  });
+
+  test("SUPABASE_DB_URL missing → fail", () => {
+    const result = checkConsistency({
+      SUPABASE_URL: restUrl(PROD_REF),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("Missing required env var: SUPABASE_DB_URL"))).toBe(true);
+  });
+
+  test("both required vars missing → both errors surfaced", () => {
+    const result = checkConsistency({});
+    expect(result.ok).toBe(false);
+    expect(result.errors.filter((e) => e.startsWith("Missing required")).length).toBe(2);
+  });
+});
+
+describe("checkConsistency — unparseable value", () => {
+  test("garbage SUPABASE_URL value → fail with shape error", () => {
+    const result = checkConsistency({
+      SUPABASE_URL: "not-a-url",
+      SUPABASE_DB_URL: poolerUrl(PROD_REF, POOLER_HOST_PROD),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("did not match any known Supabase URL shape"))).toBe(true);
+  });
+});
+
+describe("checkConsistency — result shape", () => {
+  test("vars dict reports value_present + ref + host + shape per var", () => {
+    const result = checkConsistency({
+      SUPABASE_URL: restUrl(PROD_REF),
+      SUPABASE_DB_URL: poolerUrl(PROD_REF, POOLER_HOST_PROD),
+    });
+    expect(result.vars.SUPABASE_URL).toEqual(
+      expect.objectContaining({ value_present: true, ref: PROD_REF, shape: "rest" }),
+    );
+    expect(result.vars.SUPABASE_DB_URL).toEqual(
+      expect.objectContaining({ value_present: true, ref: PROD_REF, host: POOLER_HOST_PROD, shape: "pooler" }),
+    );
+    expect(result.vars.NEXT_PUBLIC_SUPABASE_URL).toEqual(
+      expect.objectContaining({ value_present: false }),
+    );
+  });
+});

--- a/scripts/check-supabase-env-consistency.ts
+++ b/scripts/check-supabase-env-consistency.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env -S npx tsx
+// ---------------------------------------------------------------------------
+// scripts/check-supabase-env-consistency.ts
+//
+// Purpose: catch the class of env-drift bug that caused the 2026-05-29
+// publish-due incident. That incident was a manual Vercel dashboard mistake
+// where SUPABASE_URL was migrated to the staging project while SUPABASE_DB_URL
+// stayed pointed at production's pooler (preview scope) and the production
+// pooler URL had the wrong region segment (aws-0- instead of aws-1-). The
+// resulting "Tenant or user not found" errors cost ~5 days of stuck scheduled
+// posts before being diagnosed.
+//
+// This script reads the three Supabase env vars, extracts the project ref
+// from each, and asserts:
+//   1. All set refs match (URL ref == NEXT_PUBLIC ref == DB_URL ref).
+//   2. SUPABASE_DB_URL host is the pooler format (aws-N-<region>.pooler.supabase.com),
+//      NOT the direct-connection format (db.<ref>.supabase.co) — the latter
+//      is IPv6-only and Vercel runtime is IPv4-only, so direct hosts always
+//      fail with ENOTFOUND at runtime.
+//
+// Exit codes:
+//   0 — all set refs match + DB URL is pooler-format.
+//   1 — mismatch detected (clear error printed to stderr).
+//   2 — required env var missing or unparseable.
+//
+// CLI usage:
+//   SUPABASE_URL=... SUPABASE_DB_URL=... npm run check:supabase-env-consistency
+//
+// Library usage (for unit tests):
+//   import { checkConsistency } from './check-supabase-env-consistency';
+//   const result = checkConsistency({ SUPABASE_URL: '...', SUPABASE_DB_URL: '...' });
+// ---------------------------------------------------------------------------
+
+export interface ConsistencyResult {
+  ok: boolean;
+  /** Single-line summary suitable for CI logs. */
+  summary: string;
+  /** Per-var breakdown for the failure-detail block. */
+  vars: Record<string, { value_present: boolean; ref: string | null; host?: string | null; shape?: string }>;
+  /** Reasons the check failed. Empty when ok === true. */
+  errors: string[];
+}
+
+const REST_URL_RE = /^https?:\/\/([a-z0-9]+)\.supabase\.co(?:\/.*)?$/;
+const DIRECT_DB_URL_RE = /^postgres(ql)?:\/\/[^@]+@db\.([a-z0-9]+)\.supabase\.co(?::\d+)?(?:\/.*)?$/;
+const POOLER_DB_URL_RE = /^postgres(ql)?:\/\/postgres\.([a-z0-9]+):[^@]+@([a-z0-9-]+\.pooler\.supabase\.com)(?::(\d+))?(?:\/.*)?$/;
+
+interface ParsedRef {
+  ref: string | null;
+  host: string | null;
+  shape: "rest" | "pooler" | "direct" | "unrecognised";
+}
+
+function parseSupabaseEnvValue(value: string): ParsedRef {
+  const rest = value.match(REST_URL_RE);
+  if (rest) return { ref: rest[1], host: null, shape: "rest" };
+
+  const pooler = value.match(POOLER_DB_URL_RE);
+  if (pooler) return { ref: pooler[2], host: pooler[3], shape: "pooler" };
+
+  const direct = value.match(DIRECT_DB_URL_RE);
+  if (direct) return { ref: direct[2], host: `db.${direct[2]}.supabase.co`, shape: "direct" };
+
+  return { ref: null, host: null, shape: "unrecognised" };
+}
+
+export function checkConsistency(env: Record<string, string | undefined>): ConsistencyResult {
+  const errors: string[] = [];
+  const vars: ConsistencyResult["vars"] = {};
+
+  // Required: SUPABASE_URL + SUPABASE_DB_URL. NEXT_PUBLIC_SUPABASE_URL is
+  // optional (production scope intentionally omits it in some configs).
+  const REQUIRED = ["SUPABASE_URL", "SUPABASE_DB_URL"] as const;
+  const OPTIONAL = ["NEXT_PUBLIC_SUPABASE_URL"] as const;
+
+  const refByVar: Record<string, string | null> = {};
+  let dbShape: "pooler" | "direct" | "unrecognised" | null = null;
+  let dbHost: string | null = null;
+
+  for (const name of [...REQUIRED, ...OPTIONAL]) {
+    const value = env[name];
+    if (!value) {
+      vars[name] = { value_present: false, ref: null };
+      if ((REQUIRED as readonly string[]).includes(name)) {
+        errors.push(`Missing required env var: ${name}`);
+      }
+      continue;
+    }
+    const parsed = parseSupabaseEnvValue(value);
+    vars[name] = {
+      value_present: true,
+      ref: parsed.ref,
+      host: parsed.host,
+      shape: parsed.shape,
+    };
+    refByVar[name] = parsed.ref;
+    if (name === "SUPABASE_DB_URL") {
+      dbShape = parsed.shape === "rest" ? "unrecognised" : parsed.shape;
+      dbHost = parsed.host;
+    }
+    if (parsed.shape === "unrecognised") {
+      errors.push(`${name} value did not match any known Supabase URL shape (REST / pooler / direct)`);
+    }
+  }
+
+  // Ref-match check: all SET refs must agree.
+  const setRefs = Object.entries(refByVar).filter(([, ref]) => ref !== null);
+  if (setRefs.length >= 2) {
+    const firstRef = setRefs[0][1] as string;
+    const mismatches = setRefs.filter(([, ref]) => ref !== firstRef);
+    if (mismatches.length > 0) {
+      const lines = setRefs.map(([k, ref]) => `  ${k}: project ref = ${ref}`).join("\n");
+      errors.push(
+        `Project ref mismatch across Supabase env vars:\n${lines}\n` +
+          `Every set Supabase URL must point at the same project. Mixing refs means REST writes go to one project ` +
+          `and DB writes go to another — silent data divergence.`,
+      );
+    }
+  }
+
+  // DB host shape check: pooler required, direct rejected.
+  if (dbShape === "direct") {
+    errors.push(
+      `SUPABASE_DB_URL host is direct-connection format (${dbHost}). Supabase direct connections are IPv6-only; ` +
+        `Vercel runtime is IPv4-only — this will always fail with ENOTFOUND. ` +
+        `Use the session pooler URL instead: postgresql://postgres.<ref>:<pwd>@aws-N-<region>.pooler.supabase.com:5432/postgres`,
+    );
+  }
+
+  const summary = errors.length === 0
+    ? `OK — all set Supabase refs match (${refByVar.SUPABASE_URL ?? "?"})${dbShape === "pooler" ? `, DB host is pooler (${dbHost})` : ""}`
+    : `FAIL — ${errors.length} consistency error(s)`;
+
+  return { ok: errors.length === 0, summary, vars, errors };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point — runs only when invoked as a script, not when imported.
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const result = checkConsistency({
+    SUPABASE_URL: process.env.SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+    SUPABASE_DB_URL: process.env.SUPABASE_DB_URL,
+  });
+
+  if (result.ok) {
+    console.log(result.summary);
+    process.exit(0);
+  }
+
+  console.error("Supabase env-var consistency check FAILED.\n");
+  console.error("Detected state:");
+  for (const [name, info] of Object.entries(result.vars)) {
+    if (!info.value_present) {
+      console.error(`  ${name}: (not set)`);
+    } else {
+      console.error(`  ${name}: ref=${info.ref ?? "(unparseable)"} host=${info.host ?? "n/a"} shape=${info.shape ?? "?"}`);
+    }
+  }
+  console.error("\nErrors:");
+  for (const err of result.errors) {
+    console.error(`  - ${err}`);
+  }
+  console.error("\nSee scripts/check-supabase-env-consistency.ts header for the incident context.");
+  // Exit 2 if a required var is missing, 1 for inconsistency.
+  const missing = result.errors.some((e) => e.startsWith("Missing required"));
+  process.exit(missing ? 2 : 1);
+}
+
+// CJS: `require.main === module`. ESM (which tsx uses): no equivalent, but
+// import.meta.url comparison works. Use a defensive check that works either way.
+const isDirectInvocation =
+  // ESM check
+  (typeof import.meta !== "undefined" &&
+    import.meta.url &&
+    process.argv[1] &&
+    new URL(import.meta.url).pathname.endsWith(process.argv[1].replace(/\\/g, "/").split("/").pop() ?? "")) ||
+  // CJS fallback
+  (typeof require !== "undefined" && typeof module !== "undefined" && require.main === module);
+
+if (isDirectInvocation) {
+  main();
+}

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
       "lib/**/__tests__/**/*.unit.test.ts",
       "tests/regressions/**/*.test.{ts,tsx}",
       "tests/security/**/*.security.test.ts",
+      "scripts/__tests__/**/*.test.ts",
     ],
     testTimeout: 10_000,
     // No globalSetup — no Supabase. Tests must mock all I/O.


### PR DESCRIPTION
## Summary

Adds a deterministic check that the three Supabase env vars (\`SUPABASE_URL\`, \`NEXT_PUBLIC_SUPABASE_URL\` if set, \`SUPABASE_DB_URL\`) all point at the **same** Supabase project, and that \`SUPABASE_DB_URL\` uses the session-pooler host shape rather than the direct-connection format. Catches the env-drift class that caused today's publish-due outage.

## Incident context

The 2026-05-29 publish-due failure was caused by a manual Vercel dashboard edit that left the Supabase env vars in an inconsistent state across scopes:

| | production | preview | development |
|---|---|---|---|
| \`SUPABASE_URL\` | sazap (prod) | bjiiq (staging) | **sazap (prod)** ← was wrong |
| \`SUPABASE_DB_URL\` ref | sazap (prod) | **sazap (prod)** ← was wrong (should be bjiiq) | **sazap (prod)** ← was wrong |
| Production \`SUPABASE_DB_URL\` host | was \`aws-0-...\` ← wrong region segment | | |

The result: \`publish-due\` cron failed with \`(ENOTFOUND) tenant/user postgres.<ref> not found\` for ~5 days before being diagnosed. Multiple diagnostic sessions repeatedly asked Steven to \"change the URL\" because each session could see the symptom but not the cross-scope mismatch underneath.

This guard prevents the same shape of bug from re-occurring without notice.

## Files

- **\`scripts/check-supabase-env-consistency.ts\`** — the check script. Exports \`checkConsistency(env)\` for unit testing; \`main()\` block when invoked as CLI. CJS/ESM dual-invocation detection so it works under \`tsx\`.
- **\`scripts/__tests__/check-supabase-env-consistency.test.ts\`** — 12 unit tests covering: happy paths (all-match, optional NEXT_PUBLIC, staging refs), ref mismatch (the exact 2026-05-29 incident shape), direct-host rejection (the IPv6-only failure mode), missing required vars, unparseable values, and result-shape contract.
- **\`vitest.unit.config.ts\`** — extends include patterns to pick up \`scripts/__tests__/\` so the new tests run with the rest of the unit suite.
- **\`package.json\`** — adds \`npm run check:supabase-env-consistency\` (\`tsx\` invocation).
- **\`.github/workflows/env-consistency.yml\`** — two jobs:
  - \`env-consistency-unit\` (always runs): the unit tests above.
  - \`env-consistency-production\` (runs when secrets present): mirrors production env via repo secrets and runs the script. Skips with a notice if the secrets aren't configured yet, so a fresh repo doesn't see a permanent red check.
- **\`docs/recon/ENV_DRIFT_KNOWN_ISSUES.md\`** — short status doc, currently resolved.

## Verification

- \`npm run typecheck\`: clean.
- \`npm run check:supabase-env-consistency\` (CLI smoke, passing case): exits 0 with summary.
- \`npm run check:supabase-env-consistency\` (CLI smoke, mismatch case): exits 1, error message names both diverging refs.
- \`npx vitest run scripts/__tests__/check-supabase-env-consistency.test.ts\`: **12/12 pass in 1.46s**.
- Pre-commit hook ran clean (no \`SKIP_PRECOMMIT_TESTS\`): **139 files, 2627 tests in 107.52s**.

## Follow-up after merge

Steven needs to configure these GitHub repo secrets to enable the production-mirror check:

- \`SUPABASE_URL\` (= Vercel production value)
- \`SUPABASE_DB_URL\` (= Vercel production value)
- \`NEXT_PUBLIC_SUPABASE_URL\` (optional)

Until they're set, the \`env-consistency-production\` job logs a notice and exits 0. The \`env-consistency-unit\` job runs unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)