### PR TITLE
feat(image-gen): slice B5 — preview mode

### DIFF
--- a/app/api/internal/image/qstash-handler/route.ts
+++ b/app/api/internal/image/qstash-handler/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/image/lease";
 import { incrementImageGenSpend } from "@/lib/image/budget";
 import { notifyImageGenBudgetThreshold } from "@/lib/image/budget-notify";
+import { generatePreview } from "@/lib/image/generator/preview";
 
 // ---------------------------------------------------------------------------
 // POST /api/internal/image/qstash-handler
@@ -70,6 +71,8 @@ const BodySchema = z.object({
   capDraftId: z.string().uuid().optional(),
   headlineText: z.string().max(200).optional(),
   logoUrl: z.string().url().optional(),
+  // B5: when true, build the prompt and return without calling Ideogram.
+  previewOnly: z.boolean().optional(),
 });
 
 type Body = z.infer<typeof BodySchema>;
@@ -99,9 +102,23 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return validationError(`Invalid body: ${err instanceof Error ? err.message : String(err)}`);
   }
 
-  const { jobId, generationParams, batchId, capDraftId, headlineText, logoUrl } = parsed;
+  const { jobId, generationParams, batchId, capDraftId, headlineText, logoUrl, previewOnly } = parsed;
 
-  logger.info("image.qstash.received", { jobId, batchId, companyId: generationParams.companyId });
+  logger.info("image.qstash.received", {
+    jobId,
+    batchId,
+    companyId: generationParams.companyId,
+    previewOnly: previewOnly === true,
+  });
+
+  // ─── B5: preview-only short-circuit ─────────────────────────────────────
+  // Bypass lease + concurrency + Ideogram. Build the prompt, write the audit
+  // row, mark the job completed with null result. Never increments spend.
+  // Preview never enters the concurrency budget — it's a synchronous read
+  // from prompt-engine and has no cost to throttle.
+  if (previewOnly) {
+    return handlePreview({ jobId, generationParams, batchId });
+  }
 
   // ─── 1. Acquire Redis lease (dedup + concurrency token) ───────────────────
 
@@ -373,6 +390,82 @@ async function linkCapDraft(
       err: err instanceof Error ? err.message : String(err),
     });
   }
+}
+
+/**
+ * B5: handle a preview-only delivery. Build the prompt via prompt-engine,
+ * persist it to the job + image_generation_log, and return 200. Never calls
+ * Ideogram. Never increments spend. Never holds a lease.
+ */
+async function handlePreview(input: {
+  jobId: string;
+  generationParams: z.infer<typeof GenerationParamsSchema>;
+  batchId: string | undefined;
+}): Promise<NextResponse> {
+  const svc = getServiceRoleClient();
+
+  let prompt: string;
+  try {
+    const result = generatePreview(input.generationParams);
+    prompt = result.prompt;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    logger.warn("image.qstash.preview_prompt_failed", { jobId: input.jobId, err: detail });
+    await svc
+      .from("image_generation_jobs")
+      .update({
+        state: "failed",
+        error_class: "PreviewPromptError",
+        error_detail: detail.slice(0, 500),
+        completed_at: new Date().toISOString(),
+      })
+      .eq("id", input.jobId);
+    if (input.batchId) void updateBatchProgress(svc, input.batchId);
+    return NextResponse.json({ ok: false, status: "preview_failed", error: detail });
+  }
+
+  // Stash prompt into generation_params so the UI can show it without a new column.
+  const enrichedParams = { ...input.generationParams, preview_prompt: prompt };
+
+  await svc
+    .from("image_generation_jobs")
+    .update({
+      state: "completed",
+      result_storage_path: null,
+      generation_params: enrichedParams,
+      completed_at: new Date().toISOString(),
+    })
+    .eq("id", input.jobId);
+
+  // Audit row — outcome='preview' per §B5. Never block on this; warn on failure.
+  await svc
+    .from("image_generation_log")
+    .insert({
+      company_id: input.generationParams.companyId,
+      style_id: input.generationParams.styleId,
+      composition_type: input.generationParams.compositionType,
+      aspect_ratio: input.generationParams.aspectRatio,
+      model_used: "preview",
+      model_tier: input.generationParams.model ?? "standard",
+      prompt_used: prompt,
+      outcome: "preview",
+    })
+    .then(({ error }) => {
+      if (error) {
+        logger.warn("image.qstash.preview_log_insert_failed", {
+          jobId: input.jobId,
+          err: error.message,
+        });
+      }
+    });
+
+  if (input.batchId) void updateBatchProgress(svc, input.batchId);
+
+  logger.info("image.qstash.preview_completed", {
+    jobId: input.jobId,
+    promptLength: prompt.length,
+  });
+  return NextResponse.json({ ok: true, status: "preview", prompt });
 }
 
 /**

--- a/app/api/platform/image/batch/route.ts
+++ b/app/api/platform/image/batch/route.ts
@@ -160,11 +160,15 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const jobId = job.id as string;
     jobIds.push(jobId);
 
-    // Preview mode: skip QStash; job state stays 'pending' as a draft marker.
-    if (mode === "preview") continue;
-
-    // Enqueue to QStash.
-    const enqueue = await enqueueImageJob({ jobId, generationParams, batchId });
+    // B5: preview mode enqueues through the same QStash handler with
+    // previewOnly=true. The handler builds the prompt and returns without
+    // calling Ideogram. Same code path exercise; zero spend.
+    const enqueue = await enqueueImageJob({
+      jobId,
+      generationParams,
+      batchId,
+      ...(mode === "preview" && { previewOnly: true }),
+    });
     if (!enqueue.ok) {
       logger.error("image.batch.enqueue_failed", { batchId, jobId, error: enqueue.error });
       // Mark job failed immediately so the batch tracker has accurate counts.
@@ -181,7 +185,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   await svc
     .from("image_generation_batches")
     .update({
-      state: mode === "preview" ? "pending" : allFailed ? "failed" : "running",
+      state: allFailed ? "failed" : "running",
       failed_jobs: jobErrors.length,
       updated_at: new Date().toISOString(),
     })

--- a/lib/__tests__/image-batch-route.unit.test.ts
+++ b/lib/__tests__/image-batch-route.unit.test.ts
@@ -208,7 +208,7 @@ describe("POST /api/platform/image/batch", () => {
     expect(vi.mocked(enqueueImageJob)).not.toHaveBeenCalled();
   });
 
-  it("mode=preview skips QStash enqueue", async () => {
+  it("mode=preview enqueues with previewOnly=true (B5)", async () => {
     mockFrom.mockImplementation((table: string) => {
       if (table === "image_generation_batches") {
         return {
@@ -243,7 +243,60 @@ describe("POST /api/platform/image/batch", () => {
     const json = await res.json() as { data: { mode: string } };
     expect(json.data.mode).toBe("preview");
 
+    // §B5: preview flows through the same handler with previewOnly=true.
+    // Batch route does NOT skip QStash; the handler refuses to call Ideogram
+    // when it sees previewOnly.
     const { enqueueImageJob } = await import("@/lib/image/enqueue");
-    expect(vi.mocked(enqueueImageJob)).not.toHaveBeenCalled();
+    expect(vi.mocked(enqueueImageJob)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(enqueueImageJob)).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: JOB_UUID, previewOnly: true }),
+    );
+  });
+
+  it("mode=preview skips budget check (B5 ↔ B3)", async () => {
+    // Tight budget that would reject a 1-job batch in 'generate' mode,
+    // but preview must pass through without consulting the budget.
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "platform_companies") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { monthly_image_gen_budget_cents: 0 },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "image_generation_batches") {
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: { id: BATCH_UUID }, error: null }),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+        };
+      }
+      if (table === "image_generation_jobs") {
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: { id: JOB_UUID }, error: null }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const req = makePostRequest({
+      company_id: COMPANY_UUID,
+      jobs: [VALID_JOB_SPEC],
+      mode: "preview",
+    }) as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(201);
   });
 });

--- a/lib/__tests__/image-preview-mode.unit.test.ts
+++ b/lib/__tests__/image-preview-mode.unit.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// B5 — preview-mode tests for the qstash handler.
+//
+// Verifies that when previewOnly=true is in the QStash payload:
+//   1. Ideogram is NOT called (generateWithFallback mock is untouched)
+//   2. The job is marked state=completed with result_storage_path=null
+//   3. An image_generation_log row is inserted with outcome='preview'
+//   4. Spend is NOT incremented
+//   5. Lease is NOT acquired
+//
+// Plus a unit test for the preview generator itself: prompt text is the
+// same shape as the real Ideogram-bound prompt.
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hoisted mocks
+// ─────────────────────────────────────────────────────────────────────────────
+const { mockVerify } = vi.hoisted(() => ({ mockVerify: vi.fn() }));
+vi.mock("@/lib/qstash", () => ({
+  verifyQstashSignature: mockVerify,
+  getQstashClient: vi.fn(() => ({ publishJSON: vi.fn() })),
+}));
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+vi.mock("@/lib/supabase", () => ({
+  getServiceRoleClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+const { mockGenerate } = vi.hoisted(() => ({ mockGenerate: vi.fn() }));
+vi.mock("@/lib/image", () => ({ generateWithFallback: mockGenerate }));
+
+const { mockAcquire, mockRelease, mockCount, mockCap } = vi.hoisted(() => ({
+  mockAcquire: vi.fn(),
+  mockRelease: vi.fn(),
+  mockCount: vi.fn(),
+  mockCap: vi.fn(),
+}));
+vi.mock("@/lib/image/lease", () => ({
+  acquireImageLease: mockAcquire,
+  releaseImageLease: mockRelease,
+  getActiveLeaseCount: mockCount,
+  getConcurrencyCap: mockCap,
+  LEASE_TTL_SECONDS: 90,
+  DEFAULT_CONCURRENCY_CAP: 12,
+}));
+
+vi.mock("@/lib/image/enqueue", () => ({
+  enqueueImageJob: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+const { mockIncrementSpend } = vi.hoisted(() => ({ mockIncrementSpend: vi.fn() }));
+vi.mock("@/lib/image/budget", () => ({
+  incrementImageGenSpend: mockIncrementSpend,
+  checkImageGenBudget: vi.fn(),
+}));
+
+vi.mock("@/lib/image/budget-notify", () => ({
+  notifyImageGenBudgetThreshold: vi.fn(),
+}));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+const JOB_UUID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const COMPANY_UUID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const BATCH_UUID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+import type { GenerationParams } from "@/lib/image/types";
+
+const VALID_PARAMS: GenerationParams = {
+  styleId: "clean_corporate",
+  primaryColour: "#1a56db",
+  compositionType: "split_layout",
+  aspectRatio: "1x1",
+  companyId: COMPANY_UUID,
+};
+
+function makeRequest(body: unknown): NextRequest {
+  return new Request("http://localhost/api/internal/image/qstash-handler", {
+    method: "POST",
+    headers: { "upstash-signature": "valid-sig", "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+interface RecordedTableCall {
+  table: string;
+  op: "update" | "insert";
+  patch?: unknown;
+  inserted?: unknown;
+}
+
+const tableCalls: RecordedTableCall[] = [];
+
+function buildFromMock(): (table: string) => unknown {
+  return (table: string) => ({
+    update: vi.fn().mockImplementation((patch: unknown) => {
+      const call: RecordedTableCall = { table, op: "update", patch };
+      return {
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockImplementation(async () => {
+            tableCalls.push(call);
+            return { error: null };
+          }),
+          then: (onFulfilled: (v: unknown) => unknown) => {
+            tableCalls.push(call);
+            return Promise.resolve({ error: null }).then(onFulfilled);
+          },
+        }),
+      };
+    }),
+    insert: vi.fn().mockImplementation((row: unknown) => {
+      const call: RecordedTableCall = { table, op: "insert", inserted: row };
+      // The handler awaits .insert(...) directly, then chains .then(...)
+      const result = Promise.resolve({ error: null });
+      tableCalls.push(call);
+      return {
+        ...result,
+        then: result.then.bind(result),
+      };
+    }),
+    select: vi.fn(),
+  });
+}
+
+import { POST } from "@/app/api/internal/image/qstash-handler/route";
+import type { NextRequest } from "next/server";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tableCalls.length = 0;
+  mockVerify.mockResolvedValue({ ok: true });
+  mockAcquire.mockResolvedValue({ ok: true });
+  mockCount.mockResolvedValue(0);
+  mockCap.mockReturnValue(12);
+  mockFrom.mockImplementation(buildFromMock());
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Preview-mode path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("qstash handler — previewOnly=true", () => {
+  it("does NOT call Ideogram, does NOT acquire lease, marks job completed with null storage path", async () => {
+    const req = makeRequest({
+      jobId: JOB_UUID,
+      generationParams: VALID_PARAMS,
+      batchId: BATCH_UUID,
+      previewOnly: true,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as { ok: boolean; status: string; prompt: string };
+    expect(json.ok).toBe(true);
+    expect(json.status).toBe("preview");
+    expect(json.prompt.length).toBeGreaterThan(0);
+
+    // Ideogram never called.
+    expect(mockGenerate).not.toHaveBeenCalled();
+    // Lease never acquired in preview mode.
+    expect(mockAcquire).not.toHaveBeenCalled();
+    // Spend NOT incremented.
+    expect(mockIncrementSpend).not.toHaveBeenCalled();
+
+    // Job state marked completed; result_storage_path = null.
+    const jobUpdates = tableCalls.filter(
+      (c) => c.op === "update" && c.table === "image_generation_jobs",
+    );
+    expect(jobUpdates.length).toBeGreaterThanOrEqual(1);
+    const patch = jobUpdates[0].patch as {
+      state: string;
+      result_storage_path: string | null;
+      generation_params: { preview_prompt: string };
+    };
+    expect(patch.state).toBe("completed");
+    expect(patch.result_storage_path).toBeNull();
+    expect(patch.generation_params.preview_prompt.length).toBeGreaterThan(0);
+
+    // image_generation_log row inserted with outcome='preview'.
+    const logInserts = tableCalls.filter(
+      (c) => c.op === "insert" && c.table === "image_generation_log",
+    );
+    expect(logInserts).toHaveLength(1);
+    const logRow = logInserts[0].inserted as {
+      outcome: string;
+      style_id: string;
+      composition_type: string;
+      aspect_ratio: string;
+      prompt_used: string;
+      company_id: string;
+    };
+    expect(logRow.outcome).toBe("preview");
+    expect(logRow.style_id).toBe("clean_corporate");
+    expect(logRow.composition_type).toBe("split_layout");
+    expect(logRow.aspect_ratio).toBe("1x1");
+    expect(logRow.company_id).toBe(COMPANY_UUID);
+    expect(logRow.prompt_used.length).toBeGreaterThan(0);
+  });
+
+  // Non-preview sanity is covered by image-qstash-handler.unit.test.ts;
+  // this file is preview-specific.
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Preview generator (pure function)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("generatePreview", () => {
+  it("returns a non-empty prompt for a valid GenerationParams", async () => {
+    const { generatePreview } = await import("@/lib/image/generator/preview");
+    const result = generatePreview(VALID_PARAMS);
+    expect(result.prompt.length).toBeGreaterThan(0);
+  });
+
+  it("varies prompt by styleId (deterministic)", async () => {
+    const { generatePreview } = await import("@/lib/image/generator/preview");
+    const a = generatePreview({ ...VALID_PARAMS, styleId: "clean_corporate" as const });
+    const b = generatePreview({ ...VALID_PARAMS, styleId: "bold_promo" as const });
+    expect(a.prompt).not.toBe(b.prompt);
+  });
+
+  it("simplifyPrompt=true changes the prompt vs default", async () => {
+    const { generatePreview } = await import("@/lib/image/generator/preview");
+    const a = generatePreview(VALID_PARAMS);
+    const b = generatePreview({ ...VALID_PARAMS, simplifyPrompt: true });
+    expect(a.prompt).not.toBe(b.prompt);
+  });
+});

--- a/lib/image/enqueue.ts
+++ b/lib/image/enqueue.ts
@@ -28,6 +28,8 @@ export interface EnqueueImageJobInput {
   headlineText?: string;
   /** Brand logo URL (fresh-signed at enqueue time) for compositing. */
   logoUrl?: string;
+  /** B5: when true, the handler builds the prompt and returns without calling Ideogram. */
+  previewOnly?: boolean;
 }
 
 export type EnqueueResult = { ok: true } | { ok: false; error: string };
@@ -56,6 +58,7 @@ export async function enqueueImageJob(input: EnqueueImageJobInput): Promise<Enqu
         ...(input.capDraftId && { capDraftId: input.capDraftId }),
         ...(input.headlineText && { headlineText: input.headlineText }),
         ...(input.logoUrl && { logoUrl: input.logoUrl }),
+        ...(input.previewOnly && { previewOnly: true }),
       },
       deduplicationId: input.jobId,
       ...(input.delaySeconds && { delay: input.delaySeconds }),

--- a/lib/image/generator/preview.ts
+++ b/lib/image/generator/preview.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+import type { GenerationParams } from "../types";
+import { buildPrompt } from "./prompt-engine";
+
+// ---------------------------------------------------------------------------
+// B5 — preview-mode generator.
+//
+// §B5 of MASS_IMAGE_GEN_BUILD_BRIEF. Builds the exact prompt that would
+// have been sent to Ideogram and returns it. Never calls Ideogram. Never
+// writes to storage. Never spends money.
+//
+// The qstash handler routes here when the QStash payload has previewOnly:
+// true. Result is persisted to image_generation_jobs (state=completed,
+// result_storage_path=null, generation_params.preview_prompt=<prompt>)
+// and to image_generation_log (outcome='preview').
+// ---------------------------------------------------------------------------
+
+export interface PreviewResult {
+  prompt: string;
+}
+
+export function generatePreview(params: GenerationParams): PreviewResult {
+  const prompt = buildPrompt({
+    styleId: params.styleId,
+    primaryColour: params.primaryColour,
+    compositionType: params.compositionType,
+    industry: params.industry,
+    mood: params.mood,
+    safeMode: false,
+    simplify: params.simplifyPrompt,
+  });
+  return { prompt };
+}

--- a/supabase/migrations/0165_image_gen_preview_outcome.sql
+++ b/supabase/migrations/0165_image_gen_preview_outcome.sql
@@ -1,0 +1,11 @@
+-- 0165: B5 — add 'preview' value to image_gen_outcome enum.
+--
+-- §B5 of MASS_IMAGE_GEN_BUILD_BRIEF. Preview-mode jobs flow through the
+-- canonical qstash handler but never call Ideogram. They write an
+-- image_generation_log row with outcome='preview' so the operator can audit
+-- exactly which prompts would have been sent without incurring spend.
+--
+-- ALTER TYPE ... ADD VALUE IF NOT EXISTS is PG13+ (already required by 0126
+-- for social_error_class). Safe re-apply.
+
+ALTER TYPE image_gen_outcome ADD VALUE IF NOT EXISTS 'preview';


### PR DESCRIPTION
## Summary

Mass-image-gen brief slice **B5** — preview mode. Operators can run a
batch in `mode: 'preview'` to see the exact prompt that would be
sent to Ideogram for each job, without spending real credits.

Brief: `docs/briefs/image-generator/MASS_IMAGE_GEN_BUILD_BRIEF.md` §B5.

## Working analog

**Working analog**: `lib/image/generator/prompt-engine.ts:buildPrompt`
is the canonical prompt builder used by `ideogram.ts:60` for every
real call to Ideogram. B5's preview generator is a one-line wrapper
around `buildPrompt` — the prompt the operator sees is byte-identical
to the prompt a real generation would send.

**Diff**: real generation passes the prompt to Ideogram via
multipart/form-data + downloads the image + writes to storage.
Preview stops at the prompt — no Ideogram call, no storage write.

**Fix**: implemented as `lib/image/generator/preview.ts` (new file)
to keep `ideogram.ts` unchanged; preview's call shape is different
enough (synchronous, no I/O) that overloading the existing function
would have widened the GenerationParams contract for no win.

## What changed

**Schema (migration 0165)**
- `ALTER TYPE image_gen_outcome ADD VALUE IF NOT EXISTS 'preview'`

**New code**
- `lib/image/generator/preview.ts` — pure function. Returns `{ prompt }`.

**Wiring**
- `lib/image/enqueue.ts` — `EnqueueImageJobInput` gains `previewOnly?: boolean`. Passed through to QStash body.
- `app/api/internal/image/qstash-handler/route.ts` — when `previewOnly` is in the body, short-circuits BEFORE lease acquisition + concurrency cap + Ideogram call. Builds the prompt, stashes it in `generation_params.preview_prompt`, writes `image_generation_log` with `outcome='preview'`, marks `image_generation_jobs.state='completed'` with `result_storage_path=null`. Spend is NOT incremented. Batch progress is still tracked.
- `app/api/platform/image/batch/route.ts` — preview mode no longer short-circuits the enqueue (it did in B3). Same code path now exercises QStash → handler → preview. Batch state transitions to `'running'` for preview too so the handler can complete it.

**Tests**
- `lib/__tests__/image-preview-mode.unit.test.ts` — 4 cases:
  1. previewOnly=true → no Ideogram call, no lease acquired, no spend increment, job marked completed with null storage path, log row inserted with `outcome='preview'`.
  2. generatePreview returns non-empty prompt for valid params.
  3. Prompt varies by styleId (deterministic, not random).
  4. simplifyPrompt=true changes the output (parity with ideogram.ts retry path).
- `lib/__tests__/image-batch-route.unit.test.ts` — updated the preview-mode test from "skips QStash enqueue" to "enqueues with previewOnly=true". Added a new test confirming preview skips the budget pre-flight (B5 ↔ B3 contract).

## Risks identified and mitigated

| Hotspot | Mitigation |
|---|---|
| Preview accidentally calls Ideogram (cost leak) | Handler short-circuits in the FIRST few lines after body parsing — before lease acquisition and well before `generateWithFallback`. Verified by unit test asserting `generateWithFallback` mock is untouched + `acquireImageLease` mock is untouched. |
| Preview accidentally increments spend (cost-accounting leak) | `recordBudgetSpend` is only called in the success block AFTER `generateWithFallback`. The preview path returns before that block. Verified by unit test asserting `incrementImageGenSpend` mock is untouched. |
| Preview job stuck in 'pending' (UX bug from B3) | Pre-B5: batch route short-circuited preview, leaving jobs in 'pending' forever. Now preview enqueues → handler completes → state advances. Verified by job-update assertion. |
| `outcome='preview'` enum value not applied at deploy time → handler INSERT fails | Migration 0165 runs via `deploy-migrations.yml` automatically on the same merge as the code that uses it. If the migration runs first (it always does — supabase db push happens before Vercel deploy completes), the enum value exists when the new handler boots. Worst case: handler INSERT fails with a warn log; the job still moves to completed; no user-facing impact. |
| QStash dedup absorbs preview re-enqueue of an already-real job | Same `Upstash-Deduplication-Id` (jobId) — if a real job got re-enqueued as preview within the 24h dedup window, the preview delivery would be absorbed. This is a non-scenario: preview jobs are created freshly per dispatch and never reuse a real job's id. |
| Batch state advancement: preview batch never has failed_jobs > 0 → state stuck at 'running' | `updateBatchProgress` (called from the preview handler) computes state from job counts: `completed+failed === total → completed/partial/failed`. Preview jobs are marked `state='completed'` so the batch advances to `'completed'` once all preview jobs finish. Same code path as real generation. |

## Pre-PR checklist

- [x] Lint, typecheck, build all green (2677/2677 unit tests pass)
- [x] Layer scripts run: test:unit
- [ ] Contract snapshots reviewed — n/a (no external SDK boundary changed)
- [ ] Cross-tenant test — n/a (preview is a single-job, single-tenant operation)
- [ ] XSS payload coverage — n/a
- [ ] Probe script updated — n/a
- [ ] Regression test added — n/a (new functionality)
- [x] Working-analog block (see above)
- [x] Risks identified and mitigated section (see above)
- [x] PR is under 500 net lines (441 lines, mostly tests)

Co-Authored-By: Claude Opus 4.7 (1M context)
