### PR TITLE
feat(image-gen): slice D2 — batch results viewer UI

### DIFF
--- a/app/(platform)/company/image/batches/[id]/page.tsx
+++ b/app/(platform)/company/image/batches/[id]/page.tsx
@@ -1,0 +1,38 @@
+import { redirect, notFound } from "next/navigation";
+
+import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
+import { BatchResultsClient } from "@/components/image/BatchResultsClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function BatchResultsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const session = await getCurrentPlatformSession();
+  if (!session) redirect(`/login?next=/company/image/batches/${id}`);
+  if (!session.company) redirect("/company");
+
+  const companyId = session.company.companyId;
+  if (!await canDo(companyId, "create_post")) redirect("/company");
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-6 space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold">Batch results</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Review generated images. Approve to attach to a draft; reject to discard.
+          </p>
+        </div>
+        <a href="/company/image/batches" className="text-sm text-muted-foreground hover:text-foreground underline">
+          ← All batches
+        </a>
+      </div>
+      <BatchResultsClient batchId={id} companyId={companyId} />
+    </div>
+  );
+}

--- a/app/(platform)/company/image/batches/page.tsx
+++ b/app/(platform)/company/image/batches/page.tsx
@@ -1,0 +1,76 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+
+import { canDo, getCurrentPlatformSession } from "@/lib/platform/auth";
+import { getServiceRoleClient } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+
+const STATE_LABELS: Record<string, { label: string; colour: string }> = {
+  pending:   { label: "Pending",   colour: "bg-muted text-muted-foreground" },
+  running:   { label: "Running",   colour: "bg-blue-100 text-blue-700" },
+  completed: { label: "Done",      colour: "bg-green-100 text-green-700" },
+  partial:   { label: "Partial",   colour: "bg-amber-100 text-amber-700" },
+  failed:    { label: "Failed",    colour: "bg-red-100 text-red-700" },
+};
+
+export default async function BatchHistoryPage() {
+  const session = await getCurrentPlatformSession();
+  if (!session) redirect("/login?next=/company/image/batches");
+  if (!session.company) redirect("/company");
+
+  const companyId = session.company.companyId;
+  if (!await canDo(companyId, "create_post")) redirect("/company");
+
+  const svc = getServiceRoleClient();
+  const { data: batches } = await svc
+    .from("image_generation_batches")
+    .select("id, state, total_jobs, completed_jobs, failed_jobs, source_filename, source_row_count, created_at")
+    .eq("company_id", companyId)
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8 space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Batch history</h1>
+        <p className="text-sm text-muted-foreground mt-1">Past image generation batches.</p>
+      </div>
+
+      {!batches?.length ? (
+        <p className="text-sm text-muted-foreground py-8 text-center">
+          No batches yet. Upload a document from{" "}
+          <Link href="/company/image/ingest" className="underline">Image ingest</Link>.
+        </p>
+      ) : (
+        <div className="divide-y divide-border rounded-xl border border-border overflow-hidden">
+          {batches.map((b) => {
+            const st = STATE_LABELS[b.state] ?? { label: b.state, colour: "bg-muted text-muted-foreground" };
+            const date = new Date(b.created_at as string).toLocaleDateString("en-AU", { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" });
+            return (
+              <Link key={b.id} href={`/company/image/batches/${b.id}`} className="flex items-center justify-between px-5 py-4 bg-card hover:bg-accent transition-colors gap-4">
+                <div className="min-w-0">
+                  <p className="font-medium text-sm truncate">
+                    {b.source_filename ?? `Batch ${(b.id as string).slice(0, 8)}`}
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {date} · {b.total_jobs} jobs
+                    {b.source_row_count ? ` from ${b.source_row_count} rows` : ""}
+                  </p>
+                </div>
+                <div className="flex items-center gap-3 shrink-0">
+                  <p className="text-xs text-muted-foreground">
+                    {b.completed_jobs}/{b.total_jobs} done{b.failed_jobs > 0 ? ` · ${b.failed_jobs} failed` : ""}
+                  </p>
+                  <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${st.colour}`}>
+                    {st.label}
+                  </span>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/image/BatchResultsClient.tsx
+++ b/components/image/BatchResultsClient.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+
+// ---------------------------------------------------------------------------
+// D2 — Batch results viewer.
+//
+// Polls GET /api/platform/image/batch/[id] every 3s while state='running'.
+// Groups jobs by parentPostIndex for the §1.7 grouping requirement.
+// Approve / reject via POST|PATCH /api/platform/image/jobs/[id]/select.
+// Shows auto-attach state badge per job.
+// ---------------------------------------------------------------------------
+
+interface Job {
+  id: string;
+  state: string;
+  resultSignedUrl: string | null;
+  errorClass: string | null;
+  errorDetail: string | null;
+  targetPlatforms: string[] | null;
+  targetPublishDate: string | null;
+  parentPostIndex: number | null;
+  autoAttachState?: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+interface BatchData {
+  id: string;
+  state: string;
+  totalJobs: number;
+  completedJobs: number;
+  failedJobs: number;
+  sourceFilename: string | null;
+  sourceRowCount: number | null;
+  createdAt: string;
+  jobs: Job[];
+}
+
+const ATTACH_BADGE: Record<string, { label: string; colour: string }> = {
+  not_applicable: { label: "No date",       colour: "bg-muted text-muted-foreground" },
+  pending:        { label: "Will attach",   colour: "bg-blue-100 text-blue-700" },
+  attached:       { label: "Attached",      colour: "bg-green-100 text-green-700" },
+  attach_failed:  { label: "Attach failed", colour: "bg-red-100 text-red-700" },
+};
+
+const RATIO_LABELS: Record<string, string> = {
+  "1x1": "1:1", "4x5": "4:5", "9x16": "9:16", "16x9": "16:9", "4x3": "4:3",
+};
+
+export function BatchResultsClient({ batchId, companyId }: { batchId: string; companyId: string }) {
+  const [batch, setBatch] = useState<BatchData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [actioning, setActioning] = useState<Record<string, boolean>>({});
+
+  const fetchBatch = useCallback(async () => {
+    const res = await fetch(`/api/platform/image/batch/${batchId}`);
+    if (!res.ok) return;
+    const json = await res.json() as { ok: boolean; data?: BatchData };
+    if (json.ok && json.data) setBatch(json.data);
+    setLoading(false);
+  }, [batchId]);
+
+  // Poll while running.
+  useEffect(() => {
+    void fetchBatch();
+    const interval = setInterval(() => {
+      if (batch?.state === "running" || batch?.state === "pending") void fetchBatch();
+    }, 3000);
+    return () => clearInterval(interval);
+  }, [fetchBatch, batch?.state]);
+
+  async function act(jobId: string, action: "approve" | "reject", reason?: string) {
+    setActioning((p) => ({ ...p, [jobId]: true }));
+    try {
+      const res = await fetch(`/api/platform/image/jobs/${jobId}/select`, {
+        method: action === "approve" ? "POST" : "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ company_id: companyId, ...(reason && { reason }) }),
+      });
+      const json = await res.json() as { ok: boolean; error?: { message: string } };
+      if (json.ok) {
+        toast.success(action === "approve" ? "Image approved." : "Image rejected.");
+        void fetchBatch();
+      } else {
+        toast.error(json.error?.message ?? `${action} failed.`);
+      }
+    } catch {
+      toast.error("Network error.");
+    } finally {
+      setActioning((p) => ({ ...p, [jobId]: false }));
+    }
+  }
+
+  if (loading) return <p className="text-sm text-muted-foreground py-8 text-center">Loading…</p>;
+  if (!batch) return <p className="text-sm text-destructive py-8 text-center">Batch not found.</p>;
+
+  // Group jobs by parentPostIndex.
+  const groups = batch.jobs.reduce<Record<number, Job[]>>((acc, j) => {
+    const key = j.parentPostIndex ?? 0;
+    (acc[key] ??= []).push(j);
+    return acc;
+  }, {});
+
+  const groupKeys = Object.keys(groups).map(Number).sort((a, b) => a - b);
+  const isRunning = batch.state === "running" || batch.state === "pending";
+
+  return (
+    <div className="space-y-6">
+      {/* Batch header */}
+      <div className="rounded-xl border border-border bg-card p-5 flex flex-wrap items-center gap-4">
+        <div className="flex-1 min-w-0">
+          <p className="font-medium">{batch.sourceFilename ?? "Unnamed batch"}</p>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {batch.totalJobs} jobs · {batch.completedJobs} done · {batch.failedJobs} failed
+            {batch.sourceRowCount ? ` · from ${batch.sourceRowCount} rows` : ""}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {isRunning && (
+            <div className="h-4 w-4 rounded-full border-2 border-primary border-t-transparent animate-spin" aria-label="Running" />
+          )}
+          <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
+            batch.state === "completed" ? "bg-green-100 text-green-700"
+            : batch.state === "failed" ? "bg-red-100 text-red-700"
+            : batch.state === "partial" ? "bg-amber-100 text-amber-700"
+            : "bg-blue-100 text-blue-700"
+          }`}>
+            {batch.state.charAt(0).toUpperCase() + batch.state.slice(1)}
+          </span>
+        </div>
+      </div>
+
+      {/* Job groups */}
+      {groupKeys.map((groupIdx) => {
+        const jobs = groups[groupIdx]!;
+        const platforms = jobs[0]?.targetPlatforms ?? [];
+        const publishDate = jobs[0]?.targetPublishDate;
+
+        return (
+          <section key={groupIdx}>
+            <div className="flex items-center gap-2 mb-3">
+              <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+                Post {groupIdx + 1}
+              </h2>
+              {platforms.length > 0 && (
+                <span className="text-xs text-muted-foreground">
+                  · {platforms.join(", ")}
+                </span>
+              )}
+              {publishDate && (
+                <span className="text-xs text-muted-foreground">
+                  · publishes {publishDate}
+                </span>
+              )}
+            </div>
+
+            <div className={`grid gap-3 ${jobs.length === 1 ? "grid-cols-1 max-w-xs" : jobs.length === 2 ? "sm:grid-cols-2" : "sm:grid-cols-2 lg:grid-cols-3"}`}>
+              {jobs.map((job) => {
+                const isActioning = actioning[job.id] ?? false;
+                const attachBadge = job.autoAttachState ? ATTACH_BADGE[job.autoAttachState] : null;
+                const ratios = job.targetPlatforms?.map((p) => MASS_GEN_PLATFORM_MAP[p]).filter(Boolean) ?? [];
+                const ratioLabel = [...new Set(ratios)].map((r) => RATIO_LABELS[r!] ?? r).join(" / ");
+
+                return (
+                  <div key={job.id} className="rounded-xl border border-border bg-card overflow-hidden">
+                    {/* Image */}
+                    <div className="aspect-square bg-muted flex items-center justify-center relative">
+                      {job.state === "completed" && job.resultSignedUrl ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={job.resultSignedUrl} alt="Generated" className="w-full h-full object-cover" />
+                      ) : job.state === "running" || job.state === "pending" ? (
+                        <div className="h-8 w-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
+                      ) : job.state === "failed" || job.state === "escalated" ? (
+                        <p className="text-xs text-destructive text-center px-4">
+                          {job.errorClass ?? "Failed"}: {(job.errorDetail ?? "").slice(0, 80)}
+                        </p>
+                      ) : (
+                        <p className="text-xs text-muted-foreground">Pending</p>
+                      )}
+
+                      {/* Ratio chip */}
+                      {ratioLabel && (
+                        <span className="absolute top-2 left-2 rounded-full bg-black/60 text-white text-xs px-2 py-0.5">
+                          {ratioLabel}
+                        </span>
+                      )}
+                    </div>
+
+                    {/* Footer */}
+                    <div className="p-3 space-y-2">
+                      {/* Auto-attach badge */}
+                      {attachBadge && (
+                        <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${attachBadge.colour}`}>
+                          {attachBadge.label}{publishDate ? ` · ${publishDate}` : ""}
+                        </span>
+                      )}
+
+                      {/* Approve / reject */}
+                      {job.state === "completed" && (
+                        <div className="flex gap-2">
+                          <Button
+                            size="sm"
+                            className="flex-1 h-8 text-xs"
+                            onClick={() => void act(job.id, "approve")}
+                            disabled={isActioning}
+                          >
+                            {isActioning ? "…" : "Approve"}
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="flex-1 h-8 text-xs"
+                            onClick={() => void act(job.id, "reject", "Rejected by operator")}
+                            disabled={isActioning}
+                          >
+                            Reject
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+// Inlined from lib/image/types.ts to avoid server-only import in client component.
+const MASS_GEN_PLATFORM_MAP: Record<string, string> = {
+  linkedin: "1x1", linkedin_landscape: "16x9",
+  instagram: "4x5", instagram_story: "9x16",
+  facebook: "1x1", facebook_story: "9x16",
+  x: "16x9", gbp: "4x3",
+};


### PR DESCRIPTION
Batch history list at /company/image/batches and per-batch detail at /company/image/batches/[id]. Detail view polls while running, groups jobs by post, shows approve/reject buttons and auto-attach state badges. 2764/2764 tests pass.