### PR TITLE
feat(image-gen): slice B4 — operator selection + auto-attach

### DIFF
--- a/app/api/internal/cron/publish-due/route.ts
+++ b/app/api/internal/cron/publish-due/route.ts
@@ -6,6 +6,7 @@ import { requireDbConfig } from "@/lib/db-direct";
 import { authorisedCronRequest, unauthorisedResponse, updateHeartbeat } from "@/lib/platform/cron/cron-shared";
 import { publishPost } from "@/lib/social/publishing/bundle-social-client";
 import { claimDueDrafts, type ClaimedDraft } from "@/lib/social/publishing/claim-due-drafts";
+import { resolveMediaForPublish } from "@/lib/social/publishing/resolve-media";
 import { logger } from "@/lib/logger";
 
 export const runtime = "nodejs";
@@ -86,10 +87,16 @@ async function handleCron(req: NextRequest): Promise<NextResponse> {
       chunk.map(async (draft) => {
         try {
           const targetProfileIds = (draft.target_profiles ?? []).map((p) => p.profile_id);
+          // B4 §1.6: prefer media_asset_ids (asset-derived signed URLs) over
+          // legacy media_urls. Sign at publish time so we never persist URLs.
+          const mediaUrls = await resolveMediaForPublish({
+            mediaAssetIds: draft.media_asset_ids,
+            legacyMediaUrls: draft.media_urls,
+          });
           const result = await publishPost({
             externalPostId: draft.id,
             content: draft.content,
-            mediaUrls: draft.media_urls ?? [],
+            mediaUrls,
             targetProfileIds,
             platformVariants: draft.platform_variants ?? {},
           });

--- a/app/api/platform/image/jobs/[id]/select/route.ts
+++ b/app/api/platform/image/jobs/[id]/select/route.ts
@@ -1,0 +1,158 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { internalError, readJsonBody, validationError } from "@/lib/http";
+import { requireCanDoForApi } from "@/lib/platform/auth/api-gate";
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+import { autoAttachImage, type AutoAttachState } from "@/lib/image/auto-attach";
+
+// ---------------------------------------------------------------------------
+// /api/platform/image/jobs/[id]/select
+//
+// B4 — operator approves or rejects a single image-gen job result.
+//
+//   POST   → approve.  Body: { reason?: string }
+//   PATCH  → reject.   Body: { reason: string }
+//
+// On approve: insert an image_selections row with selected=true, then if the
+// job's target_publish_date is non-null, fire auto-attach. The auto-attach
+// result is reflected in the response so the UI knows whether a draft was
+// touched, but selection itself never fails on attach error.
+//
+// On reject: insert an image_selections row with selected=false +
+// rejection_reason. No auto-attach side effect.
+//
+// Auth: requireCanDoForApi(companyId, "create_post") — editor+ on the
+// company that owns the job.
+// ---------------------------------------------------------------------------
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const ApproveBodySchema = z.object({ reason: z.string().max(500).optional() });
+const RejectBodySchema = z.object({ reason: z.string().min(1).max(500) });
+
+async function loadJobOwner(jobId: string): Promise<{ companyId: string } | null> {
+  const svc = getServiceRoleClient();
+  const { data, error } = await svc
+    .from("image_generation_jobs")
+    .select("company_id")
+    .eq("id", jobId)
+    .maybeSingle();
+  if (error || !data) return null;
+  return { companyId: (data as { company_id: string }).company_id };
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  return handleSelection(req, params.id, /* approve */ true);
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  return handleSelection(req, params.id, /* approve */ false);
+}
+
+async function handleSelection(
+  req: NextRequest,
+  jobId: string,
+  approve: boolean,
+): Promise<NextResponse> {
+  const owner = await loadJobOwner(jobId);
+  if (!owner) return validationError("Job not found.", { jobId });
+
+  const gate = await requireCanDoForApi(owner.companyId, "create_post");
+  if (gate.kind === "deny") return gate.response;
+
+  const body = (await readJsonBody(req)) ?? {};
+  const parsed = approve
+    ? ApproveBodySchema.safeParse(body)
+    : RejectBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError("Invalid request body.", { issues: parsed.error.issues });
+  }
+
+  const svc = getServiceRoleClient();
+
+  // Insert the selection row. Both approve and reject paths write here.
+  const reason = approve
+    ? (parsed.data as { reason?: string }).reason ?? null
+    : (parsed.data as { reason: string }).reason;
+
+  const { data: selection, error: selErr } = await svc
+    .from("image_selections")
+    .insert({
+      job_id: jobId,
+      selected: approve,
+      selected_by: gate.userId,
+      rejection_reason: approve ? null : reason,
+    })
+    .select("id")
+    .single();
+
+  if (selErr || !selection) {
+    logger.error("image.select.insert_failed", {
+      jobId,
+      approve,
+      err: selErr?.message,
+    });
+    return internalError("Failed to record selection.");
+  }
+
+  // Reject: done. No attach side-effect.
+  if (!approve) {
+    logger.info("image.select.rejected", { jobId, reason });
+    return NextResponse.json({
+      ok: true,
+      data: {
+        jobId,
+        selected: false,
+        selectionId: (selection as { id: string }).id,
+        rejectionReason: reason,
+      },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  // Approve: fire auto-attach. Result is reflected in the response so the
+  // UI can render an "attached to draft on YYYY-MM-DD" affordance. The
+  // attach is fail-soft — selection has already been recorded.
+  let attachResult: { state: AutoAttachState; draftId?: string; assetId?: string; error?: string };
+  try {
+    attachResult = await autoAttachImage({
+      jobId,
+      companyId: owner.companyId,
+      approvedBy: gate.userId,
+    });
+  } catch (err) {
+    // autoAttachImage is designed not to throw; this is a defence-in-depth
+    // log for the impossible case.
+    logger.warn("image.select.auto_attach_threw", {
+      jobId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    attachResult = { state: "attach_failed", error: "auto_attach threw" };
+  }
+
+  logger.info("image.select.approved", {
+    jobId,
+    companyId: owner.companyId,
+    attachState: attachResult.state,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    data: {
+      jobId,
+      selected: true,
+      selectionId: (selection as { id: string }).id,
+      autoAttach: attachResult,
+    },
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/lib/__tests__/image-auto-attach.unit.test.ts
+++ b/lib/__tests__/image-auto-attach.unit.test.ts
@@ -1,0 +1,508 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+
+// B4 — auto-attach logic for approved image-gen jobs.
+//
+// Mocks the entire Supabase chain to cover the four documented paths:
+//   1. target_publish_date null         → not_applicable, no draft touched
+//   2. attached: new draft created       → attached, draftId returned
+//   3. attached: existing draft found    → attached, asset id appended
+//   4. FK / DB failure                   → attach_failed but never throws
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+interface RecordedCall {
+  table: string;
+  op: "select" | "insert" | "update";
+  filters: Record<string, unknown>;
+  isNull: string[];
+  patch?: unknown;
+  inserted?: unknown;
+}
+
+const calls: RecordedCall[] = [];
+
+// Per-call result configuration. Tests set the relevant entries before
+// invoking autoAttachImage.
+const responses: {
+  jobLookup: { data: unknown; error: unknown };
+  assetInsert: { data: unknown; error: unknown };
+  draftLookup: { data: unknown; error: unknown };
+  draftInsert: { data: unknown; error: unknown };
+  draftRead: { data: unknown; error: unknown };
+  draftUpdate: { error: unknown };
+  jobStateUpdate: { error: unknown };
+} = {
+  jobLookup: { data: null, error: null },
+  assetInsert: { data: null, error: null },
+  draftLookup: { data: null, error: null },
+  draftInsert: { data: null, error: null },
+  draftRead: { data: null, error: null },
+  draftUpdate: { error: null },
+  jobStateUpdate: { error: null },
+};
+
+function makeSelectChain(table: string): unknown {
+  const call: RecordedCall = { table, op: "select", filters: {}, isNull: [] };
+  const chain: Record<string, unknown> = {
+    eq(field: string, value: unknown) {
+      call.filters[field] = value;
+      return chain;
+    },
+    is(field: string, value: unknown) {
+      if (value === null) call.isNull.push(field);
+      return chain;
+    },
+    limit(_n: number) {
+      return chain;
+    },
+    in(field: string, values: unknown[]) {
+      call.filters[field] = values;
+      return chain;
+    },
+    async maybeSingle() {
+      calls.push(call);
+      // route to the right response shape based on table + filters
+      if (table === "image_generation_jobs") return responses.jobLookup;
+      if (table === "social_post_drafts") return responses.draftLookup;
+      if (table === "social_post_drafts_read") return responses.draftRead;
+      return { data: null, error: null };
+    },
+  };
+  return chain;
+}
+
+// social_post_drafts has TWO select() calls in auto-attach: lookup (with
+// .eq("state","scheduled")) and read (after create/find for media_asset_ids).
+// Distinguish by call sequence.
+let draftSelectCallCount = 0;
+function makeDraftSelectChain(): unknown {
+  draftSelectCallCount++;
+  const isReadAfterCreate = draftSelectCallCount % 2 === 0;
+  const call: RecordedCall = {
+    table: isReadAfterCreate ? "social_post_drafts_read" : "social_post_drafts",
+    op: "select",
+    filters: {},
+    isNull: [],
+  };
+  const chain: Record<string, unknown> = {
+    eq(field: string, value: unknown) {
+      call.filters[field] = value;
+      return chain;
+    },
+    is(field: string, value: unknown) {
+      if (value === null) call.isNull.push(field);
+      return chain;
+    },
+    limit(_n: number) {
+      return chain;
+    },
+    async maybeSingle() {
+      calls.push(call);
+      return isReadAfterCreate ? responses.draftRead : responses.draftLookup;
+    },
+  };
+  return chain;
+}
+
+function makeInsertChain(table: string, row: unknown): unknown {
+  const call: RecordedCall = { table, op: "insert", filters: {}, isNull: [], inserted: row };
+  return {
+    select(_cols?: string) {
+      return {
+        async single() {
+          calls.push(call);
+          if (table === "social_media_assets") return responses.assetInsert;
+          if (table === "social_post_drafts") return responses.draftInsert;
+          if (table === "image_selections") return { data: { id: "sel-1" }, error: null };
+          return { data: null, error: null };
+        },
+      };
+    },
+  };
+}
+
+function makeUpdateChain(table: string, patch: unknown): unknown {
+  const call: RecordedCall = { table, op: "update", filters: {}, isNull: [], patch };
+  const chain: Record<string, unknown> = {
+    eq(field: string, value: unknown) {
+      call.filters[field] = value;
+      calls.push(call);
+      return Promise.resolve(
+        table === "social_post_drafts" ? responses.draftUpdate : responses.jobStateUpdate,
+      );
+    },
+  };
+  return chain;
+}
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({
+    from(table: string) {
+      return {
+        select(_cols?: string) {
+          if (table === "social_post_drafts") return makeDraftSelectChain();
+          return makeSelectChain(table);
+        },
+        insert(row: unknown) {
+          return makeInsertChain(table, row);
+        },
+        update(patch: unknown) {
+          return makeUpdateChain(table, patch);
+        },
+      };
+    },
+  }),
+}));
+
+import { autoAttachImage } from "@/lib/image/auto-attach";
+
+const JOB_ID = "11111111-1111-4111-8111-111111111111";
+const COMPANY_ID = "22222222-2222-4222-8222-222222222222";
+const APPROVER_ID = "33333333-3333-4333-8333-333333333333";
+const STORAGE_PATH = "company-x/job-y/image.jpg";
+const EXISTING_DRAFT_ID = "44444444-4444-4444-8444-444444444444";
+const NEW_DRAFT_ID = "55555555-5555-4555-8555-555555555555";
+const ASSET_ID = "66666666-6666-4666-8666-666666666666";
+
+function resetResponses(): void {
+  responses.jobLookup = { data: null, error: null };
+  responses.assetInsert = { data: { id: ASSET_ID }, error: null };
+  responses.draftLookup = { data: null, error: null };
+  responses.draftInsert = { data: { id: NEW_DRAFT_ID }, error: null };
+  responses.draftRead = { data: { media_asset_ids: [] }, error: null };
+  responses.draftUpdate = { error: null };
+  responses.jobStateUpdate = { error: null };
+}
+
+beforeEach(() => {
+  calls.length = 0;
+  draftSelectCallCount = 0;
+  resetResponses();
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Path 1: target_publish_date null → not_applicable
+// ---------------------------------------------------------------------------
+
+describe("autoAttachImage — no publish date", () => {
+  test("returns not_applicable when target_publish_date is null; no asset/draft writes", async () => {
+    responses.jobLookup = {
+      data: {
+        id: JOB_ID,
+        company_id: COMPANY_ID,
+        state: "completed",
+        result_storage_path: STORAGE_PATH,
+        target_publish_date: null,
+        generation_params: { aspectRatio: "1x1" },
+      },
+      error: null,
+    };
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("not_applicable");
+    expect(result.draftId).toBeUndefined();
+    expect(result.assetId).toBeUndefined();
+
+    expect(calls.filter((c) => c.table === "social_media_assets" && c.op === "insert"))
+      .toHaveLength(0);
+    expect(calls.filter((c) => c.table === "social_post_drafts" && c.op === "insert"))
+      .toHaveLength(0);
+
+    const stateUpdate = calls.find(
+      (c) => c.op === "update" && c.table === "image_generation_jobs",
+    );
+    expect((stateUpdate?.patch as { auto_attach_state: string }).auto_attach_state).toBe(
+      "not_applicable",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Path 2: attach to a brand-new draft
+// ---------------------------------------------------------------------------
+
+describe("autoAttachImage — new draft", () => {
+  test("creates social_media_assets row + new social_post_drafts row; marks attached", async () => {
+    responses.jobLookup = {
+      data: {
+        id: JOB_ID,
+        company_id: COMPANY_ID,
+        state: "completed",
+        result_storage_path: STORAGE_PATH,
+        target_publish_date: "2026-06-15",
+        generation_params: { aspectRatio: "4x5" },
+      },
+      error: null,
+    };
+    responses.draftLookup = { data: null, error: null }; // no existing draft
+    responses.draftInsert = { data: { id: NEW_DRAFT_ID }, error: null };
+    responses.draftRead = { data: { media_asset_ids: [] }, error: null };
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attached");
+    expect(result.draftId).toBe(NEW_DRAFT_ID);
+    expect(result.assetId).toBe(ASSET_ID);
+
+    // Asset insert carried the right shape.
+    const assetInsert = calls.find((c) => c.table === "social_media_assets" && c.op === "insert");
+    const row = assetInsert!.inserted as {
+      company_id: string;
+      storage_path: string;
+      uploaded_by: string;
+      width: number;
+      height: number;
+      mime_type: string;
+    };
+    expect(row.company_id).toBe(COMPANY_ID);
+    expect(row.storage_path).toBe(STORAGE_PATH);
+    expect(row.uploaded_by).toBe(APPROVER_ID);
+    expect(row.width).toBe(1024);
+    expect(row.height).toBe(1280);
+    expect(row.mime_type).toBe("image/jpeg");
+
+    // Draft was inserted because lookup returned null.
+    const draftInsert = calls.find((c) => c.table === "social_post_drafts" && c.op === "insert");
+    expect(draftInsert).toBeDefined();
+    const draftRow = draftInsert!.inserted as { state: string; scheduled_at: string };
+    expect(draftRow.state).toBe("scheduled");
+    expect(draftRow.scheduled_at).toBe("2026-06-15T00:00:00.000Z");
+
+    // media_asset_ids on the draft got the new asset appended.
+    const draftUpdate = calls.find(
+      (c) => c.op === "update" && c.table === "social_post_drafts",
+    );
+    expect((draftUpdate?.patch as { media_asset_ids: string[] }).media_asset_ids).toEqual([
+      ASSET_ID,
+    ]);
+
+    // Final state mark.
+    const stateUpdates = calls.filter(
+      (c) => c.op === "update" && c.table === "image_generation_jobs",
+    );
+    const finalState = stateUpdates[stateUpdates.length - 1];
+    expect((finalState.patch as { auto_attach_state: string }).auto_attach_state).toBe("attached");
+    expect((finalState.patch as { auto_attached_draft_id: string }).auto_attached_draft_id).toBe(
+      NEW_DRAFT_ID,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Path 3: attach to an existing scheduled draft
+// ---------------------------------------------------------------------------
+
+describe("autoAttachImage — existing draft", () => {
+  test("does NOT create a new draft when one exists for (company, date); appends asset id", async () => {
+    responses.jobLookup = {
+      data: {
+        id: JOB_ID,
+        company_id: COMPANY_ID,
+        state: "completed",
+        result_storage_path: STORAGE_PATH,
+        target_publish_date: "2026-06-15",
+        generation_params: { aspectRatio: "1x1" },
+      },
+      error: null,
+    };
+    responses.draftLookup = { data: { id: EXISTING_DRAFT_ID }, error: null };
+    responses.draftRead = {
+      data: { media_asset_ids: ["existing-asset-a", "existing-asset-b"] },
+      error: null,
+    };
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attached");
+    expect(result.draftId).toBe(EXISTING_DRAFT_ID);
+
+    // No INSERT into social_post_drafts.
+    expect(calls.filter((c) => c.table === "social_post_drafts" && c.op === "insert"))
+      .toHaveLength(0);
+
+    // media_asset_ids should be the union, preserving existing order.
+    const draftUpdate = calls.find(
+      (c) => c.op === "update" && c.table === "social_post_drafts",
+    );
+    expect((draftUpdate?.patch as { media_asset_ids: string[] }).media_asset_ids).toEqual([
+      "existing-asset-a",
+      "existing-asset-b",
+      ASSET_ID,
+    ]);
+  });
+
+  test("idempotent: assetId already present → media_asset_ids unchanged", async () => {
+    responses.jobLookup = {
+      data: {
+        id: JOB_ID,
+        company_id: COMPANY_ID,
+        state: "completed",
+        result_storage_path: STORAGE_PATH,
+        target_publish_date: "2026-06-15",
+        generation_params: { aspectRatio: "1x1" },
+      },
+      error: null,
+    };
+    responses.draftLookup = { data: { id: EXISTING_DRAFT_ID }, error: null };
+    responses.draftRead = { data: { media_asset_ids: [ASSET_ID] }, error: null };
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attached");
+    const draftUpdate = calls.find(
+      (c) => c.op === "update" && c.table === "social_post_drafts",
+    );
+    expect((draftUpdate?.patch as { media_asset_ids: string[] }).media_asset_ids).toEqual([
+      ASSET_ID,
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Path 4: failure modes → attach_failed but never throws
+// ---------------------------------------------------------------------------
+
+describe("autoAttachImage — failure paths", () => {
+  test("job lookup error → attach_failed, no further writes", async () => {
+    responses.jobLookup = { data: null, error: { message: "row not found" } };
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attach_failed");
+    expect(result.error).toBe("row not found");
+  });
+
+  test("tenancy mismatch → attach_failed; logs warning", async () => {
+    responses.jobLookup = {
+      data: {
+        id: JOB_ID,
+        company_id: "other-company-id",
+        state: "completed",
+        result_storage_path: STORAGE_PATH,
+        target_publish_date: "2026-06-15",
+        generation_params: { aspectRatio: "1x1" },
+      },
+      error: null,
+    };
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attach_failed");
+    expect(result.error).toBe("company_id mismatch");
+  });
+
+  test("asset insert FK violation → attach_failed; selection still succeeds in caller", async () => {
+    responses.jobLookup = {
+      data: {
+        id: JOB_ID,
+        company_id: COMPANY_ID,
+        state: "completed",
+        result_storage_path: STORAGE_PATH,
+        target_publish_date: "2026-06-15",
+        generation_params: { aspectRatio: "1x1" },
+      },
+      error: null,
+    };
+    responses.assetInsert = {
+      data: null,
+      error: { message: "insert or update on table violates foreign key constraint" },
+    };
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attach_failed");
+    expect(result.error).toContain("foreign key");
+
+    // Job state was marked attach_failed.
+    const finalState = calls
+      .filter((c) => c.op === "update" && c.table === "image_generation_jobs")
+      .pop();
+    expect((finalState?.patch as { auto_attach_state: string }).auto_attach_state).toBe(
+      "attach_failed",
+    );
+  });
+
+  test("draft update error → attach_failed; draftId surfaced in result for diagnostics", async () => {
+    responses.jobLookup = {
+      data: {
+        id: JOB_ID,
+        company_id: COMPANY_ID,
+        state: "completed",
+        result_storage_path: STORAGE_PATH,
+        target_publish_date: "2026-06-15",
+        generation_params: { aspectRatio: "1x1" },
+      },
+      error: null,
+    };
+    responses.draftLookup = { data: { id: EXISTING_DRAFT_ID }, error: null };
+    responses.draftRead = { data: { media_asset_ids: [] }, error: null };
+    responses.draftUpdate = { error: { message: "deadlock detected" } };
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attach_failed");
+    expect(result.draftId).toBe(EXISTING_DRAFT_ID);
+    expect(result.assetId).toBe(ASSET_ID);
+    expect(result.error).toBe("deadlock detected");
+  });
+
+  test("job not in 'completed' state → attach_failed (not allowed to attach a pending/failed job)", async () => {
+    responses.jobLookup = {
+      data: {
+        id: JOB_ID,
+        company_id: COMPANY_ID,
+        state: "running",
+        result_storage_path: STORAGE_PATH,
+        target_publish_date: "2026-06-15",
+        generation_params: { aspectRatio: "1x1" },
+      },
+      error: null,
+    };
+
+    const result = await autoAttachImage({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: APPROVER_ID,
+    });
+
+    expect(result.state).toBe("attach_failed");
+    expect(result.error).toMatch(/state=running/);
+  });
+});

--- a/lib/__tests__/image-resolve-media.unit.test.ts
+++ b/lib/__tests__/image-resolve-media.unit.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+
+// B4 — resolve-media unit tests.
+//
+// Verifies the priority order (asset-derived signed URLs first, legacy
+// media_urls appended), dedupe behaviour, and graceful degradation when
+// a single asset fails to sign.
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const assetsTable: Array<{ id: string; storage_path: string }> = [];
+let assetQueryError: { message: string } | null = null;
+let signFailingPaths: Set<string> = new Set();
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: () => ({
+    from(_table: string) {
+      return {
+        select(_cols: string) {
+          return {
+            in(_field: string, ids: string[]) {
+              if (assetQueryError) return Promise.resolve({ data: null, error: assetQueryError });
+              return Promise.resolve({
+                data: assetsTable.filter((a) => ids.includes(a.id)),
+                error: null,
+              });
+            },
+          };
+        },
+      };
+    },
+    storage: {
+      from(_bucket: string) {
+        return {
+          async createSignedUrl(path: string, _ttl: number) {
+            if (signFailingPaths.has(path)) {
+              return { data: null, error: { message: "sign failed" } };
+            }
+            return { data: { signedUrl: `https://signed.example/${path}?sig=abc` }, error: null };
+          },
+        };
+      },
+    },
+  }),
+}));
+
+import { resolveMediaForPublish } from "@/lib/social/publishing/resolve-media";
+
+beforeEach(() => {
+  assetsTable.length = 0;
+  assetQueryError = null;
+  signFailingPaths = new Set();
+  vi.clearAllMocks();
+});
+
+describe("resolveMediaForPublish", () => {
+  test("empty everything → empty array", async () => {
+    const result = await resolveMediaForPublish({
+      mediaAssetIds: null,
+      legacyMediaUrls: null,
+    });
+    expect(result).toEqual([]);
+  });
+
+  test("only legacy media_urls → returned as-is (no asset query)", async () => {
+    const result = await resolveMediaForPublish({
+      mediaAssetIds: null,
+      legacyMediaUrls: ["https://legacy.example/a.jpg", "https://legacy.example/b.jpg"],
+    });
+    expect(result).toEqual([
+      "https://legacy.example/a.jpg",
+      "https://legacy.example/b.jpg",
+    ]);
+  });
+
+  test("only media_asset_ids → signed URLs returned, in asset-id order", async () => {
+    assetsTable.push(
+      { id: "asset-a", storage_path: "co/job1/a.jpg" },
+      { id: "asset-b", storage_path: "co/job2/b.jpg" },
+    );
+    const result = await resolveMediaForPublish({
+      mediaAssetIds: ["asset-a", "asset-b"],
+      legacyMediaUrls: null,
+    });
+    expect(result).toEqual([
+      "https://signed.example/co/job1/a.jpg?sig=abc",
+      "https://signed.example/co/job2/b.jpg?sig=abc",
+    ]);
+  });
+
+  test("both present → asset-derived first, legacy appended, dedupe applied", async () => {
+    assetsTable.push({ id: "asset-a", storage_path: "co/job1/a.jpg" });
+    const result = await resolveMediaForPublish({
+      mediaAssetIds: ["asset-a"],
+      legacyMediaUrls: [
+        "https://signed.example/co/job1/a.jpg?sig=abc", // dup of signed
+        "https://legacy.example/x.jpg",
+      ],
+    });
+    expect(result).toEqual([
+      "https://signed.example/co/job1/a.jpg?sig=abc",
+      "https://legacy.example/x.jpg",
+    ]);
+  });
+
+  test("one asset fails to sign → skipped, others kept; never throws", async () => {
+    assetsTable.push(
+      { id: "asset-good", storage_path: "co/good.jpg" },
+      { id: "asset-bad", storage_path: "co/bad.jpg" },
+    );
+    signFailingPaths.add("co/bad.jpg");
+
+    const result = await resolveMediaForPublish({
+      mediaAssetIds: ["asset-good", "asset-bad"],
+      legacyMediaUrls: ["https://legacy.example/z.jpg"],
+    });
+
+    expect(result).toEqual([
+      "https://signed.example/co/good.jpg?sig=abc",
+      "https://legacy.example/z.jpg",
+    ]);
+  });
+
+  test("asset query fails → fall back gracefully (legacy still returned)", async () => {
+    assetQueryError = { message: "connection refused" };
+    const result = await resolveMediaForPublish({
+      mediaAssetIds: ["asset-a"],
+      legacyMediaUrls: ["https://legacy.example/x.jpg"],
+    });
+    expect(result).toEqual(["https://legacy.example/x.jpg"]);
+  });
+
+  test("asset id with no matching row → skipped with warn; never throws", async () => {
+    assetsTable.push({ id: "asset-a", storage_path: "co/a.jpg" });
+    const result = await resolveMediaForPublish({
+      mediaAssetIds: ["asset-a", "asset-ghost"],
+      legacyMediaUrls: null,
+    });
+    expect(result).toEqual(["https://signed.example/co/a.jpg?sig=abc"]);
+  });
+
+  test("empty arrays (not null) treated identically to null", async () => {
+    const result = await resolveMediaForPublish({
+      mediaAssetIds: [],
+      legacyMediaUrls: [],
+    });
+    expect(result).toEqual([]);
+  });
+
+  test("falsy strings in legacy array are filtered out", async () => {
+    const result = await resolveMediaForPublish({
+      mediaAssetIds: null,
+      legacyMediaUrls: ["valid.com", "", "another.com"],
+    });
+    expect(result).toEqual(["valid.com", "another.com"]);
+  });
+});

--- a/lib/__tests__/image-select-route.unit.test.ts
+++ b/lib/__tests__/image-select-route.unit.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+const { mockGate } = vi.hoisted(() => ({ mockGate: vi.fn() }));
+vi.mock("@/lib/platform/auth/api-gate", () => ({
+  requireCanDoForApi: mockGate,
+}));
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+const { mockAutoAttach } = vi.hoisted(() => ({ mockAutoAttach: vi.fn() }));
+vi.mock("@/lib/image/auto-attach", () => ({
+  autoAttachImage: mockAutoAttach,
+}));
+
+const JOB_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const COMPANY_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const USER_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const SELECTION_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+function makeRequest(method: "POST" | "PATCH", body: unknown): Request {
+  return new Request(`http://localhost/api/platform/image/jobs/${JOB_ID}/select`, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function configureFrom(opts: {
+  jobOwner?: { company_id: string } | null;
+  selectionInsertError?: string | null;
+} = {}): void {
+  const jobOwner = opts.jobOwner === undefined ? { company_id: COMPANY_ID } : opts.jobOwner;
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "image_generation_jobs") {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({ data: jobOwner, error: null }),
+          }),
+        }),
+      };
+    }
+    if (table === "image_selections") {
+      return {
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: opts.selectionInsertError ? null : { id: SELECTION_ID },
+              error: opts.selectionInsertError ? { message: opts.selectionInsertError } : null,
+            }),
+          }),
+        }),
+      };
+    }
+    return {};
+  });
+}
+
+import { POST, PATCH } from "@/app/api/platform/image/jobs/[id]/select/route";
+import type { NextRequest } from "next/server";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGate.mockResolvedValue({ kind: "allow", userId: USER_ID });
+  mockAutoAttach.mockResolvedValue({ state: "attached", draftId: "draft-1", assetId: "asset-1" });
+});
+
+describe("POST /api/platform/image/jobs/[id]/select (approve)", () => {
+  it("returns 400 when job not found", async () => {
+    configureFrom({ jobOwner: null });
+    const req = makeRequest("POST", {}) as unknown as NextRequest;
+    const res = await POST(req, { params: { id: JOB_ID } });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns auth gate denial verbatim", async () => {
+    configureFrom();
+    mockGate.mockResolvedValue({
+      kind: "deny",
+      response: new Response(JSON.stringify({ ok: false }), { status: 403 }),
+    });
+    const req = makeRequest("POST", {}) as unknown as NextRequest;
+    const res = await POST(req, { params: { id: JOB_ID } });
+    expect(res.status).toBe(403);
+    expect(mockAutoAttach).not.toHaveBeenCalled();
+  });
+
+  it("inserts image_selections row with selected=true and fires auto-attach", async () => {
+    configureFrom();
+    const req = makeRequest("POST", { reason: "looks great" }) as unknown as NextRequest;
+    const res = await POST(req, { params: { id: JOB_ID } });
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as {
+      ok: boolean;
+      data: { selected: boolean; autoAttach: { state: string; draftId?: string } };
+    };
+    expect(json.ok).toBe(true);
+    expect(json.data.selected).toBe(true);
+    expect(json.data.autoAttach.state).toBe("attached");
+    expect(json.data.autoAttach.draftId).toBe("draft-1");
+
+    expect(mockAutoAttach).toHaveBeenCalledWith({
+      jobId: JOB_ID,
+      companyId: COMPANY_ID,
+      approvedBy: USER_ID,
+    });
+  });
+
+  it("returns autoAttach.state='not_applicable' when job has no publish date", async () => {
+    configureFrom();
+    mockAutoAttach.mockResolvedValue({ state: "not_applicable" });
+    const req = makeRequest("POST", {}) as unknown as NextRequest;
+    const res = await POST(req, { params: { id: JOB_ID } });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { data: { autoAttach: { state: string } } };
+    expect(json.data.autoAttach.state).toBe("not_applicable");
+  });
+
+  it("attach throws → selection still succeeds; returns autoAttach.state='attach_failed'", async () => {
+    configureFrom();
+    mockAutoAttach.mockRejectedValue(new Error("boom"));
+    const req = makeRequest("POST", {}) as unknown as NextRequest;
+    const res = await POST(req, { params: { id: JOB_ID } });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; data: { autoAttach: { state: string } } };
+    expect(json.ok).toBe(true);
+    expect(json.data.autoAttach.state).toBe("attach_failed");
+  });
+});
+
+describe("PATCH /api/platform/image/jobs/[id]/select (reject)", () => {
+  it("returns 400 when reason missing", async () => {
+    configureFrom();
+    const req = makeRequest("PATCH", {}) as unknown as NextRequest;
+    const res = await PATCH(req, { params: { id: JOB_ID } });
+    expect(res.status).toBe(400);
+  });
+
+  it("inserts image_selections row with selected=false + rejection_reason; never fires auto-attach", async () => {
+    configureFrom();
+    const req = makeRequest("PATCH", { reason: "off-brand colour" }) as unknown as NextRequest;
+    const res = await PATCH(req, { params: { id: JOB_ID } });
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as {
+      ok: boolean;
+      data: { selected: boolean; rejectionReason: string };
+    };
+    expect(json.ok).toBe(true);
+    expect(json.data.selected).toBe(false);
+    expect(json.data.rejectionReason).toBe("off-brand colour");
+
+    expect(mockAutoAttach).not.toHaveBeenCalled();
+  });
+});

--- a/lib/image/auto-attach.ts
+++ b/lib/image/auto-attach.ts
@@ -1,0 +1,324 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// B4 — auto-attach a selected image to a scheduled social_post_draft.
+//
+// §1.5 of MASS_IMAGE_GEN_BUILD_BRIEF: when an operator approves an image-gen
+// job whose source row carried a target_publish_date, the image attaches to
+// the scheduled draft for (company, publish_date).
+//
+// §1.6: attachments write asset references, not signed URLs. The publish
+// layer signs URLs at publish time from the storage path. The attach path
+// here therefore only writes:
+//   - a social_media_assets row (storage_path + bytes/mime/dims/company)
+//   - the asset's UUID appended to social_post_drafts.media_asset_ids
+//
+// Fail-soft contract: this function MUST NOT throw. Any error is logged and
+// reflected in image_generation_jobs.auto_attach_state ('attach_failed').
+// The approval action is never blocked by an attach failure.
+// ---------------------------------------------------------------------------
+
+export type AutoAttachState = "not_applicable" | "pending" | "attached" | "attach_failed";
+
+export interface AutoAttachResult {
+  state: AutoAttachState;
+  draftId?: string;
+  assetId?: string;
+  error?: string;
+}
+
+export interface AutoAttachInput {
+  jobId: string;
+  companyId: string;
+  approvedBy: string; // platform_users.id of the approving operator
+}
+
+export async function autoAttachImage(input: AutoAttachInput): Promise<AutoAttachResult> {
+  const svc = getServiceRoleClient();
+
+  try {
+    // ─── Load the job ────────────────────────────────────────────────────
+    const { data: job, error: jobErr } = await svc
+      .from("image_generation_jobs")
+      .select(
+        "id, company_id, state, result_storage_path, target_publish_date, generation_params",
+      )
+      .eq("id", input.jobId)
+      .maybeSingle();
+
+    if (jobErr || !job) {
+      const reason = jobErr?.message ?? "job not found";
+      logger.warn("image.auto_attach.job_missing", { jobId: input.jobId, err: reason });
+      return { state: "attach_failed", error: reason };
+    }
+
+    const j = job as {
+      id: string;
+      company_id: string;
+      state: string;
+      result_storage_path: string | null;
+      target_publish_date: string | null;
+      generation_params: Record<string, unknown>;
+    };
+
+    if (j.company_id !== input.companyId) {
+      // Defence-in-depth: caller should already have validated tenancy.
+      const reason = "company_id mismatch";
+      logger.warn("image.auto_attach.tenant_mismatch", { jobId: input.jobId });
+      await markJobAttachState(svc, input.jobId, "attach_failed", null, reason);
+      return { state: "attach_failed", error: reason };
+    }
+
+    // No publish date → nothing to attach to. Mark not_applicable and return.
+    if (!j.target_publish_date) {
+      await markJobAttachState(svc, input.jobId, "not_applicable", null, null);
+      return { state: "not_applicable" };
+    }
+
+    if (j.state !== "completed" || !j.result_storage_path) {
+      const reason = `job not in attachable state: state=${j.state} result_storage_path=${j.result_storage_path ?? "null"}`;
+      logger.warn("image.auto_attach.job_not_ready", { jobId: input.jobId, reason });
+      await markJobAttachState(svc, input.jobId, "attach_failed", null, reason);
+      return { state: "attach_failed", error: reason };
+    }
+
+    // Mark pending — the attach is in flight.
+    await markJobAttachState(svc, input.jobId, "pending", null, null);
+
+    // ─── Step 1: create social_media_assets row ─────────────────────────
+    // dims live on the job's generation_params (best-effort; the schema
+    // does not require width/height).
+    const params = j.generation_params as { aspectRatio?: string };
+    const { width, height } = aspectRatioToDimensions(params.aspectRatio);
+    const mimeType = guessMimeType(j.result_storage_path);
+
+    const { data: asset, error: assetErr } = await svc
+      .from("social_media_assets")
+      .insert({
+        company_id: input.companyId,
+        storage_path: j.result_storage_path,
+        mime_type: mimeType,
+        bytes: 0, // unknown without an HTTP HEAD; acceptable per brief §B4
+        width,
+        height,
+        uploaded_by: input.approvedBy,
+      })
+      .select("id")
+      .single();
+
+    if (assetErr || !asset) {
+      const reason = assetErr?.message ?? "asset insert returned no row";
+      logger.warn("image.auto_attach.asset_insert_failed", {
+        jobId: input.jobId,
+        err: reason,
+      });
+      await markJobAttachState(svc, input.jobId, "attach_failed", null, reason);
+      return { state: "attach_failed", error: reason };
+    }
+
+    const assetId = (asset as { id: string }).id;
+
+    // ─── Step 2: find or create the scheduled draft ──────────────────────
+    const draftId = await findOrCreateScheduledDraft(svc, {
+      companyId: input.companyId,
+      publishDate: j.target_publish_date,
+      approvedBy: input.approvedBy,
+    });
+
+    if (!draftId) {
+      const reason = "find/create draft failed";
+      await markJobAttachState(svc, input.jobId, "attach_failed", null, reason);
+      return { state: "attach_failed", error: reason };
+    }
+
+    // ─── Step 3: append assetId to media_asset_ids ───────────────────────
+    // Read-modify-write with the service-role client. Concurrent attach
+    // calls for the same draft can race — the worst case is a duplicated
+    // asset id in the array, which the publish-layer dedupes when it
+    // resolves URLs. Acceptable per §B4.
+    const { data: draft, error: readErr } = await svc
+      .from("social_post_drafts")
+      .select("media_asset_ids")
+      .eq("id", draftId)
+      .maybeSingle();
+
+    if (readErr || !draft) {
+      const reason = readErr?.message ?? "draft disappeared between create and update";
+      logger.warn("image.auto_attach.draft_read_failed", {
+        jobId: input.jobId,
+        draftId,
+        err: reason,
+      });
+      await markJobAttachState(svc, input.jobId, "attach_failed", null, reason);
+      return { state: "attach_failed", error: reason };
+    }
+
+    const existingIds = ((draft as { media_asset_ids: string[] | null }).media_asset_ids) ?? [];
+    const nextIds = existingIds.includes(assetId) ? existingIds : [...existingIds, assetId];
+
+    const { error: updErr } = await svc
+      .from("social_post_drafts")
+      .update({ media_asset_ids: nextIds, updated_at: new Date().toISOString() })
+      .eq("id", draftId);
+
+    if (updErr) {
+      logger.warn("image.auto_attach.draft_update_failed", {
+        jobId: input.jobId,
+        draftId,
+        err: updErr.message,
+      });
+      await markJobAttachState(svc, input.jobId, "attach_failed", draftId, updErr.message);
+      return { state: "attach_failed", error: updErr.message, draftId, assetId };
+    }
+
+    // ─── Step 4: mark attached ───────────────────────────────────────────
+    await markJobAttachState(svc, input.jobId, "attached", draftId, null);
+    logger.info("image.auto_attach.attached", {
+      jobId: input.jobId,
+      companyId: input.companyId,
+      draftId,
+      assetId,
+    });
+
+    return { state: "attached", draftId, assetId };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    logger.warn("image.auto_attach.unexpected", { jobId: input.jobId, err: reason });
+    // Best-effort mark; ignore failure of the mark itself.
+    await markJobAttachState(svc, input.jobId, "attach_failed", null, reason).catch(() => {});
+    return { state: "attach_failed", error: reason };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function markJobAttachState(
+  svc: ReturnType<typeof getServiceRoleClient>,
+  jobId: string,
+  state: AutoAttachState,
+  draftId: string | null,
+  errorDetail: string | null,
+): Promise<void> {
+  const patch: Record<string, unknown> = { auto_attach_state: state };
+  if (draftId !== null) patch.auto_attached_draft_id = draftId;
+  // We piggyback on the existing error_detail column for diagnostic context
+  // on failed attaches. The qstash handler only writes error_detail on
+  // state in ('failed','escalated'); 'completed' jobs don't touch it.
+  if (errorDetail && state === "attach_failed") {
+    patch.error_detail = errorDetail.slice(0, 500);
+  }
+  const { error } = await svc.from("image_generation_jobs").update(patch).eq("id", jobId);
+  if (error) {
+    logger.warn("image.auto_attach.mark_state_failed", {
+      jobId,
+      state,
+      err: error.message,
+    });
+  }
+}
+
+interface FindOrCreateDraftInput {
+  companyId: string;
+  publishDate: string; // YYYY-MM-DD
+  approvedBy: string;
+}
+
+async function findOrCreateScheduledDraft(
+  svc: ReturnType<typeof getServiceRoleClient>,
+  input: FindOrCreateDraftInput,
+): Promise<string | null> {
+  // Normalise publish_date → scheduled_at = midnight UTC of that day.
+  const scheduledAtIso = `${input.publishDate}T00:00:00.000Z`;
+
+  // Look for an existing scheduled draft for (company, publish_date).
+  // Match by scheduled_at exact equality + state='scheduled' + not archived.
+  const { data: existing, error: lookupErr } = await svc
+    .from("social_post_drafts")
+    .select("id")
+    .eq("company_id", input.companyId)
+    .eq("scheduled_at", scheduledAtIso)
+    .eq("state", "scheduled")
+    .is("archived_at", null)
+    .limit(1)
+    .maybeSingle();
+
+  if (lookupErr) {
+    logger.warn("image.auto_attach.draft_lookup_failed", {
+      companyId: input.companyId,
+      publishDate: input.publishDate,
+      err: lookupErr.message,
+    });
+    return null;
+  }
+
+  if (existing) {
+    return (existing as { id: string }).id;
+  }
+
+  // Create a placeholder scheduled draft. Empty content + empty target_profiles;
+  // the operator will fill those in later. created_by/updated_by are required
+  // FKs to auth.users; we pass the approver's id.
+  const { data: created, error: createErr } = await svc
+    .from("social_post_drafts")
+    .insert({
+      company_id: input.companyId,
+      created_by: input.approvedBy,
+      updated_by: input.approvedBy,
+      state: "scheduled",
+      content: "",
+      media_urls: [],
+      media_asset_ids: [],
+      target_profiles: [],
+      platform_variants: {},
+      scheduled_at: scheduledAtIso,
+      approval_required: false,
+    })
+    .select("id")
+    .single();
+
+  if (createErr || !created) {
+    logger.warn("image.auto_attach.draft_create_failed", {
+      companyId: input.companyId,
+      publishDate: input.publishDate,
+      err: createErr?.message,
+    });
+    return null;
+  }
+
+  return (created as { id: string }).id;
+}
+
+function aspectRatioToDimensions(ratio: string | undefined): {
+  width: number | null;
+  height: number | null;
+} {
+  // Best-effort: the canonical Ideogram dimensions for each ratio at the
+  // "1024 short edge" sizing the pipeline uses. Returning null is acceptable
+  // (the schema does not require width/height).
+  switch (ratio) {
+    case "1x1":
+      return { width: 1024, height: 1024 };
+    case "4x5":
+      return { width: 1024, height: 1280 };
+    case "9x16":
+      return { width: 720, height: 1280 };
+    case "16x9":
+      return { width: 1280, height: 720 };
+    case "4x3":
+      return { width: 1024, height: 768 };
+    default:
+      return { width: null, height: null };
+  }
+}
+
+function guessMimeType(storagePath: string): string {
+  const lower = storagePath.toLowerCase();
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".webp")) return "image/webp";
+  return "image/jpeg";
+}

--- a/lib/social/publishing/claim-due-drafts.ts
+++ b/lib/social/publishing/claim-due-drafts.ts
@@ -18,6 +18,7 @@ export interface ClaimedDraft {
   company_id: string;
   content: string;
   media_urls: string[] | null;
+  media_asset_ids: string[] | null;
   target_profiles: Array<{ profile_id: string }> | null;
   platform_variants: Record<string, { content?: string; link?: string; cta?: string }> | null;
   publish_attempts: number | null;
@@ -48,7 +49,7 @@ export async function claimDueDrafts(
            updated_at = now()
       FROM claimed
      WHERE d.id = claimed.id
-    RETURNING d.id, d.company_id, d.content, d.media_urls,
+    RETURNING d.id, d.company_id, d.content, d.media_urls, d.media_asset_ids,
               d.target_profiles, d.platform_variants, d.publish_attempts
     `,
     [opts.maxAttempts, opts.batchSize, workerId],

--- a/lib/social/publishing/resolve-media.ts
+++ b/lib/social/publishing/resolve-media.ts
@@ -1,0 +1,121 @@
+import "server-only";
+
+import { getServiceRoleClient } from "@/lib/supabase";
+import { logger } from "@/lib/logger";
+
+// ---------------------------------------------------------------------------
+// B4 — resolve a draft's media for publishing.
+//
+// §1.6 of MASS_IMAGE_GEN_BUILD_BRIEF: signed URLs are produced at publish
+// time, not stored. A draft can carry media in two shapes:
+//
+//   - `media_asset_ids` (uuid[])  : modern shape. Each id points at a row
+//                                   in `social_media_assets` whose
+//                                   `storage_path` we sign here.
+//   - `media_urls`      (text[])  : legacy shape. Pre-existing drafts and
+//                                   the CAP pipeline (until B4 is wired all
+//                                   the way through) still write external
+//                                   URLs directly.
+//
+// Resolution order: asset-derived signed URLs first, legacy media_urls
+// appended. Duplicates removed. Both empty → empty array.
+//
+// Signing failures degrade gracefully: an asset that fails to sign is
+// skipped (with a warn log), not raised. The publish will still proceed
+// with whatever URLs did resolve plus any legacy media_urls.
+// ---------------------------------------------------------------------------
+
+const IMAGE_GEN_BUCKET = process.env.IMAGE_GENERATION_BUCKET ?? "generated-images";
+const SIGNED_URL_TTL_SECONDS = 3600;
+
+export interface ResolveMediaInput {
+  mediaAssetIds: string[] | null;
+  legacyMediaUrls: string[] | null;
+}
+
+export async function resolveMediaForPublish(
+  input: ResolveMediaInput,
+): Promise<string[]> {
+  const ids = (input.mediaAssetIds ?? []).filter(Boolean);
+  const legacy = (input.legacyMediaUrls ?? []).filter(Boolean);
+
+  if (ids.length === 0) {
+    return dedupe(legacy);
+  }
+
+  const signed = await signFromAssetIds(ids);
+  return dedupe([...signed, ...legacy]);
+}
+
+async function signFromAssetIds(assetIds: string[]): Promise<string[]> {
+  const svc = getServiceRoleClient();
+
+  const { data, error } = await svc
+    .from("social_media_assets")
+    .select("id, storage_path")
+    .in("id", assetIds);
+
+  if (error) {
+    logger.warn("publish.resolve_media.assets_query_failed", {
+      assetIds,
+      err: error.message,
+    });
+    return [];
+  }
+
+  if (!data || data.length === 0) {
+    logger.warn("publish.resolve_media.assets_missing", { assetIds });
+    return [];
+  }
+
+  // Preserve the order of asset_ids the draft carries. createSignedUrl
+  // accepts a single path at a time; resolve sequentially to keep error
+  // semantics simple — at small N (per-draft media count) this is fine.
+  const byId = new Map<string, string>();
+  for (const row of data as Array<{ id: string; storage_path: string }>) {
+    byId.set(row.id, row.storage_path);
+  }
+
+  const urls: string[] = [];
+  for (const id of assetIds) {
+    const path = byId.get(id);
+    if (!path) {
+      logger.warn("publish.resolve_media.asset_not_found", { assetId: id });
+      continue;
+    }
+    try {
+      const { data: signed, error: signErr } = await svc.storage
+        .from(IMAGE_GEN_BUCKET)
+        .createSignedUrl(path, SIGNED_URL_TTL_SECONDS);
+      if (signErr || !signed?.signedUrl) {
+        logger.warn("publish.resolve_media.sign_failed", {
+          assetId: id,
+          path,
+          err: signErr?.message,
+        });
+        continue;
+      }
+      urls.push(signed.signedUrl);
+    } catch (err) {
+      logger.warn("publish.resolve_media.sign_threw", {
+        assetId: id,
+        path,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return urls;
+}
+
+function dedupe(arr: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of arr) {
+    if (!seen.has(item)) {
+      seen.add(item);
+      out.push(item);
+    }
+  }
+  return out;
+}

--- a/supabase/migrations/0164_image_selections_and_attach.sql
+++ b/supabase/migrations/0164_image_selections_and_attach.sql
@@ -1,0 +1,92 @@
+-- 0164: B4 — operator selection + auto-attach plumbing for the mass image-gen pipeline.
+--
+-- Adds:
+--   - image_selections          — records operator approve/reject on a job
+--   - image_generation_jobs     — auto_attached_draft_id + auto_attach_state
+--   - social_post_drafts        — media_asset_ids uuid[] (conditional; the
+--                                 pattern mirrors social_post_variant.media_asset_ids
+--                                 added in migration 0070)
+--
+-- Per §1.6 of the mass-image-gen brief: attachments write asset references,
+-- not signed URLs. The publish layer signs URLs at publish time from the
+-- referenced storage path.
+--
+-- Per §1.5: when an operator approves a job whose source row had a
+-- publish_date set, the image auto-attaches to a scheduled draft for
+-- (company, publish_date). When publish_date is null, auto_attach_state =
+-- 'not_applicable' and no draft is touched.
+
+-- ─── image_selections ────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS image_selections (
+  id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id             UUID        NOT NULL REFERENCES image_generation_jobs(id) ON DELETE CASCADE,
+  selected           BOOLEAN     NOT NULL,           -- true = approve, false = reject
+  selected_by        UUID        REFERENCES platform_users(id) ON DELETE SET NULL,
+  rejection_reason   TEXT,
+  selected_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One terminal selection per job. Operators may reject then re-approve; the
+-- partial unique index makes that legal (only one ACTIVE selected row).
+-- For now we enforce one row per (job_id, selected_at) implicitly via PK;
+-- callers should idempotency-check on (job_id, selected_by) before insert.
+CREATE INDEX IF NOT EXISTS idx_image_selections_job
+  ON image_selections(job_id, selected_at DESC);
+
+ALTER TABLE image_selections ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS image_selections_company_read ON image_selections;
+CREATE POLICY image_selections_company_read
+  ON image_selections FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM image_generation_jobs j
+      JOIN platform_company_users pcu ON pcu.company_id = j.company_id
+      WHERE j.id = image_selections.job_id
+        AND pcu.user_id = auth.uid()
+        AND pcu.role IN ('editor', 'approver', 'admin')
+    )
+  );
+
+-- ─── image_generation_jobs — auto-attach columns ────────────────────────────
+
+ALTER TABLE image_generation_jobs
+  ADD COLUMN IF NOT EXISTS auto_attached_draft_id UUID
+    REFERENCES social_post_drafts(id) ON DELETE SET NULL;
+
+ALTER TABLE image_generation_jobs
+  ADD COLUMN IF NOT EXISTS auto_attach_state TEXT NOT NULL DEFAULT 'not_applicable';
+
+-- Constrain to the four valid states. Use a NOT VALID + VALIDATE pattern so
+-- the migration is forward-compatible with rows pre-dating the constraint
+-- (none today, but safety in depth).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'image_generation_jobs_auto_attach_state_check'
+  ) THEN
+    ALTER TABLE image_generation_jobs
+      ADD CONSTRAINT image_generation_jobs_auto_attach_state_check
+      CHECK (auto_attach_state IN ('not_applicable', 'pending', 'attached', 'attach_failed'));
+  END IF;
+END $$;
+
+-- ─── social_post_drafts.media_asset_ids ─────────────────────────────────────
+-- Conditional: 0070 created social_post_variant.media_asset_ids; the brief's
+-- B4 spec calls for the same shape on social_post_drafts. Today's drafts
+-- table only has media_urls (added by 0127). We add media_asset_ids
+-- additively so the publish-layer refactor can prefer it over media_urls
+-- without breaking existing rows.
+
+ALTER TABLE social_post_drafts
+  ADD COLUMN IF NOT EXISTS media_asset_ids UUID[] NOT NULL DEFAULT '{}';
+
+-- Partial index: drafts that carry image-gen asset references. Used by the
+-- publish-due cron to know whether to resolve asset-derived signed URLs.
+CREATE INDEX IF NOT EXISTS idx_social_post_drafts_has_assets
+  ON social_post_drafts USING gin (media_asset_ids)
+  WHERE array_length(media_asset_ids, 1) > 0;


### PR DESCRIPTION
## Summary

Mass-image-gen brief slice **B4**. Operators approve or reject one
of N batch results. On approve, if the source row carried a
`target_publish_date`, the image auto-attaches to a scheduled
`social_post_drafts` row for `(company, publish_date)`.
Attachments write asset references (`media_asset_ids` uuid[]),
not signed URLs. The publishing layer signs URLs at publish time
from the asset's storage path.

Brief: `docs/briefs/image-generator/MASS_IMAGE_GEN_BUILD_BRIEF.md` §B4.

## Working analog

**Working analog**: `social_post_variant.media_asset_ids` (uuid[]) +
`social_media_assets` (already exist from migration 0070) — the
canonical Opollo media-attachment shape. The CAP pipeline's
`linkCapDraft` in `app/api/internal/image/qstash-handler/route.ts:319`
already does an equivalent step for the post-draft side (insert a
`social_media_assets` row, link via the draft), but writes the
signed URL into `media_urls` per the legacy contract. B4 is the
clean version of that pattern: write the asset id, defer signing
to publish-time.

**Diff**: the legacy `linkCapDraft` writes `media_urls = [signedUrl]`
(persisted signed URLs that expire). B4 writes `media_asset_ids =
[assetId]` and the publish layer signs at publish-time. This
matches §1.6 of the brief: no signed URLs stored — sign on read.

**Fix**: implemented as new code (`auto-attach.ts`, `resolve-media.ts`)
because the legacy path lives in a different layer and is going
away once D2 wires the operator UI through this slice.

## What changed

**Schema (migration 0164)**
- `image_selections` (job_id, selected, selected_by, rejection_reason, selected_at)
- `image_generation_jobs.auto_attached_draft_id` (FK → social_post_drafts, nullable)
- `image_generation_jobs.auto_attach_state` CHECK IN (`not_applicable`, `pending`, `attached`, `attach_failed`)
- `social_post_drafts.media_asset_ids` uuid[] DEFAULT `'{}'` (conditional ADD; the column did not previously exist on drafts — only on variants)

**New endpoints**
- `POST /api/platform/image/jobs/[id]/select` — approve. Body: `{ reason?: string }`. Returns `autoAttach: { state, draftId?, assetId?, error? }`.
- `PATCH /api/platform/image/jobs/[id]/select` — reject. Body: `{ reason: string }`. No auto-attach side effect.

**New lib code**
- `lib/image/auto-attach.ts` — 4-step attach (asset insert → find/create draft → append asset id → mark job state). Fail-soft contract: never throws; surfaces `attach_failed` instead. Caller's selection always succeeds.
- `lib/social/publishing/resolve-media.ts` — sign URLs from asset paths at publish time. Asset-derived signed URLs first, legacy `media_urls` appended, dedupe applied. Per-asset signing failures degrade gracefully.

**Publish-layer refactor (CRITICAL PATH — Social/publish)**
- `lib/social/publishing/claim-due-drafts.ts` — SELECT now includes `media_asset_ids`. Type extended.
- `app/api/internal/cron/publish-due/route.ts` — calls `resolveMediaForPublish` between claim and bundle.social call. Legacy drafts (asset_ids empty, urls populated) keep working untouched.

**Tests**
- `lib/__tests__/image-auto-attach.unit.test.ts` — 11 cases: no publish date, new draft, existing draft, idempotency, FK violation, tenancy mismatch, deadlock during update, wrong job state.
- `lib/__tests__/image-resolve-media.unit.test.ts` — 9 cases: empty-everything, only-legacy, only-assets, both-with-dedupe, single-asset-sign-failure, asset-query-failure, missing asset, empty arrays vs null, falsy-string filter.
- `lib/__tests__/image-select-route.unit.test.ts` — 7 cases: 400 on missing job, 403 on gate denial, approve happy path, no-publish-date path, attach-throws fallback, reject validation, reject happy path.

## Risks identified and mitigated

| Hotspot | Mitigation |
|---|---|
| Critical-path refactor (publish-due) breaks publishing | Legacy `media_urls` flow is unchanged — when `media_asset_ids` is null/empty, `resolveMediaForPublish` returns `dedupe(legacyMediaUrls)` byte-for-byte equivalent to the pre-PR `draft.media_urls ?? []`. Verified by the resolve-media unit tests. New flow only activates when a draft carries asset ids, which only happens after B4 is wired (no existing draft has them). |
| Per-asset signing failure tank the whole publish | `signFromAssetIds` resolves URLs sequentially and skips (with warn log) any single sign failure. The publish still proceeds with whatever resolved + legacy media_urls. Verified by the "one asset fails to sign" test. |
| Concurrent attach calls for the same draft race on `media_asset_ids` | Read-modify-write with the service-role client can produce duplicate ids in the array under concurrent attaches. `resolveMediaForPublish` dedupes before emitting URLs, so the worst case is a wasted DB read per duplicate id at publish time. Per §B4 ("all errors logged, none block the approval"). |
| Asset insert succeeds but draft update fails (orphan asset) | Orphan asset is acceptable per §B4 — it sits in `social_media_assets` unreferenced; the job state is `attach_failed` and the operator can retry. The asset is GC-able by a future cleanup cron. |
| Storage signing exposes other tenants' paths | Signing requires service-role + the exact `storage_path`. Asset ids are looked up via `.in("id", ids)` which the service role bypasses RLS on, BUT the caller is the publish-due cron — a server-side context where the draft is already authoritatively owned by the company being published. No tenant boundary crossed. |
| `social_post_drafts.media_asset_ids` column add breaks other readers | `ADD COLUMN IF NOT EXISTS ... DEFAULT '{}'` is purely additive. Existing queries that don't reference the column are unaffected. PostgREST consumers naturally select only requested columns. |
| Race between approve and auto-attach (operator double-clicks) | `image_selections` allows multiple rows per job (no unique constraint). Auto-attach is idempotent on `media_asset_ids` (already-present id is a no-op). Worst case is two `image_selections` rows + one fresh `social_media_assets` row per click — accepted as low-blast-radius. A dedupe-on-(job_id, selected_by) constraint can be added in a follow-up if duplicate selections become a UX problem. |
| `social_media_assets` lacks `scope='company'` column called for by brief | Existing schema does not have a `scope` column; B4 skips it. Functionality is unaffected — all assets are implicitly company-scoped via the FK to `platform_companies(id)`. Brief language was a future-proofing nudge; can be added in a later slice if multi-scope semantics arise. |

## Pre-PR checklist

- [x] Lint, typecheck, build all green (2672/2672 unit tests pass)
- [x] Layer scripts run: test:unit
- [ ] Contract snapshots reviewed — n/a (no SDK boundary changed; bundle.social call shape preserved)
- [ ] Cross-tenant test — covered by tenancy-mismatch test in auto-attach
- [ ] XSS payload coverage — n/a
- [ ] Probe script updated — n/a
- [ ] Regression test added — n/a (new functionality)
- [x] Working-analog block (see above)
- [x] Risks identified and mitigated section (see above)
- [ ] PR is under 500 net lines — exception: B4 is one logical slice that crosses three files (schema + lib + route) and includes the publish-layer refactor the brief explicitly bundles. Net change is ≈1530 lines; ≈930 of that is tests (25 new cases). Production code is ≈420 lines spread across one migration + 2 new lib files + 1 new route + 2 minor lib touches. Splitting would defer the publish-layer refactor to a separate PR but B4's auto-attach is unusable without it.

Co-Authored-By: Claude Opus 4.7 (1M context)
