### PR TITLE
docs(image-gen): scrub remaining Bannerbear references after Sharp migration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -112,9 +112,10 @@ CLOUDFLARE_IMAGES_API_TOKEN=
 CLOUDFLARE_IMAGES_HASH=
 
 # --- AI image generation (company/image/generate) --------------------------
-# Provider selection. Default: "ideogram". Other value: "bannerbear" (legacy).
-COMPOSITING_PROVIDER=
-# Ideogram API key — required when COMPOSITING_PROVIDER is unset or "ideogram".
+# Compositing: sharp-native renderer (A-NEW-4). COMPOSITING_PROVIDER and all
+# BANNERBEAR_* vars removed — templates live in image_templates DB table
+# (A-NEW-2), edited via /company/image/templates (A-NEW-3).
+# Ideogram API key — required for background generation.
 # Obtain at https://ideogram.ai/manage-api
 IDEOGRAM_API_KEY=
 # Optional model overrides (defaults built in to lib/image/generator/ideogram.ts).
@@ -126,12 +127,6 @@ IMAGE_GENERATION_TIMEOUT_MS=
 IMAGE_GENERATION_BUCKET=generated-images
 # Set to "true" to enable the mood-board generation endpoint.
 IMAGE_FEATURE_MOOD_BOARD=
-# Bannerbear API key + template IDs — only needed when COMPOSITING_PROVIDER=bannerbear.
-BANNERBEAR_API_KEY=
-BANNERBEAR_TEMPLATE_1080x1080=
-BANNERBEAR_TEMPLATE_1080x1350=
-BANNERBEAR_TEMPLATE_1920x1080=
-BANNERBEAR_TEMPLATE_1080x1920=
 
 # --- Observability: Sentry (M10, optional) ---------------------------------
 # All four are optional. Sentry is gated on SENTRY_DSN / NEXT_PUBLIC_SENTRY_DSN;

--- a/app/api/internal/image/qstash-handler/route.ts
+++ b/app/api/internal/image/qstash-handler/route.ts
@@ -44,7 +44,7 @@ import { generatePreview } from "@/lib/image/generator/preview";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-export const maxDuration = 90; // matches lease TTL; Ideogram ~11s + Bannerbear ~30s
+export const maxDuration = 90; // matches lease TTL; Ideogram ~11s + sharp composite ~1-2s
 
 const GenerationParamsSchema = z.object({
   styleId: z.enum(["clean_corporate", "bold_promo", "minimal_modern", "editorial", "product_focus"]),

--- a/docs/briefs/image-generator/MASS_IMAGE_GEN_BUILD_BRIEF.md
+++ b/docs/briefs/image-generator/MASS_IMAGE_GEN_BUILD_BRIEF.md
@@ -553,7 +553,7 @@ These apply to every PR in the programme. Claude Code must respect them.
 - **Read the relevant skill before touching the layer.** `lib/image/**` → image-generation skill. `lib/platform/brand/**` → platform-brand-governance skill. `lib/social/**` → n-series-layer-rules skill.
 - **Every generation writes to `image_generation_log`.** No exceptions, no bypasses. Composer AI tab, CAP, mood board, batch handler, previews — all log.
 - **All file outputs go inside the repo.** `docs/`, `lib/`, `app/`, `supabase/migrations/`, `scripts/`. Never `/tmp`, never the Desktop, never outside the project.
-- **Tests for every new module.** Unit tests at minimum. Integration tests for any route that touches Ideogram or Bannerbear. Acceptance test for the slice from §5 if listed.
+- **Tests for every new module.** Unit tests at minimum. Integration tests for any route that touches Ideogram or the compositing layer. Acceptance test for the slice from §5 if listed.
 - **No `console.log`.** Use `lib/logger`.
 - **No direct UPDATE on `platform_brand_profiles`.** Always `update_brand_profile()` RPC.
 - **Cost-conscious.** Every Ideogram call costs money. Don't generate in tests if a fixture works. Mark all probe / test generations with `triggered_by='<slice_id>_<purpose>'` so they're filterable.
@@ -563,7 +563,6 @@ These apply to every PR in the programme. Claude Code must respect them.
 
 ## 8. How to start
 
-1. **Steven:** start D1 (Bannerbear account, **five** templates per §1.1, env vars). Half a day of dashboard work. This is the only thing blocking parallel Claude Code work.
 2. **Claude Code:** start A1 (Ideogram model identifier fix). Hand it this brief plus the recon, point it at the slice description, let it run with the standard checkpoint discipline.
 3. When A1 lands, proceed to A2, then A3. Each is a single PR with a clear checkpoint.
 4. By the time A3 is done, D1 should be complete on Steven's side, and Claude Code can proceed to B1 → A4 → A5 → A6.
@@ -574,16 +573,4 @@ If at any point a slice surfaces a contradiction with this brief or the recon, *
 
 ## 9. v1.1 backlog — deferred template variety
 
-After v1 ships, the following template enhancements were identified from real client examples (Blackbird IT, Cybersecure) and deferred. Do not implement in v1. Revisit after v1 is in production with at least 4 weeks of real client output.
-
-1. **CTA button as a fourth Bannerbear layer.** Pill-shaped call-to-action button with configurable text and icon. Example: "Shop Now →", "Book now →". Requires brand profile to gain a `cta_text` (per-post) field and template UID per CTA style.
-2. **Two-zone headline (multi-zone compositing).** Headline with highlighted phrase — e.g. white text + lime-highlighted phrase on next line. This was gap #22 in the recon. Requires Bannerbear template with second text layer + composite call to pass both zones.
-3. **Per-client template selection.** Cybersecure's split-photo-with-colour-block layout is fundamentally different from Blackbird's full-bleed-with-overlay layout. Both need to coexist. Requires:
-   - `brand_profile.template_pack` field (enum: `default`, `split_photo`, `full_bleed_overlay`, etc.)
-   - Bannerbear templates per pack per ratio (5 ratios × N packs)
-   - Compositing layer reads pack from brand profile, picks template UID accordingly
-4. **Configurable logo position.** Bottom-right is the v1 default. Some brands (Cybersecure) anchor top-right/top-left; some (Blackbird image 6) put logo top-centre. Requires `brand_profile.logo_position` field with enum and corresponding Bannerbear template variants.
-5. **Subhead / supporting copy layer.** A smaller text line below the main headline (e.g. "Tech-driven in harmony, simplifies life"). New `subhead` Bannerbear layer + per-post `subhead_text` field.
-6. **Photo style support — illustrated vs photographic.** Cybersecure image 10 uses an illustrated background instead of photographic. Requires either an Ideogram style addition (`style_id='illustrated'`) or a Bannerbear-side illustration-asset library.
-
-These six items together would constitute a v1.1 release worth 1.5–2 weeks of focused work after v1 stabilises. Reference examples live in `docs/briefs/image-generator/reference-examples/` (Blackbird IT + Cybersecure samples) — copy them into the repo before v1.1 scoping begins.
+See the [v3 addendum §5](./MASS_IMAGE_GEN_BUILD_BRIEF_v3_ADDENDUM.md#5-v11-backlog) for the current v1.1 backlog.

--- a/lib/__tests__/image-compositing.test.ts
+++ b/lib/__tests__/image-compositing.test.ts
@@ -4,9 +4,9 @@ import { TEXT_ZONE_MAP } from "@/lib/image/compositing/text-zones";
 import type { CompositionType } from "@/lib/image/types";
 
 // Unit tests for the text-zone map and pixel coordinate conversion.
-// The conversion logic is inline in bannerbear.ts; we test the TEXT_ZONE_MAP
-// contract here so a future maintainer can't shift coordinates without
-// breaking these assertions.
+// The conversion logic is inline in lib/image/compositing/sharp-renderer.ts;
+// we test the TEXT_ZONE_MAP contract here so a future maintainer can't shift
+// coordinates without breaking these assertions.
 
 function toPixels(
   zonePercent: { x: number; y: number; width: number; height: number },


### PR DESCRIPTION
## Summary

After the Sharp migration shipped via #1142 (A-NEW-1), #1148 (A-NEW-2), #1150 (A-NEW-3), #1158 (v3 addendum), and #1159 (A-NEW-4 pipeline integration + Bannerbear removal), a few stale references remained. This PR scrubs the load-bearing ones.

## Changes (file:line)

| File | Change |
|---|---|
| `docs/briefs/image-generator/MASS_IMAGE_GEN_BUILD_BRIEF.md:556` | §7 bullet 7 wording: `Ideogram or Bannerbear` -> `Ideogram or the compositing layer` |
| `docs/briefs/image-generator/MASS_IMAGE_GEN_BUILD_BRIEF.md:566` | §8: delete bullet 1 referencing D1 Bannerbear setup. D1 was deleted by addendum §1 - no Steven dashboard work required. Bullets 2-4 left untouched per instruction. |
| `docs/briefs/image-generator/MASS_IMAGE_GEN_BUILD_BRIEF.md:574-588` | §9: replace 6-item v1.1 backlog (5 of 6 items referenced Bannerbear layers/templates) with a single pointer to the addendum's §5, which is the canonical v1.1 backlog. |
| `lib/__tests__/image-compositing.test.ts:7` | Update stale `bannerbear.ts` comment to reference `sharp-renderer.ts`. Test logic unchanged. |
| `.env.local.example:114-134` | Mirror `.env.example`'s A-NEW-4 cleanup: remove `COMPOSITING_PROVIDER` and 4 `BANNERBEAR_*` template-UID vars. Replace with the same supersession comment block. |
| `app/api/internal/image/qstash-handler/route.ts:47` | Update `maxDuration` rationale comment: `Ideogram ~11s + Bannerbear ~30s` -> `Ideogram ~11s + sharp composite ~1-2s` |

## Verification - rg "bannerbear|Bannerbear" -i audit

Ran across the full repo after the edits. All remaining hits classified below.

### Kept - intentional supersession notes (explain what was removed)

- `.env.example:110` - comment block explaining what A-NEW-4 removed (was already there)
- `.env.local.example:116` - same comment, just added
- `lib/image/compositing/index.ts:31` - design-decision comment that helps future readers
- `lib/image/compositing/sharp-renderer.ts:16` - historical rationale

### Kept - immutable history files

- `CHANGELOG.md:87` - historical changelog entry for I2 (#457)
- `supabase/migrations/0158_create_generated_images_bucket.sql:1,9` - migration comments; migrations are immutable once shipped

### Kept - the addendum itself, by design

`docs/briefs/image-generator/MASS_IMAGE_GEN_BUILD_BRIEF_v3_ADDENDUM.md:11,30,38,41,42,45,60,61,125,131` - addendum's job is to describe what was removed.

### Kept - main brief, out of scope per instruction

The main brief's addendum banner (line 3) supersedes these in-context. Steven explicitly scoped this PR to §7/§8/§9; brief §0/§1.1/§1.7/§2/§3/§A4/§B1/§Stream-D/§sequencing references were left untouched per instruction.

- `MASS_IMAGE_GEN_BUILD_BRIEF.md:3` - addendum banner (intentional pointer)
- `MASS_IMAGE_GEN_BUILD_BRIEF.md:25,27` - §0 recon findings
- `MASS_IMAGE_GEN_BUILD_BRIEF.md:46,57` - §1.1 platform/aspect table + template-count note
- `MASS_IMAGE_GEN_BUILD_BRIEF.md:180` - §1.7 image-job definition
- `MASS_IMAGE_GEN_BUILD_BRIEF.md:219,221` - §2 programme shape
- `MASS_IMAGE_GEN_BUILD_BRIEF.md:230,233` - §3 out-of-scope
- `MASS_IMAGE_GEN_BUILD_BRIEF.md:292,295,297` - §A4 slice description
- `MASS_IMAGE_GEN_BUILD_BRIEF.md:334,337` - §B1 retry semantics + lease lifetime
- `MASS_IMAGE_GEN_BUILD_BRIEF.md:464,466,470,479` - §Stream D / §D1 (addendum kills D1)
- `MASS_IMAGE_GEN_BUILD_BRIEF.md:534` - §6 sequencing constraint

### Flagged for follow-up - out of scope for this PR

Both files describe the old multi-provider architecture and would need paragraph-level rewrites (not find-replace) to describe the sharp-native architecture properly. A dedicated follow-up PR can do this cleanly.

- `.claude/skills/image-generation/image-generation.SKILL.md` (8 hits) - active operational doc; needs rewrite to describe sharp + DB templates per addendum §1.8 + §1.9.
- `docs/architecture/BUILD.md` (7 hits) - canonical architecture doc. Sections §3, §I2 status table, §security-headers comment, §compositing line all describe old arch.

## Gate evidence

- `npm run typecheck` - clean (after `npm install` to pick up the `fabric` dep added by #1150)
- `npm run lint` - clean

## Companion action

`gh pr close 1140 --comment "Superseded by #1158, which is the merged canonical v3 addendum."` run alongside this PR.

Co-Authored-By: Claude Opus 4.7 (1M context)
